### PR TITLE
refactor(telegram): skip unused draft prefix preparation

### DIFF
--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -572,11 +572,14 @@ export function createTelegramDraftStream(params: {
     if (plan.nextPageIndex <= 0 || plan.nextPageIndex >= plan.pages.length) {
       return undefined;
     }
+    const fullSourceText = plan.pages[0]?.fullSourceText;
+    if (fullSourceText === undefined) {
+      return undefined;
+    }
     const acceptedSourceText = plan.pages
       .slice(0, plan.nextPageIndex)
       .map((page) => page.sourceText)
       .join("");
-    const fullSourceText = plan.pages[0]?.fullSourceText;
     if (!fullSourceText?.startsWith(acceptedSourceText)) {
       return undefined;
     }


### PR DESCRIPTION
Closes #142403

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

This is a maintainer-authored and requested optimization. Telegram draft pagination repeatedly builds earlier-page prefixes even when the plan has no original HTML source to recover. Plain, rich and ordinary Markdown plans cannot use that work.

## Why This Change Was Made

This maintainer-requested change checks for undefined `fullSourceText` immediately after the existing page-index guard. Explicit HTML still performs the original exact prefix/suffix recovery; empty strings retain the same behavior.

Page order, accepted-page retention, retries, current-generation checks, reply targets, transport arguments and snapshots are unchanged. No new cache, configuration, persistence or Telegram API contract is introduced.

## User Impact

The same draft pages are sent with less unused prefix preparation for long pagination. Full mocked-flow sampled allocation was about 38% lower for eight plain pages, 88% lower for 32 plain pages and 40% lower for eight rich pages. Rich elapsed time increased about 10%; small and explicit-HTML controls were mixed. Two observations per arm do not establish general latency, retained-memory, RSS or whole-Gateway improvement.

One production file grows by 3 lines; no test or bookkeeping changes.

## Evidence

- 193 existing draft, rich-content and fallback tests pass before and after.
- 41 exact public draft/planner/mock-transport captures match arguments, ordering, retained pages, suffixes and generation outcomes. Timestamps are compared for presence only.
- Explicit HTML entity recovery, prefix mismatch, retry exhaustion, formatted-to-plain fallback and superseded completion retain their original outcomes.
- Full selected changed gate and independent review pass. The corrected 4,000-character draft cap is used in the final comparisons; the earlier 4,096-request experiment is retained separately and excluded.

These are real owner/planner flows with a synthetic transport, not external Telegram sends. No live Telegram behavior change is claimed.
