### PR TITLE
fix(release): honor frozen ClawHub request contract

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -18,7 +18,9 @@ async function assertPrepublishRequests(
   baseUrl,
   requestedPackage,
   version,
-  securityMode = "required",
+  securityMode = process.env.OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_PACKAGE === requestedPackage
+    ? "absent"
+    : "required",
   attempts = "1",
   minimumAttempts = "1",
 ) {

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -91,6 +91,7 @@ function runPrepublishAssertion(
   cwd = process.cwd(),
   attempts?: number | "complete",
   minimumAttempts?: number,
+  env = process.env,
 ) {
   return spawnSync(
     process.execPath,
@@ -104,7 +105,7 @@ function runPrepublishAssertion(
       ...(attempts ? [String(attempts)] : []),
       ...(minimumAttempts ? [String(minimumAttempts)] : []),
     ],
-    { cwd, encoding: "utf8", env: { ...process.env } },
+    { cwd, encoding: "utf8", env: { ...env } },
   );
 }
 
@@ -500,6 +501,28 @@ ${runner.slice(boundary)}
     expect(
       runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version, undefined, isolatedCwd).status,
     ).toBe(0);
+    const { baseUrl: legacyBaseUrl } = await startFixtureServer(
+      "prepublish-artifacts",
+      [manifestPath],
+      isolatedCwd,
+    );
+    await fetchJson(legacyBaseUrl, whatsappPath);
+    await fetchJson(legacyBaseUrl, `${whatsappPath}/versions/${version}/artifact`);
+    await fetch(`${legacyBaseUrl}${whatsappPath}/versions/${version}/artifact/download`);
+    const legacyAssertion = runPrepublishAssertion(
+      legacyBaseUrl,
+      "@openclaw/whatsapp",
+      version,
+      undefined,
+      isolatedCwd,
+      undefined,
+      undefined,
+      {
+        ...process.env,
+        OPENCLAW_FROZEN_UPGRADE_SURVIVOR_CLAWHUB_PACKAGE: "@openclaw/whatsapp",
+      },
+    );
+    expect(legacyAssertion.status, legacyAssertion.stderr).toBe(0);
     const completeWithMinimum = runPrepublishAssertion(
       baseUrl,
       "@openclaw/whatsapp",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where extended-stable upgrade-survivor and package self-upgrade validation stopped during fixture setup because their correctly selected legacy ClawHub install omitted the newer security-audit request, while the shared request-ledger assertion still required that request.

## Why This Change Was Made

The request-ledger owner now derives its omitted security-mode default from the existing frozen-candidate package capability signal. Explicit modes still win, the package match is exact, and modern candidates remain on the strict four-request contract.

No candidate backport is needed: the candidate produced its legacy three-request sequence correctly; this repairs trusted-main validation tooling.

## User Impact

Release operators can validate frozen candidates that predate ClawHub security-audit requests without weakening request-ledger checks for current candidates.

## Evidence

- Red: release validation run 34273871537, upgrade-survivor job 102224215234 and package self-upgrade job 102223299969 rejected the candidate's exact package/artifact/download ledger during `prepare-state`.
- Red locally before the owner fix: `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts` failed on the same three-request ledger.
- Green after the fix: `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts test/scripts/upgrade-survivor-assertions.test.ts` (99 tests).
- Green: `pnpm exec oxfmt --check scripts/e2e/lib/clawhub-fixture-server.cjs test/scripts/clawhub-fixture-server.test.ts`.
- Green: `git diff --check`.
- Autoreview: scoped-clean, no P0/P1 findings; confirmed exact package scoping, explicit-mode precedence, and modern strictness.

Production/tooling delta is one default expression (+3/-1 raw due formatting; no new branch, flag, or compatibility surface). Test delta is +24/-1.
