### PR TITLE
fix(msteams): decode HTML-only message text correctly

### DIFF
--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -15,7 +15,7 @@ type MSTeamsQuoteInfo = {
 /**
  * Strip HTML tags, preserving text content.
  */
-function htmlToPlainText(html: string): string {
+export function htmlToPlainText(html: string): string {
   return decodeHtmlEntities(html.replace(/<[^>]*>/g, " "))
     .replaceAll("\u00a0", " ")
     .replace(/\s+/g, " ")

--- a/extensions/msteams/src/monitor-handler/inbound-facts.test.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-facts.test.ts
@@ -11,7 +11,7 @@ describe("msteams inbound facts", () => {
     const textEntry = await prepareMSTeamsDebounceEntry({
       context: context({
         type: "message",
-        text: "  hello  ",
+        text: "  <at>Bot</at> hello &lt;tag&gt;  ",
         attachments: [{ contentType: "text/html", content: "<p>ignored</p>" }],
         value: { action: "ignored" },
       }),
@@ -29,10 +29,44 @@ describe("msteams inbound facts", () => {
       }),
     });
 
-    expect(textEntry.text).toBe("hello");
+    expect(textEntry.text).toBe("hello &lt;tag&gt;");
     expect(htmlEntry.text).toBe("hello & goodbye");
     expect(valueEntry.text).toContain("approve");
     expect(valueEntry.text).toContain("7");
+  });
+
+  it.each([
+    ["<p>Use x &lt; 5 and &#39;yes&#39; &copy;</p>", "Use x < 5 and 'yes' ©"],
+    ["<p>Smile &#x1F600; and &quot;hello&quot;</p>", 'Smile 😀 and "hello"'],
+    ["<p>literal &amp;lt;tag&amp;gt;</p>", "literal &lt;tag&gt;"],
+    ["<p>literal &lt;at&gt;Alice&lt;/at&gt;</p>", "literal <at>Alice</at>"],
+    ["<p>one<br>two</p><p>three&nbsp;four</p>", "one two three four"],
+    [
+      '<at>Bot</at><p>See <a href="https://example.test/?a=1&amp;b=2">report</a></p>',
+      "See report https://example.test/?a=1&b=2",
+    ],
+  ])("preserves HTML text in the inbound body: %s", async (html, expected) => {
+    const entry = await prepareMSTeamsDebounceEntry({
+      context: context({
+        type: "message",
+        attachments: [{ contentType: "text/html", content: html }],
+        value: { action: "ignored" },
+      }),
+    });
+
+    expect(assembleMSTeamsInboundFacts({ entry, mediaMaxBytes: 1024 }).rawBody).toBe(expected);
+  });
+
+  it("strips native mentions from card text when HTML has no visible text", async () => {
+    const entry = await prepareMSTeamsDebounceEntry({
+      context: context({
+        type: "message",
+        attachments: [{ contentType: "text/html", content: "<at>Bot</at>" }],
+        value: "<at>Bot</at> answer &lt;tag&gt;",
+      }),
+    });
+
+    expect(entry.text).toBe("answer &lt;tag&gt;");
   });
 
   it("preserves raw Bot Framework IDs while normalizing routing facts", async () => {

--- a/extensions/msteams/src/monitor-handler/inbound-facts.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-facts.ts
@@ -11,6 +11,7 @@ import type { StoredConversationReference } from "../conversation-store.js";
 import {
   extractMSTeamsConversationMessageId,
   extractMSTeamsQuoteInfo,
+  htmlToPlainText,
   normalizeMSTeamsConversationId,
   stripMSTeamsMentionTags,
   wasMSTeamsBotMentioned,
@@ -25,16 +26,11 @@ function extractTextFromHtmlAttachments(attachments: MSTeamsAttachmentLike[]): s
     if (!raw) {
       continue;
     }
-    const text = raw
-      .replace(/<at[^>]*>.*?<\/at>/gis, " ")
-      .replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gis, "$2 $1")
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<\/p>/gi, "\n")
-      .replace(/<[^>]+>/g, " ")
-      .replace(/&nbsp;/gi, " ")
-      .replace(/&amp;/gi, "&")
-      .replace(/\s+/g, " ")
-      .trim();
+    const text = htmlToPlainText(
+      raw
+        .replace(/<at[^>]*>.*?<\/at>/gis, " ")
+        .replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gis, "$2 $1"),
+    );
     if (text) {
       return text;
     }
@@ -61,10 +57,11 @@ export async function prepareMSTeamsDebounceEntry(params: {
     ? activity.attachments
     : [];
   const rawText = activity.text?.trim() ?? "";
-  const htmlText = extractTextFromHtmlAttachments(attachments);
-  const valueText =
-    rawText || htmlText ? "" : serializeMSTeamsAdaptiveCardActionValue(activity.value);
-  const text = stripMSTeamsMentionTags(rawText || htmlText || valueText || "");
+  // HTML mentions are stripped before decoding so literally typed <at> tags survive.
+  const text = rawText
+    ? stripMSTeamsMentionTags(rawText)
+    : extractTextFromHtmlAttachments(attachments) ||
+      stripMSTeamsMentionTags(serializeMSTeamsAdaptiveCardActionValue(activity.value) || "");
   const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
   const replyToId = activity.replyToId ?? undefined;
   const implicitMentionKinds: Array<"reply_to_bot"> =

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -203,6 +203,38 @@ describe("Microsoft Teams drain claim ownership", () => {
     expect(second.abandonedCount()).toBe(0);
   });
 
+  it("dispatches HTML-only text through the immediate debounce flush without double stripping", async () => {
+    const handler = createHandler({
+      channels: { msteams: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    const lifecycle = createLifecycle();
+
+    await handler(
+      context({
+        ...directActivity("activity-html", ""),
+        attachments: [
+          {
+            contentType: "text/html",
+            content: "<at>Bot</at><p>Use x &lt; 5 &copy;; literal &lt;at&gt;Alice&lt;/at&gt;</p>",
+          },
+        ],
+      }),
+      lifecycle,
+    );
+
+    expect(
+      runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher,
+    ).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          BodyForAgent: expect.stringContaining("Use x < 5 ©; literal <at>Alice</at>"),
+        }),
+      }),
+    );
+    expect(lifecycle.adoptedCount()).toBe(1);
+    expect(lifecycle.abandonedCount()).toBe(0);
+  });
+
   it("completes a gated no-dispatch turn instead of stalling its claim", async () => {
     const { deps } = createMessageHandlerDeps(
       {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending HTML-only Teams messages would pass encoded text such as `&lt;`, `&#39;`, and `&copy;` to the agent instead of the intended characters. For example, `Use x &lt; 5 &copy;` arrived as literal entity text.

## Why This Change Was Made

Reuse the Teams plugin's existing quote-text HTML converter for inbound attachment text, replacing the partial entity decoder and duplicate whitespace/tag processing. Native mentions and links are prepared before single-pass decoding; raw activity text still takes precedence, and Adaptive Card value fallback keeps its existing behavior. Production code decreases by 3 lines.

## User Impact

HTML-only messages reach the agent with the intended punctuation, symbols, and Unicode characters. Literally typed entity text and encoded `<at>...</at>` text stay intact, while native bot addressing is removed once.

## Evidence

- Original-code regression: three inbound-body cases and the real Teams handler's `BodyForAgent` assertion failed for encoded entities/literal tags; six preservation controls passed.
- **68 focused tests passed**: inbound facts, the handler/debounce lifecycle, quote extraction, Graph text projection, and shared HTML entity decoding. Coverage retains raw-text precedence, card-value fallback, links, whitespace, double-encoded entities, and literal mention tags.
- The handler proof uses actual preparation, the actual attachment-triggered immediate debounce flush, inbound body processing, and the shared context builder. Provider/reply and persistence boundaries use the existing synthetic test runtime. This is not a live Teams-client rendering test and makes no external Microsoft API claim.
- Scoped `check-changed` passed, including extension production/test typechecks, lint, boundary checks and selected guards. Independent P2 review found no actionable P0–P2 issues. Node 24.19.0, pnpm 12.3.4; unchanged dependency lockfile.
- The reviewed owner/caller/decoder source remains unchanged on main at `b9f1e86810cc093ab97fc2b04c3fc269ecac95e2`; no rebase was needed.

Focused command:

```sh
node scripts/run-vitest.mjs extensions/msteams/src/monitor-handler/inbound-facts.test.ts extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts extensions/msteams/src/inbound.test.ts extensions/msteams/src/graph-thread.test.ts src/shared/html-entities.test.ts
```
