### PR TITLE
fix(release): align frozen 7.33 Docker contracts

### DIFF
--- a/scripts/e2e/agent-bundle-mcp-tools-docker.sh
+++ b/scripts/e2e/agent-bundle-mcp-tools-docker.sh
@@ -29,15 +29,18 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 agent-bundle-m
 CLIENT_PATH="test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
 CLIENT_MOUNT_ARGS=()
 if [ "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" = "legacy" ]; then
-  # The selected release's client imports sibling E2E helpers and ../../dist.
+  # The selected release's client imports a trusted E2E helper and ../../../../dist.
   # Materialize its committed source tree outside the trusted read-only harness.
   LEGACY_CLIENT_SOURCE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-frozen-agent-bundle-mcp-tools.XXXXXX")"
   # Preserve its root package.json so tsx retains the selected release's ESM scope,
   # then link the package-owned dependencies.
-  git -C "$SOURCE_ROOT" archive "$OPENCLAW_SELECTED_SHA" -- package.json scripts/e2e |
+  git -C "$SOURCE_ROOT" archive "$OPENCLAW_SELECTED_SHA" -- \
+    package.json \
+    scripts/e2e/lib/temp-state-dir.ts \
+    test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts |
     tar -x -C "$LEGACY_CLIENT_SOURCE_ROOT"
   LEGACY_CLIENT_ROOT="/tmp/openclaw-frozen-agent-bundle-mcp-tools"
-  CLIENT_PATH="$LEGACY_CLIENT_ROOT/scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"
+  CLIENT_PATH="$LEGACY_CLIENT_ROOT/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
   ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"
   ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"
   # The functional image runs as UID 1001 and must traverse this host-owned staging root.

--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -154,7 +154,10 @@ function assertPluginUninstallConfigState(config, pluginId, label = pluginId) {
 
 function assertPluginRemoved(params) {
   const list = readJson(params.listFile);
-  if ((list.plugins || []).some((entry) => entry.id === params.pluginId)) {
+  if (
+    !params.allowLegacyRetainedListing &&
+    (list.plugins || []).some((entry) => entry.id === params.pluginId)
+  ) {
     throw new Error(`${params.pluginId} still listed after uninstall`);
   }
 
@@ -757,6 +760,10 @@ function assertNpmPluginRetained() {
   assertPluginRemoved({
     pluginId: "demo-plugin-npm",
     listFile: scratchFile("plugins-npm-retained.json"),
+    // Historical --keep-files removed config ownership but retained a
+    // discoverable plugin directory. Its list entry is expected until the
+    // subsequent reinstall; current releases persist an exact disabled marker.
+    allowLegacyRetainedListing: pluginUninstallMode === "legacy",
   });
   if (!fs.existsSync(installPath)) {
     throw new Error(`npm managed package was deleted by --keep-files: ${installPath}`);

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -48,6 +48,7 @@ function resolvePackageTelegramOutputDir(env: NodeJS.ProcessEnv, repoRoot: strin
 
 const DEFAULT_RTT_CHECK_ID = "channel-canary";
 const EXTENDED_STABLE_2026_6_35 = "2026.6.35";
+const EXTENDED_STABLE_2026_7_33 = "2026.7.33";
 const LEGACY_CONFIG_CUTOFF = "2026.7.2-beta.4";
 
 function projectExtendedStable2026_6_35QaConfig(cfg: OpenClawConfig): OpenClawConfig {
@@ -108,7 +109,10 @@ function projectLegacyPackageQaConfig(cfg: OpenClawConfig): OpenClawConfig {
 
 function resolvePackageConfigMutation(env: NodeJS.ProcessEnv = process.env) {
   const packageVersion = env.OPENCLAW_NPM_TELEGRAM_PACKAGE_VERSION?.trim();
-  if (packageVersion === EXTENDED_STABLE_2026_6_35) {
+  if (
+    packageVersion === EXTENDED_STABLE_2026_6_35 ||
+    packageVersion === EXTENDED_STABLE_2026_7_33
+  ) {
     return projectExtendedStable2026_6_35QaConfig;
   }
   const comparison = packageVersion

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -227,7 +227,11 @@ node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-config-channel 
 
 status_json="$(openclaw update status --json)"
 printf "%s\n" "$status_json"
-STATUS_JSON="$status_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-status-kind git
+if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" = "1" ]; then
+  STATUS_JSON="$status_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-status-kind package
+else
+  STATUS_JSON="$status_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-status-kind git
+fi
 
 echo "==> git -> package stable channel"
 set +e

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -63,6 +63,8 @@ UPGRADE_SCENARIO_STAGE=""
 UPGRADE_RUNNER="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh"
 UPGRADE_SCENARIO_DIR=""
 UPGRADE_TARGET_TRAIN=""
+UPGRADE_TRUSTED_ASSERTIONS="scripts/e2e/lib/upgrade-survivor/assertions.mjs"
+UPGRADE_TRUSTED_DIAGNOSTICS="/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs"
 context_status=0
 openclaw_prepare_frozen_target_context "$ROOT_DIR" || context_status=$?
 case "$context_status" in
@@ -97,6 +99,8 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
     exit 2
   fi
   UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"
+  UPGRADE_TRUSTED_ASSERTIONS="/app/scripts/e2e/lib/upgrade-survivor-trusted/assertions.mjs"
+  UPGRADE_TRUSTED_DIAGNOSTICS="/app/scripts/e2e/lib/upgrade-survivor-trusted/diagnostics.mjs"
   UPGRADE_NPM_PUBLISH_PLAN="$(openclaw_resolve_frozen_target_file \
     "$ROOT_DIR" scripts/lib/npm-publish-plan.mjs)"
   UPGRADE_WINDOWS_HELPERS="$(openclaw_resolve_frozen_target_file \
@@ -120,6 +124,7 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
   UPGRADE_SCENARIO_ARGS+=(
     -v "$UPGRADE_SCENARIO_STAGE:/app/scripts/e2e/lib/upgrade-survivor:ro"
     -v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"
+    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor:/app/scripts/e2e/lib/upgrade-survivor-trusted:ro"
     -v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"
     -v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"
     -v "$UPGRADE_PLUGIN_INDEX:/app/scripts/e2e/lib/plugin-index-sqlite.mjs:ro"
@@ -422,6 +427,8 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
   -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
   -e OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER=/tmp/openclaw-config-parking.mjs \
+  -e OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_ASSERTIONS="$UPGRADE_TRUSTED_ASSERTIONS" \
+  -e OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_DIAGNOSTICS="$UPGRADE_TRUSTED_DIAGNOSTICS" \
   -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_SERVER_SCRIPT=/tmp/openclaw-release-harness/scripts/e2e/lib/plugins/npm-registry-server.mjs \
   ${UPGRADE_COMPAT_ENV_ARGS[@]+"${UPGRADE_COMPAT_ENV_ARGS[@]}"} \
   "${PROBE_ENV_ARGS[@]}" \
@@ -442,6 +449,8 @@ export npm_config_fund=false
 export npm_config_audit=false
 export OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT="${OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT:-/tmp/openclaw-upgrade-survivor-artifacts}"
 export OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT="${OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT:-/tmp/openclaw-upgrade-survivor-runtime}"
+TRUSTED_ASSERTIONS="${OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_ASSERTIONS:-scripts/e2e/lib/upgrade-survivor/assertions.mjs}"
+TRUSTED_DIAGNOSTICS="${OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_DIAGNOSTICS:-$PWD/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs}"
 mkdir -p "$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT"
 export TMPDIR="${OPENCLAW_UPGRADE_SURVIVOR_TMPDIR:-$OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT/tmp}"
 export OPENCLAW_TEST_STATE_TMPDIR="${OPENCLAW_UPGRADE_SURVIVOR_TEST_STATE_TMPDIR:-$OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT/state-tmp}"
@@ -513,7 +522,7 @@ on_exit() {
     result=1
   fi
   if [ "$result" -ne 0 ]; then
-    node scripts/e2e/lib/upgrade-survivor/diagnostics.mjs capture \
+    node "$TRUSTED_DIAGNOSTICS" capture \
       "$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT" "$CURRENT_PHASE" "$result" ||
       echo "Upgrade survivor diagnostics missing; preserving original phase failure." >&2
   fi
@@ -627,6 +636,7 @@ NODE
 
 install_companion_plugins() {
   local authored_config="$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/companion-install-authored.json"
+  local trusted_assertions="${OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_ASSERTIONS:-scripts/e2e/lib/upgrade-survivor/assertions.mjs}"
   local install_status=0
   local restore_status=0
   node "$OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER" \
@@ -654,7 +664,7 @@ install_companion_plugins() {
   if [ "$install_status" -eq 0 ]; then
     # Inspection validates config too; keep the legacy migration specimen parked
     # until companion installation and its provenance checks have both finished.
-    node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
+    node "$trusted_assertions" \
       assert-companion-installs "$package_version" \
       "${OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED:?missing candidate capability-consent support}"
     install_status=$?
@@ -715,13 +725,14 @@ if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
 fi
 
 echo "Running package update against the mounted tarball..."
+TRUSTED_DIAGNOSTICS="${OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_DIAGNOSTICS:-$PWD/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs}"
 CURRENT_PHASE="update-candidate"
 update_args=(update --tag "${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}" --yes --json)
 if [ "$UPDATE_RESTART_MODE" != "auto-auth" ]; then
   update_args+=(--no-restart)
 fi
 set +e
-openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD OPENCLAW_ALLOW_ROOT=1 NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import=$PWD/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs" openclaw "${update_args[@]}" >"$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/update.json" 2>"$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/update.err"
+openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD OPENCLAW_ALLOW_ROOT=1 NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--import=$TRUSTED_DIAGNOSTICS" openclaw "${update_args[@]}" >"$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/update.json" 2>"$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/update.err"
 update_status=$?
 set -e
 if [ "$update_status" -ne 0 ]; then

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -99,8 +99,8 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
     exit 2
   fi
   UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"
-  UPGRADE_TRUSTED_ASSERTIONS="/app/scripts/e2e/lib/upgrade-survivor-trusted/assertions.mjs"
-  UPGRADE_TRUSTED_DIAGNOSTICS="/app/scripts/e2e/lib/upgrade-survivor-trusted/diagnostics.mjs"
+  UPGRADE_TRUSTED_ASSERTIONS="/tmp/openclaw-release-harness/scripts/e2e/lib/upgrade-survivor/assertions.mjs"
+  UPGRADE_TRUSTED_DIAGNOSTICS="/tmp/openclaw-release-harness/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs"
   UPGRADE_NPM_PUBLISH_PLAN="$(openclaw_resolve_frozen_target_file \
     "$ROOT_DIR" scripts/lib/npm-publish-plan.mjs)"
   UPGRADE_WINDOWS_HELPERS="$(openclaw_resolve_frozen_target_file \
@@ -124,7 +124,6 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
   UPGRADE_SCENARIO_ARGS+=(
     -v "$UPGRADE_SCENARIO_STAGE:/app/scripts/e2e/lib/upgrade-survivor:ro"
     -v "$UPGRADE_NPM_REGISTRY_SERVER:/app/scripts/e2e/lib/plugins/npm-registry-server.mjs:ro"
-    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor:/app/scripts/e2e/lib/upgrade-survivor-trusted:ro"
     -v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"
     -v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"
     -v "$UPGRADE_PLUGIN_INDEX:/app/scripts/e2e/lib/plugin-index-sqlite.mjs:ro"

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -156,9 +156,9 @@ openclaw_resolve_frozen_core_harness_capabilities() {
   [ "$authorization_status" -eq 1 ] && return 0
   [ "$authorization_status" -eq 0 ] || return "$authorization_status"
 
-  # The pre-consent onboarding flow does not accept the wizard record or the
-  # newer guided case. Run its own established non-interactive coverage.
-  if ! openclaw_frozen_target_source_contains "$source_root" src/config/zod-schema.ts 'securityAcknowledgedAt:' &&
+  # Older onboarding schemas do not accept the guided fixture's full wizard
+  # consent record. Run their own established non-interactive coverage.
+  if ! openclaw_frozen_target_source_contains "$source_root" src/config/zod-schema.ts 'accessMode:' &&
     openclaw_frozen_target_source_contains "$source_root" src/config/zod-schema.ts 'lastRunAt:'; then
     export OPENCLAW_FROZEN_TARGET_ONBOARD_CASES="local-basic,remote-non-interactive,reset,channels,skills"
   fi
@@ -214,7 +214,7 @@ openclaw_resolve_frozen_core_harness_capabilities() {
   # new dist entry the release cannot contain.
   if ! git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-manager-api.ts" 2>/dev/null &&
     git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-runtime.ts" 2>/dev/null &&
-    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:scripts/e2e/agent-bundle-mcp-tools-docker-client.ts" 2>/dev/null; then
+    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts" 2>/dev/null; then
     export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="legacy"
   fi
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5955,6 +5955,8 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     const upgradeRunner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     expectTextToIncludeAll(upgradeRunner, [
       "scripts/e2e/lib/upgrade-survivor",
+      'UPGRADE_TRUSTED_DIAGNOSTICS="/app/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs"',
+      '-e OPENCLAW_UPGRADE_SURVIVOR_TRUSTED_DIAGNOSTICS="$UPGRADE_TRUSTED_DIAGNOSTICS"',
       'UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"',
       'cp -R "$UPGRADE_SCENARIO_DIR/." "$UPGRADE_SCENARIO_STAGE/"',
       'cp "$UPGRADE_DIAGNOSTICS" "$UPGRADE_SCENARIO_STAGE/diagnostics.mjs"',
@@ -6537,6 +6539,9 @@ process.exit(73);
     const runner = readFileSync(AGENT_BUNDLE_MCP_TOOLS_DOCKER_E2E_PATH, "utf8");
 
     expectTextToIncludeAll(runner, [
+      "scripts/e2e/lib/temp-state-dir.ts \\",
+      "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts |",
+      'CLIENT_PATH="$LEGACY_CLIENT_ROOT/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"',
       'ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"',
       'ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"',
       '-v "$LEGACY_CLIENT_SOURCE_ROOT:$LEGACY_CLIENT_ROOT:ro"',

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -444,9 +444,20 @@ export function parseRegistryNpmSpec(spec: string) {
     mkdirSync(path.join(root, "src/agents/embedded-agent-runner/run"), { recursive: true });
     mkdirSync(path.join(root, "src/commands"), { recursive: true });
     mkdirSync(path.join(root, "scripts"), { recursive: true });
+    mkdirSync(path.join(root, "src/config"), { recursive: true });
+    mkdirSync(path.join(root, "test/e2e/qa-lab/runtime"), { recursive: true });
     writeFileSync(
       path.join(root, "src/agents/code-mode-namespaces.ts"),
       'export const globals = ["ALL_TOOLS"];\n',
+    );
+    writeFileSync(path.join(root, "src/agents/agent-bundle-mcp-runtime.ts"), "export {};\n");
+    writeFileSync(
+      path.join(root, "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"),
+      "export {};\n",
+    );
+    writeFileSync(
+      path.join(root, "src/config/zod-schema.ts"),
+      "const wizard = { lastRunAt: true };\n",
     );
     writeFileSync(
       path.join(root, "src/agents/embedded-agent-runner/run/runtime-context-prompt.ts"),
@@ -471,7 +482,7 @@ export function parseRegistryNpmSpec(spec: string) {
     }).trim();
     const resolveCoreDialects = [
       "-c",
-      'set -euo pipefail; source "$1"; openclaw_resolve_frozen_core_harness_capabilities "$2"; openclaw_resolve_frozen_live_cli_backend_package_mode "$2"; printf "%s %s %s %s\\n" "$OPENCLAW_FROZEN_TARGET_SESSION_REPAIR_MODE" "$OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE" "$OPENCLAW_FROZEN_TARGET_LIVE_CLI_BACKEND_PACKAGE_MODE" "$OPENCLAW_FROZEN_TARGET_RUNTIME_CONTEXT_INPUT_MODE"',
+      'set -euo pipefail; source "$1"; openclaw_resolve_frozen_core_harness_capabilities "$2"; openclaw_resolve_frozen_live_cli_backend_package_mode "$2"; printf "%s|%s|%s|%s|%s|%s\\n" "$OPENCLAW_FROZEN_TARGET_SESSION_REPAIR_MODE" "$OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE" "$OPENCLAW_FROZEN_TARGET_LIVE_CLI_BACKEND_PACKAGE_MODE" "$OPENCLAW_FROZEN_TARGET_RUNTIME_CONTEXT_INPUT_MODE" "$OPENCLAW_FROZEN_TARGET_ONBOARD_CASES" "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE"',
       "test",
       stageScriptPath,
       root,
@@ -486,7 +497,7 @@ export function parseRegistryNpmSpec(spec: string) {
     });
 
     expect(strictResult.status, strictResult.stderr).toBe(0);
-    expect(strictResult.stdout.trim()).toBe("sqlite current current producer-fragments");
+    expect(strictResult.stdout.trim()).toBe("sqlite|current|current|producer-fragments||current");
 
     const result = spawnSync("bash", resolveCoreDialects, {
       encoding: "utf8",
@@ -499,7 +510,9 @@ export function parseRegistryNpmSpec(spec: string) {
     });
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout.trim()).toBe("jsonl legacy legacy legacy-marked-prompt");
+    expect(result.stdout.trim()).toBe(
+      "jsonl|legacy|legacy|legacy-marked-prompt|local-basic,remote-non-interactive,reset,channels,skills|legacy",
+    );
   });
 
   it.each([

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -593,9 +593,9 @@ describe("package Telegram live Docker E2E", () => {
     ).toBeUndefined();
   });
 
-  it("preserves the frozen 2026.6.35 package projection", () => {
+  it.each(["2026.6.35", "2026.7.33"])("preserves the frozen %s package projection", (version) => {
     const mutateConfig = testing.resolvePackageConfigMutation({
-      OPENCLAW_NPM_TELEGRAM_PACKAGE_VERSION: "2026.6.35",
+      OPENCLAW_NPM_TELEGRAM_PACKAGE_VERSION: version,
     });
     const config = {
       agents: {

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -1850,6 +1850,53 @@ fs.renameSync = (source, destination) => {
     }
   });
 
+  it("accepts a retained legacy npm listing only for the keep-files assertion", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugins-assertions-"));
+    const home = path.join(root, "home");
+    const scratchRoot = path.join(root, "scratch");
+    const installPath = path.join(home, ".openclaw", "npm", "demo-plugin-npm");
+    const dependencyPackagePath = path.join(installPath, "node_modules", "is-number");
+
+    try {
+      mkdirSync(dependencyPackagePath, { recursive: true });
+      writeJson(path.join(scratchRoot, "plugins-npm-retained.json"), {
+        plugins: [{ id: "demo-plugin-npm", status: "disabled", enabled: false }],
+      });
+      writeFileSync(path.join(scratchRoot, "plugins-npm-install-path.txt"), installPath, "utf8");
+      writeFileSync(
+        path.join(scratchRoot, "plugins-npm-dependency-path.txt"),
+        dependencyPackagePath,
+        "utf8",
+      );
+      writeJson(path.join(home, ".openclaw", "plugins", "installs.json"), {
+        installRecords: {},
+      });
+      writeJson(path.join(home, ".openclaw", "openclaw.json"), { plugins: { entries: {} } });
+      const env = {
+        ...process.env,
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw", "openclaw.json"),
+        OPENCLAW_PLUGINS_TMP_DIR: scratchRoot,
+        OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+      };
+
+      const current = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "plugin-npm-retained"], {
+        encoding: "utf8",
+        env,
+      });
+      const legacy = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "plugin-npm-retained"], {
+        encoding: "utf8",
+        env: { ...env, OPENCLAW_FROZEN_TARGET_PLUGIN_UNINSTALL_MODE: "legacy" },
+      });
+
+      expect(current.status).not.toBe(0);
+      expect(current.stderr).toContain("still listed after uninstall");
+      expect(legacy.status, legacy.stderr).toBe(0);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("rejects unreadable config during plugin uninstall proof", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugins-assertions-"));
     const home = path.join(root, "home");

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -10,6 +10,12 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+it("keeps the frozen legacy dev status on its shipped package contract", () => {
+  const script = readFileSync("scripts/e2e/update-channel-switch-docker.sh", "utf8");
+  expect(script).toContain('if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" = "1" ]; then');
+  expect(script).toContain("assert-status-kind package");
+});
+
 it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -94,6 +94,8 @@ source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 ${policy}
 printf '%s\\n' "\${UPGRADE_SCENARIO_DIR:-$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor}/assertions.mjs"
 printf '%s\\n' "$UPGRADE_RUNNER"
+printf '%s\\n' "$UPGRADE_TRUSTED_ASSERTIONS"
+printf '%s\\n' "$UPGRADE_TRUSTED_DIAGNOSTICS"
 printf '%s\\n' \${UPGRADE_SCENARIO_ARGS[@]+"\${UPGRADE_SCENARIO_ARGS[@]}"}
 printf '%s' "$OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE" > "$MODE_PATH"
 `,
@@ -113,13 +115,18 @@ printf '%s' "$OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_MODE" > "$MODE_PATH"
       },
     },
   );
-  const [oracle, runner, ...mounts] = result.stdout.trim().split("\n").filter(Boolean);
+  const [oracle, runner, trustedAssertions, trustedDiagnostics, ...mounts] = result.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean);
   const clawhubMode = existsSync(modePath) ? readFileSync(modePath, "utf8") : undefined;
   const stagedScenario = mounts[0] === "-v" ? mounts[1]?.split(":", 1)[0] : undefined;
   return {
     result,
     oracle,
     runner,
+    trustedAssertions,
+    trustedDiagnostics,
     mounts,
     selectedOracle,
     selectedScenario,
@@ -1036,6 +1043,13 @@ describe("upgrade survivor assertions", () => {
           ),
         );
         if (selected) {
+          expect(proof.trustedAssertions).toBe(
+            "/tmp/openclaw-release-harness/scripts/e2e/lib/upgrade-survivor/assertions.mjs",
+          );
+          expect(proof.trustedDiagnostics).toBe(
+            "/tmp/openclaw-release-harness/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs",
+          );
+          expect(proof.mounts.join("\n")).not.toContain("upgrade-survivor-trusted");
           expect(readFileSync(join(proof.stagedScenario!, "assertions.mjs"), "utf8")).toBe(
             readFileSync(proof.selectedOracle, "utf8"),
           );
@@ -1053,10 +1067,6 @@ describe("upgrade survivor assertions", () => {
                 "-v",
                 expect.stringMatching(
                   /npm-registry-server\.mjs:\/app\/scripts\/e2e\/lib\/plugins\/npm-registry-server\.mjs:ro$/u,
-                ),
-                "-v",
-                expect.stringMatching(
-                  /scripts\/e2e\/lib\/upgrade-survivor:\/app\/scripts\/e2e\/lib\/upgrade-survivor-trusted:ro$/u,
                 ),
                 "-v",
                 expect.stringMatching(

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1056,6 +1056,10 @@ describe("upgrade survivor assertions", () => {
                 ),
                 "-v",
                 expect.stringMatching(
+                  /scripts\/e2e\/lib\/upgrade-survivor:\/app\/scripts\/e2e\/lib\/upgrade-survivor-trusted:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
                   /npm-publish-plan\.mjs:\/app\/scripts\/lib\/npm-publish-plan\.mjs:ro$/u,
                 ),
                 "-v",


### PR DESCRIPTION
## What problem this solves

Full validation of the frozen 2026.7.33 candidate applies several current harness assumptions to older shipped contracts. The affected lanes fail before proving candidate behavior: onboarding chooses a guided fixture with unsupported keys, agent-bundle MCP stages a current-only client path, legacy plugin uninstall expects the modern listing cleanup, update-channel status expects Git ownership after a historical package transition, Telegram QA passes current-only config, and upgrade-survivor diagnostics/assertions are looked up in the candidate tree.

## What changed

- derive the 7.33 onboarding and agent-bundle behavior from files that actually exist in the selected source
- preserve the historical `--keep-files` plugin-listing contract while still proving install/config ownership removal
- accept the shipped package-owned status after the legacy dev-channel transition
- apply the existing frozen Telegram config projection to exact 2026.7.33
- invoke trusted current upgrade-survivor assertions and diagnostics through the existing complete trusted scripts mount while retaining candidate-owned scenario state checks

## Validation

- upgrade-survivor assertions: 92/92 passed, including SQLite/file-store migration and post-inference survival cases
- Docker build/helper contracts: 285 passed, 2 skipped
- affected release-tooling contracts: 221/221 passed
- exact-head CI large-5 retry passed; the prior unrelated subagent announce state leak passes 16/16 in isolation
- Bash syntax and `git diff --check` passed

## Data-model scope

Product runtime and stored-data schemas are unchanged. `scripts/e2e/upgrade-survivor-docker.sh` is an external validation orchestrator; it does not implement a migration, backfill, or repair. It selects already-shipped 2026.7.33 scenario assertions and trusted current diagnostics. The 92-test survivor suite explicitly exercises the existing SQLite/file-store compatibility and migrated-session invariants.