### PR TITLE
fix(skills): show body titles for accepted frontmatter formats

### DIFF
--- a/src/skills/library/selection.ts
+++ b/src/skills/library/selection.ts
@@ -13,7 +13,7 @@ import {
   resolveSkillInvocationPolicy,
   resolveSkillManifestMetadata,
 } from "../loading/frontmatter.js";
-import { createSyntheticSourceInfo, resolveSkillDisplayName } from "../loading/skill-contract.js";
+import { materializeSkill } from "../loading/skill-materializer.js";
 import type { SkillEntry } from "../types.js";
 import { readSkillLibraryManifestTree, skillLibraryRevisionDir } from "./bundle.js";
 import { SkillLibraryError } from "./errors.js";
@@ -227,19 +227,16 @@ export function loadSkillLibrarySelection(
         const invocation = resolveSkillInvocationPolicy(frontmatter);
         const name = selection.name;
         return {
-          skill: {
+          skill: materializeSkill({
+            content,
+            frontmatter,
             name,
-            displayName: resolveSkillDisplayName(content, frontmatter.name ?? name),
             description: revision.description,
             baseDir,
             filePath,
             source: "openclaw-library",
-            sourceInfo: createSyntheticSourceInfo(filePath, {
-              source: "openclaw-library",
-              baseDir,
-            }),
-            disableModelInvocation: invocation.disableModelInvocation,
-          },
+            sourceOptions: { source: "openclaw-library" },
+          }),
           frontmatter,
           invocation,
           // Untrusted frontmatter can constrain executable eligibility, but cannot claim global credentials/config.

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -86,29 +86,43 @@ async function beginZipUpload(
 }
 
 describe("profile-owned skill publication and selection", () => {
-  it("uses the same readable identity in the prompt and picker and rejects a copied workspace command", async () => {
-    const { options, alice, stateDir } = fixture();
-    await saveSkillLibrary(alice, draft("long---skill---name"), options);
-    const pins = seedSkillLibrarySelection(alice, options);
-    const entries = loadSkillLibrarySelection(pins, options);
-    const { buildSkillSnapshot } = await import("../loading/workspace-skill-prompt.js");
-    const { buildWorkspaceSkillCommandSpecs } = await import("../discovery/command-specs.js");
-    const snapshot = buildSkillSnapshot(stateDir, { entries });
-    const commands = buildWorkspaceSkillCommandSpecs(stateDir, { entries });
-    expect(pins[0]!.name).toMatch(/^s_long_skil_[a-f0-9]{20}$/);
-    expect(commands[0]).toMatchObject({ name: pins[0]!.name, skillName: pins[0]!.name });
-    expect(snapshot.prompt).toContain(`<name>${pins[0]!.name}</name>`);
-    const copied = {
-      ...entries[0]!,
-      skill: { ...entries[0]!.skill, source: "openclaw-workspace" },
-    };
-    expect(() => buildSkillSnapshot(stateDir, { entries: [copied, ...entries] })).toThrow(
-      "ambiguous",
-    );
-    expect(() =>
-      buildWorkspaceSkillCommandSpecs(stateDir, { entries: [copied, ...entries] }),
-    ).toThrow("ambiguous");
-  });
+  it.each([
+    ["heading", "# Friendly Title", "Friendly Title"],
+    ["metadata fallback", "Plain introduction", "Guide"],
+  ])(
+    "keeps the %s separate from the selected command identity",
+    async (_label, heading, displayName) => {
+      const { options, alice, stateDir } = fixture();
+      await saveSkillLibrary(
+        alice,
+        { ...draft("long---skill---name"), content: content.replace("# Guide", heading) },
+        options,
+      );
+      const pins = seedSkillLibrarySelection(alice, options);
+      const entries = loadSkillLibrarySelection(pins, options);
+      const { buildSkillSnapshot } = await import("../loading/workspace-skill-prompt.js");
+      const { buildWorkspaceSkillCommandSpecs } = await import("../discovery/command-specs.js");
+      const snapshot = buildSkillSnapshot(stateDir, { entries });
+      const commands = buildWorkspaceSkillCommandSpecs(stateDir, { entries });
+      expect(pins[0]!.name).toMatch(/^s_long_skil_[a-f0-9]{20}$/);
+      expect(commands[0]).toMatchObject({
+        name: pins[0]!.name,
+        skillName: pins[0]!.name,
+        displayName,
+      });
+      expect(snapshot.prompt).toContain(`<name>${pins[0]!.name}</name>`);
+      const copied = {
+        ...entries[0]!,
+        skill: { ...entries[0]!.skill, source: "openclaw-workspace" },
+      };
+      expect(() => buildSkillSnapshot(stateDir, { entries: [copied, ...entries] })).toThrow(
+        "ambiguous",
+      );
+      expect(() =>
+        buildWorkspaceSkillCommandSpecs(stateDir, { entries: [copied, ...entries] }),
+      ).toThrow("ambiguous");
+    },
+  );
   it("discovers pinned commands through the loader without leaking them into workspace state", async () => {
     const { alice, options, stateDir } = fixture();
     const saved = await saveSkillLibrary(alice, draft(), options);

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -14,6 +14,51 @@ function loadSkillsFromPath(dir: string) {
 }
 
 describe("loadSkills", () => {
+  it.each([
+    ["LF", "---", "---", "\n"],
+    ["CRLF", "---", "---", "\r\n"],
+    ["BOM", "\uFEFF---", "---", "\n"],
+    ["opening delimiter whitespace", "---   ", "---", "\n"],
+    ["closing delimiter whitespace", "---", "---\t", "\n"],
+    ["CR", "---", "---", "\r"],
+  ])("uses the body title after accepted %s frontmatter", async (_label, opening, closing, eol) => {
+    const skillDir = tempDirs.make("openclaw-skill-title-");
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        opening,
+        "name: change-log",
+        "description: Summarize changes",
+        "# Metadata comment",
+        closing,
+        "# Release Notes",
+      ].join(eol),
+    );
+    const session = loadSkillsFromPath(skillDir);
+    const diagnostics: LocalSkillLoadDiagnostic[] = [];
+    const local = loadSingleSkillDirectory({
+      skillDir,
+      source: "workspace",
+      rootRealPath: await fs.realpath(skillDir),
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    });
+
+    expect(session.diagnostics).toEqual([]);
+    expect(diagnostics).toEqual([]);
+    expect(session.skills[0]?.displayName).toBe("Release Notes");
+    expect(local?.skill.displayName).toBe("Release Notes");
+  });
+
+  it("humanizes the identifier when the skill has no H1", async () => {
+    const skillDir = tempDirs.make("openclaw-skill-title-");
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: daily-brief\ndescription: Summarize updates\n---\nSkill body without a title.\n",
+    );
+
+    expect(loadSkillsFromPath(skillDir).skills[0]?.displayName).toBe("Daily Brief");
+  });
+
   it.each(["user", "project", "path"] as const)(
     "preserves %s session provenance and its untrimmed fallback name beside local loading",
     async (source) => {

--- a/src/skills/loading/skill-contract.test.ts
+++ b/src/skills/loading/skill-contract.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import {
   formatSkillsForPromptCore,
-  resolveSkillDisplayName,
   type Skill,
   formatSkillsCompactForPrompt as formatSkillsCompact,
 } from "./skill-contract.js";
@@ -18,23 +17,6 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
     source: "workspace",
   });
 }
-
-describe("resolveSkillDisplayName", () => {
-  it("uses the first Markdown H1 after frontmatter", () => {
-    expect(
-      resolveSkillDisplayName(
-        `---\nname: auto-review\ndescription: Review code.\n---\n# Auto Review\n`,
-        "auto-review",
-      ),
-    ).toBe("Auto Review");
-  });
-
-  it("humanizes the identifier when the skill has no H1", () => {
-    expect(resolveSkillDisplayName("Skill body without a title.\n", "patrick-daily_brief")).toBe(
-      "Patrick Daily Brief",
-    );
-  });
-});
 
 describe("formatSkillsCompact", () => {
   it("keeps the full-format XML output aligned with the upstream formatter for visible skills", () => {

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -42,26 +42,6 @@ export function decodeSkillXml(value: string): string {
 }
 
 export const COMPACT_DESCRIPTION_MAX_CHARS = 220;
-const SKILL_FRONTMATTER_BLOCK = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u;
-const SKILL_TITLE_HEADING = /^#\s+(.+?)\s*#*\s*$/mu;
-
-function humanizeSkillIdentifier(value: string): string {
-  return value
-    .trim()
-    .split(/[-_]+/u)
-    .filter(Boolean)
-    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
-    .join(" ");
-}
-
-export function resolveSkillDisplayName(content: string, fallbackName: string): string {
-  const body = content.replace(SKILL_FRONTMATTER_BLOCK, "");
-  const heading = body.match(SKILL_TITLE_HEADING)?.[1]?.trim();
-  const displayName = heading || humanizeSkillIdentifier(fallbackName) || fallbackName;
-  // A captured heading can retain the whole skill body in metadata caches.
-  // Copy UTF-16 code units without changing lone surrogates.
-  return Buffer.from(displayName, "utf16le").toString("utf16le");
-}
 
 function truncateSkillDescription(description: string, maxChars: number): string {
   const normalized = description.replace(/\s+/g, " ").trim();

--- a/src/skills/loading/skill-materializer.ts
+++ b/src/skills/loading/skill-materializer.ts
@@ -1,10 +1,27 @@
+import { extractFrontmatterBlock } from "../../../packages/markdown-core/src/frontmatter.js";
 import type { ParsedSkillFrontmatter } from "../types.js";
 import { resolveSkillInvocationPolicy } from "./frontmatter.js";
-import {
-  createSyntheticSourceInfo,
-  resolveSkillDisplayName,
-  type Skill,
-} from "./skill-contract.js";
+import { createSyntheticSourceInfo, type Skill } from "./skill-contract.js";
+
+const SKILL_TITLE_HEADING = /^#\s+(.+?)\s*#*\s*$/mu;
+
+function humanizeSkillIdentifier(value: string): string {
+  return value
+    .trim()
+    .split(/[-_]+/u)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+function resolveSkillDisplayName(content: string, fallbackName: string): string {
+  const body = extractFrontmatterBlock(content)?.body ?? content;
+  const heading = body.match(SKILL_TITLE_HEADING)?.[1]?.trim();
+  const displayName = heading || humanizeSkillIdentifier(fallbackName) || fallbackName;
+  // A captured heading can retain the whole skill body in metadata caches.
+  // Copy UTF-16 code units without changing lone surrogates.
+  return Buffer.from(displayName, "utf16le").toString("utf16le");
+}
 
 export function materializeSkill(params: {
   content: string;
@@ -18,7 +35,7 @@ export function materializeSkill(params: {
 }): Skill {
   return {
     name: params.name,
-    displayName: resolveSkillDisplayName(params.content, params.name),
+    displayName: resolveSkillDisplayName(params.content, params.frontmatter.name || params.name),
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository and is editable by maintainers; the fork-only collaboration setting is not applicable.

</details>

## What Problem This Solves

Fixes an issue where users see a YAML comment as a skill's title in the skill picker, and cannot find the skill by its body title, when otherwise valid frontmatter contains a BOM, whitespace after a delimiter, or CR line endings. For example, a skill with the body heading `# Release Notes` could appear as `Metadata comment` because its frontmatter contained `# Metadata comment`.

## Why This Change Was Made

Skill materialization now uses the same frontmatter boundary extractor as metadata parsing, and library selections use that materializer too. This removes the narrower duplicate stripping rule while preserving command aliases, source information, heading precedence, and the original frontmatter name as the library's display fallback; catalog-only imports remain free of YAML loading.

## User Impact

Accepted skill files consistently show their body title and can be found by that title in the composer. A selected library alias remains the executable command name, including when a skill has no heading.

## Evidence

A synthetic before/after probe ran actual local and session loaders, the public `commands.list` result builder, and the UI display-name and command-completion functions. All six formats loaded successfully before and after. The skill was named `change-log`, with description `Summarize changes`, so the search result depended on its display title.

| Frontmatter format | Before: displayed title / search for `release` | After |
| --- | --- | --- |
| LF | `Release Notes` / found | `Release Notes` / found |
| CRLF | `Release Notes` / found | `Release Notes` / found |
| BOM | `Metadata comment` / missing | `Release Notes` / found |
| Opening delimiter whitespace | `Metadata comment` / missing | `Release Notes` / found |
| Closing delimiter whitespace | `Metadata comment` / missing | `Release Notes` / found |
| CR | `Metadata comment` / missing | `Release Notes` / found |

- The repository regression failed in the four affected formats before the production change; controls passed. All 43 focused tests now pass across `session.test.ts`, `service.test.ts`, and `skill-contract.test.ts`, including library heading/name fallback, selected aliases, and catalog serialization.
- A fresh-process catalog import loaded no YAML modules. Full `pnpm build` and the complete changed-file gate passed, including formatting, lint, types, unused exports, import cycles, and applicable guards.
- Independent review through P2 found no actionable findings. Production changes remove 6 net lines; tests add 41 net lines.

This is real loader-to-payload-to-display-function evidence using synthetic files; no interactive browser, live Gateway, or provider session was run. Hosted checks will validate the published head before landing.
