### PR TITLE
fix(sessions): avoid premature daily resets before daylight-saving gaps

### DIFF
--- a/src/config/sessions/reset-policy.test.ts
+++ b/src/config/sessions/reset-policy.test.ts
@@ -1,5 +1,6 @@
 // Session reset policy tests cover defaults, opt-in schedules, and compatibility overrides.
 import { describe, expect, it } from "vitest";
+import { execNodeEvalSync } from "../../test-utils/node-process.js";
 import { SessionSchema } from "../zod-schema.session.js";
 import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset-policy.js";
 import { resolveChannelResetConfig } from "./reset.js";
@@ -54,6 +55,98 @@ describe("session reset policy", () => {
       evaluateSessionFreshness({ updatedAt: startedAt, sessionStartedAt: startedAt, now, policy }),
     ).toMatchObject({ fresh: false, staleReason: "daily" });
   });
+
+  it.each([
+    {
+      name: "before New York's spring gap",
+      timezone: "America/New_York",
+      now: "2027-03-14T06:00:00Z",
+      startedAt: "2027-03-13T07:30:00Z",
+      atHour: 2,
+      boundary: "2027-03-13T07:00:00Z",
+      fresh: true,
+    },
+    {
+      name: "before Lord Howe's half-hour spring gap",
+      timezone: "Australia/Lord_Howe",
+      now: "2026-10-03T14:30:00Z",
+      startedAt: "2026-10-02T15:45:00Z",
+      atHour: 2,
+      boundary: "2026-10-02T15:30:00Z",
+      fresh: true,
+    },
+    {
+      name: "after New York's spring gap",
+      timezone: "America/New_York",
+      now: "2027-03-14T07:15:00Z",
+      startedAt: "2027-03-14T06:30:00Z",
+      atHour: 2,
+      boundary: "2027-03-14T07:00:00Z",
+      fresh: false,
+    },
+    {
+      name: "the day after New York's spring gap",
+      timezone: "America/New_York",
+      now: "2027-03-15T05:00:00Z",
+      startedAt: "2027-03-14T07:30:00Z",
+      atHour: 2,
+      boundary: "2027-03-14T07:00:00Z",
+      fresh: true,
+    },
+    {
+      name: "during New York's repeated hour",
+      timezone: "America/New_York",
+      now: "2026-11-01T06:15:00Z",
+      startedAt: "2026-11-01T05:30:00Z",
+      atHour: 1,
+      boundary: "2026-11-01T05:00:00Z",
+      fresh: true,
+    },
+    {
+      name: "before an ordinary UTC reset",
+      timezone: "UTC",
+      now: "2027-03-14T01:00:00Z",
+      startedAt: "2027-03-13T02:30:00Z",
+      atHour: 2,
+      boundary: "2027-03-13T02:00:00Z",
+      fresh: true,
+    },
+    {
+      name: "before Nuuk's spring gap crosses midnight",
+      timezone: "America/Nuuk",
+      now: "2027-03-28T00:30:00Z",
+      startedAt: "2027-03-27T01:30:00Z",
+      atHour: 23,
+      boundary: "2027-03-27T01:00:00Z",
+      fresh: true,
+    },
+    {
+      name: "after Troll's two-hour fold rewinds past the reset hour",
+      timezone: "Antarctica/Troll",
+      now: "2026-10-25T01:30:00Z",
+      startedAt: "2026-10-24T23:30:00Z",
+      atHour: 2,
+      boundary: "2026-10-25T00:00:00Z",
+      fresh: false,
+    },
+  ])(
+    "uses the configured local reset hour $name",
+    ({ timezone, now, startedAt, atHour, boundary, fresh }) => {
+      // Native Date captures the host timezone in each process; Vitest workers
+      // cannot reliably change it through a late process.env.TZ assignment.
+      const output = execNodeEvalSync(
+        `import { evaluateSessionFreshness } from ${JSON.stringify(new URL("./reset-policy.ts", import.meta.url).href)};
+       console.log(JSON.stringify(evaluateSessionFreshness(${JSON.stringify({
+         updatedAt: Date.parse(startedAt),
+         sessionStartedAt: Date.parse(startedAt),
+         now: Date.parse(now),
+         policy: { mode: "daily", atHour },
+       })})));`,
+        { env: { ...process.env, TZ: timezone }, timeout: 10_000 },
+      );
+      expect(JSON.parse(output)).toMatchObject({ fresh, dailyResetAt: Date.parse(boundary) });
+    },
+  );
 
   it.each([
     {

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -25,14 +25,11 @@ const DEFAULT_IDLE_MINUTES = 0;
 
 /** Returns the most recent daily reset boundary for the supplied wall-clock time. */
 function resolveDailyResetAtMs(now: number, atHour: number): number {
-  const normalizedAtHour = normalizeResetAtHour(atHour);
-  const resetAt = new Date(now);
-  resetAt.setHours(normalizedAtHour, 0, 0, 0);
-  if (now < resetAt.getTime()) {
-    // Before today's reset hour, the active reset boundary is yesterday's scheduled reset.
-    resetAt.setDate(resetAt.getDate() - 1);
-  }
-  return resetAt.getTime();
+  const hour = normalizeResetAtHour(atHour);
+  const today = new Date(now).setHours(hour, 0, 0, 0);
+  // Resolve each calendar day's authored hour from now; reusing today's date
+  // can carry a spring-forward adjustment into yesterday.
+  return now < today ? new Date(now).setHours(hour - 24, 0, 0, 0) : today;
 }
 
 /** Resolves the effective reset policy for direct, group, or thread sessions. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`, so maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users with a daily session reset configured during a spring daylight-saving gap could lose their conversation context before that day's reset.

For example, with a 2 AM reset in New York, checking freshness at 1 AM on the spring transition day incorrectly uses yesterday's 3 AM boundary. A session started yesterday at 2:30 AM is then considered stale, although it began after the configured reset.

## Why This Change Was Made

Resolve each day's configured local hour independently from the original time, removing the mutable date rewrite that carried today's DST adjustment into yesterday. Keep the comparison between actual instants so a repeated hour cannot hide a reset that already occurred.

## User Impact

Explicit daily reset schedules retain fresh sessions through spring transitions, including half-hour gaps and gaps that cross midnight. Repeated-hour and ordinary-day reset behavior remains consistent.

## Evidence

- Three regression cases fail on the original code: New York, Lord Howe, and Nuuk spring gaps. Five ordinary, repeated-hour, and next-day controls pass.
- All 30 tests pass with the repair: `node scripts/run-vitest.mjs src/config/sessions/reset-policy.test.ts src/config/sessions/entry-freshness.test.ts` on Node 24.19.0.
- Native subprocesses set the host timezone at startup and call the exported freshness function. Coverage includes Troll's two-hour fall-back across an already-observed reset hour.
- Core production and test typechecks, targeted lint/format, and the remaining selected changed-scope guards pass. Independent P2 review is clean.
- Production code decreases by three lines; regression coverage adds 93 test lines. Proof covers the freshness boundary and existing session-entry tests; no live session rollover was exercised.
