### PR TITLE
perf(plugins): reuse startup facts for shared config

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -81,6 +81,7 @@ import {
   listExplicitConfiguredChannelIdsForConfig,
   resolveConfiguredChannelPluginIds,
   resolveConfiguredChannelPresencePolicy,
+  createGatewayStartupMetadataPluginIdScope,
   loadGatewayStartupPluginPlanWithMetadata,
   resolveGatewayStartupMetadataPluginIds,
   resolveGatewayStartupPluginIdsFromRegistry,
@@ -2020,6 +2021,52 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
         index,
       }),
     ).toEqual(["browser", "demo-channel"]);
+  });
+
+  it("recomputes shared config facts when a metadata scope resolves again", () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "gpt-5.4@work" } },
+      channels: {},
+      plugins: { allow: ["browser"], slots: { memory: "none" } },
+    };
+    const index = createInstalledPluginIndexFixture(createManifestRegistryFixture());
+    const scope = createGatewayStartupMetadataPluginIdScope({
+      config,
+      activationSourceConfig: config,
+      env: createPluginPlanningTestEnv(),
+    });
+
+    expect(scope.resolve({ index })).toEqual(["browser", "openai"]);
+    config.agents = { defaults: { model: "anthropic/claude-test" } };
+    expect(scope.resolve({ index })).toEqual(["anthropic", "browser"]);
+    config.plugins = { ...config.plugins, deny: ["anthropic"] };
+    expect(scope.resolve({ index })).toEqual(["browser"]);
+  });
+
+  it("preserves both config roles and their exclusions in metadata scopes", () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-test" } },
+      channels: { "demo-other-channel": { token: "configured" } },
+      plugins: { allow: ["browser"], deny: ["qa-lab"], slots: { memory: "none" } },
+    };
+    const activationSourceConfig: OpenClawConfig = {
+      channels: { "demo-channel": { token: "configured" } },
+      cloudWorkers: { profiles: { development: { provider: "static-ssh" } } },
+      plugins: {
+        allow: ["demo-channel"],
+        entries: { openai: { enabled: false } },
+        slots: { memory: "none" },
+      },
+    };
+
+    expect(
+      resolveGatewayStartupMetadataPluginIds({
+        config,
+        activationSourceConfig,
+        env: createPluginPlanningTestEnv(),
+        index: createInstalledPluginIndexFixture(createManifestRegistryFixture()),
+      }),
+    ).toEqual(["browser", "demo-channel", "demo-other-channel"]);
   });
 
   it("keeps config-path activation owners in restrictive startup metadata scopes", () => {

--- a/src/plugins/effective-plugin-ids.test.ts
+++ b/src/plugins/effective-plugin-ids.test.ts
@@ -108,8 +108,7 @@ describe("resolveEffectivePluginIds", () => {
     );
     const collect = (includePersistedAuthState = false) =>
       collectConfiguredStartupChannelIds({
-        config: {},
-        activationSourceConfig: {},
+        configs: [{}, {}],
         env: {},
         ...(includePersistedAuthState ? { includePersistedAuthState: true } : {}),
       });

--- a/src/plugins/gateway-startup-plugin-config.ts
+++ b/src/plugins/gateway-startup-plugin-config.ts
@@ -377,22 +377,19 @@ export function addConfiguredSlotPluginIds(
 }
 
 export function collectConfiguredStartupChannelIds(params: {
-  activationSourceConfig: OpenClawConfig;
-  config: OpenClawConfig;
+  configs: readonly OpenClawConfig[];
   env: NodeJS.ProcessEnv;
   ambientEnvTriggers?: AmbientEnvTriggerPolicy;
   includePersistedAuthState?: boolean;
 }): string[] {
-  return sortUniquePluginIds([
-    ...listPotentialEnabledChannelIds(params.config, params.env, {
-      ambientEnvTriggers: params.ambientEnvTriggers,
-      includePersistedAuthState: params.includePersistedAuthState,
-    }),
-    ...listPotentialEnabledChannelIds(params.activationSourceConfig, params.env, {
-      ambientEnvTriggers: params.ambientEnvTriggers,
-      includePersistedAuthState: params.includePersistedAuthState,
-    }),
-  ]);
+  return sortUniquePluginIds(
+    params.configs.flatMap((config) =>
+      listPotentialEnabledChannelIds(config, params.env, {
+        ambientEnvTriggers: params.ambientEnvTriggers,
+        includePersistedAuthState: params.includePersistedAuthState,
+      }),
+    ),
+  );
 }
 
 export function collectConfiguredProviderIds(config: OpenClawConfig): string[] {
@@ -412,7 +409,7 @@ export function collectConfiguredProviderIds(config: OpenClawConfig): string[] {
   ]);
 }
 
-export function collectValidationConfiguredProviderIds(config: OpenClawConfig): string[] {
+export function collectValidationConfiguredRefs(config: OpenClawConfig) {
   const providerIds: string[] = [];
   const pushProviderId = (value: unknown) => {
     if (typeof value !== "string") {
@@ -437,23 +434,24 @@ export function collectValidationConfiguredProviderIds(config: OpenClawConfig): 
       pushProviderId(providerId);
     }
   }
+  const shorthandModelRefs: string[] = [];
   for (const ref of collectConfiguredModelRefs(config)) {
     const slashIndex = ref.value.indexOf("/");
     if (slashIndex > 0) {
       pushProviderId(ref.value.slice(0, slashIndex));
+    } else if (slashIndex < 0) {
+      shorthandModelRefs.push(ref.value);
     }
   }
   pushProviderId(config.tools?.web?.search?.provider);
   pushProviderId(config.tools?.web?.fetch?.provider);
-  return sortUniquePluginIds(providerIds);
+  return { providerIds: sortUniquePluginIds(providerIds), shorthandModelRefs };
 }
 
-export function collectValidationConfiguredShorthandModelIds(config: OpenClawConfig): string[] {
+export function collectValidationConfiguredShorthandModelIds(
+  modelRefs: readonly string[],
+): string[] {
   return sortUniquePluginIds(
-    collectConfiguredModelRefs(config)
-      .map((ref) => ref.value)
-      .filter((ref) => !ref.includes("/"))
-      .map((ref) => splitTrailingAuthProfile(ref).model.trim())
-      .filter(Boolean),
+    modelRefs.map((ref) => splitTrailingAuthProfile(ref).model.trim()).filter(Boolean),
   );
 }

--- a/src/plugins/gateway-startup-plugin-metadata.ts
+++ b/src/plugins/gateway-startup-plugin-metadata.ts
@@ -8,7 +8,7 @@ import {
   addPluginConfigEntryIds,
   collectConfiguredProviderIds,
   collectConfiguredStartupChannelIds,
-  collectValidationConfiguredProviderIds,
+  collectValidationConfiguredRefs,
   collectValidationConfiguredShorthandModelIds,
   normalizePluginsConfigForInstalledIndex,
   readStartupBundledDiscoveryMode,
@@ -33,11 +33,11 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
 }): string[] | undefined {
   const lookup = createInstalledPluginIndexScopeLookup(params.index);
   const activationSourceConfig = params.activationSourceConfig ?? params.config;
+  const sameConfig = activationSourceConfig === params.config;
   const pluginsConfig = normalizePluginsConfigForInstalledIndex(params.config.plugins, lookup);
-  const activationSourcePlugins = normalizePluginsConfigForInstalledIndex(
-    activationSourceConfig.plugins,
-    lookup,
-  );
+  const activationSourcePlugins = sameConfig
+    ? pluginsConfig
+    : normalizePluginsConfigForInstalledIndex(activationSourceConfig.plugins, lookup);
   if (!pluginsConfig.enabled || !activationSourcePlugins.enabled) {
     return [];
   }
@@ -51,9 +51,13 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
     return undefined;
   }
 
-  const scope = new Set<string>([...pluginsConfig.allow, ...activationSourcePlugins.allow]);
-  addPluginConfigEntryIds(scope, pluginsConfig);
-  addPluginConfigEntryIds(scope, activationSourcePlugins);
+  // Facts belong to this invocation; raw activation and effective configs can differ.
+  const configs = sameConfig ? [params.config] : [params.config, activationSourceConfig];
+  const pluginConfigs = sameConfig ? [pluginsConfig] : [pluginsConfig, activationSourcePlugins];
+  const scope = new Set(pluginConfigs.flatMap((plugins) => plugins.allow));
+  for (const plugins of pluginConfigs) {
+    addPluginConfigEntryIds(scope, plugins);
+  }
 
   const memorySlotStartupPluginId = resolveMemorySlotStartupPluginId({
     activationSourceConfig,
@@ -88,8 +92,7 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
   });
 
   const configuredChannelIds = collectConfiguredStartupChannelIds({
-    config: params.config,
-    activationSourceConfig,
+    configs,
     env: params.env,
     ambientEnvTriggers: params.ambientEnvTriggers,
     includePersistedAuthState: false,
@@ -99,11 +102,11 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
   }
   lookup.addDirectChannelOwners(scope, configuredChannelIds);
 
+  const providerIds = configs.flatMap(collectConfiguredProviderIds);
+  const validationRefs = configs.map(collectValidationConfiguredRefs);
   const configuredProviderIds = sortUniquePluginIds([
-    ...collectConfiguredProviderIds(params.config),
-    ...collectConfiguredProviderIds(activationSourceConfig),
-    ...collectValidationConfiguredProviderIds(params.config),
-    ...collectValidationConfiguredProviderIds(activationSourceConfig),
+    ...providerIds,
+    ...validationRefs.flatMap((refs) => refs.providerIds),
   ]);
   if (!lookup.canResolveDirectProviderIds(configuredProviderIds, scope)) {
     return undefined;
@@ -111,8 +114,7 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
   lookup.addDirectProviderOwners(scope, configuredProviderIds);
 
   const workerProviderIds = normalizeWorkerProviderIds([
-    ...collectConfiguredWorkerProviderIds(params.config),
-    ...collectConfiguredWorkerProviderIds(activationSourceConfig),
+    ...configs.flatMap(collectConfiguredWorkerProviderIds),
     ...(params.workerProviderIds ?? []),
   ]);
   if (!lookup.hasProviderContributionOwners(workerProviderIds)) {
@@ -120,10 +122,11 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
   }
   lookup.addProviderContributionOwners(scope, workerProviderIds);
 
-  const configuredShorthandModelIds = sortUniquePluginIds([
-    ...collectValidationConfiguredShorthandModelIds(params.config),
-    ...collectValidationConfiguredShorthandModelIds(activationSourceConfig),
-  ]);
+  const configuredShorthandModelIds = sortUniquePluginIds(
+    validationRefs.flatMap((refs) =>
+      collectValidationConfiguredShorthandModelIds(refs.shorthandModelRefs),
+    ),
+  );
   if (!lookup.hasShorthandModelOwners(configuredShorthandModelIds)) {
     return undefined;
   }
@@ -142,18 +145,15 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
     platform: params.platform,
   });
 
-  const deniedPluginIds = new Set([...pluginsConfig.deny, ...activationSourcePlugins.deny]);
+  const deniedPluginIds = new Set(pluginConfigs.flatMap((plugins) => plugins.deny));
   for (const pluginId of deniedPluginIds) {
     scope.delete(pluginId);
   }
-  for (const [pluginId, entry] of Object.entries(pluginsConfig.entries)) {
-    if (entry?.enabled === false) {
-      scope.delete(pluginId);
-    }
-  }
-  for (const [pluginId, entry] of Object.entries(activationSourcePlugins.entries)) {
-    if (entry?.enabled === false) {
-      scope.delete(pluginId);
+  for (const plugins of pluginConfigs) {
+    for (const [pluginId, entry] of Object.entries(plugins.entries)) {
+      if (entry?.enabled === false) {
+        scope.delete(pluginId);
+      }
     }
   }
   if (!lookup.hasInstalledPluginIds(scope)) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Local hook discovery has avoidable plugin-metadata planning overhead, especially with many configured agent/model references. This path serves the permitted local fallback for hook reports and the local inspection used by hook enable/disable commands.

## Why This Change Was Made

Reuse config facts within one metadata-planning invocation when effective and activation config are the same object, and collect qualified and shorthand model references in one traversal per distinct config. Preserve distinct config roles, ordering, early fallbacks and exclusions; later calls still read config mutations. This adds no process cache, configuration option, storage change or plugin runtime import.

## User Impact

Plugin selection and hook behavior stay unchanged. The actual selector is faster in the measured small and 64-agent shared-config cases with restrictive allowlists, a shape supported by local hooks discovery. Complete hooks-command latency was not measured.

This is **not a general Gateway performance win**. Gateway bootstrap/reload pass prepared metadata when available, bypassing this selector. Distinct-config selector/caller cases were slower in both measured orders, so the change is not uniformly faster.

## Evidence

- Two new behavior cases passed against original production; all 188 focused tests and all 29 changed checks passed on the candidate's owned dependency installation.
- Required `pnpm build` passed all 16 phases on an isolated Linux Testbox; the lease was stopped. Local tests used Node 26.8.1; the build used Node 24.19.0 and pnpm 12.3.4.
- Codex P2 review was scoped-clean. Independent source-oracle and numeric-data audits found no blocking correctness/evidence issue; the mixed performance results remain explicit below.
- Fixed B0/C0/C1/B1 component workload: 16 cases × 289 calls per phase, with one initial call, eight warmups and 280 timed calls. All 18,496 calls, 12 separate config-mutation checks and 64 complete initial finite data/behavior captures passed. Every timing ordinal and caller timing record was retained. Warm/timed payloads were checked in process, not serialized in full; normalization-function closure identity is outside the captured data domain.

The table gives candidate time changes for the forward/reverse pairs. Negative means faster. Each result is the median of 280 timed calls through the actual export; the two target lookup cases omit `metadataSnapshot` so the changed resolver remains inside the call. The prepared-snapshot row is an explicit bypass control.

| Workload | Forward | Reverse |
| --- | ---: | ---: |
| Shared config, small selector | −33.28% | −26.81% |
| Shared config, 64-agent selector | −28.86% | −34.40% |
| Equal-valued distinct configs, 64-agent selector | +3.51% | +7.37% |
| Distinct effective/activation roles, selector | +15.70% | +20.28% |
| Globally disabled | −26.56% | +106.15% |
| Compatibility fallback | +7.73% | +30.27% |
| No restrictive allowlist | +8.94% | +20.97% |
| Incomplete config-path metadata | +9.95% | +12.05% |
| Unknown channel | −29.41% | −31.90% |
| Unknown qualified provider | −30.23% | −33.21% |
| Unknown worker provider | −34.27% | −35.95% |
| Unknown shorthand model | −31.34% | −28.92% |
| Unknown installed plugin ID | −26.92% | −29.53% |
| Shared 64-agent config, actual lookup caller | −12.57% | −30.95% |
| Distinct roles, actual lookup caller | +14.11% | +15.35% |
| Prepared-snapshot lookup control | +12.78% | +5.40% |

The shared-config lookup medians were 875.584 → 765.500 µs and 1,113.854 → 769.125 µs. The distinct-config lookup medians instead increased 185.209 → 211.333 µs and 198.584 → 229.063 µs. The disabled reverse case increased from 0.667 to 1.375 µs. The unchanged bypass control also slowed, showing run variation; that does not erase the distinct-config adverse results or establish statistical significance.

All 53,330 descriptive comparisons were independently checked. Higher candidate observations were retained: 15/32 primary wall medians, 260/688 timed descriptors, 134/344 warmup descriptors, 70/172 initial metrics, 947/2,408 batch descriptors, 16,113/49,708 indexed metrics and 4/10 native metrics. Signed heap/RSS deltas and quantized CPU values are not automatically causal regressions; nonpositive baselines have no percentage.

Whole-phase native wall changed −7.02%/+5.25%; kernel peak RSS −1.37%/−0.40%; sampled tree peak RSS −1.61%/−0.56%; native user CPU +1.17%/−3.46%; system CPU +7.96%/+0.46%. These totals include imports, fixtures and assertions. No live Gateway/provider turn or full CLI latency was measured. All four runs closed cleanly and the exact candidate was restored; there were no numeric retries or dropped cases.

A missing locked development dependency was reconciled through an ordinary frozen install before the passing local proof. Earlier review disk and Testbox environment checks refused before launching review or creating a lease; those refusals are preserved separately from the successful proof. No failing run is represented as passing.
