### PR TITLE
refactor(agents): specialize extra bootstrap file loading

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2046,7 +2046,7 @@ src/agents/utils/frontmatter.ts	2
 src/agents/utils/tools-manager.ts	2
 src/agents/workspace-legacy-state.ts	2
 src/agents/workspace-state-store.ts	1
-src/agents/workspace.ts	8
+src/agents/workspace.ts	6
 src/agents/worktrees/git.ts	2
 src/agents/worktrees/provisioned-files.ts	3
 src/agents/worktrees/registry.ts	11

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -3,11 +3,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  loadExtraBootstrapFilesWithDiagnostics,
-  loadWorkspacePatternFilesWithDiagnostics,
-} from "./workspace.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { loadExtraBootstrapFilesWithDiagnostics } from "./workspace.js";
 
 describe("loadExtraBootstrapFilesWithDiagnostics", () => {
   let fixtureRoot = "";
@@ -186,63 +183,32 @@ describe("loadExtraBootstrapFilesWithDiagnostics", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "reports unreadable glob branches during strict doctor discovery",
+    "falls back to a shallow scan without entering unrelated unreadable branches",
     async () => {
-      const workspaceDir = await createWorkspaceDir("strict-unreadable");
-      const blockedDir = path.join(workspaceDir, "packages", "blocked");
-      const readableDir = path.join(workspaceDir, "packages", "readable");
-      await fs.mkdir(blockedDir, { recursive: true });
-      await fs.mkdir(readableDir, { recursive: true });
-      await fs.writeFile(path.join(blockedDir, "TOOLS.md"), "blocked", "utf-8");
-      await fs.writeFile(path.join(readableDir, "TOOLS.md"), "readable", "utf-8");
-      await fs.chmod(blockedDir, 0o000);
-      try {
-        const result = await loadWorkspacePatternFilesWithDiagnostics(
-          workspaceDir,
-          ["packages/*/TOOLS.md"],
-          {
-            acceptedBasenames: new Set(["TOOLS.md"]),
-            strictPatternRead: true,
-          },
-        );
-        expect(result.files).toEqual([]);
-        expect(result.diagnostics).toEqual([
-          expect.objectContaining({
-            reason: "io",
-            path: path.join(workspaceDir, "packages", "*", "TOOLS.md"),
-          }),
-        ]);
-      } finally {
-        await fs.chmod(blockedDir, 0o700);
-      }
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "does not descend into unreadable branches that cannot satisfy a shallow pattern",
-    async () => {
-      const workspaceDir = await createWorkspaceDir("strict-pruned");
+      const workspaceDir = await createWorkspaceDir("shallow-pattern");
       const privateDir = path.join(workspaceDir, "packages", "blocked", "node_modules", "private");
       const readableDir = path.join(workspaceDir, "packages", "readable");
       await fs.mkdir(privateDir, { recursive: true });
       await fs.mkdir(readableDir, { recursive: true });
-      await fs.writeFile(path.join(privateDir, "TOOLS.md"), "irrelevant", "utf-8");
-      await fs.writeFile(path.join(readableDir, "TOOLS.md"), "readable", "utf-8");
+      await fs.writeFile(path.join(privateDir, "AGENTS.md"), "irrelevant", "utf-8");
+      await fs.writeFile(path.join(readableDir, "AGENTS.md"), "readable", "utf-8");
       await fs.chmod(privateDir, 0o000);
+      const glob = vi.spyOn(fs, "glob").mockImplementation(() => {
+        throw new Error("native glob failed");
+      });
+      const readDirectory = vi.spyOn(fs, "readdir");
       try {
-        const result = await loadWorkspacePatternFilesWithDiagnostics(
-          workspaceDir,
-          ["packages/*/TOOLS.md"],
-          {
-            acceptedBasenames: new Set(["TOOLS.md"]),
-            strictPatternRead: true,
-          },
-        );
+        const result = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
+          "packages/*/AGENTS.md",
+        ]);
         expect(result.diagnostics).toEqual([]);
         expect(result.files).toEqual([
-          expect.objectContaining({ path: path.join(readableDir, "TOOLS.md") }),
+          expect.objectContaining({ path: path.join(readableDir, "AGENTS.md") }),
         ]);
+        expect(readDirectory).not.toHaveBeenCalledWith(privateDir, expect.anything());
       } finally {
+        readDirectory.mockRestore();
+        glob.mockRestore();
         await fs.chmod(privateDir, 0o700);
       }
     },

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -274,12 +274,6 @@ export type ExtraBootstrapLoadDiagnostic = {
   detail: string;
 };
 
-export type WorkspacePatternFile = {
-  name: string;
-  path: string;
-  content: string;
-};
-
 /** Set of recognized bootstrap filenames for runtime validation */
 const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set(WORKSPACE_BOOTSTRAP_FILENAMES);
 
@@ -1403,7 +1397,6 @@ function resolveGlobWalkRoot(pattern: string): string {
 async function* walkWorkspaceFiles(
   workspaceDir: string,
   initialRelativeDir: string,
-  strictRead: boolean,
   matcher: Minimatch,
 ): AsyncGenerator<string> {
   const stack = [initialRelativeDir === "." ? "" : initialRelativeDir];
@@ -1417,10 +1410,7 @@ async function* walkWorkspaceFiles(
     let entries: syncFs.Dirent[];
     try {
       entries = await fs.readdir(currentDir, { withFileTypes: true });
-    } catch (error) {
-      if (strictRead && (error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
+    } catch {
       continue;
     }
 
@@ -1445,9 +1435,8 @@ async function* walkWorkspaceFiles(
 async function resolveExtraBootstrapPatternPaths(
   workspaceDir: string,
   pattern: string,
-  strictRead: boolean,
 ): Promise<string[]> {
-  if (!strictRead && typeof fs.glob === "function") {
+  if (typeof fs.glob === "function") {
     try {
       const matches: string[] = [];
       for await (const match of fs.glob(pattern, { cwd: workspaceDir })) {
@@ -1473,7 +1462,6 @@ async function resolveExtraBootstrapPatternPaths(
   for await (const candidate of walkWorkspaceFiles(
     workspaceDir,
     resolveGlobWalkRoot(normalizedPattern),
-    strictRead,
     matcher,
   )) {
     matches.push(candidate);
@@ -1486,17 +1474,11 @@ function patternWalkRootStaysInWorkspace(workspaceDir: string, pattern: string):
   return isPathInside(workspaceDir, walkRoot);
 }
 
-export async function loadWorkspacePatternFilesWithDiagnostics(
+export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
-  options: {
-    acceptedBasenames: ReadonlySet<string>;
-    acceptedBasenamePrefixes?: readonly string[];
-    reportUnsupportedBasenames?: boolean;
-    strictPatternRead?: boolean;
-  },
 ): Promise<{
-  files: WorkspacePatternFile[];
+  files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
 }> {
   if (!extraPatterns.length) {
@@ -1516,11 +1498,7 @@ export async function loadWorkspacePatternFilesWithDiagnostics(
     }
     try {
       if (hasGlobPattern(pattern)) {
-        const matches = await resolveExtraBootstrapPatternPaths(
-          resolvedDir,
-          pattern,
-          options.strictPatternRead === true,
-        );
+        const matches = await resolveExtraBootstrapPatternPaths(resolvedDir, pattern);
         for (const match of matches) {
           resolvedPaths.add(match);
         }
@@ -1536,21 +1514,16 @@ export async function loadWorkspacePatternFilesWithDiagnostics(
     }
   }
 
-  const files: WorkspacePatternFile[] = [];
+  const files: WorkspaceBootstrapFile[] = [];
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
     const baseName = path.basename(relPath);
-    const accepted =
-      options.acceptedBasenames.has(baseName) ||
-      options.acceptedBasenamePrefixes?.some((prefix) => baseName.startsWith(prefix)) === true;
-    if (!accepted) {
-      if (options.reportUnsupportedBasenames !== false) {
-        diagnostics.push({
-          path: filePath,
-          reason: "invalid-bootstrap-filename",
-          detail: `unsupported bootstrap basename: ${baseName}`,
-        });
-      }
+    if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
+      diagnostics.push({
+        path: filePath,
+        reason: "invalid-bootstrap-filename",
+        detail: `unsupported bootstrap basename: ${baseName}`,
+      });
       continue;
     }
     const loaded = await readWorkspaceFileWithGuards({
@@ -1558,24 +1531,19 @@ export async function loadWorkspacePatternFilesWithDiagnostics(
       workspaceDir: resolvedDir,
     });
     if (loaded.ok) {
-      const file: WorkspacePatternFile = {
-        name: baseName,
+      const file: WorkspaceBootstrapFile = {
+        name: baseName as WorkspaceBootstrapFileName,
         path: filePath,
         content: loaded.content,
+        missing: false,
       };
       setWorkspaceFileSourceIdentity(file, loaded.sourceIdentity);
       files.push(file);
       continue;
     }
 
-    const missing = (loaded.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
     const reason: ExtraBootstrapLoadDiagnosticCode =
-      loaded.reason === "validation" ||
-      (options.strictPatternRead === true && loaded.reason === "path" && !missing)
-        ? "security"
-        : loaded.reason === "path"
-          ? "missing"
-          : "io";
+      loaded.reason === "validation" ? "security" : loaded.reason === "path" ? "missing" : "io";
     diagnostics.push({
       path: filePath,
       reason,
@@ -1590,31 +1558,4 @@ export async function loadWorkspacePatternFilesWithDiagnostics(
   return { files, diagnostics };
 }
 
-export async function loadExtraBootstrapFilesWithDiagnostics(
-  dir: string,
-  extraPatterns: string[],
-): Promise<{
-  files: WorkspaceBootstrapFile[];
-  diagnostics: ExtraBootstrapLoadDiagnostic[];
-}> {
-  const loaded = await loadWorkspacePatternFilesWithDiagnostics(dir, extraPatterns, {
-    acceptedBasenames: VALID_BOOTSTRAP_NAMES,
-  });
-  return {
-    files: loaded.files.map((file) => {
-      const bootstrapFile: WorkspaceBootstrapFile = {
-        name: file.name as WorkspaceBootstrapFileName,
-        path: file.path,
-        content: file.content,
-        missing: false,
-      };
-      const sourceIdentity = getWorkspaceFileSourceIdentity(file);
-      if (sourceIdentity) {
-        setWorkspaceFileSourceIdentity(bootstrapFile, sourceIdentity);
-      }
-      return bootstrapFile;
-    }),
-    diagnostics: loaded.diagnostics,
-  };
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #142468

## What Problem This Solves

Extra bootstrap loading maintains an unused generic discovery mode and converts every loaded record through a second representation. Production always selects the existing bootstrap filename list; strict nested TOOLS.md discovery belongs only to obsolete tests.

## Why This Change Was Made

Have the existing bootstrap owner return its final records directly, preserving file provenance on those records. Remove the generic type/options, unused strict branches and projection wrapper. The actual Doctor migration still handles workspace-root TOOLS.md independently. Current source, stable exports and the integrity-verified published package were checked for public exposure.

## User Impact

No user-visible behavior changes. Bootstrap names, result fields, diagnostics, file guards, glob fallback and traversal pruning remain. The complete change removes 59 production and 34 test physical lines. Default cloc counts 58 production code lines and one test code line removed; comment markers inside glob strings explain its test classification difference.

## Evidence

- Existing loader, privacy/provenance, bootstrap, hook and Doctor suites: 102 baseline /101 retained tests passed. Only the obsolete strict-doctor case was removed.
- The retained fallback/pruning test passes with the original production source and fails when traversal pruning is deliberately removed. Final source restores pruning and passes.
- Full changed gate passed, including production/core-test types, all dead-export scans, lint and architecture guards. The assertion baseline shrinks exactly 8→6; no budget is widened.
- Fresh independent P0–P2 review: scoped-clean, no findings. Committed bytes match the complete tested/reviewed patch. This is synthetic filesystem and owner-boundary proof; no operator workspace or live Gateway was touched.

Related #89040 retains the generic wrapper and proposes broader walker/error/performance changes, with real overlapping hunks. #141628 changes the canonical basename list and remains a separate product proposal. Neither PR was copied or superseded.
