### PR TITLE
fix: ChatGPT OAuth tool payload keeps strict=null instead of false

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -669,7 +669,7 @@ function buildRequestBody(
   }
 
   if (context.tools) {
-    const tools = convertResponsesToolPayload(context.tools, { strict: null });
+    const tools = convertResponsesToolPayload(context.tools, { strict: false });
     if (tools.length > 0) {
       body.tools = tools;
       body.tool_choice = "auto";


### PR DESCRIPTION
Closes #142377

## What Problem This Solves

Fixes an issue where users of the ChatGPT OAuth Responses route would have their function tools' optional parameters silently promoted to required fields, breaking the tool's original schema contract.

## Why This Change Was Made

`convertResponsesToolPayload` was called with `strict: null` when building the ChatGPT OAuth request body, letting the backend apply its default strict-mode normalization instead of explicitly opting out. Changed it to `strict: false`, matching how native Codex's own request builder (`responses_api.rs`) always serializes this field.

## User Impact

Function tools with optional scalar fields on the ChatGPT OAuth route now keep their original optional/required schema instead of having all fields silently forced to required, preserving intended tool behavior.

## Evidence

This is a single-line change matching the exact fix the issue reporter already identified (`strict: null` → `strict: false` in `buildRequestBody`). I made this edit directly via github.dev and have not independently run the test suite in this environment — no local clone/Node setup was used. The issue itself documents the before/after regression results (2 failing → passing, 135 tests green) from the reporter's own investigation; I have not reproduced those results myself.
