### PR TITLE
fix(ui): first-run recovery checks fail before startup settles

### DIFF
--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { routeIdFromPath } from "../../app-routes.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
@@ -11,12 +12,14 @@ const defaultLanding = { pathname: "/chat/main", search: "", hash: "" };
 async function startRedirect(
   context: ApplicationContext<RouteId>,
   currentLocation = defaultLanding,
+  onInitialDecision?: () => void,
 ): Promise<() => void> {
   return startModelSetupFirstRunRedirectAfterLocation({
     context,
     enabled: true,
     history: { location: () => currentLocation, replace: () => undefined },
     initialLocationReady: Promise.resolve(defaultLanding),
+    onInitialDecision,
   });
 }
 
@@ -269,11 +272,11 @@ describe("model setup first-run redirect", () => {
       modelRef: "openai/expected",
     });
 
-    const dispose = await startRedirect(context);
+    const decision = createDeferred();
+    const dispose = await startRedirect(context, defaultLanding, decision.resolve);
 
-    await vi.waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
-    });
+    await decision.promise;
+    expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
     dispose();
   });
 
@@ -285,11 +288,11 @@ describe("model setup first-run redirect", () => {
     });
     context.gateway.connection.token = "different-owner-token";
 
-    const dispose = await startRedirect(context);
+    const decision = createDeferred();
+    const dispose = await startRedirect(context, defaultLanding, decision.resolve);
 
-    await vi.waitFor(() => {
-      expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
-    });
+    await decision.promise;
+    expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
     expect(replace).not.toHaveBeenCalled();
     dispose();
   });


### PR DESCRIPTION
Closes #142330

## What Problem This Solves

Resolves a problem where the Control UI first-run recovery tests fail before asynchronous startup settles, blocking unrelated PRs when lazy recovery initialization exceeds one second. The original failure in [checks-ui (3/3)](https://github.com/openclaw/openclaw/actions/runs/34248512298/job/102137050918) was `Number of calls: 0` at `first-run.test.ts:275`, after approximately 1006 ms.

## Why This Change Was Made

Both receipt-recovery tests now await the existing `onInitialDecision` callback used by the application bootstrap, then assert the same redirect and credential-replacement outcomes. Production behavior, mocks, assertions, and timeouts are unchanged.

Commit `1473333f46d1b89e2bf1342d9ac5919d2c628d0c` ([#129815](https://github.com/openclaw/openclaw/pull/129815), @steipete) introduced the lazy recovery flow and the tests' one-second polling assumption together. This fixes that synchronization defect; the expected onboarding behavior remains current.

## User Impact

No user-visible behavior changes. CI verifies completed startup decisions without treating module-loading duration as a functional failure.

## Evidence

- Original CI and a separate local checkout recorded the same failure at 1006/1007 ms.
- Current clean-main focused runs and all 315 model-setup tests passed locally; no spontaneous product regression is claimed.
- Controlled slow-module diagnostic: delaying evaluation of the real setup-page module by 1200 ms reproduces the original assertion failure (1 failed / 15 passed). This patch passes all 16 cases under the same diagnostic, including a 1510 ms restore and rejection of a receipt whose Gateway credentials changed. Diagnostic code is not included in the PR.
- Standard model-setup suite after the patch: 19 files, 315 tests passed, with two workers.
- Final focused first-run and receipt tests: 25 passed.
- After rebasing onto the separate catalog repair ([#142346](https://github.com/openclaw/openclaw/pull/142346), @steipete), all 16 first-run tests passed again. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34254924327) passed for `5280b22b494d84555e0679585ae9240e02470f2e`; the repository watcher finished GREEN.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/pages/model-setup/first-run.test.ts` passed; `git diff --check` passed.
- Independent final review and audit: no actionable findings.

## Risk and coverage

Only two existing tests and their local helper change. The same production callback gates router startup. Successful restoration still requires the exact model-setup redirect; replaced credentials must still clear the receipt without redirecting. Synchronous default routing, deep links, admin gating, terminal startup, activation ownership, and application recovery pass in the owner suite. No live-provider proof is needed for this test-only change.
