### PR TITLE
fix(release): capability-bind Bun install runtime

### DIFF
--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -47,6 +47,7 @@ LOCAL_AGENT_LOG=""
 GATEWAY_LOG=""
 GATEWAY_HEALTH_LOG=""
 GATEWAY_AGENT_LOG=""
+DIRECT_BUN_LOG=""
 
 cleanup() {
   openclaw_e2e_stop_process "${GATEWAY_PID:-}"
@@ -73,7 +74,8 @@ dump_debug_logs() {
     "$LOCAL_AGENT_LOG" \
     "$GATEWAY_LOG" \
     "$GATEWAY_HEALTH_LOG" \
-    "$GATEWAY_AGENT_LOG" >&2 || true
+    "$GATEWAY_AGENT_LOG" \
+    "$DIRECT_BUN_LOG" >&2 || true
 }
 
 prepare_ai_candidate() {
@@ -246,12 +248,15 @@ main() {
 
   local bun_path
   local bun_version
+  local direct_bun_status
   local gateway_port
   local mock_port
   local openclaw_entry
   local openclaw_bin
   local package_root
+  local runtime_label
   local success_marker
+  local -a runtime_command
   bun_path="$(command -v "$BUN_BIN")"
   bun_version="$("$bun_path" --version)"
   node scripts/e2e/lib/bun-global-install/assertions.mjs assert-bun-version "$bun_version"
@@ -301,6 +306,7 @@ NODE
   GATEWAY_LOG="$SMOKE_DIR/gateway.log"
   GATEWAY_HEALTH_LOG="$SMOKE_DIR/gateway-health.json"
   GATEWAY_AGENT_LOG="$SMOKE_DIR/gateway-agent.log"
+  DIRECT_BUN_LOG="$SMOKE_DIR/direct-bun.log"
 
   echo "==> Install packed OpenClaw with trusted lifecycle scripts on Bun $bun_version"
   run_with_timeout "$COMMAND_TIMEOUT_MS" \
@@ -338,20 +344,36 @@ NODE
   echo "==> OpenClaw help through Bun global install"
   run_with_timeout "$COMMAND_TIMEOUT_MS" "$openclaw_bin" --help >/dev/null
 
-  run_bun_cli() {
-    run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" "$openclaw_entry" "$@"
+  run_installed_cli() {
+    run_with_timeout "$COMMAND_TIMEOUT_MS" "${runtime_command[@]}" "$@"
   }
 
   echo "==> Installed package entry under Bun"
-  run_bun_cli --version
-  run_bun_cli --help >/dev/null
-  pushd "$HOME" >/dev/null
-  run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" run --bun openclaw --version
-  popd >/dev/null
+  if run_with_timeout "$COMMAND_TIMEOUT_MS" \
+    "$bun_path" "$openclaw_entry" --version >"$DIRECT_BUN_LOG" 2>&1; then
+    cat "$DIRECT_BUN_LOG"
+    runtime_command=("$bun_path" "$openclaw_entry")
+    runtime_label="Bun"
+    run_installed_cli --help >/dev/null
+    pushd "$HOME" >/dev/null
+    run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" run --bun openclaw --version
+    popd >/dev/null
+  else
+    direct_bun_status=$?
+    if ! grep -Fq "Bun runtime is unsupported" "$DIRECT_BUN_LOG" || \
+      ! grep -Fq "node:sqlite" "$DIRECT_BUN_LOG"; then
+      cat "$DIRECT_BUN_LOG" >&2
+      return "$direct_bun_status"
+    fi
+    echo "==> Candidate explicitly requires Node runtime; continuing with Bun-installed launcher"
+    cat "$DIRECT_BUN_LOG"
+    runtime_command=("$openclaw_bin")
+    runtime_label="Node"
+  fi
 
-  echo "==> OpenClaw image providers under Bun"
+  echo "==> OpenClaw image providers under $runtime_label"
   local providers_json
-  providers_json="$(run_bun_cli infer image providers --json)"
+  providers_json="$(run_installed_cli infer image providers --json)"
   OPENCLAW_IMAGE_PROVIDERS_JSON="$providers_json" node scripts/e2e/lib/bun-global-install/assertions.mjs assert-image-providers
 
   read -r gateway_port mock_port < <(reserve_runtime_ports)
@@ -363,15 +385,15 @@ NODE
     "$mock_port" \
     "$gateway_port"
 
-  echo "==> Representative CLI state under Bun"
-  run_bun_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
-  run_bun_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
+  echo "==> Representative CLI state under $runtime_label"
+  run_installed_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
+  run_installed_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
 
-  echo "==> Local mocked agent turn under Bun"
+  echo "==> Local mocked agent turn under $runtime_label"
   MOCK_PID="$(openclaw_e2e_start_mock_openai "$mock_port" "$MOCK_LOG")"
   openclaw_e2e_wait_mock_openai "$mock_port"
   : >"$MOCK_REQUEST_LOG"
-  run_bun_cli agent --local \
+  run_installed_cli agent --local \
     --agent main \
     --session-id bun-global-local-agent \
     --message "Return marker $success_marker" \
@@ -383,22 +405,21 @@ NODE
     "$LOCAL_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "==> Gateway health and mocked agent turn under Bun"
+  echo "==> Gateway health and mocked agent turn under $runtime_label"
   : >"$MOCK_REQUEST_LOG"
   GATEWAY_PID="$(
     openclaw_e2e_start_tracked_process \
       "$GATEWAY_LOG" \
-      "$bun_path" \
-      "$openclaw_entry" \
+      "${runtime_command[@]}" \
       gateway \
       --port "$gateway_port" \
       --bind loopback
   )"
   openclaw_e2e_wait_gateway_ready "$GATEWAY_PID" "$GATEWAY_LOG" 300 "$gateway_port"
-  run_bun_cli gateway health \
+  run_installed_cli gateway health \
     --token "$OPENCLAW_GATEWAY_TOKEN" \
     --json >"$GATEWAY_HEALTH_LOG" 2>&1
-  run_bun_cli agent \
+  run_installed_cli agent \
     --agent main \
     --session-id bun-global-gateway-agent \
     --message "Return marker $success_marker" \
@@ -410,22 +431,23 @@ NODE
     "$GATEWAY_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "bun-global-install-smoke: Bun $bun_version package, CLI, local agent, and Gateway runtime OK"
+  echo "bun-global-install-smoke: Bun $bun_version install with $runtime_label CLI, local agent, and Gateway runtime OK"
 
   if [ -n "${OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH:-}" ]; then
     node --input-type=module - \
       "$OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH" \
       "$bun_path" \
       "$openclaw_bin" \
-      "$openclaw_version" <<'NODE'
+      "$openclaw_version" \
+      "$runtime_label" <<'NODE'
 import fs from "node:fs";
 import path from "node:path";
 
-const [, , proofPath, bunPath, openclawPath, openclawVersion] = process.argv;
+const [, , proofPath, bunPath, openclawPath, openclawVersion, runtime] = process.argv;
 fs.mkdirSync(path.dirname(proofPath), { recursive: true });
 fs.writeFileSync(
   proofPath,
-  `${JSON.stringify({ bunPath, openclawPath, openclawVersion }, null, 2)}\n`,
+  `${JSON.stringify({ bunPath, openclawPath, openclawVersion, runtime }, null, 2)}\n`,
 );
 NODE
   fi

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2300,7 +2300,7 @@ syncBuiltinESMExports();
     },
   );
 
-  it("packs the current tree and verifies the installed package runtime through Bun", () => {
+  it("packs the current tree and capability-binds the installed package runtime", () => {
     const script = readFileSync(BUN_GLOBAL_SMOKE_PATH, "utf8");
     const assertions = readFileSync(BUN_GLOBAL_ASSERTIONS_PATH, "utf8");
     const packageHelper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
@@ -2317,6 +2317,10 @@ syncBuiltinESMExports();
     expect(script).not.toContain("npm pack --ignore-scripts --json --pack-destination");
     expect(script).toContain('"$bun_path" install -g --trust "$PACKAGE_TGZ" --no-progress');
     expect(script).toContain('"$openclaw_bin" --help');
+    expect(script).toContain('grep -Fq "Bun runtime is unsupported" "$DIRECT_BUN_LOG"');
+    expect(script).toContain('grep -Fq "node:sqlite" "$DIRECT_BUN_LOG"');
+    expect(script).toContain('runtime_command=("$openclaw_bin")');
+    expect(script).toContain('return "$direct_bun_status"');
     expect(script).toContain("OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH");
     expect(script).toContain("infer image providers --json");
     expect(script).toContain("assert-image-providers");
@@ -2497,19 +2501,34 @@ syncBuiltinESMExports();
     {
       name: "uses bundled AI bytes when a prebuilt tarball is provided",
       bundledAi: true,
+      bunRuntime: "supported",
       statusExit: 0,
     },
     {
       name: "installs an older tarball with no bundled AI dependency unchanged",
       bundledAi: false,
+      bunRuntime: "supported",
       statusExit: 0,
     },
     {
       name: "preserves redirected Bun command diagnostics and exit status",
       bundledAi: true,
+      bunRuntime: "supported",
       statusExit: 23,
     },
-  ])("$name", ({ bundledAi, statusExit }) => {
+    {
+      name: "uses Node for a Bun-installed package that explicitly rejects the Bun runtime",
+      bundledAi: true,
+      bunRuntime: "unsupported",
+      statusExit: 0,
+    },
+    {
+      name: "does not hide an unexpected direct Bun runtime failure",
+      bundledAi: true,
+      bunRuntime: "unexpected-failure",
+      statusExit: 0,
+    },
+  ])("$name", ({ bundledAi, bunRuntime, statusExit }) => {
     const tempDir = tempDirs.make("openclaw-bun-prebuilt-");
     const packageDir = join(tempDir, "fixture", "package");
     const aiDir = join(packageDir, "node_modules", "@openclaw", "ai");
@@ -2570,6 +2589,14 @@ if [[ "\${1:-}" == */verify-fs-safe-native.mjs ]]; then
   exit 0
 fi
 if [[ "\${1:-}" == */openclaw.mjs ]]; then
+  if [ "$FAKE_BUN_RUNTIME" = "unsupported" ]; then
+    echo 'openclaw: the Bun runtime is unsupported because OpenClaw requires node:sqlite.' >&2
+    exit 1
+  fi
+  if [ "$FAKE_BUN_RUNTIME" = "unexpected-failure" ]; then
+    echo 'synthetic direct Bun runtime failure' >&2
+    exit 42
+  fi
   shift
   exec node "$BUN_INSTALL/install/global/node_modules/openclaw/openclaw.mjs" "$@"
 fi
@@ -2648,6 +2675,7 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
         ...process.env,
         BUN_BIN: bunPath,
         EXPECT_AI_OVERRIDE: bundledAi ? "1" : "0",
+        FAKE_BUN_RUNTIME: bunRuntime,
         FAKE_STATUS_EXIT: String(statusExit),
         FAKE_STATE_PATH: statePath,
         FAKE_AI_TARBALL_PATH: aiTarballPath,
@@ -2657,15 +2685,21 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
       },
     });
 
-    expect(result.status, result.stderr).toBe(statusExit);
+    const expectedExit = bunRuntime === "unexpected-failure" ? 42 : statusExit;
+    expect(result.status, result.stderr).toBe(expectedExit);
     expect(existsSync(path.dirname(readFileSync(statePath, "utf8").trim()))).toBe(false);
     if (bundledAi) {
       expect(existsSync(path.dirname(readFileSync(aiTarballPath, "utf8").trim()))).toBe(false);
     }
-    expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
-    if (statusExit === 0) {
+    if (bunRuntime !== "unexpected-failure") {
+      expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
+    }
+    if (bunRuntime === "unexpected-failure") {
+      expect(result.stderr).toContain("synthetic direct Bun runtime failure");
+      expect(result.stdout).not.toContain("Gateway runtime OK");
+    } else if (statusExit === 0) {
       expect(result.stdout).toContain(
-        "bun-global-install-smoke: Bun 1.4.0 package, CLI, local agent, and Gateway runtime OK",
+        `bun-global-install-smoke: Bun 1.4.0 install with ${bunRuntime === "supported" ? "Bun" : "Node"} CLI, local agent, and Gateway runtime OK`,
       );
     } else {
       expect(result.stderr).toContain("bun global install smoke failed with exit code 23");


### PR DESCRIPTION
## Summary
- keep Bun global install and lifecycle verification mandatory
- use Bun runtime when supported
- accept only the exact Bun/node:sqlite capability rejection before continuing coverage under Node
- preserve unexpected Bun failures as hard failures

## Validation
- bash syntax check
- focused installer suite: 122 passed
- formatting check