### PR TITLE
docs(help): link the allowlist env vars orphaned by the testing split

### DIFF
--- a/docs/help/testing/live-workflows.md
+++ b/docs/help/testing/live-workflows.md
@@ -88,5 +88,5 @@ When debugging real providers/models (requires real creds):
   assistant transcript stores normalized `usage.cost`.
 
 <Tip>
-When you only need one failing case, prefer narrowing live tests via the allowlist env vars described below.
+When you only need one failing case, prefer narrowing live tests via the [allowlist env vars](/help/testing/docker).
 </Tip>


### PR DESCRIPTION
## What

One sentence in `docs/help/testing/live-workflows.md` pointed "below" at content that is no longer on that page.

## Why it matters

The page ends one line after:

> prefer narrowing live tests via the allowlist env vars described below.

Those env vars moved to `docs/help/testing/docker.md` when the testing guide was split. The sentence now sends the reader to the bottom of the page, where there is nothing.

**No gate in this repository can catch this.** It is valid prose containing no link, so `docs-link-audit`, `format-docs`, `markdownlint` and `check-docs-mdx` all pass. It reached `main` through a full review.

## How I found it

I wrote `.audit/check-orphan-refs.py` after this class of defect appeared three separate times in the docs audit program — every time spotted by a reader, never by tooling. It flags directional phrasing ("described below", "the section above", "at the top of this page") for a human to confirm, since a directional word is perfectly fine when its target is on the same page.

Scoped to the six recently split trees it reports 8 candidates. Seven resolve on their own page — including numeric phrasing like "patch `33` or above", which it deliberately does not flag. This was the one real defect.

Tree-wide it reports 184 candidates, which is too noisy to gate on; the value is in running it against the pages a split touches.

## Validation

```
docs-link-audit --anchors   0 broken links
format-docs --check         clean, 912 files
check-orphan-refs docs/help/testing   0 candidates remaining
```