### PR TITLE
refactor(plugins): share registration provenance types

### DIFF
--- a/src/plugins/registry-registrars-providers.ts
+++ b/src/plugins/registry-registrars-providers.ts
@@ -5,17 +5,13 @@ import type { EmbeddingProviderAdapter } from "./embedding-providers.js";
 import { normalizeRegisteredProvider } from "./provider-validation.js";
 import { canClaimReservedCommandOwnership } from "./registry-registrars-operations.js";
 import type { PluginRegistryState } from "./registry-state.js";
-import type { PluginRecord, PluginTextTransformsRegistration } from "./registry-types.js";
+import type {
+  PluginOwnedProviderRegistration,
+  PluginRecord,
+  PluginTextTransformsRegistration,
+} from "./registry-types.js";
 import type { CliBackendPlugin, ProviderPlugin, WorkerProvider } from "./types.js";
 import { validateWorkerProviderContract } from "./worker-provider-registry.js";
-
-type PluginOwnedProviderRegistration<T extends { id: string }> = {
-  pluginId: string;
-  pluginName?: string;
-  provider: T;
-  source: string;
-  rootDir?: string;
-};
 
 export function createProviderRegistrars(state: PluginRegistryState) {
   const {

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -101,28 +101,28 @@ type WebSearchProviderPlugin = import("./types.js").WebSearchProviderPlugin;
 type WorkerProvider = import("./types.js").WorkerProvider;
 type UnifiedModelCatalogProviderPlugin = import("./types.js").UnifiedModelCatalogProviderPlugin;
 
-/** Agent tool factory registered by one plugin runtime. */
-export type PluginToolRegistration = {
+/** Registration provenance; this shape carries no execution or resource authority. */
+type PluginRegistrationOwner = {
   pluginId: string;
   pluginName?: string;
+  source: string;
+  rootDir?: string;
+};
+
+/** Agent tool factory registered by one plugin runtime. */
+export type PluginToolRegistration = PluginRegistrationOwner & {
   factory: OpenClawPluginToolFactory;
   names: string[];
   declaredNames?: string[];
   optional: boolean;
   /** Loader-owned provenance. Missing values are conservative legacy registrations. */
   origin?: PluginOrigin;
-  source: string;
-  rootDir?: string;
 };
-type PluginCliRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginCliRegistration = PluginRegistrationOwner & {
   register: OpenClawPluginCliRegistrar;
   parentPath: string[];
   commands: string[];
   descriptors: OpenClawPluginCliRootCommandDescriptor[];
-  source: string;
-  rootDir?: string;
 };
 
 /** Gateway HTTP route registered by a plugin runtime. */
@@ -144,51 +144,31 @@ export type PluginHttpRouteRegistration = {
   source?: string;
 };
 
-type PluginHostedMediaResolverRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginHostedMediaResolverRegistration = PluginRegistrationOwner & {
   resolver: OpenClawPluginHostedMediaResolver;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginChannelRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginChannelRegistration = PluginRegistrationOwner & {
   plugin: ChannelPlugin;
   /** Exact record-bound runtime resolver captured when the active plugin registered the channel. */
   resolveChannelRuntime?: () => PluginRuntime["channel"];
   /** Loader-owned provenance. Missing values are conservative legacy registrations. */
   origin?: PluginOrigin;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginChannelSetupRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginChannelSetupRegistration = PluginRegistrationOwner & {
   plugin: ChannelPlugin;
   /** Loader-owned provenance. Missing values are conservative legacy registrations. */
   origin?: PluginOrigin;
-  source: string;
   enabled: boolean;
-  rootDir?: string;
 };
 
-type PluginModelCatalogProviderRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginModelCatalogProviderRegistration = PluginRegistrationOwner & {
   provider: UnifiedModelCatalogProviderPlugin;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginSessionCatalogRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginSessionCatalogRegistration = PluginRegistrationOwner & {
   provider: SessionCatalogProvider;
-  source: string;
-  rootDir?: string;
 };
 
 export type PluginDashboardDataBindingRegistration = PluginManifestDashboardDataBinding & {
@@ -209,29 +189,17 @@ export type PluginBoardWidgetContentKindRegistration = {
   definition: PluginBoardWidgetContentKind;
 };
 
-type PluginCliBackendRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginCliBackendRegistration = PluginRegistrationOwner & {
   builtWithOpenClawVersion?: string;
   backend: CliBackendPlugin;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginTextTransformsRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginTextTransformsRegistration = PluginRegistrationOwner & {
   transforms: PluginTextTransformRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginOwnedProviderRegistration<T extends { id: string }> = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginOwnedProviderRegistration<T extends { id: string }> = PluginRegistrationOwner & {
   provider: T;
-  source: string;
-  rootDir?: string;
 };
 
 type PluginSpeechProviderRegistration = PluginOwnedProviderRegistration<SpeechProviderPlugin>;
@@ -255,36 +223,24 @@ type PluginWebFetchProviderRegistration = PluginOwnedProviderRegistration<WebFet
 type PluginWebSearchProviderRegistration = PluginOwnedProviderRegistration<WebSearchProviderPlugin>;
 type PluginWorkerProviderRegistration = PluginOwnedProviderRegistration<WorkerProvider>;
 type PluginMigrationProviderRegistration = PluginOwnedProviderRegistration<MigrationProviderPlugin>;
-type PluginCodexAppServerExtensionFactoryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginCodexAppServerExtensionFactoryRegistration = PluginRegistrationOwner & {
   rawFactory: CodexAppServerExtensionFactory;
   factory: CodexAppServerExtensionFactory;
-  source: string;
-  rootDir?: string;
 };
-export type PluginAgentToolResultMiddlewareRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginAgentToolResultMiddlewareRegistration = PluginRegistrationOwner & {
   rawHandler: AgentToolResultMiddleware;
   handler: AgentToolResultMiddleware;
   runtimes: AgentToolResultMiddlewareRuntime[];
   scopes?: AgentToolResultMiddlewareScope[];
-  source: string;
-  rootDir?: string;
 };
 export type PluginAgentToolResultMiddlewareOwner = {
   pluginId: string;
   runtimes: AgentToolResultMiddlewareRuntime[];
   manifest: PluginManifestRecord;
 };
-type PluginAgentHarnessRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginAgentHarnessRegistration = PluginRegistrationOwner & {
   harness: AgentHarness;
   nativeCompaction?: AgentHarnessNativeCompaction;
-  source: string;
-  rootDir?: string;
 };
 
 type PluginHookRegistration = {
@@ -295,71 +251,39 @@ type PluginHookRegistration = {
   rootDir?: string;
 };
 
-export type PluginServiceRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginServiceRegistration = PluginRegistrationOwner & {
   service: OpenClawPluginService;
-  source: string;
   origin: PluginOrigin;
   trustedOfficialInstall?: boolean;
-  rootDir?: string;
 };
 
-export type PluginGatewayDiscoveryServiceRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginGatewayDiscoveryServiceRegistration = PluginRegistrationOwner & {
   service: OpenClawGatewayDiscoveryService;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginReloadRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginReloadRegistration = PluginRegistrationOwner & {
   registration: OpenClawPluginReloadRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginNodeHostCommandRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginNodeHostCommandRegistration = PluginRegistrationOwner & {
   command: import("./types.js").OpenClawPluginNodeHostCommand;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginNodeInvokePolicyRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginNodeInvokePolicyRegistration = PluginRegistrationOwner & {
   policy: import("./types.js").OpenClawPluginNodeInvokePolicy;
   pluginConfig?: Record<string, unknown>;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginWidgetPresenterRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginWidgetPresenterRegistration = PluginRegistrationOwner & {
   presenter: import("./plugin-registration.types.js").WidgetPresenter;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginSecurityAuditCollectorRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginSecurityAuditCollectorRegistration = PluginRegistrationOwner & {
   collector: OpenClawPluginSecurityAuditCollector;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginCommandRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginCommandRegistration = PluginRegistrationOwner & {
   command: OpenClawPluginCommandDefinition;
-  source: string;
-  rootDir?: string;
   trustedOwnerStatusExposure?: true;
 };
 
@@ -381,79 +305,43 @@ type PluginInteractiveHandlerRegistryRegistration = PluginInteractiveHandlerRegi
   pluginRoot?: string;
 };
 
-type PluginSessionExtensionRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginSessionExtensionRegistryRegistration = PluginRegistrationOwner & {
   extension: PluginSessionExtensionRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginTrustedToolPolicyRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginTrustedToolPolicyRegistryRegistration = PluginRegistrationOwner & {
   policy: PluginTrustedToolPolicyRegistration;
   origin?: PluginRecord["origin"];
-  source: string;
-  rootDir?: string;
 };
 
-type PluginToolMetadataRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginToolMetadataRegistryRegistration = PluginRegistrationOwner & {
   metadata: PluginToolMetadataRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginControlUiDescriptorRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginControlUiDescriptorRegistryRegistration = PluginRegistrationOwner & {
   descriptor: PluginControlUiDescriptor;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginRuntimeLifecycleRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginRuntimeLifecycleRegistryRegistration = PluginRegistrationOwner & {
   lifecycle: PluginRuntimeLifecycleRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginAgentEventSubscriptionRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginAgentEventSubscriptionRegistryRegistration = PluginRegistrationOwner & {
   subscription: PluginAgentEventSubscriptionRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginSessionSchedulerJobRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginSessionSchedulerJobRegistryRegistration = PluginRegistrationOwner & {
   job: PluginSessionSchedulerJobRegistration;
   generation?: number;
-  source: string;
-  rootDir?: string;
 };
 
-export type PluginSessionActionRegistryRegistration = {
-  pluginId: string;
-  pluginName?: string;
+export type PluginSessionActionRegistryRegistration = PluginRegistrationOwner & {
   action: PluginSessionActionRegistration;
-  source: string;
-  rootDir?: string;
 };
 
-type PluginConversationBindingResolvedHandlerRegistration = {
-  pluginId: string;
-  pluginName?: string;
+type PluginConversationBindingResolvedHandlerRegistration = PluginRegistrationOwner & {
   pluginRoot?: string;
   handler: (event: PluginConversationBindingResolvedEvent) => void | Promise<void>;
-  source: string;
-  rootDir?: string;
 };
 
 export type PluginRecord = {


### PR DESCRIPTION
Closes #142351

## What Problem This Solves

Thirty plugin registration types independently repeat the same provenance fields, and the provider registrar keeps another copy of its generic registration shape. This maintainer-requested consolidation removes those duplicate definitions.

## Why This Change Was Made

The existing registration aliases now share one private provenance type, and the provider registrar imports the existing generic provider shape from the internal registry module. Each payload, required/optional field and mutability contract is preserved. Partial HTTP and diagnostic shapes remain separate.

## User Impact

No runtime behavior change. Public SDK entrypoints and exported signatures are preserved; the complete change removes 117 production code lines (116 physical lines).

## Evidence

- Canonical changed-file gate passes, including production/test typechecks, lint, dead-export and runtime-cycle checks.
- Canonical SDK declaration generation and export-map synchronization pass. All 152 SDK entrypoints remain; the API renderer reports 113 expected reachable-declaration text changes from the shared type, with no direct exported signature changes.
- TypeScript emits byte-identical runtime JavaScript for both touched files.
- Fresh independent P0–P2 review is scoped-clean.

Validation used an isolated physical dependency installation. No runtime tests were added for this type-only change; the declaration build is not a full package artifact build.
