### PR TITLE
fix(diagnostics): defer recovery on observed loop stalls, not timer lateness

### DIFF
--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -646,14 +646,16 @@ export async function prepareGatewayLifecycle(params: {
       getConfig: getRuntimeConfig,
       startupGraceMs: 60_000,
       sampleLiveness: () => {
-        const sample = readinessEventLoopHealth.persistentDegradationSnapshot();
-        if (!sample || sample.degradedSinceMs == null) {
+        // Loop-delay evidence is fresh every tick; warning reasons need persistent degradation.
+        const sample = readinessEventLoopHealth.snapshot();
+        if (!sample) {
           return null;
         }
+        const persistent = readinessEventLoopHealth.persistentDegradationSnapshot();
         return {
-          reasons: sample.reasons,
+          reasons: persistent?.reasons ?? [],
           intervalMs: sample.intervalMs,
-          degradedSinceMs: sample.degradedSinceMs,
+          degradedSinceMs: persistent?.degradedSinceMs ?? undefined,
           eventLoopDelayP99Ms: sample.delayP99Ms,
           eventLoopDelayMaxMs: sample.delayMaxMs,
           eventLoopUtilization: sample.utilization,

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -506,7 +506,8 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
+    // No loop monitor reading: heartbeat lateness stays the only stall evidence.
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession, sampleLiveness: () => null });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     vi.setSystemTime(120_001);
@@ -516,7 +517,7 @@ describe("stuck session diagnostics threshold", () => {
     const delayedHeartbeat = loggerMessages(warnSpy).find((message) =>
       message.includes("liveness heartbeat delayed"),
     );
-    expect(delayedHeartbeat).toMatch(/overdue=\d+ms elapsed=\d+ms/u);
+    expect(delayedHeartbeat).toMatch(/overdue=\d+ms elapsed=\d+ms eventLoopDelayMaxMs=unknown/u);
     const timing = delayedHeartbeat?.match(/overdue=(\d+)ms elapsed=(\d+)ms/u);
     expect(Number(timing?.[2]) - Number(timing?.[1])).toBe(30_000);
     expect(recoverStuckSession).not.toHaveBeenCalled();
@@ -533,9 +534,13 @@ describe("stuck session diagnostics threshold", () => {
   it("defers a material heartbeat stall even when elapsed time is below the abort threshold", () => {
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    let eventLoopDelayMaxMs = 0;
 
     vi.setSystemTime(0);
-    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      sampleLiveness: () => ({ reasons: [], intervalMs: 30_000, eventLoopDelayMaxMs }),
+    });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
@@ -548,12 +553,18 @@ describe("stuck session diagnostics threshold", () => {
     });
     vi.advanceTimersByTime(10_000);
 
+    // The loop monitor recorded the 5s stall that made this tick late.
+    eventLoopDelayMaxMs = 5_000;
     vi.setSystemTime(35_000);
     vi.advanceTimersByTime(30_000);
 
-    expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expectLoggerMessageContaining(
+      warnSpy,
+      "eventLoopDelayMaxMs=5000; deferring recovery decisions",
+    );
     expect(recoverStuckSession).not.toHaveBeenCalled();
 
+    eventLoopDelayMaxMs = 0;
     vi.advanceTimersByTime(30_000);
 
     expectRecoveryCall(
@@ -594,6 +605,36 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("recovers on late heartbeat ticks when the event loop stayed responsive (#142200)", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    vi.setSystemTime(0);
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      // Reporter's WSL2 readings: the 30s timer wakes ~1.5s late while loop delay stays ~13ms.
+      sampleLiveness: () => ({
+        reasons: [],
+        intervalMs: 31_500,
+        eventLoopDelayP99Ms: 10,
+        eventLoopDelayMaxMs: 13,
+      }),
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    for (let tick = 0; tick < 3; tick += 1) {
+      vi.setSystemTime(Date.now() + 1_500);
+      vi.advanceTimersByTime(30_000);
+    }
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0 },
+      ["ageMs", "stateGeneration"],
+    );
+    expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
   });
 
   it("does not warn while a processing session continues reporting progress", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -122,6 +122,7 @@ type DiagnosticWorkSnapshot = {
 };
 
 type DiagnosticLivenessSample = {
+  /** Empty when the window was healthy; the heartbeat then uses only the loop-delay evidence. */
   reasons: DiagnosticLivenessWarningReason[];
   intervalMs: number;
   degradedSinceMs?: number;
@@ -347,9 +348,6 @@ function sampleDiagnosticLiveness(now: number): DiagnosticLivenessSample | null 
   }
   if (cpuCoreRatio >= DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN) {
     reasons.push("cpu");
-  }
-  if (reasons.length === 0) {
-    return null;
   }
 
   return {
@@ -1158,21 +1156,31 @@ export function startDiagnosticHeartbeat(
     lastDiagnosticHeartbeatTickAt = now;
     const heartbeatOverdueMs = Math.max(0, heartbeatElapsedMs - DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
     const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
-    // Observe ordinary timer jitter at the scheduled tick so it cannot consume
-    // a run's remaining recovery budget. Material lateness can also hide queued
-    // progress events, so the next healthy heartbeat owns recovery instead.
-    const recoveryObservationNow = now - heartbeatOverdueMs;
-    const shouldDeferRecovery = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
-    if (shouldDeferRecovery && !inStartupGrace) {
-      diag.warn(
-        `liveness heartbeat delayed: overdue=${Math.round(heartbeatOverdueMs)}ms elapsed=${Math.round(heartbeatElapsedMs)}ms; deferring recovery decisions`,
-      );
-    }
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot(now);
     const rawLivenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
     // Keep sampling during grace so event-loop delay baselines reset, but suppress startup-only reports.
-    const livenessSample = inStartupGrace ? null : rawLivenessSample;
+    const livenessSample =
+      inStartupGrace || !rawLivenessSample || rawLivenessSample.reasons.length === 0
+        ? null
+        : rawLivenessSample;
+    // Observe ordinary timer jitter at the scheduled tick so it cannot consume
+    // a run's remaining recovery budget. A stalled event loop can also hide queued
+    // progress events, so the next healthy heartbeat owns recovery instead.
+    // Timer lateness alone is not that evidence: VM hosts wake a 30s timer late while
+    // the loop stays responsive (#142200), so defer only when the loop monitor saw a
+    // matching stall. Without a monitor reading, lateness remains the only evidence.
+    const recoveryObservationNow = now - heartbeatOverdueMs;
+    const eventLoopDelayMaxMs = rawLivenessSample?.eventLoopDelayMaxMs;
+    const shouldDeferRecovery =
+      heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS &&
+      (eventLoopDelayMaxMs === undefined ||
+        eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS);
+    if (shouldDeferRecovery && !inStartupGrace) {
+      diag.warn(
+        `liveness heartbeat delayed: overdue=${Math.round(heartbeatOverdueMs)}ms elapsed=${Math.round(heartbeatElapsedMs)}ms eventLoopDelayMaxMs=${formatOptionalDiagnosticMetric(eventLoopDelayMaxMs)}; deferring recovery decisions`,
+      );
+    }
     const shouldEmitLivenessEvent =
       livenessSample !== null && shouldEmitDiagnosticLivenessEvent(now);
     const shouldEmitLivenessWarning =


### PR DESCRIPTION
Closes #142200

WIP draft: stuck-session recovery deferral keys off measured event-loop delay instead of heartbeat timer lateness. Body will be completed before marking ready.
