### PR TITLE
fix(telegram): include duration in voice and audio uploads

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -7,7 +7,8 @@ import { createTelegramPromptContextProjectionSequence } from "../prompt-context
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
-const { probeVideoDimensions } = vi.hoisted(() => ({
+const { probeAudioDurationMs, probeVideoDimensions } = vi.hoisted(() => ({
+  probeAudioDurationMs: vi.fn(),
   probeVideoDimensions: vi.fn(),
 }));
 const triggerInternalHook = vi.hoisted(() => vi.fn(async () => {}));
@@ -39,6 +40,7 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
   return {
     ...actual,
+    probeAudioDurationMs,
     probeVideoDimensions,
   };
 });
@@ -320,6 +322,8 @@ function createVoiceFailureHarness(params: {
 describe("deliverReplies", () => {
   beforeEach(() => {
     loadWebMedia.mockClear();
+    probeAudioDurationMs.mockReset();
+    probeAudioDurationMs.mockResolvedValue(undefined);
     probeVideoDimensions.mockReset();
     probeVideoDimensions.mockResolvedValue(undefined);
     triggerInternalHook.mockReset();
@@ -1931,6 +1935,32 @@ describe("deliverReplies", () => {
       width: 720,
       height: 1280,
     });
+  });
+
+  it.each([
+    { name: "voice", contentType: "audio/ogg", fileName: "note.ogg", audioAsVoice: true },
+    { name: "audio", contentType: "audio/mpeg", fileName: "track.mp3", audioAsVoice: false },
+  ])("passes a rounded probed duration to streaming $name sends", async (testCase) => {
+    const runtime = createRuntime();
+    const sendAudio = vi.fn().mockResolvedValue({ message_id: 23, chat: { id: "123" } });
+    const sendVoice = vi.fn().mockResolvedValue({ message_id: 23, chat: { id: "123" } });
+    probeAudioDurationMs.mockResolvedValueOnce(12_600);
+    mockMediaLoad(testCase.fileName, testCase.contentType, "audio");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: `https://example.com/${testCase.fileName}`,
+          audioAsVoice: testCase.audioAsVoice,
+        },
+      ],
+      runtime,
+      bot: createBot({ sendAudio, sendVoice }),
+    });
+
+    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"));
+    const send = testCase.audioAsVoice ? sendVoice : sendAudio;
+    expect(mockCallArg(send, 0, 2)).toMatchObject({ duration: 13 });
   });
 
   it("does not probe GIF reply animations", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1958,7 +1958,7 @@ describe("deliverReplies", () => {
       bot: createBot({ sendAudio, sendVoice }),
     });
 
-    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"));
+    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"), testCase.contentType);
     const send = testCase.audioAsVoice ? sendVoice : sendAudio;
     expect(mockCallArg(send, 0, 2)).toMatchObject({ duration: 13 });
   });

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -11,6 +11,7 @@ import type { TelegramOutboundPromptContextMessage } from "./outbound-message-co
 import { isTelegramEmptyContentError, isTelegramHtmlParseError } from "./rich-plain-fallback.js";
 import type { TelegramApi } from "./send-context.js";
 import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
+import { probeAudioDurationMs } from "./send.runtime.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
 
 type TelegramLoadedMedia = Awaited<ReturnType<typeof loadWebMedia>>;
@@ -143,6 +144,7 @@ export function resolveTelegramOutboundMediaSenders<
   asVoice?: boolean;
   sendImageAsPhoto?: boolean;
 }): { sender: TelegramOutboundMediaSender<T>; documentSender: TelegramOutboundMediaSender<T> } {
+  let audioDurationMsPromise: Promise<number | undefined> | undefined;
   const createSender = (label: TelegramOutboundMediaKind): TelegramOutboundMediaSender<T> => {
     const operation = `send${label
       .split("_")
@@ -156,15 +158,19 @@ export function resolveTelegramOutboundMediaSenders<
     return {
       label,
       operation,
-      send: (effectiveParams) =>
-        method.call(
-          params.api,
-          params.chatId,
-          params.plan.file,
-          label === "document" && params.forceDocument
-            ? { ...effectiveParams, disable_content_type_detection: true }
-            : effectiveParams,
-        ),
+      send: async (effectiveParams) => {
+        const durationMs =
+          label === "voice" || label === "audio"
+            ? await (audioDurationMsPromise ??= probeAudioDurationMs(params.media.buffer))
+            : undefined;
+        return await method.call(params.api, params.chatId, params.plan.file, {
+          ...effectiveParams,
+          ...(durationMs ? { duration: Math.max(1, Math.round(durationMs / 1000)) } : {}),
+          ...(label === "document" && params.forceDocument
+            ? { disable_content_type_detection: true }
+            : {}),
+        });
+      },
     };
   };
   const documentSender = createSender("document");

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -161,7 +161,10 @@ export function resolveTelegramOutboundMediaSenders<
       send: async (effectiveParams) => {
         const durationMs =
           label === "voice" || label === "audio"
-            ? await (audioDurationMsPromise ??= probeAudioDurationMs(params.media.buffer))
+            ? await (audioDurationMsPromise ??= probeAudioDurationMs(
+                params.media.buffer,
+                params.media.contentType,
+              ))
             : undefined;
         return await method.call(params.api, params.chatId, params.plan.file, {
           ...effectiveParams,

--- a/extensions/telegram/src/send.runtime.ts
+++ b/extensions/telegram/src/send.runtime.ts
@@ -7,6 +7,7 @@ export {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
   normalizePollInput,
+  probeAudioDurationMs,
   probeVideoDimensions,
 } from "openclaw/plugin-sdk/media-runtime";
 export { loadWebMedia } from "openclaw/plugin-sdk/web-media";

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -86,7 +86,8 @@ const { imageMetadata } = vi.hoisted(() => ({
   },
 }));
 
-const { probeVideoDimensions } = vi.hoisted(() => ({
+const { probeAudioDurationMs, probeVideoDimensions } = vi.hoisted(() => ({
+  probeAudioDurationMs: vi.fn(),
   probeVideoDimensions: vi.fn(),
 }));
 
@@ -140,6 +141,7 @@ type TelegramSendTestMocks = {
   loadWebMedia: MockFn;
   maybePersistResolvedTelegramTarget: MockFn;
   imageMetadata: { width: number | undefined; height: number | undefined };
+  probeAudioDurationMs: MockFn;
   probeVideoDimensions: MockFn;
 };
 
@@ -217,6 +219,7 @@ vi.mock("./send.runtime.js", () => ({
   loadConfig,
   loadWebMedia,
   normalizePollInput,
+  probeAudioDurationMs,
   probeVideoDimensions,
   requireRuntimeConfig: vi.fn((cfg: unknown) => cfg ?? loadConfig()),
   resolveMarkdownTableMode,
@@ -238,6 +241,7 @@ export function getTelegramSendTestMocks(): TelegramSendTestMocks {
     loadWebMedia,
     maybePersistResolvedTelegramTarget,
     imageMetadata,
+    probeAudioDurationMs,
     probeVideoDimensions,
   };
 }
@@ -247,6 +251,8 @@ export function installTelegramSendTestHooks() {
     loadConfig.mockReturnValue({});
     resolveStorePath.mockReturnValue("/tmp/openclaw-telegram-send-tests.json");
     loadWebMedia.mockReset();
+    probeAudioDurationMs.mockReset();
+    probeAudioDurationMs.mockResolvedValue(undefined);
     probeVideoDimensions.mockReset();
     probeVideoDimensions.mockResolvedValue(undefined);
     imageMetadata.width = 1200;

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -134,6 +134,7 @@ const {
   loadConfig,
   loadWebMedia,
   maybePersistResolvedTelegramTarget,
+  probeAudioDurationMs,
   probeVideoDimensions,
 } = getTelegramSendTestMocks();
 const telegramSendModule = await importTelegramSendModule();
@@ -4456,6 +4457,32 @@ describe("sendMessageTelegram", () => {
       );
       expect(notCalled, testCase.name).not.toHaveBeenCalled();
     }
+  });
+
+  it.each([
+    { name: "voice", contentType: "audio/ogg", fileName: "note.ogg", asVoice: true },
+    { name: "audio", contentType: "audio/mpeg", fileName: "track.mp3", asVoice: false },
+  ])("passes a rounded probed duration to durable $name sends", async (testCase) => {
+    const sendAudio = vi.fn().mockResolvedValue({ message_id: 11, chat: { id: "123" } });
+    const sendVoice = vi.fn().mockResolvedValue({ message_id: 11, chat: { id: "123" } });
+    probeAudioDurationMs.mockResolvedValueOnce(12_600);
+    mockLoadedMedia({
+      buffer: Buffer.from("audio"),
+      contentType: testCase.contentType,
+      fileName: testCase.fileName,
+    });
+
+    await sendMessageTelegram("123", "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api: makeTelegramApiTestMock({ sendAudio, sendVoice }),
+      mediaUrl: `https://example.com/${testCase.fileName}`,
+      asVoice: testCase.asVoice,
+    });
+
+    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"));
+    const send = testCase.asVoice ? sendVoice : sendAudio;
+    expect(firstMockCall(send, `send ${testCase.name} call`)[2]).toMatchObject({ duration: 13 });
   });
 
   it("keeps message_thread_id for forum/private/group sends", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4480,7 +4480,7 @@ describe("sendMessageTelegram", () => {
       asVoice: testCase.asVoice,
     });
 
-    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"));
+    expect(probeAudioDurationMs).toHaveBeenCalledWith(Buffer.from("audio"), testCase.contentType);
     const send = testCase.asVoice ? sendVoice : sendAudio;
     expect(firstMockCall(send, `send ${testCase.name} call`)[2]).toMatchObject({ duration: 13 });
   });

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -363,7 +363,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: one exec policy object replaces two deprecated comparator exports.
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
-      4447,
+      // +1: seekable audio-duration probing for channel-owned Telegram metadata.
+      4448,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -495,7 +496,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -2: exec comparators are members of the shared policy object.
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
-      2629,
+      // +1: seekable audio-duration probing for channel-owned Telegram metadata.
+      2630,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -16,14 +16,19 @@ let testDir = "";
 let songPath = "";
 let clipPath = "";
 let voicePath = "";
+let probeAudioDurationMs: typeof import("./media-probe.js").probeAudioDurationMs;
 let probeMediaFilesWithinBudget: typeof import("./media-probe.js").probeMediaFilesWithinBudget;
 let probePlaybackMediaFileDescriptor: typeof import("./media-probe.js").probePlaybackMediaFileDescriptor;
 let probeVideoDimensions: typeof import("./media-probe.js").probeVideoDimensions;
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ probeMediaFilesWithinBudget, probePlaybackMediaFileDescriptor, probeVideoDimensions } =
-    await import("./media-probe.js"));
+  ({
+    probeAudioDurationMs,
+    probeMediaFilesWithinBudget,
+    probePlaybackMediaFileDescriptor,
+    probeVideoDimensions,
+  } = await import("./media-probe.js"));
   testDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-probe-"));
   songPath = path.join(testDir, "song.mp3");
   clipPath = path.join(testDir, "clip.mp4");
@@ -58,6 +63,24 @@ async function probeMediaFile(filePath: string, kind: MediaProbeKind): Promise<M
 }
 
 describe("probeMediaFile", () => {
+  it("probes buffered audio through a seekable temporary file", async () => {
+    let probedPath: string | undefined;
+    runFfprobe.mockImplementation(async (args) => {
+      probedPath = args.at(-1);
+      return probedPath === "pipe:0" ? "{}" : JSON.stringify({ format: { duration: "0.257" } });
+    });
+
+    await expect(probeAudioDurationMs(Buffer.from("audio"))).resolves.toBe(257);
+    expect(probedPath).toEqual(expect.stringContaining("media-probe-"));
+    await expect(fs.access(probedPath ?? "")).rejects.toThrow();
+  });
+
+  it("omits buffered audio duration when probing fails", async () => {
+    runFfprobe.mockRejectedValueOnce(new Error("ffprobe unavailable"));
+
+    await expect(probeAudioDurationMs(Buffer.from("audio"))).resolves.toBeUndefined();
+  });
+
   it("returns audio duration from one bounded file probe", async () => {
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ format: { duration: "12.3456" } }));
 

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -70,15 +70,25 @@ describe("probeMediaFile", () => {
       return probedPath === "pipe:0" ? "{}" : JSON.stringify({ format: { duration: "0.257" } });
     });
 
-    await expect(probeAudioDurationMs(Buffer.from("audio"))).resolves.toBe(257);
+    await expect(probeAudioDurationMs(Buffer.from("audio"), "audio/ogg")).resolves.toBe(257);
     expect(probedPath).toEqual(expect.stringContaining("media-probe-"));
+    expect(runFfprobe).toHaveBeenCalledWith(
+      expect.arrayContaining(["-f", "ogg", probedPath ?? ""]),
+    );
     await expect(fs.access(probedPath ?? "")).rejects.toThrow();
+  });
+
+  it("skips playlist audio without invoking ffprobe", async () => {
+    await expect(
+      probeAudioDurationMs(Buffer.from("#EXTM3U"), "application/vnd.apple.mpegurl"),
+    ).resolves.toBeUndefined();
+    expect(runFfprobe).not.toHaveBeenCalled();
   });
 
   it("omits buffered audio duration when probing fails", async () => {
     runFfprobe.mockRejectedValueOnce(new Error("ffprobe unavailable"));
 
-    await expect(probeAudioDurationMs(Buffer.from("audio"))).resolves.toBeUndefined();
+    await expect(probeAudioDurationMs(Buffer.from("audio"), "audio/ogg")).resolves.toBeUndefined();
   });
 
   it("returns audio duration from one bounded file probe", async () => {

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -5,6 +5,8 @@ import {
   asSafeIntegerInRange,
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { withTempWorkspace } from "../infra/private-temp-workspace.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
@@ -144,7 +146,10 @@ function parseFfprobeMediaMetadata(
   };
 }
 
-function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
+type FfprobeInput = { protocol: "fd" | "pipe" } | { protocol: "file"; filePath: string };
+
+function buildFfprobeMetadataArgs(input: FfprobeInput): string[] {
+  const protocol = input.protocol;
   const isFileDescriptor = protocol === "fd";
   return [
     "-v",
@@ -156,7 +161,7 @@ function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
     "-of",
     "json",
     ...(isFileDescriptor ? ["-fd", "0"] : []),
-    isFileDescriptor ? "fd:" : "pipe:0",
+    protocol === "file" ? input.filePath : isFileDescriptor ? "fd:" : "pipe:0",
   ];
 }
 
@@ -177,7 +182,7 @@ async function probeMediaSource(
 ): Promise<PlaybackMediaProbeResult | null> {
   const runProbe = async (protocol: "fd" | "pipe") =>
     await runFfprobe(
-      buildFfprobeMetadataArgs(protocol),
+      buildFfprobeMetadataArgs({ protocol }),
       source.kind === "buffer"
         ? { input: source.buffer, ...options }
         : { stdinFileDescriptor: source.fd, ...options },
@@ -239,6 +244,31 @@ async function probeMediaFile(
   }
 }
 
+async function probeSeekableMediaBuffer(
+  buffer: Buffer,
+  kind: MediaProbeKind,
+): Promise<MediaProbeResult> {
+  try {
+    return await withTempWorkspace(
+      {
+        rootDir: resolvePreferredOpenClawTmpDir(),
+        prefix: "media-probe-",
+      },
+      async (workspace) => {
+        const filePath = await workspace.write("media", buffer);
+        return toMediaProbeResult(
+          parseFfprobeMediaMetadata(
+            await runFfprobe(buildFfprobeMetadataArgs({ protocol: "file", filePath })),
+            kind,
+          ),
+        );
+      },
+    );
+  } catch {
+    return {};
+  }
+}
+
 /** Probes a bounded batch under one elapsed-time budget, unaffected by wall-clock steps. */
 export async function probeMediaFilesWithinBudget(
   inputs: readonly MediaFileProbeInput[],
@@ -285,4 +315,9 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
     await probeMediaSource({ kind: "buffer", buffer }, "video"),
   );
   return width && height ? { width, height } : undefined;
+}
+
+/** Positive audio duration in milliseconds. */
+export async function probeAudioDurationMs(buffer: Buffer): Promise<number | undefined> {
+  return (await probeSeekableMediaBuffer(buffer, "audio")).durationMs;
 }

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import type { MediaKind } from "@openclaw/media-core/constants";
+import { normalizeMimeType } from "@openclaw/media-core/mime";
 import {
   asPositiveSafeInteger as parsePositiveInteger,
   asSafeIntegerInRange,
@@ -146,7 +147,9 @@ function parseFfprobeMediaMetadata(
   };
 }
 
-type FfprobeInput = { protocol: "fd" | "pipe" } | { protocol: "file"; filePath: string };
+type FfprobeInput =
+  | { protocol: "fd" | "pipe" }
+  | { protocol: "file"; filePath: string; format: "ogg" | "mp3" | "mov" };
 
 function buildFfprobeMetadataArgs(input: FfprobeInput): string[] {
   const protocol = input.protocol;
@@ -161,6 +164,7 @@ function buildFfprobeMetadataArgs(input: FfprobeInput): string[] {
     "-of",
     "json",
     ...(isFileDescriptor ? ["-fd", "0"] : []),
+    ...(input.protocol === "file" ? ["-f", input.format] : []),
     protocol === "file" ? input.filePath : isFileDescriptor ? "fd:" : "pipe:0",
   ];
 }
@@ -247,6 +251,7 @@ async function probeMediaFile(
 async function probeSeekableMediaBuffer(
   buffer: Buffer,
   kind: MediaProbeKind,
+  format: "ogg" | "mp3" | "mov",
 ): Promise<MediaProbeResult> {
   try {
     return await withTempWorkspace(
@@ -258,7 +263,8 @@ async function probeSeekableMediaBuffer(
         const filePath = await workspace.write("media", buffer);
         return toMediaProbeResult(
           parseFfprobeMediaMetadata(
-            await runFfprobe(buildFfprobeMetadataArgs({ protocol: "file", filePath })),
+            // Fixed demuxers keep playlist-like bytes from opening nested local paths.
+            await runFfprobe(buildFfprobeMetadataArgs({ protocol: "file", filePath, format })),
             kind,
           ),
         );
@@ -317,7 +323,28 @@ export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensi
   return width && height ? { width, height } : undefined;
 }
 
-/** Positive audio duration in milliseconds. */
-export async function probeAudioDurationMs(buffer: Buffer): Promise<number | undefined> {
-  return (await probeSeekableMediaBuffer(buffer, "audio")).durationMs;
+function resolveAudioProbeFormat(contentType?: string): "ogg" | "mp3" | "mov" | undefined {
+  switch (normalizeMimeType(contentType)) {
+    case "audio/ogg":
+    case "audio/opus":
+      return "ogg";
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "mp3";
+    case "audio/mp4":
+    case "audio/m4a":
+    case "audio/x-m4a":
+      return "mov";
+    default:
+      return undefined;
+  }
+}
+
+/** Positive audio duration in milliseconds for a known safe container. */
+export async function probeAudioDurationMs(
+  buffer: Buffer,
+  contentType?: string,
+): Promise<number | undefined> {
+  const format = resolveAudioProbeFormat(contentType);
+  return format ? (await probeSeekableMediaBuffer(buffer, "audio", format)).durationMs : undefined;
 }

--- a/src/media/media-services.ts
+++ b/src/media/media-services.ts
@@ -3,4 +3,4 @@
 export * from "./audio-transcode.js";
 export * from "./ffmpeg-exec.js";
 export * from "./image-ops.js";
-export { probeVideoDimensions } from "./media-probe.js";
+export { probeAudioDurationMs, probeVideoDimensions } from "./media-probe.js";

--- a/src/plugin-sdk/media-runtime.ts
+++ b/src/plugin-sdk/media-runtime.ts
@@ -27,6 +27,7 @@ export {
   getImageMetadata,
   isImageProcessorUnavailableError,
   parseFfprobeCodecAndSampleRate,
+  probeAudioDurationMs,
   probeVideoDimensions,
   resolveFfmpegBin,
   resizeToJpeg,


### PR DESCRIPTION
Closes #142548

## What Problem This Solves

Fixes an issue where Telegram users receiving OGG/Opus voice messages larger than 1 MiB could see 0:00 even though the audio was playable. M4A audio uploads could return the same zero duration.

## Why This Change Was Made

Telegram inferred the duration for the smaller tested uploads, but returned zero for the tested OGG/Opus and M4A files above 1 MiB when OpenClaw omitted the optional duration field. OpenClaw's existing buffer probe could not fill that gap because it fed ffprobe through a non-seekable pipe; these containers may store duration metadata at the end, so the probe returned no duration for the affected files.

The media probe writes an audio buffer to OpenClaw's private temporary workspace and probes the seekable file through the existing ffprobe parser. Only OGG/Opus, MP3, and MP4/M4A MIME types use this path. Each maps to a fixed ffprobe demuxer through `-f`; all other MIME types skip optional duration probing. A playlist mislabeled as audio therefore cannot select the HLS demuxer and follow nested paths.

Its helper is exposed through the existing `media-runtime` Plugin SDK subpath so Telegram can use the core-owned probe without importing core internals. The shared Telegram media sender passes the rounded duration to `sendVoice` and `sendAudio`. Probe or filesystem failures still omit the optional field and allow delivery to continue.

## User Impact

Telegram now receives an explicit duration for voice and audio uploads. In live tests, the patched sender changed a 310-second OGG/Opus voice upload from 0 to 310 seconds and a 310-second M4A audio upload from 0 to 310 seconds.

Telegram's waveform for the tested long voice message remained flat. This change fixes the time display only.

## Evidence

The before, after, and 1 MiB boundary screenshots are posted in #142548.

- Live reproduction on OpenClaw 2026.9.2:
  - A 310.0065-second, 1,933,848-byte OGG/Opus voice message displayed 0:00.
  - With the patch, the shared sender supplied `duration=310` for the same 1,933,848-byte OGG/Opus upload and Telegram displayed 5:10.
  - A 2,546,108-byte M4A upload without an explicit duration returned 0. The patched `sendAudio` path returned 310 for a separately generated 310-second M4A equivalent of 2,545,899 bytes.
- Bot API boundary controls without an explicit duration:
  - 1,048,514-byte OGG/Opus, 62 bytes below 1 MiB: 235 seconds.
  - 1,048,606-byte OGG/Opus, 30 bytes above 1 MiB: 0 seconds.
  - 289-, 290-, and 291-second OGG/Opus files below 640 KB: correct durations.
  - A 2,480,631-byte MP3 control: correct 310-second duration.
- Regression coverage:
  - `src/media/media-probe.test.ts` proves buffered audio uses a seekable temporary file, selects the fixed OGG demuxer, skips playlist MIME before ffprobe, and cleans up the file.
  - `extensions/telegram/src/send.test.ts` and `extensions/telegram/src/bot/delivery.test.ts` cover rounded durations for `sendVoice` and `sendAudio` in durable and streaming delivery.
  - An exact-head run of the real helper with system ffprobe returned OGG `2007 ms` and M4A `2000 ms`. The same HLS playlist bytes mislabeled as `audio/ogg` returned no duration.
- Validation:
  - Current-head owner tests: 31 media-probe tests passed. Four focused durable and streaming Telegram duration tests passed.
  - Current-head type checks passed: `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, and `pnpm tsgo:extensions:test`.
  - Plugin SDK export and surface checks (`scripts/sync-plugin-sdk-exports.mts --check` and `scripts/plugin-sdk-surface-report.mts --check`): passed.
  - Formatting and `git diff --check`: passed.
  - Exact-head `pnpm build` compiled core, packages, SDK declarations, and 91 plugins, then stopped in runtime postbuild on unchanged `extensions/imessage/contract-api.js` with `SyntaxError: Unexpected identifier 'prompt'`. The same iMessage source matches current `upstream/main`; this is not caused by this PR.

Production code changes are +85/-13 lines (net +72). Test and test-support changes are +100/-4, and SDK surface tooling is +4/-2. The production growth is the seekable temporary-file probe with cleanup and fixed demuxers, shared Telegram metadata injection, and the Plugin SDK export required by the plugin boundary.

Before merge, this needs a Telegram Test Server E2E send and Plugin SDK owner acceptance for the new `media-runtime` export and its export-budget increase. Streaming delivery is otherwise covered by `extensions/telegram/src/bot/delivery.test.ts` without a live send.

The patch adds no dependency, configuration, database, or protocol change. Related PR #65999 was closed without merging; it used a custom OGG parser in one delivery path, while this change uses the existing media probe and shared sender.
