### PR TITLE
refactor(tests): size Telegram markdown fixture for the text limit

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1815,7 +1815,7 @@ describe("sendMessageTelegram", () => {
 
   it("chunks markdown above the Telegram text-message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 54, chat: { id: "123" } });
-    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
+    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(200)}`;
 
     await sendMessageTelegram("123", markdown, {
       cfg: TELEGRAM_TEST_CFG,
@@ -1827,6 +1827,9 @@ describe("sendMessageTelegram", () => {
     const joinedChunks = chunks.join("");
     expect(joinedChunks).toContain("Long");
     expect(joinedChunks).toContain("section");
+    expect(joinedChunks.match(/<b>section<\/b>/g)).toHaveLength(200);
+    expect(joinedChunks.match(/<i>style<\/i>/g)).toHaveLength(200);
+    expect(joinedChunks.match(/<code>code<\/code>/g)).toHaveLength(200);
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
     expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What Problem This Solves

The default Telegram text chunking test still repeats its formatted input 3,000 times, inherited from an older 32,768-character rich-message limit. It now tests the 4,000-character HTML path, where that input performs far more rendering work than the boundary requires.

## Why This Change Was Made

Use 200 repetitions, still 7,208 Markdown characters and over 4,000 visible characters. Keep every existing assertion and add exact counts for all 200 bold, italic, and code spans. Large inline, fenced, paragraph, and HTTP delivery sibling tests remain unchanged.

## User Impact

No production behavior changes. The test retains message splitting and payload-limit coverage while checking formatted content preservation more thoroughly.

## Evidence

- Full send suite: 276/276 before and after, identical ordered case names and results, no skips. Renderer and real HTTP siblings: 151/151.
- Mapped changed gate and fresh independent P2 review passed without findings.
- In one local comparison, the target case took 23.86s before and 1.49s after. Full wrapper time was 62.82s versus 28.82s; preparation was 5.48s versus 5.21s. The larger wrapper difference is not attributed solely to this fixture, and no global suite speedup is claimed.

The change adds three test lines for stronger assertions.
