### PR TITLE
fix(ui): restore default-model picker discovery after the catalog store rewrite

### DIFF
--- a/docs/gateway/protocol/operator-methods.md
+++ b/docs/gateway/protocol/operator-methods.md
@@ -156,8 +156,12 @@ remains empty.
 
 The Gateway advertises `session-scoped-model-catalog` for this contract.
 `chat.metadata` remains available to legacy clients; the Control UI reads models
-directly and keeps commands in its metadata cache. Opening its picker performs a
-passive read, without a model-cache timer or implicit provider refresh.
+directly and keeps commands in its metadata cache. Opening a conversation picker
+performs a passive read, without a model-cache timer or implicit provider refresh.
+The Models settings page requests `refresh: true` when a primary, utility, or
+fallback model picker opens, so it can discover additional models on demand.
+Pending opens share that page's request; reopening after completion requests a
+new refresh, and the Gateway shares concurrent provider acquisition.
 
 `preparedOnly: true` and `refresh: true` remain mutually exclusive.
 The Gateway advertises these published-read and details controls as

--- a/ui/src/pages/model-providers/catalog-discovery.ts
+++ b/ui/src/pages/model-providers/catalog-discovery.ts
@@ -2,9 +2,9 @@
 //
 // The initial page load uses the fast prepared catalog (configured models only)
 // so full discovery stays out of first navigation. Opening a default-model picker
-// signals interest; this controller fetches the full catalog through the shared
-// model-catalog store (cooldown + concurrency dedupe) and merges it in without
-// disturbing the saved selection.
+// signals interest; this controller explicitly refreshes the Gateway-owned catalog
+// and merges it in without disturbing the saved selection. Pending opens share
+// this page's request; the Gateway owns concurrent provider acquisition.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
@@ -91,7 +91,7 @@ export function createCatalogDiscoveryController(
     try {
       const result = await loadModelCatalog(client, {
         agentId,
-        refreshIfDue: true,
+        refresh: true,
         signal: request.signal,
       });
       if (ownsResult()) {

--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -4,7 +4,6 @@ import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogResult } from "../../api/types.ts";
 import type { SelectPicker } from "../../components/select-picker.ts";
-import { invalidateModelCatalogCache } from "../../lib/model-catalog-store.ts";
 import { updatePickers } from "../../test-helpers/select-picker.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { EMPTY_MODEL_PROVIDERS_DATA } from "./load.ts";
@@ -169,8 +168,8 @@ describe("ModelProvidersPage catalog discovery", () => {
       );
       expect(page.data?.config).toEqual(savedModelConfig);
       expect(runtimeConfig.patch).not.toHaveBeenCalled();
-      expect(discover).toHaveBeenCalledOnce();
-      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(2);
+      expect(discover).toHaveBeenCalledTimes(2);
+      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(3);
     },
   );
 
@@ -270,8 +269,7 @@ describe("ModelProvidersPage catalog discovery", () => {
       await openModelPicker(page);
       expect(discover).toHaveBeenCalledOnce();
 
-      // A published config change retires the shared catalog before reloading the page.
-      invalidateModelCatalogCache(snapshot.client!);
+      // Replacing page data retires its request; direct reads have no cache to invalidate.
       if (replacement === "core refresh") {
         page.querySelector<HTMLButtonElement>('button[aria-label="Refresh"]')!.click();
       } else {
@@ -321,7 +319,6 @@ describe("ModelProvidersPage catalog discovery", () => {
       await openModelPicker(page);
       expect(discover).toHaveBeenCalledOnce();
 
-      invalidateModelCatalogCache(snapshot.client!);
       page.routeData = {
         gateway: context.gateway,
         gatewaySnapshot: snapshot,
@@ -362,7 +359,7 @@ describe("ModelProvidersPage catalog discovery", () => {
     },
   );
 
-  it("keeps a shared discovery alive when another page retires its subscription", async () => {
+  it("keeps discovery alive when another page retires its own request", async () => {
     const { context, discover, snapshot } = createCatalogHarness();
     const pending = deferred<ModelCatalogResult>();
     discover.mockReturnValue(pending.promise);
@@ -374,7 +371,7 @@ describe("ModelProvidersPage catalog discovery", () => {
     await second.updateComplete;
     await openModelPicker(first);
     await openModelPicker(second);
-    expect(discover).toHaveBeenCalledOnce();
+    expect(discover).toHaveBeenCalledTimes(2);
     first.routeData = {
       gateway: context.gateway,
       gatewaySnapshot: snapshot,
@@ -399,6 +396,6 @@ describe("ModelProvidersPage catalog discovery", () => {
     expect(second.querySelector('[role="option"][data-value="openai/shared"]')).not.toBeNull();
     expect(first.querySelector(".model-providers__catalog-progress")).toBeNull();
     expect(second.querySelector(".model-providers__catalog-progress")).toBeNull();
-    expect(discover).toHaveBeenCalledOnce();
+    expect(discover).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Related: #142105, #142165

## What Problem This Solves

Resolves a problem where Control UI typechecks on main fail after the merge race between #142105 and #142165. The Models settings default-model pickers also stopped issuing discovery requests.

#142105 merged at 16:11 UTC on September 8; #142165 replaced the catalog store at 16:24 UTC without reconciling the new picker caller and tests. The resulting errors are:

```text
catalog-discovery.ts(94,9): TS2353: 'refreshIfDue' does not exist in the loadModelCatalog options type.
model-providers-page.catalog.test.ts(7,10): TS2305: model-catalog-store.ts has no exported member 'invalidateModelCatalogCache'.
```

## Why This Change Was Made

Use the supported `refresh: true` request to preserve demand-driven discovery for primary, utility, and fallback pickers. Ordinary catalog reads are passive; the Gateway owns acquisition and publication, while the page retains its cancellation and stale-result guards.

Remove the tests' obsolete cache invalidation setup. Core refresh and route replacement directly retire the page request. Update request counts for direct reads: overlapping opens on one page still share its pending request, reopening after completion requests again, and separate pages own independent requests. No removed cache, cooldown, or invalidation API is restored. Clarify this Models settings behavior in the protocol documentation.

## User Impact

Opening a default-model picker discovers additional choices while preserving saved selections, usable controls, search, progress, retry, and protection against stale replies. Initial page loading remains passive. There are no appearance changes.

## Evidence

Before the repair, `pnpm tsgo:ui` reproduced TS2353 and all 11 picker discovery tests failed because no refresh request was issued.

- `pnpm tsgo:ui` — passed.
- `pnpm tsgo:core:test` — passed.
- `node scripts/run-vitest.mjs ui/src/pages/model-providers/model-providers-page.catalog.test.ts ui/src/pages/model-providers/model-providers-page.test.ts ui/src/lib/model-catalog-store.test.ts ui/src/pages/model-providers/load.test.ts` — 73 tests passed, including all 11 picker discovery cases.
- `node scripts/run-vitest.mjs ui/src/lib/chat/chat-metadata-store.test.ts` — 16 tests passed.
- `node scripts/check-changed.mjs` — passed; complete log inspected, including typechecks, formatting, i18n, ratchets, dead exports, and lint.
- `node scripts/check-docs-mdx.mjs docs/gateway/protocol/operator-methods.md` and `git diff --check` — passed.
- Independent review — no actionable P0–P2 findings.

The page tests exercise rendered controls against a mocked Gateway. No live provider or browser capture was used for this API reconciliation.
