### PR TITLE
refactor(tests): remove unused Doctor config mocks

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -570,59 +570,7 @@ vi.mock("../config/legacy.js", async () => {
 });
 
 vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: vi.fn((channelId: string) => {
-    if (channelId !== "discord") {
-      return undefined;
-    }
-    return {
-      doctor: {
-        normalizeCompatibilityConfig: ({
-          cfg,
-        }: {
-          cfg: { channels?: { discord?: Record<string, unknown> } };
-        }) => {
-          const discord = cfg.channels?.discord;
-          if (!discord) {
-            return { config: cfg, changes: [] };
-          }
-          if (
-            !("streamMode" in discord) &&
-            typeof discord.streaming !== "boolean" &&
-            typeof discord.streaming !== "string"
-          ) {
-            return { config: cfg, changes: [] };
-          }
-          const next = structuredClone(cfg);
-          const nextDiscord = next.channels?.discord;
-          if (!nextDiscord) {
-            return { config: cfg, changes: [] };
-          }
-          const nextStreaming =
-            nextDiscord.streaming && typeof nextDiscord.streaming === "object"
-              ? { ...(nextDiscord.streaming as Record<string, unknown>) }
-              : {};
-          if (!("mode" in nextStreaming)) {
-            nextStreaming.mode =
-              nextDiscord.streamMode === "block"
-                ? "partial"
-                : nextDiscord.streaming === false
-                  ? "off"
-                  : "partial";
-          }
-          delete nextDiscord.streamMode;
-          nextDiscord.streaming = nextStreaming;
-          return {
-            config: next,
-            changes: ["Discord allowlist ids normalized to strings."],
-          };
-        },
-      },
-    };
-  }),
-}));
-
-vi.mock("../channels/plugins/doctor-contract-api.js", () => ({
-  loadBundledChannelDoctorContractApi: vi.fn(() => undefined),
+  getBootstrapChannelPlugin: vi.fn((_channelId: string) => undefined),
 }));
 
 vi.mock("../channels/plugins/setup-promotion-helpers.js", () => {
@@ -781,22 +729,6 @@ vi.mock("./doctor/shared/stale-plugin-config.js", () => ({
 vi.mock("./doctor/shared/plugin-tool-allowlist-warnings.js", () => ({
   collectBundledProviderAllowlistPolicyWarnings: vi.fn(() => []),
   collectPluginToolAllowlistWarnings: vi.fn(() => []),
-}));
-
-vi.mock("../doctor-plugin-host-links.js", () => ({
-  maybeRepairPluginOpenClawHostLinks: vi.fn(async () => undefined),
-}));
-
-vi.mock("../doctor-plugin-registry.js", () => ({
-  maybeRepairStaleManagedNpmBundledPlugins: vi.fn(() => undefined),
-}));
-
-vi.mock("../doctor-auth-oauth-sidecar.js", () => ({
-  maybeRepairLegacyOAuthSidecarProfiles: vi.fn(async () => ({
-    detected: [],
-    changes: [],
-    warnings: [],
-  })),
 }));
 
 vi.mock("./doctor/shared/context-engine-host-compat.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

The Doctor config-flow tests carry unused mock registrations and an unexercised bootstrap migration implementation, making their actual dependency boundary harder to see.

## Why This Change Was Made

Remove four unused registrations and retain the needed bootstrap export as a fresh, same-arity mock returning undefined. All test cases, inputs, assertions and deadlines remain unchanged; this removes 68 net test lines.

## User Impact

No user-visible behavior changes. Developers maintain less misleading test scaffolding.

## Evidence

- Complete config-flow and repair-sequencing suites: 97 passing cases before and after, with identical ordered names and outcomes.
- An original-source diagnostic counted one bootstrap factory initialization, zero bootstrap implementation calls, and zero calls to all four removed factories across all 69 config-flow cases. Counters survived mock resets and were asserted at suite end.
- Required changed-file gate and independent P2 review passed. Diagnostic instrumentation is excluded from the change. No runtime improvement is claimed.
