### PR TITLE
docs: clarify the v2026.9.3 release statistics label

### DIFF
--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -14,7 +14,7 @@ Updates recover cleanly and sessions reconnect faster in OpenClaw v2026.9.3, hel
 
 Alongside those highlights, Skill Workshop now keeps each agent's learned skills together across workspaces. The Mac app gains native browser tabs that stay open when you switch conversations, and Models settings adds individual account controls and supported account ordering.
 
-**Release scale:** 1,844 pull requests, 40 direct commits, and 190 contributors.
+**This release in numbers:** 1,844 pull requests, 40 direct commits, and 190 contributors.
 
 ## Installation and Onboarding
 


### PR DESCRIPTION
## What Problem This Solves

Makes the v2026.9.3 release statistics label clearer: “Release scale” becomes “This release in numbers.”

## Why This Change Was Made

A small reader-facing copy improvement also provides a visible marker for measuring the normal docs deployment path after https://github.com/openclaw/docs/pull/176 and https://github.com/openclaw/openclaw/pull/142400. No release claims, counts, sources, links, layout, or workflow behavior change.

## User Impact

The same release statistics appear under a clearer label. The production timing experiment starts at merge and finishes when the new wording is observed at https://docs.openclaw.ai/releases/2026.9.3; queue, sync, build, and publication timings will be reported separately.

## Evidence

- Read the current introductory copy and live page before editing.
- `pnpm docs:list` resolves the release page.
- Exact-file comparison against HEAD verifies that replacing this single label is the entire change; counts and every other byte remain intact.
- `git diff --check` passed. This is a one-line plain-text label edit inside existing Markdown emphasis; no runtime tests or broad build needed.
- Production proof: user merged at **2026-09-08 18:50:48 UTC** as `a9707e15bcdab23bfa472b53ae631910f7e1f42c`. The public page showed the new rendered label, no old label, and unchanged release counts at **19:03:05.616 UTC**, **12m17.616s after merge**. The preceding old-label check was at 19:02:29.376 UTC; this is time to observation, not an invented exact public transition timestamp. Upload completed at 19:02:42 UTC, **11m54s after merge**.
- [Source sync](https://github.com/openclaw/openclaw/actions/runs/34265469962) passed: queue 31s, source checkout **27s**, actual copy 3s, full MDX validation **2m20s**.
- [R2 publication](https://github.com/openclaw/docs/actions/runs/34265891141) passed: queue **2m12s**, artifact build **2m50s**, generated smoke 33s, upload 8s. Article cache reused **15,079** pages; two pages rendered and one snippet owner bypassed caching. Pagefind alone took 92.835s within the artifact build. One concurrent `docs/ci/pipeline.md` update was bundled with this edit.
- Earlier production observations were 3m13s for source checkout and 10m07s for the artifact build. Those steps improved, but the whole path still took roughly 12 minutes because queues, validation, setup, and indexing remain. These are real production-run observations, not an isolated identical-machine/content benchmark.
- No production runs were manually dispatched, cancelled, or rerun during the experiment.
