### PR TITLE
improve(read): avoid duplicate copies of matching text results

### DIFF
--- a/src/agents/sessions/tools/read.retention.test-support.ts
+++ b/src/agents/sessions/tools/read.retention.test-support.ts
@@ -3,7 +3,7 @@ import { setImmediate } from "node:timers/promises";
 import { createReadToolDefinition } from "./read.js";
 
 const mode = process.argv[2];
-assert.ok(mode === "line" || mode === "range" || mode === "cursor");
+assert.ok(mode === "line" || mode === "range" || mode === "cursor" || mode === "eof");
 const gc = globalThis.gc;
 assert.ok(gc, "The retention child requires --expose-gc");
 const inputUnits = 2 * 1024 * 1024;
@@ -22,7 +22,12 @@ const tool = createReadToolDefinition(process.cwd(), {
       const index = readIndex++ % 8;
       const bytes = Buffer.alloc(inputUnits * 2);
       bytes.fill(Buffer.from([65 + index, 0]));
-      bytes.write(`${line(index)}\n${line(index)}\n${line(index)}\n`, 0, "utf16le");
+      if (mode === "eof") {
+        const tail = `\n${line(index)}`;
+        bytes.write(tail, bytes.length - tail.length * 2, "utf16le");
+      } else {
+        bytes.write(`${line(index)}\n${line(index)}\n${line(index)}\n`, 0, "utf16le");
+      }
       return bytes;
     },
   },
@@ -36,7 +41,7 @@ async function makeResults() {
         `read-${index}`,
         {
           path: "synthetic-large.txt",
-          offset: mode === "range" ? 2 : 1,
+          offset: mode === "range" || mode === "eof" ? 2 : 1,
           limit: mode === "range" ? 2 : 1,
           ...(mode === "cursor" ? { cursor: 10 } : {}),
         },
@@ -68,6 +73,11 @@ for (const [index, result] of results.entries()) {
     mode === "range"
       ? `${line(index)}\n${line(index)}`
       : line(index).slice(mode === "cursor" ? 10 : 0);
+  if (mode === "eof") {
+    assert.deepEqual(result.details, { kind: "text", content: expected });
+    assert.deepEqual(result.content, [{ type: "text", text: expected }]);
+    continue;
+  }
   assert.equal(result.details?.kind, "truncated");
   assert.equal(result.details?.content, expected);
   assert.deepEqual(result.details?.continuation, {

--- a/src/agents/sessions/tools/read.retention.test.ts
+++ b/src/agents/sessions/tools/read.retention.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
 import { runNodeScript } from "../../../../test/helpers/run-node-script.js";
 
-it.for(["line", "range", "cursor"])(
+it.for(["line", "range", "cursor", "eof"])(
   "owns both output channels for a partial-file %s page",
   { timeout: 30_000 },
   async (mode, { signal }) => {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -603,10 +603,11 @@ export function createReadToolDefinition(
               if (textDetails) {
                 // A full-fit selection can still have a continuation and borrow the decoded file.
                 // Detach both bounded channels regardless of EOF, preserving exact UTF-16 units.
+                const sameContent = outputText === textDetails.content;
                 outputText = Buffer.from(outputText, "utf16le").toString("utf16le");
-                textDetails.content = Buffer.from(textDetails.content, "utf16le").toString(
-                  "utf16le",
-                );
+                textDetails.content = sameContent
+                  ? outputText
+                  : Buffer.from(textDetails.content, "utf16le").toString("utf16le");
               }
               content = [{ type: "text", text: outputText }];
             }


### PR DESCRIPTION
## What Problem This Solves

Complete text reads often return identical display text and structured content. The reader detaches both strings independently, repeating a UTF-16 Buffer roundtrip for the same page.

## Why This Change Was Made

Capture exact equality before detaching display text, then share that detached immutable string with structured content when they match. Continuation footers and blank-line summaries still detach each channel separately. This preserves the existing protection against small pages retaining a large decoded file. Production grows one line; the EOF retention case adds ten test/support lines.

## User Impact

Larger complete pages avoid a duplicate text copy, with unchanged content, paging, budgets and UTF-16 code units. The measured 24 KiB ASCII case improved in both orders. Smaller and unequal-channel cases are mixed; this is a workload-specific improvement, not a blanket read-tool or Gateway speedup.

## Evidence

All **86 tests in three whole suites passed on both baseline and candidate**, including the new EOF case. That test holds both channels from eight large decoded sources and performs GC before inspecting strings; existing retention limits and malformed-surrogate coverage remain intact. All **29 normal changed checks** passed. Independent Codex review through P2 found no actionable findings.

A fixed B0/C0/C1/B1 workload ran the actual wrapped read tool through **832 complete execute calls**, using synthetic public byte operations and the real decoder, page builder, queue, budgets and result normalization. Independent auditing checked all 2,504 journal events and 32 complete plain-data graph snapshots, including property order/descriptors, prototypes, references, strings and continuation metadata. Every returned snapshot matched its baseline counterpart. These snapshots are separate from the normal GC-retention proof; they do not measure per-object allocation or arbitrary class identity.

Observed medians in microseconds per call, computed from six means of four individually timed calls:

| Workload | Forward baseline → candidate | Reverse baseline → candidate |
| --- | --- | --- |
| Complete ASCII, 4 KiB | 89.693 → 76.537 (−14.67%) | 88.724 → 88.688 (−0.04%) |
| Complete ASCII, 24 KiB | 106.047 → 94.385 (−11.00%) | 107.282 → 89.141 (−16.91%) |
| Complete Unicode | 172.615 → 190.088 (+10.12%) | 197.583 → 180.745 (−8.52%) |
| EOF tail from a large source | 281.765 → 269.505 (−4.35%) | 303.448 → 278.026 (−8.38%) |
| Explicit line continuation | 119.255 → 106.208 (−10.94%) | 88.287 → 120.896 (+36.94%) |
| Cursor-capped page | 408.234 → 369.568 (−9.47%) | 368.995 → 355.646 (−3.62%) |
| Blank summary | 54.802 → 65.146 (+18.88%) | 48.844 → 57.969 (+18.68%) |
| Empty input | 58.500 → 55.156 (−5.72%) | 46.250 → 42.172 (−8.82%) |

The tradeoff is accepted for the larger complete-page benefit and the small, behavior-preserving implementation. All adverse results remain: 4/16 medians, 17/48 original summary metrics, 172/416 indexed calls and 3/10 process-resource comparisons. First and warmup observations were retained. No calibration, favorable rerun, row removal, statistical significance or population-tail claim.

Whole-child elapsed time was 13.313→11.528 seconds forward and 12.118→11.938 seconds reverse, including test/module startup and capture work. Process-tree peak RSS increased 0.88%/0.97%; no overall memory or startup improvement is inferred. The numerical fixture supplies bytes through public operations, so it does not measure real filesystem I/O, provider or Gateway latency. One low-disk preflight refusal made zero product calls and remains recorded; all four actual phases ran once, closed, and restored the candidate and uninstrumented test.

Local proof used Node 26.8.1 on macOS at base `1ff45cad`. Fresh exact-head CI remains the integration gate. No authorization, persistence, configuration, dependency or public API changes.
