### PR TITLE
fix(ui): consolidate skill import source controls

### DIFF
--- a/ui/src/e2e/skills-library.e2e.test.ts
+++ b/ui/src/e2e/skills-library.e2e.test.ts
@@ -370,15 +370,25 @@ suite.define(() => {
         page.waitForEvent("filechooser"),
         chooseFiles.press("Enter"),
       ]);
-      await fileChooser.setFiles([
+      const selectedFiles = [
         { name: "SKILL.md", mimeType: "text/markdown", buffer: Buffer.from(own.content) },
         { name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("untouched\r\n") },
-      ]);
-      await page.getByText("SKILL.md, notes.txt", { exact: true }).waitFor();
-      await page
+      ];
+      await fileChooser.setFiles(selectedFiles);
+      await page.getByText("2 files · SKILL.md, notes.txt", { exact: true }).waitFor();
+      const importSkill = page
         .locator("openclaw-modal-dialog")
-        .getByRole("button", { name: "Import skill", exact: true })
-        .click();
+        .getByRole("button", { name: "Import skill", exact: true });
+      await page.getByRole("button", { name: "Clear", exact: true }).click();
+      expect(await importSkill.isDisabled()).toBe(true);
+      expect(await page.getByText(/SKILL.md, notes.txt/u).count()).toBe(0);
+      expect(await gateway.getRequests("skills.library.save")).toHaveLength(0);
+      const [reselection] = await Promise.all([
+        page.waitForEvent("filechooser"),
+        chooseFiles.press("Enter"),
+      ]);
+      await reselection.setFiles(selectedFiles);
+      await importSkill.click();
       await page.getByRole("button", { name: "Save skill", exact: true }).click();
       expect((await gateway.waitForRequest("skills.library.save")).params).toMatchObject({
         expectedRevision: null,

--- a/ui/src/e2e/skills-library.e2e.test.ts
+++ b/ui/src/e2e/skills-library.e2e.test.ts
@@ -365,10 +365,16 @@ suite.define(() => {
           .evaluate((element: HTMLInputElement) => element.checkValidity()),
       ).toBe(false);
       await page.getByLabel("Skill name", { exact: true }).fill("checklist");
-      await page.locator('input[name="library-import-files"]').setInputFiles([
+      const chooseFiles = page.getByRole("button", { name: "Choose files", exact: true });
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent("filechooser"),
+        chooseFiles.press("Enter"),
+      ]);
+      await fileChooser.setFiles([
         { name: "SKILL.md", mimeType: "text/markdown", buffer: Buffer.from(own.content) },
         { name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("untouched\r\n") },
       ]);
+      await page.getByText("SKILL.md, notes.txt", { exact: true }).waitFor();
       await page
         .locator("openclaw-modal-dialog")
         .getByRole("button", { name: "Import skill", exact: true })

--- a/ui/src/i18n/locales/en-skill-library.ts
+++ b/ui/src/i18n/locales/en-skill-library.ts
@@ -82,17 +82,18 @@ const enSkillLibrary = {
     pending:
       "Proposal {id} saved for workspace {agent}. It is pending review and is not active yet.",
     workspaceSaved: "Workspace {agent}: {state}. Start a new session to use the skill.",
-    importHelp:
-      "Import SKILL.md with supporting files, a local folder, or a ZIP into your private library. Text bundles open for review before saving; ZIP imports publish when you choose Import skill.",
-    importWorkspace:
-      "Choose SKILL.md and supporting text files or a folder. Review the content, then save and apply a Workshop proposal to the selected agent workspace. Use ClawHub below for workspace installs.",
-    importClawHub:
-      "Import {source} into your private library. This does not publish your files or install host dependencies.",
-    chooseFiles: "SKILL.md, supporting files, or ZIP",
-    chooseFolder: "Skill folder",
+    importHelp: "Import a skill into your private library.",
+    importWorkspace: "Prepare a skill for review in the selected workspace.",
+    importClawHub: "Import {source} into your private library.",
+    files: "Files",
+    filesHelp: "SKILL.md with supporting files, a folder, or a ZIP (saved on import).",
+    workspaceFilesHelp: "SKILL.md with supporting text files, or a folder.",
     chooseFilesButton: "Choose files",
     chooseFolderButton: "Choose folder",
     noFilesSelected: "No files selected.",
+    selectedFile: "{count} file · {names}",
+    selectedFiles: "{count} files · {names}",
+    clearSelection: "Clear",
     confirm: {
       remove: "Remove {slug} from the library?",
       transfer: "Transfer {slug} to team ownership? Team administrators will manage it.",

--- a/ui/src/i18n/locales/en-skill-library.ts
+++ b/ui/src/i18n/locales/en-skill-library.ts
@@ -90,6 +90,9 @@ const enSkillLibrary = {
       "Import {source} into your private library. This does not publish your files or install host dependencies.",
     chooseFiles: "SKILL.md, supporting files, or ZIP",
     chooseFolder: "Skill folder",
+    chooseFilesButton: "Choose files",
+    chooseFolderButton: "Choose folder",
+    noFilesSelected: "No files selected.",
     confirm: {
       remove: "Remove {slug} from the library?",
       transfer: "Transfer {slug} to team ownership? Team administrators will manage it.",

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -535,6 +535,17 @@ function renderLibraryImport(library: SkillLibraryController) {
   if (!library.importOpen) {
     return nothing;
   }
+  const selectedFiles = library.importSelection;
+  const selectionLabel = selectedFiles.length
+    ? t(selectedFiles.length === 1 ? "skillLibrary.selectedFile" : "skillLibrary.selectedFiles", {
+        count: String(selectedFiles.length),
+        names:
+          selectedFiles
+            .slice(0, 2)
+            .map((file) => file.webkitRelativePath || file.name)
+            .join(", ") + (selectedFiles.length > 2 ? ", …" : ""),
+      })
+    : t("skillLibrary.noFilesSelected");
   const close = () => library.close();
   return html`<openclaw-modal-dialog
     label=${t("skillLibrary.import")}
@@ -653,26 +664,10 @@ function renderLibraryImport(library: SkillLibraryController) {
                     class="settings-row__desc"
                     aria-live="polite"
                   >
-                    ${
-                      library.importSelection.length
-                        ? t(
-                            library.importSelection.length === 1
-                              ? "skillLibrary.selectedFile"
-                              : "skillLibrary.selectedFiles",
-                            {
-                              count: String(library.importSelection.length),
-                              names:
-                                library.importSelection
-                                  .slice(0, 2)
-                                  .map((file) => file.webkitRelativePath || file.name)
-                                  .join(", ") + (library.importSelection.length > 2 ? ", …" : ""),
-                            },
-                          )
-                        : t("skillLibrary.noFilesSelected")
-                    }
+                    ${selectionLabel}
                   </small>
                   ${
-                    library.importSelection.length
+                    selectedFiles.length
                       ? html`<button
                           type="button"
                           class="btn btn--sm btn--ghost"
@@ -698,9 +693,7 @@ function renderLibraryImport(library: SkillLibraryController) {
         <button
           type="submit"
           class="btn primary"
-          ?disabled=${
-            library.busy || (!library.importSource && library.importSelection.length === 0)
-          }
+          ?disabled=${library.busy || (!library.importSource && selectedFiles.length === 0)}
         >
           ${library.busy ? t("common.loading") : t("skillLibrary.import")}
         </button>

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -570,10 +570,7 @@ function renderLibraryImport(library: SkillLibraryController) {
           ${icons.x}
         </button>
       </div>
-      <div
-        class="skill-reader-dialog__body"
-        style="display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-4);"
-      >
+      <div class="skill-reader-dialog__body skill-library-import">
         <p class="muted">
           ${
             library.importSource
@@ -600,25 +597,59 @@ function renderLibraryImport(library: SkillLibraryController) {
         /></label>
         ${
           !library.importSource
-            ? [false, true].map(
-                (directory) => html`<label class="field"
-                  ><span
-                    >${t(directory ? "skillLibrary.chooseFolder" : "skillLibrary.chooseFiles")}</span
-                  ><input
-                    type="file"
-                    style="min-width: 0;"
-                    ?webkitdirectory=${directory}
-                    multiple
-                    name=${directory ? "library-import-directory" : "library-import-files"}
-                    ?disabled=${library.busy}
-                    @change=${(event: Event) => {
-                      library.importSelection = Array.from(
-                        libraryEventControl(event, HTMLInputElement).files ?? [],
-                      );
-                      library.changed();
-                    }}
-                /></label>`,
-              )
+            ? html`
+                ${[false, true].map(
+                  (directory) => html`<div class="field">
+                    <span
+                      >${t(directory ? "skillLibrary.chooseFolder" : "skillLibrary.chooseFiles")}</span
+                    >
+                    <button
+                      type="button"
+                      class="btn"
+                      aria-describedby="library-import-selection"
+                      ?disabled=${library.busy}
+                      @click=${(event: Event) => {
+                        const input = libraryEventControl(
+                          event,
+                          HTMLButtonElement,
+                        ).nextElementSibling;
+                        if (input instanceof HTMLInputElement) {
+                          input.click();
+                        }
+                      }}
+                    >
+                      ${t(
+                        directory
+                          ? "skillLibrary.chooseFolderButton"
+                          : "skillLibrary.chooseFilesButton",
+                      )}
+                    </button>
+                    <input
+                      type="file"
+                      hidden
+                      ?webkitdirectory=${directory}
+                      multiple
+                      name=${directory ? "library-import-directory" : "library-import-files"}
+                      ?disabled=${library.busy}
+                      @change=${(event: Event) => {
+                        const input = libraryEventControl(event, HTMLInputElement);
+                        library.importSelection = Array.from(input.files ?? []);
+                        input.value = "";
+                        library.changed();
+                      }}
+                    />
+                  </div>`,
+                )}
+                <p id="library-import-selection" class="muted" aria-live="polite">
+                  ${
+                    library.importSelection.length
+                      ? library.importSelection
+                          .map((file) => file.webkitRelativePath || file.name)
+                          .join(", ")
+                      : t("skillLibrary.noFilesSelected")
+                  }
+                </p>
+              `
             : nothing
         }
         ${

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -597,59 +597,97 @@ function renderLibraryImport(library: SkillLibraryController) {
         /></label>
         ${
           !library.importSource
-            ? html`
-                ${[false, true].map(
-                  (directory) => html`<div class="field">
-                    <span
-                      >${t(directory ? "skillLibrary.chooseFolder" : "skillLibrary.chooseFiles")}</span
-                    >
-                    <button
-                      type="button"
-                      class="btn"
-                      aria-describedby="library-import-selection"
-                      ?disabled=${library.busy}
-                      @click=${(event: Event) => {
-                        const input = libraryEventControl(
-                          event,
-                          HTMLButtonElement,
-                        ).nextElementSibling;
-                        if (input instanceof HTMLInputElement) {
-                          input.click();
-                        }
-                      }}
-                    >
-                      ${t(
-                        directory
-                          ? "skillLibrary.chooseFolderButton"
-                          : "skillLibrary.chooseFilesButton",
-                      )}
-                    </button>
-                    <input
-                      type="file"
-                      hidden
-                      ?webkitdirectory=${directory}
-                      multiple
-                      name=${directory ? "library-import-directory" : "library-import-files"}
-                      ?disabled=${library.busy}
-                      @change=${(event: Event) => {
-                        const input = libraryEventControl(event, HTMLInputElement);
-                        library.importSelection = Array.from(input.files ?? []);
-                        input.value = "";
-                        library.changed();
-                      }}
-                    />
-                  </div>`,
-                )}
-                <p id="library-import-selection" class="muted" aria-live="polite">
+            ? html`<div class="field" role="group" aria-labelledby="library-import-files-label">
+                <span id="library-import-files-label">${t("skillLibrary.files")}</span>
+                <small id="library-import-files-help" class="settings-row__desc">
+                  ${t(
+                    library.createTarget === "workspace"
+                      ? "skillLibrary.workspaceFilesHelp"
+                      : "skillLibrary.filesHelp",
+                  )}
+                </small>
+                <div class="plugins-toolbar skill-library-import__pickers">
+                  ${[false, true].map(
+                    (directory) => html`
+                      <button
+                        type="button"
+                        class="btn"
+                        aria-describedby="library-import-files-help library-import-selection"
+                        ?disabled=${library.busy}
+                        @click=${(event: Event) => {
+                          const input = libraryEventControl(
+                            event,
+                            HTMLButtonElement,
+                          ).nextElementSibling;
+                          if (input instanceof HTMLInputElement) {
+                            input.click();
+                          }
+                        }}
+                      >
+                        ${t(
+                          directory
+                            ? "skillLibrary.chooseFolderButton"
+                            : "skillLibrary.chooseFilesButton",
+                        )}
+                      </button>
+                      <input
+                        type="file"
+                        hidden
+                        ?webkitdirectory=${directory}
+                        multiple
+                        name=${directory ? "library-import-directory" : "library-import-files"}
+                        ?disabled=${library.busy}
+                        @change=${(event: Event) => {
+                          const input = libraryEventControl(event, HTMLInputElement);
+                          library.importSelection = Array.from(input.files ?? []);
+                          input.value = "";
+                          library.changed();
+                        }}
+                      />
+                    `,
+                  )}
+                </div>
+                <div class="plugins-toolbar">
+                  <small
+                    id="library-import-selection"
+                    class="settings-row__desc"
+                    aria-live="polite"
+                  >
+                    ${
+                      library.importSelection.length
+                        ? t(
+                            library.importSelection.length === 1
+                              ? "skillLibrary.selectedFile"
+                              : "skillLibrary.selectedFiles",
+                            {
+                              count: String(library.importSelection.length),
+                              names:
+                                library.importSelection
+                                  .slice(0, 2)
+                                  .map((file) => file.webkitRelativePath || file.name)
+                                  .join(", ") + (library.importSelection.length > 2 ? ", …" : ""),
+                            },
+                          )
+                        : t("skillLibrary.noFilesSelected")
+                    }
+                  </small>
                   ${
                     library.importSelection.length
-                      ? library.importSelection
-                          .map((file) => file.webkitRelativePath || file.name)
-                          .join(", ")
-                      : t("skillLibrary.noFilesSelected")
+                      ? html`<button
+                          type="button"
+                          class="btn btn--sm btn--ghost"
+                          ?disabled=${library.busy}
+                          @click=${() => {
+                            library.importSelection = [];
+                            library.changed();
+                          }}
+                        >
+                          ${t("skillLibrary.clearSelection")}
+                        </button>`
+                      : nothing
                   }
-                </p>
-              `
+                </div>
+              </div>`
             : nothing
         }
         ${

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -977,13 +977,6 @@ h3.plugins-subheader {
 
 /* ---------- responsive ---------- */
 
-@media (max-width: 400px) {
-  .skill-library-import__pickers {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
 @media (max-width: 640px) {
   openclaw-skills-page .plugins-toolbar--fields {
     display: grid;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -974,14 +974,20 @@ h3.plugins-subheader {
 
 .skill-library-import > p {
   margin: 0;
-  overflow-wrap: anywhere;
 }
 
-.skill-library-import .btn {
-  justify-self: start;
+.skill-library-import > .btn {
+  justify-self: end;
 }
 
 /* ---------- responsive ---------- */
+
+@media (max-width: 400px) {
+  .skill-library-import__pickers {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
 
 @media (max-width: 640px) {
   openclaw-skills-page .plugins-toolbar--fields {

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -968,12 +968,7 @@ h3.plugins-subheader {
 .skill-library-import {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  align-content: start;
   gap: var(--space-4);
-}
-
-.skill-library-import > p {
-  margin: 0;
 }
 
 .skill-library-import > .btn {

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -965,6 +965,22 @@ h3.plugins-subheader {
   justify-content: flex-end;
 }
 
+.skill-library-import {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-content: start;
+  gap: var(--space-4);
+}
+
+.skill-library-import > p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.skill-library-import .btn {
+  justify-self: start;
+}
+
 /* ---------- responsive ---------- */
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Quick fix, bigger pass later.

Closes #142511

Related: #142143 (general alignment pass, by @roboclaw-bot), #124362 (broader modal consistency, by @vyctorbrzezowski), #124365 (broader input/focus consistency, by @vyctorbrzezowski).

## What Problem This Solves

The skill import dialog exposes native file inputs, repeats source labels, and stretches its primary action. Selecting a bundle needs one clear field with readable feedback and a way to clear it.

## Why This Change Was Made

Groups file and folder selection under one **Files** label with a small muted formats helper. Existing secondary buttons share a row on desktop and at 390 px, wrapping only when space runs out. The selection shows its count and up to two names, followed by an ellipsis for additional files, plus **Clear**. The introduction is one short sentence.

The final primary action is aligned right, following the action rows in `ui/src/pages/skill-workshop/view.ts:158` and `ui/src/pages/channels/view.pairing.ts:363` (their styles use `justify-content: flex-end`). Existing `.btn`, `.field`, `.plugins-toolbar`, spacing and text tokens provide the sizing and rhythm. Header, Close, and modal height were landed in #142550 by @vyctorbrzezowski; this PR's own changes only affect import content.

## User Impact

Keyboard users can activate either native picker. Clearing the selection disables import; selecting the same files again works. Folder paths, supporting-file bytes, private text review, ZIP import, workspace restrictions and name validation keep their existing behavior. The helper retains the warning that ZIPs are saved on import.

## Evidence

Fresh dark-theme captures with synthetic data at 390 × 844 and 1440 × 1000. Both sides use the canonical surface, border, and X header from #142550 by @vyctorbrzezowski at captured baseline `6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6`. Before uses that exact baseline's import source files; after uses this PR. Instrument Sans is loaded from `ui/public/fonts/instrument-sans.css`, with font readiness and actual rendered glyphs verified before capture. Each width shows the empty/disabled state and three selected files with import enabled. All eight captures were refreshed on that lower-header baseline.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">390 px · empty / disabled</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/3ee3c094-3cea-4a84-933c-acac7112ce98"><img src="https://github.com/user-attachments/assets/3ee3c094-3cea-4a84-933c-acac7112ce98" alt="Before: 390 px · empty / disabled, lower canonical header and app fonts" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/d7136c83-adcb-48c2-8bc3-aafe8c04738e"><img src="https://github.com/user-attachments/assets/d7136c83-adcb-48c2-8bc3-aafe8c04738e" alt="After: 390 px · empty / disabled, lower canonical header and app fonts" width="420"></a></td></tr>
<tr><th colspan="2">390 px · 3 files selected / enabled</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/e61f39cc-e03c-4599-b6f2-f9d655e0ef8b"><img src="https://github.com/user-attachments/assets/e61f39cc-e03c-4599-b6f2-f9d655e0ef8b" alt="Before: 390 px · 3 files selected / enabled, lower canonical header and app fonts" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/11caeaa0-a4f2-4aa8-b609-4a616f1168ad"><img src="https://github.com/user-attachments/assets/11caeaa0-a4f2-4aa8-b609-4a616f1168ad" alt="After: 390 px · 3 files selected / enabled, lower canonical header and app fonts" width="420"></a></td></tr>
<tr><th colspan="2">1440 px · empty / disabled</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/50ce4e2a-923a-4354-a6c2-6f5e781f55cd"><img src="https://github.com/user-attachments/assets/50ce4e2a-923a-4354-a6c2-6f5e781f55cd" alt="Before: 1440 px · empty / disabled, lower canonical header and app fonts" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/b66cccb1-13e7-4c21-88ee-f567c8b86c58"><img src="https://github.com/user-attachments/assets/b66cccb1-13e7-4c21-88ee-f567c8b86c58" alt="After: 1440 px · empty / disabled, lower canonical header and app fonts" width="420"></a></td></tr>
<tr><th colspan="2">1440 px · 3 files selected / enabled</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/1f99ebe5-f059-4d64-bef4-3fae0de230e3"><img src="https://github.com/user-attachments/assets/1f99ebe5-f059-4d64-bef4-3fae0de230e3" alt="Before: 1440 px · 3 files selected / enabled, lower canonical header and app fonts" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/fe10d887-e8c4-4975-9e4f-7345143d039a"><img src="https://github.com/user-attachments/assets/fe10d887-e8c4-4975-9e4f-7345143d039a" alt="After: 1440 px · 3 files selected / enabled, lower canonical header and app fonts" width="420"></a></td></tr>
</table>

After rebasing onto main with #142550 merged, the reader-shell browser tests passed in all four cases at 390 and 1440 px. Four fresh captures also confirmed identical modal geometry and rendered fonts against the approved proof. Fresh browser checks passed for keyboard file selection, folder paths, Clear, same-file reselection, supporting-file bytes, close/reset, long filenames, busy controls, and the registry branch. Picker buttons stay on one row at 390 and 1440 px and wrap naturally when space runs out. Scoped styles, formatting, and diff whitespace passed. The prior seven-scenario library E2E proof is retained; the rebase preserves the approved import changes; the shell-selector test correction is now supplied by main.

Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34291445562) on `5f09275a8943b810a00d807def007ca3200ff453`.

## Risk and coverage

The import controller and upload handling are unchanged. The selected names are intentionally abbreviated after two entries; the full selection is preserved for import. Header and height changes were reviewed and landed separately in #142550 by @vyctorbrzezowski, completing the review's required landing order. No additional rank-up recommendations were listed or deferred. Proof uses the isolated mocked application and native file-input boundary; no live Gateway is involved. The broad changed-check command expands to unrelated core-test type graphs, so validation uses the relevant UI checks directly.
