### PR TITLE
chore: group TUI typechecks with command tests

### DIFF
--- a/test/tsconfig/tsconfig.core.test.commands.json
+++ b/test/tsconfig/tsconfig.core.test.commands.json
@@ -8,6 +8,8 @@
     "../../src/agents/command/**/*.test.tsx",
     "../../src/commands/**/*.test.ts",
     "../../src/commands/**/*.test.tsx",
+    "../../src/tui/**/*.test.ts",
+    "../../src/tui/**/*.test.tsx",
     "../../src/wizard/**/*.test.ts",
     "../../src/wizard/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.plugins-platform.json
+++ b/test/tsconfig/tsconfig.core.test.plugins-platform.json
@@ -10,8 +10,6 @@
     "../../src/security/**/*.test.tsx",
     "../../src/acp/**/*.test.ts",
     "../../src/acp/**/*.test.tsx",
-    "../../src/tui/**/*.test.ts",
-    "../../src/tui/**/*.test.tsx",
     "../../src/system-agent/**/*.test.ts",
     "../../src/system-agent/**/*.test.tsx",
     "../../src/hooks/**/*.test.ts",


### PR DESCRIPTION
## What Problem This Solves

The plugin/platform typecheck shard has 706 test roots against its 720-root budget, leaving little room for incoming plugin lifecycle coverage. This maintainer-requested preparation rebalances existing tests; current main is within the limit.

## Why This Change Was Made

Move all 58 TUI test roots into the command shard, alongside command entrypoints and the interactive wizard. The plugin/platform shard drops to 648 roots and the command shard grows from 573 to 631. Every test root remains assigned exactly once, and the 720-root limit stays unchanged.

## User Impact

No runtime behavior changes. Developers retain the same typecheck coverage with more room for plugin tests. Only two include lists change; no tests or checks are removed.

## Evidence

- Canonical core tsgo boundary guard passed on the candidate, including complete root coverage, unique shard ownership, and extension-free core graphs.
- All 22 selected shard-planner unit tests passed.
- Compiler-expanded root sets confirm all 58 TUI roots moved without omissions or duplicates.
- Net production and test-body LOC: 0. Config LOC: +2/-2.
