### PR TITLE
perf(ui): reuse speaker metadata during chat export

### DIFF
--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -28,7 +28,7 @@ import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
 import { projectImportedMessageForDisplay } from "./imported-message-display.ts";
 import { normalizeAttachmentContentBlock } from "./message-normalizer-attachments.ts";
-import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
+import { formatSenderLabel, normalizeSenderIdentity, type SenderIdentity } from "./sender-label.ts";
 
 // Keep legacy labels readable without treating their UUID suffix as profile evidence.
 const OPAQUE_ID_LABEL_SUFFIX_RE =
@@ -131,6 +131,34 @@ export function resolveMessageRole(message: unknown): string {
   return hasToolContent || hasToolMessageEnvelope(m)
     ? "toolResult"
     : (readStringField(m, "role") ?? "unknown");
+}
+
+function resolveMessageSender(
+  metadata: Record<string, unknown> | undefined,
+): SenderIdentity | null {
+  const identity = readTranscriptSenderIdentity(metadata?.senderIdentity);
+  return normalizeSenderIdentity({
+    identity,
+    id: metadata?.senderId,
+    name: metadata?.senderName,
+    username: metadata?.senderUsername,
+    profileAvatarUrl: identity?.type === "profile" ? metadata?.senderProfileAvatarUrl : undefined,
+  });
+}
+
+export function resolveMessageSenderLabel(
+  message: unknown,
+  sender?: SenderIdentity | null,
+): string | null {
+  const m = asOptionalRecord(message);
+  const rawLabel = readStringField(m, "senderLabel")?.trim() ?? "";
+  if (rawLabel) {
+    return rawLabel.replace(OPAQUE_ID_LABEL_SUFFIX_RE, "").trim();
+  }
+  // Full normalization already prepared the sender; null is a known absence.
+  return formatSenderLabel(
+    sender === undefined ? resolveMessageSender(asOptionalRecord(m?.["__openclaw"])) : sender,
+  );
 }
 
 export function isToolResultMessage(message: unknown): boolean {
@@ -569,19 +597,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const replyPreviewRecord = asOptionalRecord(openClawMeta?.replyToPreview);
   const replyPreviewText = readStringField(replyPreviewRecord, "text")?.trim() ?? "";
   const replyPreviewSender = readStringField(replyPreviewRecord, "senderLabel")?.trim() ?? "";
-  const identity = readTranscriptSenderIdentity(openClawMeta?.senderIdentity);
-  const metaSender = normalizeSenderIdentity({
-    identity,
-    id: openClawMeta?.senderId,
-    name: openClawMeta?.senderName,
-    username: openClawMeta?.senderUsername,
-    profileAvatarUrl:
-      identity?.type === "profile" ? openClawMeta?.senderProfileAvatarUrl : undefined,
-  });
-  const rawLabel = readStringField(m, "senderLabel")?.trim() ?? "";
-  const senderLabel = rawLabel
-    ? rawLabel.replace(OPAQUE_ID_LABEL_SUFFIX_RE, "").trim()
-    : formatSenderLabel(metaSender);
+  const metaSender = resolveMessageSender(openClawMeta);
+  const senderLabel = resolveMessageSenderLabel(m, metaSender);
   const sender = metaSender ?? (senderLabel ? { name: senderLabel } : null);
 
   content = stripMessageDisplayMetadata(content);

--- a/ui/src/pages/chat/export.test.ts
+++ b/ui/src/pages/chat/export.test.ts
@@ -69,4 +69,55 @@ describe("exportChatMarkdown", () => {
         "## Tool\n\nexit 0\n",
     );
   });
+
+  it.each([
+    {
+      name: "empty string tool envelope",
+      message: { role: "assistant", toolCallId: "", content: "Visible body" },
+      speaker: "Tool",
+    },
+    {
+      name: "tool content inside a user message",
+      message: {
+        role: "user",
+        content: [null, { type: "text", text: "Visible body" }, { type: "tool_result" }],
+      },
+      speaker: "Tool",
+    },
+    {
+      name: "non-string tool envelope",
+      message: { role: "assistant", toolCallId: 0, content: "Visible body" },
+      speaker: "OpenClaw",
+    },
+  ])("keeps canonical speaker classification for $name", ({ message, speaker }) => {
+    expect(buildChatMarkdown([message], "OpenClaw")).toBe(
+      `# Chat with OpenClaw\n\n## ${speaker}\n\nVisible body\n`,
+    );
+  });
+
+  it.each(["string", "blocks", "text"])(
+    "preserves imported %s content and explicit attribution independently of display normalization",
+    (shape) => {
+      const body = "    indented code\n\nMEDIA:https://example.invalid/report.pdf";
+      const framed =
+        '<<<EXTERNAL_UNTRUSTED_CONTENT id="1234567890abcdef">>>\nSource: External\n---\n' +
+        body +
+        '\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id="1234567890abcdef">>>';
+      const message = {
+        role: "assistant",
+        senderLabel: "Imported assistant (123e4567-e89b-12d3-a456-426614174000)",
+        __openclaw: { idempotencyKey: "fixture-catalog:thread:message", senderName: "Other name" },
+        timestamp: "1000",
+        ...(shape === "text"
+          ? { text: framed }
+          : { content: shape === "blocks" ? [{ type: "output_text", text: framed }] : framed }),
+      };
+      const original = structuredClone(message);
+
+      expect(buildChatMarkdown([message], "OpenClaw")).toBe(
+        `# Chat with OpenClaw\n\n## Imported assistant\n\n${body}\n`,
+      );
+      expect(message).toEqual(original);
+    },
+  );
 });

--- a/ui/src/pages/chat/export.ts
+++ b/ui/src/pages/chat/export.ts
@@ -1,7 +1,11 @@
 // Control UI chat module implements export behavior.
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
-import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import {
+  normalizeRoleForGrouping,
+  resolveMessageRole,
+  resolveMessageSenderLabel,
+} from "../../lib/chat/message-normalizer.ts";
 import { visibleChatHistoryMessages } from "../../lib/chat/message-visibility.ts";
 import { downloadTextFile } from "../../lib/download.ts";
 
@@ -27,13 +31,12 @@ export function buildChatMarkdown(messages: unknown[], assistantName: string): s
   const lines: string[] = [`# Chat with ${assistantName}`, ""];
   for (const msg of history) {
     const m = msg as Record<string, unknown>;
-    const normalized = normalizeMessage(msg);
-    const role = normalizeRoleForGrouping(normalized.role);
+    const role = normalizeRoleForGrouping(resolveMessageRole(msg));
     const speaker =
       role === "user"
-        ? (normalized.senderLabel ?? "You")
+        ? (resolveMessageSenderLabel(msg) ?? "You")
         : role === "assistant"
-          ? (normalized.senderLabel ?? assistantName)
+          ? (resolveMessageSenderLabel(msg) ?? assistantName)
           : "Tool";
     const content = extractTextCached(msg) ?? "";
     const ts = timestampMsToIsoString(m.timestamp) ?? "";


### PR DESCRIPTION
Closes #142490

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

Related: #136439

## What Problem This Solves

Chat Markdown exports normalize each complete message just to obtain its role and speaker label, then extract the exported body separately. The resulting content arrays and media/Canvas preparation are discarded, including when the existing text cache is warm.

## Why This Change Was Made

This is a maintainer-requested performance cleanup. Use canonical role classification and a scalar sender-label resolver in the shared export builder. The existing metadata-to-sender policy moves into one private helper; full normalization reuses its already prepared sender, including explicit `null`. Export resolves a label only for user and assistant rows, retaining fixed Tool headings.

Imported-body projection remains with `extractTextCached`. Visibility, raw timestamp handling, identity/avatar provenance, full normalized output shape, Markdown bytes, download MIME/filename and clipboard behavior remain unchanged. Production grows by 20 lines across two owners, with six cases added to the existing export suite. No cache, configuration, persistence or public API is introduced.

## User Impact

Downloaded and copied conversations retain the speaker attribution established in #136439 and the same content. The export path avoids constructing display content that it does not use.

## Evidence

Validation:

- Six reference cohorts containing 26 messages match exact Markdown and download Blob bytes, MIME/filename, complete normalized values and property order. Inputs remain unchanged. Cases include canonical tool envelopes, explicit and durable sender metadata, imported content shapes, timestamps, filtering, media and Canvas.
- **127 focused tests pass**, including six additional export cases for tool classification and imported attribution/body bytes. Existing sender identity and provenance tests are unchanged. The full selected changed gate and independent review pass.
- The existing full synthetic Control UI export E2E passes both download and clipboard flows before and after. All four Markdown files are byte-identical; visible speaker names are retained and neither action sends `chat.send`. The application runs with a mocked Gateway and isolated Chromium contexts.

Probes exporting 128-message synthetic transcripts six times per trial recorded **27.66–47.02% less cumulative sampled allocation** across text, mixed-block and imported-text cohorts with cold and warm caches. V8 sampling used an 8 KiB interval and includes collected objects. Input creation, cache warming and output hashing/serialization were excluded. Baseline ran before candidate, with three trials per arm; timing is supporting microbenchmark evidence. No retained-heap, RSS, whole-Gateway or full-browser latency improvement is claimed.

![Before: synthetic speaker attribution after Markdown download](https://github.com/user-attachments/assets/eca8eb6d-bcbf-4ac9-b313-5561e0d55b05)

![After: preserved speaker attribution after Markdown download](https://github.com/user-attachments/assets/423fdc43-7439-41b1-b189-e96f8fbc2bc8)