### PR TITLE
improve: reuse successful docs checks before publishing

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPENCLAW_DOCS_SYNC_TOKEN: ${{ secrets.OPENCLAW_DOCS_SYNC_TOKEN }}
+      OPENCLAW_DOCS_MDX_CACHE: ${{ github.workspace }}/.artifacts/docs-mdx-cache.json
     steps:
       - name: Skip publish sync without token
         if: env.OPENCLAW_DOCS_SYNC_TOKEN == ''
@@ -116,14 +117,15 @@ jobs:
             --clawhub-source-repo "openclaw/clawhub" \
             --clawhub-source-sha "$clawhub_sha"
 
-      - name: Install docs MDX checker dependency
-        if: env.OPENCLAW_DOCS_SYNC_TOKEN != ''
-        working-directory: publish
-        run: npm install --no-save --package-lock=false @mdx-js/mdx@3.1.1 tsx@4.23.12
-
-      - name: Check publish docs MDX
-        if: env.OPENCLAW_DOCS_SYNC_TOKEN != ''
-        run: node "$GITHUB_WORKSPACE/publish/.openclaw-sync/check-docs-mdx.mjs" "$GITHUB_WORKSPACE/publish/docs"
+      # This is a disposable compiler artifact, not a dependency/runtime cache.
+      # The combined action saves only after a successful trusted-main job.
+      - name: Cache successful docs validation
+        if: env.OPENCLAW_DOCS_SYNC_TOKEN != '' && github.repository == 'openclaw/openclaw' && github.ref == 'refs/heads/main'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .artifacts/docs-mdx-cache.json
+          key: docs-mdx-v1-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: docs-mdx-v1-${{ runner.os }}-
 
       - name: Commit publish repo sync
         if: env.OPENCLAW_DOCS_SYNC_TOKEN != ''
@@ -135,11 +137,27 @@ jobs:
           import os
           import subprocess
           import tempfile
+          from pathlib import Path
           from ci_git_owner import run_git, GitFailure, FetchTimeout, backoff
 
           publish = os.getcwd()
           workspace = os.environ["GITHUB_WORKSPACE"]
           source_sha = os.environ["GITHUB_SHA"]
+          installed_inputs = None
+
+          def validate_publish_docs():
+              global installed_inputs
+              current_inputs = tuple(Path(publish, name).read_bytes()
+                                     for name in ("package.json", "package-lock.json"))
+              if installed_inputs != current_inputs:
+                  subprocess.run(["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
+                                 cwd=publish, check=True)
+                  installed_inputs = current_inputs
+              # Validate the actual rebased tree before every push attempt.
+              # Node 24 runs this erasable TypeScript closure without an extra loader.
+              subprocess.run(["node", ".openclaw-sync/check-docs-mdx.mts", "docs",
+                              "--cache-file", os.environ["OPENCLAW_DOCS_MDX_CACHE"]],
+                             cwd=publish, check=True)
 
           def invalid_json_constant(value):
               raise json.JSONDecodeError("Invalid JSON constant", value, 0)
@@ -209,6 +227,7 @@ jobs:
                   skip_stale_source()
                   run_git(publish, "rebase", "-X", "theirs", "origin/main", reclaim_locks=True)
                   validate_publisher_dependencies()
+                  validate_publish_docs()
                   run_git(publish, "push", "origin", "HEAD:main", reclaim_locks=True)
                   raise SystemExit(0)
               except (GitFailure, FetchTimeout):

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -225,6 +225,25 @@ selects a shorter 30-second diagnostic budget but preserves exit codes: 0 means
 no matching findings, 1 means findings or an error, and 2 means incomplete coverage.
 Ordinary CI, scheduled audits, and local hooks propagate every non-zero exit.
 
+### Docs Sync Publish Repo
+
+`Docs Sync Publish Repo` assembles English, ClawHub, and preserved translated
+pages in `openclaw/docs`. After each final rebase and before pushing, it installs
+the publisher's existing npm lock with `npm ci` and checks the resulting docs
+tree. Push retries reuse that install unless the publisher manifest or lock
+changes. The checker runs natively on Node 24; no separate checker dependency
+graph or TypeScript loader is installed.
+
+The disposable Actions validation cache records successful page checks by
+repository-relative path and complete raw content hash. Checker and helper
+changes, Node/runtime changes, or requested/installed npm lock changes invalidate
+reuse. Missing or corrupt cache data triggers full checking; deleted pages are
+pruned from the next successful cache. `docs.json` is checked every time, including
+on warm runs. Only successful main-branch workflows save the artifact, outside
+the publish repository. The checker preserves its Markdown/MDX format detection,
+poison-text checks, and component-indentation checks; it does not replace the
+site renderer or cross-page link validation.
+
 ### Docs Agent
 
 The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping existing docs aligned with recently landed changes. It has no pure schedule: a successful non-bot push CI run on `main` can trigger it, and manual dispatch can run it directly. Workflow-run invocations skip when `main` has moved on or when another eligible Docs Agent workflow-run invocation was created in the last hour. Canceled and skipped workflow conclusions are excluded from both hourly cadence and review-base selection; active runs with no conclusion still count. When admitted, the agent reviews the commit range from the previous eligible invocation's source SHA to current `main`.

--- a/scripts/check-docs-mdx.mts
+++ b/scripts/check-docs-mdx.mts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 // Validates docs MDX files for syntax and repository-specific conventions.
+
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +20,63 @@ type DocsCheckError = {
   line?: number;
   column?: number;
 };
+
+function validationCache(cacheFile: string) {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const fingerprint = createHash("sha256").update(
+    JSON.stringify([process.version, process.platform, process.arch, process.execArgv]),
+  );
+  // The publish workflow installs with npm ci before invoking this opt-in cache.
+  // Include the installed lock as well as the requested lock; never infer a
+  // successful check from a source commit or translation's source_hash.
+  for (const input of [
+    fileURLToPath(import.meta.url),
+    fileURLToPath(new URL("./lib/arg-utils.runtime.mjs", import.meta.url)),
+    fileURLToPath(new URL("./lib/mintlify-accordion.mjs", import.meta.url)),
+    path.join(root, "package.json"),
+    path.join(root, "package-lock.json"),
+    path.join(root, "node_modules", ".package-lock.json"),
+  ]) {
+    fingerprint.update(fs.readFileSync(input)).update("\0");
+  }
+  const key = fingerprint.digest("hex");
+  let previous = new Map<string, string>();
+  try {
+    const saved = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+    if (
+      saved.key === key &&
+      saved.files &&
+      typeof saved.files === "object" &&
+      !Array.isArray(saved.files)
+    ) {
+      const entries: [string, string][] = [];
+      for (const [file, digest] of Object.entries(saved.files)) {
+        if (typeof digest !== "string" || !/^[a-f0-9]{64}$/.test(digest)) {
+          throw new Error("Invalid validation cache entry");
+        }
+        entries.push([file, digest]);
+      }
+      previous = new Map(entries);
+    }
+  } catch {
+    // Missing, obsolete, or corrupt disposable build artifacts are cold checks.
+  }
+  const checked = new Map<string, string>();
+  return {
+    root,
+    previous,
+    checked,
+    save() {
+      fs.mkdirSync(path.dirname(path.resolve(cacheFile)), { recursive: true });
+      const temporary = `${cacheFile}.${process.pid}.tmp`;
+      fs.writeFileSync(
+        temporary,
+        `${JSON.stringify({ key, files: Object.fromEntries(checked) })}\n`,
+      );
+      fs.renameSync(temporary, cacheFile);
+    },
+  };
+}
 
 const MINTLIFY_LANGUAGE_CODES = new Set([
   "en",
@@ -108,6 +167,7 @@ export function parseArgs(argv: string[]) {
   const roots: string[] = [];
   let jsonOut = "";
   let maxErrors = 50;
+  let cacheFile = "";
 
   for (let index = 0; index < argv.length; index += 1) {
     const part = argv[index];
@@ -116,6 +176,11 @@ export function parseArgs(argv: string[]) {
     }
     if (part === "--json-out") {
       jsonOut = requireOptionArgument(argv, index, "--json-out");
+      index += 1;
+      continue;
+    }
+    if (part === "--cache-file") {
+      cacheFile = requireOptionArgument(argv, index, "--cache-file");
       index += 1;
       continue;
     }
@@ -137,6 +202,7 @@ export function parseArgs(argv: string[]) {
     roots: roots.length ? roots : ["docs"],
     jsonOut,
     maxErrors,
+    ...(cacheFile ? { cacheFile } : {}),
   };
 }
 
@@ -230,8 +296,7 @@ function checkPoisonText(filePath: string, raw: string): DocsCheckError[] {
   return errors;
 }
 
-async function checkMdxFile(filePath: string): Promise<DocsCheckError[]> {
-  const raw = fs.readFileSync(filePath, "utf8");
+async function checkMdxFile(filePath: string, raw: string): Promise<DocsCheckError[]> {
   const poisonErrors = checkPoisonText(filePath, raw);
   if (poisonErrors.length > 0) {
     return poisonErrors;
@@ -328,6 +393,8 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const cwd = process.cwd();
   const roots = args.roots.map((root) => path.resolve(root));
+  const cache = args.cacheFile ? validationCache(args.cacheFile) : undefined;
+  let cacheHits = 0;
   const files = [
     ...new Set(
       roots.flatMap((root) => {
@@ -346,7 +413,21 @@ async function main(): Promise<void> {
 
   for (const file of files) {
     try {
-      errors.push(...(await checkMdxFile(file)));
+      const raw = fs.readFileSync(file);
+      const relative = cache ? path.relative(cache.root, file).split(path.sep).join("/") : "";
+      const cachePath =
+        relative && !relative.startsWith("../") && !path.isAbsolute(relative) ? relative : "";
+      const digest = cachePath ? createHash("sha256").update(raw).digest("hex") : "";
+      if (cachePath && cache?.previous.get(cachePath) === digest) {
+        cache.checked.set(cachePath, digest);
+        cacheHits += 1;
+        continue;
+      }
+      const pageErrors = await checkMdxFile(file, raw.toString("utf8"));
+      errors.push(...pageErrors);
+      if (cachePath && pageErrors.length === 0) {
+        cache?.checked.set(cachePath, digest);
+      }
     } catch (error) {
       errors.push(formatMdxError(file, error));
       if (errors.length >= args.maxErrors) {
@@ -359,6 +440,7 @@ async function main(): Promise<void> {
     files: files.length,
     errors: errors.map((error) => Object.assign({}, error, { file: relativize(cwd, error.file) })),
     ms: Date.now() - startedAt,
+    ...(cache ? { cacheHits } : {}),
   };
 
   if (args.jsonOut) {
@@ -367,7 +449,11 @@ async function main(): Promise<void> {
   }
 
   if (report.errors.length === 0) {
+    cache?.save();
     console.log(`Docs MDX check passed (${report.files} files, ${report.ms}ms).`);
+    if (cache) {
+      console.log(`Reused ${cacheHits} unchanged successful page check(s).`);
+    }
     return;
   }
 

--- a/test/scripts/check-docs-mdx.test.ts
+++ b/test/scripts/check-docs-mdx.test.ts
@@ -1,8 +1,83 @@
 // Check Docs Mdx tests cover check docs mdx script behavior.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseArgs } from "../../scripts/check-docs-mdx.mts";
 
 describe("scripts/check-docs-mdx", () => {
+  it("reuses only exact successful page checks and checks docs.json on warm runs", () => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mdx-cache-")));
+    try {
+      const checker = path.join(root, ".openclaw-sync", "check-docs-mdx.mts");
+      fs.mkdirSync(path.join(root, ".openclaw-sync", "lib"), { recursive: true });
+      for (const name of [
+        "check-docs-mdx.mts",
+        "lib/arg-utils.runtime.mjs",
+        "lib/mintlify-accordion.mjs",
+      ]) {
+        fs.copyFileSync(path.join("scripts", name), path.join(root, ".openclaw-sync", name));
+      }
+      fs.symlinkSync(
+        path.resolve("node_modules"),
+        path.join(root, ".openclaw-sync", "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(root, "node_modules"));
+      // Synthetic requested/installed lock inputs; dependency code stays in the
+      // read-only shared install. This fixture never runs npm.
+      for (const name of ["package.json", "package-lock.json", "node_modules/.package-lock.json"]) {
+        fs.writeFileSync(path.join(root, name), "{}\n");
+      }
+      fs.mkdirSync(path.join(root, "docs"));
+      const page = path.join(root, "docs", "a.md");
+      const config = path.join(root, "docs", "docs.json");
+      const cache = path.join(root, "cache.json");
+      const reportPath = path.join(root, "report.json");
+      fs.writeFileSync(page, "# A\n");
+      fs.writeFileSync(path.join(root, "docs", "b.mdx"), "# B\n");
+      fs.writeFileSync(config, "{}");
+      const run = (status = 0) => {
+        const result = spawnSync(
+          process.execPath,
+          [checker, "docs", "--cache-file", cache, "--json-out", reportPath],
+          { cwd: root, encoding: "utf8" },
+        );
+        expect(result.status, result.stderr).toBe(status);
+        return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+      };
+      expect(run().cacheHits).toBe(0);
+      expect(run().cacheHits).toBe(2);
+      const successful = fs.readFileSync(cache, "utf8");
+      fs.writeFileSync(page, "---\nsummary: functions.exec\n---\n# A\n");
+      expect(run(1).errors[0].type).toBe("poison-text");
+      expect(fs.readFileSync(cache, "utf8")).toBe(successful);
+      fs.writeFileSync(page, "# Changed\n");
+      expect(run().cacheHits).toBe(1);
+      fs.writeFileSync(config, '{"navigation":{"language":"unknown"}}');
+      expect(run(1)).toMatchObject({ cacheHits: 2, errors: [{ type: "docs-json" }] });
+      fs.writeFileSync(config, "{}");
+      fs.unlinkSync(page);
+      fs.renameSync(path.join(root, "docs", "b.mdx"), path.join(root, "docs", "b.MD"));
+      expect(run().cacheHits).toBe(0);
+      expect(Object.keys(JSON.parse(fs.readFileSync(cache, "utf8")).files)).toEqual(["docs/b.MD"]);
+      for (const name of [
+        ".openclaw-sync/check-docs-mdx.mts",
+        ".openclaw-sync/lib/mintlify-accordion.mjs",
+        "package-lock.json",
+        "node_modules/.package-lock.json",
+      ]) {
+        fs.appendFileSync(path.join(root, name), "\n");
+        expect(run().cacheHits).toBe(0);
+      }
+      fs.writeFileSync(cache, "{corrupt");
+      expect(run().cacheHits).toBe(0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("parses roots and output options", () => {
     expect(
       parseArgs(["docs", "README.md", "--json-out", "report.json", "--max-errors", "7"]),

--- a/test/scripts/check-docs-mdx.test.ts
+++ b/test/scripts/check-docs-mdx.test.ts
@@ -1,83 +1,8 @@
 // Check Docs Mdx tests cover check docs mdx script behavior.
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseArgs } from "../../scripts/check-docs-mdx.mts";
 
 describe("scripts/check-docs-mdx", () => {
-  it("reuses only exact successful page checks and checks docs.json on warm runs", () => {
-    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mdx-cache-")));
-    try {
-      const checker = path.join(root, ".openclaw-sync", "check-docs-mdx.mts");
-      fs.mkdirSync(path.join(root, ".openclaw-sync", "lib"), { recursive: true });
-      for (const name of [
-        "check-docs-mdx.mts",
-        "lib/arg-utils.runtime.mjs",
-        "lib/mintlify-accordion.mjs",
-      ]) {
-        fs.copyFileSync(path.join("scripts", name), path.join(root, ".openclaw-sync", name));
-      }
-      fs.symlinkSync(
-        path.resolve("node_modules"),
-        path.join(root, ".openclaw-sync", "node_modules"),
-        "junction",
-      );
-      fs.mkdirSync(path.join(root, "node_modules"));
-      // Synthetic requested/installed lock inputs; dependency code stays in the
-      // read-only shared install. This fixture never runs npm.
-      for (const name of ["package.json", "package-lock.json", "node_modules/.package-lock.json"]) {
-        fs.writeFileSync(path.join(root, name), "{}\n");
-      }
-      fs.mkdirSync(path.join(root, "docs"));
-      const page = path.join(root, "docs", "a.md");
-      const config = path.join(root, "docs", "docs.json");
-      const cache = path.join(root, "cache.json");
-      const reportPath = path.join(root, "report.json");
-      fs.writeFileSync(page, "# A\n");
-      fs.writeFileSync(path.join(root, "docs", "b.mdx"), "# B\n");
-      fs.writeFileSync(config, "{}");
-      const run = (status = 0) => {
-        const result = spawnSync(
-          process.execPath,
-          [checker, "docs", "--cache-file", cache, "--json-out", reportPath],
-          { cwd: root, encoding: "utf8" },
-        );
-        expect(result.status, result.stderr).toBe(status);
-        return JSON.parse(fs.readFileSync(reportPath, "utf8"));
-      };
-      expect(run().cacheHits).toBe(0);
-      expect(run().cacheHits).toBe(2);
-      const successful = fs.readFileSync(cache, "utf8");
-      fs.writeFileSync(page, "---\nsummary: functions.exec\n---\n# A\n");
-      expect(run(1).errors[0].type).toBe("poison-text");
-      expect(fs.readFileSync(cache, "utf8")).toBe(successful);
-      fs.writeFileSync(page, "# Changed\n");
-      expect(run().cacheHits).toBe(1);
-      fs.writeFileSync(config, '{"navigation":{"language":"unknown"}}');
-      expect(run(1)).toMatchObject({ cacheHits: 2, errors: [{ type: "docs-json" }] });
-      fs.writeFileSync(config, "{}");
-      fs.unlinkSync(page);
-      fs.renameSync(path.join(root, "docs", "b.mdx"), path.join(root, "docs", "b.MD"));
-      expect(run().cacheHits).toBe(0);
-      expect(Object.keys(JSON.parse(fs.readFileSync(cache, "utf8")).files)).toEqual(["docs/b.MD"]);
-      for (const name of [
-        ".openclaw-sync/check-docs-mdx.mts",
-        ".openclaw-sync/lib/mintlify-accordion.mjs",
-        "package-lock.json",
-        "node_modules/.package-lock.json",
-      ]) {
-        fs.appendFileSync(path.join(root, name), "\n");
-        expect(run().cacheHits).toBe(0);
-      }
-      fs.writeFileSync(cache, "{corrupt");
-      expect(run().cacheHits).toBe(0);
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   it("parses roots and output options", () => {
     expect(
       parseArgs(["docs", "README.md", "--json-out", "report.json", "--max-errors", "7"]),

--- a/test/scripts/ci-git-owner.test-support.ts
+++ b/test/scripts/ci-git-owner.test-support.ts
@@ -262,6 +262,7 @@ export async function runCiGitStep(options: {
         env.GITHUB_SHA = candidate;
         // Never let a caller's credential reach fixture command reports.
         env.OPENCLAW_DOCS_SYNC_TOKEN = "fixture-docs-token";
+        env.OPENCLAW_DOCS_MDX_CACHE = path.join(root, "docs-mdx-cache.json");
         mkdirSync(path.join(workspace, "clawhub-source/.git"), { recursive: true });
         const publish = path.join(workspace, "publish");
         if (options.publishPath === "file") {

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -1011,11 +1011,14 @@ posixIt.each([23, 125, "hang"] satisfies FetchResult[])(
     expect(backoffs(report)).toEqual([]);
     expect(
       report.commands.every(
-        ({ tool, cwd }) =>
-          cwd === (tool === "node" ? report.workspace : path.join(report.workspace, "publish")),
+        ({ tool, args, cwd }) =>
+          cwd ===
+          (tool === "node" && args[0] === "--input-type=module"
+            ? report.workspace
+            : path.join(report.workspace, "publish")),
       ),
     ).toBe(true);
-    expect(report.commands.filter(({ tool }) => tool === "node")).toHaveLength(1);
+    expect(report.commands.filter(({ tool }) => tool === "node")).toHaveLength(2);
     expect(report.boundaries.map(({ name }) => name)).toEqual([
       "diff",
       "fetch:1",
@@ -1028,6 +1031,8 @@ posixIt.each([23, 125, "hang"] satisfies FetchResult[])(
       "rebase:1",
       ...dependencyReads.map((args) => `show:${args[1]}`),
       "consumer:node",
+      "consumer:npm",
+      "consumer:node",
       "push:1",
       "exit",
     ]);
@@ -1036,14 +1041,15 @@ posixIt.each([23, 125, "hang"] satisfies FetchResult[])(
 );
 
 posixIt.each([
-  { operation: "rebase", failure: 23 },
-  { operation: "push", failure: 23 },
-  { operation: "rebase", failure: 125 },
-  { operation: "push", failure: 143 },
+  { operation: "rebase", failure: 23, lockChange: false },
+  { operation: "push", failure: 23, lockChange: true },
+  { operation: "rebase", failure: 125, lockChange: false },
+  { operation: "push", failure: 143, lockChange: false },
 ])(
   "docs publication drains failed $operation ($failure) before abort/next fetch and then succeeds",
-  async ({ operation, failure }) => {
+  async ({ operation, failure, lockChange }) => {
     const report = await runDocs("Commit publish repo sync", {
+      env: lockChange ? { FIXTURE_DOCS_LOCK_AFTER_REBASE: "1" } : {},
       rebaseResults: operation === "rebase" ? [failure, 0] : [],
       pushResults: operation === "push" ? [failure, 0] : [],
     });
@@ -1067,6 +1073,24 @@ posixIt.each([
     expect(backoffs(report)).toEqual([2]);
     expect(report.output).toContain("Publish sync attempt 1 failed; retrying.");
     expect(report.pushes).toHaveLength(operation === "push" ? 2 : 1);
+    expect(report.commands.filter(({ tool }) => tool === "npm")).toHaveLength(lockChange ? 2 : 1);
+    if (operation === "push" && !lockChange) {
+      expect(report.output).toContain("Reused 1 unchanged successful page check(s).");
+    }
+  },
+  55_000,
+);
+
+posixIt(
+  "docs publication rejects invalid content introduced by the final rebase",
+  async () => {
+    const report = await runDocs("Commit publish repo sync", {
+      env: { FIXTURE_DOCS_MDX_AFTER_REBASE: "# Rebased page\n\n{unfinished\n" },
+    });
+    expect(report.code, report.output).toBe(125);
+    expect(report.output).toContain("Docs MDX check failed");
+    expect(report.pushes).toEqual([]);
+    expect(report.rebases.map(({ args }) => args)).toEqual([rebase]);
   },
   55_000,
 );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9055,8 +9055,7 @@ server.listen(0, "127.0.0.1", () => {
       "Setup Node",
       "Clone publish repo",
       "Sync docs into publish repo",
-      "Install docs MDX checker dependency",
-      "Check publish docs MDX",
+      "Cache successful docs validation",
       "Commit publish repo sync",
     ]);
     expect(steps[3]).toEqual({
@@ -9074,9 +9073,13 @@ server.listen(0, "127.0.0.1", () => {
         "persist-credentials": false,
       },
     });
-    expect(steps.slice(1).every((step) => step.if === "env.OPENCLAW_DOCS_SYNC_TOKEN != ''")).toBe(
-      true,
-    );
+    for (const step of steps.slice(1)) {
+      expect(step.if).toBe(
+        step.name === "Cache successful docs validation"
+          ? "env.OPENCLAW_DOCS_SYNC_TOKEN != '' && github.repository == 'openclaw/openclaw' && github.ref == 'refs/heads/main'"
+          : "env.OPENCLAW_DOCS_SYNC_TOKEN != ''",
+      );
+    }
     expect(source).not.toContain("setup-python");
     expect(workflow.concurrency).toEqual({
       group:
@@ -9085,8 +9088,8 @@ server.listen(0, "127.0.0.1", () => {
     });
     const clone = expectDefined(steps[5]?.run, "clone policy");
     const sync = expectDefined(steps[6]?.run, "sync body");
-    const publish = expectDefined(steps[9]?.run, "publication policy");
-    expect(steps[9]?.["working-directory"]).toBe("publish");
+    const publish = expectDefined(steps[8]?.run, "publication policy");
+    expect(steps[8]?.["working-directory"]).toBe("publish");
     for (const policy of [clone, publish]) {
       expect(
         policy.startsWith(

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -80,6 +80,77 @@ function collectPages(entry: unknown, pages: string[] = []): string[] {
 }
 
 describe("docs-sync-publish", () => {
+  it("reuses only exact successful page checks and checks docs.json on warm runs", () => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mdx-cache-")));
+    try {
+      const checker = path.join(root, ".openclaw-sync", "check-docs-mdx.mts");
+      fs.mkdirSync(path.join(root, ".openclaw-sync", "lib"), { recursive: true });
+      for (const name of [
+        "check-docs-mdx.mts",
+        "lib/arg-utils.runtime.mjs",
+        "lib/mintlify-accordion.mjs",
+      ]) {
+        fs.copyFileSync(path.join("scripts", name), path.join(root, ".openclaw-sync", name));
+      }
+      fs.symlinkSync(
+        path.resolve("node_modules"),
+        path.join(root, ".openclaw-sync", "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(root, "node_modules"));
+      // Synthetic requested/installed lock inputs; dependency code stays in the
+      // read-only shared install. This fixture never runs npm.
+      for (const name of ["package.json", "package-lock.json", "node_modules/.package-lock.json"]) {
+        fs.writeFileSync(path.join(root, name), "{}\n");
+      }
+      fs.mkdirSync(path.join(root, "docs"));
+      const page = path.join(root, "docs", "a.md");
+      const config = path.join(root, "docs", "docs.json");
+      const cache = path.join(root, "cache.json");
+      const reportPath = path.join(root, "report.json");
+      fs.writeFileSync(page, "# A\n");
+      fs.writeFileSync(path.join(root, "docs", "b.mdx"), "# B\n");
+      fs.writeFileSync(config, "{}");
+      const run = (status = 0) => {
+        const result = spawnSync(
+          process.execPath,
+          [checker, "docs", "--cache-file", cache, "--json-out", reportPath],
+          { cwd: root, encoding: "utf8" },
+        );
+        expect(result.status, result.stderr).toBe(status);
+        return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+      };
+      expect(run().cacheHits).toBe(0);
+      expect(run().cacheHits).toBe(2);
+      const successful = fs.readFileSync(cache, "utf8");
+      fs.writeFileSync(page, "---\nsummary: functions.exec\n---\n# A\n");
+      expect(run(1).errors[0].type).toBe("poison-text");
+      expect(fs.readFileSync(cache, "utf8")).toBe(successful);
+      fs.writeFileSync(page, "# Changed\n");
+      expect(run().cacheHits).toBe(1);
+      fs.writeFileSync(config, '{"navigation":{"language":"unknown"}}');
+      expect(run(1)).toMatchObject({ cacheHits: 2, errors: [{ type: "docs-json" }] });
+      fs.writeFileSync(config, "{}");
+      fs.unlinkSync(page);
+      fs.renameSync(path.join(root, "docs", "b.mdx"), path.join(root, "docs", "b.MD"));
+      expect(run().cacheHits).toBe(0);
+      expect(Object.keys(JSON.parse(fs.readFileSync(cache, "utf8")).files)).toEqual(["docs/b.MD"]);
+      for (const name of [
+        ".openclaw-sync/check-docs-mdx.mts",
+        ".openclaw-sync/lib/mintlify-accordion.mjs",
+        "package-lock.json",
+        "node_modules/.package-lock.json",
+      ]) {
+        fs.appendFileSync(path.join(root, name), "\n");
+        expect(run().cacheHits).toBe(0);
+      }
+      fs.writeFileSync(cache, "{corrupt");
+      expect(run().cacheHits).toBe(0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("executes the copied MDX checker and shared anchor runtime closures", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-sync-runtime-"));
     const publishRoot = path.join(tempRoot, "publish");

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -91,6 +91,13 @@ function prepareDocsPublisher() {
       output,
     );
   }
+  fs.mkdirSync(path.join(target, "docs"));
+  fs.writeFileSync(path.join(target, "docs", "page.mdx"), "# Valid page\n");
+  fs.symlinkSync(
+    path.join(source, "node_modules"),
+    path.join(target, ".openclaw-sync", "node_modules"),
+    "junction",
+  );
 }
 
 function resolveRef(cwd, ref) {
@@ -446,7 +453,7 @@ async function command() {
     }
     return;
   }
-  if (["gh", "node", "pnpm", "go", "crabbox"].includes(mode)) {
+  if (["gh", "node", "npm", "pnpm", "go", "crabbox"].includes(mode)) {
     const cwd = insideOwnedPath(process.cwd());
     recordCommand(mode, cwd, args);
     if (options.performance && mode === "node") {
@@ -472,6 +479,20 @@ async function command() {
       process.exit(0);
     }
     await boundary(`consumer:${mode}`);
+    if (mode === "npm" && options.docsPublish) {
+      // Model npm ci's installed-lock output without downloading or modifying
+      // the real dependencies borrowed by the copied checker.
+      fs.mkdirSync(path.join(cwd, "node_modules"), { recursive: true });
+      fs.copyFileSync(
+        path.join(cwd, "package-lock.json"),
+        path.join(cwd, "node_modules", ".package-lock.json"),
+      );
+      process.exit(0);
+    }
+    if (mode === "node" && options.docsPublish && args[0] === ".openclaw-sync/check-docs-mdx.mts") {
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      process.exit(result.status ?? 1);
+    }
     if (mode === "node" && options.docsPublish && args[0] === "--input-type=module") {
       const validator =
         "import fs from 'node:fs'; " +
@@ -624,6 +645,19 @@ async function command() {
       ? JSON.parse(fs.readFileSync(treeCounter, "utf8")) + 1
       : 1;
     await boundary(`${operation}:${resultAttempt}`);
+    if (operation === "rebase" && options.env?.FIXTURE_DOCS_MDX_AFTER_REBASE) {
+      fs.writeFileSync(
+        path.join(cwd, "docs", "page.mdx"),
+        options.env.FIXTURE_DOCS_MDX_AFTER_REBASE,
+      );
+    }
+    if (
+      operation === "rebase" &&
+      resultAttempt === 2 &&
+      options.env?.FIXTURE_DOCS_LOCK_AFTER_REBASE
+    ) {
+      fs.appendFileSync(path.join(cwd, "package-lock.json"), "\n");
+    }
     publish("tree-attempt.json", attempt);
     await record(process.pid, "parent", attempt);
     if (operation === "clone" || operation === "worktree") {
@@ -1007,7 +1041,7 @@ async function supervise() {
   }
   const extraTools = [
     ...(linux ? ["find"] : []),
-    ...(options.docsPublish ? ["rm"] : []),
+    ...(options.docsPublish ? ["rm", "npm"] : []),
     ...(options.performance ? ["curl", "tar", "sha256sum", "npm"] : []),
     ...(options.docsAgent ? ["date"] : []),
     ...(options.consumers ? ["gh", "node", "pnpm", "go"] : []),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every docs synchronization recompiles all unchanged English and translated pages before publication. The production measurement in https://github.com/openclaw/openclaw/pull/142437 spent **2m20s checking 15,123 files** after a one-line copy edit and one concurrent documentation update.

Related build-side improvement: https://github.com/openclaw/docs/pull/177.

## Why This Change Was Made

Reuse successful page checks only when complete raw bytes, repository-relative path, checker/imported helpers, Node/runtime arguments, and requested/installed publisher dependency locks match. Always check `docs.json`; missing or damaged artifacts are cold checks. Failed runs preserve the previous success cache, and successful runs prune removed entries. Native Markdown/MDX format detection, poison-text checks, component-indentation checks, errors and the general `.mjs` entrypoint remain intact.

Move the publication check to **after the final rebase and before every push attempt**, so concurrent rebased content cannot bypass this check. Install the publisher's existing frozen npm graph there, reusing that install on retries unless the manifest or lock changes. The Node 24 workflow invokes the erasable `.mts` checker directly instead of adding a separate TypeScript loader/dependency graph.

The small disposable compiler artifact stays outside the publish Git tree. The repository's standard combined, SHA-pinned Actions cache is scoped to canonical `main` and saves only after job success. No cache-policy exception, application runtime store, database schema, or generic caching framework is introduced. Queueing, Git retry/ownership policy, and publication order are preserved.

## User Impact

After one successful cold run, unchanged documents do not get recompiled on each publication. Changed/new content and incompatible cache inputs still check normally. The first run and validator/toolchain changes remain cold. This changes the validation portion of deployment, not the entire merge-to-live duration.

## Evidence

- On the same **15,131-file local corpus**, cold validation took **59,724ms**; warm validation took **634ms**, with **15,131 hits and zero errors**. Process wall times were 59,852ms and 744ms; the artifact was 1,536,797 bytes. These exclude npm installation, cache transfer, queueing, and site build. The measured checker predates only final formatting/import ordering; the final copy was directly compared and its behavior tested. No hosted end-to-end ETA is claimed.
- A separate compiler-processor-reuse experiment was **61,622ms versus 61,674ms** and showed no benefit. That specialization was removed.
- Real copied-checker CLI proof covered raw-frontmatter poison, a single changed page, invalid `docs.json` despite warm page hits, renames/deletions, checker/helper/manifest/requested-lock/installed-lock changes, and corrupt-cache fallback.
- Executed the actual publication Python body with local Git/npm substitutes and the real checker: the old policy allowed one push for invalid post-rebase content; the new policy allowed **zero**. A push retry checked twice and installed once; a changed lock on retry installed twice. No production commands were used for these probes.
- The initial three owner-test files ran **636 passing tests, one cache-wiring policy failure, and 32 platform skips**. The failure led to the standard compiler-artifact action above, not a policy-test exemption. The final affected cache, docs-publication and Git-lifecycle cases passed: **27 tests**, with the other 642 tests intentionally filtered out rather than repeating the full six-minute owner suite. The cache guard itself was not weakened.
- Repository `check:changed` completed successfully: format, script erasability, script/root-test typechecking, lint and selected guards. Final workflow/test formatting and diff checks passed after the wiring simplification.
- Pinned actionlint and the configured zizmor audit passed for the final workflow. Fresh final independent autoreview was scoped-clean through P1, with no actionable findings.
- Hosted CI exposed a test-placement regression: adding filesystem work to the pure argument-parser test file moved it into the heavier tooling inventory, producing 81 planned jobs against the unchanged 80-job cap. The cache case now lives beside the existing publisher integration checks; the pure parser file is restored byte-for-byte. The cache/copied-checker cases passed (2 tests), and all three previously failing planner cases passed. No test was discarded and no planner limit/policy was changed.

- Exact-head hosted CI passed at `7eebac5e83291adad9286c0373b73c8e03fbe3e2`, including `openclaw/ci-gate`: [run 34271357253, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34271357253/attempts/2). One unchanged profiler argument-validation test timed out in attempt 1, then passed in 430ms on a single targeted job retry; its tooling group finished with 798 passed and 3 skipped. No profiler implementation, test timeout, or Windows CI behavior was changed to obtain this result. Passing jobs were retained, not rerun.

Plan: implementation, local performance/correctness proof, owner-boundary checks, documentation, review and hosted PR checks complete. No production workflow was manually dispatched or cancelled, and this PR is not merged.

### Review clarifications

- The serialized cache is a disposable compiler build artifact, not a user/application data model or SQLite schema. There is no existing durable state to migrate. Compatibility is a cold check for missing, corrupt or incompatible cache inputs; those cases and preserved no-cache CLI behavior are covered. No legacy-cache conversion path is needed.
- Hosted installation/cache-transfer/end-to-end costs are explicitly unmeasured. This PR claims the measured checker improvement only. A missing cache still performs all checks, so correctness does not depend on a particular speedup. Production timing can be collected after a separately authorized merge and successful cache-populating run; no live publication is required to substantiate a claim this PR does not make.
