### PR TITLE
refactor(plugins): derive manifest registry records

### DIFF
--- a/src/plugins/manifest-registry.types.ts
+++ b/src/plugins/manifest-registry.types.ts
@@ -1,41 +1,17 @@
-import type { DoctorSessionRouteStateOwner } from "./doctor-session-route-state-owner-types.js";
-import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
 import type {
   PluginBundleFormat,
   PluginConfigUiHint,
   PluginDiagnostic,
   PluginFormat,
-  PluginManifestBackupResource,
-  PluginManifestDoctorContract,
-  PluginManifestActivation,
-  PluginManifestCatalog,
-  PluginManifestConfigContracts,
   PluginManifest,
-  PluginManifestCapabilityProviderMetadata,
   PluginManifestChannelCommandDefaults,
   PluginManifestChannelConfig,
-  PluginManifestContracts,
-  PluginManifestControlUi,
-  PluginManifestDashboard,
-  PluginManifestMediaUnderstandingProviderMetadata,
-  PluginManifestMcpServer,
-  PluginManifestModelCatalog,
-  PluginManifestModelIdNormalization,
-  PluginManifestModelPricing,
-  PluginManifestModelSupport,
-  PluginManifestProviderEndpoint,
-  PluginManifestProviderRequest,
-  PluginManifestQaRunner,
-  PluginManifestSecretProviderIntegration,
-  PluginManifestSetup,
-  PluginManifestToolMetadata,
 } from "./manifest-types.js";
 import type {
   OpenClawPackageManifest,
   PluginPackageChannel,
   PluginPackageInstall,
 } from "./package-manifest.types.js";
-import type { PluginKind } from "./plugin-kind.types.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import type { PluginTrust } from "./plugin-trust.js";
 import type { PluginDependencySpecMap } from "./status-dependencies-core.js";
@@ -60,52 +36,37 @@ export type PluginManifestContractListKey =
   | "migrationProviders"
   | "gatewayMethodDispatch";
 
-export type PluginManifestRecord = {
-  id: string;
+type PluginManifestRecordStatic = Omit<
+  PluginManifest,
+  | "capabilityCatalogEntry"
+  | "channels"
+  | "cliBackends"
+  | "configSchema"
+  | "enabledByDefaultOnPlatforms"
+  | "providerCatalogEntry"
+  | "providers"
+  | "requiresPlugins"
+  | "skills"
+  | "uiHints"
+>;
+
+export type PluginManifestRecord = PluginManifestRecordStatic & {
   /** Process-local source selection, never persisted in the installed index. */
   sourcePreferred?: true;
-  backupResources?: PluginManifestBackupResource[];
-  name?: string;
-  description?: string;
-  catalog?: PluginManifestCatalog;
   iconPath?: string;
-  version?: string;
   packageName?: string;
   packageVersion?: string;
   packageDescription?: string;
-  enabledByDefault?: boolean;
   enabledByDefaultOnPlatforms?: string[];
-  autoEnableWhenConfiguredProviders?: string[];
-  legacyPluginIds?: string[];
   format?: PluginFormat;
   bundleFormat?: PluginBundleFormat;
   bundleCapabilities?: string[];
-  kind?: PluginKind | PluginKind[];
   channels: string[];
   providers: string[];
   providerDiscoverySource?: string;
   /** Undefined is undeclared; null retains a rejected declaration without enabling full-entry fallback. */
   capabilityCatalogSource?: string | null;
-  modelSupport?: PluginManifestModelSupport;
-  modelCatalog?: PluginManifestModelCatalog;
-  modelPricing?: PluginManifestModelPricing;
-  modelIdNormalization?: PluginManifestModelIdNormalization;
-  providerEndpoints?: PluginManifestProviderEndpoint[];
-  providerRequest?: PluginManifestProviderRequest;
-  secretProviderIntegrations?: Record<string, PluginManifestSecretProviderIntegration>;
   cliBackends: string[];
-  syntheticAuthRefs?: string[];
-  nonSecretAuthMarkers?: string[];
-  commandAliases?: PluginManifestCommandAlias[];
-  cliCommands?: PluginManifest["cliCommands"];
-  providerUsageAuthEnvVars?: Record<string, string[]>;
-  providerAuthAliases?: Record<string, string>;
-  providerAuthChoices?: PluginManifest["providerAuthChoices"];
-  activation?: PluginManifestActivation;
-  setup?: PluginManifestSetup;
-  doctorContract?: PluginManifestDoctorContract;
-  doctorHealthChecks?: boolean;
-  sessionRouteStateOwners?: DoctorSessionRouteStateOwner[];
   packageManifest?: OpenClawPackageManifest;
   packageDependencies?: PluginDependencySpecMap;
   packageOptionalDependencies?: PluginDependencySpecMap;
@@ -113,10 +74,6 @@ export type PluginManifestRecord = {
   packageInstall?: PluginPackageInstall;
   trustedOfficialInstall?: boolean;
   trust?: PluginTrust;
-  qaRunners?: PluginManifestQaRunner[];
-  dashboard?: PluginManifestDashboard;
-  controlUi?: PluginManifestControlUi;
-  mcpServers?: Record<string, PluginManifestMcpServer>;
   skills: string[];
   settingsFiles?: string[];
   hooks: string[];
@@ -129,18 +86,6 @@ export type PluginManifestRecord = {
   schemaCacheKey?: string;
   configSchema?: Record<string, unknown>;
   configUiHints?: Record<string, PluginConfigUiHint>;
-  contracts?: PluginManifestContracts;
-  transcriptSources?: PluginManifest["transcriptSources"];
-  mediaUnderstandingProviderMetadata?: Record<
-    string,
-    PluginManifestMediaUnderstandingProviderMetadata
-  >;
-  imageGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
-  videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
-  musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
-  toolMetadata?: Record<string, PluginManifestToolMetadata>;
-  configContracts?: PluginManifestConfigContracts;
-  channelConfigs?: Record<string, PluginManifestChannelConfig>;
   channelCatalogMeta?: {
     id: string;
     label?: string;


### PR DESCRIPTION
## Summary

- derive static plugin manifest registry fields from the canonical manifest contract
- retain normalized arrays, registry provenance, and widened platform/config-schema fields
- remove the duplicated handwritten registry record surface

## Data-model compatibility

- migration/backfill/repair: none required; this changes TypeScript declarations only
- no registry builder, parser, serializer, cache, stored payload, or runtime object construction changes
- native and bundled manifest record builders emit the same runtime objects as before
- required normalized arrays and registry-only provenance remain explicit overrides
- upgrade proof: `manifest-registry-installed.ownership.test.ts` writes a persisted installed index, clears lifecycle caches, reloads it, reconstructs the manifest registry, and verifies package identities and enabled entries
- that persisted cold-reload test and the broader registry/snapshot/config-contract suite are included in the 180 focused passing tests

## Testing

- core typecheck
- 180 focused manifest registry tests
- `pnpm check:changed`
