### PR TITLE
fix(sessions): skip cleanup for newly protected history

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -570,6 +570,14 @@ session writes can continue during those checks. It reacquires the writer and
 revalidates current authority before index repair, schema work, or deletion.
 The connection and lease remain owned throughout admission; refusal unwinds that
 owner, and final writer admission remains held until the worker exits.
+
+Disk-budget cleanup rechecks protection after archive materialization. A candidate
+already excluded by that fresh protection set is canceled before worker admission
+and is not counted as reclaimed. After releasing its lifecycle holds, cleanup
+remeasures physical usage before considering another candidate, so space freed by
+a peer does not cause unnecessary eviction. Every admitted worker still performs
+the full integrity, foreign-key, and current-owner checks described here.
+
 Archive publication and cascading deletion remain atomic. Before COMMIT, the
 worker publishes its authorization request in shared memory and waits for the
 parent's current owner check. Synchronous writers service that request at the shared

--- a/src/config/sessions/session-history-eviction.protected-cancellation.test.ts
+++ b/src/config/sessions/session-history-eviction.protected-cancellation.test.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { isSessionLifecycleMutationActive } from "../../sessions/session-lifecycle-admission.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  appendTranscriptMessage,
+  loadTranscriptEventsSync,
+  replaceSessionEntry,
+  replaceSessionEntrySync,
+  resetSessionEntryLifecycle,
+} from "./session-accessor.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import { enforceSqliteSessionHistoryDiskBudget } from "./session-history-eviction.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+describe("protected historical session cancellation", () => {
+  let testState: OpenClawTestState;
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      prefix: "openclaw-protected-history-cancellation-",
+      layout: "state-only",
+    });
+    tempDir = testState.sessionsDir();
+    fs.mkdirSync(tempDir, { recursive: true });
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    resetAgentRunRegistryForTest();
+    vi.restoreAllMocks();
+    await enforceSqliteSessionHistoryDiskBudget({
+      storePath,
+      mode: "warn",
+      maintenance: { maxDiskBytes: null, highWaterBytes: null },
+    });
+    closeOpenClawAgentDatabasesForTest();
+    await testState.cleanup();
+  });
+
+  it.each([false, true])(
+    "cancels newly protected history before Worker admission and refreshes released pressure (measurement fails: %s)",
+    async (measurementFails) => {
+      const dayMs = 24 * 60 * 60 * 1000;
+      const oldestAt = Date.now() - 8 * dayMs;
+      const histories = ["protected", "next"].map((name, index) => ({
+        sessionKey: `agent:main:${name}-history`,
+        sessionId: `${name}-old`,
+        nextSessionId: `${name}-live`,
+        updatedAt: oldestAt + index,
+        content: `retain ${name} history`,
+      }));
+      for (const history of histories) {
+        await createHistoricalTranscript(history);
+      }
+      const protectedHistory = histories[0]!;
+      const beforeEvents = histories.map((history) =>
+        loadTranscriptEventsSync({ ...history, storePath }),
+      );
+      expect(beforeEvents.every((events) => events.length > 0)).toBe(true);
+      settlePhysicalUsage();
+      // This live peer artifact counts toward pressure but is not an archive-pruning target.
+      const peerArtifact = path.join(tempDir, "peer-live.jsonl");
+      const peerBytes = 2 * 1024 * 1024;
+      fs.writeFileSync(peerArtifact, Buffer.alloc(peerBytes));
+      const diskBudget = await import("./disk-budget.js");
+      const measure = diskBudget.measureSessionPhysicalDiskUsage;
+      const before = await measure(storePath);
+      const highWaterBytes = before.totalBytes - peerBytes / 2;
+      const measurementFailure = new Error("synthetic post-cancellation measurement failure");
+      let protectionChanged = false;
+      vi.spyOn(diskBudget, "measureSessionPhysicalDiskUsage").mockImplementation(
+        async (pathname) => {
+          if (protectionChanged) {
+            expect(isSessionLifecycleMutationActive(storePath, [protectedHistory.sessionId])).toBe(
+              false,
+            );
+            if (measurementFails) {
+              throw measurementFailure;
+            }
+          }
+          return await measure(pathname);
+        },
+      );
+      const archive = await import("./session-accessor.sqlite-archive.js");
+      const materialize = archive.materializeSessionStateDeletePlans;
+      vi.spyOn(archive, "materializeSessionStateDeletePlans").mockImplementationOnce(
+        async (plans) => {
+          expect(plans.map((plan) => plan.sessionId)).toEqual([protectedHistory.sessionId]);
+          const prepared = await materialize(plans);
+          replaceSessionEntrySync(
+            { sessionKey: protectedHistory.sessionKey, storePath },
+            { sessionId: protectedHistory.nextSessionId, updatedAt: Date.now() },
+          );
+          fs.unlinkSync(peerArtifact);
+          expect((await measure(storePath)).totalBytes).toBeLessThanOrEqual(highWaterBytes);
+          protectionChanged = true;
+          return prepared;
+        },
+      );
+      const admissions: Array<{ workerThreadId: number; admissionId: number | undefined }> = [];
+      const detachWorkerListeners: Array<() => void> = [];
+      const observeWorker = (worker: Worker) => {
+        const workerThreadId = worker.threadId;
+        const observeMessage = (message: { type?: string; admissionId?: number }) => {
+          // Archive materialization and disk scans do not request reclamation write admission.
+          if (message.type === "admission-request") {
+            admissions.push({ workerThreadId, admissionId: message.admissionId });
+          }
+        };
+        worker.on("message", observeMessage);
+        detachWorkerListeners.push(() => worker.off("message", observeMessage));
+      };
+      process.on("worker", observeWorker);
+      try {
+        const sweep = enforceSqliteSessionHistoryDiskBudget({
+          storePath,
+          mode: "enforce",
+          maintenance: {
+            maxDiskBytes: before.totalBytes - 1,
+            highWaterBytes,
+            preserveRecentMs: 7 * dayMs,
+          },
+        });
+        if (measurementFails) {
+          await expect(sweep).rejects.toBe(measurementFailure);
+        } else {
+          const result = await sweep;
+          expect(result).toMatchObject({ removedEntries: 0, removedFiles: 0 });
+          expect(result?.totalBytesAfter).toBeLessThanOrEqual(highWaterBytes);
+          expect(result?.totalBytesAfter).toBe((await measure(storePath)).totalBytes);
+        }
+        expect(protectionChanged).toBe(true);
+        expect(fs.existsSync(peerArtifact)).toBe(false);
+        for (const [index, history] of histories.entries()) {
+          expect(sessionExists(history.sessionId)).toBe(true);
+          expect(loadTranscriptEventsSync({ ...history, storePath })).toEqual(beforeEvents[index]);
+          expect(readArchiveNames(history.sessionId)).toEqual([]);
+        }
+        expect(admissions).toEqual([]);
+      } finally {
+        process.off("worker", observeWorker);
+        detachWorkerListeners.forEach((detach) => detach());
+      }
+    },
+  );
+
+  async function createHistoricalTranscript(params: {
+    content: string;
+    nextSessionId: string;
+    sessionId: string;
+    sessionKey: string;
+    updatedAt: number;
+  }): Promise<void> {
+    await replaceSessionEntry(
+      { sessionKey: params.sessionKey, storePath },
+      { sessionId: params.sessionId, updatedAt: params.updatedAt },
+    );
+    await appendTranscriptMessage(
+      { sessionId: params.sessionId, sessionKey: params.sessionKey, storePath },
+      { message: { role: "user", content: params.content } },
+    );
+    await resetSessionEntryLifecycle({
+      storePath,
+      target: { canonicalKey: params.sessionKey, storeKeys: [params.sessionKey] },
+      buildNextEntry: () => ({ sessionId: params.nextSessionId, updatedAt: params.updatedAt + 1 }),
+    });
+    setSessionUpdatedAt(params.sessionId, params.updatedAt);
+  }
+
+  function database() {
+    const target = resolveSqliteTargetFromSessionStorePath(storePath);
+    if (!target.path) {
+      throw new Error("expected SQLite database path");
+    }
+    return openOpenClawAgentDatabase({ agentId: target.agentId ?? "main", path: target.path });
+  }
+
+  function settlePhysicalUsage(): void {
+    const owner = database();
+    owner.walMaintenance.checkpoint();
+    const row = owner.db.prepare("PRAGMA freelist_count").get() as
+      | { freelist_count?: unknown }
+      | undefined;
+    const freePages = Number(row?.freelist_count ?? 0);
+    if (Number.isSafeInteger(freePages) && freePages > 0) {
+      owner.db.exec(`PRAGMA incremental_vacuum(${freePages});`);
+    }
+    owner.walMaintenance.checkpoint();
+  }
+
+  function setSessionUpdatedAt(sessionId: string, updatedAt: number): void {
+    const owner = database();
+    const db = getSessionKysely(owner.db);
+    executeSqliteQuerySync(
+      owner.db,
+      db
+        .updateTable("session_windows")
+        .set({ updated_at: updatedAt })
+        .where("session_id", "=", sessionId),
+    );
+  }
+
+  function sessionExists(sessionId: string): boolean {
+    const owner = database();
+    const db = getSessionKysely(owner.db);
+    return (
+      executeSqliteQuerySync(
+        owner.db,
+        db.selectFrom("session_windows").select("session_id").where("session_id", "=", sessionId),
+      ).rows.length === 1
+    );
+  }
+
+  function readArchiveNames(sessionId: string): string[] {
+    return fs.readdirSync(tempDir).filter((name) => name.startsWith(`${sessionId}.jsonl.deleted.`));
+  }
+});

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -545,28 +545,35 @@ async function enforceSessionHistoryMaintenanceSerialized(
         }
         // Extract-before-delete is the retention invariant. The lifecycle hold
         // fences admission while the store writer is released for archive I/O.
-        const committedArchives = await runExclusiveSqliteSessionReclamation(async () => {
+        return await runExclusiveSqliteSessionReclamation(async () => {
           const materialized = await materializeSessionStateDeletePlans([plan]);
           const diagnostics: SqliteSessionReclamationDiagnostics = {};
           const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
             async () => {
               const database = openOpenClawAgentDatabase(databaseOptions);
+              const protectedSessionIds = collectCandidateAdditionalProtection({
+                database,
+                preserveRecentMs: params.maintenance.preserveRecentMs,
+                sessionId,
+                storePath: params.storePath,
+              });
+              if (protectedSessionIds.has(sessionId)) {
+                return null;
+              }
               return createHistoryEvictionReclamationPlan({
                 databaseOptions,
                 diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
                 materializedPlans: materialized,
-                protectedSessionIds: collectCandidateAdditionalProtection({
-                  database,
-                  preserveRecentMs: params.maintenance.preserveRecentMs,
-                  sessionId,
-                  storePath: params.storePath,
-                }),
+                protectedSessionIds,
                 sessionId,
               });
             },
             diagnostics,
           );
+          if (!reclamationPlan) {
+            return { kind: "protected" as const };
+          }
           const reclaimed = await runSqliteSessionReclamation({
             diagnostics,
             forceInProcess: false,
@@ -580,17 +587,20 @@ async function enforceSessionHistoryMaintenanceSerialized(
           if (!reclaimed.value.deleted) {
             return null;
           }
-          return reclaimed.value.archivedTranscripts;
+          return {
+            kind: "reclaimed" as const,
+            archivedTranscripts: reclaimed.value.archivedTranscripts,
+          };
         });
-        if (!committedArchives) {
-          return null;
-        }
-        return {
-          archivedTranscripts: committedArchives,
-        };
       },
     });
     if (!eviction) {
+      continue;
+    }
+    if (eviction.kind === "protected") {
+      // A peer may have freed space during materialization. Recheck after both
+      // holds release so stale pressure cannot evict another candidate.
+      usage = await measureSessionPhysicalDiskUsage(params.storePath);
       continue;
     }
     // The lifecycle and SQLite writer lanes are both released before file I/O;


### PR DESCRIPTION
Related: #112423.

<details>
<summary>Maintainer edits</summary>

This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where disk-budget cleanup continued expensive reclamation after a historical session became protected while its archive was being prepared. Cleanup could also continue to another candidate using an outdated pressure estimate after another actor freed physical space.

## Why This Change Was Made

The parent uses its existing fresh protection set to cancel an excluded candidate before reclamation Worker admission. A distinct cancellation outcome triggers physical-usage measurement after lifecycle and writer holds are released, before another candidate is considered. Other no-op outcomes retain their existing behavior.

Every admitted Worker retains the full integrity and foreign-key checks, current-owner and commit fences, and actual-exit ownership. Canceled work is not credited for another actor's removal and does not open a Worker solely to validate discarded work; earlier preparation failures and subsequent measurement failures still propagate.

## User Impact

Newly protected history avoids unnecessary Worker startup and database validation. Cleanup checks actual remaining pressure before deleting more history. Retention settings, archive durability, schema, and the handling of work protected after dispatch remain unchanged.

## Evidence

- The reviewed pre-fix test on `a92c15a5dc3710c0799320d07c35df862b074b0d` reached its intended failure after a real reclamation Worker received an already-protected historical ID. History remained intact and no removal occurred.
- Both permanent regression cases failed against unchanged production code: after real peer artifact bytes were removed, cleanup still deleted the next candidate. They pass with this change and observe actual Worker admission messages, retained transcript bytes, post-hold physical measurement, and exact measurement-error propagation.
- Final local focused proof: 81 tests passed across history eviction, protected cancellation, reclamation, commit, and admission-race suites. This includes the unchanged protection-after-dispatch coverage. The runner exited naturally and verified Worker-artifact cleanup.
- Changed-scope formatting, typechecking, lint, schema, boundary, and import-cycle checks passed. Independent Codex review through P2 found no actionable findings.
- [Blacksmith Testbox Linux proof](https://github.com/openclaw/openclaw/actions/runs/34273524347): normal build, 36 history/cancellation tests, API seeding, the real explicit-offline `sessions cleanup --enforce --store ... --json` command, and verification all exited naturally with code 0 and closed their process groups. Cleanup removed one eligible historical generation and preserved both current generations plus protected history; integrity and foreign-key assertions passed.
- The combined Testbox command remains recorded as failed: a runner footer joined the final heredoc delimiter after those five successful phases. A separate read-only SSH postcheck about 20 minutes later verified the retained full source tree, file hashes, and original step receipts. The workload was not replayed and the original failure was preserved. This later source check is separate evidence, not an original successful wrapper exit.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34273220992) passed for `5d95fdfb952767ded3fdad8d8cba5bfb76cfa120`. ClawSweeper reviewed that head and found no actionable introduced defect.

The peer artifact fixture proves released physical byte pressure; it does not reproduce a peer deleting a session window. This change is a focused follow-up within the broader cleanup work tracked in #112423 and does not claim that all cleanup stalls or its other tracks are resolved.
