### PR TITLE
docs(cli): point the Gateway catalog link at a real anchor

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -176,7 +176,7 @@ Notes:
 
 Provider discovery through `models list --refresh` is separate from the hosted
 metadata download performed by `models refresh`, described below. See the
-[Gateway catalog request](/gateway/protocol/operator-methods#modelslist-views)
+[Gateway catalog request](/gateway/protocol/operator-methods#models-list-views)
 for the wire controls.
 
 ### Refresh the hosted catalog


### PR DESCRIPTION
## What

One link on `docs/cli/models.md` pointed at an anchor that does not exist. One line.

## Why

It targeted `/gateway/protocol/operator-methods#modelslist-views`. The protocol split ([#141055](https://github.com/openclaw/openclaw/pull/141055)) moved that section onto its own page, and the heading `\`models.list\` views` mints two ids — `models.list-views` and `models-list-views` — but never `modelslist-views`. The link has been dead on `main`.

I used the punctuation-free alias, which stays valid if the heading is later reworded.

## How it surfaced

`docs-link-audit --anchors` flagged it while I was rebasing an unrelated split. It is not caused by that branch — I confirmed the same failure on a clean `origin/main` checkout before separating it into this PR rather than burying a main-branch fix inside a structural change.

## Validation

```
docs-link-audit --anchors   0 broken links (9,491 checked)
format-docs --check         clean, 872 files
```

I also swept every cross-page anchor link in the tree with the repository's own `parseDocsDocument`: **1,709 checked**. A naive regex reports ten more failures, but those are an artifact of matching — an unescaped `(` in a fragment truncates the match. The repo's own anchor audit is authoritative and reports zero.