### PR TITLE
fix(discord): retain repeated component captions and link emoji

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -351,6 +351,7 @@ Supported blocks:
 
 - `text`, `section`, `separator`, `actions`, `media-gallery`, `file`
 - Action rows allow up to 5 buttons or a single select menu
+- Buttons support emoji, including link buttons
 - Select types: `string`, `user`, `role`, `mentionable`, `channel`
 
 By default, components are single use. Set `components.reusable=true` to allow buttons, selects, and forms to be used multiple times until they expire.
@@ -366,6 +367,7 @@ File attachments:
 - `file` blocks must point to an attachment reference (`attachment://<filename>`)
 - Provide the attachment via `media`/`path`/`filePath` (single file); use `media-gallery` for multiple files
 - Use `filename` to override the upload name when it should match the attachment reference
+- Attachment captions preserve text-block order and repeated paragraphs
 
 Modal forms:
 

--- a/extensions/discord/src/components.builders.ts
+++ b/extensions/discord/src/components.builders.ts
@@ -106,6 +106,7 @@ function createButtonComponent(params: {
     class DynamicLinkButton extends LinkButton {
       label = params.spec.label;
       url = linkUrl;
+      override emoji = params.spec.emoji;
       override disabled = params.spec.disabled ?? false;
     }
     return { component: new DynamicLinkButton() };

--- a/extensions/discord/src/send.components.multipart.test.ts
+++ b/extensions/discord/src/send.components.multipart.test.ts
@@ -14,6 +14,9 @@ const CASES: Array<{
   filename?: string;
   componentsV2?: boolean;
   expectedName: string;
+  text?: string;
+  textBlocks?: string[];
+  expectedText?: string;
 }> = [
   { label: "classic declared name", declaredName: "report.pdf", expectedName: "report.pdf" },
   {
@@ -35,6 +38,35 @@ const CASES: Array<{
     componentsV2: true,
     expectedName: "report.pdf",
   },
+  {
+    label: "classic repeated text blocks",
+    text: "",
+    textBlocks: ["Step A", "Step B", "Step A"],
+    expectedText: "Step A\n\nStep B\n\nStep A",
+    expectedName: "source.pdf",
+  },
+  {
+    label: "classic repeated blocks beside top-level fallback",
+    text: "Step A",
+    textBlocks: ["Step A", "Step B", "Step A"],
+    expectedText: "Step A\n\nStep B\n\nStep A",
+    expectedName: "source.pdf",
+  },
+  {
+    label: "component repeated text blocks",
+    text: "",
+    textBlocks: ["Step A", "Step B", "Step A"],
+    expectedText: "Step A\n\nStep B\n\nStep A",
+    componentsV2: true,
+    expectedName: "source.pdf",
+  },
+  {
+    label: "classic later matches beside a distinct leading block",
+    text: "Step A",
+    textBlocks: ["Step B", "Step A", "Step A"],
+    expectedText: "Step A\n\nStep B\n\nStep A\n\nStep A",
+    expectedName: "source.pdf",
+  },
 ];
 
 describe("Discord component attachment multipart filenames", () => {
@@ -46,10 +78,13 @@ describe("Discord component attachment multipart filenames", () => {
       const loopback = await createDiscordLoopbackRest();
       try {
         const spec: DiscordComponentMessageSpec = {
-          text: "See attached report",
-          blocks: testCase.declaredName
-            ? [{ type: "file", file: `attachment://${testCase.declaredName}` }]
-            : [],
+          text: testCase.text ?? "See attached report",
+          blocks: [
+            ...(testCase.textBlocks ?? []).map((text) => ({ type: "text" as const, text })),
+            ...(testCase.declaredName
+              ? [{ type: "file" as const, file: `attachment://${testCase.declaredName}` as const }]
+              : []),
+          ],
           ...(testCase.componentsV2 ? { container: { accentColor: 0x123456 } } : {}),
         };
         const result = await sendDiscordComponentMessage("channel:789", spec, {
@@ -80,7 +115,14 @@ describe("Discord component attachment multipart filenames", () => {
         const payload = JSON.parse(payloadJson) as {
           attachments?: Array<{ id: number; filename: string }>;
           flags?: number;
+          content?: string;
+          components?: Array<{ components?: Array<{ content?: string }> }>;
         };
+        const text = testCase.componentsV2
+          ? payload.components?.[0]?.components
+              ?.flatMap((component) => (component.content ? [component.content] : []))
+              .join("\n\n")
+          : payload.content;
         process.stdout.write(
           `${JSON.stringify({
             case: testCase.label,
@@ -88,6 +130,7 @@ describe("Discord component attachment multipart filenames", () => {
             contentType: file.type,
             attachments: payload.attachments,
             componentsV2: Boolean((payload.flags ?? 0) & MessageFlags.IsComponentsV2),
+            text,
           })}\n`,
         );
         expect(await file.text()).toBe(FILE_CONTENT);
@@ -97,6 +140,9 @@ describe("Discord component attachment multipart filenames", () => {
         expect(Boolean((payload.flags ?? 0) & MessageFlags.IsComponentsV2)).toBe(
           testCase.componentsV2 === true,
         );
+        if (testCase.expectedText !== undefined) {
+          expect(text).toBe(testCase.expectedText);
+        }
       } finally {
         await loopback.close();
       }

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -1,5 +1,10 @@
 // Discord tests cover send.components plugin behavior.
-import { ChannelType, ComponentType, MessageFlags } from "discord-api-types/v10";
+import {
+  ChannelType,
+  ComponentType,
+  MessageFlags,
+  type APIContainerComponent,
+} from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordLoopbackRest, makeDiscordRest } from "./send.test-harness.js";
 
@@ -279,6 +284,70 @@ describe("sendDiscordComponentMessage", () => {
       await loopback.close();
     }
   });
+
+  it.each(["send", "edit"] as const)(
+    "preserves link-button emoji in rows and sections during %s",
+    async (operation) => {
+      const loopback = await createDiscordLoopbackRest();
+      try {
+        const spec: Parameters<typeof sendDiscordComponentMessage>[1] = {
+          blocks: [
+            {
+              type: "actions",
+              buttons: [
+                {
+                  label: "Docs",
+                  url: "https://example.test/docs",
+                  emoji: { name: "📖" },
+                  disabled: true,
+                },
+              ],
+            },
+            {
+              type: "section",
+              text: "Read the guide",
+              accessory: {
+                type: "button",
+                button: {
+                  label: "Guide",
+                  style: "link",
+                  url: "https://example.test/guide",
+                  emoji: { id: "123456789012345678", name: "guide", animated: true },
+                },
+              },
+            },
+          ],
+        };
+        const opts = { cfg: DISCORD_TEST_CFG, rest: loopback.rest, token: "test-token" };
+        if (operation === "send") {
+          await sendDiscordComponentMessage("channel:789", spec, opts);
+        } else {
+          await editDiscordComponentMessage("channel:789", "message-1", spec, opts);
+        }
+        const request = loopback.requests.find(
+          (entry) => entry.method === (operation === "send" ? "POST" : "PATCH"),
+        );
+        const body = JSON.parse(request?.body ?? "{}") as { components?: APIContainerComponent[] };
+        const components = body.components?.[0]?.components;
+        const row = components?.find((entry) => entry.type === ComponentType.ActionRow);
+        const section = components?.find((entry) => entry.type === ComponentType.Section);
+        expect(row?.components[0]).toMatchObject({
+          url: "https://example.test/docs",
+          emoji: { name: "📖" },
+          disabled: true,
+        });
+        expect(section?.accessory).toMatchObject({
+          url: "https://example.test/guide",
+          emoji: { id: "123456789012345678", name: "guide", animated: true },
+        });
+        expect(registerDiscordComponentEntries).toHaveBeenCalledWith(
+          expect.objectContaining({ entries: [], modals: [] }),
+        );
+      } finally {
+        await loopback.close();
+      }
+    },
+  );
 
   it("treats bare numeric component edit targets as channels", async () => {
     const { rest, patchMock, getMock } = makeDiscordRest();
@@ -714,7 +783,22 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     expect(readMockCall(postMock, 0)[0]).toContain("/channels/273512430271856640/messages");
   });
 
-  it("keeps spoiler file blocks on the component path", async () => {
+  it.each([
+    {
+      label: "spoiler",
+      blocks: [{ type: "file", file: "attachment://report.pdf", spoiler: true }],
+    },
+    {
+      label: "multiple",
+      blocks: [
+        { type: "file", file: "attachment://report.pdf" },
+        { type: "file", file: "attachment://report.pdf" },
+      ],
+    },
+  ] satisfies Array<{
+    label: string;
+    blocks: NonNullable<Parameters<typeof sendDiscordComponentMessage>[1]["blocks"]>;
+  }>)("keeps $label file blocks on the component path", async ({ blocks }) => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({
       type: ChannelType.GuildText,
@@ -726,7 +810,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
       "channel:chan-1",
       {
         text: "report",
-        blocks: [{ type: "file", file: "attachment://report.pdf", spoiler: true }],
+        blocks,
       },
       {
         cfg: DISCORD_TEST_CFG,

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -76,63 +76,33 @@ function withImplicitComponentAttachmentBlock(
   };
 }
 
-function hasClassicOnlyBlocks(spec: DiscordComponentMessageSpec): boolean {
-  return (spec.blocks ?? []).every((block) => block.type === "text" || block.type === "file");
-}
-
-function hasUnsupportedClassicFeatures(spec: DiscordComponentMessageSpec): boolean {
-  return Boolean(spec.modal || spec.container);
-}
-
-function hasAtMostOneNonSpoilerFile(spec: DiscordComponentMessageSpec): boolean {
-  let fileBlockCount = 0;
-  for (const block of spec.blocks ?? []) {
-    if (block.type !== "file") {
-      continue;
-    }
-    fileBlockCount += 1;
-    if (block.spoiler) {
-      return false;
-    }
-  }
-  return fileBlockCount <= 1;
-}
-
-type ClassicDiscordMessageDecision =
-  | {
-      mode: "classic";
-      reason: "plain-text-single-file";
-    }
-  | {
-      mode: "components";
-      reason: "unsupported-feature" | "unsupported-block" | "multiple-or-spoiler-files";
-    };
-
-/**
- * Keep the downgrade rules explicit because this path is only safe when the
- * spec means exactly what a plain Discord message can represent.
- */
-function getClassicDiscordMessageDecision(
+function resolveClassicDiscordMessage(
   spec: DiscordComponentMessageSpec,
-): ClassicDiscordMessageDecision {
-  if (hasUnsupportedClassicFeatures(spec)) {
-    return { mode: "components", reason: "unsupported-feature" };
+): { text: string; filename?: string } | undefined {
+  if (spec.modal || spec.container) {
+    return undefined;
   }
-  if (!hasClassicOnlyBlocks(spec)) {
-    return { mode: "components", reason: "unsupported-block" };
+  const parts = hasNonEmptyString(spec.text) ? [spec.text] : [];
+  // Only the leading text block can mirror the fallback caption. Later matching
+  // blocks are authored content, so retain their repetitions and order.
+  let captionToMatch: string | undefined = parts[0];
+  let filename: string | undefined;
+  for (const block of spec.blocks ?? []) {
+    if (block.type === "text") {
+      if (!hasNonEmptyString(block.text)) {
+        continue;
+      }
+      if (block.text !== captionToMatch) {
+        parts.push(block.text);
+      }
+      captionToMatch = undefined;
+    } else if (block.type === "file" && !block.spoiler && filename === undefined) {
+      filename = resolveDiscordComponentAttachmentName(block.file);
+    } else {
+      return undefined;
+    }
   }
-  if (!hasAtMostOneNonSpoilerFile(spec)) {
-    return { mode: "components", reason: "multiple-or-spoiler-files" };
-  }
-  return { mode: "classic", reason: "plain-text-single-file" };
-}
-
-function collapseClassicComponentText(spec: DiscordComponentMessageSpec): string {
-  const parts = [
-    spec.text,
-    ...(spec.blocks ?? []).flatMap((block) => (block.type === "text" ? [block.text] : [])),
-  ];
-  return uniqueStrings(parts.filter(hasNonEmptyString)).join("\n\n");
+  return { text: parts.join("\n\n"), filename };
 }
 
 type DiscordComponentSendOpts = {
@@ -261,15 +231,15 @@ export async function sendDiscordComponentMessage(
   spec: DiscordComponentMessageSpec,
   opts: DiscordComponentSendOpts,
 ): Promise<DiscordSendResult> {
-  const classicDecision = getClassicDiscordMessageDecision(spec);
-  if (opts.mediaUrl && classicDecision.mode === "classic") {
-    return await sendMessageDiscord(to, collapseClassicComponentText(spec), {
+  const classicMessage = opts.mediaUrl ? resolveClassicDiscordMessage(spec) : undefined;
+  if (classicMessage) {
+    return await sendMessageDiscord(to, classicMessage.text, {
       cfg: opts.cfg,
       accountId: opts.accountId,
       token: opts.token,
       rest: opts.rest,
       mediaUrl: opts.mediaUrl,
-      filename: opts.filename?.trim() || extractComponentAttachmentNames(spec)[0],
+      filename: opts.filename?.trim() || classicMessage.filename,
       mediaLocalRoots: opts.mediaLocalRoots,
       mediaReadFile: opts.mediaReadFile,
       mediaAccess: opts.mediaAccess,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated authored paragraphs disappear from Discord component messages when an attachment selects plain caption delivery. It also fixes link-button emoji disappearing from both message sends and edits, in action rows and section accessories.

## Why This Change Was Made

A single-pass caption owner now determines classic-delivery eligibility while collecting ordered text and the declared filename, replacing the separate eligibility helpers, unused decision reasons, set-based text collapse, and repeated filename extraction. Only a mirrored leading fallback caption is deduplicated; later authored matches remain intact. Link buttons now receive the already-supported emoji field.

The change removes **29 production lines** while preserving modal, spoiler, container, unsupported-block, multiple-file, filename-override, media, and reply constraints. No configuration, dependency, schema, store, or SDK contract is added.

## User Impact

Component attachment captions retain repeated instructions and paragraphs in their original order. Link-button emoji behave consistently with other button types. The existing leading-caption fallback remains deduplicated.

## Evidence

- Four assertions failed on untouched production through actual localhost multipart, POST, and PATCH requests. Captions with `Step A / Step B / Step A` lost the final paragraph; link buttons lost both Unicode and custom emoji. Existing controls and the V2 repeated-text control passed.
- Independent P2 review found an additional edge within the caption root: a top-level caption matching a non-leading block could still remove authored content. A real multipart regression reproduced it, then passed after restricting matching to the first substantive text block.
- Final sender, HTTP, and caption/file controls: **36 passed**. The unchanged builder/registry sibling surface was also covered in an earlier **75-test** passing run. These counts overlap and are not a sum of distinct tests.
- Final production and actual extension-test TypeScript graphs, full-file lint/format, `git diff --check`, and the full pinned-base `check:changed` gate passed, including zero runtime import cycles. The corrected candidate received a scoped-clean independent review through P2.

Proof uses actual sender/serialization paths, a real localhost receiver, a synthetic local PDF, and test configuration. No live Discord account, client rendering, provider, or operator Gateway is claimed. The diff adds 130 test lines and two documentation lines.

The earlier hosted [CI run](https://github.com/openclaw/openclaw/actions/runs/34252846199) failed its production and core-test type checks on inherited UI catalog code: `refreshIfDue` was not a supported `models.list` parameter. This Discord diff did not alter that code. After the owning [catalog repair #142346](https://github.com/openclaw/openclaw/pull/142346) merged, this branch was mechanically rebased onto `f74837eec91453eb26ec18de94f907a0698721e7`. The rebase had no conflicts; range comparison is patch-identical and all five reviewed file hashes are unchanged. On refreshed head `be11e8b2aecfd6a6942fd6b43e31d768672893d7`, `pnpm tsgo:prod` and the previously failing core-test job’s stripes 1/5 and 2/5 passed locally. New exact-head hosted CI is pending; the earlier failed run remains failed.
