### PR TITLE
fix(ui): render Markdown in conversation position previews

### DIFF
--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -44,7 +44,15 @@ suite.define(() => {
                       },
                     },
                   ]
-                : [{ text: `Transcript checkpoint ${index}`, type: "text" }],
+                : [
+                    {
+                      text:
+                        index === 1
+                          ? "![Preview](data:image/gif;base64,R0lGODlhAAQABIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)"
+                          : `Transcript **checkpoint ${index}** with \`code\` and *emphasis*.`,
+                      type: "text",
+                    },
+                  ],
             role: index % 2 === 0 ? "user" : "assistant",
             timestamp: Date.UTC(2026, 8, 4, 12, index),
           }));
@@ -67,7 +75,7 @@ suite.define(() => {
           const transcript = page.locator(".chat-thread");
           await transcript
             .locator(".chat-virtual-row")
-            .getByText("Transcript checkpoint 239", { exact: true })
+            .getByText("Transcript checkpoint 239 with code and emphasis.", { exact: true })
             .waitFor();
 
           const rail = page.locator(".chat-position-rail");
@@ -241,8 +249,25 @@ suite.define(() => {
           await page.mouse.wheel(0, -6000);
           await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBe(0);
           await expect.poll(fades).toEqual({ top: false, bottom: true });
+          await markers.nth(1).hover();
+          const previewImage = preview.locator("img");
+          await expect
+            .poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalHeight))
+            .toBe(1024);
+          expect(
+            await preview.evaluate(
+              (element) =>
+                element.getBoundingClientRect().height /
+                Number.parseFloat(getComputedStyle(element).lineHeight),
+            ),
+          ).toBeLessThanOrEqual(3.01);
+          await page.mouse.move(600, 100);
+
           await markers.nth(4).hover();
           await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 4");
+          expect(await preview.locator("strong").textContent()).toBe("checkpoint 4");
+          expect(await preview.locator("code").textContent()).toBe("code");
+          expect(await preview.locator("em").textContent()).toBe("emphasis");
           expect(await transcript.evaluate((element) => element.scrollTop)).toBe(readerOffset);
           expect(await scroller.evaluate((element) => element.scrollTop)).toBe(0);
           // Pointer focus must not move an edge mark before its click completes.
@@ -328,7 +353,9 @@ suite.define(() => {
           await expect.poll(strokeSizes).toEqual(["8px × 2px"]);
           await expect.poll(visibilityMatchesViewport).toBe(true);
           await markers.first().hover();
-          await expect.poll(() => preview.textContent()).toBe("Preview unavailable");
+          await expect
+            .poll(async () => (await preview.textContent())?.trim())
+            .toBe("Preview unavailable");
           expect(await preview.boundingBox()).not.toBeNull();
           await page.mouse.move(600, 100);
           await markers.nth(5).focus();

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -229,6 +229,40 @@ describe("conversation position rail", () => {
     }
   });
 
+  it.each(["user", "assistant"])("renders safe Markdown in %s previews", (role) => {
+    const messages = [
+      message(
+        "formatted",
+        role,
+        "**Important** *detail* `code`\n\n- [Guide](https://example.com)\n<script>alert(1)</script>",
+        1,
+      ),
+      message("next", role === "user" ? "assistant" : "user", "Next turn", 2),
+    ];
+    const props = threadProps("rail-markdown", "agent:main:markdown", messages);
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    props.onRequestUpdate = rerender;
+    try {
+      rerender();
+      transcript.hostConnected();
+      container.querySelector<HTMLButtonElement>(".chat-position-rail__marker")!.focus();
+      const preview = container.querySelector(".chat-position-rail__preview-copy")!;
+      expect(preview.querySelector("strong")?.textContent).toBe("Important");
+      expect(preview.querySelector("em")?.textContent).toBe("detail");
+      expect(preview.querySelector("code")?.textContent).toBe("code");
+      expect(preview.querySelector("li a")?.textContent).toBe("Guide");
+      expect(preview.querySelector("script")).toBeNull();
+      expect(preview.closest("[inert]")).not.toBeNull();
+    } finally {
+      transcript.hostDisconnected();
+    }
+  });
+
   it("uses the visible completed answer and keeps attachment-only user landmarks", () => {
     const messages = [
       message("question", "user", "Inspect the design", 1),

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -5,6 +5,8 @@ import { directive } from "lit/directive.js";
 import { guard } from "lit/directives/guard.js";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import { normalizeMessage, resolveMessageRole } from "../../../lib/chat/message-normalizer.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
@@ -379,9 +381,7 @@ class ChatPositionRailDirective extends AsyncDirective {
           resolveMessageDisplayMarkdown(
             previewMarker.message,
             normalizeMessage(previewMarker.message),
-          )
-            .replace(/\s+/g, " ")
-            .trim(),
+          ).trim(),
           PREVIEW_LENGTH,
         )
       : "";
@@ -493,9 +493,10 @@ class ChatPositionRailDirective extends AsyncDirective {
                     aria-hidden="true"
                   >
                     <span class="chat-position-rail__preview-label">${previewMarker.label}</span>
-                    <span class="chat-position-rail__preview-copy"
-                      >${previewText || t("chat.attachments.previewUnavailable")}</span
-                    >
+                    <!-- Preview links remain non-interactive; the marker owns keyboard navigation. -->
+                    <div class="chat-position-rail__preview-copy" inert>
+                      ${previewText ? unsafeHTML(toSanitizedMarkdownHtml(previewText, { codeBlockChrome: "none" })) : t("chat.attachments.previewUnavailable")}
+                    </div>
                   </div>
                 `
               : nothing

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -218,9 +218,24 @@
 
 .chat-position-rail__preview-copy {
   display: -webkit-box;
+  max-height: 3lh;
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+  overflow-wrap: anywhere;
+}
+
+.chat-position-rail__preview-copy :where(p, h1, h2, h3, h4, ul, ol, blockquote, pre) {
+  margin: 0;
+  font: inherit;
+}
+
+.chat-position-rail__preview-copy :where(ul, ol) {
+  padding-inline-start: 1.25em;
+}
+
+.chat-position-rail__preview-copy :where(code) {
+  font-family: var(--mono);
 }
 
 .chat-thread-inner > :first-child {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Fixes an issue where users hovering conversation markers in the Control UI's conversation position rail would see raw Markdown delimiters instead of formatted message previews. This affects both user-turn and assistant-turn bubbles, not sidebar session hovercards.

## Why This Change Was Made

Reuse the existing sanitized Markdown renderer and preserve line breaks before rendering. Compact styling preserves the current three-line preview; preview content is inert so links do not introduce hidden keyboard targets or compete with marker navigation. No new dependency, setting, or storage contract.

## User Impact

Conversation previews now show bold, italics, inline code, and list structure. Hover bridging, keyboard navigation, scroll jumps, and narrow-layout behavior remain intact. The existing 140-character source limit remains; Markdown cut at that limit may still be incomplete.

## Evidence

- Rebased onto main at `8a26b70c633`; preserved the full-turn scrollable rail, lazy preview extraction, attachment fallback, and three-line layout. Rebased component tests: 7 passed; dark/light Chromium scenarios: 2 passed, with new captures inspected.
- Rebase review found only template whitespace in raw fallback `textContent`. This is not a visible-text contract; the browser assertion now checks exact text after trimming template indentation, preserving the user-facing fallback requirement without coupling it to HTML formatting.

- Component regression failed before the fix on missing rendered emphasis; all 7 component tests pass after the fix, including both message roles and unsafe HTML handling.
- Both dark/light browser scenarios pass: rendered emphasis/code, pointer movement into the bubble, Escape, keyboard navigation, scrolling, and responsive widths.
- Added a 1024px inline-image regression: the preview exceeded 63 lines before an explicit height cap; the rebased cap matches main’s three-line design.
- Independent autoreview completed with no actionable P0–P2 findings after addressing the image-height issue.
- Changed-file checks passed, including formatting, core/UI type checks, unused exports, and lint.
- Proof uses a built Control UI in real Chromium via Playwright with synthetic messages and a mocked Gateway. Screenshots were opened and visually inspected. This is not live-provider/Gateway proof; the operator's running Gateway was not touched.

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-position-rail.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-position-rail.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-position-rail.ts ui/src/pages/chat/components/chat-position-rail.test.ts ui/src/e2e/chat-position-rail.e2e.test.ts ui/src/styles/chat/message-layout.css
git diff --check
```

The screenshots below document the original Markdown change before main moved the rail. The rebase preserves main’s current rail placement and full-turn scrolling.

### Before

![Before: raw Markdown in the right-side user-turn preview](https://github.com/user-attachments/assets/fa5a02f6-f1f1-44f2-9eb5-121bc1a1c53d)

### After — dark

![After: formatted Markdown in the right-side preview, dark theme](https://github.com/user-attachments/assets/dad8d45c-ba06-44f9-9aa1-bfcbc0b3dbf9)

### After — light

![After: formatted Markdown in the right-side preview, light theme](https://github.com/user-attachments/assets/eb71ac91-ccd0-4584-9cf0-39ca3edf1aea)

