### PR TITLE
fix(ci): keep hosted TypeScript preflight within runner limits

### DIFF
--- a/scripts/lib/local-check-runtime.mts
+++ b/scripts/lib/local-check-runtime.mts
@@ -156,11 +156,8 @@ export function applyLocalTsgoPolicy(args: string[], env: Env, hostResources: Re
     insertBeforeSeparator(nextArgs, "--declaration", "false");
   }
 
-  if (!isLocalCheckEnabled(nextEnv)) {
-    return { env: nextEnv, args: nextArgs };
-  }
-
-  if (defaultProjectRun) {
+  const localCheckEnabled = isLocalCheckEnabled(nextEnv);
+  if (localCheckEnabled && defaultProjectRun) {
     insertBeforeSeparator(nextArgs, "--incremental");
     insertBeforeSeparator(
       nextArgs,
@@ -170,12 +167,15 @@ export function applyLocalTsgoPolicy(args: string[], env: Env, hostResources: Re
   }
 
   const resolvedHostResources = resolveHostResources(hostResources);
-  if (shouldThrottleLocalChecks(nextEnv, resolvedHostResources, "auto")) {
+  if (
+    shouldThrottleLocalChecks(nextEnv, resolvedHostResources, "auto") ||
+    (isCiLikeEnv(nextEnv) && isConstrainedCiCheckHost(resolvedHostResources))
+  ) {
     insertBeforeSeparator(nextArgs, "--singleThreaded");
     insertBeforeSeparator(nextArgs, "--checkers", "1");
     applyThrottledGoRuntimeEnv(nextEnv, resolvedHostResources);
   }
-  if (nextEnv.OPENCLAW_TSGO_PPROF_DIR && !hasFlag(nextArgs, "--pprofDir")) {
+  if (localCheckEnabled && nextEnv.OPENCLAW_TSGO_PPROF_DIR && !hasFlag(nextArgs, "--pprofDir")) {
     insertBeforeSeparator(nextArgs, "--pprofDir", nextEnv.OPENCLAW_TSGO_PPROF_DIR);
   }
 

--- a/test/scripts/local-check-runtime.test.ts
+++ b/test/scripts/local-check-runtime.test.ts
@@ -160,6 +160,27 @@ describe("local-check-runtime", () => {
     expect(args).toEqual(["--declaration", "false"]);
   });
 
+  it("throttles tsgo on constrained CI hosts when local safeguards are disabled", () => {
+    const { args, env } = applyLocalTsgoPolicy(
+      ["-b", "tsconfig.projects.json"],
+      makeEnv({ CI: "true", OPENCLAW_LOCAL_CHECK: "0" }),
+      CONSTRAINED_HOST,
+    );
+
+    expect(args).toEqual([
+      "-b",
+      "tsconfig.projects.json",
+      "--declaration",
+      "false",
+      "--singleThreaded",
+      "--checkers",
+      "1",
+    ]);
+    expect(env.GOMAXPROCS).toBe("2");
+    expect(env.GOGC).toBe("30");
+    expect(env.GOMEMLIMIT).toBe("3GiB");
+  });
+
   it("keeps explicit tsgo flags and Go env overrides intact when throttled", () => {
     const { args, env } = applyLocalTsgoPolicy(
       ["--checkers", "4", "--singleThreaded", "--pprofDir", "/tmp/existing"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where npm preflight's full TypeScript check repeatedly receives runner shutdown on constrained GitHub-hosted runners.

The same `2026.6.35` source preflight failed in `typecheck all` on three attempts after 80.66s, 74.77s, and 177.09s. Each attempt had already passed its release guards and shrinkwrap checks.

## Why This Change Was Made

The shared check runtime already identifies constrained CI hosts and throttles Oxlint there. Tsgo returned early when CI explicitly disabled local-only safeguards, so it ran without the existing single-thread/checker and Go memory limits.

This applies those existing limits to constrained CI while leaving local-only incremental caching and profiling local. Roomy CI remains unthrottled.

## User Impact

Release preflight can complete its authoritative typecheck on supported small hosted runners instead of repeatedly losing the runner under load. Product runtime behavior is unchanged.

## Evidence

- Original failure, attempt 3: https://github.com/openclaw/openclaw/actions/runs/34261043602/job/102191144495
- Pre-fix regression: the constrained-CI policy test received only `--declaration false`; expected throttling flags were absent.
- Post-fix: `test/scripts/local-check-runtime.test.ts` — 44/44 passed.
- OXLint, Oxfmt, and `git diff --check` passed.
- Independent P0-P2 autoreview: scoped-clean, confidence 0.94.

Production/tooling: +7/-7. Tests: +21/-0.
