### PR TITLE
perf(ui): reuse prepared code block facts

### DIFF
--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -185,20 +185,6 @@ function codeClassAttribute(lang: string, highlighted: string): string {
   return classes.length > 0 ? ` class="${escapeMarkdownHtml(classes.join(" "))}"` : "";
 }
 
-function renderCodeElement(
-  text: string,
-  lang: string,
-  options: { blockArt?: boolean; highlight?: boolean } = {},
-): string {
-  if (options.blockArt || isMarkdownBlockArtText(text)) {
-    return `<pre><code class="markdown-block-art">${escapeMarkdownHtml(text)}</code></pre>`;
-  }
-  const highlighted =
-    options.highlight === false ? escapeMarkdownHtml(text) : highlightCodeHtml(text, lang);
-  const classAttr = codeClassAttribute(lang, highlighted);
-  return `<pre><code${classAttr}>${highlighted}</code></pre>`;
-}
-
 function renderCodeBlockHeader(lang: string, actions: string): string {
   const language = escapeMarkdownHtml(lang || t("chat.codeBlock.languageFallback"));
   return `<div class="code-block-header"><span class="code-block-lang">${language}</span><div class="code-block-actions">${actions}</div></div>`;
@@ -217,7 +203,13 @@ export function renderMarkdownCodeBlock(
   options: { blockArt?: boolean; copyText?: string; highlight?: boolean } = {},
 ): string {
   const blockArt = options.blockArt || isMarkdownBlockArtText(text);
-  const codeBlock = renderCodeElement(text, lang, { blockArt, highlight: options.highlight });
+  const highlight = options.highlight;
+  const highlighted =
+    blockArt || highlight === false ? escapeMarkdownHtml(text) : highlightCodeHtml(text, lang);
+  const classAttr = blockArt
+    ? ' class="markdown-block-art"'
+    : codeClassAttribute(lang, highlighted);
+  const codeBlock = `<pre><code${classAttr}>${highlighted}</code></pre>`;
   if (!shouldRenderCodeBlockCopy(env) && !shouldRenderCodeBlockInteraction(env)) {
     return codeBlock;
   }
@@ -231,7 +223,7 @@ export function renderMarkdownCodeBlock(
   }
   const hiddenLineCount = ["text", "md", "markdown"].includes(lang.trim().toLowerCase())
     ? 0
-    : Math.max(0, markdownCodeBlockCopyText(text).split("\n").length - CODE_PREVIEW_LINE_COUNT);
+    : Math.max(0, countCodeBlockLines(text) - CODE_PREVIEW_LINE_COUNT);
   const hiddenCount = { count: String(hiddenLineCount) };
   const expandLabel = t(
     hiddenLineCount === 1 ? "chat.codeBlock.showHiddenLine" : "chat.codeBlock.showHiddenLines",
@@ -248,6 +240,16 @@ export function renderMarkdownCodeBlock(
   const wrapButton = `<button type="button" class="code-block-wrap" aria-label="${wrapLabel}" title="${wrapLabel}" aria-pressed="false"><span class="code-block-wrap__enable" aria-hidden="true"></span><span class="code-block-wrap__disable" aria-hidden="true"></span></button>`;
   const header = renderCodeBlockHeader(lang, `${wrapButton}${copyButton}`);
   return `<div class="code-block-wrapper${hiddenLineCount ? " is-collapsible" : ""}">${header}<div class="code-block-viewport">${codeBlock}</div>${expandButton}</div>`;
+}
+
+function countCodeBlockLines(text: string): number {
+  let lines = 1;
+  let index = -1;
+  // Match copied code: one terminal newline does not add a displayed line.
+  while ((index = text.indexOf("\n", index + 1)) >= 0 && index < text.length - 1) {
+    lines += 1;
+  }
+  return lines;
 }
 
 export function markdownCodeBlockCopyText(content: string): string {


### PR DESCRIPTION
Closes #142443

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Code-block rendering repeated block-art classification after a negative result and built a temporary line array solely to count hidden preview lines. Those extra source passes and arrays were unnecessary on the chat rendering path, including streaming code fences.

## Why This Change Was Made

This is a maintainer-requested, behavior-preserving cleanup. Absorb the sole private code renderer into its caller so it consumes the prepared block-art decision, and count LF boundaries without splitting the text. The counter preserves the existing copied-text rule that ignores exactly one terminal newline. Eager highlight-option access, highlighting, escaping, copied bytes, seven-line preview, labels and controls stay unchanged. Production grows by two lines; no tests, cache, dependency or public API are added.

## User Impact

Code blocks retain their appearance and copy, expand and wrap behavior. The change avoids redundant preparation work; it does not change parser limits, clipboard transport or highlighting policy.

Config, defaults, stored data, migrations and Gateway/API contracts are unchanged.

## Evidence

- Fifty-three exact HTML/control/copy/getter cases match the original renderer; all 105 existing tests pass before and after.
- Both full production UI builds passed the synthetic full-app flow with mocked Gateway data, 14 captures and six exact Clipboard API stub writes per run. Navigation, streaming, reveal, wrap, responsive resize and virtual unmount/remount behavior passed. This is not native OS clipboard or real Gateway/provider proof.
- Reachable 33,600-character open fences, below the existing 40,000-character message parse limit, showed 34.10% and 36.80% lower sampled cumulative allocation in the ordinary and negative-art fixtures. Completed highlighted-fence cohorts were small/mixed; no broad latency, retained-memory or whole-Gateway gain is claimed.
- The selected changed-code gate passed, and final managed P0–P2 review was scoped-clean with no findings. Final source remained unchanged.

The approved before/after collapsed-code pair shows matching seven-line preview and 34-hidden-line controls. Transient completion confetti differs, so the images are not claimed to be pixel-identical. The exact selected DOM/control/clipboard projection is preserved separately.

![Before: synthetic collapsed code controls](https://github.com/user-attachments/assets/1c2b2083-d2eb-4781-a870-780ee942e9ba)

![After: preserved collapsed code controls; confetti varies](https://github.com/user-attachments/assets/7b0d2885-e7ad-4ba4-8e22-5fc94f99c8da)