### PR TITLE
fix: keep agent file preview headers compact on phones

### DIFF
--- a/ui/src/pages/agents/agent-file-preview-state.ts
+++ b/ui/src/pages/agents/agent-file-preview-state.ts
@@ -1,56 +1,5 @@
 import { t } from "../../i18n/index.ts";
 
-export function previewMetadataRef() {
-  let current: Element | undefined;
-  let observer: ResizeObserver | undefined;
-  return (element: Element | undefined) => {
-    current = element;
-    observer?.disconnect();
-    if (!(element instanceof HTMLElement)) {
-      return;
-    }
-    // Lit commits the ref before its children; a replaced ref must not attach observers.
-    queueMicrotask(() => {
-      if (current !== element || !element.isConnected) {
-        return;
-      }
-      const chips = [...element.children];
-      const fit = () => {
-        const compact = window.matchMedia("(max-width: 400px)").matches;
-        const style = getComputedStyle(element);
-        let remaining =
-          element.clientWidth -
-          Number.parseFloat(style.paddingLeft) -
-          Number.parseFloat(style.paddingRight);
-        const gap = Number.parseFloat(style.columnGap);
-        // Opening scales the dialog's client rects without changing its layout widths.
-        const widths = chips.map((chip) => {
-          const chipStyle = getComputedStyle(chip);
-          return {
-            chip,
-            width: chipStyle.display === "none" ? 0 : Number.parseFloat(chipStyle.width),
-          };
-        });
-        for (const { chip, width } of widths) {
-          const hidden = compact && width > remaining;
-          chip.classList.toggle("is-overflowing", hidden);
-          if (!hidden && width > 0) {
-            remaining -= width + gap;
-          }
-        }
-      };
-      fit();
-      if (typeof ResizeObserver === "function") {
-        observer = new ResizeObserver(fit);
-        observer.observe(element);
-        for (const chip of chips) {
-          observer.observe(chip);
-        }
-      }
-    });
-  };
-}
-
 export function setPreviewExpandButtonState(
   button: Element | null | undefined,
   isFullscreen: boolean,

--- a/ui/src/pages/agents/agent-file-preview-state.ts
+++ b/ui/src/pages/agents/agent-file-preview-state.ts
@@ -1,5 +1,56 @@
 import { t } from "../../i18n/index.ts";
 
+export function previewMetadataRef() {
+  let current: Element | undefined;
+  let observer: ResizeObserver | undefined;
+  return (element: Element | undefined) => {
+    current = element;
+    observer?.disconnect();
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    // Lit commits the ref before its children; a replaced ref must not attach observers.
+    queueMicrotask(() => {
+      if (current !== element || !element.isConnected) {
+        return;
+      }
+      const chips = [...element.children];
+      const fit = () => {
+        const compact = window.matchMedia("(max-width: 400px)").matches;
+        const style = getComputedStyle(element);
+        let remaining =
+          element.clientWidth -
+          Number.parseFloat(style.paddingLeft) -
+          Number.parseFloat(style.paddingRight);
+        const gap = Number.parseFloat(style.columnGap);
+        // Opening scales the dialog's client rects without changing its layout widths.
+        const widths = chips.map((chip) => {
+          const chipStyle = getComputedStyle(chip);
+          return {
+            chip,
+            width: chipStyle.display === "none" ? 0 : Number.parseFloat(chipStyle.width),
+          };
+        });
+        for (const { chip, width } of widths) {
+          const hidden = compact && width > remaining;
+          chip.classList.toggle("is-overflowing", hidden);
+          if (!hidden && width > 0) {
+            remaining -= width + gap;
+          }
+        }
+      };
+      fit();
+      if (typeof ResizeObserver === "function") {
+        observer = new ResizeObserver(fit);
+        observer.observe(element);
+        for (const chip of chips) {
+          observer.observe(chip);
+        }
+      }
+    });
+  };
+}
+
 export function setPreviewExpandButtonState(
   button: Element | null | undefined,
   isFullscreen: boolean,

--- a/ui/src/pages/agents/agent-file-preview.browser.test.ts
+++ b/ui/src/pages/agents/agent-file-preview.browser.test.ts
@@ -4,34 +4,48 @@ import "../../styles.css";
 import "../../styles/settings.css";
 import "../../styles/agents.css";
 import "../../styles/sidebar-markdown.css";
+import { i18n } from "../../i18n/index.ts";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderAgentFiles } from "./panels-status-files.ts";
 
 const browserMode = "__vitest_browser__" in globalThis;
 let container: HTMLDivElement;
+let tooltipProvider: HTMLElement;
+let viewport: { width: number; height: number };
 
 beforeEach(() => {
+  viewport = { width: window.innerWidth, height: window.innerHeight };
   container = document.createElement("div");
   container.className = "settings-page";
-  document.body.append(container);
+  tooltipProvider = document.createElement("openclaw-tooltip-provider");
+  tooltipProvider.append(container);
+  document.body.append(tooltipProvider);
 });
 
-afterEach(() => {
+afterEach(async () => {
   render(nothing, container);
-  container.remove();
+  tooltipProvider.remove();
+  await i18n.setLocale("en");
+  if (browserMode) {
+    const { page } = await import("vitest/browser");
+    await page.viewport(viewport.width, viewport.height);
+  }
 });
 
-function afterOwnHide(dialog: HTMLElement): Promise<void> {
+function afterOwnTransition(
+  dialog: HTMLElement,
+  eventName: "wa-after-show" | "wa-after-hide",
+): Promise<void> {
   return new Promise((resolve) => {
-    const hidden = (event: Event) => {
+    const completed = (event: Event) => {
       if (event.target !== dialog) {
         return;
       }
-      dialog.removeEventListener("wa-after-hide", hidden);
-      // The real dialog and adapter queue return focus before this observer's task.
+      dialog.removeEventListener(eventName, completed);
+      // Dialog and adapter focus work completes before this observer's next task.
       setTimeout(resolve, 0);
     };
-    dialog.addEventListener("wa-after-hide", hidden);
+    dialog.addEventListener(eventName, completed);
   });
 }
 
@@ -43,36 +57,40 @@ function requireButton(selector: string): HTMLButtonElement {
   return button;
 }
 
-describe.runIf(browserMode)("agent file preview focus", () => {
+function renderPreview(draft: string, onChange = (_name: string, _content: string) => {}) {
+  render(
+    renderAgentFiles({
+      agentId: "main",
+      agentFilesList: {
+        agentId: "main",
+        workspace: "/synthetic/workspace",
+        files: [{ name: "AGENTS.md", path: "/synthetic/workspace/AGENTS.md", missing: false }],
+      },
+      agentFilesLoading: false,
+      agentFilesError: null,
+      agentFileActive: "AGENTS.md",
+      agentFileContents: { "AGENTS.md": "Saved instructions" },
+      agentFileDrafts: { "AGENTS.md": draft },
+      agentFileSaving: false,
+      canWrite: true,
+      onLoadFiles: () => undefined,
+      onSelectFile: () => undefined,
+      onFileDraftChange: onChange,
+      onFileReset: () => undefined,
+      onFileSave: () => undefined,
+    }),
+    container,
+  );
+}
+
+describe.runIf(browserMode)("agent file preview", () => {
   it.each(["edit", "close"] as const)(
     "returns focus to the intended owner after %s and retained reopen",
     async (action) => {
       const { userEvent } = await import("vitest/browser");
       const changes: string[] = [];
       let expectedDraft = "Unsaved file preview draft\n\n".repeat(80);
-      render(
-        renderAgentFiles({
-          agentId: "main",
-          agentFilesList: {
-            agentId: "main",
-            workspace: "/synthetic/workspace",
-            files: [{ name: "AGENTS.md", path: "/synthetic/workspace/AGENTS.md", missing: false }],
-          },
-          agentFilesLoading: false,
-          agentFilesError: null,
-          agentFileActive: "AGENTS.md",
-          agentFileContents: { "AGENTS.md": "Saved instructions" },
-          agentFileDrafts: { "AGENTS.md": expectedDraft },
-          agentFileSaving: false,
-          canWrite: true,
-          onLoadFiles: () => undefined,
-          onSelectFile: () => undefined,
-          onFileDraftChange: (_name, content) => changes.push(content),
-          onFileReset: () => undefined,
-          onFileSave: () => undefined,
-        }),
-        container,
-      );
+      renderPreview(expectedDraft, (_name, content) => changes.push(content));
       const textarea = container.querySelector<HTMLTextAreaElement>(".agent-file-textarea");
       if (!textarea) {
         throw new Error("Missing agent file editor");
@@ -85,10 +103,11 @@ describe.runIf(browserMode)("agent file preview focus", () => {
       for (let opening = 0; opening < 2; opening += 1) {
         textarea.setSelectionRange(textarea.value.length, textarea.value.length);
         preview.focus();
+        // Opening animations may start after dialog.open becomes true.
+        const shown = afterOwnTransition(webAwesomeDialog, "wa-after-show");
         await userEvent.keyboard("{Enter}");
-        await getRenderedModalDialog(container);
-        await expect.poll(() => dialog.open).toBe(true);
-        await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
+        await shown;
+        expect(dialog.open).toBe(true);
         const panel = container.querySelector<HTMLElement>(".md-preview-dialog__panel")!;
         const body = container.querySelector<HTMLElement>(".md-preview-dialog__body")!;
         const bounds = dialog.getBoundingClientRect();
@@ -96,7 +115,7 @@ describe.runIf(browserMode)("agent file preview focus", () => {
         expect(panel.getBoundingClientRect().bottom).toBeLessThanOrEqual(bounds.bottom + 1);
         expect(body.clientHeight).toBeGreaterThan(0);
         expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
-        const closed = afterOwnHide(webAwesomeDialog);
+        const closed = afterOwnTransition(webAwesomeDialog, "wa-after-hide");
         await userEvent.click(
           requireButton(
             action === "edit" ? '[aria-label="Edit file"]' : '[aria-label="Close preview"]',
@@ -119,6 +138,65 @@ describe.runIf(browserMode)("agent file preview focus", () => {
           expect(changes).toEqual([]);
         }
       }
+    },
+  );
+  it.each([320, 390, 1440])(
+    "keeps identity, actions and metadata accessible across preview modes at %ipx",
+    async (width) => {
+      const { page, userEvent } = await import("vitest/browser");
+      await page.viewport(width, 900);
+      await i18n.setLocale(width === 320 ? "ru" : "en");
+      container.classList.add("shell--settings");
+      renderPreview(
+        "# Workspace operating instructions\n\n" + "Readable document content.\n\n".repeat(80),
+      );
+      const preview = requireButton(".agent-file-actions button");
+      const { webAwesomeDialog, dialog } = await getRenderedModalDialog(container);
+      const shown = afterOwnTransition(webAwesomeDialog, "wa-after-show");
+      await userEvent.click(preview);
+      await shown;
+      expect(dialog.open).toBe(true);
+      const identity = container.querySelector<HTMLElement>(".md-preview-dialog__header-main")!;
+      const actions = container.querySelector<HTMLElement>(".md-preview-dialog__actions")!;
+      const meta = container.querySelector<HTMLElement>(".md-preview-dialog__meta")!;
+      const chips = [...meta.children];
+      const body = container.querySelector<HTMLElement>(".md-preview-dialog__body")!;
+      const normalInset = getComputedStyle(body).paddingInlineStart;
+      for (const mode of ["normal", "fullscreen", "return"]) {
+        if (mode !== "normal") {
+          await userEvent.click(requireButton(".md-preview-expand-btn"));
+        }
+        await expect.poll(() => identity.getBoundingClientRect().width).toBeGreaterThan(1);
+        const name = identity.getBoundingClientRect();
+        const buttons = actions.getBoundingClientRect();
+        expect(name.right).toBeLessThanOrEqual(buttons.left);
+        expect(buttons.top).toBeLessThan(name.bottom);
+        expect(buttons.bottom).toBeGreaterThan(name.top);
+        expect(buttons.right).toBeLessThanOrEqual(dialog.getBoundingClientRect().right);
+        for (const chip of chips) {
+          expect(chip.scrollWidth).toBeLessThanOrEqual(chip.clientWidth);
+          expect(chip.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+            meta.getBoundingClientRect().bottom,
+          );
+        }
+        expect(new Set(chips.map((chip) => chip.getBoundingClientRect().top)).size).toBe(1);
+        if (width <= 390) {
+          meta.scrollLeft = meta.scrollWidth;
+          expect(meta.scrollLeft).toBeGreaterThan(0);
+          expect(chips.at(-1)!.getBoundingClientRect().right).toBeLessThanOrEqual(
+            meta.getBoundingClientRect().right,
+          );
+        }
+        expect(getComputedStyle(body).paddingInlineStart).toBe(normalInset);
+        body.scrollTop = body.scrollHeight;
+        expect(body.scrollTop).toBeGreaterThan(0);
+        body.scrollTop = 0;
+      }
+      const closed = afterOwnTransition(webAwesomeDialog, "wa-after-hide");
+      await userEvent.keyboard("{Escape}");
+      await closed;
+      expect(dialog.open).toBe(false);
+      expect(document.activeElement).toBe(preview);
     },
   );
 });

--- a/ui/src/pages/agents/agent-file-preview.browser.test.ts
+++ b/ui/src/pages/agents/agent-file-preview.browser.test.ts
@@ -142,11 +142,10 @@ describe.runIf(browserMode)("agent file preview", () => {
   );
   it.each([
     [320, "ru"],
-    [320, "fr"],
     [390, "en"],
     [1440, "en"],
   ] as const)(
-    "keeps actions and whole metadata chips within each preview mode at %ipx (%s)",
+    "keeps actions aligned and shows metadata by priority in each preview mode at %ipx (%s)",
     async (width, locale) => {
       const { page, userEvent } = await import("vitest/browser");
       await page.viewport(width, 900);
@@ -164,7 +163,12 @@ describe.runIf(browserMode)("agent file preview", () => {
       const identity = container.querySelector<HTMLElement>(".md-preview-dialog__header-main")!;
       const actions = container.querySelector<HTMLElement>(".md-preview-dialog__actions")!;
       const meta = container.querySelector<HTMLElement>(".md-preview-dialog__meta")!;
-      const chips = [...meta.children];
+      const essentialChips = meta.querySelectorAll<HTMLDivElement>('[data-priority="essential"]');
+      const secondaryMetadata = meta.querySelectorAll<HTMLElement>(
+        '[data-priority="secondary"], .md-preview-dialog__chip > span',
+      );
+      expect(essentialChips).toHaveLength(3);
+      expect(secondaryMetadata).toHaveLength(4);
       const body = container.querySelector<HTMLElement>(".md-preview-dialog__body")!;
       const normalInset = getComputedStyle(body).paddingInlineStart;
       for (const mode of ["normal", "fullscreen", "return"]) {
@@ -178,29 +182,14 @@ describe.runIf(browserMode)("agent file preview", () => {
         expect(buttons.top).toBeLessThan(name.bottom);
         expect(buttons.bottom).toBeGreaterThan(name.top);
         expect(buttons.right).toBeLessThanOrEqual(dialog.getBoundingClientRect().right);
-        const visibleChips = chips.filter(
-          (chip) =>
-            getComputedStyle(chip).visibility !== "hidden" &&
-            chip.getBoundingClientRect().width > 0,
-        );
-        expect(visibleChips.length).toBeGreaterThan(0);
-        for (const chip of visibleChips) {
-          expect(chip.scrollWidth).toBeLessThanOrEqual(chip.clientWidth);
-          expect(chip.getBoundingClientRect().bottom).toBeLessThanOrEqual(
-            meta.getBoundingClientRect().bottom,
-          );
+        for (const chip of essentialChips) {
+          await expect.element(chip).toBeVisible();
         }
-        expect(new Set(visibleChips.map((chip) => chip.getBoundingClientRect().top)).size).toBe(1);
-        if (width <= 390) {
-          meta.scrollLeft = meta.scrollWidth;
-          expect(meta.scrollLeft).toBe(0);
-          for (const chip of visibleChips) {
-            expect(chip.getBoundingClientRect().left).toBeGreaterThanOrEqual(
-              meta.getBoundingClientRect().left,
-            );
-            expect(chip.getBoundingClientRect().right).toBeLessThanOrEqual(
-              meta.getBoundingClientRect().right,
-            );
+        for (const metadata of secondaryMetadata) {
+          if (width <= 400) {
+            await expect.element(metadata).not.toBeVisible();
+          } else {
+            await expect.element(metadata).toBeVisible();
           }
         }
         expect(getComputedStyle(body).paddingInlineStart).toBe(normalInset);
@@ -208,22 +197,10 @@ describe.runIf(browserMode)("agent file preview", () => {
         expect(body.scrollTop).toBeGreaterThan(0);
         body.scrollTop = 0;
       }
-      if (width <= 390) {
+      if (width <= 400) {
         await page.viewport(1440, 900);
-        await expect
-          .poll(
-            () =>
-              chips.filter(
-                (chip) =>
-                  getComputedStyle(chip).visibility !== "hidden" &&
-                  chip.getBoundingClientRect().width > 0,
-              ).length,
-          )
-          .toBe(chips.length);
-        for (const chip of chips) {
-          expect(chip.getBoundingClientRect().right).toBeLessThanOrEqual(
-            meta.getBoundingClientRect().right,
-          );
+        for (const metadata of secondaryMetadata) {
+          await expect.element(metadata).toBeVisible();
         }
       }
       const closed = afterOwnTransition(webAwesomeDialog, "wa-after-hide");

--- a/ui/src/pages/agents/agent-file-preview.browser.test.ts
+++ b/ui/src/pages/agents/agent-file-preview.browser.test.ts
@@ -140,12 +140,17 @@ describe.runIf(browserMode)("agent file preview", () => {
       }
     },
   );
-  it.each([320, 390, 1440])(
-    "keeps identity, actions and metadata accessible across preview modes at %ipx",
-    async (width) => {
+  it.each([
+    [320, "ru"],
+    [320, "fr"],
+    [390, "en"],
+    [1440, "en"],
+  ] as const)(
+    "keeps actions and whole metadata chips within each preview mode at %ipx (%s)",
+    async (width, locale) => {
       const { page, userEvent } = await import("vitest/browser");
       await page.viewport(width, 900);
-      await i18n.setLocale(width === 320 ? "ru" : "en");
+      await i18n.setLocale(locale);
       container.classList.add("shell--settings");
       renderPreview(
         "# Workspace operating instructions\n\n" + "Readable document content.\n\n".repeat(80),
@@ -173,24 +178,53 @@ describe.runIf(browserMode)("agent file preview", () => {
         expect(buttons.top).toBeLessThan(name.bottom);
         expect(buttons.bottom).toBeGreaterThan(name.top);
         expect(buttons.right).toBeLessThanOrEqual(dialog.getBoundingClientRect().right);
-        for (const chip of chips) {
+        const visibleChips = chips.filter(
+          (chip) =>
+            getComputedStyle(chip).visibility !== "hidden" &&
+            chip.getBoundingClientRect().width > 0,
+        );
+        expect(visibleChips.length).toBeGreaterThan(0);
+        for (const chip of visibleChips) {
           expect(chip.scrollWidth).toBeLessThanOrEqual(chip.clientWidth);
           expect(chip.getBoundingClientRect().bottom).toBeLessThanOrEqual(
             meta.getBoundingClientRect().bottom,
           );
         }
-        expect(new Set(chips.map((chip) => chip.getBoundingClientRect().top)).size).toBe(1);
+        expect(new Set(visibleChips.map((chip) => chip.getBoundingClientRect().top)).size).toBe(1);
         if (width <= 390) {
           meta.scrollLeft = meta.scrollWidth;
-          expect(meta.scrollLeft).toBeGreaterThan(0);
-          expect(chips.at(-1)!.getBoundingClientRect().right).toBeLessThanOrEqual(
-            meta.getBoundingClientRect().right,
-          );
+          expect(meta.scrollLeft).toBe(0);
+          for (const chip of visibleChips) {
+            expect(chip.getBoundingClientRect().left).toBeGreaterThanOrEqual(
+              meta.getBoundingClientRect().left,
+            );
+            expect(chip.getBoundingClientRect().right).toBeLessThanOrEqual(
+              meta.getBoundingClientRect().right,
+            );
+          }
         }
         expect(getComputedStyle(body).paddingInlineStart).toBe(normalInset);
         body.scrollTop = body.scrollHeight;
         expect(body.scrollTop).toBeGreaterThan(0);
         body.scrollTop = 0;
+      }
+      if (width <= 390) {
+        await page.viewport(1440, 900);
+        await expect
+          .poll(
+            () =>
+              chips.filter(
+                (chip) =>
+                  getComputedStyle(chip).visibility !== "hidden" &&
+                  chip.getBoundingClientRect().width > 0,
+              ).length,
+          )
+          .toBe(chips.length);
+        for (const chip of chips) {
+          expect(chip.getBoundingClientRect().right).toBeLessThanOrEqual(
+            meta.getBoundingClientRect().right,
+          );
+        }
       }
       const closed = afterOwnTransition(webAwesomeDialog, "wa-after-hide");
       await userEvent.keyboard("{Escape}");

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -1,6 +1,5 @@
 // Control UI view renders agents panels status files screen content.
 import { html, nothing } from "lit";
-import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type {
   AgentFileEntry,
@@ -35,11 +34,7 @@ import {
   formatCronState,
   formatNextRun,
 } from "../../lib/presenter.ts";
-import {
-  previewMetadataRef,
-  resetAgentFilePreview,
-  setPreviewExpandButtonState,
-} from "./agent-file-preview-state.ts";
+import { resetAgentFilePreview, setPreviewExpandButtonState } from "./agent-file-preview-state.ts";
 import { renderAgentContextSection } from "./panels-overview.ts";
 
 function countWords(text: string) {
@@ -671,11 +666,14 @@ export function renderAgentFiles(params: {
                                   </openclaw-tooltip>
                                 </div>
                               </div>
-                              <div class="md-preview-dialog__meta" ${ref(previewMetadataRef())}>
-                                <div class="md-preview-dialog__chip ${previewStatusClass}">
+                              <div class="md-preview-dialog__meta">
+                                <div
+                                  class="md-preview-dialog__chip ${previewStatusClass}"
+                                  data-priority="essential"
+                                >
                                   <strong>${previewStatusLabel}</strong>
                                 </div>
-                                <div class="md-preview-dialog__chip">
+                                <div class="md-preview-dialog__chip" data-priority="essential">
                                   <strong>${estimateReadingTimeLabel(draftWordCount)}</strong>
                                   <span
                                     >${t("agents.files.words", {
@@ -683,11 +681,11 @@ export function renderAgentFiles(params: {
                                     })}</span
                                   >
                                 </div>
-                                <div class="md-preview-dialog__chip">
+                                <div class="md-preview-dialog__chip" data-priority="secondary">
                                   <strong>${draftLineCount}</strong>
                                   <span>${t("agents.files.lines")}</span>
                                 </div>
-                                <div class="md-preview-dialog__chip">
+                                <div class="md-preview-dialog__chip" data-priority="essential">
                                   <strong>${draftByteSize}</strong>
                                   <span>${previewUpdatedLabel}</span>
                                 </div>

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -569,6 +569,7 @@ export function renderAgentFiles(params: {
                             ></textarea>
                           </label>
                           <openclaw-modal-dialog
+                            class="agent-file-preview"
                             manual
                             label=${activeEntry.name}
                             style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -1,5 +1,6 @@
 // Control UI view renders agents panels status files screen content.
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type {
   AgentFileEntry,
@@ -34,7 +35,11 @@ import {
   formatCronState,
   formatNextRun,
 } from "../../lib/presenter.ts";
-import { resetAgentFilePreview, setPreviewExpandButtonState } from "./agent-file-preview-state.ts";
+import {
+  previewMetadataRef,
+  resetAgentFilePreview,
+  setPreviewExpandButtonState,
+} from "./agent-file-preview-state.ts";
 import { renderAgentContextSection } from "./panels-overview.ts";
 
 function countWords(text: string) {
@@ -666,7 +671,7 @@ export function renderAgentFiles(params: {
                                   </openclaw-tooltip>
                                 </div>
                               </div>
-                              <div class="md-preview-dialog__meta">
+                              <div class="md-preview-dialog__meta" ${ref(previewMetadataRef())}>
                                 <div class="md-preview-dialog__chip ${previewStatusClass}">
                                   <strong>${previewStatusLabel}</strong>
                                 </div>

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4569,24 +4569,12 @@ td.data-table-key-col {
   }
 
   .agent-file-preview .md-preview-dialog__meta {
-    position: relative;
     overflow: clip;
   }
 
-  .agent-file-preview .md-preview-dialog__chip {
-    width: max-content;
-  }
-
-  .agent-file-preview .md-preview-dialog__chip:nth-child(3),
+  .agent-file-preview .md-preview-dialog__chip[data-priority="secondary"],
   .agent-file-preview .md-preview-dialog__chip > span {
     display: none;
-  }
-
-  .agent-file-preview .md-preview-dialog__chip.is-overflowing {
-    position: absolute;
-    inset-inline-start: 0;
-    top: 0;
-    visibility: hidden;
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4270,7 +4270,9 @@ td.data-table-key-col {
 
 .md-preview-dialog__meta {
   display: flex;
-  flex-wrap: wrap;
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
   gap: 8px;
   padding: 0 22px 16px;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 88%, white 6%);
@@ -4283,9 +4285,10 @@ td.data-table-key-col {
 
 .md-preview-dialog__chip {
   display: inline-flex;
+  flex-shrink: 0;
+  white-space: nowrap;
   align-items: center;
   gap: 8px;
-  max-width: 100%;
   min-height: 32px;
   padding: 6px 12px;
   border-radius: var(--radius-full);
@@ -4476,42 +4479,6 @@ td.data-table-key-col {
   border-bottom: none;
 }
 
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__header {
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0;
-  padding: 10px 12px;
-}
-
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__header-main {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__actions {
-  margin-left: auto;
-}
-
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__meta {
-  display: none;
-}
-
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__body {
-  padding: clamp(10px, 1.5vw, 18px);
-}
-
-.md-preview-dialog__panel.fullscreen .md-preview-dialog__reader {
-  width: min(100%, 96ch);
-  padding: clamp(24px, 3vw, 52px);
-}
-
 @media (max-width: 768px) {
   .md-preview-dialog__panel {
     min-height: var(--openclaw-modal-height-limit);
@@ -4524,22 +4491,60 @@ td.data-table-key-col {
     padding: 16px 16px 14px;
   }
 
-  .md-preview-dialog__actions {
-    justify-content: flex-end;
-    flex-wrap: wrap;
-  }
-
-  .md-preview-dialog__meta {
-    padding: 0 16px 14px;
-  }
-
   .md-preview-dialog__body {
     padding: 14px;
   }
 
   .md-preview-dialog__reader {
     width: 100%;
-    padding: 20px 16px 22px;
+    padding: var(--space-4);
+  }
+
+  .agent-file-preview .md-preview-dialog__header {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3);
+  }
+
+  .md-preview-dialog__eyebrow {
+    display: none;
+  }
+
+  .md-preview-dialog__title-wrap {
+    gap: var(--space-1);
+  }
+
+  .agent-file-preview .md-preview-dialog__title {
+    font-size: var(--control-ui-text-lg);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .md-preview-dialog__actions {
+    gap: var(--space-1);
+  }
+
+  .md-preview-dialog__meta {
+    padding: 0 var(--space-3) var(--space-2);
+  }
+
+  .agent-file-preview .md-preview-dialog__body {
+    padding: var(--space-3);
+  }
+
+  .md-preview-dialog__reader.sidebar-markdown h1 {
+    font-size: 1.65em;
+    line-height: 1.25;
+  }
+
+  .md-preview-dialog__reader.sidebar-markdown h2 {
+    font-size: 1.35em;
+  }
+
+  .md-preview-dialog__reader.sidebar-markdown h3 {
+    font-size: 1.15em;
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4548,6 +4548,48 @@ td.data-table-key-col {
   }
 }
 
+@media (max-width: 400px) {
+  .agent-file-preview .btn.md-preview-icon-btn {
+    width: var(--space-7);
+    height: var(--space-7);
+    min-width: var(--space-7);
+    min-height: var(--space-7);
+    border-color: transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--muted);
+    box-shadow: none;
+  }
+
+  .agent-file-preview .btn.md-preview-icon-btn:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--bg-hover);
+    color: var(--text);
+    box-shadow: none;
+  }
+
+  .agent-file-preview .md-preview-dialog__meta {
+    position: relative;
+    overflow: clip;
+  }
+
+  .agent-file-preview .md-preview-dialog__chip {
+    width: max-content;
+  }
+
+  .agent-file-preview .md-preview-dialog__chip:nth-child(3),
+  .agent-file-preview .md-preview-dialog__chip > span {
+    display: none;
+  }
+
+  .agent-file-preview .md-preview-dialog__chip.is-overflowing {
+    position: absolute;
+    inset-inline-start: 0;
+    top: 0;
+    visibility: hidden;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .md-preview-dialog__panel {
     animation: none;


### PR DESCRIPTION
Quick fix, bigger pass later.

Closes #142517

Related: #142143 (general alignment pass by @roboclaw-bot), #124362 (broader modal consistency), #124365 (broader input/focus consistency).

## What Problem This Solves

Fixes an issue where users reading agent files on phones lose much of the viewport to a stacked preview header. Fullscreen also hides the filename and path and changes the document insets.

## Why This Change Was Made

Keep the filename/path and all three actions on one row, show the three essential status, reading-time, and size chips on phones, and use the same header and reader spacing in fullscreen. On phones, omit the redundant format eyebrow and use the shared Markdown heading proportions and spacing tokens.

At 390 px, content heading sizes reuse the existing shared Markdown scale: h1 `1.65em` from [ui/src/styles/sidebar-markdown.css:13](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/sidebar-markdown.css#L13), h2 `1.35em` from [ui/src/styles/sidebar-markdown.css:25](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/sidebar-markdown.css#L25), and h3 `1.15em` from [ui/src/styles/sidebar-markdown.css:35](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/sidebar-markdown.css#L35). The preview applies these same proportions at [ui/src/styles/components.css:4538](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/components.css#L4538) (h2/h3 immediately below); h1 line-height `1.25` also comes from [ui/src/styles/sidebar-markdown.css:16](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/sidebar-markdown.css#L16). These are the app's established Markdown values, not newly chosen magic sizes. There is no named Markdown heading-size CSS token in this source; the inherited reader size remains governed by the existing `--control-ui-text-scale` token at [ui/src/styles/components.css:4358](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/components.css#L4358).

## User Impact

At 390 px, the header and metadata take about 106 px instead of 254 px. The three actions use the app’s ghost styling at 32 px with the existing gap. Status, reading time, and size have static `data-priority="essential"` attributes. At widths up to 400 px, CSS hides the secondary line-count chip and subordinate word-count/update details with `display: none`. There is no horizontal scrollbar. These refinements use the existing 400 px breakpoint; all three 1440 px states are pixel-identical to the previously reviewed `3cbfb927196` head. File identity remains visible through fullscreen and return.

## Evidence

Dark theme, identical synthetic document, 390 × 844 and 1440 × 900. Before uses main at `52a4af04ea2`; after captures show the approved `c6386867ead6` layout. The current CSS-only simplification preserves the recorded geometry and button styles in all six states, verified again with actual rendered app fonts, so these 12 inspected captures are retained. They were generated with the app fonts loaded from `ui/public/fonts`: Instrument Sans for UI/prose and JetBrains Mono for paths/code. The fixture uses the production loader at [ui/src/app/typography.ts:90](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/app/typography.ts#L90), waits for the stylesheets and FontFaces to load, and verifies the actual rendered custom fonts for every state. The existing preview heading serif stack at [ui/src/styles/components.css:4324](https://github.com/openclaw/openclaw/blob/183de74a0de94af3cfb4325198b731578c9815cc/ui/src/styles/components.css#L4324) is intentional and remains unchanged.

<table>
<tr><th>State</th><th>Before</th><th>After</th></tr>
<tr><td>390 px — Normal</td><td><a href="https://github.com/user-attachments/assets/b9b759cd-e92f-4a3e-bd0e-c348077c24b5"><img src="https://github.com/user-attachments/assets/b9b759cd-e92f-4a3e-bd0e-c348077c24b5" alt="390 px — Normal before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/0e6d9307-ff05-496f-a6d1-43c3cfa34e9e"><img src="https://github.com/user-attachments/assets/0e6d9307-ff05-496f-a6d1-43c3cfa34e9e" alt="390 px — Normal after" width="480"></a></td></tr>
<tr><td>390 px — Fullscreen</td><td><a href="https://github.com/user-attachments/assets/5d2e89d7-0c74-432c-988b-0fbdfb9a9a09"><img src="https://github.com/user-attachments/assets/5d2e89d7-0c74-432c-988b-0fbdfb9a9a09" alt="390 px — Fullscreen before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/c0886f11-67ad-42a5-a1ef-e4c36fbb88a9"><img src="https://github.com/user-attachments/assets/c0886f11-67ad-42a5-a1ef-e4c36fbb88a9" alt="390 px — Fullscreen after" width="480"></a></td></tr>
<tr><td>390 px — Return from fullscreen</td><td><a href="https://github.com/user-attachments/assets/b12d5633-f07c-431c-9f87-c5b42b95a69c"><img src="https://github.com/user-attachments/assets/b12d5633-f07c-431c-9f87-c5b42b95a69c" alt="390 px — Return from fullscreen before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/4f04efcc-e8d3-4c6f-bfbc-a49c027102c9"><img src="https://github.com/user-attachments/assets/4f04efcc-e8d3-4c6f-bfbc-a49c027102c9" alt="390 px — Return from fullscreen after" width="480"></a></td></tr>
<tr><td>1440 px — Normal</td><td><a href="https://github.com/user-attachments/assets/67eca505-544e-4d9f-9252-b8692e5e213b"><img src="https://github.com/user-attachments/assets/67eca505-544e-4d9f-9252-b8692e5e213b" alt="1440 px — Normal before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/1e3682f7-e98e-4df9-af2a-20f9f09621c7"><img src="https://github.com/user-attachments/assets/1e3682f7-e98e-4df9-af2a-20f9f09621c7" alt="1440 px — Normal after" width="480"></a></td></tr>
<tr><td>1440 px — Fullscreen</td><td><a href="https://github.com/user-attachments/assets/2a6a7d35-ba58-4fb9-b364-0bcac2ceb3e8"><img src="https://github.com/user-attachments/assets/2a6a7d35-ba58-4fb9-b364-0bcac2ceb3e8" alt="1440 px — Fullscreen before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/c103736a-1692-496a-9177-d10e13ed14f5"><img src="https://github.com/user-attachments/assets/c103736a-1692-496a-9177-d10e13ed14f5" alt="1440 px — Fullscreen after" width="480"></a></td></tr>
<tr><td>1440 px — Return from fullscreen</td><td><a href="https://github.com/user-attachments/assets/a4c5fdb3-00ab-4a1f-a0d1-f4a35640c41d"><img src="https://github.com/user-attachments/assets/a4c5fdb3-00ab-4a1f-a0d1-f4a35640c41d" alt="1440 px — Return from fullscreen before" width="480"></a></td><td><a href="https://github.com/user-attachments/assets/af6b39be-96f4-473a-8dab-e069ce002448"><img src="https://github.com/user-attachments/assets/af6b39be-96f4-473a-8dab-e069ce002448" alt="1440 px — Return from fullscreen after" width="480"></a></td></tr>
</table>

- Agent preview browser suite: 5 passing cases: 320/Russian, 390/1440 normal/fullscreen/return, and existing edit/close focus restoration. Metadata assertions check that essential chips stay visible, secondary metadata is hidden on mobile, and all metadata returns on desktop resize. They do not measure chip pixels. The observer-specific French animation case was removed with the observer.
- Existing agent view suite: 23 passing tests. Preview tests include the real tooltip provider and wait for the dialog’s own opening completion, preserving pointer/keyboard modality and retained-reopen focus checks.
- Prior real rendered-control proof at 390, 768, and 1440 remains applicable: expand/collapse, Escape from fullscreen, focus return, reopen reset, document wheel scrolling, edit/reset/save/refresh. These control paths are unchanged; final browser coverage reruns fullscreen, scrolling, Escape and retained-reopen focus behavior.
- Scoped validation: passed on the UI patch before the mechanical rebases: 5/5 browser cases, 23/23 agent unit tests, UI production and agent-page test types, type-aware TypeScript lint, CSS lint, formatting, whitespace, and the test-file changed check (global guards, translation catalog, dependency checks, and unused-export scans).


The rebased head `183de74a0de` preserves the reviewed UI files byte for byte. [Hosted CI passed on that exact head](https://github.com/openclaw/openclaw/actions/runs/34290000122), including the real-Gateway E2E. The inherited main lint failure was repaired separately in #142648 by @RomneyDa.

## Risk and coverage

The shared stylesheet also serves the skills detail, ClawHub detail, library editor, library importer, and pinned library reader. Their templates and selectors were checked: compact shared header/body changes are scoped to the agent modal; metadata, reader, and removed fullscreen rules belong to the agent preview. Those five sibling surfaces retain their shared layout rules. The metadata priorities are static markup, and the existing 400 px media query owns their visibility. There is no metadata observer, resize handler, or runtime measurement. The rule always retains the three essential chips; it does not select chips based on translated text length. The state helper is back to its original fullscreen/focus responsibilities. Adaptive handling of unusually long translations is deferred to the broader pass under the approved small-fix scope.

Proof uses the production renderer and real dialogs with synthetic file data in Chromium. No live Gateway or provider calls were needed; physical-device and other-browser rendering were not exercised.
