### PR TITLE
fix(ui): size skill readers to content and compact headers

### DIFF
--- a/ui/src/e2e/chat-skill-library.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-library.e2e.test.ts
@@ -230,7 +230,7 @@ suite.define(() => {
       expect(await page.getByLabel("SKILL.md", { exact: true }).inputValue()).toBe(alice.content);
       expect(await page.getByRole("button", { name: "Save skill", exact: true }).count()).toBe(0);
       expect(await page.getByLabel("Retained revision", { exact: true }).count()).toBe(0);
-      const panel = page.locator(".md-preview-dialog__panel");
+      const panel = page.locator(".skill-reader-dialog");
       expect(await panel.evaluate((node) => node.scrollWidth <= node.clientWidth + 1)).toBe(true);
       expect(await gateway.getRequests("skills.library.activate")).toHaveLength(0);
       await page.getByRole("button", { name: "Close", exact: true }).click();

--- a/ui/src/e2e/skills-library.e2e.test.ts
+++ b/ui/src/e2e/skills-library.e2e.test.ts
@@ -215,7 +215,7 @@ suite.define(() => {
       });
       await page.getByRole("alert").filter({ hasText: "Your draft is preserved" }).waitFor();
       expect(await page.getByLabel("SKILL.md", { exact: true }).inputValue()).toBe(draft);
-      const form = page.locator("form.md-preview-dialog__panel");
+      const form = page.locator("form.skill-reader-dialog");
       expect(await form.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(
         true,
       );
@@ -232,7 +232,7 @@ suite.define(() => {
       expect(await importer.getByRole("status").allTextContents()).toEqual([]);
       expect(
         await importer
-          .locator(".md-preview-dialog__body")
+          .locator(".skill-reader-dialog__body")
           .evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
       ).toBe(true);
       await importer.getByLabel("Skill name", { exact: true }).fill("abandoned-import");

--- a/ui/src/pages/skills/library-detail.ts
+++ b/ui/src/pages/skills/library-detail.ts
@@ -3,6 +3,7 @@ import type {
   SkillLibraryEntry,
   SkillsLibraryReadResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
+import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { libraryEventControl } from "./library-events.ts";
 import { libraryFileText } from "./library-files.ts";
@@ -39,11 +40,16 @@ export function renderLibraryPinRead(props: {
     style="--openclaw-modal-width: 960px;"
     @modal-cancel=${props.onClose}
   >
-    <div class="md-preview-dialog__panel">
+    <div class="md-preview-dialog__panel skill-reader-dialog">
       <div class="md-preview-dialog__header">
-        <strong>${read.entry.slug}</strong
-        ><button type="button" class="btn btn--sm" @click=${props.onClose}>
-          ${t("common.close")}
+        <strong class="md-preview-dialog__title">${read.entry.slug}</strong
+        ><button
+          type="button"
+          class="btn btn--sm md-preview-icon-btn"
+          aria-label=${t("common.close")}
+          @click=${props.onClose}
+        >
+          <span aria-hidden="true">${icons.x}</span>
         </button>
       </div>
       <div

--- a/ui/src/pages/skills/library-detail.ts
+++ b/ui/src/pages/skills/library-detail.ts
@@ -40,20 +40,20 @@ export function renderLibraryPinRead(props: {
     style="--openclaw-modal-width: 960px;"
     @modal-cancel=${props.onClose}
   >
-    <div class="md-preview-dialog__panel skill-reader-dialog">
-      <div class="md-preview-dialog__header">
-        <strong class="md-preview-dialog__title">${read.entry.slug}</strong
+    <div class="exec-approval-card skill-reader-dialog">
+      <div class="exec-approval-header">
+        <strong class="exec-approval-title">${read.entry.slug}</strong
         ><button
           type="button"
-          class="btn btn--sm md-preview-icon-btn"
+          class="btn btn--icon btn--ghost"
           aria-label=${t("common.close")}
           @click=${props.onClose}
         >
-          <span aria-hidden="true">${icons.x}</span>
+          ${icons.x}
         </button>
       </div>
       <div
-        class="md-preview-dialog__body"
+        class="skill-reader-dialog__body"
         style="display: grid; gap: var(--space-4); min-width: 0;"
       >
         <p>

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -2,13 +2,14 @@ import { html, nothing } from "lit";
 import { live } from "lit/directives/live.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { SkillsLibraryMutateParams } from "../../../../packages/gateway-protocol/src/index.ts";
+import { icons } from "../../components/icons.ts";
+import "../../components/modal-dialog.ts";
 import {
   renderSettingsEmpty,
   renderSettingsSection,
   renderSettingsSegmented,
   renderSettingsStatus,
 } from "../../components/settings-ui.ts";
-import "../../components/modal-dialog.ts";
 import { t } from "../../i18n/index.ts";
 import type { SkillLibraryController, LibraryView } from "./library-controller.ts";
 import { renderLibraryIdentity } from "./library-detail.ts";
@@ -228,7 +229,7 @@ function renderLibraryEditor(library: SkillLibraryController) {
     }}
   >
     <form
-      class="md-preview-dialog__panel"
+      class="md-preview-dialog__panel skill-reader-dialog"
       @submit=${(event: SubmitEvent) => {
         event.preventDefault();
         void library.save();
@@ -241,14 +242,16 @@ function renderLibraryEditor(library: SkillLibraryController) {
       }}
     >
       <div class="md-preview-dialog__header">
-        <strong>${draft.entry?.slug ?? t("skillLibrary.create")}</strong
+        <strong class="md-preview-dialog__title"
+          >${draft.entry?.slug ?? t("skillLibrary.create")}</strong
         ><button
           type="button"
-          class="btn btn--sm"
+          class="btn btn--sm md-preview-icon-btn"
+          aria-label=${t("common.close")}
           ?disabled=${library.busy}
           @click=${() => library.close()}
         >
-          ${t("common.close")}
+          <span aria-hidden="true">${icons.x}</span>
         </button>
       </div>
       <div
@@ -542,7 +545,7 @@ function renderLibraryImport(library: SkillLibraryController) {
     }}
   >
     <form
-      class="md-preview-dialog__panel"
+      class="md-preview-dialog__panel skill-reader-dialog"
       @submit=${(event: SubmitEvent) => {
         event.preventDefault();
         if (library.importSource) {
@@ -557,9 +560,15 @@ function renderLibraryImport(library: SkillLibraryController) {
       }}
     >
       <div class="md-preview-dialog__header">
-        <strong>${t("skillLibrary.import")}</strong
-        ><button type="button" class="btn btn--sm" ?disabled=${library.busy} @click=${close}>
-          ${t("common.close")}
+        <strong class="md-preview-dialog__title">${t("skillLibrary.import")}</strong
+        ><button
+          type="button"
+          class="btn btn--sm md-preview-icon-btn"
+          aria-label=${t("common.close")}
+          ?disabled=${library.busy}
+          @click=${close}
+        >
+          <span aria-hidden="true">${icons.x}</span>
         </button>
       </div>
       <div

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -229,7 +229,7 @@ function renderLibraryEditor(library: SkillLibraryController) {
     }}
   >
     <form
-      class="md-preview-dialog__panel skill-reader-dialog"
+      class="exec-approval-card skill-reader-dialog"
       @submit=${(event: SubmitEvent) => {
         event.preventDefault();
         void library.save();
@@ -241,21 +241,20 @@ function renderLibraryEditor(library: SkillLibraryController) {
         }
       }}
     >
-      <div class="md-preview-dialog__header">
-        <strong class="md-preview-dialog__title"
-          >${draft.entry?.slug ?? t("skillLibrary.create")}</strong
+      <div class="exec-approval-header">
+        <strong class="exec-approval-title">${draft.entry?.slug ?? t("skillLibrary.create")}</strong
         ><button
           type="button"
-          class="btn btn--sm md-preview-icon-btn"
+          class="btn btn--icon btn--ghost"
           aria-label=${t("common.close")}
           ?disabled=${library.busy}
           @click=${() => library.close()}
         >
-          <span aria-hidden="true">${icons.x}</span>
+          ${icons.x}
         </button>
       </div>
       <div
-        class="md-preview-dialog__body"
+        class="skill-reader-dialog__body"
         style="display: grid; gap: var(--space-4); min-width: 0;"
       >
         <p class="muted">
@@ -545,7 +544,7 @@ function renderLibraryImport(library: SkillLibraryController) {
     }}
   >
     <form
-      class="md-preview-dialog__panel skill-reader-dialog"
+      class="exec-approval-card skill-reader-dialog"
       @submit=${(event: SubmitEvent) => {
         event.preventDefault();
         if (library.importSource) {
@@ -559,20 +558,20 @@ function renderLibraryImport(library: SkillLibraryController) {
         }
       }}
     >
-      <div class="md-preview-dialog__header">
-        <strong class="md-preview-dialog__title">${t("skillLibrary.import")}</strong
+      <div class="exec-approval-header">
+        <strong class="exec-approval-title">${t("skillLibrary.import")}</strong
         ><button
           type="button"
-          class="btn btn--sm md-preview-icon-btn"
+          class="btn btn--icon btn--ghost"
           aria-label=${t("common.close")}
           ?disabled=${library.busy}
           @click=${close}
         >
-          <span aria-hidden="true">${icons.x}</span>
+          ${icons.x}
         </button>
       </div>
       <div
-        class="md-preview-dialog__body"
+        class="skill-reader-dialog__body"
         style="display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-4);"
       >
         <p class="muted">

--- a/ui/src/pages/skills/reader-shell.browser.test.ts
+++ b/ui/src/pages/skills/reader-shell.browser.test.ts
@@ -48,7 +48,7 @@ describe.runIf(browserMode)("skill reader shell", () => {
         image: style.backgroundImage,
         border: style.border,
         radius: style.borderRadius,
-        button: [button.background, button.border, button.boxShadow, button.width, button.height],
+        button: [button.background, button.border, button.boxShadow],
         icon: [icon.width, icon.height, icon.strokeWidth],
       };
     };

--- a/ui/src/pages/skills/reader-shell.browser.test.ts
+++ b/ui/src/pages/skills/reader-shell.browser.test.ts
@@ -2,7 +2,7 @@ import { nothing, render } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
 import "../../styles.css";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
-import { createProps } from "./view.test-support.ts";
+import { createProps, createSkill } from "./view.test-support.ts";
 import { renderSkills } from "./view.ts";
 
 const browserMode = "__vitest_browser__" in globalThis;
@@ -16,38 +16,63 @@ afterEach(() => {
 });
 
 describe.runIf(browserMode)("skill reader shell", () => {
-  it.each([390, 1440])(
-    "keeps a short error compact with Close beside its title at %i px",
-    async (width) => {
-      const { page, userEvent } = await import("vitest/browser");
-      await page.viewport(width, 844);
-      container = document.createElement("openclaw-skills-page");
-      document.body.append(container);
+  it.each(
+    [390, 1440].flatMap((width) => ["error", "installed"].map((variant) => ({ width, variant }))),
+  )("sizes $variant content within the viewport at $width px", async ({ width, variant }) => {
+    const { page, userEvent } = await import("vitest/browser");
+    await page.viewport(width, 844);
+    container = document.createElement("openclaw-skills-page");
+    document.body.append(container);
+    const showContent = (content: string) => {
       render(
         renderSkills(
-          createProps({
-            clawhubDetailRef: "example-skill",
-            clawhubDetailError: "The skill could not be loaded. Try again later.",
-          }),
+          createProps(
+            variant === "error"
+              ? { clawhubDetailRef: "example-skill", clawhubDetailError: content }
+              : {
+                  detailKey: "repo-skill",
+                  report: {
+                    workspaceDir: "/fixture/workspace",
+                    managedSkillsDir: "/fixture/skills",
+                    skills: [createSkill({ description: content, primaryEnv: undefined })],
+                  },
+                },
+          ),
         ),
-        container,
+        container!,
       );
-      const { modal, dialog } = await getRenderedModalDialog(container);
-      await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
-      const title = container.querySelector<HTMLElement>(".md-preview-dialog__title")!;
-      const close = container.querySelector<HTMLButtonElement>(
-        ".md-preview-dialog__header button",
-      )!;
-      const panel = container.querySelector<HTMLElement>(".md-preview-dialog__panel")!;
-      const titleRect = title.getBoundingClientRect();
-      const closeRect = close.getBoundingClientRect();
-      expect(closeRect.top).toBeLessThan(titleRect.bottom);
-      expect(closeRect.left).toBeGreaterThanOrEqual(titleRect.right);
-      expect(panel.getBoundingClientRect().height).toBeLessThan(window.innerHeight / 2);
-      expect(dialog.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
-      expect(modal.label).toBe("example-skill");
-      await userEvent.keyboard("{Escape}");
-      await expect.poll(() => dialog.open).toBe(false);
-    },
-  );
+    };
+    const shortContent = "Read the source and report actionable findings.";
+    showContent(shortContent);
+    const { modal, dialog } = await getRenderedModalDialog(container);
+    await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
+    const title = container.querySelector<HTMLElement>(".md-preview-dialog__title")!;
+    const close = container.querySelector<HTMLButtonElement>(".md-preview-dialog__header button")!;
+    const panel = container.querySelector<HTMLElement>(".md-preview-dialog__panel")!;
+    const titleRect = title.getBoundingClientRect();
+    const closeRect = close.getBoundingClientRect();
+    expect(closeRect.top).toBeLessThan(titleRect.bottom);
+    expect(closeRect.left).toBeGreaterThanOrEqual(titleRect.right);
+    expect(panel.getBoundingClientRect().height).toBeLessThan(window.innerHeight / 2);
+    expect(dialog.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
+    expect(modal.label).toBe(variant === "error" ? "example-skill" : "Repo Skill");
+
+    showContent(shortContent.repeat(200));
+    const body = panel.querySelector<HTMLElement>(".md-preview-dialog__body")!;
+    await expect.poll(() => body.scrollHeight > body.clientHeight).toBe(true);
+    expect(panel.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+    expect(panel.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
+    const headerTop = close.getBoundingClientRect().top;
+    body.scrollTop = body.scrollHeight;
+    expect(body.scrollTop).toBeGreaterThan(0);
+    expect(close.getBoundingClientRect().top).toBe(headerTop);
+
+    showContent(shortContent);
+    await expect
+      .poll(() => panel.getBoundingClientRect().height)
+      .toBeLessThan(window.innerHeight / 2);
+    expect(body.scrollHeight).toBe(body.clientHeight);
+    await userEvent.keyboard("{Escape}");
+    await expect.poll(() => dialog.open).toBe(false);
+  });
 });

--- a/ui/src/pages/skills/reader-shell.browser.test.ts
+++ b/ui/src/pages/skills/reader-shell.browser.test.ts
@@ -1,0 +1,53 @@
+import { nothing, render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import "../../styles.css";
+import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
+import { createProps } from "./view.test-support.ts";
+import { renderSkills } from "./view.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+let container: HTMLElement | undefined;
+
+afterEach(() => {
+  if (container) {
+    render(nothing, container);
+    container.remove();
+  }
+});
+
+describe.runIf(browserMode)("skill reader shell", () => {
+  it.each([390, 1440])(
+    "keeps a short error compact with Close beside its title at %i px",
+    async (width) => {
+      const { page, userEvent } = await import("vitest/browser");
+      await page.viewport(width, 844);
+      container = document.createElement("openclaw-skills-page");
+      document.body.append(container);
+      render(
+        renderSkills(
+          createProps({
+            clawhubDetailRef: "example-skill",
+            clawhubDetailError: "The skill could not be loaded. Try again later.",
+          }),
+        ),
+        container,
+      );
+      const { modal, dialog } = await getRenderedModalDialog(container);
+      await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
+      const title = container.querySelector<HTMLElement>(".md-preview-dialog__title")!;
+      const close = container.querySelector<HTMLButtonElement>(
+        ".md-preview-dialog__header button",
+      )!;
+      const panel = container.querySelector<HTMLElement>(".md-preview-dialog__panel")!;
+      const titleRect = title.getBoundingClientRect();
+      const closeRect = close.getBoundingClientRect();
+      expect(closeRect.top).toBeLessThan(titleRect.bottom);
+      expect(closeRect.left).toBeGreaterThanOrEqual(titleRect.right);
+      expect(panel.getBoundingClientRect().height).toBeLessThan(window.innerHeight / 2);
+      expect(dialog.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
+      expect(modal.label).toBe("example-skill");
+      await userEvent.keyboard("{Escape}");
+      await expect.poll(() => dialog.open).toBe(false);
+    },
+  );
+});

--- a/ui/src/pages/skills/reader-shell.browser.test.ts
+++ b/ui/src/pages/skills/reader-shell.browser.test.ts
@@ -2,6 +2,7 @@ import { nothing, render } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
 import "../../styles.css";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
+import { renderConnectMachineDialog } from "../new-session/connect-machine-dialog.ts";
 import { createProps, createSkill } from "./view.test-support.ts";
 import { renderSkills } from "./view.ts";
 
@@ -23,6 +24,37 @@ describe.runIf(browserMode)("skill reader shell", () => {
     await page.viewport(width, 844);
     container = document.createElement("openclaw-skills-page");
     document.body.append(container);
+    render(
+      renderConnectMachineDialog({
+        open: true,
+        loading: false,
+        error: null,
+        setup: null,
+        onRefresh: () => undefined,
+        onClose: () => undefined,
+        onManageDevices: () => undefined,
+      }),
+      container,
+    );
+    const canonical = await getRenderedModalDialog(container);
+    await Promise.all(canonical.dialog.getAnimations().map((animation) => animation.finished));
+    const readChrome = (panel: HTMLElement) => {
+      const style = getComputedStyle(panel);
+      const close = panel.querySelector<HTMLButtonElement>("button")!;
+      const button = getComputedStyle(close);
+      const icon = getComputedStyle(close.querySelector("svg")!);
+      return {
+        surface: style.backgroundColor,
+        image: style.backgroundImage,
+        border: style.border,
+        radius: style.borderRadius,
+        button: [button.background, button.border, button.boxShadow, button.width, button.height],
+        icon: [icon.width, icon.height, icon.strokeWidth],
+      };
+    };
+    const canonicalChrome = readChrome(
+      container.querySelector<HTMLElement>(".exec-approval-card")!,
+    );
     const showContent = (content: string) => {
       render(
         renderSkills(
@@ -46,9 +78,14 @@ describe.runIf(browserMode)("skill reader shell", () => {
     showContent(shortContent);
     const { modal, dialog } = await getRenderedModalDialog(container);
     await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
-    const title = container.querySelector<HTMLElement>(".md-preview-dialog__title")!;
-    const close = container.querySelector<HTMLButtonElement>(".md-preview-dialog__header button")!;
-    const panel = container.querySelector<HTMLElement>(".md-preview-dialog__panel")!;
+    const title = container.querySelector<HTMLElement>(
+      ".skill-reader-dialog > :first-child > :first-child",
+    )!;
+    const close = container.querySelector<HTMLButtonElement>(
+      ".skill-reader-dialog > :first-child button",
+    )!;
+    const panel = container.querySelector<HTMLElement>(".skill-reader-dialog")!;
+    expect(readChrome(panel)).toEqual(canonicalChrome);
     const titleRect = title.getBoundingClientRect();
     const closeRect = close.getBoundingClientRect();
     expect(closeRect.top).toBeLessThan(titleRect.bottom);
@@ -58,7 +95,7 @@ describe.runIf(browserMode)("skill reader shell", () => {
     expect(modal.label).toBe(variant === "error" ? "example-skill" : "Repo Skill");
 
     showContent(shortContent.repeat(200));
-    const body = panel.querySelector<HTMLElement>(".md-preview-dialog__body")!;
+    const body = panel.querySelector<HTMLElement>(".skill-reader-dialog__body")!;
     await expect.poll(() => body.scrollHeight > body.clientHeight).toBe(true);
     expect(panel.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
     expect(panel.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);

--- a/ui/src/pages/skills/view.clawhub.test.ts
+++ b/ui/src/pages/skills/view.clawhub.test.ts
@@ -58,7 +58,7 @@ describe("renderSkills ClawHub", () => {
     expect(dialog.open).toBe(true);
 
     const closeButton = container.querySelector<HTMLButtonElement>(
-      ".md-preview-dialog__header .btn",
+      ".skill-reader-dialog .exec-approval-header .btn",
     );
     expect(closeButton).toBeInstanceOf(HTMLButtonElement);
     closeButton!.click();
@@ -154,7 +154,7 @@ describe("renderSkills ClawHub", () => {
     expect(
       Array.from(container.querySelectorAll(".callout")).map((node) => normalizeText(node)),
     ).toEqual(["rate limited", "Installed github"]);
-    expect(normalizeText(container.querySelector(".md-preview-dialog__body")!)).toBe(
+    expect(normalizeText(container.querySelector(".skill-reader-dialog__body")!)).toBe(
       "GitHub integration for OpenClaw By OpenClaw (@openclaw) Latest: v1.2.3 Added search support Platforms: macos, linux Install GitHub",
     );
     expect(container.querySelector<HTMLImageElement>(".clawhub-skill-icon--detail")?.src).toBe(
@@ -163,7 +163,7 @@ describe("renderSkills ClawHub", () => {
     expect(container.querySelector(".clawhub-skill-icon--profile")).toBeNull();
 
     const detailInstallButton = container.querySelector<HTMLButtonElement>(
-      ".md-preview-dialog__body .btn.primary",
+      ".skill-reader-dialog__body .btn.primary",
     );
     expect(detailInstallButton).toBeInstanceOf(HTMLButtonElement);
     detailInstallButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/ui/src/pages/skills/view.clawhub.test.ts
+++ b/ui/src/pages/skills/view.clawhub.test.ts
@@ -378,28 +378,6 @@ describe("renderSkills ClawHub", () => {
     expect(onClawHubDetailOpen).toHaveBeenCalledWith("@alice/email");
   });
 
-  it("sizes the ClawHub detail dialog to a refusal message instead of a reader", async () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    dialogRestores.push(() => container.remove());
-
-    render(
-      renderSkills(
-        createProps({
-          clawhubDetailRef: "skills-sh:acme/tools/imap-smtp-email",
-          clawhubDetailError:
-            "ClawHub cannot return details for skills-sh:acme/tools/imap-smtp-email; external skill sources are install-only.",
-        }),
-      ),
-      container,
-    );
-    await Promise.resolve();
-
-    // Without this the panel keeps the tall reader height meant for skill documents, so a
-    // two-line refusal renders in a mostly empty dialog and reads as broken.
-    expect(container.querySelectorAll(".md-preview-dialog__panel--message-only")).toHaveLength(1);
-  });
-
   it("renders installed ClawHub verdicts and the local Skill Card tab", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -229,7 +229,7 @@ describe("renderSkills", () => {
     );
     await Promise.resolve();
 
-    const warning = container.querySelector(".md-preview-dialog__body .callout");
+    const warning = container.querySelector(".skill-reader-dialog__body .callout");
     expect(normalizeText(expectDefined(warning, "alternative binary requirement"))).toContain(
       "bin:any of (claude, codex, opencode)",
     );

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -533,13 +533,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onClawHubDetailClose}
     >
-      <div
-        class="md-preview-dialog__panel skill-reader-dialog ${
-          props.clawhubDetailError && !props.clawhubDetailLoading
-            ? "md-preview-dialog__panel--message-only"
-            : ""
-        }"
-      >
+      <div class="md-preview-dialog__panel skill-reader-dialog">
         <div class="md-preview-dialog__header">
           <div class="clawhub-skill-detail__identity">
             ${

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -533,8 +533,8 @@ function renderClawHubDetailDialog(props: SkillsProps) {
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onClawHubDetailClose}
     >
-      <div class="md-preview-dialog__panel skill-reader-dialog">
-        <div class="md-preview-dialog__header">
+      <div class="exec-approval-card skill-reader-dialog">
+        <div class="exec-approval-header">
           <div class="clawhub-skill-detail__identity">
             ${
               detailImageUrl
@@ -547,20 +547,20 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                   />`
                 : nothing
             }
-            <div class="md-preview-dialog__title">
+            <div class="exec-approval-title">
               ${detail?.skill?.displayName ?? props.clawhubDetailRef}
             </div>
           </div>
           <button
             type="button"
-            class="btn btn--sm md-preview-icon-btn"
+            class="btn btn--icon btn--ghost"
             aria-label=${t("skillsPage.close")}
             @click=${props.onClawHubDetailClose}
           >
-            <span aria-hidden="true">${icons.x}</span>
+            ${icons.x}
           </button>
         </div>
-        <div class="md-preview-dialog__body" style="display: grid; gap: var(--space-4);">
+        <div class="skill-reader-dialog__body" style="display: grid; gap: var(--space-4);">
           ${
             props.clawhubDetailLoading
               ? html`<div class="muted">${t("common.loading")}</div>`
@@ -694,26 +694,23 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onDetailClose}
     >
-      <div class="md-preview-dialog__panel skill-reader-dialog">
-        <div class="md-preview-dialog__header">
-          <div
-            class="md-preview-dialog__title"
-            style="display: flex; align-items: center; gap: 8px;"
-          >
+      <div class="exec-approval-card skill-reader-dialog">
+        <div class="exec-approval-header">
+          <div class="exec-approval-title" style="display: flex; align-items: center; gap: 8px;">
             <span class="statusDot ${skillStatusClass(skill)}"></span>
             ${skill.emoji ? html`<span style="font-size: 18px;">${skill.emoji}</span>` : nothing}
             <span>${skill.name}</span>
           </div>
           <button
             type="button"
-            class="btn btn--sm md-preview-icon-btn"
+            class="btn btn--icon btn--ghost"
             aria-label=${t("skillsPage.close")}
             @click=${props.onDetailClose}
           >
-            <span aria-hidden="true">${icons.x}</span>
+            ${icons.x}
           </button>
         </div>
-        <div class="md-preview-dialog__body" style="display: grid; gap: var(--space-4);">
+        <div class="skill-reader-dialog__body" style="display: grid; gap: var(--space-4);">
           <div>
             <div style="font-size: 14px; line-height: 1.5; color: var(--text);">
               ${skill.description}

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -534,7 +534,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
       @modal-cancel=${props.onClawHubDetailClose}
     >
       <div
-        class="md-preview-dialog__panel ${
+        class="md-preview-dialog__panel skill-reader-dialog ${
           props.clawhubDetailError && !props.clawhubDetailLoading
             ? "md-preview-dialog__panel--message-only"
             : ""
@@ -557,16 +557,24 @@ function renderClawHubDetailDialog(props: SkillsProps) {
               ${detail?.skill?.displayName ?? props.clawhubDetailRef}
             </div>
           </div>
-          <button class="btn btn--sm" @click=${props.onClawHubDetailClose}>
-            ${t("skillsPage.close")}
+          <button
+            type="button"
+            class="btn btn--sm md-preview-icon-btn"
+            aria-label=${t("skillsPage.close")}
+            @click=${props.onClawHubDetailClose}
+          >
+            <span aria-hidden="true">${icons.x}</span>
           </button>
         </div>
-        <div class="md-preview-dialog__body" style="display: grid; gap: 16px;">
+        <div class="md-preview-dialog__body" style="display: grid; gap: var(--space-4);">
           ${
             props.clawhubDetailLoading
               ? html`<div class="muted">${t("common.loading")}</div>`
               : props.clawhubDetailError
-                ? html`<div class="callout danger">${props.clawhubDetailError}</div>`
+                ? html`<div class="callout danger skill-reader-dialog__error" role="alert">
+                    <span aria-hidden="true">${icons.alertTriangle}</span>
+                    <span>${props.clawhubDetailError}</span>
+                  </div>`
                 : detail?.skill
                   ? html`
                       <div style="font-size: 14px; line-height: 1.5;">
@@ -692,7 +700,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onDetailClose}
     >
-      <div class="md-preview-dialog__panel">
+      <div class="md-preview-dialog__panel skill-reader-dialog">
         <div class="md-preview-dialog__header">
           <div
             class="md-preview-dialog__title"
@@ -702,11 +710,16 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             ${skill.emoji ? html`<span style="font-size: 18px;">${skill.emoji}</span>` : nothing}
             <span>${skill.name}</span>
           </div>
-          <button class="btn btn--sm" @click=${props.onDetailClose}>
-            ${t("skillsPage.close")}
+          <button
+            type="button"
+            class="btn btn--sm md-preview-icon-btn"
+            aria-label=${t("skillsPage.close")}
+            @click=${props.onDetailClose}
+          >
+            <span aria-hidden="true">${icons.x}</span>
           </button>
         </div>
-        <div class="md-preview-dialog__body" style="display: grid; gap: 16px;">
+        <div class="md-preview-dialog__body" style="display: grid; gap: var(--space-4);">
           <div>
             <div style="font-size: 14px; line-height: 1.5; color: var(--text);">
               ${skill.description}

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4551,8 +4551,20 @@ td.data-table-key-col {
 .skill-reader-dialog .exec-approval-header {
   flex-shrink: 0;
   gap: var(--space-3);
-  padding: var(--skill-reader-inset);
+  padding: var(--space-2) var(--skill-reader-inset);
   border-bottom: 1px solid var(--border);
+}
+
+.skill-reader-dialog .exec-approval-header > .btn--icon {
+  min-width: var(--space-7);
+  height: var(--space-7);
+  padding: 0;
+}
+
+.skill-reader-dialog .exec-approval-header .clawhub-skill-icon {
+  width: var(--space-7);
+  height: var(--space-7);
+  flex-basis: var(--space-7);
 }
 
 .skill-reader-dialog .exec-approval-header > :first-child {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4122,12 +4122,6 @@ td.data-table-key-col {
   overflow: hidden;
 }
 
-/* A refusal or empty-state message is a few lines; without this the reader height reserved for
-   long skill documents leaves the dialog looking broken rather than deliberate. */
-.md-preview-dialog__panel--message-only {
-  min-height: 0;
-}
-
 .md-preview-dialog__header {
   display: flex;
   align-items: flex-start;
@@ -4541,6 +4535,69 @@ td.data-table-key-col {
     width: 100%;
     padding: 20px 16px 22px;
   }
+}
+
+.md-preview-dialog__panel.skill-reader-dialog {
+  --skill-reader-inset: var(--space-5);
+
+  max-height: calc(100dvh - 2 * var(--space-6));
+}
+
+.skill-reader-dialog .md-preview-dialog__header {
+  flex-direction: row;
+  align-items: center;
+  flex-shrink: 0;
+  gap: var(--space-3);
+  padding: var(--skill-reader-inset);
+}
+
+.skill-reader-dialog .md-preview-dialog__header > :first-child {
+  min-width: 0;
+}
+
+.skill-reader-dialog .md-preview-icon-btn,
+.skill-reader-dialog .statusDot {
+  flex-shrink: 0;
+}
+
+.skill-reader-dialog .md-preview-dialog__body {
+  align-content: start;
+  padding: var(--skill-reader-inset);
+}
+
+.skill-reader-dialog .md-preview-dialog__body > p {
+  margin: 0;
+}
+
+.skill-reader-dialog__error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  overflow-wrap: anywhere;
+}
+
+.skill-reader-dialog__error > [aria-hidden] {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.skill-reader-dialog__error svg {
+  width: var(--space-5);
+  height: var(--space-5);
+}
+
+@media (max-width: 768px) {
+  .md-preview-dialog__panel.skill-reader-dialog {
+    --skill-reader-inset: var(--space-4);
+
+    min-height: 90dvh;
+    max-height: 90dvh;
+  }
+}
+
+/* Keep brief errors content-sized even inside the mobile Skills page. */
+.skill-reader-dialog.md-preview-dialog__panel--message-only {
+  min-height: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4537,36 +4537,44 @@ td.data-table-key-col {
   }
 }
 
-.md-preview-dialog__panel.skill-reader-dialog {
+/* Use the same card and ghost close control as Connect machine and confirmations. */
+.exec-approval-card.skill-reader-dialog {
   --skill-reader-inset: var(--space-5);
 
+  height: fit-content;
   min-height: 0;
-  max-height: calc(100dvh - 2 * var(--space-6));
+  max-height: var(--openclaw-modal-max-height, calc(100dvh - 2 * var(--space-6)));
+  padding: 0;
+  overflow: hidden;
 }
 
-.skill-reader-dialog .md-preview-dialog__header {
-  flex-direction: row;
-  align-items: center;
+.skill-reader-dialog .exec-approval-header {
   flex-shrink: 0;
   gap: var(--space-3);
   padding: var(--skill-reader-inset);
+  border-bottom: 1px solid var(--border);
 }
 
-.skill-reader-dialog .md-preview-dialog__header > :first-child {
+.skill-reader-dialog .exec-approval-header > :first-child {
   min-width: 0;
+  overflow-wrap: anywhere;
 }
 
-.skill-reader-dialog .md-preview-icon-btn,
+.skill-reader-dialog .btn--icon,
 .skill-reader-dialog .statusDot {
   flex-shrink: 0;
 }
 
-.skill-reader-dialog .md-preview-dialog__body {
+.skill-reader-dialog__body {
+  flex: 0 1 auto;
+  min-height: 0;
   align-content: start;
+  overflow: auto;
+  overscroll-behavior: contain;
   padding: var(--skill-reader-inset);
 }
 
-.skill-reader-dialog .md-preview-dialog__body > p {
+.skill-reader-dialog__body > p {
   margin: 0;
 }
 
@@ -4588,10 +4596,14 @@ td.data-table-key-col {
 }
 
 @media (max-width: 768px) {
-  .md-preview-dialog__panel.skill-reader-dialog {
+  .exec-approval-card.skill-reader-dialog {
     --skill-reader-inset: var(--space-4);
+  }
+}
 
-    max-height: 90dvh;
+@media (max-width: 640px) {
+  .exec-approval-card.skill-reader-dialog {
+    max-height: var(--openclaw-modal-max-height, 90dvh);
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4540,6 +4540,7 @@ td.data-table-key-col {
 .md-preview-dialog__panel.skill-reader-dialog {
   --skill-reader-inset: var(--space-5);
 
+  min-height: 0;
   max-height: calc(100dvh - 2 * var(--space-6));
 }
 
@@ -4590,14 +4591,8 @@ td.data-table-key-col {
   .md-preview-dialog__panel.skill-reader-dialog {
     --skill-reader-inset: var(--space-4);
 
-    min-height: 90dvh;
     max-height: 90dvh;
   }
-}
-
-/* Keep brief errors content-sized even inside the mobile Skills page. */
-.skill-reader-dialog.md-preview-dialog__panel--message-only {
-  min-height: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Quick fix, bigger pass later.

Closes #142510

Related: #142143 (general alignment pass by @roboclaw-bot), #124362 (broader modal consistency), #124365 (broader input/focus consistency).

## What Problem This Solves

Opening a skill reader on a phone puts Close on a full-width second header row. The reader also inherits a bright border, layered gradients, and raised controls that differ from the standard dialog appearance. The six skill-reader frames impose a tall minimum even on short content: an import form or ClawHub error leaves a large empty area. The pinned reader can extend below the viewport, and stretched grids spread metadata, fields, and actions apart.

## Why This Change Was Made

All six skill reader variants reuse the existing Connect machine dialog composition: `exec-approval-card`, `exec-approval-header`, and the `btn btn--icon btn--ghost` close button with `icons.x` from `ui/src/pages/new-session/connect-machine-dialog.ts:143-155`. This gives them the same neutral surface, border, corner radius, and ghost close control with an 18 px icon and 1.5 px stroke. The reader uses a compact 49 px header: 8 px vertical insets around a 32 px close control, with a 14 px title and the divider directly below. Optional ClawHub header images use the same 32 px size. Header/body spacing uses existing tokens. Every frame sizes to its content, using the native modal maximum-height variable and internal body scrolling only when needed. The header stays visible during scrolling, and short ClawHub failures use a compact inline alert. Styles are scoped to skill readers; native dismissal and library busy/discard guards are preserved.

## User Impact

Close stays beside the title at both phone and desktop widths. At 390 px, the example import modal shrinks from about 760 px to 464 px, the installed reader to 307 px, and the error to 152 px. At 1440 px, import shrinks from 684 px to 451 px. Longer editors retain a bounded scrolling body. All existing skill details, editor fields, import controls, and actions remain available.

## Evidence

Fresh dark-theme captures use the same production render functions, synthetic data, viewports, and application fonts before and after: Instrument Sans for UI text and JetBrains Mono for code. Captures load the real public font files and mirror the application dark-theme attributes. Actual rendered custom font glyphs were verified. Every image was opened and inspected for frame height, border, neutral background/backdrop, close control, and typography. The 12 resulting frames have no trailing space beyond the intended padding; only the full editor needs internal scrolling. Each image links to its full-size capture.

<table>
<tr><th>Surface</th><th>Before</th><th>After</th></tr>
<tr><td>Installed skill, 390 px</td><td><a href="https://github.com/user-attachments/assets/e93429d2-ff3d-4805-93fb-22dfa8febf07"><img src="https://github.com/user-attachments/assets/e93429d2-ff3d-4805-93fb-22dfa8febf07" alt="Installed skill, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/80418a85-d868-4464-8446-c62c34bd3af8"><img src="https://github.com/user-attachments/assets/80418a85-d868-4464-8446-c62c34bd3af8" alt="Installed skill, 390 px, after" width="420"></a></td></tr>
<tr><td>ClawHub detail, 390 px</td><td><a href="https://github.com/user-attachments/assets/ce289824-f61e-4385-a528-8c90f5b4c9b7"><img src="https://github.com/user-attachments/assets/ce289824-f61e-4385-a528-8c90f5b4c9b7" alt="ClawHub detail, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/c61ff92b-5e53-4a11-926c-385b008e16bb"><img src="https://github.com/user-attachments/assets/c61ff92b-5e53-4a11-926c-385b008e16bb" alt="ClawHub detail, 390 px, after" width="420"></a></td></tr>
<tr><td>ClawHub error, 390 px</td><td><a href="https://github.com/user-attachments/assets/ebd5417f-f7c0-4e32-ba68-05d8508c5a3c"><img src="https://github.com/user-attachments/assets/ebd5417f-f7c0-4e32-ba68-05d8508c5a3c" alt="ClawHub error, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/8f7e5bb0-9a32-43fa-b7aa-1c50be3d2138"><img src="https://github.com/user-attachments/assets/8f7e5bb0-9a32-43fa-b7aa-1c50be3d2138" alt="ClawHub error, 390 px, after" width="420"></a></td></tr>
<tr><td>Library editor, 390 px</td><td><a href="https://github.com/user-attachments/assets/24a3d58d-f312-4584-bd6f-aec82177f12e"><img src="https://github.com/user-attachments/assets/24a3d58d-f312-4584-bd6f-aec82177f12e" alt="Library editor, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/9d68f09e-343b-430f-bb10-8558e3e5b9ae"><img src="https://github.com/user-attachments/assets/9d68f09e-343b-430f-bb10-8558e3e5b9ae" alt="Library editor, 390 px, after" width="420"></a></td></tr>
<tr><td>Library import, 390 px</td><td><a href="https://github.com/user-attachments/assets/6d0bb6be-0337-42a8-9d30-41634860a5be"><img src="https://github.com/user-attachments/assets/6d0bb6be-0337-42a8-9d30-41634860a5be" alt="Library import, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/62050c29-7cc9-4cd8-b771-9d7f5d8dde08"><img src="https://github.com/user-attachments/assets/62050c29-7cc9-4cd8-b771-9d7f5d8dde08" alt="Library import, 390 px, after" width="420"></a></td></tr>
<tr><td>Session-pinned skill, 390 px</td><td><a href="https://github.com/user-attachments/assets/72769d9c-4a66-43a8-9a75-8e0020455fbe"><img src="https://github.com/user-attachments/assets/72769d9c-4a66-43a8-9a75-8e0020455fbe" alt="Session-pinned skill, 390 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/0621110a-b397-4cc1-b53f-681f1a7ffc25"><img src="https://github.com/user-attachments/assets/0621110a-b397-4cc1-b53f-681f1a7ffc25" alt="Session-pinned skill, 390 px, after" width="420"></a></td></tr>
<tr><td>Installed skill, 1440 px</td><td><a href="https://github.com/user-attachments/assets/b7489059-ef26-4ff1-b518-75d0bea683d7"><img src="https://github.com/user-attachments/assets/b7489059-ef26-4ff1-b518-75d0bea683d7" alt="Installed skill, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/15edd285-4f0f-4150-aa95-25f23c84a97e"><img src="https://github.com/user-attachments/assets/15edd285-4f0f-4150-aa95-25f23c84a97e" alt="Installed skill, 1440 px, after" width="420"></a></td></tr>
<tr><td>ClawHub detail, 1440 px</td><td><a href="https://github.com/user-attachments/assets/344df82c-809b-4caa-8e5a-d1db74b472e1"><img src="https://github.com/user-attachments/assets/344df82c-809b-4caa-8e5a-d1db74b472e1" alt="ClawHub detail, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/d9262da3-99a9-4387-9d0a-47984af796b4"><img src="https://github.com/user-attachments/assets/d9262da3-99a9-4387-9d0a-47984af796b4" alt="ClawHub detail, 1440 px, after" width="420"></a></td></tr>
<tr><td>ClawHub error, 1440 px</td><td><a href="https://github.com/user-attachments/assets/a926b175-8b3e-427d-bfc9-6cb17e0881e1"><img src="https://github.com/user-attachments/assets/a926b175-8b3e-427d-bfc9-6cb17e0881e1" alt="ClawHub error, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/f5c4e645-f684-41e3-9ac8-1f65629e337e"><img src="https://github.com/user-attachments/assets/f5c4e645-f684-41e3-9ac8-1f65629e337e" alt="ClawHub error, 1440 px, after" width="420"></a></td></tr>
<tr><td>Library editor, 1440 px</td><td><a href="https://github.com/user-attachments/assets/1986e457-a3ab-4657-a82c-e4022de3a1cd"><img src="https://github.com/user-attachments/assets/1986e457-a3ab-4657-a82c-e4022de3a1cd" alt="Library editor, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/434e6563-397c-425b-8fd7-3d0be5a90427"><img src="https://github.com/user-attachments/assets/434e6563-397c-425b-8fd7-3d0be5a90427" alt="Library editor, 1440 px, after" width="420"></a></td></tr>
<tr><td>Library import, 1440 px</td><td><a href="https://github.com/user-attachments/assets/fe7587c6-9a84-49f1-9e82-0a92ccc529ee"><img src="https://github.com/user-attachments/assets/fe7587c6-9a84-49f1-9e82-0a92ccc529ee" alt="Library import, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/d23b4dce-9488-4b5e-a625-cdea129cf551"><img src="https://github.com/user-attachments/assets/d23b4dce-9488-4b5e-a625-cdea129cf551" alt="Library import, 1440 px, after" width="420"></a></td></tr>
<tr><td>Session-pinned skill, 1440 px</td><td><a href="https://github.com/user-attachments/assets/021214a1-7166-457c-85a5-d99d603223f4"><img src="https://github.com/user-attachments/assets/021214a1-7166-457c-85a5-d99d603223f4" alt="Session-pinned skill, 1440 px, before" width="420"></a></td><td><a href="https://github.com/user-attachments/assets/4af080bc-384d-41dd-8006-b6862284c7a7"><img src="https://github.com/user-attachments/assets/4af080bc-384d-41dd-8006-b6862284c7a7" alt="Session-pinned skill, 1440 px, after" width="420"></a></td></tr>
</table>

Validation: the browser regression fails on the original mobile header and on the previous minimum-height behavior at both widths. Four browser cases compare computed surface, border, radius, and close-control styles against the real Connect machine renderer, then cover installed/error content growing from short to long, internal scrolling with a fixed header, shrinking again, and Escape at 390/1440. These comparisons fail on the previous gradient/raised-button styling. The obsolete class-only sizing assertion was replaced by real geometry checks. Skills tests (25), native modal tests (9), and agent file-preview tests (2) pass; the latter two suites were validated in the initial header change. All 12 header/viewport combinations measure 49 px, including a centered 32 px close button. Optional ClawHub skill icons and profile images also retain this header height at both widths. All six variants pass accessible Close, click dismissal, reopen, keyboard focus containment, Escape, and focus return at both widths. Interactive proof also covers Skill Card tabs, enable/disable, simulated installation, pinned supporting files, editor saves, and text-file import into the editor.

Landing validation: after rebasing on current main, all four reader browser cases and both complete skill-library E2E suites (9 tests) pass. The three obsolete library editor, import, and pinned-reader selectors identified in review now address the shared reader shell, preserving their existing assertions. This also completes the requested test-integration rank-up. The approved visual design is unchanged.

## Risk and coverage

The shared stylesheet changes are restricted to the six skill-reader consumers: installed skill, ClawHub detail, ClawHub error, library editor, library import, and session-pinned skill. The agent file preview retains its existing chrome and passes its focus tests. The native modal adapter is unchanged. ClawHub detail text and import content are unchanged; only their enclosing frame and spacing participate.

The fixture uses synthetic Gateway and registry responses. Focused formatting, styles, lint, and UI production/page-test type checks pass. Live service connectivity is outside this synthetic visual proof.
