### PR TITLE
fix(ui): remove unintended underlines from button links

### DIFF
--- a/ui/src/styles/about.css
+++ b/ui/src/styles/about.css
@@ -154,7 +154,6 @@
   color: var(--text);
   font-size: var(--control-ui-text-sm);
   font-weight: 550;
-  text-decoration: none;
   transition:
     transform 140ms ease,
     background 140ms ease,
@@ -165,7 +164,6 @@
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--border) 40%, var(--text) 60%);
   background: var(--bg-hover);
-  text-decoration: none;
 }
 
 .about-hero__link:focus-visible {

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -75,7 +75,6 @@ openclaw-activity-page {
   gap: var(--space-3);
   padding: var(--space-2) var(--space-4);
   color: var(--text);
-  text-decoration: none;
 }
 
 .activity-current-work__row + .activity-current-work__row {
@@ -377,7 +376,6 @@ a.activity-current-work__row:hover {
   min-height: 54px;
   padding: var(--space-3) var(--space-4);
   color: var(--text);
-  text-decoration: none;
 }
 
 .activity-feed__session-row {
@@ -432,7 +430,6 @@ a.activity-current-work__row:hover {
 .activity-feed__session-row:hover .activity-feed__session,
 .activity-feed__session-row:focus-within .activity-feed__session {
   background: var(--bg-hover);
-  text-decoration: none;
 }
 
 .activity-feed__session-row:has(.activity-feed__inspect-run) .activity-feed__session {
@@ -452,7 +449,6 @@ a.activity-current-work__row:hover {
   background: var(--bg-elevated);
   font-size: var(--control-ui-text-xs);
   line-height: 1;
-  text-decoration: none;
   pointer-events: none;
   translate: 0 -50%;
   transition: opacity var(--duration-fast) ease;
@@ -468,7 +464,6 @@ a.activity-current-work__row:hover {
 .activity-feed__inspect-run:focus-visible {
   border-color: var(--border-strong);
   color: var(--text);
-  text-decoration: none;
 }
 
 .activity-feed__session .viewer-avatar {
@@ -641,7 +636,6 @@ a.activity-current-work__row:hover {
   height: 16px;
   flex: 0 0 auto;
   color: var(--muted);
-  text-decoration: none;
 }
 
 .activity-feed__device-attribution svg {
@@ -863,13 +857,11 @@ a.activity-current-work__row:hover {
   margin-bottom: var(--space-3);
   color: var(--muted);
   font-size: var(--control-ui-text-sm);
-  text-decoration: none;
 }
 
 .activity-run-inspector-back:hover,
 .activity-run-inspector-back:focus-visible {
   color: var(--text);
-  text-decoration: none;
 }
 
 .activity-run-inspector-back svg {

--- a/ui/src/styles/approval.css
+++ b/ui/src/styles/approval.css
@@ -410,7 +410,6 @@
   padding: 12px 16px;
   color: var(--muted-strong);
   font-size: var(--control-ui-text-sm);
-  text-decoration: none;
 }
 
 .approval-page__back-link:hover {

--- a/ui/src/styles/apps.css
+++ b/ui/src/styles/apps.css
@@ -163,7 +163,6 @@
   font: inherit;
   font-size: var(--control-ui-text-sm);
   font-weight: 550;
-  text-decoration: none;
   cursor: var(--cursor-action);
   transition:
     transform 140ms ease,
@@ -181,7 +180,6 @@
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--border) 40%, var(--text) 60%);
   background: var(--bg-hover);
-  text-decoration: none;
 }
 
 .apps-card__cta--primary:hover {
@@ -238,7 +236,6 @@
   color: var(--text);
   font-size: var(--control-ui-text-sm);
   font-weight: 550;
-  text-decoration: none;
   transition:
     transform 140ms ease,
     background 140ms ease,
@@ -249,7 +246,6 @@
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--border) 40%, var(--text) 60%);
   background: var(--bg-hover);
-  text-decoration: none;
 }
 
 .apps-pill:focus-visible {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -850,8 +850,30 @@ input:is(
 
 a {
   color: var(--accent);
-  text-decoration: underline;
+  text-decoration: none;
   text-underline-offset: 2px;
+}
+
+/* Content links opt in; navigation and button anchors stay undecorated. */
+a:where(
+    :not([class]),
+    [class=""],
+    .activity-entry__run-link,
+    .settings-row__value,
+    .memory-page__link,
+    .portals-preview__notice-url,
+    .settings-account,
+    .transcripts-back,
+    .chat-text a,
+    .chat-thinking a,
+    .sidebar-markdown a,
+    .markdown a,
+    .markdown-body a,
+    .chat-session-rail__answer a,
+    .chat-position-rail__preview-copy a,
+    .dreams-diary__para a
+  ):not(:where(.btn, [role="button"])) {
+  text-decoration: underline;
 }
 
 /* Real links keep the hand even when styled as controls. */
@@ -867,11 +889,6 @@ a[href] {
 
 a:hover {
   text-decoration-thickness: 2px;
-}
-
-.learn-more-link,
-.learn-more-link:hover {
-  text-decoration: none;
 }
 
 /* Web Awesome defaults checked switches to brand blue. Keep every switch on

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -390,11 +390,6 @@
   gap: var(--space-2);
 }
 
-.channels-wizard__link,
-.channels-wizard__link:hover {
-  text-decoration: none;
-}
-
 .channels-wizard__footer {
   display: flex;
   align-items: center;

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -959,7 +959,6 @@
   display: block;
   width: 100%;
   color: inherit;
-  text-decoration: none;
 }
 
 .mcp-server-dialog {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -954,7 +954,6 @@ openclaw-chat-page {
   align-items: center;
   gap: 6px;
   color: var(--muted);
-  text-decoration: none;
   transition: color 150ms ease-out;
 }
 
@@ -2122,7 +2121,6 @@ openclaw-chat-video-player {
   gap: 8px;
   min-width: 0;
   color: var(--text);
-  text-decoration: none;
 }
 
 .chat-pr__link--static {
@@ -2368,7 +2366,6 @@ button.chat-pr__diff {
   color: var(--muted);
   font-size: 12px;
   font-weight: 600;
-  text-decoration: none;
   white-space: nowrap;
 }
 

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -593,7 +593,6 @@
   color: var(--text);
   font-size: 13px;
   font-weight: 600;
-  text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -667,7 +666,6 @@
   color: var(--text);
   background: transparent;
   font: inherit;
-  text-decoration: none;
   cursor: var(--cursor-action);
   transition:
     color 120ms ease,
@@ -678,7 +676,6 @@
 .chat-assistant-attachment-card__action:hover {
   color: var(--text-strong);
   background: color-mix(in srgb, var(--media-foreground) 8%, transparent);
-  text-decoration: none;
 }
 
 .chat-assistant-attachment-card__action:focus-visible {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -493,7 +493,6 @@
    opacity, which composited the link toward its background and cost another 1.1. */
 .chat-text :where(a) {
   color: var(--link);
-  text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
   text-underline-offset: 2px;
 }
@@ -789,7 +788,6 @@
 :is(.chat-text, .sidebar-markdown) .markdown-external-image > a:hover {
   background: color-mix(in srgb, var(--text) 13%, transparent);
   color: var(--link-hover);
-  text-decoration: none;
 }
 
 /* Code surfaces must lift off the host bubble in every theme. --secondary equals

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -733,7 +733,6 @@
 .chat-tool-card__detail-link:hover,
 .chat-tool-card__detail-link:focus-visible {
   color: var(--text);
-  text-decoration: none;
 }
 
 .chat-tool-card__block {
@@ -1174,7 +1173,6 @@
   color: var(--muted);
   font: inherit;
   cursor: var(--cursor-action);
-  text-decoration: none;
 }
 
 .chat-tasks-status__link:hover,

--- a/ui/src/styles/community-invite-card.css
+++ b/ui/src/styles/community-invite-card.css
@@ -193,7 +193,6 @@
     cursor: pointer;
     font-size: var(--control-ui-text-sm, 12px);
     font-weight: 600;
-    text-decoration: none;
     transition:
       background 120ms ease,
       transform 120ms ease;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1659,7 +1659,6 @@ openclaw-session-progress-hovercard-provider {
   margin: 0 -6px;
   border-radius: var(--radius-sm);
   color: var(--text);
-  text-decoration: none;
 }
 
 .person-activity-card__session-copy {
@@ -2483,7 +2482,6 @@ openclaw-chat-session-rail {
   color: var(--text);
   font-size: 10.5px;
   line-height: 1;
-  text-decoration: none;
 }
 
 .chat-session-rail__pr:hover {
@@ -4581,7 +4579,6 @@ td.data-table-key-col {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--card) 86%, transparent);
   color: inherit;
-  text-decoration: none;
   transition:
     background-color var(--duration-fast) var(--ease-in-out),
     border-color var(--duration-fast) var(--ease-in-out),
@@ -4896,7 +4893,6 @@ td.data-table-key-col {
 
 .agent-tool-jump {
   color: var(--accent);
-  text-decoration: none;
   align-self: end;
   margin-left: auto;
 }
@@ -6073,8 +6069,9 @@ td.data-table-key-col {
   color: inherit;
 }
 
-.person-activity-link:not(:hover, :focus-visible) {
-  text-decoration: none;
+.person-activity-link:not(:where(.learn-more-link)):hover,
+.person-activity-link:not(:where(.learn-more-link)):focus-visible {
+  text-decoration-line: underline;
 }
 
 .person-activity-avatar-link {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -599,7 +599,6 @@
   color: var(--accent);
   font-size: 12px;
   font-weight: 600;
-  text-decoration: none;
 }
 
 .settings-theme-import__external:hover {

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -3,8 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import postcss from "postcss";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import { controlUiHoverGuardPlugin } from "../../config/control-ui-hover-guard.ts";
 import { dockPanelStyles } from "../components/dock-layout-controller.ts";
 import {
   canRunPlaywrightChromium,
@@ -73,12 +75,13 @@ const CURSOR_CASES: readonly CursorCase[] = [
 ];
 
 function readUiCss(): string {
-  return [
+  const css = [
     "ui/src/styles/base.css",
     "ui/src/styles/components.css",
     "ui/src/styles/layout.css",
     "ui/src/styles/sidebar-update-card.css",
     "ui/src/styles/sidebar-issues.css",
+    "ui/src/styles/sidebar-markdown.css",
     "ui/src/styles/sessions.css",
     "ui/src/styles/settings-controls.css",
     "ui/src/styles/settings.css",
@@ -91,6 +94,7 @@ function readUiCss(): string {
   ]
     .map((file) => readStyleSheet(file))
     .join("\n");
+  return postcss([controlUiHoverGuardPlugin()]).process(css, { from: undefined }).css;
 }
 
 function fixtureDocument(): string {
@@ -104,6 +108,32 @@ function fixtureDocument(): string {
       <input id="plain-text-input" type="text" value="text" />
       <div id="role-button" role="button" tabindex="0">Role button</div>
       <a id="real-link" href="https://example.com">Real link</a>
+      <a id="primary-button-link" class="btn primary" href="/new">Primary action</a>
+      <a id="ghost-button-link" class="btn btn--ghost" href="/new">Secondary action</a>
+      <a id="role-button-link" role="button" href="/new">Action</a>
+      <div class="callout"><a id="docs-link" href="https://example.com/docs">Documentation</a></div>
+      <div class="chat-text">
+        <a id="chat-content-link" href="https://example.com">Chat link</a>
+        <a id="chat-button-link" class="btn" href="/new">Chat action</a>
+      </div>
+      <div class="sidebar-markdown"><a id="sidebar-content-link" href="https://example.com">Sidebar link</a></div>
+      <div class="markdown"><a class="markdown-bare-url" href="https://example.com">Transcript link</a></div>
+      <div class="chat-thinking"><a class="markdown-bare-url" href="https://example.com">Reasoning link</a></div>
+      <div class="markdown-body"><a class="markdown-bare-url" href="https://example.com">Logbook link</a></div>
+      <div class="chat-session-rail__answer"><a class="markdown-bare-url" href="https://example.com">Answer link</a></div>
+      <div class="chat-position-rail__preview-copy" inert>
+        <a class="markdown-bare-url" href="https://example.com">Preview URL</a>
+        <a id="preview-github-link" class="markdown-github-link" href="https://github.com/example/project">Preview repository</a>
+      </div>
+      <div class="dreams-diary__para"><a class="markdown-bare-url" href="https://example.com">Diary link</a></div>
+      <a class="activity-entry__run-link" href="/activity">Run</a>
+      <a class="settings-row__value" href="https://example.com/docs">Setup documentation</a>
+      <a class="memory-page__link" href="/settings/memory">Memory settings</a>
+      <a class="portals-preview__notice-url" href="https://example.com">Portal address</a>
+      <a class="settings-account" href="https://github.com/example">Account</a>
+      <a class="transcripts-back" href="/meetings">Transcripts</a>
+      <a id="person-link" class="person-activity-link" href="/activity">Person</a>
+      <a id="participant-link" class="session-menu__item learn-more-link session-hovercard__participant-link person-activity-link" href="/activity">Participant</a>
       <aside class="sidebar">
         <a class="nav-item" href="/chat"><span class="nav-item__text">Home</span></a>
         <a class="sidebar-recent-session__link" href="/chat/test"><span class="sidebar-recent-session__name">Session</span></a>
@@ -216,10 +246,18 @@ afterAll(async () => {
 });
 
 describeCursorPolicy("Control UI cursor policy", () => {
-  it("keeps Online names undecorated for links and buttons", async () => {
-    const page = await tabBrowser.newPage();
+  it.each([
+    { theme: "light", hasTouch: false },
+    { theme: "dark", hasTouch: false },
+    { theme: "light", hasTouch: true },
+    { theme: "dark", hasTouch: true },
+  ])("underlines content, not controls ($theme, touch=$hasTouch)", async ({ theme, hasTouch }) => {
+    const page = await tabBrowser.newPage({ hasTouch });
     try {
       await page.goto(`file://${fixtureFile}`);
+      await page.evaluate((mode) => {
+        document.documentElement.dataset.themeMode = mode;
+      }, theme);
       const people = await page.locator(".sidebar-online__person").all();
       expect(people).toHaveLength(2);
       for (const person of people) {
@@ -233,11 +271,78 @@ describeCursorPolicy("Control UI cursor policy", () => {
             .evaluate((element) => getComputedStyle(element).textDecorationLine),
         ).toBe("none");
       }
+      for (const [expected, selectors] of [
+        [
+          "none",
+          [
+            "#new-tab-link",
+            "#primary-button-link",
+            "#ghost-button-link",
+            "#role-button-link",
+            "#chat-button-link",
+            ".person-activity-link",
+            ".markdown-github-item",
+            ".markdown-file-link",
+          ],
+        ],
+        [
+          "underline",
+          [
+            "#real-link",
+            "#docs-link",
+            "#chat-content-link",
+            "#sidebar-content-link",
+            ".markdown-bare-url",
+            "#preview-github-link",
+            ".activity-entry__run-link",
+            ".settings-row__value",
+            ".memory-page__link",
+            ".portals-preview__notice-url",
+            ".settings-account",
+            ".transcripts-back",
+          ],
+        ],
+      ] as const) {
+        for (const selector of selectors) {
+          const links = await page.locator(selector).all();
+          expect(links.length, selector).toBeGreaterThan(0);
+          for (const link of links) {
+            expect(
+              await link.evaluate((element) => getComputedStyle(element).textDecorationLine),
+              selector,
+            ).toBe(expected);
+          }
+        }
+      }
+      const personLink = page.locator("#person-link");
+      if (!hasTouch) {
+        await personLink.hover();
+        expect(
+          await personLink.evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("underline");
+        expect(
+          await personLink.evaluate((element) => getComputedStyle(element).textDecorationThickness),
+        ).toBe("2px");
+      }
+      await page.mouse.move(0, 0);
+      await page.keyboard.press("Tab");
+      await personLink.focus();
       expect(
-        await page
-          .locator("#real-link")
-          .evaluate((element) => getComputedStyle(element).textDecorationLine),
+        await personLink.evaluate((element) => getComputedStyle(element).textDecorationLine),
       ).toBe("underline");
+      const participantLink = page.locator("#participant-link");
+      if (!hasTouch) {
+        await participantLink.hover();
+        expect(
+          await participantLink.evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("none");
+      }
+      await page.mouse.move(0, 0);
+      await page.keyboard.press("Tab");
+      await participantLink.focus();
+      expect(
+        await participantLink.evaluate((element) => getComputedStyle(element).textDecorationLine),
+      ).toBe("none");
     } finally {
       await page.close().catch(() => {});
     }

--- a/ui/src/styles/dashboards.css
+++ b/ui/src/styles/dashboards.css
@@ -134,7 +134,6 @@
 .dashboard-card__main {
   display: block;
   color: inherit;
-  text-decoration: none;
 }
 
 .dashboard-card__main:focus-visible {

--- a/ui/src/styles/github-link-hovercard.css
+++ b/ui/src/styles/github-link-hovercard.css
@@ -83,7 +83,6 @@
   min-width: 0;
   color: inherit;
   overflow: hidden;
-  text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -93,7 +92,6 @@
 .github-link-hovercard__author:hover,
 .github-link-hovercard__author:focus-visible {
   color: var(--text-strong);
-  text-decoration: none;
 }
 
 .github-link-hovercard__time {
@@ -111,7 +109,6 @@
   letter-spacing: -0.012em;
   line-height: 1.35;
   overflow-wrap: anywhere;
-  text-decoration: none;
 }
 
 .github-link-hovercard__title:hover,
@@ -160,7 +157,6 @@
   color: var(--muted);
   font-size: var(--control-ui-text-md);
   overflow: hidden;
-  text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -70,7 +70,6 @@
   background: var(--panel);
   color: var(--text);
   box-shadow: var(--shadow-md), var(--focus-ring);
-  text-decoration: none;
   transform: translate(-50%, -160%);
   transition: transform var(--duration-fast) var(--ease-out);
 }
@@ -597,7 +596,6 @@ html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrom
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -608,7 +606,6 @@ html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrom
   color: var(--text);
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
   border-color: color-mix(in srgb, var(--border) 72%, transparent);
-  text-decoration: none;
 }
 
 .settings-sidebar__item:focus-visible {
@@ -668,12 +665,10 @@ html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrom
   padding: 0 9px;
   border-radius: var(--radius-sm);
   color: var(--text);
-  text-decoration: none;
 }
 
 .settings-sidebar__subitem:hover {
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-  text-decoration: none;
 }
 
 .settings-sidebar__subitem--active {
@@ -2021,7 +2016,6 @@ openclaw-settings-save-indicator:empty {
   padding: var(--sidebar-session-link-padding-block) 2px var(--sidebar-session-link-padding-block)
     var(--sidebar-inset);
   color: inherit;
-  text-decoration: none;
 }
 
 .sidebar-child-session-toggle {
@@ -2094,10 +2088,6 @@ openclaw-settings-save-indicator:empty {
   font-size: calc(9px * var(--control-ui-text-scale));
   font-variant-numeric: tabular-nums;
   line-height: 1;
-}
-
-.sidebar-recent-session__link:hover {
-  text-decoration: none;
 }
 
 .viewer-facepile {
@@ -2379,7 +2369,6 @@ openclaw-settings-save-indicator:empty {
   color: var(--text);
   font: inherit;
   text-align: left;
-  text-decoration: none;
   transition:
     background var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease,
@@ -2550,7 +2539,6 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   font: inherit;
   font-size: calc(13px * var(--control-ui-text-scale));
   text-align: left;
-  text-decoration: none;
 }
 
 /* Keep expanded state separate from :hover so hover media scoping preserves
@@ -3115,7 +3103,6 @@ a:is(
   border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
-  text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -3162,7 +3149,6 @@ a:is(
   color: var(--text);
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
   border-color: color-mix(in srgb, var(--border) 72%, transparent);
-  text-decoration: none;
 }
 
 .nav-item:hover .nav-item__icon {
@@ -4126,13 +4112,11 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   font-size: var(--control-ui-text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-decoration: none;
 }
 
 .sidebar-footer-build:hover,
 .sidebar-footer-build:focus-visible {
   color: var(--text);
-  text-decoration: none;
 }
 
 .sidebar-footer-build__text {

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -1532,10 +1532,6 @@ openclaw-lobster-pet[data-dex-complete]::after {
   justify-items: start;
 }
 
-.lobsterdex__open {
-  text-decoration: none;
-}
-
 .lobsterdex__tooltip {
   display: grid;
   max-width: 230px;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -373,7 +373,6 @@ h3.plugins-subheader {
 .plugins-group__link {
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
-  text-decoration: none;
   white-space: nowrap;
 }
 

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -467,7 +467,6 @@ footer.sidebar-issues-panel__mentions-note {
   align-items: center;
   gap: 8px;
   color: inherit;
-  text-decoration: none;
 }
 
 .sidebar-issues-panel__summary--navigation {

--- a/ui/src/styles/sidebar-markdown.css
+++ b/ui/src/styles/sidebar-markdown.css
@@ -91,7 +91,6 @@
    link colors side by side. */
 .sidebar-markdown :where(a) {
   color: var(--link);
-  text-decoration: underline;
   text-decoration-color: color-mix(in srgb, var(--link) 40%, transparent);
   text-underline-offset: 2px;
   transition: text-decoration-color var(--duration-fast) ease;


### PR DESCRIPTION
Closes #142287

## What Problem This Solves

Fixes an issue where Control UI buttons rendered as links have underlined labels unless their component adds a local reset. The Docs button in a channel's details reproduces the issue.

## Why This Change Was Made

The shared stylesheet now applies underlines to content links, with explicit exclusions for `.btn` and anchor controls using `role="button"`. Existing Markdown and classed content links keep their underlines, including the current chat-position preview. Removing 55 redundant resets leaves production CSS 47 lines smaller; intentional chip and menu exceptions remain. The redundant local underline reset for Online names is removed because the root policy now covers it; the existing Online assertions remain.

## User Impact

Button links render without underlines. Existing navigation styling is preserved. Chat, reasoning, sidebar Markdown, documentation, memory, portal notices, account, activity, and transcript content links retain their existing treatment. Person links still underline on hover or keyboard focus, preserving their existing hover thickness. Participant menu rows remain undecorated.

## Evidence

- Extended the existing browser policy test: **7 tests passed**, covering light/dark, mouse/touch, primary/secondary/ghost button links, classless role buttons, content links, Online names, Markdown chips, and browser/native/installed-window cursors. The original defect failed on the parent stylesheet with `expected none, received underline`.
- The test uses the production hover processing, protecting content links on touch devices. It also covers bare URLs and labeled GitHub links inside the inert chat-position preview; the missing content opt-in failed in all four theme/touch cases before the fix.
- Changed-file validation completed: formatting, core-test and UI typechecks, i18n, dependency/static guards, unused exports, and TypeScript/CSS lint (`node scripts/check-changed.mjs -- <22 changed paths>`).
- Inspected 1440 × 900 captures (assembled below by theme; click to enlarge) from the real mock Gateway app. Before/after pairs use identical component state and switch only between the parent's decoration declarations and the candidate. The original unmodified-source reproduction is attached to the issue. Chat panels were refreshed with the invitation dismissed before rendering.
- Checked visible interactions: Online opens its activity card, the channel details dialog opens/closes, New agent opens the creation surface, and the Markdown preview opens/closes with its content link still underlined in both themes. The Docs destination remains the channel documentation URL; the standalone harness intentionally blocks external navigation, so opening that site was not exercised.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">light: Channels, chat and Online, Markdown preview, current Agents</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/5e2126c7-f4cf-4a1e-a6c6-199ad8383018"><img src="https://github.com/user-attachments/assets/5e2126c7-f4cf-4a1e-a6c6-199ad8383018" alt="light theme, before: Channels, chat and Online, Markdown preview, current Agents" width="640"></a></td><td><a href="https://github.com/user-attachments/assets/58cb5016-7640-40e8-9b1f-63589b3e327b"><img src="https://github.com/user-attachments/assets/58cb5016-7640-40e8-9b1f-63589b3e327b" alt="light theme, after: Channels, chat and Online, Markdown preview, current Agents" width="640"></a></td></tr>
<tr><th colspan="2">dark: Channels, chat and Online, Markdown preview, current Agents</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/20060835-7774-48d9-ac1d-fdc51c30af94"><img src="https://github.com/user-attachments/assets/20060835-7774-48d9-ac1d-fdc51c30af94" alt="dark theme, before: Channels, chat and Online, Markdown preview, current Agents" width="640"></a></td><td><a href="https://github.com/user-attachments/assets/70c44369-adb3-43e5-a443-9c39410d12c4"><img src="https://github.com/user-attachments/assets/70c44369-adb3-43e5-a443-9c39410d12c4" alt="dark theme, after: Channels, chat and Online, Markdown preview, current Agents" width="640"></a></td></tr>
</table>

## Risk and coverage

The shared CSS policy affects multiple consumers. Browser assertions cover button variants, role buttons, chat and reasoning, sidebar Markdown, transcript/logbook/answer/position-preview/diary Markdown, activity run IDs, channel setup documentation, memory links, portal notices, account handles, transcript navigation, identity hover/focus and thickness, participant menu controls, Online, and file/GitHub chips.

Source review also checked the reset removals in About links, Activity rows and inspection controls, approval navigation, Apps actions, channel wizard links, composer capability links, context/PR controls, attachment controls, tool cards, community invite actions, person cards, runtime chips, tool jumps, theme import links, dashboard cards, GitHub hovercards, sidebar navigation, Lobsterdex, plugin groups, and issue navigation. Their dedicated decoration overrides remain where content or classless-link rules still require them.

The screenshots cover the current Channels and Agents pages, chat/Online, and sidebar Markdown in light and dark themes. The current Agents page uses a native New agent button, whose styling is unchanged. Channels reproduces the anchor-button defect. Authenticated live Gateway behavior and other browsers were not exercised; this is a CSS-only change.
