### PR TITLE
docs(release): verify exact ClawHub versions and publish sets

### DIFF
--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -49,10 +49,14 @@ Use these checks only for the regular orchestrated release track.
    - Get exact tag metadata from GitHub, not the local checkout when dirty:
      download `https://api.github.com/repos/openclaw/openclaw/tarball/v<VERSION>`
      into `/tmp/openclaw-v<VERSION>-src`.
-   - Count `extensions/*/package.json` with
-     `openclaw.release.publishToNpm === true` and
-     `openclaw.release.publishToClawHub === true`.
-   - Compare expected counts to workflow job counts:
+   - Derive the expected npm and ClawHub package sets with the canonical
+     publication planners/collector from the recorded release Tooling SHA,
+     using the exact tag's package metadata and the selected publication scope.
+     Do not count raw publish flags: `openclaw.build.bundledDist === true`
+     explicitly defers external publication even when publish flags are set.
+     Record deferred package names and reasons separately.
+   - Compare expected package identities, versions, and counts with the immutable
+     publication plans and workflow jobs:
      `gh api repos/openclaw/openclaw/actions/runs/<RUN>/jobs --paginate`.
    - Each expected npm plugin must have version `<VERSION>` and
      `dist-tags.latest === <VERSION>`.

--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -49,14 +49,16 @@ Use these checks only for the regular orchestrated release track.
    - Get exact tag metadata from GitHub, not the local checkout when dirty:
      download `https://api.github.com/repos/openclaw/openclaw/tarball/v<VERSION>`
      into `/tmp/openclaw-v<VERSION>-src`.
-   - Derive the expected npm and ClawHub package sets with the canonical
-     publication planners/collector from the recorded release Tooling SHA,
-     using the exact tag's package metadata and the selected publication scope.
+   - Derive the full expected npm and ClawHub package sets for the release track
+     with the canonical publication planners/collector from the recorded release
+     Tooling SHA, using the exact tag's package metadata.
      Do not count raw publish flags: `openclaw.build.bundledDist === true`
      explicitly defers external publication even when publish flags are set.
      Record deferred package names and reasons separately.
-   - Compare expected package identities, versions, and counts with the immutable
-     publication plans and workflow jobs:
+   - Reconcile expected package identities, versions, and counts across original
+     publication, previously published versions, and selected recovery runs using
+     immutable publication plans, registry readback, and workflow jobs. A selected
+     recovery subset must not narrow the full expected release set:
      `gh api repos/openclaw/openclaw/actions/runs/<RUN>/jobs --paginate`.
    - Each expected npm plugin must have version `<VERSION>` and
      `dist-tags.latest === <VERSION>`.

--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -60,9 +60,11 @@ Use these checks only for the regular orchestrated release track.
    - Check the Plugin ClawHub Release workflow conclusion and publish job count.
    - Use OpenClaw itself for live registry proof:
      `openclaw plugins search <known-plugin> --json`.
-   - Install one official plugin from ClawHub in an isolated HOME:
-     `openclaw plugins install clawhub:@openclaw/matrix --pin`.
-     Prefer `matrix` unless that plugin is not in the expected set.
+   - Install one official plugin at the exact requested release version from
+     ClawHub in an isolated HOME:
+     `openclaw plugins install clawhub:@openclaw/matrix@<VERSION>`.
+     Prefer `matrix` unless that plugin is not in the expected set. ClawHub
+     versions belong in the spec; `--pin` is only supported for npm installs.
 5. Release workflows:
    - Verify conclusions for release notes evidence links:
      Full Release Validation, OpenClaw Release Checks, OpenClaw NPM Release,


### PR DESCRIPTION
## What Problem This Solves

Release verification prescribed an unsupported ClawHub `--pin` option and counted raw plugin publish flags. The CLI reserves `--pin` for npm installs, and the canonical publication collector excludes core-owned `bundledDist` packages even when their publish flags are set.

## Why This Change Was Made

Install the exact requested release with `clawhub:@openclaw/matrix@<VERSION>`. Derive the full expected npm and ClawHub release-track package sets with the recorded release tooling's canonical planner/collector over exact tag metadata, recording explicit deferrals separately. Reconcile original publication, previously published versions, and selected recovery runs using immutable plans, registry readback, and workflow jobs; a recovery subset must not narrow the expected release set.

## User Impact

Maintainers can run the documented ClawHub smoke against the requested release without mistaking an explicit publication deferral for a missing package. Runtime behavior and release gates are unchanged.

## Evidence

- Source checked against the ClawHub spec parser, install preflight, and canonical publication collector. The tagged OpenCode Go provider is explicitly core-owned through `bundledDist: true` despite its publish flags.
- Docs-only `check:changed`, formatting, and diff checks passed for both corrections. Fresh independent P2 reviews found no actionable findings.
- Published OpenClaw 2026.9.3 (`1391f7c`) smoke in isolated HOME/state: the corrected Matrix 2026.9.3 install exited 0; plugin listing reported `loaded`, `trusted-official`, `installSource: clawhub`, the exact versioned install spec, and installed dependencies. The old `--pin` command was rejected before installation. No user Gateway or state was changed.
