### PR TITLE
fix(a2a): honor stable peer bindings for inbound tasks

### DIFF
--- a/docs/channels/a2a.md
+++ b/docs/channels/a2a.md
@@ -161,6 +161,10 @@ Each authenticated peer and A2A `contextId` pair gets its own agent session. A2A
 isolated direct-message scope rather than inheriting `session.dmScope`, so remote peer content never
 joins the operator's main session and one peer cannot read another peer's conversation history.
 
+For agent bindings, use the configured peer name as the canonical direct-peer ID, such as
+`hermes`. A context-specific `hermes:<contextId>` binding takes precedence over that stable peer
+binding, and the stable peer binding takes precedence over broader A2A account or channel routes.
+
 ## Security
 
 Agent Card discovery is intentionally public: anyone who can reach the gateway can read the instance description and exposed agent IDs. Use `exposeAgents` to limit disclosure, and expose the gateway through HTTPS when it is reachable over an untrusted network.

--- a/extensions/a2a/src/inbound.test.ts
+++ b/extensions/a2a/src/inbound.test.ts
@@ -157,6 +157,76 @@ describe("A2A channel inbound dispatch", () => {
     fixture.store.stop();
   });
 
+  it("routes a stable peer binding before account fallback while preserving exact context overrides", async () => {
+    const fixture = createA2aInboundFixture();
+    const exactTask = fixture.store.create("ctx-exact", "hermes");
+    fixture.store.start(exactTask.id);
+    vi.mocked(fixture.runtime.channel.inbound.dispatch).mockImplementation(async (turn) => ({
+      admission: { kind: "dispatch" },
+      dispatched: true,
+      ctxPayload: turn.ctxPayload,
+      routeSessionKey: turn.route.sessionKey,
+      dispatchResult: createA2aDispatchResult(false),
+    }));
+    const config = {
+      agents: {
+        entries: {
+          main: {},
+          a2a_restricted: {},
+          a2a_context: {},
+        },
+      },
+      bindings: [
+        {
+          type: "route" as const,
+          agentId: "a2a_context",
+          match: {
+            channel: "a2a",
+            accountId: "default",
+            peer: { kind: "direct" as const, id: "hermes:ctx-exact" },
+          },
+        },
+        {
+          type: "route" as const,
+          agentId: "a2a_restricted",
+          match: {
+            channel: "a2a",
+            accountId: "default",
+            peer: { kind: "direct" as const, id: "hermes" },
+          },
+        },
+        {
+          type: "route" as const,
+          agentId: "main",
+          match: { channel: "a2a", accountId: "default" },
+        },
+      ],
+    };
+
+    try {
+      await dispatchA2aInbound({ ...fixture.params, config });
+      await dispatchA2aInbound({
+        ...fixture.params,
+        config,
+        taskId: exactTask.id,
+        contextId: exactTask.contextId,
+        messageId: "exact-message",
+      });
+
+      const dispatches = vi.mocked(fixture.runtime.channel.inbound.dispatch).mock.calls;
+      expect(dispatches.map(([turn]) => turn.route.agentId)).toEqual([
+        "a2a_restricted",
+        "a2a_context",
+      ]);
+      expect(dispatches.map(([turn]) => turn.route.sessionKey)).toEqual([
+        "agent:a2a_restricted:a2a:default:direct:hermes:ctx-inbound",
+        "agent:a2a_context:a2a:default:direct:hermes:ctx-exact",
+      ]);
+    } finally {
+      fixture.store.stop();
+    }
+  });
+
   it("rejects a sender missing from the configured peer allowlist before dispatch", async () => {
     const fixture = createA2aInboundFixture("unknown-peer");
 

--- a/extensions/a2a/src/inbound.ts
+++ b/extensions/a2a/src/inbound.ts
@@ -36,6 +36,7 @@ export async function dispatchA2aInbound(params: A2aInboundDispatchParams): Prom
       channel: "a2a",
       accountId: params.account.accountId,
       peer: { kind: "direct", id: `${params.peerName}:${params.contextId}` },
+      parentPeer: { kind: "direct", id: params.peerName },
       // Untrusted remote peers must never land in the operator's main session,
       // so A2A pins the most isolated scope instead of inheriting session.dmScope.
       // The peer id embeds the A2A contextId, giving one session per peer+context.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators routing an authenticated A2A peer to a dedicated agent could see inbound tasks fall through to a broader account route when the task used a conversation context ID.

## Why This Change Was Made

Inbound A2A routing now carries the configured peer name as the stable parent identity while retaining the peer-and-context identity for exact routing and session isolation. This uses the existing route precedence instead of changing configuration or resolver behavior.

## User Impact

Peer-specific A2A bindings now reliably select the intended agent before account or channel fallbacks. Exact context-specific bindings still take precedence, and every peer/context pair keeps its isolated session.

## Evidence

- Added a regression that failed before the fix because the stable peer routed to the account fallback while the exact-context route worked.
- `node scripts/run-vitest.mjs extensions/a2a/src/inbound.test.ts` — 12 tests passed.
- `pnpm test:extension a2a` — 107 tests passed across 7 files.
- Repository-selected formatting, extension typecheck, lint, plugin-boundary, contract, dead-export, dependency-policy, and import-cycle checks passed for the changed paths.
- An isolated loopback HTTP proof on exact head `6dd85c0ffe4` used synthetic credentials with the real A2A HTTP handler, Gateway HTTP admission, inbound adapter, route resolver, and task store (only downstream agent execution was stubbed). A wrong bearer returned 401; the stable peer request returned 200 and selected `a2a_restricted` with session `agent:a2a_restricted:a2a:default:direct:hermes:ctx-stable`; the exact-context request returned 200 and selected `a2a_context` with session `agent:a2a_context:a2a:default:direct:hermes:ctx-exact`.
