### PR TITLE
test(live): classify upstream unavailable models

### DIFF
--- a/src/agents/live-test-provider-drift.test.ts
+++ b/src/agents/live-test-provider-drift.test.ts
@@ -78,6 +78,11 @@ describe("live test provider drift", () => {
         "Error Code unknown: Service temporarily unavailable. The model's availability is currently degraded.",
       ),
     ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "400 Error from provider (Console Go): Upstream request failed: Model is unavailable.",
+      ),
+    ).toBe(true);
   });
 
   it("returns explicit skip labels only for enabled drift classes", () => {

--- a/src/agents/live-test-provider-drift.ts
+++ b/src/agents/live-test-provider-drift.ts
@@ -113,6 +113,7 @@ function isLiveProviderUnavailableDrift(error: unknown): boolean {
     msg.includes("unable to access non-serverless model") ||
     msg.includes("create and start a new dedicated endpoint") ||
     msg.includes("no available capacity was found for the model") ||
+    msg.includes("upstream request failed: model is unavailable") ||
     (msg.includes("502") && msg.includes("internal server error"))
   );
 }


### PR DESCRIPTION
## Summary
- classify the Console Go upstream model-unavailable response as provider availability drift
- keep the classification scoped to live tests rather than production failover

## Validation
- focused provider drift suite: 5 passed
- formatting check