### PR TITLE
fix: hide phantom sidebar children after subagent deletion

### DIFF
--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -6,7 +6,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   countActiveDescendantRuns,
   getSessionDisplaySubagentRunByChildSessionKey,
-  listSubagentRunsForController,
 } from "../agents/subagents/registry/subagent-registry-read.js";
 import {
   RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS,
@@ -245,7 +244,7 @@ export function isFinitePositiveTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-export function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): boolean {
+function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): boolean {
   if (isTerminalSessionStatus(entry.status) || isFinitePositiveTimestamp(entry.endedAt)) {
     const endedAt = isFinitePositiveTimestamp(entry.endedAt) ? entry.endedAt : entry.updatedAt;
     return (
@@ -263,174 +262,63 @@ export function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): 
   );
 }
 
-function buildStoreChildSessionCandidateIndex(
-  store: Record<string, SessionEntry>,
-  selectedParents: ReadonlySet<string>,
-): Map<string, string[]> {
-  const childSessionsByKey = new Map<string, string[]>();
-  for (const [key, entry] of Object.entries(store)) {
-    if (!entry) {
-      continue;
-    }
-    const parentKeys = [
-      normalizeOptionalString(entry.spawnedBy),
-      normalizeOptionalString(entry.parentSessionKey),
-    ].filter((value): value is string => Boolean(value) && value !== key);
-    for (const parentKey of parentKeys) {
-      if (selectedParents.has(parentKey)) {
-        addChildSessionKey(childSessionsByKey, parentKey, key);
-      }
-    }
-  }
-  return childSessionsByKey;
-}
-
-export function resolveRuntimeChildSessionKeys(
-  controllerSessionKey: string,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
-): string[] | undefined {
-  const childSessionKeys = new Set<string>();
-  const controllerKey = controllerSessionKey.trim();
-  const runs = subagentRuns
-    ? (subagentRuns.runsByControllerSessionKey.get(controllerKey) ?? [])
-    : listSubagentRunsForController(controllerSessionKey);
-  for (const entry of runs) {
-    const childSessionKey = normalizeOptionalString(entry.childSessionKey);
-    if (!childSessionKey) {
-      continue;
-    }
-    const latest = subagentRuns
-      ? subagentRuns.getDisplaySubagentRun(childSessionKey)
-      : getSessionDisplaySubagentRunByChildSessionKey(childSessionKey);
-    if (!latest) {
-      continue;
-    }
-    const latestControllerSessionKey =
-      normalizeOptionalString(latest?.controllerSessionKey) ||
-      normalizeOptionalString(latest?.requesterSessionKey);
-    if (latestControllerSessionKey !== controllerSessionKey) {
-      continue;
-    }
-    if (
-      !shouldKeepSubagentRunChildLink(latest, {
+/** Resolve navigation owners from canonical existence and current run liveness. */
+export function resolveSessionChildOwners(params: {
+  key: string;
+  entry: SessionEntry;
+  now: number;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
+}): string[] {
+  const { key, entry, now, subagentRuns } = params;
+  const latest = subagentRuns
+    ? subagentRuns.getDisplaySubagentRun(key)
+    : getSessionDisplaySubagentRunByChildSessionKey(key);
+  const keep = latest
+    ? shouldKeepSubagentRunChildLink(latest, {
         activeDescendants: subagentRuns
-          ? subagentRuns.countActiveDescendantRuns(childSessionKey)
-          : countActiveDescendantRuns(childSessionKey),
+          ? subagentRuns.countActiveDescendantRuns(key)
+          : countActiveDescendantRuns(key),
         now,
       })
-    ) {
-      continue;
-    }
-    childSessionKeys.add(childSessionKey);
+    : shouldKeepStoreOnlyChildLink(entry, now);
+  if (!keep) {
+    return [];
   }
-  const childSessions = Array.from(childSessionKeys);
-  return childSessions.length > 0 ? childSessions : undefined;
-}
-
-function addChildSessionKey(
-  childSessionsByKey: Map<string, string[]>,
-  parentKey: string,
-  childKey: string,
-) {
-  const current = childSessionsByKey.get(parentKey);
-  if (current) {
-    if (!current.includes(childKey)) {
-      current.push(childKey);
-    }
-    return;
-  }
-  childSessionsByKey.set(parentKey, [childKey]);
-}
-
-export function isCurrentSessionChildOwner(params: {
-  entry: Pick<SessionEntry, "parentSessionKey">;
-  ownerSessionKey: string;
-  controllerSessionKey: string | undefined;
-}): boolean {
-  // Live control supersedes stale spawnedBy, but explicit navigation lineage
-  // remains authoritative so dashboard parents can discover controlled children.
-  return (
-    params.controllerSessionKey === params.ownerSessionKey ||
-    normalizeOptionalString(params.entry.parentSessionKey) === params.ownerSessionKey
+  // Runtime control replaces spawnedBy, but explicit navigation lineage survives moves.
+  const controller = latest
+    ? normalizeOptionalString(latest.controllerSessionKey) ||
+      normalizeOptionalString(latest.requesterSessionKey)
+    : normalizeOptionalString(entry.spawnedBy);
+  return [...new Set([controller, normalizeOptionalString(entry.parentSessionKey)])].filter(
+    (owner): owner is string => Boolean(owner) && owner !== key,
   );
 }
 
-// Combined-store reads create fresh entries. Keep only selected parents' links for
-// this projection; an identity cache would miss and retain the previous metadata.
+/** Index only canonical children; retained run results cannot create session links. */
 export function buildStoreChildSessionIndex(params: {
   store: Record<string, SessionEntry>;
   keys: readonly string[];
   now: number;
   subagentRuns?: SessionListRowContext["subagentRuns"];
   excludedChildKeys?: ReadonlySet<string>;
-  requireCurrentController?: boolean;
 }): Map<string, string[]> {
   const children = new Map<string, string[]>();
   if (params.keys.length === 0) {
     return children;
   }
-  const candidates = buildStoreChildSessionCandidateIndex(params.store, new Set(params.keys));
-  for (const key of params.keys) {
-    const childKeys = resolveStoreChildSessionKeysFromCandidates({ ...params, key, candidates });
-    if (childKeys) {
-      children.set(key, childKeys);
+  const parents = new Set(params.keys);
+  // One store pass discovers both persisted navigation and runtime-only controller links.
+  for (const [key, entry] of Object.entries(params.store)) {
+    if (!entry || params.excludedChildKeys?.has(key)) {
+      continue;
+    }
+    for (const owner of resolveSessionChildOwners({ ...params, key, entry })) {
+      if (parents.has(owner)) {
+        const siblings = children.get(owner) ?? [];
+        siblings.push(key);
+        children.set(owner, siblings);
+      }
     }
   }
   return children;
-}
-
-function resolveStoreChildSessionKeysFromCandidates(params: {
-  store: Record<string, SessionEntry>;
-  key: string;
-  now: number;
-  candidates: ReadonlyMap<string, readonly string[]>;
-  subagentRuns?: SessionListRowContext["subagentRuns"];
-  excludedChildKeys?: ReadonlySet<string>;
-  requireCurrentController?: boolean;
-}): string[] | undefined {
-  const childSessionKeys: string[] = [];
-  for (const childKey of params.candidates.get(params.key) ?? []) {
-    if (params.excludedChildKeys?.has(childKey)) {
-      continue;
-    }
-    const entry = params.store[childKey];
-    if (!entry) {
-      continue;
-    }
-    const latest = params.subagentRuns
-      ? params.subagentRuns.getDisplaySubagentRun(childKey)
-      : getSessionDisplaySubagentRunByChildSessionKey(childKey);
-    if (latest) {
-      const latestControllerSessionKey =
-        normalizeOptionalString(latest.controllerSessionKey) ||
-        normalizeOptionalString(latest.requesterSessionKey);
-      const matchesOwner = isCurrentSessionChildOwner({
-        entry,
-        ownerSessionKey: params.key,
-        controllerSessionKey: latestControllerSessionKey,
-      });
-      if (params.requireCurrentController && !matchesOwner) {
-        continue;
-      }
-      if (
-        !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: params.subagentRuns
-            ? params.subagentRuns.countActiveDescendantRuns(childKey)
-            : countActiveDescendantRuns(childKey),
-          now: params.now,
-        }) ||
-        (latestControllerSessionKey && !matchesOwner)
-      ) {
-        continue;
-      }
-      childSessionKeys.push(childKey);
-      continue;
-    }
-    if (!shouldKeepStoreOnlyChildLink(entry, params.now)) {
-      continue;
-    }
-    childSessionKeys.push(childKey);
-  }
-  return childSessionKeys.length > 0 ? childSessionKeys : undefined;
 }

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -8,11 +8,6 @@ import {
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { listAgentIds } from "../agents/agent-scope-config.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
-import {
-  countActiveDescendantRuns,
-  getSessionDisplaySubagentRunByChildSessionKey,
-} from "../agents/subagents/registry/subagent-registry-read.js";
-import { shouldKeepSubagentRunChildLink } from "../agents/subagents/registry/subagent-run-liveness.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { GatewayStoredSessionTargets } from "../config/sessions/combined-store-gateway.js";
@@ -49,8 +44,7 @@ import {
   deriveSessionTitle,
   buildStoreChildSessionIndex,
   isFinitePositiveTimestamp,
-  isCurrentSessionChildOwner,
-  shouldKeepStoreOnlyChildLink,
+  resolveSessionChildOwners,
 } from "./session-utils-core.js";
 import { getSessionDefaults } from "./session-utils-model.js";
 import {
@@ -70,7 +64,6 @@ import type {
 
 // Bound synchronous projection work without repeatedly requeueing cheap prepared rows.
 const SESSIONS_LIST_YIELD_INTERVAL_MS = 12;
-const SESSIONS_LIST_ROW_CONTEXT_THRESHOLD = 10;
 
 const SESSIONS_LIST_DEFAULT_LIMIT = 100;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
@@ -237,25 +230,12 @@ function filterSessionEntries(params: {
         return false;
       }
       const filterRowContext = resolveSessionListRowContext(params);
-      const latest = filterRowContext
-        ? filterRowContext.subagentRuns.getDisplaySubagentRun(key)
-        : getSessionDisplaySubagentRunByChildSessionKey(key);
-      const keepSpawned = latest
-        ? isCurrentSessionChildOwner({
-            entry,
-            ownerSessionKey: spawnedBy,
-            controllerSessionKey:
-              normalizeOptionalString(latest.controllerSessionKey) ||
-              normalizeOptionalString(latest.requesterSessionKey),
-          }) &&
-          shouldKeepSubagentRunChildLink(latest, {
-            activeDescendants: filterRowContext
-              ? filterRowContext.subagentRuns.countActiveDescendantRuns(key)
-              : countActiveDescendantRuns(key),
-            now,
-          })
-        : shouldKeepStoreOnlyChildLink(entry, now) &&
-          (entry.spawnedBy === spawnedBy || entry.parentSessionKey === spawnedBy);
+      const keepSpawned = resolveSessionChildOwners({
+        key,
+        entry,
+        now,
+        subagentRuns: filterRowContext?.subagentRuns,
+      }).includes(spawnedBy);
       if (!keepSpawned) {
         return false;
       }
@@ -466,15 +446,8 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     ownerFirstActorId: params.ownerFirstActorId,
     projectActiveRun: params.projectActiveRun,
   });
-  // The two registry caches can differ after an external worker write. Preserve
-  // live child reads where the existing short-list path did not prepare a snapshot.
-  const usePreparedChildReads =
-    Boolean(rowContext) ||
-    hasSpawnedByFilter ||
-    filteredSessionKeys.size > 0 ||
-    selection.entries.length > SESSIONS_LIST_ROW_CONTEXT_THRESHOLD;
-  const sharedRowContext =
-    usePreparedChildReads || selection.entries.length > 0 ? getRowContext() : undefined;
+  // Filtering, child links, and row display share one registry snapshot per response.
+  const sharedRowContext = selection.entries.length > 0 ? getRowContext() : undefined;
   const storePath = hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath);
   const storeChildSessionsByKey = buildStoreChildSessionIndex({
     store,
@@ -484,9 +457,8 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
       ),
     ],
     now,
-    subagentRuns: usePreparedChildReads ? sharedRowContext?.subagentRuns : undefined,
+    subagentRuns: sharedRowContext?.subagentRuns,
     excludedChildKeys: filteredSessionKeys,
-    requireCurrentController: !usePreparedChildReads,
   });
   populateSessionListAcpMetadata({
     cfg,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -1,5 +1,4 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { readSessionRuntimeOwnership } from "../agents/harness/session-runtime-ownership.js";
 import { normalizeStoredOverrideModel } from "../agents/model-selection.js";
@@ -24,7 +23,6 @@ import {
   buildStoreChildSessionIndex,
   resolveEstimatedSessionCostUsd,
   resolvePositiveNumber,
-  resolveRuntimeChildSessionKeys,
 } from "./session-utils-core.js";
 
 export function buildSessionListRowMetadataContext(params: {
@@ -53,7 +51,6 @@ export function buildSingleRowStoreChildSessionsByKey(params: {
     keys: [params.key],
     now: params.now,
     subagentRuns: params.subagentRuns,
-    requireCurrentController: true,
   });
 }
 
@@ -98,39 +95,6 @@ export function resolveSessionSelectedModelRef(params: {
   });
   params.rowContext.selectedModelByOverrideRef.set(key, selected);
   return selected;
-}
-
-export function mergeChildSessionKeys(
-  runtimeChildSessions: string[] | undefined,
-  storeChildSessions: string[] | undefined,
-): string[] | undefined {
-  if (!runtimeChildSessions?.length) {
-    return storeChildSessions?.length ? storeChildSessions : undefined;
-  }
-  if (!storeChildSessions?.length) {
-    return runtimeChildSessions;
-  }
-  return uniqueStrings([...runtimeChildSessions, ...storeChildSessions]);
-}
-
-export function resolveChildSessionKeys(
-  controllerSessionKey: string,
-  store: Record<string, SessionEntry>,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
-): string[] | undefined {
-  const runtimeChildSessions = resolveRuntimeChildSessionKeys(
-    controllerSessionKey,
-    now,
-    subagentRuns,
-  );
-  const storeChildSessions = buildStoreChildSessionIndex({
-    store,
-    keys: [controllerSessionKey],
-    now,
-    subagentRuns,
-  }).get(controllerSessionKey);
-  return mergeChildSessionKeys(runtimeChildSessions, storeChildSessions);
 }
 
 export function resolveTranscriptUsageFallback(params: {

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -56,7 +56,7 @@ import {
   resolveLatestCompactionCheckpoint,
   resolvePositiveNumber,
   resolveProjectableCompactionCheckpoints,
-  resolveRuntimeChildSessionKeys,
+  buildStoreChildSessionIndex,
 } from "./session-utils-core.js";
 import {
   resolveGatewaySessionDisplayName,
@@ -69,8 +69,6 @@ import {
   resolveSessionDisplayModelIdentityRefCached,
 } from "./session-utils-model.js";
 import {
-  mergeChildSessionKeys,
-  resolveChildSessionKeys,
   resolveSessionSelectedModelRef,
   resolveTranscriptUsageFallback,
 } from "./session-utils-projection.js";
@@ -188,12 +186,15 @@ export function buildGatewaySessionRow(params: {
     totalTokensFresh,
     totalTokensVersion: totalTokensFresh ? SESSION_TOTAL_TOKENS_VERSION : undefined,
   });
-  const childSessions = params.storeChildSessionsByKey
-    ? mergeChildSessionKeys(
-        resolveRuntimeChildSessionKeys(key, now, rowContext?.subagentRuns),
-        params.storeChildSessionsByKey.get(key),
-      )
-    : resolveChildSessionKeys(key, store, now, rowContext?.subagentRuns);
+  const childSessions = (
+    params.storeChildSessionsByKey ??
+    buildStoreChildSessionIndex({
+      store,
+      keys: [key],
+      now,
+      subagentRuns: rowContext?.subagentRuns,
+    })
+  ).get(key);
   const pinnedAt =
     entry?.pinnedAt !== undefined && isPinnableSessionEntry(key, entry)
       ? entry.pinnedAt

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentIds } from "../agents/agent-scope.js";
+import { listSubagentRunsForController } from "../agents/subagents/registry/subagent-registry-read.js";
 import {
   isConfiguredSessionStoreAgentId,
   resolveAgentMainSessionKey,
@@ -184,18 +185,20 @@ function prepareGatewaySessionStoreLookup(
       resolve: () => ({ storePath: fallback.storePath, store: {}, match: undefined }),
     };
   }
-  const reads = candidates.map((target, index): GatewaySessionStoreRead => ({
-    storePath: target.storePath,
-    agentId: target.agentId,
-    clone: params.clone,
-    options: {
-      readOnly: configured ? params.readOnly : true,
-      ...(params.exactRead ? { exactKeys: scanTargets } : {}),
-      ...(params.projection ? { projection: params.projection } : {}),
-      ...(params.storeCache ? { cache: params.storeCache } : {}),
-    },
-    store: index === 0 && target.storePath === fallback.storePath ? params.store : undefined,
-  }));
+  const reads = candidates.map(
+    (target, index): GatewaySessionStoreRead => ({
+      storePath: target.storePath,
+      agentId: target.agentId,
+      clone: params.clone,
+      options: {
+        readOnly: configured ? params.readOnly : true,
+        ...(params.exactRead ? { exactKeys: scanTargets } : {}),
+        ...(params.projection ? { projection: params.projection } : {}),
+        ...(params.storeCache ? { cache: params.storeCache } : {}),
+      },
+      store: index === 0 && target.storePath === fallback.storePath ? params.store : undefined,
+    }),
+  );
   return {
     reads,
     resolve: () => {
@@ -275,17 +278,19 @@ function prepareExplicitDeletedLegacyMainStoreTarget(
   );
   const reads = existing
     .filter((target) => target.agentId === legacyAgentId)
-    .map((target): GatewaySessionStoreRead => ({
-      storePath: target.storePath,
-      clone: params.clone,
-      agentId: target.agentId,
-      options: {
-        readOnly: true,
-        ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
-        ...(params.projection ? { projection: params.projection } : {}),
-        ...(params.storeCache ? { cache: params.storeCache } : {}),
-      },
-    }));
+    .map(
+      (target): GatewaySessionStoreRead => ({
+        storePath: target.storePath,
+        clone: params.clone,
+        agentId: target.agentId,
+        options: {
+          readOnly: true,
+          ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
+          ...(params.projection ? { projection: params.projection } : {}),
+          ...(params.storeCache ? { cache: params.storeCache } : {}),
+        },
+      }),
+    );
   return {
     reads,
     resolve: () => {
@@ -413,6 +418,7 @@ export function resolveGatewaySessionStoreTargetWithStore(
     deletedMain ?? prepareGatewaySessionStoreTarget(normalized).resolve(),
     params.includeStoreChildEntries,
     params.projection,
+    params.cfg,
   );
 }
 
@@ -420,6 +426,7 @@ export function resolveGatewaySessionStoreTargetWithStore(
 export function resolveGatewaySessionStoreTargetsReadOnly(params: {
   cfg: OpenClawConfig;
   targets: readonly { key: string; agentId?: string }[];
+  projection?: SessionEntryListScope["projection"];
 }): GatewaySessionStoreTargetWithStore[] {
   const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
   const requests = params.targets.map((target) => {
@@ -430,7 +437,7 @@ export function resolveGatewaySessionStoreTargetsReadOnly(params: {
       clone: false,
       readOnly: true,
       exactRead: true,
-      projection: "list",
+      projection: params.projection ?? "list",
       targetDiscoveryCache,
     };
     return { lookup, legacy: prepareExplicitDeletedLegacyMainStoreTarget(lookup) };
@@ -453,12 +460,14 @@ function includeDirectChildEntries(
   target: GatewaySessionStoreTargetWithStore,
   include: boolean | undefined,
   projection: SessionEntryListScope["projection"],
+  cfg: OpenClawConfig,
 ): GatewaySessionStoreTargetWithStore {
   if (!include) {
     return target;
   }
   try {
     const parentKeys = new Set([target.canonicalKey, ...target.storeKeys]);
+    const childKeys = new Set<string>();
     for (const parentKey of parentKeys) {
       for (const { sessionKey, entry } of listSessionChildEntriesReadOnly({
         agentId: target.agentId,
@@ -468,6 +477,21 @@ function includeDirectChildEntries(
         storePath: target.storePath,
       })) {
         target.store[sessionKey] = entry;
+      }
+      for (const { childSessionKey } of listSubagentRunsForController(parentKey)) {
+        childKeys.add(childSessionKey);
+      }
+    }
+    // Retained runs are discovery hints, not existence: deduplicate and batch exact reads.
+    const targets = [...childKeys].filter((key) => !target.store[key]).map((key) => ({ key }));
+    for (const child of resolveGatewaySessionStoreTargetsReadOnly({
+      cfg,
+      targets,
+      projection: projection ?? "full",
+    })) {
+      const entry = child.store[child.canonicalKey];
+      if (entry) {
+        target.store[child.canonicalKey] = entry;
       }
     }
   } catch {

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -185,20 +185,18 @@ function prepareGatewaySessionStoreLookup(
       resolve: () => ({ storePath: fallback.storePath, store: {}, match: undefined }),
     };
   }
-  const reads = candidates.map(
-    (target, index): GatewaySessionStoreRead => ({
-      storePath: target.storePath,
-      agentId: target.agentId,
-      clone: params.clone,
-      options: {
-        readOnly: configured ? params.readOnly : true,
-        ...(params.exactRead ? { exactKeys: scanTargets } : {}),
-        ...(params.projection ? { projection: params.projection } : {}),
-        ...(params.storeCache ? { cache: params.storeCache } : {}),
-      },
-      store: index === 0 && target.storePath === fallback.storePath ? params.store : undefined,
-    }),
-  );
+  const reads = candidates.map((target, index): GatewaySessionStoreRead => ({
+    storePath: target.storePath,
+    agentId: target.agentId,
+    clone: params.clone,
+    options: {
+      readOnly: configured ? params.readOnly : true,
+      ...(params.exactRead ? { exactKeys: scanTargets } : {}),
+      ...(params.projection ? { projection: params.projection } : {}),
+      ...(params.storeCache ? { cache: params.storeCache } : {}),
+    },
+    store: index === 0 && target.storePath === fallback.storePath ? params.store : undefined,
+  }));
   return {
     reads,
     resolve: () => {
@@ -278,19 +276,17 @@ function prepareExplicitDeletedLegacyMainStoreTarget(
   );
   const reads = existing
     .filter((target) => target.agentId === legacyAgentId)
-    .map(
-      (target): GatewaySessionStoreRead => ({
-        storePath: target.storePath,
-        clone: params.clone,
-        agentId: target.agentId,
-        options: {
-          readOnly: true,
-          ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
-          ...(params.projection ? { projection: params.projection } : {}),
-          ...(params.storeCache ? { cache: params.storeCache } : {}),
-        },
-      }),
-    );
+    .map((target): GatewaySessionStoreRead => ({
+      storePath: target.storePath,
+      clone: params.clone,
+      agentId: target.agentId,
+      options: {
+        readOnly: true,
+        ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
+        ...(params.projection ? { projection: params.projection } : {}),
+        ...(params.storeCache ? { cache: params.storeCache } : {}),
+      },
+    }));
   return {
     reads,
     resolve: () => {

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
 import { resolveInternalSessionEffectsIdentity } from "../config/sessions/internal-session-key.js";
 import {
+  deleteSessionEntryLifecycle,
   loadExactSessionEntryReadOnly,
   replaceSessionEntry,
   updateSessionEntry,
@@ -472,6 +473,39 @@ describe("single gateway session row child projections", () => {
       },
     );
   });
+
+  test.each(["main", "worker"])(
+    "removes deleted runtime-only children from exact rows (%s)",
+    async (agentId) => {
+      await withSingleRowCacheStore(
+        "openclaw-canonical-child-",
+        "/tmp/openclaw-canonical-child",
+        async ({ now, storePath }) => {
+          const parentKey = "agent:main:parent";
+          const childKey = `agent:${agentId}:subagent:child`;
+          const childStorePath = resolveSessionStorePathCore(undefined, { agentId });
+          await seedSessionEntries(storePath, { [parentKey]: parentSession("parent", now) });
+          await replaceSessionEntry(
+            { agentId, storePath: childStorePath, sessionKey: childKey },
+            {
+              sessionId: "child",
+              updatedAt: now,
+            },
+          );
+          setSubagentControllerRun(childKey, parentKey, now);
+          expect(loadGatewaySessionRow(parentKey, { now })?.childSessions).toEqual([childKey]);
+
+          await deleteSessionEntryLifecycle({
+            agentId,
+            storePath: childStorePath,
+            archiveTranscript: false,
+            target: { canonicalKey: childKey, storeKeys: [childKey] },
+          });
+          expect(loadGatewaySessionRow(parentKey, { now })?.childSessions).toBeUndefined();
+        },
+      );
+    },
+  );
 
   test("builds shared subagent metadata context for single-row session lists", async () => {
     await withSingleRowCacheStore(

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -1217,7 +1217,7 @@ describe("session list subagent metadata", () => {
         cleanupCompletedAt: now - 500,
       });
       const list = (spawnedBy?: string) =>
-        listSessionsFromStoreAsync({
+        listSessionFixture({
           cfg,
           storePath: "/tmp/sessions.json",
           store,

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -1192,6 +1192,54 @@ describe("session list subagent metadata", () => {
     expect(filtered.sessions.map((session) => session.key)).toStrictEqual([]);
   });
 
+  test.each([false, true])(
+    "omits deleted child sessions while retaining runs (collector=%s)",
+    async (collect) => {
+      const now = Date.now();
+      const parentKey = "agent:main:parent";
+      const childKey = "agent:main:subagent:deleted";
+      const store: Record<string, SessionEntry> = {
+        [parentKey]: { sessionId: "parent", updatedAt: now },
+        [childKey]: { sessionId: "child", updatedAt: now - 1 },
+      };
+      addSubagentRunForTests({
+        runId: "retained-child",
+        childSessionKey: childKey,
+        requesterSessionKey: parentKey,
+        requesterDisplayKey: "parent",
+        task: "retained result",
+        cleanup: "delete",
+        collect,
+        createdAt: now - 5_000,
+        startedAt: now - 4_000,
+        endedAt: now - 1_000,
+        outcome: { status: collect ? "ok" : "error" },
+        cleanupCompletedAt: now - 500,
+      });
+      const list = (spawnedBy?: string) =>
+        listSessionsFromStoreAsync({
+          cfg,
+          storePath: "/tmp/sessions.json",
+          store,
+          opts: { spawnedBy },
+        });
+      const before = await list();
+      expect(before.sessions.find((row) => row.key === parentKey)?.childSessions).toEqual([
+        childKey,
+      ]);
+      expect((await list(parentKey)).sessions.map((row) => row.key)).toEqual([childKey]);
+
+      // Session deletion must remove navigation without discarding the retained run/result.
+      delete store[childKey];
+      const after = await list();
+      expect((await list(parentKey)).sessions).toEqual([]);
+      expect(after.sessions.find((row) => row.key === parentKey)?.childSessions).toBeUndefined();
+      expect(
+        buildSingleRowStoreChildSessionsByKey({ store, key: parentKey, now }).get(parentKey),
+      ).toBeUndefined();
+    },
+  );
+
   test("does not keep old ended registry runs attached as child sessions", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {


### PR DESCRIPTION
Closes #126455 — deleted subagents leave a phantom sidebar child count.

## What Problem This Solves

Fixes an issue where users deleting a subagent session would still see a child count in the Control UI sidebar when its completed run record was retained. Expanding the parent could return no children despite that count.

## Why This Change Was Made

The Gateway session projection now derives child existence from canonical session rows, sharing ownership and liveness filtering between parent child indexes and expansion. This replaces the separate runtime-only resolver and runtime/store union, while preserving current controller ownership, explicit navigation lineage, and exact-row discovery of cross-agent children. Retained task results are not deleted; there are no schema, configuration, dependency, or registry-retention changes.



## User Impact

Deleted subagents no longer leave phantom child links. Existing children remain discoverable after controller moves and across agents, and retained collector results remain available.

## Evidence

### Completed before rebasing

The passing runtime/build/check evidence below applies to the original reviewed commit `8edb1e3c76d`, before rebasing onto `f73b5c009e7`.

- Two deleted-child regressions failed before the fix; the existing 31 tests passed on that baseline.
- 86 tests passed across subagent projection, exact-row cache, child retention, session-list cache, and chat-history suites.
- After removing the now-private helper's unused export, the two directly affected suites passed again: 43 tests.
- Full build passed. Final changed-file checks passed, including production/test typechecks, lint (zero warnings/errors), unused-export scans, database-first storage guards, and runtime import-cycle checks.
- Independent autoreview of the final patch found no actionable P0–P2 findings.
- A real isolated localhost Gateway advertised a synthetic child before deletion. After `sessions.delete`, the parent's child list and `spawnedBy` expansion were both empty; the retained collector record still existed.
- Visual proof limitation: the browser reached the isolated Gateway's model-setup screen, which requires verified model access. Sidebar rendering was not visually verified; the real Gateway RPC path was verified without using the operator's credentials or live state.

### Rebase validation

Resolved conflicts while retaining upstream batched store lookup, ACP metadata batching, extracted goal projection, and root-only pin checks. Retained child keys are deduplicated across parent aliases and hydrated through the existing batched exact-read resolver, avoiding serial reads per historical run while preserving the requested projection. `git diff --check` passes. The local focused test rerun stopped before executing tests with `TypeError: defineCacheKeyGenerator is not a function`: this worktree still has Vitest 4 installed, while the current harness requires Vitest 5. No dependencies or test configuration were changed to bypass that mismatch. Fresh independent autoreview of the final staged patch is clean through P2, including the deduplicated batched reads. Exact-head CI validation is pending.

Reproduction commands (the original checks were run before committing):

```sh
node scripts/run-vitest.mjs src/gateway/session-utils.subagent.test.ts src/gateway/session-utils.single-row-cache.test.ts src/gateway/session-utils.child-cache-retention.test.ts src/gateway/server-methods/sessions-read-cache.test.ts src/gateway/server-methods/chat-history-handler.test.ts
pnpm build
node scripts/check-changed.mjs --base HEAD --head HEAD -- src/gateway/session-utils-core.ts src/gateway/session-utils-projection.ts src/gateway/session-utils-row.ts src/gateway/session-utils-list.ts src/gateway/session-utils-store-lookup.ts src/gateway/session-utils.subagent.test.ts src/gateway/session-utils.single-row-cache.test.ts
```


### ClawSweeper feedback repair

The rebased deletion regression was still calling an undefined listing function without current ownership metadata. Both collector variants reproduced `ReferenceError` on `00417a808c51` using the exact frozen-lockfile Vitest 5 toolchain. They now use the already-imported `listSessionFixture`, which supplies `targetsBySessionKey`; all 44 tests in the two affected suites pass. The lookup file was formatted with the pinned formatter, addressing the exact-head CI formatting failure without changing production behavior. Independent autoreview is clean through P2. The complete changed-file gate passed, including production/test typechecks, formatting, lint, unused-export scans, and storage/runtime guards. Exact-head hosted CI remains pending.

```sh
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/gateway/session-utils.subagent.test.ts src/gateway/session-utils.single-row-cache.test.ts
node scripts/check-changed.mjs --base HEAD --head HEAD -- src/gateway/session-utils.subagent.test.ts src/gateway/session-utils-store-lookup.ts
```
