### PR TITLE
refactor(system-agent): remove unused verification callback argument

### DIFF
--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -1,6 +1,5 @@
 // Shared execution helpers keep the public dispatcher small and reviewable.
 import { tryResolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
-import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import type { ConfigSetOptions } from "../cli/config-set-input.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -614,10 +613,7 @@ export async function executeSetDefaultModel(
               ...(targetAgentId ? { agentId: targetAgentId } : {}),
               ...(opts.onVerifiedInferenceChanged
                 ? {
-                    onVerifiedExecution: (
-                      _auth: AgentExecutionAuthBinding,
-                      binding: SystemAgentVerifiedInferenceBinding,
-                    ) => {
+                    onVerifiedExecution: (binding: SystemAgentVerifiedInferenceBinding) => {
                       latestBinding = binding;
                     },
                   }

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -567,7 +567,7 @@ describe("parseSystemAgentOperation", () => {
           channels: { telegram: { enabled: true } },
         });
       } else {
-        onVerifiedExecution?.({} as never, reboundBinding);
+        onVerifiedExecution?.(reboundBinding);
       }
       return { ok: true as const, modelRef: "openai/gpt-5.5", latencyMs: 17 };
     });

--- a/src/system-agent/setup-inference-error-reporting.test.ts
+++ b/src/system-agent/setup-inference-error-reporting.test.ts
@@ -154,7 +154,7 @@ async function observeScenario(scenario: Scenario, json: boolean) {
                   runtime,
                   requireExecutionOwner: true,
                   deps,
-                  onVerifiedExecution: (_auth, verified) => {
+                  onVerifiedExecution: (verified) => {
                     phases.push("callback");
                     callbackAttempts += 1;
                     if (scenario === "callback") {

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -5,7 +5,6 @@ import { isDeepStrictEqual } from "node:util";
 import { resolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store-runtime.js";
-import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
@@ -96,10 +95,7 @@ export async function verifySetupInference(
     ...(params.deps ? { deps: params.deps } : {}),
     ...(params.bindSession
       ? {
-          onVerifiedExecution: (
-            _auth: AgentExecutionAuthBinding,
-            binding: SystemAgentVerifiedInferenceBinding,
-          ) => {
+          onVerifiedExecution: (binding: SystemAgentVerifiedInferenceBinding) => {
             verifiedBinding = binding;
           },
         }
@@ -233,11 +229,8 @@ export async function verifySetupInferenceConfig(params: {
   runtime: RuntimeEnv;
   timeoutMs?: number;
   deps?: ActivateSetupInferenceDeps;
-  /** Internal session gate: capture only the final exact successful credential. */
-  onVerifiedExecution?: (
-    auth: AgentExecutionAuthBinding,
-    binding: SystemAgentVerifiedInferenceBinding,
-  ) => void;
+  /** Internal session gate: capture only the final verified execution binding. */
+  onVerifiedExecution?: (binding: SystemAgentVerifiedInferenceBinding) => void;
   /** Reject a successful turn unless its runner reports the exact execution owner. */
   requireExecutionOwner?: boolean;
 }): Promise<VerifySetupInferenceResult> {
@@ -451,7 +444,7 @@ export async function verifySetupInferenceConfig(params: {
             stagedOwnerPluginArtifacts,
             deps,
           });
-          params.onVerifiedExecution?.(test.auth, binding);
+          params.onVerifiedExecution?.(binding);
         } catch (error) {
           return {
             ok: false,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

The internal setup-verification callback passes an authentication argument that
its consumers discard, obscuring the verified binding they actually need.

## Why This Change Was Made

Pass only the verified execution binding and update the internal consumers and
test callbacks together. Authentication checks, execution-owner validation,
verified session binding and failure handling remain unchanged.

## User Impact

No user-visible behavior change. No public API, provider protocol or credential
ownership change.

## Evidence

- 261 tests passed across seven complete setup, execution and wizard suites.
- All 29 selected checks passed, including typechecking, formatting and lint.
- Script, production and full-tree Knip scans each passed with zero entries.
- Fresh code review completed with no actionable findings.
- Provider boundary tests use mocks; no live Codex provider validation is claimed.
- Five portal-sync timeout warnings were retained. Native commands and owned lease
  cleanup completed successfully; reporting failures are retained separately.
