### PR TITLE
fix: tool previews alter filenames and slow down on large batches

### DIFF
--- a/src/agents/tool-display-common.test.ts
+++ b/src/agents/tool-display-common.test.ts
@@ -7,6 +7,98 @@ import { describe, expect, it } from "vitest";
 import { resolveToolVerbAndDetailForArgs } from "./tool-display-common.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
+describe("tool detail separators", () => {
+  it.each([
+    {
+      input: { name: "read", args: { path: "/notes/Project · Notes.md" } },
+      expected: "from /notes/Project · Notes.md",
+    },
+    {
+      input: { name: "web_search", args: { query: "Project · Notes" } },
+      expected: 'for "Project · Notes"',
+    },
+    {
+      input: {
+        name: "image",
+        args: { path: "/notes/Project · Notes.png", prompt: "Summarize A · B" },
+      },
+      expected: "path /notes/Project · Notes.png, prompt Summarize A · B",
+    },
+    {
+      input: { name: "custom_tool", meta: "Project · Notes" },
+      expected: "Project · Notes",
+    },
+    {
+      input: {
+        name: "exec",
+        args: {
+          command: 'cat "/notes/Project · Notes.md"',
+          host: "node",
+          node: "preview-node",
+          workdir: "/app",
+        },
+      },
+      expected:
+        'show /notes/Project · Notes.md (in /app), node: preview-node, `cat "/notes/Project · Notes.md"`',
+    },
+    {
+      input: {
+        name: "exec",
+        args: { command: "npm install", host: "node", node: "preview-node", workdir: "/app" },
+      },
+      expected: "install dependencies (in /app), node: preview-node, `npm install`",
+    },
+  ])("preserves literal details and formats owned separators: $expected", ({ input, expected }) => {
+    expect(formatToolDetail(resolveToolDisplay(input))).toBe(expected);
+  });
+});
+
+describe("bounded tool detail previews", () => {
+  it("stops reading an upload batch once the preview and ellipsis are determined", () => {
+    let reads = 0;
+    const paths = new Proxy(
+      Array.from({ length: 1_000 }, (_, index) => `/uploads/photo-${index + 1}.jpg`),
+      {
+        get(target, key, receiver) {
+          if (typeof key === "string" && /^\d+$/.test(key)) {
+            reads++;
+          }
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+
+    expect(resolveToolDisplay({ name: "browser", args: { action: "upload", paths } }).detail).toBe(
+      "/uploads/photo-1.jpg, /uploads/photo-2.jpg, /uploads/photo-3.jpg…",
+    );
+    expect(reads).toBeLessThanOrEqual(4);
+  });
+
+  it.each([
+    { value: [], expected: undefined, includeFalsy: false },
+    { value: [null, "", false, 0], expected: undefined, includeFalsy: false },
+    { value: [null, "", false, 0], expected: "false, 0", includeFalsy: true },
+    { value: ["a", "b", "c", "", null], expected: "a, b, c", includeFalsy: false },
+    { value: ["a", "b", "c", "", "d"], expected: "a, b, c…", includeFalsy: false },
+    { value: [["a", "b", "c", "d"], [], "e"], expected: "a, b, c…, e", includeFalsy: false },
+    {
+      value: "\n  First line\r\nSecond line\nThird line",
+      expected: "First line",
+      includeFalsy: false,
+    },
+  ])("preserves compact detail semantics: $value", ({ value, expected, includeFalsy }) => {
+    expect(
+      resolveToolVerbAndDetailForArgs({
+        toolKey: "custom_tool",
+        args: { note: value },
+        fallbackDetailKeys: ["note"],
+        detailMode: "first",
+        detailCoerce: { includeFalsy },
+      }).detail,
+    ).toBe(expected);
+  });
+});
+
 function isHighSurrogate(codeUnit: number): boolean {
   return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
 }

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -126,7 +126,7 @@ function coerceDisplayValue(
     if (!trimmed) {
       return undefined;
     }
-    const rawLine = normalizeOptionalString(trimmed.split(/\r?\n/)[0]) ?? "";
+    const rawLine = normalizeOptionalString(trimmed.split(/\r?\n/, 1)[0]) ?? "";
     if (!rawLine) {
       return undefined;
     }
@@ -153,22 +153,18 @@ function coerceDisplayValue(
   }
   if (Array.isArray(value)) {
     const values: string[] = [];
-    let displayValueCount = 0;
     for (const item of value) {
       const display = coerceDisplayValue(item, opts);
       if (!display) {
         continue;
       }
-      displayValueCount += 1;
-      if (values.length < 3) {
-        values.push(display);
+      // The fourth visible value determines the ellipsis; later items cannot affect the preview.
+      if (values.length === 3) {
+        return `${values.join(", ")}…`;
       }
+      values.push(display);
     }
-    if (displayValueCount === 0) {
-      return undefined;
-    }
-    const preview = values.join(", ");
-    return displayValueCount > 3 ? `${preview}…` : preview;
+    return values.length > 0 ? values.join(", ") : undefined;
   }
   return undefined;
 }
@@ -724,7 +720,7 @@ function resolveDetailFromKeys(
       parts.push(`${entry.label} ${entry.value}`);
     }
   }
-  return parts.join(" · ");
+  return parts.join(", ");
 }
 
 function resolveToolVerbAndDetail(params: {
@@ -788,29 +784,4 @@ function resolveToolVerbAndDetail(params: {
   return { verb, detail };
 }
 
-/** Normalize final detail text before attaching it to a tool display line. */
-export function formatToolDetailText(
-  detail: string | undefined,
-  opts: { prefixWithWith?: boolean } = {},
-): string | undefined {
-  if (!detail) {
-    return undefined;
-  }
-  const normalized = detail.includes(" · ")
-    ? (() => {
-        const parts: string[] = [];
-        for (const part of detail.split(" · ")) {
-          const trimmed = part.trim();
-          if (trimmed) {
-            parts.push(trimmed);
-          }
-        }
-        return parts.join(", ");
-      })()
-    : detail;
-  if (!normalized) {
-    return undefined;
-  }
-  return opts.prefixWithWith ? `with ${normalized}` : normalized;
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -716,7 +716,7 @@ export function resolveExecDetail(
       : typeof record.cwd === "string"
         ? record.cwd
         : undefined;
-  const nodeFragment = nodeName ? ` · node: ${nodeName}` : "";
+  const nodeFragment = nodeName ? `, node: ${nodeName}` : "";
   if (hasShellCompoundCommand(unwrapped)) {
     const cwdSuffix = cwdRaw?.trim() ? formatCwdSuffix(cwdRaw.trim()) : undefined;
     return `${cwdSuffix ? `${compact} ${cwdSuffix}` : compact}${nodeFragment}`;
@@ -741,7 +741,7 @@ export function resolveExecDetail(
     compact !== displaySummary &&
     compact !== summary
   ) {
-    return `${displaySummary}${nodeFragment} · ${formatInlineCodeSpan(compact)}`;
+    return `${displaySummary}${nodeFragment}, ${formatInlineCodeSpan(compact)}`;
   }
 
   return `${displaySummary}${nodeFragment}`;

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -12,7 +12,6 @@ import { redactToolDetail } from "../logging/redact.js";
 import { shortenHomeInString } from "../utils.js";
 import {
   defaultTitle,
-  formatToolDetailText,
   formatDetailKey,
   normalizeToolDisplayName,
   resolveToolVerbAndDetailForArgs,
@@ -94,8 +93,7 @@ export function resolveToolDisplay(params: {
 
 /** Formats and redacts detail text for display. */
 export function formatToolDetail(display: ToolDisplay): string | undefined {
-  const detailRaw = display.detail ? redactToolDetail(display.detail) : undefined;
-  return formatToolDetailText(detailRaw);
+  return display.detail ? redactToolDetail(display.detail) : undefined;
 }
 
 /** Infers compact display metadata for a tool invocation from its arguments. */

--- a/ui/src/lib/chat/tool-display.ts
+++ b/ui/src/lib/chat/tool-display.ts
@@ -3,7 +3,6 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import SHARED_TOOL_DISPLAY_JSON from "../../../../apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json" with { type: "json" };
 import {
   defaultTitle,
-  formatToolDetailText,
   normalizeToolDisplayName,
   resolveToolVerbAndDetailForArgs,
   type ToolDisplaySpec as ToolDisplaySpecBase,
@@ -145,7 +144,7 @@ export function resolveToolDisplay(params: {
 }
 
 export function formatToolDetail(display: ToolDisplay): string | undefined {
-  return formatToolDetailText(display.detail, { prefixWithWith: true });
+  return display.detail ? `with ${display.detail}` : undefined;
 }
 
 function isCanvasHttpPath(pathname: string): boolean {

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -1048,32 +1048,4 @@ describe("tool-cards", () => {
     expect(sidebar.docId).toBe("cv_sidebar");
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
   });
-
-  it("opens ambiguous tool details with the same sidebar output", () => {
-    const container = document.createElement("div");
-    const onOpenSidebar = vi.fn();
-    render(
-      renderToolCard(
-        {
-          id: "msg:tool:full",
-          name: "browser.open",
-          outputText: "Opened page",
-          messageId: "msg-tool-full",
-        },
-        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
-      ),
-      container,
-    );
-
-    const sidebarButton = container.querySelector<HTMLButtonElement>(".chat-tool-card__action-btn");
-    expect(sidebarButton).toBeInstanceOf(HTMLButtonElement);
-    sidebarButton!.click();
-
-    const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
-    expect(sidebar).toEqual({
-      kind: "markdown",
-      content: "## Browser.open\n\n**Tool:** `browser.open`\n\n### Tool output\nOpened page",
-      rawText: "Opened page",
-    });
-  });
 });

--- a/ui/src/pages/chat/components/chat-tool-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-sidebar.test.ts
@@ -1,0 +1,51 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { SidebarContent } from "./chat-sidebar.ts";
+import { renderToolCard } from "./chat-tool-cards.ts";
+
+describe("tool detail sidebar", () => {
+  it.each([
+    {
+      name: "browser.open",
+      args: undefined,
+      content: "## Browser.open\n\n**Tool:** `browser.open`\n\n### Tool output\nOpened page",
+    },
+    {
+      name: "read",
+      args: { path: "/notes/Project · Notes.md" },
+      content: expect.stringContaining("**Summary:** with from /notes/Project · Notes.md"),
+    },
+    {
+      name: "web_search",
+      args: { query: "Project · Notes" },
+      content: expect.stringContaining('**Summary:** with for "Project · Notes"'),
+    },
+  ])("opens $name details with literal output", ({ name, args, content }) => {
+    const container = document.createElement("div");
+    const onOpenSidebar = vi.fn<(content: SidebarContent) => void>();
+    render(
+      renderToolCard(
+        {
+          id: "msg:tool:full",
+          name,
+          args,
+          outputText: "Opened page",
+          messageId: "msg-tool-full",
+        },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
+      ),
+      container,
+    );
+
+    container.querySelector<HTMLButtonElement>(".chat-tool-card__action-btn")?.click();
+
+    expect(onOpenSidebar).toHaveBeenCalledOnce();
+    expect(onOpenSidebar.mock.calls[0]?.[0]).toEqual({
+      kind: "markdown",
+      content,
+      rawText: "Opened page",
+    });
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users inspecting tool details would see altered filenames, queries, metadata, and command examples when the text contained a literal middle dot. For example, reading `/notes/Project · Notes.md` displayed `/notes/Project, Notes.md` in the Control UI sidebar, disagreeing with the tool input shown beneath it. Large tool batches also spent time formatting every omitted entry even though the preview showed only three values.

## Why This Change Was Made

Generate final comma separators at the summary and exec producers, and delete the consumer that reparsed literal text as metadata boundaries. Keep previews bounded by stopping after the fourth displayable array item determines the ellipsis and splitting only the first task-text line needed for display; the combined repair removes 32 net production lines.

## User Impact

Tool details preserve literal middle dots in file names, queries, metadata, and command text, while large preview batches require much less formatting work. Raw UI snippets now use the same generated comma separators as expanded/core summaries; this is a small punctuation normalization, while literal argument and command bytes stay intact. Existing redaction and execution behavior is preserved.

## Evidence

The two defects were reproduced independently. Before the repair, the real formatter read 1,000 array entries against its four-entry work budget; original-source core/UI/sidebar regressions also showed the literal-data corruption while generated-summary controls passed. All **152 affected core/exec/display and UI card/sidebar tests** pass after the combined repair. The complete `node scripts/check-changed.mjs` gate passed, including production/core-test/UI types, i18n, formatting, core/UI lint, all unused-export scans, and zero runtime import cycles. Fresh independent P0–P2 review found no actionable issues.

A fixed-settings benchmark through the real public formatter used synthetic inputs, Node 24.19.0, warmup, and seven timing samples per case. Final combined-candidate medians were:

| Preview | Before | After |
| --- | ---: | ---: |
| 100 upload paths | 0.16030 ms | 0.00806 ms |
| 1,000 upload paths | 1.62951 ms | 0.00805 ms |
| First line of a 5,000-line task | 0.10714 ms | 0.00226 ms |

The benchmark previews stayed byte-identical. Three/four-path cases stayed at microsecond scale with overlapping sample ranges. These measurements cover formatter calls, not whole-app latency or actual uploads; process RSS remained approximately 228 MB, so no memory improvement is claimed. The original bounded-formatting evidence is retained separately from the added literal-data repair.

The following captures show the **actual rendered Control UI sidebar in Chromium**, using the existing UI harness and a mocked Gateway. Both original-source and corrected read/query summaries were asserted against rendered text. All four full captures were inspected and contain only synthetic data.

| Read sidebar — before | Read sidebar — after |
| --- | --- |
| ![Read sidebar changes the literal middle dot to a comma](https://github.com/user-attachments/assets/f11b4948-59ba-4b9b-b7d6-9dd0783a516b) | ![Read sidebar preserves the literal middle dot](https://github.com/user-attachments/assets/363d2563-e893-49dd-b4f6-33f9e44a08ca) |

| Search sidebar — before | Search sidebar — after |
| --- | --- |
| ![Search sidebar changes the literal middle dot to a comma](https://github.com/user-attachments/assets/ff4337ee-0bd2-407b-b4ee-36fd2eabd96f) | ![Search sidebar preserves the literal middle dot](https://github.com/user-attachments/assets/84a52593-5887-4352-a9a7-f05c9225e9c3) |

The first combined lint run caught the old UI test exceeding its line budget. Moving the complete sidebar-opening test, including its original exact-output control, into a focused sibling file preserved every case and made the full gate pass without a waiver or weaker assertion.
