### PR TITLE
fix(release): keep 7.33 ClawHub bootstrap hermetic

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -1,4 +1,5 @@
 // CommonJS fixture server for ClawHub package/install E2E scenarios.
+const { execFileSync } = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const http = require("node:http");
@@ -8,11 +9,178 @@ const { createRequire } = require("node:module");
 
 const profile = process.argv[2];
 const portFile = process.argv[3];
+const artifactManifestFile = process.argv[4];
 const requireFromApp = createRequire(path.join(process.cwd(), "package.json"));
-const JSZip = requireFromApp("jszip");
-const tar = requireFromApp("tar");
 const packageName = "@openclaw/kitchen-sink";
 const pluginId = "openclaw-kitchen-sink-fixture";
+
+async function assertNoRequests(baseUrl) {
+  if (!baseUrl) {
+    throw new Error("assert-no-requests requires <base-url>");
+  }
+  const response = await fetch(new URL("/__fixture__/requests", baseUrl));
+  if (!response.ok) {
+    throw new Error(`ClawHub fixture request ledger returned HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (!Array.isArray(payload?.requests)) {
+    throw new Error("ClawHub fixture request ledger must contain a requests array");
+  }
+  if (payload.requests.length !== 0) {
+    throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(payload.requests)}`);
+  }
+}
+
+function startPrepublishArtifactServer() {
+  const manifest = JSON.parse(fs.readFileSync(artifactManifestFile, "utf8"));
+  if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+    throw new Error("prepublish artifact manifest must contain packages");
+  }
+  const artifacts = new Map(
+    manifest.packages.flatMap((entry) => {
+      if (
+        typeof entry.name !== "string" ||
+        typeof entry.version !== "string" ||
+        typeof entry.tarball !== "string" ||
+        path.basename(entry.tarball) !== entry.tarball
+      ) {
+        throw new Error("invalid prepublish artifact manifest entry");
+      }
+      const tarballPath = path.join(path.dirname(artifactManifestFile), entry.tarball);
+      const archive = fs.readFileSync(tarballPath);
+      const sha256 = crypto.createHash("sha256").update(archive).digest("hex");
+      const packedPackage = JSON.parse(
+        execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], {
+          encoding: "utf8",
+        }),
+      );
+      if (
+        sha256 !== entry.sha256 ||
+        packedPackage.name !== entry.name ||
+        packedPackage.version !== entry.version
+      ) {
+        throw new Error(`prepublish artifact metadata mismatch for ${entry.name}`);
+      }
+      if (!Array.isArray(packedPackage.openclaw?.extensions)) {
+        return [];
+      }
+      const packedPlugin = JSON.parse(
+        execFileSync("tar", ["-xOf", tarballPath, "package/openclaw.plugin.json"], {
+          encoding: "utf8",
+        }),
+      );
+      if (typeof packedPlugin.id !== "string" || packedPlugin.id.length === 0) {
+        throw new Error(`prepublish artifact metadata mismatch for ${entry.name}`);
+      }
+      return [
+        [
+          entry.name,
+          {
+            ...entry,
+            archive,
+            runtimeId: packedPlugin.id,
+            npmIntegrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
+            npmShasum: crypto.createHash("sha1").update(archive).digest("hex"),
+          },
+        ],
+      ];
+    }),
+  );
+  const requestLog = [];
+  const json = (response, value, status = 200) => {
+    response.writeHead(status, { "content-type": "application/json" });
+    response.end(`${JSON.stringify(value)}\n`);
+  };
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (url.pathname === "/__fixture__/requests") {
+      json(response, { requests: requestLog });
+      return;
+    }
+    requestLog.push(`${request.method} ${url.pathname}${url.search}`);
+    const match =
+      /^\/api\/v1\/packages\/([^/]+)(?:\/versions\/([^/]+)(?:\/(artifact(?:\/download)?|security))?)?$/u.exec(
+        url.pathname,
+      );
+    const entry = match ? artifacts.get(decodeURIComponent(match[1])) : undefined;
+    if (request.method !== "GET" || !entry) {
+      response.writeHead(request.method === "GET" ? 404 : 405);
+      response.end(request.method === "GET" ? "not found" : "method not allowed");
+      return;
+    }
+    const version = match[2] ? decodeURIComponent(match[2]) : undefined;
+    if (version && version !== entry.version) {
+      json(response, { error: "version not found" }, 404);
+      return;
+    }
+    const packageRecord = { name: entry.name, family: "code-plugin", runtimeId: entry.runtimeId };
+    const artifact = {
+      kind: "npm-pack",
+      sha256: entry.sha256,
+      npmIntegrity: entry.npmIntegrity,
+      npmShasum: entry.npmShasum,
+    };
+    const versionRecord = { version: entry.version, artifact };
+    if (!version) {
+      json(response, {
+        package: {
+          ...packageRecord,
+          channel: "official",
+          isOfficial: true,
+          latestVersion: entry.version,
+          tags: { latest: entry.version, beta: entry.version },
+        },
+      });
+    } else if (!match[3]) {
+      json(response, { package: packageRecord, version: versionRecord });
+    } else if (match[3] === "security") {
+      json(response, {
+        package: { name: entry.name, displayName: entry.name, family: "code-plugin" },
+        release: {
+          releaseId: `fixture:${entry.name}@${entry.version}`,
+          version: entry.version,
+          artifactKind: "npm-pack",
+          artifactSha256: entry.sha256,
+          npmIntegrity: entry.npmIntegrity,
+          npmShasum: entry.npmShasum,
+          npmTarballName: entry.tarball,
+          createdAt: 0,
+        },
+        overview: "No security concerns found in the fixture release.",
+        securityAuditUrl: `http://${request.headers.host}${url.pathname}`,
+        trust: {
+          scanStatus: "clean",
+          moderationState: null,
+          blockedFromDownload: false,
+          reasons: [],
+          pending: false,
+          stale: false,
+        },
+      });
+    } else if (match[3] === "artifact") {
+      json(response, {
+        version: versionRecord,
+        artifact: {
+          artifactKind: "npm-pack",
+          artifactSha256: entry.sha256,
+          npmIntegrity: entry.npmIntegrity,
+        },
+      });
+    } else {
+      response.writeHead(200, {
+        "content-type": "application/octet-stream",
+        "X-ClawHub-Artifact-Sha256": entry.sha256,
+        "X-ClawHub-Npm-Integrity": entry.npmIntegrity,
+        "X-ClawHub-Npm-Shasum": entry.npmShasum,
+        "X-ClawHub-Npm-Tarball-Name": entry.tarball,
+      });
+      response.end(entry.archive);
+    }
+  });
+  server.listen(0, "127.0.0.1", () => {
+    fs.writeFileSync(portFile, String(server.address().port));
+  });
+}
 
 const buildArtifactSummary = ({
   clawpackSha256,
@@ -47,6 +215,7 @@ const buildClawPackSummary = ({
 });
 
 async function buildNpmPackArtifact(fixture) {
+  const tar = requireFromApp("tar");
   const packRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-fixture-"));
   try {
     const packageDir = path.join(packRoot, "package");
@@ -359,13 +528,30 @@ export default definePluginEntry({
   },
 };
 
+if (profile === "assert-no-requests") {
+  assertNoRequests(portFile).catch(
+    /** @param {unknown} error */ (error) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
+  return;
+}
+
 const fixture = profiles[profile];
 if (!fixture || !portFile) {
-  console.error("usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins> <port-file>");
+  if (profile === "prepublish-artifacts" && portFile && artifactManifestFile) {
+    startPrepublishArtifactServer();
+    return;
+  }
+  console.error(
+    "usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins|prepublish-artifacts> <port-file> [manifest-file]",
+  );
   process.exit(1);
 }
 
 async function main() {
+  const JSZip = requireFromApp("jszip");
   const zip = new JSZip();
   zip.file("package/package.json", `${JSON.stringify(fixture.packageJson, null, 2)}\n`, {
     date: new Date(0),

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
 
 export npm_config_loglevel=error
 export npm_config_fund=false
@@ -52,6 +53,7 @@ FAILURE_PHASE=""
 FAILURE_MESSAGE=""
 gateway_pid=""
 plugin_registry_pid=""
+clawhub_fixture_pid=""
 baseline_spec=""
 baseline_version=""
 baseline_version_expected="0"
@@ -224,9 +226,8 @@ NODE
 }
 
 cleanup() {
-  if [ -n "${plugin_registry_pid:-}" ]; then
-    kill "$plugin_registry_pid" >/dev/null 2>&1 || true
-  fi
+  openclaw_e2e_stop_process "${plugin_registry_pid:-}"
+  openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"
   openclaw_e2e_terminate_gateways "${gateway_pid:-}"
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     local shim_pid
@@ -235,6 +236,40 @@ cleanup() {
       openclaw_e2e_terminate_gateways "$shim_pid"
     fi
   fi
+}
+
+wait_for_fixture_port() {
+  local pid="$1" port_file="$2" log_file="$3" label="$4"
+  for _ in $(seq 1 100); do
+    [ -s "$port_file" ] && return 0
+    openclaw_e2e_process_alive "$pid" || break
+    sleep 0.1
+  done
+  openclaw_e2e_print_log "$log_file" >&2
+  echo "Timed out waiting for upgrade survivor $label." >&2
+  return 1
+}
+
+configure_clawhub_fixture() {
+  unset OPENCLAW_CLAWHUB_URL CLAWHUB_URL
+  [ -z "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] && return 0
+  local fixture_root="$ARTIFACT_ROOT/clawhub-fixture" port_file log_file
+  port_file="$fixture_root/port"
+  log_file="$fixture_root/server.log"
+  mkdir -p "$fixture_root"
+  rm -f "$port_file"
+  node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    prepublish-artifacts "$port_file" \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" >"$log_file" 2>&1 &
+  clawhub_fixture_pid="$!"
+  wait_for_fixture_port "$clawhub_fixture_pid" "$port_file" "$log_file" "ClawHub fixture"
+  export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"
+}
+
+assert_prepublish_fixture_idle() {
+  [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] || return 0
+  node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    assert-no-requests "$OPENCLAW_CLAWHUB_URL"
 }
 
 on_error() {
@@ -961,12 +996,16 @@ write_update_restart_service_secretref_env() {
   local dotenv_path="$OPENCLAW_STATE_DIR/.env"
   local tmp_path="$dotenv_path.tmp.$$"
   if [ -f "$dotenv_path" ]; then
-    grep -v '^GATEWAY_AUTH_TOKEN_REF=' "$dotenv_path" >"$tmp_path" || true
+    grep -Ev '^(GATEWAY_AUTH_TOKEN_REF|OPENCLAW_CLAWHUB_URL)=' "$dotenv_path" >"$tmp_path" || true
   else
     : >"$tmp_path"
   fi
   # Managed restarts resolve SecretRefs from service-owned durable env, not the update caller.
   printf 'GATEWAY_AUTH_TOKEN_REF=%s\n' "$GATEWAY_AUTH_TOKEN_REF" >>"$tmp_path"
+  if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
+    printf 'OPENCLAW_CLAWHUB_URL=%s\n' "$OPENCLAW_CLAWHUB_URL" >>"$tmp_path"
+  fi
+  chmod 600 "$tmp_path"
   mv "$tmp_path" "$dotenv_path"
 }
 
@@ -976,10 +1015,38 @@ prepare_update_restart_probe() {
   fi
   echo "Preparing configured-auth gateway for automatic update restart."
   install_update_restart_systemctl_shim
-  seed_update_restart_probe_device_auth
-  start_gateway legacy-ready-log-ok
-  write_update_restart_service_secretref_env
-  install_update_restart_service_unit
+  local probe_status=0 restore_status=0
+  local authored_config="$RUNTIME_ROOT/baseline-authored-openclaw.json"
+  local parking_helper="${OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER:-scripts/e2e/lib/upgrade-survivor/config-parking.mjs}"
+  # Bootstrap service auth while keeping candidate-era plugin config away from
+  # the historical baseline. The updater must receive that config unchanged.
+  node "$parking_helper" \
+    park-restart-probe "$OPENCLAW_CONFIG_PATH" "$authored_config" 18789 || probe_status=$?
+  if [ "$probe_status" -eq 0 ]; then
+    seed_update_restart_probe_device_auth || probe_status=$?
+  fi
+  if [ "$probe_status" -eq 0 ]; then
+    start_gateway legacy-ready-log-ok || probe_status=$?
+  fi
+  if [ "$probe_status" -eq 0 ]; then
+    write_update_restart_service_secretref_env || probe_status=$?
+  fi
+  if [ "$probe_status" -eq 0 ]; then
+    assert_prepublish_fixture_idle || probe_status=$?
+  fi
+  if [ "$probe_status" -eq 0 ]; then
+    install_update_restart_service_unit || probe_status=$?
+  fi
+  # Service installation can replace the bootstrap PID. Stop through the
+  # manager so its current PID remains owned until shutdown is verified.
+  stop_update_restart_probe_gateway "$COMMAND_TIMEOUT" || return "$?"
+  if [ -e "$authored_config" ]; then
+    node "$parking_helper" restore "$OPENCLAW_CONFIG_PATH" "$authored_config" || restore_status=$?
+  fi
+  if [ "$restore_status" -ne 0 ]; then
+    return "$restore_status"
+  fi
+  return "$probe_status"
 }
 
 assert_baseline_state() {
@@ -1173,7 +1240,10 @@ start_gateway() {
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
     printf '%s\n' "$gateway_pid" >"$SYSTEMCTL_SHIM_PID_FILE"
   fi
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"
+  if ! openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"; then
+    openclaw_e2e_print_log "$GATEWAY_LOG" >&2
+    return 1
+  fi
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$budget" ]; then
@@ -1232,6 +1302,7 @@ phase seed-source-only-plugin-shadow seed_source_only_plugin_shadow
 phase assert-baseline assert_baseline_state
 phase seed-legacy-runtime-deps-symlink seed_legacy_runtime_deps_symlink
 phase resolve-candidate resolve_candidate_version
+phase configure-clawhub-fixture configure_clawhub_fixture
 phase prepare-update-restart-probe prepare_update_restart_probe
 phase update-candidate update_candidate
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -238,6 +238,35 @@ write_update_restart_service_auth_env() {
   printf 'GATEWAY_AUTH_TOKEN_REF=%s\n' "$GATEWAY_AUTH_TOKEN_REF" >"$OPENCLAW_STATE_DIR/gateway.systemd.env"
 }
 
+assert_update_restart_probe_inactive() {
+  local active_status=0
+  systemctl --user is-active --quiet openclaw-gateway.service || active_status=$?
+  [ "$active_status" -eq 3 ] && return 0
+  echo "gateway service is not confirmed inactive" >&2
+  [ "$active_status" -ne 0 ] || active_status=1
+  return "$active_status"
+}
+
+stop_update_restart_probe_gateway() {
+  local command_timeout="$1" stop_status=0
+  local stop_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG}.stop"
+  openclaw_e2e_maybe_timeout "$command_timeout" \
+    systemctl --user stop openclaw-gateway.service >"$stop_log" 2>&1 || stop_status=$?
+  if [ "$stop_status" -eq 0 ]; then
+    assert_update_restart_probe_inactive >>"$stop_log" 2>&1 || stop_status=$?
+  fi
+  if [ "$stop_status" -eq 0 ] && openclaw_e2e_probe_tcp 127.0.0.1 18789 400; then
+    echo "Baseline gateway listener is still open after service stop." >>"$stop_log"
+    stop_status=1
+  fi
+  if [ "$stop_status" -ne 0 ]; then
+    echo "gateway service shutdown could not be verified; preserving authored config snapshot" >&2
+    openclaw_e2e_print_log "$stop_log" >&2
+    return "$stop_status"
+  fi
+  gateway_pid=""
+}
+
 prepare_update_restart_probe_current_install() {
   local port="$1"
   local log_file="$2"

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -55,6 +55,17 @@ LANE_ARTIFACT_SUFFIX="$(resolve_lane_artifact_suffix)"
 LANE_ARTIFACT_SUFFIX="${LANE_ARTIFACT_SUFFIX//[^A-Za-z0-9_.-]/_}"
 ARTIFACT_DIR="${OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/upgrade-survivor/$LANE_ARTIFACT_SUFFIX}"
 DOCKER_RUN_USER_ARGS=()
+PREPUBLISH_PLUGIN_REGISTRY_ARGS=()
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  if [ ! -f "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" ]; then
+    echo "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR must contain prepublish-plugin-registry.json" >&2
+    exit 1
+  fi
+  PREPUBLISH_PLUGIN_REGISTRY_ARGS+=(
+    -e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry
+    -v "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:/tmp/openclaw-prepublish-plugin-registry:ro"
+  )
+fi
 PROBE_ENV_ARGS=(
   -e OPENCLAW_UPGRADE_SURVIVOR_PROBE_TIMEOUT_MS="$PROBE_TIMEOUT_MS"
   -e OPENCLAW_UPGRADE_SURVIVOR_PROBE_ATTEMPT_TIMEOUT_MS="$PROBE_ATTEMPT_TIMEOUT_MS"
@@ -161,6 +172,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
     "${PROBE_ENV_ARGS[@]}" \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
+    "${PREPUBLISH_PLUGIN_REGISTRY_ARGS[@]}" \
     "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
     "${DOCKER_RUN_USER_ARGS[@]}" \
     "$IMAGE_NAME" \
@@ -189,6 +201,7 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
   "${PROBE_ENV_ARGS[@]}" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
+  "${PREPUBLISH_PLUGIN_REGISTRY_ARGS[@]}" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "${DOCKER_RUN_USER_ARGS[@]}" \
   "$IMAGE_NAME" \

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -1,12 +1,18 @@
 // ClawHub Fixture Server tests cover the local package fixture HTTP contract.
-import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import {
+  execFileSync,
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
-const SCRIPT_PATH = "scripts/e2e/lib/clawhub-fixture-server.cjs";
+const SCRIPT_PATH = path.resolve("scripts/e2e/lib/clawhub-fixture-server.cjs");
 const PACKAGE_NAME = "@openclaw/kitchen-sink";
 const PACKAGE_PATH = `/api/v1/packages/${encodeURIComponent(PACKAGE_NAME)}`;
 const KITCHEN_SINK_VERSION = "0.2.5";
@@ -42,11 +48,11 @@ async function stopServer(child: ChildProcessWithoutNullStreams) {
   }
 }
 
-async function startFixtureServer(profile: string) {
+async function startFixtureServer(profile: string, args: string[] = [], cwd = process.cwd()) {
   const root = makeTempDir(tempDirs, "openclaw-clawhub-fixture-server-");
   const portFile = path.join(root, "port");
-  const child = spawn(process.execPath, [SCRIPT_PATH, profile, portFile], {
-    cwd: process.cwd(),
+  const child = spawn(process.execPath, [SCRIPT_PATH, profile, portFile, ...args], {
+    cwd,
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -119,7 +125,63 @@ describe("ClawHub fixture server", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins> <port-file>",
+      "usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins|prepublish-artifacts> <port-file> [manifest-file]",
     );
+    const assertion = spawnSync(process.execPath, [SCRIPT_PATH, "assert-no-requests", ""], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env },
+    });
+    expect(assertion.status).toBe(1);
+    expect(assertion.stderr).toContain("assert-no-requests requires <base-url>");
+  });
+
+  it("serves exact prepublish plugin artifacts and audits an empty request ledger", async () => {
+    const root = makeTempDir(tempDirs, "openclaw-clawhub-prepublish-");
+    const isolatedCwd = makeTempDir(tempDirs, "openclaw-clawhub-isolated-");
+    const packageDir = path.join(root, "package");
+    const tarball = "openclaw-whatsapp-2026.7.33.tgz";
+    const tarballPath = path.join(root, tarball);
+    const version = "2026.7.33";
+    mkdirSync(packageDir);
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify({ name: "@openclaw/whatsapp", version, openclaw: { extensions: ["./index.js"] } })}\n`,
+    );
+    writeFileSync(
+      path.join(packageDir, "openclaw.plugin.json"),
+      `${JSON.stringify({ id: "whatsapp", configSchema: { type: "object" } })}\n`,
+    );
+    execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
+    const archive = readFileSync(tarballPath);
+    const sha256 = createHash("sha256").update(archive).digest("hex");
+    const manifestPath = path.join(root, "prepublish-plugin-registry.json");
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ packages: [{ name: "@openclaw/whatsapp", version, tarball, sha256 }] })}\n`,
+    );
+
+    const { baseUrl } = await startFixtureServer(
+      "prepublish-artifacts",
+      [manifestPath],
+      isolatedCwd,
+    );
+    const emptyAssertion = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "assert-no-requests", baseUrl],
+      { cwd: isolatedCwd, encoding: "utf8", env: { ...process.env } },
+    );
+    expect(emptyAssertion.status).toBe(0);
+
+    const packageResponse = await fetch(
+      `${baseUrl}/api/v1/packages/${encodeURIComponent("@openclaw/whatsapp")}`,
+    );
+    expect(await packageResponse.json()).toMatchObject({
+      package: { name: "@openclaw/whatsapp", runtimeId: "whatsapp", latestVersion: version },
+    });
+    const artifactResponse = await fetch(
+      `${baseUrl}/api/v1/packages/${encodeURIComponent("@openclaw/whatsapp")}/versions/${version}/artifact/download`,
+    );
+    expect(Buffer.from(await artifactResponse.arrayBuffer())).toEqual(archive);
   });
 });

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -783,10 +783,19 @@ describe("package artifact reuse", () => {
     expect(publishedUpgradeSurvivor).toContain("upgrade survivor restart probe");
     expect(publishedUpgradeSurvivor).toContain("write_update_restart_service_secretref_env");
     expect(publishedUpgradeSurvivor).toContain("GATEWAY_AUTH_TOKEN_REF=%s");
+    expect(publishedUpgradeSurvivor).toContain("OPENCLAW_CLAWHUB_URL=%s");
+    expect(publishedUpgradeSurvivor).toContain("park-restart-probe");
+    expect(publishedUpgradeSurvivor).toContain(
+      'restore "$OPENCLAW_CONFIG_PATH" "$authored_config"',
+    );
     expect(publishedUpgradeSurvivor).toContain(
       "env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw",
     );
     expect(publishedUpgradeSurvivor).toContain("phase prepare-update-restart-probe");
+    expect(publishedUpgradeSurvivor).toContain("phase configure-clawhub-fixture");
+    expect(publishedUpgradeSurvivor.indexOf("phase configure-clawhub-fixture")).toBeLessThan(
+      publishedUpgradeSurvivor.indexOf("phase prepare-update-restart-probe"),
+    );
     expect(publishedUpgradeSurvivor).toContain("openclaw@(alpha|beta|latest|");
     expect(publishedUpgradeSurvivor).toContain("plugin_deps_cleanup_plugin_dirs");
     expect(publishedUpgradeSurvivor).toContain('"$(package_root)/extensions/$plugin"');

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -1,12 +1,107 @@
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const PARKING_SCRIPT = "scripts/e2e/lib/upgrade-survivor/config-parking.mjs";
+const RUNNER_SCRIPT = "scripts/e2e/lib/upgrade-survivor/run.sh";
+const RESTART_AUTH_SCRIPT = "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
+const DOCKER_WRAPPER_SCRIPT = "scripts/e2e/upgrade-survivor-docker.sh";
 
 describe("upgrade survivor config parking", () => {
+  it("loads restart lifecycle helpers and mounts a supplied prepublish registry", () => {
+    const runner = readFileSync(RUNNER_SCRIPT, "utf8");
+    const wrapper = readFileSync(DOCKER_WRAPPER_SCRIPT, "utf8");
+    expect(runner).toContain("source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh");
+    expect(wrapper).toContain(
+      "-e OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR=/tmp/openclaw-prepublish-plugin-registry",
+    );
+    expect(wrapper).toContain(
+      '-v "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:/tmp/openclaw-prepublish-plugin-registry:ro"',
+    );
+    expect(wrapper.match(/"\$\{PREPUBLISH_PLUGIN_REGISTRY_ARGS\[@\]\}"/gu)).toHaveLength(2);
+  });
+
+  it("propagates an early baseline gateway readiness failure", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-restart-readiness-"));
+    try {
+      const source = readFileSync(RUNNER_SCRIPT, "utf8");
+      const start = source.lastIndexOf("\nstart_gateway() {");
+      const end = source.indexOf("\nensure_gateway_started()", start);
+      const gateway = join(root, "openclaw");
+      writeFileSync(gateway, "#!/usr/bin/env bash\nsleep 30\n");
+      chmodSync(gateway, 0o755);
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -uo pipefail
+openclaw_e2e_read_positive_int_env() { printf '90\\n'; }
+openclaw_e2e_wait_gateway_ready() { return 1; }
+openclaw_e2e_print_log() { :; }
+${source.slice(start + 1, end)}
+UPDATE_RESTART_MODE=manual
+GATEWAY_LOG=${JSON.stringify(join(root, "gateway.log"))}
+start_gateway
+status=$?
+[ -z "\${gateway_pid:-}" ] || kill "$gateway_pid" >/dev/null 2>&1 || true
+exit "$status"`,
+        ],
+        { env: { ...process.env, PATH: `${root}:${process.env.PATH}` } },
+      );
+      expect(result.status, result.stderr.toString()).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stops the service-owned replacement gateway before restoration", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-restart-stop-"));
+    try {
+      const systemctl = join(root, "systemctl");
+      writeFileSync(
+        systemctl,
+        `#!/usr/bin/env bash
+printf '%s\\n' "$*" >>"$SYSTEMCTL_LOG"
+case "$*" in
+  *stop*)
+    pid="$(cat "$SYSTEMCTL_PID_FILE")"
+    kill "$pid"
+    rm -f "$SYSTEMCTL_PID_FILE" ;;
+  *is-active*) exit 3 ;;
+esac
+`,
+      );
+      chmodSync(systemctl, 0o755);
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+source ${JSON.stringify(RESTART_AUTH_SCRIPT)}
+export SYSTEMCTL_LOG=${JSON.stringify(join(root, "systemctl.log"))}
+export SYSTEMCTL_PID_FILE=${JSON.stringify(join(root, "systemctl.pid"))}
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG=${JSON.stringify(join(root, "gateway.log"))}
+sleep 30 &
+replacement_pid=$!
+printf '%s\\n' "$replacement_pid" >"$SYSTEMCTL_PID_FILE"
+openclaw_e2e_maybe_timeout() { shift; "$@"; }
+openclaw_e2e_probe_tcp() { return 1; }
+openclaw_e2e_print_log() { :; }
+stop_update_restart_probe_gateway 10s
+[ ! -e "$SYSTEMCTL_PID_FILE" ]
+grep -q -- '--user stop openclaw-gateway.service' "$SYSTEMCTL_LOG"
+! kill -0 "$replacement_pid" >/dev/null 2>&1`,
+        ],
+        { env: { ...process.env, PATH: `${root}:${process.env.PATH}` } },
+      );
+      expect(result.status, result.stderr.toString()).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("parks a minimal auth-only gateway config and restores authored bytes", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-config-parking-"));
     try {


### PR DESCRIPTION
## Summary

- route the published-baseline upgrade survivor through the prepublished ClawHub fixture
- park candidate-era authored plugin config while the historical baseline gateway and service are bootstrapped
- persist the fixture URL in service-owned env so the updater-owned restart remains hermetic

## Why

The 2026.7.33 validation reached the public ClawHub registry while exercising historical published baselines. Current Matrix and WhatsApp packages require a newer plugin API than the frozen candidate, and the oldest restart baseline encountered candidate-era plugin config before the candidate update. Both failures are moving-registry/historical-bootstrap contamination rather than candidate package defects.

## Validation

- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh`
- `pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/package-acceptance-workflow.test.ts` (48 passed)
- `pnpm exec oxfmt --check test/scripts/package-acceptance-workflow.test.ts`
- `git diff --check`
