### PR TITLE
fix: avoid full-history reads for delivery mirrors

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -8,8 +8,13 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { appendTranscriptEvent, persistSessionTranscriptTurn } from "./session-accessor.js";
 import {
+  appendTranscriptEvent,
+  persistSessionTranscriptTurn,
+  readActiveTranscriptEntryAnchor,
+} from "./session-accessor.js";
+import {
+  readLatestSessionTranscriptMessageEvent,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptActivePathEntryRelation,
   readSessionTranscriptActiveStats,
@@ -23,6 +28,7 @@ import {
 } from "./session-accessor.sqlite-history-events.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { runWithSessionTranscriptReadFence } from "./session-transcript-read-fence.js";
 import {
   reconcileSessionTranscriptIndexes,
   startSessionTranscriptIndexReconcile,
@@ -109,6 +115,9 @@ describe("SQLite active transcript event projection", () => {
     expect(() => readSessionTranscriptMessageEventCount(scope)).toThrow(
       SessionTranscriptProjectionUnavailableError,
     );
+    expect(() => readLatestSessionTranscriptMessageEvent(scope)).toThrow(
+      SessionTranscriptProjectionUnavailableError,
+    );
     await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
 
     const page = readSessionTranscriptMessageEventPage(scope, { maxMessages: 10, offset: 0 });
@@ -118,6 +127,7 @@ describe("SQLite active transcript event projection", () => {
       "active",
     ]);
     expect(readSessionTranscriptActivePathEntryRelation(scope, "active")).toBe("exact");
+    expect(readLatestSessionTranscriptMessageEvent(scope)?.event).toMatchObject({ id: "active" });
     expect(readSessionTranscriptActivePathEntryRelation(scope, "root")).toBe("ancestor");
     expect(page.events.map((entry) => entry.seq)).toEqual([1, 2]);
     expect(page.totalMessages).toBe(2);
@@ -189,6 +199,46 @@ describe("SQLite active transcript event projection", () => {
 
     expect(readSessionTranscriptActiveStats(scope)).toMatchObject({ eventCount: 1 });
     expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeLessThan(1_000);
+    expect(readLatestSessionTranscriptMessageEvent(scope)?.event).toMatchObject({
+      id: "post-reset",
+    });
+  });
+
+  it("reads the latest message before an admission fence and follows a selected older leaf", async () => {
+    expect(readLatestSessionTranscriptMessageEvent(scope)).toBeUndefined();
+    await persistSessionTranscriptTurn(scope, {
+      messages: ["prior", "admitted", "later"].map((eventId, index) => ({
+        eventId,
+        parentId: index === 0 ? null : index === 1 ? "prior" : "admitted",
+        message: { role: "user", content: eventId },
+      })),
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    const anchor = readActiveTranscriptEntryAnchor({
+      ...scope,
+      storePath: database.path,
+      entryId: "admitted",
+    });
+    if (!anchor) {
+      throw new Error("expected admitted message anchor");
+    }
+    expect(readLatestSessionTranscriptMessageEvent(scope)?.event).toMatchObject({ id: "later" });
+    expect(
+      runWithSessionTranscriptReadFence(
+        { ...anchor, logicalTurnId: "fenced-turn", role: "user" },
+        () => readLatestSessionTranscriptMessageEvent(scope),
+      )?.event,
+    ).toMatchObject({ id: "prior" });
+
+    await appendTranscriptEvent(scope, {
+      type: "leaf",
+      id: "selected-leaf",
+      parentId: "later",
+      targetId: "prior",
+    });
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    expect(readLatestSessionTranscriptMessageEvent(scope)?.event).toMatchObject({ id: "prior" });
   });
 
   it("keeps counting genuinely oversized post-reset events", async () => {

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -84,6 +84,39 @@ export function readSessionTranscriptMessageEvents(
   });
 }
 
+/** Reads the last active-path message without hydrating its historical ancestors. */
+export function readLatestSessionTranscriptMessageEvent(
+  scope: SessionTranscriptReadScope,
+): SessionTranscriptMessageEvent | undefined {
+  return withCurrentProjectionSnapshot(scope, (projection) => {
+    const fence = resolveSqliteSessionTranscriptReadFence({
+      database: projection.database,
+      ...projection.resolved,
+    });
+    const row = executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      getActiveTranscriptKysely(projection.database)
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select(["active.event_seq", "active.message_position", "event.event_json"])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .where("active.message_position", "is not", null)
+        .where(
+          "active.message_position",
+          "<",
+          fence?.beforeActiveMessagePosition ?? projection.state.activeMessageCount,
+        )
+        .orderBy("active.message_position", "desc")
+        .limit(1),
+    );
+    return row ? parseActiveTranscriptMessageRow(row) : undefined;
+  });
+}
+
 /** Visits messages synchronously inside one active-path read snapshot. */
 export function visitSessionTranscriptMessageEvents(
   scope: SessionTranscriptReadScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -284,6 +284,7 @@ export { readActiveTranscriptEntryAnchor } from "./session-accessor.sqlite-trans
 export { validateSessionTranscriptContextAdmission } from "./session-accessor.sqlite-model-context.js";
 export {
   isSessionTranscriptProjectionUnavailableError,
+  readLatestSessionTranscriptMessageEvent,
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -23,6 +23,7 @@ import {
   persistSessionTranscriptTurn,
   readLatestTranscriptAssistantText,
   replaceSessionEntry,
+  replaceTranscriptEvents,
   updateSessionEntry,
 } from "./session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
@@ -1718,6 +1719,53 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         content: [{ type: "text", text: "[redacted by hook]" }],
       }),
     ]);
+  });
+
+  it("dedupes a delivery mirror without parsing historical message bodies", async () => {
+    await writeTranscriptStore();
+    const scope = createFixtureTranscriptScope();
+    const history = Array.from({ length: 500 }, (_, index) => ({
+      type: "message",
+      id: `history-${index}`,
+      parentId: index === 0 ? null : `history-${index - 1}`,
+      message: {
+        role: "user",
+        content: `archived-mirror-body-${index} ${"x".repeat(2_000)}`,
+      },
+    }));
+    await replaceTranscriptEvents(scope, [
+      ...history,
+      {
+        type: "message",
+        id: "latest-reply",
+        parentId: "history-499",
+        message: createExactAssistantMessage({ text: "The current reply" }),
+      },
+    ]);
+    await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
+      path: resolveSqliteTargetFromSessionStorePath(fixture.storePath(), { agentId: "main" }).path,
+    });
+    const parse = JSON.parse;
+    let parsedHistoricalBodies = 0;
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (typeof text === "string" && text.includes("archived-mirror-body-")) {
+        parsedHistoricalBodies += 1;
+      }
+      return parse(text, reviver);
+    });
+    try {
+      const result = await appendAssistantMessageToSessionTranscript({
+        sessionKey,
+        storePath: fixture.storePath(),
+        text: "The current reply",
+      });
+      expect(result).toMatchObject({ ok: true, messageId: "latest-reply" });
+      expect(parsedHistoricalBodies).toBe(0);
+    } finally {
+      parseSpy.mockRestore();
+    }
+    expect(await loadFixtureMessages()).toHaveLength(history.length + 1);
   });
 
   it("reports assistant messages blocked by before_message_write", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -30,14 +30,15 @@ import {
 import { resolveDefaultSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
 import {
   loadSessionEntryReadOnly,
-  loadTranscriptEvents,
   isSessionTranscriptProjectionUnavailableError,
   persistSessionTranscriptTurn,
   readActiveTranscriptEntryAnchor,
+  readLatestSessionTranscriptMessageEvent,
   readLatestTranscriptAssistantText,
   readSessionTranscriptMessageEventPage,
   resolveSessionEntrySelection,
   updateSessionEntry,
+  waitForSessionTranscriptProjection,
   type SessionTranscriptTurnPersistOptions,
   type SessionTranscriptTurnWriteContext,
   type SessionTranscriptTurnExpectedState,
@@ -59,10 +60,6 @@ import {
   readPreferredUpstreamUserText,
 } from "./transcript-recent-window.js";
 import { streamSessionTranscriptLinesReverse } from "./transcript-stream.js";
-import {
-  scanSessionTranscriptTree,
-  selectSessionTranscriptTreePathNodes,
-} from "./transcript-tree.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 type SessionTranscriptAppendTarget = {
@@ -592,6 +589,11 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
       sessionKey: resolved.normalizedKey,
       storePath,
     };
+    if (isRedundantDeliveryMirror(params.message) && !identifiedDeliveryMirror) {
+      // Reconciliation needs the writer queue. Wait before entering it, then
+      // read the current projected tail again inside the guarded append.
+      await waitForSessionTranscriptProjection(target);
+    }
     let latestEquivalentAssistantId: string | undefined;
     // Identified delivery mirrors, including suppressed finals, dedupe only by
     // key so same-text markers from different source ids remain separate rows.
@@ -741,29 +743,23 @@ async function readLatestVisibleTranscriptMessage(scope: {
   sessionKey?: string;
   storePath: string;
 }): Promise<{ id?: string; message: unknown } | undefined> {
-  const events = await loadTranscriptEvents(scope).catch(() => []);
-  const tree = scanSessionTranscriptTree(events);
-  const visiblePath = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
-  const visibleEvents =
-    visiblePath.length > 0
-      ? visiblePath.map((node) => node.entry)
-      : tree.hasLeafControl
-        ? []
-        : events;
-  for (const event of visibleEvents.toReversed()) {
+  try {
+    const event = readLatestSessionTranscriptMessageEvent(scope)?.event;
     if (!event || typeof event !== "object" || Array.isArray(event)) {
-      continue;
+      return undefined;
     }
     const record = event as { id?: unknown; message?: unknown };
     if (record.message === undefined) {
-      continue;
+      return undefined;
     }
     return {
       ...(typeof record.id === "string" ? { id: record.id } : {}),
       message: record.message,
     };
+  } catch {
+    // Mirror deduplication remains best-effort when transcript reads are unavailable.
+    return undefined;
   }
-  return undefined;
 }
 
 function isIdentifiedDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {


### PR DESCRIPTION
Related: #119720

## Summary

### High Level TLDR

Delivery confirmations could pause the Gateway while checking whether the same reply was already saved: the check loaded and parsed the entire retained conversation. This change reads the latest active message through the existing SQLite index instead.

This is the first scoped repair for #119720. Full-history reset hooks, reset navigation planning, existing duplicated history, and projection rebuild costs remain follow-up work. This PR does not claim to resolve the entire reported `/new` stall.

## What Problem This Solves

Fixes an issue where users receiving delivery confirmations could experience a Gateway pause when the session had a large retained history. The affected path is duplicate detection for delivery mirrors without a source identity, including reset confirmation persistence.

## Root Cause

The latest-visible-message helper loaded all transcript events, parsed historical JSON, rebuilt the active tree, and searched backward to obtain one message. Its cost therefore grew with the entire retained archive even when the active transcript projection was already current. The redacted production timeline and historical attribution are in #119720.

## Why This Change Was Made

Read one message from the existing active-path projection in a current snapshot, respecting admission read fences and branch selection. Preserve the existing behavior across reset boundaries by using the active path rather than the post-reset window.

Wait for pending projection reconciliation before entering the transcript writer queue, then reread the tail inside the guarded append. Reconciliation itself needs that queue. No schema, configuration, retention, or historical-data migration is introduced.

## User Impact

For sessions with a current projection, this duplicate check no longer parses historical message bodies. Existing source-identified delivery mirrors retain their key-based deduplication behavior. Other sources of reset latency remain tracked in the linked issue.

## Verification

### Real behavior proof

- Regression fixture: 500 historical messages followed by the matching assistant reply. The original lookup parsed all 500 historical bodies and failed the zero-history-read assertion. The patched lookup parsed none, returned the existing reply ID, and appended no duplicate.
- Both focused suites passed: **82 tests**, covering transcript appends and active-event reads, including pending branch reconciliation, reset history, empty history, and admission fences.
- Synthetic reader comparison using an isolated SQLite store, 6,000 messages with 4,000-character bodies, Node 24.19.0, three warmups and seven interleaved samples per implementation: the old full-load/tree-scan lookup had a **25.58 ms median**, versus **0.77 ms** for the indexed lookup. Both selected the same final message. This measures the reader, not end-to-end Gateway latency.
- Changed-file checks passed (`node scripts/check-changed.mjs -- <the five changed files>`), including core and core-test typechecks, changed-file lint/format, dead-export scans, import-cycle checks, and repository guards. `git diff --check` also passed.

Focused command:

```sh
node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts --reporter=dot
```

### Independent pickup validation — September 8, 2026

Verified on unchanged head `4318512d6cec71b9743bf2396bc71f168b481f05`:

- **Before/after tests:** 99 original-code baseline tests passed. The identical regression failed before the fix with 500 historical message bodies parsed, then passed after the fix with zero. Complete final suites passed **101 tests**: 66 transcript, 16 active-event reader, and 19 tree controls. Canonical changed-file checks passed again. Isolated test runtime: Node 24.19.0, pnpm 12.3.4, Vitest 5.0.0.
- **AUTOREVIEW:** the actual structured branch-review helper completed with **exit 0**, no accepted/actionable findings in its default P0 blocking-review scope, and an overall “patch is correct” result. It reviewed the nonempty five-file diff against main `5734578e448b7959141cc68c70a89f939e465933`. The scanner, reviewer isolation, and final source verification remained enabled. The local process used existing native authentication without inheriting Gateway-only proxy or shared-store environment values.
- **CI:** [attempt 2 passed](https://github.com/openclaw/openclaw/actions/runs/34269936602/attempts/2), with **143 successful jobs, 16 skipped, and no failures**, including the required `openclaw/ci-gate`. Attempt 1 had a shutdown-fixture timeout. Before the single targeted rerun, the exact 26-file / 350-test sequence passed on this head, the original base, and pinned main with unchanged ordering and assertions. The original timeout was not reproduced; no source fix, timeout increase, or specific environmental root cause is claimed.
- **ClawSweeper:** [Revision 2](https://github.com/openclaw/openclaw/pull/142453#issuecomment-5590459907) reviewed this exact head and reports no actionable findings or before-merge items; ready for maintainer review, not a human approval.

AUTOREVIEW command (executed in the clean native-auth subprocess described above):

```sh
.agents/skills/autoreview/scripts/autoreview --mode branch --base 5734578e448b7959141cc68c70a89f939e465933 --engine codex --stream-engine-output
```

No additional source edits or commits were needed. Broader reset/hooks/history recovery remains in #119720.

### What was not tested

No live Gateway or Telegram deployment, full repository test run, production-history migration, or end-to-end reset latency proof. The synthetic benchmark does not measure a stale projection rebuild.

## Evidence

The redacted incident evidence, existing-history amplification, timings, source history, and remaining repair areas are recorded in #119720. Regression coverage is included in this PR; no private transcripts or production identifiers are committed.

## Worked on by

- @VACInc
