### PR TITLE
fix(markdown): align short columns in code tables

### DIFF
--- a/extensions/discord/src/markdown.test.ts
+++ b/extensions/discord/src/markdown.test.ts
@@ -21,7 +21,7 @@ describe("renderDiscordMarkdown", () => {
   it("converts tables only when requested and leaves length enforcement to chunking", () => {
     const table = "| A | B |\n| - | - |\n| x | y |";
     expect(renderDiscordMarkdown(table, "code")).toBe(
-      "```\n| A | B |\n| --- | --- |\n| x | y |\n```",
+      "```\n| A   | B   |\n| --- | --- |\n| x   | y   |\n```",
     );
 
     const oversized = "x".repeat(2_001);

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -76,7 +76,7 @@ describe("Discord webhook delivery", () => {
     {
       label: "configured table formatting",
       text: "| A | B |\n| - | - |\n| x | y |",
-      expected: "```\n| A | B |\n| --- | --- |\n| x | y |\n```",
+      expected: "```\n| A   | B   |\n| --- | --- |\n| x   | y   |\n```",
       tableMode: undefined,
     },
     {

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -15,7 +15,7 @@ const TEST_CFG = {};
 const MATTERMOST_TABLE_GOLDEN = {
   name: "keeps native Mattermost tables instead of downgrading them to code",
   input: "| A | B |\n|---|---|\n| 1 | 2 |",
-  before: "```\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```",
+  before: "```\n| A   | B   |\n| --- | --- |\n| 1   | 2   |\n```",
   after: "| A | B |\n|---|---|\n| 1 | 2 |",
 };
 const MATTERMOST_MARKDOWN_GOLDENS = [MATTERMOST_TABLE_GOLDEN];

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -372,7 +372,7 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const sent = firstSendText(sendMessage);
     expect(sent).toContain("Before");
-    expect(sent).toContain(`<pre><code>${table}\n</code></pre>`);
+    expect(sent).toContain("<pre><code>| A   | B   |\n| --- | --- |\n| 1   | 2   |\n</code></pre>");
     expect(sent).toContain("After");
     expectRecordFields(firstMockCallArg(sendMessage, 2), { parse_mode: "HTML" });
   });

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -179,9 +179,9 @@ describe("markdownToTelegramHtml", () => {
     const html = markdownToTelegramHtml(markdown, { tableMode: "block" });
     const chunks = markdownToTelegramChunks(markdown, 4096, { tableMode: "block" });
 
-    expect(html).toContain(`<pre><code>${table}\n</code></pre>`);
+    expect(html).toContain("<pre><code>| A   | B   |\n| --- | --- |\n| 1   | 2   |\n</code></pre>");
     expect(chunks.map((chunk) => chunk.html)).toEqual([html]);
-    expect(chunks[0]?.text).toContain("| 1 | 2 |");
+    expect(chunks[0]?.text).toContain("| 1   | 2   |");
     if (before) {
       expect(html).toContain("Before");
     }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1759,7 +1759,7 @@ describe("sendMessageTelegram", () => {
     });
 
     expect(botApi.sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessageTexts(botApi.sendMessage).join("")).toContain("| H1 | H2 |");
+    expect(sendMessageTexts(botApi.sendMessage).join("")).toContain("| H1  | H2  |");
     expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 

--- a/packages/markdown-core/src/ir.table-bullets.test.ts
+++ b/packages/markdown-core/src/ir.table-bullets.test.ts
@@ -98,8 +98,8 @@ describe("markdownToIR tableMode bullets", () => {
 
     const ir = markdownToIR(md, { tableMode: "code" });
 
-    expect(ir.text).toContain("| A | B |");
-    expect(ir.text).toContain("| 1 | 2 |");
+    expect(ir.text).toContain("| A   | B   |");
+    expect(ir.text).toContain("| 1   | 2   |");
     expect(ir.styles.map((style) => style.style)).toContain("code_block");
   });
 

--- a/packages/markdown-core/src/ir.table-code.test.ts
+++ b/packages/markdown-core/src/ir.table-code.test.ts
@@ -1,8 +1,27 @@
 // Markdown Core tests cover ir.table code behavior.
 import { describe, expect, it } from "vitest";
 import { markdownToIR } from "./ir.js";
+import { convertMarkdownTables } from "./tables.js";
 
 describe("markdownToIR tableMode code", () => {
+  it.each(["ir", "code", "block"] as const)(
+    "aligns short and empty columns through %s output",
+    (mode) => {
+      const source = "| | A | BB | Long |\n| --- | --- | --- | --- |\n| | 1 | 22 | data |";
+      const expected = [
+        "|     | A   | BB  | Long |",
+        "| --- | --- | --- | ---- |",
+        "|     | 1   | 22  | data |",
+        "",
+      ].join("\n");
+      const rendered =
+        mode === "ir"
+          ? markdownToIR(source, { tableMode: "code" }).text
+          : convertMarkdownTables(source, mode);
+      expect(rendered).toBe(mode === "ir" ? expected : `\`\`\`\n${expected}\`\`\``);
+    },
+  );
+
   it("aligns CJK and emoji cells by display width", () => {
     const md = `
 | Kind | Value |
@@ -37,11 +56,11 @@ describe("markdownToIR tableMode code", () => {
 
     expect(ir.text).toBe(
       [
-        "| I | L        |",
+        "| I   | L        |",
         "| --- | -------- |",
-        "| © | text     |",
-        "| 1️ | selector |",
-        "| A | ascii    |",
+        "| ©   | text     |",
+        "| 1️   | selector |",
+        "| A   | ascii    |",
         "",
       ].join("\n"),
     );
@@ -68,8 +87,8 @@ describe("markdownToIR tableMode code", () => {
   });
 
   it.each([
-    { name: "leading", cell: "` a`", expected: "| V  |\n| --- |\n|  a |\n" },
-    { name: "trailing", cell: "`a `", expected: "| V  |\n| --- |\n| a  |\n" },
+    { name: "leading", cell: "` abc`", expected: "| V    |\n| ---- |\n|  abc |\n" },
+    { name: "trailing", cell: "`abc `", expected: "| V    |\n| ---- |\n| abc  |\n" },
   ])("measures code-owned $name space as cell content", ({ cell, expected }) => {
     expect(markdownToIR(`| V |\n| --- |\n| ${cell} |`, { tableMode: "code" })).toEqual({
       text: expected,

--- a/packages/markdown-core/src/table-layout.ts
+++ b/packages/markdown-core/src/table-layout.ts
@@ -41,7 +41,7 @@ export function renderMarkdownCodeTable(headers: readonly string[], rows: readon
   const widths: number[] = [];
   for (const row of measured) {
     for (const [index, cell] of row.entries()) {
-      widths[index] = Math.max(widths[index] ?? 0, cell.width);
+      widths[index] = Math.max(widths[index] ?? 3, cell.width);
     }
   }
   if (widths.length === 0) {
@@ -49,8 +49,7 @@ export function renderMarkdownCodeTable(headers: readonly string[], rows: readon
   }
   const renderRow = (row: (typeof measured)[number]) =>
     `|${widths.map((width, index) => ` ${row[index]?.text ?? ""}${" ".repeat(width - (row[index]?.width ?? 0))} |`).join("")}`;
-  const divider = `|${widths.map((width) => ` ${"-".repeat(Math.max(3, width))} |`).join("")}`;
-  return [renderRow(measured[0] ?? []), divider, ...measured.slice(1).map(renderRow), ""].join(
-    "\n",
-  );
+  const divider = widths.map((width) => ({ text: "-".repeat(width), width }));
+  measured.splice(1, 0, divider);
+  return [...measured.map(renderRow), ""].join("\n");
 }

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -66,7 +66,7 @@ describe("convertMarkdownTables", () => {
   it("keeps the existing table recognition for list-like headers", () => {
     const rendered = convertMarkdownTables("- A | B\n---|---\nx|y", "code");
 
-    expect(rendered).toContain("| - A | B |");
+    expect(rendered).toContain("| - A | B   |");
     expect(new MarkdownIt().render(rendered)).toContain("<pre><code>");
   });
 
@@ -115,7 +115,7 @@ describe("convertMarkdownTables", () => {
 
     expect(rendered.startsWith(`${first}\`\`\``)).toBe(true);
     expect(html).toContain(container);
-    expect(html).toContain("<pre><code>| A | B |");
+    expect(html).toContain("<pre><code>| A   | B   |");
   });
 
   it("keeps reference labels in code tables and leaves document definitions untouched", () => {
@@ -150,7 +150,7 @@ describe("convertMarkdownTables", () => {
   it("falls back to code rendering for block mode", () => {
     const rendered = convertMarkdownTables("| A | B |\n|---|---|\n| 1 | 2 |", "block");
 
-    expect(rendered).toBe("```\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```");
+    expect(rendered).toBe("```\n| A   | B   |\n| --- | --- |\n| 1   | 2   |\n```");
   });
 
   it("does not parse ordinary text that cannot contain a table", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading code-block table fallbacks saw jagged column borders when headers and values were shorter than three display columns. Divider rows were wider than their corresponding header and data rows.

Before:

```text
| A | B |
| --- | --- |
| 1 | 2 |
```

After:

```text
| A   | B   |
| --- | --- |
| 1   | 2   |
```

## Why This Change Was Made

Use one minimum width for each column and render the divider through the same row formatter as headers and data. This deletes the divergent divider-rendering path and restores the alignment already promised by the formatting documentation. Existing guards and caller-owned input arrays remain intact.

## User Impact

Short and empty columns remain aligned in code-table fallbacks. Unicode display widths, literal cell content, and longer columns retain their existing behavior.

## Evidence

Three regressions through the public Markdown parser and code/block converter failed before the repair. Afterward, 76 focused core table tests and 20 table-focused Discord, Mattermost, and Telegram caller tests pass, including local synthetic webhook delivery. Direct probes cover empty and short columns, CJK, emoji, variation selectors, and literal cell spaces; every row now has matching column positions.

Scoped Markdown production/test types, full-file core and caller-test lint, formatting, and diff checks pass. Independent P2 review found no actionable findings. The production formatter shrinks by one line; test changes correct padding expectations and strengthen the existing literal-space cases so padding cannot hide trimming. No live-channel delivery is claimed. Exact-head CI remains required before landing.

CI follow-through: the initial run caught one remaining Telegram send-test expectation for short headers. Its padding was corrected without changing production code; the exact focused test and independent P2 review pass.
