### PR TITLE
fix(release): unblock Codex plugin security validation

### DIFF
--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -142,7 +142,7 @@ const CURRENT_REVIEWED_RELEASE_LAYOUT = {
   ]),
 };
 
-const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
+const FROZEN_RELEASE_2026_9_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
   ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.test.ts", 3],
@@ -168,6 +168,14 @@ const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>(
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);
+
+const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map(
+  FROZEN_RELEASE_2026_9_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
+);
+CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS.set(
+  "@openclaw/codex:dangerous-exec:src/doctor.test.ts",
+  1,
+);
 
 const CURRENT_SECURITY_INVENTORY_POLICY: PluginSecurityInventoryPolicy = {
   layout: CURRENT_REVIEWED_RELEASE_LAYOUT,
@@ -230,6 +238,7 @@ const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurit
     "release/2026.9.1",
     {
       ...CURRENT_SECURITY_INVENTORY_POLICY,
+      optionalPackedFindingCounts: FROZEN_RELEASE_2026_9_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
       requiredSourceFindingCounts: RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
     },
   ],
@@ -237,10 +246,17 @@ const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurit
     "release/2026.9.2",
     {
       ...CURRENT_SECURITY_INVENTORY_POLICY,
+      optionalPackedFindingCounts: FROZEN_RELEASE_2026_9_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
       requiredSourceFindingCounts: RELEASE_2026_9_2_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
     },
   ],
-  ["release/2026.9.3", CURRENT_SECURITY_INVENTORY_POLICY],
+  [
+    "release/2026.9.3",
+    {
+      ...CURRENT_SECURITY_INVENTORY_POLICY,
+      optionalPackedFindingCounts: FROZEN_RELEASE_2026_9_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
+    },
+  ],
   [
     "extended-stable/2026.6.33",
     {

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -415,6 +415,67 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     },
   );
 
+  it.each([null, 0, 1, 2])(
+    "freezes release doctor-test counts while reviewing the current fixture: %s",
+    async (count) => {
+      const packageName = "@openclaw/codex";
+      const fixturePath = "src/doctor.test.ts";
+      const fixtureKey = `${packageName}:dangerous-exec:${fixturePath}`;
+      const spawnProbe =
+        'import { spawn } from "node:child_process";\nspawn(process.execPath, []);\n';
+      for (const context of ["", "release/2026.9.1", "release/2026.9.2", "release/2026.9.3"]) {
+        const requiresLegacyDoctor =
+          context === "release/2026.9.1" || context === "release/2026.9.2";
+        const artifact = writePluginArtifact({
+          extensionId: "codex",
+          packageName,
+          files: {
+            "src/app-server/transport-stdio.ts": spawnProbe,
+            "src/app-server/sandbox-exec-server/sandbox-child.ts": spawnProbe,
+            "src/app-server/transport-process-snapshot.ts": spawnProbe,
+            ...(requiresLegacyDoctor ? { "src/doctor.ts": spawnProbe } : {}),
+            ...(count === null
+              ? {}
+              : {
+                  [fixturePath]:
+                    'import { spawn } from "node:child_process";\n' +
+                    "spawn(process.execPath, []);\n".repeat(count),
+                }),
+          },
+        });
+        const scanned = await scanPublishablePluginPackages([artifact.artifact], context);
+        expect(scanned.scanErrors).toEqual([]);
+        const result = scanned.packageResults[0]!;
+        const current = context === "";
+        expect(
+          result.expectedReviewedCriticalFindings.filter((finding) => finding === fixtureKey),
+          context,
+        ).toEqual(current && count !== null ? [fixtureKey] : []);
+        expect(
+          result.reviewedCriticalFindings.filter((finding) => finding === fixtureKey),
+          context,
+        ).toEqual(current ? Array.from({ length: count ?? 0 }, () => fixtureKey) : []);
+        expect(
+          result.unexpectedCriticalFindings.filter((finding) => finding.path === fixturePath),
+          context,
+        ).toHaveLength(current ? 0 : (count ?? 0));
+
+        const report = buildPluginNpmSecurityScanReport({
+          candidateSha: CANDIDATE_SHA,
+          packageResults: scanned.packageResults,
+          targetContextRef: context,
+          toolingSha: TOOLING_SHA,
+        });
+        expect(
+          report.errors.filter((error) => error.startsWith(`${packageName}:`)),
+          context,
+        ).toHaveLength(
+          current ? (count === null || count === 1 ? 0 : 1) : count === null || count === 0 ? 0 : 1,
+        );
+      }
+    },
+  );
+
   it.each([1, 2])(
     "reviews exactly one current hardware probe, preserving frozen policy: %s",
     async (count) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the plugin npm security scan rejected the reviewed detached-process fixture in the current Codex package.

## Why This Change Was Made

The current inventory now admits exactly one `dangerous-exec` finding from `src/doctor.test.ts` when that file is packed. The 2026.9.1 through 2026.9.3 release inventories remain frozen, so older candidate contexts still reject the new finding.

## User Impact

Maintainers can qualify current OpenClaw candidates without weakening the scanner contract for previously frozen releases.

## Evidence

- Reproduced the hosted failure as `@openclaw/codex:dangerous-exec:src/doctor.test.ts` with count 1.
- Focused tooling tests: 29/29 passed.
- Regression matrix covers absent, zero, exact-one, and excess findings for current and frozen release contexts.
- Exact candidate artifact passes under the current policy; `release/2026.9.3` rejects the new finding.
- Formatting, script erasability, policy guards, and targeted Oxlint checks passed.
- `check:changed` reached the script typecheck and then stopped at the linked-worktree compiler-symlink guard; exact-head CI will provide the checkout-local typecheck.
- Independent autoreview found no actionable issues.

## ClawSweeper Note

The requested data-model compatibility proof is not applicable. This change updates an in-memory static-scan policy inventory used during release validation; it does not read, write, migrate, or reinterpret persisted operator data.
