### PR TITLE
fix(plugins): release one-shot exporter resources after cleanup

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -140,6 +140,8 @@ paths.
   more for the flush, so an unreachable collector cannot hold the command open.
   A collector that accepts the connection but never answers can still delay exit
   until the exporter's own request timeout (`OTEL_EXPORTER_OTLP_TIMEOUT`).
+  Plugin registration resources remain open until exporter cleanup finishes,
+  even when either wait times out.
   In JSON output mode, these one-shot runs suppress only the stdout JSONL log
   sink so command stdout stays reserved for the JSON response; OTLP traces,
   metrics, and logs continue when configured.

--- a/src/plugins/one-shot-diagnostics.resources.test.ts
+++ b/src/plugins/one-shot-diagnostics.resources.test.ts
@@ -1,0 +1,426 @@
+import { AsyncResource } from "node:async_hooks";
+import type { DatabaseSync } from "node:sqlite";
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { acquirePluginRegistryForInspection } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import {
+  startOneShotDiagnosticsExporters,
+  type OneShotDiagnosticsHandle,
+} from "./one-shot-diagnostics.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "./runtime.js";
+import { startPluginServices } from "./services.js";
+import type { OpenClawPluginServiceContext } from "./types.js";
+
+type NativeConnection = {
+  database: DatabaseSync;
+  disposals: number;
+  stops: number;
+  lateRead?: number;
+  context?: OpenClawPluginServiceContext;
+};
+let fixtureSequence = 0;
+
+function createNativeExporter(
+  options: { service?: boolean; failStart?: boolean; pauseDisposal?: boolean } = {},
+) {
+  useNoBundledPlugins();
+  const key = `__openclaw_one_shot_native_${fixtureSequence++}`;
+  const connections: NativeConnection[] = [];
+  const state = {
+    connections,
+    started: createDeferredCore(),
+    stopStarted: createDeferredCore(),
+    finishStop: createDeferredCore(),
+    stopFinished: createDeferredCore(),
+    disposalStarted: createDeferredCore(),
+    finishDisposal: createDeferredCore(),
+  };
+  if (!options.pauseDisposal) {
+    state.finishDisposal.resolve();
+  }
+  Object.defineProperty(globalThis, key, { value: state, configurable: true });
+  const plugin = writePlugin({
+    id: "diagnostics-otel",
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: "diagnostics-otel",
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, stops: 0 };
+    state.connections.push(connection);
+    api.registerRuntimeLifecycle({
+      id: "native-exporter-database",
+      async dispose() {
+        connection.disposals++;
+        state.disposalStarted.resolve();
+        await state.finishDisposal.promise;
+        database.close();
+      },
+    });
+    if (${options.service !== false}) api.registerService({
+      id: "diagnostics-otel",
+      start(context) {
+        connection.context = context;
+        state.started.resolve();
+        if (${options.failStart === true}) throw new Error("native exporter start failed");
+      },
+      async stop() {
+        connection.stops++;
+        state.stopStarted.resolve();
+        try {
+          await state.finishStop.promise;
+          connection.lateRead = database.prepare("SELECT 42 AS value").get().value;
+        } finally {
+          state.stopFinished.resolve();
+        }
+      },
+    });
+  },
+};`,
+  });
+  const config = {
+    diagnostics: { otel: { enabled: true } },
+    plugins: {
+      allow: [plugin.id],
+      load: { paths: [plugin.file] },
+      slots: { memory: "none" },
+    },
+  };
+  return {
+    config,
+    state,
+    connection() {
+      const connection = connections[0];
+      if (!connection) {
+        throw new Error("Native exporter did not register its database");
+      }
+      return connection;
+    },
+    async cleanup(handle?: OneShotDiagnosticsHandle | null) {
+      state.finishStop.resolve();
+      state.finishDisposal.resolve();
+      await handle?.stop();
+      for (const connection of connections) {
+        if (connection.stops > 0) {
+          await state.stopFinished.promise;
+        }
+        if (connection.database.isOpen) {
+          connection.database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("one-shot diagnostics registration resources", () => {
+  it("disposes the actual exporter database after successful service stop", async () => {
+    const fixture = createNativeExporter();
+    const active = createEmptyPluginRegistry();
+    setActivePluginRegistry(active);
+    let handle: OneShotDiagnosticsHandle | null | undefined;
+    try {
+      handle = await startOneShotDiagnosticsExporters({ config: fixture.config });
+      const connection = fixture.connection();
+      expect(handle).not.toBeNull();
+      expect(connection.database.isOpen).toBe(true);
+      expect(connection.context?.internalDiagnostics).toBeUndefined();
+      fixture.state.finishStop.resolve();
+      await handle?.stop();
+      expect(connection.lateRead).toBe(42);
+      await vi.waitFor(() => expect(connection.database.isOpen).toBe(false));
+      expect(connection.disposals).toBe(1);
+      await handle?.stop();
+      expect(connection.stops).toBe(1);
+      expect(connection.disposals).toBe(1);
+      expect(getActivePluginRegistry()).toBe(active);
+    } finally {
+      await fixture.cleanup(handle);
+    }
+  });
+
+  it("disposes a loaded registry when it has no exporter service", async () => {
+    const fixture = createNativeExporter({ service: false });
+    try {
+      await expect(
+        startOneShotDiagnosticsExporters({ config: fixture.config }),
+      ).resolves.toBeNull();
+      await vi.waitFor(() => expect(fixture.connection().database.isOpen).toBe(false));
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("waits for actual registration disposal before returning no-service null", async () => {
+    const fixture = createNativeExporter({ service: false, pauseDisposal: true });
+    let returned = false;
+    const starting = startOneShotDiagnosticsExporters({ config: fixture.config }).then((handle) => {
+      returned = true;
+      return handle;
+    });
+    try {
+      await fixture.state.disposalStarted.promise;
+      await nextEventLoopTurn();
+      expect(returned).toBe(false);
+      expect(fixture.connection().database.isOpen).toBe(true);
+      fixture.state.finishDisposal.resolve();
+      await expect(starting).resolves.toBeNull();
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      fixture.state.finishDisposal.resolve();
+      await starting;
+      await fixture.cleanup();
+    }
+  });
+
+  it("retains slow registration disposal in the actual stop caller's work scope", async () => {
+    const fixture = createNativeExporter({ pauseDisposal: true });
+    const handle = await startOneShotDiagnosticsExporters({ config: fixture.config });
+    if (!handle) {
+      throw new Error("Native exporter did not produce a one-shot handle");
+    }
+    const caller = new AsyncWorkScope();
+    let draining: Promise<void> | undefined;
+    try {
+      fixture.state.finishStop.resolve();
+      const stopping = caller.track(() => handle.stop());
+      await fixture.state.disposalStarted.promise;
+      await stopping;
+      let drained = false;
+      draining = caller.drain().then(() => {
+        drained = true;
+      });
+      await nextEventLoopTurn();
+      expect(drained).toBe(false);
+      expect(fixture.connection().database.isOpen).toBe(true);
+      fixture.state.finishDisposal.resolve();
+      await draining;
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+      const repeatedStop = handle.stop();
+      await repeatedStop;
+      expect(handle.stop()).toBe(repeatedStop);
+      expect(fixture.connection().stops).toBe(1);
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      fixture.state.finishDisposal.resolve();
+      await draining;
+      await caller.drain();
+      await fixture.cleanup(handle);
+    }
+  });
+
+  it("retains pending registration disposal for a second live stop caller", async () => {
+    const fixture = createNativeExporter({ pauseDisposal: true });
+    const handle = await startOneShotDiagnosticsExporters({ config: fixture.config });
+    if (!handle) {
+      throw new Error("Native exporter did not produce a one-shot handle");
+    }
+    const caller = new AsyncWorkScope();
+    let draining: Promise<void> | undefined;
+    try {
+      fixture.state.finishStop.resolve();
+      const firstStop = handle.stop();
+      await firstStop;
+      await fixture.state.disposalStarted.promise;
+      let repeatedStop: Promise<void> | undefined;
+      await caller.track(() => {
+        repeatedStop = handle.stop();
+        return repeatedStop;
+      });
+      expect(repeatedStop).toBe(firstStop);
+      let drained = false;
+      draining = caller.drain().then(() => {
+        drained = true;
+      });
+      await nextEventLoopTurn();
+      expect(drained).toBe(false);
+      expect(fixture.connection().database.isOpen).toBe(true);
+      fixture.state.finishDisposal.resolve();
+      await draining;
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+      expect(fixture.connection().stops).toBe(1);
+    } finally {
+      fixture.state.finishDisposal.resolve();
+      await draining;
+      await caller.drain();
+      await fixture.cleanup(handle);
+    }
+  });
+
+  it("retains cached failed-start cleanup in a later stop caller's work scope", async () => {
+    const fixture = createNativeExporter({ failStart: true });
+    const acquired = await acquirePluginRegistryForInspection({ config: fixture.config });
+    const caller = new AsyncWorkScope();
+    let starting: ReturnType<typeof startPluginServices> | undefined;
+    let released: Promise<void> | undefined;
+    vi.useFakeTimers();
+    try {
+      starting = startPluginServices({
+        registry: acquired.registry,
+        config: fixture.config,
+        oneShotStopTimeouts: { eventDrainMs: 5_000, serviceStopMs: 10_000 },
+      });
+      await fixture.state.stopStarted.promise;
+      await vi.advanceTimersByTimeAsync(5_000);
+      const services = await starting;
+      const stopping = caller.track(() => services.stop());
+      const rejected = expect(stopping).rejects.toThrow("timed out");
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejected;
+      released = caller.drain().then(() => acquired.release());
+      await nextEventLoopTurn();
+      expect(fixture.connection().database.isOpen).toBe(true);
+      expect(fixture.connection().stops).toBe(1);
+      fixture.state.finishStop.resolve();
+      await fixture.state.stopFinished.promise;
+      await released;
+      expect(fixture.connection().lateRead).toBe(42);
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      fixture.state.finishStop.resolve();
+      await starting;
+      await fixture.state.stopFinished.promise;
+      await caller.drain();
+      await released;
+      await acquired.release();
+      await fixture.cleanup();
+    }
+  });
+
+  it("disposes resources when a retained stop callback restores a closed startup scope", async () => {
+    const fixture = createNativeExporter();
+    const startup = new AsyncWorkScope();
+    let handle: OneShotDiagnosticsHandle | null | undefined;
+    const retainedStop = await startup.track(async () => {
+      handle = await startOneShotDiagnosticsExporters({ config: fixture.config });
+      if (!handle) {
+        throw new Error("Native exporter did not produce a one-shot handle");
+      }
+      return AsyncResource.bind(handle.stop);
+    });
+    await startup.drain();
+    try {
+      fixture.state.finishStop.resolve();
+      await retainedStop();
+      expect(fixture.connection().lateRead).toBe(42);
+      expect(fixture.connection().stops).toBe(1);
+      await vi.waitFor(() => expect(fixture.connection().database.isOpen).toBe(false));
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      await fixture.cleanup(handle);
+    }
+  });
+
+  it.each([false, true])(
+    "retains the native database beyond the flush deadline (failed start: %s)",
+    async (failStart) => {
+      const fixture = createNativeExporter({ failStart });
+      let handle: OneShotDiagnosticsHandle | null | undefined;
+      let starting: Promise<OneShotDiagnosticsHandle | null> | undefined;
+      let stopping: Promise<void> | undefined;
+      vi.useFakeTimers();
+      try {
+        starting = startOneShotDiagnosticsExporters({ config: fixture.config });
+        await fixture.state.started.promise;
+        if (failStart) {
+          await fixture.state.stopStarted.promise;
+          await vi.advanceTimersByTimeAsync(5_000);
+        }
+        handle = await starting;
+        const connection = fixture.connection();
+        expect(handle).not.toBeNull();
+        expect(connection.context?.internalDiagnostics).toBeUndefined();
+        let stopped = false;
+        stopping = handle?.stop().then(() => {
+          stopped = true;
+        });
+        await fixture.state.stopStarted.promise;
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(stopped).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        await stopping;
+        expect(stopped).toBe(true);
+        expect(connection.database.isOpen).toBe(true);
+        expect(connection.disposals).toBe(0);
+        expect(connection.stops).toBe(1);
+
+        fixture.state.finishStop.resolve();
+        await fixture.state.stopFinished.promise;
+        vi.useRealTimers();
+        expect(connection.lateRead).toBe(42);
+        await vi.waitFor(() => expect(connection.database.isOpen).toBe(false));
+        expect(connection.disposals).toBe(1);
+      } finally {
+        fixture.state.finishStop.resolve();
+        await starting;
+        await stopping;
+        await fixture.cleanup(handle);
+      }
+    },
+  );
+
+  it("keeps raw service cleanup in the caller's work scope after the stop observer times out", async () => {
+    const fixture = createNativeExporter();
+    const acquired = await acquirePluginRegistryForInspection({ config: fixture.config });
+    const work = new AsyncWorkScope();
+    const broadcast = vi.fn();
+    const services = await work.track(() =>
+      startPluginServices({
+        registry: acquired.registry,
+        config: fixture.config,
+        broadcastPluginEvent: broadcast,
+        oneShotStopTimeouts: { eventDrainMs: 5_000, serviceStopMs: 10_000 },
+      }),
+    );
+    let released: Promise<void> | undefined;
+    vi.useFakeTimers();
+    try {
+      const stopping = work.track(() => services.stop());
+      const rejected = expect(stopping).rejects.toThrow("timed out");
+      await fixture.state.stopStarted.promise;
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejected;
+      expect(() =>
+        fixture.connection().context?.gatewayEvents?.emit("late", {}, { scope: "operator.read" }),
+      ).toThrow("no longer active");
+      expect(broadcast).not.toHaveBeenCalled();
+      released = work.drain().then(() => acquired.release());
+      await nextEventLoopTurn();
+      expect(fixture.connection().database.isOpen).toBe(true);
+      fixture.state.finishStop.resolve();
+      await fixture.state.stopFinished.promise;
+      await released;
+      expect(fixture.connection().lateRead).toBe(42);
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      fixture.state.finishStop.resolve();
+      await fixture.state.stopFinished.promise;
+      await work.drain();
+      await released;
+      await acquired.release();
+      await fixture.cleanup();
+    }
+  });
+});

--- a/src/plugins/one-shot-diagnostics.test.ts
+++ b/src/plugins/one-shot-diagnostics.test.ts
@@ -6,12 +6,12 @@ import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginServicesHandle } from "./services.js";
 import type { OpenClawPluginService, OpenClawPluginServiceContext } from "./types.js";
 
-const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+const acquirePluginRegistryForInspection = vi.hoisted(() => vi.fn());
 const startPluginServices = vi.hoisted(() => vi.fn());
 const waitForDiagnosticEventsDrained = vi.hoisted(() => vi.fn(async () => {}));
 const warn = vi.hoisted(() => vi.fn());
 
-vi.mock("./loader.js", () => ({ loadOpenClawPlugins }));
+vi.mock("./loader.js", () => ({ acquirePluginRegistryForInspection }));
 vi.mock("./services.js", () => ({ startPluginServices }));
 vi.mock("../logging/subsystem.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../logging/subsystem.js")>()),
@@ -38,7 +38,10 @@ function mockRegistryWithServices(serviceIds: string[]) {
       origin: "bundled",
     })),
   };
-  loadOpenClawPlugins.mockReturnValue(registry);
+  acquirePluginRegistryForInspection.mockResolvedValue({
+    registry,
+    release: vi.fn(async () => {}),
+  });
   return registry;
 }
 
@@ -47,7 +50,10 @@ async function mockRealExporter(service: OpenClawPluginService, origin: "bundled
     await vi.importActual<typeof import("./services.js")>("./services.js");
   const registry = createEmptyPluginRegistry();
   registry.services.push({ pluginId: "diagnostics-otel", service, source: "test", origin });
-  loadOpenClawPlugins.mockReturnValue(registry);
+  acquirePluginRegistryForInspection.mockResolvedValue({
+    registry,
+    release: vi.fn(async () => {}),
+  });
   let servicesHandle: PluginServicesHandle | undefined;
   startPluginServices.mockImplementationOnce(
     async (params: Parameters<typeof startRealServices>[0]) => {
@@ -73,7 +79,7 @@ describe("startOneShotDiagnosticsExporters", () => {
     const handle = await startOneShotDiagnosticsExporters({ config: config as OpenClawConfig });
 
     expect(handle).toBeNull();
-    expect(loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(acquirePluginRegistryForInspection).not.toHaveBeenCalled();
     expect(startPluginServices).not.toHaveBeenCalled();
   });
 
@@ -84,11 +90,10 @@ describe("startOneShotDiagnosticsExporters", () => {
     const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
 
     expect(handle).not.toBeNull();
-    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+    expect(acquirePluginRegistryForInspection).toHaveBeenCalledWith(
       expect.objectContaining({
         config: otelEnabledConfig,
         onlyPluginIds: ["diagnostics-otel"],
-        activate: false,
         preferBuiltPluginArtifacts: true,
       }),
     );

--- a/src/plugins/one-shot-diagnostics.ts
+++ b/src/plugins/one-shot-diagnostics.ts
@@ -1,6 +1,7 @@
 /** Starts diagnostics exporter plugin services for one-shot CLI embedded agent runs. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { AsyncWorkScope, captureAsyncWorkTracker } from "../shared/async-work-scope.js";
 
 const log = createSubsystemLogger("plugins");
 
@@ -68,50 +69,79 @@ export async function startOneShotDiagnosticsExporters(params: {
   if (!isOtelExportConfigured(config)) {
     return null;
   }
-  const [{ loadOpenClawPlugins }, { startPluginServices }] = await Promise.all([
+  const [{ acquirePluginRegistryForInspection }, { startPluginServices }] = await Promise.all([
     import("./loader.js"),
     import("./services.js"),
   ]);
   // Scoped, non-activating load: honors the same plugin enablement config as
   // the gateway's startup load without replacing the active runtime registry
   // the embedded run resolves providers/tools from.
-  const registry = loadOpenClawPlugins({
+  const acquired = await acquirePluginRegistryForInspection({
     config,
     onlyPluginIds: [...ONE_SHOT_DIAGNOSTICS_SERVICE_IDS],
-    activate: false,
     preferBuiltPluginArtifacts: true,
   });
-  // The scope-piggyback loader rules (e.g. dreaming sidecars) can widen a
-  // scoped load, so re-filter to the flush-safe exporter allowlist.
-  const services = registry.services.filter((entry) =>
-    ONE_SHOT_DIAGNOSTICS_SERVICE_IDS.has(entry.service.id),
-  );
-  if (services.length === 0) {
-    // diagnostics-otel is an external plugin, so "enabled in config, never
-    // installed" is an ordinary state. Say so: the run would otherwise export
-    // nothing with nothing explaining why.
-    log.warn(
-      "diagnostics.otel is enabled but the diagnostics-otel plugin is not installed or not enabled; this run exports no telemetry.",
-    );
-    return null;
-  }
-  const handle = await startPluginServices({
-    registry: { ...registry, services },
-    config,
-    oneShotStopTimeouts: {
-      eventDrainMs: ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS,
-      serviceStopMs: ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS,
-    },
-  });
-  return {
-    stop: async () => {
-      try {
-        await handle.stop();
-      } catch (error) {
-        for (const failure of error instanceof AggregateError ? error.errors : [error]) {
-          log.warn(`one-shot diagnostics shutdown failed: ${String(failure)}`);
-        }
-      }
-    },
+  const work = new AsyncWorkScope();
+  let servicesHandle: Awaited<ReturnType<typeof startPluginServices>> | undefined;
+  let shutdown: { stopping: Promise<void>; released: Promise<void> } | undefined;
+  const reportShutdownFailure = (error: unknown) => {
+    for (const failure of error instanceof AggregateError ? error.errors : [error]) {
+      log.warn(`one-shot diagnostics shutdown failed: ${String(failure)}`);
+    }
   };
+  const release = async () => {
+    await work.drain();
+    await acquired.release();
+  };
+  const stop = () => {
+    // Every caller retains physical cleanup, including callers after a bounded stop settled.
+    const trackCaller = captureAsyncWorkTracker();
+    if (!shutdown) {
+      const stopping = work.track(async () => {
+        try {
+          await servicesHandle?.stop();
+        } catch (error) {
+          reportShutdownFailure(error);
+        }
+      });
+      // Cleanup must run even if a retained callback restores a closed caller scope.
+      const released = stopping.then(release, release).catch(reportShutdownFailure);
+      shutdown = { stopping, released };
+    }
+    const { stopping, released } = shutdown;
+    void trackCaller(() => released).catch(reportShutdownFailure);
+    return stopping;
+  };
+  try {
+    // The scope-piggyback loader rules (e.g. dreaming sidecars) can widen a
+    // scoped load, so re-filter to the flush-safe exporter allowlist.
+    const services = acquired.registry.services.filter((entry) =>
+      ONE_SHOT_DIAGNOSTICS_SERVICE_IDS.has(entry.service.id),
+    );
+    if (services.length === 0) {
+      // Enabled but not installed is ordinary; explain why this run exports nothing.
+      log.warn(
+        "diagnostics.otel is enabled but the diagnostics-otel plugin is not installed or not enabled; this run exports no telemetry.",
+      );
+      await release().catch(reportShutdownFailure);
+      return null;
+    }
+    servicesHandle = await work.track(() =>
+      startPluginServices({
+        registry: { ...acquired.registry, services },
+        config,
+        oneShotStopTimeouts: {
+          eventDrainMs: ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS,
+          serviceStopMs: ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS,
+        },
+        onHandle: (handle) => {
+          servicesHandle = handle;
+        },
+      }),
+    );
+    return { stop };
+  } catch (error) {
+    await stop();
+    throw error;
+  }
 }

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -15,6 +15,7 @@ import {
   type DiagnosticExporterHealthUpdate,
 } from "../logging/diagnostic-stability.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveRuntimeServiceBuildId } from "../version.js";
 import {
@@ -260,20 +261,24 @@ export async function startPluginServices(params: {
     entry.stopping = true;
     try {
       const cleanup = () => {
-        if (entry.cleanup) {
-          return entry.cleanup;
+        if (!entry.cleanup) {
+          try {
+            // Deadlines bound observers; raw startup still owns the one final cleanup.
+            const ready = beforeStop ? beforeStop.then(() => entry.startup) : entry.startup;
+            const invokeStop = () =>
+              withPluginHttpRouteRegistry(params.registry, () => entry.stop?.(), entry.lease);
+            entry.cleanup = ready ? ready.then(invokeStop) : Promise.resolve(invokeStop());
+          } catch (error) {
+            const failure = createDeferredCore();
+            failure.reject(error);
+            entry.cleanup = failure.promise;
+          }
         }
-        try {
-          // Deadlines bound observers; raw startup still owns the one final cleanup.
-          const ready = beforeStop ? beforeStop.then(() => entry.startup) : entry.startup;
-          const invokeStop = () =>
-            withPluginHttpRouteRegistry(params.registry, () => entry.stop?.(), entry.lease);
-          return (entry.cleanup = ready ? ready.then(invokeStop) : Promise.resolve(invokeStop()));
-        } catch (error) {
-          const failure = createDeferredCore();
-          failure.reject(error);
-          return (entry.cleanup = failure.promise);
-        }
+        const cleanupPromise = entry.cleanup;
+        // Track custody separately: an async wrapper can change a zero-budget deadline race.
+        // The deadline path already reports the original cleanup rejection.
+        void trackAsyncWork(() => cleanupPromise).catch(() => {});
+        return cleanupPromise;
       };
       await runBeforeDeadline(
         cleanup,


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes one-shot diagnostic exporters retaining registration resources after a local agent command finishes. Cleanup can continue after its stop timeout, so those resources must remain usable until cleanup actually settles.

## Why This Change Was Made

One-shot exporters now use the existing owned inspection acquisition and release it after actual service cleanup. Every stop caller retains the same physical cleanup, including later callers joining a previously timed-out stop. Service deadline races continue using their original raw promises, preserving synchronous completion at an expired deadline.

## User Impact

Exporter registration resources close once after their last use. Existing five-second event-drain and ten-second flush waits, diagnostic privileges, and warning behavior remain intact. A closed caller context cannot suppress cleanup, and a missing exporter service releases its registration before returning.

## Evidence

The final change passed 10 native SQLite cases, 66 existing one-shot/service tests, the full five-file changed gate, formatting/typed lint, and an ordinary build. Independent Codex review found no remaining actionable defects after two cached-caller ownership gaps were reproduced and corrected.

A real compiled `openclaw agent --local --json` invocation used an isolated workspace, synthetic exporter and loopback model endpoint. It returned `ready` in 2.02 seconds; the exporter read SQLite during stop, closed it through registration disposal, and reopened the file with the expected value. The ordinary plugin received no privileged diagnostic grant. This proves the CLI/service/resource boundary, not delivery to an external telemetry collector. The build took 223.6 seconds.
