### PR TITLE
refactor(tests): remove dead Telegram edit scaffolding

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1826,7 +1826,6 @@ describe("sendMessageTelegram", () => {
     const chunks = sendMessageTexts(botApi.sendMessage);
     const joinedChunks = chunks.join("");
     expect(joinedChunks).toContain("Long");
-    expect(joinedChunks).toContain("section");
     expect(joinedChunks.match(/<b>section<\/b>/g)).toHaveLength(200);
     expect(joinedChunks.match(/<i>style<\/i>/g)).toHaveLength(200);
     expect(joinedChunks.match(/<code>code<\/code>/g)).toHaveLength(200);
@@ -5663,34 +5662,22 @@ describe("editMessageTelegram", () => {
       name: "buttons undefined keeps existing keyboard",
       text: "hi",
       buttons: undefined as Parameters<typeof buildInlineKeyboard>[0],
-      expectedCalls: 1,
       firstExpectNoReplyMarkup: true,
-      parseFallback: false,
     },
     {
       name: "buttons empty clears keyboard",
       text: "hi",
       buttons: [] as Parameters<typeof buildInlineKeyboard>[0],
-      expectedCalls: 1,
       firstExpectReplyMarkup: { inline_keyboard: [] } as Record<string, unknown>,
-      parseFallback: false,
     },
     {
-      name: "rich edit preserves cleared keyboard",
+      name: "HTML edit preserves cleared keyboard",
       text: "<bad> html",
       buttons: [] as Parameters<typeof buildInlineKeyboard>[0],
-      expectedCalls: 1,
       firstExpectReplyMarkup: { inline_keyboard: [] } as Record<string, unknown>,
-      parseFallback: false,
     },
   ])("$name", async (testCase) => {
-    if (testCase.parseFallback) {
-      botApi.editMessageText
-        .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))
-        .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
-    } else {
-      botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
-    }
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
 
     await editMessageTelegram("123", 1, testCase.text, {
       token: "tok",
@@ -5700,7 +5687,7 @@ describe("editMessageTelegram", () => {
 
     expect(botCtorSpy, testCase.name).toHaveBeenCalledTimes(1);
     expect(firstMockCall(botCtorSpy, "bot constructor call")[0], testCase.name).toBe("tok");
-    expect(botApi.editMessageText, testCase.name).toHaveBeenCalledTimes(testCase.expectedCalls);
+    expect(botApi.editMessageText, testCase.name).toHaveBeenCalledTimes(1);
 
     const firstParams = requireRecord(
       firstMockCall(botApi.editMessageText, "editMessageText call")[3],
@@ -5712,14 +5699,6 @@ describe("editMessageTelegram", () => {
     }
     if ("firstExpectReplyMarkup" in testCase && testCase.firstExpectReplyMarkup) {
       expect(firstParams.reply_markup, testCase.name).toEqual(testCase.firstExpectReplyMarkup);
-    }
-
-    if ("secondExpectReplyMarkup" in testCase && testCase.secondExpectReplyMarkup) {
-      const secondParams = requireRecord(
-        mockCall(botApi.editMessageText, 1, "second editMessageText call")[3],
-        "second edit params",
-      );
-      expect(secondParams.reply_markup, testCase.name).toEqual(testCase.secondExpectReplyMarkup);
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Telegram edit table retains fallback setup and assertions that none of its three rows can reach. Every row disables that fallback and expects exactly one edit call. A long-message check also repeats a condition already guaranteed by its exact formatted-span count.

## Why This Change Was Made

Remove the dead fallback branches and uniform row metadata, assert the shared call count directly, and rename the third case to describe its actual HTML path. Keep all three invocations, their inputs, mock behavior, and meaningful keyboard and formatting assertions.

## User Impact

No production changes. Removes 21 net test lines and makes the retained coverage clearer.

## Evidence

- The full send suite passes 276/276 before and after, with no skips. Exactly one title changes from “rich edit preserves cleared keyboard” to “HTML edit preserves cleared keyboard”; the other 275 ordered identities and all statuses remain unchanged.
- Static checks verify all three old fallback predicates are false, all expected call counts are one, and no row has the second-call expectation. The retained mock statement and production-call input expression are identical.
- The mapped changed gate and fresh independent P2 review pass with no findings.

No runtime improvement is claimed.
