### PR TITLE
fix(ui): Kind sorting and grouping misclassify cron sessions

### DIFF
--- a/ui/src/e2e/session-kinds.e2e.test.ts
+++ b/ui/src/e2e/session-kinds.e2e.test.ts
@@ -1,0 +1,109 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI session kinds" });
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+suite.define(() => {
+  it("sorts and groups by displayed kind while preserving pins", async () => {
+    await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+      const sessions = [
+        { key: "agent:main:alpha", kind: "direct", label: "Alpha conversation", updatedAt: 6 },
+        { key: "agent:main:cron:daily", kind: "direct", label: "Daily check", updatedAt: 5 },
+        { key: "agent:main:beta", kind: "direct", label: "Beta conversation", updatedAt: 4 },
+        { key: "agent:main:room", kind: "group", label: "Project room", updatedAt: 3 },
+        { key: "cron:weekly", kind: "direct", label: "Weekly check", updatedAt: 2 },
+        {
+          key: "agent:main:pinned",
+          kind: "direct",
+          label: "Pinned conversation",
+          updatedAt: 1,
+          pinned: true,
+          pinnedAt: 100,
+        },
+      ];
+      const gateway = await installMockGateway(page, {
+        sessionKey: "unknown",
+        methodResponses: {
+          "sessions.list": {
+            count: sessions.length,
+            defaults: { contextTokens: null, model: null, modelProvider: null },
+            path: "",
+            sessions,
+            ts: 10,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}sessions`);
+      const table = page.locator(".sessions-table");
+      await expect.poll(() => table.locator(".session-data-row").count()).toBe(6);
+      const kinds = () => table.locator(".session-data-row .session-kind").allTextContents();
+      const kindHeader = table.locator("th[data-sortable]").filter({ hasText: "Kind" });
+      await kindHeader.getByRole("button").click();
+      await expect.poll(() => kindHeader.getAttribute("aria-sort")).toBe("descending");
+      expect.soft(await kinds()).toEqual(["direct", "group", "direct", "direct", "cron", "cron"]);
+      await kindHeader.getByRole("button").click();
+      await expect.poll(() => kindHeader.getAttribute("aria-sort")).toBe("ascending");
+      const ascending = await kinds();
+      if (captureUiProof) {
+        await writeFile(
+          path.join(suite.artifactDir, "kind-sort.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [table]),
+        );
+      }
+      expect.soft(ascending).toEqual(["direct", "cron", "cron", "direct", "direct", "group"]);
+
+      await page.getByRole("button", { name: "Filters", exact: true }).click();
+      await page.locator("wa-popover.sessions-filter-popover[open]").waitFor();
+      await page.locator(".session-groupby__select").selectOption("kind");
+      await page.keyboard.press("Escape");
+      await page.locator("wa-popover.sessions-filter-popover").waitFor({ state: "hidden" });
+      await table.locator(".session-group-row").first().waitFor();
+      const groups = await table.locator(".session-group-row__label").allTextContents();
+      if (captureUiProof) {
+        await writeFile(
+          path.join(suite.artifactDir, "kind-groups.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [table]),
+        );
+        await writeFile(
+          path.join(suite.artifactDir, "kind-proof.json"),
+          JSON.stringify(
+            { ascending, groups, requests: await gateway.getRequests("sessions.list") },
+            null,
+            2,
+          ),
+        );
+      }
+      expect.soft(groups).toEqual(["cron", "direct", "group"]);
+      expect.soft(await kinds()).toEqual(["cron", "cron", "direct", "direct", "direct", "group"]);
+      await page.getByRole("button", { name: "Filters", exact: true }).click();
+      await page.locator("wa-popover.sessions-filter-popover[open]").waitFor();
+      await page.locator(".session-groupby__select").selectOption("none");
+      await expect.poll(() => table.locator(".session-group-row").count()).toBe(0);
+      expect(await table.locator(".session-data-row").first().textContent()).toContain(
+        "Pinned conversation",
+      );
+      await page.keyboard.press("Escape");
+      await page.locator("wa-popover.sessions-filter-popover").waitFor({ state: "hidden" });
+      await table
+        .locator(".session-data-row")
+        .filter({ hasText: "Daily check" })
+        .locator(".session-details-toggle")
+        .click();
+      const details = table.locator(".session-details-panel");
+      await details.waitFor();
+      expect(await details.locator(".session-kind").textContent()).toBe("cron");
+      expect(
+        await details
+          .locator(".session-detail-stat")
+          .filter({ has: page.locator(".session-detail-stat__label", { hasText: "Kind" }) })
+          .locator(".session-detail-stat__value")
+          .textContent(),
+      ).toBe("cron");
+    });
+  });
+});

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -2,8 +2,8 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-// Control UI module implements session display behavior.
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { GatewaySessionRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
 
 const CHANNEL_LABELS: Record<string, string> = {
@@ -340,4 +340,11 @@ export function isCronSessionKey(key: string): boolean {
     normalized.startsWith("cron:") ||
     (normalized.startsWith("agent:") && parts.length >= 4 && parts[2] === "cron")
   );
+}
+
+// Wire kinds exclude cron; labels, sorting and grouping share this display classification.
+export function resolveSessionDisplayKind(
+  row: GatewaySessionRow,
+): GatewaySessionRow["kind"] | "cron" {
+  return isCronSessionKey(row.key) ? "cron" : row.kind;
 }

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -1,6 +1,7 @@
 // Pure grouping helpers for the sessions table "Group by" modes.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { resolveSessionDisplayKind } from "../session-display.ts";
 import {
   checkoutDisplayName,
   foldWorktreeCheckoutPath,
@@ -166,7 +167,7 @@ function resolveSessionGroupId(row: GatewaySessionRow, mode: SessionsGroupBy): s
     case "channel":
       return sessionRowChannel(row);
     case "kind":
-      return row.kind;
+      return resolveSessionDisplayKind(row);
     case "agent":
       // parseSessionKeyParts only matches channel-style keys; plain agent
       // sessions like "agent:main:main" need the agent:<id>:<rest> parser.

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -3,7 +3,6 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-// Control UI view renders sessions screen content.
 import { html, nothing } from "lit";
 import type { SessionsSearchHit } from "../../../../packages/gateway-protocol/src/index.js";
 import type {
@@ -44,7 +43,7 @@ import { handleContextMenuEvent } from "../../lib/keyboard-shortcuts.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
 import { presenceViewerLabel } from "../../lib/presence-users.ts";
 import { formatSessionTokens } from "../../lib/presenter.ts";
-import { isCronSessionKey } from "../../lib/session-display.ts";
+import { resolveSessionDisplayKind } from "../../lib/session-display.ts";
 import { formatGoalDetail, formatGoalSummary } from "../../lib/session-goal.ts";
 import { sessionModelMatchesDefaults } from "../../lib/session-model-defaults.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
@@ -285,12 +284,6 @@ const SESSION_KIND_ICONS = {
   global: icons.globe,
   unknown: icons.circle,
 } satisfies Record<GatewaySessionRow["kind"] | "cron", unknown>;
-
-// The server row kind never carries "cron" — cron is a key-shape fact, so the
-// display kind derives it from the key for the avatar, badge class, and label.
-function resolveSessionDisplayKind(row: GatewaySessionRow): GatewaySessionRow["kind"] | "cron" {
-  return isCronSessionKey(row.key) ? "cron" : row.kind;
-}
 
 // Kind glyph anchors each row; the dot mirrors isSessionRunActive so run
 // state also reads at the identity anchor while scanning the key column.
@@ -591,28 +584,6 @@ function renderSkeletonRows(columnCount: number) {
   );
 }
 
-function sortRows(
-  rows: GatewaySessionRow[],
-  column: "key" | "kind" | "updated" | "tokens",
-  dir: "asc" | "desc",
-): GatewaySessionRow[] {
-  const cmp = dir === "asc" ? 1 : -1;
-  return [...rows].toSorted((a, b) => {
-    const pinnedDiff = (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0);
-    if (pinnedDiff !== 0) {
-      return pinnedDiff;
-    }
-    const diff =
-      column === "key" || column === "kind"
-        ? (a[column] ?? "").localeCompare(b[column] ?? "")
-        : column === "updated"
-          ? (a.updatedAt ?? 0) - (b.updatedAt ?? 0)
-          : (a.totalTokens ?? a.inputTokens ?? a.outputTokens ?? 0) -
-            (b.totalTokens ?? b.inputTokens ?? b.outputTokens ?? 0);
-    return diff * cmp;
-  });
-}
-
 function paginateRows<T>(rows: T[], page: number, pageSize: number): T[] {
   const start = page * pageSize;
   return rows.slice(start, start + pageSize);
@@ -704,7 +675,7 @@ function sessionDetailItems(params: {
   const { row, updated, checkpointCount } = params;
   const details: Array<{ label: string; value: string }> = [
     { label: t("sessionsView.key"), value: row.key },
-    { label: t("sessionsView.kind"), value: row.kind },
+    { label: t("sessionsView.kind"), value: resolveSessionDisplayKind(row) },
     { label: t("sessionsView.updated"), value: updated },
     { label: t("sessionsView.tokens"), value: formatSessionTokens(row) },
     { label: t("sessionsView.compaction"), value: formatCheckpointCount(checkpointCount) },
@@ -974,7 +945,23 @@ function renderOverrideSelect(params: {
 
 export function renderSessions(props: SessionsProps) {
   const rawRows = props.result?.sessions ?? [];
-  const sorted = sortRows(rawRows, props.sortColumn, props.sortDir);
+  const direction = props.sortDir === "asc" ? 1 : -1;
+  const sorted = rawRows.toSorted((a, b) => {
+    const pinnedDiff = (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0);
+    if (pinnedDiff !== 0) {
+      return pinnedDiff;
+    }
+    const diff =
+      props.sortColumn === "kind"
+        ? resolveSessionDisplayKind(a).localeCompare(resolveSessionDisplayKind(b))
+        : props.sortColumn === "key"
+          ? a.key.localeCompare(b.key)
+          : props.sortColumn === "updated"
+            ? (a.updatedAt ?? 0) - (b.updatedAt ?? 0)
+            : (a.totalTokens ?? a.inputTokens ?? a.outputTokens ?? 0) -
+              (b.totalTokens ?? b.inputTokens ?? b.outputTokens ?? 0);
+    return diff * direction;
+  });
   const totalRows = sorted.length;
   const totalPages = Math.max(1, Math.ceil(totalRows / props.pageSize));
   const page = Math.min(props.page, totalPages - 1);
@@ -1592,7 +1579,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
       </td>
       ${categoryMode ? renderCategoryCell(row, props) : nothing}
       <td>
-        <span class=${kindClass}>${resolveSessionDisplayKind(row)}</span>
+        <span class=${kindClass}>${displayKind}</span>
       </td>
       <td class="session-status-col">
         <div class="session-status-stack">


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users sorting or grouping the Sessions table by Kind would see cron sessions mixed with direct chats, despite their visible `cron` labels. The details drawer's Kind field also disagreed with its badge.

## Why This Change Was Made

Share the existing key-derived display-kind classification across labels, avatars, details, sorting, and grouping. Gateway wire kinds, routing, and stored rows remain unchanged; the single-use sorting wrapper and redundant array copy are removed.

## User Impact

Kind sorting and grouping match the visible labels. Pinned-first ordering and other sort/group modes retain their behavior.

## Evidence

The bundled Chromium mock-Gateway scenario failed before the repair on both Kind sort directions and grouping, then passed after it. It also checks pinned ordering, ungrouping, and the details drawer. The four replacement captures below were inspected in full, use only synthetic data, and dismiss the invitation card before the first sidebar render.

133 existing view/grouping/display tests passed. The required changed-file gate passed, including test and UI type graphs, i18n, dead-export checks, full-file lint, and stylesheet checks. Independent explicit P2 review is scoped-clean. No real Gateway/provider account was used.

Production: 30 added / 35 removed (net −5, including two empty comment removals; functional refactor net −3). One browser regression: 109 lines.

| Surface | Before | After |
| --- | --- | --- |
| Ascending Kind sort | ![Ascending Kind sort before](https://github.com/user-attachments/assets/98cdbb5e-3604-495a-825a-78f03e9742d9) | ![Ascending Kind sort after](https://github.com/user-attachments/assets/6142579e-5874-4fa4-b8a1-afc95eb4479f) |
| Group by Kind | ![Group by Kind before](https://github.com/user-attachments/assets/a965b7c1-fd68-4c72-9b18-977911ff3225) | ![Group by Kind after](https://github.com/user-attachments/assets/808ef638-6952-41ed-9d23-0e7eb543579b) |
