### PR TITLE
docs: make extended-stable validation dispatch reliable

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -442,9 +442,7 @@ the same candidate. Reject narrow runs, untrusted tooling, mismatched targets,
 and earlier-attempt evidence.
 
 Run the npm preflight separately from trusted `main`. Here `tag` is the exact
-candidate SHA; it is an npm-preflight input, not the workflow transport ref.
-This extended-stable requirement overrides the regular final qualification
-guidance that reuses Full Release Validation's integrated npm artifact:
+candidate SHA; it is an npm-preflight input, not the workflow transport ref:
 
 ```bash
 gh workflow run openclaw-npm-release.yml \
@@ -455,6 +453,12 @@ gh workflow run openclaw-npm-release.yml \
   -f npm_dist_tag=extended-stable \
   -f release_candidate_branch="$CONTEXT_REF"
 ```
+
+This standalone run is a supplemental validation-only preflight. Do not pass
+its run ID as publication `preflight_run_id`: a `main` workflow head does not
+have the canonical candidate branch/SHA identity required by that publication
+input. Publication continues to use the Full Release Validation run's
+manifest-bound integrated npm artifact and exact run attempt.
 
 Product failures need an approved backport. Frozen-target tooling failures need
 the smallest behavior-preserving repair. Provider, approval, runner, or log

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -380,23 +380,81 @@ publish workflow reads the effective profile from the full-validation manifest.
 
 ### Extended-stable validation
 
-For `.33+`, dispatch from and target the canonical branch. This direct route is
-intentional: downstream extended-stable evidence requires the canonical branch
-identity, while Telegram still authenticates the exact branch SHA:
+Use one remote-only procedure for `.33+` extended-stable validation. Keep these
+four identities separate:
+
+- **Validation SHA:** exact 40-character candidate commit to validate.
+- **Tooling SHA:** exact trusted-main commit whose workflows and helpers run.
+- **Context ref:** canonical `extended-stable/YYYY.M.33` branch containing the
+  candidate.
+- **Workflow transport ref:** immutable
+  `release-ci/<tooling-sha-prefix>-<unique-id>` branch at the Tooling SHA.
+
+GitHub workflow dispatch `--ref` accepts a branch or tag name, not a raw commit
+SHA. Never raw-dispatch this validation or hand-assemble its identity inputs.
+Use the checked helper exclusively:
 
 ```bash
-RELEASE_SHA="$(git rev-parse HEAD)"
-gh workflow run full-release-validation.yml \
-  --ref extended-stable/YYYY.M.33 \
-  -f ref=extended-stable/YYYY.M.33 \
-  -f expected_sha="$RELEASE_SHA" \
-  -f release_profile=stable
+VALIDATION_SHA="<exact-candidate-sha>"
+TOOLING_SHA="<recorded-full-main-ancestor-sha>"
+CONTEXT_REF="extended-stable/YYYY.M.33"
+pnpm ci:full-release \
+  --sha "$VALIDATION_SHA" \
+  --target-ref "$CONTEXT_REF" \
+  --workflow-sha "$TOOLING_SHA" \
+  -f release_profile=stable \
+  -f run_release_soak=true \
+  -f fail_fast=false \
+  -f rerun_group=all \
+  -f reuse_evidence=false \
+  -f dispatch_release_evidence=false
 ```
 
-Accept only a complete `rerun_group=all` run whose branch, head/target SHAs,
-manifest `workflowRef`, and package versions identify the same commit. Save its
-successful `run_attempt` and require the final tag to resolve there. Reject
-`release-ci/*`, current-main, narrow, and earlier-attempt evidence.
+The helper verifies both SHAs, creates the transport ref with the equivalent of
+the following GitHub refs operation, and dispatches from that branch:
+
+```bash
+gh api --method POST repos/openclaw/openclaw/git/refs \
+  -f ref="refs/heads/release-ci/${TOOLING_SHA:0:12}-<unique-id>" \
+  -f sha="$TOOLING_SHA"
+```
+
+Do not run that operation separately. The helper also supplies
+`ref=$VALIDATION_SHA`, `expected_sha=$VALIDATION_SHA`,
+`target_context_ref=$CONTEXT_REF`, and this exact trusted identity:
+
+```text
+{"fullRef":"refs/heads/main","ref":"main","sha":"<tooling-sha>"}
+```
+
+Outside this extended-stable procedure, a direct canonical-branch dispatch is
+valid only when that branch's own head is both the Validation SHA and the
+trusted workflow implementation to execute. It cannot use a different
+trusted-main Tooling SHA. Current extended-stable validation requires distinct
+trusted-main tooling, so it must use the immutable `release-ci/*` transport
+above. Direct canonical-branch and mutable-`main` dispatches are not valid
+alternatives for this procedure.
+
+Accept only a complete `rerun_group=all` run with a supported exact-target
+manifest. Bind its workflow SHA separately from the candidate SHA; require the
+manifest target, package versions, saved `run_attempt`, and final tag to identify
+the same candidate. Reject narrow runs, untrusted tooling, mismatched targets,
+and earlier-attempt evidence.
+
+Run the npm preflight separately from trusted `main`. Here `tag` is the exact
+candidate SHA; it is an npm-preflight input, not the workflow transport ref.
+This extended-stable requirement overrides the regular final qualification
+guidance that reuses Full Release Validation's integrated npm artifact:
+
+```bash
+gh workflow run openclaw-npm-release.yml \
+  --repo openclaw/openclaw \
+  --ref main \
+  -f tag="$VALIDATION_SHA" \
+  -f preflight_only=true \
+  -f npm_dist_tag=extended-stable \
+  -f release_candidate_branch="$CONTEXT_REF"
+```
 
 Product failures need an approved backport. Frozen-target tooling failures need
 the smallest behavior-preserving repair. Provider, approval, runner, or log

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -95,7 +95,9 @@ The helper dispatches from an immutable `release-ci/*` ref at the Tooling SHA,
 passes the Validation SHA as `ref` and `expected_sha`, and records the canonical
 branch as `target_context_ref`. GitHub workflow dispatch `--ref` must name a
 branch or tag; it cannot be a raw SHA. Save the successful run ID and
-`run_attempt` as full validation evidence.
+`run_attempt`. When its manifest contains `publicationArtifacts.npmPreflight`,
+use that same Full Release Validation run and attempt for both npm preflight and
+full validation publication evidence.
 
 Extended-stable also requires a separate npm preflight from trusted `main`:
 
@@ -109,9 +111,11 @@ gh workflow run openclaw-npm-release.yml \
   -f release_candidate_branch="$CONTEXT_REF"
 ```
 
-Save that run's ID and attempt as the npm preflight evidence. Do not substitute
-the integrated Full Release Validation npm artifact for this extended-stable
-preflight.
+This standalone run is a supplemental validation-only preflight. Do not pass
+its run ID as publication `preflight_run_id`: its `main` workflow head is not
+the canonical candidate branch/SHA identity required for standalone
+publication evidence. Publication continues to use the integrated Full Release
+Validation npm artifact and exact run attempt.
 
 Classify failures before editing:
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -71,24 +71,47 @@ policy, shared classifier, tests, and workflow validation. GitHub loads tag
 workflows from the tagged commit; an incomplete copy can fail after building or
 move regular aliases. Run focused checks.
 
-Freeze the full branch-tip SHA. Before tagging, run Full Release Validation
-against that SHA; it also prepares and qualifies the exact npm and Docker bytes:
+Freeze the full branch-tip SHA and record the exact trusted-main Tooling SHA.
+Before tagging, run Full Release Validation through its immutable workflow
+transport; it also prepares and qualifies the exact npm and Docker bytes:
 
 ```bash
-RELEASE_SHA="$(git rev-parse HEAD)"
-
-gh workflow run full-release-validation.yml \
-  --ref extended-stable/YYYY.M.33 \
-  -f ref=extended-stable/YYYY.M.33 \
-  -f expected_sha="$RELEASE_SHA" \
-  -f release_profile=stable
+VALIDATION_SHA="<exact-candidate-sha>"
+TOOLING_SHA="<recorded-full-main-ancestor-sha>"
+CONTEXT_REF="extended-stable/YYYY.M.33"
+pnpm ci:full-release \
+  --sha "$VALIDATION_SHA" \
+  --target-ref "$CONTEXT_REF" \
+  --workflow-sha "$TOOLING_SHA" \
+  -f release_profile=stable \
+  -f run_release_soak=true \
+  -f fail_fast=false \
+  -f rerun_group=all \
+  -f reuse_evidence=false \
+  -f dispatch_release_evidence=false
 ```
 
-Run validation on the canonical branch; publish binds its workflow ref,
-head/target SHA, run ID, and attempt. Save the successful run ID and
-`run_attempt`. Use that ID for both npm preflight and full validation evidence
-when the manifest contains `publicationArtifacts.npmPreflight`. Historical
-manifests without it still need a standalone npm preflight for the same SHA.
+The helper dispatches from an immutable `release-ci/*` ref at the Tooling SHA,
+passes the Validation SHA as `ref` and `expected_sha`, and records the canonical
+branch as `target_context_ref`. GitHub workflow dispatch `--ref` must name a
+branch or tag; it cannot be a raw SHA. Save the successful run ID and
+`run_attempt` as full validation evidence.
+
+Extended-stable also requires a separate npm preflight from trusted `main`:
+
+```bash
+gh workflow run openclaw-npm-release.yml \
+  --repo openclaw/openclaw \
+  --ref main \
+  -f tag="$VALIDATION_SHA" \
+  -f preflight_only=true \
+  -f npm_dist_tag=extended-stable \
+  -f release_candidate_branch="$CONTEXT_REF"
+```
+
+Save that run's ID and attempt as the npm preflight evidence. Do not substitute
+the integrated Full Release Validation npm artifact for this extended-stable
+preflight.
 
 Classify failures before editing:
 
@@ -99,7 +122,7 @@ Classify failures before editing:
   the bounded retry path.
 
 Any branch change invalidates both gates. Once they pass, require the tip still
-equals `RELEASE_SHA`, then push signed `vYYYY.M.P`. Later changes need the next
+equals `VALIDATION_SHA`, then push signed `vYYYY.M.P`. Later changes need the next
 patch; never move or delete the tag. Tagging fixes the immutable release
 identity; it does not publish Docker images.
 

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -199,23 +199,36 @@ wrong-SHA tag, parent mismatch, or disallowed parent state fails closed. Other
 privileged writers require their dependent enforcement changes before the
 protected-tag publication route is globally complete.
 
-## Extended-stable exception
+## Extended-stable validation
 
-Extended-stable publish requires a run whose workflow and target are both the
-canonical branch:
+Extended-stable validation uses the same checked helper with an immutable
+trusted-main Tooling SHA. Keep the exact candidate, Tooling SHA, canonical
+context, and workflow transport separate:
 
 ```bash
-RELEASE_SHA="$(git rev-parse HEAD)"
-gh workflow run full-release-validation.yml \
-  --ref extended-stable/YYYY.M.33 \
-  -f ref=extended-stable/YYYY.M.33 \
-  -f expected_sha="$RELEASE_SHA" \
-  -f release_profile=stable
+VALIDATION_SHA="<exact-candidate-sha>"
+TOOLING_SHA="<recorded-full-main-ancestor-sha>"
+CONTEXT_REF="extended-stable/YYYY.M.33"
+pnpm ci:full-release \
+  --sha "$VALIDATION_SHA" \
+  --target-ref "$CONTEXT_REF" \
+  --workflow-sha "$TOOLING_SHA" \
+  -f release_profile=stable \
+  -f run_release_soak=true \
+  -f fail_fast=false \
+  -f rerun_group=all \
+  -f reuse_evidence=false \
+  -f dispatch_release_evidence=false
 ```
 
-Do not use `pnpm ci:full-release` or `release-ci/*`. Publish binds the run's
-branch, head/target SHA, manifest `workflowRef`, ID, and attempt to the canonical
-branch and release commit.
+The helper creates `release-ci/<tooling-prefix>-<unique-id>` at the Tooling SHA,
+dispatches from that named branch, supplies the trusted-main identity, and uses
+the exact Validation SHA for both `ref` and `expected_sha` with the canonical
+branch in `target_context_ref`. GitHub workflow dispatch `--ref` accepts a branch
+or tag, not a raw SHA. Outside extended-stable validation, a direct
+canonical-branch dispatch is valid only when its head is also the trusted
+workflow implementation. Current extended-stable validation uses distinct
+trusted-main tooling and therefore requires the immutable helper.
 
 Backport product failures; make the smallest behavior-preserving repair for
 frozen-target tooling; retry provider, approval, or runner failures without a

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -1087,11 +1087,11 @@ function main() {
     ...(trustedWorkflowHarness.contract === RELEASE_ISOLATION_TOOLING_CONTRACT
       ? {
           trusted_workflow_json: JSON.stringify({
-            ref: args.trustedWorkflowRef,
             fullRef:
               args.trustedWorkflowRef === "main"
                 ? "refs/heads/main"
                 : `refs/tags/${args.trustedWorkflowRef}`,
+            ref: args.trustedWorkflowRef,
             sha: workflowSha,
           }),
         }

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -73,6 +73,7 @@ function createDispatchFixture(
     runDiscoveryMisses?: number;
     targetAlreadyRemote?: boolean;
     includeTargetRef?: boolean;
+    releaseRef?: string;
     workflowSource?: string;
     targetSource?: Record<string, string>;
   } = {},
@@ -88,7 +89,7 @@ function createDispatchFixture(
   const runDiscoveryIndexPath = join(root, "run-discovery-index.txt");
   const preloadPath = join(root, "immediate-poll.mjs");
   const waitCallsPath = join(root, "wait-calls.txt");
-  const releaseRef = "release/2026.8.1";
+  const releaseRef = options.releaseRef ?? "release/2026.8.1";
   mkdirSync(checkout);
   mkdirSync(binDir);
   writeFileSync(gitCallsPath, "");
@@ -1296,6 +1297,74 @@ describe("full-release-validation-at-sha", () => {
       }
     },
   );
+
+  it("dispatches the canonical extended-stable tuple without conflating its SHAs", () => {
+    const contextRef = "extended-stable/2026.8.33";
+    const fixture = createDispatchFixture({
+      releaseRef: contextRef,
+      targetSource: {
+        "package.json": '{"version":"2026.8.33"}\n',
+        "CHANGELOG.md":
+          "## 2026.8.33\n\nRelease notes for the complete extended-stable candidate.\n",
+      },
+    });
+    try {
+      const result = fixture.run([
+        "--sha",
+        fixture.targetSha,
+        "--target-ref",
+        contextRef,
+        "--workflow-sha",
+        fixture.workflowSha,
+        "-f",
+        "release_profile=stable",
+        "-f",
+        "run_release_soak=true",
+        "-f",
+        "fail_fast=false",
+        "-f",
+        "rerun_group=all",
+        "-f",
+        "reuse_evidence=false",
+        "-f",
+        "dispatch_release_evidence=false",
+      ]);
+      expect(result.status, result.stderr).toBe(0);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      const dispatch = calls.find((args) => args[0] === "workflow" && args[1] === "run");
+      const transportRef = dispatch?.[4] ?? "";
+      expect(transportRef).toMatch(
+        new RegExp(`^release-ci/${fixture.workflowSha.slice(0, 12)}-[0-9]+$`, "u"),
+      );
+      expect(transportRef).not.toBe(fixture.targetSha);
+      expect(transportRef).not.toBe(fixture.workflowSha);
+      const inputs = Object.fromEntries(
+        (dispatch ?? [])
+          .filter((_value, index, args) => args[index - 1] === "-f")
+          .map((assignment) => {
+            const separator = assignment.indexOf("=");
+            return [assignment.slice(0, separator), assignment.slice(separator + 1)];
+          }),
+      );
+      expect(inputs).toMatchObject({
+        ref: fixture.targetSha,
+        expected_sha: fixture.targetSha,
+        target_context_ref: contextRef,
+        release_profile: "stable",
+        run_release_soak: "true",
+        fail_fast: "false",
+        rerun_group: "all",
+        reuse_evidence: "false",
+        dispatch_release_evidence: "false",
+      });
+      expect(inputs.ref).not.toBe(contextRef);
+      expect(inputs.trusted_workflow_json).toBe(
+        JSON.stringify({ fullRef: "refs/heads/main", ref: "main", sha: fixture.workflowSha }),
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
 
   it.each([
     { failure: "target" as const, created: 0, deleted: 0 },

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -12432,14 +12432,25 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     ]);
     expectTextToIncludeAll(releasingDocs, [
       "Extended-stable also requires a separate npm preflight from trusted `main`",
-      "Do not substitute",
-      "integrated Full Release Validation npm artifact",
+      "supplemental validation-only preflight",
+      "Do not pass",
+      "publication `preflight_run_id`",
+      "Publication continues to use the integrated Full Release",
+      "Validation npm artifact and exact run attempt",
       "--ref main",
       '-f tag="$VALIDATION_SHA"',
       "-f preflight_only=true",
       "-f npm_dist_tag=extended-stable",
       '-f release_candidate_branch="$CONTEXT_REF"',
     ]);
+    for (const text of [releaseCi, releasingDocs]) {
+      expectTextToIncludeAll(text, [
+        "standalone run is a supplemental validation-only preflight",
+        "Do not pass",
+        "publication `preflight_run_id`",
+        "Publication continues to use",
+      ]);
+    }
     expectTextToIncludeAll(ciDocs, [
       'VALIDATION_SHA="<full-commit-sha>"',
       '-f ref="$VALIDATION_SHA"',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -12382,7 +12382,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     }
   });
 
-  it("pins every documented raw Full Release Validation caller to one exact SHA", () => {
+  it("documents checked extended-stable dispatch instead of a raw-SHA workflow ref", () => {
     const nightly = readFileSync(".agents/skills/release-openclaw-nightly/SKILL.md", "utf8");
     const releaseCi = readFileSync(".agents/skills/release-openclaw-ci/SKILL.md", "utf8");
     // The CI page is an index over docs/ci/*. Read the whole set so this
@@ -12398,13 +12398,48 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const releasingDocs = readFileSync("docs/reference/RELEASING.md", "utf8");
 
     expect(nightly).toContain('-f expected_sha="$SHA"');
+    const canonicalExtendedStableDispatch = [
+      'VALIDATION_SHA="<exact-candidate-sha>"',
+      'TOOLING_SHA="<recorded-full-main-ancestor-sha>"',
+      'CONTEXT_REF="extended-stable/YYYY.M.33"',
+      "pnpm ci:full-release",
+      '--sha "$VALIDATION_SHA"',
+      '--target-ref "$CONTEXT_REF"',
+      '--workflow-sha "$TOOLING_SHA"',
+      "-f release_profile=stable",
+      "-f run_release_soak=true",
+      "-f fail_fast=false",
+      "-f rerun_group=all",
+      "-f reuse_evidence=false",
+      "-f dispatch_release_evidence=false",
+    ];
     for (const text of [releaseCi, fullReleaseDocs, releasingDocs]) {
-      expectTextToIncludeAll(text, [
-        'RELEASE_SHA="$(git rev-parse HEAD)"',
-        "-f ref=extended-stable/YYYY.M.33",
-        '-f expected_sha="$RELEASE_SHA"',
-      ]);
+      expectTextToIncludeAll(text, canonicalExtendedStableDispatch);
+      expect(text).not.toContain('--ref "$VALIDATION_SHA"');
+      expect(text).not.toContain('-f ref="$CONTEXT_REF"');
     }
+    expectTextToIncludeAll(releaseCi, [
+      "`--ref` accepts a branch or tag name, not a raw commit",
+      '{"fullRef":"refs/heads/main","ref":"main","sha":"<tooling-sha>"}',
+      "Outside this extended-stable procedure, a direct canonical-branch dispatch",
+      "Current extended-stable validation requires distinct",
+      "Direct canonical-branch and mutable-`main` dispatches are not valid",
+      "--ref main",
+      '-f tag="$VALIDATION_SHA"',
+      "-f preflight_only=true",
+      "-f npm_dist_tag=extended-stable",
+      '-f release_candidate_branch="$CONTEXT_REF"',
+    ]);
+    expectTextToIncludeAll(releasingDocs, [
+      "Extended-stable also requires a separate npm preflight from trusted `main`",
+      "Do not substitute",
+      "integrated Full Release Validation npm artifact",
+      "--ref main",
+      '-f tag="$VALIDATION_SHA"',
+      "-f preflight_only=true",
+      "-f npm_dist_tag=extended-stable",
+      '-f release_candidate_branch="$CONTEXT_REF"',
+    ]);
     expectTextToIncludeAll(ciDocs, [
       'VALIDATION_SHA="<full-commit-sha>"',
       '-f ref="$VALIDATION_SHA"',

--- a/test/scripts/release-tooling-identity.test.ts
+++ b/test/scripts/release-tooling-identity.test.ts
@@ -42,6 +42,17 @@ function protectedIdentity(
 }
 
 describe("release tooling identity", () => {
+  it("rejects a raw commit SHA as the workflow transport ref", () => {
+    expect(() =>
+      resolveReleaseToolingIdentity({
+        workflowContract: "2",
+        workflowFullRef: `refs/heads/${SHA}`,
+        workflowRef: SHA,
+        workflowSha: SHA,
+      }),
+    ).toThrow("workflow ref is not a trusted direct, release-ci, or protected-tag route");
+  });
+
   it.each([
     ["1", "main", "refs/heads/main"],
     ["2", "release/2026.8.1", "refs/heads/release/2026.8.1"],
@@ -118,6 +129,40 @@ describe("release tooling identity", () => {
         workflowSha: SHA,
       }),
     ).toEqual({ ref: "main", fullRef: "refs/heads/main", sha: SHA });
+  });
+
+  it("rejects a release-ci transport whose prefix does not match the Tooling SHA", () => {
+    const releaseCiRef = `release-ci/${OTHER_SHA.slice(0, 12)}-123`;
+    expect(() =>
+      resolveReleaseToolingIdentity({
+        requestedIdentityJson: JSON.stringify({
+          fullRef: "refs/heads/main",
+          ref: "main",
+          sha: SHA,
+        }),
+        workflowContract: "2",
+        workflowFullRef: `refs/heads/${releaseCiRef}`,
+        workflowRef: releaseCiRef,
+        workflowSha: SHA,
+      }),
+    ).toThrow("release-ci workflow ref does not match the workflow SHA");
+  });
+
+  it("rejects a candidate SHA substituted for the release-ci Tooling SHA", () => {
+    const releaseCiRef = `release-ci/${SHA.slice(0, 12)}-123`;
+    expect(() =>
+      resolveReleaseToolingIdentity({
+        requestedIdentityJson: JSON.stringify({
+          fullRef: "refs/heads/main",
+          ref: "main",
+          sha: OTHER_SHA,
+        }),
+        workflowContract: "2",
+        workflowFullRef: `refs/heads/${releaseCiRef}`,
+        workflowRef: releaseCiRef,
+        workflowSha: SHA,
+      }),
+    ).toThrow("release-ci workflow identity must be trusted main");
   });
 
   it("rejects explicit identity that does not match a direct workflow", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators following the extended-stable instructions could submit invalid Full Release Validation dispatches by using a raw commit as the workflow ref, omitting trusted identity on a `release-ci/*` transport, or using the canonical branch as the validation target while also supplying `target_context_ref`.

Observed failure evidence:

- GitHub rejected a workflow dispatch whose `--ref` was a raw commit SHA; workflow dispatch refs must be named branches or tags.
- [Run 34272098670](https://github.com/openclaw/openclaw/actions/runs/34272098670) used `release-ci/b76ead71a300-1788919200` at Tooling SHA `b76ead71a3009db949eb9fe8e206097e9d7f7188`, but `REQUESTED_IDENTITY_JSON` was empty. `Resolve target ref` failed with: `release-ci and protected-tag workflows require explicit trusted workflow identity.`
- Earlier instructions combined a branch-valued target with `target_context_ref`, although the workflow requires `ref` to be the exact 40-character candidate SHA in that form.

## Why This Change Was Made

The release CI skill now defines one canonical remote-only extended-stable procedure using the existing checked `pnpm ci:full-release` helper. It separates Validation SHA, trusted-main Tooling SHA, canonical context ref, and immutable `release-ci/*` workflow transport; the helper creates the transport and emits the exact trusted identity JSON instead of requiring hand assembly.

The corrected Full Release Validation command is:

```bash
VALIDATION_SHA="<exact-candidate-sha>"
TOOLING_SHA="<recorded-full-main-ancestor-sha>"
CONTEXT_REF="extended-stable/YYYY.M.33"
pnpm ci:full-release \
  --sha "$VALIDATION_SHA" \
  --target-ref "$CONTEXT_REF" \
  --workflow-sha "$TOOLING_SHA" \
  -f release_profile=stable \
  -f run_release_soak=true \
  -f fail_fast=false \
  -f rerun_group=all \
  -f reuse_evidence=false \
  -f dispatch_release_evidence=false
```

The helper dispatches with `ref=<candidate SHA>`, `expected_sha=<same candidate SHA>`, `target_context_ref=extended-stable/YYYY.M.33`, and `trusted_workflow_json={"fullRef":"refs/heads/main","ref":"main","sha":"<tooling-sha>"}`. Extended-stable npm preflight is documented separately from trusted `main`, using the candidate SHA as `tag` and the canonical candidate branch as context. That standalone run is supplemental validation-only; publication remains bound to the integrated Full Release Validation npm artifact and exact attempt.

Direct canonical-branch dispatch remains documented only for outside-procedure same-tip validation. Current extended-stable validation requires distinct trusted-main tooling and therefore always uses the immutable helper.

## User Impact

Release operators get one checked command that cannot conflate the candidate, tooling, context, and workflow transport identities. The official release guides no longer preserve the contradictory direct-branch recipe and now distinguish the standalone trusted-main validation-only preflight from the manifest-bound integrated Full Release Validation evidence required for publication.

## Evidence

- `node scripts/check-changed.mjs`
- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts -t "canonical extended-stable tuple"`
- `node scripts/run-vitest.mjs test/scripts/release-tooling-identity.test.ts`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -t "documents checked extended-stable dispatch"`
- TypeScript-aware `oxlint` for the changed script and tests
- `oxfmt` and `git diff --check`
- `node scripts/docs-list.js`
- Fresh autoreview: scoped clean, no actionable findings

Regression coverage rejects raw-SHA workflow refs, missing trusted identity on `release-ci/*`, branch targets combined with context, and candidate/tooling SHA mismatches; it accepts the canonical extended-stable tuple.

Production/tooling LOC is net zero (`scripts/full-release-validation-at-sha.mts`: 1 added, 1 removed). Skill/docs and tests are counted separately. No dependencies changed, and `pnpm-lock.yaml` is unchanged. No release, publish, tag, npm, or release-branch mutation was performed.
