### PR TITLE
fix(models): stop model checks from rediscovering providers

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -91,8 +91,10 @@ configured or completed catalog. They do not start provider discovery, including
 after a restart. If the owner is not yet published, the request reports that the
 catalog is not ready. Retry after startup or an in-progress refresh finishes.
 Use an explicit Refresh action or `openclaw models list --refresh` to acquire
-provider inventory. Startup and turn-path capability preparation keep their
-separate runtime responsibilities.
+provider inventory. Model selection, subagent capability checks, and hook-model
+validation also use the published inventory. Missing capability facts do not
+start another provider discovery. Native runtime observations keep their separate
+owner and authentication requirements.
 For models configured to use a CLI runtime, channel picker availability follows that
 runtime's prepared authentication; a provider API key does not substitute for its
 native login.

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1622,6 +1622,7 @@ function resolveAllowedModelSelection(
 
 export type ModelVisibilityPolicy = {
   allowAny: boolean;
+  configuredCatalog: readonly ModelCatalogEntry[];
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
   policyAliasIndex: ModelAliasIndex;
@@ -1733,6 +1734,7 @@ export function createModelVisibilityPolicyWithFallbacks(
     allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key);
   const policy: ModelVisibilityPolicy = {
     allowAny: allowed.allowAny,
+    configuredCatalog,
     allowedCatalog: allowed.allowedCatalog,
     allowedKeys: allowed.allowedKeys,
     policyAliasIndex,

--- a/src/agents/prepared-model-catalog.scoped-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.scoped-thinking.test.ts
@@ -48,6 +48,7 @@ function owner(config: OpenClawConfig, entries: ModelCatalogEntry[]): PreparedMo
   return {
     agentDir: "/tmp/model-catalog-passive-test",
     activeProjectKeys: [],
+    catalogOwner: undefined,
     config,
     observationConfig: config,
     isCurrent: () => true,
@@ -105,6 +106,7 @@ describe("loadProviderScopedThinkingCatalog", () => {
       const snapshot: PreparedModelRuntimeSnapshot = {
         agentDir: "/tmp/model-catalog-passive-test",
         activeProjectKeys: [],
+        catalogOwner: undefined,
         config,
         observationConfig: config,
         isCurrent: () => true,

--- a/src/agents/prepared-model-catalog.scoped-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.scoped-thinking.test.ts
@@ -1,53 +1,77 @@
-// Turn-path thinking reuses published facts before manifest/scoped discovery fallback.
+// Capability reads retain published facts and use static ownership when no owner exists.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
+import { setPreparedModelFullCatalogAuth } from "./prepared-model-runtime-auth.js";
 import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.errors.js";
-import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
 
-const manifestCatalogMock = vi.fn((..._args: unknown[]): Array<Record<string, unknown>> => []);
-const scopedStaticMock = vi.fn(async (..._args: unknown[]): Promise<Record<string, unknown>> => ({
+const manifestCatalogMock = vi.fn((): ModelCatalogEntry[] => []);
+const scopedStaticMock = vi.fn(async (): Promise<ModelCatalogSnapshot> => ({
   entries: [],
   routeVariants: [],
 }));
-const scopedLiveMock = vi.fn(async (..._args: unknown[]): Promise<Record<string, unknown>> => ({
+const scopedLiveMock = vi.fn(async (): Promise<ModelCatalogSnapshot> => ({
   entries: [],
   routeVariants: [],
 }));
-const publishedSnapshotMock = vi.fn((..._args: unknown[]) => undefined as unknown);
-const preparedSnapshotMock = vi.fn<
-  (input: { agentDir: string }) => Promise<PreparedModelRuntimeSnapshot>
->(async (input) => {
-  throw new PreparedModelRuntimeOwnerNotPublishedError(
-    `not published for test (${input.agentDir})`,
-  );
-});
+const publishedSnapshotMock =
+  vi.fn<(input: PreparedModelRuntimeInput) => PreparedModelRuntimeSnapshot | undefined>();
+const preparedSnapshotMock =
+  vi.fn<(input: PreparedModelRuntimeInput) => Promise<PreparedModelRuntimeSnapshot>>();
+const acquireSnapshotMock =
+  vi.fn<(input: PreparedModelRuntimeInput) => Promise<PreparedModelRuntimeSnapshot>>();
+const releaseSnapshotMock = vi.fn();
 
-vi.mock("./model-catalog.js", () => ({
-  loadManifestModelCatalog: (...args: unknown[]) => manifestCatalogMock(...args),
+vi.mock("./model-catalog.js", () => ({ loadManifestModelCatalog: () => manifestCatalogMock() }));
+vi.mock("./prepared-model-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./prepared-model-runtime.js")>()),
+  getPreparedModelRuntimeSnapshot: (input: PreparedModelRuntimeInput) =>
+    publishedSnapshotMock(input),
+  prepareModelRuntimeSnapshot: (input: PreparedModelRuntimeInput) => preparedSnapshotMock(input),
+  acquireReadOnlyPreparedModelRuntime: async (input: PreparedModelRuntimeInput) => ({
+    snapshot: await acquireSnapshotMock(input),
+    release: releaseSnapshotMock,
+  }),
 }));
-
-vi.mock("./prepared-model-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./prepared-model-runtime.js")>();
-  return {
-    ...actual,
-    getPreparedModelRuntimeSnapshot: (...args: unknown[]) => publishedSnapshotMock(...args),
-    // No published lifecycle owner: force the scoped read-only builders to run.
-    prepareModelRuntimeSnapshot: (...args: Parameters<typeof preparedSnapshotMock>) =>
-      preparedSnapshotMock(...args),
-  };
-});
-
 vi.mock("./prepared-model-runtime.scoped-catalog.js", () => ({
-  prepareScopedReadOnlyModelCatalog: (...args: unknown[]) => scopedStaticMock(...args),
-  prepareScopedReadOnlyLiveModelCatalog: (...args: unknown[]) => scopedLiveMock(...args),
+  prepareScopedReadOnlyModelCatalog: () => scopedStaticMock(),
+  prepareScopedReadOnlyLiveModelCatalog: () => scopedLiveMock(),
 }));
 
-const ollamaEntry = {
-  provider: "ollama",
-  id: "minimax-m3:cloud",
-  name: "minimax-m3:cloud",
-  reasoning: true,
+function owner(config: OpenClawConfig, entries: ModelCatalogEntry[]): PreparedModelRuntimeSnapshot {
+  return {
+    agentDir: "/tmp/model-catalog-passive-test",
+    activeProjectKeys: [],
+    config,
+    observationConfig: config,
+    isCurrent: () => true,
+    authModes: {},
+    metadataSnapshot: createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    }),
+    allowGatewaySubagentBinding: false,
+    modelCatalog: { entries, routeVariants: entries },
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    createStores: () => {
+      throw new Error("Passive capability reads must not create stores");
+    },
+  };
+}
+
+const entry: ModelCatalogEntry = {
+  provider: "acme",
+  id: "selected",
+  name: "Selected",
+  api: "openai-responses",
+  baseUrl: "https://provider.invalid/v1",
 };
 
 describe("loadProviderScopedThinkingCatalog", () => {
@@ -58,222 +82,201 @@ describe("loadProviderScopedThinkingCatalog", () => {
     scopedLiveMock.mockResolvedValue({ entries: [], routeVariants: [] });
     publishedSnapshotMock.mockReturnValue(undefined);
     preparedSnapshotMock.mockImplementation(async (input) => {
-      throw new PreparedModelRuntimeOwnerNotPublishedError(
-        `not published for test (${input.agentDir})`,
-      );
+      const published = publishedSnapshotMock(input);
+      if (!published) {
+        throw new PreparedModelRuntimeOwnerNotPublishedError("No published test owner");
+      }
+      return published;
     });
-  });
-
-  it("prefers the published prepared generation over partial manifest compatibility", async () => {
-    manifestCatalogMock.mockReturnValue([
-      {
-        provider: "openai",
-        id: "gpt-5.6-sol",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
-      },
-    ]);
-    publishedSnapshotMock.mockImplementation((input: unknown) => ({
-      config: (input as { config: unknown }).config,
-      modelCatalog: {
-        entries: [
-          {
-            provider: "openai",
-            id: "gpt-5.6-sol",
-            reasoning: true,
-            compat: {
-              supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-            },
-          },
-        ],
-        routeVariants: [],
-      },
-    }));
-    const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
-
-    const catalog = await loadProviderScopedThinkingCatalog({
-      config: {},
-      provider: "openai",
-      model: "gpt-5.6-sol",
-    });
-
-    expect(catalog[0]?.compat?.supportedReasoningEfforts).toContain("ultra");
-    expect(manifestCatalogMock).not.toHaveBeenCalled();
-    expect(scopedStaticMock).not.toHaveBeenCalled();
-    expect(scopedLiveMock).not.toHaveBeenCalled();
+    acquireSnapshotMock.mockImplementation(async (input) => owner(input.config, []));
   });
 
   it.each(["thinking", "input"] as const)(
-    "reuses completed owner catalogs for runtime-only %s capabilities",
+    "keeps missing published %s facts passive",
     async (capability) => {
-      const entry: ModelCatalogEntry = {
-        ...ollamaEntry,
-        api: "ollama",
-        baseUrl: "https://ollama.invalid",
-        input: ["text", "image"],
+      const config = {};
+      const missingEntry: ModelCatalogEntry = {
+        provider: "acme",
+        id: "selected",
+        name: "Selected",
+        api: "openai-responses",
+        baseUrl: "https://provider.invalid/v1",
       };
-      const completed: ModelCatalogSnapshot = { entries: [entry], routeVariants: [entry] };
-      publishedSnapshotMock.mockImplementation((input: unknown) => ({
-        config: (input as { config: unknown }).config,
-        modelCatalog: { entries: [], routeVariants: [] },
-        readFullModelCatalog: () => completed,
-      }));
+      const snapshot: PreparedModelRuntimeSnapshot = {
+        agentDir: "/tmp/model-catalog-passive-test",
+        activeProjectKeys: [],
+        config,
+        observationConfig: config,
+        isCurrent: () => true,
+        authModes: {},
+        metadataSnapshot: createPluginMetadataSnapshot({
+          config,
+          manifestRegistry: { plugins: [], diagnostics: [] },
+        }),
+        allowGatewaySubagentBinding: false,
+        modelCatalog: { entries: [missingEntry], routeVariants: [missingEntry] },
+        configuredRuntimeModels: [],
+        inlineProviderModels: [],
+        createStores: () => {
+          throw new Error("Passive capability reads must not create stores");
+        },
+      };
+      publishedSnapshotMock.mockReturnValue(snapshot);
+      preparedSnapshotMock.mockResolvedValue(snapshot);
+      scopedStaticMock.mockResolvedValue({
+        entries: [{ ...missingEntry, reasoning: true, input: ["text", "image"] }],
+        routeVariants: [],
+      });
       const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
       const catalog = await loadProviderScopedThinkingCatalog({
-        config: {},
-        provider: entry.provider,
-        model: entry.id,
+        config,
+        provider: missingEntry.provider,
+        model: missingEntry.id,
         ...(capability === "input"
-          ? { requiredInputRoute: { api: entry.api, baseUrl: entry.baseUrl } }
+          ? { requiredInputRoute: { api: missingEntry.api, baseUrl: missingEntry.baseUrl } }
           : {}),
       });
 
-      expect(catalog).toEqual([expect.objectContaining(entry)]);
+      if (capability === "input") {
+        expect(catalog).toEqual([]);
+      } else {
+        expect(catalog).toEqual([missingEntry]);
+      }
       expect(manifestCatalogMock).not.toHaveBeenCalled();
       expect(scopedStaticMock).not.toHaveBeenCalled();
       expect(scopedLiveMock).not.toHaveBeenCalled();
     },
   );
 
-  it("resolves manifest-backed models without any scoped catalog build", async () => {
-    manifestCatalogMock.mockReturnValue([
-      { provider: "openai", id: "gpt-5.6-luna", reasoning: true },
-    ]);
+  it.each(["thinking", "input"] as const)(
+    "reuses paired completed catalogs for %s capabilities",
+    async (capability) => {
+      const config = {};
+      const completedEntry: ModelCatalogEntry = {
+        ...entry,
+        reasoning: true,
+        input: ["text", "image"],
+      };
+      const completed: ModelCatalogSnapshot = {
+        entries: [completedEntry],
+        routeVariants: [completedEntry],
+      };
+      setPreparedModelFullCatalogAuth(completed, {
+        authStore: { version: 1, profiles: {} },
+        authModes: {},
+      });
+      const loadFullModelCatalog = vi.fn(async () => completed);
+      const snapshot = {
+        ...owner(config, []),
+        readFullModelCatalog: () => completed,
+        loadFullModelCatalog,
+      };
+      publishedSnapshotMock.mockReturnValue(snapshot);
+      const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
+      const catalog = await loadProviderScopedThinkingCatalog({
+        config,
+        provider: entry.provider,
+        model: entry.id,
+        ...(capability === "input"
+          ? { requiredInputRoute: { api: entry.api, baseUrl: entry.baseUrl } }
+          : {}),
+      });
+      expect(catalog).toEqual([completedEntry]);
+      expect(loadFullModelCatalog).not.toHaveBeenCalled();
+      expect(manifestCatalogMock).not.toHaveBeenCalled();
+      expect(scopedStaticMock).not.toHaveBeenCalled();
+      expect(scopedLiveMock).not.toHaveBeenCalled();
+      expect(acquireSnapshotMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses and releases a static owner when no published owner exists", async () => {
+    const config = {};
+    const staticEntry = { ...entry, reasoning: true };
+    acquireSnapshotMock.mockResolvedValue(owner(config, [staticEntry]));
     const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
-    const catalog = await loadProviderScopedThinkingCatalog({
-      config: {},
-      provider: "openai",
-      model: "gpt-5.6-luna",
-    });
-    expect(catalog).toEqual([
-      expect.objectContaining({ provider: "openai", id: "gpt-5.6-luna", reasoning: true }),
-    ]);
+    expect(
+      await loadProviderScopedThinkingCatalog({
+        config,
+        provider: entry.provider,
+        model: entry.id,
+      }),
+    ).toEqual([staticEntry]);
+    expect(releaseSnapshotMock).toHaveBeenCalledOnce();
+    expect(manifestCatalogMock).not.toHaveBeenCalled();
     expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
   });
 
-  it("stops at the scoped static catalog when it resolves the entry", async () => {
-    scopedStaticMock.mockResolvedValue({
-      entries: [{ provider: "acme", id: "static-model", reasoning: false }],
-      routeVariants: [],
-    });
+  it("rejects an owner whose configuration was replaced", async () => {
+    const config = { skills: { entries: { marker: { enabled: true } } } };
+    const replaced = { skills: { entries: { marker: { enabled: false } } } };
+    publishedSnapshotMock.mockReturnValue(owner(replaced, [{ ...entry, reasoning: true }]));
     const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
-    const catalog = await loadProviderScopedThinkingCatalog({
-      config: {},
-      provider: "acme",
-      model: "static-model",
-    });
-    expect(catalog).toEqual([
-      expect.objectContaining({ provider: "acme", id: "static-model", reasoning: false }),
-    ]);
-    expect(scopedStaticMock).toHaveBeenCalledTimes(1);
-    expect(scopedStaticMock).toHaveBeenCalledWith(expect.anything(), ["acme"]);
+    await expect(
+      loadProviderScopedThinkingCatalog({ config, provider: entry.provider, model: entry.id }),
+    ).rejects.toBeInstanceOf(PreparedModelCatalogConfigReplacedError);
+    expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the scoped catalog while a published owner has the replaced config", async () => {
-    const config = { skills: { entries: { marker: { enabled: false } } } };
-    preparedSnapshotMock.mockResolvedValue({
-      catalogOwner: undefined,
-      agentDir: "/tmp/model-catalog-test",
-      activeProjectKeys: [],
-      config,
-      observationConfig: config,
-      isCurrent: () => true,
-      authModes: {},
-      metadataSnapshot: createPluginMetadataSnapshot({
-        config: {},
-        manifestRegistry: { plugins: [], diagnostics: [] },
-      }),
-      allowGatewaySubagentBinding: false,
-      modelCatalog: { entries: [], routeVariants: [] },
-      configuredRuntimeModels: [],
-      inlineProviderModels: [],
-      createStores: () => {
-        throw new Error("stores are outside this catalog fallback test");
-      },
-    });
-    scopedStaticMock.mockResolvedValue({
-      entries: [{ provider: "acme", id: "replacement-model", reasoning: true }],
-      routeVariants: [],
-    });
-    const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
-
-    const catalog = await loadProviderScopedThinkingCatalog({
-      config: { skills: { entries: { marker: { enabled: true } } } },
-      provider: "acme",
-      model: "replacement-model",
-    });
-
-    expect(catalog).toEqual([
-      expect.objectContaining({ provider: "acme", id: "replacement-model", reasoning: true }),
-    ]);
-    expect(scopedStaticMock).toHaveBeenCalledWith(expect.anything(), ["acme"]);
-  });
-
-  it("runs provider-scoped live discovery for runtime-only models and keeps their thinking", async () => {
-    scopedLiveMock.mockResolvedValue({ entries: [ollamaEntry], routeVariants: [] });
-    const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
-    const catalog = await loadProviderScopedThinkingCatalog({
-      config: {},
-      provider: "ollama",
-      model: "minimax-m3:cloud",
-    });
-    expect(catalog).toEqual([expect.objectContaining(ollamaEntry)]);
-    // Live discovery stays scoped to the requested provider: no broad plugin fanout.
-    expect(scopedLiveMock).toHaveBeenCalledTimes(1);
-    expect(scopedLiveMock).toHaveBeenCalledWith(expect.anything(), ["ollama"]);
-    expect(scopedStaticMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([
     {
-      name: "prepared vision",
+      name: "vision",
       input: ["text", "image"],
       expected: ["text", "image"],
-      source: "published",
+      baseUrl: entry.baseUrl,
     },
-    { name: "prepared text-only", input: ["text"], expected: ["text"], source: "published" },
-    { name: "reasoning-only published row", expected: ["text", "image"], source: "manifest" },
+    { name: "text only", input: ["text"], expected: ["text"], baseUrl: entry.baseUrl },
+    { name: "missing input", input: undefined, expected: undefined, baseUrl: entry.baseUrl },
     {
-      name: "different prepared and manifest route",
+      name: "different route",
       input: ["text", "image"],
-      expected: ["text"],
-      source: "scoped",
-      customRoute: true,
+      expected: undefined,
+      baseUrl: "https://custom.invalid/v1",
     },
-  ])("resolves input independently of reasoning: $name", async (testCase) => {
-    const base = {
-      provider: "acme",
-      id: "selected",
-      name: "Selected",
-      reasoning: true,
-      api: "openai-responses" as const,
-      baseUrl: "https://provider.invalid/v1",
-    };
-    const requiredInputRoute = {
-      api: base.api,
-      baseUrl: testCase.customRoute ? "https://custom.invalid/v1" : base.baseUrl,
-    };
-    publishedSnapshotMock.mockImplementation((input: unknown) => ({
-      config: (input as { config: unknown }).config,
-      modelCatalog: { entries: [{ ...base, input: testCase.input }], routeVariants: [] },
-    }));
-    manifestCatalogMock.mockReturnValue([{ ...base, input: ["text", "image"] }]);
-    scopedStaticMock.mockResolvedValue({
-      entries: [{ ...base, ...requiredInputRoute, input: ["text"] }],
-      routeVariants: [],
-    });
+  ] satisfies Array<{
+    name: string;
+    input: ModelCatalogEntry["input"];
+    expected: ModelCatalogEntry["input"];
+    baseUrl: string | undefined;
+  }>)("keeps input independent of reasoning: $name", async (testCase) => {
+    const config = {};
+    publishedSnapshotMock.mockReturnValue(
+      owner(config, [{ ...entry, reasoning: true, input: testCase.input }]),
+    );
     const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
     const catalog = await loadProviderScopedThinkingCatalog({
-      config: {},
-      provider: "acme",
-      model: "selected",
-      requiredInputRoute,
+      config,
+      provider: entry.provider,
+      model: entry.id,
+      requiredInputRoute: { api: entry.api, baseUrl: testCase.baseUrl },
     });
-    expect(catalog.find((entry) => entry.id === "selected")?.input).toEqual(testCase.expected);
-    expect(manifestCatalogMock).toHaveBeenCalledTimes(testCase.source === "published" ? 0 : 1);
-    expect(scopedStaticMock).toHaveBeenCalledTimes(testCase.source === "scoped" ? 1 : 0);
+    if (testCase.expected) {
+      expect(catalog[0]?.input).toEqual(testCase.expected);
+    } else {
+      expect(catalog).toEqual([]);
+    }
+    expect(manifestCatalogMock).not.toHaveBeenCalled();
+    expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the completed catalog to nonblocking readers without a refresh", async () => {
+    const config = {};
+    const completed: ModelCatalogSnapshot = {
+      entries: [{ ...entry, reasoning: true }],
+      routeVariants: [],
+    };
+    const loadFullModelCatalog = vi.fn(async () => completed);
+    publishedSnapshotMock.mockReturnValue({
+      ...owner(config, [entry]),
+      readFullModelCatalog: () => completed,
+      loadFullModelCatalog,
+    });
+    const { getPreparedModelCatalogSnapshot } = await import("./prepared-model-catalog.js");
+    expect(getPreparedModelCatalogSnapshot({ config })).toBe(completed);
+    expect(loadFullModelCatalog).not.toHaveBeenCalled();
+    expect(acquireSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -39,10 +39,7 @@ import {
   prepareScopedReadOnlyLiveModelCatalog,
   prepareScopedReadOnlyModelCatalog,
 } from "./prepared-model-runtime.scoped-catalog.js";
-import {
-  hasResolvedThinkingCatalogEntry,
-  normalizeThinkingCatalogProviders,
-} from "./thinking-runtime.js";
+import { normalizeThinkingCatalogProviders } from "./thinking-runtime.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 
 export type LoadPreparedModelCatalogParams = {
@@ -226,15 +223,8 @@ export function getPublishedPreparedModelCatalogOwnerSnapshot(
   return getPreparedModelRuntimeSnapshot(activationFull);
 }
 
-/** Returns the configured catalog for the current generation without starting discovery. */
+/** Returns the newest published catalog without starting discovery. */
 export function getPreparedModelCatalogSnapshot(
-  params: LoadPreparedModelCatalogParams = {},
-): ModelCatalogSnapshot | undefined {
-  return getPreparedModelCatalogOwnerSnapshot(params)?.modelCatalog;
-}
-
-/** Returns the newest completed catalog for the current generation without starting discovery. */
-export function getAvailablePreparedModelCatalogSnapshot(
   params: LoadPreparedModelCatalogParams = {},
 ): ModelCatalogSnapshot | undefined {
   const owner = getPreparedModelCatalogOwnerSnapshot(params);
@@ -363,9 +353,8 @@ async function loadScopedReadOnlyModelCatalog(
 }
 
 /**
- * Turn-path capability reads (thinking levels and similar per-model facts) must stay off a new
- * full catalog build: reuse the published generation, then manifest/scoped read-only metadata,
- * then scoped live discovery only for providers whose models exist solely at runtime.
+ * Missing turn-path capabilities do not authorize another inventory. Keep native harness
+ * observations on their existing owner and hold temporary catalog reads through projection.
  */
 export async function loadProviderScopedThinkingCatalog(params: {
   config: OpenClawConfig;
@@ -377,72 +366,41 @@ export async function loadProviderScopedThinkingCatalog(params: {
   /** Input preparation must resolve modalities for this route, independently of reasoning. */
   requiredInputRoute?: Pick<ModelCatalogEntry, "api" | "baseUrl">;
 }): Promise<ModelCatalogEntry[]> {
-  const scopedParams = {
-    config: params.config,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    ...(params.agentDir ? { agentDir: params.agentDir } : {}),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    readOnly: true,
-    providerDiscoveryProviderIds: [params.provider],
-  } satisfies LoadPreparedModelCatalogParams;
-  const entryResolved = (catalog: readonly ModelCatalogEntry[]) => {
-    if (params.requiredInputRoute === undefined) {
-      return hasResolvedThinkingCatalogEntry({
-        catalog,
-        provider: params.provider,
-        model: params.model,
-      });
-    }
-    const entry = findModelInCatalog(catalog, params.provider, params.model);
-    return (
-      entry?.input !== undefined && modelTransportRoutesMatch(entry, params.requiredInputRoute)
-    );
-  };
-  const augmentHarnessCatalog = async (snapshot: ModelCatalogSnapshot) => {
-    const agentId = params.agentId ?? resolveAmbientOwnerAgentId(params.config);
-    const { augmentModelCatalogWithAgentHarness } = await import("./harness/model-catalog.js");
-    const augmented = await augmentModelCatalogWithAgentHarness({
-      cfg: params.config,
-      agentId,
-      agentDir: params.agentDir ?? resolveAgentDir(params.config, agentId),
-      workspaceDir:
-        params.workspaceDir ??
-        resolveAgentWorkspaceDir(params.config, agentId) ??
-        resolveDefaultAgentWorkspaceDir(),
-      defaultProvider: params.provider,
-      defaultModel: `${params.provider}/${params.model}`,
-      snapshot,
-    });
-    const entries = normalizeThinkingCatalogProviders(augmented.entries);
-    return params.requiredInputRoute !== undefined && !entryResolved(entries) ? [] : entries;
-  };
-  const publishedCatalog = getAvailablePreparedModelCatalogSnapshot(scopedParams);
-  if (publishedCatalog && entryResolved(publishedCatalog.entries)) {
-    return await augmentHarnessCatalog(publishedCatalog);
-  }
-  const { loadManifestModelCatalog } = await import("./model-catalog.js");
-  const manifestCatalog = normalizeThinkingCatalogProviders(
-    loadManifestModelCatalog({
+  return await withPreparedModelCatalogOwner(
+    {
       config: params.config,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.agentDir ? { agentDir: params.agentDir } : {}),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    }),
-  );
-  if (entryResolved(manifestCatalog)) {
-    return await augmentHarnessCatalog({
-      entries: manifestCatalog,
-      routeVariants: manifestCatalog,
-      staticEntries: manifestCatalog,
-    });
-  }
-  const scopedStatic = await loadPreparedModelCatalogSnapshot(scopedParams);
-  if (entryResolved(scopedStatic.entries)) {
-    return await augmentHarnessCatalog(scopedStatic);
-  }
-  return await augmentHarnessCatalog(
-    await loadPreparedModelCatalogSnapshot({
-      ...scopedParams,
-      scopedLiveProviderDiscovery: true,
-    }),
+      readOnly: true,
+    },
+    async (owner) => {
+      const agentId = params.agentId ?? resolveAmbientOwnerAgentId(params.config);
+      const { augmentModelCatalogWithAgentHarness } = await import("./harness/model-catalog.js");
+      const snapshot = await augmentModelCatalogWithAgentHarness({
+        cfg: params.config,
+        agentId,
+        agentDir: params.agentDir ?? resolveAgentDir(params.config, agentId),
+        workspaceDir:
+          params.workspaceDir ??
+          resolveAgentWorkspaceDir(params.config, agentId) ??
+          resolveDefaultAgentWorkspaceDir(),
+        defaultProvider: params.provider,
+        defaultModel: `${params.provider}/${params.model}`,
+        snapshot: owner.modelCatalog,
+      });
+      const entries = normalizeThinkingCatalogProviders(snapshot.entries);
+      if (params.requiredInputRoute !== undefined) {
+        const entry = findModelInCatalog(entries, params.provider, params.model);
+        if (
+          entry?.input === undefined ||
+          !modelTransportRoutesMatch(entry, params.requiredInputRoute)
+        ) {
+          return [];
+        }
+      }
+      return entries;
+    },
   );
 }
 

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -231,7 +231,7 @@ const {
   refreshPreparedModelRuntimeSnapshots,
   registerPreparedModelRuntimePublicationListener,
 } = await import("./prepared-model-runtime.js");
-const { getAvailablePreparedModelCatalogSnapshot, loadPreparedModelCatalogSnapshot } =
+const { getPreparedModelCatalogSnapshot, loadPreparedModelCatalogSnapshot } =
   await import("./prepared-model-catalog.js");
 const { prepareScopedReadOnlyLiveModelCatalog, prepareScopedReadOnlyModelCatalog } =
   await import("./prepared-model-runtime.scoped-catalog.js");
@@ -623,7 +623,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
       workspaceDir: "/tmp/prepared-static-workspace",
     });
     expect(
-      getAvailablePreparedModelCatalogSnapshot({
+      getPreparedModelCatalogSnapshot({
         agentId: "default",
         config,
         agentDir: "/tmp/prepared-static-agent",
@@ -655,7 +655,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     expect(snapshot?.readFullModelCatalog?.()).toBe(fullCatalog);
     expect(
-      getAvailablePreparedModelCatalogSnapshot({
+      getPreparedModelCatalogSnapshot({
         agentId: "default",
         config,
         agentDir: "/tmp/prepared-static-agent",

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -75,8 +75,6 @@ async function resolveSpawnModelError(params: {
       agentDir: params.targetAgentDir,
       workspaceDir: params.workspaceDir,
       readOnly: true,
-      providerDiscoveryProviderIds: [provider],
-      scopedLiveProviderDiscovery: true,
     });
   } catch (error) {
     return `sessions_spawn could not verify ${requestedModel ? "the requested model" : "outputSchema model capabilities"}: ${summarizeSpawnError(error)}`;

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1405,9 +1405,8 @@ describe("spawnSubagentDirect seam flow", () => {
       };
       if (
         scoped.readOnly !== true ||
-        scoped.scopedLiveProviderDiscovery !== true ||
-        scoped.providerDiscoveryProviderIds?.[0] !== "openai" ||
-        scoped.providerDiscoveryProviderIds.length !== 1
+        scoped.scopedLiveProviderDiscovery !== undefined ||
+        scoped.providerDiscoveryProviderIds !== undefined
       ) {
         return await hoisted.loadFullModelCatalogMock();
       }
@@ -1440,8 +1439,6 @@ describe("spawnSubagentDirect seam flow", () => {
       agentDir: expect.any(String),
       workspaceDir: resolveUserPath("/tmp/workspace-main"),
       readOnly: true,
-      providerDiscoveryProviderIds: ["openai"],
-      scopedLiveProviderDiscovery: true,
     });
     expect(hoisted.updateSessionStoreMock).not.toHaveBeenCalled();
     expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -525,10 +525,10 @@ describe("createModelSelectionState catalog loading", () => {
     },
   );
 
-  it("uses manifest metadata before hydrating the runtime thinking catalog", async () => {
+  it("uses published metadata without a second manifest inventory", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
     vi.mocked(loadManifestModelCatalog).mockClear();
-    vi.mocked(loadManifestModelCatalog).mockReturnValueOnce([
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([
       { provider: "openai", id: "gpt-5.5", name: "GPT-5.5", reasoning: true },
     ]);
     const cfg = {
@@ -554,14 +554,12 @@ describe("createModelSelectionState catalog loading", () => {
     await expect(state.resolveThinkingCatalog()).resolves.toEqual([
       expect.objectContaining({ provider: "openai", id: "gpt-5.5", reasoning: true }),
     ]);
-    expect(loadManifestModelCatalog).toHaveBeenCalledWith({
-      config: cfg,
-      fallbackToMetadataScan: false,
-    });
+    expect(loadManifestModelCatalog).not.toHaveBeenCalled();
+    expect(loadProviderScopedThinkingCatalog).toHaveBeenCalledOnce();
     expect(loadModelCatalogLocal).not.toHaveBeenCalled();
   });
 
-  it("keeps configured compat when manifest thinking metadata is used", async () => {
+  it("keeps configured compat in published thinking metadata", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
     vi.mocked(loadManifestModelCatalog).mockReturnValueOnce([
       { provider: "vllm", id: "Qwen/Qwen3-8B", name: "Qwen3", reasoning: true },
@@ -702,7 +700,7 @@ describe("createModelSelectionState catalog loading", () => {
     await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("minimal");
   });
 
-  it("loads the full catalog for explicit model directives", async () => {
+  it("reads published catalog for explicit model directives", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
     const cfg = {
       agents: {
@@ -714,7 +712,7 @@ describe("createModelSelectionState catalog loading", () => {
       },
     } as OpenClawConfig;
 
-    await createModelSelectionState({
+    const state = await createModelSelectionState({
       cfg,
       agentCfg: cfg.agents?.defaults,
       defaultProvider: "openai",
@@ -725,7 +723,10 @@ describe("createModelSelectionState catalog loading", () => {
     });
 
     expect(loadModelCatalogLocal).toHaveBeenCalledOnce();
-    expect(vi.mocked(loadModelCatalogLocal).mock.calls[0]?.[0]).not.toHaveProperty("readOnly");
+    expect(vi.mocked(loadModelCatalogLocal).mock.calls[0]?.[0]).toHaveProperty("readOnly", true);
+    expect(state.allowedModelCatalog).toContainEqual(
+      expect.objectContaining({ provider: "openai", id: "gpt-4o" }),
+    );
   });
 
   it("carries catalog context limits into cold model selection", async () => {
@@ -2387,10 +2388,10 @@ describe("createModelSelectionState auth-profile override flapping regression", 
 });
 
 describe("createModelSelectionState resolveDefaultReasoningLevel", () => {
-  it("uses manifest metadata before hydrating the runtime reasoning catalog", async () => {
+  it("uses published reasoning without a second manifest inventory", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
     vi.mocked(loadManifestModelCatalog).mockClear();
-    vi.mocked(loadManifestModelCatalog).mockReturnValueOnce([
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([
       { provider: "local", id: "fast-reasoner", name: "Fast Reasoner", reasoning: true },
     ]);
     const state = await createModelSelectionState({
@@ -2404,10 +2405,8 @@ describe("createModelSelectionState resolveDefaultReasoningLevel", () => {
     });
 
     await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
-    expect(loadManifestModelCatalog).toHaveBeenCalledWith({
-      config: {},
-      fallbackToMetadataScan: false,
-    });
+    expect(loadManifestModelCatalog).not.toHaveBeenCalled();
+    expect(loadProviderScopedThinkingCatalog).toHaveBeenCalledOnce();
     expect(loadModelCatalogLocal).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -12,7 +12,6 @@ import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import type { ModelFallbackRouteResolution } from "../../agents/model-fallback.types.js";
 import {
   type ModelAliasIndex,
-  buildConfiguredModelCatalog,
   legacyModelKey,
   modelKey,
   normalizeProviderId,
@@ -167,9 +166,9 @@ export async function createModelSelectionState(params: {
     ).loadPreparedModelCatalogSnapshot({
       config: cfg,
       ...(params.agentId ? { agentId: params.agentId } : {}),
+      readOnly: true,
     }));
   const runtimeModelNormalization = resolveRuntimeNormalization(cfg);
-  const { manifestPlugins } = runtimeModelNormalization;
 
   let provider = params.provider;
   let model = params.model;
@@ -197,7 +196,7 @@ export async function createModelSelectionState(params: {
     model: defaultModel,
   });
   const configuredModelCatalog = mergePreparedConfiguredCatalog({
-    configured: buildConfiguredModelCatalog({ cfg, manifestPlugins }),
+    configured: [...visibilityPolicy.configuredCatalog],
     prepared: params.preparedModelCatalog?.entries,
   });
   const needsModelCatalog =
@@ -519,7 +518,6 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  let manifestModelCatalog: ModelCatalog | null = null;
   const buildThinkingCatalog = (catalog: ModelCatalog): ModelCatalog =>
     createModelVisibilityPolicy({
       cfg,
@@ -529,18 +527,6 @@ export async function createModelSelectionState(params: {
       agentId: params.agentId,
       ...runtimeModelNormalization,
     }).allowedCatalog;
-  const loadManifestCatalog = async () => {
-    if (manifestModelCatalog) {
-      return manifestModelCatalog;
-    }
-    const { loadManifestModelCatalog } = await loadPreparedModelCatalogRuntime();
-    manifestModelCatalog = loadManifestModelCatalog({
-      config: cfg,
-      fallbackToMetadataScan: false,
-    });
-    logStage("manifest-catalog-loaded", `entries=${manifestModelCatalog.length}`);
-    return manifestModelCatalog;
-  };
   const thinkingCatalogs = new Map<string, ModelCatalog>();
   const resolveThinkingCatalog = async (
     selection: ThinkingDefaultSelection = { provider, model },
@@ -551,31 +537,21 @@ export async function createModelSelectionState(params: {
       return cached.length > 0 ? cached : undefined;
     }
     let catalog = allowedModelCatalog;
-    const hasReasoning = (entries: ModelCatalog) =>
-      findSelectedCatalogEntry({
-        catalog: entries,
-        provider: selection.provider,
-        model: selection.model,
-      })?.reasoning !== undefined;
-    if (!hasReasoning(catalog)) {
-      const manifestCatalog = buildThinkingCatalog(await loadManifestCatalog());
-      if (hasReasoning(manifestCatalog)) {
-        catalog = manifestCatalog;
-      } else {
-        // Capability reads stay scoped to the actual selection, including a model
-        // chosen after this state was prepared. Never discover every provider here.
-        const { loadProviderScopedThinkingCatalog } = await loadPreparedModelCatalogRuntime();
-        const scopedCatalog = buildThinkingCatalog(
-          await loadProviderScopedThinkingCatalog({
-            config: cfg,
-            agentId: params.agentId,
-            provider: selection.provider,
-            model: selection.model,
-          }),
-        );
-        if (findSelectedCatalogEntry({ catalog: scopedCatalog, ...selection })) {
-          catalog = scopedCatalog;
-        }
+    if (
+      findSelectedCatalogEntry({ catalog, provider: selection.provider, model: selection.model })
+        ?.reasoning === undefined
+    ) {
+      const { loadProviderScopedThinkingCatalog } = await loadPreparedModelCatalogRuntime();
+      const preparedCatalog = buildThinkingCatalog(
+        await loadProviderScopedThinkingCatalog({
+          config: cfg,
+          agentId: params.agentId,
+          provider: selection.provider,
+          model: selection.model,
+        }),
+      );
+      if (findSelectedCatalogEntry({ catalog: preparedCatalog, ...selection })) {
+        catalog = preparedCatalog;
       }
     }
     thinkingCatalogs.set(key, catalog);

--- a/src/commands/models/list.probe.ollama.test.ts
+++ b/src/commands/models/list.probe.ollama.test.ts
@@ -1,4 +1,4 @@
-// Ollama probe planning tests cover keyless runtime auth and provider-scoped catalog reads.
+// Ollama probe planning tests cover keyless runtime auth and published catalog reads.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -99,7 +99,6 @@ describe("Ollama probe targets", () => {
     expect(loadPreparedModelCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         readOnly: true,
-        providerDiscoveryProviderIds: ["ollama"],
       }),
     );
     expect(plan.targets).toEqual([

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -390,10 +390,7 @@ export async function buildProbeTargets(params: {
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(agentDir ? { agentDir } : {}),
     ...(workspaceDir ? { workspaceDir } : {}),
-    // A provider probe only needs candidate selection. Keep it request-scoped so it cannot
-    // supersede or be superseded by the Gateway's concurrent full-catalog materialization.
     readOnly: true,
-    providerDiscoveryProviderIds: providers,
   });
   const candidates = buildProbeCandidateMap(modelCandidates);
   const targets: AuthProbeTarget[] = [];

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3908,9 +3908,8 @@ describe("startGatewayPostAttachRuntime", () => {
       };
       if (
         scoped.readOnly !== true ||
-        scoped.scopedLiveProviderDiscovery !== true ||
-        scoped.providerDiscoveryProviderIds?.[0] !== "openai" ||
-        scoped.providerDiscoveryProviderIds.length !== 1
+        scoped.scopedLiveProviderDiscovery !== undefined ||
+        scoped.providerDiscoveryProviderIds !== undefined
       ) {
         return await hoisted.loadFullModelCatalog();
       }
@@ -3940,8 +3939,6 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.loadModelCatalog).toHaveBeenCalledWith({
       config: expect.any(Object),
       readOnly: true,
-      providerDiscoveryProviderIds: ["openai"],
-      scopedLiveProviderDiscovery: true,
     });
     expect(hoisted.getModelRefStatus).toHaveBeenCalledWith(
       expect.objectContaining({ ref: { provider: "openai", model: "gpt-5.4" } }),

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -992,8 +992,6 @@ export async function startGatewaySidecars(params: {
             const catalog = await loadPreparedModelCatalog({
               config: params.cfg,
               readOnly: true,
-              providerDiscoveryProviderIds: [hooksModelRef.provider],
-              scopedLiveProviderDiscovery: true,
             });
             if (isStopped()) {
               return;


### PR DESCRIPTION
Related: #136257, #125969, #142100.

## What Problem This Solves

Fixes an issue where an ordinary session model-selection command started provider discovery even though browsing should use published inventory.

## Why This Change Was Made

Turn capability, subagent/hook validation and probe planning read the published catalog. Remove separate live and manifest fallbacks for missing facts, retain catalog ownership through asynchronous projection, and reuse configured rows already captured by visibility policy.

## User Impact

Model selection saves the requested model without unrequested discovery. Explicit Refresh still acquires new inventory. Existing route checks, tool refusals and authentication boundaries remain.

Consumers: model selection, capability validation and public cached catalog reads use published facts.

## Evidence

A real Gateway reproduced two unrequested discovery calls before the fix. The candidate saved the exact selection with no catalog or inference requests; explicit Refresh then published the model. Fifty-nine focused controls passed. Compiled public-interface checks confirmed passive getters; standalone installation and external inference were not tested.
