### PR TITLE
fix(browser): report blocked and interrupted CLI actions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -110,7 +110,6 @@ extensions/browser/src/browser/system-profiles.ts	1
 extensions/browser/src/browser/test-port.ts	1
 extensions/browser/src/browser/unhandled-rejections.ts	2
 extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts	1
-extensions/browser/src/cli/browser-cli-actions-input/register.element.ts	2
 extensions/browser/src/cli/browser-cli-inspect.ts	2
 extensions/browser/src/cli/browser-cli-manage.ts	3
 extensions/browser/src/cli/browser-cli-shared.ts	1

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -301,7 +301,7 @@ Managed Chrome profiles save ordinary click-triggered downloads into the OpenCla
 
 If saving a download fails, OpenClaw requests cancellation of the transfer and reports the original save error. Correct the output path or filesystem problem before starting a new download.
 
-When an action opens a modal dialog, the action response returns `blockedByDialog` with `browserState.dialogs.pending`; pass `--dialog-id` to answer it directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
+When an action opens a modal dialog, text output reports the block and pending dialog IDs. The JSON response returns `blockedByDialog` with `browserState.dialogs.pending`; pass `--dialog-id` to answer it directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
 
 Batch actions:
 
@@ -312,6 +312,8 @@ openclaw browser batch --actions-file - --continue
 ```
 
 `openclaw browser batch` sends a `kind="batch"` `/act` request with nested `BrowserActRequest` actions (`wait`, `click`, `type`, `evaluate`, ...) — not `open`/`navigate`/`snapshot`/`screenshot`, which are CLI subcommands, not `/act` kinds. `--continue` sets `stopOnError=false` (default stops on first error); `--target-id` scopes the whole batch to one tab. A failed nested action makes the command exit nonzero; use `--json` to retain the ordered `results` response. See [Browser batch CLI](/tools/browser-control#browser-batch-cli) for the full contract (ref lifecycle, target id conflicts, error summary). `batch` is not supported on `profile="user"` / existing-session profiles.
+
+If navigation or a closed page stops the batch, text output reports the action number and skipped count. Take a fresh snapshot before continuing with dependent actions.
 
 `--actions-file` and `--actions-file -` stdin input are capped at 1,000,000 bytes. Split larger plans into multiple `openclaw browser batch` commands.
 

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.batch.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.batch.test.ts
@@ -1,5 +1,6 @@
 // Browser tests cover register.batch plugin behavior.
 import { Command } from "commander";
+import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as browserCliSharedModule from "../browser-cli-shared.js";
 import {
@@ -51,8 +52,7 @@ const SAMPLE_ACTIONS = [
 
 describe("browser action input batch command", () => {
   beforeEach(() => {
-    mocks.callBrowserRequest.mockClear();
-    mocks.readActionsPayload.mockClear();
+    vi.clearAllMocks();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
   });
 
@@ -130,6 +130,65 @@ describe("browser action input batch command", () => {
     ).rejects.toThrow("__exit__:1");
 
     expect(getBrowserCliRuntimeCapture().defaultRuntime.writeJson).toHaveBeenCalledWith(result);
+  });
+
+  it.each(["navigation", "closed"])("reports actions skipped after %s", async (reason) => {
+    const result = {
+      ok: true,
+      results: [{ ok: true }],
+      aborted: { reason, afterAction: 1, skipped: 1, url: "https://example.com/next" },
+    };
+    mocks.readActionsPayload.mockResolvedValueOnce(JSON.stringify(SAMPLE_ACTIONS));
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+    await createActionInputProgram().parseAsync(
+      ["browser", "batch", "--actions", JSON.stringify(SAMPLE_ACTIONS)],
+      { from: "user" },
+    );
+    const capture = getBrowserCliRuntimeCapture();
+    const text = capture.runtimeLogs.join("\n");
+    expect(text).toContain("stopped after action 1");
+    expect(text).toContain("1 action(s) skipped");
+    expect(text).not.toContain("batch ran 2");
+    expect(capture.defaultRuntime.exit).not.toHaveBeenCalled();
+
+    capture.resetRuntimeCapture();
+    vi.clearAllMocks();
+    mocks.readActionsPayload.mockResolvedValueOnce(JSON.stringify(SAMPLE_ACTIONS));
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+    await createActionInputProgram().parseAsync(
+      ["browser", "--json", "batch", "--actions", JSON.stringify(SAMPLE_ACTIONS)],
+      { from: "user" },
+    );
+    expect(capture.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(result);
+    expect(capture.runtimeLogs).toEqual([JSON.stringify(result, null, 2)]);
+  });
+
+  it("retains the child error and interruption when an action fails during navigation", async () => {
+    const result = {
+      ok: true,
+      results: [{ ok: false, error: "Synthetic failure" }],
+      aborted: {
+        reason: "navigation",
+        afterAction: 1,
+        skipped: 1,
+        url: "https://example.com/next",
+      },
+    };
+    mocks.readActionsPayload.mockResolvedValueOnce(JSON.stringify(SAMPLE_ACTIONS));
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+    vi.mocked(cliCoreApiModule.defaultRuntime.exit).mockImplementationOnce(
+      createNonExitingRuntime().exit,
+    );
+    await expect(
+      createActionInputProgram().parseAsync(
+        ["browser", "batch", "--actions", JSON.stringify(SAMPLE_ACTIONS)],
+        { from: "user" },
+      ),
+    ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+    const capture = getBrowserCliRuntimeCapture();
+    expect(capture.runtimeErrors).toEqual(["batch failed: action 1: Synthetic failure"]);
+    expect(capture.runtimeLogs.join("\n")).toContain("1 action(s) skipped");
+    expect(capture.runtimeLogs.join("\n")).not.toContain("batch ran");
   });
 
   it("reads actions from a file via --actions-file", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.batch.ts
@@ -4,14 +4,13 @@
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { BrowserActRequest } from "../../browser/client-actions.types.js";
-import { BROWSER_TAB_REFERENCE_HELP, type BrowserParentOpts } from "../browser-cli-shared.js";
-import { danger, defaultRuntime } from "../core-api.js";
 import {
-  callBrowserAct,
-  logBrowserActionResult,
-  readActionsPayload,
-  resolveBrowserActionContext,
-} from "./shared.js";
+  BROWSER_TAB_REFERENCE_HELP,
+  runBrowserCliCommand,
+  type BrowserParentOpts,
+} from "../browser-cli-shared.js";
+import { danger, defaultRuntime } from "../core-api.js";
+import { runBrowserAction, readActionsPayload, resolveBrowserActionContext } from "./shared.js";
 
 /** Registers the Browser CLI batch command. */
 export function registerBrowserBatchCommands(
@@ -37,9 +36,7 @@ export function registerBrowserBatchCommands(
         defaultRuntime.exit(1);
         return;
       }
-      let actions: unknown[];
-      let result: { results?: Array<{ ok: boolean; error?: string }> };
-      try {
+      await runBrowserCliCommand(async () => {
         const payload = await readActionsPayload({
           actions: opts.actions,
           actionsFile: opts.actionsFile,
@@ -59,41 +56,20 @@ export function registerBrowserBatchCommands(
         if (!parsed.length) {
           throw new Error("actions must contain at least one entry");
         }
-        actions = parsed;
+        const actions = parsed;
         const targetId = normalizeOptionalString(opts.targetId);
-        const body: Record<string, unknown> = {
+        const request = {
           kind: "batch",
           actions,
           ...(targetId ? { targetId } : {}),
           ...(opts.continue ? { stopOnError: false } : {}),
-        };
-        const request = body as unknown as BrowserActRequest;
-        result = await callBrowserAct<{
-          results?: Array<{ ok: boolean; error?: string }>;
-        }>({
+        } as BrowserActRequest;
+        await runBrowserAction({
           parent,
           profile,
           body: request,
+          successMessage: `batch ran ${actions.length} action(s)`,
         });
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-        return;
-      }
-      const failures = (result.results ?? []).flatMap((entry, index) =>
-        entry.ok ? [] : [`action ${index + 1}: ${entry.error ?? "failed"}`],
-      );
-      // /act represents recoverable child errors in a successful response.
-      // Surface them as a command failure so text-mode scripts do not report a false success.
-      if (failures.length) {
-        if (parent?.json) {
-          defaultRuntime.writeJson(result);
-        } else {
-          defaultRuntime.error(danger(`batch failed: ${failures.join("; ")}`));
-        }
-        defaultRuntime.exit(1);
-        return;
-      }
-      logBrowserActionResult(parent, result, `batch ran ${actions.length} action(s)`);
+      });
     });
 }

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
@@ -7,17 +7,13 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
+  runBrowserCliCommand,
   parseBrowserNonNegativeIntegerOption,
   parseBrowserPositiveIntegerOption,
   type BrowserParentOpts,
 } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
-import {
-  callBrowserAct,
-  logBrowserActionResult,
-  requireRef,
-  resolveBrowserActionContext,
-} from "./shared.js";
+import { runBrowserAction, requireRef, resolveBrowserActionContext } from "./shared.js";
 
 function parseBrowserMouseButtonOption(value: string): "left" | "right" | "middle" {
   if (value === "left" || value === "right" || value === "middle") {
@@ -57,24 +53,17 @@ export function registerBrowserElementCommands(
   const runElementAction = async (params: {
     cmd: Command;
     body: BrowserActRequest;
-    successMessage: string | ((result: unknown) => string);
+    successMessage: string | ((result: { url?: string }) => string);
   }): Promise<void> => {
     const { parent, profile } = resolveBrowserActionContext(params.cmd, parentOpts);
-    try {
-      const result = await callBrowserAct({
+    await runBrowserCliCommand(async () => {
+      await runBrowserAction({
         parent,
         profile,
         body: params.body,
+        successMessage: params.successMessage,
       });
-      const successMessage =
-        typeof params.successMessage === "function"
-          ? params.successMessage(result)
-          : params.successMessage;
-      logBrowserActionResult(parent, result, successMessage);
-    } catch (err) {
-      defaultRuntime.error(danger(String(err)));
-      defaultRuntime.exit(1);
-    }
+    });
   };
 
   browser
@@ -107,7 +96,7 @@ export function registerBrowserElementCommands(
           modifiers,
         },
         successMessage: (result) => {
-          const url = (result as { url?: unknown }).url;
+          const url = result.url;
           const suffix = typeof url === "string" && url ? ` on ${url}` : "";
           return `clicked ref ${refValue}${suffix}`;
         },
@@ -143,7 +132,7 @@ export function registerBrowserElementCommands(
           delayMs: Number.isFinite(opts.delayMs) ? opts.delayMs : undefined,
         },
         successMessage: (result) => {
-          const url = (result as { url?: unknown }).url;
+          const url = result.url;
           const suffix = typeof url === "string" && url ? ` on ${url}` : "";
           return `clicked ${x},${y}${suffix}`;
         },

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -282,4 +282,57 @@ describe("browser action input evaluate command", () => {
     ).rejects.toThrow("--timeout-ms must be a positive integer.");
     expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
   });
+
+  it.each([false, 0, "", null, undefined])("preserves the successful value %j", async (value) => {
+    mocks.callBrowserRequest.mockResolvedValueOnce({ ok: true, result: value });
+    await createActionInputProgram().parseAsync(["browser", "evaluate", "--fn", "() => 0"], {
+      from: "user",
+    });
+    expect(getBrowserCliRuntimeCapture().defaultRuntime.writeJson).toHaveBeenCalledWith(
+      value ?? null,
+    );
+  });
+});
+
+describe("browser action dialog outcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it.each([
+    ["evaluate", "--fn", "() => confirm('Continue?')"],
+    ["press", "Enter"],
+    ["fill", "--fields", '[{"ref":"name","value":"Ada"}]'],
+    ["wait", "--fn", "() => confirm('Continue?')"],
+    ["batch", "--actions", '[{"kind":"press","key":"Enter"}]'],
+  ])("reports a pending dialog for %s", async (...args) => {
+    const result = {
+      ok: true,
+      blockedByDialog: true,
+      browserState: {
+        dialogs: {
+          pending: [{ id: "d1", type: "confirm", message: "Page content stays in JSON output" }],
+          recent: [],
+        },
+      },
+    };
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+    await createActionInputProgram().parseAsync(["browser", ...args], { from: "user" });
+    const capture = getBrowserCliRuntimeCapture();
+    const text = capture.runtimeLogs.join("\n");
+    expect(text).toContain("blocked by a modal dialog");
+    expect(text).toContain('"d1"');
+    expect(text).toContain("--dialog-id");
+    expect(text).not.toContain("Page content stays in JSON output");
+    expect(capture.defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(capture.defaultRuntime.exit).not.toHaveBeenCalled();
+
+    capture.resetRuntimeCapture();
+    vi.clearAllMocks();
+    mocks.callBrowserRequest.mockResolvedValueOnce(result);
+    await createActionInputProgram().parseAsync(["browser", "--json", ...args], { from: "user" });
+    expect(capture.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(result);
+    expect(capture.runtimeLogs).toEqual([JSON.stringify(result, null, 2)]);
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -6,17 +6,13 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
+  runBrowserCliCommand,
   parseBrowserNonNegativeIntegerOption,
   parseBrowserPositiveIntegerOption,
   type BrowserParentOpts,
 } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
-import {
-  callBrowserAct,
-  logBrowserActionResult,
-  readFields,
-  resolveBrowserActionContext,
-} from "./shared.js";
+import { runBrowserAction, readFields, resolveBrowserActionContext } from "./shared.js";
 
 type BrowserWaitLoadState = "load" | "domcontentloaded" | "networkidle";
 
@@ -47,12 +43,12 @@ export function registerBrowserFormWaitEvalCommands(
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .action(async (opts, cmd) => {
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
-      try {
+      await runBrowserCliCommand(async () => {
         const fields = await readFields({
           fields: opts.fields,
           fieldsFile: opts.fieldsFile,
         });
-        const result = await callBrowserAct<{ result?: unknown }>({
+        await runBrowserAction({
           parent,
           profile,
           body: {
@@ -60,12 +56,9 @@ export function registerBrowserFormWaitEvalCommands(
             fields,
             targetId: normalizeOptionalString(opts.targetId),
           },
+          successMessage: `filled ${fields.length} field(s)`,
         });
-        logBrowserActionResult(parent, result, `filled ${fields.length} field(s)`);
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
+      });
     });
 
   browser
@@ -88,7 +81,7 @@ export function registerBrowserFormWaitEvalCommands(
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .action(async (selector: string | undefined, opts, cmd) => {
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
-      try {
+      await runBrowserCliCommand(async () => {
         const sel = normalizeOptionalString(selector);
         const load = parseBrowserWaitLoadState(opts.load);
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
@@ -109,16 +102,13 @@ export function registerBrowserFormWaitEvalCommands(
           targetId: normalizeOptionalString(opts.targetId),
           timeoutMs,
         };
-        const result = await callBrowserAct<{ result?: unknown }>({
+        await runBrowserAction({
           parent,
           profile,
           body: request,
+          successMessage: "wait complete",
         });
-        logBrowserActionResult(parent, result, "wait complete");
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
+      });
     });
 
   browser
@@ -142,9 +132,9 @@ export function registerBrowserFormWaitEvalCommands(
         defaultRuntime.exit(1);
         return;
       }
-      try {
+      await runBrowserCliCommand(async () => {
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
-        const result = await callBrowserAct<{ result?: unknown }>({
+        await runBrowserAction({
           parent,
           profile,
           body: {
@@ -155,14 +145,6 @@ export function registerBrowserFormWaitEvalCommands(
             timeoutMs,
           },
         });
-        if (parent?.json) {
-          defaultRuntime.writeJson(result);
-          return;
-        }
-        defaultRuntime.writeJson(result.result ?? null);
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
+      });
     });
 }

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -4,16 +4,24 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { FsSafeError, readRegularFile } from "openclaw/plugin-sdk/security-runtime";
+import { asRecord, readStringField } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveBrowserActRequestTimeoutMs } from "../../browser/act-policy.js";
+import type { browserAct } from "../../browser/client-actions-core.js";
 import type { BrowserActRequest, BrowserFormField } from "../../browser/client-actions.types.js";
 import { normalizeBrowserFormFields } from "../../browser/form-fields.js";
-import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import {
+  callBrowserRequest,
+  printBrowserJsonResult,
+  type BrowserParentOpts,
+} from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
 
 type BrowserActionContext = {
   parent: BrowserParentOpts;
   profile: string | undefined;
 };
+
+type BrowserActionResult = Awaited<ReturnType<typeof browserAct>>;
 
 /** Resolves inherited Browser action context from a commander command. */
 export function resolveBrowserActionContext(
@@ -25,13 +33,14 @@ export function resolveBrowserActionContext(
   return { parent, profile };
 }
 
-/** Calls the Browser /act route for one CLI action body. */
-export async function callBrowserAct<T = unknown>(params: {
+/** Execute and present an action, preserving recorded interruptions and child failures. */
+export async function runBrowserAction(params: {
   parent: BrowserParentOpts;
   profile?: string;
   body: BrowserActRequest;
-}): Promise<T> {
-  return await callBrowserRequest<T>(
+  successMessage?: string | ((result: BrowserActionResult) => string);
+}): Promise<void> {
+  const result = await callBrowserRequest<BrowserActionResult>(
     params.parent,
     {
       method: "POST",
@@ -41,19 +50,43 @@ export async function callBrowserAct<T = unknown>(params: {
     },
     { timeoutMs: resolveBrowserActRequestTimeoutMs(params.body) },
   );
-}
-
-/** Writes Browser action output as JSON or a terse success message. */
-export function logBrowserActionResult(
-  parent: BrowserParentOpts,
-  result: unknown,
-  successMessage: string,
-) {
-  if (parent?.json) {
-    defaultRuntime.writeJson(result);
-    return;
+  const { parent, successMessage } = params;
+  const failures = (result.results ?? []).flatMap((entry, index) =>
+    entry.ok ? [] : [`action ${index + 1}: ${entry.error ?? "failed"}`],
+  );
+  if (!printBrowserJsonResult(parent, result)) {
+    if (failures.length) {
+      defaultRuntime.error(danger(`batch failed: ${failures.join("; ")}`));
+    }
+    if (result.blockedByDialog) {
+      const pending = asRecord(asRecord(result.browserState).dialogs).pending;
+      const ids = Array.isArray(pending)
+        ? pending.flatMap((dialog) => {
+            const id = readStringField(asRecord(dialog), "id");
+            return id ? [JSON.stringify(id)] : [];
+          })
+        : [];
+      defaultRuntime.log(
+        `Action blocked by a modal dialog${ids.length ? ` (${ids.join(", ")})` : ""}. Use openclaw browser dialog --accept or --dismiss${ids.length ? " --dialog-id <id>" : ""} to continue.`,
+      );
+    } else if (result.aborted) {
+      const { reason, afterAction, skipped } = result.aborted;
+      defaultRuntime.log(
+        `Batch stopped after action ${afterAction}: page ${reason === "navigation" ? "navigated" : "closed"}; ${skipped} action(s) skipped. Take a fresh snapshot before continuing.`,
+      );
+    } else if (!failures.length) {
+      if (successMessage !== undefined) {
+        defaultRuntime.log(
+          typeof successMessage === "function" ? successMessage(result) : successMessage,
+        );
+      } else {
+        defaultRuntime.writeJson(result.result ?? null);
+      }
+    }
   }
-  defaultRuntime.log(successMessage);
+  if (failures.length) {
+    defaultRuntime.exit(1);
+  }
 }
 
 /** Requires and trims an element ref, exiting through the CLI runtime on failure. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running browser CLI actions would see `null` or a success message when a modal dialog blocked the action, or when navigation or page closure stopped a batch before its remaining actions ran.

## Why This Change Was Made

One shared CLI action runner now presents the outcomes already recorded by the browser: pending dialog IDs, interrupted batches, and failed child actions. This removes parallel output paths and repeated error handling, with 20 fewer production lines. Browser execution, request deadlines, and protocol behavior are unchanged.

## User Impact

Users can identify a pending dialog and see how many batch actions were skipped before deciding what to do next. Successful action messages, primitive evaluate values, and complete `--json` output are preserved. Failed batch children still exit nonzero; a failure combined with navigation reports both the error and skipped actions.

## Evidence

| Actual scenario | Before | After |
| --- | --- | --- |
| Evaluate opens a confirm dialog | `null` | Reports the blocked action, dialog ID, and accept/dismiss guidance |
| Press opens a confirm dialog | `pressed Enter` | Reports the blocked action and dialog ID |
| First batch action reloads or closes its page | `batch ran 2 action(s)` | Reports the stop after action 1 and one skipped action |
| First batch action fails while reloading | Child error only, exit 1 | Child error plus skipped count, exit 1 |

- Eight regression assertions fail against the original code. All 83 focused tests pass, including CLI registration, JSON output, primitive values, failed-child exit behavior, and lazy loading.
- Ten scenarios pass before and after through isolated Chromium, a local synthetic page, the actual CLI parser, and the real `/act` and `/hooks/dialog` HTTP routes. Returned dialog IDs were answered through the real route. The fixture adapts Gateway transport to loopback HTTP; this is not a full installed-Gateway end-to-end claim. Independent modal cases use fresh pages and do not claim sequential dialog lifecycle behavior.
- Required changed-scope checks pass, including extension production/test typechecks, lint, formatting, boundaries, and import-cycle guards. The assertion baseline shrinks by the exact entry for two removed element casts.
- Independent P0–P2 review found no actionable issues. Current-main qualification found the browser output owners and dependency pins unchanged; newer, disjoint baseline reductions are preserved by the normal merge.
