### PR TITLE
fix(agents): clarify settled finalizer is text-only

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -3306,6 +3306,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       prompt: SETTLED_TOOL_CONTINUATION_INSTRUCTION,
       suppressNextUserMessagePersistence: true,
     });
+    expect(runAttemptCall(1).prompt).toContain(
+      "Tools are unavailable in this step: it is a text-only pass",
+    );
     expect(result.meta.finalAssistantVisibleText).toBe("Write completed.");
     expectWarnMessageWith("settled post-tool turn lacked a final answer");
   });

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -137,7 +137,7 @@ export const REASONING_ONLY_RETRY_INSTRUCTION =
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 export const SETTLED_TOOL_CONTINUATION_INSTRUCTION =
-  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete


### PR DESCRIPTION
## Problem

The 2026.6.35 package-acceptance Telegram run reached a settled side-effecting write, then its tools-disabled recovery attempt returned another `toolUse` with no payload. The continuation prompt said not to repeat completed tools but never stated that tools are unavailable, so a model can still attempt one and the existing incomplete-turn guard surfaces an error.

## Fix

State the existing execution contract in the settled-turn continuation: tools are unavailable and the pass must reply with plain text. Tools remain disabled; replay/capability guards are unchanged.

## Proof

- Red evidence: [Telegram package-acceptance job 102223637021](https://github.com/openclaw/openclaw/actions/runs/34273871537/job/102223637021) failed only `telegram-empty-response-after-write-recovery`; the gateway recorded `settled post-tool turn lacked a final answer`, then `stopReason=toolUse` with `payloads=0`. The other six Telegram package scenarios passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 113 passed. The regression exercises the actual settled-write recovery boundary and fails before this prompt contract is present.
- `pnpm exec oxfmt --check --threads=1` (changed files), `pnpm lint:core`, and `git diff --check` passed.
- `node scripts/check-changed.mjs -- ...` is running in Testbox: `tbx_01m21cfkqa62n5xj9wrsx2jfn0`.

## Scope

Production: +1/-1 in `src/agents/embedded-agent-runner/run/incomplete-turn.ts`. Test: +3/-0. This is a direct adaptation of main PR #141705 to the pre-refactor extended-stable owner; it is not a Telegram transport change.