### PR TITLE
refactor(matrix): remove unreachable forced-reset repair retry

### DIFF
--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -75,8 +75,6 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: forceReset,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
-      // A repair retry would generate another identity after the SDK already rotated local keys.
-      // Fail closed instead; the server identity and existing recovery material remain authoritative.
       allowSecretStorageRecreateWithoutRecoveryKey: forceReset
         ? false
         : options.allowSecretStorageRecreateWithoutRecoveryKey === true,
@@ -209,40 +207,15 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     };
 
     if (options.forceResetCrossSigning) {
-      const resetCrossSigning = async (): Promise<void> => {
+      try {
         await crypto.bootstrapCrossSigning({
           setupNewCrossSigning: true,
           authUploadDeviceSigningKeys,
         });
-      };
-      try {
-        await resetCrossSigning();
         await this.trustFreshOwnIdentity(crypto);
       } catch (err) {
-        const shouldRepairSecretStorage =
-          options.allowSecretStorageRecreateWithoutRecoveryKey &&
-          isRepairableSecretStorageAccessError(err);
-        if (shouldRepairSecretStorage) {
-          LogService.warn(
-            "MatrixClientLite",
-            "Forced cross-signing reset could not unlock secret storage; recreating secret storage and retrying.",
-          );
-          try {
-            await this.deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey(crypto, {
-              allowSecretStorageRecreateWithoutRecoveryKey: true,
-              forceNewSecretStorage: true,
-            });
-            await resetCrossSigning();
-            await this.trustFreshOwnIdentity(crypto);
-          } catch (repairErr) {
-            LogService.warn("MatrixClientLite", "Forced cross-signing reset failed:", repairErr);
-            if (options.strict) {
-              throw toStringifiedError(repairErr);
-            }
-            return { ready: false, published: false };
-          }
-          return await finalize();
-        }
+        // A repair retry would generate another identity after the SDK already rotated local keys.
+        // Fail closed instead; the server identity and existing recovery material remain authoritative.
         LogService.warn("MatrixClientLite", "Forced cross-signing reset failed:", err);
         if (options.strict) {
           if (isRepairableSecretStorageAccessError(err)) {


### PR DESCRIPTION
Closes #142493

## What Problem This Solves

Matrix forced-reset handling maintains an unreachable secret-storage repair and second-reset flow. Its only private caller always disables that flow during forced reset, leaving duplicate recovery logic to maintain.

## Why This Change Was Made

Remove the unreachable branch, inline its single-use reset wrapper and keep the existing explanation at the forced-reset error owner. The public entry point still disables forced recreation. The reachable ordinary repair path remains unchanged.

## User Impact

No user-visible behavior changes. The active recovery-key check, strict errors and causes, nonstrict status fields, successful single-reset/trust/export sequence and public bootstrap options remain. This removes 27 production code/physical lines without changing tests, dependencies or storage semantics.

## Evidence

- Unchanged crypto-bootstrap and full SDK suites: 171 tests passed before and 171 after, covering forced failures without recreation/second reset, successful reset, ordinary stale-key/bad-MAC repair, trust/free and staged recovery results.
- Full changed gate passed, including both extension typecheck lanes, six doctor contract tests, lint/format, all three dead-export scans and selected architecture guards.
- Fresh independent P0–P2 review: scoped-clean, no findings. Committed bytes match the complete tested/reviewed patch; caller and actual installed matrix-js-sdk 42.2.0 contracts were inspected.
- Synthetic SDK/owner-boundary proof; no live Matrix account or cryptographic reset was used.

Related #74504 remains a distinct MAS/MSC3967 issue; this retirement does not claim to fix it.
