### PR TITLE
fix(cli): dispose plugin resources after invocation cleanup

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -506,6 +506,17 @@ still does not invoke a discovery-only engine factory. `dispose()` must not dele
 durable state or disable another registration. Existing raw loader and Gateway
 lifetimes do not gain automatic disposal: keep their `cleanup(ctx)` behavior.
 
+Executable CLI command registration also uses an owned, uncached registry. Its
+resources remain available through asynchronous registration, command actions,
+and their tracked cleanup, then `dispose()` runs. Closing command preparation
+before parsing does not release those resources. Return asynchronous work from
+registrars and actions; a plugin's disposer must also stop and join any background
+work it owns before closing resources that work uses. The CLI's bounded cleanup
+grace can report pending work without treating that work as completed.
+Standalone programmatic CLI calls and caller-owned Commander programs retain
+their existing lifecycle. `cli-metadata` remains inert and accepts CLI descriptors
+only; keep its `machineOutput` resolver pure and synchronous.
+
 `registerBoardWidgetContentKind(...)` is for plugins that own a declarative
 widget source format. The registration supplies a globally unique lowercase
 `kind`, a short label, one capability-scoped plugin surface plus its renderer

--- a/src/cli/plugin-invocation-resources.owner.test.ts
+++ b/src/cli/plugin-invocation-resources.owner.test.ts
@@ -1,0 +1,399 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { Command } from "commander";
+import { afterAll, afterEach, expect, it, vi } from "vitest";
+import { getRegisteredAgentHarness, registerAgentHarness } from "../agents/harness/registry.js";
+import type { AgentHarness } from "../agents/harness/types.js";
+import { registerPluginCliCommands } from "../plugins/cli.js";
+import { acquirePluginRegistryForInspection } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { withPluginRegistrationContext } from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { CliPluginInvocationResources } from "./plugin-invocation-resources.js";
+import { registerCommandGroups } from "./program/register-command-groups.js";
+import {
+  getCliPluginInvocationResources,
+  withCliCommandCleanup,
+  withCliProcessScope,
+} from "./runtime-cleanup-scope.js";
+import { closeCliResources, getPendingCliDisposers } from "./runtime-cleanup.js";
+
+const fixtureCleanups: Array<() => void> = [];
+const quietLogger = { info() {}, warn() {}, error() {}, debug() {} };
+let sequence = 0;
+
+function nativeFixture(
+  options: {
+    disposalFailure?: boolean;
+    capturedDisposal?: "async-context" | "work-tracker";
+    queuedAbortCleanup?: boolean;
+  } = {},
+) {
+  const id = `cli-owned-native-${sequence++}`;
+  const key = `__${id}`;
+  const state = {
+    database: undefined as DatabaseSync | undefined,
+    disposals: 0,
+    entered: createDeferredCore(),
+    resume: createDeferredCore(),
+    afterCleanup: undefined as unknown,
+    disposalRead: undefined as unknown,
+    trackAsyncWork,
+    captureAsyncWorkTracker,
+    getAsyncWorkSignal,
+    abortCleanup: undefined as Promise<void> | undefined,
+    abortRead: undefined as unknown,
+  };
+  Object.defineProperty(globalThis, key, { value: state, configurable: true });
+  const plugin = writePlugin({
+    id,
+    filename: "index.cjs",
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  if (api.registrationMode === "cli-metadata") throw new Error("Use the inert metadata entry");
+  const state = globalThis[${JSON.stringify(key)}];
+  const database = state.database = new DatabaseSync(":memory:");
+  database.exec("CREATE TABLE observations (value INTEGER)");
+  const closeResource = () => {
+    state.disposals++;
+    database.close();
+    if (${options.disposalFailure === true}) throw new Error("synthetic disposal failure");
+  };
+  const cooperatingCleanup = async () => {
+    await Promise.resolve();
+    state.disposalRead = database.prepare("SELECT 42 AS value").get();
+    closeResource();
+  };
+  const captureMode = ${JSON.stringify(options.capturedDisposal)};
+  const track = state.captureAsyncWorkTracker();
+  if (${options.queuedAbortCleanup === true}) {
+    state.getAsyncWorkSignal().addEventListener("abort", () => queueMicrotask(() => {
+      state.abortCleanup = track(async () => {
+        await require("node:fs/promises").readFile(__filename);
+        state.abortRead = database.prepare("SELECT 42 AS value").get();
+      });
+      void state.abortCleanup.catch(() => {});
+    }), { once: true });
+  }
+  const dispose = captureMode === "async-context"
+    ? require("node:async_hooks").AsyncLocalStorage.bind(() => state.trackAsyncWork(cooperatingCleanup))
+    : captureMode === "work-tracker" ? () => track(cooperatingCleanup) : closeResource;
+  api.registerRuntimeLifecycle({ id: "native", dispose });
+  api.registerCli(async ({ program }) => {
+    state.entered.resolve();
+    await state.resume.promise;
+    database.prepare("INSERT INTO observations VALUES (?)").run(42);
+    program.command("native").action(() => {
+      state.afterCleanup = database.prepare("SELECT value FROM observations").get();
+    });
+  }, { descriptors: [{name: "native", description: "Native", hasSubcommands: false}] });
+} };`,
+  });
+  fs.writeFileSync(
+    path.join(plugin.dir, "cli-metadata.cjs"),
+    `module.exports = {
+    id: ${JSON.stringify(id)}, register(api) {
+      api.registerCli(() => {}, { descriptors: [{name: "native", description: "Native", hasSubcommands: false}] });
+    }
+  };`,
+  );
+  const config = { plugins: { allow: [id], load: { paths: [plugin.dir] } } };
+  const env = {
+    HOME: plugin.dir,
+    OPENCLAW_STATE_DIR: `${plugin.dir}/state`,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  };
+  const fixture = {
+    id,
+    key,
+    state,
+    config,
+    env,
+    load: async () => {
+      const acquisition = await acquirePluginRegistryForInspection({
+        config,
+        env,
+        logger: quietLogger,
+      });
+      try {
+        expect(
+          acquisition.registry.plugins,
+          JSON.stringify(acquisition.registry.diagnostics),
+        ).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id, source: plugin.file, status: "loaded" }),
+          ]),
+        );
+        expect(state.database).toBeDefined();
+        return acquisition;
+      } catch (error) {
+        await acquisition.release().catch(() => {});
+        throw error;
+      }
+    },
+  };
+  fixtureCleanups.push(() => {
+    state.resume.resolve();
+    if (state.database?.isOpen) {
+      state.database.close();
+    }
+    Reflect.deleteProperty(globalThis, key);
+  });
+  return fixture;
+}
+
+afterEach(() => {
+  for (const cleanup of fixtureCleanups.splice(0)) {
+    cleanup();
+  }
+  resetPluginLoaderTestStateForTest();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it("joins the shipped eager registrar's real promise before releasing its native resource", async () => {
+  const fixture = nativeFixture();
+  await withCliProcessScope(() =>
+    withCliCommandCleanup(false, async () => {
+      const resources = getCliPluginInvocationResources()!;
+      const registry = await resources.acquire(fixture.load);
+      const program = new Command();
+      const registered = registerCommandGroups(
+        program,
+        [
+          {
+            placeholders: [{ name: "native", description: "Native" }],
+            register: (target) =>
+              registry.cliRegistrars[0]!.register({
+                program: target,
+                parentPath: [],
+                config: fixture.config,
+                logger: quietLogger,
+              }),
+          },
+        ],
+        { eager: true, primary: null, registerPrimaryOnly: false },
+      );
+      expect(registered).toBeUndefined();
+      await fixture.state.entered.promise;
+      let released = false;
+      const closing = resources.release().then(() => {
+        released = true;
+      });
+      try {
+        await expect(resources.run(() => undefined)).rejects.toThrow("invocation is closed");
+        expect(released).toBe(false);
+        expect(fixture.state.database!.isOpen).toBe(true);
+      } finally {
+        fixture.state.resume.resolve();
+        await closing;
+      }
+      expect(program.commands.map((command) => command.name())).toEqual(["native"]);
+      expect(fixture.state.disposals).toBe(1);
+      expect(fixture.state.database!.isOpen).toBe(false);
+    }),
+  );
+});
+
+it("releases an acquisition that finishes after admission closes", async () => {
+  const fixture = nativeFixture();
+  const resources = new CliPluginInvocationResources();
+  const entered = createDeferredCore();
+  const resume = createDeferredCore();
+  const loading = resources.acquire(async () => {
+    const acquisition = await fixture.load();
+    entered.resolve();
+    await resume.promise;
+    return acquisition;
+  });
+  await Promise.race([entered.promise, loading]);
+  const rejected = expect(loading).rejects.toThrow("closed during registry acquisition");
+  const closing = resources.release();
+  expect(fixture.state.database!.isOpen).toBe(true);
+  resume.resolve();
+  await rejected;
+  await closing;
+  expect(fixture.state.disposals).toBe(1);
+});
+
+it.each(["returned", "cooperating"] as const)(
+  "keeps native resources through %s cleanup work after the five-second grace",
+  async (mode) => {
+    const fixture = nativeFixture();
+    await withCliProcessScope(() =>
+      withCliCommandCleanup(false, async (cleanup) => {
+        const resources = getCliPluginInvocationResources()!;
+        const registry = await resources.acquire(fixture.load);
+        const entered = createDeferredCore();
+        const resume = createDeferredCore();
+        let descendant: Promise<void> | undefined;
+        const actualCleanup = async () => {
+          entered.resolve();
+          await resume.promise;
+          fixture.state.afterCleanup = fixture.state.database!.prepare("SELECT 42 AS value").get();
+        };
+        const dispose = async () => {
+          descendant = trackAsyncWork(actualCleanup);
+          if (mode === "returned") {
+            await descendant;
+          }
+        };
+        const harness: AgentHarness = {
+          id: "native-cleanup",
+          label: "Native cleanup",
+          supports: () => ({ supported: true }),
+          runAttempt: async () => {
+            throw new Error("cleanup-only fixture");
+          },
+          dispose,
+        };
+        withPluginRegistrationContext(registry, fixture.id, () => registerAgentHarness(harness));
+        withPluginRuntimeRegistryScope(registry, () => getRegisteredAgentHarness(harness.id));
+        vi.useFakeTimers();
+        const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+        const closing = closeCliResources(cleanup);
+        let release: Promise<void> | undefined;
+        try {
+          await entered.promise;
+          await vi.advanceTimersByTimeAsync(5_000);
+          await closing;
+          if (mode === "returned") {
+            expect(getPendingCliDisposers()).toContain("agent-harness/native-cleanup");
+            expect(stderr).toHaveBeenCalledWith(expect.stringContaining("native-cleanup"));
+          } else {
+            // A completed disposer wrapper is not evidence that its admitted descendant finished.
+            expect(getPendingCliDisposers()).not.toContain("agent-harness/native-cleanup");
+          }
+          release = resources.release();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(fixture.state.database!.isOpen).toBe(true);
+          expect(fixture.state.disposals).toBe(0);
+        } finally {
+          resume.resolve();
+          await Promise.allSettled([closing, descendant]);
+          await (release ?? resources.release());
+        }
+        await expect(descendant).resolves.toBeUndefined();
+        expect(fixture.state.afterCleanup).toEqual({ value: 42 });
+        expect(fixture.state.disposals).toBe(1);
+        expect(getPendingCliDisposers()).not.toContain("agent-harness/native-cleanup");
+      }),
+    );
+  },
+);
+
+it("releases the first native acquisition even when it is created only during cleanup", async () => {
+  const fixture = nativeFixture();
+  await withCliProcessScope(() =>
+    withCliCommandCleanup(false, async (cleanup) => {
+      // The invocation captures its owner before any registry or command preparation exists.
+      const resources = cleanup?.pluginResources;
+      const dispose = async () => {
+        await getCliPluginInvocationResources()!.acquire(fixture.load);
+        fixture.state.afterCleanup = fixture.state.database!.prepare("SELECT 42 AS value").get();
+      };
+      const harness: AgentHarness = {
+        id: "late-native-cleanup",
+        label: "Late native cleanup",
+        supports: () => ({ supported: true }),
+        runAttempt: async () => {
+          throw new Error("cleanup-only fixture");
+        },
+        dispose,
+      };
+      cleanup!.harnesses.set(harness, dispose);
+      try {
+        await closeCliResources(cleanup);
+      } finally {
+        await resources?.release();
+      }
+      expect(fixture.state.afterCleanup).toEqual({ value: 42 });
+      expect(fixture.state.disposals).toBe(1);
+      expect(fixture.state.database!.isOpen).toBe(false);
+    }),
+  );
+});
+
+it("attempts independent resource releases and retains cleanup failures", async () => {
+  const failed = nativeFixture({ disposalFailure: true });
+  const sibling = nativeFixture();
+  const resources = new CliPluginInvocationResources();
+  await resources.acquire(failed.load);
+  await resources.acquire(sibling.load);
+  let reentered: Promise<void> | undefined;
+  await resources.run(() =>
+    getAsyncWorkSignal()!.addEventListener("abort", () => {
+      reentered = resources.release();
+    }),
+  );
+  const release = resources.release();
+  expect(resources.release()).toBe(release);
+  await expect(release).rejects.toThrow("could not all be disposed");
+  expect(reentered).toBe(release);
+  await expect(resources.release()).rejects.toThrow("could not all be disposed");
+  expect([failed.state.disposals, sibling.state.disposals]).toEqual([1, 1]);
+});
+
+it("leaves standalone command programs with their caller after registration returns", async () => {
+  const fixture = nativeFixture();
+  fixture.state.resume.resolve();
+  const program = new Command();
+  await registerPluginCliCommands(program, fixture.config, fixture.env);
+  expect(getCliPluginInvocationResources()).toBeUndefined();
+  expect(program.commands.map((command) => command.name())).toEqual(["native"]);
+  await program.parseAsync(["node", "fixture", "native"]);
+  expect(fixture.state.afterCleanup).toEqual({ value: 42 });
+  expect(fixture.state.disposals).toBe(0);
+  expect(fixture.state.database!.isOpen).toBe(true);
+});
+
+it.each(["async-context", "work-tracker"] as const)(
+  "keeps the registration's captured %s usable through native disposal",
+  async (capturedDisposal) => {
+    const fixture = nativeFixture({ capturedDisposal });
+    const resources = new CliPluginInvocationResources();
+    await resources.acquire(fixture.load);
+    let failure: unknown;
+    try {
+      await resources.release();
+    } catch (error) {
+      failure = error;
+    }
+    expect(
+      {
+        nativeRead: fixture.state.disposalRead,
+        disposals: fixture.state.disposals,
+        open: fixture.state.database!.isOpen,
+      },
+      JSON.stringify(failure, ["message", "errors", "cause"]),
+    ).toEqual({
+      nativeRead: { value: 42 },
+      disposals: 1,
+      open: false,
+    });
+    expect(failure).toBeUndefined();
+  },
+);
+
+it("joins queued abort cleanup before starting native resource disposal", async () => {
+  const fixture = nativeFixture({ queuedAbortCleanup: true });
+  const resources = new CliPluginInvocationResources();
+  await resources.acquire(fixture.load);
+  await resources.release();
+  await expect(fixture.state.abortCleanup).resolves.toBeUndefined();
+  expect(fixture.state.abortRead).toEqual({ value: 42 });
+  expect(fixture.state.disposals).toBe(1);
+  expect(fixture.state.database!.isOpen).toBe(false);
+});

--- a/src/cli/plugin-invocation-resources.test.ts
+++ b/src/cli/plugin-invocation-resources.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  formatCliProcessFailure,
+  runCliProcessChild,
+  waitForCliProcessStderrMarker,
+} from "./cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const require = createRequire(import.meta.url);
+const entry = fileURLToPath(new URL("../entry.ts", import.meta.url));
+
+type ResourceEvent = { event: string; database: string; mode: string };
+
+it("keeps native plugin resources through registration and action, then disposes at CLI completion", async () => {
+  const root = tempDirs.make("openclaw-cli-registration-resources-");
+  const pluginDir = path.join(root, "plugin");
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(root, "openclaw.json");
+  const eventsPath = path.join(root, "resource-events.jsonl");
+  fs.mkdirSync(pluginDir);
+  fs.mkdirSync(stateDir);
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "cli-native-resource",
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "descriptor.cjs"),
+    `module.exports = {
+  name: "native-resource",
+  description: "Synthetic native resource command",
+  hasSubcommands: false,
+  machineOutput: ({ argv }) => argv.includes("--rows"),
+};
+`,
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "cli-metadata.cjs"),
+    `const descriptor = require("./descriptor.cjs");
+module.exports = {
+  id: "cli-native-resource",
+  register(api) { api.registerCli(() => {}, { descriptors: [descriptor] }); },
+};
+`,
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "index.cjs"),
+    `const fs = require("node:fs");
+const path = require("node:path");
+const { DatabaseSync } = require("node:sqlite");
+let sequence = 0;
+module.exports = {
+  id: "cli-native-resource",
+  register(api) {
+    const mode = api.registrationMode;
+    if (mode === "cli-metadata") throw new Error("Use the inert metadata entry");
+    const databasePath = path.join(${JSON.stringify(root)}, mode + "-" + sequence++ + ".sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.exec("CREATE TABLE observations (value TEXT NOT NULL)");
+    const record = (event) => fs.appendFileSync(${JSON.stringify(eventsPath)}, JSON.stringify({ event, database: databasePath, mode }) + "\\n");
+    record("opened");
+    api.registerRuntimeLifecycle({
+      id: "native-cli-resource",
+      dispose() {
+        database.close();
+        record("disposed");
+      },
+      cleanup() { record("cleanup"); },
+    });
+    api.registerCli(async ({ program }) => {
+      record("registrar-entered");
+      await Promise.resolve();
+      database.prepare("INSERT INTO observations VALUES (?)").run("registrar");
+      program.command("native-resource").option("--rows").action(async () => {
+        const resume = new Promise((resolve) => process.stdin.once("data", resolve));
+        process.stdin.resume();
+        record("action-entered");
+        process.stderr.write("native-resource action entered\\n");
+        await resume;
+        database.prepare("INSERT INTO observations VALUES (?)").run("action");
+        const rows = database.prepare("SELECT value FROM observations ORDER BY rowid").all();
+        record("action-completed");
+        console.log("native-resource diagnostic");
+        process.stdout.write(JSON.stringify(rows) + "\\n");
+      });
+      record("registrar-completed");
+    }, {
+      descriptors: [require("./descriptor.cjs")],
+    });
+  },
+};
+`,
+  );
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      agents: { defaults: { workspace: path.join(root, "workspace") } },
+      plugins: { allow: ["cli-native-resource"], load: { paths: [pluginDir] } },
+    }),
+  );
+  const readEvents = (): ResourceEvent[] =>
+    fs
+      .readFileSync(eventsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+  const result = await runCliProcessChild({
+    nodeArgs: ["--import", require.resolve("tsx"), entry, "native-resource", "--rows"],
+    cwd: root,
+    env: {
+      PATH: process.env.PATH,
+      SystemRoot: process.env.SystemRoot,
+      TEMP: process.env.TEMP,
+      TMPDIR: process.env.TMPDIR,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_HOME: root,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_NO_RESPAWN: "1",
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+      NO_COLOR: "1",
+    },
+    async interact(child) {
+      try {
+        await waitForCliProcessStderrMarker(child, "native-resource action entered");
+        const events = readEvents();
+        expect(events.some((event) => event.event === "registrar-completed")).toBe(true);
+        expect(events.some((event) => event.event === "action-completed")).toBe(false);
+        expect(events.filter((event) => event.event === "disposed")).toEqual([]);
+      } finally {
+        child.stdin.end("continue\n");
+      }
+    },
+  });
+  const diagnostics = formatCliProcessFailure({ reason: "Native plugin CLI result", ...result });
+  expect(result.code, diagnostics).toBe(0);
+  expect(result.signal, diagnostics).toBeNull();
+  expect(JSON.parse(result.stdout), diagnostics).toEqual([
+    { value: "registrar" },
+    { value: "action" },
+  ]);
+  expect(result.stderr).toContain("native-resource diagnostic");
+
+  const events = readEvents();
+  const opened = events.filter((event) => event.event === "opened");
+  expect(opened, diagnostics).toHaveLength(1);
+  expect(opened[0]!.mode).not.toBe("cli-metadata");
+  const completed = events.find((event) => event.event === "action-completed");
+  expect(completed, diagnostics).toBeDefined();
+  const reopened = new DatabaseSync(completed!.database);
+  try {
+    expect(reopened.prepare("SELECT value FROM observations ORDER BY rowid").all()).toEqual([
+      { value: "registrar" },
+      { value: "action" },
+    ]);
+  } finally {
+    reopened.close();
+  }
+  expect(events.filter((event) => event.event === "cleanup")).toEqual([]);
+  expect(
+    events
+      .filter((event) => event.event === "disposed")
+      .map((event) => event.database)
+      .toSorted(),
+    diagnostics,
+  ).toEqual(opened.map((event) => event.database).toSorted());
+});

--- a/src/cli/plugin-invocation-resources.ts
+++ b/src/cli/plugin-invocation-resources.ts
@@ -1,0 +1,85 @@
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+
+type RegistryAcquisition = { registry: PluginRegistry; release: () => Promise<void> };
+
+/** The executable owns installed command callbacks until their actual work and cleanup settle. */
+export class CliPluginInvocationResources {
+  private readonly work = new AsyncWorkScope();
+  private readonly acquisitions = new Set<RegistryAcquisition>();
+  private readonly registrations = new Set<Promise<void>>();
+  private readonly registrationErrors: unknown[] = [];
+  private closing = false;
+  private released?: Promise<void>;
+
+  run<T>(run: () => T | Promise<T>): Promise<T> {
+    if (this.closing) {
+      return Promise.reject(new Error("Plugin CLI invocation is closed"));
+    }
+    return this.work.track(run);
+  }
+
+  acquire(load: () => Promise<RegistryAcquisition>): Promise<PluginRegistry> {
+    return this.run(async () => {
+      const acquisition = await load();
+      // Release owns late acquisitions too, even when admission closed during the load.
+      this.acquisitions.add(acquisition);
+      if (this.closing) {
+        throw new Error("Plugin CLI invocation closed during registry acquisition");
+      }
+      return acquisition.registry;
+    });
+  }
+
+  register(run: () => void | Promise<void>): void {
+    const pending = this.run(run);
+    this.registrations.add(pending);
+    void pending.then(
+      () => this.registrations.delete(pending),
+      (error: unknown) => {
+        this.registrationErrors.push(error);
+        this.registrations.delete(pending);
+      },
+    );
+  }
+
+  async waitForRegistrations(): Promise<void> {
+    while (this.registrations.size > 0) {
+      await Promise.allSettled(this.registrations);
+    }
+    if (this.registrationErrors.length > 0) {
+      throw new AggregateError(this.registrationErrors, "CLI command registration failed");
+    }
+  }
+
+  /** Invoke cleanup in this owner so cooperating descendants join its physical lifetime. */
+  runCleanup = <T>(run: () => T | Promise<T>): Promise<T> => this.work.track(run);
+
+  release(): Promise<void> {
+    if (!this.released) {
+      this.closing = true;
+      // Publish the result before drain delivers synchronous abort callbacks.
+      this.released = Promise.resolve().then(() => this.releaseResources());
+    }
+    return this.released;
+  }
+
+  private async releaseResources(): Promise<void> {
+    // Registration disposers can capture this context; terminal closure must follow them.
+    this.work.beginClose();
+    const results = await this.work.runWhenIdle(() =>
+      Promise.allSettled(
+        [...this.acquisitions].map((acquisition) => this.work.track(() => acquisition.release())),
+      ),
+    );
+    await this.work.drain();
+    this.acquisitions.clear();
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        "Plugin CLI registration resources could not all be disposed",
+      );
+    }
+  }
+}

--- a/src/cli/program/register-command-groups.ts
+++ b/src/cli/program/register-command-groups.ts
@@ -1,5 +1,6 @@
 // Lazy command-group registration: placeholder commands are replaced by real subcommand groups.
 import type { Command } from "commander";
+import { getCliPluginInvocationResources } from "../runtime-cleanup-scope.js";
 import { removeCommandByName } from "./command-tree.js";
 import { registerLazyCommand } from "./register-lazy-command.js";
 
@@ -87,8 +88,13 @@ export function registerCommandGroups(
   },
 ) {
   if (params.eager) {
+    const resources = getCliPluginInvocationResources();
     for (const entry of entries) {
-      void entry.register(program);
+      if (resources) {
+        resources.register(() => entry.register(program));
+      } else {
+        void entry.register(program);
+      }
     }
     return;
   }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -16,12 +16,14 @@ import { loggingState } from "../logging/state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginCache, getScopedPluginCache, type PluginCache } from "../plugins/plugin-cache.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { ExpectedCliError } from "./failure-output.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
-import { registerSignalExitBarrier } from "./signal-exit-barrier.js";
+import { getPendingCliDisposers } from "./runtime-cleanup.js";
+import { registerSignalExitBarrier, waitForSignalExitBarriers } from "./signal-exit-barrier.js";
 
 const TLS_FINGERPRINT = "ab".repeat(32);
 const PREFIXED_TLS_FINGERPRINT = `sha256:${TLS_FINGERPRINT.toUpperCase()}`;
@@ -3432,6 +3434,43 @@ describe("runCli exit behavior", () => {
       exitSpy.mockRestore();
       processOnceSpy.mockRestore();
     }
+  });
+
+  it("keeps the original signal proxy stop pending through bounded command cleanup", async () => {
+    const handle = makeProxyHandle();
+    const route = createDeferredCore<boolean>();
+    const stopping = createDeferredCore();
+    const resume = createDeferredCore();
+    startProxyMock.mockResolvedValueOnce(handle);
+    tryRouteCliMock.mockReturnValueOnce(route.promise);
+    stopProxyMock.mockImplementationOnce(async () => {
+      stopping.resolve();
+      await resume.promise;
+    });
+    const running = runCli(["node", "openclaw", "plugins", "marketplace", "list"]);
+    let barrier: Promise<void> | undefined;
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await vi.waitFor(() => expect(tryRouteCliMock).toHaveBeenCalled());
+      barrier = waitForSignalExitBarriers();
+      await stopping.promise;
+      vi.useFakeTimers();
+      route.resolve(true);
+      await vi.waitFor(() => expect(getPendingCliDisposers()).toContain("managed-proxy"));
+      await vi.advanceTimersByTimeAsync(5_000);
+      await running;
+      expect(getPendingCliDisposers()).toContain("managed-proxy");
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("managed-proxy"));
+      expect(stopProxyMock).toHaveBeenCalledExactlyOnceWith(handle);
+    } finally {
+      route.resolve(true);
+      resume.resolve();
+      vi.useRealTimers();
+      await barrier;
+      await running;
+      stderr.mockRestore();
+    }
+    expect(getPendingCliDisposers()).not.toContain("managed-proxy");
   });
 
   it("synchronously kills the managed proxy during hard process exit", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -991,6 +991,19 @@ export async function runCli(
             }
           }
           throw error;
+        } finally {
+          const resources = harnessCleanup?.pluginResources;
+          if (resources) {
+            await runCliDisposer("plugin-registration-resources", async () => {
+              try {
+                await resources.release();
+              } catch (error) {
+                console.error(`Plugin CLI resource disposal failed: ${String(error)}`);
+                throw error;
+              }
+            });
+            pauseNonTtyStdinForCliExit();
+          }
         }
       };
       // Nested registrars and late actions share this lightweight owner, even when no
@@ -1158,6 +1171,7 @@ async function runCliWithPreparedOutputMode(
   // Local Gateway/control-plane commands keep direct loopback access while
   // runtime, provider, plugin, update, and manifest/metadata-owned plugin commands route egress.
   let proxyHandle: ProxyHandle | null = null;
+  let proxyStopPromise: Promise<void> | undefined;
   let onSigterm: (() => void) | null = null;
   let onSigint: (() => void) | null = null;
   let onExit: (() => void) | null = null;
@@ -1224,16 +1238,26 @@ async function runCliWithPreparedOutputMode(
       onExit = null;
     }
   };
-  const stopStartedProxy = async () => {
+  const stopStartedProxy = () => {
+    if (proxyStopPromise) {
+      return proxyStopPromise;
+    }
     unregisterProxySignalExitBarrier?.();
     unregisterProxySignalExitBarrier = null;
     uninstallProxySignalHandlers();
     const handle = proxyHandle;
     proxyHandle = null;
-    if (handle) {
-      const { stopProxy } = await loadProxyLifecycleModule();
-      await stopProxy(handle);
-    }
+    const stop = async () => {
+      if (handle) {
+        const { stopProxy } = await loadProxyLifecycleModule();
+        await stopProxy(handle);
+      }
+    };
+    const resources = options.harnessCleanup?.pluginResources;
+    proxyStopPromise = Promise.resolve().then(() =>
+      resources ? resources.runCleanup(stop) : stop(),
+    );
+    return proxyStopPromise;
   };
   const killStartedProxy = () => {
     const handle = proxyHandle;
@@ -1261,6 +1285,7 @@ async function runCliWithPreparedOutputMode(
     await stopStartedProxy();
     const { startProxy } = await loadProxyLifecycleModule();
     proxyHandle = await startProxy(config);
+    proxyStopPromise = undefined;
     installProxySignalHandlers();
   };
   let uninstallGatewayRunRuntimeHooks: (() => void) | null = null;
@@ -1541,6 +1566,7 @@ async function runCliWithPreparedOutputMode(
         ]),
       );
       const program = await startupTrace.measure("build-program", () => buildProgram());
+      await options.harnessCleanup?.pluginResources?.waitForRegistrations();
 
       // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
       // These log the error and exit gracefully instead of crashing without trace.
@@ -1648,11 +1674,16 @@ async function runCliWithPreparedOutputMode(
 
       let completedHelpOrVersion = false;
       try {
+        const resources = options.harnessCleanup?.pluginResources;
+        await resources?.waitForRegistrations();
         pluginCliSession?.close();
         // The invocation's cache scope survives closed preparation through action completion.
-        await startupTrace.measure("parse", () => program.parseAsync(parseArgv), {
-          timeline: false,
-        });
+        const parse = () =>
+          startupTrace.measure("parse", () => program.parseAsync(parseArgv), {
+            timeline: false,
+          });
+        await (resources ? resources.run(parse) : parse());
+        await resources?.waitForRegistrations();
         completedHelpOrVersion = isHelpOrVersionInvocation;
       } catch (error) {
         if (!isCommanderParseExit(error)) {
@@ -1676,9 +1707,12 @@ async function runCliWithPreparedOutputMode(
   } finally {
     pluginCliSession?.close();
     uninstallGatewayRunRuntimeHooks?.();
-    await runCliDisposer("managed-proxy", stopStartedProxy);
+    const resources = options.harnessCleanup?.pluginResources;
+    await runCliDisposer("managed-proxy", stopStartedProxy, resources?.runCleanup);
     await closeCliResources(options.harnessCleanup);
-    pauseNonTtyStdinForCliExit();
+    if (!resources) {
+      pauseNonTtyStdinForCliExit();
+    }
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/runtime-cleanup-scope.ts
+++ b/src/cli/runtime-cleanup-scope.ts
@@ -2,10 +2,12 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { AgentHarness } from "../agents/harness/types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { CliPluginInvocationResources } from "./plugin-invocation-resources.js";
 
 export type CliHarnessCleanup = {
   harnesses: Map<AgentHarness, () => Promise<void>>;
   registries: Set<PluginRegistry>;
+  pluginResources?: CliPluginInvocationResources;
 };
 
 // Entry modules must stay runtime-free. Only executable bootstraps grant this scope;
@@ -21,6 +23,12 @@ export function withCliProcessScope<T>(run: () => T): T {
 
 export function hasCliProcessScope(): boolean {
   return scope.getStore() !== undefined;
+}
+
+/** Caller-owned programs and Gateway boot have no executable resource owner. */
+export function getCliPluginInvocationResources(): CliPluginInvocationResources | undefined {
+  const current = scope.getStore();
+  return current && current !== "process" ? current.pluginResources : undefined;
 }
 
 /** Finalizers own their Windows descendants until executable process exit. */
@@ -46,7 +54,11 @@ export function withCliCommandCleanup<T>(
   if (scope.getStore() !== "process") {
     return run();
   }
-  const cleanup: CliHarnessCleanup = { harnesses: new Map(), registries: new Set() };
+  const cleanup: CliHarnessCleanup = {
+    harnesses: new Map(),
+    registries: new Set(),
+    pluginResources: new CliPluginInvocationResources(),
+  };
   return scope.run(cleanup, () => run(cleanup));
 }
 
@@ -64,7 +76,11 @@ export function retainCliRegistryHarnesses(
       // Preserve request facts as well as the exact registry binding after helpers unwind.
       current.harnesses.set(
         harness,
-        AsyncLocalStorage.bind(() => dispose(harness)),
+        AsyncLocalStorage.bind(() =>
+          current.pluginResources
+            ? current.pluginResources.runCleanup(() => dispose(harness))
+            : dispose(harness),
+        ),
       );
     }
   }

--- a/src/cli/runtime-cleanup.ts
+++ b/src/cli/runtime-cleanup.ts
@@ -9,12 +9,16 @@ export function getPendingCliDisposers(): string[] {
   return [...pendingDisposers.values()];
 }
 
-export async function runCliDisposer(name: string, dispose: () => Promise<void>): Promise<void> {
+export async function runCliDisposer(
+  name: string,
+  dispose: () => Promise<void>,
+  runCleanup?: (dispose: () => Promise<void>) => Promise<void>,
+): Promise<void> {
   const token = Symbol(name);
   pendingDisposers.set(token, name);
   let timer: ReturnType<typeof setTimeout> | undefined;
   const operation = Promise.resolve()
-    .then(dispose)
+    .then(() => (runCleanup ? runCleanup(dispose) : dispose()))
     .finally(() => pendingDisposers.delete(token));
   try {
     await Promise.race([
@@ -34,6 +38,7 @@ export async function runCliDisposer(name: string, dispose: () => Promise<void>)
 }
 
 export async function closeCliResources(cleanup?: CliHarnessCleanup): Promise<void> {
+  const runCleanup = cleanup?.pluginResources?.runCleanup;
   const finalizers: Record<string, () => Promise<void>> = {
     "agent-harnesses": async () => {
       const { listRegisteredAgentHarnesses, disposeRegisteredAgentHarnesses } =
@@ -49,7 +54,7 @@ export async function closeCliResources(cleanup?: CliHarnessCleanup): Promise<vo
       try {
         await Promise.all(
           [...cleanup.harnesses].map(([harness, dispose]) =>
-            runCliDisposer(`agent-harness/${harness.id}`, dispose),
+            runCliDisposer(`agent-harness/${harness.id}`, dispose, runCleanup),
           ),
         );
       } finally {
@@ -98,6 +103,6 @@ export async function closeCliResources(cleanup?: CliHarnessCleanup): Promise<vo
     },
   };
   for (const [name, finalize] of Object.entries(finalizers)) {
-    await runCliDisposer(name, finalize);
+    await runCliDisposer(name, finalize, runCleanup);
   }
 }

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -2,7 +2,9 @@
 import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { CliPluginInvocationResources } from "../cli/plugin-invocation-resources.js";
 import { collectUniqueCommandDescriptors } from "../cli/program/command-descriptor-utils.js";
+import { getCliPluginInvocationResources } from "../cli/runtime-cleanup-scope.js";
 import { cloneEnvWithPlatformSemantics } from "../config/config-env-vars.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -14,7 +16,11 @@ import { createPluginCliGatewayNodesRuntime } from "./cli-gateway-nodes-runtime.
 import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
 import { getCurrentPluginMetadataSnapshotState } from "./current-plugin-metadata-state.js";
 import type { PluginLoadOptions } from "./loader.js";
-import { loadOpenClawPluginCliRegistry, loadPluginRegistryHandle } from "./loader.js";
+import {
+  acquirePluginRegistryForInspection,
+  loadOpenClawPluginCliRegistry,
+  loadPluginRegistryHandle,
+} from "./loader.js";
 import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import {
   resolvePluginMetadataEnvFingerprint,
@@ -60,6 +66,7 @@ type PreparedPluginCliLoad = {
   context: PluginRuntimeLoadContext;
   assertCurrent: () => void;
   withCache: <T>(run: () => T) => T;
+  resources?: CliPluginInvocationResources;
   metadataRegistry?: Promise<PluginRegistry>;
   entries?: Promise<PluginCliCommandGroupEntry[]>;
 };
@@ -67,7 +74,13 @@ type PreparedPluginCliLoad = {
 export type PluginCliLoadSession = ReturnType<typeof createPluginCliLoadSession>;
 
 /** Invocation authority closes before actions; its package generation lives through them. */
-export function createPluginCliLoadSession(cache = createPluginCache()) {
+export function createPluginCliLoadSession(
+  cache = createPluginCache(),
+  ownership: { resources?: CliPluginInvocationResources } = {
+    resources: getCliPluginInvocationResources(),
+  },
+) {
+  const { resources } = ownership;
   const withCache = <T>(run: () => T): T => withPluginCache(cache, run);
   let closed = false;
   let revision = getCurrentPluginMetadataSnapshotState().revision;
@@ -102,6 +115,7 @@ export function createPluginCliLoadSession(cache = createPluginCache()) {
     }
   };
   return {
+    resources,
     withCache,
     readConfig: async <T>(read: () => Promise<T>): Promise<T> => {
       refreshRevision();
@@ -165,6 +179,7 @@ export function createPluginCliLoadSession(cache = createPluginCache()) {
         const prepared: PreparedPluginCliLoad = {
           context,
           withCache,
+          resources,
           assertCurrent() {
             assertRevision(captured);
             if (
@@ -305,16 +320,18 @@ async function loadPluginCliCommandRegistryWithContext(params: {
   if (onlyPluginIds && onlyPluginIds.length === 0) {
     return createEmptyPluginRegistry();
   }
+  const options = buildPluginRuntimeLoadOptions(context, {
+    ...params.loaderOptions,
+    ...(onlyPluginIds && onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
+    cache: false,
+    channelPluginLoadIntent: "full",
+    runtimeOptions: { nodes: createPluginCliGatewayNodesRuntime() },
+  });
+  const resources = params.prepared.resources;
   return params.prepared.withCache(() =>
-    loadPluginRegistryHandle(
-      buildPluginRuntimeLoadOptions(context, {
-        ...params.loaderOptions,
-        ...(onlyPluginIds && onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
-        cache: false,
-        channelPluginLoadIntent: "full",
-        runtimeOptions: { nodes: createPluginCliGatewayNodesRuntime() },
-      }),
-    ),
+    resources
+      ? resources.acquire(() => acquirePluginRegistryForInspection(options))
+      : loadPluginRegistryHandle(options),
   );
 }
 
@@ -325,6 +342,7 @@ function buildPluginCliCommandGroupEntries(params: {
   logger: PluginLogger;
   assertCurrent: () => void;
   withCache: PreparedPluginCliLoad["withCache"];
+  resources?: CliPluginInvocationResources;
 }): PluginCliCommandGroupEntry[] {
   return params.registry.cliRegistrars.map((entry) => ({
     pluginId: entry.pluginId,
@@ -333,15 +351,17 @@ function buildPluginCliCommandGroupEntries(params: {
     names: entry.commands,
     register: async (program) => {
       params.assertCurrent();
-      await params.withCache(() =>
-        entry.register({
-          program,
-          parentPath: entry.parentPath ?? [],
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          logger: params.logger,
-        }),
-      );
+      const register = () =>
+        params.withCache(() =>
+          entry.register({
+            program,
+            parentPath: entry.parentPath ?? [],
+            config: params.config,
+            workspaceDir: params.workspaceDir,
+            logger: params.logger,
+          }),
+        );
+      await (params.resources ? params.resources.run(register) : register());
       params.assertCurrent();
     },
   }));
@@ -386,6 +406,7 @@ export async function loadPluginCliRegistrationEntriesWithDefaults(
       registry,
       assertCurrent: prepared.assertCurrent,
       withCache: prepared.withCache,
+      resources: prepared.resources,
     });
   }));
   prepared.assertCurrent();

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -62,7 +62,9 @@ export async function registerPluginCliCommands(
       // startup registrars past close, including help/completion on a prepared program.
       return Object.assign({}, entry, {
         register: async (target: Command) => {
-          const deferred = createPluginCliLoadSession(getPluginCache());
+          const deferred = createPluginCliLoadSession(getPluginCache(), {
+            resources: session.resources,
+          });
           try {
             const fresh = await loadPluginCliRegistrationEntriesWithDefaults({
               cfg,

--- a/src/shared/async-work-scope.test.ts
+++ b/src/shared/async-work-scope.test.ts
@@ -10,6 +10,25 @@ import {
 import { createDeferredCore } from "./deferred.js";
 
 describe("async work scope", () => {
+  it("settles work for cleanup without closing its captured tracker, then fences final drain", async () => {
+    const scope = new AsyncWorkScope();
+    const track = await scope.track(captureAsyncWorkTracker);
+    scope.beginClose();
+    const cleanup = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    await scope.runWhenIdle(() => {
+      expect(getAsyncWorkSignal()).toBe(scope.signal);
+      return track(cleanup);
+    });
+    expect(cleanup).toHaveBeenCalledOnce();
+    const drained = scope.drain();
+    const late = vi.fn();
+    await expect(track(late)).rejects.toThrow("Async work scope is closed");
+    expect(late).not.toHaveBeenCalled();
+    await drained;
+  });
+
   it("joins an inherited descendant after its parent returns", async () => {
     const scope = new AsyncWorkScope();
     const gate = createDeferredCore();

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -50,6 +50,14 @@ export class AsyncWorkScope {
     this.controller.abort(reason);
   }
 
+  /** Starts the next phase in the same continuation that observes settled pending work. */
+  async runWhenIdle<T>(run: () => T | Promise<T>): Promise<T> {
+    do {
+      await Promise.allSettled(this.pending);
+    } while (this.pending.size > 0);
+    return this.track(run);
+  }
+
   async drain(): Promise<void> {
     this.beginClose();
     // An admitted parent can register a cleanup tail while it settles.


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes plugin CLI commands leaving registration resources open after the command finishes. Cleanup can also outlast its initial wait, so releasing those resources at a timeout can close a database that cleanup still needs.

## Why This Change Was Made

An executable invocation now owns its command registries through asynchronous registration, actions, and actual proxy and harness cleanup. It joins pending work and starts registration disposal in the same async continuation, keeps captured cleanup contexts usable, then closes the work scope after disposal and its children finish.

The managed proxy retains its original stop promise. Eager registrars are joined before parsing. Metadata discovery remains inert, and caller-owned/programmatic CLI APIs retain their existing lifecycle.

## User Impact

Normal commands release their registration resources once. Slow cleanup retains its database through the existing grace period and finishes without racing a closed connection. Existing forced-exit behavior remains unchanged; a bounded wait is not reported as completed physical cleanup.

## Evidence

The final candidate passed 16 targeted native/shared-scope tests, the full 13-file changed gate, an ordinary build, and three real compiled CLI scenarios. The candidate files remained identical through commit and rebase onto current main.

The compiled normal command recorded registration, action and cleanup writes, closed SQLite once, and passed read-only reopen. A second command kept its connection usable beyond the actual five-second warning, then wrote its cleanup row and closed after the test released the pending disposer (5,003 ms after cleanup began). Manifest root help advertised the command without opening a native resource.

Independent Codex review identified two ordering gaps. Three native regressions reproduced them: two disposers retained a closed async context, and queued abort cleanup lost a race with database closure. The final revision passes all three and received a clean independent review. The build took 261.6 seconds. Tests used synthetic state and loopback cleanup traffic, without real credentials or a live operator Gateway.

Public SDK callbacks that outlive an invocation need their own host and originating resource context; that separate migration remains in the aggregate campaign.
