### PR TITLE
fix(ui): avoid repeated model discovery when reopening Settings pickers

### DIFF
--- a/docs/gateway/protocol/operator-methods.md
+++ b/docs/gateway/protocol/operator-methods.md
@@ -158,10 +158,17 @@ The Gateway advertises `session-scoped-model-catalog` for this contract.
 `chat.metadata` remains available to legacy clients; the Control UI reads models
 directly and keeps commands in its metadata cache. Opening a conversation picker
 performs a passive read, without a model-cache timer or implicit provider refresh.
-The Models settings page requests `refresh: true` when a primary, utility, or
-fallback model picker opens, so it can discover additional models on demand.
-Pending opens share that page's request; reopening after completion requests a
-new refresh, and the Gateway shares concurrent provider acquisition.
+The Models settings page uses `preparedOnly: true` for its initial load, then
+requests `refresh: true` the first time a primary, utility, or fallback model
+picker opens for the current core-data snapshot. Pending opens share that page's request; completed reopens read the
+current published catalog without acquiring providers again. Explicit **Retry**
+requests a new acquisition. Replacing core settings data, the page, agent, or
+Gateway resets this request state. Core data reloads after configuration changes,
+so the next picker open can discover models from newly configured providers.
+Usable choices remain available when refresh fails.
+This replaces the former five-minute automatic refresh policy; elapsed time alone
+does not make a reopened Settings picker refresh. The Gateway shares concurrent
+provider acquisition.
 
 `preparedOnly: true` and `refresh: true` remain mutually exclusive.
 The Gateway advertises these published-read and details controls as

--- a/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
@@ -264,6 +264,7 @@ suite.define(() => {
             .locator(".model-providers__catalog-progress")
             .getByRole("button", { name: "Retry", exact: true });
           await retry.waitFor({ state: "visible" });
+          expect(await settings.textContent()).not.toContain("Open Models to try again.");
           expect(acquisitions()).toBe(initialAcquisitions + 5);
           await primary
             .locator('[role="option"][data-value="ollama/published-fixture:latest"]')

--- a/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
@@ -10,6 +10,8 @@ import {
 } from "../../../test/helpers/openclaw-test-instance.ts";
 import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { pickerValue } from "../test-helpers/select-picker-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const requireRecord = createRequireRecord("record", "expected-object-value");
@@ -19,9 +21,10 @@ const models = (id: string) => [
 ];
 let instance: OpenClawTestInstance;
 let providerMode: "ready" | "failed" | "empty" = "ready";
+let providerModel = "refresh-fixture:latest";
 const providerTraffic: Array<{ path: string; status: number }> = [];
 const suite = createControlUiE2eSuite({
-  name: "Command Palette catalog publication with a real Gateway",
+  name: "Control UI catalog publication with a real Gateway",
   startServerBeforeBrowser: true,
   async startServer() {
     const provider = http.createServer((req, res) => {
@@ -31,7 +34,7 @@ const suite = createControlUiE2eSuite({
         status === 503
           ? { error: "private upstream error body" }
           : req.url === "/api/tags"
-            ? { models: providerMode === "empty" ? [] : [{ name: "refresh-fixture:latest" }] }
+            ? { models: providerMode === "empty" ? [] : [{ name: providerModel }] }
             : {
                 capabilities: ["completion", "tools"],
                 model_info: { "llama.context_length": 8192 },
@@ -55,7 +58,7 @@ const suite = createControlUiE2eSuite({
     try {
       instance = await createOpenClawTestInstance({
         name: "palette-catalog-publication",
-        env: { OPENCLAW_TEST_MINIMAL_GATEWAY: undefined, VITEST: undefined },
+        env: { OPENCLAW_TEST_MINIMAL_GATEWAY: undefined, VITEST: undefined, OLLAMA_API_KEY: "" },
         config: {
           gateway: { controlUi: { enabled: true } },
           cron: { enabled: false },
@@ -71,6 +74,7 @@ const suite = createControlUiE2eSuite({
             ],
           },
           models: {
+            catalogRefresh: { enabled: false },
             providers: {
               fixture: {
                 api: "openai-completions",
@@ -103,6 +107,204 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("acquires on the first Settings picker open and Retry, while completed reopens read publication", async () => {
+    const frames: unknown[] = [];
+    const requests: Array<{ id: string; params: Record<string, unknown> }> = [];
+    const replies = new Map<string, Record<string, unknown>>();
+    const stages: unknown[] = [];
+    const assets: Array<Promise<{ path: string; sha256: string }>> = [];
+    const acquisitions = () => providerTraffic.filter((entry) => entry.path === "/api/tags").length;
+    const publish = async () => {
+      const result = await instance.cli([
+        "gateway",
+        "call",
+        "models.list",
+        "--json",
+        "--timeout",
+        "30000",
+        "--params",
+        JSON.stringify({ agentId: "main", view: "configured", refresh: true }),
+      ]);
+      expect(result.code, result.stderr).toBe(0);
+      return requireRecord(JSON.parse(result.stdout));
+    };
+    const handoff = await instance.cli(["dashboard", "--json"]);
+    expect(handoff.code, handoff.stderr).toBe(0);
+    const browserUrl = requireRecord(JSON.parse(handoff.stdout)).browserUrl;
+    if (typeof browserUrl !== "string") {
+      throw new Error("Dashboard did not return a browser handoff");
+    }
+    const url = new URL("/settings/model-providers", browserUrl);
+    url.hash = new URL(browserUrl).hash;
+    try {
+      // Settle startup acquisition before measuring page-owned requests.
+      expect((await publish()).providerOutcomes).toContainEqual({
+        provider: "ollama",
+        status: "ready",
+      });
+      await suite.withPage(
+        { serviceWorkers: "block", locale: "en-US", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          page.on("response", (response) => {
+            const asset = new URL(response.url());
+            if (asset.origin === url.origin && /\/assets\/.*\.(?:js|css)$/u.test(asset.pathname)) {
+              assets.push(
+                response.body().then((body) => ({
+                  path: asset.pathname,
+                  sha256: createHash("sha256").update(body).digest("hex"),
+                })),
+              );
+            }
+          });
+          page.on("websocket", (socket) => {
+            socket.on("framesent", ({ payload }) => {
+              const frame = requireRecord(JSON.parse(payload.toString()));
+              if (
+                frame.type === "req" &&
+                frame.method === "models.list" &&
+                typeof frame.id === "string"
+              ) {
+                requests.push({ id: frame.id, params: requireRecord(frame.params) });
+                frames.push({ direction: "sent", frame });
+              }
+            });
+            socket.on("framereceived", ({ payload }) => {
+              const frame = requireRecord(JSON.parse(payload.toString()));
+              if (
+                frame.type === "res" &&
+                typeof frame.id === "string" &&
+                requests.some(({ id }) => id === frame.id)
+              ) {
+                replies.set(frame.id, frame);
+                frames.push({ direction: "received", frame });
+              }
+            });
+          });
+          const initialAcquisitions = acquisitions();
+          await page.goto(url.href);
+          await waitForControlUiGatewayReady(page);
+          const settings = page.locator("openclaw-model-providers-page");
+          const pickers = settings.locator(".model-providers__defaults openclaw-select-picker");
+          const primary = pickers.first();
+          const trigger = primary.locator(".picker-select__trigger");
+          const capture = async (name: string) =>
+            fs.writeFile(
+              path.join(suite.artifactDir, name),
+              await takeControlUiViewportScreenshot(page, settings, [primary]),
+            );
+          await trigger.waitFor({ state: "visible" });
+          await expect.poll(() => pickerValue(primary)).toBe("fixture/anchor");
+          await expect
+            .poll(() => requests.some(({ params }) => params.preparedOnly === true))
+            .toBe(true);
+          expect(acquisitions()).toBe(initialAcquisitions);
+          stages.push({ stage: "initial", acquisitions: acquisitions() });
+
+          const catalogRequest = async (refresh: boolean, action: () => Promise<void>) => {
+            const before = requests.length;
+            await action();
+            await expect.poll(() => requests.length).toBe(before + 1);
+            const request = requests.at(-1)!;
+            await expect.poll(() => replies.has(request.id)).toBe(true);
+            expect(request.params).toEqual({
+              view: "configured",
+              agentId: "main",
+              ...(refresh ? { refresh: true } : {}),
+            });
+            expect(replies.get(request.id)?.ok).toBe(true);
+          };
+          const open = async (refresh: boolean) => {
+            if ((await trigger.getAttribute("aria-expanded")) === "true") {
+              await trigger.click();
+            }
+            await catalogRequest(refresh, () => trigger.click());
+          };
+          await open(true);
+          await primary
+            .locator('[role="option"][data-value="ollama/refresh-fixture:latest"]')
+            .waitFor({ state: "visible" });
+          expect(acquisitions()).toBe(initialAcquisitions + 1);
+          expect(await pickerValue(primary)).toBe("fixture/anchor");
+          stages.push({ stage: "first-open", acquisitions: acquisitions() });
+          await capture("settings-first-open.png");
+
+          await trigger.click();
+          providerModel = "published-fixture:latest";
+          expect((await publish()).providerOutcomes).toContainEqual({
+            provider: "ollama",
+            status: "ready",
+          });
+          expect(acquisitions()).toBe(initialAcquisitions + 2);
+          await open(false);
+          await primary
+            .locator('[role="option"][data-value="ollama/published-fixture:latest"]')
+            .waitFor({ state: "visible" });
+          expect(acquisitions()).toBe(initialAcquisitions + 2);
+          expect(await pickerValue(primary)).toBe("fixture/anchor");
+          stages.push({ stage: "published-reopen", acquisitions: acquisitions() });
+          await capture("settings-published-reopen.png");
+
+          await trigger.click();
+          await catalogRequest(true, () =>
+            settings.getByRole("button", { name: "Refresh", exact: true }).click(),
+          );
+          expect(acquisitions()).toBe(initialAcquisitions + 3);
+          await open(true);
+          expect(acquisitions()).toBe(initialAcquisitions + 4);
+          stages.push({ stage: "core-replacement-open", acquisitions: acquisitions() });
+
+          // A new page starts its own request lifetime and keeps the published rows on failure.
+          await page.reload();
+          await waitForControlUiGatewayReady(page);
+          await trigger.waitFor({ state: "visible" });
+          await expect.poll(() => pickerValue(primary)).toBe("fixture/anchor");
+          providerMode = "failed";
+          await open(true);
+          const retry = settings
+            .locator(".model-providers__catalog-progress")
+            .getByRole("button", { name: "Retry", exact: true });
+          await retry.waitFor({ state: "visible" });
+          expect(acquisitions()).toBe(initialAcquisitions + 5);
+          await primary
+            .locator('[role="option"][data-value="ollama/published-fixture:latest"]')
+            .waitFor({ state: "visible" });
+          expect(requireRecord(replies.get(requests.at(-1)!.id)?.payload).refreshFailed).toBe(true);
+          stages.push({ stage: "failed-first-open", acquisitions: acquisitions() });
+          await capture("settings-refresh-failed.png");
+
+          providerMode = "ready";
+          providerModel = "recovered-fixture:latest";
+          await catalogRequest(true, () => retry.click());
+          await retry.waitFor({ state: "hidden" });
+          await open(false);
+          await primary
+            .locator('[role="option"][data-value="ollama/recovered-fixture:latest"]')
+            .waitFor({ state: "visible" });
+          expect(acquisitions()).toBe(initialAcquisitions + 6);
+          expect(await pickerValue(primary)).toBe("fixture/anchor");
+          stages.push({ stage: "retry", acquisitions: acquisitions() });
+          await capture("settings-retry.png");
+        },
+      );
+    } finally {
+      providerMode = "ready";
+      providerModel = "refresh-fixture:latest";
+      await fs.writeFile(
+        path.join(suite.artifactDir, "settings-acquisition.json"),
+        JSON.stringify(
+          {
+            frames,
+            stages,
+            providerTraffic,
+            assets: await Promise.all(assets),
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  }, 120_000);
+
   it("shows actual acquisition failures in Automations and model search without losing compatible rows", async () => {
     const outcomes: unknown[] = [];
     const refresh = async () => {
@@ -347,3 +549,4 @@ suite.define(() => {
     }
   }, 120_000);
 });
+import { createHash } from "node:crypto";

--- a/ui/src/pages/model-providers/catalog-discovery.ts
+++ b/ui/src/pages/model-providers/catalog-discovery.ts
@@ -1,13 +1,13 @@
 // Demand-driven catalog discovery for the Models settings page.
 //
-// The initial page load uses the fast prepared catalog (configured models only)
+// The initial page load uses the fast prepared catalog
 // so full discovery stays out of first navigation. Opening a default-model picker
-// signals interest; this controller explicitly refreshes the Gateway-owned catalog
-// and merges it in without disturbing the saved selection. Pending opens share
-// this page's request; the Gateway owns concurrent provider acquisition.
+// signals interest; the first open for this core-data snapshot and explicit retries
+// refresh the Gateway-owned catalog. Completed reopens read its current publication.
+// Pending opens share this page's request without disturbing the saved selection.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
+import { loadModelCatalog, modelCatalogRefreshError } from "../../lib/model-catalog-store.ts";
 import type { ModelProvidersData } from "./load.ts";
 
 type DiscoveryGateway = {
@@ -26,7 +26,7 @@ export type CatalogDiscoveryController = {
   openPicker: () => void;
   /** Retries a failed discovery. */
   retry: () => void;
-  /** Resets in-flight/error state (e.g. on agent switch). */
+  /** Resets request history and pending/error state when core data or its owner changes. */
   reset: () => void;
 };
 
@@ -44,6 +44,7 @@ export function createCatalogDiscoveryController(
 ): CatalogDiscoveryController {
   let pending: AbortController | null = null;
   let error: string | null = null;
+  let requestedDiscovery = false;
 
   const controller: CatalogDiscoveryController = {
     get discovering() {
@@ -53,21 +54,22 @@ export function createCatalogDiscoveryController(
       return error;
     },
     openPicker() {
-      void discover();
+      void discover(!requestedDiscovery);
     },
     retry() {
-      void discover();
+      void discover(true);
     },
     reset() {
       const retired = pending;
       pending = null;
       error = null;
+      requestedDiscovery = false;
       retired?.abort();
       options.requestUpdate();
     },
   };
 
-  async function discover(): Promise<void> {
+  async function discover(refresh: boolean): Promise<void> {
     const agentId = options.getAgentId();
     if (!agentId || pending) {
       return;
@@ -87,21 +89,23 @@ export function createCatalogDiscoveryController(
       options.getAgentEpoch() === agentEpoch;
     pending = request;
     error = null;
+    requestedDiscovery = true;
     options.requestUpdate();
     try {
       const result = await loadModelCatalog(client, {
         agentId,
-        refresh: true,
+        ...(refresh ? { refresh: true } : {}),
         signal: request.signal,
       });
       if (ownsResult()) {
+        error = modelCatalogRefreshError(result);
         const data = options.getData();
         if (data) {
           options.setData({
             ...data,
             models: result.models,
             providerOutcomes: result.providerOutcomes ?? [],
-            catalogError: null,
+            catalogError: error,
           });
         }
       }

--- a/ui/src/pages/model-providers/catalog-discovery.ts
+++ b/ui/src/pages/model-providers/catalog-discovery.ts
@@ -6,8 +6,9 @@
 // refresh the Gateway-owned catalog. Completed reopens read its current publication.
 // Pending opens share this page's request without disturbing the saved selection.
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { loadModelCatalog, modelCatalogRefreshError } from "../../lib/model-catalog-store.ts";
+import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
 import type { ModelProvidersData } from "./load.ts";
 
 type DiscoveryGateway = {
@@ -98,14 +99,14 @@ export function createCatalogDiscoveryController(
         signal: request.signal,
       });
       if (ownsResult()) {
-        error = modelCatalogRefreshError(result);
+        error = result.refreshFailed ? t("modelProviders.defaults.discoverFailed") : null;
         const data = options.getData();
         if (data) {
           options.setData({
             ...data,
             models: result.models,
             providerOutcomes: result.providerOutcomes ?? [],
-            catalogError: error,
+            catalogError: null,
           });
         }
       }

--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -71,9 +71,17 @@ function createCatalogHarness() {
   const harness = createHarness("main");
   const originalRequest = harness.request.getMockImplementation()!;
   const discover = vi.fn<() => Promise<ModelCatalogResult>>();
-  const catalogRequest = async (method: string, params?: { refresh?: boolean }) => {
+  const readPublished = vi.fn(() => preparedCatalog);
+  const catalogRequest = async (
+    method: string,
+    params?: { refresh?: boolean; preparedOnly?: boolean },
+  ) => {
     if (method === "models.list") {
-      return params?.refresh ? discover() : preparedCatalog;
+      return params?.preparedOnly
+        ? preparedCatalog
+        : params?.refresh
+          ? discover()
+          : readPublished();
     }
     if (method === "config.get") {
       return { config: savedModelConfig, hash: "saved-model-config" };
@@ -81,7 +89,7 @@ function createCatalogHarness() {
     return originalRequest(method);
   };
   harness.request.mockImplementation(catalogRequest);
-  return { ...harness, discover, catalogRequest };
+  return { ...harness, discover, readPublished, catalogRequest };
 }
 
 describe("ModelProvidersPage catalog discovery", () => {
@@ -92,7 +100,7 @@ describe("ModelProvidersPage catalog discovery", () => {
   ])(
     "discovers the full catalog when the $picker picker opens and merges it without clearing saved state",
     async ({ index: firstPicker }) => {
-      const { context, request, discover, runtimeConfig } = createCatalogHarness();
+      const { context, request, discover, readPublished, runtimeConfig } = createCatalogHarness();
       const pending = deferred<ModelCatalogResult>();
       discover.mockReturnValue(pending.promise);
       const discovered: ModelCatalogResult = {
@@ -150,8 +158,19 @@ describe("ModelProvidersPage catalog discovery", () => {
       expect(page.data?.config).toEqual(savedModelConfig);
       expect(runtimeConfig.patch).not.toHaveBeenCalled();
       expect(page.querySelector(".model-providers__catalog-progress")).toBeNull();
+      const published = {
+        models: [
+          ...discovered.models,
+          { id: "published-later", name: "Published later", provider: "openai", available: true },
+        ],
+      };
+      readPublished.mockReturnValue(published);
       await openModelPicker(page, 1);
       await drainPageUpdates(page);
+      expect(page.data?.models).toEqual(published.models);
+      expect(
+        page.querySelector('[role="option"][data-value="openai/published-later"]'),
+      ).not.toBeNull();
       const utility = modelPickers(page)[1]!;
       const search = utility.querySelector<HTMLInputElement>('input[type="search"]');
       expect(search).not.toBeNull();
@@ -168,49 +187,61 @@ describe("ModelProvidersPage catalog discovery", () => {
       );
       expect(page.data?.config).toEqual(savedModelConfig);
       expect(runtimeConfig.patch).not.toHaveBeenCalled();
-      expect(discover).toHaveBeenCalledTimes(2);
+      expect(discover).toHaveBeenCalledOnce();
+      expect(readPublished).toHaveBeenCalledOnce();
       expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(3);
     },
   );
 
-  it("surfaces a retryable error when picker catalog discovery fails", async () => {
-    const { context, discover } = createCatalogHarness();
-    const pending = deferred<ModelCatalogResult>();
-    discover
-      .mockRejectedValueOnce(new Error("discovery failed"))
-      .mockReturnValueOnce(pending.promise);
-    const page = appendPage(context);
-    await waitForFast(() => expect(page.data?.config).toEqual(savedModelConfig));
-    await page.updateComplete;
+  it.each(["rejected request", "nonfatal refresh failure"])(
+    "retains choices and reacquires on Retry after a %s",
+    async (failure) => {
+      const { context, discover } = createCatalogHarness();
+      const pending = deferred<ModelCatalogResult>();
+      if (failure === "rejected request") {
+        discover.mockRejectedValueOnce(new Error("discovery failed"));
+      } else {
+        discover.mockResolvedValueOnce({ ...preparedCatalog, refreshFailed: true });
+      }
+      discover.mockReturnValueOnce(pending.promise);
+      const page = appendPage(context);
+      await waitForFast(() => expect(page.data?.config).toEqual(savedModelConfig));
+      await page.updateComplete;
 
-    await openModelPicker(page);
-    await waitForFast(() =>
-      expect(page.querySelector('.model-providers__catalog-progress[role="alert"]')).not.toBeNull(),
-    );
-    expect(page.querySelector(".model-providers__catalog-progress")?.textContent).toContain(
-      "More models could not be discovered.",
-    );
-    expect(page.data?.models).toEqual(preparedCatalog.models);
-    const retry = page.querySelector<HTMLButtonElement>(
-      ".model-providers__catalog-progress button",
-    );
-    expect(retry?.textContent?.trim()).toBe("Retry");
-    retry!.click();
-    await page.updateComplete;
-    expect(discover).toHaveBeenCalledTimes(2);
-    expect(page.querySelector('.model-providers__catalog-progress[role="status"]')).not.toBeNull();
+      await openModelPicker(page);
+      await waitForFast(() =>
+        expect(
+          page.querySelector('.model-providers__catalog-progress[role="alert"]'),
+        ).not.toBeNull(),
+      );
+      expect(page.querySelector(".model-providers__catalog-progress")?.textContent).toContain(
+        "More models could not be discovered.",
+      );
+      expect(page.data?.models).toEqual(preparedCatalog.models);
+      const retry = page.querySelector<HTMLButtonElement>(
+        ".model-providers__catalog-progress button",
+      );
+      expect(retry?.textContent?.trim()).toBe("Retry");
+      retry!.click();
+      await page.updateComplete;
+      expect(discover).toHaveBeenCalledTimes(2);
+      expect(
+        page.querySelector('.model-providers__catalog-progress[role="status"]'),
+      ).not.toBeNull();
 
-    pending.resolve({
-      models: [
-        ...preparedCatalog.models,
-        { id: "recovered", name: "Recovered model", provider: "openai", available: true },
-      ],
-    });
-    await waitForFast(() => expect(page.data?.models?.at(-1)?.id).toBe("recovered"));
-    await drainPageUpdates(page);
-    expect(page.querySelector(".model-providers__catalog-progress")).toBeNull();
-    expect(page.querySelector('[role="option"][data-value="openai/recovered"]')).not.toBeNull();
-  });
+      pending.resolve({
+        models: [
+          ...preparedCatalog.models,
+          { id: "recovered", name: "Recovered model", provider: "openai", available: true },
+        ],
+      });
+      await waitForFast(() => expect(page.data?.models?.at(-1)?.id).toBe("recovered"));
+      await drainPageUpdates(page);
+      expect(page.querySelector(".model-providers__catalog-progress")).toBeNull();
+      expect(page.querySelector('[role="option"][data-value="openai/recovered"]')).not.toBeNull();
+      expect(page.data?.catalogError).toBeNull();
+    },
+  );
 
   it.each([false, true])(
     "clears a prior catalog error after successful discovery (unrelated auth error: %s)",
@@ -256,13 +287,13 @@ describe("ModelProvidersPage catalog discovery", () => {
   it.each(["core refresh", "route data"] as const)(
     "keeps newer %s after an older picker response settles",
     async (replacement) => {
-      const { context, request, discover, snapshot } = createCatalogHarness();
+      const { context, request, discover, readPublished, snapshot } = createCatalogHarness();
       const pending = deferred<ModelCatalogResult>();
       const newer: ModelCatalogResult = {
         models: [{ id: "newer", name: "Newer model", provider: "openai", available: true }],
         providerOutcomes: [{ provider: "openai", status: "ready" }],
       };
-      discover.mockReturnValueOnce(pending.promise).mockResolvedValueOnce(newer);
+      discover.mockReturnValueOnce(pending.promise).mockResolvedValue(newer);
       const page = appendPage(context);
       await waitForFast(() => expect(page.data?.config).toEqual(savedModelConfig));
       await page.updateComplete;
@@ -303,6 +334,12 @@ describe("ModelProvidersPage catalog discovery", () => {
       expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(
         replacement === "core refresh" ? 3 : 2,
       );
+      readPublished.mockReturnValue(newer);
+      await openModelPicker(page, 1);
+      await drainPageUpdates(page);
+      expect(discover).toHaveBeenCalledTimes(replacement === "core refresh" ? 3 : 2);
+      expect(readPublished).not.toHaveBeenCalled();
+      expect(page.data?.models).toEqual(newer.models);
     },
   );
 

--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -217,6 +217,7 @@ describe("ModelProvidersPage catalog discovery", () => {
       expect(page.querySelector(".model-providers__catalog-progress")?.textContent).toContain(
         "More models could not be discovered.",
       );
+      expect(page.textContent).not.toContain("Open Models to try again.");
       expect(page.data?.models).toEqual(preparedCatalog.models);
       const retry = page.querySelector<HTMLButtonElement>(
         ".model-providers__catalog-progress button",


### PR DESCRIPTION
Related: #142346, #142343

## What Problem This Solves

Fixes an issue where users reopening primary, utility, or fallback pickers in Models Settings would repeatedly wait for full provider discovery even after the current page data had already requested it. A nonfatal provider refresh failure also retained usable choices without showing the picker Retry control.

## Why This Change Was Made

The page records whether the current core-data snapshot has requested discovery. First open and explicit Retry request acquisition; completed reopens read the Gateway’s current publication. Existing core/page/agent/Gateway replacement resets remain intact, because configuration changes can introduce providers that have not been discovered yet. Nonfatal refresh results keep usable choices and expose the existing Settings-local Retry feedback.

## User Impact

Users can reopen pickers without another provider acquisition while keeping saved selections and newly published choices current. Core settings reloads, including reloads after saves, intentionally allow a new acquisition on the next open. This replaces the former five-minute refresh policy; elapsed time alone does not trigger a refresh.

## Evidence

The same real Chromium → Gateway WebSocket/schema → bundled Ollama acquisition scenario fails on the merged predecessor controller at the completed reopen: it sends `refresh: true` and performs an extra `/api/tags` request. The candidate passes using an isolated Gateway and a synthetic loopback HTTP provider, with no mocked RPC responses or provider-acquisition function.

| Action | Additional provider acquisitions |
| --- | ---: |
| Initial prepared-only Settings load | 0 |
| First picker open | 1 |
| Completed reopen after another request publishes newer choices | 0 |
| First open after core settings replacement | 1 |
| Failed acquisition returning HTTP 503 | 1, with retained choices and Retry |
| Explicit Retry | 1 |
| Completed reopen after Retry | 0 |

The setup acquisition and separate publisher/core Refresh acquisitions are recorded independently. Every browser catalog request is joined to its actual response, and served JavaScript asset hashes are retained. All three real-Gateway scenarios pass, including the existing Automations and Command Palette siblings. Ninety focused tests passed; the updated twelve-case picker suite was replayed after clarifying the core-reset contract. Full `pnpm build`, final `check:changed`, documentation sanity, and managed independent review through P2 passed. The final Gateway and UI were rebuilt and the complete real-Gateway scenario replayed after the Settings-specific guidance correction. The earlier before-proof and acquisition-owner comparison are retained.

The captures show the same synthetic Settings surface before and after; the request/acquisition assertions establish the performance difference. No production latency claim is made.

![Before: completed reopen triggered another acquisition](https://github.com/user-attachments/assets/ec27b761-1453-4105-bc25-0bbbfffd20eb)

![After: completed reopen reads current publication without acquisition](https://github.com/user-attachments/assets/51af975d-3fe6-496f-aa8d-adb457d4e885)

![After: retained model choices and Settings-local Retry after a real provider failure](https://github.com/user-attachments/assets/7d8bf49f-5c8c-42ae-911a-7a1ace3d0ed0)