### PR TITLE
perf(scripts): combine legacy file boundary scans

### DIFF
--- a/scripts/check-database-first-legacy-stores.mts
+++ b/scripts/check-database-first-legacy-stores.mts
@@ -464,63 +464,47 @@ function isLegacyRestartSentinelPreflightDetection(
   );
 }
 
-function collectLegacyRestartSentinelBoundaryViolations(
-  sourceFile: ts.SourceFile,
-  relativePath: string,
-) {
-  if (relativePath === legacyRestartSentinelMigrationPath) {
-    return [];
-  }
-
-  const violations: LegacyStoreViolation[] = [];
-  const seen = new Set<string>();
-  function add(node: ts.Node, kind: string) {
+function collectLegacyFileBoundaryViolations(sourceFile: ts.SourceFile, relativePath: string) {
+  const checkRestartSentinel = relativePath !== legacyRestartSentinelMigrationPath;
+  const checkExecApprovals =
+    relativePath !== legacyExecApprovalsMigrationPath &&
+    relativePath !== legacyExecApprovalsConfigPath &&
+    relativePath !== stableExecApprovalsPolicyUriPath;
+  const restartViolations: LegacyStoreViolation[] = [];
+  const approvalViolations: LegacyStoreViolation[] = [];
+  const seenRestartViolations = new Set<string>();
+  function addRestartViolation(node: ts.Node, kind: string) {
     const line = toLine(sourceFile, node);
     const key = `${line}:${kind}`;
-    if (seen.has(key)) {
+    if (seenRestartViolations.has(key)) {
       return;
     }
-    seen.add(key);
-    violations.push({ kind, line });
+    seenRestartViolations.add(key);
+    restartViolations.push({ kind, line });
   }
 
   function visit(node: ts.Node) {
     if (
+      checkRestartSentinel &&
       ts.isStringLiteralLike(node) &&
       legacyRestartSentinelFilenamePattern.test(node.text) &&
       !isLegacyRestartSentinelPreflightDetection(node, relativePath)
     ) {
-      add(node, "legacy restart sentinel reference");
+      addRestartViolation(node, "legacy restart sentinel reference");
     }
     if (
       relativePath === legacyRestartSentinelRuntimePath &&
       ts.isImportDeclaration(node) &&
       legacyRestartSentinelRuntimeImportSpecifiers.has(importSource(node))
     ) {
-      add(node, "legacy restart sentinel filesystem import");
+      addRestartViolation(node, "legacy restart sentinel filesystem import");
     }
-    ts.forEachChild(node, visit);
-  }
-  visit(sourceFile);
-  return violations;
-}
-
-function collectLegacyExecApprovalsBoundaryViolations(
-  sourceFile: ts.SourceFile,
-  relativePath: string,
-) {
-  if (
-    relativePath === legacyExecApprovalsMigrationPath ||
-    relativePath === legacyExecApprovalsConfigPath ||
-    relativePath === stableExecApprovalsPolicyUriPath
-  ) {
-    return [];
-  }
-
-  const violations: LegacyStoreViolation[] = [];
-  function visit(node: ts.Node) {
-    if (ts.isStringLiteralLike(node) && legacyExecApprovalsFilenamePattern.test(node.text)) {
-      violations.push({
+    if (
+      checkExecApprovals &&
+      ts.isStringLiteralLike(node) &&
+      legacyExecApprovalsFilenamePattern.test(node.text)
+    ) {
+      approvalViolations.push({
         kind: "legacy exec approvals reference",
         line: toLine(sourceFile, node),
       });
@@ -530,7 +514,7 @@ function collectLegacyExecApprovalsBoundaryViolations(
       ts.isImportDeclaration(node) &&
       legacyRestartSentinelRuntimeImportSpecifiers.has(importSource(node))
     ) {
-      violations.push({
+      approvalViolations.push({
         kind: "legacy exec approvals filesystem import",
         line: toLine(sourceFile, node),
       });
@@ -538,7 +522,8 @@ function collectLegacyExecApprovalsBoundaryViolations(
     ts.forEachChild(node, visit);
   }
   visit(sourceFile);
-  return violations;
+  // Preserve rule-family ordering and the restart rule's distinct deduplication policy.
+  return [...restartViolations, ...approvalViolations];
 }
 
 function isHelperWriteModuleSource(source: string) {
@@ -751,10 +736,7 @@ export function collectDatabaseFirstLegacyStoreViolations(
 ): LegacyStoreViolation[] {
   const relativePath = inputRelativePath.replaceAll("\\", "/");
   const sourceFile = ts.createSourceFile(relativePath, content, ts.ScriptTarget.Latest, true);
-  const boundaryViolations = [
-    ...collectLegacyRestartSentinelBoundaryViolations(sourceFile, relativePath),
-    ...collectLegacyExecApprovalsBoundaryViolations(sourceFile, relativePath),
-  ];
+  const boundaryViolations = collectLegacyFileBoundaryViolations(sourceFile, relativePath);
   if (isAllowedLegacyOwnerPath(relativePath)) {
     return boundaryViolations;
   }

--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -295,6 +295,25 @@ describe("check-database-first-legacy-stores", () => {
     expect(copiedUriViolations).toEqual([{ kind: "legacy exec approvals reference", line: 1 }]);
   });
 
+  it("preserves boundary family order and distinct duplicate policies in migration paths", () => {
+    const content = String.raw`
+      type ApprovalPath = "exec\x2dapprovals.json";
+      const sentinels = ["restart-sentinel.json", "restart-sentinel.json"];
+      type SentinelPath = "restart\x2dsentinel.json";
+      const approvals = ["exec-approvals.json", "exec-approvals.json"];
+    `;
+
+    expect(
+      collectDatabaseFirstLegacyStoreViolations(content, "src/commands/doctor/boundaries.ts"),
+    ).toEqual([
+      { kind: "legacy restart sentinel reference", line: 3 },
+      { kind: "legacy restart sentinel reference", line: 4 },
+      { kind: "legacy exec approvals reference", line: 2 },
+      { kind: "legacy exec approvals reference", line: 5 },
+      { kind: "legacy exec approvals reference", line: 5 },
+    ]);
+  });
+
   // Legacy paths and literal propagation.
   it.each(
     namedCases({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

The database-first architecture guard takes roughly 39 seconds to scan this source tree. It performs unnecessary repeated traversal while examining every source file.

## Why This Change Was Made

Combine the two pure legacy-file boundary walks over each parsed AST. Keep separate result buffers and the existing sentinel-only deduplication so findings retain their exact family order, lines and duplicates. Exact migration/config/URI exceptions, CLI preflight checks and type-position literals remain unchanged. The abstract interpreter, source discovery, reads, native Swift rules and failure behavior are untouched.

This removes 18 tooling lines; one 19-line preservation fixture covers the combined rules at the existing exported scanner boundary.

## User Impact

Developers get a small reduction in full guard runtime without changing scan coverage or accepted code. This has no Gateway or end-user runtime behavior change.

## Evidence

The full scanner test file passed **537 tests on both baseline and candidate**, including the new preservation fixture. Formatting and all **19 normal changed checks** passed. Independent source review and fresh managed Codex P2 review found no actionable findings; independent saved-data audit passed.

On macOS with Node 26.8.1 at base `b138ae4f`, fixed **B0, C0, C1, B1**, one fresh process per arm, ran the real command:

```sh
node --import ./scripts/tsx.mjs scripts/check-database-first-legacy-stores.mts
```

All four exits succeeded with byte-identical complete stdout/stderr. Untimed before/after inventories matched all **15,142 source files (109,133,378 bytes)** and **332 native Swift files (3,611,542 bytes)**.

| Arm | Wall seconds | User CPU seconds | System CPU seconds | Total child CPU seconds | Kernel child peak RSS bytes | Observed tree peak RSS bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| B0 | 38.616763917 | 41.918298 | 1.416053 | 43.334351 | 350978048 | 374702080 |
| C0 | 38.167997542 | 41.474562 | 1.418249 | 42.892811 | 350715904 | 375013376 |
| C1 | 38.206350333 | 41.463567 | 1.430512 | 42.894079 | 349421568 | 373440512 |
| B1 | 38.815833583 | 42.038972 | 1.409033 | 43.448005 | 347750400 | 371539968 |

Reductions below use `(baseline - candidate) / baseline`; negative values are regressions and are retained.

| Order | Wall | User CPU | System CPU | Total child CPU | Kernel child peak RSS | Observed tree peak RSS |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| B0 → C0 | +1.162% | +1.059% | -0.155% | +1.019% | +0.075% | -0.083% |
| B1 → C1 | +1.570% | +1.369% | -1.524% | +1.275% | -0.481% | -0.512% |

Wall reduction was **1.162% forward / 1.570% reverse**, with **1.019% / 1.275%** less total child CPU. System CPU increased slightly in both orders; observed tree RSS increased in both, and kernel child RSS increased in reverse order. No memory improvement is claimed.

Limitations: inventory reads warmed filesystem caches before B0. Each arm used a fresh process and phase-owned caches; one sample per arm does not establish a confidence interval. CPU/kernel RSS describe the direct child; tree RSS is sampled. These are tooling measurements, not live Gateway latency.

All phases closed cleanly and the exact candidate was restored. A typo in the first final-inventory launcher path exited 2 before the adapter or a child started; that error was retained and the originally planned inventory ran once after correcting the path. None of the four measured scanner runs was repeated. No thresholds, corpus, checks or limits were relaxed.
