### PR TITLE
ci: keep isolated UI unit changes out of E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
       run_control_ui_i18n: ${{ steps.manifest.outputs.run_control_ui_i18n }}
       strict_control_ui_i18n: ${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || steps.changed_scope.outputs.strict_control_ui_i18n }}
       run_ui_tests: ${{ steps.manifest.outputs.run_ui_tests }}
+      run_ui_e2e: ${{ steps.manifest.outputs.run_ui_e2e }}
       ui_e2e_matrix: ${{ steps.manifest.outputs.ui_e2e_matrix }}
       run_native_i18n: ${{ steps.manifest.outputs.run_native_i18n }}
       strict_native_i18n: ${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || steps.changed_scope.outputs.strict_native_i18n }}
@@ -1407,6 +1408,14 @@ jobs:
           const runControlUiI18n =
             parseBoolean(process.env.OPENCLAW_CI_RUN_CONTROL_UI_I18N) && !docsOnly;
           const runUiTests = parseBoolean(process.env.OPENCLAW_CI_RUN_UI_TESTS) && !docsOnly;
+          // Only ordinary current PR unit entries may omit browser integration;
+          // main, dispatches, frozen targets and unknown selectors retain their owners.
+          const runUiE2e = runUiTests && (
+            !isCanonicalRepository || eventName !== "pull_request" || frozenTarget || compatibilityTarget ||
+            changedPaths === null ||
+            typeof changedNodeTestPlan.hasUiE2eAffectingChange !== "function" ||
+            changedNodeTestPlan.hasUiE2eAffectingChange(changedPaths)
+          );
           const runnerProfile = process.env.OPENCLAW_CI_RUNNER_PROFILE ?? "blacksmith";
           const usesHostedRunnerProfile =
             runnerProfile === "github" || runnerProfile === "hybrid";
@@ -1544,7 +1553,7 @@ jobs:
             }
             changedNodeTestShards = changedNodeTestPlan.createChangedNodeTestShards(changedPaths, {
               dedicatedContractShards: [...pluginContractShards, ...channelContractShards],
-              dedicatedUiE2e: runUiTests && !compatibilityTarget,
+              dedicatedUiE2e: runUiE2e && !compatibilityTarget,
             });
             if (changedNodeTestShards === null) {
               changedExtensionFallbackShards =
@@ -1778,6 +1787,7 @@ jobs:
             run_format_check: runFormatCheck,
             run_control_ui_i18n: runControlUiI18n,
             run_ui_tests: runUiTests,
+            run_ui_e2e: runUiE2e,
             ui_e2e_matrix: createMatrix(Array.from({ length: uiE2eJobCount }, (_, index) => {
               const shard = index + 1;
               return {
@@ -2682,7 +2692,7 @@ jobs:
     needs: [preflight]
     # Compatibility targets pin a frozen Control UI whose e2e expectations track
     # that release, not current main.
-    if: needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'
+    if: needs.preflight.outputs.run_ui_e2e == 'true' && needs.preflight.outputs.compatibility_target != 'true'
     # Backend and contributor routing stays shared with real-Gateway tests.
     # UI's two workers received two CPUs on the 8-vCPU label; request the measured
     # eight-CPU class only for Control UI, retaining browser-extension placement.
@@ -2780,7 +2790,7 @@ jobs:
     needs: [preflight]
     # Compatibility targets pin a frozen Control UI whose e2e expectations track
     # that release, not current main.
-    if: needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'
+    if: needs.preflight.outputs.run_ui_e2e == 'true' && needs.preflight.outputs.compatibility_target != 'true'
     # First-attempt same-repo runs use Blacksmith unless the backend breaker is
     # set; manual dispatches, forks, and same-repo PR retries also use GitHub-hosted capacity.
     # Keep the existing hybrid route for the prepared Chromium workload:
@@ -5735,8 +5745,8 @@ jobs:
             control-ui-performance=${{ needs.control-ui-performance.result }}|${{ needs.preflight.outputs.run_build_artifacts == 'true' || needs.preflight.outputs.run_ui_tests == 'true' }}
             native-i18n=${{ needs.native-i18n.result }}|${{ needs.preflight.outputs.run_native_i18n }}
             checks-ui=${{ needs.checks-ui.result }}|${{ needs.preflight.outputs.run_ui_tests }}
-            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
-            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
+            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}|${{ needs.preflight.outputs.run_ui_e2e == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
+            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}|${{ needs.preflight.outputs.run_ui_e2e == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
             control-ui-i18n=${{ needs.control-ui-i18n.result }}|${{ needs.preflight.outputs.run_control_ui_i18n }}
             checks-fast-core=${{ needs.checks-fast-core.result }}|${{ needs.preflight.outputs.run_checks_fast_core }}
             qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}|${{ needs.preflight.outputs.run_qa_smoke_ci }}

--- a/docs/ci/pipeline.md
+++ b/docs/ci/pipeline.md
@@ -74,6 +74,13 @@ the job's uploaded artifacts.
 | `openclaw-performance`           | Separate workflow: daily/on-demand Kova runtime performance reports with mock-provider, deep-profile, and GPT 5.6 live lanes                                                                                                                                                                             | Scheduled and manual dispatch                          |
 | `docs-external-links`            | Separate workflow: Docs External Link Audit checks external documentation links with lychee and uploads a report; it reports findings without failing, so it never blocks a pull request                                                                                                                 | Scheduled and manual dispatch                          |
 
+Ordinary pull requests that change only independent Control UI unit-test entries
+keep all three UI unit rows, performance checks, and existing type/lint gates,
+without repeating dedicated UI E2E jobs. Browser and Node test entries, shared
+fixtures/helpers, production or build inputs, and tests imported by another
+owner retain E2E coverage. Main pushes, manual validation, and frozen targets
+keep their existing selection.
+
 The `docker-seed-e2e` job selects the executable owners of changed E2E helpers
 and the published-upgrade regression gate through one scheduler invocation.
 The published lane runs `legacy-operator-state` against only `openclaw@latest`

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -1,13 +1,18 @@
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync } from "node:fs";
 import path from "node:path";
 import { pluginContractPatterns } from "../../test/vitest/vitest.contracts-paths.mjs";
-import { isPluginControlUiPath, isUiBrowserTestFile } from "../../test/vitest/vitest.ui-paths.mjs";
+import {
+  isPluginControlUiPath,
+  isUiBrowserTestFile,
+  isUiTestTarget,
+} from "../../test/vitest/vitest.ui-paths.mjs";
 import { detectChangedLanes } from "../changed-lanes.mts";
 import {
   buildVitestRunPlans,
   CHANNEL_CONTRACT_CONFIG_PATTERNS,
   CONTRACTS_PLUGIN_VITEST_CONFIG,
   findUnmatchedExplicitTestTargets,
+  hasImportGraphConsumers,
   hasImportGraphImpactOnTargets,
   isTestFileTarget,
   isTestSupportFileTarget,
@@ -52,6 +57,30 @@ type ChangedNodeTestShard = {
 };
 type ChangedExtensionConfigShard = ChangedNodeTestShard & { predictedSeconds: number };
 type CwdOptions = { cwd?: string };
+
+/** Ordinary UI unit entries retain their unit owner; fixtures and their consumers retain E2E. */
+export function hasUiE2eAffectingChange(changedPaths: string[], options: CwdOptions = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  if (
+    !Array.isArray(changedPaths) ||
+    changedPaths.length === 0 ||
+    changedPaths.some(
+      (file) =>
+        !file.startsWith("ui/src/") ||
+        !isUiTestTarget(file) ||
+        /\.(?:browser|node)\.test\.ts$/u.test(file) ||
+        /(?:^|\/)(?:e2e|test-helpers|test-fixtures|fixtures|__fixtures__)(?:\/|$)/u.test(file) ||
+        path.posix.normalize(file) !== file ||
+        !existsSync(path.join(cwd, file)) ||
+        !lstatSync(path.join(cwd, file)).isFile(),
+    )
+  ) {
+    return true;
+  }
+  // Test entry names are not enough: a fixture or application may import one.
+  // Reuse the canonical import graph rather than orphaning that consumer's proof.
+  return hasImportGraphConsumers(changedPaths, cwd, { tooling: true });
+}
 
 const DEFAULT_NODE_TEST_RUNNER = "blacksmith-8vcpu-ubuntu-2404";
 const MAX_CHANGED_NODE_TEST_TARGETS = 96;

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -879,11 +879,19 @@ const SOURCE_ROOTS_FOR_IMPORT_GRAPH = [
   "packages",
   "ui/src",
   "ui/config",
+  "ui/public",
   "test",
 ];
 const IMPORTABLE_FILE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
-const IMPORT_GRAPH_GREP_PATHS = SOURCE_ROOTS_FOR_IMPORT_GRAPH.flatMap((root) =>
-  IMPORTABLE_FILE_EXTENSIONS.map((ext) => `:(glob)${root}/**/*${ext}`),
+function importGraphPathspecs(roots: string[], suffixes: readonly string[]) {
+  return [
+    ...roots.flatMap((root) => suffixes.map((suffix) => `:(glob)${root}/**/*${suffix}`)),
+    ...suffixes.map((suffix) => `:(glob)ui/*${suffix}`),
+  ];
+}
+const IMPORT_GRAPH_GREP_PATHS = importGraphPathspecs(
+  SOURCE_ROOTS_FOR_IMPORT_GRAPH,
+  IMPORTABLE_FILE_EXTENSIONS,
 );
 const TOOLING_IMPORT_GRAPH_ROOTS = [...SOURCE_ROOTS_FOR_IMPORT_GRAPH, "scripts"];
 const TOOLING_IMPORTABLE_FILE_EXTENSIONS = [
@@ -893,8 +901,9 @@ const TOOLING_IMPORTABLE_FILE_EXTENSIONS = [
   ".mjs",
   ".cjs",
 ];
-const TOOLING_IMPORT_GRAPH_GREP_PATHS = TOOLING_IMPORT_GRAPH_ROOTS.flatMap((root) =>
-  TOOLING_IMPORTABLE_FILE_EXTENSIONS.map((ext) => `:(glob)${root}/**/*${ext}`),
+const TOOLING_IMPORT_GRAPH_GREP_PATHS = importGraphPathspecs(
+  TOOLING_IMPORT_GRAPH_ROOTS,
+  TOOLING_IMPORTABLE_FILE_EXTENSIONS,
 );
 const BROAD_CHANGED_ENV_KEY = "OPENCLAW_TEST_CHANGED_BROAD";
 const VITEST_NO_OUTPUT_TIMEOUT_ENV_KEY = "OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS";
@@ -1509,6 +1518,7 @@ function listImportGraphFiles(
   directory: string,
   files: string[] = [],
   extensions: readonly string[] = IMPORTABLE_FILE_EXTENSIONS,
+  recursive = true,
 ) {
   let entries;
   try {
@@ -1520,7 +1530,7 @@ function listImportGraphFiles(
   for (const entry of entries) {
     const relative = normalizePathPattern(path.posix.join(directory, entry.name));
     if (entry.isDirectory()) {
-      if (!isSkippedImportGraphDirectory(entry.name)) {
+      if (recursive && !isSkippedImportGraphDirectory(entry.name)) {
         listImportGraphFiles(cwd, relative, files, extensions);
       }
       continue;
@@ -1580,11 +1590,14 @@ function listImportGraphFilesForCwd(cwd: string, options: ImportGraphOptions = {
   }
   const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
   const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
-  const files =
-    listTrackedTestPlanFiles(
-      cwd,
-      tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS,
-    ) ?? roots.flatMap((root) => listImportGraphFiles(cwd, root, [], extensions));
+  const files = listTrackedTestPlanFiles(
+    cwd,
+    tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS,
+  ) ?? [
+    ...roots.flatMap((root) => listImportGraphFiles(cwd, root, [], extensions)),
+    // Root configs are inputs; UI caches and generated sibling trees are not.
+    ...listImportGraphFiles(cwd, "ui", [], extensions, false),
+  ];
   cachedImportGraphFiles.set(cacheKey, files);
   return files;
 }
@@ -1681,9 +1694,7 @@ function listImportGraphGrepMatches(
   const suffixes = testFilesOnly
     ? extensions.flatMap((ext) => [`.test${ext}`, `.spec${ext}`])
     : extensions;
-  const grepPaths = roots.flatMap((root) =>
-    suffixes.map((suffix) => `:(glob)${root}/**/*${suffix}`),
-  );
+  const grepPaths = importGraphPathspecs(roots, suffixes);
   const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
     cwd,
     encoding: "utf8",
@@ -1761,6 +1772,33 @@ function findDirectImporters(
     }
   }
   return skippedBroadTerm && importers.length === 0 && !isTestHelper ? null : importers;
+}
+
+/** Prove an entry is unshared using the canonical targeted reverse-import scan. */
+export function hasImportGraphConsumers(
+  changedPaths: string[],
+  cwd = process.cwd(),
+  options: ImportGraphOptions = {},
+) {
+  const tracked = listTrackedTestPlanFiles(
+    cwd,
+    options.tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS,
+  );
+  // An incomplete archive/filesystem inventory cannot prove that an entry is unshared.
+  if (tracked === null) {
+    return true;
+  }
+  cachedImportGraphFiles.set(`${cwd}\0${options.tooling ? "tooling" : "source"}`, tracked);
+  const files = new Set(tracked);
+  const extensions = options.tooling
+    ? TOOLING_IMPORTABLE_FILE_EXTENSIONS
+    : IMPORTABLE_FILE_EXTENSIONS;
+  const terms = changedPaths.flatMap((file) => resolveImportGraphSearchTerms(file, extensions));
+  const matches = listImportGraphGrepMatches(cwd, terms, options);
+  return changedPaths.some((file) => {
+    const consumers = files.has(file) ? findDirectImporters(file, matches, extensions) : null;
+    return consumers === null || consumers.length > 0;
+  });
 }
 
 function resolveAffectedTestsFromTargetedImportScan(

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -11,6 +12,7 @@ import {
   hasPromptSnapshotAffectingChange,
   hasQaSmokeAffectingChange,
   hasSqliteSessionLifecycleAffectingChange,
+  hasUiE2eAffectingChange,
   resolveChangedDockerSeedLanes,
 } from "../../scripts/lib/ci-changed-node-test-plan.mts";
 import {
@@ -27,6 +29,90 @@ import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.m
 
 const CODEX_TEST_PROCESS_FILE_LIMIT = 12;
 const githubActivityHelper = ".agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh";
+
+it("keeps ordinary activity unit changes with their UI unit owner", () => {
+  expect(hasUiE2eAffectingChange(["ui/src/pages/activity/activity-page.test.ts"])).toBe(false);
+});
+
+it.each(
+  [
+    [],
+    ["ui/src/pages/activity/deleted.test.ts"],
+    ["ui/src/pages/activity/activity-page.test.ts", "ui/src/pages/activity/activity-page.ts"],
+    ["ui/src/pages/activity/activity-page.test.ts", "package.json"],
+    ["ui/src/test-helpers/control-ui-e2e.test.ts"],
+    ["ui/src/app/gateway-store.test-support.ts"],
+    ["ui/src/e2e/board-a2ui.e2e.test.ts"],
+    ["ui/src/styles/cursor-policy.browser.test.ts"],
+    ["ui/src/components/web-awesome-migration.node.test.ts"],
+    ["test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts"],
+    ["ui/vitest.config.ts"],
+    ["extensions/example/browser/page.test.ts"],
+    ["ui/src/pages/activity/../activity/activity-page.test.ts"],
+  ].map((paths) => ({ paths })),
+)("retains UI E2E for protected or unresolved inputs $paths", ({ paths }) => {
+  expect(hasUiE2eAffectingChange(paths)).toBe(true);
+});
+
+it.each([
+  [null, false],
+  ["ui/src/e2e/page.e2e.test.ts", true],
+  ["ui/src/pages/page.ts", true],
+  ["scripts/fixture.mts", true],
+  ["ui/vite.config.ts", true],
+  ["ui/public/sw.js", true],
+  ["ui/.cache/vitest/generated.mjs", false],
+  ["ui/.artifacts/generated.mjs", false],
+  ["ui/dist/generated.js", false],
+  ["ui/node_modules/dependency/index.js", false],
+] as const)("resolves UI E2E ownership for importer %s: %s", (consumer, expected) => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-ui-unit-consumer-"));
+  const target = "ui/src/pages/unit.test.ts";
+  try {
+    mkdirSync(path.dirname(path.join(cwd, target)), { recursive: true });
+    writeFileSync(path.join(cwd, target), "export const fixture = 1;\n");
+    if (consumer) {
+      mkdirSync(path.dirname(path.join(cwd, consumer)), { recursive: true });
+      const relative = path.relative(path.dirname(consumer), target).split(path.sep).join("/");
+      writeFileSync(
+        path.join(cwd, consumer),
+        `import "${relative.startsWith(".") ? relative : `./${relative}`}";\n`,
+      );
+    }
+    writeFileSync(path.join(cwd, ".gitignore"), ".cache/\n.artifacts/\ndist/\nnode_modules/\n");
+    execFileSync("git", ["init", "-q"], { cwd });
+    execFileSync("git", ["add", "."], { cwd });
+    expect(
+      hasImportGraphImpactOnTargets([target], (file) => file !== target, cwd, { tooling: true }),
+    ).toBe(expected);
+    expect(hasUiE2eAffectingChange([target], { cwd })).toBe(expected);
+  } finally {
+    rmSync(cwd, { force: true, recursive: true });
+  }
+});
+
+it.each(["archive", "untracked", "symlink"])("retains UI E2E for %s unit inputs", (mode) => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-ui-unit-inventory-"));
+  const target = "ui/src/unit.test.ts";
+  try {
+    mkdirSync(path.join(cwd, "ui/src"), { recursive: true });
+    if (mode === "symlink") {
+      writeFileSync(path.join(cwd, "ui/src/source.ts"), "export {};\n");
+      symlinkSync("source.ts", path.join(cwd, target));
+    } else {
+      writeFileSync(path.join(cwd, target), "export {};\n");
+    }
+    if (mode !== "archive") {
+      execFileSync("git", ["init", "-q"], { cwd });
+    }
+    if (mode === "symlink") {
+      execFileSync("git", ["add", "."], { cwd });
+    }
+    expect(hasUiE2eAffectingChange([target], { cwd })).toBe(true);
+  } finally {
+    rmSync(cwd, { force: true, recursive: true });
+  }
+});
 
 function expectBoundedCodexFallback(
   shards: ReturnType<typeof createChangedExtensionFallbackShards>,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1994,6 +1994,88 @@ function runControlUiI18nSourceFixture(options: {
 }
 
 describe("ci workflow guards", () => {
+  it("keeps activity unit proof without unrelated dedicated UI E2E on a PR", () => {
+    const manifest = runCiManifestFixture({
+      bundledPlanner: true,
+      eventName: "pull_request",
+      changedPaths: ["ui/src/pages/activity/activity-page.test.ts"],
+      scopeEnv: { OPENCLAW_CI_RUN_UI_TESTS: "true" },
+      changedPlannerSource: `
+        export const hasUiE2eAffectingChange = () => false;
+        export const hasBuildArtifactAffectingChange = () => false;
+        export const createChangedNodeTestShards = (_paths, options) => [{
+          checkName: "dedicated-ui-" + options.dedicatedUiE2e,
+          configs: [], requiresDist: false, runner: "ubuntu-24.04", shardName: "unit",
+        }];
+        export const createChangedExtensionFallbackShards = () => [];
+      `,
+    });
+    expect(manifest.status, manifest.output).toBe(0);
+    const workflow = readCiWorkflow();
+    const context = {
+      eventName: "pull_request" as const,
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      preflightOutputs: manifest.outputs,
+    };
+    for (const name of ["checks-ui", "control-ui-performance"]) {
+      expect(evaluateWorkflowExpression(`\${{ ${workflow.jobs[name].if} }}`, context)).toBe(true);
+    }
+    for (const name of ["checks-ui-e2e", "checks-ui-e2e-real-gateway"]) {
+      expect(evaluateWorkflowExpression(`\${{ ${workflow.jobs[name].if} }}`, context)).toBe(false);
+    }
+    expect(JSON.stringify(manifest.outputs)).toContain("dedicated-ui-false");
+    expect(
+      runCiGateFixture(
+        renderCiGateEnvironment(
+          { preflightOutputs: manifest.outputs },
+          {
+            "checks-ui-e2e": "skipped",
+            "checks-ui-e2e-real-gateway": "skipped",
+          },
+        ),
+      ).status,
+    ).toBe(0);
+    expect(
+      runCiGateFixture(
+        renderCiGateEnvironment(
+          { preflightOutputs: manifest.outputs },
+          {
+            "checks-ui": "skipped",
+          },
+        ),
+      ).status,
+    ).toBe(1);
+  });
+
+  it.each([
+    { eventName: "push" as const },
+    { eventName: "workflow_dispatch" as const, historicalCompatibility: false },
+    { eventName: "workflow_dispatch" as const, historicalCompatibility: true },
+    { eventName: "pull_request" as const, repository: "example/openclaw" },
+    { eventName: "pull_request" as const, changedPaths: null },
+    { eventName: "pull_request" as const, missingSelector: true },
+  ])("retains UI E2E outside current known unit-only PR selection %j", (options) => {
+    const manifest = runCiManifestFixture({
+      bundledPlanner: true,
+      changedPaths: ["ui/src/pages/activity/activity-page.test.ts"],
+      scopeEnv: { OPENCLAW_CI_RUN_UI_TESTS: "true" },
+      ...options,
+      changedPlannerSource: `
+        ${"missingSelector" in options && options.missingSelector ? "" : "export const hasUiE2eAffectingChange = () => false;"}
+        export const createChangedNodeTestShards = () => [];
+        export const createChangedExtensionFallbackShards = () => [];
+      `,
+    });
+    // Current PRs with an unusable manifest fail rather than narrowing proof.
+    if ("changedPaths" in options && options.changedPaths === null) {
+      expect(manifest.status).not.toBe(0);
+    } else {
+      expect(manifest.status, manifest.output).toBe(0);
+      expect(manifest.outputs.run_ui_tests).toBe("true");
+      expect(manifest.outputs.run_ui_e2e).toBe("true");
+    }
+  });
   it("isolates mutations between workflow fixtures", () => {
     const workflow = readCiWorkflow();
     const expected = structuredClone(workflow);
@@ -13371,7 +13453,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(uiE2e.permissions).toEqual({ contents: "read" });
     expect(uiE2e.needs).toEqual(["preflight"]);
     expect(uiE2e.if).toBe(
-      "needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'",
+      "needs.preflight.outputs.run_ui_e2e == 'true' && needs.preflight.outputs.compatibility_target != 'true'",
     );
     expect(uiE2e["runs-on"]).not.toBe(ui["runs-on"]);
     expect(uiE2e["timeout-minutes"]).toBe(25);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an ordinary Control UI unit-test-only PR repeats the full UI end-to-end workload. For example, #142282 changed one Activity page test teardown but selected all seven normal Chromium E2E jobs and the real-Gateway job in addition to its three UI unit jobs.

## Why This Change Was Made

CI now computes a separate E2E selection fact for ordinary current PRs. Existing, tracked, unshared unit-test entries under `ui/src` retain their unit coverage without repeating unrelated E2E jobs. The same fact drives dedicated test ownership, both E2E job conditions, and the aggregate gate.

The selector reuses the canonical UI test classifier and targeted import query. Shared tests, fixtures/helpers, browser/Node tests, production/build inputs, mixed changes, deleted or symlinked paths, and incomplete inventories retain E2E. The canonical query now includes root UI configuration files and the public service worker without recursively scanning UI cache or build directories.

## User Impact

Qualifying PRs can omit eight dedicated E2E jobs on the normal profile. All three UI unit jobs, performance checks, existing type/lint checks, and main/manual/frozen-target behavior remain intact. The full E2E matrix remains unchanged whenever selected; runner labels, shard counts and caches are unchanged.

Product runtime delta is zero. CI tooling/workflow grows by 77 lines to separate unit and E2E admission and verify entry ownership; tests add 168 net lines and documentation adds seven.

## Evidence

- The original manifest/job-condition regression selected E2E for the Activity unit-only change. Root build-config importer regressions exposed and verified the inventory/query boundary correction.
- Final focused proof: 34 passing cases, including tracked Git fixtures with an unshared negative control, application/E2E/build consumers, protected input families, main/manual/frozen contexts, and aggregate enforcement of the retained unit jobs.
- Required changed checks and workflow validation pass, including actionlint and zizmor. Independent P2 review found no actionable issues.
- An intermediate 1,145-test owner sweep passed before the final targeted-query refinement; it is not claimed as a final-source whole-suite run. Final focused tests and required checks cover the refined source.

The final entry query measured about three seconds locally. No query speedup or observed whole-PR time saving is claimed; the benefit is the verified omission of unrelated jobs for qualifying changes. This workflow/planner PR itself retains the broad validation workload, and exact-head CI must pass before landing.
