### PR TITLE
fix(opencode-go): give 7.33 live probes stable session identity

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -432,6 +432,40 @@ describe("opencode-go provider plugin", () => {
     ]);
   });
 
+  it("adds the OpenCode session header to direct completions", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedOptions: unknown[] = [];
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      capturedOptions.push(options);
+      return {} as never;
+    };
+
+    const streamFn = provider.wrapSimpleCompletionStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "opencode-go",
+      modelId: "glm-5",
+    } as never);
+
+    expect(streamFn).toBeTypeOf("function");
+    await streamFn?.(
+      {
+        provider: "opencode-go",
+        id: "glm-5",
+        api: "openai-completions",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+      } as never,
+      {} as never,
+      { sessionId: "live-probe-session" },
+    );
+
+    expect(capturedOptions).toEqual([
+      {
+        sessionId: "live-probe-session",
+        headers: { "x-opencode-session": "live-probe-session" },
+      },
+    ]);
+  });
+
   it("canonicalizes stale OpenCode Go base URLs", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -12,7 +12,7 @@ import {
   normalizeOpencodeGoResolvedModel,
   resolveOpencodeGoModel,
 } from "./provider-catalog.js";
-import { createOpencodeGoWrapper } from "./stream.js";
+import { createOpencodeGoSessionHeaderWrapper, createOpencodeGoWrapper } from "./stream.js";
 
 const PROVIDER_ID = "opencode-go";
 const OPENCODE_SHARED_PROFILE_IDS = ["opencode:default", "opencode-go:default"] as const;
@@ -137,6 +137,7 @@ export default definePluginEntry({
       augmentModelCatalog: () => listOpencodeGoModelCatalogEntries(),
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
       wrapStreamFn: (ctx) => createOpencodeGoWrapper(ctx.streamFn, ctx.thinkingLevel),
+      wrapSimpleCompletionStreamFn: (ctx) => createOpencodeGoSessionHeaderWrapper(ctx.streamFn),
       isModernModelRef: () => true,
     });
     api.registerMediaUnderstandingProvider(opencodeGoMediaUnderstandingProvider);

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -1450,6 +1450,19 @@ async function completeSimpleWithTimeout<TApi extends Api>(
   }
 }
 
+function resolveLiveModelSessionId(model: Pick<Model, "id" | "provider">): string | undefined {
+  return model.provider === "opencode-go" ? `openclaw-live-model-${model.id}` : undefined;
+}
+
+describe("resolveLiveModelSessionId", () => {
+  it("gives direct OpenCode Go probes a stable conversation identity", () => {
+    expect(resolveLiveModelSessionId({ provider: "opencode-go", id: "glm-5" })).toBe(
+      "openclaw-live-model-glm-5",
+    );
+    expect(resolveLiveModelSessionId({ provider: "openai", id: "gpt-5" })).toBeUndefined();
+  });
+});
+
 function requireToolChoicePayload(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return undefined;
@@ -1485,6 +1498,9 @@ async function completeOkWithRetry(params: {
   progressLabel: string;
 }) {
   const runOnce = async (maxTokens: number) => {
+    // OpenCode Go requires a stable conversation identity. Normal agent turns
+    // provide one; this direct transport probe must model that contract too.
+    const sessionId = resolveLiveModelSessionId(params.model);
     const res = await completeSimpleWithTimeout(
       params.model,
       {
@@ -1501,6 +1517,7 @@ async function completeOkWithRetry(params: {
         apiKey: params.apiKey,
         reasoning: resolveTestReasoning(params.model),
         maxTokens,
+        ...(sessionId ? { sessionId } : {}),
       },
       params.timeoutMs,
       `${params.progressLabel}: prompt call (maxTokens=${maxTokens})`,


### PR DESCRIPTION
## Summary
- supply a stable `sessionId` to direct OpenCode Go live-model probes
- keep other provider probes unchanged
- cover the provider-scoped identity contract

## Why
The 7.33 provider wrapper correctly derives `x-opencode-session` from normal agent-turn session IDs. The direct release live-model probe bypassed that normal caller contract and supplied no session ID, so OpenCode rejected all four Go models with HTTP 400.

## Validation
- `pnpm exec vitest run --config test/vitest/vitest.live.config.ts src/agents/models.profiles.live.test.ts --testNamePattern resolveLiveModelSessionId`
- `pnpm exec oxfmt --check src/agents/models.profiles.live.test.ts`