### PR TITLE
perf(plugins): keep provider discovery metadata lightweight

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -520,7 +520,7 @@ extensions/google/onboard.ts	3
 extensions/google/provider-registration.ts	2
 extensions/google/realtime-voice-provider.ts	6
 extensions/google/transport-stream.ts	13
-extensions/google/vertex-adc.ts	6
+extensions/google/vertex-adc.ts	4
 extensions/google/video-generation-provider.ts	13
 extensions/googlechat/src/accounts.ts	1
 extensions/googlechat/src/actions.ts	1

--- a/extensions/anthropic-vertex/api.ts
+++ b/extensions/anthropic-vertex/api.ts
@@ -17,12 +17,14 @@ export {
 export {
   hasAnthropicVertexAvailableAuth,
   hasAnthropicVertexCredentials,
-  resolveAnthropicVertexClientRegion,
   resolveAnthropicVertexConfigApiKey,
   resolveAnthropicVertexProjectId,
   resolveAnthropicVertexRegion,
-  resolveAnthropicVertexRegionFromBaseUrl,
 } from "./region.js";
+export {
+  resolveAnthropicVertexClientRegion,
+  resolveAnthropicVertexRegionFromBaseUrl,
+} from "./region-endpoint.js";
 
 const loadStreamRuntimeModule = createLazyRuntimeModule(() => import("./stream-runtime.js"));
 

--- a/extensions/anthropic-vertex/provider-catalog.ts
+++ b/extensions/anthropic-vertex/provider-catalog.ts
@@ -15,7 +15,8 @@ import {
   resolveClaudeSonnet5ModelIdentity,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveAnthropicVertexClientRegion, resolveAnthropicVertexRegion } from "./region.js";
+import { resolveAnthropicVertexClientRegion } from "./region-endpoint.js";
+import { resolveAnthropicVertexRegion } from "./region.js";
 /** Default Anthropic Vertex model used for implicit provider catalogs. */
 export const ANTHROPIC_VERTEX_DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_VERTEX_DEFAULT_CONTEXT_WINDOW = 1_000_000;

--- a/extensions/anthropic-vertex/provider-discovery.import-guard.test.ts
+++ b/extensions/anthropic-vertex/provider-discovery.import-guard.test.ts
@@ -1,11 +1,35 @@
-// Anthropic Vertex tests cover provider discovery.import guard plugin behavior.
-import { describe, expect, it } from "vitest";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({ loaded: false, run: vi.fn() }));
+vi.mock("./provider-catalog-runtime.js", () => {
+  runtime.loaded = true;
+  return { runAnthropicVertexCatalog: runtime.run };
+});
+vi.mock("openclaw/plugin-sdk/provider-http", () => {
+  throw new Error("Discovery metadata must not load HTTP runtime");
+});
 
 describe("anthropic-vertex provider discovery entry", () => {
-  it("imports without loading the full plugin entry", async () => {
-    const module = await import("./provider-discovery.js");
+  it("loads catalog runtime only when discovery executes", async () => {
+    const { default: provider } = await import("./provider-discovery.js");
+    expect(provider.id).toBe("anthropic-vertex");
+    expect(provider.catalog.order).toBe("simple");
+    expect(runtime.loaded).toBe(false);
+    expect(
+      provider.resolveConfigApiKey({ env: { ANTHROPIC_VERTEX_USE_GCP_METADATA: "true" } }),
+    ).toBe("gcp-vertex-credentials");
 
-    expect(module.default.id).toBe("anthropic-vertex");
-    expect(module.default.catalog.order).toBe("simple");
+    const ctx: ProviderCatalogContext = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    };
+    const result = { provider: { models: [] } };
+    runtime.run.mockResolvedValue(result);
+    expect(await provider.catalog.run(ctx)).toBe(result);
+    expect(runtime.loaded).toBe(true);
+    expect(runtime.run).toHaveBeenCalledExactlyOnceWith(ctx);
   });
 });

--- a/extensions/anthropic-vertex/provider-discovery.ts
+++ b/extensions/anthropic-vertex/provider-discovery.ts
@@ -2,43 +2,28 @@
  * Provider discovery descriptor for Anthropic Vertex. This variant is used by
  * catalog surfaces that need the provider contract without full plugin entry setup.
  */
-import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
-import { runAnthropicVertexCatalog } from "./provider-catalog-runtime.js";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { hasAnthropicVertexAvailableAuth, resolveAnthropicVertexConfigApiKey } from "./region.js";
 
 const PROVIDER_ID = "anthropic-vertex";
 const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 
-type AnthropicVertexProviderPlugin = {
-  id: string;
-  label: string;
-  docsPath: string;
-  auth: [];
-  catalog: {
-    order: "simple";
-    run: (ctx: ProviderCatalogContext) => ReturnType<typeof runAnthropicVertexCatalog>;
-  };
-  resolveConfigApiKey: (params: { env: NodeJS.ProcessEnv }) => string | undefined;
-  resolveSyntheticAuth: () =>
-    | {
-        apiKey: string;
-        source: string;
-        mode: "api-key";
-      }
-    | undefined;
-};
-
 /** Anthropic Vertex provider discovery descriptor. */
-export const anthropicVertexProviderDiscovery: AnthropicVertexProviderPlugin = {
+export const anthropicVertexProviderDiscovery = {
   id: PROVIDER_ID,
   label: "Anthropic Vertex",
   docsPath: "/providers/models",
   auth: [],
   catalog: {
     order: "simple",
-    run: runAnthropicVertexCatalog,
+    // Descriptor reads need ADC facts; catalog execution owns model/runtime loading.
+    run: async (ctx) => {
+      const { runAnthropicVertexCatalog } = await import("./provider-catalog-runtime.js");
+      return await runAnthropicVertexCatalog(ctx);
+    },
   },
-  resolveConfigApiKey: ({ env }) => resolveAnthropicVertexConfigApiKey(env),
+  resolveConfigApiKey: ({ env }: { env: NodeJS.ProcessEnv }) =>
+    resolveAnthropicVertexConfigApiKey(env),
   resolveSyntheticAuth: () => {
     if (!hasAnthropicVertexAvailableAuth()) {
       return undefined;
@@ -49,6 +34,6 @@ export const anthropicVertexProviderDiscovery: AnthropicVertexProviderPlugin = {
       mode: "api-key",
     };
   },
-};
+} satisfies ProviderPlugin;
 
 export default anthropicVertexProviderDiscovery;

--- a/extensions/anthropic-vertex/region-endpoint.ts
+++ b/extensions/anthropic-vertex/region-endpoint.ts
@@ -1,0 +1,19 @@
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
+import { resolveAnthropicVertexRegion } from "./region.js";
+
+/** Extract a Vertex region from a provider base URL when possible. */
+export function resolveAnthropicVertexRegionFromBaseUrl(baseUrl?: string): string | undefined {
+  const endpoint = resolveProviderEndpoint(baseUrl);
+  return endpoint.endpointClass === "google-vertex" ? endpoint.googleVertexRegion : undefined;
+}
+
+/** Resolve the client region from model base URL first, then env fallback. */
+export function resolveAnthropicVertexClientRegion(params?: {
+  baseUrl?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  return (
+    resolveAnthropicVertexRegionFromBaseUrl(params?.baseUrl) ||
+    resolveAnthropicVertexRegion(params?.env)
+  );
+}

--- a/extensions/anthropic-vertex/region.adc.test.ts
+++ b/extensions/anthropic-vertex/region.adc.test.ts
@@ -1,7 +1,7 @@
 // Anthropic Vertex tests cover region.adc plugin behavior.
 import { platform } from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
@@ -10,20 +10,12 @@ const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-  existsSyncMock.mockImplementation((pathname) => actual.existsSync(pathname));
-  readFileSyncMock.mockImplementation((pathname, options) =>
-    String(pathname) === "/tmp/vertex-adc.json"
-      ? '{"project_id":"vertex-project"}'
-      : actual.readFileSync(pathname, options as never),
-  );
   return {
     ...actual,
     existsSync: existsSyncMock,
-    readFileSync: readFileSyncMock,
     default: {
       ...actual,
       existsSync: existsSyncMock,
-      readFileSync: readFileSyncMock,
     },
   };
 });
@@ -35,9 +27,16 @@ vi.mock("openclaw/plugin-sdk/secret-file-runtime", () => ({
 import { hasAnthropicVertexAvailableAuth, resolveAnthropicVertexProjectId } from "./region.js";
 
 describe("anthropic-vertex ADC reads", () => {
-  afterEach(() => {
-    existsSyncMock.mockClear();
-    readFileSyncMock.mockClear();
+  beforeEach(() => {
+    existsSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+    // The secret-file fixture owns its contents, independently of unrelated fs imports.
+    readFileSyncMock.mockImplementation((pathname) => {
+      if (String(pathname) !== "/tmp/vertex-adc.json") {
+        throw new Error(`unexpected ADC fixture path: ${String(pathname)}`);
+      }
+      return '{"project_id":"vertex-project"}';
+    });
   });
 
   afterAll(() => {
@@ -72,11 +71,9 @@ describe("anthropic-vertex ADC reads", () => {
     readFileSyncMock.mockImplementation((pathname, options) =>
       String(pathname) === defaultAdcPath
         ? '{"project_id":"vertex-project"}'
-        : String(pathname) === "/tmp/vertex-adc.json"
-          ? '{"project_id":"vertex-project"}'
-          : (() => {
-              throw new Error(`unexpected readFileSync(${String(pathname)}, ${String(options)})`);
-            })(),
+        : (() => {
+            throw new Error(`unexpected readFileSync(${String(pathname)}, ${String(options)})`);
+          })(),
     );
 
     expect(resolveAnthropicVertexProjectId(env)).toBe("vertex-project");

--- a/extensions/anthropic-vertex/region.ts
+++ b/extensions/anthropic-vertex/region.ts
@@ -5,7 +5,6 @@
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { GoogleAuthOptions } from "google-auth-library";
-import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -42,23 +41,6 @@ export function resolveAnthropicVertexProjectId(
     normalizeOptionalSecretInput(env.GOOGLE_CLOUD_PROJECT) ||
     normalizeOptionalSecretInput(env.GOOGLE_CLOUD_PROJECT_ID) ||
     resolveAnthropicVertexProjectIdFromAdc(env)
-  );
-}
-
-/** Extract a Vertex region from a provider base URL when possible. */
-export function resolveAnthropicVertexRegionFromBaseUrl(baseUrl?: string): string | undefined {
-  const endpoint = resolveProviderEndpoint(baseUrl);
-  return endpoint.endpointClass === "google-vertex" ? endpoint.googleVertexRegion : undefined;
-}
-
-/** Resolve the client region from model base URL first, then env fallback. */
-export function resolveAnthropicVertexClientRegion(params?: {
-  baseUrl?: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
-  return (
-    resolveAnthropicVertexRegionFromBaseUrl(params?.baseUrl) ||
-    resolveAnthropicVertexRegion(params?.env)
   );
 }
 

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -25,11 +25,8 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { copyProviderAcceptanceObserver } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
-import {
-  resolveAnthropicVertexAdcCredentials,
-  resolveAnthropicVertexClientRegion,
-  resolveAnthropicVertexProjectId,
-} from "./region.js";
+import { resolveAnthropicVertexClientRegion } from "./region-endpoint.js";
+import { resolveAnthropicVertexAdcCredentials, resolveAnthropicVertexProjectId } from "./region.js";
 
 const GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 

--- a/extensions/deepinfra/api.ts
+++ b/extensions/deepinfra/api.ts
@@ -1,7 +1,10 @@
 // Deepinfra API module exposes the plugin public contract.
-export { buildDeepInfraProvider, buildStaticDeepInfraProvider } from "./provider-catalog.js";
+export { buildDeepInfraProvider } from "./provider-catalog.js";
 export { applyDeepInfraConfig } from "./onboard.js";
-export { DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-models.js";
+export {
+  DEEPINFRA_DEFAULT_MODEL_REF,
+  buildStaticDeepInfraProvider,
+} from "./provider-static-catalog.js";
 export { buildDeepInfraImageGenerationProvider } from "./image-generation-provider.js";
 export { deepinfraMediaUnderstandingProvider } from "./media-understanding-provider.js";
 export { deepinfraEmbeddingProviderAdapter } from "./embedding-adapter.js";

--- a/extensions/deepinfra/index.ts
+++ b/extensions/deepinfra/index.ts
@@ -11,11 +11,12 @@ import { buildDeepInfraEmbeddingAdapter } from "./embedding-adapter.js";
 import { buildDeepInfraImageGenerationProvider } from "./image-generation-provider.js";
 import { buildDeepInfraMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyDeepInfraConfig } from "./onboard.js";
-import { buildDeepInfraApiKeyCatalog, buildStaticDeepInfraProvider } from "./provider-catalog.js";
+import { buildDeepInfraApiKeyCatalog } from "./provider-catalog.js";
+import { getDeepInfraSurfaceFallbackCatalog } from "./provider-models.js";
 import {
   DEEPINFRA_DEFAULT_MODEL_REF,
-  getDeepInfraSurfaceFallbackCatalog,
-} from "./provider-models.js";
+  buildStaticDeepInfraProvider,
+} from "./provider-static-catalog.js";
 import { buildDeepInfraSpeechProvider } from "./speech-provider.js";
 import {
   listDeepInfraImageGenCatalog,

--- a/extensions/deepinfra/onboard.test.ts
+++ b/extensions/deepinfra/onboard.test.ts
@@ -8,7 +8,7 @@ import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEEPINFRA_BASE_URL } from "./media-models.js";
 import { applyDeepInfraConfig } from "./onboard.js";
-import { DEEPINFRA_DEFAULT_MODEL_REF, DEEPINFRA_MODEL_CATALOG } from "./provider-models.js";
+import { DEEPINFRA_DEFAULT_MODEL_REF, DEEPINFRA_MODEL_CATALOG } from "./provider-static-catalog.js";
 
 const { resolveEnvApiKey } = providerAuth;
 

--- a/extensions/deepinfra/onboard.ts
+++ b/extensions/deepinfra/onboard.ts
@@ -3,7 +3,7 @@ import {
   createAliasOnlyPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
-import { DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-models.js";
+import { DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-static-catalog.js";
 
 export function applyDeepInfraConfig(
   cfg: OpenClawConfig,

--- a/extensions/deepinfra/provider-catalog.ts
+++ b/extensions/deepinfra/provider-catalog.ts
@@ -7,19 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { DEEPINFRA_BASE_URL } from "./media-models.js";
-import {
-  DEEPINFRA_MODEL_CATALOG,
-  buildDeepInfraModelDefinition,
-  discoverDeepInfraModels,
-} from "./provider-models.js";
-
-export function buildStaticDeepInfraProvider(): ModelProviderConfig {
-  return {
-    baseUrl: DEEPINFRA_BASE_URL,
-    api: "openai-completions",
-    models: DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition),
-  };
-}
+import { discoverDeepInfraModels } from "./provider-models.js";
 
 export async function buildDeepInfraProvider(options?: {
   hasApiKey?: boolean;

--- a/extensions/deepinfra/provider-discovery.test.ts
+++ b/extensions/deepinfra/provider-discovery.test.ts
@@ -1,0 +1,44 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({ loaded: false, run: vi.fn() }));
+vi.mock("./provider-catalog.js", () => {
+  runtime.loaded = true;
+  return { buildDeepInfraApiKeyCatalog: runtime.run };
+});
+
+describe("DeepInfra provider discovery entry", () => {
+  it("publishes static models before loading live catalog runtime", async () => {
+    const { default: provider } = await import("./provider-discovery.js");
+    expect(runtime.loaded).toBe(false);
+    const ctx: ProviderCatalogContext = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    };
+    const catalog = await provider.staticCatalog?.run(ctx);
+    expect(catalog).toMatchObject({
+      provider: {
+        baseUrl: "https://api.deepinfra.com/v1/openai",
+        api: "openai-completions",
+        models: expect.arrayContaining([
+          expect.objectContaining({
+            id: "deepseek-ai/DeepSeek-V4-Flash",
+            compat: expect.objectContaining({
+              supportsUsageInStreaming: true,
+              thinkingFormat: "deepseek",
+            }),
+          }),
+        ]),
+      },
+    });
+    expect(runtime.loaded).toBe(false);
+
+    const result = { provider: { models: [] } };
+    runtime.run.mockResolvedValue(result);
+    expect(await provider.catalog?.run(ctx)).toBe(result);
+    expect(runtime.loaded).toBe(true);
+    expect(runtime.run).toHaveBeenCalledExactlyOnceWith(ctx);
+  });
+});

--- a/extensions/deepinfra/provider-discovery.ts
+++ b/extensions/deepinfra/provider-discovery.ts
@@ -1,7 +1,6 @@
 // Deepinfra provider module implements model/runtime integration.
-import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildDeepInfraApiKeyCatalog, buildStaticDeepInfraProvider } from "./provider-catalog.js";
+import { buildStaticDeepInfraProvider } from "./provider-static-catalog.js";
 
 const PROVIDER_ID = "deepinfra";
 
@@ -12,7 +11,11 @@ const deepinfraProviderDiscovery: ProviderPlugin = {
   auth: [],
   catalog: {
     order: "simple",
-    run: (ctx: ProviderCatalogContext) => buildDeepInfraApiKeyCatalog(ctx),
+    // Static inventory stays independent of credential and network discovery.
+    run: async (ctx) => {
+      const { buildDeepInfraApiKeyCatalog } = await import("./provider-catalog.js");
+      return await buildDeepInfraApiKeyCatalog(ctx);
+    },
   },
   staticCatalog: {
     order: "simple",

--- a/extensions/deepinfra/provider-models.pricing.test.ts
+++ b/extensions/deepinfra/provider-models.pricing.test.ts
@@ -1,7 +1,8 @@
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildDeepInfraProvider } from "./api.js";
-import { DEEPINFRA_MODEL_CATALOG, discoverDeepInfraModels } from "./provider-models.js";
+import { discoverDeepInfraModels } from "./provider-models.js";
+import { DEEPINFRA_MODEL_CATALOG } from "./provider-static-catalog.js";
 
 const DEEPINFRA_MODELS_URL =
   "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta";

--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -7,13 +7,12 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
   isProviderApiKeyConfigured: isProviderApiKeyConfiguredMock,
 }));
 
+import { discoverDeepInfraModels, discoverDeepInfraSurfaces } from "./provider-models.js";
 import {
   buildDeepInfraModelDefinition,
   DEEPINFRA_DEFAULT_MODEL_REF,
   DEEPINFRA_MODEL_CATALOG,
-  discoverDeepInfraModels,
-  discoverDeepInfraSurfaces,
-} from "./provider-models.js";
+} from "./provider-static-catalog.js";
 
 const DEEPINFRA_MODELS_URL =
   "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta";

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -2,10 +2,7 @@ import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-r
 // Deepinfra provider module implements model/runtime integration.
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { fetchLiveProviderModelRows } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import {
-  buildManifestModelProviderConfig,
-  getCachedLiveCatalogValue,
-} from "openclaw/plugin-sdk/provider-catalog-shared";
+import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -17,24 +14,18 @@ import {
 } from "./media-models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { parseDeepInfraPricingCatalog } from "./pricing-api.js";
+import {
+  DEEPINFRA_MODEL_CATALOG,
+  buildDeepInfraModelDefinition,
+} from "./provider-static-catalog.js";
 
 const log = createSubsystemLogger("deepinfra-models");
-
-const DEEPINFRA_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
-  providerId: "deepinfra",
-  catalog: manifest.modelCatalog.providers.deepinfra,
-});
 
 const DEEPINFRA_MODELS_URL = `${DEEPINFRA_BASE_URL}/models?sort_by=openclaw&filter=with_meta`;
 const DEEPINFRA_PRICING_URL = "https://api.deepinfra.com/models/list";
 
-const DEEPINFRA_DEFAULT_MODEL_ID = "deepseek-ai/DeepSeek-V4-Flash";
-export const DEEPINFRA_DEFAULT_MODEL_REF = `deepinfra/${DEEPINFRA_DEFAULT_MODEL_ID}`;
-
 const DEEPINFRA_DEFAULT_CONTEXT_WINDOW = 128000;
 const DEEPINFRA_DEFAULT_MAX_TOKENS = 8192;
-
-export const DEEPINFRA_MODEL_CATALOG: ModelDefinitionConfig[] = DEEPINFRA_MANIFEST_PROVIDER.models;
 
 const DISCOVERY_TIMEOUT_MS = 5000;
 const DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -282,30 +273,6 @@ function manifestFallbackCatalog(): DeepInfraDiscoveredCatalog {
 // register with these defaults; live discovery feeds the chat, image, and video catalog hooks.
 export function getDeepInfraSurfaceFallbackCatalog(): DeepInfraDiscoveredCatalog {
   return manifestFallbackCatalog();
-}
-
-// DeepInfra serves every model family over one OpenAI-compatible endpoint, so
-// core's endpoint-based attribution resolves all of them to thinkingFormat
-// "openai". DeepSeek models emit DSML tool-call markup (`<|DSML|tool_calls>`)
-// and reasoning_content that core only strips/recovers when thinkingFormat is
-// "deepseek"; without this tag the markup leaks into user channels and the tool
-// calls are lost. Declare the dialect per family like opencode-go does for Qwen
-// (extensions/opencode-go/provider-catalog.ts).
-function resolveDeepInfraThinkingFormat(modelId: string | undefined): "deepseek" | undefined {
-  const vendor = (modelId ?? "").toLowerCase().split("/")[0];
-  return vendor === "deepseek-ai" ? "deepseek" : undefined;
-}
-
-export function buildDeepInfraModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
-  const thinkingFormat = model.compat?.thinkingFormat ?? resolveDeepInfraThinkingFormat(model.id);
-  return {
-    ...model,
-    compat: {
-      ...model.compat,
-      supportsUsageInStreaming: model.compat?.supportsUsageInStreaming ?? true,
-      ...(thinkingFormat ? { thinkingFormat } : {}),
-    },
-  };
 }
 
 function chatSurfaceModelToModelDefinition(

--- a/extensions/deepinfra/provider-static-catalog.ts
+++ b/extensions/deepinfra/provider-static-catalog.ts
@@ -1,0 +1,49 @@
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-model-metadata";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { DEEPINFRA_BASE_URL } from "./media-models.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const DEEPINFRA_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "deepinfra",
+  catalog: manifest.modelCatalog.providers.deepinfra,
+});
+
+const DEEPINFRA_DEFAULT_MODEL_ID = "deepseek-ai/DeepSeek-V4-Flash";
+export const DEEPINFRA_DEFAULT_MODEL_REF = `deepinfra/${DEEPINFRA_DEFAULT_MODEL_ID}`;
+
+export const DEEPINFRA_MODEL_CATALOG: ModelDefinitionConfig[] = DEEPINFRA_MANIFEST_PROVIDER.models;
+
+// DeepInfra serves every model family over one OpenAI-compatible endpoint, so
+// core's endpoint-based attribution resolves all of them to thinkingFormat
+// "openai". DeepSeek models emit DSML tool-call markup (`<|DSML|tool_calls>`)
+// and reasoning_content that core only strips/recovers when thinkingFormat is
+// "deepseek"; without this tag the markup leaks into user channels and the tool
+// calls are lost. Declare the dialect per family like opencode-go does for Qwen
+// (extensions/opencode-go/provider-catalog.ts).
+function resolveDeepInfraThinkingFormat(modelId: string | undefined): "deepseek" | undefined {
+  const vendor = (modelId ?? "").toLowerCase().split("/")[0];
+  return vendor === "deepseek-ai" ? "deepseek" : undefined;
+}
+
+export function buildDeepInfraModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
+  const thinkingFormat = model.compat?.thinkingFormat ?? resolveDeepInfraThinkingFormat(model.id);
+  return {
+    ...model,
+    compat: {
+      ...model.compat,
+      supportsUsageInStreaming: model.compat?.supportsUsageInStreaming ?? true,
+      ...(thinkingFormat ? { thinkingFormat } : {}),
+    },
+  };
+}
+
+export function buildStaticDeepInfraProvider(): ModelProviderConfig {
+  return {
+    baseUrl: DEEPINFRA_BASE_URL,
+    api: "openai-completions",
+    models: DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition),
+  };
+}

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -18,7 +18,7 @@ import type { RealtimeVoiceBridge } from "openclaw/plugin-sdk/realtime-voice";
 import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
-import { buildGoogleLiveCatalogProvider } from "./provider-catalog.js";
+import { buildGoogleLiveCatalogProvider } from "./provider-catalog-runtime.js";
 import { buildGoogleRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
 

--- a/extensions/google/provider-catalog-runtime.ts
+++ b/extensions/google/provider-catalog-runtime.ts
@@ -1,0 +1,119 @@
+import {
+  buildLiveModelProviderConfig,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asOptionalRecord,
+  asPositiveSafeInteger,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  GOOGLE_GEMINI_MANIFEST_PROVIDER,
+  GOOGLE_GEMINI_TEXT_MODEL_BY_ID,
+  GOOGLE_GEMINI_TEXT_MODEL_IDS,
+  GOOGLE_GEMINI_COST,
+  buildGoogleStaticCatalogProvider,
+} from "./provider-catalog.js";
+import { isGoogleTextGenerationModelId, resolveGoogleStaticModelId } from "./provider-models.js";
+
+const GOOGLE_GEMINI_MODELS_CACHE_TTL_MS = 60_000;
+const GOOGLE_GEMINI_MODELS_ENDPOINT = `${GOOGLE_GEMINI_MANIFEST_PROVIDER.baseUrl}/models?pageSize=1000`;
+
+function readGoogleLiveModels(body: unknown): readonly unknown[] {
+  const record = asOptionalRecord(body);
+  if (!record || (record.models !== undefined && !Array.isArray(record.models))) {
+    throw new Error("Google models.list returned an invalid model list");
+  }
+  return record.models ?? [];
+}
+
+function googleLiveModelInput(id: string): ModelDefinitionConfig["input"] {
+  if (!id.startsWith("gemma-")) {
+    return ["text", "image", "video"];
+  }
+  const isMultimodalGemma =
+    /^gemma-3-(?:4b|12b|27b)(?:-|$)/.test(id) ||
+    id.startsWith("gemma-3n-") ||
+    id.startsWith("gemma-4-");
+  return isMultimodalGemma ? ["text", "image"] : ["text"];
+}
+
+function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
+  const record = asOptionalRecord(row);
+  if (!record) {
+    throw new Error("Google models.list returned an invalid model row");
+  }
+  const resourceName = normalizeOptionalString(record.name);
+  const id = resourceName?.startsWith("models/") ? resourceName.slice("models/".length) : undefined;
+  const methods = record.supportedGenerationMethods;
+  const contextWindow = asPositiveSafeInteger(record.inputTokenLimit);
+  const maxTokens = asPositiveSafeInteger(record.outputTokenLimit);
+  if (
+    !id ||
+    !isGoogleTextGenerationModelId(id) ||
+    !Array.isArray(methods) ||
+    !methods.includes("generateContent") ||
+    !contextWindow ||
+    !maxTokens
+  ) {
+    return undefined;
+  }
+  // Compat flags apply to evaluated weights only. Resolve discovered id
+  // variants (aliases, dated previews, -latest) to the bundled entry with the
+  // same weights; ids that do not resolve keep no compat (fail closed).
+  const staticId = resolveGoogleStaticModelId(id, GOOGLE_GEMINI_TEXT_MODEL_IDS);
+  const staticModel = staticId ? GOOGLE_GEMINI_TEXT_MODEL_BY_ID.get(staticId) : undefined;
+  return {
+    id,
+    name: normalizeOptionalString(record.displayName) ?? id,
+    reasoning: record.thinking === true,
+    // models.list omits modalities. Gemma has both text-only small variants and
+    // multimodal families, so keep this capability distinction explicit.
+    input: googleLiveModelInput(id),
+    cost: GOOGLE_GEMINI_COST,
+    contextWindow,
+    maxTokens,
+    ...(staticModel?.compat ? { compat: { ...staticModel.compat } } : {}),
+    ...(staticModel?.thinkingLevelMap
+      ? { thinkingLevelMap: { ...staticModel.thinkingLevelMap } }
+      : {}),
+  };
+}
+
+function parseGoogleLiveModels(rows: readonly unknown[]): ModelDefinitionConfig[] {
+  const models = rows
+    .map(buildGoogleLiveModel)
+    .filter((model): model is ModelDefinitionConfig => Boolean(model));
+  return [...new Map(models.map((model) => [model.id, model])).values()].toSorted((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+}
+
+export async function buildGoogleLiveCatalogProvider(params: {
+  discoveryMode?: "strict";
+  apiKey?: string;
+  discoveryApiKey?: string;
+  fetchGuard?: LiveModelCatalogFetchGuard;
+  signal?: AbortSignal;
+}): Promise<ModelProviderConfig> {
+  const { models, ...providerConfig } = buildGoogleStaticCatalogProvider();
+  return await buildLiveModelProviderConfig({
+    providerId: "google",
+    endpoint: GOOGLE_GEMINI_MODELS_ENDPOINT,
+    providerConfig,
+    models,
+    ...params,
+    ttlMs: GOOGLE_GEMINI_MODELS_CACHE_TTL_MS,
+    auditContext: "google-model-discovery",
+    readRows: readGoogleLiveModels,
+    buildRequestHeaders: ({ discoveryApiKey, apiKey }) => ({
+      Accept: "application/json",
+      ...((discoveryApiKey ?? apiKey) ? { "x-goog-api-key": discoveryApiKey ?? apiKey } : {}),
+    }),
+    projectRows: parseGoogleLiveModels,
+  });
+}

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -4,8 +4,8 @@ import {
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildGoogleLiveCatalogProvider } from "./provider-catalog-runtime.js";
 import {
-  buildGoogleLiveCatalogProvider,
   buildGoogleStaticCatalogProvider,
   buildGoogleVertexStaticCatalogProvider,
 } from "./provider-catalog.js";

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -1,32 +1,20 @@
-import {
-  buildLiveModelProviderConfig,
-  type LiveModelCatalogFetchGuard,
-} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-model-metadata";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import {
-  asOptionalRecord,
-  asPositiveSafeInteger,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import { isGoogleTextGenerationModelId, resolveGoogleStaticModelId } from "./provider-models.js";
 
 const GOOGLE_VERTEX_BASE_URL = "https://{location}-aiplatform.googleapis.com";
-const GOOGLE_GEMINI_MODELS_CACHE_TTL_MS = 60_000;
-const GOOGLE_GEMINI_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+export const GOOGLE_GEMINI_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
   providerId: "google",
   catalog: manifest.modelCatalog.providers.google,
 });
-const GOOGLE_GEMINI_MODELS_ENDPOINT = `${GOOGLE_GEMINI_MANIFEST_PROVIDER.baseUrl}/models?pageSize=1000`;
 const GOOGLE_GEMINI_TEXT_MODELS = GOOGLE_GEMINI_MANIFEST_PROVIDER.models;
-const GOOGLE_GEMINI_TEXT_MODEL_BY_ID = new Map(
+export const GOOGLE_GEMINI_TEXT_MODEL_BY_ID = new Map(
   GOOGLE_GEMINI_TEXT_MODELS.map((model) => [model.id, model]),
 );
-const GOOGLE_GEMINI_TEXT_MODEL_IDS: ReadonlySet<string> = new Set(
+export const GOOGLE_GEMINI_TEXT_MODEL_IDS: ReadonlySet<string> = new Set(
   GOOGLE_GEMINI_TEXT_MODEL_BY_ID.keys(),
 );
 
@@ -38,7 +26,7 @@ function requireGoogleManifestCost(): NonNullable<ModelDefinitionConfig["cost"]>
   return cost;
 }
 
-const GOOGLE_GEMINI_COST = requireGoogleManifestCost();
+export const GOOGLE_GEMINI_COST = requireGoogleManifestCost();
 
 export function buildGoogleStaticCatalogProvider(): ModelProviderConfig {
   return {
@@ -48,101 +36,6 @@ export function buildGoogleStaticCatalogProvider(): ModelProviderConfig {
       input: [...model.input, "video"],
     })),
   };
-}
-
-function readGoogleLiveModels(body: unknown): readonly unknown[] {
-  const record = asOptionalRecord(body);
-  if (!record || (record.models !== undefined && !Array.isArray(record.models))) {
-    throw new Error("Google models.list returned an invalid model list");
-  }
-  return record.models ?? [];
-}
-
-function googleLiveModelInput(id: string): ModelDefinitionConfig["input"] {
-  if (!id.startsWith("gemma-")) {
-    return ["text", "image", "video"];
-  }
-  const isMultimodalGemma =
-    /^gemma-3-(?:4b|12b|27b)(?:-|$)/.test(id) ||
-    id.startsWith("gemma-3n-") ||
-    id.startsWith("gemma-4-");
-  return isMultimodalGemma ? ["text", "image"] : ["text"];
-}
-
-function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
-  const record = asOptionalRecord(row);
-  if (!record) {
-    throw new Error("Google models.list returned an invalid model row");
-  }
-  const resourceName = normalizeOptionalString(record.name);
-  const id = resourceName?.startsWith("models/") ? resourceName.slice("models/".length) : undefined;
-  const methods = record.supportedGenerationMethods;
-  const contextWindow = asPositiveSafeInteger(record.inputTokenLimit);
-  const maxTokens = asPositiveSafeInteger(record.outputTokenLimit);
-  if (
-    !id ||
-    !isGoogleTextGenerationModelId(id) ||
-    !Array.isArray(methods) ||
-    !methods.includes("generateContent") ||
-    !contextWindow ||
-    !maxTokens
-  ) {
-    return undefined;
-  }
-  // Compat flags apply to evaluated weights only. Resolve discovered id
-  // variants (aliases, dated previews, -latest) to the bundled entry with the
-  // same weights; ids that do not resolve keep no compat (fail closed).
-  const staticId = resolveGoogleStaticModelId(id, GOOGLE_GEMINI_TEXT_MODEL_IDS);
-  const staticModel = staticId ? GOOGLE_GEMINI_TEXT_MODEL_BY_ID.get(staticId) : undefined;
-  return {
-    id,
-    name: normalizeOptionalString(record.displayName) ?? id,
-    reasoning: record.thinking === true,
-    // models.list omits modalities. Gemma has both text-only small variants and
-    // multimodal families, so keep this capability distinction explicit.
-    input: googleLiveModelInput(id),
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow,
-    maxTokens,
-    ...(staticModel?.compat ? { compat: { ...staticModel.compat } } : {}),
-    ...(staticModel?.thinkingLevelMap
-      ? { thinkingLevelMap: { ...staticModel.thinkingLevelMap } }
-      : {}),
-  };
-}
-
-function parseGoogleLiveModels(rows: readonly unknown[]): ModelDefinitionConfig[] {
-  const models = rows
-    .map(buildGoogleLiveModel)
-    .filter((model): model is ModelDefinitionConfig => Boolean(model));
-  return [...new Map(models.map((model) => [model.id, model])).values()].toSorted((a, b) =>
-    a.id.localeCompare(b.id),
-  );
-}
-
-export async function buildGoogleLiveCatalogProvider(params: {
-  discoveryMode?: "strict";
-  apiKey?: string;
-  discoveryApiKey?: string;
-  fetchGuard?: LiveModelCatalogFetchGuard;
-  signal?: AbortSignal;
-}): Promise<ModelProviderConfig> {
-  const { models, ...providerConfig } = buildGoogleStaticCatalogProvider();
-  return await buildLiveModelProviderConfig({
-    providerId: "google",
-    endpoint: GOOGLE_GEMINI_MODELS_ENDPOINT,
-    providerConfig,
-    models,
-    ...params,
-    ttlMs: GOOGLE_GEMINI_MODELS_CACHE_TTL_MS,
-    auditContext: "google-model-discovery",
-    readRows: readGoogleLiveModels,
-    buildRequestHeaders: ({ discoveryApiKey, apiKey }) => ({
-      Accept: "application/json",
-      ...((discoveryApiKey ?? apiKey) ? { "x-goog-api-key": discoveryApiKey ?? apiKey } : {}),
-    }),
-    projectRows: parseGoogleLiveModels,
-  });
 }
 
 export function buildGoogleVertexStaticCatalogProvider(): ModelProviderConfig {

--- a/extensions/google/provider-discovery.import-guard.test.ts
+++ b/extensions/google/provider-discovery.import-guard.test.ts
@@ -1,0 +1,39 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", () => {
+  throw new Error("Static Google discovery must not load live catalog runtime");
+});
+vi.mock("./provider-models.js", () => {
+  throw new Error("Static Google discovery must not load runtime model resolution");
+});
+vi.mock("./vertex-adc.js", () => {
+  throw new Error("Static Google discovery must not load token refresh runtime");
+});
+
+describe("Google provider discovery entry", () => {
+  it("publishes Studio and Vertex metadata without live catalog or token runtime", async () => {
+    const { default: provider } = await import("./provider-discovery.js");
+    const ctx: ProviderCatalogContext = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    };
+    const result = await provider.staticCatalog?.run(ctx);
+    if (!result || !("providers" in result)) {
+      throw new Error("expected Google static provider catalogs");
+    }
+    const studio = result.providers.google;
+    const vertex = result.providers["google-vertex"];
+    expect(studio?.api).toBe("google-generative-ai");
+    expect(vertex?.api).toBe("google-vertex");
+    expect(studio?.models.length).toBeGreaterThan(0);
+    expect(vertex?.models.map((model) => model.id)).toEqual(
+      studio?.models.map((model) => model.id),
+    );
+    expect(studio?.models[0]?.input).toContain("video");
+    expect(vertex?.models[0]?.input).not.toContain("video");
+    expect(provider.resolveConfigApiKey?.({ provider: "google-vertex", env: {} })).toBeUndefined();
+  });
+});

--- a/extensions/google/provider-discovery.ts
+++ b/extensions/google/provider-discovery.ts
@@ -4,7 +4,7 @@ import {
   buildGoogleStaticCatalogProvider,
   buildGoogleVertexStaticCatalogProvider,
 } from "./provider-catalog.js";
-import { resolveGoogleVertexConfigApiKey } from "./vertex-adc.js";
+import { resolveGoogleVertexConfigApiKey } from "./vertex-adc-config.js";
 
 const googleProviderDiscovery: ProviderPlugin = {
   id: "google",

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -7,8 +7,8 @@ import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-ent
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeGoogleModelId } from "./model-id.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL, applyGoogleGeminiModelDefault } from "./onboard.js";
+import { buildGoogleLiveCatalogProvider } from "./provider-catalog-runtime.js";
 import {
-  buildGoogleLiveCatalogProvider,
   buildGoogleStaticCatalogProvider,
   buildGoogleVertexStaticCatalogProvider,
 } from "./provider-catalog.js";
@@ -28,7 +28,7 @@ import {
   createGoogleGenerativeAiTransportStreamFn,
   createGoogleVertexTransportStreamFn,
 } from "./transport-stream.js";
-import { resolveGoogleVertexConfigApiKey } from "./vertex-adc.js";
+import { resolveGoogleVertexConfigApiKey } from "./vertex-adc-config.js";
 
 function normalizeGoogleVideoInput(
   ctx: Parameters<NonNullable<ProviderPlugin["normalizeResolvedModel"]>>[0],

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -57,10 +57,8 @@ import {
   type GoogleThinkingInputLevel,
   type GoogleThinkingLevel,
 } from "./thinking-api.js";
-import {
-  isGoogleVertexCredentialsMarker,
-  resolveGoogleVertexAuthorizedUserHeaders,
-} from "./vertex-adc.js";
+import { isGoogleVertexCredentialsMarker } from "./vertex-adc-config.js";
+import { resolveGoogleVertexAuthorizedUserHeaders } from "./vertex-adc.js";
 
 type CanonicalGoogleTransportApi = "google-generative-ai" | "google-vertex";
 type GoogleTransportApi = CanonicalGoogleTransportApi | "openclaw-google-generative-ai-transport";

--- a/extensions/google/vertex-adc-config.ts
+++ b/extensions/google/vertex-adc-config.ts
@@ -1,0 +1,104 @@
+// Synchronous Vertex discovery facts do not load token exchange or transport helpers.
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { GoogleAuthOptions } from "google-auth-library";
+import { readSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
+
+export function isGoogleVertexCredentialsMarker(
+  apiKey: string | undefined,
+): apiKey is undefined | typeof GCP_VERTEX_CREDENTIALS_MARKER {
+  return apiKey === undefined || apiKey === GCP_VERTEX_CREDENTIALS_MARKER;
+}
+
+function hasGoogleVertexProjectEnv(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(env.GCLOUD_PROJECT),
+  );
+}
+
+function hasGoogleVertexLocationEnv(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(normalizeOptionalString(env.GOOGLE_CLOUD_LOCATION));
+}
+
+export function resolveGoogleApplicationCredentialsPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const explicit = normalizeOptionalString(env.GOOGLE_APPLICATION_CREDENTIALS);
+  if (explicit) {
+    return existsSync(explicit) ? explicit : undefined;
+  }
+  const cloudSdkDir = normalizeOptionalString(env.CLOUDSDK_CONFIG);
+  if (cloudSdkDir) {
+    const cloudSdkFallback = path.join(cloudSdkDir, "application_default_credentials.json");
+    return existsSync(cloudSdkFallback) ? cloudSdkFallback : undefined;
+  }
+  const homeDir = normalizeOptionalString(env.HOME) ?? os.homedir();
+  const homeFallback = path.join(
+    homeDir,
+    ".config",
+    "gcloud",
+    "application_default_credentials.json",
+  );
+  if (existsSync(homeFallback)) {
+    return homeFallback;
+  }
+  const appDataDir = normalizeOptionalString(env.APPDATA);
+  if (!appDataDir) {
+    return undefined;
+  }
+  const appDataFallback = path.join(appDataDir, "gcloud", "application_default_credentials.json");
+  return existsSync(appDataFallback) ? appDataFallback : undefined;
+}
+
+export type GoogleAdcConfig = NonNullable<GoogleAuthOptions["credentials"]>;
+const GOOGLE_VERTEX_ADC_FILE_MAX_BYTES = 1024 * 1024;
+
+export function readGoogleAdcCredentials(adcPath: string): GoogleAdcConfig {
+  const text = readSecretFileSync(adcPath, "Google Vertex ADC credentials", {
+    maxBytes: GOOGLE_VERTEX_ADC_FILE_MAX_BYTES,
+    rejectHardlinks: false,
+  });
+  const parsed = JSON.parse(text) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Google Vertex ADC credentials must be a JSON object: ${adcPath}`);
+  }
+  // SAFETY: Discovery needs an object; the token/auth owner interprets its ADC fields.
+  return parsed as GoogleAdcConfig;
+}
+
+function readGoogleAdcCredentialsTypeSync(credentialsPath: string): string | undefined {
+  try {
+    const type = readGoogleAdcCredentials(credentialsPath).type;
+    return typeof type === "string" ? type : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// File-backed ADC includes authorized users, workload identity, and service accounts.
+// Metadata-server ADC stays with the asynchronous google-auth-library request owner.
+function hasGoogleVertexAdcSync(env: NodeJS.ProcessEnv = process.env): boolean {
+  const credentialsPath = resolveGoogleApplicationCredentialsPath(env);
+  if (credentialsPath) {
+    const type = readGoogleAdcCredentialsTypeSync(credentialsPath);
+    if (type === "authorized_user" || type === "external_account" || type === "service_account") {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveGoogleVertexConfigApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return hasGoogleVertexProjectEnv(env) &&
+    hasGoogleVertexLocationEnv(env) &&
+    hasGoogleVertexAdcSync(env)
+    ? GCP_VERTEX_CREDENTIALS_MARKER
+    : undefined;
+}

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -1,9 +1,5 @@
 // Google plugin module implements vertex adc behavior.
-import { existsSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { gunzipSync } from "node:zlib";
-import type { GoogleAuthOptions } from "google-auth-library";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import {
   asDateTimestampMs,
@@ -11,9 +7,13 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { readSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  readGoogleAdcCredentials,
+  resolveGoogleApplicationCredentialsPath,
+  type GoogleAdcConfig,
+} from "./vertex-adc-config.js";
 
 type GoogleAuthorizedUserCredentials = {
   type: "authorized_user";
@@ -41,7 +41,6 @@ type GoogleOauthTokenResponsePayload = {
   error_description?: unknown;
 };
 
-const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_VERTEX_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 const GOOGLE_VERTEX_ADC_TOKEN_REFRESH_TIMEOUT_MS = 30_000;
@@ -108,68 +107,6 @@ if (process.env.VITEST) {
   };
 }
 
-export function isGoogleVertexCredentialsMarker(
-  apiKey: string | undefined,
-): apiKey is undefined | typeof GCP_VERTEX_CREDENTIALS_MARKER {
-  return apiKey === undefined || apiKey === GCP_VERTEX_CREDENTIALS_MARKER;
-}
-
-function hasGoogleVertexProjectEnv(env: NodeJS.ProcessEnv): boolean {
-  return Boolean(
-    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT) ||
-    normalizeOptionalString(env.GCLOUD_PROJECT),
-  );
-}
-
-function hasGoogleVertexLocationEnv(env: NodeJS.ProcessEnv): boolean {
-  return Boolean(normalizeOptionalString(env.GOOGLE_CLOUD_LOCATION));
-}
-
-function resolveGoogleApplicationCredentialsPath(
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const explicit = normalizeOptionalString(env.GOOGLE_APPLICATION_CREDENTIALS);
-  if (explicit) {
-    return existsSync(explicit) ? explicit : undefined;
-  }
-  const cloudSdkDir = normalizeOptionalString(env.CLOUDSDK_CONFIG);
-  if (cloudSdkDir) {
-    const cloudSdkFallback = path.join(cloudSdkDir, "application_default_credentials.json");
-    return existsSync(cloudSdkFallback) ? cloudSdkFallback : undefined;
-  }
-  const homeDir = normalizeOptionalString(env.HOME) ?? os.homedir();
-  const homeFallback = path.join(
-    homeDir,
-    ".config",
-    "gcloud",
-    "application_default_credentials.json",
-  );
-  if (existsSync(homeFallback)) {
-    return homeFallback;
-  }
-  const appDataDir = normalizeOptionalString(env.APPDATA);
-  if (!appDataDir) {
-    return undefined;
-  }
-  const appDataFallback = path.join(appDataDir, "gcloud", "application_default_credentials.json");
-  return existsSync(appDataFallback) ? appDataFallback : undefined;
-}
-
-type GoogleAdcConfig = NonNullable<GoogleAuthOptions["credentials"]>;
-const GOOGLE_VERTEX_ADC_FILE_MAX_BYTES = 1024 * 1024;
-
-function readGoogleAdcCredentials(adcPath: string): GoogleAdcConfig {
-  const text = readSecretFileSync(adcPath, "Google Vertex ADC credentials", {
-    maxBytes: GOOGLE_VERTEX_ADC_FILE_MAX_BYTES,
-    rejectHardlinks: false,
-  });
-  const parsed = JSON.parse(text) as unknown;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`Google Vertex ADC credentials must be a JSON object: ${adcPath}`);
-  }
-  return parsed as GoogleAdcConfig;
-}
-
 function resolveGoogleAuthorizedUserCredentials(
   adcConfig: GoogleAdcConfig,
 ): GoogleAuthorizedUserCredentials | undefined {
@@ -183,51 +120,6 @@ function resolveGoogleAuthorizedUserCredentials(
     client_secret: normalizeOptionalString(record.client_secret),
     refresh_token: normalizeOptionalString(record.refresh_token),
   };
-}
-
-function readGoogleAdcCredentialsTypeSync(credentialsPath: string): string | undefined {
-  try {
-    const type = (readGoogleAdcCredentials(credentialsPath) as { type?: unknown }).type;
-    return typeof type === "string" ? type : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Returns true when a file/env Application Default Credentials source usable
- * for Google Vertex AI is detectable synchronously. We still call the function
- * `...AuthorizedUserAdcSync` for backwards compatibility with older tests; the
- * predicate now also covers:
- *
- *   1. `authorized_user` credentials file (existing case - `gcloud auth
- *      application-default login` produces this).
- *   2. `external_account` credentials file (Workload Identity Federation).
- *   3. `service_account` credentials file (raw GSA key - rarely used in
- *      OpenClaw, included for completeness).
- * Metadata-server ADC is intentionally not detected here: `google-auth-library`
- * probes the default metadata hosts asynchronously at request time, and the
- * provider wires the Vertex transport without this sync predicate.
- */
-function hasGoogleVertexAuthorizedUserAdcSync(env: NodeJS.ProcessEnv = process.env): boolean {
-  const credentialsPath = resolveGoogleApplicationCredentialsPath(env);
-  if (credentialsPath) {
-    const type = readGoogleAdcCredentialsTypeSync(credentialsPath);
-    if (type === "authorized_user" || type === "external_account" || type === "service_account") {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function resolveGoogleVertexConfigApiKey(
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  return hasGoogleVertexProjectEnv(env) &&
-    hasGoogleVertexLocationEnv(env) &&
-    hasGoogleVertexAuthorizedUserAdcSync(env)
-    ? GCP_VERTEX_CREDENTIALS_MARKER
-    : undefined;
 }
 
 async function refreshGoogleVertexAuthorizedUserAccessToken(params: {


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary cold-import work when offline CLI commands prepare the model catalog. Loading metadata descriptors for Anthropic Vertex, DeepInfra and Google also loaded live catalog, transport or token code before that work was needed.

## Why This Change Was Made

Static metadata and live execution now have separate owners within the existing plugins. Vertex defers its catalog runtime and keeps environment/ADC facts separate from endpoint helpers. DeepInfra shares one static manifest/model-definition module between its descriptor and live catalog. Google keeps static Studio/Vertex models and synchronous ADC facts independent of live discovery and token exchange.

Existing public Vertex/DeepInfra API names and canonical model builders are retained. Google token refresh, caching and deadline logic stays with its existing owner. No new dependency, SDK subpath, configuration option, cache infrastructure, or shard change is introduced.

The tests enforce these import boundaries and retain real static output and live delegation coverage. A Vertex ADC fixture now initializes its fake reader explicitly instead of depending on an unrelated import. The moved ADC type boundary is documented, an unnecessary assertion is removed, and the old file's assertion baseline decreases from six to four.

## User Impact

Less startup work for metadata-only catalog reads. Both existing unknown-provider process tests remain intact; they protect separate CLI routes and a specific past JSON error regression.

Production changes are mostly moves, with three net added lines. Test changes add 104 net lines; the assertion-baseline adjustment is neutral in line count and reduces the old allowance.

## Evidence

- A fresh-process original/candidate/original Linux comparison, with each arm built from its corresponding source, measured the representative Commander JSON error case at **40.52s / 30.15s / 32.60s**. Source, loaded descriptors and compiled chunks were verified, and original descriptor bytes returned in the final arm. The variation between originals limits any general percentage claim.
- New import-boundary guards fail against the original eager imports and pass with the separated owners. Models and auth behavior remain covered by existing tests.
- Normal full build passed on Linux, including SDK/export/bootstrap checks and the UI build. **575 tests passed across 36 files:** 530 provider cases, all 28 unchanged help/exit cases, and 17 prepared-catalog CLI cases.
- Independent P2 review found no actionable issue. The final 30-path changed-file gate passed after the assertion annotation/baseline cleanup. Exact-head CI will be verified before landing.

The timing comparison and full runtime tests precede the final non-executable assertion annotation/baseline cleanup. Earlier diagnostic attempts and differing raw-CLI environments are not used as performance evidence. No live provider request was needed for the unchanged token implementations; existing transport/auth tests and the full build verify their retained boundaries.
