### PR TITLE
refactor(queue): remove unused prompt deduplication mode

### DIFF
--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -326,7 +326,7 @@ describe("followup queue deduplication", () => {
     expect(second).toBe(true);
   });
 
-  it("deduplicates exact prompt when routing matches and no message id", () => {
+  it("admits identical prompts when routing matches and no message id is present", () => {
     const key = `test-dedup-whatsapp-${Date.now()}`;
 
     const first = enqueueFollowupRun(
@@ -668,33 +668,5 @@ describe("followup queue deduplication", () => {
       originatingTo: "group:G1",
     });
     expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
-  });
-
-  it("can opt-in to prompt-based dedupe when message id is absent", () => {
-    const key = `test-dedup-prompt-mode-${Date.now()}`;
-
-    const first = enqueueFollowupRun(
-      key,
-      createRun({
-        prompt: "Hello world",
-        originatingChannel: "whatsapp",
-        originatingTo: "+1234567890",
-      }),
-      collectSettings,
-      "prompt",
-    );
-    expect(first).toBe(true);
-
-    const second = enqueueFollowupRun(
-      key,
-      createRun({
-        prompt: "Hello world",
-        originatingChannel: "whatsapp",
-        originatingTo: "+1234567890",
-      }),
-      collectSettings,
-      "prompt",
-    );
-    expect(second).toBe(false);
   });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -419,7 +419,7 @@ export function resolveFollowupDeliveryContextKey(run: FollowupRun): string {
   ]);
 }
 
-export function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined {
+function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined {
   if (run.originatingReplyToMode === "off") {
     return undefined;
   }

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -19,7 +19,6 @@ import {
   kickFollowupDrainIfIdle,
   rememberFollowupDrainCallback,
   resolveFollowupDeliveryContextKey,
-  resolveFollowupReplyAnchor,
 } from "./drain.js";
 import {
   peekRecentQueueMessageId,
@@ -43,20 +42,6 @@ import {
   type QueueSettings,
 } from "./types.js";
 
-function followupRouteIdentityKey(run: FollowupRun): string {
-  return JSON.stringify([
-    channelRouteDedupeKey({
-      channel: run.originatingChannel,
-      to: run.originatingTo,
-      accountId: run.originatingAccountId,
-      threadId: run.originatingThreadId,
-    }),
-    resolveFollowupReplyAnchor(run) ?? "",
-    run.originatingReplyToMode ?? "",
-    normalizeChatType(run.originatingChatType) ?? "",
-  ]);
-}
-
 function followupMessageRouteIdentityKey(run: FollowupRun): string {
   return JSON.stringify([
     channelRouteDedupeKey({
@@ -79,11 +64,7 @@ function buildRecentMessageIdKey(run: FollowupRun, queueKey: string): string | u
   return JSON.stringify(["queue", queueKey, followupMessageRouteIdentityKey(run), messageId]);
 }
 
-function isRunAlreadyQueued(
-  run: FollowupRun,
-  items: FollowupRun[],
-  allowPromptFallback = false,
-): boolean {
+function isRunAlreadyQueued(run: FollowupRun, items: FollowupRun[]): boolean {
   const messageId = normalizeOptionalString(run.messageId);
   if (messageId) {
     const messageRouteKey = followupMessageRouteIdentityKey(run);
@@ -93,13 +74,7 @@ function isRunAlreadyQueued(
         followupMessageRouteIdentityKey(item) === messageRouteKey,
     );
   }
-  if (!allowPromptFallback) {
-    return false;
-  }
-  const routeKey = followupRouteIdentityKey(run);
-  return items.some(
-    (item) => item.prompt === run.prompt && followupRouteIdentityKey(item) === routeKey,
-  );
+  return false;
 }
 
 function appendQueueItem(params: {
@@ -176,11 +151,7 @@ export function enqueueFollowupRun(
   }
   const queue = getFollowupQueue(key, settings);
 
-  const dedupe =
-    dedupeMode === "none"
-      ? undefined
-      : (item: FollowupRun, items: FollowupRun[]) =>
-          isRunAlreadyQueued(item, items, dedupeMode === "prompt");
+  const dedupe = dedupeMode === "none" ? undefined : isRunAlreadyQueued;
 
   // Deduplicate: skip if the same message is already queued.
   if (shouldSkipQueueItem({ item: run, items: queue.items, dedupe })) {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -63,7 +63,7 @@ export type ResolveQueueSettingsParams = {
   pluginDebounceMs?: number;
 };
 
-export type QueueDedupeMode = "message-id" | "prompt" | "none";
+export type QueueDedupeMode = "message-id" | "none";
 
 type QueueInsertPosition = "tail" | "front";
 


### PR DESCRIPTION
Closes #142454

## What Problem This Solves

The follow-up queue maintains a second deduplication algorithm that no production caller can select. Its private mode and test add maintenance work alongside the actual message-ID behavior.

## Why This Change Was Made

Remove prompt-based comparison and narrow the internal mode to message-ID deduplication or the existing explicit bypass. The drain still owns reply-anchor resolution; its helper becomes file-private because all remaining uses are inside that owner. Current and stable package/SDK exports, configuration, protocol types and all five production selectors were checked.

## User Impact

No user-visible behavior changes. Equal prompts without message IDs remain distinct, redelivery suppression stays route-sensitive, and recovery, overflow, steering and lifecycle handling are preserved. This is a maintainer-requested internal retirement, reducing production by 28 code lines and tests by 25 code lines (57 physical lines overall).

## Evidence

- Existing queue dedupe, collect, in-flight and ingress-retry suites: 134 baseline tests passed; 133 retained tests passed. Only the obsolete prompt opt-in case was removed; the existing no-ID admission assertions remain unchanged.
- Full normal changed gate passed, including typechecks, lint/format, dead exports and architecture guards. Its initial dead-export finding was fixed by retaining the reply-anchor helper as file-private; the complete rerun passed.
- Fresh independent P0–P2 review of all four files: scoped-clean, no findings. Committed bytes match the tested and reviewed patch.
- This is local boundary proof with synthetic state, not a live channel run. No external API, configuration, protocol, schema or persistent-store behavior changes.

Related #133248 modifies different lifecycle hunks and #72314 operates at inbound deduplication. Neither is replaced by this retirement.
