### PR TITLE
refactor(qa): remove redundant Matrix scenario forwarder

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -427,22 +427,6 @@ export async function runConfigurableTopLevelScenario(params: {
   };
 }
 
-async function runTopLevelMentionScenario(params: {
-  accessToken: string;
-  actorId: MatrixQaActorId;
-  baseUrl: string;
-  observedEvents: MatrixQaObservedEvent[];
-  roomId: string;
-  syncState: MatrixQaSyncState;
-  syncStreams?: MatrixQaSyncStreams;
-  sutUserId: string;
-  timeoutMs: number;
-  tokenPrefix: string;
-  withMention?: boolean;
-}) {
-  return await runConfigurableTopLevelScenario(params);
-}
-
 export async function runDriverTopLevelMentionScenario(params: {
   baseUrl: string;
   driverAccessToken: string;
@@ -454,7 +438,7 @@ export async function runDriverTopLevelMentionScenario(params: {
   timeoutMs: number;
   tokenPrefix: string;
 }) {
-  return await runTopLevelMentionScenario({
+  return await runConfigurableTopLevelScenario({
     accessToken: params.driverAccessToken,
     actorId: "driver",
     baseUrl: params.baseUrl,
@@ -539,7 +523,7 @@ export async function runTopologyScopedTopLevelScenario(params: {
   withMention?: boolean;
 }) {
   const roomId = resolveMatrixQaScenarioRoomId(params.context, params.roomKey);
-  const result = await runTopLevelMentionScenario({
+  const result = await runConfigurableTopLevelScenario({
     accessToken: params.accessToken,
     actorId: params.actorId,
     baseUrl: params.context.baseUrl,


### PR DESCRIPTION
Closes #142539

## What Problem This Solves

Matrix QA scenarios carry a private forwarding layer with a duplicated parameter declaration and no policy or adaptation. Its mention-specific name also obscures that unmentioned scenarios use the same existing configurable owner.

## Why This Change Was Made

Delete the forwarder and call the existing owner directly from both callers. Their argument objects, await forms, exported helpers, scenarios, bindings, filters and result shapes remain unchanged.

## User Impact

No scenario or user-visible behavior changes. The complete one-file retirement removes 15 production code lines and 16 physical lines, with no test, helper, import or metadata changes.

## Evidence

- 27 unchanged Matrix shared, scenario-binding and CLI-runtime tests pass before and after. The full 24-step changed gate passed, including six additional Doctor contract tests.
- Whole-file source proof verifies the exact private forwarder deletion and two callee substitutions, unchanged caller objects, real owner body and export declarations.
- Fresh independent P0–P2 review: scoped-clean, no findings. Committed bytes match the complete tested/reviewed patch.
- Existing tests cover no-reply/preview behavior, scenario bindings and CLI construction/cleanup; they are not a new live Matrix top-level reply proof. The remaining forwarding equivalence is supported by the exact source check.
