### PR TITLE
fix(ci): stabilize mobile screenshot qualification

### DIFF
--- a/.github/workflows/android-beta-release.yml
+++ b/.github/workflows/android-beta-release.yml
@@ -96,7 +96,7 @@ jobs:
       actions: read
       attestations: read
       contents: read
-    runs-on: macos-26
+    runs-on: macos-26-intel
     timeout-minutes: 120
     environment: android-beta-release
     concurrency:
@@ -146,6 +146,9 @@ jobs:
         with:
           cache-mode: off
           install-screenshot-emulators: "true"
+
+      - name: Verify Android emulator acceleration
+        run: emulator -accel-check
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1

--- a/.github/workflows/ios-beta-release.yml
+++ b/.github/workflows/ios-beta-release.yml
@@ -269,6 +269,8 @@ jobs:
           OPENCLAW_MOBILE_RELEASE_INTENT_PATH: ${{ runner.temp }}/mobile-release-intent-ios/intent.json
           OPENCLAW_MOBILE_RELEASE_REF_MODE: intent
           OPENCLAW_MOBILE_RELEASE_TARGET_REF: ${{ needs.authorize.outputs.target_ref }}
+          SCAN_APP_NAME: OpenClaw
+          SCAN_DEPLOYMENT_TARGET_VERSION: "18.0"
           TESTFLIGHT_INTERNAL_GROUP: ${{ vars.TESTFLIGHT_INTERNAL_GROUP }}
         run: |
           set -euo pipefail

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1757,6 +1757,7 @@ describe("mobile release authority", () => {
         file: ".github/workflows/ios-beta-release.yml",
         name: "iOS Beta Release",
         platform: "ios",
+        releaseRunner: "macos-26",
         signingCheckoutName: "Checkout encrypted iOS signing assets",
         signingCheckoutRevalidateName:
           "Revalidate release authority immediately before iOS signing checkout",
@@ -1770,6 +1771,7 @@ describe("mobile release authority", () => {
         file: ".github/workflows/android-beta-release.yml",
         name: "Android Beta Release",
         platform: "android",
+        releaseRunner: "macos-26-intel",
         signingCheckoutName: "Checkout encrypted Android signing assets",
         signingCheckoutRevalidateName:
           "Revalidate release authority immediately before Android signing checkout",
@@ -1791,6 +1793,7 @@ describe("mobile release authority", () => {
       file,
       name,
       platform,
+      releaseRunner,
       signingCheckoutName,
       signingCheckoutRevalidateName,
       signingMaterializeName,
@@ -1805,6 +1808,7 @@ describe("mobile release authority", () => {
             environment?: string;
             if?: unknown;
             needs?: string;
+            "runs-on"?: string;
             steps: Array<{
               "continue-on-error"?: unknown;
               env?: Record<string, string>;
@@ -1849,6 +1853,7 @@ describe("mobile release authority", () => {
         throw new Error(`${file}: missing release job`);
       }
       expect(release.needs).toBe("authorize");
+      expect(release["runs-on"]).toBe(releaseRunner);
       expect(release.if).toBe(
         "inputs.operation == 'upload-and-record' && needs.authorize.outputs.approved == 'true'",
       );
@@ -1965,10 +1970,22 @@ describe("mobile release authority", () => {
       expect(release.steps[recordIndex]?.with?.operation).toBe("record");
 
       if (platform === "android") {
+        const androidSetupIndex = release.steps.findIndex(
+          (step) => step.name === "Setup Android toolchain",
+        );
+        const accelerationCheckIndex = release.steps.findIndex(
+          (step) => step.name === "Verify Android emulator acceleration",
+        );
         const rubyStep = release.steps.find((step) => step.name === "Setup Ruby");
         const bundleStep = release.steps.find(
           (step) => step.name === "Install locked Fastlane bundle",
         );
+        expect(androidSetupIndex).toBeGreaterThanOrEqual(0);
+        expect(accelerationCheckIndex).toBe(androidSetupIndex + 1);
+        expect(accelerationCheckIndex).toBeLessThan(signingRevalidateIndex);
+        expect(release.steps[accelerationCheckIndex]?.run?.trim()).toBe("emulator -accel-check");
+        expect(release.steps[accelerationCheckIndex]?.if).toBeUndefined();
+        expect(release.steps[accelerationCheckIndex]?.["continue-on-error"]).toBeUndefined();
         expect(rubyStep?.with).toMatchObject({
           "bundler-cache": false,
           "ruby-version": "3.4.10",
@@ -2151,8 +2168,12 @@ describe("mobile release authority", () => {
     }
   });
 
-  it("passes the protected TestFlight group variable only to the iOS upload step", () => {
+  it("passes protected iOS release inputs only to the iOS upload step", () => {
     const source = fs.readFileSync(".github/workflows/ios-beta-release.yml", "utf8");
+    const project = parse(fs.readFileSync("apps/ios/project.yml", "utf8")) as {
+      name?: string;
+      options?: { deploymentTarget?: { iOS?: string } };
+    };
     const workflow = parse(source) as {
       jobs: Record<
         string,
@@ -2188,6 +2209,35 @@ describe("mobile release authority", () => {
         jobName: "release",
         runsUpload: true,
         value: "${{ vars.TESTFLIGHT_INTERNAL_GROUP }}",
+      },
+    ]);
+
+    const uploadStep = workflow.jobs.release?.steps.find((step) =>
+      step.run?.includes("pnpm ios:release:upload"),
+    );
+    expect(uploadStep?.env).toMatchObject({
+      SCAN_APP_NAME: project.name,
+      SCAN_DEPLOYMENT_TARGET_VERSION: project.options?.deploymentTarget?.iOS,
+    });
+    const scanPlacements = Object.entries(workflow.jobs).flatMap(([jobName, job]) =>
+      job.steps.flatMap((step) =>
+        Object.entries(step.env ?? {})
+          .filter(([envName]) => envName.startsWith("SCAN_"))
+          .map(([envName, value]) => ({ envName, jobName, stepName: step.name, value })),
+      ),
+    );
+    expect(scanPlacements).toEqual([
+      {
+        envName: "SCAN_APP_NAME",
+        jobName: "release",
+        stepName: "Upload and distribute iOS beta",
+        value: project.name,
+      },
+      {
+        envName: "SCAN_DEPLOYMENT_TARGET_VERSION",
+        jobName: "release",
+        stepName: "Upload and distribute iOS beta",
+        value: project.options?.deploymentTarget?.iOS,
       },
     ]);
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves mobile beta CI blockers where the iOS screenshot lane lacked explicit canonical Scan project inputs and the Android screenshot lane did not require emulator acceleration before protected signing access.

## Why This Change Was Made

The iOS upload step now passes the app name and iOS deployment target already defined by `apps/ios/project.yml` through Fastlane's supported Scan inputs. The Android upload job now uses the Intel macOS runner and fails closed on `emulator -accel-check` immediately after Android toolchain setup, before any signing token or key access.

Release authority, environment approval, signing-secret placement, upload commands, internal-only destinations, intent recording, and immutable-ref behavior are unchanged. The frozen mobile candidate remains unchanged.

## User Impact

There is no app runtime change. Mobile release operators get deterministic iOS screenshot project selection and an early Android acceleration prerequisite instead of reaching protected signing and upload stages with an unsuitable emulator host.

## Evidence

- Red: the parsed workflow regression read the original Android upload runner as `macos-26` instead of `macos-26-intel`, found no acceleration check, and found neither canonical Scan input on the iOS upload step.
- Green: `test/scripts/mobile-release-authority.test.ts` passed 60/60. The test binds iOS values to parsed `apps/ios/project.yml`, requires the Android runner and setup/check adjacency, and preserves existing authority, signing-secret, upload, and recorder ordering assertions.
- Static: both workflows pass `actionlint`; all three files pass `oxfmt --check`; the TypeScript test passes `oxlint`; `git diff --check` is clean.
- Review: exact-diff P1 autoreview is scoped-clean with 0.98 confidence.
- Dependency contract: Fastlane 2.238.0 Scan/Snapshot inputs were inspected directly during the platform review. The isolated command-generation probe is **UNRUN** because its prerequisites were absent (no generated project and an ambient Ruby 4 runtime); this PR does not broaden into local environment repair.
- Runtime proof: successful hosted acceleration plus actual iOS and Android phone/Wear screenshot and build execution remains mandatory in the next separately authorized beta release run. No workflow was dispatched and no store, credential, environment, candidate, App Review, or production state was mutated by this repair.
- Maintainer decision: land the narrow prerequisite repair before that protected runtime proof. The release remains held; the next separately authorized internal-beta run must prove acceleration and all screenshot/build paths before upload, with no App Review or production promotion.
- LOC: production/tooling `+6/-1`; tests `+51/-1`. The production growth is the two explicit platform prerequisites; the test growth protects runner, project-value, ordering, and secret-boundary invariants.
