### PR TITLE
refactor: remove unreachable process poll test branch

### DIFF
--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -681,40 +681,31 @@ test("process poll resets retryInMs when output appears and clears on completion
 });
 
 test.each([
-  { name: "below the retained tail", outputLength: 1_999, expectsOmissionNote: false },
-  { name: "at the retained tail", outputLength: 2_000, expectsOmissionNote: false },
-  { name: "above the retained tail", outputLength: 2_001, expectsOmissionNote: false },
-])(
-  "process poll returns unread finished output $name",
-  async ({ outputLength, expectsOmissionNote }) => {
-    const sessionId = `sess-finished-tail-${outputLength}`;
-    const { processTool, session } = createProcessSessionHarness(sessionId);
-    const earlierMarker = "[earlier-output]";
-    const latestMarker = "[latest-output]";
-    const fillerLength = outputLength - earlierMarker.length - latestMarker.length;
-    const aggregated = `${earlierMarker}${"x".repeat(fillerLength)}${latestMarker}`;
+  { name: "below the retained tail", outputLength: 1_999 },
+  { name: "at the retained tail", outputLength: 2_000 },
+  { name: "above the retained tail", outputLength: 2_001 },
+])("process poll returns unread finished output $name", async ({ outputLength }) => {
+  const sessionId = `sess-finished-tail-${outputLength}`;
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+  const earlierMarker = "[earlier-output]";
+  const latestMarker = "[latest-output]";
+  const fillerLength = outputLength - earlierMarker.length - latestMarker.length;
+  const aggregated = `${earlierMarker}${"x".repeat(fillerLength)}${latestMarker}`;
 
-    appendOutput(session, "stdout", aggregated);
-    markExited(session, 0, null, "completed");
+  appendOutput(session, "stdout", aggregated);
+  markExited(session, 0, null, "completed");
 
-    const poll = await pollSession(processTool, "toolcall-finished-tail", sessionId);
-    const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
-    const details = poll.details as { aggregated?: string };
+  const poll = await pollSession(processTool, "toolcall-finished-tail", sessionId);
+  const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
+  const details = poll.details as { aggregated?: string };
 
-    expect(aggregated).toHaveLength(outputLength);
-    expect(details.aggregated).toBe(aggregated);
-    expect(text).toContain(latestMarker);
-    if (expectsOmissionNote) {
-      expect(text).not.toContain(earlierMarker);
-      expect(text).toContain("earlier retained output is omitted");
-      expect(text).toContain("action=log with offset and limit");
-    } else {
-      expect(text).toContain(earlierMarker);
-      expect(text).not.toContain("earlier retained output is omitted");
-    }
-    expect(text).not.toContain("discarded at the retention cap");
-  },
-);
+  expect(aggregated).toHaveLength(outputLength);
+  expect(details.aggregated).toBe(aggregated);
+  expect(text).toContain(latestMarker);
+  expect(text).toContain(earlierMarker);
+  expect(text).not.toContain("earlier retained output is omitted");
+  expect(text).not.toContain("discarded at the retention cap");
+});
 
 test.each([
   { name: "below the retained tail", outputLength: 1_500, aggregateCap: 1_000 },


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The finished-process output table retained an omission-note branch after all three rows had changed to expect complete unread output. Every row set the same false flag, so that branch could never run.

## Why This Change Was Made

Remove the unused row flags and unreachable branch, executing the existing six assertions directly for each of the three output lengths. Real omission and retention-cap coverage remains in the neighboring cases.

## User Impact

No production change or lost test case. This removes nine net test lines: six lines of dead code/scaffolding and three lines from the resulting callback formatting.

## Evidence

The full owning file and process-registry sibling passed all 66 tests before and after, with identical names and order. Selecting the original table's false branch produces the same complete AST as the revised file, preserving the three row names, lengths, generated output, call arguments/order and six executed assertions per row. No helpers or deadlines changed, and no runtime improvement is claimed.

Required changed-file checks and independent P2 review passed.
