### PR TITLE
fix(installer): default 2026.6.35 installs to Node 24

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -52,7 +52,9 @@ resolve_openclaw_effective_home() {
 OPENCLAW_EFFECTIVE_HOME="$(resolve_openclaw_effective_home)"
 PREFIX="${OPENCLAW_PREFIX:-${HOME}/.openclaw}"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-latest}"
-NODE_VERSION="${OPENCLAW_NODE_VERSION:-22.22.3}"
+DEFAULT_NODE_VERSION="24.19.0"
+NODE_VERSION="${OPENCLAW_NODE_VERSION:-$DEFAULT_NODE_VERSION}"
+NODE_VERSION_DEFAULTED="$([[ -z "${OPENCLAW_NODE_VERSION:-}" ]] && echo 1 || echo 0)"
 MIN_NODE_VERSION="22.19.0"
 APK_NODE_BIN_DIR="/usr/bin"
 NPM_LOGLEVEL="${OPENCLAW_NPM_LOGLEVEL:-error}"
@@ -74,7 +76,7 @@ Usage: install-cli.sh [options]
   --git, --github                     Shortcut for --install-method git
   --git-dir, --dir <path>             Checkout directory (default: ~/openclaw, or \$OPENCLAW_HOME/openclaw)
   --version <ver>                     OpenClaw version (default: latest)
-  --node-version <ver>                Node version (default: 22.22.3)
+  --node-version <ver>                Node version (default: 24.19.0; Alpine uses distro Node >=22.19.0)
   --onboard                           Run "openclaw onboard" after install
   --no-onboard                        Skip onboarding (default)
   --set-npm-prefix                    Force npm prefix to ~/.npm-global if current prefix is not writable (Linux)
@@ -269,6 +271,7 @@ parse_args() {
           fail "Missing value for $1"
         fi
         NODE_VERSION="$2"
+        NODE_VERSION_DEFAULTED=0
         shift 2
         ;;
       --install-method|--method)
@@ -767,6 +770,11 @@ install_node() {
   dir="$(node_dir)"
 
   if [[ "$os" == "linux" ]] && command -v apk >/dev/null 2>&1 && is_musl_linux; then
+    if [[ "$NODE_VERSION_DEFAULTED" -eq 1 && "$NODE_VERSION" == "$DEFAULT_NODE_VERSION" ]]; then
+      NODE_VERSION="$MIN_NODE_VERSION"
+      PATH="$(node_dir)/bin:${PATH}"
+      export PATH
+    fi
     install_alpine_node
     return
   fi
@@ -812,7 +820,7 @@ install_node() {
     local required_version
     installed_version="$("$(node_bin)" -v 2>/dev/null || echo unknown)"
     required_version="$(required_node_version)"
-    fail "Installed Node ${NODE_VERSION} must provide Node >= ${required_version} with node:sqlite; found ${installed_version}. Re-run with --node-version 22.22.3 (or newer)"
+    fail "Installed Node ${NODE_VERSION} must provide Node >= ${required_version} with node:sqlite; found ${installed_version}. Re-run with --node-version 24.19.0 (or newer)"
   fi
   emit_json "{\"event\":\"step\",\"name\":\"node\",\"status\":\"ok\",\"version\":\"${NODE_VERSION}\"}"
 }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -85,7 +85,7 @@ describe("install-cli.sh", () => {
     expect(output).toContain(`git=${join(openclawHome, "openclaw")}`);
   });
 
-  it("defaults user-space Node installs to the current supported Node 22 patch", () => {
+  it("defaults user-space Node installs to Node 24", () => {
     const result = runInstallCliShell(`
       set -euo pipefail
       source "${SCRIPT_PATH}"
@@ -95,9 +95,11 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("node=22.22.3");
-    expect(result.stdout).toContain("required=22.22.3");
-    expect(result.stdout).toContain("Node version (default: 22.22.3)");
+    expect(result.stdout).toContain("node=24.19.0");
+    expect(result.stdout).toContain("required=24.19.0");
+    expect(result.stdout).toContain(
+      "Node version (default: 24.19.0; Alpine uses distro Node >=22.19.0)",
+    );
   });
 
   it("resolves requested git install versions to checkout refs", () => {
@@ -181,10 +183,7 @@ describe("install-cli.sh", () => {
     mkdirSync(bin, { recursive: true });
     mkdirSync(outer, { recursive: true });
     mkdirSync(repo, { recursive: true });
-    writeFileSync(
-      join(outer, "package.json"),
-      '{\n  "packageManager": "yarn@4.5.0"\n}\n',
-    );
+    writeFileSync(join(outer, "package.json"), '{\n  "packageManager": "yarn@4.5.0"\n}\n');
     writeFileSync(
       join(repo, "package.json"),
       '{\n  "packageManager": "pnpm@11.2.2+sha512.test"\n}\n',
@@ -411,7 +410,7 @@ describe("install-cli.sh", () => {
     }
   });
 
-  it("uses apk-managed Node and Git on Alpine/musl when the existing Node is unusable", () => {
+  it("uses the supported distro Node floor for default Alpine/musl installs", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-alpine-apk-"));
     const bin = join(tmp, "bin");
     const prefix = join(tmp, "prefix");
@@ -471,8 +470,8 @@ describe("install-cli.sh", () => {
           "is_root() { return 0; }",
           `PREFIX=${JSON.stringify(prefix)}`,
           `APK_NODE_BIN_DIR=${JSON.stringify(bin)}`,
-          "NODE_VERSION=22.22.0",
           "install_node",
+          'printf "node-command=%s\\n" "$(command -v node)"',
         ].join("\n"),
         {
           APK_LOG: apkLog,
@@ -484,8 +483,9 @@ describe("install-cli.sh", () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("Installing Node via apk");
       expect(readFileSync(apkLog, "utf8")).toContain("add --no-cache nodejs npm");
-      const nodeLink = join(prefix, "tools", "node-v22.22.0", "bin", "node");
-      const npmLink = join(prefix, "tools", "node-v22.22.0", "bin", "npm");
+      const nodeLink = join(prefix, "tools", "node-v22.19.0", "bin", "node");
+      const npmLink = join(prefix, "tools", "node-v22.19.0", "bin", "npm");
+      expect(result.stdout).toContain(`node-command=${nodeLink}`);
       expect(lstatSync(nodeLink).isSymbolicLink()).toBe(true);
       expect(readlinkSync(nodeLink)).toBe(fakeNode);
       expect(readlinkSync(npmLink)).toBe(fakeNpm);
@@ -970,7 +970,7 @@ describe("install-cli.sh", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-freshness-"));
     const prefix = join(tmp, "prefix");
     const home = join(tmp, "home");
-    const nodeBin = join(prefix, "tools/node-v22.22.3/bin");
+    const nodeBin = join(prefix, "tools/node-v24.19.0/bin");
     const argsLog = join(tmp, "npm-args.log");
     mkdirSync(nodeBin, { recursive: true });
     mkdirSync(home, { recursive: true });
@@ -1006,7 +1006,7 @@ describe("install-cli.sh", () => {
     const prefix = join(tmp, "prefix");
     const home = join(tmp, "home");
     const project = join(tmp, "project");
-    const nodeBin = join(prefix, "tools/node-v22.22.3/bin");
+    const nodeBin = join(prefix, "tools/node-v24.19.0/bin");
     const argsLog = join(tmp, "npm-args.log");
     mkdirSync(nodeBin, { recursive: true });
     mkdirSync(home, { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.6.35 non-root CLI installer provisioned Node 22.22.3, then could not install current OpenClaw packages that require Node 24 or newer.

## Why This Change Was Made

Updates the shipped user-space installer default and recovery guidance to Node 24.19.0. The release still accepts explicitly selected Node versions allowed by its existing runtime contract; this changes only the safe default.

## User Impact

Fresh non-root installs from the 2026.6.35 installer use a Node runtime compatible with current OpenClaw packages.

## Evidence

- Red: [2026.6.35 non-root installer smoke](https://github.com/openclaw/openclaw/actions/runs/34262060226/job/102184176440) provisioned Node 22.22.3 and failed the package's Node >=24.16 preinstall gate.
- Green: `node scripts/run-vitest.mjs test/scripts/install-cli.test.ts` — 21/21.
- `bash -n scripts/install-cli.sh`
- Oxfmt, OXLint, and `git diff --check` pass.
- Production: +3/-3; tests: +7/-10.
