### PR TITLE
test: reuse compiled CLI for message cleanup cases

### DIFF
--- a/src/cli/message-plugin-cleanup.process.test.ts
+++ b/src/cli/message-plugin-cleanup.process.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
 import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -82,9 +84,8 @@ export default { id: plugin.id, register(api) {
 
     const result = await runCliProcessChild({
       nodeArgs: [
-        "--import",
-        "tsx",
-        "src/entry.ts",
+        // Share immutable CLI code; each case still owns a fresh process and plugin lifecycle.
+        ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cli)),
         "message",
         "send",
         "--dry-run",


### PR DESCRIPTION
## What Problem This Solves

The message-cleanup process tests repeatedly transpile the full source CLI before checking output and shutdown. In a recent successful CI job, the five cases took 71.2 seconds, including 40.1 seconds in the first case.

## Why This Change Was Made

Launch the same CLI through the existing invocation-owned compiled entry and canonical worker resolver, already used by CLI recovery tests. Each case still gets a separate native process, temporary home/config/plugin, complete output streams and real plugin shutdown. The existing runner owns compilation, source/artifact verification and cleanup; standalone Vitest/watch retain source execution.

All five cases, assertions, environment values and deadlines remain unchanged. Production delta: zero. Test delta: +4/-3 in one file.

## User Impact

Faster local and CI regression checks. No runtime or user-facing behavior changes, additional sharding, cache infrastructure or dependency changes.

## Evidence

Measured through the repository's Linux test runner with Node 24.19.0 and pnpm 12.3.4, preserving all five cases and their order:

| Run | Whole test command |
| --- | ---: |
| Original, first run | 38.12s |
| Original, warmed source with diagnostic observers | 19.27s |
| Candidate with the same observers | 14.75s |
| Original restored, same observers | 20.28s |
| Final candidate, all diagnostics removed | 15.27s |

Candidate command times include fresh invocation compilation: 5.664s in the bracket and 5.460s in the final run. The existing CI group already prepares this artifact generation, but no whole-CI speedup is claimed from the standalone comparison. Cold/warm source variation is shown explicitly.

The transparent observers verified real child argv, entry bytes matching the invocation manifest, first output, native exit and both stream EOFs. Ordinary output moved from 2.86–3.26s to 0.81–0.84s; shutdown completed milliseconds afterward. The stalled case retained the actual 2.5-second hook deadline. Diagnostics are absent from the patch.

The final uninstrumented run passed all five cases (1.097/0.988/0.949/0.975/3.461s). Independent P0–P2 review found no actionable findings. The exact changed-file gate passed all required guards, type checks, dead-export analysis and lint (zero warnings/errors).
