### PR TITLE
fix(tts): keep ordinary Markdown prose in spoken replies

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -18,6 +18,8 @@ Talk mode covers these runtime shapes:
 
 Native Talk is a continuous loop: listen for speech, send the transcript to the model through the active session, wait for the response, then speak it via the configured Talk provider (`talk.speak`).
 
+For replies dominated by fenced code, `talk.speak` uses a short spoken message directing the listener to the screen. Inline code and ordinary prose remain part of the spoken reply.
+
 Apple Watch also retains **Talk to Claw**, the separate [one-turn companion flow](/platforms/ios#talk-to-claw-with-the-iphone): native dictation, text relayed through the iPhone, and system-voice readback. **Talk on Watch** is the realtime path included in normal Watch setup; see [standalone voice setup](/platforms/ios#standalone-voice).
 
 ## Choose a Talk voice from chat

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -873,6 +873,7 @@ When `tts.auto` is enabled, OpenClaw:
   auto-TTS behavior for the assistant's answer.
 - Skips TTS if the reply already contains structured media.
 - Skips very short replies (under 10 chars).
+- Skips replies dominated by fenced code; inline code and surrounding prose remain eligible for speech.
 - Summarizes long replies when summaries are enabled, using
   `summaryModel` (or `agents.defaults.model.primary`).
 - Attaches the generated audio to the reply.

--- a/packages/markdown-core/src/ir.fenced-content.test.ts
+++ b/packages/markdown-core/src/ir.fenced-content.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { countMarkdownFencedCodeChars } from "./ir.js";
+
+describe("fenced code content length", () => {
+  it.each([
+    { name: "below half", text: "```\n1234567\n```", count: 7 },
+    { name: "exactly half", text: "```\n12345678\n```", count: 8 },
+    { name: "above half", text: "```\n123456789\n```", count: 9 },
+    { name: "empty fence", text: "```\n```", count: 0 },
+    { name: "one blank body line", text: "```\n\n```", count: 0 },
+    { name: "two blank body lines", text: "```\n\n\n```", count: 1 },
+    { name: "trailing code spaces", text: "```\nx  \n```", count: 3 },
+    { name: "trailing code tab", text: "```\nx\t\n```", count: 2 },
+    { name: "interior blank line", text: "```\nleft\n\nright\n```", count: 11 },
+    { name: "CRLF body", text: "```\r\nleft\r\nright\r\n```", count: 10 },
+    { name: "unterminated body", text: "```ts\nconst answer = 42;", count: 18 },
+    { name: "unterminated empty fence", text: "```ts", count: 0 },
+    { name: "longer closer", text: "```\nconst answer = 42;\n````", count: 18 },
+    { name: "tilde fence", text: "~~~ts\nconst answer = 42;\n~~~", count: 18 },
+    { name: "mismatched interior marker", text: "```\n~~~\nconst answer = 42;\n```", count: 22 },
+    { name: "indented closer", text: "```\nconst answer = 42;\n   ```", count: 18 },
+    { name: "quoted fence", text: "> ```\n> const answer = 42;\n> ```", count: 18 },
+    {
+      name: "two-level list fence",
+      text: '- Outer\n  - Inner\n    ```\n    const detailedAnswer = "this body dominates the reply";\n    ```',
+      count: 55,
+    },
+    {
+      name: "tab terminated closer",
+      text: "```\nx\n```\t\nThis prose follows the code fence and is much longer than it.",
+      count: 1,
+    },
+    {
+      name: "indented code excluded",
+      text: "Ordinary paragraph.\n\n    const answer = 42;",
+      count: 0,
+    },
+  ])("preserves body characters: $name", ({ text, count }) => {
+    expect(countMarkdownFencedCodeChars(text)).toBe(count);
+  });
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -391,6 +391,22 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   return md;
 }
 
+/** Count fenced code body characters using the same block grammar as rendering. */
+export function countMarkdownFencedCodeChars(markdown: string): number {
+  const tokens = createMarkdownIt({ linkify: false, autolink: false, tableMode: "bullets" }).parse(
+    markdown,
+    {},
+  );
+  let count = 0;
+  for (const token of tokens) {
+    if (token.type === "fence") {
+      // The parser's final LF frames the code body; counting it shifts the speech threshold.
+      count += token.content.length - (token.content.endsWith("\n") ? 1 : 0);
+    }
+  }
+  return count;
+}
+
 function preserveDunderIdentifier(state: StateInline, silent: boolean): boolean {
   const match = /^__[\p{L}_][\p{L}\p{N}_]*__/u.exec(state.src.slice(state.pos, state.posMax));
   if (!match) {

--- a/src/gateway/server.talk-runtime.test.ts
+++ b/src/gateway/server.talk-runtime.test.ts
@@ -187,6 +187,24 @@ describe("gateway talk runtime", () => {
     );
   });
 
+  it.each(["```printf```", "> ```\n> x"])("preserves talk.speak prose after %s", async (prefix) => {
+    await setAcmeTalkConfig();
+    const text = `${prefix}\n\nThis explanation is ordinary prose and should be spoken in full.`;
+    await withAcmeSpeechProvider(
+      async () => ({
+        audioBuffer: Buffer.from([7, 8, 9]),
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: false,
+      }),
+      async () => {
+        const res = await invokeTalkSpeakDirect({ text });
+        expect(res?.ok, JSON.stringify(res?.error)).toBe(true);
+        expect(expectSingleSynthesizeSpeechCall().text).toBe(text);
+      },
+    );
+  });
+
   it("uses the spoken fallback for code-heavy talk.speak replies", async () => {
     await setAcmeTalkConfig();
 

--- a/src/tts/speech-text.test.ts
+++ b/src/tts/speech-text.test.ts
@@ -85,6 +85,34 @@ const ready = true;
     expect(isCodeHeavySpeechText(input)).toBe(true);
   });
 
+  it.each([
+    [
+      "inline code",
+      "```printf```\n\nThis explanation is ordinary prose and should be spoken in full.",
+    ],
+    [
+      "prose after a quoted fence",
+      "> ```\n> x\n\nThis explanation is ordinary prose and should be spoken in full.",
+    ],
+  ])("does not classify %s as fenced code", (_name, text) => {
+    expect(isCodeHeavySpeechText(text)).toBe(false);
+  });
+
+  it("recognizes a fence opened on the list marker line", () => {
+    const text = '- ```js\n  const detailedAnswer = "this body dominates the reply";\n  ```';
+    expect(isCodeHeavySpeechText(text)).toBe(true);
+  });
+
+  it.each([
+    ["1234567", false],
+    ["12345678", true],
+    ["123456789", true],
+    ["12345  ", false],
+    ["123456  ", true],
+  ])("keeps the inclusive half-code boundary for %j", (code, expected) => {
+    expect(isCodeHeavySpeechText(`\`\`\`\n${code}\n\`\`\``)).toBe(expected);
+  });
+
   it("keeps blockquoted code and surrounding prose aligned with Markdown stripping", () => {
     const input = `> This explanation is deliberately much longer than the code it introduces, so it remains the reply's main content for speech.
 >

--- a/src/tts/speech-text.ts
+++ b/src/tts/speech-text.ts
@@ -1,3 +1,4 @@
+import { countMarkdownFencedCodeChars } from "../../packages/markdown-core/src/ir.js";
 import { stripMarkdown } from "../shared/text/strip-markdown.js";
 
 export const CODE_HEAVY_SPOKEN_FALLBACK = "I've put the detailed response on screen.";
@@ -6,115 +7,12 @@ export const CODE_HEAVY_SPOKEN_FALLBACK = "I've put the detailed response on scr
 // Keep the threshold deterministic so Talk clients and providers hear the same fallback.
 const CODE_HEAVY_FENCED_CHAR_RATIO = 0.5;
 
-type CodeFence = {
-  marker: "`" | "~";
-  length: number;
-  blockquoteDepth: number;
-  listIndent: number;
-};
-
-type FenceContainer = Pick<CodeFence, "blockquoteDepth" | "listIndent">;
-
-function unwrapFenceContainer(line: string): { content: string; container: FenceContainer } {
-  let content = line;
-  let blockquoteDepth = 0;
-  while (true) {
-    const match = /^(?: {0,3}>[ \t]?)/u.exec(content);
-    if (!match) {
-      break;
-    }
-    content = content.slice(match[0].length);
-    blockquoteDepth += 1;
-  }
-
-  const indentation = /^ +/u.exec(content)?.[0].length ?? 0;
-  const listIndent = indentation > 3 && indentation <= 8 ? indentation : 0;
-  if (listIndent > 0) {
-    content = content.slice(listIndent);
-  }
-  return { content, container: { blockquoteDepth, listIndent } };
-}
-
-function parseFenceOpener(line: string): CodeFence | undefined {
-  const { content, container } = unwrapFenceContainer(line);
-  const match = /^(?: {0,3})(`{3,}|~{3,})/u.exec(content);
-  const fence = match?.[1];
-  if (!fence) {
-    return undefined;
-  }
-
-  const marker = fence[0];
-  if (marker !== "`" && marker !== "~") {
-    return undefined;
-  }
-  return { marker, length: fence.length, ...container };
-}
-
-function isFenceCloser(line: string, opener: CodeFence): boolean {
-  const { content, container } = unwrapFenceContainer(line);
-  if (
-    container.blockquoteDepth !== opener.blockquoteDepth ||
-    container.listIndent !== opener.listIndent
-  ) {
-    return false;
-  }
-  const match = /^(?: {0,3})(`+|~+)([ \t]*)$/u.exec(content);
-  const fence = match?.[1];
-  return fence !== undefined && fence[0] === opener.marker && fence.length >= opener.length;
-}
-
-function unwrapFenceBodyLine(line: string, opener: CodeFence): string {
-  let content = line;
-  for (let index = 0; index < opener.blockquoteDepth; index += 1) {
-    const match = /^(?: {0,3}>[ \t]?)/u.exec(content);
-    if (!match) {
-      return line;
-    }
-    content = content.slice(match[0].length);
-  }
-  if (opener.listIndent > 0 && content.startsWith(" ".repeat(opener.listIndent))) {
-    return content.slice(opener.listIndent);
-  }
-  return content;
-}
-
-function countFencedCodeChars(text: string): number {
-  // Match common fenced-block containers so fallback and stripping classify the same code.
-  // This shallow scanner stops at two list levels; deeply nested exotic containers may misclassify.
-  // That only makes speech routing suboptimal, never loses message data.
-  const lines = text.split(/\r?\n/u);
-  let fencedCodeChars = 0;
-  let opener: CodeFence | undefined;
-  let bodyLines: string[] = [];
-
-  for (const line of lines) {
-    if (!opener) {
-      opener = parseFenceOpener(line);
-      continue;
-    }
-
-    if (isFenceCloser(line, opener)) {
-      fencedCodeChars += bodyLines.join("\n").length;
-      opener = undefined;
-      bodyLines = [];
-      continue;
-    }
-
-    bodyLines.push(unwrapFenceBodyLine(line, opener));
-  }
-
-  if (opener) {
-    fencedCodeChars += bodyLines.join("\n").length;
-  }
-  return fencedCodeChars;
-}
-
 export function isCodeHeavySpeechText(text: string): boolean {
   const trimmed = text.trim();
   if (!trimmed) {
     return false;
   }
-  return countFencedCodeChars(trimmed) / trimmed.length >= CODE_HEAVY_FENCED_CHAR_RATIO;
+  return countMarkdownFencedCodeChars(trimmed) / trimmed.length >= CODE_HEAVY_FENCED_CHAR_RATIO;
 }
 
 export function normalizeSpeechText(text: string): string {

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -657,6 +657,24 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
     }
   });
 
+  it.each(["```printf```", "> ```\n> x"])("keeps auto-TTS prose after %s", async (prefix) => {
+    const prose = "This explanation is ordinary prose and should be spoken in full.";
+    const text = `${prefix}\n\n${prose}`;
+    const result = await maybeApplyTtsToPayloadCore(
+      {
+        payload: { text },
+        cfg: createTtsConfig("fenced-prose"),
+        channel: "telegram",
+        kind: "final",
+      },
+      async () => "/synthetic-speech.mp3",
+    );
+
+    expect(synthesizeMock).toHaveBeenCalledOnce();
+    expect(requireFirstSynthesisRequest("prose speech").text).toContain(prose);
+    expect(result).toEqual(expect.objectContaining({ text, mediaUrl: "/synthetic-speech.mp3" }));
+  });
+
   it("skips channel auto-TTS audio for code-heavy replies", async () => {
     const text = "```ts\nexport function answer() {\n  return 42;\n}\n```";
     const result = await maybeApplyTtsToPayload({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users receiving speech replies with inline code or prose after a quoted code block would hear no audio, or Talk would replace the prose with its short screen fallback. Code blocks opened directly on a list marker could also be missed by the code-heavy filter.

## Why This Change Was Made

Speech classification used a separate approximate fence scanner that disagreed with the Markdown renderer. Remove it and count actual fenced content through the existing cached Markdown parser. Preserve the inclusive half-code threshold and code whitespace by excluding only the parser's terminal framing line break.

## User Impact

Ordinary prose with inline-code examples remains eligible for speech. Actual fenced code, including nested list forms, follows the existing code-heavy behavior. Explicit speech overrides and normal speech rendering keep their current contracts.

## Evidence

Before the repair, both auto-TTS caller regressions failed because synthesis was never invoked; both Talk regressions received the canned fallback instead of the requested prose. The three shared classifier regressions also failed. After the repair, 110 focused tests pass across the classifier, exact fenced-content accounting, Markdown block metadata, auto-TTS runtime, and Talk runtime. The two changed Talk cases passed again after completing a required field in the fake provider result.

Full changed-scope validation passes, including core production/test typing, full-file lint, dead-export scans and guards. Managed P2 review is scoped-clean. One initial cold Talk import timed out before assertions; the unchanged retry reached the real regression, and the repaired full suite passed without changing timeouts or widening mocks. Proof used synthetic text/audio with fake providers through production callers; no external provider or live channel session was used.

The change deletes 86 net production lines by removing the duplicate parser. No configuration, dependency, storage, protocol or SDK return-shape changes are included.
