### PR TITLE
fix(ci): retry performance artifact finalization

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -730,7 +730,9 @@ jobs:
           fi
 
       - name: Upload Kova artifacts
+        id: upload_kova_artifacts
         if: ${{ always() && steps.lane.outputs.run == 'true' }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-performance-${{ matrix.lane }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -740,6 +742,19 @@ jobs:
             .artifacts/kova/summaries/${{ matrix.lane }}.md
           if-no-files-found: error
           retention-days: ${{ matrix.deep_profile == 'true' && 14 || 30 }}
+
+      - name: Retry Kova artifact upload
+        if: ${{ always() && steps.lane.outputs.run == 'true' && steps.upload_kova_artifacts.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-performance-${{ matrix.lane }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .artifacts/kova/reports/${{ matrix.lane }}
+            .artifacts/kova/bundles/${{ matrix.lane }}
+            .artifacts/kova/summaries/${{ matrix.lane }}.md
+          if-no-files-found: error
+          retention-days: ${{ matrix.deep_profile == 'true' && 14 || 30 }}
+          overwrite: true
 
   source_performance:
     name: OpenClaw source performance probes
@@ -1070,13 +1085,25 @@ jobs:
           cat "$SOURCE_PERF_DIR/index.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload source performance artifacts
+        id: upload_source_performance_artifacts
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-performance-source-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/openclaw-performance/source
           if-no-files-found: error
           retention-days: 30
+
+      - name: Retry source performance artifact upload
+        if: ${{ always() && steps.upload_source_performance_artifacts.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-performance-source-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/openclaw-performance/source
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
 
   publish:
     name: Publish ${{ matrix.title }} report

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -1365,6 +1365,12 @@ printf '%s\\n' \
   it("requires Kova evidence before uploading selected lane artifacts", () => {
     const validateEvidence = findStep("Validate Kova evidence");
     const upload = findStep("Upload Kova artifacts");
+    const retryUpload = findStep("Retry Kova artifact upload");
+    const sourceUpload = findStep("Upload source performance artifacts", "source_performance");
+    const retrySourceUpload = findStep(
+      "Retry source performance artifact upload",
+      "source_performance",
+    );
 
     expect(validateEvidence.if).toContain("always()");
     expect(validateEvidence.if).toContain("steps.lane.outputs.run == 'true'");
@@ -1373,5 +1379,15 @@ printf '%s\\n' \
     expect(validateEvidence.run).toContain('"$SUMMARY_DIR/${LANE_ID}.md"');
     expect(validateEvidence.run).toContain("exit 1");
     expect(upload.with?.["if-no-files-found"]).toBe("error");
+    expect(upload.id).toBe("upload_kova_artifacts");
+    expect(upload["continue-on-error"]).toBe(true);
+    expect(retryUpload.if).toContain("steps.upload_kova_artifacts.outcome == 'failure'");
+    expect(retryUpload.with?.overwrite).toBe(true);
+    expect(sourceUpload.id).toBe("upload_source_performance_artifacts");
+    expect(sourceUpload["continue-on-error"]).toBe(true);
+    expect(retrySourceUpload.if).toContain(
+      "steps.upload_source_performance_artifacts.outcome == 'failure'",
+    );
+    expect(retrySourceUpload.with?.overwrite).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- retry Kova and source performance artifact uploads once when GitHub rejects finalization
- overwrite any partially registered artifact on retry
- keep missing artifacts and a failed second attempt blocking

## Why

Run 34250523607 completed all source probes and uploaded 84 KB, then GitHub's artifact intermediary returned a non-retryable 403 during `FinalizeArtifact`. The action itself does not retry that response, so a transient service error incorrectly failed the completed producer job.

## Validation

- `pnpm exec vitest run test/scripts/openclaw-performance-workflow.test.ts` — 42 passed
- `pnpm exec oxfmt --check .github/workflows/openclaw-performance.yml test/scripts/openclaw-performance-workflow.test.ts`
- `git diff --check`

## Worked on by

- Dallin Romney
