### PR TITLE
fix: allow updates during agent database writes

### DIFF
--- a/src/cli/update-cli/schema-preflight.test.ts
+++ b/src/cli/update-cli/schema-preflight.test.ts
@@ -4,16 +4,18 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../../state/openclaw-agent-db-contract.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { checkTargetDatabaseSchemasForContexts } from "./schema-preflight.js";
+import { checkTargetDatabaseSchemasForContexts, hasSchemaRefusal } from "./schema-preflight.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -23,6 +25,57 @@ afterEach(() => {
 });
 
 describe("target-release database schema preflight", () => {
+  it.each([
+    { outcome: "accepts compatible", version: OPENCLAW_AGENT_SCHEMA_VERSION, refusal: false },
+    { outcome: "refuses newer", version: OPENCLAW_AGENT_SCHEMA_VERSION + 1, refusal: true },
+  ])("$outcome agent schemas committed to active WAL", async ({ version, refusal }) => {
+    const stateDir = fs.realpathSync.native(tempDirs.make("openclaw-update-wal-state-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const config: OpenClawConfig = { agents: { list: [{ id: "main" }] } };
+    openOpenClawStateDatabase({ env });
+    const agentPath = openOpenClawAgentDatabase({ agentId: "main", env }).path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    // Capture before opening the writer: closing another main-file descriptor
+    // in its process would release the writer's POSIX locks.
+    const databaseBefore = fs.readFileSync(agentPath);
+    const agent = new DatabaseSync(agentPath);
+    try {
+      agent.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+      agent.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+      // Keep the committed schema change in WAL while the connection remains open.
+      agent.exec(`PRAGMA user_version = ${version};`);
+      const walBefore = fs.readFileSync(`${agentPath}-wal`);
+      expect(databaseBefore.readUInt32BE(60)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+      expect(walBefore.length).toBeGreaterThan(32);
+
+      const result = await checkTargetDatabaseSchemasForContexts(
+        { state: OPENCLAW_STATE_SCHEMA_VERSION, agent: OPENCLAW_AGENT_SCHEMA_VERSION },
+        [{ config, env }],
+      );
+
+      expect(result.indeterminate).toEqual([]);
+      expect(result.incompatible).toEqual(
+        refusal
+          ? [
+              expect.objectContaining({
+                kind: "agent",
+                path: agentPath,
+                foundVersion: version,
+                supportedVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+              }),
+            ]
+          : [],
+      );
+      expect(hasSchemaRefusal(result)).toBe(refusal);
+      expect(fs.readFileSync(agentPath)).toEqual(databaseBefore);
+      expect(fs.readFileSync(`${agentPath}-wal`)).toEqual(walBefore);
+    } finally {
+      agent.close();
+    }
+  });
+
   it.runIf(process.platform !== "win32")(
     "deduplicates caller and managed aliases of one physical database",
     async () => {
@@ -78,6 +131,7 @@ describe("target-release database schema preflight", () => {
     expect(result.indeterminate).toEqual([
       expect.objectContaining({ kind: "agent", path: agentPath }),
     ]);
+    expect(hasSchemaRefusal(result)).toBe(true);
     expect(fs.readFileSync(statePath)).toEqual(stateBefore);
     const inspectedState = new DatabaseSync(statePath, { readOnly: true });
     try {
@@ -126,6 +180,7 @@ describe("target-release database schema preflight", () => {
       [configuredPath, unregisteredPath, registeredCustomPath].toSorted(),
     );
     expect(result.indeterminate).toEqual([]);
+    expect(hasSchemaRefusal(result)).toBe(true);
     expect(
       before.map(({ pathname }) => ({
         pathname,

--- a/src/state/openclaw-database-preflight.artifacts.test.ts
+++ b/src/state/openclaw-database-preflight.artifacts.test.ts
@@ -1,4 +1,6 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +8,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   captureTargetDatabaseSchemaContext,
   checkTargetDatabaseSchemasForContexts,
+  hasSchemaRefusal,
 } from "../cli/update-cli/schema-preflight.js";
 import { resolveConfiguredAgentDatabaseCandidatePaths } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -82,7 +85,7 @@ function createFixture(storeDirectory?: string) {
   };
 }
 
-function sourceArtifacts(paths: string[]): unknown {
+function sourceArtifacts(paths: string[], allowReadMarks: string[] = []): unknown {
   // Observe in a child too: opening/closing these in the writer's process can
   // itself release POSIX locks and would invalidate the writer-isolation probe.
   const result = spawnSync(
@@ -90,18 +93,24 @@ function sourceArtifacts(paths: string[]): unknown {
     [
       "-e",
       `const fs = require('node:fs'), path = require('node:path'), crypto = require('node:crypto');
+       const allowReadMarks = JSON.parse(process.argv[1]);
        const record = file => {
          const s = fs.statSync(file, { bigint: true });
+         const readMarks = allowReadMarks.some(database => file === database + '-shm');
+         const bytes = s.isFile() ? fs.readFileSync(file) : undefined;
+         if (readMarks) bytes.fill(0, 100, 120);
          return { file, mode: String(s.mode), dev: String(s.dev), ino: String(s.ino),
-           size: String(s.size), mtime: String(s.mtimeNs), ctime: String(s.ctimeNs),
-           ...(s.isFile() ? { hash: crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex') }
+           size: String(s.size),
+           ...(!readMarks ? { mtime: String(s.mtimeNs), ctime: String(s.ctimeNs) } : {}),
+           ...(bytes ? { hash: crypto.createHash('sha256').update(bytes).digest('hex') }
              : { entries: fs.readdirSync(file).sort() }) };
        };
-       console.log(JSON.stringify(process.argv.slice(1).map(file => ({
+       console.log(JSON.stringify(process.argv.slice(2).map(file => ({
          directory: record(path.dirname(file)),
          family: ['', '-wal', '-shm', '-journal'].map(suffix => file + suffix)
            .filter(fs.existsSync).map(record)
        }))));`,
+      JSON.stringify(allowReadMarks),
       ...paths,
     ],
     { encoding: "utf8" },
@@ -352,12 +361,14 @@ describe("schema preflight source artifacts", () => {
     expect(sourceArtifacts(fixture.paths)).toEqual(before);
   });
 
-  it("reads newer committed schema versions from live WAL without blocking or changing the family", async () => {
+  it("reads newer live WAL schemas without changing contents beyond agent SHM read marks", async () => {
     const fixture = createFixture();
     fixture.state.db.exec(`PRAGMA user_version = ${supportedVersions.state + 10};`);
     fixture.main.db.exec(`PRAGMA user_version = ${supportedVersions.agent + 10};`);
     fixture.worker.db.exec(`PRAGMA user_version = ${supportedVersions.agent + 10};`);
-    const before = sourceArtifacts(fixture.paths);
+    // SQLite's WAL-index read-mark array occupies bytes 100..119 of SHM.
+    const allowReadMarks = [fixture.main.path, fixture.worker.path];
+    const before = sourceArtifacts(fixture.paths, allowReadMarks);
     let eventLoopServiced = false;
     const immediate = setImmediate(() => {
       eventLoopServiced = true;
@@ -377,11 +388,119 @@ describe("schema preflight source artifacts", () => {
         [fixture.main.path, supportedVersions.agent + 10],
         [fixture.worker.path, supportedVersions.agent + 10],
       ]);
-      expect(sourceArtifacts(fixture.paths)).toEqual(before);
+      expect(sourceArtifacts(fixture.paths, allowReadMarks)).toEqual(before);
     } finally {
       clearImmediate(immediate);
     }
   });
+
+  it.each(["compatible", "incompatible"] as const)(
+    "inspects %s agent schemas while an independent WAL writer keeps committing",
+    async (outcome) => {
+      const fixture = createFixture();
+      const foundVersion = supportedVersions.agent + (outcome === "incompatible" ? 1 : 0);
+      // A 64 MiB source makes each byte-copy attempt overlap real commits.
+      fixture.main.db.exec(`
+        CREATE TABLE payloads (value BLOB NOT NULL) STRICT;
+        WITH RECURSIVE rows(n) AS (VALUES(1) UNION ALL SELECT n + 1 FROM rows WHERE n < 1024)
+        INSERT INTO payloads SELECT zeroblob(65536) FROM rows;
+        CREATE TABLE heartbeat (value INTEGER NOT NULL) STRICT;
+        INSERT INTO heartbeat VALUES (0);
+        PRAGMA user_version = ${foundVersion};
+      `);
+      fixture.close();
+      const mainHash = () =>
+        createHash("sha256").update(fs.readFileSync(fixture.main.path)).digest("hex");
+      const mainBefore = mainHash();
+      const stateBefore = sourceArtifacts([fixture.state.path]);
+      const writer = spawn(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `
+          import { DatabaseSync } from "node:sqlite";
+          const database = new DatabaseSync(process.argv[1]);
+          database.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+          const write = database.prepare("UPDATE heartbeat SET value = value + 1");
+          let commits = 0;
+          function commit() {
+            write.run();
+            commits += 1;
+            setImmediate(commit);
+          }
+          process.on("message", () => process.send(commits));
+          process.on("disconnect", () => process.exit());
+          commit();
+          process.send(commits);
+          `,
+          fixture.main.path,
+        ],
+        { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+      );
+      let stderr = "";
+      writer.stderr?.setEncoding("utf8").on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      const closed = once(writer, "close");
+      // IPC samples committed progress without attaching a reader to the source.
+      const receiveProgress = async () => {
+        const [commits] = await Promise.race([
+          once(writer, "message"),
+          closed.then(() => {
+            throw new Error(`SQLite writer exited during inspection: ${stderr}`);
+          }),
+        ]);
+        if (typeof commits !== "number") {
+          throw new Error("SQLite writer did not report its committed progress");
+        }
+        return commits;
+      };
+      try {
+        await receiveProgress();
+        const walBefore = fs.readFileSync(`${fixture.main.path}-wal`);
+        for (const inspect of [
+          () => preflightOpenClawDatabaseSchemas({ env: fixture.env, supportedVersions }),
+          () =>
+            checkTargetDatabaseSchemasForContexts(supportedVersions, [
+              { env: fixture.env, config: {} },
+            ]),
+        ]) {
+          const before = receiveProgress();
+          writer.send("progress");
+          const commitsBefore = await before;
+          const result = await inspect();
+          const after = receiveProgress();
+          writer.send("progress");
+          expect(await after).toBeGreaterThan(commitsBefore);
+          expect(writer.exitCode).toBeNull();
+          expect(result.indeterminate).toEqual([]);
+          expect(result.incompatible).toEqual(
+            outcome === "compatible"
+              ? []
+              : [expect.objectContaining({ kind: "agent", path: fixture.main.path, foundVersion })],
+          );
+          expect(hasSchemaRefusal(result)).toBe(outcome === "incompatible");
+        }
+        // The writer appends WAL frames. Inspection must not checkpoint the main
+        // database or rewrite any preexisting WAL bytes while those commits run.
+        expect(mainHash()).toBe(mainBefore);
+        const wal = fs.openSync(`${fixture.main.path}-wal`, "r");
+        try {
+          const prefix = Buffer.alloc(walBefore.length);
+          expect(fs.readSync(wal, prefix, 0, prefix.length, 0)).toBe(prefix.length);
+          expect(prefix).toEqual(walBefore);
+        } finally {
+          fs.closeSync(wal);
+        }
+        expect(sourceArtifacts([fixture.state.path])).toEqual(stateBefore);
+      } finally {
+        writer.kill();
+        await closed;
+      }
+    },
+    30_000,
+  );
 
   it("ignores uncommitted writer versions without ending the owning transactions", async () => {
     const fixture = createFixture();
@@ -390,14 +509,15 @@ describe("schema preflight source artifacts", () => {
       opened.db.exec("BEGIN IMMEDIATE; PRAGMA user_version = 999;");
     }
     try {
-      const before = sourceArtifacts(fixture.paths);
+      const allowReadMarks = [fixture.main.path, fixture.worker.path];
+      const before = sourceArtifacts(fixture.paths, allowReadMarks);
       const locks =
         process.platform === "linux" ? fixture.paths.map(readMainDatabasePosixLocks) : [];
       expect(await checkTargetDatabaseSchemas(supportedVersions, fixture.env)).toEqual({
         incompatible: [],
         indeterminate: [],
       });
-      expect(sourceArtifacts(fixture.paths)).toEqual(before);
+      expect(sourceArtifacts(fixture.paths, allowReadMarks)).toEqual(before);
       for (const opened of databases) {
         expect(opened.db.isTransaction).toBe(true);
         expect(opened.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 999 });

--- a/src/state/openclaw-database-preflight.test-support.ts
+++ b/src/state/openclaw-database-preflight.test-support.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+import { expect } from "vitest";
+
+/** Capture persistent artifacts without releasing the test writer's POSIX locks. */
+export function snapshotPreflightSourceManifest(stateDir: string, allowAgentReadMarks?: string) {
+  // Opening/closing the main file in the writer's process releases its POSIX
+  // locks. Observe in a child so SQLite still sees a live owner during inspection.
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `
+      import fs from "node:fs";
+      import path from "node:path";
+      import { createHash } from "node:crypto";
+      const [stateDir, allowAgentReadMarks] = process.argv.slice(1);
+      const manifest = fs.readdirSync(stateDir, { recursive: true, encoding: "utf8" })
+        .filter(entry => !entry.startsWith("tmp" + path.sep))
+        .filter(entry => fs.statSync(path.join(stateDir, entry)).isFile())
+        .toSorted().map(entry => {
+          const pathname = path.join(stateDir, entry);
+          const bytes = fs.readFileSync(pathname);
+          if (pathname === allowAgentReadMarks + "-shm") bytes.fill(0, 100, 120);
+          return [entry, createHash("sha256").update(bytes).digest("hex")];
+        });
+      console.log(JSON.stringify(manifest));
+      `,
+      stateDir,
+      allowAgentReadMarks ?? "",
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return JSON.parse(result.stdout);
+}

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -20,6 +19,7 @@ import {
   preflightOpenClawStateDatabasePath,
   preflightOpenClawDatabaseSchemas,
 } from "./openclaw-database-preflight.js";
+import { snapshotPreflightSourceManifest } from "./openclaw-database-preflight.test-support.js";
 import { repairAuditEventsSchema } from "./openclaw-state-db-audit-migration.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
@@ -83,21 +83,6 @@ describe("OpenClaw database schema preflight", () => {
     return databasePath;
   }
 
-  function sourceManifest(stateDir: string) {
-    // Coordinator tmp/ files are lifecycle scratch; persistent artifacts must not change.
-    return fs
-      .readdirSync(stateDir, { recursive: true, encoding: "utf8" })
-      .filter((entry) => !entry.startsWith(`tmp${path.sep}`))
-      .filter((entry) => fs.statSync(path.join(stateDir, entry)).isFile())
-      .toSorted()
-      .map((entry) => [
-        entry,
-        createHash("sha256")
-          .update(fs.readFileSync(path.join(stateDir, entry)))
-          .digest("hex"),
-      ]);
-  }
-
   function createReleasedStateDatabase() {
     const stateDir = tempDirs.make("openclaw-startup-database-admission-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -120,11 +105,11 @@ describe("OpenClaw database schema preflight", () => {
 
   it("refuses released legacy audit state before changing any persistent artifact", async () => {
     const { env, stateDir, statePath } = createReleasedStateDatabase();
-    const before = sourceManifest(stateDir);
+    const before = snapshotPreflightSourceManifest(stateDir);
     await expect(
       assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config: {} }),
     ).rejects.toBeInstanceOf(OpenClawStateDatabaseSchemaMigrationRequiredError);
-    expect(sourceManifest(stateDir)).toEqual(before);
+    expect(snapshotPreflightSourceManifest(stateDir)).toEqual(before);
     await expect(preflightOpenClawStateDatabasePath(statePath)).resolves.toMatchObject({
       foundVersion: 1,
     });
@@ -153,11 +138,11 @@ describe("OpenClaw database schema preflight", () => {
           layout === "configured"
             ? { session: { store: path.join(stateDir, "custom", "sessions.json") } }
             : {};
-        const before = sourceManifest(stateDir);
+        const before = snapshotPreflightSourceManifest(stateDir, agentPath);
         await expect(
           assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config }),
         ).rejects.toBeInstanceOf(OpenClawAgentDatabaseMediaMigrationRequiredError);
-        expect(sourceManifest(stateDir)).toEqual(before);
+        expect(snapshotPreflightSourceManifest(stateDir, agentPath)).toEqual(before);
       } finally {
         writer.close();
       }
@@ -177,7 +162,7 @@ describe("OpenClaw database schema preflight", () => {
     });
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
-    const before = sourceManifest(root);
+    const before = snapshotPreflightSourceManifest(root);
     await expect(
       assertOpenClawDatabasesReady({
         env,
@@ -185,7 +170,7 @@ describe("OpenClaw database schema preflight", () => {
         config: { session: { store } },
       }),
     ).rejects.toThrow("belongs to agent beta; requested agent alpha");
-    expect(sourceManifest(root)).toEqual(before);
+    expect(snapshotPreflightSourceManifest(root)).toEqual(before);
   });
 
   it("admits supported forward state migration after the Doctor-owned audit repair", async () => {
@@ -197,11 +182,11 @@ describe("OpenClaw database schema preflight", () => {
     } finally {
       database.close();
     }
-    const before = sourceManifest(stateDir);
+    const before = snapshotPreflightSourceManifest(stateDir);
     await expect(
       assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config: {} }),
     ).resolves.toBeUndefined();
-    expect(sourceManifest(stateDir)).toEqual(before);
+    expect(snapshotPreflightSourceManifest(stateDir)).toEqual(before);
     const migrated = openOpenClawStateDatabase({ env });
     expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
       user_version: OPENCLAW_STATE_SCHEMA_VERSION,

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -633,8 +633,9 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       }
       inspectedAgentPaths.add(realAgentPath);
       inspectedAgentTargets.add(inspectionKey);
+      // Live agents keep committing during inspection. Online backup preserves
+      // database/WAL contents while allowing SQLite to update SHM read marks.
       agentSnapshot = await prepareSqliteReadOnlyLocation(realAgentPath, {
-        preserveSourceArtifacts: true,
         signal: options.signal,
       });
       options.signal?.throwIfAborted();


### PR DESCRIPTION
Closes #142392

## What Problem This Solves

Fixes an issue where users updating from the Control UI receive a `database-schema-preflight` refusal while the Gateway continuously commits to a large, compatible agent database. The inspection requires a byte-stable copy even though update validation deliberately leaves the Gateway serving.

## Why This Change Was Made

The shared preflight selects snapshot policy by database kind: state inspection retains its byte-neutral copy, and agent inspection uses the asynchronous SQLite online-backup worker. This applies the live-agent contract established in #142361: preserve database and WAL contents while allowing ordinary SQLite reader updates to SHM read marks. Callers do not select a separate strategy.

The worker's crash-residue handling, cancellation, schema checks, and fail-closed classification remain unchanged. Legacy-agent startup tests capture artifacts in a child process so their own main-file reads cannot release the writer's POSIX locks.

## User Impact

Schema inspection can complete while an agent database receives commits. Compatible databases pass the update guard; genuinely incompatible or indeterminate databases still refuse the update before mutation.

The installed updater must receive this fix before it can use the repaired path. This PR does not deploy to or repair a live Gateway.

## Evidence

- Before the production change, both independent-writer regressions fail with `SQLite source did not stabilize for read-only inspection` while the writer advances.
- After the change, a separate process continuously commits to a real 64 MiB WAL agent database through both shared preflight and update-context inspection. Compatible and incompatible schema results are correct, and IPC confirms committed progress across each inspection.
- Active-WAL fixtures preserve the full database and WAL bytes. The continuous-writer fixture also preserves the main database and preexisting WAL prefix while the writer appends frames. Artifact checks permit only SHM read-mark bytes 100–119 to change; state checks remain byte-neutral.
- Focused validation: **132 passed, 1 Linux-only test skipped on macOS**, using Node 24.19.0. Includes state/schema refusal, snapshot recovery, orphan SHM, copying, and cancellation/deadline coverage.
- Final preflight and update-execution validation: **77 passed**, including all 13 update-execution tests, after extracting the artifact helper. Across the seven focused suites, **145 distinct tests pass**.
- Fresh autoreview: no actionable P0–P2 findings.
- `mise exec -- node scripts/check-changed.mjs` passes all selected formatting, core/core-test typechecking, lint, and repository guards. No dependency or lockfile changes are included.

```sh
mise exec -- node scripts/run-vitest.mjs \
  src/state/openclaw-database-preflight.test.ts \
  src/state/openclaw-database-preflight.artifacts.test.ts \
  src/cli/update-cli/schema-preflight.test.ts \
  src/infra/sqlite-readonly-location.test.ts \
  src/infra/sqlite-readonly-location.copy.test.ts \
  src/infra/sqlite-readonly-location.cancellation.test.ts

mise exec -- node scripts/run-vitest.mjs \
  src/state/openclaw-database-preflight.test.ts \
  src/state/openclaw-database-preflight.artifacts.test.ts \
  src/cli/update-cli/schema-preflight.test.ts \
  src/cli/update-cli/update-command-execution.test.ts
```
