### PR TITLE
refactor(infra): share diagnostic listener registration

### DIFF
--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1585,25 +1585,34 @@ export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "
   });
 }
 
+function registerDiagnosticEventListener<T>(
+  state: DiagnosticEventsGlobalState,
+  listeners: Map<T, InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined>,
+  listener: T,
+  filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
+): () => void {
+  if (listeners.has(listener)) {
+    updateInternalDiagnosticEventInterest(listeners.get(listener), -1);
+  }
+  listeners.set(listener, filter);
+  updateInternalDiagnosticEventInterest(filter, 1);
+  setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
+  return () => {
+    const interest = listeners.get(listener);
+    if (listeners.delete(listener)) {
+      updateInternalDiagnosticEventInterest(interest, -1);
+    }
+    setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
+  };
+}
+
 /** Subscribes to diagnostic events with dispatcher metadata. */
 export function onInternalDiagnosticEvent(
   listener: DiagnosticEventListener,
   filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
 ): () => void {
   const state = getDiagnosticEventsState();
-  if (state.listeners.has(listener)) {
-    updateInternalDiagnosticEventInterest(state.listeners.get(listener), -1);
-  }
-  state.listeners.set(listener, filter);
-  updateInternalDiagnosticEventInterest(filter, 1);
-  setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
-  return () => {
-    const interest = state.listeners.get(listener);
-    if (state.listeners.delete(listener)) {
-      updateInternalDiagnosticEventInterest(interest, -1);
-    }
-    setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
-  };
+  return registerDiagnosticEventListener(state, state.listeners, listener, filter);
 }
 
 /** Subscribes to diagnostic events plus trusted private payload data. */
@@ -1612,19 +1621,7 @@ export function onTrustedInternalDiagnosticEvent(
   filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
 ): () => void {
   const state = getDiagnosticEventsState();
-  if (state.trustedListeners.has(listener)) {
-    updateInternalDiagnosticEventInterest(state.trustedListeners.get(listener), -1);
-  }
-  state.trustedListeners.set(listener, filter);
-  updateInternalDiagnosticEventInterest(filter, 1);
-  setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
-  return () => {
-    const interest = state.trustedListeners.get(listener);
-    if (state.trustedListeners.delete(listener)) {
-      updateInternalDiagnosticEventInterest(interest, -1);
-    }
-    setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
-  };
+  return registerDiagnosticEventListener(state, state.trustedListeners, listener, filter);
 }
 
 /** Subscribes to trusted metadata-only tool execution events, even when diagnostics are disabled. */


### PR DESCRIPTION
## What Problem This Solves

Public and trusted diagnostic listeners duplicate registration and unsubscribe bookkeeping, making the two paths easier to change inconsistently.

## Why This Change Was Made

Share that bookkeeping through one private generic helper. The existing wrappers still select their own listener maps and acquire state once. Registration order, current-filter removal, both listener-count publications, callback/filter identity, and separate trust/privacy policy remain unchanged.

## User Impact

No intended user-visible behavior or public API change. This is a one-file mechanical refactor with no new SDK exports, configuration, storage, dependencies, or tests.

## Evidence

- All 41 distinct selected cases passed before and after across `diagnostic-events.test.ts`, `diagnostic-events.event-loop.test.ts`, and `diagnostic-events.plugin-usage.test.ts`.
- Targeted formatting and `git diff --check` passed. Fresh independent review found no actionable P0-P2 findings.
- Local `check-changed` passed its first 15 steps, then stopped at the declaration-boundary guard because the shared compiler installation resolves outside the checkout. The compiler did not execute; subsequent typecheck/lint lanes were not run locally.
- The complete `check-changed` gate passed in a physical Blacksmith Testbox checkout, including core and core-test typechecking, changed-file lint, and the remaining guards.
- A fresh private-QA build and real Gateway OTel hot-reload proof passed on commit `cc0502d16b965030736bc67cb6511ef7190b61f0`. All five maintained hot-reload checks retained one Gateway PID/boot identity; A/B/C generations exported traces, metrics, and logs successfully. The fixture's retirement, metrics-only, Prometheus continuity, and shutdown checks passed with no returned failures.
- The private capture was downloaded and hash-verified. Actual source paths, file digests, and tree identity were checked against the committed candidate, including restored sparse-checkout omissions. Raw captures remain private.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34272183225
- Existing focused coverage and exporter proof are not exhaustive listener replacement/getter permutations or content-redaction proof.
