### PR TITLE
refactor(skills): derive workshop store contracts

### DIFF
--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -1,7 +1,12 @@
+import type {
+  SkillProposalEvaluation as ProtocolSkillProposalEvaluation,
+  SkillProposalLifecycleEvent,
+  SkillsProposalCreateParams,
+  SkillsProposalRecordResult,
+  SkillsProposalsListResult,
+} from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 // Workshop types define generated skill draft, policy, and config contracts.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { PluginHookSkillProposalEvaluationOutcome } from "../../plugins/hook-types.js";
-import type { SkillScanFinding } from "../security/scanner.js";
 
 /** Schema id for persisted skill workshop proposal records. */
 export const SKILL_WORKSHOP_SCHEMA = "openclaw.skill-workshop.proposal.v1" as const;
@@ -10,57 +15,17 @@ export const SKILL_WORKSHOP_MANIFEST_SCHEMA =
 export const SKILL_WORKSHOP_ROLLBACK_SCHEMA = "openclaw.skill-workshop.rollback.v1" as const;
 export const MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS = 4096;
 
-type SkillProposalKind = "create" | "update";
-export type SkillProposalStatus = "pending" | "applied" | "rejected" | "quarantined" | "stale";
-type SkillProposalScannerState = "pending" | "clean" | "failed" | "quarantined";
-type SkillProposalSource = "skill-workshop" | "cli" | "gateway";
-type SkillProposalEvaluationTrigger = "manual" | "apply";
-export type SkillProposalEventType =
-  | "created"
-  | "revised"
-  | "evaluation_completed"
-  | "applied"
-  | "rejected"
-  | "quarantined"
-  | "stale";
+type ProtocolSkillProposalRecord = SkillsProposalRecordResult;
+type ProtocolSkillProposalManifestEntry = SkillsProposalsListResult["proposals"][number];
 
-export type SkillProposalEvaluation = {
-  id: string;
-  proposedVersion: string;
-  revisionHash: string;
-  trigger: SkillProposalEvaluationTrigger;
-  startedAt: string;
-  completedAt: string;
-  correlationId?: string;
-  targetTreeSha256?: string;
-  outcomes: PluginHookSkillProposalEvaluationOutcome[];
-};
-
-export type SkillProposalEventActor = {
-  type: "agent" | "gateway" | "plugin" | "system";
-  id?: string;
-};
-
-export type SkillProposalEvent = {
-  sequence: number;
-  eventId: string;
-  proposalId: string;
-  proposedVersion: string;
-  revisionHash: string;
-  type: SkillProposalEventType;
-  occurredAt: string;
-  actor: SkillProposalEventActor;
-  correlationId?: string;
-  payload?: Record<string, string | number | boolean | null>;
-  evaluation?: SkillProposalEvaluation;
-};
-
-export type SkillProposalOrigin = {
-  agentId?: string;
-  sessionKey?: string;
-  runId?: string;
-  messageId?: string;
-};
+export type SkillProposalStatus = ProtocolSkillProposalRecord["status"];
+type SkillProposalSource = ProtocolSkillProposalRecord["createdBy"];
+type SkillProposalEvaluationTrigger = ProtocolSkillProposalEvaluation["trigger"];
+export type SkillProposalEventType = SkillProposalLifecycleEvent["type"];
+export type SkillProposalEvaluation = ProtocolSkillProposalEvaluation;
+export type SkillProposalEventActor = SkillProposalLifecycleEvent["actor"];
+export type SkillProposalEvent = SkillProposalLifecycleEvent;
+export type SkillProposalOrigin = NonNullable<ProtocolSkillProposalRecord["origin"]>;
 
 export type SkillWorkshopPreparedPatch = {
   skillFile: string;
@@ -117,46 +82,19 @@ export type SkillWorkshopRunOptions = {
   proposalRevision?: SkillWorkshopProposalRevisionConstraint;
 };
 
-export type SkillProposalScan = {
-  state: SkillProposalScannerState;
-  scannedAt: string;
-  critical: number;
-  warn: number;
-  info: number;
-  findings: SkillScanFinding[];
-};
-
-type SkillProposalTarget = {
-  skillName: string;
-  skillKey: string;
-  skillDir: string;
-  skillFile: string;
-  source?: string;
-  currentContentHash?: string;
-};
-
-export type SkillProposalSupportFile = {
-  path: string;
-  sizeBytes: number;
-  hash: string;
-  targetExisted?: boolean;
-  targetContentHash?: string;
-};
+export type SkillProposalScan = ProtocolSkillProposalRecord["scan"];
+export type SkillProposalSupportFile = NonNullable<
+  ProtocolSkillProposalRecord["supportFiles"]
+>[number];
 
 export type PreparedSkillProposalSupportFile = SkillProposalSupportFile & { content: string };
 
 export type SkillProposalDraftFile = "PROPOSAL.md" | `generations/${string}/PROPOSAL.md`;
 
-export type SkillProposalRecord = {
-  schema: typeof SKILL_WORKSHOP_SCHEMA;
-  id: string;
-  kind: SkillProposalKind;
-  status: SkillProposalStatus;
-  title: string;
-  description: string;
-  createdAt: string;
-  updatedAt: string;
-  createdBy: SkillProposalSource;
+export type SkillProposalRecord = Omit<
+  ProtocolSkillProposalRecord,
+  "draftFile" | "evaluation" | "origin"
+> & {
   /** True only for proposals created by autonomous correction or experience capture. */
   autonomousCapture?: true;
   origin?: SkillProposalOrigin;
@@ -164,36 +102,15 @@ export type SkillProposalRecord = {
   originRunIds?: string[];
   /** Durable mutation counts keyed by run id for bounded interrupted-run recovery. */
   originRunMutationCounts?: Record<string, number>;
-  proposedVersion: string;
   draftFile: SkillProposalDraftFile;
-  draftHash: string;
-  supportFiles?: SkillProposalSupportFile[];
-  target: SkillProposalTarget;
-  scan: SkillProposalScan;
   evaluation?: SkillProposalEvaluation;
-  goal?: string;
-  evidence?: string;
-  appliedAt?: string;
-  rejectedAt?: string;
-  quarantinedAt?: string;
-  staleAt?: string;
-  statusReason?: string;
 };
 
-export type SkillProposalManifestEntry = {
-  id: string;
-  kind: SkillProposalKind;
-  status: SkillProposalStatus;
-  title: string;
-  description: string;
-  skillName: string;
-  skillKey: string;
-  createdAt: string;
-  updatedAt: string;
-  scanState: SkillProposalScannerState;
+export type SkillProposalManifestEntry = Omit<
+  ProtocolSkillProposalManifestEntry,
+  "revisionHash"
+> & {
   revisionHash: string;
-  /** The durable proposal body is unavailable; metadata remains inspectable in list output. */
-  degradedState?: "draft-missing";
 };
 
 export type SkillProposalManifest = {
@@ -218,10 +135,9 @@ export type SkillProposalRollback = {
   }>;
 };
 
-export type SkillProposalSupportFileInput = {
-  path: string;
-  content: string;
-};
+export type SkillProposalSupportFileInput = NonNullable<
+  SkillsProposalCreateParams["supportFiles"]
+>[number];
 
 export type SkillProposalCreateInput = {
   workspaceDir: string;


### PR DESCRIPTION
## Summary

- derive workshop store contracts from their canonical protocol owners
- preserve generation draft paths, autonomous capture, run attribution, mutation counts, and revision hashes
- remove duplicated handwritten persisted contract fields

## Testing

- core typecheck
- 36 focused workshop tests
- `pnpm check:changed`

