### PR TITLE
fix(agents): preserve settled tool continuation boundary

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -77,6 +77,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     prompt?: string;
     disableTools?: boolean;
     clientTools?: unknown[];
+    suppressNextUserMessagePersistence?: boolean;
   } {
     // Continuation prompt assertions read the exact prompt passed to the runner
     // attempt rather than derived result metadata.
@@ -84,7 +85,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     if (!call) {
       throw new Error(`Expected run embedded attempt call ${index}`);
     }
-    return call[0] as { prompt?: string; disableTools?: boolean; clientTools?: unknown[] };
+    return call[0] as {
+      prompt?: string;
+      disableTools?: boolean;
+      clientTools?: unknown[];
+      suppressNextUserMessagePersistence?: boolean;
+    };
   }
 
   it("emits the before_agent_run hook block message as the agent payload", async () => {
@@ -3250,15 +3256,20 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(
-        makeAttemptResult({
+      .mockImplementationOnce(async (attemptParams) => {
+        (
+          attemptParams as {
+            onUserMessagePersisted?: (message: { role: "user"; content: string }) => void;
+          }
+        ).onUserMessagePersisted?.({ role: "user", content: "Write the note." });
+        return makeAttemptResult({
           assistantTexts: [],
           toolMetas: [{ toolName: "write", meta: "path=note.txt", replaySafe: false }],
           itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
           lastAssistant: emptyStopAssistant,
           currentAttemptAssistant: emptyStopAssistant,
-        }),
-      )
+        });
+      })
       .mockResolvedValueOnce(
         makeAttemptResult({
           assistantTexts: ["Write completed."],
@@ -3278,6 +3289,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       provider: "openai",
       model: "gpt-5.5",
       runId: "run-settled-write-empty-stop",
+      currentMessageId: "telegram-message-1",
       agentHarnessRuntimeOverride: "openclaw",
       clientTools: [
         {
@@ -3291,7 +3303,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(runAttemptCall(1)).toMatchObject({
       disableTools: true,
       clientTools: undefined,
-      prompt: expect.stringContaining(SETTLED_TOOL_CONTINUATION_INSTRUCTION),
+      prompt: SETTLED_TOOL_CONTINUATION_INSTRUCTION,
+      suppressNextUserMessagePersistence: true,
     });
     expect(result.meta.finalAssistantVisibleText).toBe("Write completed.");
     expectWarnMessageWith("settled post-tool turn lacked a final answer");

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2095,9 +2095,8 @@ async function runEmbeddedAgentInternal(
             currentInboundContext: params.currentInboundContext,
             images: params.images,
             imageOrder: params.imageOrder,
-            clientTools:
-              settledToolContinuationInstruction === null ? params.clientTools : undefined,
-            disableTools: params.disableTools || settledToolContinuationInstruction !== null,
+            clientTools: settledToolContinuationAttempts === 0 ? params.clientTools : undefined,
+            disableTools: params.disableTools || settledToolContinuationAttempts > 0,
             provider,
             modelId,
             requestedModelId,
@@ -3809,7 +3808,17 @@ async function runEmbeddedAgentInternal(
                 });
           if (nextSettledToolContinuationInstruction && settledToolContinuationAttempts < 1) {
             settledToolContinuationAttempts += 1;
-            settledToolContinuationInstruction = nextSettledToolContinuationInstruction;
+            if (
+              params.currentMessageId !== undefined &&
+              params.currentMessageId === lastPersistedCurrentMessageId
+            ) {
+              // The settled tool batch already follows this inbound leaf. Keep the
+              // continuation as the new model prompt instead of replaying that leaf.
+              nextAttemptPromptOverride = nextSettledToolContinuationInstruction;
+              suppressNextUserMessagePersistence = true;
+            } else {
+              settledToolContinuationInstruction = nextSettledToolContinuationInstruction;
+            }
             log.warn(
               `settled post-tool turn lacked a final answer: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — continuing from settled tool results`,


### PR DESCRIPTION
## Release blocker

The packaged Telegram recovery scenario in [Full Release Validation 34261943173](https://github.com/openclaw/openclaw/actions/runs/34261943173) reached the settled-tool continuation from #141916, then produced no matching final marker. Its artifact records four model fetches before the only outbound reply and a retry of the same Telegram inbound message.

## Root cause

#141916 disabled tools for its one recovery pass but left the already-persisted inbound message as the next attempt's prompt. That replays the source user turn instead of continuing from the settled assistant/tool transcript. The runner already owns the canonical boundary for this case: internal continuations use a new model prompt and suppress re-persisting the current inbound message.

## Fix

When the current channel message is known to be persisted, use the settled-tool instruction as the next model prompt and mark the next attempt as persistence-suppressed. The recovery still has no tools. If persistence is not proven, retain #141916's existing prompt-addition path rather than dropping user input.

## Proof

- Red: the focused settled-write test observed the old second attempt as `prompt: "hello\\n\\n<continuation>"` with `suppressNextUserMessagePersistence: false`.
- Green: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 113 passed.
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — passed.
- `node scripts/check-changed.mjs --dry-run -- src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — `core, coreTests`.
- `git diff --check` — passed.

Production delta: +9 lines; test delta: +13 lines. The production addition is the current-message identity gate plus an ownership comment; it avoids reintroducing a second user leaf into a persisted conversation.
