### PR TITLE
fix(ui): stabilize composer alignment browser test

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4037,8 +4037,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const page = await openFixture(width, height);
       try {
         await expectNoHorizontalOverflow(page);
-        // Measure the settled footer row after the context ring's 200ms entrance animation.
-        await page.waitForTimeout(220);
+        // Wall-clock sleeps can expire before Chromium advances compositor animations
+        // on a contended CI runner. Measure the footer after its finite entrance effect.
+        await page.locator(".context-ring").evaluate(finishElementAnimations);
         const controls = await page.evaluate(() => {
           const rectFor = (selector: string) => {
             const node = document.querySelector(selector) as HTMLElement | null;
@@ -4135,6 +4136,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(rectsOverlap(model, send)).toBe(false);
         const contextModelGap = model.x - (context.x + context.width);
         expect(contextModelGap).toBeGreaterThanOrEqual(-1);
+        expect(
+          Math.abs(context.y + context.height / 2 - (model.y + model.height / 2)),
+        ).toBeLessThanOrEqual(2);
         const composerFontSizes = await page.evaluate(() => {
           const textareaNode = document.querySelector<HTMLTextAreaElement>(
             ".agent-chat__composer-combobox > textarea",
@@ -4195,11 +4199,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         if (width <= 768) {
           expect(send.width).toBeCloseTo(32, 2);
           expect(send.height).toBeCloseTo(32, 2);
-          for (const control of [model, context]) {
-            expect(
-              Math.abs(control.y + control.height / 2 - (model.y + model.height / 2)),
-            ).toBeLessThanOrEqual(2);
-          }
           expect(footer.height).toBeLessThanOrEqual(53);
         } else {
           // The editor reads at input size, while the controls around it stay


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Control UI responsive composer browser test could sample the context control during its entrance transform on a contended Chromium runner, producing a false 4px vertical-alignment failure despite a 2px settled-layout tolerance.

The failure was observed in [CI run 34270805824, job 102211997399](https://github.com/openclaw/openclaw/actions/runs/34270805824/job/102211997399) while testing PR #142461. That PR's release-harness files are unrelated and remain untouched.

## Why This Change Was Made

The test now finishes the context control's finite animations before reading geometry instead of assuming a 220ms wall-clock sleep advances Chromium's compositor. The existing context/model center assertion now covers desktop viewports as well as mobile, retaining direct regression coverage for the 1366x900 case on current `main`.

## User Impact

No user-visible layout changes. Maintainers get deterministic responsive composer coverage without weakening the 2px alignment tolerance.

## Evidence

- Recorded-head repro: forcing the context animation to its first frame reproduced the exact `expected 4 to be less than or equal to 2` failure; finishing finite animations made the unchanged geometry assertion pass.
- Focused five-viewport matrix: 5/5 passed.
- Focused stress run: 20 repetitions passed (100 viewport-case executions).
- Full `chat-responsive.browser.test.ts`: 123/123 passed.
- `pnpm check:changed`: passed.
- Autoreview through P2: scoped-clean.
- Exact-head [CI run 34273838902](https://github.com/openclaw/openclaw/actions/runs/34273838902): all three Linux `checks-ui` Playwright/Chromium shards passed.
