### PR TITLE
fix(node-host): stabilize native CLI fixtures on Windows

### DIFF
--- a/src/node-host/invoke-agent-cli-claude.test.ts
+++ b/src/node-host/invoke-agent-cli-claude.test.ts
@@ -11,6 +11,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 import type { NodeHostClient } from "./client.js";
 import { decodeClaudeCliNodeRunParams } from "./invoke-agent-cli-claude-params.js";
 import { runClaudeCliNodeCommand } from "./invoke-agent-cli-claude.js";
+import type { RunResult } from "./invoke-types.js";
 import { handleInvoke, type NodeInvokeRequestPayload } from "./invoke.js";
 
 const tempDirs: string[] = [];
@@ -60,10 +61,11 @@ async function nativeCliFixture(source: string) {
     // Keep the installed runtime's loader paths; POSIX can approve the script itself.
     return { executable: script, runArgv: [process.execPath, script] };
   }
-  // Windows approval needs a native executable, not a .cjs file or a PATHEXT override.
+  // Approval needs a distinct native CLI identity, but execution stays on the installed
+  // runtime so teardown never races a launched copy that Windows still has locked.
   const executable = path.join(path.dirname(script), "claude-test.exe");
   await fs.copyFile(process.execPath, executable);
-  return { executable, runArgv: [executable, script] };
+  return { executable, runArgv: [process.execPath, script] };
 }
 
 function runCommand(
@@ -316,6 +318,7 @@ process.stdout.write(JSON.stringify({
   gitInstructionsDisabled: process.env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS,
 }) + "\\n");`);
       const calls: Array<{ method: string; params: unknown }> = [];
+      let runResult: RunResult | undefined;
       const handleSystemRun = vi.fn(
         async (options: {
           params: { command: string[]; env?: Record<string, string>; timeoutMs?: number };
@@ -324,11 +327,11 @@ process.stdout.write(JSON.stringify({
             cwd: string | undefined,
             env: Record<string, string> | undefined,
             timeoutMs: number | undefined,
-          ) => Promise<unknown>;
+          ) => Promise<RunResult>;
           sendInvokeResult: (result: unknown) => Promise<void>;
         }) => {
           const argv = [...runArgv, ...options.params.command.slice(1)];
-          await options.runCommand(
+          runResult = await options.runCommand(
             argv,
             undefined,
             {
@@ -353,8 +356,8 @@ process.stdout.write(JSON.stringify({
             "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
             "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
           ],
-          idleTimeoutMs: 1_000,
-          timeoutMs: 5_000,
+          idleTimeoutMs: 5_000,
+          timeoutMs: 10_000,
         }),
         client(calls),
         { current: async () => [] },
@@ -362,6 +365,12 @@ process.stdout.write(JSON.stringify({
         { claudePath: executable, handleSystemRun: handleSystemRun as never },
       );
 
+      expect(runResult).toMatchObject({
+        exitCode: 0,
+        success: true,
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
       const progress = calls
         .filter((call) => call.method === "node.invoke.progress")
         .map((call) => (call.params as { chunk: string }).chunk)
@@ -392,6 +401,7 @@ process.stdout.write(JSON.stringify({
   scrub: process.env.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB,
 }) + "\\n");`);
     const calls: Array<{ method: string; params: unknown }> = [];
+    let runResult: RunResult | undefined;
     const handleSystemRun = vi.fn(
       async (options: {
         params: { command: string[]; timeoutMs?: number };
@@ -400,11 +410,11 @@ process.stdout.write(JSON.stringify({
           cwd: string | undefined,
           env: Record<string, string> | undefined,
           timeoutMs: number | undefined,
-        ) => Promise<unknown>;
+        ) => Promise<RunResult>;
         sendInvokeResult: (result: unknown) => Promise<void>;
       }) => {
         const argv = [...runArgv, ...options.params.command.slice(1)];
-        const result = await options.runCommand(
+        runResult = await options.runCommand(
           argv,
           undefined,
           {
@@ -415,20 +425,14 @@ process.stdout.write(JSON.stringify({
           } as Record<string, string>,
           options.params.timeoutMs,
         );
-        expect(result).toMatchObject({
-          exitCode: 0,
-          success: true,
-          timedOut: false,
-          noOutputTimedOut: false,
-        });
         await options.sendInvokeResult({ ok: true });
       },
     );
     await handleInvoke(
       frame({
         argv: ["-p"],
-        idleTimeoutMs: 1_000,
-        timeoutMs: 5_000,
+        idleTimeoutMs: 5_000,
+        timeoutMs: 10_000,
       }),
       client(calls),
       { current: async () => [] },
@@ -436,6 +440,12 @@ process.stdout.write(JSON.stringify({
       { claudePath: executable, handleSystemRun: handleSystemRun as never },
     );
 
+    expect(runResult).toMatchObject({
+      exitCode: 0,
+      success: true,
+      timedOut: false,
+      noOutputTimedOut: false,
+    });
     const progress = calls
       .filter((call) => call.method === "node.invoke.progress")
       .map((call) => (call.params as { chunk: string }).chunk)


### PR DESCRIPTION
## What Problem This Solves

Resolves a Windows CI failure where native Claude CLI credential fixtures could hit the minimum idle watchdog, report empty progress, and leave a copied executable locked during cleanup.

## Why This Change Was Made

Windows keeps a distinct native executable alias for approval planning, but executes the fixture with the installed Node runtime so the temporary copy is never launched or locked. Positive credential fixtures use bounded non-minimum watchdogs and assert the child result after invocation returns, so callback errors cannot be swallowed before the observable assertions run.

Dedicated timeout cases remain unchanged.

## User Impact

No product runtime behavior changes. Windows CI gets deterministic native CLI fixture execution and cleanup without weakening timeout coverage.

## Evidence

- Hosted FRV reproduction: empty progress followed by `EPERM` unlinking `claude-test.exe`.
- Local pre-fix reproduction: the first credential fixture exceeded its 1-second idle watchdog and failed with empty progress.
- The first hosted PR run proved that using `node.exe` as the approval identity fails closed before execution; the revised fixture preserves a distinct approval identity while launching only the installed runtime.
- Affected positive cases passed four repeats after the repair.
- Full `src/node-host/invoke-agent-cli-claude.test.ts`: 35/35 passed after refreshing onto current main.
- Formatting, assertion-safety, dependency, boundary, typecheck, and targeted Oxlint checks passed.
- `check:changed` stopped only at the global dead-export scan because the sparse linked worktree omits UI-only modules; exact-head hosted CI will provide the full-tree proof.
- Independent P0-P2 autoreview found no actionable issues.
