### PR TITLE
fix(release): pin complete 7.33 Kova compatibility ref

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -158,10 +158,9 @@ jobs:
               process.stdout.write(version);
             ' "$TARGET_CHECKOUT_DIR/package.json")"
             if [[ "$target_version" == "2026.7.33" ]]; then
-              # Kova #116 carries the historical 250% status CLI calibration for this release only;
-              # Kova #118 keeps process-census time out of CPU scan uncertainty;
-              # Kova #119 discovers a starting gateway before its zero baseline is lost.
-              kova_ref="cf6e26f0ca1241c9e7a626e96e66f392ff58012d"
+              # This compatibility ref keeps Kova #116's historical 250% status CLI calibration
+              # while backporting #118-#120's complete CPU-accounting fixes for this release only.
+              kova_ref="18c9eb8c3950a35794d196f4e40ad471e9308e27"
             fi
           fi
           if [[ "$kova_ref" == *$'\n'* || "$kova_ref" == *$'\r'* ]]; then

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -277,7 +277,7 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.run).toContain('detected_kova_config_contract="canonical"');
     expect(resolveTarget.run).toContain('detected_kova_config_contract="legacy-list"');
     expect(resolveTarget.run).toContain('kova_ref="${KOVA_REF_INPUT:-}"');
-    expect(resolveTarget.run).toContain('kova_ref="cf6e26f0ca1241c9e7a626e96e66f392ff58012d"');
+    expect(resolveTarget.run).toContain('kova_ref="18c9eb8c3950a35794d196f4e40ad471e9308e27"');
     expect(resolveTarget.run).toContain('kova_ref="${kova_ref:-$default_kova_ref}"');
     expect(resolveTarget.run).toContain(
       'if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then',


### PR DESCRIPTION
Uses merged compatibility lineage: openclaw/Kova#121

## Summary

- pin OpenClaw 2026.7.33 to the dedicated Kova compatibility lineage
- retain #116's reviewed 250% historical `status-cli` calibration
- include #118–#120's complete CPU-accounting fixes

## Why

The current selector points 2026.7.33 at Kova #120 and claims it retains #116's calibration, but #117 restored Kova main to 200% before #120 landed. Normal validation therefore lost the intended release-scoped allowance, while selecting old #116 would lose the subsequent accounting fixes. The compatibility ref combines both without weakening Kova main.

## Validation

- `pnpm exec vitest run test/scripts/openclaw-performance-workflow.test.ts` — 42 passed
- `pnpm exec oxfmt --check .github/workflows/openclaw-performance.yml test/scripts/openclaw-performance-workflow.test.ts`
- exact release-profile proof: https://github.com/openclaw/openclaw/actions/runs/34252950425

## Worked on by

- Dallin Romney
