### PR TITLE
fix(ci): prevent mobile beta authorization archive failures

### DIFF
--- a/.github/actions/mobile-release-authority/authority.mjs
+++ b/.github/actions/mobile-release-authority/authority.mjs
@@ -417,11 +417,13 @@ async function releaseTooling(baseSha) {
     const stage = fs.mkdtempSync(
       path.join(process.env.RUNNER_TEMP ?? path.dirname(trustedRoot), "mobile-release-tooling-"),
     );
-    const archive = gitBuffer(trustedRoot, "archive", "--format=tar", baseSha, "--", "scripts");
-    runBuffer("tar", ["-xf", "-", "-C", stage], {
-      input: archive,
-      stdio: ["pipe", "pipe", "inherit"],
-    });
+    const archive = path.join(stage, "scripts.tar");
+    try {
+      git(trustedRoot, "archive", "--format=tar", `--output=${archive}`, baseSha, "--", "scripts");
+      runBuffer("tar", ["-xf", archive, "-C", stage]);
+    } finally {
+      fs.rmSync(archive, { force: true });
+    }
     releaseToolingPromises.set(
       baseSha,
       Promise.all([

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -201,6 +201,26 @@ if (gitArgs[0] === "remote" && gitArgs[1] === "get-url") {
 if (gitArgs[0] === "fetch" && !${JSON.stringify(realFetch)}) {
   process.exit(0);
 }
+if (gitArgs[0] === "archive" && process.env.GIT_ARCHIVE_MODE) {
+  const outputArgument = gitArgs.find((value) => value.startsWith("--output="));
+  if (!outputArgument) {
+    console.error("archive test mode requires disk-backed output");
+    process.exit(74);
+  }
+  const outputPath = outputArgument.slice("--output=".length);
+  if (process.env.GIT_ARCHIVE_MODE === "partial-failure") {
+    fs.writeFileSync(outputPath, "partial archive");
+    process.exit(75);
+  }
+  if (process.env.GIT_ARCHIVE_MODE === "corrupt-success") {
+    const result = spawnSync("/usr/bin/git", args, { stdio: "inherit" });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+    fs.writeFileSync(outputPath, "not a tar archive");
+    process.exit(0);
+  }
+  console.error("unknown archive test mode");
+  process.exit(76);
+}
 const result = spawnSync("/usr/bin/git", args, { stdio: "inherit" });
 process.exit(result.status ?? 1);
 `,
@@ -565,6 +585,24 @@ function readGhTrace(file: string): Array<{ args: string[]; token: string }> {
     .map((line) => JSON.parse(line) as { args: string[]; token: string });
 }
 
+function readGitTrace(file: string): string[][] {
+  return fs
+    .readFileSync(file, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as string[]);
+}
+
+function archiveSpoolPath(fixture: Fixture): string {
+  const archive = readGitTrace(fixture.gitLog).find((args) => args.includes("archive"));
+  const output = archive?.find((value) => value.startsWith("--output="));
+  if (!output) {
+    throw new Error("git archive did not use disk-backed output");
+  }
+  return output.slice("--output=".length);
+}
+
 function resetState(fixture: Fixture): void {
   fs.rmSync(fixture.stateDir, { recursive: true, force: true });
   fs.mkdirSync(fixture.stateDir);
@@ -773,6 +811,48 @@ describe("mobile release authority", () => {
     });
 
     expect(authorize(fixture).target_sha).toBe(fixture.targetSha);
+  });
+
+  it("authorizes when the trusted scripts archive exceeds the subprocess output buffer", () => {
+    const fixture = createFixture({
+      mutateBase(repository) {
+        writeFile(
+          repository,
+          "scripts/fixtures/unused-large-resource.txt",
+          "x".repeat(8 * 1024 * 1024 + 64 * 1024),
+        );
+      },
+    });
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readOutputs(fixture.outputPath)).toMatchObject({
+      approved: "true",
+      gateway_version: "2026.9.2",
+      target_ref: TARGET_REF,
+      target_sha: fixture.targetSha,
+    });
+    const spool = archiveSpoolPath(fixture);
+    expect(path.dirname(spool).startsWith(fixture.runnerTemp)).toBe(true);
+    expect(fs.existsSync(path.dirname(spool))).toBe(true);
+    expect(fs.existsSync(spool)).toBe(false);
+  });
+
+  it.each([
+    ["partial Git archive", "partial-failure"],
+    ["archive extraction", "corrupt-success"],
+  ] as const)("removes the disk-backed scripts archive after %s failure", (_label, mode) => {
+    const fixture = createFixture();
+
+    const result = runAuthority(fixture, "authorize", { GIT_ARCHIVE_MODE: mode });
+
+    expect(result.status).toBe(1);
+    expect(fs.readFileSync(fixture.outputPath, "utf8")).toBe("");
+    const spool = archiveSpoolPath(fixture);
+    expect(path.dirname(spool).startsWith(fixture.runnerTemp)).toBe(true);
+    expect(fs.existsSync(path.dirname(spool))).toBe(true);
+    expect(fs.existsSync(spool)).toBe(false);
   });
 
   it("rejects a forbidden code commit hidden by a later revert", () => {


### PR DESCRIPTION
Related: #142115

## What Problem This Solves

Fixes an issue where guarded iOS and Android beta release authorization failed before protected-environment entry when the trusted `scripts/` archive exceeded the authority process's 8 MiB stdout buffer.

The two preserved failed runs stopped in authorization with `spawnSync git ENOBUFS`; protected release jobs were skipped, and no deployment, artifact, upload, or immutable release ref was created:

- https://github.com/openclaw/openclaw/actions/runs/34250129692
- https://github.com/openclaw/openclaw/actions/runs/34250211009

## Why This Change Was Made

The authority now asks native `git archive` to write `scripts.tar` inside its existing private tooling stage, extracts it only after Git succeeds, and removes only that transient spool in `finally`. The trusted Tooling SHA, complete `scripts` path, cached import stage, subprocess limits, metadata bounds, and all authority/receipt/ref policy remain unchanged.

The regression harness covers the original oversized archive, a partial Git archive failure, and an extraction failure. Both failure paths retain the private stage but remove the spool and emit no authorization output.

## User Impact

Mobile beta release operators can authorize an exact guarded candidate even when trusted release tooling grows beyond the subprocess capture limit. This repair does not alter the frozen mobile candidate and does not authorize App Review, production promotion, or a release retry.

## Evidence

- Red: `test/scripts/mobile-release-authority.test.ts` passed 51/54; the oversized trusted archive failed exactly at `spawnSync git ENOBUFS`, and both cleanup cases proved the old flow had no disk-backed spool.
- Green: focused authority suite 54/54.
- Green: archive boundary regressions 3/3 after formatting.
- Green: targeted test-root oxlint, `node --check`, `oxfmt --check`, conflict-marker check, privacy scan, and `git diff --check`.
- `check:changed` passed 11 stages, then stopped at the expected worktree-only `tsgo` admission guard because the required shared `node_modules` symlink points outside the checkout. No install or dependency workaround was performed; exact-head hosted CI owns clean-install typecheck proof.
- Fresh P1 autoreview: scoped clean, no findings, confidence 0.98.
- Diff: production/tooling `+7/-5` (`+2 net`); tests `+80/-0`.
