### PR TITLE
fix: load the host SDK for plugins in sibling checkouts

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -349,6 +349,8 @@ function runCompiledEsmSidecarFastPathProbe(): SpawnSyncReturns<string> {
     },
   });
   fs.writeFileSync(path.join(tempRoot, "openclaw.mjs"), "#!/usr/bin/env node\n", "utf8");
+  fs.mkdirSync(path.join(tempRoot, "src"));
+  fs.mkdirSync(path.join(tempRoot, "extensions"));
   fs.mkdirSync(path.join(tempRoot, "dist", "plugin-sdk"), { recursive: true });
   fs.writeFileSync(
     path.join(tempRoot, "dist", "plugin-sdk", "channel-outbound.js"),
@@ -383,7 +385,11 @@ function runCompiledEsmSidecarFastPathProbe(): SpawnSyncReturns<string> {
   return spawnSync(process.execPath, ["--import", "tsx", probePath], {
     cwd: process.cwd(),
     encoding: "utf8",
-    env: { ...process.env, OPENCLAW_DIAGNOSTICS: "plugin.load-profile" },
+    env: {
+      ...process.env,
+      OPENCLAW_DIAGNOSTICS: "plugin.load-profile",
+      OPENCLAW_DEV_SOURCE_ROOT: tempRoot,
+    },
   });
 }
 
@@ -661,7 +667,7 @@ describe("loadBundledEntryExportSync", () => {
   it("keeps compiled ESM sidecars with SDK imports on the nodeRequire fast-path", async () => {
     const result = compiledEsmSidecarFastPathResult;
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe("adapter");
     expect(result.stderr).toMatch(/sourceLoaderCreateMs=0(?:\.0+)?(?:\s|$)/u);
     expect(result.stderr).toMatch(/sourceLoaderCallMs=0(?:\.0+)?(?:\s|$)/u);

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1553,6 +1553,58 @@ describe("plugin sdk alias helpers", () => {
     });
   });
 
+  it.each(
+    (["src", "dist"] as const).flatMap((preference) =>
+      ["sibling-argv", "missing-argv", "no-argv", "development", "no-host", "invalid-host"].map(
+        (mode) => ({ preference, mode }),
+      ),
+    ),
+  )("selects the running SDK host across checkouts ($preference/$mode)", ({ preference, mode }) => {
+    const fixtureOptions = {
+      srcFile: "plugin-state-store-runtime.ts",
+      distFile: "plugin-state-store-runtime.js",
+      srcBody: 'throw new Error("SDK metadata selection must not execute source");\n',
+      distBody: 'throw new Error("SDK metadata selection must not execute dist");\n',
+      packageExports: {
+        "./plugin-sdk/plugin-state-store-runtime": {
+          default: "./dist/plugin-sdk/plugin-state-store-runtime.js",
+        },
+      },
+    };
+    const host = createPluginSdkAliasFixture(fixtureOptions);
+    const sibling = createPluginSdkAliasFixture(fixtureOptions);
+    const pluginEntry = writePluginEntry(sibling.root, ".artifacts/plugin/index.ts");
+    const loader = writePluginEntry(host.root, "src/plugins/loader.ts");
+    const noHost = mode === "no-host" || mode === "invalid-host";
+    const expected = noHost || mode === "development" ? sibling : host;
+    const prepared = preparePluginLoaderAliases({
+      modulePath: pluginEntry,
+      cwd: sibling.root,
+      moduleUrl:
+        mode === "no-host"
+          ? undefined
+          : mode === "invalid-host"
+            ? "not-a-file-url"
+            : pathToFileURL(loader).href,
+      argv1:
+        mode === "no-argv"
+          ? undefined
+          : mode === "missing-argv"
+            ? path.join(makeTempDir(), "missing-launcher")
+            : path.join(noHost ? host.root : sibling.root, "openclaw.mjs"),
+      devSourceRoot: mode === "development" ? sibling.root : null,
+      pluginSdkResolution: preference,
+    });
+    for (const prefix of ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"]) {
+      const specifier = `${prefix}/plugin-state-store-runtime`;
+      const target = prepared.resolveAlias(specifier);
+      expect(fs.realpathSync(target ?? "")).toBe(
+        fs.realpathSync(preference === "src" ? expected.srcFile : expected.distFile),
+      );
+      expect(prepared.getAliasMap()[specifier]).toBe(target);
+    }
+  });
+
   it("resolves plugin-sdk aliases for user-installed plugins via moduleUrl hint", () => {
     const {
       externalPluginEntry,
@@ -1566,16 +1618,11 @@ describe("plugin sdk alias helpers", () => {
     // This covers installations where argv1 does not resolve to the openclaw root
     // (e.g. single-binary distributions or custom process launchers).
     // Use openclaw.mjs which is created by createPluginSdkAliasFixture (bin+marker mode).
-    // Use fixture.root as cwd so process.cwd() fallback also resolves to fixture, not the
-    // real openclaw repo root in the test runner environment.
     const loaderModuleUrl = pathToFileURL(path.join(fixture.root, "openclaw.mjs")).href;
 
     // Use externalPluginRoot as cwd so process.cwd() fallback cannot accidentally
     // resolve to the fixture root — only the moduleUrl hint can bridge the gap.
-    // Pass "" for argv1: undefined would trigger the STARTUP_ARGV1 default (the vitest
-    // runner binary, inside the openclaw repo), which resolves before moduleUrl is checked.
-    // An empty string is falsy so resolveTrustedOpenClawRootFromArgvHint returns null,
-    // meaning only the moduleUrl hint can bridge the gap.
+    // Disable the startup argv hint so this row exercises the explicit host alone.
     const aliases = withCwd(externalPluginRoot, () =>
       withEnv({ NODE_ENV: undefined }, () =>
         buildPluginLoaderAliasMap(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -398,18 +398,11 @@ function resolveLoaderPluginSdkPackageRoot(
     return devSourceRoot;
   }
   const cwd = params.cwd ?? path.dirname(params.modulePath);
-  const fromCwd = resolveOpenClawPackageRootSync({ cwd });
-  const fromExplicitHints =
-    resolveTrustedOpenClawRootFromArgvHint({ cwd, argv1: params.argv1 }) ??
-    (params.moduleUrl
-      ? resolveOpenClawPackageRootSync({
-          cwd,
-          moduleUrl: params.moduleUrl,
-        })
-      : null);
+  // The running loader owns the SDK, even when plugin source lives in another checkout.
   return (
-    fromCwd ??
-    fromExplicitHints ??
+    (params.moduleUrl ? resolveOpenClawPackageRootSync({ moduleUrl: params.moduleUrl }) : null) ??
+    resolveOpenClawPackageRootSync({ cwd }) ??
+    resolveTrustedOpenClawRootFromArgvHint({ cwd, argv1: params.argv1 }) ??
     findNearestPluginSdkPackageRoot(path.dirname(params.modulePath)) ??
     (params.cwd ? findNearestPluginSdkPackageRoot(params.cwd) : null) ??
     findNearestPluginSdkPackageRoot(process.cwd())


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

Fixes an issue where plugins stored inside another OpenClaw checkout could load that checkout's older SDK instead of the SDK belonging to the running Gateway. This can cause incompatible runtime or storage helpers to be selected even when the Gateway itself is up to date.

## Why This Change Was Made

Resolve the SDK from the executing loader's explicit module URL before considering the plugin's directory or launcher. Keep the explicit development-source override and existing no-host fallbacks, trust checks and private SDK ownership rules. The change removes seven production lines.

## User Impact

Plugins can live under a sibling checkout without silently selecting its SDK. Existing standalone and development-source loading continue to work.

## Evidence

Six source/dist cross-checkout cases failed before the fix; all 12 cases now pass, including misleading or missing launchers, development overrides and no-host controls. The full channel-entry, alias and native-resolver suites passed 118 tests with one existing skipped test. The synthetic SDK artifacts are inspected as metadata and never executed by the new regression cases.

A synthetic actor scenario in #135599 exposed the wrong-host selection. After integration, the same isolated Gateway storage probe succeeded using the running host SDK. Broader actor integration work remains in #135599; this is not a claim that the whole actor scenario passed. This repair does not change database schemas.

The first CI run exposed a fast-path fixture that implicitly selected its temporary SDK as the host. The fixture now declares that host through the existing development override, preserving its native-load and zero-transform assertions. The original production change is unchanged. Local changed-file gates passed, including the follow-up test gate, and fresh review of the complete candidate through P2 found no actionable issues.
