### PR TITLE
fix: avoid unnecessary diagnostic loading during CLI startup

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -55,7 +55,7 @@ const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const pinConfigDirMock = vi.hoisted(() => vi.fn());
 const pinRuntimePathsMock = vi.hoisted(() => vi.fn());
 const ensurePathMock = vi.hoisted(() => vi.fn());
-const assertRuntimeMock = vi.hoisted(() => vi.fn());
+const assertRuntimeMock = vi.hoisted(() => vi.fn(async () => {}));
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));
 const listRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn((): unknown[] => []));
@@ -2647,6 +2647,17 @@ describe("runCli exit behavior", () => {
     const configReadOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[0] ?? 0;
     expect(runtimeGuardOrder).toBeGreaterThan(0);
     expect(configReadOrder).toBeGreaterThan(runtimeGuardOrder);
+  });
+
+  it("stops before config selection when asynchronous runtime validation rejects", async () => {
+    const error = new Error("unsupported runtime");
+    const validation = Promise.reject(error);
+    // The regression must also join this rejection when old code ignores the returned promise.
+    void validation.catch(() => {});
+    assertRuntimeMock.mockReturnValueOnce(validation);
+
+    await expect(runCli(["node", "openclaw", "gateway", "run"])).rejects.toBe(error);
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("re-pins runtime paths after selecting gateway config", async () => {

--- a/src/cli/run-main.profile-env.test.ts
+++ b/src/cli/run-main.profile-env.test.ts
@@ -73,7 +73,7 @@ vi.mock("../infra/env.js", async (importOriginal) => ({
 }));
 
 vi.mock("../infra/runtime-guard.js", () => ({
-  assertSupportedRuntime: vi.fn(),
+  assertSupportedRuntime: vi.fn(async () => {}),
 }));
 
 vi.mock("../infra/path-env.js", () => ({

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1097,7 +1097,7 @@ async function runCliWithPreparedOutputMode(
 
   // Enforce the minimum supported runtime before gateway selection can read or recover config.
   const { assertSupportedRuntime } = await import("../infra/runtime-guard.js");
-  assertSupportedRuntime();
+  await assertSupportedRuntime();
 
   if (
     !isHelpOrVersionInvocation &&

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -537,7 +537,7 @@ export async function setupWizardCommand(
   opts: OnboardOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  assertSupportedRuntime(runtime);
+  await assertSupportedRuntime(runtime);
   const { authChoice: normalizedAuthChoice, deprecated } = resolveLegacyOnboardAuthChoice(
     opts.authChoice,
     { env: process.env },

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -136,7 +136,7 @@ if (
     loadCliDotEnv({ quiet: true });
     await configureGatewayStartupTraceConsoleFormatting(gatewayEntryStartupTrace);
   }
-  assertSupportedRuntime();
+  await assertSupportedRuntime();
   gatewayEntryStartupTrace.mark("bootstrap");
 
   const waitingForCompileCacheRespawn = await respawnWithoutOpenClawCompileCacheIfNeeded({

--- a/src/infra/runtime-guard.test.ts
+++ b/src/infra/runtime-guard.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
   version: "24.16.0",
   error: vi.fn(),
   run: vi.fn(),
+  diagnosticLoads: 0,
 }));
 
 vi.mock("node:process", async (importOriginal) => {
@@ -29,11 +30,21 @@ vi.mock("node:process", async (importOriginal) => {
     },
   };
 });
+vi.mock("../logging/json-console-line.js", async (importOriginal) => {
+  state.diagnosticLoads += 1;
+  return await importOriginal<typeof import("../logging/json-console-line.js")>();
+});
 vi.mock("../worker/worker-deploy-runtime.js", () => ({}));
 vi.mock("../worker/worker-deploy-browser-runtime.js", () => ({ default: {} }));
 vi.mock("../worker/worker-process.js", () => ({ runWorkerProcess: state.run }));
 
 describe("runtime-guard", () => {
+  it("keeps healthy runtime checks independent of diagnostic formatting", async () => {
+    await assertSupportedRuntime();
+    expect(state.diagnosticLoads).toBe(0);
+    expect(state.error).not.toHaveBeenCalled();
+  });
+
   it("parses semver with or without leading v", () => {
     expect(parseSemver("v22.1.3")).toEqual({ major: 22, minor: 1, patch: 3 });
     expect(parseSemver("1.3.0")).toEqual({ major: 1, minor: 3, patch: 0 });
@@ -96,7 +107,7 @@ describe("runtime-guard", () => {
     expect(isSupportedBunVersion(version)).toBe(expected);
   });
 
-  it("throws via exit when runtime is too old", () => {
+  it("throws via exit when runtime is too old", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -112,7 +123,7 @@ describe("runtime-guard", () => {
       hasNodeSqlite: false,
       sqliteVersion: null,
     };
-    expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");
+    await expect(assertSupportedRuntime(runtime, details)).rejects.toThrow("exit");
     expect(runtime.error).toHaveBeenCalledOnce();
     expect(runtime.error).toHaveBeenCalledWith(
       [
@@ -126,7 +137,7 @@ describe("runtime-guard", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("returns silently when runtime meets requirements", () => {
+  it("returns silently when runtime meets requirements", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -140,11 +151,11 @@ describe("runtime-guard", () => {
       hasNodeSqlite: true,
       sqliteVersion: "3.53.3",
     };
-    expect(assertSupportedRuntime(runtime, details)).toBeUndefined();
+    await expect(assertSupportedRuntime(runtime, details)).resolves.toBeUndefined();
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 
-  it("accepts Bun when the runtime provides WAL-reset-safe node:sqlite", () => {
+  it("accepts Bun when the runtime provides WAL-reset-safe node:sqlite", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -158,17 +169,17 @@ describe("runtime-guard", () => {
       hasNodeSqlite: true,
       sqliteVersion: "3.53.2",
     };
-    expect(assertSupportedRuntime(runtime, details)).toBeUndefined();
+    await expect(assertSupportedRuntime(runtime, details)).resolves.toBeUndefined();
     expect(runtime.exit).not.toHaveBeenCalled();
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("reports a SQLite selection failure through the runtime diagnostic sink", () => {
+  it("reports a SQLite selection failure through the runtime diagnostic sink", async () => {
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
     const sqliteSelectionError =
       "Cannot use SQLite library /nonexistent.dylib: missing file. " +
       "Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.";
-    assertSupportedRuntime(runtime, {
+    await assertSupportedRuntime(runtime, {
       kind: "bun",
       version: "1.4.2",
       execPath: "/usr/bin/bun",
@@ -184,7 +195,7 @@ describe("runtime-guard", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("rejects Bun when it does not provide node:sqlite", () => {
+  it("rejects Bun when it does not provide node:sqlite", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -201,7 +212,7 @@ describe("runtime-guard", () => {
       sqliteVersion: null,
     };
 
-    expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");
+    await expect(assertSupportedRuntime(runtime, details)).rejects.toThrow("exit");
     expect(runtime.error).toHaveBeenCalledWith(
       [
         "openclaw requires Bun 1.4 or newer with WAL-reset-safe node:sqlite (SQLite 3.51.3+ or a patched 3.50.x/3.44.x release).",
@@ -214,7 +225,7 @@ describe("runtime-guard", () => {
     );
   });
 
-  it("rejects Bun below 1.4 even when node:sqlite is available", () => {
+  it("rejects Bun below 1.4 even when node:sqlite is available", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -223,7 +234,7 @@ describe("runtime-guard", () => {
       }),
     };
 
-    expect(() =>
+    await expect(
       assertSupportedRuntime(runtime, {
         kind: "bun",
         version: "1.3.14",
@@ -232,10 +243,10 @@ describe("runtime-guard", () => {
         hasNodeSqlite: true,
         sqliteVersion: "3.53.2",
       }),
-    ).toThrow("exit");
+    ).rejects.toThrow("exit");
   });
 
-  it("rejects Bun when its node:sqlite version is not WAL-reset-safe", () => {
+  it("rejects Bun when its node:sqlite version is not WAL-reset-safe", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -244,7 +255,7 @@ describe("runtime-guard", () => {
       }),
     };
 
-    expect(() =>
+    await expect(
       assertSupportedRuntime(runtime, {
         kind: "bun",
         version: "1.4.0",
@@ -253,11 +264,11 @@ describe("runtime-guard", () => {
         hasNodeSqlite: true,
         sqliteVersion: "3.51.2",
       }),
-    ).toThrow("exit");
+    ).rejects.toThrow("exit");
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Detected SQLite: 3.51.2."));
   });
 
-  it("reports unknown runtimes with fallback labels", () => {
+  it("reports unknown runtimes with fallback labels", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -274,7 +285,7 @@ describe("runtime-guard", () => {
       sqliteVersion: null,
     };
 
-    expect(() => assertSupportedRuntime(runtime, details)).toThrow("exit");
+    await expect(assertSupportedRuntime(runtime, details)).rejects.toThrow("exit");
     expect(runtime.error).toHaveBeenCalledOnce();
     expect(runtime.error).toHaveBeenCalledWith(
       [
@@ -286,6 +297,36 @@ describe("runtime-guard", () => {
       ].join("\n"),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("runtime failure diagnostics", () => {
+  it("preserves configured JSON diagnostics and redaction with the default runtime", async () => {
+    const { loggingState } = await import("../logging/state.js");
+    const previous = loggingState.overrideSettings;
+    const secret = "synthetic-runtime-secret-0123456789";
+    state.error.mockClear();
+    loggingState.overrideSettings = { consoleStyle: "json" };
+    try {
+      await expect(
+        assertSupportedRuntime(undefined, {
+          kind: "node",
+          version: "20.0.0",
+          execPath: "/usr/bin/node",
+          pathEnv: `https://example.test/?token=${secret}`,
+          hasNodeSqlite: false,
+          sqliteVersion: null,
+        }),
+      ).rejects.toThrow("runtime exit 1");
+      const output = String(state.error.mock.lastCall?.[0]);
+      expect(JSON.parse(output)).toMatchObject({
+        level: "error",
+        message: expect.stringContaining("Detected: node 20.0.0"),
+      });
+      expect(output).not.toContain(secret);
+    } finally {
+      loggingState.overrideSettings = previous;
+    }
   });
 });
 

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -200,12 +200,13 @@ export function nodeVersionSatisfiesEngine(
 
 /** Exits through the provided runtime when the current Node runtime is unsupported. */
 export async function assertSupportedRuntime(
-  runtime?: RuntimeEnv,
+  providedRuntime?: RuntimeEnv,
   details: RuntimeDetails = detectRuntime(),
 ): Promise<void> {
   if (runtimeSatisfies(details)) {
     return;
   }
+  let runtime = providedRuntime;
   // Healthy starts need no diagnostic graph; a supplied runtime already owns its error sink.
   if (!runtime) {
     const { formatConsoleDiagnosticBlock } = await import("../logging/json-console-line.js");

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -1,32 +1,18 @@
 // Validates the current runtime against OpenClaw's Node engine floor.
 import process from "node:process";
 import { format } from "node:util";
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import {
   isNodeVersionAtLeast,
   isSupportedOpenClawNodeVersion,
   parseNodeReleaseVersion,
 } from "../../node-version.mjs";
-import { formatConsoleDiagnosticBlock } from "../logging/json-console-line.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import {
   detectCurrentRuntimeSqliteVersion,
   isSqliteWalResetSafeVersion,
 } from "./sqlite-runtime-version.js";
-
-// Runtime validation precedes console capture. Keep this direct sink aligned
-// with configured JSONL output without pulling in the full logger.
-const defaultRuntime: RuntimeEnv = {
-  log: (...args) => console.log(...args),
-  error: (...args) => {
-    const message = format(...args);
-    process.stderr.write(formatConsoleDiagnosticBlock({ level: "error", message: `${message}\n` }));
-  },
-  exit: (code) => {
-    process.exit(code);
-  },
-};
 
 type RuntimeKind = "bun" | "node" | "unknown";
 
@@ -213,12 +199,26 @@ export function nodeVersionSatisfiesEngine(
 }
 
 /** Exits through the provided runtime when the current Node runtime is unsupported. */
-export function assertSupportedRuntime(
-  runtime: RuntimeEnv = defaultRuntime,
+export async function assertSupportedRuntime(
+  runtime?: RuntimeEnv,
   details: RuntimeDetails = detectRuntime(),
-): void {
+): Promise<void> {
   if (runtimeSatisfies(details)) {
     return;
+  }
+  // Healthy starts need no diagnostic graph; a supplied runtime already owns its error sink.
+  if (!runtime) {
+    const { formatConsoleDiagnosticBlock } = await import("../logging/json-console-line.js");
+    runtime = {
+      log: (...args) => console.log(...args),
+      error: (...args) => {
+        const message = format(...args);
+        process.stderr.write(
+          formatConsoleDiagnosticBlock({ level: "error", message: `${message}\n` }),
+        );
+      },
+      exit: (code) => process.exit(code),
+    };
   }
 
   const versionLabel = details.version ?? "unknown";

--- a/src/worker/worker-deploy-entry.ts
+++ b/src/worker/worker-deploy-entry.ts
@@ -4,7 +4,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import workerDeployBrowserRuntime from "./worker-deploy-browser-runtime.js";
 import { runWorkerProcess } from "./worker-process.js";
 
-assertSupportedRuntime();
+await assertSupportedRuntime();
 
 const args = process.argv.slice(2);
 const internalWorkerIpc = args.includes("--internal-worker-ipc");


### PR DESCRIPTION
## What Problem This Solves

Fixes unnecessary startup work when users launch OpenClaw or prepare a cloud computer on a supported runtime. The supervising CLI eagerly loaded the diagnostic formatter and its logging/configuration dependencies even when no runtime error needed reporting.

## Why This Change Was Made

Load the existing diagnostic formatter only after runtime validation fails and no caller-provided error sink exists. Await validation in each existing caller so unsupported runtimes still stop before configuration selection, onboarding, or worker startup. Use the existing normalization helper subpath to avoid another unrelated barrel import.

## User Impact

Healthy startup no longer loads this failure-only dependency graph. Node/Bun/SQLite requirements, configured JSON diagnostics and redaction, supervised respawn, and worker behavior remain unchanged. This is a bounded startup improvement; it does not by itself make cloud desktops ready in under ten seconds.

## Evidence

- Regression proof failed on the old eager diagnostic import and on a caller that ignored asynchronous validation; both pass with the repair.
- 598 focused and sibling tests passed, covering runtime predicates and errors, CLI ordering, onboarding, entry/respawn, and sealed worker construction.
- Full `pnpm build` passed, including the single-file worker build contract.
- Independent Codex review found no actionable P0–P2 findings.
- The first changed check hit a pre-existing UI `refreshIfDue` type error; the branch now includes the canonical main repair from #142346. The refreshed check then caught a parameter-reassignment lint error in this patch. That is corrected, with 333 focused tests and targeted lint passing; the final full changed check passed on `c9649042`; the exact-head full build passed as well.

Production code grows by one line. The exact build has a nine-file / 36,248-byte static runtime-guard graph; diagnostic formatting is reachable only through its failure-path dynamic import. No before/after timing claim is inferred from import counts.

Live validation on the exact head:

- The dev Gateway started healthily, and the retained macOS node returned a real native screenshot.
- A fresh AWS session created in 670 ms and became active in 265 seconds. It forked the existing desktop image and installed the changed runtime; this is not an identical-runtime warm-reuse comparison.
- The real OpenAI-backed agent completed Computer screenshots, typing, Return, and marker verification before WebVNC opened. It then completed another fresh-frame Computer input turn while the real Chrome WebVNC viewer remained connected. Both markers were inspected in the Computer results and the rendered viewer; no native VNC client or manual terminal input substituted for agent actions.
- An earlier AWS attempt failed: its desktop stream closed immediately after the first Computer screenshot call, the turn timed out, and normal reclaim hit the admission-drain deadline. A bounded diagnostic found both SSH ports unreachable and never ran remotely. Documented forced teardown completed, the provider confirmed release, and the session was archived. The cause is unresolved; the passing comparison does not erase that failure or prove which component caused it.

The ten-second desktop-readiness target is not met. These timings are absolute observations, not a claimed speedup from the import change. Normal cleanup of the passing comparison completed: the provider confirmed release, the allocation pin was removed, and the session was archived. Both Linux test environments are gone. The prepared candidate image remains under the existing retention policy.
