### PR TITLE
docs: restore the v2026.9.3 release statistics label

### DIFF
--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -14,7 +14,7 @@ Updates recover cleanly and sessions reconnect faster in OpenClaw v2026.9.3, hel
 
 Alongside those highlights, Skill Workshop now keeps each agent's learned skills together across workspaces. The Mac app gains native browser tabs that stay open when you switch conversations, and Models settings adds individual account controls and supported account ordering.
 
-**This release in numbers:** 1,844 pull requests, 40 direct commits, and 190 contributors.
+**Release scale:** 1,844 pull requests, 40 direct commits, and 190 contributors.
 
 ## Installation and Onboarding
 


### PR DESCRIPTION
Related: #142437, #142475; https://github.com/openclaw/docs/pull/177.

## What Problem This Solves

Restores the original v2026.9.3 release statistics label after the earlier deployment-timing experiment.

## Why This Change Was Made

Reverts only “This release in numbers:” to “Release scale:”. This visible one-line change provides a comparable measurement of the normal docs deployment path after the validation and image-cache improvements. No workflow, runtime, release claim, count, link, or layout changes.

## User Impact

The same release statistics appear under their original label: 1,844 pull requests, 40 direct commits, and 190 contributors.

## Evidence

- Exact-file comparison verifies this label replacement is the entire change; every other byte is unchanged.
- `pnpm docs:list`, exact-file formatting with the repository's installed formatter, and `git diff --check` passed. Fresh independent review found no actionable P0/P1 issues. No runtime tests or broad build are needed for this plain-text label change.
- Exact-head [CI 34275660075](https://github.com/openclaw/openclaw/actions/runs/34275660075) passed for `e31bcd3ad01a649246d51c2c868efd6c73528649`, using the docs-only route.
- Validation-cache warm-up is verified: [run 34275177921](https://github.com/openclaw/openclaw/actions/runs/34275177921), at #142475's merge SHA, passed 15,149 files in 141,003ms and saved `docs-mdx-v1-Linux-34275177921-1` on trusted `main` at 20:36:41 UTC. This was the first cold population, not the warm measurement.
- User merged at **20:44:13 UTC** as `5209f0690aec05601b5976368114d567484d44da`. The normal HTML page first showed **Release scale:**, no old label, and unchanged counts at **20:49:37.790 UTC**: **5m24.790s merge-to-observed-live**, versus **12m17.616s** previously (56.0% shorter). The preceding old-label observation was 20:49:22.307; these observations bracket the transition, not an invented exact public switch time.
- [Source sync 34276548264](https://github.com/openclaw/openclaw/actions/runs/34276548264) succeeded at the exact merge SHA. Validation reused **15,148 of 15,149 pages**, checked one, and took **1,237ms**, versus 139,193ms in the earlier deployment. Source checkout was 26s; workflow queue was 2s.
- [Containing R2 deployment 34276686720](https://github.com/openclaw/docs/actions/runs/34276686720) succeeded at mirror `121aa5a5282755d36139d8268d4b8883c1dcc9d1`. Upload finished **20:49:38 UTC**, **5m25s after merge** (previously 11m54s). R2 queue 12s; artifact build 135s; smoke 31s; upload 10s. Image preparation reused all 695 cards in 220ms; articles reused 15,106 and rendered one, plus one snippet-owner bypass. Pagefind took 89.663s.
- Total improvement includes **149s less workflow queueing**. This run's mirror content diff was only the label plus source metadata; the earlier run included another docs change and fewer pages. Overall timings are observed deployments, not a controlled cache-only benchmark.
- Separate cache caveat: the rendered HTML is verified updated, but the normal downloadable `.md` URL still served the old label at 20:51 UTC. A distinct diagnostic query returned the new label. The existing Markdown route uses a 3,600s CDN TTL with 86,400s stale-while-revalidate, unlike HTML's Worker-cache bypass. No purge or cache-policy change was performed; the HTML timing above does not claim freshness for the cached Markdown URL.
- Prior experiment (#142437): upload completed 11m54s after merge; the changed label was first observed live after 12m17.616s. Queueing and concurrent changes will be reported separately, not presented as a controlled identical-input benchmark.

No production workflow was manually dispatched, cancelled, or retried for this measurement.
