### PR TITLE
fix(e2e): keep frozen typed onboarding helpers coherent

### DIFF
--- a/scripts/e2e/release-typed-onboarding-docker.sh
+++ b/scripts/e2e/release-typed-onboarding-docker.sh
@@ -19,6 +19,14 @@ SCENARIO_PATH="$ROOT_DIR/scripts/e2e/lib/release-typed-onboarding/scenario.sh"
 # overlay later companion-plugin setup onto the selected package's config.
 SCENARIO_PATH="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
   scripts/e2e/lib/release-typed-onboarding/scenario.sh "$SCENARIO_PATH")"
+ONBOARD_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/release-scenarios/assertions.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/release-scenarios/assertions.mjs")"
+# The selected assertion and mock config writer form one package-era contract.
+# Mixing them can write a config shape that the frozen package cannot parse.
+ONBOARD_MOCK_OPENAI_CONFIG="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/fixtures/mock-openai-config.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/fixtures/mock-openai-config.mjs")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-release-typed-onboarding-e2e" OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_SKIP_BUILD:-0}"
@@ -61,6 +69,8 @@ if ! docker_e2e_run_with_harness \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -v "$SCENARIO_PATH:/app/scripts/e2e/lib/release-typed-onboarding/scenario.sh:ro" \
+  -v "$ONBOARD_ASSERTIONS:/app/scripts/e2e/lib/release-scenarios/assertions.mjs:ro" \
+  -v "$ONBOARD_MOCK_OPENAI_CONFIG:/app/scripts/e2e/lib/fixtures/mock-openai-config.mjs:ro" \
   -i "$IMAGE_NAME" bash scripts/e2e/lib/release-typed-onboarding/scenario.sh >"$run_log" 2>&1; then
   docker_e2e_print_log "$run_log"
   exit 1

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2999,6 +2999,23 @@ docker_e2e_docker_run_cmd run demo
     expect(script).not.toContain('"$HOME/.openclaw/agents/main/agent/auth-profiles.json"');
   });
 
+  it("keeps frozen typed onboarding assertions with their config producer", () => {
+    const runner = readFileSync("scripts/e2e/release-typed-onboarding-docker.sh", "utf8");
+
+    expect(runner).toContain(
+      'scripts/e2e/lib/release-scenarios/assertions.mjs \\\n  "$ROOT_DIR/scripts/e2e/lib/release-scenarios/assertions.mjs"',
+    );
+    expect(runner).toContain(
+      'scripts/e2e/lib/fixtures/mock-openai-config.mjs \\\n  "$ROOT_DIR/scripts/e2e/lib/fixtures/mock-openai-config.mjs"',
+    );
+    expect(runner).toContain(
+      '-v "$ONBOARD_ASSERTIONS:/app/scripts/e2e/lib/release-scenarios/assertions.mjs:ro"',
+    );
+    expect(runner).toContain(
+      '-v "$ONBOARD_MOCK_OPENAI_CONFIG:/app/scripts/e2e/lib/fixtures/mock-openai-config.mjs:ro"',
+    );
+  });
+
   it("prints channel-add failures through the shared E2E logger", () => {
     const script = readFileSync(NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH, "utf8");
     expect(script).toContain(


### PR DESCRIPTION
## Summary

- bind a frozen typed-onboarding scenario to its selected release assertion module
- keep that assertion paired with the selected release mock-config producer
- leave current and unauthorized targets on the trusted current helpers

## Root cause

Full validation selected the 2026.6.35 onboarding scenario but mounted the current helper tree. The current mock-config producer writes `agents.defaults.mediaModels`, which the selected package does not accept, so the first post-onboarding agent turn failed config validation. The assertion and config producer are one target-owned contract, matching the existing npm-onboarding boundary.

## Verification

- exact pre-fix candidate/tarball Docker reproduction: `agents.defaults: Invalid input`
- exact post-fix candidate/tarball Docker run: `Release typed onboarding Docker E2E passed.`
- focused Docker-helper tests: 2/2
- Bash syntax, Oxfmt, OXLint, diff check

## LOC

- release tooling: +10/-0
- tests: +17/-0
- application runtime: +0/-0

@clawsweeper review