### PR TITLE
refactor(tests): share cloud agent response fixtures

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -15,6 +15,7 @@ import {
   captureUiProofEnabled,
   controlUiSessionPath,
   controlUiSessionUrl,
+  createCloudAgentsListResponse,
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   expectPendingSessionPlacementStartupBeforeRuntime,
@@ -137,20 +138,7 @@ suite.define(() => {
       workspaceGit: true,
       sessionKey: "agent:cloud:neutral-e2e",
       methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "cloud",
-              identity: { name: "Cloud" },
-              name: "Cloud",
-              workspace: WORKSPACE,
-              workspaceGit: true,
-            },
-          ],
-          defaultId: "cloud",
-          mainKey: "main",
-          scope: "agent",
-        },
+        "agents.list": createCloudAgentsListResponse(),
         "projects.list": {
           projects: [
             {

--- a/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
@@ -5,8 +5,8 @@ import type { SessionPlacementPendingRecovery } from "../lib/sessions/session-pl
 import type { ChatPageHost } from "../pages/chat/chat-state-host.ts";
 import { holdModuleResponse } from "./control-ui-e2e-suite.test-support.ts";
 import {
-  WORKSPACE,
   controlUiSessionPath,
+  createCloudAgentsListResponse,
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   expectPastedPngImage,
@@ -61,20 +61,7 @@ suite.define(() => {
         featureMethods: ["sessions.create", "sessions.dispatch", "chat.startup"],
         workspaceGit: true,
         methodResponses: {
-          "agents.list": {
-            agents: [
-              {
-                id: "cloud",
-                identity: { name: "Cloud" },
-                name: "Cloud",
-                workspace: WORKSPACE,
-                workspaceGit: true,
-              },
-            ],
-            defaultId: "cloud",
-            mainKey: "main",
-            scope: "agent",
-          },
+          "agents.list": createCloudAgentsListResponse(),
           "environments.list": {
             environments: [],
             profiles: [{ id: "aws", providerId: "crabbox" }],

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
   controlUiSessionPath,
+  createCloudAgentsListResponse,
   createNewSessionPageE2eSuite,
   expectPastedPngImage,
   installMockGateway,
@@ -113,20 +114,7 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       workspaceGit: true,
       methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "cloud",
-              identity: { name: "Cloud" },
-              name: "Cloud",
-              workspace: WORKSPACE,
-              workspaceGit: true,
-            },
-          ],
-          defaultId: "cloud",
-          mainKey: "main",
-          scope: "agent",
-        },
+        "agents.list": createCloudAgentsListResponse(),
         "environments.list": {
           environments: [],
           profiles: [{ id: "aws", providerId: "crabbox" }],
@@ -320,20 +308,7 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       workspaceGit: true,
       methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "cloud",
-              identity: { name: "Cloud" },
-              name: "Cloud",
-              workspace: WORKSPACE,
-              workspaceGit: true,
-            },
-          ],
-          defaultId: "cloud",
-          mainKey: "main",
-          scope: "agent",
-        },
+        "agents.list": createCloudAgentsListResponse(),
         "environments.list": {
           environments: [],
           profiles: [{ id: "aws", providerId: "crabbox" }],

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
   controlUiSessionPath,
+  createCloudAgentsListResponse,
   createNewSessionPageE2eSuite,
   expectPastedPngImage,
   installMockGateway,
@@ -237,20 +238,7 @@ suite.define(() => {
       deferredMethods: ["sessions.create", "sessions.delete"],
       workspaceGit: true,
       methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "cloud",
-              identity: { name: "Cloud" },
-              name: "Cloud",
-              workspace: WORKSPACE,
-              workspaceGit: true,
-            },
-          ],
-          defaultId: "cloud",
-          mainKey: "main",
-          scope: "agent",
-        },
+        "agents.list": createCloudAgentsListResponse(),
         "environments.list": {
           environments: [],
           profiles: [{ id: "aws", providerId: "crabbox" }],
@@ -361,20 +349,7 @@ suite.define(() => {
         deferredMethods: ["sessions.create"],
         workspaceGit: true,
         methodResponses: {
-          "agents.list": {
-            agents: [
-              {
-                id: "cloud",
-                identity: { name: "Cloud" },
-                name: "Cloud",
-                workspace: WORKSPACE,
-                workspaceGit: true,
-              },
-            ],
-            defaultId: "cloud",
-            mainKey: "main",
-            scope: "agent",
-          },
+          "agents.list": createCloudAgentsListResponse(),
           "environments.list": {
             environments: [],
             profiles: [{ id: "aws", providerId: "crabbox" }],
@@ -532,20 +507,7 @@ suite.define(() => {
       deferredMethods: ["sessions.send"],
       workspaceGit: true,
       methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "cloud",
-              identity: { name: "Cloud" },
-              name: "Cloud",
-              workspace: WORKSPACE,
-              workspaceGit: true,
-            },
-          ],
-          defaultId: "cloud",
-          mainKey: "main",
-          scope: "agent",
-        },
+        "agents.list": createCloudAgentsListResponse(),
         "environments.list": {
           environments: [],
           profiles: [{ id: "aws", providerId: "crabbox" }],

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -38,6 +38,23 @@ export function installMockGateway(
 
 export const WORKSPACE = "/home/peter/openclaw";
 
+export function createCloudAgentsListResponse() {
+  return {
+    agents: [
+      {
+        id: "cloud",
+        identity: { name: "Cloud" },
+        name: "Cloud",
+        workspace: WORKSPACE,
+        workspaceGit: true,
+      },
+    ],
+    defaultId: "cloud",
+    mainKey: "main",
+    scope: "agent",
+  };
+}
+
 export const LOCAL_GIT_WORKSPACE_RESPONSES = {
   "agents.list": {
     agents: [


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four related new-session browser suites repeat the same cloud-agent response setup, making shared fixture data harder to maintain.

## Why This Change Was Made

Seven exact input literals now use a fresh constructor in the existing new-session test support module. It preserves the response, agents array, agent and identity allocations, the existing workspace binding, and every field and key order. Distinct multi-agent and model-bearing responses remain explicit.

## User Impact

No production behavior, UI appearance, test scenario, assertion or browser lifecycle changes. The change removes 71 net test/support lines without introducing defaults or configurable fixture overrides.

## Evidence

- All four complete browser suites passed 18 cases before and after, with identical per-file ordered case identities and no skips.
- Existing suite-lifecycle and mock-Gateway support tests passed 26 cases.
- Complete AST expansion verified all seven replacements and unchanged surrounding cases; runtime checks compared the preserved original literal and verified deep values, prototypes and four fresh nested allocations.
- Full mapped checks, diff-scoped cleanup, and fresh full-scope P2 review passed without findings.

No runtime speedup or aggregate coverage percentage is claimed. No new visual capture is needed for this input-only refactor.
