### PR TITLE
fix(e2e): keep frozen survivor tooling coherent

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -77,6 +77,29 @@ async function assertNoRequests(baseUrl) {
   if (!Array.isArray(payload?.requests)) {
     throw new Error("ClawHub fixture request ledger must contain a requests array");
   }
+  const legacyPackage = process.env.OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_PACKAGE;
+  if (legacyPackage) {
+    const packagePath = `/api/v1/packages/${encodeURIComponent(legacyPackage)}`;
+    const artifactPrefix = `GET ${packagePath}/versions/`;
+    const artifactSuffix = "/artifact";
+    const artifactRequest = payload.requests[1] ?? "";
+    const version =
+      artifactRequest.startsWith(artifactPrefix) && artifactRequest.endsWith(artifactSuffix)
+        ? decodeURIComponent(artifactRequest.slice(artifactPrefix.length, -artifactSuffix.length))
+        : "";
+    const expected = [
+      `GET ${packagePath}`,
+      `GET ${packagePath}/versions/${encodeURIComponent(version)}/artifact`,
+      `GET ${packagePath}/versions/${encodeURIComponent(version)}/artifact/download`,
+    ];
+    if (!version || JSON.stringify(payload.requests) !== JSON.stringify(expected)) {
+      throw new Error(
+        `unexpected legacy ClawHub fixture requests: ${JSON.stringify(payload.requests)}`,
+      );
+    }
+    console.log("Verified complete legacy ClawHub artifact audit sequence.");
+    return;
+  }
   if (payload.requests.length !== 0) {
     throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(payload.requests)}`);
   }

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -54,6 +54,7 @@ source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 UPGRADE_SCENARIO_ARGS=()
+UPGRADE_COMPAT_ENV_ARGS=()
 UPGRADE_RUNNER="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh"
 UPGRADE_SCENARIO_DIR=""
 UPGRADE_TARGET_TRAIN=""
@@ -80,6 +81,7 @@ NODE
   1) ;;
   *) exit "$context_status" ;;
 esac
+openclaw_resolve_frozen_upgrade_survivor_capabilities "$ROOT_DIR"
 if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
   # Extended-stable retains shipped state expectations. Regular releases keep
   # the trusted runner and its serving-turn/post-inference assertions together.
@@ -95,8 +97,9 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
   UPGRADE_WINDOWS_HELPERS="$(openclaw_resolve_frozen_target_file \
     "$ROOT_DIR" scripts/windows-cmd-helpers.mjs)"
   DOCKER_E2E_WINDOWS_HELPERS_PATH="$UPGRADE_WINDOWS_HELPERS"
-  UPGRADE_BOUNDED_RESPONSE="$(openclaw_resolve_frozen_target_file \
-    "$ROOT_DIR" scripts/lib/bounded-response.mjs)"
+  UPGRADE_BOUNDED_RESPONSE="$HARNESS_ROOT_DIR/scripts/lib/bounded-response.mjs"
+  UPGRADE_DIAGNOSTICS="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs"
+  UPGRADE_NPM_REGISTRY_SERVER="$HARNESS_ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs"
   UPGRADE_PLUGIN_INDEX="$(openclaw_resolve_frozen_target_file \
     "$ROOT_DIR" scripts/e2e/lib/plugin-index-sqlite.mjs)"
   UPGRADE_ENV_LIMITS="$(openclaw_resolve_frozen_target_file \
@@ -105,6 +108,8 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
     "$ROOT_DIR" scripts/e2e/lib/text-file-utils.mjs)"
   UPGRADE_SCENARIO_ARGS+=(
     -v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"
+    -v "$UPGRADE_DIAGNOSTICS:/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs:ro"
+    -v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"
     -v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"
     -v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"
     -v "$UPGRADE_PLUGIN_INDEX:/app/scripts/e2e/lib/plugin-index-sqlite.mjs:ro"
@@ -118,6 +123,13 @@ SKIP_BUILD="${OPENCLAW_UPGRADE_SURVIVOR_E2E_SKIP_BUILD:-0}"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1200s}"
 BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-}"
 SCENARIO="${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}"
+if [ "$OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE" = legacy ]; then
+  legacy_clawhub_package="@openclaw/whatsapp"
+  [ "$SCENARIO" = configured-plugin-installs ] && legacy_clawhub_package="@openclaw/matrix"
+  UPGRADE_COMPAT_ENV_ARGS+=(
+    -e "OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_PACKAGE=$legacy_clawhub_package"
+  )
+fi
 UPDATE_RESTART_MODE="${OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE:-manual}"
 if [ "$SCENARIO" = "abandoned-update" ] && [ -z "${OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE:-}" ]; then
   UPDATE_RESTART_MODE="auto-auth"
@@ -346,6 +358,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
     -e OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER=/tmp/openclaw-config-parking.mjs \
     -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_SERVER_SCRIPT=/tmp/openclaw-release-harness/scripts/e2e/lib/plugins/npm-registry-server.mjs \
+    ${UPGRADE_COMPAT_ENV_ARGS[@]+"${UPGRADE_COMPAT_ENV_ARGS[@]}"} \
     "${PROBE_ENV_ARGS[@]}" \
     ${LIVE_OPENAI_ENV_ARGS[@]+"${LIVE_OPENAI_ENV_ARGS[@]}"} \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
@@ -400,6 +413,7 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
   -e OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER=/tmp/openclaw-config-parking.mjs \
   -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_SERVER_SCRIPT=/tmp/openclaw-release-harness/scripts/e2e/lib/plugins/npm-registry-server.mjs \
+  ${UPGRADE_COMPAT_ENV_ARGS[@]+"${UPGRADE_COMPAT_ENV_ARGS[@]}"} \
   "${PROBE_ENV_ARGS[@]}" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
   -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 PACKAGE_TGZ=""
 AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT=""
+UPGRADE_SCENARIO_STAGE=""
 run_completed="0"
 diagnostics_ready=0
 cleanup_outer() {
@@ -36,6 +37,9 @@ cleanup_outer() {
   if [ -n "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT" ]; then
     rm -rf "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT"
   fi
+  if [ -n "$UPGRADE_SCENARIO_STAGE" ]; then
+    rm -rf "$UPGRADE_SCENARIO_STAGE"
+  fi
   if [ "$exit_status" -ne 0 ]; then
     printf '[upgrade-survivor] FAILED (exit %s)\n' "$exit_status" >&2
   fi
@@ -55,6 +59,7 @@ source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 UPGRADE_SCENARIO_ARGS=()
 UPGRADE_COMPAT_ENV_ARGS=()
+UPGRADE_SCENARIO_STAGE=""
 UPGRADE_RUNNER="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh"
 UPGRADE_SCENARIO_DIR=""
 UPGRADE_TARGET_TRAIN=""
@@ -106,9 +111,14 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
     "$ROOT_DIR" scripts/e2e/lib/env-limits.mjs)"
   UPGRADE_TEXT_FILE_UTILS="$(openclaw_resolve_frozen_target_file \
     "$ROOT_DIR" scripts/e2e/lib/text-file-utils.mjs)"
+  # Build the complete scenario tree before mounting it read-only. A nested
+  # diagnostics bind cannot create its destination beneath a read-only mount.
+  UPGRADE_SCENARIO_STAGE="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-upgrade-scenario.XXXXXX")"
+  cp -R "$UPGRADE_SCENARIO_DIR/." "$UPGRADE_SCENARIO_STAGE/"
+  cp "$UPGRADE_DIAGNOSTICS" "$UPGRADE_SCENARIO_STAGE/diagnostics.mjs"
+  chmod 0755 "$UPGRADE_SCENARIO_STAGE"
   UPGRADE_SCENARIO_ARGS+=(
-    -v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"
-    -v "$UPGRADE_DIAGNOSTICS:/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs:ro"
+    -v "$UPGRADE_SCENARIO_STAGE:/app/scripts/e2e/lib/upgrade-survivor:ro"
     -v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"
     -v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"
     -v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -73,6 +73,23 @@ openclaw_frozen_target_source_contains() {
   git -C "$source_root" show "$OPENCLAW_SELECTED_SHA:$relative_path" 2>/dev/null | grep -F -- "$needle" >/dev/null
 }
 
+openclaw_resolve_frozen_upgrade_survivor_capabilities() {
+  local source_root="${1:?missing selected source root}" authorization_status=0
+
+  export OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE="current"
+  openclaw_prepare_frozen_target_context "$source_root" || authorization_status=$?
+  [ "$authorization_status" -eq 1 ] && return 0
+  [ "$authorization_status" -eq 0 ] || return "$authorization_status"
+
+  # The older shipped installer fetched its official companion through ClawHub
+  # and therefore owns a three-request audit instead of the current idle ledger.
+  if ! openclaw_frozen_target_source_has_path "$source_root" src/infra/clawhub-install-trust.ts &&
+    openclaw_frozen_target_source_contains \
+      "$source_root" src/plugins/clawhub.ts 'from "../infra/clawhub.js"'; then
+    export OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE="legacy"
+  fi
+}
+
 openclaw_resolve_frozen_live_cli_backend_package_mode() {
   local source_root="${1:?missing selected source root}" authorization_status=0
 

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -108,11 +108,11 @@ function runPrepublishAssertion(
   );
 }
 
-function runNoRequestsAssertion(baseUrl?: string, cwd = process.cwd()) {
+function runNoRequestsAssertion(baseUrl?: string, cwd = process.cwd(), env = process.env) {
   return spawnSync(process.execPath, [SCRIPT_PATH, "assert-no-requests", baseUrl ?? ""], {
     cwd,
     encoding: "utf8",
-    env: { ...process.env },
+    env: { ...env },
   });
 }
 
@@ -165,6 +165,15 @@ describe("ClawHub fixture server", () => {
     expect(artifactResponse.headers.get("x-clawhub-artifact-type")).toBe("npm-pack-tarball");
     expect(artifactResponse.headers.get("x-clawhub-artifact-sha256")).toMatch(/^[a-f0-9]{64}$/u);
     expect(Buffer.from(await artifactResponse.arrayBuffer()).length).toBeGreaterThan(100);
+
+    const legacyAssertion = runNoRequestsAssertion(baseUrl, process.cwd(), {
+      ...process.env,
+      OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_PACKAGE: PACKAGE_NAME,
+    });
+    expect(legacyAssertion.status, legacyAssertion.stderr).toBe(0);
+    expect(legacyAssertion.stdout).toContain(
+      "Verified complete legacy ClawHub artifact audit sequence.",
+    );
 
     const missingResponse = await fetch(`${baseUrl}/missing`);
     expect(missingResponse.status).toBe(404);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5939,8 +5939,9 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expectTextToIncludeAll(upgradeRunner, [
       "scripts/e2e/lib/upgrade-survivor",
       'UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"',
-      '-v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"',
-      '-v "$UPGRADE_DIAGNOSTICS:/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs:ro"',
+      'cp -R "$UPGRADE_SCENARIO_DIR/." "$UPGRADE_SCENARIO_STAGE/"',
+      'cp "$UPGRADE_DIAGNOSTICS" "$UPGRADE_SCENARIO_STAGE/diagnostics.mjs"',
+      '-v "$UPGRADE_SCENARIO_STAGE:/app/scripts/e2e/lib/upgrade-survivor:ro"',
       '-v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"',
       '-v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"',
       'DOCKER_E2E_WINDOWS_HELPERS_PATH="$UPGRADE_WINDOWS_HELPERS"',

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5940,6 +5940,8 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       "scripts/e2e/lib/upgrade-survivor",
       'UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"',
       '-v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"',
+      '-v "$UPGRADE_DIAGNOSTICS:/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs:ro"',
+      '-v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"',
       '-v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"',
       'DOCKER_E2E_WINDOWS_HELPERS_PATH="$UPGRADE_WINDOWS_HELPERS"',
       '-v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"',

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -29,6 +29,7 @@ function selectFrozenUpgradeOracle(
   version: string,
   baseline = "openclaw@2026.6.35",
   workingVersion?: string,
+  legacyClawHub = false,
 ) {
   const selectedRoot = join(root, "selected");
   const selectedScenario = join(selectedRoot, "scripts/e2e/lib/upgrade-survivor");
@@ -40,6 +41,13 @@ function selectFrozenUpgradeOracle(
     'throw new Error("selected oracle has no serving-turn command");\n',
   );
   writeFileSync(join(selectedScenario, "run.sh"), "# selected scenario runner\n");
+  if (legacyClawHub) {
+    mkdirSync(join(selectedRoot, "src/plugins"), { recursive: true });
+    writeFileSync(
+      join(selectedRoot, "src/plugins/clawhub.ts"),
+      'import { install } from "../infra/clawhub.js";\n',
+    );
+  }
   for (const path of [
     "scripts/lib/npm-publish-plan.mjs",
     "scripts/windows-cmd-helpers.mjs",
@@ -66,6 +74,7 @@ function selectFrozenUpgradeOracle(
     "selected release contract",
   );
   const selectedSha = git("rev-parse", "HEAD");
+  const modePath = join(root, "clawhub-mode");
   if (workingVersion) {
     writeFileSync(join(selectedRoot, "package.json"), JSON.stringify({ version: workingVersion }));
   }
@@ -86,6 +95,7 @@ ${policy}
 printf '%s\\n' "\${UPGRADE_SCENARIO_DIR:-$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor}/assertions.mjs"
 printf '%s\\n' "$UPGRADE_RUNNER"
 printf '%s\\n' \${UPGRADE_SCENARIO_ARGS[@]+"\${UPGRADE_SCENARIO_ARGS[@]}"}
+printf '%s' "$OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE" > "$MODE_PATH"
 `,
     ],
     {
@@ -98,11 +108,13 @@ printf '%s\\n' \${UPGRADE_SCENARIO_ARGS[@]+"\${UPGRADE_SCENARIO_ARGS[@]}"}
         OPENCLAW_TOOLING_SHA: "f".repeat(40),
         OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
         OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: baseline,
+        MODE_PATH: modePath,
       },
     },
   );
   const [oracle, runner, ...mounts] = result.stdout.trim().split("\n").filter(Boolean);
-  return { result, oracle, runner, mounts, selectedOracle, selectedScenario };
+  const clawhubMode = existsSync(modePath) ? readFileSync(modePath, "utf8") : undefined;
+  return { result, oracle, runner, mounts, selectedOracle, selectedScenario, clawhubMode };
 }
 
 function writeJson(path: string, value: unknown): void {
@@ -1019,6 +1031,14 @@ describe("upgrade survivor assertions", () => {
                 `${proof.selectedScenario}:/app/scripts/e2e/lib/upgrade-survivor:ro`,
                 "-v",
                 expect.stringMatching(
+                  /diagnostics\.mjs:\/app\/scripts\/e2e\/lib\/upgrade-survivor\/diagnostics\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
+                  /npm-registry-server\.mjs:\/app\/scripts\/e2e\/lib\/plugins\/npm-registry-server\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
                   /npm-publish-plan\.mjs:\/app\/scripts\/lib\/npm-publish-plan\.mjs:ro$/u,
                 ),
                 "-v",
@@ -1052,6 +1072,23 @@ describe("upgrade survivor assertions", () => {
       const proof = selectFrozenUpgradeOracle(root, version);
       expect(proof.result.status).not.toBe(0);
       expect(proof.oracle).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("derives the shipped ClawHub request contract from the authorized selected source", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-clawhub-mode-"));
+    try {
+      const proof = selectFrozenUpgradeOracle(
+        root,
+        "2026.6.35",
+        "openclaw@2026.6.34",
+        undefined,
+        true,
+      );
+      expect(proof.result.status, proof.result.stderr).toBe(0);
+      expect(proof.clawhubMode).toBe("legacy");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -109,12 +109,23 @@ printf '%s' "$OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE" > "$MODE_PATH"
         OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
         OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: baseline,
         MODE_PATH: modePath,
+        TMPDIR: root,
       },
     },
   );
   const [oracle, runner, ...mounts] = result.stdout.trim().split("\n").filter(Boolean);
   const clawhubMode = existsSync(modePath) ? readFileSync(modePath, "utf8") : undefined;
-  return { result, oracle, runner, mounts, selectedOracle, selectedScenario, clawhubMode };
+  const stagedScenario = mounts[0] === "-v" ? mounts[1]?.split(":", 1)[0] : undefined;
+  return {
+    result,
+    oracle,
+    runner,
+    mounts,
+    selectedOracle,
+    selectedScenario,
+    stagedScenario,
+    clawhubMode,
+  };
 }
 
 function writeJson(path: string, value: unknown): void {
@@ -1024,14 +1035,20 @@ describe("upgrade survivor assertions", () => {
             "run.sh",
           ),
         );
+        if (selected) {
+          expect(readFileSync(join(proof.stagedScenario!, "assertions.mjs"), "utf8")).toBe(
+            readFileSync(proof.selectedOracle, "utf8"),
+          );
+          expect(readFileSync(join(proof.stagedScenario!, "diagnostics.mjs"), "utf8")).toBe(
+            readFileSync("scripts/e2e/lib/upgrade-survivor/diagnostics.mjs", "utf8"),
+          );
+        }
         expect(proof.mounts).toEqual(
           selected
             ? [
                 "-v",
-                `${proof.selectedScenario}:/app/scripts/e2e/lib/upgrade-survivor:ro`,
-                "-v",
                 expect.stringMatching(
-                  /diagnostics\.mjs:\/app\/scripts\/e2e\/lib\/upgrade-survivor\/diagnostics\.mjs:ro$/u,
+                  /openclaw-upgrade-scenario\.[^/]+:\/app\/scripts\/e2e\/lib\/upgrade-survivor:ro$/u,
                 ),
                 "-v",
                 expect.stringMatching(


### PR DESCRIPTION
## What Problem This Solves

Full validation of the 2026.6.35 candidate mixes the selected historical upgrade-survivor scenario with current trusted helper modules. The historical runner hardcodes paths under `/app/scripts`, so it loaded the current npm fixture server against the selected target old bounded-response module and failed before testing the candidate. Failure diagnostics were also absent because the historical scenario predates the trusted diagnostics module.

## Why This Change Was Made

Keep the selected release scenario and assertions, but bind the current trusted npm fixture server, its bounded-response dependency, and diagnostics module as one coherent helper closure at the exact hardcoded paths. This does not add a compatibility mode or weaken scenario assertions.

## User Impact

Extended-stable validation can exercise historical upgrade scenarios without module-generation skew in the test harness. Product runtime is unchanged.

## Evidence

- Red: full validation run 34261943173, candidate release-check jobs 102187203871 and 102188432481. The fixture server failed because `createBoundedResponseTooLargeError` was missing from the selected old helper; diagnostics then failed with `MODULE_NOT_FOUND`.
- Green: focused `docker-build-helper` contract test; Bash syntax; Oxfmt; OXLint; diff check.
- Production/runtime LOC: 0. Release harness: +5/-2. Tests: +2/-0.