### PR TITLE
fix(sessions): expose slow reclamation between writer scopes

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -312,6 +312,18 @@ integrity check; resumed validation and repair can still run on the opener.
 Correlate the process ID with the log timestamp and current process; PIDs can be
 reused after exit.
 
+SQLite reclamation Workers also emit `slow SQLite reclamation Worker operation`
+at `warn` when their joined operation takes at least one second. The record is
+emitted after Worker exit and parent admission settlement. It includes the
+parent's `pid`, `threadId` and `isMainThread`, the actual Node `workerThreadId`,
+`reclamationKind`, `elapsedMs`, terminal `outcome` (`resolved` or `rejected`), and
+`exitCode`. Timing starts after admission to the archive Worker queue and includes
+startup, validation, admission waits, work, and cleanup. It does not measure CPU
+time or isolate a validation phase. Short writer sections can therefore remain
+quiet while this whole-operation warning exposes slow preparation between them.
+The record inherits an existing parent trace when available; it contains no
+database path, session identifier, plan content, or raw error.
+
 ### Slow reply preparation
 
 When a reply spends a long time preparing, inspect the normal Gateway logs:

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -1,11 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { Worker } from "node:worker_threads";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId, Worker } from "node:worker_threads";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { syncDirectoryBestEffortSync } from "../../infra/directory-durability.js";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
@@ -19,12 +21,18 @@ import {
   isSessionArchiveArtifactName,
   type SessionArchiveReason,
 } from "./artifacts.js";
-import type { SessionLifecycleArchivedTranscript } from "./session-accessor.sqlite-contract.js";
+import type {
+  SessionLifecycleArchivedTranscript,
+  SqliteSessionReclamationDiagnostics,
+} from "./session-accessor.sqlite-contract.js";
 import {
   readSessionStateDeleteSnapshot,
   sqliteSessionStateDeleteSnapshotsEqual,
 } from "./session-accessor.sqlite-delete-snapshot.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
+
+const log = createSubsystemLogger("session-sqlite");
+const SLOW_RECLAMATION_WORKER_MS = 1_000;
 
 export type SessionStateDeletePlan = {
   agentId: string;
@@ -295,7 +303,7 @@ function resolveSourceWorkerExecArgv(): string[] {
 }
 
 function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
-  diagnostics?: { workerThreadId?: number };
+  diagnostics?: SqliteSessionReclamationDiagnostics;
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
   withWriteAdmission?: (
@@ -304,6 +312,8 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   transferList?: ArrayBuffer[];
   workerData: object;
 }): Promise<Result[]> {
+  const reclamationKind = params.diagnostics?.kind;
+  const startedAt = performance.now();
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sessionTranscriptArchive);
   let worker: Worker;
   try {
@@ -323,13 +333,14 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
     return Promise.reject(toStringifiedError(error));
   }
 
-  return new Promise((resolve, reject) => {
+  const workerThreadId = worker.threadId;
+  let exitCode: number | undefined;
+  const operation = new Promise<Result[]>((resolve, reject) => {
     let results: Result[] | undefined;
     let workerError: Error | undefined;
     let admission: { id: number; released: Deferred } | undefined;
     let admissionId = 0;
     let exited = false;
-    let exitCode: number | undefined;
     const admissionTasks: Promise<void>[] = [];
     worker.on("message", (message: { results: Result[]; type: string; admissionId?: number }) => {
       if (message.type === "commit-request") {
@@ -431,6 +442,33 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
       }, reject);
     });
   });
+  if (reclamationKind) {
+    const observeCompletion = (outcome: "resolved" | "rejected") => {
+      const elapsedMs = Math.round(performance.now() - startedAt);
+      if (elapsedMs < SLOW_RECLAMATION_WORKER_MS) {
+        return;
+      }
+      log.warn("slow SQLite reclamation Worker operation", {
+        pid: process.pid,
+        threadId,
+        isMainThread,
+        reclamationKind,
+        workerThreadId,
+        elapsedMs,
+        outcome,
+        exitCode,
+      });
+    };
+    // Observe in the caller's trace scope, after Worker exit and admission settlement.
+    // A failed log must neither change the operation nor leave an unhandled rejection.
+    void operation
+      .then(
+        () => observeCompletion("resolved"),
+        () => observeCompletion("rejected"),
+      )
+      .catch(() => {});
+  }
+  return operation;
 }
 
 // Serialize lifecycle archive Workers so this path cannot multiply
@@ -439,7 +477,7 @@ const sqliteTranscriptArchiveWorkerQueue = new KeyedAsyncQueue();
 const SQLITE_TRANSCRIPT_ARCHIVE_WORKER_QUEUE_KEY = "lifecycle-archive";
 
 export function runSqliteTranscriptArchiveWorkerOperation<Result>(params: {
-  diagnostics?: { workerThreadId?: number };
+  diagnostics?: SqliteSessionReclamationDiagnostics;
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
   withWriteAdmission?: (

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -1,13 +1,17 @@
+import assert from "node:assert/strict";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { symlinkSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { setImmediate as yieldToEventLoop, setTimeout as delay } from "node:timers/promises";
 import { isMainThread, threadId } from "node:worker_threads";
 import type { Worker } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
+import { runWithDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { configureSqliteWalMaintenance } from "../../infra/sqlite-wal.js";
 import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import { onSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
@@ -45,8 +49,31 @@ import { reclaimSqliteFreePages } from "./session-history-archive-pruning.js";
 
 const hooks = vi.hoisted(() => ({
   beforeAuthorization: undefined as (() => void) | undefined,
+  beforeWriteAdmission: undefined as (() => Promise<void>) | undefined,
   afterWriteAdmission: undefined as (() => Promise<void>) | undefined,
+  failWorkerLog: false,
+  workerLogAttempts: 0,
 }));
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (name: string) => {
+      const logger = actual.createSubsystemLogger(name);
+      const warn = logger.warn;
+      logger.warn = (message, meta) => {
+        if (message === "slow SQLite reclamation Worker operation") {
+          hooks.workerLogAttempts += 1;
+          if (hooks.failWorkerLog) {
+            throw new Error("synthetic log transport failure");
+          }
+        }
+        warn(message, meta);
+      };
+      return logger;
+    },
+  };
+});
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
   return {
@@ -59,11 +86,13 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
         ...params,
         ...(withWriteAdmission
           ? {
-              withWriteAdmission: (run: Parameters<typeof withWriteAdmission>[0]) =>
-                withWriteAdmission(async (refusal) => {
+              withWriteAdmission: async (run: Parameters<typeof withWriteAdmission>[0]) => {
+                await hooks.beforeWriteAdmission?.();
+                return withWriteAdmission(async (refusal) => {
                   await hooks.afterWriteAdmission?.();
                   return await run(refusal);
-                }),
+                });
+              },
             }
           : {}),
         onCommitRequest: () => {
@@ -76,7 +105,10 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
 });
 afterEach(() => {
   hooks.beforeAuthorization = undefined;
+  hooks.beforeWriteAdmission = undefined;
   hooks.afterWriteAdmission = undefined;
+  hooks.failWorkerLog = false;
+  hooks.workerLogAttempts = 0;
 });
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -663,3 +695,101 @@ test("file warnings link an awaited native worker without attributing it to the 
     setLoggerOverride(null);
   }
 });
+
+test.each([
+  { elapsedMs: 0, rejected: false, failLog: false },
+  { elapsedMs: 1_500, rejected: false, failLog: false },
+  { elapsedMs: 1_500, rejected: true, failLog: false },
+  { elapsedMs: 1_500, rejected: false, failLog: true },
+  { elapsedMs: 1_500, rejected: true, failLog: true },
+])(
+  "records the joined reclamation lifetime outside writers (elapsed=$elapsedMs, rejected=$rejected, log failure=$failLog)",
+  async ({ elapsedMs, rejected, failLog }) => {
+    const { databaseOptions, plan } = createFixture();
+    const file = path.join(tempDirs.make("openclaw-reclamation-log-"), "reclamation.log");
+    await fs.writeFile(file, "");
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file });
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const workers: Array<{ worker: Worker; id: number }> = [];
+    const observeWorker = (worker: Worker) => workers.push({ worker, id: worker.threadId });
+    process.on("worker", observeWorker);
+    const failure = new Error("synthetic reclamation refusal; private plan details");
+    let revoked = false;
+    let admissions = 0;
+    let otherWriterRan = false;
+    hooks.failWorkerLog = failLog;
+    hooks.beforeWriteAdmission = async () => {
+      if (++admissions !== 2) {
+        return;
+      }
+      // The first admission has ended; the second has not entered the writer FIFO.
+      await runExclusiveSqliteSessionWrite(databaseOptions, async () => {
+        otherWriterRan = true;
+      });
+      clock = elapsedMs;
+      revoked = rejected;
+    };
+    const trace = { traceId: "1".repeat(32), spanId: "2".repeat(16), traceFlags: "01" };
+    const operation = runWithDiagnosticTraceContext(trace, () =>
+      runSqliteSessionReclamation({
+        forceInProcess: false,
+        plan,
+        diagnostics: { kind: "history-eviction" },
+        assertCommitAllowed: () => {
+          if (revoked) {
+            throw failure;
+          }
+        },
+      }),
+    );
+    try {
+      if (rejected) {
+        await expect(operation).rejects.toBe(failure);
+      } else {
+        await expect(operation).resolves.toMatchObject({ kind: "history-eviction" });
+      }
+      await flushLogger();
+      const records = (await fs.readFile(file, "utf8"))
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const value: unknown = JSON.parse(line);
+          assert.ok(isRecord(value));
+          return value;
+        });
+      const slow = records.filter(
+        (record) => record.message === "slow SQLite reclamation Worker operation",
+      );
+      expect(otherWriterRan).toBe(true);
+      expect(workers).toHaveLength(1);
+      expect(workers[0]?.id).toBeGreaterThan(0);
+      expect(workers[0]?.worker.threadId).toBe(-1);
+      expect(records.some((record) => record["1"] === "slow SQLite session write")).toBe(false);
+      expect(hooks.workerLogAttempts).toBe(elapsedMs > 0 ? 1 : 0);
+      expect(slow).toHaveLength(elapsedMs > 0 && !failLog ? 1 : 0);
+      if (slow[0]) {
+        expect(slow[0]).toMatchObject(trace);
+        expect(slow[0]["1"]).toEqual({
+          pid: process.pid,
+          threadId,
+          isMainThread,
+          reclamationKind: "history-eviction",
+          workerThreadId: workers[0]?.id,
+          elapsedMs,
+          outcome: rejected ? "rejected" : "resolved",
+          exitCode: rejected ? 1 : 0,
+        });
+      }
+      await expect(
+        runExclusiveSqliteSessionWrite(databaseOptions, async () => "after"),
+      ).resolves.toBe("after");
+    } finally {
+      await Promise.allSettled([operation]);
+      process.off("worker", observeWorker);
+      vi.restoreAllMocks();
+      await flushLogger();
+      setLoggerOverride(null);
+    }
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating slow session cleanup could see no operation-duration warning when reclamation preparation took several seconds between otherwise short SQLite writer admissions.

## Why This Change Was Made

The archive Worker dispatcher now observes the existing joined completion promise and emits one warning for reclamation operations taking at least one second. It records the typed reclamation kind, actual Node Worker identity, parent process/thread identity, elapsed lifetime, terminal outcome and exit code after Worker exit and parent admission settlement. The original result or rejection stays authoritative even if logging fails.

The timing excludes the outer archive queue, includes startup/preparation/admission/work/cleanup, and does not claim CPU time or isolate validation. Existing parent trace context is retained without logging paths, session identifiers, plan content or raw errors. No configuration, storage, authorization or concurrency behavior changes.

## User Impact

Operators can identify slow whole reclamation operations even when their individual writer sections remain below the warning threshold. This is an observability repair, not a claimed cleanup speedup.

## Evidence

- The real-Worker regression failed before the fix in all four slow cases because the terminal diagnostic was missing; the fast case already passed. All five cases pass after the fix, including successful/rejected outcomes and logging transport failures.
- All 76 focused reclamation, archive Worker, writer-scope, commit and admission-race tests passed locally.
- A real-clock fixture delayed the second admission by 1.25 seconds. Another writer progressed, no slow-writer warning appeared, and the joined terminal record retained the actual Worker identity after exit.
- Independent source review and isolated Codex autoreview through P2 found no actionable findings.
- Full local build and changed-file checks passed. The source-verified Linux build also passed on Blacksmith Testbox with Node 24.19.0 and pnpm 12.3.4.
- Real CLI/Gateway create, rename, reset, delete, repeated-delete and final-health assertions passed locally and on Linux. Linux additionally verified wrapper exit, process-group disappearance and listener closure. CLI timings include client startup and are not RPC latency measurements.

The first Gateway fixture incorrectly expected reset to replace the session ID; the corrected fixture verifies the existing stable-ID/new-lifecycle-revision contract. A later archive helper failed after the Linux runtime assertions and shutdown checks completed; evidence collection was repaired separately. Both failed proof-tool attempts are retained. These synthetic flows do not establish sustained production performance or a CPU cause.
