### PR TITLE
fix(telegram): stop adding blank lines inside code examples

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -446,6 +446,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
   <Accordion title="Rich message formatting">
     Outbound text uses standard Telegram HTML messages by default, readable across current clients: bold, italic, links, code, spoilers, quotes — not Bot API 10.3 rich-only blocks (native tables, details, rich media, formulas).
+    Fenced code retains its literal content and spacing, including fence examples inside the block.
 
     Opt into Bot API 10.3 rich messages:
 

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -303,24 +303,45 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toContain("report/draft.\n\n3. Cognee");
   });
 
-  it("does not insert Telegram list boundary spacing inside fenced code", () => {
-    const input = ["```", "  • literal bullet", "3. literal number", "```"].join("\n");
-
-    const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
-
-    expect(res).toBe("<pre><code>  • literal bullet\n3. literal number\n</code></pre>");
-  });
-
-  it("does not insert Telegram list boundary spacing inside indented code", () => {
-    const input = ["    • literal bullet", "    3. literal number"].join("\n");
-
+  it.each([
+    {
+      name: "fenced code",
+      input: "```\n  • literal bullet\n3. literal number\n```",
+      html: "<pre><code>  • literal bullet\n3. literal number\n</code></pre>",
+    },
+    {
+      name: "a shorter fence inside code",
+      input: "````\n```\n• literal bullet\n3. literal number\n````",
+      html: "<pre><code>```\n• literal bullet\n3. literal number\n</code></pre>",
+    },
+    {
+      name: "a different fence marker inside code",
+      input: "```\n~~~\n• literal bullet\n3. literal number\n```",
+      html: "<pre><code>~~~\n• literal bullet\n3. literal number\n</code></pre>",
+    },
+    {
+      name: "a fence with a trailing word inside code",
+      input: "```\n```example\n• literal bullet\n3. literal number\n```",
+      html: "<pre><code>```example\n• literal bullet\n3. literal number\n</code></pre>",
+    },
+    {
+      name: "multiline inline code",
+      input: "`start\n• literal bullet\n3. literal number`",
+      html: "<code>start • literal bullet 3. literal number</code>",
+    },
+    {
+      name: "indented code",
+      input: "    • literal bullet\n    3. literal number",
+      html: "<pre><code>• literal bullet\n3. literal number\n</code></pre>",
+    },
+  ])("does not insert Telegram list boundary spacing inside $name", ({ input, html }) => {
     const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
     const chunks = markdownToTelegramChunks(input, 4096)
       .map((chunk) => chunk.html)
       .join("");
 
-    expect(res).toBe("<pre><code>• literal bullet\n3. literal number\n</code></pre>");
-    expect(chunks).toBe(res);
+    expect(res).toBe(html);
+    expect(chunks).toBe(html);
   });
 
   it("does not treat single pipe as spoiler", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -3,7 +3,9 @@ import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   FILE_REF_EXTENSIONS_WITH_TLD,
+  findCodeRegions,
   isAutoLinkedFileRef,
+  isInsideCode,
   markdownToIR,
   type MarkdownLinkSpan,
   type MarkdownIR,
@@ -112,14 +114,8 @@ function isTelegramListBoundaryLine(line: string): boolean {
   return /^[ \t]*(?:\d+\.|#{1,6})[ \t]+\S/.test(line);
 }
 
-function isMarkdownIndentedCodeLine(line: string): boolean {
-  return /^(?: {4}|\t)/.test(line);
-}
-
 function shouldPreserveTelegramListBoundarySpacing(previous: string, next: string): boolean {
   return (
-    !isMarkdownIndentedCodeLine(previous) &&
-    !isMarkdownIndentedCodeLine(next) &&
     isTelegramBulletLine(previous) &&
     isTelegramListBoundaryLine(next) &&
     leadingWhitespaceLength(next) <= leadingWhitespaceLength(previous)
@@ -127,25 +123,25 @@ function shouldPreserveTelegramListBoundarySpacing(previous: string, next: strin
 }
 
 function preserveTelegramListBoundarySpacing(markdown: string): string {
-  const lines = markdown.split("\n");
-  const out: string[] = [];
-  let inFence = false;
+  // Preserve literal fence examples and indented code when separating prose lists.
+  let codeRegions: ReturnType<typeof findCodeRegions> | undefined;
   let previousLine = "";
-
-  for (const line of lines) {
-    const normalizedLine = line.replace(/\r$/, "");
-    const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
-    if (!inFence && shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine)) {
-      out.push("");
-    }
-    out.push(line);
-    if (isFenceLine) {
-      inFence = !inFence;
-    }
-    previousLine = normalizedLine;
-  }
-
-  return out.join("\n");
+  let previousOffset = 0;
+  let offset = 0;
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const normalizedLine = line.replace(/\r$/, "");
+      const insertBoundary =
+        shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine) &&
+        !isInsideCode(previousOffset, (codeRegions ??= findCodeRegions(markdown))) &&
+        !isInsideCode(offset, codeRegions);
+      previousLine = normalizedLine;
+      previousOffset = offset;
+      offset += line.length + 1;
+      return insertBoundary ? `\n${line}` : line;
+    })
+    .join("\n");
 }
 
 function parseTelegramLegacyMarkdown(markdown: string, tableMode?: MarkdownTableMode): MarkdownIR {

--- a/extensions/telegram/src/send.telegram-http.test.ts
+++ b/extensions/telegram/src/send.telegram-http.test.ts
@@ -184,6 +184,24 @@ describe("Telegram physical send acceptance over HTTP", () => {
     expect(requests.at(-1)?.fields.text).toBe("Manual");
   });
 
+  it.each(["text", "caption"] as const)(
+    "preserves literal code spacing in the %s sent over HTTP",
+    async (kind) => {
+      await sendMessageTelegram("123", "````\n```\n• literal bullet\n3. literal number\n````", {
+        cfg,
+        api: bot.api,
+        ...(kind === "caption" ? { mediaUrl: photoPath, mediaLocalRoots: [mediaDir] } : {}),
+      });
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.method).toBe(kind === "caption" ? "sendPhoto" : "sendMessage");
+      expect(requests[0]?.fields.parse_mode).toBe("HTML");
+      expect(requests[0]?.fields[kind]).toBe(
+        "<pre><code>```\n• literal bullet\n3. literal number\n</code></pre>",
+      );
+    },
+  );
+
   it.each(["active", "closed", "aborted"])(
     "checks %s send authority after the real account queue drains",
     async (state) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users receiving Telegram code examples would see extra blank lines when a literal bullet line was followed by a numbered line inside a longer or mixed-marker fence. Multiline inline code could also lose its code formatting. The problem affects normal messages and media captions.

## Why This Change Was Made

The list-spacing pass now uses the existing Markdown code-region owner for both adjacent lines, removing its independent fence and indentation guesses. It keeps the existing prose-spacing rule and computes code regions only when a separator could be inserted.

## User Impact

Code examples retain their intended content and spacing, including shorter or different fence markers shown literally inside a code block. Ordinary list and numbered-section spacing remains covered by the existing controls.

## Evidence

- Before the repair: **6 intended failures and 2 passing controls**, including actual formatter/chunker output and grammY localhost HTTP payloads for text and photo captions.
- Final focused formatter, wrapping/chunking, and HTTP-send tests: **135 passed** across 3 files.
- Full changed-file gate: **passed** for all 4 changed files against the pinned base.
- Managed P2 review: **scoped-clean**, no actionable findings. The review and tests include the final cleanup and lazy parser call.
- **Proof scope and maintainer assessment:** the accepted boundary proof exercises actual grammY HTTP serialization for text and photo captions. This formatter-only repair preserves the Telegram endpoint and API contract. Telegram Test Server and client-rendering proof remain unavailable because no supported Convex CLI or broker inputs were present; no authenticated Telegram live proof is claimed. This assessment does not waive enforced CI or review gates.

Production: **20 added, 24 removed (net −4)**. The shared parser replaces the deleted local guesses; no configuration or dependency changes are needed.
