### PR TITLE
fix(mcp): node tool results copy large text twice

### DIFF
--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -1,5 +1,6 @@
 /** Tests connected node-hosted plugin tool materialization. */
 
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/index.js";
@@ -12,9 +13,11 @@ import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js
 import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
+import { consumeMcpCodeModeGuestResult } from "./mcp-content.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";
 import { isToolResultError } from "./tool-result-error.js";
 import { compactToolSearchCatalogEntry } from "./tool-search-catalog.js";
+import { snapshotToolSearchTargetTranscriptResult } from "./tool-search-transcript.js";
 import { createToolSearchCatalogRef } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -344,6 +347,43 @@ describe("createNodePluginTools", () => {
     });
     expect(JSON.stringify(result.details)).not.toContain("canary");
     expect(isToolResultError(result)).toBe(true);
+  });
+
+  it.each([false, true])("snapshots node MCP text once (isError: %s)", async (isError) => {
+    const text = "ordinary report line\n".repeat(25_000);
+    const payload = CallToolResultSchema.parse({
+      content: [
+        { type: "text", text },
+        { type: "resource_link", uri: "memo://report", name: "Report" },
+        { type: "text", text: "résumé\n東京", _meta: { source: "report" } },
+      ],
+      isError,
+    });
+    replaceNodePluginTools({
+      nodeId: "node-1",
+      tools: [
+        {
+          pluginId: "node-mcp",
+          name: "docs_read",
+          description: "Read node-local reports",
+          command: "mcp.tools.call.v1",
+          mcp: { server: "docs", tool: "read" },
+        },
+      ],
+    });
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({ payload });
+    const tool = expectDefined(createNodePluginTools({})[0], "node MCP report tool");
+    const result = snapshotToolSearchTargetTranscriptResult(await tool.execute("report", {}));
+
+    expect(result.content).toEqual([
+      { type: "text", text },
+      { type: "text", text: "[Report] memo://report" },
+      { type: "text", text: "résumé\n東京" },
+    ]);
+    expect(isToolResultError(result)).toBe(isError);
+    expect(consumeMcpCodeModeGuestResult(result)).toEqual(payload);
+    const contentBytes = Buffer.byteLength(JSON.stringify(result.content));
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThan(contentBytes + 1_024);
   });
 
   it("projects node MCP schemas and calls through the exact namespace catalog entry", async () => {

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -49,18 +49,9 @@ function mapMcpPayloadToAgentToolResult(
   if (!isRecord(payload)) {
     return jsonResult(payload);
   }
-  const textContent =
-    payload.structuredContent === undefined && Array.isArray(payload.content)
-      ? payload.content.flatMap((block) =>
-          isRecord(block) && block.type === "text" && typeof block.text === "string"
-            ? [{ type: "text" as const, text: block.text }]
-            : [],
-        )
-      : [];
   return projectMcpCallToolResult(payload, {
     mcpServer: mcp.server,
     mcpTool: mcp.tool,
-    ...(textContent.length > 0 ? { content: textContent } : {}),
   });
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled so maintainers can resolve small issues before merging.

</details>

## What Problem This Solves

Fixes an issue where agents using node-hosted MCP tools copy large plain-text results twice into each result snapshot, increasing allocation and serialization work.

## Why This Change Was Made

Remove the auxiliary text mirror left over from the former Code Mode result format. The existing MCP projector already supplies model content and independently retains the native MCP result for Code Mode; the mirror's old caller was migrated to that native contract.

## User Impact

Text-heavy node MCP calls produce smaller result snapshots while preserving model text, resource links, error status and native Code Mode data. Structured results and non-MCP node tools retain their existing behavior.

## Evidence

The new actual node-tool boundary regression failed on both normal and error results before the deletion because snapshot size was about 1.1 MB rather than under 551,141 bytes. All model/raw/error assertions already passed. After the nine-line production deletion, all 21 node-plugin-tool tests pass, including structured results, empty errors and native namespace siblings.

On Node 24.19.0, the isolated actual baseline/edited-owner snapshot benchmark for 525,000 bytes of text shrank serialized results from 1,100,125 to 550,087 bytes. Median mapper+snapshot times across three runs were 1.409–1.426 ms before and 0.685–0.707 ms after. Separate benchmark-process peak RSS was 157,089,792 bytes before and 111,427,584 bytes after. These are isolated boundary measurements, not end-to-end network latency or production RSS claims.

Managed P2 review is scoped-clean. The complete selected changed-file gate passed, including owning production/test types, full-file lint/format and all selected guards. Production removes 9 lines; tests add 40 lines. No live MCP server or provider call was made.
