### PR TITLE
fix(cli): inspect the agent model catalog without readding excluded rows

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -127,6 +127,8 @@ A good infer-based skill maps common user intents to the right subcommand, inclu
 
 Text inference and model/provider inspection.
 
+`model list`, `model inspect`, and `model providers` read the selected agent's model catalog. They preserve configured model details and exclude models outside that catalog. Use `infer model --agent <id> list --json` or `infer model --agent <id> inspect --model <provider/model> --json` to select an agent. Provider counts use the same inventory.
+
 ```bash
 openclaw infer model run --prompt "Reply with exactly: smoke-ok" --json
 openclaw infer model run --prompt "Summarize this changelog entry" --model openai/gpt-5.4 --json

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -6,6 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
 import type { inspectLocalAudioSelection } from "../media-understanding/local-audio.js";
 import { registerCapabilityCli } from "./capability-cli.js";
 import { CAPABILITY_METADATA } from "./capability-cli/metadata.js";
@@ -929,7 +930,14 @@ describe("capability cli", () => {
         entries: { main: {}, work: {} },
       },
     });
-    const workModel = { provider: "catalog-fixture", id: "work-model", name: "Work model" };
+    const workModel: ModelCatalogEntry = {
+      provider: "catalog-fixture",
+      id: "work-model",
+      name: "Work model",
+      contextWindow: 24576,
+      reasoning: false,
+      input: ["text", "image"],
+    };
     mocks.loadModelCatalog.mockImplementation(async (params) =>
       params?.agentId === "work"
         ? [workModel]
@@ -1172,32 +1180,40 @@ describe("capability cli", () => {
     });
   });
 
-  it("inspects runtime-declared manifest models without live discovery", async () => {
-    mocks.loadModelCatalog.mockResolvedValueOnce([] as never);
-    mocks.planEffectiveModelCatalogRows.mockReturnValueOnce({
-      rows: [
-        {
-          provider: "openai",
-          id: "gpt-5.6-sol",
-          name: "GPT-5.6 Sol",
-          ref: "openai/gpt-5.6-sol",
-          mergeKey: "openai/gpt-5.6-sol",
-          source: "manifest",
-          input: ["text"],
-          reasoning: true,
-          status: "available",
-        },
-      ],
-      entries: [],
-      conflicts: [],
-    });
+  it.each(["list", "inspect", "providers"])(
+    "keeps excluded manifest models out of infer model %s",
+    async (command) => {
+      mocks.loadModelCatalog.mockResolvedValue([]);
+      mocks.planEffectiveModelCatalogRows.mockReturnValue({
+        rows: [
+          {
+            provider: "cerebras",
+            id: "gpt-oss-120b",
+            name: "GPT OSS 120B",
+            ref: "cerebras/gpt-oss-120b",
+            mergeKey: "cerebras::gpt-oss-120b",
+            source: "manifest",
+            input: ["text"],
+            reasoning: true,
+            status: "available",
+          },
+        ],
+        entries: [],
+        conflicts: [],
+      });
 
-    await runCap("capability", "model", "inspect", "--model", "openai/gpt-5.6-sol", "--json");
-
-    expect(firstJsonOutput()).toEqual(
-      expect.objectContaining({ provider: "openai", id: "gpt-5.6-sol" }),
-    );
-  });
+      if (command === "inspect") {
+        await expect(
+          runCap("infer", "model", command, "--model", "cerebras/gpt-oss-120b", "--json"),
+        ).rejects.toThrow("exit 1");
+        expectRuntimeErrorContains("Model not found: cerebras/gpt-oss-120b");
+        expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+      } else {
+        await runCap("infer", "model", command, "--json");
+        expect(mocks.runtime.writeJson).toHaveBeenCalledWith([]);
+      }
+    },
+  );
 
   it("defaults model run to local transport", async () => {
     await runCapability("model", "run", "--prompt", "hello", "--json");

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -31,8 +31,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
 import { ADMIN_SCOPE } from "../../gateway/operator-scopes.js";
 import { convertHeicToJpeg } from "../../media/media-services.js";
-import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
-import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
@@ -62,19 +60,7 @@ async function loadModelCatalogForInspection(cfg: OpenClawConfig, rawAgentId?: s
   const agentId =
     rawAgentId === undefined ? undefined : resolveCapabilityProviderAgentId(cfg, rawAgentId);
   const prepared = await loadPreparedModelCatalog({ config: cfg, agentId, readOnly: true });
-  const metadataSnapshot = loadManifestMetadataSnapshot({ config: cfg, env: process.env });
-  const manifest = planEffectiveModelCatalogRows({
-    registry: metadataSnapshot.manifestRegistry,
-    config: cfg,
-  }).rows;
-  const entries = new Map<string, (typeof prepared)[number] | (typeof manifest)[number]>();
-  for (const entry of manifest) {
-    entries.set(`${entry.provider}\0${entry.id}`, entry);
-  }
-  for (const entry of prepared) {
-    entries.set(`${entry.provider}\0${entry.id}`, entry);
-  }
-  return [...entries.values()].toSorted(
+  return prepared.toSorted(
     (a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id),
   );
 }


### PR DESCRIPTION
Related: #136257, #141859.

## What Problem This Solves

Fixes an issue where model inspection commands showed manifest models excluded from the selected agent’s prepared catalog. One configuration listed three models normally but 292 through inference inspection.

## Why This Change Was Made

Use the prepared catalog directly for model listing, inspection and provider listing. Remove the extra manifest load and merge while preserving selected-agent scope, sorting, model details and provider flags.

## User Impact

Inspection commands agree with model listing and retain authored metadata, empty output and existing errors.

Consumers: inference model list, inspect and provider commands use prepared inventory.

## Evidence

Compiled command-line checks returned the same three models, or four with an authored row, and matching provider counts. Excluded-model inspection and unknown-agent selection retained their errors; configuration bytes were unchanged. Three regressions failed before the fix and 76 focused tests passed. No external inference or operator credentials were used.
