### PR TITLE
fix(skills): render ClawHub Markdown and compact actions

### DIFF
--- a/ui/src/pages/skills/view.clawhub.browser.test.ts
+++ b/ui/src/pages/skills/view.clawhub.browser.test.ts
@@ -13,10 +13,11 @@ afterEach(() => {
 });
 
 describe("ClawHub detail content", () => {
-  it.each([390, 1440])("contains long plain-text details at %ipx", async (width) => {
+  it.each([390, 1440])("contains rendered Markdown details at %ipx", async (width) => {
     await page.viewport(width, 960);
     document.body.append(container);
-    const changelog = `# Release notes\n\n<em>Keep this literal</em>\n${"long_identifier_".repeat(80)}\nLast line`;
+    const code = "long_identifier_".repeat(80);
+    const changelog = `# Release notes\n\nFirst paragraph starts here.\n\n\`\`\`text\n${code}\n\`\`\`\n\n| Change | Status |\n| --- | --- |\n| Preview | Ready |\n\n<img src="javascript:alert(1)" onerror="alert(1)">`;
     render(
       renderSkills(
         createProps({
@@ -45,10 +46,10 @@ describe("ClawHub detail content", () => {
     for (const child of body.children) {
       expect(child.scrollWidth).toBeLessThanOrEqual(child.clientWidth);
     }
-    const changelogElement = Array.from(body.children).find((child) =>
-      child.textContent?.includes("# Release notes"),
-    );
-    expect(changelogElement?.textContent).toBe(changelog);
-    expect(changelogElement?.children).toHaveLength(0);
+    expect(body.querySelector("h1")?.textContent).toBe("Release notes");
+    expect(body.querySelector("article > p")?.textContent).toBe("First paragraph starts here.");
+    expect(body.querySelector("pre code")?.textContent).toBe(`${code}\n`);
+    expect(body.querySelector("td")?.textContent).toBe("Preview");
+    expect(body.querySelector("[onerror], [src^='javascript:']")).toBeNull();
   });
 });

--- a/ui/src/pages/skills/view.clawhub.browser.test.ts
+++ b/ui/src/pages/skills/view.clawhub.browser.test.ts
@@ -1,0 +1,54 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import "../../styles.css";
+import { createProps } from "./view.test-support.ts";
+import { renderSkills } from "./view.ts";
+
+const container = document.createElement("openclaw-skills-page");
+
+afterEach(() => {
+  render(null, container);
+  container.remove();
+});
+
+describe("ClawHub detail content", () => {
+  it.each([390, 1440])("contains long plain-text details at %ipx", async (width) => {
+    await page.viewport(width, 960);
+    document.body.append(container);
+    const changelog = `# Release notes\n\n<em>Keep this literal</em>\n${"long_identifier_".repeat(80)}\nLast line`;
+    render(
+      renderSkills(
+        createProps({
+          clawhubDetailRef: "@fixture/guide",
+          clawhubDetail: {
+            skill: {
+              slug: "guide",
+              displayName: "Guide",
+              summary: `Review and verification instructions. ${"long_summary_".repeat(80)}`,
+              createdAt: 1,
+              updatedAt: 2,
+            },
+            owner: { displayName: "Fixture operator" },
+            latestVersion: { version: "1.0.0", createdAt: 2, changelog },
+          },
+        }),
+      ),
+      container,
+    );
+    const body = container.querySelector<HTMLElement>(".skill-reader-dialog__body")!;
+    await expect
+      .element(page.getByRole("button", { name: "Install Guide", exact: true }))
+      .toBeVisible();
+    expect(body.clientWidth).toBeGreaterThan(0);
+    expect(body.scrollWidth).toBeLessThanOrEqual(body.clientWidth);
+    for (const child of body.children) {
+      expect(child.scrollWidth).toBeLessThanOrEqual(child.clientWidth);
+    }
+    const changelogElement = Array.from(body.children).find((child) =>
+      child.textContent?.includes("# Release notes"),
+    );
+    expect(changelogElement?.textContent).toBe(changelog);
+    expect(changelogElement?.children).toHaveLength(0);
+  });
+});

--- a/ui/src/pages/skills/view.clawhub.browser.test.ts
+++ b/ui/src/pages/skills/view.clawhub.browser.test.ts
@@ -17,7 +17,8 @@ describe("ClawHub detail content", () => {
     await page.viewport(width, 960);
     document.body.append(container);
     const code = "long_identifier_".repeat(80);
-    const changelog = `# Release notes\n\nFirst paragraph starts here.\n\n\`\`\`text\n${code}\n\`\`\`\n\n| Change | Status |\n| --- | --- |\n| Preview | Ready |\n\n<img src="javascript:alert(1)" onerror="alert(1)">`;
+    const tableIdentifier = "table_identifier_".repeat(80);
+    const changelog = `# Release notes\n\nFirst paragraph starts here.\n\n\`\`\`text\n${code}\n\`\`\`\n\n| Change | Status |\n| --- | --- |\n| ${tableIdentifier} | Ready |\n\n<img src="javascript:alert(1)" onerror="alert(1)">`;
     render(
       renderSkills(
         createProps({
@@ -49,7 +50,10 @@ describe("ClawHub detail content", () => {
     expect(body.querySelector("h1")?.textContent).toBe("Release notes");
     expect(body.querySelector("article > p")?.textContent).toBe("First paragraph starts here.");
     expect(body.querySelector("pre code")?.textContent).toBe(`${code}\n`);
-    expect(body.querySelector("td")?.textContent).toBe("Preview");
+    const table = body.querySelector("table")!;
+    expect(table.scrollWidth).toBeGreaterThan(table.clientWidth);
+    table.scrollLeft = 100;
+    expect(table.scrollLeft).toBeGreaterThan(0);
     expect(body.querySelector("[onerror], [src^='javascript:']")).toBeNull();
   });
 });

--- a/ui/src/pages/skills/view.clawhub.test.ts
+++ b/ui/src/pages/skills/view.clawhub.test.ts
@@ -155,7 +155,7 @@ describe("renderSkills ClawHub", () => {
       Array.from(container.querySelectorAll(".callout")).map((node) => normalizeText(node)),
     ).toEqual(["rate limited", "Installed github"]);
     expect(normalizeText(container.querySelector(".skill-reader-dialog__body")!)).toBe(
-      "GitHub integration for OpenClaw By OpenClaw (@openclaw) Latest: v1.2.3 Added search support Platforms: macos, linux Install GitHub",
+      "GitHub integration for OpenClaw By OpenClaw (@openclaw) · Latest: v1.2.3 Added search support Platforms: macos, linux Install GitHub",
     );
     expect(container.querySelector<HTMLImageElement>(".clawhub-skill-icon--detail")?.src).toBe(
       `https://clawhub.ai/api/v1/skill-icons/${"b".repeat(64)}`,

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -574,7 +574,10 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                       <div>${detail.skill.summary ?? ""}</div>
                       ${
                         detail.owner?.displayName || detail.latestVersion
-                          ? html`<div class="clawhub-skill-detail__meta muted">
+                          ? html`<div
+                              class="clawhub-skill-detail__meta muted"
+                              style="letter-spacing: normal;"
+                            >
                               ${
                                 detail.owner?.displayName
                                   ? html`${t("skillsPage.by")}

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -560,7 +560,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
             ${icons.x}
           </button>
         </div>
-        <div class="skill-reader-dialog__body" style="display: grid; gap: var(--space-4);">
+        <div class="skill-reader-dialog__body clawhub-skill-detail__body">
           ${
             props.clawhubDetailLoading
               ? html`<div class="muted">${t("common.loading")}</div>`
@@ -571,38 +571,42 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                   </div>`
                 : detail?.skill
                   ? html`
-                      <div style="font-size: 14px; line-height: 1.5;">
-                        ${detail.skill.summary ?? ""}
-                      </div>
+                      <div>${detail.skill.summary ?? ""}</div>
                       ${
-                        detail.owner?.displayName
-                          ? html`<div class="muted" style="font-size: 13px;">
-                              ${t("skillsPage.by")}
-                              ${detail.owner.displayName}${
-                                detail.owner.handle ? html` (@${detail.owner.handle})` : nothing
+                        detail.owner?.displayName || detail.latestVersion
+                          ? html`<div class="clawhub-skill-detail__meta muted">
+                              ${
+                                detail.owner?.displayName
+                                  ? html`${t("skillsPage.by")}
+                                    ${detail.owner.displayName}${
+                                      detail.owner.handle
+                                        ? html` (@${detail.owner.handle})`
+                                        : nothing
+                                    }`
+                                  : nothing
                               }
-                            </div>`
-                          : nothing
-                      }
-                      ${
-                        detail.latestVersion
-                          ? html`<div class="muted" style="font-size: 13px;">
-                              ${t("skillsPage.latest", { version: detail.latestVersion.version })}
+                              ${detail.owner?.displayName && detail.latestVersion ? " · " : nothing}
+                              ${
+                                detail.latestVersion
+                                  ? t("skillsPage.latest", {
+                                      version: detail.latestVersion.version,
+                                    })
+                                  : nothing
+                              }
                             </div>`
                           : nothing
                       }
                       ${
                         detail.latestVersion?.changelog
                           ? html`<div
-                              style="font-size: 13px; border-top: 1px solid var(--border); padding-top: 12px; white-space: pre-wrap;"
-                            >
-                              ${detail.latestVersion.changelog}
-                            </div>`
+                              class="clawhub-skill-detail__changelog"
+                              .textContent=${detail.latestVersion.changelog}
+                            ></div>`
                           : nothing
                       }
                       ${
                         detail.metadata?.os
-                          ? html`<div class="muted" style="font-size: 12px;">
+                          ? html`<div class="clawhub-skill-detail__meta muted">
                               ${t("skillsPage.platforms", { platforms: detail.metadata.os.join(", ") })}
                             </div>`
                           : nothing

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -598,10 +598,14 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                       }
                       ${
                         detail.latestVersion?.changelog
-                          ? html`<div
-                              class="clawhub-skill-detail__changelog"
-                              .textContent=${detail.latestVersion.changelog}
-                            ></div>`
+                          ? html`<article class="clawhub-skill-detail__changelog sidebar-markdown">
+                              ${unsafeHTML(
+                                toSanitizedMarkdownHtml(detail.latestVersion.changelog, {
+                                  codeBlockChrome: "none",
+                                  mode: "document",
+                                }),
+                              )}
+                            </article>`
                           : nothing
                       }
                       ${
@@ -611,23 +615,25 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                             </div>`
                           : nothing
                       }
-                      <button
-                        class="btn primary"
-                        ?disabled=${skillInstallLocked(props)}
-                        @click=${() => {
-                          if (props.clawhubDetailRef) {
-                            props.onClawHubInstall(props.clawhubDetailRef);
+                      <div class="exec-approval-actions" style="margin-top: 0;">
+                        <button
+                          class="btn primary"
+                          ?disabled=${skillInstallLocked(props)}
+                          @click=${() => {
+                            if (props.clawhubDetailRef) {
+                              props.onClawHubInstall(props.clawhubDetailRef);
+                            }
+                          }}
+                        >
+                          ${
+                            activeClawHubMutation(props, props.clawhubDetailRef ?? "")
+                              ? t("skillsPage.installing")
+                              : props.personalImport
+                                ? t("skillLibrary.import")
+                                : t("skillsPage.installNamed", { name: detail.skill.displayName })
                           }
-                        }}
-                      >
-                        ${
-                          activeClawHubMutation(props, props.clawhubDetailRef ?? "")
-                            ? t("skillsPage.installing")
-                            : props.personalImport
-                              ? t("skillLibrary.import")
-                              : t("skillsPage.installNamed", { name: detail.skill.displayName })
-                        }
-                      </button>
+                        </button>
+                      </div>
                     `
                   : html`<div class="muted">${t("skillsPage.notFound")}</div>`
           }

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -253,6 +253,10 @@
   padding-top: var(--space-3);
 }
 
+.clawhub-skill-detail__changelog :where(table) {
+  overflow-wrap: normal;
+}
+
 .clawhub-skill-icon--detail {
   width: 56px;
   height: 56px;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -235,6 +235,26 @@
   gap: var(--space-3);
 }
 
+.clawhub-skill-detail__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-content: start;
+  gap: var(--space-3);
+  overflow-wrap: anywhere;
+  font-size: var(--control-ui-text-md);
+  line-height: 1.5;
+}
+
+.clawhub-skill-detail__meta {
+  font-size: var(--control-ui-text-sm);
+}
+
+.clawhub-skill-detail__changelog {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-3);
+  white-space: pre-wrap;
+}
+
 .clawhub-skill-icon--detail {
   width: 56px;
   height: 56px;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -242,7 +242,6 @@
   gap: var(--space-3);
   overflow-wrap: anywhere;
   font-size: var(--control-ui-text-md);
-  line-height: 1.5;
 }
 
 .clawhub-skill-detail__meta {
@@ -252,7 +251,6 @@
 .clawhub-skill-detail__changelog {
   border-top: 1px solid var(--border);
   padding-top: var(--space-3);
-  white-space: pre-wrap;
 }
 
 .clawhub-skill-icon--detail {


### PR DESCRIPTION
Quick fix, bigger pass later.

Closes #142514

Stacked on #142550 (canonical reader headers, by @vyctorbrzezowski), at `39efd54bf54cf24f63ae31c9b476411194842217`. Landing order: #142550 first, then #142555. The header is now merged as `c906d02d4f2002f4c4b0e13083adaaa2e251cae7`. The PR base remains `main`; this PR's own changes follow the header dependency.

Related: #142143 (general alignment pass), #124362 (broader modal consistency), #124365 (broader input/focus consistency). The alignment pass is by @roboclaw-bot; the two broader issues were filed by @vyctorbrzezowski.

## What Problem This Solves

ClawHub detail could clip long descriptions, display Markdown syntax literally, indent the first changelog line, separate author/version with large gaps, and stretch Install across the desktop dialog.

## Why This Change Was Made

Constrain the body grid, wrap long prose, place author/version on one secondary line immediately below the description, and render changelog markup with the existing sanitized Markdown renderer and shared Markdown styles. Tables retain whole words and scroll horizontally within their own viewport.

The apparent first-line indentation came from whitespace surrounding the template interpolation being preserved by `white-space: pre-wrap`. It was not a centered heading or `text-indent`. Rendering the source through the canonical renderer and removing that whitespace mode keeps headings and paragraphs left aligned.

The wire contract is [`SkillsDetailResultSchema`, packages/gateway-protocol/src/schema/agents-models-skills.ts:553–600](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/packages/gateway-protocol/src/schema/agents-models-skills.ts#L553-L600): `skill.summary` is an optional string at line 558, and `latestVersion.changelog` is `Type.Optional(Type.String())` at line 573. The schema declares neither a Markdown format nor a plain-text-only restriction. [`ClawHubSkillDetail`, src/infra/clawhub-skills.ts:68](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/src/infra/clawhub-skills.ts#L68) aliases that result; [`fetchClawHubSkillDetail`, lines 254–278](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/src/infra/clawhub-skills.ts#L254-L278) reads `/api/v1/skills/{slug}` and returns the detail. This flow does not fetch README/SKILL.md file contents.

The synthetic fixture deliberately puts a heading, fenced code and a pipe table into the changelog string to exercise the reported raw-Markdown display and long-content overflow. This is a Markdown-bearing changelog fixture, not evidence of a README endpoint. [The detail renderer, ui/src/pages/skills/view.ts:603–611](https://github.com/openclaw/openclaw/blob/7dc30b1f5d7962520f9664112c7b4e53475e0528/ui/src/pages/skills/view.ts#L603-L611), now parses that string through the canonical sanitized renderer with the [same document/no-chrome options as the agent file preview, panels-status-files.ts:401–403](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/pages/agents/panels-status-files.ts#L401-L403). It uses the shared `.sidebar-markdown` styles from [ui/src/styles/sidebar-markdown.css:1–64](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/sidebar-markdown.css#L1-L64), also applied by the [agent preview at panels-status-files.ts:689–692](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/pages/agents/panels-status-files.ts#L689-L692). Summary and metadata remain text.

The [canonical table style, ui/src/styles/sidebar-markdown.css:195–203](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/sidebar-markdown.css#L195-L203), already supplies `display: block`, `width: 100%` and `overflow-x: auto`. The detail body's inherited `overflow-wrap: anywhere` was allowing words to split before scrolling became necessary. The scoped [table rule, ui/src/styles/plugins.css:256–258](https://github.com/openclaw/openclaw/blob/7dc30b1f5d7962520f9664112c7b4e53475e0528/ui/src/styles/plugins.css#L256-L258), resets that inheritance to `normal`; it reuses the canonical scrolling behavior and keeps prose wrapping. DOM inspection confirms `By Fixture operator · Latest: v1.2.0`, including a U+0020 space between `Fixture` and `operator`. The line inherited `letter-spacing: -0.14px` from [body tracking at ui/src/styles/base.css:709–715](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/base.css#L709-L715). [Only the author/version line now uses `letter-spacing: normal`, ui/src/pages/skills/view.ts:577–580](https://github.com/openclaw/openclaw/blob/7dc30b1f5d7962520f9664112c7b4e53475e0528/ui/src/pages/skills/view.ts#L577-L580), preserving its secondary text size/color and exact textContent.

Install now uses the same action group as [confirmation dialogs](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/components/confirm-dialog.ts#L69-L85) and [input dialogs](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/components/input-dialog.ts#L150-L162). That group uses [intrinsic width on desktop](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/components.css#L3534-L3544) and [full width below 768px](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/components.css#L5274-L5281). The [standard primary-button sizing, components.css:1093–1139](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/components.css#L1093-L1139) is retained, including the [44px Skills touch-target floor](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/styles/settings.css#L867-L874).

## User Impact

Details stay within the modal, Markdown is readable, related metadata stays together, and Install follows the app's desktop/mobile action layout.

## Evidence

All captures use the canonical header dependency, synthetic registry data, dark theme, and equal viewports. Before is the header dependency `6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6`; after is head `7dc30b1f5d7962520f9664112c7b4e53475e0528`, including rendered Markdown and the standard Install action. Every capture was rebuilt with the shorter header from `6c314430`: 61px high at 390px and 49px high at 1440px. The four body commits were rebased unchanged, verified by `git range-diff`. The last row isolates the table fix: before is `1b0cd3d`, after shows the final table scrolled to its rightmost columns. All images were individually inspected. Actual rendered fonts were verified in Chrome: Instrument Sans for UI/prose and JetBrains Mono for code, with no fallback fonts. The canonical [typeface loader, ui/src/app/typography.ts:79–99](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/src/app/typography.ts#L79-L99), loads the self-hosted [Instrument Sans CSS/WOFF2, ui/public/fonts/instrument-sans.css:32–53](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/public/fonts/instrument-sans.css#L32-L53) and [JetBrains Mono CSS/WOFF2, ui/public/fonts/jetbrains-mono.css:32–53](https://github.com/openclaw/openclaw/blob/6c3144302bb9ac9d50d32c4e16f42c1a387dd1d6/ui/public/fonts/jetbrains-mono.css#L32-L53). Served stylesheet/font bytes were verified against those repository assets, and Chrome confirmed actual custom-font glyphs in UI, headings, prose, code and table cells.

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>390 px</td><td><a href="https://github.com/user-attachments/assets/e7003532-bb69-465a-8d7b-0bc6dc43b2a6"><img src="https://github.com/user-attachments/assets/e7003532-bb69-465a-8d7b-0bc6dc43b2a6" alt="ClawHub before at 390 px with real app fonts" width="280" /></a></td><td><a href="https://github.com/user-attachments/assets/3162da4a-614c-4c76-9497-13a4b872fb2e"><img src="https://github.com/user-attachments/assets/3162da4a-614c-4c76-9497-13a4b872fb2e" alt="ClawHub after at 390 px with real app fonts" width="280" /></a></td></tr>
<tr><td>1440 px</td><td><a href="https://github.com/user-attachments/assets/6c5d1154-e12a-41b6-8cd0-c9f77e18f32b"><img src="https://github.com/user-attachments/assets/6c5d1154-e12a-41b6-8cd0-c9f77e18f32b" alt="ClawHub before at 1440 px with real app fonts" width="560" /></a></td><td><a href="https://github.com/user-attachments/assets/18b7adfb-b2f3-4076-9bd0-acd979f29cf8"><img src="https://github.com/user-attachments/assets/18b7adfb-b2f3-4076-9bd0-acd979f29cf8" alt="ClawHub after at 1440 px with real app fonts" width="560" /></a></td></tr>
<tr><td>390 px table scroll<br/>Before table fix → after horizontal scroll</td><td><a href="https://github.com/user-attachments/assets/45805289-a09b-4d6a-b0f3-8ae0f02c076f"><img src="https://github.com/user-attachments/assets/45805289-a09b-4d6a-b0f3-8ae0f02c076f" alt="Table before scrolling fix at 1b0cd3d" width="280" /></a></td><td><a href="https://github.com/user-attachments/assets/5b37d69e-8a8f-4552-9e65-6b420b93148d"><img src="https://github.com/user-attachments/assets/5b37d69e-8a8f-4552-9e65-6b420b93148d" alt="Table after horizontal scrolling with whole words" width="280" /></a></td></tr>
</table>

Final body scroll/client widths are 356/356px at 390px and 1038/1038px at 1440px; before they were 1504/356px and 1512/1038px. The first paragraph's first glyph aligns with its left edge; `text-indent` is zero. Metadata occupies one line. At 390px the table has a 324px viewport and 936px content width; scrolling it to 612px exposes the remaining columns without splitting words. The modal itself has no horizontal overflow.

Install matches a real confirmation-dialog button at 1440px: 163.016px wide and 38.141px tall. At 390px it fills its 324px action row and retains the 44px Skills touch target. The full button is visible without vertical scrolling in the mobile fixture.

- All 31 focused cases passed on the rebased head: 25 Skills/ClawHub unit cases and six body/header browser cases. Earlier pre-rebase evidence retains one intermittent installed-reader Escape timeout followed by a passing fresh run; the current run passed all cases without a retry.
- The body regression failed on the previous renderer for missing rendered headings at both widths. Coverage includes heading/paragraph/code/table output, unsafe-attribute removal, and horizontal containment. The extended table regression also fails on `3fc4977` at both widths and passes with real horizontal table scrolling after the fix.
- Fresh checks for the header update passed: focused formatting, CSS lint, `git diff --check`, and mock Close/Escape/search/install interactions. Existing body type/lint proof remains applicable to the byte-identical body patch; no TypeScript body code changed during this rebase.
- Close, Escape, search empty/results, detail opening, both install paths, pending state and success callout were exercised.
- During initial development, the combined changed check was interrupted when it expanded into unrelated core-test type graphs. The owning UI checks passed separately; the full combined check is not reported as passing.

## Risk and coverage

The API shape and install controllers are unchanged. This is an intentional display change for changelog strings: Markdown is parsed through the existing sanitizer instead of displayed literally. Summary and metadata remain text. Code blocks and wide tables keep the canonical renderer's local scrolling; the modal body has no horizontal overflow. Header/card/Close behavior comes from #142550. No live skill installation was performed.

Landing validation: the branch is now rebased onto merged header/main `c906d02d4f2002f4c4b0e13083adaaa2e251cae7`, at head `16898995c80f1053726d3c503a2379d66d4f3583`. Only the four detail files remain in this PR: production +73/-38, tests +60/-1. All four body commits retain the approved patch in range-diff. The 31 focused cases passed on the preceding unchanged body implementation, and scoped reviews of the body and dependency selector repair are clean. Exact-head hosted [CI run 34290864470](https://github.com/openclaw/openclaw/actions/runs/34290864470) passed; the canonical watcher completed green.

Earlier CI found an unrelated protocol max-lines violation, repaired in #142648 by @RomneyDa, and three E2E cases using retired header selectors, repaired by @vyctorbrzezowski in #142550. Both owner repairs are now in main; all behavioral assertions are preserved. The screenshots remain pinned to their inspected revisions and the approved visual design is unchanged.

The durable ClawSweeper report was rechecked at `updated_at=2026-09-08T23:37:06Z` for exact head `16898995c80f1053726d3c503a2379d66d4f3583`. It is ready for maintainer review, with no code findings, Before merge items, or Rank-up moves to apply or skip. The dependency-first requirement is satisfied and the library E2E selector fixes are preserved.
