### PR TITLE
fix(qa): follow Telegram menu edits in callback proofs

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
@@ -119,7 +119,7 @@ class EventRecorder:
             "isOutgoing": bool(message.get("is_outgoing")),
             **self._reply_fields(message),
         }
-        self.messages[message_id] = message
+        self.messages[message_id] = dict(message)
 
     def _known_message_fields(self, message_id):
         return self.message_fields.get(message_id, {})
@@ -166,6 +166,8 @@ class EventRecorder:
         elif kind == "updateMessageContent":
             content = update.get("new_content") or {}
             message_id = update.get("message_id")
+            if message_id in self.messages:
+                self.messages[message_id]["content"] = content
             text = content_text(content)
             rich_message = content.get("message") if content.get("@type") == "messageRichMessage" else None
             yield (

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
@@ -162,6 +162,52 @@ class CallbackScenarioTest(unittest.TestCase):
             ],
         )
 
+    def test_finds_callback_under_current_heading_after_content_and_keyboard_edits(self):
+        for content_first in (True, False):
+            with self.subTest(content_first=content_first):
+                recorder = record.EventRecorder(FakeClient(), -1001, "", 42)
+                message = {
+                    "id": 1048576, "chat_id": -1001,
+                    "sender_id": {"@type": "messageSenderUser", "user_id": 42},
+                    "content": {
+                        "@type": "messageText",
+                        "text": {"@type": "formattedText", "text": "Select a provider:"},
+                    },
+                    "reply_markup": {
+                        "@type": "replyMarkupInlineKeyboard",
+                        "rows": [[{"text": "Example", "type": {
+                            "@type": "inlineKeyboardButtonTypeCallback", "data": "cHJvdmlkZXI=",
+                        }}]],
+                    },
+                }
+                content_edit = {
+                    "@type": "updateMessageContent", "chat_id": -1001, "message_id": 1048576,
+                    "new_content": {
+                        "@type": "messageText",
+                        "text": {"@type": "formattedText", "text": "Models (example) — 2 available"},
+                    },
+                }
+                keyboard_edit = {
+                    "@type": "updateMessageEdited", "chat_id": -1001, "message_id": 1048576,
+                    "reply_markup": {
+                        "@type": "replyMarkupInlineKeyboard",
+                        "rows": [[{"text": "middle", "type": {
+                            "@type": "inlineKeyboardButtonTypeCallback", "data": "bWlkZGxl",
+                        }}]],
+                    },
+                }
+                recorder.ingest({"@type": "updateNewMessage", "message": message})
+                edits = ((content_edit, keyboard_edit) if content_first
+                         else (keyboard_edit, content_edit))
+                for update in edits:
+                    recorder.ingest(update)
+
+                self.assertEqual(recorder.find_callback_button("Models (", "middle"),
+                                 (1048576, "bWlkZGxl"))
+                self.assertIsNone(recorder.find_callback_button("Select a provider:", "middle"))
+                self.assertEqual(message["content"]["text"]["text"], "Select a provider:")
+                self.assertEqual(message["reply_markup"]["rows"][0][0]["text"], "Example")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Related: #142100.

## What Problem This Solves

Fixes Telegram Test Server proof clicks timing out after a menu is edited, even when the requested button is visible. The recorder emitted the new text and updated the keyboard, but callback lookup still searched the original cached heading.

## Why This Change Was Made

Update cached content when Telegram delivers a content edit. Give the cache its own shallow message copy so later content or keyboard updates preserve the original raw evidence.

## User Impact

Callback actions can follow edited menus using their current headings, regardless of whether content or keyboard updates arrive first. Recorded original updates remain unchanged.

## Evidence

A real Test Server recording exposed the failure: provider selection succeeded, the message changed to the model menu with a `middle` button, and the recorder missed that button because its cached heading still said `Select a provider:`.

The regression replays that exact order and reversed edit arrival. Both fail against the original code and pass after repair, including stale-heading rejection and preservation of original text and keyboard data. All 6 recorder tests, 18 driver tests, the full required changed-file gate, and independent P2 review passed.

Combined Telegram Test Server validation passed on [#142100 at `6809ebee`](https://github.com/openclaw/openclaw/commit/6809ebee5cba9e0e2fec0c381480ede2aa8b04f6), whose two recorder files are byte-identical to this PR. The real provider-menu and model-button callbacks completed after the menu edit. All 11 actions passed, including model selection, thinking/status checks and two matching provider requests across a Gateway restart. The corrected file judge preserves exact turn matching while recognizing existing internal-context messages; the fresh complete run passed.

The source/runtime/input guards remained unchanged, the runner exited zero, all owned processes stopped, ports closed, and temporary runtime state was removed. Earlier failed runs remain preserved. This is combined-source live evidence, not a separate build of this recorder branch. [Exact-head CI also passed](https://github.com/openclaw/openclaw/actions/runs/34270276235).

Product runtime LOC is unchanged; this adds two tooling lines.
