### PR TITLE
fix(matrix): keep escaped mentions literal after unmatched backticks

### DIFF
--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -543,6 +543,16 @@ describe("markdownToMatrixHtml", () => {
       html: "<p>`literal then @alice:example.org</p>",
     },
     {
+      name: "keeps escaped mentions literal after unmatched backticks",
+      markdown: "`literal then \\@alice:example.org",
+      html: "<p>`literal then @alice:example.org</p>",
+    },
+    {
+      name: "keeps escaped room mentions literal after unmatched double backticks",
+      markdown: "``literal then \\@room",
+      html: "<p>``literal then @room</p>",
+    },
+    {
       name: "restores escaped mentions in markdown link labels without linking them",
       markdown: "[\\@alice:example.org](https://example.com)",
       html: '<p><a href="https://example.com">@alice:example.org</a></p>',

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -10,13 +10,11 @@ import {
 } from "openclaw/plugin-sdk/text-chunking";
 import {
   createMatrixPrivateMarkers,
-  isMarkdownEscaped,
   MATRIX_FORMAT_PROFILE,
   projectMatrixMarkdown,
 } from "./format-profile.js";
 import type { MatrixSpoilerMarkers, MatrixSpoilerProtection } from "./format-profile.js";
 import {
-  findMatrixMarkdownMetadataRanges,
   findMatrixSpoilerDelimiterOffsets,
   hasMatrixSpoilerMetadataCollision,
 } from "./format-spoiler-ranges.js";
@@ -129,6 +127,12 @@ md.renderer.rules.image = (tokens, idx, options, env, self) => {
 md.renderer.rules.html_block = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
 md.renderer.rules.html_inline = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
 md.renderer.rules.text_special = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
+md.renderer.rules.matrix_escaped_mention = () => "@";
+md.core.ruler.before("text_join", "matrix_escaped_mentions", (state) => {
+  // Preserve the parser's escape decision before text_join erases it; otherwise
+  // literal IDs become mentions when their surrounding Markdown is incomplete.
+  preserveEscapedMentionTokens(state.tokens);
+});
 md.renderer.rules.link_open = (tokens, idx, _options, _env, self) =>
   shouldSuppressAutoLink(tokens, idx) ? "" : self.renderToken(tokens, idx, _options);
 md.renderer.rules.link_close = (tokens, idx, _options, _env, self) => {
@@ -139,60 +143,13 @@ md.renderer.rules.link_close = (tokens, idx, _options, _env, self) => {
   return self.renderToken(tokens, idx, _options);
 };
 
-function maskEscapedMentions(markdown: string): { markdown: string; marker?: string } {
-  let masked = "";
-  let idx = 0;
-  let codeFenceLength = 0;
-  let marker: string | undefined;
-  const metadataRanges = markdown.includes("\\@") ? findMatrixMarkdownMetadataRanges(markdown) : [];
-
-  while (idx < markdown.length) {
-    if (markdown[idx] === "`" && !isMarkdownEscaped(markdown, idx)) {
-      let runLength = 1;
-      while (markdown[idx + runLength] === "`") {
-        runLength += 1;
-      }
-      if (codeFenceLength === 0) {
-        codeFenceLength = runLength;
-      } else if (runLength === codeFenceLength) {
-        codeFenceLength = 0;
-      }
-      masked += markdown.slice(idx, idx + runLength);
-      idx += runLength;
-      continue;
-    }
-    if (
-      codeFenceLength === 0 &&
-      markdown[idx] === "\\" &&
-      markdown[idx + 1] === "@" &&
-      !metadataRanges.some((range) => idx >= range.start && idx < range.end)
-    ) {
-      marker ??= createMatrixPrivateMarkers(
-        markdown,
-        "Matrix mention formatting exhausted its private marker pool",
-      ).open;
-      masked += marker;
-      idx += 2;
-      continue;
-    }
-    masked += markdown[idx] ?? "";
-    idx += 1;
-  }
-
-  return { markdown: masked, ...(marker ? { marker } : {}) };
-}
-
-function restoreEscapedMentions(text: string, marker?: string, inCode = false): string {
-  return marker ? text.replaceAll(marker, inCode ? "\\@" : "@") : text;
-}
-
-function restoreEscapedMentionsInBlockTokens(tokens: MarkdownToken[], marker?: string): void {
-  if (!marker) {
-    return;
-  }
+function preserveEscapedMentionTokens(tokens: MarkdownToken[]): void {
   for (const token of tokens) {
-    if ((token.type === "fence" || token.type === "code_block") && token.content) {
-      token.content = restoreEscapedMentions(token.content, marker, true);
+    if (token.type === "text_special" && token.info === "escape" && token.content === "@") {
+      token.type = "matrix_escaped_mention";
+    }
+    if (token.children) {
+      preserveEscapedMentionTokens(token.children);
     }
   }
 }
@@ -414,11 +371,8 @@ function mutateInlineTokensWithMentions(params: {
   userIds: string[];
   seenUserIds: Set<string>;
   selfUserId: string | null;
-  escapedMentionMarker?: string;
 }): { children: MarkdownInlineToken[]; roomMentioned: boolean } {
   const nextChildren: MarkdownInlineToken[] = [];
-  const restoreMention = (text: string) =>
-    restoreEscapedMentions(text, params.escapedMentionMarker);
   let roomMentioned = false;
   let insideLinkDepth = 0;
   for (const child of params.children) {
@@ -433,30 +387,24 @@ function mutateInlineTokensWithMentions(params: {
       continue;
     }
     if (child.type !== "text" || !child.content) {
-      for (const nested of child.children ?? []) {
-        nested.content = restoreMention(nested.content);
-      }
       nextChildren.push(child);
       continue;
     }
 
-    const visibleContent = restoreMention(child.content);
     if (insideLinkDepth > 0) {
-      nextChildren.push(createTextToken(child, visibleContent));
+      nextChildren.push(child);
       continue;
     }
     const matches = collectMentionCandidates(child.content);
     if (matches.length === 0) {
-      nextChildren.push(createTextToken(child, visibleContent));
+      nextChildren.push(child);
       continue;
     }
 
     let cursor = 0;
     for (const match of matches) {
       if (match.start > cursor) {
-        nextChildren.push(
-          createTextToken(child, restoreMention(child.content.slice(cursor, match.start))),
-        );
+        nextChildren.push(createTextToken(child, child.content.slice(cursor, match.start)));
       }
       cursor = match.end;
       if (match.kind === "room") {
@@ -483,7 +431,7 @@ function mutateInlineTokensWithMentions(params: {
       );
     }
     if (cursor < child.content.length) {
-      nextChildren.push(createTextToken(child, restoreMention(child.content.slice(cursor))));
+      nextChildren.push(createTextToken(child, child.content.slice(cursor)));
     }
   }
   return { children: nextChildren, roomMentioned };
@@ -624,9 +572,7 @@ async function resolveMarkdownMentionState(params: {
   client: MatrixClient;
   tableMode?: MarkdownTableMode;
 }): Promise<{ tokens: MarkdownToken[]; mentions: MatrixMentions }> {
-  const { markdown, marker } = maskEscapedMentions(projectMatrixMarkdown(params.markdown));
-  const tokens = parseMatrixMarkdown(markdown, params.tableMode);
-  restoreEscapedMentionsInBlockTokens(tokens, marker);
+  const tokens = parseMatrixMarkdown(projectMatrixMarkdown(params.markdown), params.tableMode);
   const selfUserId = await resolveMatrixSelfUserId(params.client);
   const userIds: string[] = [];
   const seenUserIds = new Set<string>();
@@ -641,7 +587,6 @@ async function resolveMarkdownMentionState(params: {
       userIds,
       seenUserIds,
       selfUserId,
-      escapedMentionMarker: marker,
     });
     token.children = mutated.children;
     roomMentioned ||= mutated.roomMentioned;

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -1135,30 +1135,38 @@ describe("sendMessageMatrix mentions", () => {
     );
   });
 
-  it("does not emit mentions for escaped qualified users", async () => {
-    const { client, sendMessage } = makeClient();
+  it.each(["\\@alice:example.org", "`literal then \\@alice:example.org"])(
+    "does not emit mentions for escaped qualified users in %j",
+    async (markdown) => {
+      const { client, sendMessage } = makeClient();
 
-    await sendMessageMatrix("room:!room:example", "\\@alice:example.org", {
-      client,
-      cfg: {} as never,
-    });
+      await sendMessageMatrix("room:!room:example", markdown, {
+        client,
+        cfg: {} as never,
+      });
 
-    expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
-    expect((sentContent(sendMessage) as { formatted_body?: string }).formatted_body).not.toContain(
-      "matrix.to/#/@alice:example.org",
-    );
-  });
+      expect(sentContent(sendMessage).body).toBe(markdown);
+      expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
+      expect(
+        (sentContent(sendMessage) as { formatted_body?: string }).formatted_body,
+      ).not.toContain("matrix.to/");
+    },
+  );
 
-  it("does not emit mentions for escaped room mentions", async () => {
-    const { client, sendMessage } = makeClient();
+  it.each(["\\@room please review", "``literal then \\@room please review"])(
+    "does not emit mentions for escaped room mentions in %j",
+    async (markdown) => {
+      const { client, sendMessage } = makeClient();
 
-    await sendMessageMatrix("room:!room:example", "\\@room please review", {
-      client,
-      cfg: {} as never,
-    });
+      await sendMessageMatrix("room:!room:example", markdown, {
+        client,
+        cfg: {} as never,
+      });
 
-    expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
-  });
+      expect(sentContent(sendMessage).body).toBe(markdown);
+      expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
+    },
+  );
 
   it("marks room mentions via m.mentions.room", async () => {
     const { client, sendMessage } = makeClient();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in the same repository, so maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where Matrix messages containing an unmatched literal backtick could turn a later escaped user or room ID into a notification mention. For example, `` `literal then \@alice:example.org `` produced a mention link and `m.mentions` metadata instead of keeping the escaped ID literal.

## Why This Change Was Made

Preserve Markdown-it's canonical escaped-`@` token before its text-joining step removes that distinction. This lets the parser own code, escape, image, and link boundaries and removes the duplicate backtick scanner, private-marker restoration, and token copies used only by that restoration path.

## User Impact

Escaped user and room IDs remain literal even when surrounding Markdown is incomplete. Normal mentions continue to work, and existing code, link, image, spoiler, and message-body behavior is preserved.

## Evidence

- Four new formatter/send regressions failed before the fix, while 189 existing controls passed. Afterward, all **208 selected tests** passed across formatting, send preparation, automatic replies, and preparation reuse.
- Actual local message-content construction and enrichment failed before and passed after the fix: body bytes stay unchanged, escaped IDs produce literal HTML and empty `m.mentions`, and the normal mention control retains its link and metadata. This used a synthetic identity callback and made no sends or network requests; it is not a live Matrix service test.
- Full `check:changed` passed, including production and owning test typegraphs, full-file lint, formatting, export checks, and zero runtime import cycles. Independent P0–P2 review was scoped-clean.
- The pinned Markdown-it escape, backtick, and text-joining implementations were inspected directly. Existing escaped image/link and private-character controls pass.
- Production code: **17 lines added, 72 removed; net −55**. Tests: net +18 lines. No new dependency, configuration, or payload field.
