### PR TITLE
fix(plugins): retain replaced registries through cleanup

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -166,6 +166,8 @@ Each plugin service startup attempt owns one cleanup operation, including failed
 
 Gateway shutdown also joins actual harness, MCP, LSP, embedding, and media cleanup after their initial grace periods. When clearing the active registry, plugin host cleanup can advance to later hooks after a timeout, but registry resets and shared database closure wait for its actual completion. These waits preserve resources for cleanup; they do not restore a retired plugin's runtime authority.
 
+Hot registry publication does not wait for retired host cleanup; terminal shutdown also joins cleanup already started by earlier registry replacements before resetting shared state. Activation and rollback apply only to their captured registry version. An activation superseded by a lifecycle callback reports an error.
+
 The cache rule is documented in [Plugin architecture internals](/plugins/architecture-internals#plugin-cache-boundary): Gateway retains one cache generation, while explicit management operations use isolated generations of the same cache. There are no wall-clock TTLs for Gateway metadata.
 
 Install, update, registry refresh, and doctor flows may read fresh package metadata to validate their changes. Their snapshots and installed-index writes do not replace the running Gateway's inventory. Runtime flows must use the startup snapshot or its lookup table instead of falling back to those cold management paths.

--- a/src/agents/bash-tools.exec-host-node.integration.test.ts
+++ b/src/agents/bash-tools.exec-host-node.integration.test.ts
@@ -43,7 +43,9 @@ let resolveDecision: (result: { decision: string }) => void;
 let decisionEntered: Deferred;
 beforeEach(async ({ onTestFinished }) => {
   const previousRegistry = captureActivePluginRegistrySnapshot();
-  onTestFinished(() => rollbackStagedPluginRegistry(previousRegistry));
+  onTestFinished(() => {
+    rollbackStagedPluginRegistry(previousRegistry);
+  });
   // A real Gateway already loaded its ingress channel before executing a tool.
   // Keep this node-policy fixture from cold-loading the whole A2A plugin graph.
   stageActivePluginRegistry(

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -89,7 +89,9 @@ function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolea
 describe("memory search config", () => {
   beforeEach(({ onTestFinished }) => {
     const previous = captureActivePluginRegistrySnapshot();
-    onTestFinished(() => rollbackStagedPluginRegistry(previous));
+    onTestFinished(() => {
+      rollbackStagedPluginRegistry(previous);
+    });
     stageActivePluginRegistry(createEmptyPluginRegistry(), null, "default");
     registerBaseMemoryEmbeddingProviders();
   });

--- a/src/auto-reply/test-helpers/command-auth-registry-fixture.test.ts
+++ b/src/auto-reply/test-helpers/command-auth-registry-fixture.test.ts
@@ -13,7 +13,9 @@ import { installDiscordRegistryHooks } from "./command-auth-registry-fixture.js"
 describe.each(["cold", "populated"])("command-auth fixture with a %s predecessor", (mode) => {
   beforeEach(({ onTestFinished }) => {
     const ambient = captureActivePluginRegistrySnapshot();
-    onTestFinished(() => rollbackStagedPluginRegistry(ambient));
+    onTestFinished(() => {
+      rollbackStagedPluginRegistry(ambient);
+    });
     const registry = createEmptyPluginRegistry();
     const entries = registry.embeddingProviders;
     const entry = {

--- a/src/auto-reply/test-helpers/command-auth-registry-fixture.ts
+++ b/src/auto-reply/test-helpers/command-auth-registry-fixture.ts
@@ -100,7 +100,9 @@ const createCommandAuthRegistry = () =>
 export function installDiscordRegistryHooks() {
   beforeEach(({ onTestFinished }) => {
     const previous = captureActivePluginRegistrySnapshot();
-    onTestFinished(() => rollbackStagedPluginRegistry(previous));
+    onTestFinished(() => {
+      rollbackStagedPluginRegistry(previous);
+    });
     // Stage without retiring the predecessor; roll back after caller cleanup
     // so its original lifecycle authority survives this temporary fixture.
     stageActivePluginRegistry(createCommandAuthRegistry(), null, "default");

--- a/src/plugins/embedding-providers.test.ts
+++ b/src/plugins/embedding-providers.test.ts
@@ -26,7 +26,9 @@ function createAdapter(id: string): EmbeddingProviderAdapter {
 
 beforeEach(({ onTestFinished }) => {
   const previous = captureActivePluginRegistrySnapshot();
-  onTestFinished(() => rollbackStagedPluginRegistry(previous));
+  onTestFinished(() => {
+    rollbackStagedPluginRegistry(previous);
+  });
   stageActivePluginRegistry(createEmptyPluginRegistry(), null, "default");
 });
 

--- a/src/plugins/loader-runtime-core.ts
+++ b/src/plugins/loader-runtime-core.ts
@@ -28,7 +28,7 @@ import type { PluginLoadOptions } from "./loader-types.js";
 import { createPluginIdScopeSet, normalizePluginIdScope } from "./plugin-scope.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistryInspectionResources } from "./registry-inspection-resources.js";
-import { pluginLoaderCacheState } from "./registry-lifecycle.js";
+import { isPluginRegistryActivated, pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { getPluginRegistryRuntime } from "./registry-runtime-binding.js";
 import { createPluginRegistry, type PluginRegistry } from "./registry.js";
 import { getActivePluginRegistry } from "./runtime.js";
@@ -325,12 +325,16 @@ export function loadOpenClawPluginsCore(
     }
     return registry;
   } catch (error) {
-    // Registration failures discard only an inactive builder. Activation is failure-atomic, and
-    // any later cache failure must not strip the registry already serving runtime consumers.
-    if (context.shouldActivate && registryBuilder?.registry !== getActivePluginRegistry()) {
-      for (const plugin of registryBuilder?.registry.plugins.toReversed() ?? []) {
+    // Published generations keep their callbacks until retirement drains admitted users.
+    // Only construction failures still own registration rollback here.
+    if (
+      context.shouldActivate &&
+      registryBuilder &&
+      !isPluginRegistryActivated(registryBuilder.registry)
+    ) {
+      for (const plugin of registryBuilder.registry.plugins.toReversed()) {
         if (plugin.status === "loaded") {
-          registryBuilder?.rollbackPluginGlobalSideEffects(plugin.id);
+          registryBuilder.rollbackPluginGlobalSideEffects(plugin.id);
         }
       }
     }

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -47,6 +47,8 @@ import type { PluginRecord, PluginRegistry } from "./registry.js";
 import {
   captureActivePluginRegistrySnapshot,
   commitStagedPluginRegistry,
+  getActivePluginRegistry,
+  getActivePluginRegistryVersion,
   rollbackStagedPluginRegistry,
   stageActivePluginRegistry,
 } from "./runtime.js";
@@ -445,19 +447,41 @@ export function activatePluginRegistry(
 ): void {
   const activeSnapshot = captureActivePluginRegistrySnapshot();
   const previousHookRegistry = getGlobalPluginRegistry();
+  let stagedVersion: number | undefined;
+  const isCurrentStage = () =>
+    stagedVersion !== undefined &&
+    getActivePluginRegistry() === registry &&
+    getActivePluginRegistryVersion() === stagedVersion;
   try {
-    // Install the complete bundle before hook-runner initialization so hook composition never
-    // observes contributions from two loads. Activation failure restores the prior selection.
-    stageActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+    // Install the complete bundle before hooks, but never resume a displaced activation.
+    stagedVersion = stageActivePluginRegistry(
+      registry,
+      cacheKey,
+      runtimeSubagentMode,
+      workspaceDir,
+    );
+    if (!isCurrentStage()) {
+      throw new Error("Plugin registry activation was superseded");
+    }
     initializeGlobalHookRunner(registry);
     activateContextEngineRegistrations(registry);
     commitStagedPluginRegistry(activeSnapshot.activeRegistry, registry);
+    if (!isCurrentStage()) {
+      throw new Error("Plugin registry activation was superseded");
+    }
   } catch (error) {
-    rollbackStagedPluginRegistry(activeSnapshot);
-    if (previousHookRegistry) {
-      initializeGlobalHookRunner(previousHookRegistry);
-    } else {
-      resetGlobalHookRunner();
+    if (isCurrentStage()) {
+      const rollbackVersion = rollbackStagedPluginRegistry(activeSnapshot);
+      if (
+        getActivePluginRegistry() === activeSnapshot.activeRegistry &&
+        getActivePluginRegistryVersion() === rollbackVersion
+      ) {
+        if (previousHookRegistry) {
+          initializeGlobalHookRunner(previousHookRegistry);
+        } else {
+          resetGlobalHookRunner();
+        }
+      }
     }
     throw error;
   }

--- a/src/plugins/plugin-command-runtime.test.ts
+++ b/src/plugins/plugin-command-runtime.test.ts
@@ -432,26 +432,32 @@ describe("plugin command runtime", () => {
     expect(cleanupReplacedPluginHostRegistry).toHaveBeenCalledOnce();
   });
 
-  it("lets repeated command-triggered clears return without deadlocking their drain", async () => {
-    const registry = createEmptyPluginRegistry();
-    registry.plugins.push({ status: "loaded" } as never);
-    registerCommand(registry, {
-      pluginId: "clear",
-      name: "clear",
-      handler: async () => {
-        await clearActivePluginRegistry();
-        await clearActivePluginRegistry();
-        return { text: "cleared" };
-      },
-    });
-    setActivePluginRegistry(registry);
-    const dispatch = requirePluginDispatch(
-      createPluginCommandRuntime().listNativeCandidates("telegram")[0]!,
-    );
-    await expect(dispatch.execute(executionContext)).resolves.toEqual({ text: "cleared" });
-    await clearActivePluginRegistry();
-    expect(cleanupReplacedPluginHostRegistry).toHaveBeenCalledOnce();
-  });
+  it.each([false, true])(
+    "lets command-triggered clears finish (replaced: %s)",
+    async (replaced) => {
+      const registry = createEmptyPluginRegistry();
+      registry.plugins.push({ status: "loaded" } as never);
+      registerCommand(registry, {
+        pluginId: "clear",
+        name: "clear",
+        handler: async () => {
+          if (replaced) {
+            setActivePluginRegistry(createEmptyPluginRegistry());
+          }
+          await clearActivePluginRegistry();
+          await clearActivePluginRegistry();
+          return { text: "cleared" };
+        },
+      });
+      setActivePluginRegistry(registry);
+      const dispatch = requirePluginDispatch(
+        createPluginCommandRuntime().listNativeCandidates("telegram")[0]!,
+      );
+      await expect(dispatch.execute(executionContext)).resolves.toEqual({ text: "cleared" });
+      await clearActivePluginRegistry();
+      expect(cleanupReplacedPluginHostRegistry).toHaveBeenCalledOnce();
+    },
+  );
 
   it("awaits cleanup from detached handler context after execution settles", async () => {
     const registry = createEmptyPluginRegistry();

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -22,6 +22,10 @@ export type RegistryState = {
   };
   commandRegistryClearTail?: Promise<void>;
   commandRegistryClearRegistries?: Map<PluginRegistry, number>;
+  retiredRegistryCleanups?: Map<
+    Promise<void>,
+    { registry: PluginRegistry; work: import("../shared/async-work-scope.js").AsyncWorkScope }
+  >;
 };
 
 type GlobalRegistryState = typeof globalThis & {

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -5,9 +5,15 @@ import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { getPluginRunContext, setPluginRunContext } from "./host-hook-runtime.js";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  capturePluginRegistryLifecycleSignal,
+  isPluginRegistryRetired,
+} from "./registry-lifecycle.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import type { PluginHttpRouteRegistration } from "./registry.js";
 import {
+  captureActivePluginRegistrySnapshot,
   clearActivePluginRegistry,
   getActivePluginRegistry,
   listImportedRuntimePluginIds,
@@ -205,11 +211,321 @@ describe("setActivePluginRegistry", () => {
     expect(cleanupCount).toBe(1);
   });
 
-  it.each(["callback", "descendant"] as const)(
-    "joins actual lifecycle %s before plugin-registry resets",
-    async (owner) => {
+  it("lets retired cleanup clear its successor without joining itself", async () => {
+    const registry = createEmptyPluginRegistry();
+    const started = createDeferredCore();
+    const finished = createDeferredCore();
+    const cleanup = vi.fn(async () => {
+      started.resolve();
+      await clearActivePluginRegistry();
+      finished.resolve();
+    });
+    registry.runtimeLifecycles.push({
+      pluginId: "reentrant-cleanup",
+      lifecycle: { id: "clear-successor", cleanup },
+      source: "/virtual/reentrant-cleanup/index.ts",
+    });
+    setActivePluginRegistry(registry);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    await started.promise;
+    await waitForCleanupSignal(finished.promise, "reentrant retired cleanup");
+    await clearActivePluginRegistry();
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(getActivePluginRegistry()).toBeNull();
+  });
+
+  it.each([
+    "install",
+    "staged",
+    "clear",
+    "activation-install",
+    "activation-staged",
+    "activation-install-replace",
+    "activation-staged-replace",
+    "catalog-install",
+    "catalog-staged",
+  ] as const)(
+    "keeps an admitted command live through a reentrant retirement abort (%s)",
+    async (retirement) => {
       const { createPluginRegistry } = await import("./registry.js");
       const { createPluginRuntime } = await import("./runtime/index.js");
+      const { activatePluginRegistry } = await import("./loader-shared.js");
+      const { withPluginCommandExecution } = await import("./command-execution-lock.js");
+      const builder = createPluginRegistry({
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+        runtime: createPluginRuntime(),
+        activateGlobalSideEffects: false,
+      });
+      const record = createPluginRecord({ id: "abort-cleanup-sqlite", status: "loaded" });
+      builder.registry.plugins.push(record);
+      const api = builder.createApi(record, { config: {} });
+      const db = new DatabaseSync(":memory:");
+      const nativeState = resolveGlobalSingleton(
+        Symbol.for("openclaw.test.actualPluginCleanupDatabase"),
+        (): { database?: DatabaseSync; resets: number } => ({ resets: 0 }),
+        (state) => {
+          if (state.database?.isOpen) {
+            state.resets++;
+            state.database.close();
+          }
+        },
+        "plugin-registry",
+      );
+      nativeState.database = db;
+      nativeState.resets = 0;
+      const cleanup = vi.fn(() => {
+        expect(db.prepare("SELECT 2 AS value").get()).toEqual({ value: 2 });
+      });
+      api.lifecycle.registerRuntimeLifecycle({ id: "abort-cleanup", cleanup });
+      setActivePluginRegistry(builder.registry);
+      const catalogReentry = retirement.startsWith("catalog-");
+      const successorBuilder = catalogReentry
+        ? createPluginRegistry({
+            logger: { info() {}, warn() {}, error() {}, debug() {} },
+            runtime: createPluginRuntime(),
+            activateGlobalSideEffects: false,
+          })
+        : undefined;
+      const successor = successorBuilder?.registry ?? createEmptyPluginRegistry();
+      const newer = createEmptyPluginRegistry();
+      const replaceAgain = retirement.endsWith("-replace");
+      const staged = retirement.split("-").includes("staged");
+      const signal = retirement.startsWith("activation-")
+        ? capturePluginRegistryLifecycleSignal(successor, undefined, { scopedRuntime: true })
+        : capturePluginRegistryLifecycleSignal(
+            builder.registry,
+            capturePluginRegistryLifecycleEpoch(builder.registry),
+          );
+      if (!signal) {
+        throw new Error("Expected an active registry lifecycle signal");
+      }
+      let innerClear: Promise<void> | undefined;
+      let outerClear: Promise<void> | undefined;
+      const reenter = () => {
+        if (replaceAgain) {
+          activatePluginRegistry(newer, "newer", "gateway-bindable", "/virtual/newer");
+          innerClear = Promise.resolve();
+        } else {
+          innerClear = clearActivePluginRegistry();
+        }
+      };
+      if (successorBuilder) {
+        const channelRecord = createPluginRecord({ id: "catalog-reentry", status: "loaded" });
+        successor.plugins.push(channelRecord);
+        successorBuilder.createApi(channelRecord, { config: {} }).registerChannel({
+          plugin: {
+            id: channelRecord.id,
+            meta: {
+              id: channelRecord.id,
+              label: "Catalog reentry",
+              selectionLabel: "Catalog reentry",
+              docsPath: "/channels/catalog-reentry",
+              blurb: "Catalog lifecycle fixture",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => [],
+              resolveAccount: () => ({ accountId: "default" }),
+            },
+            message: {
+              get durableFinal() {
+                if (getActivePluginRegistry() === successor) {
+                  reenter();
+                }
+                return undefined;
+              },
+            },
+          },
+        });
+      } else {
+        signal.addEventListener("abort", reenter);
+      }
+      const escape = createDeferredCore();
+      const commandRead = createDeferredCore();
+      const releaseCommand = createDeferredCore();
+      const reads: unknown[] = [];
+      const failures: unknown[] = [];
+      const activationErrors: unknown[] = [];
+      const command = withPluginCommandExecution(builder.registry, async () => {
+        if (retirement === "clear") {
+          outerClear = clearActivePluginRegistry();
+        } else if (staged) {
+          try {
+            activatePluginRegistry(successor, "successor", "explicit", "/virtual/successor");
+          } catch (error) {
+            activationErrors.push(error);
+          }
+        } else {
+          setActivePluginRegistry(successor, "successor", "explicit", "/virtual/successor");
+        }
+        if (!innerClear) {
+          throw new Error("Expected synchronous retirement notification");
+        }
+        await Promise.race([innerClear, escape.promise]);
+        try {
+          reads.push(db.prepare("SELECT 1 AS value").get());
+        } catch (error) {
+          failures.push(error);
+        }
+        commandRead.resolve();
+        await releaseCommand.promise;
+      });
+      try {
+        await waitForCleanupSignal(commandRead.promise, "command after retirement abort clear");
+        expect(failures).toEqual([]);
+        expect(reads).toEqual([{ value: 1 }]);
+        expect(db.isOpen).toBe(true);
+        expect(nativeState.resets).toBe(0);
+        expect(cleanup).not.toHaveBeenCalled();
+        if (catalogReentry) {
+          expect(isPluginRegistryRetired(successor)).toBe(true);
+        }
+        expect(captureActivePluginRegistrySnapshot()).toEqual(
+          replaceAgain
+            ? {
+                activeRegistry: newer,
+                key: "newer",
+                workspaceDir: "/virtual/newer",
+                runtimeSubagentMode: "gateway-bindable",
+              }
+            : {
+                activeRegistry: null,
+                key: null,
+                workspaceDir: null,
+                runtimeSubagentMode: "default",
+              },
+        );
+        expect(activationErrors).toEqual(
+          staged
+            ? [expect.objectContaining({ message: "Plugin registry activation was superseded" })]
+            : [],
+        );
+        if (replaceAgain) {
+          const { getGlobalPluginRegistry } = await import("./hook-runner-global.js");
+          expect(getGlobalPluginRegistry()).toBe(newer);
+        }
+      } finally {
+        escape.resolve();
+        releaseCommand.resolve();
+        await command;
+        await innerClear;
+        await outerClear;
+        await clearActivePluginRegistry();
+        if (db.isOpen) {
+          db.close();
+        }
+        nativeState.database = undefined;
+      }
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(nativeState.resets).toBe(1);
+    },
+  );
+
+  it("retains a displaced loaded registry's cleanup through its admitted command", async () => {
+    const { loadOpenClawPlugins } = await import("./loader.js");
+    const { resolvePluginLoadCacheContext } = await import("./loader-load-context.js");
+    const { pluginLoaderCacheState } = await import("./registry-lifecycle.js");
+    const { withPluginCommandExecution } = await import("./command-execution-lock.js");
+    const { useNoBundledPlugins, writePlugin, resetPluginLoaderTestStateForTest } =
+      await import("./loader.test-fixtures.js");
+    useNoBundledPlugins();
+    onTestFinished(resetPluginLoaderTestStateForTest);
+    const db = new DatabaseSync(":memory:");
+    const nativeState = resolveGlobalSingleton(
+      Symbol.for("openclaw.test.actualPluginCleanupDatabase"),
+      (): { database?: DatabaseSync; resets: number } => ({ resets: 0 }),
+      (state) => {
+        if (state.database?.isOpen) {
+          state.resets++;
+          state.database.close();
+        }
+      },
+      "plugin-registry",
+    );
+    nativeState.database = db;
+    nativeState.resets = 0;
+    const reads: unknown[] = [];
+    const bridge = resolveGlobalSingleton(
+      Symbol.for("openclaw.test.loadedRetirementCleanup"),
+      (): { read?: () => void } => ({}),
+    );
+    bridge.read = () => {
+      reads.push(db.prepare("SELECT 1 AS value").get());
+    };
+    const plugin = writePlugin({
+      id: "loaded-retirement",
+      body: `module.exports = { id: "loaded-retirement", register(api) {
+        const read = globalThis[Symbol.for("openclaw.test.loadedRetirementCleanup")].read;
+        api.lifecycle.registerRuntimeLifecycle({ id: "native-cleanup", cleanup: read });
+      } };`,
+    });
+    const options = {
+      config: {
+        plugins: {
+          allow: [plugin.id],
+          load: { paths: [plugin.file] },
+          slots: { memory: "none" },
+        },
+      },
+    };
+    const original = createEmptyPluginRegistry();
+    setActivePluginRegistry(original);
+    const signal = capturePluginRegistryLifecycleSignal(
+      original,
+      capturePluginRegistryLifecycleEpoch(original),
+    );
+    if (!signal) {
+      throw new Error("Expected an active predecessor signal");
+    }
+    const releaseCommand = createDeferredCore();
+    let heldCommand: ReturnType<typeof withPluginCommandExecution> | undefined;
+    let closing: Promise<void> | undefined;
+    signal.addEventListener("abort", () => {
+      const loaded = getActivePluginRegistry();
+      if (loaded) {
+        heldCommand = withPluginCommandExecution(loaded, () => releaseCommand.promise);
+        closing = clearActivePluginRegistry();
+      }
+    });
+    try {
+      expect(() => loadOpenClawPlugins(options)).toThrow(
+        "Plugin registry activation was superseded",
+      );
+      expect(heldCommand).toBeDefined();
+      expect(closing).toBeDefined();
+      expect(db.isOpen).toBe(true);
+      expect(reads).toEqual([]);
+      expect(
+        pluginLoaderCacheState.get(resolvePluginLoadCacheContext(options).cacheKey),
+      ).toBeUndefined();
+    } finally {
+      releaseCommand.resolve();
+      await heldCommand;
+      await closing;
+      await clearActivePluginRegistry();
+      bridge.read = undefined;
+      if (db.isOpen) {
+        db.close();
+      }
+      nativeState.database = undefined;
+    }
+    expect(reads).toEqual([{ value: 1 }]);
+    expect(nativeState.resets).toBe(1);
+  });
+
+  it.each(
+    (["active", "replaced", "command-held"] as const).flatMap((lifetime) =>
+      (["callback", "descendant"] as const).map((owner) => ({ lifetime, owner })),
+    ),
+  )(
+    "joins $lifetime lifecycle $owner before plugin-registry resets",
+    async ({ lifetime, owner }) => {
+      const { createPluginRegistry } = await import("./registry.js");
+      const { createPluginRuntime } = await import("./runtime/index.js");
+      const { activatePluginRegistry } = await import("./loader-shared.js");
+      const { withPluginCommandExecution, getPluginCommandExecutionCount } =
+        await import("./command-execution-lock.js");
       const builder = createPluginRegistry({
         logger: { info() {}, warn() {}, error() {}, debug() {} },
         runtime: createPluginRuntime(),
@@ -258,11 +574,38 @@ describe("setActivePluginRegistry", () => {
       api.lifecycle.registerRuntimeLifecycle({ id: "held-cleanup", cleanup });
       setActivePluginRegistry(builder.registry);
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const commandGate = createDeferredCore();
+      const command =
+        lifetime === "command-held"
+          ? withPluginCommandExecution(builder.registry, () => commandGate.promise)
+          : undefined;
+      if (lifetime === "command-held") {
+        expect(getPluginCommandExecutionCount(builder.registry)).toBe(1);
+      }
+      if (lifetime !== "active") {
+        const replacement = createEmptyPluginRegistry();
+        activatePluginRegistry(replacement, null, "default");
+        expect(getActivePluginRegistry()).toBe(replacement);
+        expect(await withPluginCommandExecution(builder.registry, () => undefined)).toEqual({
+          admitted: false,
+        });
+        if (lifetime === "replaced") {
+          await entered.promise;
+        }
+      }
       let closed = false;
       const closing = clearActivePluginRegistry().then(() => {
         closed = true;
       });
       try {
+        if (lifetime === "command-held") {
+          await vi.advanceTimersByTimeAsync(5000);
+          expect(cleanup).not.toHaveBeenCalled();
+          expect(db.isOpen).toBe(true);
+          expect(closed).toBe(false);
+          commandGate.resolve();
+          expect(await command).toEqual({ admitted: true, value: undefined });
+        }
         await entered.promise;
         await vi.advanceTimersByTimeAsync(5000);
         expect(getActivePluginRegistry()).toBeNull();
@@ -270,8 +613,11 @@ describe("setActivePluginRegistry", () => {
         expect(nativeState.resets).toBe(0);
         expect(closed).toBe(false);
       } finally {
+        commandGate.resolve();
         release.resolve();
+        await command;
         await finished.promise;
+        await Promise.allSettled(cleanup.mock.results.map((result) => result.value));
         await closing;
         vi.useRealTimers();
         if (db.isOpen) {

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -1,7 +1,8 @@
 // Coordinates active plugin runtime registries and event hooks.
 import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { AsyncWorkScope, getAsyncWorkSignal } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import {
@@ -103,27 +104,48 @@ async function cleanupPreviousPluginHostRegistry(params: {
   }
 }
 
-function cleanupRetiredPluginHostRegistry(previousRegistry: PluginRegistry): void {
-  if (!registryHasPluginHostCleanupWork(previousRegistry)) {
-    return;
+function preparePluginRegistryRetirement(previousRegistry: PluginRegistry | null) {
+  if (!previousRegistry) {
+    return undefined;
   }
-  const cleanup = () =>
-    cleanupPreviousPluginHostRegistry({ previousRegistry }).catch((error: unknown) => {
-      log.warn(`plugin host registry cleanup failed: ${String(error)}`);
-    });
-  if (getPluginCommandExecutionCount(previousRegistry) > 0) {
-    void waitForPluginCommandExecutions(previousRegistry).then(cleanup);
-    return;
-  }
-  void cleanup();
-}
-
-function retirePluginRegistryIfUnused(registry: PluginRegistry | null): boolean {
-  if (!registry || isRegistryLive(registry)) {
-    return false;
-  }
-  markPluginRegistryRetired(registry);
-  return true;
+  const work = new AsyncWorkScope();
+  const completion = createDeferredCore();
+  const pending = (state.retiredRegistryCleanups ??= new Map());
+  // Activation and retirement listeners can clear the successor from an admitted command.
+  pending.set(completion.promise, { registry: previousRegistry, work });
+  const release = () => {
+    pending.delete(completion.promise);
+    completion.resolve();
+  };
+  const cleanup = async () => {
+    try {
+      await work.track(async () => {
+        if (getPluginCommandExecutionCount(previousRegistry) > 0) {
+          await waitForPluginCommandExecutions(previousRegistry);
+        }
+        if (registryHasPluginHostCleanupWork(previousRegistry)) {
+          await cleanupPreviousPluginHostRegistry({ previousRegistry });
+        }
+      });
+    } finally {
+      await work.drain();
+    }
+  };
+  return {
+    release,
+    retireIfUnused() {
+      if (isRegistryLive(previousRegistry)) {
+        release();
+        return;
+      }
+      markPluginRegistryRetired(previousRegistry);
+      void cleanup()
+        .catch((error: unknown) => {
+          log.warn(`plugin host registry cleanup failed: ${String(error)}`);
+        })
+        .then(release);
+    },
+  };
 }
 
 function syncPluginAgentEventBridge(): void {
@@ -168,8 +190,8 @@ export function stageActivePluginRegistry(
   cacheKey: string | null,
   runtimeSubagentMode: RegistryState["runtimeSubagentMode"],
   workspaceDir?: string,
-): void {
-  installActivePluginRegistry({
+): number {
+  return installActivePluginRegistry({
     registry,
     key: cacheKey,
     runtimeSubagentMode,
@@ -182,10 +204,9 @@ export function commitStagedPluginRegistry(
   previousRegistry: PluginRegistry | null,
   registry: PluginRegistry,
 ): void {
-  if (state.activeRegistry !== registry || !retirePluginRegistryIfUnused(previousRegistry)) {
-    return;
+  if (state.activeRegistry === registry) {
+    preparePluginRegistryRetirement(previousRegistry)?.retireIfUnused();
   }
-  cleanupRetiredPluginHostRegistry(previousRegistry!);
 }
 
 export function captureActivePluginRegistrySnapshot() {
@@ -211,8 +232,8 @@ export function restoreActivePluginRegistrySnapshot(
 /** Rolls back a staged registry without reactivating the prior committed generation. */
 export function rollbackStagedPluginRegistry(
   snapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>,
-): void {
-  installActivePluginRegistry({
+): number {
+  return installActivePluginRegistry({
     registry: snapshot.activeRegistry,
     key: snapshot.key,
     runtimeSubagentMode: snapshot.runtimeSubagentMode,
@@ -230,33 +251,49 @@ function installActivePluginRegistry(params: {
   workspaceDir: string | null;
   retirePrevious?: boolean;
   activateRegistry?: boolean;
-}): void {
-  const previousRegistry = asPluginRegistry(state.activeRegistry);
+}): number {
+  const previousSnapshot = captureActivePluginRegistrySnapshot();
+  const retirement =
+    previousSnapshot.activeRegistry !== params.registry
+      ? preparePluginRegistryRetirement(previousSnapshot.activeRegistry)
+      : undefined;
   state.activeRegistry = params.registry;
-  if (params.activateRegistry !== false) {
-    markPluginRegistryActive(params.registry);
-  }
-  state.activeVersion += 1;
-  if (params.registry) {
-    settlePreparedMessageToolCatalog(params.registry, state.activeVersion);
-  } else {
-    settlePreparedMessageToolCatalog();
-  }
+  const installedVersion = ++state.activeVersion;
   state.key = params.key;
   state.workspaceDir = params.workspaceDir;
   state.runtimeSubagentMode = params.runtimeSubagentMode;
-  syncPluginAgentEventBridge();
-  if (
-    params.retirePrevious === false ||
-    !previousRegistry ||
-    previousRegistry === params.registry
-  ) {
-    return;
+  const isCurrent = () =>
+    state.activeRegistry === params.registry && state.activeVersion === installedVersion;
+  try {
+    if (params.activateRegistry !== false) {
+      markPluginRegistryActive(params.registry);
+    }
+    if (!isCurrent()) {
+      return installedVersion;
+    }
+    if (params.registry) {
+      settlePreparedMessageToolCatalog(params.registry, installedVersion);
+    } else {
+      settlePreparedMessageToolCatalog();
+    }
+    if (!isCurrent()) {
+      return installedVersion;
+    }
+    syncPluginAgentEventBridge();
+  } catch (error) {
+    if (params.retirePrevious === false && isCurrent()) {
+      rollbackStagedPluginRegistry(previousSnapshot);
+    }
+    throw error;
+  } finally {
+    // A successful stage preserves the predecessor's epoch for rollback. Displacement does not.
+    if (params.retirePrevious === false && isCurrent()) {
+      retirement?.release();
+    } else {
+      retirement?.retireIfUnused();
+    }
   }
-  if (!retirePluginRegistryIfUnused(previousRegistry)) {
-    return;
-  }
-  cleanupRetiredPluginHostRegistry(previousRegistry);
+  return installedVersion;
 }
 
 export function getActivePluginRegistry(): PluginRegistry | null {
@@ -408,9 +445,6 @@ function clearActivePluginRegistryState(): PluginRegistry | null {
   state.runtimeSubagentMode = "default";
   settlePreparedMessageToolCatalog();
   syncPluginAgentEventBridge();
-  if (previousRegistry) {
-    markPluginRegistryRetired(previousRegistry);
-  }
   return previousRegistry;
 }
 
@@ -436,6 +470,10 @@ export async function clearActivePluginRegistry(): Promise<void> {
       } finally {
         // A cleanup timeout advances other hooks, but its actual descendants still own state.
         await cleanupWork.drain();
+        // Earlier hot publications returned before their retired owners finished cleanup.
+        while (state.retiredRegistryCleanups?.size) {
+          await Promise.all(state.retiredRegistryCleanups.keys());
+        }
         // A handler-triggered clear may publish a successor before its own drain settles.
         // Never let the retired generation's tail erase that successor's host state.
         if (state.activeRegistry === null && state.activeVersion === clearVersion) {
@@ -460,7 +498,17 @@ export async function clearActivePluginRegistry(): Promise<void> {
   state.commandRegistryClearTail = completion.catch((error: unknown) => {
     log.warn(`plugin registry clear failed: ${String(error)}`);
   });
-  if ([...clearRegistries.keys()].some(isPluginCommandExecutionActiveHere)) {
+  // Publish the clear owner and tail before synchronous retirement listeners can reenter.
+  markPluginRegistryRetired(previousRegistry);
+  // Reentrant commands and retired cleanup callbacks must not await their own pending attempt.
+  const currentCleanupSignal = getAsyncWorkSignal();
+  if (
+    [...clearRegistries.keys()].some(isPluginCommandExecutionActiveHere) ||
+    [...(state.retiredRegistryCleanups?.values() ?? [])].some(
+      ({ registry, work }) =>
+        isPluginCommandExecutionActiveHere(registry) || work.signal === currentCleanupSignal,
+    )
+  ) {
     return;
   }
   await completion;
@@ -472,7 +520,7 @@ export async function prepareActivePluginRegistryShutdown(): Promise<void> {
 
 export function resetPluginRuntimeStateForTest(): void {
   state.registrationContext = undefined;
-  clearActivePluginRegistryState();
+  markPluginRegistryRetired(clearActivePluginRegistryState());
   state.importedPluginIds.clear();
   void drainGlobalSingletonLifecycleState("plugin-registry");
   // Keep the synchronous test reset aligned with clearActivePluginRegistry.


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes shutdown closing shared state while cleanup from an earlier plugin reload is still running. Reentrant activation or retirement callbacks could also strand an admitted command or let a superseded activation overwrite the newer registry selection.

## Why This Change Was Made

Each retirement records its owner before activation and retirement notifications can invoke callbacks. Hot replacement remains nonblocking; terminal clear joins pending retirement work before shared-state reset.

Registry publication records its version and workspace fields before notifying listeners. Exact-version checks stop a displaced activation and prevent rollback from overwriting its successor. Published registries retain their cleanup callbacks until admitted users finish, including when loader initialization fails.

## User Impact

Reload and shutdown keep existing resources usable through accepted cleanup. A newer registry selection stays authoritative, and superseded activation fails explicitly instead of being cached as successful. Existing runtime authority revocation, normal staged rollback, and process watchdog behavior remain intact.

## Evidence

Native SQLite regressions cover pending retired callbacks, command-held cleanup, synchronous retirement and activation reentry, getter-triggered displacement, and cleanup preservation after failed activation. The logical change passed 153 focused plugin/command-auth tests; the final twelve-file changed gate, callback-only formatting/type checks, ordinary build and private-QA build passed. Independent Codex review found no remaining actionable defects.

A real compiled Gateway reloaded from A to B in 548 ms and served a successful health check while A cleanup remained pending. During shutdown, B cleanup and the actual HTTP listener closed while SQLite stayed usable beyond the five-second grace period. A then performed its final query; the process exited successfully, the captured connection closed, and read-only reopen preserved the schema version and passed the integrity check. This used synthetic task-owned state and the existing private-QA observer, without real credentials or an operator Gateway.

The full gate took 339.1 seconds; the ordinary build took 206.6 seconds. The final compiled scenario took 8.62 seconds. All twelve candidate files were unchanged through commit and rebase.
