### PR TITLE
perf(line): reuse prepared table cells

### DIFF
--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -69,9 +69,7 @@ export {
 export {
   type CodeBlock,
   convertCodeBlockToFlexBubble,
-  convertTableToFlexBubble,
   hasMarkdownToConvert,
-  type MarkdownTable,
   type ProcessedLineMessage,
   processLineMessage,
   stripMarkdown,

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 import {
   stripMarkdown,
   processLineMessage,
-  convertTableToFlexBubble,
   convertCodeBlockToFlexBubble,
   hasMarkdownToConvert,
 } from "./markdown-to-line.js";
@@ -33,17 +32,15 @@ Some deleted content.`);
   });
 });
 
-describe("convertTableToFlexBubble", () => {
+describe("processLineMessage table cards", () => {
   it("replaces empty cells with placeholders", () => {
-    const table = {
-      headers: ["A", "B"],
-      rows: [["", ""]],
+    const result = processLineMessage("| A | B |\n|---|---|\n| | |");
+    expect(result.flexMessages).toHaveLength(1);
+    const bubble = requireEntry(result.flexMessages, 0, "empty-cell table flex message")
+      .contents as {
+      body: { contents: Array<{ contents?: Array<{ contents?: Array<{ text: string }> }> }> };
     };
-
-    const bubble = convertTableToFlexBubble(table);
-    const body = bubble.body as {
-      contents: Array<{ contents?: Array<{ contents?: Array<{ text: string }> }> }>;
-    };
+    const body = bubble.body;
     const rowsBox = requireEntry(body.contents, 2, "third flex body content") as {
       contents: Array<{ contents: Array<{ text: string }> }>;
     };

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -32,13 +32,6 @@ export interface ProcessedLineMessage {
 
 type LineMessageSegment = NonNullable<ProcessedLineMessage["segments"]>[number];
 
-export interface MarkdownTable {
-  headers: string[];
-  rows: string[][];
-  headerCells?: MarkdownTableCell[];
-  rowCells?: MarkdownTableCell[][];
-}
-
 export interface CodeBlock {
   language?: string;
   code: string;
@@ -59,17 +52,8 @@ const TRANSCRIPT_ROLE_PREFIX = "[assistant-authored transcript] ";
 // rather than cut down to it.
 const LINE_FLEX_CODE_CARD_MAX_CHARS = 2000;
 
-function parseLineMarkdown(text: string, tableMode: "block" | "bullets" | "off" = "block") {
+function parseLineMarkdown(text: string, tableMode: "block" | "bullets" = "block") {
   return markdownToIRWithMeta(text, { ...LINE_MARKDOWN_OPTIONS, tableMode });
-}
-
-function toMarkdownTable(table: MarkdownTableMeta): MarkdownTable {
-  return {
-    headers: table.headers,
-    rows: table.rows,
-    headerCells: table.headerCells,
-    rowCells: table.rowCells,
-  };
 }
 
 function codeBlockSpans(ir: MarkdownIR): MarkdownStyleSpan[] {
@@ -318,21 +302,38 @@ function renderTableCell(cell: MarkdownTableCell | undefined, fallback: string):
   };
 }
 
-function plainTableCell(text: string): MarkdownTableCell {
-  return parseLineMarkdown(text, "off").ir;
-}
-
-/** Convert a markdown table to a LINE Flex Message bubble. */
-export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
-  const headerCells = (table.headerCells ?? table.headers.map(plainTableCell)).map((cell) =>
-    renderTableCell(cell, "-"),
-  );
-  const rowCells = (table.rowCells ?? table.rows.map((row) => row.map(plainTableCell))).map((row) =>
-    row.map((cell) => renderTableCell(cell, "-")),
-  );
-  const hasInlineMarkup =
-    headerCells.some((cell) => cell.hasMarkup) ||
-    rowCells.some((row) => row.some((cell) => cell.hasMarkup));
+/** Convert a table to a Flex bubble when its rows fit the layout. */
+function convertTableToFlexBubble(table: MarkdownTableMeta): FlexBubble | undefined {
+  // Receipt cards keep 12 plain rows; generic and styled layouts keep only 10.
+  const requiresPlainCells = table.rowCells.length > 10;
+  if (requiresPlainCells && (table.headers.length !== 2 || table.rowCells.length > 12)) {
+    return undefined;
+  }
+  let hasInlineMarkup = false;
+  const renderCells = (cells: MarkdownTableCell[]): RenderedCell[] | undefined => {
+    const rendered: RenderedCell[] = [];
+    for (const cell of cells) {
+      const prepared = renderTableCell(cell, "-");
+      if (requiresPlainCells && prepared.hasMarkup) {
+        return undefined;
+      }
+      hasInlineMarkup ||= prepared.hasMarkup;
+      rendered.push(prepared);
+    }
+    return rendered;
+  };
+  const headerCells = renderCells(table.headerCells);
+  if (!headerCells) {
+    return undefined;
+  }
+  const rowCells: RenderedCell[][] = [];
+  for (const row of table.rowCells) {
+    const cells = renderCells(row);
+    if (!cells) {
+      return undefined;
+    }
+    rowCells.push(cells);
+  }
 
   if (table.headers.length === 2 && !hasInlineMarkup) {
     return createReceiptCard({
@@ -360,7 +361,7 @@ export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
     paddingBottom: "sm",
   } as FlexBox;
 
-  const dataRows: FlexComponent[] = rowCells.slice(0, 10).map((row, rowIndex) => ({
+  const dataRows: FlexComponent[] = rowCells.map((row, rowIndex) => ({
     type: "box",
     layout: "horizontal",
     contents: table.headers.map((_, colIndex) => {
@@ -440,15 +441,7 @@ export function processLineMessage(text: string): ProcessedLineMessage {
   const plainTextInsertions: PlainTextInsertion[] = [];
 
   for (const table of tables) {
-    // Receipt cards keep 12 plain rows; generic and styled table layouts keep only 10.
-    const rowOverflow =
-      table.rowCells.length > 10 &&
-      (table.headers.length !== 2 ||
-        table.rowCells.length > 12 ||
-        [table.headerCells, ...table.rowCells].some((cells) =>
-          cells.some((cell) => renderTableCell(cell, "-").hasMarkup),
-        ));
-    const bubble = rowOverflow ? undefined : convertTableToFlexBubble(toMarkdownTable(table));
+    const bubble = convertTableToFlexBubble(table);
     if (!bubble || !fitsLineFlexBubble(bubble)) {
       plainTextInsertions.push({
         position: table.placeholderOffset,


### PR DESCRIPTION
LINE rendered accepted plain 11/12-row table cells during admission, then rendered them again while building the card. The production path already receives canonical parsed cells, but a private raw-table type, conversion object and fallback parser still supported a test-only input path.

This moves admission into the private builder and carries each rendered cell into the existing layout. It removes the raw-table adapter/private barrel exports and the now-redundant generic-row slice: any table reaching the generic branch already has at most ten rows. Two-column plain receipts still allow twelve rows; larger or styled overflow tables still fall back to complete bullet text. Cheap row rejection and stopping at the first markup cell remain intact. Public plugin/SDK exports and code-card conversion are unchanged.

The empty-cell assertion now exercises literal Markdown through `processLineMessage`, preserving both dash placeholders without retaining a private helper seam. The net change is −9 production lines and −3 test lines. Exact spans, own `contents: undefined` fields, UTF-8 bubble-size limits, fallback text, shared Flex-message references and source-ordered delivery remain covered.

Validation: 99 passing tests across the formatter/canonical table IR, auto-reply, real SDK/HTTP loopback, and mapped doctor-contract suites; all 25 scoped changed checks; normal `pnpm build`; and a fresh Codex P2 review with no findings. Build warnings from Playwright/web-tree-sitter direct eval and media-core browser externalization were nonfatal, unrelated to this diff, and retained.

The fixed B0/C0/C1/B1 benchmark made 1,792 timed calls through the actual formatter and actual reply-token, push-auto-reply and outbound-adapter paths. Physical sends used bounded synthetic captures and deterministic receipts; the real formatter, chunker and delivery assembly ran. The data-only reducer verified full cross-variant DTO/input parity over 5,608 events and 465 V8 graph members. An independent saved-data audit verified all returned/input graphs, event associations, comparisons, closure and candidate restoration.

**Performance is mixed, not a blanket speedup.** The plain two-column 11/12-row delivery cases improved in both orders, but direct plain-12 formatter medians were 2.66%/0.98% slower. Empty-cell direct/reply cases and several fallback controls were adverse. All 220 adverse summary metrics, 34/112 adverse steady medians, 288/896 adverse indexed calls and 2/10 adverse resource comparisons are retained. Unchanged plain-text controls also improved substantially, so their gains cannot be attributed to this table cleanup.

<details>
<summary>All steady median comparisons (positive reduction means faster)</summary>

| Context | Forward B→C, µs | Reduction | Reverse B→C, µs | Reduction |
|---|---:|---:|---:|---:|
| formatter/plain-2col-0rows | 92.688→82.916 | 10.54% | 88.459→107.292 | -21.29% |
| formatter/plain-2col-1rows | 70.603→80.687 | -14.28% | 71.501→80.604 | -12.73% |
| formatter/plain-2col-10rows | 196.604→169.792 | 13.64% | 172.563→160.020 | 7.27% |
| formatter/plain-2col-11rows | 236.292→194.833 | 17.55% | 186.980→172.147 | 7.93% |
| formatter/plain-2col-12rows | 229.625→235.729 | -2.66% | 212.792→214.875 | -0.98% |
| formatter/plain-2col-13rows | 299.541→289.354 | 3.40% | 340.938→350.250 | -2.73% |
| formatter/plain-3col-0rows | 30.355→27.604 | 9.06% | 33.792→27.104 | 19.79% |
| formatter/plain-3col-10rows | 172.395→179.042 | -3.86% | 178.333→150.104 | 15.83% |
| formatter/plain-3col-11rows | 279.541→268.666 | 3.89% | 268.521→262.000 | 2.43% |
| formatter/plain-3col-12rows | 294.812→240.020 | 18.59% | 242.937→261.062 | -7.46% |
| formatter/plain-3col-13rows | 257.375→255.729 | 0.64% | 232.562→217.167 | 6.62% |
| formatter/markup-11-header-first | 238.146→273.584 | -14.88% | 238.938→227.583 | 4.75% |
| formatter/markup-11-body-first | 218.292→250.688 | -14.84% | 199.938→200.292 | -0.18% |
| formatter/markup-11-body-last | 199.688→172.021 | 13.85% | 220.896→202.396 | 8.37% |
| formatter/markup-12-header-first | 149.020→148.458 | 0.38% | 180.188→156.729 | 13.02% |
| formatter/markup-12-body-first | 157.333→169.062 | -7.46% | 177.083→148.625 | 16.07% |
| formatter/markup-12-body-last | 168.688→167.500 | 0.70% | 183.667→167.042 | 9.05% |
| formatter/styled-10 | 227.355→189.188 | 16.79% | 194.270→234.333 | -20.62% |
| formatter/empty-cells-2 | 34.084→41.895 | -22.92% | 35.166→36.146 | -2.79% |
| formatter/empty-cells-3 | 35.458→33.104 | 6.64% | 35.229→35.000 | 0.65% |
| formatter/ragged-body | 42.104→48.542 | -15.29% | 35.916→34.937 | 2.73% |
| formatter/equal-label-link-11 | 179.270→166.937 | 6.88% | 184.812→146.625 | 20.66% |
| formatter/inline-code-11 | 181.792→137.625 | 24.30% | 152.333→124.875 | 18.02% |
| formatter/unicode-12 | 148.688→126.520 | 14.91% | 151.104→124.812 | 17.40% |
| formatter/valid-large-cell | 174.229→194.771 | -11.79% | 193.271→190.458 | 1.46% |
| formatter/oversized-cell | 475.228→438.562 | 7.72% | 467.458→415.896 | 11.03% |
| formatter/oversized-unicode | 279.938→289.812 | -3.53% | 295.271→295.333 | -0.02% |
| formatter/escaped-pipe | 26.354→28.605 | -8.54% | 28.417→25.625 | 9.83% |
| formatter/prose | 36.020→29.959 | 16.83% | 34.209→34.291 | -0.24% |
| formatter/code | 27.166→30.062 | -10.66% | 38.396→26.646 | 30.60% |
| formatter/mixed-order | 455.209→434.562 | 4.54% | 422.708→415.541 | 1.70% |
| formatter/plain-no-markdown | 16.834→11.479 | 31.81% | 13.854→9.041 | 34.73% |
| reply/plain-2col-11rows | 158.167→141.875 | 10.30% | 157.000→139.687 | 11.03% |
| reply/plain-2col-12rows | 127.666→105.625 | 17.26% | 143.167→113.770 | 20.53% |
| reply/plain-2col-13rows | 164.770→165.833 | -0.65% | 178.271→182.167 | -2.19% |
| reply/plain-3col-11rows | 193.917→199.375 | -2.81% | 215.562→198.334 | 7.99% |
| reply/markup-11-body-first | 152.000→149.708 | 1.51% | 149.312→138.854 | 7.00% |
| reply/empty-cells-2 | 42.354→52.770 | -24.59% | 29.541→32.542 | -10.16% |
| reply/oversized-cell | 1136.667→1080.500 | 4.94% | 1142.417→1155.458 | -1.14% |
| reply/mixed-order | 292.312→285.771 | 2.24% | 284.812→267.021 | 6.25% |
| push/plain-2col-11rows | 104.146→100.625 | 3.38% | 124.292→85.563 | 31.16% |
| push/plain-2col-12rows | 109.812→90.375 | 17.70% | 108.125→104.291 | 3.55% |
| push/plain-2col-13rows | 142.125→169.729 | -19.42% | 146.458→141.208 | 3.58% |
| push/plain-3col-11rows | 164.354→162.833 | 0.93% | 173.271→168.458 | 2.78% |
| push/markup-11-body-first | 141.145→134.792 | 4.50% | 129.396→125.438 | 3.06% |
| push/empty-cells-2 | 25.291→24.146 | 4.53% | 23.500→22.729 | 3.28% |
| push/oversized-cell | 1136.167→1271.833 | -11.94% | 1071.562→1143.438 | -6.71% |
| push/mixed-order | 301.146→272.646 | 9.46% | 287.916→242.000 | 15.95% |
| outbound/plain-2col-11rows | 164.938→103.645 | 37.16% | 112.770→98.396 | 12.75% |
| outbound/plain-2col-12rows | 193.417→86.896 | 55.07% | 111.291→86.459 | 22.31% |
| outbound/plain-2col-13rows | 280.166→137.563 | 50.90% | 139.188→143.292 | -2.95% |
| outbound/plain-3col-11rows | 290.791→162.792 | 44.02% | 157.792→157.458 | 0.21% |
| outbound/markup-11-body-first | 236.562→135.625 | 42.67% | 129.896→135.521 | -4.33% |
| outbound/empty-cells-2 | 42.730→27.875 | 34.76% | 24.875→22.896 | 7.96% |
| outbound/oversized-cell | 989.605→1020.666 | -3.14% | 1046.333→988.958 | 5.48% |
| outbound/mixed-order | 370.812→236.667 | 36.18% | 273.438→243.396 | 10.99% |

</details>

Measurement limits: each context retains one first call, one warmup and six single-call steady samples. The clock covers the actual synchronous formatter or awaited delivery caller plus declared synthetic-send bookkeeping. Argument/receipt setup, snapshotting, assertions and serialization are outside it; 256 receipt-builder setup calls and four runtime injections are accounted for separately. No samples, adverse cases or acquired runs were repeated or discarded. Six samples per case do not establish statistical significance or tail latency, and these are not real LINE network or Gateway latency measurements.

Snapshots retain full UTF-16 strings, plain-object/array structure, local reference IDs, property descriptors and own undefined fields. Auto-reply input checking projects the actual data fields while explicitly excluding injected callbacks; it does not preserve the top-level wrapper descriptors. Separate snapshot roots do not establish input/output aliases or stability of original returned objects across later calls. Unsupported classes, proxies, accessors, symbols, functions, bigints and nonfinite values reject capture instead of being normalized into a passing result.

Whole-child wall times were 20.391/18.838/16.056/16.983 seconds and include Vitest/import/transform/capture overhead; they are not application-latency claims. Reverse-order candidate tree RSS increased 6.40% and kernel peak RSS increased 1.30%. No per-object allocation or universal memory-saving claim is made.

For disk headroom, only eight completed phase-private compile/Vitest cache leaves were retired, after positive native/outer closure and no-consumer/no-byte-pin checks. This cleanup was outside measured calls; raw graphs, journals, stdio, dependencies, store, HOME/state and normal build output were preserved. One original self-observing process preflight and its false-admission host refusal occurred before any source placement or numeric child; both zero-target events are retained. The corrected preflight ran outside the target checkout, without excluding unknown consumers. All four actual phases ran once with unchanged source/corpus/clock/caps, and the normal candidate was restored afterward.

Local measurements and checks used base `b138ae4f`; all three touched files are unchanged on inspected main `987cc698`. Exact-head CI will validate integration before landing.
