### PR TITLE
refactor(update): remove unused triage result field

### DIFF
--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -257,7 +257,6 @@ describe("update-startup", () => {
     triageResult = {
       status: "completed",
       hint: `Triage prompt: ${path.join(tempDir, "triage-prompt.md")}`,
-      contextPath: path.join(tempDir, "update-failure.json"),
     };
     runUpdateFailureTriageMock.mockReset().mockResolvedValue(triageResult);
 

--- a/src/infra/update-triage.test.ts
+++ b/src/infra/update-triage.test.ts
@@ -87,6 +87,7 @@ describe("update triage child lifecycle", () => {
 
   it("keeps artifact paths in local output and returns the partial-export outcome", async () => {
     const { target, promptPath } = await createInstalledTriage();
+    const runCommand = vi.spyOn(exec, "runCommandWithTimeout");
     const runtime = { log: vi.fn(), error: vi.fn() };
     const result = await runUpdateFailureTriage({
       failure: { error: "Update could not install the package" },
@@ -96,9 +97,11 @@ describe("update triage child lifecycle", () => {
     });
     expect(result).toMatchObject({
       status: "completed",
-      contextPath: expect.any(String),
       hint: expect.stringContaining("Diagnostics export unavailable: Snapshot unavailable"),
     });
+    expect(runCommand).toHaveBeenCalledOnce();
+    const args = runCommand.mock.calls[0]![0];
+    expect(args.slice(-3)).toEqual(["--update-result", expect.any(String), "--json"]);
     expect("hint" in result && result.hint).not.toContain(target.root);
     expect(runtime.log).toHaveBeenCalledWith(
       JSON.stringify({ promptPath, bundlePath: null, bundleError: "Snapshot unavailable" }),
@@ -228,9 +231,11 @@ describe("update triage child lifecycle", () => {
         OPENCLAW_WORKSPACE_DIR: workspaceDir,
       };
       const credential = "synthetic-triage-bearer-value";
-      vi.spyOn(exec, "runCommandWithTimeout").mockRejectedValueOnce(
-        new Error(`ENOSPC Authorization: Bearer ${credential}\n${"detail ".repeat(1000)}`),
-      );
+      const runCommand = vi
+        .spyOn(exec, "runCommandWithTimeout")
+        .mockRejectedValueOnce(
+          new Error(`ENOSPC Authorization: Bearer ${credential}\n${"detail ".repeat(1000)}`),
+        );
       const runtime = { log: vi.fn(), error: vi.fn() };
       const result = await runUpdateFailureTriage({
         failure: { error: "Update failed" },
@@ -244,23 +249,26 @@ describe("update triage child lifecycle", () => {
         const guidance = runtime.log.mock.calls.flat().join("\n");
         expect(result.hint).not.toContain(target.root);
         expect(result.hint.split("\n")[0]?.length).toBeLessThan(284);
-        expect(result.contextPath).toEqual(expect.any(String));
+        expect(runCommand).toHaveBeenCalledOnce();
+        const args = runCommand.mock.calls[0]![0];
+        expect(args.slice(-3)).toEqual(["--update-result", expect.any(String), "--json"]);
+        const contextPath = args.at(-2)!;
         if (platformName === "win32") {
           expect(guidance).toContain(
-            `& openclaw triage --update-result '${result.contextPath!.replaceAll("'", "''")}'`,
+            `& openclaw triage --update-result '${contextPath.replaceAll("'", "''")}'`,
           );
           for (const selector of [targetEnv.OPENCLAW_STATE_DIR, configPath, workspaceDir]) {
             expect(guidance).toContain(`'${selector.replaceAll("'", "''")}'`);
           }
         } else {
-          expect(guidance).toContain(`--update-result ${quoteCliArg(result.contextPath!)}`);
+          expect(guidance).toContain(`--update-result ${quoteCliArg(contextPath)}`);
           expect(guidance).toContain(
             `OPENCLAW_STATE_DIR=${quoteCliArg(targetEnv.OPENCLAW_STATE_DIR)}`,
           );
           expect(guidance).toContain(`OPENCLAW_CONFIG_PATH=${quoteCliArg(configPath)}`);
           expect(guidance).toContain(`OPENCLAW_WORKSPACE_DIR=${quoteCliArg(workspaceDir)}`);
         }
-        await expect(fs.stat(result.contextPath!)).resolves.toMatchObject({
+        await expect(fs.stat(contextPath)).resolves.toMatchObject({
           size: expect.any(Number),
         });
       }

--- a/src/infra/update-triage.ts
+++ b/src/infra/update-triage.ts
@@ -28,8 +28,8 @@ export type UpdateTriageTarget = {
 };
 
 type UpdateTriageResult =
-  | { status: "completed"; hint: string; contextPath?: string }
-  | { status: "failed"; hint: string; contextPath?: string }
+  | { status: "completed"; hint: string }
+  | { status: "failed"; hint: string }
   | { status: "cancelled" };
 
 type UpdateTriageInvocation = {
@@ -228,7 +228,7 @@ async function runPreparedUpdateFailureTriage(
         hint += `\nDiagnostics export unavailable: ${reason}`;
       }
     }
-    return { status: "completed", hint, ...(contextPath ? { contextPath } : {}) };
+    return { status: "completed", hint };
   } catch (error) {
     if (!isCurrent()) {
       return { status: "cancelled" };
@@ -253,7 +253,6 @@ async function runPreparedUpdateFailureTriage(
     return {
       status: "failed",
       hint: `${message}\n${TRIAGE_OUTPUT_HINT}`,
-      ...(contextPath ? { contextPath } : {}),
     };
   }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Update failure triage returns a `contextPath` field that no caller uses, leaving
unused metadata in its internal result contract.

## Why This Change Was Made

Remove the unused result field while preserving artifact creation, triage
invocation and recovery guidance. Tests verify the artifact path at the triage
invocation boundary instead of relying on the removed field.

## User Impact

No user-visible behavior change. Update failure diagnostics and guidance remain
unchanged.

## Evidence

- 216 focused tests passed across five suites.
- All 29 changed-scope checks passed, including formatting, lint and type checks.
- All three Knip checks reported no findings.
- Fresh independent review returned no actionable findings.
