### PR TITLE
fix(models): harden SDK catalog loads with passive defaults

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -95,6 +95,13 @@ provider inventory. Model selection, subagent capability checks, and hook-model
 validation also use the published inventory. Missing capability facts do not
 start another provider discovery. Native runtime observations keep their separate
 owner and authentication requirements.
+
+Programmatic catalog loads, including the public SDK loader, also default to
+passive reads. Without a published owner they use existing read-only facts. Callers
+that explicitly request a full refresh keep inventory acquisition; an explicit
+read-only request keeps its narrower refresh scope. Runtime callers can retain
+explicit writable ownership when needed.
+
 For models configured to use a CLI runtime, channel picker availability follows that
 runtime's prepared authentication; a provider API key does not substitute for its
 native login.

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -225,6 +225,7 @@ describe("prepared model catalog access", () => {
   });
 
   it.each([
+    { readOnly: undefined, refreshFullCatalog: true },
     { readOnly: true, refreshFullCatalog: true },
     { readOnly: false, refreshFullCatalog: true },
   ] as const)(
@@ -259,6 +260,8 @@ describe("prepared model catalog access", () => {
   );
 
   it.each([
+    { readOnly: undefined, refreshFullCatalog: undefined },
+    { readOnly: undefined, refreshFullCatalog: false },
     { readOnly: true, refreshFullCatalog: undefined },
     { readOnly: true, refreshFullCatalog: false },
     { readOnly: false, refreshFullCatalog: undefined },
@@ -283,7 +286,7 @@ describe("prepared model catalog access", () => {
         loadPreparedModelCatalogOwnerSnapshot({ readOnly, refreshFullCatalog }),
       ).resolves.toMatchObject({ modelCatalog: fullSnapshot.modelCatalog });
       expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
-      if (readOnly) {
+      if (readOnly !== false) {
         expect(snapshot.readFullModelCatalog).toHaveBeenCalledOnce();
         expect(snapshot.loadFullModelCatalog).not.toHaveBeenCalled();
       } else {
@@ -510,11 +513,47 @@ describe("prepared model catalog access", () => {
     expect(mocks.getSnapshot.mock.calls[0]?.[0]).not.toHaveProperty("readOnly");
   });
 
-  it("activates a persistent full owner for a standalone catalog read", async () => {
+  it("defaults exact and published data reads to completed facts without acquisition", async () => {
+    const completedCatalog = {
+      entries: [{ provider: "test", id: "completed", name: "Completed" }],
+      routeVariants: [],
+    };
+    const snapshot = {
+      ...fullSnapshot,
+      readFullModelCatalog: vi.fn(() => completedCatalog),
+      loadFullModelCatalog: vi.fn().mockRejectedValue(new Error("unrequested discovery")),
+    };
+    setPreparedModelFullCatalogAuth(completedCatalog, {
+      authStore: fullSnapshot.authStore,
+      authModes: fullSnapshot.authModes,
+    });
+    mocks.getSnapshot.mockReturnValue(snapshot);
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+
+    await expect(loadPreparedModelCatalogSnapshot()).resolves.toBe(completedCatalog);
+    await expect(loadPublishedPreparedModelCatalog()).resolves.toBe(completedCatalog.entries);
+    expect(snapshot.loadFullModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
+  });
+
+  it("releases an ordinary standalone read without activating a persistent owner", async () => {
+    mocks.prepareSnapshot.mockRejectedValue(new PreparedModelRuntimeOwnerNotPublishedError());
+    mocks.loadSnapshot.mockResolvedValue(readOnlySnapshot);
+    mocks.activateSnapshot.mockResolvedValue(fullSnapshot);
+
+    await expect(loadPreparedModelCatalogSnapshot()).resolves.toBe(readOnlySnapshot.modelCatalog);
+    expect(mocks.activateSnapshot).not.toHaveBeenCalled();
+    expect(mocks.acquireSnapshot).not.toHaveBeenCalled();
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("activates a persistent full owner for an explicitly writable catalog read", async () => {
     mocks.prepareSnapshot.mockRejectedValue(new PreparedModelRuntimeOwnerNotPublishedError());
     mocks.activateSnapshot.mockResolvedValue(fullSnapshot);
 
-    await expect(loadPreparedModelCatalogSnapshot()).resolves.toBe(fullSnapshot.modelCatalog);
+    await expect(loadPreparedModelCatalogSnapshot({ readOnly: false })).resolves.toBe(
+      fullSnapshot.modelCatalog,
+    );
 
     expect(mocks.activateSnapshot).toHaveBeenCalledWith(
       expect.not.objectContaining({ readOnly: true }),
@@ -531,7 +570,9 @@ describe("prepared model catalog access", () => {
       config: { agents: { defaults: { model: "openai/old" } } },
     });
 
-    await expect(loadPreparedModelCatalogSnapshot()).rejects.toThrow("requested config");
+    await expect(loadPreparedModelCatalogSnapshot({ readOnly: false })).rejects.toThrow(
+      "requested config",
+    );
   });
 
   it("leases a full generation for a gateway preflight in a dynamic workspace", async () => {
@@ -540,7 +581,7 @@ describe("prepared model catalog access", () => {
     mocks.acquireSnapshot.mockResolvedValue(fullSnapshot);
 
     await expect(
-      loadPreparedModelCatalogSnapshot({ workspaceDir: "/tmp/spawned-workspace" }),
+      loadPreparedModelCatalogSnapshot({ workspaceDir: "/tmp/spawned-workspace", readOnly: false }),
     ).resolves.toBe(fullSnapshot.modelCatalog);
 
     expect(mocks.acquireSnapshot).toHaveBeenCalledWith(
@@ -558,7 +599,9 @@ describe("prepared model catalog access", () => {
       config: { agents: { defaults: { model: "openai/old" } } },
     });
 
-    await expect(loadPreparedModelCatalogSnapshot()).rejects.toThrow("requested config");
+    await expect(loadPreparedModelCatalogSnapshot({ readOnly: false })).rejects.toThrow(
+      "requested config",
+    );
     expect(mocks.releaseSnapshot).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -300,22 +300,27 @@ async function withPreparedModelCatalogOwnerPolicy<T>(
   configPolicy: PreparedModelCatalogConfigPolicy,
   read: (snapshot: PreparedModelRuntimeSnapshot) => T | Promise<T>,
 ): Promise<T> {
-  const publishedReadOnlyOwner = params.readOnly
-    ? getPreparedModelCatalogOwnerSnapshot(params)
+  // Ordinary reads stay passive; explicit refresh keeps its existing writable default.
+  const request = {
+    ...params,
+    readOnly: params.readOnly ?? params.refreshFullCatalog !== true,
+  };
+  const publishedReadOnlyOwner = request.readOnly
+    ? getPreparedModelCatalogOwnerSnapshot(request)
     : undefined;
   const { snapshot, release } = await resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
-    params,
+    request,
     configPolicy,
   );
   try {
     // Only published owners expose generation caches; temporary reads use their prepared facts.
     const owner =
-      params.readOnly && !publishedReadOnlyOwner
+      request.readOnly && !publishedReadOnlyOwner
         ? snapshot
         : await materializeRequestedModelCatalog(
             snapshot,
-            params.readOnly,
-            params.refreshFullCatalog,
+            request.readOnly,
+            request.refreshFullCatalog,
           );
     // Projection must finish before a temporary lease retires its liveness predicate.
     return await read(owner);
@@ -439,8 +444,9 @@ export async function loadResolvedPublishedModelCatalogOwner(
 export async function loadPreparedModelCatalogSnapshot(
   params: LoadPreparedModelCatalogParams = {},
 ): Promise<ModelCatalogSnapshot> {
-  if (params.readOnly && params.providerDiscoveryProviderIds) {
-    return loadScopedReadOnlyModelCatalog(params);
+  const readOnly = params.readOnly ?? params.refreshFullCatalog !== true;
+  if (readOnly && params.providerDiscoveryProviderIds) {
+    return loadScopedReadOnlyModelCatalog({ ...params, readOnly });
   }
   return (await loadPreparedModelCatalogOwnerSnapshot(params)).modelCatalog;
 }

--- a/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
+++ b/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
@@ -58,10 +58,19 @@ describe("agent-runtime model catalog compatibility", () => {
       routeVariants: [],
     });
 
-    await expect(loadModelCatalog({ cacheOnly: true, useCache: true })).resolves.toEqual([
-      { provider: "test", id: "cached", name: "Cached" },
-    ]);
+    await expect(
+      loadModelCatalog({ cacheOnly: true, useCache: true, refreshFullCatalog: true }),
+    ).resolves.toEqual([{ provider: "test", id: "cached", name: "Cached" }]);
     expect(mocks.loadCatalog).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit refresh intent through the legacy loader", async () => {
+    const entries = [{ provider: "test", id: "refreshed", name: "Refreshed" }];
+    mocks.loadCatalog.mockResolvedValue(entries);
+
+    await expect(loadModelCatalog({ refreshFullCatalog: true })).resolves.toBe(entries);
+    expect(mocks.loadCatalog).toHaveBeenCalledExactlyOnceWith({ refreshFullCatalog: true });
+    expect(mocks.getSnapshot).not.toHaveBeenCalled();
   });
 
   it("accepts legacy options without overriding lifecycle metadata", async () => {

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -52,13 +52,15 @@ type LoadModelCatalogCompatibilityParams = LoadPreparedModelCatalogParams & {
 
 /** @deprecated Use loadPreparedModelCatalog or getPreparedModelCatalogSnapshot. */
 export async function loadModelCatalog(params: LoadModelCatalogCompatibilityParams = {}) {
-  const { agentId, agentDir, cacheOnly, config, env, readOnly, workspaceDir } = params;
+  const { agentId, agentDir, cacheOnly, config, env, readOnly, refreshFullCatalog, workspaceDir } =
+    params;
   const preparedParams: LoadPreparedModelCatalogParams = {
     ...(agentId ? { agentId } : {}),
     ...(agentDir ? { agentDir } : {}),
     ...(config ? { config } : {}),
     ...(env ? { env } : {}),
     ...(readOnly !== undefined ? { readOnly } : {}),
+    ...(refreshFullCatalog !== undefined ? { refreshFullCatalog } : {}),
     ...(workspaceDir ? { workspaceDir } : {}),
   };
   if (cacheOnly) {


### PR DESCRIPTION
## What Problem This Solves

Ordinary catalog loads started provider discovery when callers omitted the read-only option, including cold data reads.

## Why This Change Was Made

Make default reads passive at the shared prepared-catalog operation. Preserve explicit writable/read-only scope and forward the existing full-refresh option through the legacy public adapter.

## User Impact

Ordinary and legacy default calls avoid discovery; explicit writable or Refresh calls still acquire models. Configured rows and default settings are preserved.

Consumers: prepared catalog reads and the legacy public adapter use passive defaults in this change.

## Evidence

Compiled package exports and a synthetic catalog service reproduced two unwanted requests for each ordinary read. The changed defaults made none, while explicit acquisition returned capability rows. Forty focused checks and two compiled scenarios covering 19 public actions passed. An unrelated native-command timeout remained; no standalone upgrade run was performed.
