### PR TITLE
fix(state): repair dangling Skill Workshop review index

### DIFF
--- a/src/flows/doctor-health.migration-refusal.test.ts
+++ b/src/flows/doctor-health.migration-refusal.test.ts
@@ -124,6 +124,39 @@ describe("Doctor maintenance admission", () => {
 });
 
 describe("Doctor agent lease admission", () => {
+  it("admits the exact dangling Workshop index without mutating state", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const opened = openOpenClawStateDatabase({ env: state.env });
+      const pathname = opened.path;
+      closeOpenClawStateDatabaseByPath(pathname);
+      const db = openNodeSqliteDatabase(pathname);
+      try {
+        db.exec(
+          "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+        );
+        db.enableDefensive?.(false);
+        db.exec("PRAGMA writable_schema = ON;");
+        db.prepare(
+          `UPDATE sqlite_schema
+              SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                           ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+            WHERE type = 'index'
+              AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+        ).run();
+        const schema = db.prepare("PRAGMA schema_version").get() as { schema_version: number };
+        db.exec(
+          `PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schema.schema_version + 1};`,
+        );
+      } finally {
+        db.close();
+      }
+      const before = fs.readFileSync(pathname);
+
+      expect(() => assertNoOpenClawAgentDatabaseLeasesReadOnly({ env: state.env })).not.toThrow();
+      expect(fs.readFileSync(pathname)).toEqual(before);
+    });
+  });
+
   it("admits a restored primary database without opening or clearing its quarantine store", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const pathname = state.statePath("state/openclaw.sqlite");

--- a/src/infra/startup-maintenance-required.ts
+++ b/src/infra/startup-maintenance-required.ts
@@ -7,6 +7,7 @@ const maintenanceReasons = {
   "agent-media": "offline media migration",
   "agent-databases-composite-primary-key": "state database schema migration",
   "audit-events-v2": "state database schema migration",
+  "legacy-workshop-review-index": "state database schema migration",
   "legacy-workspace": "workspace setup state migration",
   "legacy-session-store": "session store migration",
 } as const;

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -22,6 +22,7 @@ import {
 } from "./agent-deletion-journal.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
+import { openDanglingWorkshopIndexReadAdmission } from "./openclaw-state-db-dangling-workshop-index.js";
 import { runExistingOpenClawStateWriteTransaction } from "./openclaw-state-db-existing-write.js";
 import { ensureAgentDatabaseLeaseSchema } from "./openclaw-state-db-schema-additive.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
@@ -281,7 +282,9 @@ export function assertNoOpenClawAgentDatabaseLeasesReadOnly(
     ? openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(pathname)
     : undefined;
   const db = cached?.db ?? openNodeSqliteDatabase(pathname, { readOnly: true });
+  let closeSchemaReadAdmission: (() => void) | undefined;
   try {
+    closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
     runWithSqliteBusyTimeout(db, 250, () => {
       if (!tableExists(db, "agent_database_leases")) {
         return;
@@ -294,9 +297,13 @@ export function assertNoOpenClawAgentDatabaseLeasesReadOnly(
       }
     });
   } finally {
-    if (!cached) {
-      clearNodeSqliteKyselyCacheForDatabase(db);
-      db.close();
+    try {
+      closeSchemaReadAdmission?.();
+    } finally {
+      if (!cached) {
+        clearNodeSqliteKyselyCacheForDatabase(db);
+        db.close();
+      }
     }
   }
 }

--- a/src/state/openclaw-database-preflight.dangling-workshop-index.test.ts
+++ b/src/state/openclaw-database-preflight.dangling-workshop-index.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import { preflightOpenClawDatabaseSchemas } from "./openclaw-database-preflight.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(closeOpenClawStateDatabaseForTest);
+
+describe("dangling Workshop index preflight", () => {
+  it("admits the exact defect for Doctor without mutating the source", async () => {
+    const stateDir = tempDirs.make("openclaw-preflight-dangling-workshop-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const statePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(statePath);
+    try {
+      database.exec(
+        "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+      );
+      database.enableDefensive?.(false);
+      database.exec("PRAGMA writable_schema = ON;");
+      database
+        .prepare(
+          `UPDATE sqlite_schema
+            SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                         ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+          WHERE type = 'index'
+            AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+        )
+        .run();
+      // SAFETY: PRAGMA schema_version always returns one numeric row for an open database.
+      const { schema_version } = database.prepare("PRAGMA schema_version").get() as {
+        schema_version: number;
+      };
+      database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schema_version + 1};`);
+    } finally {
+      database.close();
+    }
+    const sourceDir = path.dirname(statePath);
+    const snapshot = () =>
+      fs
+        .readdirSync(sourceDir)
+        .toSorted()
+        .map((name) => [name, fs.readFileSync(path.join(sourceDir, name))]);
+    const before = snapshot();
+
+    await expect(
+      preflightOpenClawDatabaseSchemas({
+        env,
+        scope: "state",
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      }),
+    ).resolves.toEqual({ incompatible: [], indeterminate: [] });
+    expect(snapshot()).toEqual(before);
+  });
+});

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -47,6 +47,10 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "./openclaw-state-db-contract.js";
 import {
+  closeWorkshopIndexReadDatabase,
+  openDanglingWorkshopIndexReadAdmission,
+} from "./openclaw-state-db-dangling-workshop-index.js";
+import {
   assertOpenClawStateDatabaseOwner,
   assertOpenClawStateDatabaseForMaintenance,
   openClawStateMigrationAssertions,
@@ -460,6 +464,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
   const statePath = path.resolve(resolveOpenClawStateSqlitePath(options.env));
   let registeredDatabases: ReturnType<typeof readRegisteredAgentDatabases> = [];
   let stateDatabase: DatabaseSync | undefined;
+  let closeStateSchemaReadAdmission: (() => void) | undefined;
   let stateSnapshot: Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>> | undefined;
   const inspectCandidatePresence = (
     databasePath: string,
@@ -490,6 +495,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       stateDatabase = openNodeSqliteDatabase(stateSnapshot.location, {
         readOnly: true,
       });
+      closeStateSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(stateDatabase);
       stateDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       const stateVersion = readSqliteUserVersion(stateDatabase);
       const contentVersion =
@@ -594,8 +600,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
   } finally {
     try {
       if (stateDatabase) {
-        clearNodeSqliteKyselyCacheForDatabase(stateDatabase);
-        stateDatabase.close();
+        closeWorkshopIndexReadDatabase(stateDatabase, closeStateSchemaReadAdmission);
       }
     } finally {
       stateSnapshot?.cleanup();

--- a/src/state/openclaw-state-db-dangling-workshop-index.ts
+++ b/src/state/openclaw-state-db-dangling-workshop-index.ts
@@ -1,0 +1,107 @@
+import type { DatabaseSync } from "node:sqlite";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
+
+const LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX =
+  "idx_skill_workshop_collection_reviews_workspace_time";
+const LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX_SQL =
+  "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)";
+
+function normalizeSqliteCatalogSql(sql: string): string {
+  return sql
+    .replace(/\s+/gu, " ")
+    .replace(/\s*([(),])\s*/gu, "$1")
+    .trim();
+}
+
+export function withSqliteWritableSchema<T>(database: DatabaseSync, operation: () => T): T {
+  database.enableDefensive?.(false);
+  // sqlite-allow-raw -- Exact legacy catalog admission requires SQLite's writable-schema pragma.
+  database.exec("PRAGMA writable_schema = ON;");
+  try {
+    return operation();
+  } finally {
+    try {
+      // sqlite-allow-raw -- Always restore catalog parsing after the bounded legacy inspection.
+      database.exec("PRAGMA writable_schema = OFF;");
+    } finally {
+      database.enableDefensive?.(true);
+    }
+  }
+}
+
+/** Detect only the known v15 review index left behind after its column was retired. */
+export function hasDanglingSkillWorkshopCollectionReviewIndex(database: DatabaseSync): boolean {
+  return withSqliteWritableSchema(database, () => {
+    const rawIndex = database // sqlite-allow-raw -- Inspect the exact malformed catalog row before ordinary schema parsing.
+      .prepare(
+        "SELECT tbl_name, rootpage, sql FROM sqlite_schema WHERE type = 'index' AND name = ?",
+      )
+      .get(LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX);
+    // SAFETY: the narrow catalog projection is validated field-by-field below.
+    const index = rawIndex as { tbl_name?: unknown; rootpage?: unknown; sql?: unknown } | undefined;
+    if (
+      index?.tbl_name !== "skill_workshop_collection_reviews" ||
+      typeof index.rootpage !== "number" ||
+      index.rootpage <= 0 ||
+      typeof index.sql !== "string" ||
+      normalizeSqliteCatalogSql(index.sql) !==
+        normalizeSqliteCatalogSql(LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX_SQL)
+    ) {
+      return false;
+    }
+    const rawColumns = database // sqlite-allow-raw -- Validate physical columns without parsing the malformed index.
+      .prepare("PRAGMA table_info(skill_workshop_collection_reviews)")
+      .all();
+    // SAFETY: PRAGMA table_info rows expose optional names compared as unknown values.
+    const columns = rawColumns as Array<{ name?: unknown }>;
+    return (
+      columns.some((column) => column.name === "owner_agent_id") &&
+      !columns.some((column) => column.name === "workspace_dir")
+    );
+  });
+}
+
+/** Keep a read-only connection tolerant of the exact malformed legacy index. */
+export function openDanglingWorkshopIndexReadAdmission(
+  database: DatabaseSync,
+): (() => void) | undefined {
+  if (!hasDanglingSkillWorkshopCollectionReviewIndex(database)) {
+    return undefined;
+  }
+  database.enableDefensive?.(false);
+  try {
+    // sqlite-allow-raw -- Hold exact legacy catalog admission for a bounded read-only operation.
+    database.exec("PRAGMA writable_schema = ON;");
+  } catch (error) {
+    database.enableDefensive?.(true);
+    throw error;
+  }
+  let open = true;
+  return () => {
+    if (!open) {
+      return;
+    }
+    open = false;
+    try {
+      // sqlite-allow-raw -- Restore ordinary schema parsing before releasing the read-only handle.
+      database.exec("PRAGMA writable_schema = OFF;");
+    } finally {
+      database.enableDefensive?.(true);
+    }
+  };
+}
+
+/** Restore schema parsing and release a private read handle even if either cleanup fails. */
+export function closeWorkshopIndexReadDatabase(
+  database: DatabaseSync,
+  closeAdmission?: () => void,
+): void {
+  try {
+    closeAdmission?.();
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(database);
+    database.close();
+  }
+}
+
+export { LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX };

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -18,6 +18,11 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
+import {
+  hasDanglingSkillWorkshopCollectionReviewIndex,
+  LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX,
+  withSqliteWritableSchema,
+} from "./openclaw-state-db-dangling-workshop-index.js";
 import { ensureColumn, tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import { migrateJsonCanonicalWideRowsV13 } from "./openclaw-state-db-schema-v13-widerow.js";
 import {
@@ -27,7 +32,10 @@ import {
 } from "./openclaw-state-db-schema-version.js";
 import type { DB } from "./openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
-import { OpenClawStateOwnershipError } from "./openclaw-state-ownership.js";
+import {
+  assertOpenClawStateWriteAllowed,
+  OpenClawStateOwnershipError,
+} from "./openclaw-state-ownership.js";
 import {
   getOpenClawStateRuntimeSchema,
   OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
@@ -38,6 +46,96 @@ import {
 } from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 import { UpdateSchemaRefusalError } from "./openclaw-update-schema-refusal.js";
+
+/**
+ * Make the known malformed index parseable, then let SQLite drop and reclaim it
+ * in the caller's transaction. A failed repair rolls both catalog edits back.
+ */
+function repairDanglingSkillWorkshopCollectionReviewIndex(database: DatabaseSync): boolean {
+  if (!hasDanglingSkillWorkshopCollectionReviewIndex(database)) {
+    return false;
+  }
+  return withSqliteWritableSchema(database, () => {
+    database
+      .prepare("UPDATE sqlite_schema SET sql = ? WHERE type = 'index' AND name = ?")
+      .run(
+        `CREATE INDEX ${LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX} ON skill_workshop_collection_reviews(create_time DESC, review_id DESC)`,
+        LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX,
+      );
+    // SAFETY: the pragma result is treated as unknown and validated before arithmetic.
+    const row = database.prepare("PRAGMA schema_version").get() as {
+      schema_version?: unknown;
+    };
+    const schemaVersion = typeof row.schema_version === "number" ? row.schema_version : 0;
+    database.exec(`PRAGMA schema_version = ${schemaVersion + 1}; PRAGMA writable_schema = OFF;`);
+    database.exec(`DROP INDEX ${LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX};`);
+    return true;
+  });
+}
+
+function repairDanglingSkillWorkshopCollectionReviewIndexChanges(database: DatabaseSync): string[] {
+  return repairDanglingSkillWorkshopCollectionReviewIndex(database)
+    ? ["Removed dangling legacy Skill Workshop review index"]
+    : [];
+}
+
+/** Run read-only schema admission while SQLite ignores malformed catalog rows. */
+function admitStateDatabaseWithDanglingWorkshopIndex<T>(
+  database: DatabaseSync,
+  operation: () => T,
+): T {
+  return withSqliteWritableSchema(database, operation);
+}
+
+/** Admit the schema before Doctor begins its write transaction. */
+function admitStateDatabaseForSchemaRepair(
+  database: DatabaseSync,
+  pathname: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const danglingWorkshopIndex = hasDanglingSkillWorkshopCollectionReviewIndex(database);
+  const admit = () => {
+    assertSupportedStateSchemaVersion(database, pathname);
+    if (danglingWorkshopIndex) {
+      assertOpenClawStateWriteAllowed({ database, databasePath: pathname, env });
+    }
+  };
+  if (danglingWorkshopIndex) {
+    admitStateDatabaseWithDanglingWorkshopIndex(database, admit);
+  } else {
+    admit();
+  }
+  return danglingWorkshopIndex;
+}
+
+/** Recheck write ownership after BEGIN IMMEDIATE and before catalog mutation. */
+function assertStateDatabaseSchemaRepairWriteAllowed(
+  database: DatabaseSync,
+  pathname: string,
+  env: NodeJS.ProcessEnv,
+  danglingWorkshopIndex: boolean,
+): void {
+  const assertAllowed = () =>
+    assertOpenClawStateWriteAllowed({ database, databasePath: pathname, env });
+  if (danglingWorkshopIndex) {
+    admitStateDatabaseWithDanglingWorkshopIndex(database, assertAllowed);
+  } else {
+    assertAllowed();
+  }
+}
+
+/** Admit Doctor repair, then return the ownership-rechecked catalog repair operation. */
+export function prepareStateDatabaseSchemaRepair(
+  database: DatabaseSync,
+  pathname: string,
+  env: NodeJS.ProcessEnv,
+): () => string[] {
+  const danglingWorkshopIndex = admitStateDatabaseForSchemaRepair(database, pathname, env);
+  return () => {
+    assertStateDatabaseSchemaRepairWriteAllowed(database, pathname, env, danglingWorkshopIndex);
+    return repairDanglingSkillWorkshopCollectionReviewIndexChanges(database);
+  };
+}
 
 const STATE_V6_ADDITIVE_TABLES = [
   // v6-v12 databases may predate this former same-version lazy table.

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -26,8 +26,10 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
+import { hasDanglingSkillWorkshopCollectionReviewIndex } from "./openclaw-state-db-dangling-workshop-index.js";
 import { openTrackedStateDatabase } from "./openclaw-state-db-handle.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import {
   assertSupportedStateSchemaVersion,
   readStateSchemaMigrationVersion,
@@ -78,6 +80,12 @@ export function openUnpublishedStateDatabase(params: {
       db,
       busyTimeoutMs,
       () => {
+        if (hasDanglingSkillWorkshopCollectionReviewIndex(db)) {
+          throw new OpenClawStateDatabaseSchemaMigrationRequiredError(
+            "legacy-workshop-review-index",
+            params.pathname,
+          );
+        }
         assertSupportedStateSchemaVersion(db, params.pathname);
         assertStateDatabaseIntegrityBeforeMutation(db, params.pathname);
         configureSqlitePreSchemaPragmas(db, { busyTimeoutMs });

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -73,6 +73,44 @@ describe.each(["admission", "explicit", "async"] as const)("%s read-only state r
       expect(fs.readFileSync(options.path)).toEqual(before);
     });
   });
+  it("reads through the exact dangling Workshop index without changing its source", async () => {
+    await withTempDir("openclaw-state-readonly-dangling-workshop-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      const opened = openOpenClawStateDatabase(options);
+      closeOpenClawStateDatabaseForTest();
+      const database = new DatabaseSync(opened.path);
+      try {
+        database.exec(
+          "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+        );
+        database.enableDefensive?.(false);
+        database.exec("PRAGMA writable_schema = ON;");
+        database
+          .prepare(
+            `UPDATE sqlite_schema
+              SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                           ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+            WHERE type = 'index'
+              AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+          )
+          .run();
+        const schema = database.prepare("PRAGMA schema_version").get() as {
+          schema_version: number;
+        };
+        database.exec(
+          `PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schema.schema_version + 1};`,
+        );
+      } finally {
+        database.close();
+      }
+      const before = fs.readFileSync(options.path);
+
+      expect(
+        await readState(({ db }) => db.prepare("SELECT role FROM schema_meta").get(), options),
+      ).toEqual({ role: "global" });
+      expect(fs.readFileSync(options.path)).toEqual(before);
+    });
+  });
   it.each(["cached", "uncached"])(
     "reads committed rows without joining a %s transaction",
     async (cacheState) => {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -15,6 +15,7 @@ import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
+import { openDanglingWorkshopIndexReadAdmission } from "./openclaw-state-db-dangling-workshop-index.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
@@ -75,12 +76,17 @@ function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
     return { reused: false };
   }
   try {
-    // Process-local terminal failures evict this handle. Persisted quarantine
-    // is checked on the next physical open so hot reads do not poll metadata.
-    // A newer build can migrate this file while the handle stays open, so the
-    // forward-compatibility gate still runs before any reused read.
-    assertSupportedStateSchemaVersion(opened.db, pathname);
-    return { reused: true, value: operation(opened) };
+    const closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(opened.db);
+    try {
+      // Process-local terminal failures evict this handle. Persisted quarantine
+      // is checked on the next physical open so hot reads do not poll metadata.
+      // A newer build can migrate this file while the handle stays open, so the
+      // forward-compatibility gate still runs before any reused read.
+      assertSupportedStateSchemaVersion(opened.db, pathname);
+      return { reused: true, value: operation(opened) };
+    } finally {
+      closeSchemaReadAdmission?.();
+    }
   } catch (error) {
     openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(opened, error);
     throw error;
@@ -113,13 +119,19 @@ function withOpenClawStateReadOnlyLocation<T>(
 ): T {
   const read = () => {
     const db = openNodeSqliteDatabase(location, { readOnly: true });
+    let closeSchemaReadAdmission: (() => void) | undefined;
     try {
+      closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
       db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       assertSupportedStateSchemaVersion(db, pathname);
       return operation({ db, path: pathname });
     } finally {
-      clearNodeSqliteKyselyCacheForDatabase(db);
-      db.close();
+      try {
+        closeSchemaReadAdmission?.();
+      } finally {
+        clearNodeSqliteKyselyCacheForDatabase(db);
+        db.close();
+      }
     }
   };
   // Only live-source descriptors join handle custody; snapshots remain private.

--- a/src/state/openclaw-state-db-schema-migration-required.ts
+++ b/src/state/openclaw-state-db-schema-migration-required.ts
@@ -2,7 +2,8 @@ import { StartupMaintenanceRequiredError } from "../infra/startup-maintenance-re
 
 type OpenClawStateDatabaseSchemaMigrationRequiredKind =
   | "agent-databases-composite-primary-key"
-  | "audit-events-v2";
+  | "audit-events-v2"
+  | "legacy-workshop-review-index";
 
 export class OpenClawStateDatabaseSchemaMigrationRequiredError extends StartupMaintenanceRequiredError {
   constructor(

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -30,6 +30,7 @@ import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.t
 import { isPathInside } from "../infra/path-guards.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { VERSION } from "../version.js";
@@ -43,6 +44,8 @@ import {
   FIRST_USE_STATE_TABLES,
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "./openclaw-state-db-contract.js";
+import { hasDanglingSkillWorkshopCollectionReviewIndex } from "./openclaw-state-db-dangling-workshop-index.js";
+import { prepareStateDatabaseSchemaRepair } from "./openclaw-state-db-maintenance.js";
 import { ensureGitHubPublicationSchema } from "./openclaw-state-db-schema-additive.js";
 import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
@@ -727,6 +730,58 @@ function materializeCurrentStateDatabase(stateDir: string): string {
   fs.mkdirSync(path.dirname(databasePath), { recursive: true });
   fs.copyFileSync(canonicalStateDatabaseTemplatePath, databasePath);
   return databasePath;
+}
+
+function createDanglingSkillWorkshopReviewIndex(databasePath: string): number {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(
+      "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+    );
+    const index = database
+      .prepare(
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND name = 'idx_skill_workshop_collection_reviews_workspace_time'",
+      )
+      .get() as { rootpage?: number } | undefined;
+    if (typeof index?.rootpage !== "number") {
+      throw new Error("failed to create legacy Skill Workshop review index fixture");
+    }
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    database
+      .prepare(
+        `UPDATE sqlite_schema
+            SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                         ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+          WHERE type = 'index'
+            AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+      )
+      .run();
+    const schemaVersion = readSqliteNumberPragma(database, "schema_version");
+    database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+    return index.rootpage;
+  } finally {
+    database.close();
+  }
+}
+
+function readDanglingSkillWorkshopReviewIndex(
+  databasePath: string,
+): { rootpage: number; sql: string } | undefined {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    return database
+      .prepare(
+        "SELECT rootpage, sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_skill_workshop_collection_reviews_workspace_time'",
+      )
+      .get() as { rootpage: number; sql: string } | undefined;
+  } finally {
+    database.close();
+  }
 }
 
 function downgradeWorkerPlacementsToV7(db: DatabaseSync): void {
@@ -1695,6 +1750,106 @@ describe("openclaw state database", () => {
         .prepare("SELECT review_id, backup_id FROM skill_workshop_collection_reviews")
         .get(),
     ).toEqual({ review_id: "review-v15", backup_id: "backup-v15" });
+  });
+
+  it("requires Doctor to repair the dangling v15 Workshop review index", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        `INSERT INTO skill_workshop_collection_reviews (
+           review_id, owner_agent_id, backup_id, create_time,
+           kept_names_json, written_names_json, dropped_json
+         ) VALUES ('review-preserved', 'main', 'backup-preserved', 1, '[]', '[]', '[]')`,
+      )
+      .run();
+    database.close();
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+
+    const defensiveProbe = new DatabaseSync(databasePath);
+    expect(hasDanglingSkillWorkshopCollectionReviewIndex(defensiveProbe)).toBe(true);
+    const schemaVersion = readSqliteNumberPragma(defensiveProbe, "schema_version");
+    defensiveProbe.exec(`PRAGMA schema_version = ${schemaVersion + 1};`);
+    expect(readSqliteNumberPragma(defensiveProbe, "schema_version")).toBe(schemaVersion);
+    defensiveProbe.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(
+      /legacy-workshop-review-index.*openclaw doctor --fix/u,
+    );
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Removed dangling legacy Skill Workshop review index"],
+      warnings: [],
+    });
+
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        repaired
+          .prepare(
+            "SELECT review_id, backup_id FROM skill_workshop_collection_reviews WHERE review_id = 'review-preserved'",
+          )
+          .get(),
+      ).toEqual({ review_id: "review-preserved", backup_id: "backup-preserved" });
+      expect(repaired.prepare("PRAGMA integrity_check").all()).toEqual([{ integrity_check: "ok" }]);
+      expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toBeUndefined();
+    } finally {
+      repaired.close();
+    }
+    expect(() => openOpenClawStateDatabase(options)).not.toThrow();
+  });
+
+  it("does not repair a dangling Workshop index in a newer unsupported schema", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec("PRAGMA writable_schema = ON;");
+    database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
+    database.exec("PRAGMA writable_schema = OFF;");
+    database.close();
+
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: [],
+      warnings: [expect.stringContaining("uses newer schema version")],
+    });
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+  });
+
+  it("rolls back dangling Workshop index reclamation and converges on retry", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    const repairAdmittedSchema = prepareStateDatabaseSchemaRepair(
+      database,
+      databasePath,
+      options.env,
+    );
+    expect(() =>
+      runSqliteImmediateTransactionSync(database, () => {
+        expect(repairAdmittedSchema()).toEqual([
+          "Removed dangling legacy Skill Workshop review index",
+        ]);
+        throw new Error("injected post-reclamation failure");
+      }),
+    ).toThrow("injected post-reclamation failure");
+    database.close();
+
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Removed dangling legacy Skill Workshop review index"],
+      warnings: [],
+    });
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toBeUndefined();
   });
 
   it("upgrades a v15 store without Workshop tables through v16 and prepared workers to v17", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -57,6 +57,7 @@ import {
   runStateSchemaMigrationTransaction,
   writeCurrentStateSchemaMetadata,
   executeCanonicalStateSchema,
+  prepareStateDatabaseSchemaRepair,
 } from "./openclaw-state-db-maintenance.js";
 import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
@@ -143,14 +144,13 @@ function repairStateSchema(
   let ownershipRefused = false;
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedStateSchemaVersion(db, pathname);
+    const repairAdmittedSchema = prepareStateDatabaseSchemaRepair(db, pathname, env);
     db.exec("PRAGMA foreign_keys = OFF;");
     const changes = runStateSchemaMigrationTransaction(
       db,
       pathname,
       () => {
-        assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
-        const applied: string[] = [];
+        const applied = repairAdmittedSchema();
         const previousVersion = readStateSchemaMigrationVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of verifyAndRepairCanonicalSqliteIndexes(

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -742,6 +742,93 @@ describe("external shared-state ownership", () => {
     }
   });
 
+  it("fences a claim made immediately before dangling Workshop index repair", () => {
+    const env = createEnv();
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const damaged = new DatabaseSync(databasePath);
+    damaged.exec(
+      "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+    );
+    damaged.enableDefensive?.(false);
+    damaged.exec("PRAGMA writable_schema = ON;");
+    damaged
+      .prepare(
+        `UPDATE sqlite_schema
+            SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                         ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+          WHERE type = 'index'
+            AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+      )
+      .run();
+    const schemaVersion = damaged.prepare("PRAGMA schema_version").get() as {
+      schema_version: number;
+    };
+    damaged.exec(
+      `PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion.schema_version + 1};`,
+    );
+    damaged.close();
+
+    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
+      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
+      | undefined;
+    if (!originalExec) {
+      throw new Error("DatabaseSync.exec descriptor is unavailable");
+    }
+    let immediateTransactionCount = 0;
+    const exec = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      if (sql === "BEGIN IMMEDIATE" && ++immediateTransactionCount === 1) {
+        const claimant = new DatabaseSync(databasePath);
+        try {
+          claimant.enableDefensive?.(false);
+          claimant.exec("PRAGMA writable_schema = ON;");
+          claimant
+            .prepare(
+              `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+               VALUES (?, ?, ?)`,
+            )
+            .run(
+              STATE_SUPERVISION_KEY,
+              JSON.stringify({
+                version: 1,
+                mode: "external",
+                managerId: "race-manager",
+                claimedAt: 1,
+              }),
+              1,
+            );
+        } finally {
+          claimant.close();
+        }
+      }
+      return originalExec.call(this, sql);
+    });
+
+    try {
+      expect(() => repairOpenClawStateDatabaseSchema({ env })).toThrow(OpenClawStateOwnershipError);
+    } finally {
+      exec.mockRestore();
+    }
+    expect(immediateTransactionCount).toBe(1);
+
+    const verify = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      verify.enableDefensive?.(false);
+      verify.exec("PRAGMA writable_schema = ON;");
+      expect(
+        verify
+          .prepare("SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND name = ?")
+          .get("idx_skill_workshop_collection_reviews_workspace_time"),
+      ).toBeDefined();
+    } finally {
+      verify.close();
+    }
+  });
+
   it("fences a claim made during a canonical current-schema cold open", () => {
     const env = createEnv();
     const databasePath = openOpenClawStateDatabase({ env }).path;

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -20,6 +20,7 @@ import {
   StateDatabaseCoordinatorContentionError,
 } from "../infra/state-database-coordinator.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
+import { openDanglingWorkshopIndexReadAdmission } from "./openclaw-state-db-dangling-workshop-index.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 
 export const STATE_SUPERVISION_KEY = "gateway.supervision";
@@ -119,19 +120,29 @@ export function inspectOpenClawStateOwnershipFromDatabase(
   databasePath: string,
   configMachineStateTableReady = false,
 ): OpenClawExternalStateOwnership | null {
-  if (!configMachineStateTableReady && !tableExists(database, "config_machine_state")) {
-    return null;
+  database.enableDefensive?.(false);
+  database.exec("PRAGMA writable_schema = ON;");
+  try {
+    if (!configMachineStateTableReady && !tableExists(database, "config_machine_state")) {
+      return null;
+    }
+    const row = database
+      .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ? LIMIT 1")
+      .get(STATE_SUPERVISION_KEY) as { value_json?: unknown } | undefined;
+    if (!row) {
+      return null;
+    }
+    if (typeof row.value_json !== "string") {
+      throw new OpenClawStateOwnershipMetadataError(databasePath, "reserved value is not text");
+    }
+    return parseExternalOwnership(row.value_json, databasePath);
+  } finally {
+    try {
+      database.exec("PRAGMA writable_schema = OFF;");
+    } finally {
+      database.enableDefensive?.(true);
+    }
   }
-  const row = database
-    .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ? LIMIT 1")
-    .get(STATE_SUPERVISION_KEY) as { value_json?: unknown } | undefined;
-  if (!row) {
-    return null;
-  }
-  if (typeof row.value_json !== "string") {
-    throw new OpenClawStateOwnershipMetadataError(databasePath, "reserved value is not text");
-  }
-  return parseExternalOwnership(row.value_json, databasePath);
 }
 
 function inspectOwnershipThroughConnection(
@@ -139,13 +150,19 @@ function inspectOwnershipThroughConnection(
   databasePath: string,
 ): OpenClawExternalStateOwnership | null {
   const database = openNodeSqliteDatabase(location, { readOnly: true });
+  let closeSchemaReadAdmission: (() => void) | undefined;
   try {
+    closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(database);
     database.exec(
       `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
     );
     return inspectOpenClawStateOwnershipFromDatabase(database, databasePath);
   } finally {
-    database.close();
+    try {
+      closeSchemaReadAdmission?.();
+    } finally {
+      database.close();
+    }
   }
 }
 
@@ -293,7 +310,10 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
     );
     return;
   }
-  const prepared = await prepareSqliteReadOnlyLocation(databasePath, { signal: options.signal });
+  const prepared = await prepareSqliteReadOnlyLocation(databasePath, {
+    preserveSourceArtifacts: true,
+    signal: options.signal,
+  });
   try {
     options.signal?.throwIfAborted();
     assertOwnershipAllowsWrite(


### PR DESCRIPTION
## What Problem This Solves

Fixes a shared-state SQLite failure after the v15→v16 Skill Workshop migration removes `workspace_dir` but leaves the legacy `idx_skill_workshop_collection_reviews_workspace_time` index behind.

The dangling index makes SQLite reject schema inspection with `no such column: workspace_dir`. Because write-admission/lease inspection happens before canonical-index repair, `openclaw doctor --fix` can report a lease failure without reaching the repair path.

## Why This Change Was Made

The repair path now removes only the known legacy review index when its table no longer contains `workspace_dir`. Cleanup runs under the state coordinator before current-schema canonical-index validation, and the same guard covers runtime schema opening.

Read-only ownership inspection remains non-mutating: it enables SQLite's catalog-inspection mode before the first schema query and leaves deletion to the admitted writable repair path. The repair deletes the exact catalog row, bumps `schema_version`, and runs `VACUUM` so the real index b-tree pages are reclaimed.

No review rows are rewritten or inferred from the malformed index; the v16 schema and canonical owner index remain the source of truth.

## User Impact

Users with this partial-migration state can run `openclaw doctor --fix` or reopen the Gateway without the dangling legacy index blocking SQLite schema inspection. Unrelated malformed schemas continue to fail closed.

## Evidence

- Exact pushed head: `0ea45e797692ccbbdd7631b61a114d67b81dd4dc`.
- The regression fixture now inserts 1,000 real review rows, creates the legacy-named index with a positive SQLite root page, mutates only its catalog SQL to reference the retired `workspace_dir`, and verifies the index is removed and `PRAGMA integrity_check` returns `ok` after repair.
- Focused state suite: **3 tests passed**, including the existing v15→v16 migration, the dangling-index regression, and canonical shared-state index repair.
- Ownership/preflight regression suites: **64 tests passed**.
- Changed-file Oxlint passed for the four state database files.
- Changed-file Oxfmt check and `git diff --check` passed.
- `pnpm tsgo:core` remains blocked by an unrelated existing error: `src/infra/archive.ts(16,3): Module "@openclaw/fs-safe/archive" has no exported member "inspectTarArchive"`.
- The initial push attempt to the upstream read-only remote returned 403; the exact head is now pushed to the PR's writable fork branch `jjjhenriksen:fix/skill-workshop-dangling-index`.

## Known Gate

The upstream CI checks are still running. This PR does not claim merge readiness until those checks complete.

## Worked on by

- Jacqueline Henriksen (@jjjhenriksen)