### PR TITLE
fix(memory): use the fallback provider's embedding model

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -292,6 +292,50 @@ describe("createEmbeddingProvider", () => {
     },
   );
 
+  it.each([
+    { name: "fallback that serves its own model", fallbackDefaultModel: "nomic-embed-text" },
+    { name: "fallback without a default model", fallbackDefaultModel: undefined },
+  ])("hands the creation fallback the model it serves: $name", async ({ fallbackDefaultModel }) => {
+    const primaryModel = "text-embedding-3-small";
+    const fallbackCreate = vi.fn<MemoryEmbeddingProviderAdapter["create"]>(async ({ model }) => ({
+      provider: {
+        id: "ollama",
+        model,
+        embed: async () => [1],
+        embedBatch: async (texts) => texts.map(() => [1]),
+      },
+    }));
+    registerTestMemoryAdapter({
+      id: "openai",
+      defaultModel: primaryModel,
+      create: async () => {
+        throw new Error("synthetic primary provider unavailable");
+      },
+    });
+    registerTestMemoryAdapter({
+      id: "ollama",
+      ...(fallbackDefaultModel ? { defaultModel: fallbackDefaultModel } : {}),
+      create: fallbackCreate,
+    });
+
+    const options = { ...createOptions("openai"), model: primaryModel, fallback: "ollama" };
+    const result = await createEmbeddingProvider(options);
+
+    // The configured model names the primary provider. Both fallback entry points must
+    // agree on what the fallback is asked to serve.
+    const runtimeActivationModel = resolveEmbeddingProviderFallbackModel(
+      "ollama",
+      primaryModel,
+      options.config,
+    );
+    const expectedModel = fallbackDefaultModel ?? primaryModel;
+    expect(runtimeActivationModel).toBe(expectedModel);
+    expect(fallbackCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "ollama", model: expectedModel }),
+    );
+    expect(result.provider?.model).toBe(expectedModel);
+  });
+
   it("does not run priority-based auto-selection after a skippable setup failure", async () => {
     registerTestMemoryAdapter(createMissingCredentialsAdapter({ autoSelectPriority: 10 }));
     registerTestMemoryAdapter({

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -152,6 +152,12 @@ export async function createEmbeddingProvider(
         const fallbackResult = await createWithAdapter(fallbackAdapter, {
           ...options,
           provider: options.fallback,
+          // The configured model names the primary provider; the fallback serves its own.
+          model: resolveEmbeddingProviderFallbackModel(
+            options.fallback,
+            options.model,
+            options.config,
+          ),
           remote: resolveEmbeddingProviderFallbackRemote(options.remote),
         });
         return {


### PR DESCRIPTION
## What Problem This Solves

A creation-time embedding fallback kept the primary provider's model. With OpenAI configured as `text-embedding-3-small` and unavailable credentials, Ollama received that OpenAI model instead of its own `nomic-embed-text` default. Memory indexing failed with a model-not-found response, leaving search without a usable index.

## Why This Change Was Made

Use the existing `resolveEmbeddingProviderFallbackModel` decision at creation time, as runtime fallback already does. Keep primary endpoint and credential scrubbing. A fallback without a declared default still receives the configured source model.

## User Impact

Memory indexing and search can continue on the configured fallback. Existing index-identity checks remain enforced: compatible indexes can be reused, and an incompatible index reports a warning until the operator requests a rebuild. No schema, stored format, configuration option, provider registration, retry count or fallback order changes.

## Evidence

The real source CLI ran with the bundled Memory Core/OpenAI/Ollama adapters and a loopback peer. Commands were `memory index --force --agent main`, `memory search ... --agent main --json`, and `memory status --deep --agent main --json`.

| Public result | Pinned main | Candidate |
| --- | --- | --- |
| Model sent to Ollama | `text-embedding-3-small` | `nomic-embed-text` |
| Index outcome | HTTP 404; exit 1 | One memory file indexed; exit 0 |
| Search | Empty, with stale-index warning | Stored marker retrieved; vector score 1 |
| Deep status | Missing index; embedding probe fails | Effective Ollama/default model; valid four-dimensional index |

Actual candidate status fields, with paths and identifiers removed:

```json
{
  "provider": "ollama",
  "model": "nomic-embed-text",
  "requestedProvider": "openai",
  "indexIdentity": { "status": "valid" },
  "embeddingProbe": { "ok": true }
}
```

Compatibility and boundary controls:

- A compatible Ollama index stayed valid after switching to creation-time fallback. Normal indexing made no document-embedding request.
- An index built for another model produced an explicit model-mismatch warning and rebuild command. `memory index --force` rebuilt it with the fallback default; search then returned the stored marker.
- The source memory files survived. A separate main-rebuild probe left all 63 tables and the database bytes of an unrelated sentinel agent unchanged; that agent still returned its marker.
- Real runtime fallback also requested `nomic-embed-text`. Its primary bearer and primary-only header were absent from the fallback request. A fresh status-only process still probes its configured primary; sticky runtime fallback across separate status processes is not claimed.
- 57 focused embedding/provider/index tests passed. The new default-model regression failed on original main for the intended wrong-model argument; the no-default control passed. Two additional boundary probes passed for both-provider error composition, original cause, one attempt per provider and unknown-fallback rejection.

The peer returns vectors only, not search text. The retrieved marker comes from the indexed file; fixed vectors do not prove semantic model quality. Hybrid retrieval keeps its maintained defaults. Complete source, request, command, index and preservation evidence is retained for exact-head review. The contributor's original real-adapter transport evidence remains preserved.

AI-assisted. Contributor implementation and credit retained.

Independent acceptance exercised fresh memory content, two queries, runtime fallback, index reuse/rebuild, and negative fallback settings. It reported 12 passes, one status finding, and five interface or final-gate limitations. Source and adapter-boundary proof cover the internal contracts. The status finding also reproduces on pinned main: after runtime fallback indexing, a new deep-status process probes the configured primary while search adopts the working fallback index. That separate diagnostic lifecycle remains a follow-up; the prescribed missing-credential creation-fallback status reports the correct provider and valid index. The original failed assessment is retained with the scope decision and full evidence.
