### PR TITLE
fix(plugins): reuse prewarmed catalog presentation

### DIFF
--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -148,12 +148,10 @@ export function prepareCatalogEntries(entries: readonly OfficialExternalPluginCa
  */
 function overlayBundledOfficialPluginCatalogMetadata(
   entries: readonly OfficialExternalPluginCatalogEntry[],
-  bundledEntries: readonly OfficialExternalPluginCatalogEntry[] = listOfficialExternalPluginCatalogEntries(),
-  options: { hostedFeaturedAuthoritative: boolean } = {
-    hostedFeaturedAuthoritative: false,
-  },
+  options: { hostedFeaturedAuthoritative: boolean },
 ): OfficialExternalPluginCatalogEntry[] {
-  const bundledFacts = entries.length > 0 ? bundledEntries.map(prepareCatalogEntry) : [];
+  const bundledFacts =
+    entries.length > 0 ? listOfficialExternalPluginCatalogEntries().map(prepareCatalogEntry) : [];
   return entries.map((entry) => {
     const { clawhub, npmPackage } = prepareCatalogEntry(entry);
     const matches = bundledFacts.filter(
@@ -188,9 +186,17 @@ function overlayBundledOfficialPluginCatalogMetadata(
 export async function loadOfficialCatalog(): Promise<OfficialCatalogResult> {
   const cache = getManagedPluginCache();
   if (!cache.officialCatalog) {
-    const promise = Promise.resolve().then(() =>
-      loadConfiguredHostedOfficialExternalPluginCatalogEntries(),
-    );
+    const promise = loadConfiguredHostedOfficialExternalPluginCatalogEntries().then((result) => {
+      const hostedFeaturedAuthoritative =
+        result.source === "hosted" || result.source === "hosted-snapshot";
+      return {
+        entries: overlayBundledOfficialPluginCatalogMetadata(result.entries, {
+          hostedFeaturedAuthoritative,
+        }),
+        hostedFeaturedAuthoritative,
+        ...("error" in result ? { error: result.error } : {}),
+      };
+    });
     cache.officialCatalog = promise;
     void promise.catch(() => {
       if (cache.officialCatalog === promise) {
@@ -198,16 +204,7 @@ export async function loadOfficialCatalog(): Promise<OfficialCatalogResult> {
       }
     });
   }
-  const result = await cache.officialCatalog;
-  const hostedFeaturedAuthoritative =
-    result.source === "hosted" || result.source === "hosted-snapshot";
-  return {
-    entries: overlayBundledOfficialPluginCatalogMetadata(result.entries, undefined, {
-      hostedFeaturedAuthoritative,
-    }),
-    hostedFeaturedAuthoritative,
-    ...("error" in result ? { error: result.error } : {}),
-  };
+  return cache.officialCatalog;
 }
 
 export function normalizeKinds(kind: string | readonly string[] | undefined): string[] | undefined {

--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -26,9 +26,9 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
   resolveOfficialExternalPluginInstallSources,
-  type HostedOfficialExternalPluginCatalogLoadResult,
   type OfficialExternalPluginCatalogEntry,
 } from "./official-external-plugin-catalog.js";
+import type { OfficialCatalogResult } from "./official-external-plugin-catalog.types.js";
 import {
   getPluginCache,
   getPluginMetadataSnapshotCache,
@@ -40,14 +40,6 @@ import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 export type ManagedPluginCatalogEntry = PluginCatalogEntry;
 export type ManagedPluginCatalog = PluginsListResult;
-
-export type OfficialCatalogResult = Pick<
-  HostedOfficialExternalPluginCatalogLoadResult,
-  "entries"
-> & {
-  error?: string;
-  hostedFeaturedAuthoritative?: boolean;
-};
 
 export function getManagedPluginCache(metadata?: PluginMetadataSnapshot) {
   if (metadata) {

--- a/src/plugins/management-service.lifecycle-cache.test.ts
+++ b/src/plugins/management-service.lifecycle-cache.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   currentMetadata: undefined as unknown,
   metadata: vi.fn(),
   officialCatalog: vi.fn(),
+  preparePackage: vi.fn(),
 }));
 
 vi.mock("./plugin-metadata-snapshot.js", async (importOriginal) => ({
@@ -26,11 +27,20 @@ vi.mock("./plugin-metadata-snapshot.js", async (importOriginal) => ({
   },
 }));
 
-vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./official-external-plugin-catalog.js")>()),
-  loadConfiguredHostedOfficialExternalPluginCatalogEntries: (...args: unknown[]) =>
-    mocks.officialCatalog(...args),
-}));
+vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./official-external-plugin-catalog.js")>();
+  return {
+    ...actual,
+    loadConfiguredHostedOfficialExternalPluginCatalogEntries: (...args: unknown[]) =>
+      mocks.officialCatalog(...args),
+    resolveOfficialExternalPluginInstall: (
+      ...args: Parameters<typeof actual.resolveOfficialExternalPluginInstall>
+    ) => {
+      mocks.preparePackage(...args);
+      return actual.resolveOfficialExternalPluginInstall(...args);
+    },
+  };
+});
 
 const { listManagedPlugins } = await import("./management-service.js");
 
@@ -112,6 +122,7 @@ describe("plugin management catalog lifecycle", () => {
   beforeEach(() => {
     mocks.metadata.mockReset();
     mocks.officialCatalog.mockReset();
+    mocks.preparePackage.mockClear();
     clearPluginMetadataLifecycleCaches();
   });
 
@@ -145,12 +156,19 @@ describe("plugin management catalog lifecycle", () => {
       .mockResolvedValueOnce({ source: "hosted", entries: [] });
 
     const prewarmed = await listManagedPlugins({ config: {}, env: {} });
+    const coldPreparations = mocks.preparePackage.mock.calls.length;
+    mocks.preparePackage.mockClear();
     const firstHandlerLoad = await listManagedPlugins({ config: {}, env: {} });
 
     expect(prewarmed.plugins).toEqual([expect.objectContaining({ id: "diffs" })]);
     expect(firstHandlerLoad.plugins).toEqual(prewarmed.plugins);
     expect(mocks.metadata).toHaveBeenCalledTimes(1);
     expect(mocks.officialCatalog).toHaveBeenCalledTimes(1);
+    expect(mocks.preparePackage.mock.calls.length).toBeLessThan(coldPreparations);
+
+    firstHandlerLoad.plugins.length = 0;
+    const secondHandlerLoad = await listManagedPlugins({ config: {}, env: {} });
+    expect(secondHandlerLoad.plugins).toEqual(prewarmed.plugins);
 
     clearPluginMetadataLifecycleCaches();
 

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -31,7 +31,6 @@ import { createInstalledPluginOwnershipResolver } from "./installed-plugin-packa
 import {
   type ManagedPluginCatalogEntry,
   type ManagedPluginCatalog,
-  type OfficialCatalogResult,
   getManagedPluginCache,
   withManagedPluginCache,
   prepareCatalogEntry,
@@ -55,6 +54,7 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginLabel,
 } from "./official-external-plugin-catalog.js";
+import type { OfficialCatalogResult } from "./official-external-plugin-catalog.types.js";
 import { tracksPluginDependencyStatus } from "./official-external-plugin-repair-hints.js";
 import { createPluginCache, getProcessPluginCache, withPluginCache } from "./plugin-cache.js";
 import {

--- a/src/plugins/official-external-plugin-catalog.types.ts
+++ b/src/plugins/official-external-plugin-catalog.types.ts
@@ -254,3 +254,11 @@ export type HostedOfficialExternalPluginCatalogLoadResult =
         checksum?: string;
       };
     };
+
+export type OfficialCatalogResult = Pick<
+  HostedOfficialExternalPluginCatalogLoadResult,
+  "entries"
+> & {
+  error?: string;
+  hostedFeaturedAuthoritative?: boolean;
+};

--- a/src/plugins/plugin-cache-management.ts
+++ b/src/plugins/plugin-cache-management.ts
@@ -1,8 +1,8 @@
 import type { PluginInstallRecordMapState } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
-import type { OfficialCatalogResult } from "./management-catalog.js";
 import type { PluginManifestRecord } from "./manifest-registry.types.js";
+import type { OfficialCatalogResult } from "./official-external-plugin-catalog.types.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import type { PluginDependencyStatus } from "./status-dependencies-core.js";
 

--- a/src/plugins/plugin-cache-management.ts
+++ b/src/plugins/plugin-cache-management.ts
@@ -1,8 +1,8 @@
 import type { PluginInstallRecordMapState } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import type { OfficialCatalogResult } from "./management-catalog.js";
 import type { PluginManifestRecord } from "./manifest-registry.types.js";
-import type { HostedOfficialExternalPluginCatalogLoadResult } from "./official-external-plugin-catalog.types.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import type { PluginDependencyStatus } from "./status-dependencies-core.js";
 
@@ -21,7 +21,7 @@ export type PluginCacheManagement<TCache> = {
     snapshot: PluginMetadataSnapshot;
   };
   dependencyStatus: WeakMap<PluginManifestRecord, PluginDependencyStatus>;
-  officialCatalog?: Promise<HostedOfficialExternalPluginCatalogLoadResult>;
+  officialCatalog?: Promise<OfficialCatalogResult>;
 };
 
 export function createPluginCacheManagement<TCache>(): PluginCacheManagement<TCache> {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where repeated plugin list and inspection requests rebuilt stable catalog presentation metadata even after startup prewarming. The hosted response was cached, but each request repeated bundled matching and package identity preparation.

## Why This Change Was Made

Cache the prepared catalog in the existing plugin-cache generation. Keep the existing identity-checked rejection eviction and lifecycle refresh behavior, and remove unused private overlay parameters and the redundant asynchronous wrapper around the loader. The shared result type lives in the existing catalog types module, keeping cache definitions independent of the runtime catalog implementation.

## User Impact

Warm plugin catalog requests reuse their prepared metadata. Current configuration and public response objects remain request-specific, so refreshes still take effect and callers can modify returned lists without changing later results.

## Evidence

The regression through the real plugin management service failed before the fix: both cold and warm requests performed 98 package preparations while the hosted feed loaded only once. After the baseline refresh, the regression and all 104 focused lifecycle, featured, inspection, list, and refresh tests pass. The extra case comes from the upstream configuration-readonly behavior, which is preserved. The test also modifies a returned public list and verifies the next response remains intact.

The original corrected candidate passed the owning plugins-platform type graph, typed lint, formatting, both import-cycle graphs, and the full architecture gate. The refresh preserves the accepted patch identity and direct type-leaf ownership; all 104 owner tests and the full pinned-base changed checks pass, including core/test types, typed lint, source guards, and the runtime import-cycle check. The accepted independent P2 review remains applicable to the unchanged catalog delta. The tests use synthetic hosted-feed and installed-metadata inputs; no live service or operator state was used.

Initial CI reported a static type-import cycle and an unexpected config-doc check selection. Moving the shared result type into the existing catalog types module resolved both: the full architecture gate and all 31 config-doc selection cases pass locally.

A later CI run reported a planner-growth timeout and subagent announcement failures. The measured planner repair landed separately in #142630, and this branch is refreshed onto main containing that repair. The announcement failure remains unreproduced: a Linux replay of its exact merged-source shard passed 1,306 tests with one skipped, but used different host capacity and fresh cache state. This PR does not claim to fix that failure.

The next integration run passed all test jobs (106 successful jobs, 17 skipped), but lint rejected an inherited oversized Codex protocol file and source-contract setup failed while downloading the Matrix native library (`ECONNRESET`, followed by a dependency installer error). The aggregate gate therefore failed. This branch now includes the separately landed protocol-size repair #142648; the catalog patch and its source hashes are unchanged. The Matrix download failure remains separate from the catalog fix. This is a qualified baseline refresh, not a rerun of the failed integration head.

Production: 27 additions, 30 deletions, net -3. Tests: 23 additions, 5 deletions, net +18.
