### PR TITLE
fix(plugin-state): reduce memory used by complete listings

### DIFF
--- a/src/plugin-state/plugin-state-store.errors.test.ts
+++ b/src/plugin-state/plugin-state-store.errors.test.ts
@@ -36,6 +36,71 @@ afterEach(() => resetPluginStateStoreForTests());
 afterAll(async () => testState?.cleanup());
 
 describe("plugin state open errors", () => {
+  it.each(["decode", "sqlite-step"] as const)(
+    "preserves %s failures and releases the listing cursor",
+    async (failure) => {
+      await withOpenClawTestState({ label: "plugin-state-entry-cursor" }, async () => {
+        const store = createPluginStateSyncKeyedStore("discord", {
+          namespace: "cursor",
+          maxEntries: 10,
+        });
+        store.register("a", { value: 1 });
+        store.register("b", { value: 2 });
+        const { db, path } = openOpenClawStateDatabase();
+        db.prepare("UPDATE plugin_state_entries SET value_json = ? WHERE entry_key = ?").run(
+          "invalid first JSON",
+          "a",
+        );
+        if (failure === "sqlite-step") {
+          // The listing index lets SQLite return the corrupt first row before
+          // evaluating the second row's native JSON expression.
+          db.exec(`
+            ALTER TABLE plugin_state_entries RENAME TO plugin_state_source;
+            CREATE VIEW plugin_state_entries AS
+              SELECT plugin_id, namespace, entry_key,
+                CASE WHEN entry_key = 'b' THEN json_extract('invalid SQL JSON', '$')
+                  ELSE value_json END AS value_json,
+                created_at, expires_at
+              FROM plugin_state_source;
+          `);
+        }
+        for (const connection of ["warm", "readonly"]) {
+          if (connection === "readonly") {
+            closePluginStateDatabase();
+          }
+          expect(() => store.entries()).toThrowError(
+            expect.objectContaining({
+              code: failure === "decode" ? "PLUGIN_STATE_CORRUPT" : "PLUGIN_STATE_READ_FAILED",
+              operation: "entries",
+              path,
+              cause:
+                failure === "decode"
+                  ? expect.any(SyntaxError)
+                  : expect.objectContaining({
+                      code: "ERR_SQLITE_ERROR",
+                      message: "malformed JSON",
+                    }),
+            }),
+          );
+          const writer = new DatabaseSync(path);
+          try {
+            writer.exec("PRAGMA busy_timeout = 0");
+            const table = failure === "decode" ? "plugin_state_entries" : "plugin_state_source";
+            writer.exec(`UPDATE ${table} SET created_at = created_at + 1`);
+            // A leaked reader would pin this committed WAL and make TRUNCATE busy.
+            expect(writer.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get()).toMatchObject({
+              busy: 0,
+              log: 0,
+              checkpointed: 0,
+            });
+          } finally {
+            writer.close();
+          }
+        }
+      });
+    },
+  );
+
   it("reports the opened database path for corrupt values with an explicit env", async () => {
     await withOpenClawTestState(
       { label: "plugin-state-corrupt-explicit-env", applyEnv: false },

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -8,6 +8,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  iterateSqliteQuerySync,
   prepareSqliteQuerySync,
   sqliteStringSet,
 } from "../infra/kysely-sync.js";
@@ -254,11 +255,11 @@ function selectPluginStateEntry(
   return query(params).rows[0];
 }
 
-function selectPluginStateEntries(
+function iteratePluginStateEntries(
   db: DatabaseSync,
   params: { pluginId: string; namespace: string; now: number },
-): PluginStateRow[] {
-  return executeSqliteQuerySync(
+): IterableIterator<PluginStateRow> {
+  return iterateSqliteQuerySync(
     db,
     getPluginStateKysely(db)
       .selectFrom("plugin_state_entries")
@@ -268,7 +269,7 @@ function selectPluginStateEntries(
       .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)]))
       .orderBy("created_at", "asc")
       .orderBy("entry_key", "asc"),
-  ).rows;
+  );
 }
 
 function selectPluginStateEntriesInKeyRange(
@@ -1406,12 +1407,28 @@ export function pluginStateEntries(params: {
       withPluginStateDatabaseReadOnly(
         "entries",
         ({ db, path: databasePath }) => {
-          const rows = selectPluginStateEntries(db, {
+          const rows = iteratePluginStateEntries(db, {
             pluginId: params.pluginId,
             namespace: params.namespace,
             now: Date.now(),
           });
-          return rows.map((row) => rowToEntry(row, "entries", databasePath));
+          const entries: PluginStateEntry<unknown>[] = [];
+          let decodeFailure: { error: unknown } | undefined;
+          for (const row of rows) {
+            if (decodeFailure) {
+              continue;
+            }
+            try {
+              entries.push(rowToEntry(row, "entries", databasePath));
+            } catch (error) {
+              // Finish the SQL read so a later step failure still precedes JSON errors.
+              decodeFailure = { error };
+            }
+          }
+          if (decodeFailure) {
+            throw decodeFailure.error;
+          }
+          return entries;
         },
         envOptions(params.env),
       ) ?? []


### PR DESCRIPTION
Related: #105002

## What Problem This Solves

Fixes unnecessary transient memory use when a plugin lists a namespace containing large JSON values. A complete listing held every serialized value alongside the decoded result: a synthetic 32 MiB namespace retained about 32 MiB of avoidable extra heap.

## Why This Change Was Made

Decode each row while consuming the existing synchronous SQLite iterator. Keep the same complete namespace, TTL cutoff, ordering, and returned array. Remember the first JSON error and finish the SQL cursor before reporting it, so a later database read failure retains its existing precedence and lifecycle handling.

The SQLite read snapshot now spans decoding within the same synchronous call. No iterator escapes and no schema, retention, quota, index, or public API changes. This is a narrow improvement to #105002; the complete returned array can still be large, and the broader bounded-enumeration decision remains open.

## User Impact

Large keyed-store listings need less temporary live heap without omitting entries or weakening error reporting. This does not establish an OOM cause or promise lower latency.

## Evidence

- Public keyed-store API reproduction on Node 24.20.0, with 64/128/256 synthetic values containing 128 KiB text: extra live heap at the final decoded row fell from 8.093/16.137/32.223 MiB to approximately 0.175 MiB. These GC-assisted retention measurements are separate from natural timing. Every child used a 512 MiB heap cap, exited naturally, and left an empty process group.
- Initial natural wall times were 10.571/15.853/28.458 ms before and 18.926/36.019/64.016 ms after. One fixed six-child, 32 MiB follow-up retained every sample: baseline wall 58.863/29.753/29.527 ms and CPU 36.651/32.338/32.090 ms; candidate wall 31.046/30.383/33.791 ms and CPU 32.959/32.744/34.143 ms. The development host was busy; no speedup is claimed.
- 95 focused tests passed across plugin-state and Kysely owners. New real-SQLite tests cover corrupt JSON followed by a later native SQL error, warm and read-only handles, and external WAL truncation after failure to detect a leaked reader.
- Independent managed Codex review through P2: no actionable findings. One earlier review preparation rejected an absolute evidence path before review; the corrected invocation completed.
- Changed checks passed, including core and test typechecking, lint, formatting, and owner guards.
- [Linux Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34278025490), lease `tbx_01m21d42wy1yv1wpa8jk588wz4`, verified tree `7364abef10fc7da8a69a981fdf115abf4bb046f1`: full build passed (262.2 s), all seven native error tests passed, and separate compiled-SDK processes persisted then reopened/listed 64 synthetic 64 KiB values. Exact values/order, TTL exclusion, delete/clear, and sibling namespace isolation passed. All child groups closed naturally, source hashes remained unchanged, wrapper exit was 0, and the one-shot lease stopped. The backing Actions run may show cancellation from delegated lease cleanup. An initial command was refused before lease allocation for an unsupported native `--stop-after` option; the corrected invocation above ran the proof.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34278429645) passed on attempt 2 at `675a6b4097066488a6e2c2bbed04913474bfa523`. Attempt 1 had announcement-test mock-boundary failures and a Gateway client shutdown timeout. Unchanged baseline checks passed the failing boundaries; the broader baseline shard remained partial because separate worktree tests failed amid low disk. One qualified rerun of only the two failed jobs passed. The workflow automatically routed the retry from Blacksmith to GitHub-hosted Ubuntu; neither original cause is established or claimed fixed by this change.
