### PR TITLE
fix(update): surface retained official plugin pin advisories

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -886,6 +886,13 @@ previously pinned.
 Already-current runtime plugins are kept in place; a no-op startup repair does
 not reinstall the package or invalidate the migration checkpoint.
 
+When the npm update probe finds a newer release for an exact-pinned official
+plugin and post-core convergence retains that pin, the update prints the pin
+advisory and reports `postUpdate.plugins.status: "warning"` in JSON. The warning
+includes the observed installed and available versions and an explicit command
+to replace the pin. Keep the pin if intentional. This advisory does not establish
+incompatibility, change the pin, or fail an otherwise successful core update.
+
 <Warning>
 If an exact pinned npm plugin update resolves to an artifact whose integrity differs from the stored install record, `openclaw update` aborts that plugin artifact update instead of installing it. Reinstall or update the plugin explicitly only after verifying you trust the new artifact.
 </Warning>

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -418,7 +418,8 @@ vi.mock("../utils.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../plugins/official-external-install-records.js", () => ({
+vi.mock("../plugins/official-external-install-records.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/official-external-install-records.js")>()),
   resolveTrustedSourceLinkedOfficialClawHubSpec: vi.fn(() => undefined),
   resolveTrustedSourceLinkedOfficialNpmSpec: vi.fn(() => undefined),
 }));
@@ -4015,6 +4016,96 @@ describe("update-cli", () => {
       );
     },
   );
+
+  it.each([false, true])("reports retained official pin advisories (json=%s)", async (json) => {
+    const message =
+      "discord is pinned to @openclaw/discord@2026.9.2 (installed 2026.9.2); " +
+      "registry latest resolves to 2026.9.3. Pass `openclaw plugins update " +
+      "@openclaw/discord@latest` to replace this version pin.";
+    const records: Record<string, PluginInstallRecord> = {
+      discord: { source: "npm", spec: "@openclaw/discord@2026.9.2", version: "2026.9.2" },
+    };
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "discord",
+        status: "unchanged",
+        currentVersion: "2026.9.2",
+        nextVersion: "2026.9.3",
+        message,
+      },
+    ]);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      ...postCoreConvergenceResult(),
+      installRecords: records,
+    });
+    const { updatePluginsAfterCoreUpdate } = await import("./update-cli/update-command-plugins.js");
+    const result = await updatePluginsAfterCoreUpdate({
+      root: process.cwd(),
+      channel: "stable",
+      configSnapshot: baseSnapshot,
+      configWriteOptions: {},
+      timeoutMs: 60_000,
+      json,
+    });
+    expect(result.status).toBe("warning");
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        pluginId: "discord",
+        reason: "retained-plugin-pin",
+        message: expect.stringContaining(message),
+      }),
+    ]);
+    expect(result.npm.outcomes[0]?.status).toBe("unchanged");
+    expect(records.discord).toEqual({
+      source: "npm",
+      spec: "@openclaw/discord@2026.9.2",
+      version: "2026.9.2",
+    });
+    const output = stripAnsi(getLogOutput());
+    expect(output.includes(message)).toBe(!json);
+  });
+
+  it.each([
+    { name: "same version", nextVersion: "2026.9.2" },
+    { name: "unknown registry version", nextVersion: undefined },
+    { name: "invalid registry version", nextVersion: "unknown" },
+    { name: "older registry version", nextVersion: "2026.9.1" },
+    { name: "repaired record", version: "2026.9.3" },
+    { name: "removed record", removed: true },
+    { name: "third-party package", spec: "third-party-plugin@2026.9.2" },
+    { name: "git source", source: "git" as const },
+  ])("does not warn for $name during post-core convergence", async (entry) => {
+    const record: PluginInstallRecord = {
+      source: entry.source ?? "npm",
+      spec: entry.spec ?? "@openclaw/discord@2026.9.2",
+      version: entry.version ?? "2026.9.2",
+    };
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "discord",
+        status: "unchanged",
+        currentVersion: "2026.9.2",
+        nextVersion: "nextVersion" in entry ? entry.nextVersion : "2026.9.3",
+        message: "Retained version.",
+      },
+    ]);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      ...postCoreConvergenceResult(),
+      installRecords: entry.removed ? {} : { discord: record },
+    });
+    const { updatePluginsAfterCoreUpdate } = await import("./update-cli/update-command-plugins.js");
+    const result = await updatePluginsAfterCoreUpdate({
+      root: process.cwd(),
+      channel: "stable",
+      configSnapshot: baseSnapshot,
+      configWriteOptions: {},
+      timeoutMs: 60_000,
+      json: true,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.warnings).toEqual([]);
+  });
 
   it("preserves typed repair outcomes from post-core convergence", async () => {
     const consentOutcome = {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1370,8 +1370,12 @@ describe("update-cli", () => {
     outcomes: [],
   });
 
-  const mockNpmPluginOutcomes = (outcomes: unknown[], changed = false) => {
-    updateNpmInstalledPlugins.mockResolvedValueOnce({ changed, config: baseConfig, outcomes });
+  const mockNpmPluginOutcomes = (
+    outcomes: unknown[],
+    changed = false,
+    config: OpenClawConfig = baseConfig,
+  ) => {
+    updateNpmInstalledPlugins.mockResolvedValueOnce({ changed, config, outcomes });
   };
 
   const postCoreConvergenceResult = (
@@ -4017,23 +4021,48 @@ describe("update-cli", () => {
     },
   );
 
-  it.each([false, true])("reports retained official pin advisories (json=%s)", async (json) => {
+  it.each(
+    [false, true].flatMap((json) =>
+      [
+        { label: "legacy version", fields: { version: "2026.9.2" } },
+        { label: "resolved version", fields: { resolvedVersion: "2026.9.2" } },
+        {
+          label: "resolved version with stale alias",
+          fields: { resolvedVersion: "2026.9.2", version: "2026.9.1" },
+        },
+      ].map(({ label, fields }) => ({ label, fields, json })),
+    ),
+  )("reports retained official pin advisories ($label, json=$json)", async ({ fields, json }) => {
+    const installPath = createCaseDir("retained-pin");
+    fsSync.mkdirSync(installPath, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(installPath, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/discord",
+        version: "2026.9.2",
+      }),
+    );
+    mockFileBackedPathExists();
     const message =
       "discord is pinned to @openclaw/discord@2026.9.2 (installed 2026.9.2); " +
       "registry latest resolves to 2026.9.3. Pass `openclaw plugins update " +
       "@openclaw/discord@latest` to replace this version pin.";
     const records: Record<string, PluginInstallRecord> = {
-      discord: { source: "npm", spec: "@openclaw/discord@2026.9.2", version: "2026.9.2" },
+      discord: { source: "npm", spec: "@openclaw/discord@2026.9.2", installPath, ...fields },
     };
-    mockNpmPluginOutcomes([
-      {
-        pluginId: "discord",
-        status: "unchanged",
-        currentVersion: "2026.9.2",
-        nextVersion: "2026.9.3",
-        message,
-      },
-    ]);
+    mockNpmPluginOutcomes(
+      [
+        {
+          pluginId: "discord",
+          status: "unchanged",
+          currentVersion: "2026.9.2",
+          nextVersion: "2026.9.3",
+          message,
+        },
+      ],
+      false,
+      { ...baseConfig, plugins: { ...baseConfig.plugins, installs: records } },
+    );
     runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
       ...postCoreConvergenceResult(),
       installRecords: records,
@@ -4060,7 +4089,8 @@ describe("update-cli", () => {
     expect(records.discord).toEqual({
       source: "npm",
       spec: "@openclaw/discord@2026.9.2",
-      version: "2026.9.2",
+      installPath,
+      ...fields,
     });
     const output = stripAnsi(getLogOutput());
     expect(output.includes(message)).toBe(!json);
@@ -4075,21 +4105,53 @@ describe("update-cli", () => {
     { name: "removed record", removed: true },
     { name: "third-party package", spec: "third-party-plugin@2026.9.2" },
     { name: "git source", source: "git" as const },
+    { name: "ClawHub source", source: "clawhub" as const },
+    { name: "version range", spec: "@openclaw/discord@^2026.9.2" },
+    { name: "bare selector", spec: "@openclaw/discord" },
+    { name: "default tag", spec: "@openclaw/discord@latest" },
+    { name: "explicit non-default tag", spec: "@openclaw/discord@beta" },
+    { name: "replaced exact pin", spec: "@openclaw/discord@2026.9.3" },
+    { name: "repaired resolved record", resolvedVersion: "2026.9.3" },
+    { name: "package replacement", beforeSpec: "third-party-plugin@2026.9.2" },
   ])("does not warn for $name during post-core convergence", async (entry) => {
+    const installPath = createCaseDir("excluded-pin");
+    fsSync.mkdirSync(installPath, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(installPath, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/discord",
+        version: "2026.9.2",
+      }),
+    );
+    mockFileBackedPathExists();
     const record: PluginInstallRecord = {
       source: entry.source ?? "npm",
       spec: entry.spec ?? "@openclaw/discord@2026.9.2",
+      installPath,
       version: entry.version ?? "2026.9.2",
+      ...("resolvedVersion" in entry ? { resolvedVersion: entry.resolvedVersion } : {}),
     };
-    mockNpmPluginOutcomes([
-      {
-        pluginId: "discord",
-        status: "unchanged",
-        currentVersion: "2026.9.2",
-        nextVersion: "nextVersion" in entry ? entry.nextVersion : "2026.9.3",
-        message: "Retained version.",
+    const beforeRecords: Record<string, PluginInstallRecord> = {
+      discord: {
+        ...record,
+        spec: "beforeSpec" in entry ? entry.beforeSpec : record.spec,
+        version: "2026.9.2",
+        ...("resolvedVersion" in entry ? { resolvedVersion: "2026.9.2" } : {}),
       },
-    ]);
+    };
+    mockNpmPluginOutcomes(
+      [
+        {
+          pluginId: "discord",
+          status: "unchanged",
+          currentVersion: "2026.9.2",
+          nextVersion: "nextVersion" in entry ? entry.nextVersion : "2026.9.3",
+          message: "Retained version.",
+        },
+      ],
+      false,
+      { ...baseConfig, plugins: { ...baseConfig.plugins, installs: beforeRecords } },
+    );
     runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
       ...postCoreConvergenceResult(),
       installRecords: entry.removed ? {} : { discord: record },

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -8,6 +8,7 @@ import { readConfigFileSnapshot } from "../../config/config.js";
 import type { ConfigWriteOptions } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import { comparePackageUpdateVersions } from "../../infra/package-update-utils.js";
 import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
 import type { PluginCapabilityConsentHandler } from "../../plugins/capability-consent.js";
 import { commitPluginInstallRecordsWithConfig } from "../../plugins/install-record-commit.js";
@@ -16,9 +17,14 @@ import {
   withoutPluginInstallRecords,
   withPluginInstallRecords,
 } from "../../plugins/installed-plugin-index-records.js";
+import { isTrustedOfficialPluginInstallRecord } from "../../plugins/official-external-install-records.js";
 import type { MissingPluginInstallPayload } from "../../plugins/payload-verification.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import { convergePluginReleaseCohort } from "../../plugins/update-cohort.js";
+import {
+  resolveExactNpmSpecVersion,
+  resolveNpmSpecPackageName,
+} from "../../plugins/update-source.js";
 import {
   isClawHubTrustSkippedOutcome,
   type PluginUpdateIntegrityDriftParams,
@@ -305,6 +311,37 @@ export async function updatePluginsAfterCoreUpdate(params: {
   // Repair already persisted this authoritative map; the commit below must not
   // restore the pre-convergence records and discard successful repairs.
   pluginConfig = withPluginInstallRecords(pluginConfig, convergence.installRecords);
+  // An unchanged npm outcome can report a newer registry release without replacing
+  // its pin. Do not retain that advisory if convergence repaired or removed the pin.
+  for (const outcome of cohort.updateOutcomes) {
+    const record = convergence.installRecords[outcome.pluginId];
+    if (
+      outcome.status !== "unchanged" ||
+      !outcome.currentVersion ||
+      !outcome.nextVersion ||
+      comparePackageUpdateVersions(outcome.nextVersion, outcome.currentVersion) <= 0 ||
+      record?.source !== "npm" ||
+      record.version !== outcome.currentVersion ||
+      resolveExactNpmSpecVersion(record.spec) !== outcome.currentVersion ||
+      !isTrustedOfficialPluginInstallRecord({
+        pluginId: outcome.pluginId,
+        packageName: resolveNpmSpecPackageName(record.spec),
+        record,
+      })
+    ) {
+      continue;
+    }
+    const message = `Plugin update retained an official plugin pin: ${outcome.message}`;
+    warnings.push({
+      pluginId: outcome.pluginId,
+      reason: "retained-plugin-pin",
+      message,
+      guidance: ["Keep the pin if intentional; replacing it is an explicit operator choice."],
+    });
+    if (!params.json) {
+      runtime.log(theme.warn(message));
+    }
+  }
   if (convergence.changes.length > 0) {
     pluginsChanged = true;
   }

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -277,6 +277,13 @@ export async function updatePluginsAfterCoreUpdate(params: {
   // Convergence checks activation before restart. Seed it from the current
   // sync/npm records so repair cannot overwrite them with an older disk snapshot.
   const convergenceBaselineRecords = pluginConfig.plugins?.installs ?? {};
+  // Keep the observed selectors stable if convergence replaces their records.
+  const probedNpmSpecs = new Map(
+    cohort.updateOutcomes.map(({ pluginId }) => {
+      const record = convergenceBaselineRecords[pluginId];
+      return [pluginId, record?.source === "npm" ? record.spec : undefined];
+    }),
+  );
   const convergence = await runPostCorePluginConvergence({
     cfg: pluginConfig,
     env: process.env,
@@ -321,7 +328,8 @@ export async function updatePluginsAfterCoreUpdate(params: {
       !outcome.nextVersion ||
       comparePackageUpdateVersions(outcome.nextVersion, outcome.currentVersion) <= 0 ||
       record?.source !== "npm" ||
-      record.version !== outcome.currentVersion ||
+      (record.resolvedVersion ?? record.version) !== outcome.currentVersion ||
+      record.spec !== probedNpmSpecs.get(outcome.pluginId) ||
       resolveExactNpmSpecVersion(record.spec) !== outcome.currentVersion ||
       !isTrustedOfficialPluginInstallRecord({
         pluginId: outcome.pluginId,


### PR DESCRIPTION
Related: #135776

## What Problem This Solves

Fixes an issue where users running an update or repair would see aggregate plugin status `ok` even though an official npm plugin remained pinned to an older version and its individual update result already reported a newer release.

## Why This Change Was Made

Promote the existing advisory into aggregate text and JSON only after plugin-record convergence confirms the same observed npm selector remains. Use the canonical installed version, including records that carry `resolvedVersion` without the older `version` field. Reuse the completed probe without another registry lookup or package mutation.

## User Impact

Operators see the installed and available versions and the explicit command to replace the pin. Deliberate pins remain intact, and an otherwise successful update still succeeds. Repaired, replaced, or removed pins and excluded package sources/selectors do not gain stale advisories.

Automatic release alignment, compatibility fencing, restart policy, and the broader decision in #135776 remain outside this diagnostic repair.

## Evidence

Real public `update repair --yes --timeout 180` commands ran in text and JSON modes with a genuine `@openclaw/lobster@2026.9.2` npm installation and the public registry reporting `2026.9.3`.

| Observation | Pinned main | Repair |
| --- | --- | --- |
| Aggregate text | Pin advisory absent | One installed/available-version advisory and explicit replacement command |
| `postUpdate.plugins.status` | `ok`, no warnings | `warning`, one `retained-plugin-pin` warning |
| Command exit | 0 | 0 |
| Exact pin, full install record, package bytes, enabled state and plugin policy | Retained | Retained |

Each matched run used a fresh isolated installation and normally prepared profile. The corrected candidate also completed both modes with the pin advisory as its only warning: Doctor reported `ok`, repair reported `warning`, and the exit was 0. The 2,385-entry payload retained its complete byte digest before and after every measured repair. No Gateway or provider request ran.

The original aggregate regression produced two intended failures. Further record-variant and replacement regressions produced six intended failures before correction. All 28 targeted owner and sibling cases now pass, covering both output modes, canonical/legacy version fields, replaced and removed records, version/source/selector exclusions, consent, integrity, compatibility and parent reporting. Formatting and scoped lint pass; full projects and typechecks belong to hosted CI.

Matched command receipts and npm logs show the same two metadata probes in each baseline and repaired run. Independent CLI validation confirmed pin retention and the advertised explicit replacement control; source-only ordering, provenance and policy invariants remain backed by separate source review and focused tests.

Proof used baseline `a5c83952639827a2694c17f57ceeb9dde9cdbeac` and the exact candidate changes applied to that same base. The three changed-file hashes match the reviewed branch. This is public repair/finalization proof, not a full core-version upgrade replay or live plugin-handler compatibility claim.

AI-assisted.
