### PR TITLE
fix: keep sandbox transports out of Linux OOM adjustment

### DIFF
--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -359,13 +359,18 @@ For eligible Linux child spawns, OpenClaw wraps the command in a short
 `1000`, then `exec`s the real command. This is unprivileged: a process may
 always raise its own OOM score.
 
-Covered child process surfaces:
+Covered Gateway-owned child process surfaces:
 
-- Supervisor-managed command children
+- Supervisor-managed command children, excluding sandbox backend transports
 - PTY shell children
 - MCP stdio server children
 - Managed local model and embedding service children
 - OpenClaw-launched browser/Chrome processes (via the plugin SDK process runtime)
+
+Sandbox backends own the workload lifecycle and resource policy beyond their
+local transport process. OpenClaw therefore launches prepared Docker, Podman,
+SSH, OpenShell, and plugin-provided sandbox transports without the OOM-score
+wrapper.
 
 The wrapper is Linux-only and skipped when `/bin/sh` is unavailable, or when
 the child env sets `OPENCLAW_CHILD_OOM_SCORE_ADJ` to `0`, `false`, `no`, or

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -203,7 +203,50 @@ describe("runExecProcess cursor tracking", () => {
   });
 });
 
-describe("sandbox exec preparation failures", () => {
+describe("sandbox exec preparation", () => {
+  it("preserves the backend transport environment when spawning sandbox exec", async () => {
+    const backendEnv = {
+      BASH_ENV: "/sandbox/transport/bash-env",
+      PATH: "/sandbox/transport/bin",
+    };
+    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) =>
+      runtimeManagedRun(input),
+    );
+
+    const run = await runExecProcess({
+      command: "sandbox-command",
+      workdir: "/tmp",
+      env: {},
+      sandbox: {
+        containerName: "sandbox",
+        workspaceDir: "/workspace",
+        containerWorkdir: "/workspace",
+        buildExecSpec: async () => ({
+          argv: ["sandbox-transport", "exec", "sandbox-command"],
+          env: backendEnv,
+          stdinMode: "pipe-closed",
+        }),
+      },
+      usePty: false,
+      warnings: [],
+      maxOutput: 1_000,
+      pendingMaxOutput: 1_000,
+      notifyOnExit: false,
+      timeoutSec: null,
+    });
+    await run.promise;
+
+    expect(supervisorMock.spawn).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        mode: "child",
+        argv: ["sandbox-transport", "exec", "sandbox-command"],
+        env: backendEnv,
+        exactEnv: true,
+        cleanupOwnership: "external",
+      }),
+    );
+  });
+
   it.each(["preparation", "supervisor"] as const)(
     "rechecks the admitting repair authority after deferred %s work",
     async (boundary) => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -935,7 +935,14 @@ export async function runExecProcess({
     usingPty = spawnSpec.mode === "pty";
     const spawnBase = {
       runId: sessionId,
-      ...(opts.sandbox ? { cleanupOwnership: "external" as const } : {}),
+      ...(opts.sandbox
+        ? {
+            cleanupOwnership: "external" as const,
+            // The local child is a backend transport, not the sandbox workload.
+            // Preserve the backend-prepared launch instead of applying local wrappers.
+            exactEnv: true as const,
+          }
+        : {}),
       scopeKey: opts.scopeKey,
       cwd: opts.workdir,
       env: spawnSpec.env,


### PR DESCRIPTION
Closes #142481

## What Problem This Solves

On Linux, sandboxed exec currently applies OpenClaw's child-first OOM-score wrapper to the local sandbox backend transport. For Docker, Podman, SSH, OpenShell, and plugin-provided backends, that local child is a transport rather than the sandbox workload, so biasing it as the first OOM victim can sever the workload's control path.

## Why This Change Was Made

This marks backend-prepared sandbox launch specifications as exact-environment child launches when they enter the generic process supervisor. That reuses the supervisor's existing wrapper-bypass contract at the ownership boundary, without adding backend-name checks or changing ordinary Gateway-owned child behavior.

The regression test covers the sandbox-to-supervisor handoff. The Linux documentation now distinguishes Gateway-owned children from backend-owned sandbox transports.

## User Impact

Sandbox backend transports no longer receive OpenClaw's `oom_score_adj=1000` wrapper. Workload resource and OOM policy remains owned by the selected sandbox backend. Non-sandboxed Gateway child processes retain the existing child-first OOM behavior.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/process/supervisor/adapters/child.test.ts`
- `pnpm test:changed`
- `node scripts/check-changed.mjs`
- `pnpm docs:check-mdx`
- `git diff --check`

All commands above passed under the repository-supported Node 24.16 runtime. The new regression assertion failed before the production change and passed afterward.

### Linux runtime proof (Podman)

Captured locally from exact head `f92ae10a557d0d462c6a8b116d544788690e6a19` through the real `runExecProcess` and `createPodmanSandboxBackend` paths, using isolated OpenClaw state and a task-owned Alpine container:

```text
platform:                         linux
parent inherited oom_score_adj:  200
ordinary host child (bash):      1000
sandbox transport (podman):      200

ordinary host child adjusted:    PASS
sandbox transport inherited:     PASS
real Podman transport observed:  PASS
```

The task-owned container and isolated state were removed after capture, and the repository remained clean.

A fresh automated review was also attempted after validation; its engine remained active without returning a verdict for 31 minutes, so it was stopped rather than represented as a passing review.
