### PR TITLE
fix(ui): prevent model picker lag with large catalogs

### DIFF
--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -6,6 +7,86 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 const suite = createControlUiE2eSuite({ name: "Control UI model and effort controls" });
 
 suite.define(() => {
+  it.each(["chat", "new"])("keeps a large model catalog usable in %s", async (route) => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const models = Array.from({ length: 1_000 }, (_, index) => ({
+        id: `model-${index}`,
+        name: `Model ${String(index).padStart(4, "0")}`,
+        provider: "example",
+        contextWindow: 128_000,
+      }));
+      const gateway = await installMockGateway(page, {
+        agentModel: "example/model-0",
+        models,
+        sessionInfo: { model: "model-0", modelProvider: "example" },
+      });
+      await page.goto(`${suite.server.baseUrl}${route}`);
+      const composer = page.locator(".agent-chat__input").first();
+      const picker = composer.locator(".chat-controls__model-picker");
+      const trigger = picker.locator("[data-chat-model-select]");
+      await expect
+        .poll(() => picker.locator("[data-chat-model-option]").count())
+        .toBe(models.length);
+      await expect.poll(() => trigger.getAttribute("aria-disabled")).toBe("false");
+      const textarea = composer.locator("textarea").first();
+      const cdp = await page.context().newCDPSession(page);
+      await cdp.send("Performance.enable");
+      const before: { metrics: Array<{ name: string; value: number }> } =
+        await cdp.send("Performance.getMetrics");
+      const started = performance.now();
+      await textarea.pressSequentially("catalog proof");
+      expect(await textarea.inputValue()).toBe("catalog proof");
+      const after: typeof before = await cdp.send("Performance.getMetrics");
+      const elapsedMs = performance.now() - started;
+      const metric = (name: string) => {
+        const earlier = before.metrics.find((entry) => entry.name === name)?.value ?? 0;
+        const later = after.metrics.find((entry) => entry.name === name)?.value ?? 0;
+        return (later - earlier) * 1_000;
+      };
+      const timings = {
+        route,
+        models: models.length,
+        elapsedMs,
+        scriptMs: metric("ScriptDuration"),
+        taskMs: metric("TaskDuration"),
+      };
+      console.log(JSON.stringify({ proof: "model-catalog-typing", ...timings }));
+      await trigger.click();
+      await picker.locator("[data-chat-model-search]").fill("Model 0999");
+      const result = picker.locator('[data-chat-model-option="example/model-999"]');
+      await expect.poll(() => result.isVisible()).toBe(true);
+      expect(await picker.locator("[data-chat-model-option]:visible").count()).toBe(1);
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactRoot) {
+        const dir = createControlUiE2eArtifactDir(`large-model-catalog-${route}`, artifactRoot);
+        await writeFile(`${dir}/timings.json`, `${JSON.stringify(timings, null, 2)}\n`);
+        await page.screenshot({ path: `${dir}/filtered-catalog.png`, animations: "disabled" });
+      }
+      const selectionBefore: typeof before = await cdp.send("Performance.getMetrics");
+      const selectionStarted = performance.now();
+      await result.click();
+      await expect.poll(() => trigger.textContent()).toContain("Model 0999");
+      const selectionAfter: typeof before = await cdp.send("Performance.getMetrics");
+      const selectionTimings = {
+        route,
+        models: models.length,
+        elapsedMs: performance.now() - selectionStarted,
+        taskMs:
+          (selectionAfter.metrics.find((entry) => entry.name === "TaskDuration")?.value ?? 0) *
+            1_000 -
+          (selectionBefore.metrics.find((entry) => entry.name === "TaskDuration")?.value ?? 0) *
+            1_000,
+      };
+      console.log(JSON.stringify({ proof: "model-catalog-selection", ...selectionTimings }));
+      await cdp.detach();
+      if (route === "chat") {
+        expect((await gateway.waitForRequest("sessions.patch")).params).toMatchObject({
+          model: "example/model-999",
+        });
+      }
+    });
+  });
+
   it("shows and changes this chat's account without changing the default for new chats", async () => {
     const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6961,8 +6961,60 @@ describe("chat welcome", () => {
 });
 
 describe("chat model controls", () => {
+  it.each([100, 400])("prepares %i catalog rows without per-option catalog rescans", (size) => {
+    let idReads = 0;
+    const models: ModelCatalogEntry[] = Array.from({ length: size }, (_, index) => ({
+      get id() {
+        idReads += 1;
+        return `model-${index}`;
+      },
+      name: `Model ${index}`,
+      provider: "example",
+      contextWindow: 128_000,
+    }));
+    const { state } = createChatHeaderState({
+      model: "model-0",
+      modelProvider: "example",
+      models,
+    });
+    idReads = 0;
+    const container = renderModelControls(state);
+    const rows = container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]");
+    expect(rows).toHaveLength(size);
+    expect(rows[0]?.dataset.chatModelOption).toBe("example/model-0");
+    expect(rows[size - 1]?.textContent).toContain(`Model ${size - 1}`);
+    expect(rows[size - 1]?.textContent).toContain("128k");
+    console.log(JSON.stringify({ proof: "model-catalog-render", size, idReads }));
+    expect(idReads).toBeLessThan(size * 60);
+  });
+
   afterEach(async () => {
     await i18n.setLocale("en");
+  });
+
+  it("retains first-match metadata and canonical labels for duplicate catalog rows", () => {
+    const { state } = createChatHeaderState({
+      model: "shared",
+      modelProvider: "example",
+      models: [
+        { id: "shared", name: "First label", provider: "example", contextWindow: 111_000 },
+        { id: "shared", name: "Last label", provider: "example", contextWindow: 222_000 },
+        { id: "gpt-5.5", name: "Legacy label", provider: "codex", contextWindow: 333_000 },
+        { id: "gpt-5.5", name: "Canonical label", provider: "openai", contextWindow: 444_000 },
+        { id: "gpt-5.5", name: "Later canonical", provider: "openai", contextWindow: 555_000 },
+      ],
+    });
+    const container = renderModelControls(state);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(3);
+    const shared = container.querySelector('[data-chat-model-option="example/shared"]');
+    expect(shared?.textContent).toContain("Last label");
+    expect(shared?.textContent).toContain("111k");
+    for (const provider of ["codex", "openai"]) {
+      const row = container.querySelector(`[data-chat-model-option="${provider}/gpt-5.5"]`);
+      expect(row?.textContent).toContain("Canonical label");
+      expect(row?.textContent).toContain("444k");
+      expect(row?.textContent).not.toContain("555k");
+    }
   });
 
   it("disables the chat header model picker while a run is active", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -81,77 +81,75 @@ function normalizeChatModelProviderGroupId(provider: string): string {
   return CHAT_MODEL_PROVIDER_GROUP_ALIASES[normalized] ?? normalized;
 }
 
-function resolveChatModelProvider(
-  value: string,
-  catalog: ModelCatalogEntry[],
-  fallbackValue = "",
-  providerHint = "",
-): string {
-  const modelRef = (value || fallbackValue).trim();
-  const normalizedModelRef = modelRef.toLowerCase();
-  const qualifiedCatalogEntry = catalog.find((entry) => {
-    const normalizedId = entry.id.trim().toLowerCase();
-    const normalizedProvider = normalizeChatModelProviderId(entry.provider);
-    return `${normalizedProvider}/${normalizedId}` === normalizedModelRef;
-  });
-  if (qualifiedCatalogEntry) {
-    return normalizeChatModelProviderGroupId(qualifiedCatalogEntry.provider);
+function prepareChatModelCatalog(catalog: ModelCatalogEntry[]) {
+  const qualified = new Map<string, ModelCatalogEntry[]>();
+  const ids = new Map<string, ModelCatalogEntry[]>();
+  // Keep source order and duplicate rows: display metadata prefers the first
+  // canonical entry, while a raw id is unambiguous only with exactly one row.
+  for (const entry of catalog) {
+    const id = entry.id.trim().toLowerCase();
+    const key = `${normalizeChatModelProviderId(entry.provider)}/${id}`;
+    const qualifiedRows = qualified.get(key) ?? [];
+    qualifiedRows.push(entry);
+    qualified.set(key, qualifiedRows);
+    const idRows = ids.get(id) ?? [];
+    idRows.push(entry);
+    ids.set(id, idRows);
   }
-  const idMatches = catalog.filter((entry) => entry.id.trim().toLowerCase() === normalizedModelRef);
-  const normalizedHint = normalizeChatModelProviderId(providerHint);
-  const hintOwnsRawId = idMatches.some(
-    (entry) => normalizeChatModelProviderId(entry.provider) === normalizedHint,
-  );
-  if (normalizedHint && (idMatches.length === 0 || hintOwnsRawId)) {
-    return normalizeChatModelProviderGroupId(normalizedHint);
-  }
-  if (idMatches.length === 1) {
-    return normalizeChatModelProviderGroupId(idMatches[0]?.provider ?? "");
-  }
-  const separator = modelRef.indexOf("/");
-  if (separator > 0) {
-    return normalizeChatModelProviderGroupId(modelRef.slice(0, separator));
-  }
-  return "other";
-}
-
-function resolveChatModelCatalogEntry(
-  value: string,
-  catalog: ModelCatalogEntry[],
-): ModelCatalogEntry | undefined {
-  const trimmedValue = value.trim().toLowerCase();
-  const separator = trimmedValue.indexOf("/");
-  const normalizedValue =
-    separator > 0
-      ? `${normalizeChatModelProviderId(trimmedValue.slice(0, separator))}/${trimmedValue.slice(
-          separator + 1,
-        )}`
-      : trimmedValue;
-  if (!normalizedValue) {
-    return undefined;
-  }
-  const matches = catalog.filter((candidate) => {
-    const provider = normalizeChatModelProviderId(candidate.provider);
-    return `${provider}/${candidate.id.trim().toLowerCase()}` === normalizedValue;
-  });
-  if (matches.length > 0) {
-    return (
-      matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ??
-      matches[0]
-    );
-  }
-  const idMatches = catalog.filter(
-    (candidate) => candidate.id.trim().toLowerCase() === normalizedValue,
-  );
-  return idMatches.length === 1 ? idMatches[0] : undefined;
+  return {
+    provider(value: string, providerHint = ""): string {
+      const modelRef = value.trim();
+      const normalizedModelRef = modelRef.toLowerCase();
+      const qualifiedCatalogEntry = qualified.get(normalizedModelRef)?.[0];
+      if (qualifiedCatalogEntry) {
+        return normalizeChatModelProviderGroupId(qualifiedCatalogEntry.provider);
+      }
+      const idMatches = ids.get(normalizedModelRef) ?? [];
+      const normalizedHint = normalizeChatModelProviderId(providerHint);
+      const hintOwnsRawId = idMatches.some(
+        (entry) => normalizeChatModelProviderId(entry.provider) === normalizedHint,
+      );
+      if (normalizedHint && (idMatches.length === 0 || hintOwnsRawId)) {
+        return normalizeChatModelProviderGroupId(normalizedHint);
+      }
+      if (idMatches.length === 1) {
+        return normalizeChatModelProviderGroupId(idMatches[0]?.provider ?? "");
+      }
+      const separator = modelRef.indexOf("/");
+      if (separator > 0) {
+        return normalizeChatModelProviderGroupId(modelRef.slice(0, separator));
+      }
+      return "other";
+    },
+    entry(value: string): ModelCatalogEntry | undefined {
+      const trimmedValue = value.trim().toLowerCase();
+      const separator = trimmedValue.indexOf("/");
+      const normalizedValue =
+        separator > 0
+          ? `${normalizeChatModelProviderId(trimmedValue.slice(0, separator))}/${trimmedValue.slice(
+              separator + 1,
+            )}`
+          : trimmedValue;
+      if (!normalizedValue) {
+        return undefined;
+      }
+      const matches = qualified.get(normalizedValue) ?? [];
+      if (matches.length > 0) {
+        return (
+          matches.find((candidate) => candidate.provider.trim().toLowerCase() === "openai") ??
+          matches[0]
+        );
+      }
+      const idMatches = ids.get(normalizedValue) ?? [];
+      return idMatches.length === 1 ? idMatches[0] : undefined;
+    },
+  };
 }
 
 function resolveChatModelPickerLabel(
-  value: string,
+  entry: ModelCatalogEntry | undefined,
   fallbackLabel: string,
-  catalog: ModelCatalogEntry[],
 ): string {
-  const entry = resolveChatModelCatalogEntry(value, catalog);
   if (entry && normalizeChatModelProviderId(entry.provider) === "openai") {
     return entry.name.trim() || fallbackLabel;
   }
@@ -199,6 +197,7 @@ function resolveCatalogTriggerStatus(
 }
 
 export function renderChatModelControls(props: ChatModelControlsProps) {
+  const catalog = prepareChatModelCatalog(props.modelCatalog);
   const {
     currentOverride,
     defaultModel,
@@ -249,19 +248,15 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       );
   const triggerModelValue = activeModelValue || currentOverride;
   const defaultProviderHint = props.sessionsResult?.defaults?.modelProvider ?? "";
-  const defaultCatalogEntry = resolveChatModelCatalogEntry(defaultModel, props.modelCatalog);
-  const canonicalDefaultLabel = resolveChatModelPickerLabel(
-    defaultModel,
-    defaultLabel,
-    props.modelCatalog,
-  );
+  const defaultCatalogEntry = catalog.entry(defaultModel);
+  const canonicalDefaultLabel = resolveChatModelPickerLabel(defaultCatalogEntry, defaultLabel);
   const pickerDefaultLabel =
     defaultModel && canonicalDefaultLabel !== defaultLabel
       ? t("chat.modelControls.defaultWithModel", { model: canonicalDefaultLabel })
       : defaultLabel;
   const normalizedDefaultModel = defaultModel.trim().toLowerCase();
   const modelOptions: ChatModelPickerOption[] = selectOptions.map((option) => {
-    const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
+    const catalogEntry = catalog.entry(option.value);
     const isDefault =
       option.value.trim().toLowerCase() === normalizedDefaultModel ||
       (catalogEntry !== undefined && catalogEntry === defaultCatalogEntry);
@@ -276,11 +271,9 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       commitValue: isDefault ? "" : option.value,
       isDefault,
       value: option.value,
-      label: resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog),
-      provider: resolveChatModelProvider(
+      label: resolveChatModelPickerLabel(catalogEntry, option.label),
+      provider: catalog.provider(
         option.value,
-        props.modelCatalog,
-        "",
         isDefault
           ? defaultProviderHint
           : option.value === currentOverride
@@ -303,7 +296,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     }
     return pickerOption;
   });
-  const currentCatalogEntry = resolveChatModelCatalogEntry(currentOverride, props.modelCatalog);
+  const currentCatalogEntry = catalog.entry(currentOverride);
   if (
     currentOverride &&
     modelOptions.length > 0 &&
@@ -323,12 +316,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       isDefault: false,
       value: currentOverride,
       label: currentCatalogEntry?.name.trim() || currentOverride,
-      provider: resolveChatModelProvider(
-        currentOverride,
-        props.modelCatalog,
-        "",
-        currentProviderHint,
-      ),
+      provider: catalog.provider(currentOverride, currentProviderHint),
     });
   }
   // A persisted pin can match a changed default; equality cannot establish inheritance.
@@ -338,18 +326,15 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ? modelOptions.find((option) => option.isDefault)
       : modelOptions.find((option) => option.value === pickerValue);
   const activeSessionModel = activeSession?.model
-    ? resolveChatModelCatalogEntry(
+    ? catalog.entry(
         resolvePreferredServerChatModelValue(
           activeSession.model,
           activeSession.modelProvider,
           props.modelCatalog,
         ),
-        props.modelCatalog,
       )
     : undefined;
-  const activeOptionModel = activeModelOption
-    ? resolveChatModelCatalogEntry(activeModelOption.value, props.modelCatalog)
-    : undefined;
+  const activeOptionModel = activeModelOption ? catalog.entry(activeModelOption.value) : undefined;
   const activeSessionRuntime = activeSession?.agentRuntime?.id.trim().toLowerCase();
   const activeOptionRuntime = (
     activeOptionModel?.agentRuntime?.id ??
@@ -378,9 +363,8 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ? t("chat.selectors.lockedSessionModel")
       : (modelOptions.find((entry) => entry.value === triggerModelValue)?.label ??
         resolveChatModelPickerLabel(
-          triggerModelValue,
+          catalog.entry(triggerModelValue),
           triggerModelValue || pickerDefaultLabel,
-          props.modelCatalog,
         ));
   const managedCatalog = props.modelCatalogState ?? {
     hasSnapshot: !props.modelsLoading,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch, so maintainers retain their normal repository access. The fork-only collaboration setting does not apply.

</details>

## What Problem This Solves

Fixes an issue where users with large model catalogs would experience slow model selection in Chat and sluggish typing in New Session.

## Why This Change Was Made

Prepare the catalog lookup once per render and reuse the original rows for metadata, provider display, and labels. Keeping source order and duplicate rows preserves first-match, canonical-label, raw-ID ambiguity, and default-selection behavior while deleting repeated scans and an unused argument.

## User Impact

Large published catalogs are cheaper to render, with the same model values, aliases, labels, search results, and selections. No configuration, authentication, routing, or API changes are needed.

## Evidence

Actual-render regression tests failed before the repair and pass after it. At 400 models, model-ID reads fell from **407,004 to 4,404** (98.9% fewer); the protected lookup work now grows linearly.

In controlled Chromium runs with a synthetic 1,000-model Gateway catalog, observed main-thread time fell from **1,142 ms to 110 ms for Chat model selection**, and **2,251 ms to 199 ms for New Session typing**. These are observed timing samples, not wall-clock assertions. There is no Chat-per-keystroke performance claim.

All **496 focused unit/sibling tests**, **18 browser tests**, and the full scoped changed-file gate passed, including test/UI type graphs, lint, styles, and export checks. Managed **P0–P2 review is scoped-clean**. Production code is **16 lines smaller**, with 133 added test lines.

The inspected synthetic captures below demonstrate unchanged search results and metadata. They were recaptured with the canonical invitation dismissal; the timing claims above remain bound to the original benchmark runs, not the recapture.

| Chat before | Chat after |
| --- | --- |
| ![Chat finds Model 0999 before the lookup repair](https://github.com/user-attachments/assets/4e99f1b6-2e44-48d9-9598-70d59f77b8e0) | ![Chat finds the same Model 0999 after the lookup repair](https://github.com/user-attachments/assets/cc448abc-d66f-477c-b75b-92fe5095cab6) |

| New Session before | New Session after |
| --- | --- |
| ![New Session finds Model 0999 before the lookup repair](https://github.com/user-attachments/assets/ade44efa-c77f-4116-ac5c-5339290619c7) | ![New Session finds the same Model 0999 after the lookup repair](https://github.com/user-attachments/assets/620c85b1-086a-44cf-9c3d-c298f7429f58) |
