### PR TITLE
fix(plugins): include assets in untracked source package builds

### DIFF
--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -258,6 +258,9 @@ node scripts/lib/plugin-npm-runtime-build.mjs --prepare-native-import extensions
 This requires existing root SDK output in `dist/plugin-sdk` and the selected
 package's standalone runtime output. If the package output is missing, build
 it first with `node scripts/lib/plugin-npm-runtime-build.mjs extensions/<package>`.
+The standalone build runs the selected package's asset build command and copies
+its declared `openclaw.build.staticAssets` into `dist`, including for new packages
+that are not yet tracked by Git. Missing declared source files fail the build.
 The preparation command does not rebuild either output or execute plugin code.
 It only links the checkout as `node_modules/openclaw` for a real immediate
 source package that declares `openclaw` in `peerDependencies` or `dependencies`.

--- a/scripts/lib/plugin-npm-runtime-assets.mts
+++ b/scripts/lib/plugin-npm-runtime-assets.mts
@@ -2,16 +2,12 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { discoverStaticExtensionAssets } from "./static-extension-assets.mts";
+import { resolvePackageStaticAssetEntries } from "./static-extension-assets.mts";
 
 type PluginRuntimeAssetPlan = {
   packageDir: string;
-  packageJson: { openclaw?: { assetScripts?: { build?: unknown } } };
+  packageJson: Record<string, unknown> & { openclaw?: { assetScripts?: { build?: unknown } } };
   pluginDir: string;
-};
-
-type PluginStaticAssetPlan = Pick<PluginRuntimeAssetPlan, "pluginDir"> & {
-  repoRoot: string;
 };
 
 function resolvePackageAssetBuildCommand(packageJson: PluginRuntimeAssetPlan["packageJson"]) {
@@ -19,8 +15,7 @@ function resolvePackageAssetBuildCommand(packageJson: PluginRuntimeAssetPlan["pa
   return typeof command === "string" && command.trim() ? command.trim() : null;
 }
 
-/** Run a package-local static asset build command when the plugin declares one. */
-export function runPackageAssetBuild(plan: PluginRuntimeAssetPlan) {
+function runPackageAssetBuild(plan: PluginRuntimeAssetPlan) {
   const command = resolvePackageAssetBuildCommand(plan.packageJson);
   if (!command) {
     return null;
@@ -38,12 +33,25 @@ export function runPackageAssetBuild(plan: PluginRuntimeAssetPlan) {
   return command;
 }
 
-/** List static asset source paths referenced by a package but missing from disk. */
-export function listMissingPackageStaticAssetSources(plan: PluginStaticAssetPlan) {
-  const packagePrefix = `extensions/${plan.pluginDir}/`;
-  return discoverStaticExtensionAssets({ rootDir: plan.repoRoot, includeExternalPlugins: true })
-    .filter((asset) => asset.src.replaceAll("\\", "/").startsWith(packagePrefix))
-    .map((asset) => asset.src)
-    .filter((src) => !fs.existsSync(path.join(plan.repoRoot, src)))
+/** Uses the selected manifest so private source packages need no Git discovery. */
+export function preparePackageRuntimeAssets(plan: PluginRuntimeAssetPlan) {
+  const assetBuildCommand = runPackageAssetBuild(plan);
+  const assets = resolvePackageStaticAssetEntries(plan.packageJson);
+  const missing = assets
+    .filter(({ source }) => !fs.existsSync(path.join(plan.packageDir, source)))
+    .map(({ source }) => path.posix.join("extensions", plan.pluginDir, source))
     .toSorted((left, right) => left.localeCompare(right));
+  if (missing.length > 0) {
+    throw new Error(`${plan.pluginDir} missing static asset source(s): ${missing.join(", ")}`);
+  }
+  const copiedStaticAssets = assets.map(({ source, output }) => {
+    const destination = path.join(plan.packageDir, "dist", output);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(plan.packageDir, source), destination);
+    return path.posix.join("dist", output);
+  });
+  return {
+    assetBuildCommand,
+    copiedStaticAssets: copiedStaticAssets.toSorted((left, right) => left.localeCompare(right)),
+  };
 }

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -10,12 +10,8 @@ import {
   resolvePluginRuntimeFormat,
 } from "./bundled-plugin-build-entries.mjs";
 import { assertRealOutputRoot } from "./output-root-guard.mjs";
-import {
-  listMissingPackageStaticAssetSources,
-  runPackageAssetBuild,
-} from "./plugin-npm-runtime-assets.mts";
+import { preparePackageRuntimeAssets } from "./plugin-npm-runtime-assets.mts";
 import { isRecord } from "./record-shared.mjs";
-import { copyStaticExtensionAssetsForPackage } from "./static-extension-assets.mts";
 
 const env = {
   NODE_ENV: "production",
@@ -417,21 +413,9 @@ export async function buildPluginNpmRuntime(params: PluginNpmRuntimeBuildParams)
     );
   }
   rewriteCommonJsRuntimeSpecifiers(plan);
-  const assetBuildCommand = runPackageAssetBuild(plan);
-  const missingStaticAssets = listMissingPackageStaticAssetSources(plan);
-  if (missingStaticAssets.length > 0) {
-    throw new Error(
-      `${plan.pluginDir} missing static asset source(s): ${missingStaticAssets.join(", ")}`,
-    );
-  }
-  const copiedStaticAssets = copyStaticExtensionAssetsForPackage({
-    rootDir: plan.repoRoot,
-    pluginDir: plan.pluginDir,
-  });
   return {
     ...plan,
-    assetBuildCommand,
-    copiedStaticAssets,
+    ...preparePackageRuntimeAssets(plan),
   };
 }
 

--- a/scripts/lib/static-extension-assets.mts
+++ b/scripts/lib/static-extension-assets.mts
@@ -144,6 +144,15 @@ function readPackageStaticAssetEntries(packageJson: Record<string, unknown>) {
   return Array.isArray(entries) ? entries.filter(isRecord) : [];
 }
 
+/** Resolves the package's declared source/output pairs for asset copying. */
+export function resolvePackageStaticAssetEntries(packageJson: Record<string, unknown>) {
+  return readPackageStaticAssetEntries(packageJson).flatMap((entry) => {
+    const source = normalizePackageRelativePath(entry.source);
+    const output = normalizePackageRelativePath(entry.output);
+    return source && output ? [{ source, output }] : [];
+  });
+}
+
 function hasPackageAssetBuild(packageJson: Record<string, unknown>) {
   const command = readPackageSection(packageJson, "assetScripts").build;
   return typeof command === "string" && command.trim().length > 0;
@@ -165,8 +174,7 @@ function isExternalDistPackage(packageJson: Record<string, unknown>) {
  * Discovers static asset copy specs from extension package metadata.
  *
  * External plugins (`bundledDist: false`) are skipped by default so their
- * launchers are not copied into core dist. Per-package plugin builds pass
- * `includeExternalPlugins` to still emit their own static assets.
+ * launchers are not copied into core dist.
  */
 export function discoverStaticExtensionAssets(params: StaticExtensionAssetParams = {}) {
   const rootDir = params.rootDir ?? process.cwd();
@@ -189,12 +197,7 @@ export function discoverStaticExtensionAssets(params: StaticExtensionAssetParams
     ) {
       continue;
     }
-    for (const entry of readPackageStaticAssetEntries(packageJson)) {
-      const source = normalizePackageRelativePath(entry.source);
-      const output = normalizePackageRelativePath(entry.output);
-      if (!source || !output) {
-        continue;
-      }
+    for (const { source, output } of resolvePackageStaticAssetEntries(packageJson)) {
       assets.push({
         pluginDir: dirName,
         src: toPosixPath(path.posix.join("extensions", dirName, source)),
@@ -351,42 +354,4 @@ export function copyStaticExtensionAssetsToRuntimeOverlay(params: StaticExtensio
       warn(`[runtime-postbuild] static asset not found, skipping: ${src}`);
     }
   }
-}
-
-/**
- * Copies declared static assets for one package runtime build.
- */
-export function copyStaticExtensionAssetsForPackage(
-  params: StaticExtensionAssetParams & { pluginDir: string },
-) {
-  const rootDir = params.rootDir ?? process.cwd();
-  const fsImpl = params.fs ?? fs;
-  const assets =
-    params.assets ??
-    discoverStaticExtensionAssets({
-      rootDir,
-      fs: fsImpl,
-      env: params.env,
-      includeExternalPlugins: true,
-    });
-  const packagePrefix = `extensions/${params.pluginDir}/`;
-  const rootDistPrefix = `dist/extensions/${params.pluginDir}/`;
-  const copied: string[] = [];
-  for (const { src, dest } of assets) {
-    const normalizedSrc = src.replaceAll("\\", "/");
-    const normalizedDest = dest.replaceAll("\\", "/");
-    if (!normalizedSrc.startsWith(packagePrefix) || !normalizedDest.startsWith(rootDistPrefix)) {
-      continue;
-    }
-    const srcPath = path.join(rootDir, src);
-    if (!fsImpl.existsSync(srcPath)) {
-      continue;
-    }
-    const packageRelativeDest = normalizedDest.slice(rootDistPrefix.length);
-    const destPath = path.join(rootDir, packagePrefix, "dist", packageRelativeDest);
-    fsImpl.mkdirSync(path.dirname(destPath), { recursive: true });
-    fsImpl.copyFileSync(srcPath, destPath);
-    copied.push(`dist/${packageRelativeDest}`);
-  }
-  return copied.toSorted((left, right) => left.localeCompare(right));
 }

--- a/test/scripts/plugin-npm-runtime-assets.test.ts
+++ b/test/scripts/plugin-npm-runtime-assets.test.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildPluginNpmRuntime } from "../../scripts/lib/plugin-npm-runtime-build.mts";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+function createAssetFixture(
+  options: { tracked?: boolean; missing?: boolean; generated?: boolean } = {},
+) {
+  const repoRoot = createTempDir("openclaw-selected-plugin-assets-");
+  const packageDir = path.join(repoRoot, "extensions", "demo");
+  fs.mkdirSync(path.join(packageDir, "assets"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "package.json"), '{"name":"openclaw","version":"1.0.0"}');
+  execFileSync("git", ["init", "--quiet"], { cwd: repoRoot });
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "@fixture/demo",
+      version: "1.0.0",
+      type: "module",
+      openclaw: {
+        extensions: ["./index.ts"],
+        build: {
+          runtimeFormat: "esm",
+          staticAssets: [{ source: "./assets/message.txt", output: "assets/message.txt" }],
+        },
+        ...(options.generated ? { assetScripts: { build: "node build-assets.cjs" } } : {}),
+      },
+    }),
+  );
+  fs.writeFileSync(path.join(packageDir, "openclaw.plugin.json"), '{"id":"demo"}');
+  fs.writeFileSync(
+    path.join(packageDir, "index.ts"),
+    'import { readFileSync } from "node:fs"; export const message = readFileSync(new URL("./assets/message.txt", import.meta.url), "utf8");',
+  );
+  if (options.generated) {
+    fs.writeFileSync(
+      path.join(packageDir, "build-assets.cjs"),
+      'require("node:fs").writeFileSync("assets/message.txt", "selected asset");',
+    );
+  } else if (!options.missing) {
+    fs.writeFileSync(path.join(packageDir, "assets", "message.txt"), "selected asset");
+  }
+  if (options.tracked) {
+    execFileSync("git", ["add", "extensions/demo/package.json"], { cwd: repoRoot });
+  }
+  return { repoRoot, packageDir };
+}
+
+describe("selected plugin runtime assets", () => {
+  it.each([
+    { name: "untracked package", options: {} },
+    { name: "tracked package with a malformed unrelated manifest", options: { tracked: true } },
+    { name: "asset generated after compilation", options: { generated: true } },
+  ])("builds loadable assets for $name", async ({ options }) => {
+    const fixture = createAssetFixture(options);
+    if (options.tracked) {
+      const other = path.join(fixture.repoRoot, "extensions", "other");
+      fs.mkdirSync(other);
+      fs.writeFileSync(path.join(other, "package.json"), "{");
+      execFileSync("git", ["add", "extensions/other/package.json"], { cwd: fixture.repoRoot });
+    }
+
+    const result = await buildPluginNpmRuntime({ ...fixture, logLevel: "silent" });
+    expect(result?.copiedStaticAssets).toEqual(["dist/assets/message.txt"]);
+    const entry = pathToFileURL(path.join(fixture.packageDir, "dist", "index.js")).href;
+    expect(
+      execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `process.stdout.write((await import(${JSON.stringify(entry)})).message);`,
+        ],
+        { encoding: "utf8" },
+      ),
+    ).toBe("selected asset");
+  });
+
+  it("reports a missing selected asset instead of publishing an incomplete package", async () => {
+    const fixture = createAssetFixture({ tracked: true, missing: true });
+    await expect(buildPluginNpmRuntime({ ...fixture, logLevel: "silent" })).rejects.toThrow(
+      "demo missing static asset source(s): extensions/demo/assets/message.txt",
+    );
+  });
+});

--- a/test/scripts/plugin-npm-runtime-build-args.test.ts
+++ b/test/scripts/plugin-npm-runtime-build-args.test.ts
@@ -1,12 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseArgs as parseBulkBuildArgs } from "../../scripts/check-plugin-npm-runtime-builds.mts";
-import { listMissingPackageStaticAssetSources } from "../../scripts/lib/plugin-npm-runtime-assets.mts";
 import { parseArgs as parseSingleBuildArgs } from "../../scripts/lib/plugin-npm-runtime-build.mts";
-import { createScriptTestHarness } from "./test-helpers.js";
-
-const { createTempDir } = createScriptTestHarness();
 
 describe("plugin npm runtime build args", () => {
   it("parses explicit plugin package build targets", () => {
@@ -64,46 +58,5 @@ describe("plugin npm runtime build args", () => {
     expect(() => parseSingleBuildArgs(["extensions/slack", "extra"])).toThrow(
       "unexpected plugin npm runtime build argument: extra",
     );
-  });
-
-  it("reports package-local missing static asset sources", () => {
-    const repoRoot = createTempDir("openclaw-plugin-npm-runtime-assets-");
-    const demoDir = path.join(repoRoot, "extensions", "demo");
-    const otherDir = path.join(repoRoot, "extensions", "other");
-    fs.mkdirSync(path.join(demoDir, "assets"), { recursive: true });
-    fs.mkdirSync(otherDir, { recursive: true });
-    fs.writeFileSync(path.join(demoDir, "assets", "present.js"), "export {};\n", "utf8");
-    fs.writeFileSync(
-      path.join(demoDir, "package.json"),
-      JSON.stringify({
-        openclaw: {
-          build: {
-            staticAssets: [
-              { source: "./assets/present.js", output: "assets/present.js" },
-              { source: "./assets/missing.js", output: "assets/missing.js" },
-            ],
-          },
-        },
-      }),
-      "utf8",
-    );
-    fs.writeFileSync(
-      path.join(otherDir, "package.json"),
-      JSON.stringify({
-        openclaw: {
-          build: {
-            staticAssets: [{ source: "./assets/other-missing.js", output: "assets/other.js" }],
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    expect(
-      listMissingPackageStaticAssetSources({
-        repoRoot,
-        pluginDir: "demo",
-      }),
-    ).toEqual(["extensions/demo/assets/missing.js"]);
   });
 });

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -5,7 +5,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   copyStaticExtensionAssets,
-  copyStaticExtensionAssetsForPackage,
   copyStaticExtensionAssetsToRuntimeOverlay,
   discoverStaticExtensionAssets,
 } from "../../scripts/lib/static-extension-assets.mts";
@@ -226,13 +225,12 @@ describe("runtime postbuild static assets", () => {
     );
   });
 
-  it("copies declared static assets into root and package dist", async () => {
+  it("copies declared static assets into root dist", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const src = "extensions/acpx/src/runtime-internals/mcp-proxy.mjs";
     const dest = "dist/extensions/acpx/mcp-proxy.mjs";
     const sourcePath = path.join(rootDir, src);
     const destPath = path.join(rootDir, dest);
-    const packageDestPath = path.join(rootDir, "extensions", "acpx", "dist", "mcp-proxy.mjs");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.writeFile(sourcePath, "proxy-data\n", "utf8");
 
@@ -240,16 +238,7 @@ describe("runtime postbuild static assets", () => {
       rootDir,
       assets: [{ src, dest }],
     });
-    expect(
-      copyStaticExtensionAssetsForPackage({
-        rootDir,
-        pluginDir: "acpx",
-        assets: [{ src, dest }],
-      }),
-    ).toEqual(["dist/mcp-proxy.mjs"]);
-
     expect(await fs.readFile(destPath, "utf8")).toBe("proxy-data\n");
-    expect(await fs.readFile(packageDestPath, "utf8")).toBe("proxy-data\n");
   });
 
   it("stages copied static assets byte-for-byte during the same postbuild run", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers building a new standalone source plugin would get a successful build that omitted its declared static assets when the package was not yet tracked by Git. Importing the resulting artifact could then fail with `ENOENT`. A malformed unrelated tracked package manifest could also break an explicitly selected build.

## Why This Change Was Made

Resolve, validate, and copy assets from the selected build plan's manifest after its existing asset build hook. The shared parser still owns path normalization; removing both per-package repository scans and the package-copy adapter deletes 43 production lines while preserving global tracked discovery, external/Docker filtering, root copies, and runtime overlays.

## User Impact

Developers can build and load new source plugins with their declared assets before adding the package to Git. Generated assets are included, and missing selected source files still fail the build with their paths.

## Evidence

A real untracked fixture was built through `node scripts/lib/plugin-npm-runtime-build.mjs`, archived, extracted, and imported by Node. Before the fix, build exited 0 but the archive omitted the asset and import failed with `ENOENT`; after the fix, the archive included the asset and import returned its expected text. This proves standalone build and artifact import, not a managed npm install or Gateway flow.

The new regression cases failed on the original code and now pass, covering untracked packages, generated assets, an unrelated malformed manifest, and the missing-source diagnostic. The focused asset, argument-parser, runtime-postbuild, and external-plugin build suites passed all 62 tests. Changed-file types, lint, formatting, guards, the full build, and docs MDX validation passed. A fresh managed review through P2 returned no findings.
