### PR TITLE
fix(release): validate Bun-installed runtime under Bun

### DIFF
--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -41,7 +41,6 @@ INSTALL_LOG=""
 UNTRUSTED_LOG=""
 CLI_STATUS_LOG=""
 CLI_PLUGINS_LOG=""
-DIRECT_BUN_LOG=""
 MOCK_LOG=""
 MOCK_REQUEST_LOG=""
 LOCAL_AGENT_LOG=""
@@ -69,7 +68,6 @@ dump_debug_logs() {
     "$UNTRUSTED_LOG" \
     "$CLI_STATUS_LOG" \
     "$CLI_PLUGINS_LOG" \
-    "$DIRECT_BUN_LOG" \
     "$MOCK_LOG" \
     "$MOCK_REQUEST_LOG" \
     "$LOCAL_AGENT_LOG" \
@@ -340,22 +338,20 @@ NODE
   echo "==> OpenClaw help through Bun global install"
   run_with_timeout "$COMMAND_TIMEOUT_MS" "$openclaw_bin" --help >/dev/null
 
-  run_installed_cli() {
-    run_with_timeout "$COMMAND_TIMEOUT_MS" "$openclaw_bin" "$@"
+  run_bun_cli() {
+    run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" "$openclaw_entry" "$@"
   }
 
-  echo "==> Installed package rejects direct Bun runtime execution"
-  DIRECT_BUN_LOG="$SMOKE_DIR/direct-bun.log"
-  if run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" "$openclaw_entry" --version \
-    >"$DIRECT_BUN_LOG" 2>&1; then
-    echo "OpenClaw unexpectedly ran under the unsupported Bun runtime" >&2
-    exit 1
-  fi
-  grep -F "Bun runtime is unsupported" "$DIRECT_BUN_LOG" >/dev/null
+  echo "==> Installed package entry under Bun"
+  run_bun_cli --version
+  run_bun_cli --help >/dev/null
+  pushd "$HOME" >/dev/null
+  run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" run --bun openclaw --version
+  popd >/dev/null
 
-  echo "==> OpenClaw image providers from Bun global install"
+  echo "==> OpenClaw image providers under Bun"
   local providers_json
-  providers_json="$(run_installed_cli infer image providers --json)"
+  providers_json="$(run_bun_cli infer image providers --json)"
   OPENCLAW_IMAGE_PROVIDERS_JSON="$providers_json" node scripts/e2e/lib/bun-global-install/assertions.mjs assert-image-providers
 
   read -r gateway_port mock_port < <(reserve_runtime_ports)
@@ -367,15 +363,15 @@ NODE
     "$mock_port" \
     "$gateway_port"
 
-  echo "==> Representative CLI state from Bun global install"
-  run_installed_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
-  run_installed_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
+  echo "==> Representative CLI state under Bun"
+  run_bun_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
+  run_bun_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
 
-  echo "==> Local mocked agent turn from Bun global install"
+  echo "==> Local mocked agent turn under Bun"
   MOCK_PID="$(openclaw_e2e_start_mock_openai "$mock_port" "$MOCK_LOG")"
   openclaw_e2e_wait_mock_openai "$mock_port"
   : >"$MOCK_REQUEST_LOG"
-  run_installed_cli agent --local \
+  run_bun_cli agent --local \
     --agent main \
     --session-id bun-global-local-agent \
     --message "Return marker $success_marker" \
@@ -387,21 +383,22 @@ NODE
     "$LOCAL_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "==> Gateway health and mocked agent turn from Bun global install"
+  echo "==> Gateway health and mocked agent turn under Bun"
   : >"$MOCK_REQUEST_LOG"
   GATEWAY_PID="$(
     openclaw_e2e_start_tracked_process \
       "$GATEWAY_LOG" \
-      "$openclaw_bin" \
+      "$bun_path" \
+      "$openclaw_entry" \
       gateway \
       --port "$gateway_port" \
       --bind loopback
   )"
   openclaw_e2e_wait_gateway_ready "$GATEWAY_PID" "$GATEWAY_LOG" 300 "$gateway_port"
-  run_installed_cli gateway health \
+  run_bun_cli gateway health \
     --token "$OPENCLAW_GATEWAY_TOKEN" \
     --json >"$GATEWAY_HEALTH_LOG" 2>&1
-  run_installed_cli agent \
+  run_bun_cli agent \
     --agent main \
     --session-id bun-global-gateway-agent \
     --message "Return marker $success_marker" \
@@ -413,7 +410,7 @@ NODE
     "$GATEWAY_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "bun-global-install-smoke: Bun $bun_version package install and Node CLI/runtime OK"
+  echo "bun-global-install-smoke: Bun $bun_version package, CLI, local agent, and Gateway runtime OK"
 
   if [ -n "${OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH:-}" ]; then
     node --input-type=module - \

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2568,8 +2568,8 @@ if [[ "\${1:-}" == */verify-fs-safe-native.mjs ]]; then
   exit 0
 fi
 if [[ "\${1:-}" == */openclaw.mjs ]]; then
-  echo "openclaw: the Bun runtime is unsupported because OpenClaw requires node:sqlite." >&2
-  exit 1
+  shift
+  exec node "$BUN_INSTALL/install/global/node_modules/openclaw/openclaw.mjs" "$@"
 fi
 test "\${1:-}" = "install"
 case " $* " in
@@ -2663,13 +2663,13 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
     expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
     if (statusExit === 0) {
       expect(result.stdout).toContain(
-        "bun-global-install-smoke: Bun 1.4.0 package install and Node CLI/runtime OK",
+        "bun-global-install-smoke: Bun 1.4.0 package, CLI, local agent, and Gateway runtime OK",
       );
     } else {
       expect(result.stderr).toContain("bun global install smoke failed with exit code 23");
       expect(result.stderr).toContain("synthetic Bun status failure");
       expect(result.stderr).not.toContain("failure log omitted");
-      expect(result.stdout).not.toContain("Node CLI/runtime OK");
+      expect(result.stdout).not.toContain("Gateway runtime OK");
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation rejected a Bun-installed OpenClaw package even though Bun 1.4 provides the required `node:sqlite` runtime and the launcher supports it.

## Why This Change Was Made

Restores the owner-level Bun runtime proof that was removed by #142034. The smoke again runs the installed CLI, provider discovery, local agent turn, Gateway, and Gateway agent turn under Bun; unsupported Bun builds still fail through the launcher's existing feature gate.

## User Impact

Bun 1.4 installations are validated as a supported runtime instead of being incorrectly classified as unsupported.

## Evidence

- Red: [2026.6.35 Bun global install smoke](https://github.com/openclaw/openclaw/actions/runs/34262060226/job/102184176307) reached `OpenClaw 2026.6.35`, then failed only because the harness demanded direct Bun rejection.
- Green: `node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts` — 120/120.
- `bash -n scripts/e2e/bun-global-install-smoke.sh`
- Oxfmt, OXLint, and `git diff --check` pass.
- Production/tooling: +21/-24; tests: +4/-4.
