### PR TITLE
security: add local security gateway and execution boundary

### DIFF
--- a/src/agents/agent-tools.before-tool-call.types.ts
+++ b/src/agents/agent-tools.before-tool-call.types.ts
@@ -13,6 +13,10 @@ import type {
   PluginHookBeforeToolCallResult,
   PluginHookToolRequesterContext,
 } from "../plugins/types.js";
+import type {
+  AuthorizationResult,
+  GatewayClassification,
+} from "../security/local-security-gateway.js";
 import type { SkillSnapshot, SkillTelemetrySource, SkillUsagePath } from "../skills/types.js";
 import type { AgentTool } from "./runtime/index.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
@@ -99,7 +103,9 @@ export type HookBlockedReason =
   | "plugin-before-tool-call"
   | "plugin-approval"
   | "plugin-approval-unavailable"
-  | "tool-loop";
+  | "tool-loop"
+  | "security-gateway-blocked"
+  | "security-gateway-rejected";
 
 type HookBlockedOutcome = {
   blocked: true;
@@ -121,4 +127,6 @@ export type HookOutcome =
       approvalResolution?: PluginApprovalResolution;
       deferredApproval?: DeferredPluginToolApproval;
       loopWarning?: ToolLoopWarning;
+      gatewayClassification?: GatewayClassification;
+      gatewayAuthorizationResult?: AuthorizationResult;
     };

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -14,6 +14,12 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import {
+  evaluateLocalSecurityGateway,
+  isEmergencyStopActive,
+  logToolExecutionCompleted,
+  logToolExecutionStarted,
+} from "../security/local-security-gateway.js";
 import { recordRunSkillUsage } from "../skills/runtime/run-usage.js";
 import { copyBeforeToolCallWrapperMetadata } from "./agent-tool-metadata.js";
 import {
@@ -524,15 +530,54 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
         });
       }
+
+      // Mandatory Local Security Gateway Evaluation on FINAL post-finalizer execution shape
+      const gatewayEvaluation = await evaluateLocalSecurityGateway({
+        toolName: normalizedToolName,
+        params: executeParams,
+        ...(ctx?.runId && { runId: ctx.runId }),
+        ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
+      });
+
+      if (!gatewayEvaluation.allowed) {
+        return await blockToolCall({
+          reason: gatewayEvaluation.reason,
+          deniedReason:
+            gatewayEvaluation.authorizationResult === "BLOCKED_POLICY"
+              ? "security-gateway-blocked"
+              : "security-gateway-rejected",
+          toolParams: executeParams,
+        });
+      }
+
       // Host capabilities can close while hooks, approval, validation, or
       // steering awaits. Recheck at the final synchronous source boundary.
       signal?.throwIfAborted();
+      if (isEmergencyStopActive()) {
+        return await blockToolCall({
+          reason: "Emergency stop active: Execution halted by operator.",
+          deniedReason: "security-gateway-rejected",
+          toolParams: executeParams,
+        });
+      }
+
       runAgentToolSourceExecutionGuard(tool);
       admitExecution?.();
       onImplementationStart?.();
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const eventBase = buildEventBase(executeParams);
       recordToolExecutionStarted(toolCallId, ctx?.runId);
+      const gatewayClassification = gatewayEvaluation.classification;
+      const gatewayAuthorizationResult = gatewayEvaluation.authorizationResult;
+
+      logToolExecutionStarted({
+        toolName: normalizedToolName,
+        params: executeParams,
+        classification: gatewayClassification,
+        authorizationResult: gatewayAuthorizationResult,
+        ...(ctx?.runId && { runId: ctx.runId }),
+        ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
+      });
       if (hookOptions.emitDiagnostics) {
         emitTrustedDiagnosticEvent({
           type: "tool.execution.started",
@@ -548,7 +593,26 @@ export function wrapToolWithBeforeToolCallHook(
           result = outcome.ownerDecision
             ? await invoke()
             : await runWithGenericToolActionDecision(tool, toolCallId, invoke);
+          logToolExecutionCompleted({
+            toolName: normalizedToolName,
+            params: executeParams,
+            classification: gatewayClassification,
+            authorizationResult: gatewayAuthorizationResult,
+            ...(ctx?.runId && { runId: ctx.runId }),
+            ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
+            success: true,
+          });
         } catch (error) {
+          logToolExecutionCompleted({
+            toolName: normalizedToolName,
+            params: executeParams,
+            classification: gatewayClassification,
+            authorizationResult: gatewayAuthorizationResult,
+            ...(ctx?.runId && { runId: ctx.runId }),
+            ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
+            success: false,
+            error: String(error),
+          });
           throw hookOptions.protectNetworkErrors !== false &&
             tool.resultContentSource === "network" &&
             getBeforeToolCallFailureDisposition(error) === undefined

--- a/src/security/local-security-gateway-operator.ts
+++ b/src/security/local-security-gateway-operator.ts
@@ -1,0 +1,49 @@
+import { registerOperatorBridge, type SecurityGatewayConfig } from "./local-security-gateway.js";
+
+/**
+ * Isolated Operator Module for Local Security Gateway.
+ *
+ * Provides operator-only administrative controls for trusted local application
+ * management. Not imported or exposed to model tools or agent runtime environments.
+ */
+
+const OPERATOR_SECRET = Symbol("LOCAL_SECURITY_GATEWAY_OPERATOR_SECRET");
+
+let operatorHandlers:
+  | {
+      configure: (config: Partial<SecurityGatewayConfig>) => void;
+      reset: () => void;
+      clearEmergencyStop: () => void;
+    }
+  | undefined = undefined;
+
+// Register the operator bridge with local-security-gateway
+registerOperatorBridge(OPERATOR_SECRET, {
+  bindHandlers(handlers) {
+    operatorHandlers = handlers;
+  },
+});
+
+/** Configure security gateway settings from a trusted operator context. */
+export function operatorConfigureGateway(config: Partial<SecurityGatewayConfig>): void {
+  if (!operatorHandlers) {
+    throw new Error("Operator bridge not initialized");
+  }
+  operatorHandlers.configure(config);
+}
+
+/** Reset security gateway configuration and state from a trusted operator context. */
+export function operatorResetGateway(): void {
+  if (!operatorHandlers) {
+    throw new Error("Operator bridge not initialized");
+  }
+  operatorHandlers.reset();
+}
+
+/** Clear active emergency stop state from a trusted operator context. */
+export function operatorClearEmergencyStop(): void {
+  if (!operatorHandlers) {
+    throw new Error("Operator bridge not initialized");
+  }
+  operatorHandlers.clearEmergencyStop();
+}

--- a/src/security/local-security-gateway.behavior.test.ts
+++ b/src/security/local-security-gateway.behavior.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Isolate SQLite in-memory database for pure tool wrapper testing in test environments
+vi.mock("../infra/node-sqlite.js", () => ({
+  openNodeSqliteDatabase: vi.fn(() => ({
+    exec: vi.fn(),
+    prepare: vi.fn(() => ({
+      get: vi.fn(() => ({})),
+      all: vi.fn(() => []),
+      run: vi.fn(() => ({})),
+    })),
+    close: vi.fn(),
+  })),
+  requireNodeSqlite: vi.fn(() => ({
+    DatabaseSync: class {
+      exec() {}
+      prepare() {
+        return { get: () => ({}), all: () => [], run: () => ({}) };
+      }
+      close() {}
+    },
+  })),
+}));
+
+import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.wrapper.js";
+import type { AnyAgentTool } from "../agents/agent-tools.types.js";
+import {
+  operatorConfigureGateway,
+  operatorResetGateway,
+} from "./local-security-gateway-operator.js";
+import {
+  calculateActionDigest,
+  evaluateLocalSecurityGateway,
+  getSecurityAuditLogs,
+  isApprovalValidForParams,
+  triggerEmergencyStop,
+  type PendingApprovalRequest,
+} from "./local-security-gateway.js";
+
+function createMockTool(
+  name: string,
+  impl = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+): AnyAgentTool {
+  return {
+    name,
+    description: `Mock tool for ${name}`,
+    execute: impl,
+  };
+}
+
+describe("Local Security Gateway Real Behavior & Adversarial Tests", () => {
+  beforeEach(() => {
+    operatorResetGateway();
+  });
+
+  afterEach(() => {
+    operatorResetGateway();
+  });
+
+  it("Test A — Concurrent approval isolation: approving A does NOT approve concurrent B", async () => {
+    const pendingRequests: PendingApprovalRequest[] = [];
+
+    operatorConfigureGateway({
+      approvalHandler: (request: PendingApprovalRequest) => {
+        pendingRequests.push(request);
+        // Do not immediately resolve; wait in queue
+      },
+    });
+
+    const toolA = wrapToolWithBeforeToolCallHook(
+      createMockTool("write_file", vi.fn().mockResolvedValue("A_DONE")),
+    );
+    const toolB = wrapToolWithBeforeToolCallHook(
+      createMockTool("write_file", vi.fn().mockResolvedValue("B_DONE")),
+    );
+
+    const promiseA = toolA.execute("call-A", { path: "a.txt", content: "AAA" });
+    const promiseB = toolB.execute("call-B", { path: "b.txt", content: "BBB" });
+
+    // Wait for both to be queued
+    await new Promise((r) => setTimeout(r, 50));
+    expect(pendingRequests).toHaveLength(2);
+
+    // Approve ONLY request A
+    const reqA = pendingRequests.find((r) => (r.params as any).path === "a.txt")!;
+    reqA.resolve("APPROVAL_GRANTED");
+
+    const resultA = await promiseA;
+    expect(resultA).toBe("A_DONE");
+
+    // Request B must still be pending/unresolved until separately approved or timed out
+    const reqB = pendingRequests.find((r) => (r.params as any).path === "b.txt")!;
+    reqB.resolve("REJECTED_USER");
+
+    const resultB = (await promiseB) as any;
+    expect(resultB.details?.deniedReason).toBe("security-gateway-rejected");
+  });
+
+  it("Test B — Parameter mutation post-approval invalidates approval", () => {
+    const originalParams = { path: "a.txt", content: "original data" };
+    const mutatedParams = { path: "a.txt", content: "MUTATED PAYLOAD" };
+
+    const digest = calculateActionDigest("write_file", originalParams);
+    const mockReq: PendingApprovalRequest = {
+      id: "req-mut",
+      toolName: "write_file",
+      params: originalParams,
+      digest,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 10_000,
+      resolve: () => {},
+      timer: setTimeout(() => {}, 10_000),
+    };
+
+    // Digest validation on original parameters passes
+    expect(isApprovalValidForParams(mockReq, "write_file", originalParams)).toBe(true);
+
+    // Digest validation on mutated parameters FAILS
+    expect(isApprovalValidForParams(mockReq, "write_file", mutatedParams)).toBe(false);
+
+    clearTimeout(mockReq.timer);
+  });
+
+  it("Test C — Emergency stop race: approved action with delayed dispatch is BLOCKED when emergency stop triggers", async () => {
+    const mockExecute = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: "text", text: "should not execute" }] });
+    const rawTool = createMockTool("write_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    let resolveApproval!: () => void;
+    const approvalWait = new Promise<void>((r) => {
+      resolveApproval = r;
+    });
+
+    operatorConfigureGateway({
+      approvalHandler: async (request: PendingApprovalRequest) => {
+        await approvalWait;
+        return "APPROVAL_GRANTED";
+      },
+    });
+
+    const execPromise = wrappedTool.execute("call-race", { path: "delay.txt", content: "x" });
+
+    // Grant approval
+    resolveApproval();
+
+    // Trigger emergency stop concurrently before dispatch completes
+    triggerEmergencyStop("Race test emergency stop");
+
+    const result = (await execPromise) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-rejected");
+    expect(result.content[0]?.text).toContain("Emergency stop");
+  });
+
+  it("Test D — Expired approval is rejected", async () => {
+    operatorConfigureGateway({
+      approvalTimeoutMs: 20, // 20ms timeout
+      approvalHandler: () => {
+        // Leave pending until timeout
+      },
+    });
+
+    const rawTool = createMockTool("write_file");
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = (await wrappedTool.execute("call-exp", { path: "expired.txt" })) as any;
+
+    expect(result.details?.deniedReason).toBe("security-gateway-rejected");
+    expect(result.content[0]?.text).toContain("Action rejected or expired");
+  });
+
+  it("Test E — Audit privacy: secrets, sensitive paths, and raw exceptions are redacted from audit logs", async () => {
+    const sensitivePath = "C:\\Users\\Administrator\\.ssh\\id_rsa";
+    const secretKey = "sk-proj-secret1234567890abcdef1234567890";
+
+    await evaluateLocalSecurityGateway({
+      toolName: "read_file",
+      params: {
+        path: sensitivePath,
+        apiKey: secretKey,
+        authorization: "Bearer secret-token-xyz",
+      },
+      runId: "run-privacy",
+    });
+
+    const logs = getSecurityAuditLogs();
+    const logString = JSON.stringify(logs);
+
+    expect(logString).not.toContain(sensitivePath);
+    expect(logString).not.toContain(secretKey);
+    expect(logString).not.toContain("secret-token-xyz");
+    expect(logs[0]?.error).toBe("Access to a sensitive or prohibited path is blocked.");
+  });
+
+  it("Test G — OpenClaw tool wrapper preserves read-only SAFE classification without prompt wait", async () => {
+    const mockExecute = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: "text", text: "safe data" }] });
+    const rawTool = createMockTool("read_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = await wrappedTool.execute("call-safe", { path: "readme.md" });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ content: [{ type: "text", text: "safe data" }] });
+  });
+});

--- a/src/security/local-security-gateway.integration.test.ts
+++ b/src/security/local-security-gateway.integration.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Isolate SQLite in-memory database for pure tool wrapper testing in test environments
+vi.mock("../infra/node-sqlite.js", () => ({
+  openNodeSqliteDatabase: vi.fn(() => ({
+    exec: vi.fn(),
+    prepare: vi.fn(() => ({
+      get: vi.fn(() => ({})),
+      all: vi.fn(() => []),
+      run: vi.fn(() => ({})),
+    })),
+    close: vi.fn(),
+  })),
+  requireNodeSqlite: vi.fn(() => ({
+    DatabaseSync: class {
+      exec() {}
+      prepare() {
+        return { get: () => ({}), all: () => [], run: () => ({}) };
+      }
+      close() {}
+    },
+  })),
+}));
+
+import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.wrapper.js";
+import type { AnyAgentTool } from "../agents/agent-tools.types.js";
+import {
+  operatorConfigureGateway,
+  operatorResetGateway,
+} from "./local-security-gateway-operator.js";
+import { triggerEmergencyStop, type PendingApprovalRequest } from "./local-security-gateway.js";
+
+function createMockTool(
+  name: string,
+  impl = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+): AnyAgentTool {
+  return {
+    name,
+    description: `Mock tool for ${name}`,
+    execute: impl,
+  };
+}
+
+describe("Local Security Gateway Tool Pipeline Integration", () => {
+  beforeEach(() => {
+    operatorResetGateway();
+  });
+
+  afterEach(() => {
+    operatorResetGateway();
+  });
+
+  it("SAFE action (read_file) automatically executes through tool wrapper", async () => {
+    const mockExecute = vi
+      .fn()
+      .mockResolvedValue({ content: [{ type: "text", text: "file content" }] });
+    const rawTool = createMockTool("read_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = await wrappedTool.execute("call-1", { path: "hello.txt" });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ content: [{ type: "text", text: "file content" }] });
+  });
+
+  it("APPROVAL_REQUIRED action (write_file) waits for approval and executes when ENTER/approved", async () => {
+    const mockExecute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "written" }] });
+    const rawTool = createMockTool("write_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    operatorConfigureGateway({
+      approvalHandler: (request: PendingApprovalRequest) => {
+        expect(request.toolName).toBe("write_file");
+        return "APPROVAL_GRANTED";
+      },
+    });
+
+    const result = await wrappedTool.execute("call-2", { path: "output.txt", content: "hello" });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ content: [{ type: "text", text: "written" }] });
+  });
+
+  it("APPROVAL_REQUIRED action (delete_file) is blocked when ESC/rejected", async () => {
+    const mockExecute = vi.fn();
+    const rawTool = createMockTool("delete_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    operatorConfigureGateway({
+      approvalHandler: () => "REJECTED_USER",
+    });
+
+    const result = (await wrappedTool.execute("call-3", { path: "output.txt" })) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-rejected");
+    expect(result.content[0]?.text).toContain("Action rejected or expired");
+  });
+
+  it("BLOCKED arbitrary shell execution (exec / powershell / cmd) NEVER executes the underlying tool", async () => {
+    const mockExecute = vi.fn();
+    const rawTool = createMockTool("exec", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = (await wrappedTool.execute("call-4", { command: "Get-Process" })) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-blocked");
+    expect(result.content[0]?.text).toContain("Arbitrary shell execution is blocked");
+  });
+
+  it("BLOCKED PowerShell tool call NEVER executes", async () => {
+    const mockExecute = vi.fn();
+    const rawTool = createMockTool("powershell", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = (await wrappedTool.execute("call-5", { command: "dir" })) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-blocked");
+    expect(result.content[0]?.text).toContain("Arbitrary shell execution is blocked");
+  });
+
+  it("Attempted sensitive path access (e.g. .ssh/id_rsa) is BLOCKED and never executes", async () => {
+    const mockExecute = vi.fn();
+    const rawTool = createMockTool("read_file", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    const result = (await wrappedTool.execute("call-6", { path: "~/.ssh/id_rsa" })) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-blocked");
+    expect(result.content[0]?.text).toContain(
+      "Access to a sensitive or prohibited path is blocked.",
+    );
+  });
+
+  it("Emergency Stop cancels active pending approval and halts execution", async () => {
+    const mockExecute = vi.fn();
+    const rawTool = createMockTool("computer", mockExecute);
+    const wrappedTool = wrapToolWithBeforeToolCallHook(rawTool);
+
+    operatorConfigureGateway({
+      approvalTimeoutMs: 5_000,
+      approvalHandler: () => {
+        // Pending...
+      },
+    });
+
+    const executionPromise = wrappedTool.execute("call-7", { action: "click" });
+
+    // Trigger emergency stop while waiting
+    setTimeout(() => {
+      triggerEmergencyStop("User Emergency Stop Hotkey");
+    }, 20);
+
+    const result = (await executionPromise) as any;
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.details?.deniedReason).toBe("security-gateway-rejected");
+    expect(result.content[0]?.text).toContain("Action cancelled by Emergency stop");
+  });
+});

--- a/src/security/local-security-gateway.test.ts
+++ b/src/security/local-security-gateway.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  operatorClearEmergencyStop,
+  operatorConfigureGateway,
+  operatorResetGateway,
+} from "./local-security-gateway-operator.js";
+import {
+  calculateActionDigest,
+  classifyAction,
+  evaluateLocalSecurityGateway,
+  getSecurityAuditLogs,
+  isApprovalValidForParams,
+  isEmergencyStopActive,
+  isSensitivePath,
+  logToolExecutionCompleted,
+  logToolExecutionStarted,
+  sanitizeParameters,
+  triggerEmergencyStop,
+  type PendingApprovalRequest,
+} from "./local-security-gateway.js";
+
+describe("Hardened LocalSecurityGateway Security & Adversarial Tests", () => {
+  beforeEach(() => {
+    operatorResetGateway();
+  });
+
+  afterEach(() => {
+    operatorResetGateway();
+  });
+
+  it("1. Malformed percent-encoding fails closed and is treated as sensitive/blocked", () => {
+    expect(isSensitivePath("%")).toBe(true);
+    expect(isSensitivePath("%ZZ")).toBe(true);
+    expect(isSensitivePath("%E0%A4%A")).toBe(true); // Incomplete UTF-8 sequence
+
+    const classification = classifyAction("read_file", { path: "hello_%ZZ_file.txt" });
+    expect(classification.classification).toBe("BLOCKED");
+  });
+
+  it("2. Windows path separator handling (slashes, backslashes, mixed, case variations)", () => {
+    expect(isSensitivePath("C:\\Users\\User\\.ssh\\id_rsa")).toBe(true);
+    expect(isSensitivePath("C:/Users/User/.ssh/id_rsa")).toBe(true);
+    expect(isSensitivePath("C:\\Users\\User/.ssh\\id_rsa")).toBe(true);
+    expect(isSensitivePath(".ENV")).toBe(true);
+    expect(isSensitivePath("system32\\config\\SAM")).toBe(true);
+    expect(isSensitivePath("SYSTEM32/CONFIG/SAM")).toBe(true);
+    expect(isSensitivePath("AppData\\Local\\Google\\Chrome\\User Data")).toBe(true);
+    expect(isSensitivePath("AppData/Local/Google/Chrome/User Data")).toBe(true);
+  });
+
+  it("3. Execution audit metadata preserves SAFE/AUTOMATIC status vs APPROVAL_REQUIRED", async () => {
+    const runId = "run-audit-meta";
+
+    // 1. SAFE action execution logs
+    await evaluateLocalSecurityGateway({ toolName: "read_file", params: { path: "a.txt" }, runId });
+    logToolExecutionStarted({
+      toolName: "read_file",
+      params: { path: "a.txt" },
+      runId,
+      classification: "SAFE",
+      authorizationResult: "AUTOMATIC",
+    });
+    logToolExecutionCompleted({
+      toolName: "read_file",
+      params: { path: "a.txt" },
+      runId,
+      classification: "SAFE",
+      authorizationResult: "AUTOMATIC",
+      success: true,
+    });
+
+    const logs = getSecurityAuditLogs();
+    const safeStarted = logs.find(
+      (l) => l.stage === "EXECUTION_STARTED" && l.toolName === "read_file",
+    );
+    expect(safeStarted?.classification).toBe("SAFE");
+    expect(safeStarted?.authorizationResult).toBe("AUTOMATIC");
+    expect(safeStarted?.executionStatus).toBe("RUNNING");
+
+    const safeCompleted = logs.find(
+      (l) => l.stage === "EXECUTION_COMPLETED" && l.toolName === "read_file",
+    );
+    expect(safeCompleted?.classification).toBe("SAFE");
+    expect(safeCompleted?.authorizationResult).toBe("AUTOMATIC");
+    expect(safeCompleted?.executionStatus).toBe("EXECUTION_SUCCEEDED");
+  });
+
+  it("4. Cycle-safe and throwing getter parameter sanitization", () => {
+    // Direct circular object
+    const circularObj: any = { name: "test" };
+    circularObj.self = circularObj;
+
+    const sanitizedCircular = sanitizeParameters(circularObj) as any;
+    expect(sanitizedCircular.name).toBe("test");
+    expect(sanitizedCircular.self).toBe("[CIRCULAR_REFERENCE]");
+
+    // Nested circular object in array
+    const nestedCircular: any = { items: [] };
+    nestedCircular.items.push(nestedCircular);
+
+    const sanitizedNested = sanitizeParameters(nestedCircular) as any;
+    expect(sanitizedNested.items[0]).toBe("[CIRCULAR_REFERENCE]");
+
+    // Property getter throwing an error
+    const throwingObj = {
+      safeProp: "ok",
+      get badProp() {
+        throw new Error("Getter error trap!");
+      },
+    };
+
+    const sanitizedThrowing = sanitizeParameters(throwingObj) as any;
+    expect(sanitizedThrowing.safeProp).toBe("ok");
+    expect(sanitizedThrowing.badProp).toBe("[ERROR_READING_PROPERTY]");
+  });
+
+  it("5. Raw path/secret parameters are NEVER leaked in audit error strings", async () => {
+    const sensitivePath = "C:\\Users\\Admin\\.ssh\\id_rsa";
+    const result = await evaluateLocalSecurityGateway({
+      toolName: "read_file",
+      params: { path: sensitivePath },
+      runId: "run-leak-check",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).not.toContain(sensitivePath);
+    expect(result.reason).toBe("Access to a sensitive or prohibited path is blocked.");
+
+    const logs = getSecurityAuditLogs();
+    expect(logs[0]?.error).not.toContain(sensitivePath);
+    expect(logs[0]?.error).toBe("Access to a sensitive or prohibited path is blocked.");
+  });
+
+  it("6. Operator controls are isolated and cannot be accessed through exported tokens or tools", () => {
+    triggerEmergencyStop("Operator Stop");
+    expect(isEmergencyStopActive()).toBe(true);
+
+    // Operator clear function succeeds
+    operatorClearEmergencyStop();
+    expect(isEmergencyStopActive()).toBe(false);
+  });
+
+  it("7. Unknown tools and shell tools fail closed", () => {
+    const unknownClass = classifyAction("unknown_mcp_tool", { arg: 1 });
+    expect(unknownClass.classification).toBe("APPROVAL_REQUIRED");
+
+    const shellClass = classifyAction("powershell", { command: "dir" });
+    expect(shellClass.classification).toBe("BLOCKED");
+  });
+});

--- a/src/security/local-security-gateway.test.ts
+++ b/src/security/local-security-gateway.test.ts
@@ -32,6 +32,7 @@ describe("Hardened LocalSecurityGateway Security & Adversarial Tests", () => {
     expect(isSensitivePath("%")).toBe(true);
     expect(isSensitivePath("%ZZ")).toBe(true);
     expect(isSensitivePath("%E0%A4%A")).toBe(true); // Incomplete UTF-8 sequence
+    expect(isSensitivePath("%2525252e%2525252e")).toBe(true); // Decode-depth anomaly (triple-encoded)
 
     const classification = classifyAction("read_file", { path: "hello_%ZZ_file.txt" });
     expect(classification.classification).toBe("BLOCKED");

--- a/src/security/local-security-gateway.ts
+++ b/src/security/local-security-gateway.ts
@@ -1,0 +1,943 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+
+/**
+ * Local Security Gateway for OpenClaw / Jarvis.
+ *
+ * Strictly fail-closed security gateway enforcing out-of-LLM security classification,
+ * hardened Windows path protection, raw-parameter authorization digests, explicit user approval gates,
+ * emergency stop protection, bounded audit logging, and single-consumption request isolation.
+ */
+
+export type GatewayClassification = "SAFE" | "APPROVAL_REQUIRED" | "BLOCKED";
+
+export type AuditEventStage =
+  | "AUTHORIZATION_DECISION"
+  | "EXECUTION_STARTED"
+  | "EXECUTION_COMPLETED";
+
+export type AuthorizationResult =
+  | "AUTOMATIC"
+  | "APPROVAL_GRANTED"
+  | "REJECTED_USER"
+  | "REJECTED_TIMEOUT"
+  | "REJECTED_EMERGENCY_STOP"
+  | "BLOCKED_POLICY";
+
+export type ExecutionStatus =
+  | "NOT_STARTED"
+  | "RUNNING"
+  | "EXECUTION_SUCCEEDED"
+  | "EXECUTION_FAILED";
+
+export type SecurityAuditEvent = {
+  eventId: string;
+  timestamp: string;
+  stage: AuditEventStage;
+  runId?: string;
+  sessionId?: string;
+  toolName: string;
+  sanitizedParams: unknown;
+  classification: GatewayClassification;
+  authorizationResult: AuthorizationResult;
+  executionStatus: ExecutionStatus;
+  error?: string;
+};
+
+export type PendingApprovalRequest = {
+  id: string;
+  toolName: string;
+  params: unknown;
+  digest: string;
+  createdAt: number;
+  expiresAt: number;
+  resolve: (result: AuthorizationResult) => void;
+  timer: NodeJS.Timeout;
+};
+
+export type SecurityGatewayConfig = {
+  approvalTimeoutMs: number;
+  auditLogger?: (event: SecurityAuditEvent) => void;
+  approvalHandler?: (
+    request: PendingApprovalRequest,
+  ) => Promise<AuthorizationResult> | AuthorizationResult | void;
+};
+
+const DEFAULT_CONFIG: SecurityGatewayConfig = {
+  approvalTimeoutMs: 30_000,
+};
+
+const MAX_AUDIT_LOG_CAPACITY = 1000;
+
+// Global Gateway State
+let currentConfig: SecurityGatewayConfig = { ...DEFAULT_CONFIG };
+let emergencyStopTriggered = false;
+let emergencyStopReason: string | undefined = undefined;
+const pendingApprovals = new Map<string, PendingApprovalRequest>();
+const pendingApprovalQueue: PendingApprovalRequest[] = [];
+const auditLogs: SecurityAuditEvent[] = [];
+const registeredAbortControllers = new Set<AbortController>();
+
+// Internal operator bridge registration
+let operatorBridgeRegistered = false;
+
+/** Internal configure gateway function. */
+function configureLocalSecurityGatewayInternal(config: Partial<SecurityGatewayConfig>): void {
+  currentConfig = {
+    ...currentConfig,
+    ...config,
+  };
+}
+
+/** Internal reset gateway state function. */
+function resetLocalSecurityGatewayInternal(): void {
+  currentConfig = { ...DEFAULT_CONFIG };
+  emergencyStopTriggered = false;
+  emergencyStopReason = undefined;
+
+  for (const [, req] of pendingApprovals) {
+    clearTimeout(req.timer);
+    req.resolve("REJECTED_EMERGENCY_STOP");
+  }
+  pendingApprovals.clear();
+  pendingApprovalQueue.length = 0;
+  auditLogs.length = 0;
+  registeredAbortControllers.clear();
+  detachStdinController();
+}
+
+/** Internal clear emergency stop function. */
+function clearEmergencyStopInternal(): void {
+  emergencyStopTriggered = false;
+  emergencyStopReason = undefined;
+}
+
+/**
+ * Registers operator handlers with the isolated operator module.
+ * Can only be called once during process startup by local-security-gateway-operator.ts.
+ */
+export function registerOperatorBridge(
+  secretSymbol: Symbol,
+  binder: {
+    bindHandlers: (handlers: {
+      configure: (config: Partial<SecurityGatewayConfig>) => void;
+      reset: () => void;
+      clearEmergencyStop: () => void;
+    }) => void;
+  },
+): void {
+  if (operatorBridgeRegistered) {
+    return;
+  }
+  if (typeof secretSymbol !== "symbol" || !secretSymbol.toString().includes("OPERATOR_SECRET")) {
+    throw new Error("Unauthorized operator bridge registration attempt.");
+  }
+  operatorBridgeRegistered = true;
+  binder.bindHandlers({
+    configure: configureLocalSecurityGatewayInternal,
+    reset: resetLocalSecurityGatewayInternal,
+    clearEmergencyStop: clearEmergencyStopInternal,
+  });
+}
+
+/** Register an AbortController associated with active agent runs. */
+export function registerAgentAbortController(controller: AbortController): () => void {
+  registeredAbortControllers.add(controller);
+  return () => {
+    registeredAbortControllers.delete(controller);
+  };
+}
+
+/** Emergency Stop mechanism: Immediately cancels pending approvals and aborts registered runs. */
+export function triggerEmergencyStop(reason = "Emergency stop activated by operator"): void {
+  emergencyStopTriggered = true;
+  emergencyStopReason = reason;
+
+  // Reject all pending approvals immediately
+  for (const [id, req] of pendingApprovals) {
+    clearTimeout(req.timer);
+    req.resolve("REJECTED_EMERGENCY_STOP");
+    pendingApprovals.delete(id);
+  }
+  pendingApprovalQueue.length = 0;
+  detachStdinController();
+
+  // Abort all active agent execution signals
+  for (const controller of registeredAbortControllers) {
+    try {
+      controller.abort(new Error(reason));
+    } catch {
+      // Ignore abort errors
+    }
+  }
+  registeredAbortControllers.clear();
+}
+
+/** Check whether emergency stop is currently active. */
+export function isEmergencyStopActive(): boolean {
+  return emergencyStopTriggered;
+}
+
+/** Retrieve active emergency stop reason if active. */
+export function getEmergencyStopReason(): string | undefined {
+  return emergencyStopTriggered ? emergencyStopReason : undefined;
+}
+
+/** Retrieve recorded in-memory security audit logs. */
+export function getSecurityAuditLogs(): readonly SecurityAuditEvent[] {
+  return [...auditLogs];
+}
+
+// Sensitive secret keys / patterns for audit scrubbing
+const SECRET_KEY_PATTERNS = [
+  /api[-_]?key/i,
+  /password/i,
+  /passwd/i,
+  /secret/i,
+  /token/i,
+  /cookie/i,
+  /auth/i,
+  /bearer/i,
+  /private[-_]?key/i,
+  /credential/i,
+  /ssn/i,
+  /credit[-_]?card/i,
+];
+
+/**
+ * Cycle-safe, throwing-getter-safe parameter sanitization for audit logs.
+ */
+export function sanitizeParameters(value: unknown, seen = new WeakSet<object>()): unknown {
+  try {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      if (
+        /bearer\s+[a-zA-Z0-9._~+/-]+=*/i.test(value) ||
+        /sk-[a-zA-Z0-9]{20,}/.test(value) ||
+        /key-[a-zA-Z0-9]{20,}/.test(value)
+      ) {
+        return "[REDACTED_SECRET]";
+      }
+      return value;
+    }
+
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+
+    if (typeof value === "function" || typeof value === "symbol") {
+      return `[${typeof value}]`;
+    }
+
+    if (typeof value !== "object") {
+      return value;
+    }
+
+    // Circular reference check
+    if (seen.has(value as object)) {
+      return "[CIRCULAR_REFERENCE]";
+    }
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      return value.map((item) => sanitizeParameters(item, seen));
+    }
+
+    const sanitizedObj: Record<string, unknown> = {};
+    const keys = Object.keys(value as object);
+
+    for (const key of keys) {
+      try {
+        if (SECRET_KEY_PATTERNS.some((pattern) => pattern.test(key))) {
+          sanitizedObj[key] = "[REDACTED_SECRET]";
+        } else {
+          const val = (value as Record<string, unknown>)[key];
+          sanitizedObj[key] = sanitizeParameters(val, seen);
+        }
+      } catch {
+        sanitizedObj[key] = "[ERROR_READING_PROPERTY]";
+      }
+    }
+    return sanitizedObj;
+  } catch {
+    return "[UNSANITIZABLE_OBJECT]";
+  }
+}
+
+/** Log a security audit event with bounded retention. */
+export function logSecurityAuditEvent(
+  event: Omit<SecurityAuditEvent, "eventId" | "sanitizedParams"> & { params: unknown },
+): void {
+  const auditEntry: SecurityAuditEvent = {
+    eventId: randomUUID(),
+    timestamp: event.timestamp,
+    stage: event.stage,
+    ...(event.runId && { runId: event.runId }),
+    ...(event.sessionId && { sessionId: event.sessionId }),
+    toolName: event.toolName,
+    sanitizedParams: sanitizeParameters(event.params),
+    classification: event.classification,
+    authorizationResult: event.authorizationResult,
+    executionStatus: event.executionStatus,
+    ...(event.error && { error: event.error }),
+  };
+
+  auditLogs.push(auditEntry);
+  if (auditLogs.length > MAX_AUDIT_LOG_CAPACITY) {
+    auditLogs.shift();
+  }
+
+  if (currentConfig.auditLogger) {
+    try {
+      currentConfig.auditLogger(auditEntry);
+    } catch {
+      // Ignore logging callback errors
+    }
+  }
+}
+
+// Sensitive Windows & System path patterns supporting both \ and / and case variations
+const SENSITIVE_PATH_PATTERNS = [
+  /([/\\]|^)\.ssh([/\\]|$)/i,
+  /([/\\]|^)\.aws([/\\]|$)/i,
+  /([/\\]|^)\.gnupg([/\\]|$)/i,
+  /([/\\]|^)\.env($|\.|[/\\])/i,
+  /id_rsa/i,
+  /id_ed25519/i,
+  /credentials(\.json|\.xml|\.ini|$)/i,
+  /shadow$/i,
+  /SAM$/i,
+  /SYSTEM$/i,
+  /SECURITY$/i,
+  /SOFTWARE$/i,
+  /Chrome[/\\]User Data/i,
+  /Firefox[/\\]Profiles/i,
+  /AppData[/\\]Local[/\\]Google[/\\]Chrome/i,
+  /AppData[/\\]Roaming[/\\]Mozilla/i,
+  /\.config[/\\]google-chrome/i,
+  /system32[/\\]config/i,
+];
+
+/**
+ * Hardened Windows-aware path check.
+ */
+export function isSensitivePath(targetPath: string): boolean {
+  if (!targetPath || typeof targetPath !== "string") {
+    return false;
+  }
+
+  const raw = targetPath.trim();
+
+  // Null byte injection attempt -> FAIL CLOSED
+  if (raw.includes("\0") || raw.includes("%00")) {
+    return true;
+  }
+
+  // Windows Device paths (e.g. \\.\PhysicalDrive0, \\?\C:\...) -> FAIL CLOSED
+  if (
+    raw.startsWith("\\\\.\\") ||
+    raw.startsWith("\\\\?\\") ||
+    raw.startsWith("//./") ||
+    raw.startsWith("//?/")
+  ) {
+    return true;
+  }
+
+  // UNC Network Paths (e.g. \\remote-server\share) -> FAIL CLOSED
+  if (raw.startsWith("\\\\") || raw.startsWith("//")) {
+    return true;
+  }
+
+  // Safe percent decoding with bounded passes; FAIL CLOSED on malformed encoding
+  let decoded = raw;
+  const maxDecodePasses = 2;
+  for (let pass = 0; pass < maxDecodePasses; pass++) {
+    if (!decoded.includes("%")) {
+      break;
+    }
+    try {
+      const nextDecoded = decodeURIComponent(decoded);
+      if (nextDecoded === decoded) {
+        break;
+      }
+      decoded = nextDecoded;
+    } catch {
+      // Malformed URI encoding -> FAIL CLOSED
+      return true;
+    }
+  }
+
+  // Re-check null bytes after decoding
+  if (decoded.includes("\0")) {
+    return true;
+  }
+
+  // Path traversal check
+  if (decoded.includes("..") || raw.includes("..")) {
+    return true;
+  }
+
+  const normalizedSlash = decoded.replace(/\//g, "\\");
+  const normalizedPath = path.normalize(normalizedSlash);
+
+  // Check normalized path against sensitive patterns
+  for (const pattern of SENSITIVE_PATH_PATTERNS) {
+    if (pattern.test(normalizedPath) || pattern.test(decoded) || pattern.test(raw)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Known OpenClaw filesystem tools
+const FS_CAPABLE_TOOLS = new Set([
+  "read_file",
+  "write_file",
+  "edit_file",
+  "apply_patch",
+  "delete_file",
+  "list_files",
+  "ls",
+  "fs_write",
+  "fs_delete",
+  "fs_move",
+  "create_directory",
+  "view_image",
+]);
+
+/**
+ * Extracts path parameters based on tool capability or heuristic search.
+ */
+export function extractPathsFromParams(toolName: string, params: unknown): string[] {
+  const paths: string[] = [];
+  if (!params || typeof params !== "object") {
+    return paths;
+  }
+
+  const normalizedTool = toolName.toLowerCase().trim();
+  const isFsTool = FS_CAPABLE_TOOLS.has(normalizedTool);
+
+  function search(obj: unknown) {
+    if (!obj || typeof obj !== "object") return;
+    for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+      if (typeof val === "string") {
+        const isPathKey = /path|file|dir|cwd|target|source|dest|folder|filename/i.test(key);
+        if (isPathKey || isFsTool) {
+          paths.push(val);
+        }
+      } else if (typeof val === "object" && val !== null) {
+        search(val);
+      }
+    }
+  }
+
+  search(params);
+  return paths;
+}
+
+// Shell / Arbitrary subprocess execution tools (Blocked initially per requirement 6)
+const BLOCKED_SHELL_TOOLS = new Set([
+  "exec",
+  "bash",
+  "powershell",
+  "cmd",
+  "terminal",
+  "spawn",
+  "shell",
+  "exec_script",
+  "process_spawn",
+  "process_send_keys",
+  "run_command",
+  "system_run",
+]);
+
+// Read-only inspection tools
+const SAFE_READONLY_TOOLS = new Set([
+  "read_file",
+  "list_files",
+  "ls",
+  "view_image",
+  "web_search",
+  "describe_image",
+  "get_status",
+  "read_memory",
+  "search_memory",
+  "time",
+]);
+
+// Dangerous tools requiring explicit user approval
+const APPROVAL_REQUIRED_TOOLS = new Set([
+  "write_file",
+  "fs_write",
+  "edit_file",
+  "apply_patch",
+  "delete_file",
+  "fs_delete",
+  "fs_move",
+  "create_directory",
+  "web_fetch",
+  "http_request",
+  "curl",
+  "send_message",
+  "conversations_send",
+  "email_send",
+  "post_data",
+  "upload",
+  "computer",
+  "mouse_click",
+  "keyboard_type",
+  "window_action",
+  "desktop_control",
+  "mobile_ui",
+  "install_software",
+  "npm_install",
+  "system_change",
+  "portal",
+  "automations",
+  "gateway",
+]);
+
+/**
+ * Classifies an action based strictly on tool name and structured parameters.
+ */
+export function classifyAction(
+  toolName: string,
+  params: unknown,
+): { classification: GatewayClassification; reason: string } {
+  const normalizedToolName = toolName.toLowerCase().trim();
+
+  // 1. Emergency stop active
+  if (emergencyStopTriggered) {
+    return {
+      classification: "BLOCKED",
+      reason: `Emergency stop active: Execution halted by operator.`,
+    };
+  }
+
+  // 2. Shell / Subprocess execution tools are BLOCKED initially
+  if (BLOCKED_SHELL_TOOLS.has(normalizedToolName)) {
+    return {
+      classification: "BLOCKED",
+      reason: `Arbitrary shell execution is blocked by security gateway policy.`,
+    };
+  }
+
+  // 3. Path Protection check (NO raw path strings in reason!)
+  const extractedPaths = extractPathsFromParams(toolName, params);
+  for (const p of extractedPaths) {
+    if (isSensitivePath(p)) {
+      return {
+        classification: "BLOCKED",
+        reason: `Access to a sensitive or prohibited path is blocked.`,
+      };
+    }
+  }
+
+  // 4. Safe Read-Only tools
+  if (SAFE_READONLY_TOOLS.has(normalizedToolName)) {
+    return {
+      classification: "SAFE",
+      reason: `Tool is classified as a safe read-only action.`,
+    };
+  }
+
+  // 5. Actions requiring explicit approval
+  if (APPROVAL_REQUIRED_TOOLS.has(normalizedToolName)) {
+    return {
+      classification: "APPROVAL_REQUIRED",
+      reason: `Action requires explicit user approval.`,
+    };
+  }
+
+  // 6. Unknown tools / Plugins / Skills default to APPROVAL_REQUIRED (fail-closed)
+  return {
+    classification: "APPROVAL_REQUIRED",
+    reason: `Unclassified action requiring explicit user approval.`,
+  };
+}
+
+/**
+ * Recursively produces a deterministic canonical representation of an object.
+ */
+function canonicalizeObject(obj: unknown, seen = new WeakSet<object>()): unknown {
+  if (obj === null || typeof obj !== "object") {
+    if (typeof obj === "bigint") {
+      return `bigint:${obj.toString()}`;
+    }
+    return obj;
+  }
+
+  if (seen.has(obj as object)) {
+    throw new Error("Circular parameter reference detected");
+  }
+  seen.add(obj as object);
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => canonicalizeObject(item, seen));
+  }
+
+  const sortedKeys = Object.keys(obj as Record<string, unknown>).sort();
+  const canonicalObj: Record<string, unknown> = {};
+  for (const key of sortedKeys) {
+    canonicalObj[key] = canonicalizeObject((obj as Record<string, unknown>)[key], seen);
+  }
+  return canonicalObj;
+}
+
+/**
+ * Calculates a deterministic authorization digest using ORIGINAL RAW parameters.
+ */
+export function calculateActionDigest(toolName: string, params: unknown): string {
+  try {
+    const canonical = canonicalizeObject(params);
+    const json = JSON.stringify({
+      toolName: toolName.toLowerCase().trim(),
+      params: canonical,
+    });
+    if (!json) {
+      throw new Error("Failed to JSON.stringify canonical parameters");
+    }
+    return createHash("sha256").update(json).digest("hex");
+  } catch {
+    return `INVALID_DIGEST_ERROR_${randomUUID()}`;
+  }
+}
+
+/** Verify if an approval digest matches a target request digest. */
+export function isApprovalValidForParams(
+  pendingRequest: PendingApprovalRequest,
+  requestedToolName: string,
+  requestedParams: unknown,
+): boolean {
+  if (Date.now() > pendingRequest.expiresAt) {
+    return false;
+  }
+  const currentDigest = calculateActionDigest(requestedToolName, requestedParams);
+  if (currentDigest.startsWith("INVALID_DIGEST_ERROR_")) {
+    return false;
+  }
+  return pendingRequest.digest === currentDigest;
+}
+
+// Single-consumption Stdin Queue Controller
+let activeDataHandler: ((data: Buffer) => void) | undefined = undefined;
+
+function detachStdinController() {
+  if (activeDataHandler) {
+    try {
+      process.stdin.off("data", activeDataHandler);
+      if (process.stdin.isRaw) {
+        process.stdin.setRawMode(false);
+      }
+    } catch {
+      // Ignore terminal mode errors
+    }
+    activeDataHandler = undefined;
+  }
+}
+
+/**
+ * Default local CLI interactive approval handler.
+ * Controls:
+ * - ENTER (\r or \n) = approve EXACTLY ONE pending request
+ * - 's' or 'S' = show details
+ * - ESC (\x1b) = reject
+ */
+export async function defaultLocalApprovalHandler(
+  request: PendingApprovalRequest,
+): Promise<AuthorizationResult> {
+  const sanitizedParams = sanitizeParameters(request.params);
+  console.log(`\n================ SECURITY GATEWAY APPROVAL REQUIRED ================`);
+  console.log(`Tool:        ${request.toolName}`);
+  console.log(`Request ID:  ${request.id}`);
+  console.log(`Summary:     ${JSON.stringify(sanitizedParams).slice(0, 100)}...`);
+  console.log(`Controls:    [ENTER] = Approve | [S] = Show Details | [ESC] = Reject`);
+  console.log(`Expires in:  ${Math.round((request.expiresAt - Date.now()) / 1000)} seconds`);
+  console.log(`====================================================================\n`);
+
+  if (!process.stdin.isTTY) {
+    return "REJECTED_TIMEOUT";
+  }
+
+  return new Promise<AuthorizationResult>((resolve) => {
+    detachStdinController();
+
+    const onData = (data: Buffer) => {
+      const str = data.toString("utf-8");
+
+      // ENTER (\r or \n) ONLY - Consumes EXACTLY this request
+      if (str === "\r" || str === "\n") {
+        detachStdinController();
+        console.log(
+          `[Security Gateway] Action APPROVAL_GRANTED for request ${request.id} (ENTER).`,
+        );
+        resolve("APPROVAL_GRANTED");
+        return;
+      }
+
+      // ESC (\x1b) ONLY
+      if (str === "\x1b") {
+        detachStdinController();
+        console.log(`[Security Gateway] Action REJECTED_USER for request ${request.id} (ESC).`);
+        resolve("REJECTED_USER");
+        return;
+      }
+
+      // 's' or 'S' = show details
+      if (str.toLowerCase() === "s") {
+        console.log(`\n--- Detailed Action Parameters ---`);
+        console.log(JSON.stringify(sanitizedParams, null, 2));
+        console.log(`----------------------------------\n`);
+        return;
+      }
+    };
+
+    activeDataHandler = onData;
+
+    try {
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.on("data", onData);
+    } catch {
+      detachStdinController();
+      resolve("REJECTED_TIMEOUT");
+    }
+  });
+}
+
+/**
+ * Main evaluation entrypoint for the Local Security Gateway.
+ * Strictly fail-closed.
+ */
+export async function evaluateLocalSecurityGateway(args: {
+  toolName: string;
+  params: unknown;
+  runId?: string;
+  sessionId?: string;
+}): Promise<{
+  allowed: boolean;
+  classification: GatewayClassification;
+  authorizationResult: AuthorizationResult;
+  reason: string;
+}> {
+  const timestamp = new Date().toISOString();
+  const { toolName, params, runId, sessionId } = args;
+
+  // 1. Classify action
+  const { classification, reason } = classifyAction(toolName, params);
+
+  // 2. Handle BLOCKED classification
+  if (classification === "BLOCKED") {
+    const authorizationResult: AuthorizationResult = emergencyStopTriggered
+      ? "REJECTED_EMERGENCY_STOP"
+      : "BLOCKED_POLICY";
+
+    logSecurityAuditEvent({
+      timestamp,
+      stage: "AUTHORIZATION_DECISION",
+      runId,
+      sessionId,
+      toolName,
+      params,
+      classification,
+      authorizationResult,
+      executionStatus: "NOT_STARTED",
+      error: reason,
+    });
+
+    return {
+      allowed: false,
+      classification,
+      authorizationResult,
+      reason,
+    };
+  }
+
+  // 3. Handle SAFE classification
+  if (classification === "SAFE") {
+    const authorizationResult: AuthorizationResult = "AUTOMATIC";
+    logSecurityAuditEvent({
+      timestamp,
+      stage: "AUTHORIZATION_DECISION",
+      runId,
+      sessionId,
+      toolName,
+      params,
+      classification,
+      authorizationResult,
+      executionStatus: "NOT_STARTED",
+    });
+
+    return {
+      allowed: true,
+      classification,
+      authorizationResult,
+      reason,
+    };
+  }
+
+  // 4. Handle APPROVAL_REQUIRED classification
+  const reqId = randomUUID();
+  const digest = calculateActionDigest(toolName, params);
+
+  // If digest calculation failed (e.g. non-serializable circular object), fail closed!
+  if (digest.startsWith("INVALID_DIGEST_ERROR_")) {
+    const authorizationResult: AuthorizationResult = "BLOCKED_POLICY";
+    const blockReason = "Invalid or non-canonicalizable parameters (fail-closed)";
+    logSecurityAuditEvent({
+      timestamp,
+      stage: "AUTHORIZATION_DECISION",
+      runId,
+      sessionId,
+      toolName,
+      params,
+      classification: "BLOCKED",
+      authorizationResult,
+      executionStatus: "NOT_STARTED",
+      error: blockReason,
+    });
+    return {
+      allowed: false,
+      classification: "BLOCKED",
+      authorizationResult,
+      reason: blockReason,
+    };
+  }
+
+  const createdAt = Date.now();
+  const expiresAt = createdAt + currentConfig.approvalTimeoutMs;
+
+  let approvalPromiseResolver!: (result: AuthorizationResult) => void;
+  const approvalPromise = new Promise<AuthorizationResult>((res) => {
+    approvalPromiseResolver = res;
+  });
+
+  const timer = setTimeout(() => {
+    if (pendingApprovals.has(reqId)) {
+      pendingApprovals.delete(reqId);
+      const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
+      if (index !== -1) {
+        pendingApprovalQueue.splice(index, 1);
+      }
+      approvalPromiseResolver("REJECTED_TIMEOUT");
+    }
+  }, currentConfig.approvalTimeoutMs);
+
+  const pendingRequest: PendingApprovalRequest = {
+    id: reqId,
+    toolName,
+    params,
+    digest,
+    createdAt,
+    expiresAt,
+    resolve: approvalPromiseResolver,
+    timer,
+  };
+
+  pendingApprovals.set(reqId, pendingRequest);
+  pendingApprovalQueue.push(pendingRequest);
+
+  const handler = currentConfig.approvalHandler || defaultLocalApprovalHandler;
+
+  Promise.resolve(handler(pendingRequest))
+    .then((result) => {
+      if (result && pendingApprovals.has(reqId)) {
+        clearTimeout(timer);
+        pendingApprovals.delete(reqId);
+        const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
+        if (index !== -1) {
+          pendingApprovalQueue.splice(index, 1);
+        }
+        approvalPromiseResolver(result);
+      }
+    })
+    .catch(() => {
+      if (pendingApprovals.has(reqId)) {
+        clearTimeout(timer);
+        pendingApprovals.delete(reqId);
+        const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
+        if (index !== -1) {
+          pendingApprovalQueue.splice(index, 1);
+        }
+        approvalPromiseResolver("REJECTED_TIMEOUT");
+      }
+    });
+
+  const authorizationResult = await approvalPromise;
+  const allowed = authorizationResult === "APPROVAL_GRANTED";
+
+  logSecurityAuditEvent({
+    timestamp,
+    stage: "AUTHORIZATION_DECISION",
+    runId,
+    sessionId,
+    toolName,
+    params,
+    classification,
+    authorizationResult,
+    executionStatus: "NOT_STARTED",
+    ...(allowed ? {} : { error: `Authorization result: ${authorizationResult}` }),
+  });
+
+  return {
+    allowed,
+    classification,
+    authorizationResult,
+    reason: allowed
+      ? "Action approved by operator."
+      : authorizationResult === "REJECTED_EMERGENCY_STOP"
+        ? "Action cancelled by Emergency stop."
+        : `Action rejected or expired (${authorizationResult}).`,
+  };
+}
+
+/** Log tool execution start event inheriting actual decision metadata. */
+export function logToolExecutionStarted(args: {
+  toolName: string;
+  params: unknown;
+  runId?: string;
+  sessionId?: string;
+  classification: GatewayClassification;
+  authorizationResult: AuthorizationResult;
+}): void {
+  logSecurityAuditEvent({
+    timestamp: new Date().toISOString(),
+    stage: "EXECUTION_STARTED",
+    toolName: args.toolName,
+    params: args.params,
+    runId: args.runId,
+    sessionId: args.sessionId,
+    classification: args.classification,
+    authorizationResult: args.authorizationResult,
+    executionStatus: "RUNNING",
+  });
+}
+
+/** Log tool execution completed event inheriting actual decision metadata. */
+export function logToolExecutionCompleted(args: {
+  toolName: string;
+  params: unknown;
+  runId?: string;
+  sessionId?: string;
+  classification: GatewayClassification;
+  authorizationResult: AuthorizationResult;
+  success: boolean;
+  error?: string;
+}): void {
+  logSecurityAuditEvent({
+    timestamp: new Date().toISOString(),
+    stage: "EXECUTION_COMPLETED",
+    toolName: args.toolName,
+    params: args.params,
+    runId: args.runId,
+    sessionId: args.sessionId,
+    classification: args.classification,
+    authorizationResult: args.authorizationResult,
+    executionStatus: args.success ? "EXECUTION_SUCCEEDED" : "EXECUTION_FAILED",
+    ...(args.error && { error: args.error }),
+  });
+}

--- a/src/security/local-security-gateway.ts
+++ b/src/security/local-security-gateway.ts
@@ -351,12 +351,15 @@ export function isSensitivePath(targetPath: string): boolean {
     return true;
   }
 
-  // Safe percent decoding with bounded passes; FAIL CLOSED on malformed encoding
+  // Safe percent decoding with bounded passes & decode-depth anomaly check; FAIL CLOSED
   let decoded = raw;
-  const maxDecodePasses = 2;
-  for (let pass = 0; pass < maxDecodePasses; pass++) {
-    if (!decoded.includes("%")) {
-      break;
+  const MAX_DECODE_PASSES = 2;
+  let decodePasses = 0;
+
+  while (decoded.includes("%")) {
+    if (decodePasses >= MAX_DECODE_PASSES) {
+      // Decode-depth anomaly check: exceeds allowed decode depth -> FAIL CLOSED
+      return true;
     }
     try {
       const nextDecoded = decodeURIComponent(decoded);
@@ -364,6 +367,7 @@ export function isSensitivePath(targetPath: string): boolean {
         break;
       }
       decoded = nextDecoded;
+      decodePasses++;
     } catch {
       // Malformed URI encoding -> FAIL CLOSED
       return true;
@@ -827,6 +831,18 @@ export async function evaluateLocalSecurityGateway(args: {
     }
   }, currentConfig.approvalTimeoutMs);
 
+  const resolveRequest = (result: AuthorizationResult) => {
+    if (pendingApprovals.has(reqId)) {
+      clearTimeout(timer);
+      pendingApprovals.delete(reqId);
+      const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
+      if (index !== -1) {
+        pendingApprovalQueue.splice(index, 1);
+      }
+      approvalPromiseResolver(result);
+    }
+  };
+
   const pendingRequest: PendingApprovalRequest = {
     id: reqId,
     toolName,
@@ -834,7 +850,7 @@ export async function evaluateLocalSecurityGateway(args: {
     digest,
     createdAt,
     expiresAt,
-    resolve: approvalPromiseResolver,
+    resolve: resolveRequest,
     timer,
   };
 
@@ -845,26 +861,12 @@ export async function evaluateLocalSecurityGateway(args: {
 
   Promise.resolve(handler(pendingRequest))
     .then((result) => {
-      if (result && pendingApprovals.has(reqId)) {
-        clearTimeout(timer);
-        pendingApprovals.delete(reqId);
-        const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
-        if (index !== -1) {
-          pendingApprovalQueue.splice(index, 1);
-        }
-        approvalPromiseResolver(result);
+      if (result) {
+        resolveRequest(result);
       }
     })
     .catch(() => {
-      if (pendingApprovals.has(reqId)) {
-        clearTimeout(timer);
-        pendingApprovals.delete(reqId);
-        const index = pendingApprovalQueue.findIndex((item) => item.id === reqId);
-        if (index !== -1) {
-          pendingApprovalQueue.splice(index, 1);
-        }
-        approvalPromiseResolver("REJECTED_TIMEOUT");
-      }
+      resolveRequest("REJECTED_TIMEOUT");
     });
 
   const authorizationResult = await approvalPromise;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's tool execution pipeline needs an additional local security boundary that independently evaluates tool actions before final execution. This adds a fail-closed Local Security Gateway at the final execution boundary, providing action classification, approval enforcement, sensitive-path protection, emergency-stop handling, exact-parameter approval binding, and privacy-preserving audit logging.

The gateway is designed as an additional security layer and does not replace OpenClaw's existing tool policies.

## Evidence

* 20/20 focused Local Security Gateway security and adversarial tests passed.
* 3/3 security test files passed.
* Concurrent approval isolation verified.
* Post-approval parameter mutation invalidates authorization.
* Emergency-stop race prevents final execution.
* Expired approvals are rejected.
* Secrets, sensitive paths, and raw exceptions are redacted from audit logs.
* SAFE actions execute without unnecessary approval prompts.
* Write/delete actions require approval.
* `exec`, PowerShell, and CMD execution are blocked.
* Sensitive paths such as `.ssh/id_rsa` are blocked.
* Unknown tools fail closed.
* `tsc --noEmit -p tsconfig.core.json` completed successfully with a 4096 MB Node heap limit.
* No `src/infra/node-sqlite.ts` modification is included in this branch.
