### PR TITLE
fix(memory-core): verify doctor readiness on continuously written agent databases

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -805,6 +805,8 @@ Asynchronous agent-database admission and maintenance run their initial full-fil
 
 The integrity child and both asynchronous and synchronous read-only snapshot workers share a lifetime budget: 30 seconds for startup and shutdown plus one second per 32 MiB of source database file size, rounded up, capped at 30 minutes. A full copy or full scan reads the whole file at least once; the budget allows for a conservative cold-cache read rate of 32 MiB/s. A 9.4 GiB database gets 331 seconds. Budgets above 30 seconds are logged once per call at debug level with the operation, path, size, and applied budget, keeping ordinary CLI output quiet. If the snapshot worker cannot stat the source, it uses the 30-second base budget and lets the child report the underlying error.
 
+The synchronous byte-neutral snapshot strategy is for small or quiescent databases. Inspections of a live agent database, including memory-core readiness, use the asynchronous online-backup worker.
+
 Integrity-child timeout and incomplete-exit errors include `lastObservedPhase`:
 
 | Value             | Last observation                                                                          |

--- a/extensions/memory-core/src/doctor-health.test.ts
+++ b/extensions/memory-core/src/doctor-health.test.ts
@@ -1,13 +1,17 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { HealthCheck, HealthCheckContext } from "openclaw/plugin-sdk/health";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   MEMORY_MANAGED_LOCAL_EMBEDDING_SETUP_CHECK_ID,
   registerMemoryCoreDoctorChecks,
 } from "./doctor-health.js";
+import { collectVectorProviderFindings } from "./doctor-vector-index-provider.js";
 
 type InspectManagedLocalEmbeddingSetup = Parameters<
   typeof registerMemoryCoreDoctorChecks
@@ -277,7 +281,7 @@ describe("managed local embedding setup health check", () => {
     },
   );
 
-  it("reads an active WAL index without changing the live SQLite family", async () => {
+  it("reads an active WAL index without changing committed database or WAL bytes", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-setup-live-wal-"));
     roots.add(stateDir);
     const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -296,7 +300,8 @@ describe("managed local embedding setup health check", () => {
           "memory_index_meta_v1",
           JSON.stringify({ model: "embeddinggemma-300m", vectorDims: 768 }),
         );
-      const familyPaths = ["", "-wal", "-shm"].map((suffix) => `${databasePath}${suffix}`);
+      // Ordinary SQLite readers may update read marks in the shared-memory sidecar.
+      const familyPaths = ["", "-wal"].map((suffix) => `${databasePath}${suffix}`);
       const before = await Promise.all(familyPaths.map(async (file) => await fs.readFile(file)));
       const check = captureCheck(async (params) => ({
         provider: params.provider,
@@ -316,6 +321,89 @@ describe("managed local embedding setup health check", () => {
       writer.close();
     }
   });
+
+  it("verifies the stored vector model while the live agent database receives continuous commits", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-readiness-writer-"));
+    roots.add(stateDir);
+    const model = "embeddinggemma-300m";
+    const databasePath = await createSemanticIndex(stateDir, model);
+    const seed = openNodeSqliteDatabase(databasePath);
+    try {
+      // A 64 MiB main file makes a raw copy overlap many real WAL commits.
+      seed.exec(`
+        CREATE TABLE payloads (value BLOB NOT NULL) STRICT;
+        WITH RECURSIVE rows(n) AS (VALUES(1) UNION ALL SELECT n + 1 FROM rows WHERE n < 1024)
+        INSERT INTO payloads SELECT zeroblob(65536) FROM rows;
+        CREATE TABLE heartbeat (value INTEGER NOT NULL) STRICT;
+        INSERT INTO heartbeat VALUES (0);
+      `);
+    } finally {
+      seed.close();
+    }
+
+    // A separate process keeps committing even when a synchronous inspector blocks Node.
+    const writer = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `
+      import { DatabaseSync } from "node:sqlite";
+      const db = new DatabaseSync(process.argv[1]);
+      db.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0; PRAGMA synchronous = NORMAL;");
+      const write = db.prepare("UPDATE heartbeat SET value = value + 1");
+      write.run();
+      setInterval(() => write.run(), 1);
+      process.stdout.write("ready\\n");
+      setTimeout(() => process.exit(2), 25000);
+    `,
+        databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    writer.stderr.setEncoding("utf8").on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    const closed = once(writer, "close");
+    try {
+      await Promise.race([
+        once(writer.stdout, "data"),
+        closed.then(() => {
+          throw new Error(`SQLite writer exited before readiness: ${stderr}`);
+        }),
+      ]);
+      const checkContext = context(stateDir, "local");
+      const config = checkContext.cfg;
+      const env = checkContext.env!;
+      const check = captureCheck(async () => null);
+      await expect(check.detect(checkContext)).resolves.toEqual([]);
+      await expect(
+        collectVectorProviderFindings({ config, env, stateDir }, async () => ({
+          provider: "local",
+          reason: "Synthetic provider setup requirement",
+        })),
+      ).resolves.toEqual([
+        {
+          agentId: "main",
+          model,
+          provider: "local",
+          configPrefix: "memory.search",
+          reason: "Synthetic provider setup requirement",
+        },
+      ]);
+      expect(writer.exitCode).toBeNull();
+      const reader = openNodeSqliteDatabase(databasePath, { readOnly: true });
+      try {
+        expect(reader.prepare("SELECT value FROM heartbeat").get()?.value).toBeGreaterThan(1);
+      } finally {
+        reader.close();
+      }
+    } finally {
+      writer.kill();
+      await closed;
+    }
+  }, 30_000);
 
   it("returns a structured non-ready result when an agent database cannot be inspected", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-setup-unreadable-"));

--- a/extensions/memory-core/src/doctor-vector-index-provider.ts
+++ b/extensions/memory-core/src/doctor-vector-index-provider.ts
@@ -36,14 +36,17 @@ async function readExistingVectorModel(databasePath: string): Promise<string | n
   if (!fs.existsSync(databasePath)) {
     return null;
   }
-  const { openNodeSqliteDatabase, prepareSqliteReadOnlyLocationSync } =
+  const { openNodeSqliteDatabase, prepareSqliteReadOnlyLocation } =
     await import("openclaw/plugin-sdk/sqlite-runtime");
-  let prepared: ReturnType<typeof prepareSqliteReadOnlyLocationSync> | undefined;
+  let prepared: Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>> | undefined;
   let db: ReturnType<typeof openNodeSqliteDatabase> | undefined;
   let failure: unknown;
   let model: string | null = null;
   try {
-    prepared = prepareSqliteReadOnlyLocationSync(databasePath);
+    // The live agent database is written continuously; a byte-neutral raw copy needs
+    // a quiescent WAL and cannot stabilize on a multi-GB live database. Online backup
+    // holds an ordinary read transaction, like every Gateway reader.
+    prepared = await prepareSqliteReadOnlyLocation(databasePath);
     db = openNodeSqliteDatabase(prepared.location, { readOnly: true });
     const table = db
       .prepare(

--- a/src/plugin-sdk/sqlite-runtime.ts
+++ b/src/plugin-sdk/sqlite-runtime.ts
@@ -20,7 +20,10 @@ export {
   sqliteStringSet,
 } from "../infra/kysely-sync.js";
 export { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-export { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+export {
+  prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocationSync,
+} from "../infra/sqlite-readonly-location.js";
 export {
   runSqliteImmediateTransaction,
   runSqliteImmediateTransactionSync,


### PR DESCRIPTION
Related: #142179

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --lint --all` on a live Gateway with a large agent database would receive `memory-core/managed-local-embedding-setup` readiness failures because the SQLite source did not stabilize for read-only inspection.

## Why This Change Was Made

Memory-core now awaits the existing online-backup snapshot worker through the existing `sqlite-runtime` SDK entrypoint. Its ordinary SQLite read transaction supports concurrent Gateway commits; the synchronous byte-neutral raw-copy strategy requires a quiescent WAL. Read-only opening, cleanup's boolean contract, and error reporting remain unchanged.

The database reference documents which strategy to use. No loader, worker, budget, schema, or other caller changes are included.

## User Impact

Doctor can verify memory-core semantic-index readiness while a live Gateway continuously writes a large agent database. This follows up on the shared worker-budget change in #142179 by selecting the appropriate existing snapshot strategy.

## Evidence

- Maintainer-provided live measurements on a 10.3 GB agent database: the release's synchronous in-process preparer failed after 73 seconds with cause `SQLite WAL changed while copying`; its asynchronous online-backup preparer succeeded in 19.1 seconds. These are the supplied production measurements, not a new production run by this PR.
- A real extension-level regression uses a 64 MiB agent database and an independent process committing every millisecond. With the original call site it failed with `Memory Core semantic-index readiness could not be verified (SQLite read-only worker SQLite source did not stabilize for read-only inspection: <temporary agent database>).`
- With the fix, the final regression passed five consecutive full doctor-suite runs (regression timings: 1.015, 0.884, 1.656, 1.390, and 3.293 seconds; all 14 doctor tests passed each time). It verifies readiness and independently verifies the stored model in a provider finding. No snapshot or filesystem mocks are used.
- The existing static-WAL test still verifies unchanged database and WAL bytes. It permits ordinary SQLite read-mark changes in the SHM coordination file, matching the requested online-backup contract.
- SDK export and surface checks passed with no generated updates. The canonical offline API renderer and diff found no public SDK API changes. The normal committed-revision wrapper installs dependencies; the offline renderer honored the instruction not to reinstall.
- Requested suites passed: `node scripts/run-vitest.mjs extensions/memory-core src/infra/sqlite-readonly-location.copy.test.ts src/infra/sqlite-readonly-worker.test.ts src/plugin-sdk` — 3,440 passed, 21 skipped across six shards (303 files passed, two skipped), 278.46 seconds.
- Core and extension typechecking, extension-test typechecking, targeted lint, formatting, and declaration boundaries passed. The broad suite preceded a test-only IPC-to-stdout typing correction; the final doctor suite and extension-test typecheck were rerun afterward.
- `node scripts/check-changed.mjs` stopped on a pre-existing core-test type error: `ui/src/pages/model-providers/catalog-discovery.ts:94`, TS2353, `refreshIfDue` is not accepted by `loadModelCatalog`. Both UI files were unchanged from the branch base and then-current `origin/main`. All remaining selected checks passed separately. The unrelated UI repair subsequently landed in #142346 and is present in the native review main baseline; exact-head CI run [34255029237](https://github.com/openclaw/openclaw/actions/runs/34255029237) passed with zero job reruns.
- Independent Codex autoreview: scoped-clean, no accepted/actionable P0/P1 findings. ClawSweeper also found no actionable or security findings.

## Known Gaps

Other synchronous callers inspect the small state database and remain outside this change. The byte-neutral strategy does not scale to large, continuously written databases; improvements to that strategy remain follow-up work for its owner. No new live-Gateway run or local package build was performed for this change.
