### PR TITLE
refactor(cli): finalize restart health snapshots once

### DIFF
--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -50,76 +50,41 @@ const STARTUP_MIGRATION_ACTIVITY_POLL_MS = 5_000;
 const STOPPED_FREE_EARLY_EXIT_GRACE_MS = 10_000;
 const WINDOWS_STOPPED_FREE_EARLY_EXIT_GRACE_MS = 90_000;
 
-function applyExpectedVersion(
-  snapshot: GatewayRestartSnapshot,
-  expectedVersion: string | undefined,
-): GatewayRestartSnapshot {
-  if (!expectedVersion) {
-    return snapshot;
-  }
-  if (snapshot.gatewayVersion === expectedVersion) {
-    return { ...snapshot, expectedVersion };
-  }
-  if (snapshot.gatewayVersion == null) {
-    return { ...snapshot, healthy: false, expectedVersion };
-  }
-  return {
-    ...snapshot,
-    healthy: false,
-    expectedVersion,
-    versionMismatch: {
-      expected: expectedVersion,
-      actual: snapshot.gatewayVersion ?? null,
-    },
-  };
-}
-
-function applyExpectedBuildId(
-  snapshot: GatewayRestartSnapshot,
-  expectedBuildId: string | undefined,
-): GatewayRestartSnapshot {
-  // Git restart verification owns Gateway runtime identity. UI artifact source
-  // must not exempt a stale process from this check.
-  if (!expectedBuildId) {
-    return snapshot;
-  }
-  if (snapshot.gatewayBuildId === expectedBuildId) {
-    return { ...snapshot, expectedBuildId };
-  }
-  if (snapshot.gatewayBuildId === undefined) {
-    return { ...snapshot, healthy: false, expectedBuildId };
-  }
-  return {
-    ...snapshot,
-    healthy: false,
-    expectedBuildId,
-    buildIdMismatch: {
-      expected: expectedBuildId,
-      actual: snapshot.gatewayBuildId ?? null,
-    },
-  };
-}
-
-function applyExpectedGatewayIdentity(
+// Both callers pass a fresh snapshot that has not escaped inspection.
+function finalizeGatewayRestartSnapshot(
   snapshot: GatewayRestartSnapshot,
   expectedVersion: string | undefined,
   expectedBuildId: string | undefined,
 ): GatewayRestartSnapshot {
-  return applyExpectedBuildId(applyExpectedVersion(snapshot, expectedVersion), expectedBuildId);
-}
-
-function applyActivatedPluginErrors(snapshot: GatewayRestartSnapshot): GatewayRestartSnapshot {
-  if (!snapshot.activatedPluginErrors?.length) {
-    return snapshot;
+  if (expectedVersion) {
+    snapshot.expectedVersion = expectedVersion;
+    if (snapshot.gatewayVersion !== expectedVersion) {
+      snapshot.healthy = false;
+      if (snapshot.gatewayVersion != null) {
+        snapshot.versionMismatch = {
+          expected: expectedVersion,
+          actual: snapshot.gatewayVersion,
+        };
+      }
+    }
   }
-  return { ...snapshot, healthy: false };
-}
-
-function applyChannelProbeErrors(snapshot: GatewayRestartSnapshot): GatewayRestartSnapshot {
-  if (!snapshot.channelProbeErrors?.length) {
-    return snapshot;
+  // Runtime identity remains required even with a separately configured UI root.
+  if (expectedBuildId) {
+    snapshot.expectedBuildId = expectedBuildId;
+    if (snapshot.gatewayBuildId !== expectedBuildId) {
+      snapshot.healthy = false;
+      if (snapshot.gatewayBuildId !== undefined) {
+        snapshot.buildIdMismatch = {
+          expected: expectedBuildId,
+          actual: snapshot.gatewayBuildId ?? null,
+        };
+      }
+    }
   }
-  return { ...snapshot, healthy: false };
+  if (snapshot.activatedPluginErrors?.length || snapshot.channelProbeErrors?.length) {
+    snapshot.healthy = false;
+  }
+  return snapshot;
 }
 
 export async function inspectGatewayRestart(params: {
@@ -191,27 +156,23 @@ export async function inspectGatewayRestart(params: {
   if (portUsage.status === "busy" && runtime.status !== "running") {
     const reachable = await loadReachability();
     if (reachable.reachable) {
-      return applyChannelProbeErrors(
-        applyActivatedPluginErrors(
-          applyExpectedGatewayIdentity(
-            {
-              runtime,
-              portUsage,
-              healthy: true,
-              staleGatewayPids: [],
-              gatewayVersion: reachable.gatewayVersion,
-              gatewayBuildId: reachable.gatewayBuildId,
-              ...(reachable.activatedPluginErrors.length > 0
-                ? { activatedPluginErrors: reachable.activatedPluginErrors }
-                : {}),
-              ...(reachable.channelProbeErrors.length > 0
-                ? { channelProbeErrors: reachable.channelProbeErrors }
-                : {}),
-            },
-            expectedVersion,
-            expectedBuildId,
-          ),
-        ),
+      return finalizeGatewayRestartSnapshot(
+        {
+          runtime,
+          portUsage,
+          healthy: true,
+          staleGatewayPids: [],
+          gatewayVersion: reachable.gatewayVersion,
+          gatewayBuildId: reachable.gatewayBuildId,
+          ...(reachable.activatedPluginErrors.length > 0
+            ? { activatedPluginErrors: reachable.activatedPluginErrors }
+            : {}),
+          ...(reachable.channelProbeErrors.length > 0
+            ? { channelProbeErrors: reachable.channelProbeErrors }
+            : {}),
+        },
+        expectedVersion,
+        expectedBuildId,
       );
     }
   }
@@ -249,12 +210,6 @@ export async function inspectGatewayRestart(params: {
     healthy = reachable.reachable;
     gatewayVersion = reachable.gatewayVersion;
     gatewayBuildId = reachable.gatewayBuildId;
-    if (reachable.activatedPluginErrors.length > 0) {
-      healthy = false;
-    }
-    if (reachable.channelProbeErrors.length > 0) {
-      healthy = false;
-    }
   }
   if (!healthy && running && portUsage.status === "busy" && !requiresGatewayProbe) {
     const reachable = await loadReachability();
@@ -282,24 +237,20 @@ export async function inspectGatewayRestart(params: {
     ]),
   );
 
-  return applyChannelProbeErrors(
-    applyActivatedPluginErrors(
-      applyExpectedGatewayIdentity(
-        {
-          runtime,
-          portUsage,
-          healthy,
-          staleGatewayPids,
-          ...(gatewayVersion !== undefined ? { gatewayVersion } : {}),
-          ...(gatewayBuildId !== undefined ? { gatewayBuildId } : {}),
-          ...(probeError ? { probeError } : {}),
-          ...(activatedPluginErrors.length ? { activatedPluginErrors } : {}),
-          ...(channelProbeErrors.length ? { channelProbeErrors } : {}),
-        },
-        expectedVersion,
-        expectedBuildId,
-      ),
-    ),
+  return finalizeGatewayRestartSnapshot(
+    {
+      runtime,
+      portUsage,
+      healthy,
+      staleGatewayPids,
+      ...(gatewayVersion !== undefined ? { gatewayVersion } : {}),
+      ...(gatewayBuildId !== undefined ? { gatewayBuildId } : {}),
+      ...(probeError ? { probeError } : {}),
+      ...(activatedPluginErrors.length ? { activatedPluginErrors } : {}),
+      ...(channelProbeErrors.length ? { channelProbeErrors } : {}),
+    },
+    expectedVersion,
+    expectedBuildId,
   );
 }
 


### PR DESCRIPTION
Closes #142512

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Gateway restart checks must report identity mismatches and readiness failures consistently. Repeated snapshot-completion logic makes those existing outcomes harder to maintain across the early and ordinary inspection returns.

## Why This Change Was Made

This is a maintainer-requested cleanup. Use one private finalizer to complete each freshly created snapshot before it leaves inspection, replacing five copying helpers and redundant branch-local health assignments. The one-file change removes 49 production lines.

Expected identity normalization, optional field presence/order, nested references and error arrays stay unchanged. Unavailable version information remains pending without a mismatch; an unobserved build remains pending, while an explicitly missing build produces a mismatch. Plugin/channel failures, listener ownership, stale-PID decisions, cancellation and wait outcomes retain their existing behavior.

## User Impact

No intended user-visible behavior change. Restart health, diagnostics and deadlines remain the same. This is code consolidation; no measured memory or latency improvement is claimed.

## Evidence

- The same 82 existing tests across inspection, wait, probe and client files pass before and after the change.
- Existing real isolated WebSocket fixtures cover token, password and no-auth connect + health flows, identity and plugin/channel failures, and unchanged isolated state. No operator Gateway was restarted or inspected.
- The complete selected changed gate, formatting/diff checks and direct managed P2 review pass. No tests, dependencies, configuration, schema or other source files change. A full build was not run for this private local control-flow refactor.

Related work remains separate: #134665 changes plugin readiness policy in the same finalization paths and needs explicit integration if it lands first; #129844 changes secondary-account probe contents; #119975 changes unmanaged startup-progress outcomes and adds type re-exports. This PR does not implement or close those behavior changes.
