### PR TITLE
fix(memory): avoid repeated local provider initialization across registrations

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -400,6 +400,17 @@ describe("memory-core plugin runtime registration", () => {
     });
   });
 
+  it("keeps the host local-service hook stable across plugin registration", async () => {
+    const firstRuntime = registerMemoryCoreRuntime();
+    await firstRuntime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const firstHost = createMemoryRuntimeMock.mock.calls.at(-1)?.[0];
+    const secondRuntime = registerMemoryCoreRuntime();
+    await secondRuntime.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const secondHost = createMemoryRuntimeMock.mock.calls.at(-1)?.[0];
+
+    expect(firstHost?.acquireLocalService).toBe(secondHost?.acquireLocalService);
+  });
+
   it("defers nested host runtime access until the injected operation runs", async () => {
     const acquireLocalService = vi.fn(async () => undefined);
     const openKeyedStore = vi.fn(() => ({}));
@@ -427,12 +438,13 @@ describe("memory-core plugin runtime registration", () => {
     expect(stateGetter).not.toHaveBeenCalled();
     await runtime?.getMemorySearchManager({ cfg: {}, agentId: "main" });
     const injectedHost = createMemoryRuntimeMock.mock.calls.at(-1)?.[0];
-    if (!injectedHost?.acquireLocalService || !injectedHost.openKeyedStore) {
+    const injectedAcquireLocalService = injectedHost?.acquireLocalService;
+    if (!injectedAcquireLocalService || !injectedHost?.openKeyedStore) {
       throw new Error("expected memory-core host operations");
     }
 
     const target = { providerId: "local", baseUrl: "http://127.0.0.1:11434" };
-    await injectedHost.acquireLocalService(target);
+    await injectedAcquireLocalService(target);
     const storeOptions = { namespace: "lazy-host", maxEntries: 1 };
     injectedHost.openKeyedStore(storeOptions);
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -226,11 +226,14 @@ export default definePluginEntry({
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
-    const acquireLocalService: MemoryCoreAcquireLocalService = (...args) =>
-      api.runtime.llm.acquireLocalService(...args);
     const openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
       api.runtime.state.openKeyedStore<T>(options);
-    const host = { acquireLocalService, openKeyedStore } satisfies MemoryCoreRuntimeHost;
+    const host = {
+      get acquireLocalService(): MemoryCoreAcquireLocalService {
+        return api.runtime.llm.acquireLocalService;
+      },
+      openKeyedStore,
+    } satisfies MemoryCoreRuntimeHost;
     configureMemoryCoreDreamingState(openKeyedStore);
     const memoryRuntime = createLazyMemoryRuntime(host);
     registerShortTermPromotionDreaming(api);

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -31,6 +31,29 @@ import {
 } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
+const scopedLocalServiceAcquirers = new WeakMap<
+  PluginRuntime["llm"]["acquireLocalService"],
+  Map<string, PluginRuntime["llm"]["acquireLocalService"]>
+>();
+
+function getScopedLocalServiceAcquirer(
+  acquireLocalService: PluginRuntime["llm"]["acquireLocalService"],
+  pluginId: string,
+): PluginRuntime["llm"]["acquireLocalService"] {
+  let byPlugin = scopedLocalServiceAcquirers.get(acquireLocalService);
+  if (!byPlugin) {
+    byPlugin = new Map();
+    scopedLocalServiceAcquirers.set(acquireLocalService, byPlugin);
+  }
+  let scoped = byPlugin.get(pluginId);
+  if (!scoped) {
+    scoped = (...args) =>
+      withPluginRuntimePluginIdScope(pluginId, () => acquireLocalService(...args));
+    byPlugin.set(pluginId, scoped);
+  }
+  return scoped;
+}
+
 export function createPluginRuntimeResolver(state: PluginRegistryState) {
   const { registry, registryParams } = state;
   const pluginRuntimeById = new Map<string, PluginRuntime>();
@@ -295,8 +318,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         if (prop === "llm") {
           const llm = getRuntimeProperty();
           return {
-            acquireLocalService: (...args) =>
-              withPluginRuntimePluginIdScope(pluginId, () => llm.acquireLocalService(...args)),
+            acquireLocalService: getScopedLocalServiceAcquirer(llm.acquireLocalService, pluginId),
             complete: (params) =>
               withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)),
           } satisfies PluginRuntime["llm"];

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -312,12 +312,41 @@ describe("plugin registry runtime config scope", () => {
     });
     const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
 
+    expect(api.runtime.llm.acquireLocalService).toBe(api.runtime.llm.acquireLocalService);
+
     await api.runtime.llm.acquireLocalService({
       providerId: "gpu-host",
       baseUrl: "http://127.0.0.1:11434",
     });
 
     expect(acquireScope).toMatchObject({ pluginId: "memory-provider" });
+  });
+
+  it("keeps local service acquisition identities separate across plugins and hosts", () => {
+    const firstHost = createPluginRuntime();
+    const secondHost = createPluginRuntime();
+    firstHost.llm.acquireLocalService = vi.fn(async () => undefined);
+    secondHost.llm.acquireLocalService = vi.fn(async () => undefined);
+    const createScopedAcquire = (runtime: PluginRuntime, pluginId: string) => {
+      const pluginRegistry = createTestRegistry(runtime);
+      const record = createPluginRecord({
+        id: pluginId,
+        source: `/plugins/${pluginId}/index.js`,
+        origin: "bundled",
+        enabled: true,
+        configSchema: false,
+      });
+      return pluginRegistry.createApi(record, { config: {} as OpenClawConfig }).runtime.llm
+        .acquireLocalService;
+    };
+
+    const first = createScopedAcquire(firstHost, "memory-provider");
+    const otherPlugin = createScopedAcquire(firstHost, "other-provider");
+    const otherHost = createScopedAcquire(secondHost, "memory-provider");
+
+    expect(createScopedAcquire(firstHost, "memory-provider")).toBe(first);
+    expect(otherPlugin).not.toBe(first);
+    expect(otherHost).not.toBe(first);
   });
 
   it.each(["materialized", "lazy"] as const)(

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -488,6 +488,13 @@ describe("plugin runtime command execution", () => {
     expect(runtime.modelAuth.getApiKeyForModel).not.toBe(rawGetApiKey);
   });
 
+  it("keeps provider-service acquisition identity stable across runtime facades", () => {
+    const first = createPluginRuntime().llm.acquireLocalService;
+    const second = createPluginRuntime().llm.acquireLocalService;
+
+    expect(second).toBe(first);
+  });
+
   it("modelAuth wrappers preserve workspace scope while stripping credential steering", async () => {
     const runtime = createPluginRuntime();
     const model = {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -113,11 +113,14 @@ function createRuntimeMusicGeneration(): PluginRuntime["musicGeneration"] {
   };
 }
 
+// Runtime facades share one host-owned acquirer so consumers can safely use
+// callback identity when caching provider resources.
+const acquireRuntimeLocalService = createLazyRuntimeMethod(
+  () => import("../../agents/provider-local-service.js"),
+  (runtime) => runtime.createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig),
+);
+
 function createRuntimeLlmFacade(): PluginRuntime["llm"] {
-  const loadAcquireLocalService = createLazyRuntimeMethod(
-    () => import("../../agents/provider-local-service.js"),
-    (runtime) => runtime.createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig),
-  );
   const loadLlm = createLazyRuntimeSurface(
     () => import("./runtime-llm.runtime.js"),
     (m) =>
@@ -129,7 +132,7 @@ function createRuntimeLlmFacade(): PluginRuntime["llm"] {
       }),
   );
   return {
-    acquireLocalService: (...args) => loadAcquireLocalService(...args),
+    acquireLocalService: acquireRuntimeLocalService,
     complete: async (params) => {
       const llm = await loadLlm();
       return llm.complete(params);


### PR DESCRIPTION
Closes #142414

## What Problem This Solves

Fixes an issue where users of local memory embeddings could pay repeated provider initialization and hit memory-search timeouts when the same memory configuration crossed repeated runtime or plugin registration paths.

## Why This Change Was Made

The runtime now exposes one process-stable host acquirer, the plugin registry reuses one scoped acquirer per host callback and plugin ID, and `memory-core` reads that reference lazily instead of allocating another forwarding function. Different plugins and genuinely different host callbacks remain isolated. The change does not alter memory configuration, index schema, ranking, or provider fallback behavior.

## User Impact

Repeated native, HTTP, CLI, or plugin registration paths can reuse a compatible local memory manager instead of replacing it solely because a wrapper function received a new identity. This avoids unnecessary local-provider cold starts while preserving plugin ownership scope.

## Evidence

- Before the production change, four new assertions fail at the runtime facade, plugin scope, and `memory-core` registration boundaries because the callback identity changes.
- Focused regression and sibling tests: 77 passed across `src/plugins/runtime/index.test.ts`, `src/plugins/registry.runtime-config.test.ts`, and `extensions/memory-core/index.test.ts`.
- Plugin contract suite: 47 files and 1117 tests passed.
- `pnpm check:changed` passed for the selected core, core-test, extension, and extension-test lanes.
- `pnpm build` passed, including CLI bootstrap imports, plugin SDK exports, runtime postbuild checks, and Control UI budgets.
- Independent autoreview found no actionable P0-P2 findings (`scoped-clean`, confidence 0.96).

### Redacted real-runtime proof

Before opening this PR, the equivalent three-boundary identity repair was exercised on an installed OpenClaw 2026.9.2 runtime using a real local GGUF embedding provider and a populated native SQLite memory index. A content-free profiler observed a cold native search, an HTTP search, and a fresh native search in one process:

```text
route   acquirer_token   manager_token   acquire_ms   search_ms   completed
native  1                2               352          5626        yes
HTTP    1                2               0            851         yes
native  1                2               0            1046        yes
```

All three requests reached `search-end`; the acquirer and manager tokens stayed identical across the registration/route transitions, and the two warm acquisitions returned immediately. The profiler was then removed byte-for-byte. A separate uninstrumented cold native -> HTTP -> native sequence completed without the prior 15-second timeout (8,886 ms, 839 ms, and 1,051 ms respectively), and every search returned without an error.

Queries, result content, paths, hostnames, endpoints, IP addresses, and credentials are omitted. This operational run used the installed 2026.9.2 build with the equivalent guarded fix at the same host-runtime, plugin-scope, and `memory-core` boundaries; the regression suites above validate the source implementation in this PR.
