### PR TITLE
fix(diagnostics): stuck-session recovery never runs on hosts with late heartbeat ticks

### DIFF
--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -620,6 +620,10 @@ export async function prepareGatewayLifecycle(params: {
     startDiagnosticHeartbeat(undefined, {
       getConfig: getRuntimeConfig,
       startupGraceMs: 60_000,
+      // Recovery reads the current observation; the warning path below reads the
+      // persistent filter, which withholds under 60s of continuous degradation and so
+      // would report a shorter genuine stall as a responsive loop.
+      readEventLoopHealth: readinessEventLoopHealth.snapshot,
       sampleLiveness: () => {
         const sample = readinessEventLoopHealth.persistentDegradationSnapshot();
         if (!sample || sample.degradedSinceMs == null) {

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -620,10 +620,10 @@ export async function prepareGatewayLifecycle(params: {
     startDiagnosticHeartbeat(undefined, {
       getConfig: getRuntimeConfig,
       startupGraceMs: 60_000,
-      // Recovery reads the current observation; the warning path below reads the
-      // persistent filter, which withholds under 60s of continuous degradation and so
-      // would report a shorter genuine stall as a responsive loop.
-      readEventLoopHealth: readinessEventLoopHealth.snapshot,
+      // Recovery asks the monitor for a verdict that accounts for its own pending sample;
+      // the warning path below reads the persistent filter, which withholds under 60s of
+      // continuous degradation and so would report a shorter genuine stall as healthy.
+      readEventLoopDelayed: readinessEventLoopHealth.eventLoopDelayed,
       sampleLiveness: () => {
         const sample = readinessEventLoopHealth.persistentDegradationSnapshot();
         if (!sample || sample.degradedSinceMs == null) {

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -148,6 +148,33 @@ describe("createGatewayEventLoopHealthMonitor", () => {
     },
   );
 
+  it("reports a delayed loop once its own sample is overdue, before any new observation", () => {
+    // Recovery asks this after a late heartbeat. A stall starves the 20ms sampler, so the
+    // retained observation still reads healthy; the pending interval is the only evidence
+    // that exists at that moment, and it is itself a delay measurement.
+    const harness = createMonitorHarness();
+    harness.samples(50);
+    expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, reasons: [] });
+    expect(harness.monitor.eventLoopDelayed()).toBe(false);
+
+    harness.elapseWithoutSampling(1_200);
+
+    expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, reasons: [] });
+    expect(harness.monitor.eventLoopDelayed()).toBe(true);
+
+    harness.sample();
+    expect(harness.monitor.eventLoopDelayed()).toBe(true);
+  });
+
+  it("reports a responsive loop while the sampler keeps up", () => {
+    const harness = createMonitorHarness();
+    harness.samples(50);
+    for (let index = 0; index < 10; index++) {
+      harness.sample();
+      expect(harness.monitor.eventLoopDelayed()).toBe(false);
+    }
+  });
+
   it("retains completed observations until the next sampling window", () => {
     const harness = createMonitorHarness();
     harness.samples(50);

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -34,6 +34,7 @@ export type GatewayEventLoopHealth = {
 type GatewayEventLoopHealthMonitor = {
   snapshot: () => GatewayEventLoopHealth | undefined;
   persistentDegradationSnapshot: () => GatewayEventLoopHealth | undefined;
+  eventLoopDelayed: () => boolean;
   reset: () => void;
   stop: () => void;
 };
@@ -203,6 +204,13 @@ export function createGatewayEventLoopHealthMonitor(
 
   return {
     snapshot: () => lastSnapshot,
+    // A stall starves this sampler, so the retained observation predates it and reads
+    // healthy. The interval since the last callback is itself a delay measurement, so the
+    // verdict comes from here rather than leaving callers to infer freshness from the
+    // observation object.
+    eventLoopDelayed: () =>
+      nowMs() - lastSampleAt >= EVENT_LOOP_DELAY_WARN_MS ||
+      (lastSnapshot?.reasons.includes("event_loop_delay") ?? false),
     // The heartbeat consumes the sampler's snapshot without advancing its window.
     persistentDegradationSnapshot: () => {
       const current = lastSnapshot;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -180,6 +180,16 @@ function expectNoLoggerMessageContaining(spy: unknown, text: string): void {
   expect(loggerMessages(spy).join("\n")).not.toContain(text);
 }
 
+/** Sampler result for a genuinely blocked event loop, the only state that defers recovery. */
+function stalledEventLoopSample() {
+  return {
+    reasons: ["event_loop_delay" as const],
+    intervalMs: 30_000,
+    eventLoopDelayP99Ms: 1_200,
+    eventLoopDelayMaxMs: 1_500,
+  };
+}
+
 function expectRecoveryCall(
   recoverStuckSession: unknown,
   fields: Record<string, unknown>,
@@ -506,7 +516,11 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: () => ({ reasons: ["event_loop_delay"] }),
+      sampleLiveness: () => stalledEventLoopSample(),
+    });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     vi.setSystemTime(120_001);
@@ -530,12 +544,101 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("keeps recovery running when ticks are late but the event loop stayed responsive", () => {
+    // Reported on WSL2: host timer wakeup latency put every tick ~1.5s past its 30s
+    // deadline while measured event-loop delay stayed at 10-13ms, so recovery deferred
+    // for the lifetime of the process.
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    vi.setSystemTime(0);
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: () => ({ reasons: [] }),
+      sampleLiveness: () => null,
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    const advanceLateTick = () => {
+      vi.setSystemTime(Date.now() + 1_500);
+      vi.advanceTimersByTime(30_000);
+    };
+
+    advanceLateTick();
+    advanceLateTick();
+    advanceLateTick();
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0 },
+      ["ageMs", "stateGeneration"],
+    );
+    expectLoggerMessageContaining(warnSpy, "event loop stayed responsive");
+  });
+
+  it("defers a late tick when no event-loop health evidence is available", () => {
+    // Without a working delay monitor nothing rules out a stall holding queued progress,
+    // so the tick keeps the original conservative behavior rather than authorizing abort.
+    const recoverStuckSession = vi.fn();
+
+    vi.setSystemTime(0);
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: () => undefined,
+      sampleLiveness: () => null,
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    vi.setSystemTime(120_001);
+    vi.advanceTimersByTime(30_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("still defers recovery when a late tick follows a real event-loop stall", () => {
+    // Chronic lateness must not buy a standing exemption: a genuine stall can queue
+    // progress that has not run yet, and aborting on that snapshot cancels healthy work.
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    let eventLoopStalled = false;
+
+    vi.setSystemTime(0);
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: () => ({ reasons: eventLoopStalled ? ["event_loop_delay"] : [] }),
+      // Deliberately still null while stalled: this is the Gateway contract, where
+      // persistentDegradationSnapshot() withholds under 60s of continuous degradation.
+      // Recovery must not read that filter as a responsive loop.
+      sampleLiveness: () => null,
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    const advanceLateTick = () => {
+      vi.setSystemTime(Date.now() + 1_500);
+      vi.advanceTimersByTime(30_000);
+    };
+
+    advanceLateTick();
+    advanceLateTick();
+    recoverStuckSession.mockClear();
+
+    eventLoopStalled = true;
+    advanceLateTick();
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expectLoggerMessageContaining(warnSpy, "deferring recovery decisions");
+  });
+
   it("defers a material heartbeat stall even when elapsed time is below the abort threshold", () => {
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: () => ({ reasons: ["event_loop_delay"] }),
+      sampleLiveness: () => stalledEventLoopSample(),
+    });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -181,16 +181,15 @@ function expectNoLoggerMessageContaining(spy: unknown, text: string): void {
 }
 
 /**
- * Mirrors the Gateway monitor's `snapshot()` contract: the same object is returned until a
- * new sampling window commits. Returning a fresh object per read would hide the stale-read
- * ordering that a starved sampler produces.
+ * Stands in for the Gateway monitor's `eventLoopDelayed()` verdict. The monitor owns the
+ * freshness rule, including its own pending sample, and is covered by its own suite.
  */
 function createFakeEventLoopMonitor() {
-  let observation: { reasons: string[] } | undefined;
+  let delayed = false;
   return {
-    read: () => observation,
-    commit: (...reasons: string[]) => {
-      observation = { reasons };
+    delayed: () => delayed,
+    setDelayed: (next: boolean) => {
+      delayed = next;
     },
   };
 }
@@ -533,7 +532,7 @@ describe("stuck session diagnostics threshold", () => {
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: () => ({ reasons: ["event_loop_delay"] }),
+      readEventLoopDelayed: () => true,
       sampleLiveness: () => stalledEventLoopSample(),
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
@@ -568,17 +567,15 @@ describe("stuck session diagnostics threshold", () => {
 
     vi.setSystemTime(0);
     const monitor = createFakeEventLoopMonitor();
-    monitor.commit();
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: monitor.read,
+      readEventLoopDelayed: monitor.delayed,
       sampleLiveness: () => null,
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     // The sampler keeps up, so every tick sees an observation covering its own interval.
     const advanceLateTick = () => {
-      monitor.commit();
       vi.setSystemTime(Date.now() + 1_500);
       vi.advanceTimersByTime(30_000);
     };
@@ -603,7 +600,7 @@ describe("stuck session diagnostics threshold", () => {
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: () => undefined,
+      readEventLoopDelayed: () => true,
       sampleLiveness: () => null,
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
@@ -620,12 +617,11 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
     const monitor = createFakeEventLoopMonitor();
-    monitor.commit();
 
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: monitor.read,
+      readEventLoopDelayed: monitor.delayed,
       // Deliberately still null while stalled: this is the Gateway contract, where
       // persistentDegradationSnapshot() withholds under 60s of continuous degradation.
       // Recovery must not read that filter as a responsive loop.
@@ -638,46 +634,15 @@ describe("stuck session diagnostics threshold", () => {
       vi.advanceTimersByTime(30_000);
     };
 
-    monitor.commit();
     advanceLateTick();
-    monitor.commit();
     advanceLateTick();
     recoverStuckSession.mockClear();
 
-    monitor.commit("event_loop_delay");
+    monitor.setDelayed(true);
     advanceLateTick();
 
     expect(recoverStuckSession).not.toHaveBeenCalled();
     expectLoggerMessageContaining(warnSpy, "deferring recovery decisions");
-  });
-
-  it("refuses recovery when a stall starved the sampler and the observation is stale", () => {
-    // The monitor commits about once a second and returns the same object until it does.
-    // A stall delays both timers; if the heartbeat resumes first, the retained observation
-    // still reads healthy and must not be mistaken for a responsive loop.
-    const recoverStuckSession = vi.fn();
-    const monitor = createFakeEventLoopMonitor();
-    monitor.commit();
-
-    vi.setSystemTime(0);
-    startEnabledDiagnosticHeartbeat({
-      recoverStuckSession,
-      readEventLoopHealth: monitor.read,
-      sampleLiveness: () => null,
-    });
-    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
-
-    // First late tick sees a fresh healthy window, so recovery is allowed to run.
-    monitor.commit();
-    vi.setSystemTime(Date.now() + 1_500);
-    vi.advanceTimersByTime(30_000);
-    recoverStuckSession.mockClear();
-
-    // Now the sampler is starved: the same object is returned, still reading healthy.
-    vi.setSystemTime(Date.now() + 1_500);
-    vi.advanceTimersByTime(30_000);
-
-    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("defers a material heartbeat stall even when elapsed time is below the abort threshold", () => {
@@ -687,7 +652,7 @@ describe("stuck session diagnostics threshold", () => {
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: () => ({ reasons: ["event_loop_delay"] }),
+      readEventLoopDelayed: () => true,
       sampleLiveness: () => stalledEventLoopSample(),
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -592,15 +592,15 @@ describe("stuck session diagnostics threshold", () => {
     expectLoggerMessageContaining(warnSpy, "event loop stayed responsive");
   });
 
-  it("defers a late tick when no event-loop health evidence is available", () => {
-    // Without a working delay monitor nothing rules out a stall holding queued progress,
-    // so the tick keeps the original conservative behavior rather than authorizing abort.
+  it("defers a late tick when the caller supplies no loop-delay verdict", () => {
+    // Standalone callers omit readEventLoopDelayed. Nothing then rules out a stall holding
+    // queued progress, so the tick keeps the original conservative behavior rather than
+    // authorizing abort from a measurement it cannot check for freshness.
     const recoverStuckSession = vi.fn();
 
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopDelayed: () => true,
       sampleLiveness: () => null,
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -180,6 +180,21 @@ function expectNoLoggerMessageContaining(spy: unknown, text: string): void {
   expect(loggerMessages(spy).join("\n")).not.toContain(text);
 }
 
+/**
+ * Mirrors the Gateway monitor's `snapshot()` contract: the same object is returned until a
+ * new sampling window commits. Returning a fresh object per read would hide the stale-read
+ * ordering that a starved sampler produces.
+ */
+function createFakeEventLoopMonitor() {
+  let observation: { reasons: string[] } | undefined;
+  return {
+    read: () => observation,
+    commit: (...reasons: string[]) => {
+      observation = { reasons };
+    },
+  };
+}
+
 /** Sampler result for a genuinely blocked event loop, the only state that defers recovery. */
 function stalledEventLoopSample() {
   return {
@@ -552,14 +567,18 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
+    const monitor = createFakeEventLoopMonitor();
+    monitor.commit();
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: () => ({ reasons: [] }),
+      readEventLoopHealth: monitor.read,
       sampleLiveness: () => null,
     });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
+    // The sampler keeps up, so every tick sees an observation covering its own interval.
     const advanceLateTick = () => {
+      monitor.commit();
       vi.setSystemTime(Date.now() + 1_500);
       vi.advanceTimersByTime(30_000);
     };
@@ -600,12 +619,13 @@ describe("stuck session diagnostics threshold", () => {
     // progress that has not run yet, and aborting on that snapshot cancels healthy work.
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
-    let eventLoopStalled = false;
+    const monitor = createFakeEventLoopMonitor();
+    monitor.commit();
 
     vi.setSystemTime(0);
     startEnabledDiagnosticHeartbeat({
       recoverStuckSession,
-      readEventLoopHealth: () => ({ reasons: eventLoopStalled ? ["event_loop_delay"] : [] }),
+      readEventLoopHealth: monitor.read,
       // Deliberately still null while stalled: this is the Gateway contract, where
       // persistentDegradationSnapshot() withholds under 60s of continuous degradation.
       // Recovery must not read that filter as a responsive loop.
@@ -618,15 +638,46 @@ describe("stuck session diagnostics threshold", () => {
       vi.advanceTimersByTime(30_000);
     };
 
+    monitor.commit();
     advanceLateTick();
+    monitor.commit();
     advanceLateTick();
     recoverStuckSession.mockClear();
 
-    eventLoopStalled = true;
+    monitor.commit("event_loop_delay");
     advanceLateTick();
 
     expect(recoverStuckSession).not.toHaveBeenCalled();
     expectLoggerMessageContaining(warnSpy, "deferring recovery decisions");
+  });
+
+  it("refuses recovery when a stall starved the sampler and the observation is stale", () => {
+    // The monitor commits about once a second and returns the same object until it does.
+    // A stall delays both timers; if the heartbeat resumes first, the retained observation
+    // still reads healthy and must not be mistaken for a responsive loop.
+    const recoverStuckSession = vi.fn();
+    const monitor = createFakeEventLoopMonitor();
+    monitor.commit();
+
+    vi.setSystemTime(0);
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      readEventLoopHealth: monitor.read,
+      sampleLiveness: () => null,
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    // First late tick sees a fresh healthy window, so recovery is allowed to run.
+    monitor.commit();
+    vi.setSystemTime(Date.now() + 1_500);
+    vi.advanceTimersByTime(30_000);
+    recoverStuckSession.mockClear();
+
+    // Now the sampler is starved: the same object is returned, still reading healthy.
+    vi.setSystemTime(Date.now() + 1_500);
+    vi.advanceTimersByTime(30_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("defers a material heartbeat stall even when elapsed time is below the abort threshold", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -311,6 +311,22 @@ function stopDiagnosticLivenessSampler(): void {
   lastDiagnosticLivenessWarnAt = 0;
 }
 
+let lastObservedEventLoopHealth: { reasons: readonly string[] } | undefined;
+
+/**
+ * The supplied monitor commits a new observation roughly once a second and keeps returning
+ * the same object until it does. An unchanged reference therefore describes a window that
+ * closed before this tick, and after a stall starves that sampler the retained observation
+ * still reads healthy. Report no evidence in that case rather than a responsive loop.
+ */
+function resolveSuppliedEventLoopDelayed(
+  health: { reasons: readonly string[] } | undefined,
+): boolean | undefined {
+  const advanced = health !== undefined && health !== lastObservedEventLoopHealth;
+  lastObservedEventLoopHealth = health;
+  return advanced && health ? health.reasons.includes("event_loop_delay") : undefined;
+}
+
 /**
  * Reads the current delay window without consuming it. `sampleDiagnosticLiveness` owns
  * the reset, so a caller earlier in the same tick observes the same window.
@@ -1160,6 +1176,7 @@ export function startDiagnosticHeartbeat(
   const livenessGraceUntil =
     opts?.startupGraceMs != null && opts.startupGraceMs > 0 ? Date.now() + opts.startupGraceMs : 0;
   lastDiagnosticHeartbeatTickAt = Date.now();
+  lastObservedEventLoopHealth = undefined;
   heartbeatInterval = setInterval(() => {
     // Reuse this tick for exporter demand changes; GC collection never adds a timer.
     reconcileDiagnosticGcObserver();
@@ -1190,9 +1207,8 @@ export function startDiagnosticHeartbeat(
     // timer late on every tick with a responsive loop, and deferring on lateness alone
     // left recovery disabled for the process lifetime. Absent health evidence the tick
     // still defers, because nothing then rules out a stall holding queued progress.
-    const suppliedHealth = opts?.readEventLoopHealth?.();
     const eventLoopDelayed = opts?.readEventLoopHealth
-      ? suppliedHealth?.reasons.includes("event_loop_delay")
+      ? resolveSuppliedEventLoopDelayed(opts.readEventLoopHealth())
       : readBuiltInEventLoopDelayed();
     const shouldDeferRecovery = heartbeatDelayed && eventLoopDelayed !== false;
     if (heartbeatDelayed && !inStartupGrace) {
@@ -1333,6 +1349,7 @@ export function stopDiagnosticHeartbeat() {
     heartbeatInterval = null;
   }
   lastDiagnosticHeartbeatTickAt = undefined;
+  lastObservedEventLoopHealth = undefined;
   stopDiagnosticRunActivityTracking();
   retireDiagnosticSessionObservations();
   stopDiagnosticLivenessSampler();

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -147,7 +147,8 @@ type StartDiagnosticHeartbeatOptions = {
    * Loop-delay verdict for recovery decisions, kept separate from `sampleLiveness`
    * because that one is the operator-warning path and its Gateway implementation
    * withholds degradation shorter than a minute. The sampler owns this answer because
-   * only it knows whether its own next sample is overdue.
+   * only it knows whether its own next sample is overdue. Omitting it keeps a late tick
+   * deferring, since nothing else can prove the loop was responsive.
    */
   readEventLoopDelayed?: () => boolean;
   recoverStuckSession?: RecoverStuckSession;
@@ -309,22 +310,6 @@ function stopDiagnosticLivenessSampler(): void {
   lastDiagnosticLivenessEventLoopUtilization = null;
   lastDiagnosticLivenessEventAt = 0;
   lastDiagnosticLivenessWarnAt = 0;
-}
-
-/**
- * Reads the current delay window without consuming it. `sampleDiagnosticLiveness` owns
- * the reset, so a caller earlier in the same tick observes the same window.
- */
-function readBuiltInEventLoopDelayed(): boolean | undefined {
-  if (!diagnosticLivenessMonitor) {
-    return undefined;
-  }
-  return (
-    nanosecondsToMilliseconds(diagnosticLivenessMonitor.percentile(99)) >=
-      DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
-    nanosecondsToMilliseconds(diagnosticLivenessMonitor.max) >=
-      DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS
-  );
 }
 
 function sampleDiagnosticLiveness(now: number): DiagnosticLivenessSample | null {
@@ -1190,7 +1175,9 @@ export function startDiagnosticHeartbeat(
     // timer late on every tick with a responsive loop, and deferring on lateness alone
     // left recovery disabled for the process lifetime. Absent health evidence the tick
     // still defers, because nothing then rules out a stall holding queued progress.
-    const eventLoopDelayed = (opts?.readEventLoopDelayed ?? readBuiltInEventLoopDelayed)();
+    // Only a positive "responsive" reading unblocks recovery. A caller without a monitor
+    // cannot rule out a stall holding queued progress, so it keeps deferring on lateness.
+    const eventLoopDelayed = opts?.readEventLoopDelayed?.();
     const shouldDeferRecovery = heartbeatDelayed && eventLoopDelayed !== false;
     if (heartbeatDelayed && !inStartupGrace) {
       diag.warn(

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -143,6 +143,13 @@ type StartDiagnosticHeartbeatOptions = {
   getConfig?: () => OpenClawConfig;
   emitMemorySample?: EmitDiagnosticMemorySample;
   sampleLiveness?: SampleDiagnosticLiveness;
+  /**
+   * Current loop-health observation for recovery decisions, kept separate from
+   * `sampleLiveness` because that one is the operator-warning path and its Gateway
+   * implementation withholds degradation shorter than a minute. An absent observation
+   * means no health evidence, not a healthy loop.
+   */
+  readEventLoopHealth?: () => { reasons: readonly string[] } | undefined;
   recoverStuckSession?: RecoverStuckSession;
   startupGraceMs?: number;
   /** Keeps fake-timer recovery tests fast without reopening runtime config tuning. */
@@ -302,6 +309,22 @@ function stopDiagnosticLivenessSampler(): void {
   lastDiagnosticLivenessEventLoopUtilization = null;
   lastDiagnosticLivenessEventAt = 0;
   lastDiagnosticLivenessWarnAt = 0;
+}
+
+/**
+ * Reads the current delay window without consuming it. `sampleDiagnosticLiveness` owns
+ * the reset, so a caller earlier in the same tick observes the same window.
+ */
+function readBuiltInEventLoopDelayed(): boolean | undefined {
+  if (!diagnosticLivenessMonitor) {
+    return undefined;
+  }
+  return (
+    nanosecondsToMilliseconds(diagnosticLivenessMonitor.percentile(99)) >=
+      DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
+    nanosecondsToMilliseconds(diagnosticLivenessMonitor.max) >=
+      DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS
+  );
 }
 
 function sampleDiagnosticLiveness(now: number): DiagnosticLivenessSample | null {
@@ -1159,13 +1182,26 @@ export function startDiagnosticHeartbeat(
     const heartbeatOverdueMs = Math.max(0, heartbeatElapsedMs - DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
     const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
     // Observe ordinary timer jitter at the scheduled tick so it cannot consume
-    // a run's remaining recovery budget. Material lateness can also hide queued
-    // progress events, so the next healthy heartbeat owns recovery instead.
+    // a run's remaining recovery budget.
     const recoveryObservationNow = now - heartbeatOverdueMs;
-    const shouldDeferRecovery = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
-    if (shouldDeferRecovery && !inStartupGrace) {
+    const heartbeatDelayed = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
+    // A late tick only hides queued progress when the loop itself was blocked, so the
+    // measured delay decides that, not the wakeup time. Virtualized hosts wake a sleeping
+    // timer late on every tick with a responsive loop, and deferring on lateness alone
+    // left recovery disabled for the process lifetime. Absent health evidence the tick
+    // still defers, because nothing then rules out a stall holding queued progress.
+    const suppliedHealth = opts?.readEventLoopHealth?.();
+    const eventLoopDelayed = opts?.readEventLoopHealth
+      ? suppliedHealth?.reasons.includes("event_loop_delay")
+      : readBuiltInEventLoopDelayed();
+    const shouldDeferRecovery = heartbeatDelayed && eventLoopDelayed !== false;
+    if (heartbeatDelayed && !inStartupGrace) {
       diag.warn(
-        `liveness heartbeat delayed: overdue=${Math.round(heartbeatOverdueMs)}ms elapsed=${Math.round(heartbeatElapsedMs)}ms; deferring recovery decisions`,
+        `liveness heartbeat delayed: overdue=${Math.round(heartbeatOverdueMs)}ms elapsed=${Math.round(heartbeatElapsedMs)}ms; ${
+          shouldDeferRecovery
+            ? "deferring recovery decisions"
+            : "event loop stayed responsive, keeping recovery decisions"
+        }`,
       );
     }
     pruneDiagnosticSessionStates(now, true);

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -144,12 +144,12 @@ type StartDiagnosticHeartbeatOptions = {
   emitMemorySample?: EmitDiagnosticMemorySample;
   sampleLiveness?: SampleDiagnosticLiveness;
   /**
-   * Current loop-health observation for recovery decisions, kept separate from
-   * `sampleLiveness` because that one is the operator-warning path and its Gateway
-   * implementation withholds degradation shorter than a minute. An absent observation
-   * means no health evidence, not a healthy loop.
+   * Loop-delay verdict for recovery decisions, kept separate from `sampleLiveness`
+   * because that one is the operator-warning path and its Gateway implementation
+   * withholds degradation shorter than a minute. The sampler owns this answer because
+   * only it knows whether its own next sample is overdue.
    */
-  readEventLoopHealth?: () => { reasons: readonly string[] } | undefined;
+  readEventLoopDelayed?: () => boolean;
   recoverStuckSession?: RecoverStuckSession;
   startupGraceMs?: number;
   /** Keeps fake-timer recovery tests fast without reopening runtime config tuning. */
@@ -309,22 +309,6 @@ function stopDiagnosticLivenessSampler(): void {
   lastDiagnosticLivenessEventLoopUtilization = null;
   lastDiagnosticLivenessEventAt = 0;
   lastDiagnosticLivenessWarnAt = 0;
-}
-
-let lastObservedEventLoopHealth: { reasons: readonly string[] } | undefined;
-
-/**
- * The supplied monitor commits a new observation roughly once a second and keeps returning
- * the same object until it does. An unchanged reference therefore describes a window that
- * closed before this tick, and after a stall starves that sampler the retained observation
- * still reads healthy. Report no evidence in that case rather than a responsive loop.
- */
-function resolveSuppliedEventLoopDelayed(
-  health: { reasons: readonly string[] } | undefined,
-): boolean | undefined {
-  const advanced = health !== undefined && health !== lastObservedEventLoopHealth;
-  lastObservedEventLoopHealth = health;
-  return advanced && health ? health.reasons.includes("event_loop_delay") : undefined;
 }
 
 /**
@@ -1176,7 +1160,6 @@ export function startDiagnosticHeartbeat(
   const livenessGraceUntil =
     opts?.startupGraceMs != null && opts.startupGraceMs > 0 ? Date.now() + opts.startupGraceMs : 0;
   lastDiagnosticHeartbeatTickAt = Date.now();
-  lastObservedEventLoopHealth = undefined;
   heartbeatInterval = setInterval(() => {
     // Reuse this tick for exporter demand changes; GC collection never adds a timer.
     reconcileDiagnosticGcObserver();
@@ -1207,9 +1190,7 @@ export function startDiagnosticHeartbeat(
     // timer late on every tick with a responsive loop, and deferring on lateness alone
     // left recovery disabled for the process lifetime. Absent health evidence the tick
     // still defers, because nothing then rules out a stall holding queued progress.
-    const eventLoopDelayed = opts?.readEventLoopHealth
-      ? resolveSuppliedEventLoopDelayed(opts.readEventLoopHealth())
-      : readBuiltInEventLoopDelayed();
+    const eventLoopDelayed = (opts?.readEventLoopDelayed ?? readBuiltInEventLoopDelayed)();
     const shouldDeferRecovery = heartbeatDelayed && eventLoopDelayed !== false;
     if (heartbeatDelayed && !inStartupGrace) {
       diag.warn(
@@ -1349,7 +1330,6 @@ export function stopDiagnosticHeartbeat() {
     heartbeatInterval = null;
   }
   lastDiagnosticHeartbeatTickAt = undefined;
-  lastObservedEventLoopHealth = undefined;
   stopDiagnosticRunActivityTracking();
   retireDiagnosticSessionObservations();
   stopDiagnosticLivenessSampler();


### PR DESCRIPTION
Fixes #142200.

## What Problem This Solves

Resolves a problem where automatic stuck-session recovery stops running for the lifetime of a Gateway process on virtualized hosts, so a session that hangs is warned about repeatedly but never recovered.

The diagnostic heartbeat treats its own lateness as a sign the event loop is congested. When a tick fires more than one second past its 30 second deadline, recovery decisions are deferred to the next healthy tick:

`src/logging/diagnostic.ts:1165`

```ts
const shouldDeferRecovery = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
```

```ts
if (!recovery || shouldDeferRecovery) {
  continue;
}
requestStuckSessionRecovery({ ... });
```

That tolerates 3.3 percent slop on a 30 second timer. The reporter measured a WSL2 host waking a sleeping timer 1120 to 1681 milliseconds late on 32 consecutive ticks while the true event-loop delay stayed at 10 to 13 milliseconds and the Gateway sat at 2.2 percent CPU. Every tick deferred, so the next healthy heartbeat the deferral waits for never arrived:

```
13:16:26.368Z WARN liveness heartbeat delayed: overdue=1483ms elapsed=31483ms; deferring recovery decisions
13:16:57.914Z WARN liveness heartbeat delayed: overdue=1546ms elapsed=31546ms; deferring recovery decisions
13:17:29.472Z WARN liveness heartbeat delayed: overdue=1558ms elapsed=31558ms; deferring recovery decisions
```

`logSessionAttention` still fires, so the operator sees stuck-session warnings, but `requestStuckSessionRecovery` is unreachable.

## Why This Change Was Made

The deferral protects a real case and is kept. What is wrong is the signal it reads. Wakeup latency is a property of the host scheduler; whether queued progress is stuck behind a blocked loop is a property of the event loop, and the Gateway already runs a sampler that measures the second one. On the reporter's ticks that sampler read 10 to 13 milliseconds while the heartbeat called the same ticks congested.

**The verdict belongs to the monitor, not the heartbeat.** Only the sampler knows whether its own next sample is overdue, and that turns out to be the whole answer:

`src/gateway/server/event-loop-health.ts`

```ts
eventLoopDelayed: () =>
  nowMs() - lastSampleAt >= EVENT_LOOP_DELAY_WARN_MS ||
  (lastSnapshot?.reasons.includes("event_loop_delay") ?? false),
```

`lastSampleAt` advances on every sampler callback, including the early-return path where a quiet window commits no snapshot, so it is a liveness marker for the sampler itself. A stall starves that 20 millisecond callback, which means the retained observation predates the stall and still reads healthy. The interval since the last callback is itself a delay measurement, so the monitor can answer correctly without waiting for a new observation to commit.

The Gateway passes that verdict for recovery and keeps the persistent filter for warnings, which are different questions:

```ts
readEventLoopDelayed: readinessEventLoopHealth.eventLoopDelayed,
```

`persistentDegradationSnapshot()` withholds anything under 60 seconds of continuous degradation (`event-loop-health.ts:14`, `:207-213`), which is right for an operator warning and wrong for a recovery decision, because a shorter genuine stall still holds queued progress.

Session ages continue to be measured against `recoveryObservationNow = now - heartbeatOverdueMs`, which is untouched, so timer jitter still cannot push a run past its threshold early.

Two earlier revisions of this PR got the mechanism wrong and are worth naming, since the current shape is a response to both. A counter capping consecutive deferrals gave chronic lateness a standing exemption. Comparing observation identity across ticks only proved that something had been published since the last heartbeat, which across a 30 second interval is about thirty commits, so a pre-stall observation still passed. Reading the pending sample interval has neither hole, adds no constant, and removes the third "no evidence" state entirely.

Because the callback is now a plain `() => boolean`, no freshness or identity semantics leak to SDK hosts implementing it. There is no longer a wrong way to return the value.

An earlier revision of this PR also carried a standalone fallback that read completed histogram samples when no verdict was supplied. That had the same ordering hole, with no way to detect its own pending sample, so it is removed rather than rebuilt. `startDiagnosticHeartbeat` is exported through `src/plugin-sdk/logging-core.ts`, and callers that omit the verdict now defer on a late tick, which is exactly main's behavior today. Only the Gateway changes.

No configuration option is added.

## User Impact

On hosts with chronic timer lateness, mainly WSL2 and other VMs, stuck sessions are recovered automatically again instead of only being warned about. A genuinely blocked event loop still defers recovery, including a stall shorter than the warning filter's minute and a stall that starved the sampler itself. The repeated warning now says which of the two it observed:

```
liveness heartbeat delayed: overdue=1483ms elapsed=31483ms; event loop stayed responsive, keeping recovery decisions
```

## Evidence

Production change is +40/-5 across three files, of which the Gateway wiring is one line.

The contract is proven at its owner, against the real monitor rather than a fake:

```ts
harness.samples(50);
expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, reasons: [] });
expect(harness.monitor.eventLoopDelayed()).toBe(false);
harness.elapseWithoutSampling(1_200);
expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, reasons: [] });
expect(harness.monitor.eventLoopDelayed()).toBe(true);
```

Healthy sampling, then the heartbeat-before-sampler window, asserting the snapshot still reads healthy while the verdict does not. Reducing the verdict to snapshot-only, the pre-fix semantics, fails it:

```
× reports a delayed loop once its own sample is overdue, before any new observation
  AssertionError: expected false to be true
  Tests  1 failed | 20 passed (21)
```

Reverting `src/logging/diagnostic.ts` to main, so the deferral reads lateness again:

```
× keeps recovery running when ticks are late but the event loop stayed responsive
  Error: missing recoverStuckSession call
```

A companion test asserts ten consecutive keeping-up samples stay `false`, so the guard fails in both directions rather than only one.

```
node scripts/run-vitest.mjs src/logging                              9 files, 110 passed
node scripts/run-vitest.mjs src/gateway/server/event-loop-health.test.ts,
  question.recovery.test.ts                                                    49 passed
node scripts/run-vitest.mjs src/gateway (recovery lane)             36 files, 697 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json                                  clean
oxlint / oxfmt on all five touched files                                         clean
```

Proof gap worth stating plainly: this is fake-timer coverage of the heartbeat decision plus real-monitor coverage of the contract it depends on, not a runtime trace on an affected host. I have no WSL2 or VM host and cannot manufacture chronic host wakeup lateness here, so producing that trace would mean fabricating it. For anyone who does have such a host: run the Gateway with diagnostics enabled, leave a session `processing` past `stuckSessionWarnMs`, and grep for `liveness heartbeat delayed`. Before this change every line ends `deferring recovery decisions` and recovery is never requested; after it, lines end `event loop stayed responsive, keeping recovery decisions` and recovery is requested.

AI-assisted: yes. I traced the source path by hand and ran every command above myself.

