### PR TITLE
feat(ui): add selected text to the main chat composer

### DIFF
--- a/ui/src/e2e/chat-selection-to-main.e2e.test.ts
+++ b/ui/src/e2e/chat-selection-to-main.e2e.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI selected text destinations" });
+const selectedText = "Review the deployment checklist.";
+const quote = `Regarding "${selectedText}": `;
+
+suite.define(() => {
+  it.each([
+    { width: 1440, height: 900 },
+    { width: 390, height: 844 },
+  ])("adds a quote without sending or replacing the draft at $width px", async (viewport) => {
+    await suite.withPage(
+      { viewport, locale: "en-US", reducedMotion: "reduce", serviceWorkers: "block" },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: [{ role: "assistant", content: selectedText }],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        const text = page.locator(".chat-bubble .chat-text p").filter({ hasText: selectedText });
+        const popup = page.getByRole("toolbar", { name: "Selection actions" });
+        const select = async () => {
+          await text.evaluate((element) => {
+            const range = document.createRange();
+            range.selectNodeContents(element);
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+          });
+          await text.dispatchEvent("pointerup", { button: 0, pointerType: "mouse" });
+          await popup.waitFor({ state: "visible" });
+        };
+
+        for (const draft of ["", "Please explain the next step."]) {
+          await composer.fill(draft);
+          await select();
+          expect(await popup.getByRole("button").allTextContents()).toEqual([
+            "Add to chat",
+            "Ask in side chat",
+          ]);
+          const bounds = await popup.boundingBox();
+          expect(bounds).not.toBeNull();
+          expect(bounds!.x).toBeGreaterThanOrEqual(0);
+          expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(viewport.width);
+          await popup.getByRole("button", { name: "Add to chat", exact: true }).click();
+          await expect
+            .poll(() => composer.inputValue())
+            .toBe(draft ? `${draft}\n\n${quote}` : quote);
+          expect(await composer.evaluate((element) => element === document.activeElement)).toBe(
+            true,
+          );
+          expect(await popup.count()).toBe(0);
+          expect(await page.locator(".chat-session-rail__input").count()).toBe(0);
+          expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+        }
+
+        const mainDraft = await composer.inputValue();
+        await select();
+        await page.keyboard.press("Escape");
+        expect(await popup.count()).toBe(0);
+        await select();
+        await popup.getByRole("button", { name: "Ask in side chat", exact: true }).click();
+        const sideComposer = page.locator(".chat-session-rail__input");
+        await sideComposer.waitFor({ state: "visible" });
+        expect(await sideComposer.inputValue()).toBe(quote);
+        expect(await composer.inputValue()).toBe(mainDraft);
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5324,6 +5324,7 @@ export const en: TranslationMap & {
       actions: "Message actions",
       selectionActions: "Selection actions",
       askInSideChat: "Ask in side chat",
+      addToChat: "Add to chat",
       rewind: "Rewind",
       rewindConfirm: "Rewind to before this message?",
       dontAskAgain: "Don't ask again",

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -65,6 +65,7 @@ export type ChatProps = Omit<
   | "onRetryQueuedMessage"
   | "onDiscardQueuedMessage"
   | "onFocusComposer"
+  | "onAddToChat"
   | "onOpenSession"
   | "onSend"
 > &
@@ -204,6 +205,14 @@ export function renderChat(props: ChatProps) {
         onDiscardQueuedMessage: props.onQueueRemove,
         onCompanionPrefill:
           props.canSend && !props.suggestionComposer ? props.onCompanionPrefill : undefined,
+        onAddToChat:
+          props.canSend && !props.suggestionComposer
+            ? (question) => {
+                const draft = props.getDraft?.() ?? props.draft;
+                props.onDraftChange(draft ? `${draft}\n\n${question}` : question);
+                requestUpdate();
+              }
+            : undefined,
         onOpenSession: props.onSessionSelect,
         onFocusComposer: () =>
           chatSection

--- a/ui/src/pages/chat/components/chat-selection-popup.test.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.test.ts
@@ -39,12 +39,14 @@ function selectRange(node: Text, start: number, end: number) {
 
 function pointerUp(thread: HTMLElement) {
   handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
+    onAddToChat: onAddToChatSpy,
     onAskSideChat: onAskSideChatSpy,
   });
   vi.runAllTimers();
 }
 
 const onAskSideChatSpy = vi.fn();
+const onAddToChatSpy = vi.fn();
 
 describe("chat selection popup", () => {
   afterEach(() => {
@@ -52,10 +54,11 @@ describe("chat selection popup", () => {
     window.getSelection()?.removeAllRanges();
     document.body.innerHTML = "";
     onAskSideChatSpy.mockReset();
+    onAddToChatSpy.mockReset();
     vi.useRealTimers();
   });
 
-  it("shows one text-only side-chat action over bubble selections", () => {
+  it.each([0, 1])("routes selection action %i to its own composer", (actionIndex) => {
     vi.useFakeTimers();
     const { thread, textNode } = buildThreadWithBubble("Let's Encrypt cert is valid");
     selectRange(textNode, 0, 18);
@@ -65,11 +68,18 @@ describe("chat selection popup", () => {
     expect(popup).not.toBeNull();
     expect(popup?.getAttribute("aria-label")).toBe("Selection actions");
     const buttons = [...(popup?.querySelectorAll("button") ?? [])];
-    expect(buttons.map((button) => button.textContent)).toEqual(["Ask in side chat"]);
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "Add to chat",
+      "Ask in side chat",
+    ]);
     expect(buttons[0]?.querySelector("svg")).toBeNull();
 
-    buttons[0]?.click();
-    expect(onAskSideChatSpy).toHaveBeenCalledWith("Let's Encrypt cert");
+    buttons[actionIndex]?.click();
+    const [called, untouched] =
+      actionIndex === 0 ? [onAddToChatSpy, onAskSideChatSpy] : [onAskSideChatSpy, onAddToChatSpy];
+    expect(called).toHaveBeenCalledWith("Let's Encrypt cert");
+    expect(untouched).not.toHaveBeenCalled();
+    expect(window.getSelection()?.isCollapsed).toBe(true);
     expect(document.body.querySelector(".chat-selection-popup")).toBeNull();
   });
 
@@ -93,6 +103,7 @@ describe("chat selection popup", () => {
     const { thread, textNode } = buildThreadWithBubble("tear down before the selection settles");
     selectRange(textNode, 0, 9);
     handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
+      onAddToChat: onAddToChatSpy,
       onAskSideChat: onAskSideChatSpy,
     });
 

--- a/ui/src/pages/chat/components/chat-selection-popup.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.ts
@@ -1,10 +1,10 @@
-// Floating toolbar over selected chat text: "Ask in side chat" pre-fills the
-// session rail.
+// Floating toolbar over selected chat text, targeting the main or side chat.
 // Mirrors the imperative reply-context-menu pattern in chat-thread.ts.
 
 import { t } from "../../../i18n/index.ts";
 
 type ChatSelectionPopupActions = {
+  onAddToChat?: (selection: string) => void;
   onAskSideChat: (selection: string) => void;
 };
 
@@ -71,6 +71,12 @@ function showChatSelectionPopup(
     window.getSelection()?.removeAllRanges();
     action(selectionText);
   };
+  if (actions.onAddToChat) {
+    const onAddToChat = actions.onAddToChat;
+    popup.append(
+      createSelectionPopupButton(t("chat.messages.addToChat"), () => activate(onAddToChat)),
+    );
+  }
   popup.append(
     createSelectionPopupButton(t("chat.messages.askInSideChat"), () =>
       activate(actions.onAskSideChat),

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -153,6 +153,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   onRewindMessage?: (entryId: string) => Promise<boolean> | boolean;
   onForkMessage?: (entryId: string) => Promise<void> | void;
   onFocusComposer?: () => void;
+  onAddToChat?: (question: string) => void;
   onCompanionPrefill?: (question: string) => void;
   onOpenSession?: (sessionKey: string) => void;
   modelSetupRequired?: boolean;
@@ -169,6 +170,7 @@ type TranscriptInteractionProps = Pick<
   | "onRewindMessage"
   | "onForkMessage"
   | "onFocusComposer"
+  | "onAddToChat"
   | "onCompanionPrefill"
 >;
 
@@ -418,6 +420,15 @@ export function handleTranscriptPointerUp(event: PointerEvent, props: Transcript
     return;
   }
   handleChatSelectionPointerUp(event, {
+    onAddToChat: props.onAddToChat
+      ? (selection) => {
+          const question = buildCompanionQuestionPrefill(selection);
+          if (question) {
+            props.onAddToChat?.(question);
+            props.onFocusComposer?.();
+          }
+        }
+      : undefined,
     onAskSideChat: (selection) => {
       const question = buildCompanionQuestionPrefill(selection);
       if (question) {


### PR DESCRIPTION
## What Problem This Solves

Selecting text in the Control UI offers only “Ask in side chat.” Users who want to discuss the selection in their main conversation must copy it and build the quote themselves.

## Why This Change Was Made

Add “Add to chat” before the existing side-chat action. Both actions reuse the existing normalized, 300-character quote format; the new action appends to the live main draft, refreshes the composer, and focuses it. It neither sends a message nor opens side chat. Read-only and suggestion composers retain their existing gates.

## User Impact

Users can quote highlighted message text directly into the main conversation without losing their draft. “Ask in side chat” continues to target its separate composer.

## Evidence

- 8 focused popup/quote tests passed.
- 2 real Control UI browser regression tests passed at 1440×900 and 390×844: empty/existing drafts, exact quote text, composer focus, no send, no unintended side pane, Escape dismissal, toolbar bounds, and unchanged side-chat behavior.
- `node scripts/check-changed.mjs` passed, including formatting, i18n verification, typechecks, lint, dead exports, and repository guards. `git diff --check` passed.
- Independent source review found no actionable P0–P2 defects. The CLI autoreview was attempted again before publication but failed with `codex engine failed (1)` and produced no verdict; it is not claimed as passing.
- An independent subagent reviewed both final recordings throughout their durations and verified the visible behavior. Recordings use actual browser mouse-drag selection, the real bundled Control UI, synthetic history, and an isolated mock Gateway. Native touch handles, on-screen keyboards, and production Gateway behavior were not tested.

Before → after toolbar → main draft:

![Before and after adding selected text to the main composer](https://github.com/user-attachments/assets/36c555af-0cc1-4c8b-83ca-6c057b428f24)

Desktop interaction:

https://github.com/user-attachments/assets/2eb3f836-9c8b-4ad6-92d2-1eb1c7333bae

Mobile-width interaction:

https://github.com/user-attachments/assets/a99e6429-1c11-499c-8237-1a3cfa8a35ff
