### PR TITLE
refactor(agents): group equivalent Nodes dispatch cases

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2009,7 +2009,7 @@ src/agents/tools/message-tool-visible-content.ts	9
 src/agents/tools/mobile-ui-tool.ts	5
 src/agents/tools/model-config.helpers.ts	1
 src/agents/tools/music-generate-tool.ts	2
-src/agents/tools/nodes-tool.ts	3
+src/agents/tools/nodes-tool.ts	2
 src/agents/tools/openclaw-delegate-tool.ts	1
 src/agents/tools/pdf-native-providers.ts	2
 src/agents/tools/pdf-tool.ts	3

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -22,7 +22,7 @@ import {
 import { type AnyAgentTool, jsonResult, readToolStringParam } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
-import { executeNodeCommandAction, type NodeCommandAction } from "./nodes-tool-commands.js";
+import { executeNodeCommandAction } from "./nodes-tool-commands.js";
 import { callNodesToolNodeInvoke } from "./nodes-tool-invoke.js";
 import { executeNodeMediaAction, MEDIA_INVOKE_ACTIONS } from "./nodes-tool-media.js";
 import { resolveAgentNodeId } from "./nodes-utils.js";
@@ -258,16 +258,11 @@ export function createNodesTool(options?: {
             });
             return jsonResult({ ok: true });
           }
-          case "camera_snap": {
-            return await executeNodeMediaAction({
-              action,
-              params,
-              gatewayOpts,
-              modelHasVision: options?.modelHasVision,
-              imageSanitization,
-            });
-          }
-          case "photos_latest": {
+          case "camera_snap":
+          case "photos_latest":
+          case "camera_clip":
+          case "screen_record":
+          case "screen_snapshot": {
             return await executeNodeMediaAction({
               action,
               params,
@@ -282,73 +277,10 @@ export function createNodesTool(options?: {
           case "device_status":
           case "device_info":
           case "device_permissions":
-          case "device_health": {
-            return await executeNodeCommandAction({
-              action: action as NodeCommandAction,
-              input: params,
-              gatewayOpts,
-              agentSessionKey: options?.agentSessionKey,
-              allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-              mediaInvokeActions: MEDIA_INVOKE_ACTIONS,
-            });
-          }
-          case "notifications_action": {
-            return await executeNodeCommandAction({
-              action,
-              input: params,
-              gatewayOpts,
-              agentSessionKey: options?.agentSessionKey,
-              allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-              mediaInvokeActions: MEDIA_INVOKE_ACTIONS,
-            });
-          }
-          case "camera_clip": {
-            return await executeNodeMediaAction({
-              action,
-              params,
-              gatewayOpts,
-              modelHasVision: options?.modelHasVision,
-              imageSanitization,
-            });
-          }
-          case "screen_record": {
-            return await executeNodeMediaAction({
-              action,
-              params,
-              gatewayOpts,
-              modelHasVision: options?.modelHasVision,
-              imageSanitization,
-            });
-          }
-          case "screen_snapshot": {
-            return await executeNodeMediaAction({
-              action,
-              params,
-              gatewayOpts,
-              modelHasVision: options?.modelHasVision,
-              imageSanitization,
-            });
-          }
-          case "location_get": {
-            return await executeNodeCommandAction({
-              action,
-              input: params,
-              gatewayOpts,
-              agentSessionKey: options?.agentSessionKey,
-              allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-              mediaInvokeActions: MEDIA_INVOKE_ACTIONS,
-            });
-          }
-          case "which": {
-            return await executeNodeCommandAction({
-              action,
-              input: params,
-              gatewayOpts,
-              agentSessionKey: options?.agentSessionKey,
-              allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-              mediaInvokeActions: MEDIA_INVOKE_ACTIONS,
-            });
-          }
+          case "device_health":
+          case "notifications_action":
+          case "location_get":
+          case "which":
           case "invoke": {
             return await executeNodeCommandAction({
               action,


### PR DESCRIPTION
Closes #142397

## What Problem This Solves

The Nodes tool repeats identical executor argument objects across its media and command switch cases. This maintainer-requested cleanup groups equivalent cases around the existing calls.

## Why This Change Was Made

The existing media and command executors retain every action, argument and return path. Switch narrowing also removes an unnecessary command-action cast. The internal assertion-baseline count decreases from 3 to 2 to match that removal; no user configuration changes.

## User Impact

No intended behavior change. The complete change removes 68 production code lines and 68 physical lines, without a new runtime abstraction or test seam.

## Evidence

- 87 focused tests pass across three existing Nodes suites.
- The final changed-file gate passes on the source and exact assertion-baseline decrease, including production/test typing, lint and dead-export checks.
- Fresh independent P0–P2 review is scoped-clean.
- The subsequent cast/import removal emits byte-identical JavaScript with object shorthand downleveled for comparison. Runtime tests were not repeated for that type-only follow-up; this is not a production bundle comparison.

No schema, protocol, permissions or persisted-data change is included. No live device was used.
