### PR TITLE
perf(ui): share message preparation within each render

### DIFF
--- a/ui/src/pages/chat/chat-view.plugin-identity.test.ts
+++ b/ui/src/pages/chat/chat-view.plugin-identity.test.ts
@@ -14,8 +14,9 @@ import { createComposerProps, resetComposerFixture } from "./chat-composer.test-
 import { createTestTranscript } from "./chat-view.test-helpers.ts";
 import { renderChat, type ChatProps } from "./chat-view.ts";
 import { renderGroupedMessage } from "./components/chat-message-bubble.ts";
-import { threadProps } from "./components/chat-transcript.test-support.ts";
+import { prepareChatMessageRender } from "./components/chat-message-markdown.ts";
 import "../../plugins/control-ui-view.runtime.ts";
+import { threadProps } from "./components/chat-transcript.test-support.ts";
 
 afterEach(() => resetComposerFixture());
 
@@ -88,12 +89,12 @@ describe("native chat view session identity", () => {
       override render() {
         return html`${renderChat(props)}
         ${renderGroupedMessage(
-          {
+          prepareChatMessageRender({
             role: "toolResult",
             toolCallId: "identity-result",
             toolName: "inspect",
             content: [{ type: "text", text: "Inspection complete" }],
-          },
+          }),
           "identity-message",
           {
             isStreaming: false,

--- a/ui/src/pages/chat/chat-view.test-helpers.ts
+++ b/ui/src/pages/chat/chat-view.test-helpers.ts
@@ -1,6 +1,9 @@
 import type { ReactiveControllerHost } from "lit";
 import { vi } from "vitest";
-import { resolveMessageActionDetails } from "./components/chat-message-markdown.ts";
+import {
+  prepareChatMessageRender,
+  resolveMessageActionDetails,
+} from "./components/chat-message-markdown.ts";
 import { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
 
 export function createTestTranscript(): ChatTranscriptController {
@@ -42,16 +45,18 @@ export function appendChatBubble(
   const group = document.createElement("div");
   group.className = options.groupClass ?? "chat-group";
   const bubble = Object.assign(document.createElement("div"), {
-    messageActions: resolveMessageActionDetails({
-      message: {
+    messageActions: resolveMessageActionDetails(
+      prepareChatMessageRender({
         role: "user",
         content: options.text ?? "",
         ...(options.entryId ? { __openclaw: { id: options.entryId } } : {}),
+      }),
+      {
+        messageId: options.messageId ?? "test-message",
+        senderLabel: options.senderLabel ?? "User",
+        onReply: () => undefined,
       },
-      messageId: options.messageId ?? "test-message",
-      senderLabel: options.senderLabel ?? "User",
-      onReply: () => undefined,
-    }),
+    ),
   });
   bubble.className = "chat-bubble";
   if (options.entryId) {

--- a/ui/src/pages/chat/components/chat-imported-history.test.ts
+++ b/ui/src/pages/chat/components/chat-imported-history.test.ts
@@ -6,6 +6,7 @@ import { extractText, extractTextCached } from "../../../lib/chat/message-extrac
 import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
 import {
+  prepareChatMessageRender,
   renderMessageActionButtons,
   resolveMessageActionDetails,
 } from "./chat-message-markdown.ts";
@@ -64,7 +65,10 @@ describe.each(["user", "assistant"])("imported %s history presentation", (role) 
     const body = "Imported **answer**\n\n~~~ts\nconst answer = 42;\n~~~";
     const message = { role, content: wrap(body), __openclaw: { idempotencyKey: importKey } };
     render(
-      renderGroupedMessage(message, "imported", { isStreaming: false, showReasoning: false }),
+      renderGroupedMessage(prepareChatMessageRender(message), "imported", {
+        isStreaming: false,
+        showReasoning: false,
+      }),
       container,
     );
     expect(container.querySelector(".chat-text strong")?.textContent).toBe("answer");
@@ -73,8 +77,7 @@ describe.each(["user", "assistant"])("imported %s history presentation", (role) 
     expect(container.textContent).not.toContain("Source: External");
     expect(container.querySelector("h2")).toBeNull();
     const onReply = vi.fn();
-    const details = resolveMessageActionDetails({
-      message,
+    const details = resolveMessageActionDetails(prepareChatMessageRender(message), {
       messageId: "imported",
       senderLabel: role,
       onReply,

--- a/ui/src/pages/chat/components/chat-json-text.test.ts
+++ b/ui/src/pages/chat/components/chat-json-text.test.ts
@@ -4,6 +4,7 @@ import { nothing, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
+import { prepareChatMessageRender } from "./chat-message-markdown.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 import { renderToolCard } from "./chat-tool-cards.ts";
 
@@ -48,11 +49,11 @@ describe.each(["user", "assistant", "toolResult"])("%s JSON message text", (role
     const container = createContainer();
     render(
       renderGroupedMessage(
-        {
+        prepareChatMessageRender({
           role,
           content: text,
           ...(role === "toolResult" ? { toolName: "lookup", toolCallId: "json-result" } : {}),
-        },
+        }),
         "json-message",
         { isStreaming, showReasoning: false, isToolMessageExpanded: () => true },
       ),

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -18,7 +18,6 @@ import type {
 import { extractThinkingCached } from "../../../lib/chat/message-extract.ts";
 import {
   isStandaloneToolMessageForDisplay,
-  normalizeMessage,
   normalizeRoleForGrouping,
 } from "../../../lib/chat/message-normalizer.ts";
 import {
@@ -35,7 +34,10 @@ import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import { workspaceResultConflictFromTranscript } from "../workspace-conflict.ts";
 import { renderAssistantAttachments, renderOmittedMedia } from "./chat-message-attachments.ts";
 import { renderMessageImages } from "./chat-message-images.ts";
-import type { MessageActionDetails } from "./chat-message-markdown.ts";
+import type {
+  ChatMessageRenderPreparation,
+  MessageActionDetails,
+} from "./chat-message-markdown.ts";
 import {
   projectMessageMedia,
   schedulePairingQrExpiryRefresh,
@@ -45,7 +47,6 @@ import {
   detectJson,
   renderMessageJson,
   renderMessageMarkdown,
-  resolveMessageDisplayMarkdown,
   type AssistantMessageDisclosure,
 } from "./chat-message-text.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -207,7 +208,7 @@ function renderPairingQrExpiryNotices(count: number) {
 }
 
 export function renderGroupedMessage(
-  message: unknown,
+  { message, normalizedMessage, displayMarkdown }: ChatMessageRenderPreparation,
   messageKey: string,
   opts: {
     isStreaming: boolean;
@@ -256,7 +257,6 @@ export function renderGroupedMessage(
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "unknown";
   const sourceRole = normalizeRoleForGrouping(role);
-  const normalizedMessage = normalizeMessage(message);
   const normalizedRole = normalizeRoleForGrouping(normalizedMessage.role);
   const workspaceConflict = workspaceResultConflictFromTranscript(message);
   if (workspaceConflict) {
@@ -288,7 +288,6 @@ export function renderGroupedMessage(
     onOpenImage: opts.onOpenImage,
     resolveArtifactDownload: opts.resolveArtifactDownload,
   };
-  const displayMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
   const actionText = opts.messageActions?.markdown ?? displayMarkdown;
   const omittedMedia = normalizedMessage.content.filter(
     (item): item is Extract<MessageContentItem, { type: "omitted_media" }> =>

--- a/ui/src/pages/chat/components/chat-message-embed-policy.test.ts
+++ b/ui/src/pages/chat/components/chat-message-embed-policy.test.ts
@@ -3,6 +3,7 @@
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
+import { prepareChatMessageRender } from "./chat-message-markdown.ts";
 import { renderStreamGroupParts } from "./chat-message-stream.ts";
 
 describe("assistant message embed policy", () => {
@@ -23,7 +24,7 @@ describe("assistant message embed policy", () => {
                 options,
                 "standalone",
               )
-            : renderGroupedMessage(message, "message", {
+            : renderGroupedMessage(prepareChatMessageRender(message), "message", {
                 ...options,
                 isStreaming: false,
                 showReasoning: false,

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -36,8 +36,8 @@ import { renderRewindButton } from "./chat-message-confirmation.ts";
 import {
   renderMessageActionButtons,
   renderReplyButton,
+  prepareChatMessageRender,
   resolveMessageActionDetails,
-  type MessageActionDetails,
   type MessageReplyTarget,
 } from "./chat-message-markdown.ts";
 import { renderChatSendStatus, type ChatSendStatusActions } from "./chat-message-send-status.ts";
@@ -103,7 +103,8 @@ type RenderMessageGroupOptions = Omit<
     rewindDisabled?: boolean;
     activeContinuation?: ActiveContinuation;
     turnRecap?: TurnRecap;
-    frameContent?: unknown;
+    /** Frame bodies are pre-rendered by the frame owner; ordinary groups omit them. */
+    frameContent?: readonly unknown[];
     frameActionOwner?: MessageGroup["messages"][number] | null;
     latestAssistant?: boolean;
   };
@@ -112,14 +113,14 @@ type RenderMessageGroupOptions = Omit<
 // this bounds auto-retries to 3 before the manual retry affordance takes over.
 const FULL_MESSAGE_RETRY_REVISION_LIMIT = 6;
 
-function prepareMessageActions(
+function prepareGroupMessage(
   group: MessageGroup,
   item: MessageGroup["messages"][number],
   opts: RenderMessageGroupOptions,
-): MessageActionDetails | null {
-  const details = resolveMessageActionDetails({
+) {
+  const source = prepareChatMessageRender(item.message);
+  const details = resolveMessageActionDetails(source, {
     ...opts,
-    message: item.message,
     messageId: item.key,
     canFetchFullMessage: Boolean(opts.loadFullAssistantMessage && opts.sessionKey),
     senderLabel: resolveMessageGroupSenderLabel(group, opts),
@@ -136,16 +137,15 @@ function prepareMessageActions(
       opts.onToggleAssistantMessageExpanded?.(messageId);
     }
   }
-  return details;
+  return { item, source, actions: details };
 }
 
-function buildGroupedMessageRenderOptions(
+function renderPreparedGroupMessage(
   group: MessageGroup,
-  item: MessageGroup["messages"][number],
   index: number,
   opts: RenderMessageGroupOptions,
-  actionDetails: MessageActionDetails | null = prepareMessageActions(group, item, opts),
-): GroupedMessageRenderOptions {
+  { item, source, actions: actionDetails }: ReturnType<typeof prepareGroupMessage>,
+) {
   let assistantMessageDisclosure: AssistantMessageDisclosure | undefined;
   const fullMessage = actionDetails?.fullMessage;
   if (fullMessage && opts.loadFullAssistantMessage && opts.onToggleAssistantMessageExpanded) {
@@ -161,19 +161,24 @@ function buildGroupedMessageRenderOptions(
         : {}),
     };
   }
-  return {
-    ...opts,
-    isStreaming: group.isStreaming && index === group.messages.length - 1,
-    entryId: persistedMessageEntryId(item.message) ?? undefined,
-    entryAnimated:
-      normalizeRoleForGrouping(group.role) === "user" &&
-      shouldAnimateUserTurnEntry(item.key, item.message),
-    duplicateCount: item.duplicateCount ?? 1,
-    showToolCalls: opts.showToolCalls ?? true,
-    autoExpandToolCalls: opts.autoExpandToolCalls ?? false,
-    assistantMessageDisclosure,
-    messageActions: actionDetails,
-  };
+  return renderGroupedMessage(
+    source,
+    item.key,
+    {
+      ...opts,
+      isStreaming: group.isStreaming && index === group.messages.length - 1,
+      entryId: persistedMessageEntryId(item.message) ?? undefined,
+      entryAnimated:
+        normalizeRoleForGrouping(group.role) === "user" &&
+        shouldAnimateUserTurnEntry(item.key, item.message),
+      duplicateCount: item.duplicateCount ?? 1,
+      showToolCalls: opts.showToolCalls ?? true,
+      autoExpandToolCalls: opts.autoExpandToolCalls ?? false,
+      assistantMessageDisclosure,
+      messageActions: actionDetails,
+    },
+    opts.onOpenSidebar,
+  );
 }
 
 function isPeerSenderGroup(
@@ -268,11 +273,11 @@ export function renderActivityGroup(
           activityExpanded
             ? groups.map((group) =>
                 group.messages.map((item, index) =>
-                  renderGroupedMessage(
-                    item.message,
-                    item.key,
-                    buildGroupedMessageRenderOptions(group, item, index, opts),
-                    opts.onOpenSidebar,
+                  renderPreparedGroupMessage(
+                    group,
+                    index,
+                    opts,
+                    prepareGroupMessage(group, item, opts),
                   ),
                 ),
               )
@@ -339,12 +344,7 @@ export function renderMessageGroupContent(group: MessageGroup, opts: RenderMessa
     return renderActivityGroup([group], opts, "continuation");
   }
   const messages = group.messages.map((item, index) =>
-    renderGroupedMessage(
-      item.message,
-      item.key,
-      buildGroupedMessageRenderOptions(group, item, index, opts),
-      opts.onOpenSidebar,
-    ),
+    renderPreparedGroupMessage(group, index, opts, prepareGroupMessage(group, item, opts)),
   );
   return html`${messages}${
     opts.showToolCalls === false ? nothing : renderBrowserTabPreviews([group], opts)
@@ -383,11 +383,11 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       ? [opts.frameActionOwner]
       : []
     : group.messages;
-  const messageActionDetails = actionOwners.map((item) => prepareMessageActions(group, item, opts));
+  const preparedMessages = actionOwners.map((item) => prepareGroupMessage(group, item, opts));
   const lastMessageIndex = group.messages.length - 1;
   const footerActionDetails = ownsRunFrame
-    ? (messageActionDetails[0] ?? null)
-    : (messageActionDetails[lastMessageIndex] ?? null);
+    ? (preparedMessages[0]?.actions ?? null)
+    : (preparedMessages[lastMessageIndex]?.actions ?? null);
   const footerActionMessageKey = ownsRunFrame
     ? opts.frameActionOwner?.key
     : group.messages[lastMessageIndex]?.key;
@@ -477,15 +477,10 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
         }
         ${
           opts.frameContent ??
-          group.messages.map((item, index) => {
-            const actionDetails = messageActionDetails[index];
+          preparedMessages.map((prepared, index) => {
+            const { item, actions: actionDetails } = prepared;
             return html`
-              ${renderGroupedMessage(
-                item.message,
-                item.key,
-                buildGroupedMessageRenderOptions(group, item, index, opts, actionDetails),
-                opts.onOpenSidebar,
-              )}
+              ${renderPreparedGroupMessage(group, index, opts, prepared)}
               ${
                 actionDetails && index < lastMessageIndex && !ownsRunFrame
                   ? html`

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -8,7 +8,7 @@ import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-
 import { extractText } from "../../../lib/chat/message-extract.ts";
 import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
-import { resolveMessageActionDetails } from "./chat-message-markdown.ts";
+import { prepareChatMessageRender, resolveMessageActionDetails } from "./chat-message-markdown.ts";
 import { renderMessageMarkdown, resolveMessageDisplayMarkdown } from "./chat-message-text.ts";
 
 const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
@@ -19,13 +19,19 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
     { role: "user", id: "msg-1", shouldFetch: false },
     { role: "user", id: "pending:input-1", shouldFetch: true },
   ])("role=$role capped by metadata -> eligible=$shouldFetch", ({ role, id, shouldFetch }) => {
-    const details = resolveMessageActionDetails({
-      message: { role, content: "Preview\n...(truncated)...", __openclaw: { ...cappedMeta, id } },
-      messageId: "msg-1",
-      canFetchFullMessage: true,
-      onReply: () => {},
-      senderLabel: role,
-    });
+    const details = resolveMessageActionDetails(
+      prepareChatMessageRender({
+        role,
+        content: "Preview\n...(truncated)...",
+        __openclaw: { ...cappedMeta, id },
+      }),
+      {
+        messageId: "msg-1",
+        canFetchFullMessage: true,
+        onReply: () => {},
+        senderLabel: role,
+      },
+    );
     expect(details?.fullMessage?.messageId).toBe(shouldFetch ? id : undefined);
   });
 
@@ -35,8 +41,7 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
       content: "Preview",
       __openclaw: { ...cappedMeta, id: "pending:input-1" },
     };
-    const details = resolveMessageActionDetails({
-      message,
+    const details = resolveMessageActionDetails(prepareChatMessageRender(message), {
       messageId: "pending-render",
       canFetchFullMessage: true,
       getAssistantMessageExpansion: () => ({
@@ -55,26 +60,34 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
   it("does not fetch an assistant message that merely contains the sentinel text", () => {
     // The in-band "...(truncated)..." is ordinary Markdown to the UI; without the
     // Gateway's structural marker it is not evidence of a display cap.
-    const details = resolveMessageActionDetails({
-      message: {
+    const details = resolveMessageActionDetails(
+      prepareChatMessageRender({
         role: "assistant",
         content: "Quoting a log line:\n...(truncated)...\nand continuing normally.",
         __openclaw: { id: "msg-3" },
+      }),
+      {
+        messageId: "msg-3",
+        canFetchFullMessage: true,
+        senderLabel: "assistant",
       },
-      messageId: "msg-3",
-      canFetchFullMessage: true,
-      senderLabel: "assistant",
-    });
+    );
     expect(details?.fullMessage).toBeUndefined();
   });
 
   it("does not fetch an untruncated assistant message", () => {
-    const details = resolveMessageActionDetails({
-      message: { role: "assistant", content: "Complete.", __openclaw: { id: "msg-2" } },
-      messageId: "msg-2",
-      canFetchFullMessage: true,
-      senderLabel: "assistant",
-    });
+    const details = resolveMessageActionDetails(
+      prepareChatMessageRender({
+        role: "assistant",
+        content: "Complete.",
+        __openclaw: { id: "msg-2" },
+      }),
+      {
+        messageId: "msg-2",
+        canFetchFullMessage: true,
+        senderLabel: "assistant",
+      },
+    );
     expect(details?.fullMessage).toBeUndefined();
   });
 
@@ -84,8 +97,7 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
       content: "[chat.history omitted: message too large]",
       __openclaw: { id: "msg-oversized", truncated: true, reason: "oversized" },
     };
-    const details = resolveMessageActionDetails({
-      message,
+    const details = resolveMessageActionDetails(prepareChatMessageRender(message), {
       messageId: "msg-oversized",
       canFetchFullMessage: true,
       onReply: () => {},
@@ -96,8 +108,7 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
     expect(details?.markdown).toBe("This message is too large to display here.");
     expect(details?.replyTarget?.text).toBe("This message is too large to display here.");
 
-    const loaded = resolveMessageActionDetails({
-      message,
+    const loaded = resolveMessageActionDetails(prepareChatMessageRender(message), {
       messageId: "msg-oversized",
       canFetchFullMessage: true,
       getAssistantMessageExpansion: () => ({
@@ -115,16 +126,18 @@ describe("resolveMessageActionDetails full-message eligibility", () => {
   });
 
   it("projects an omitted historical image into reply text", () => {
-    const details = resolveMessageActionDetails({
-      message: {
+    const details = resolveMessageActionDetails(
+      prepareChatMessageRender({
         role: "assistant",
         content: [{ type: "image", omitted: true, bytes: 12 * 1024 }],
         __openclaw: { id: "msg-omitted-image" },
+      }),
+      {
+        messageId: "msg-omitted-image",
+        onReply: () => {},
+        senderLabel: "assistant",
       },
-      messageId: "msg-omitted-image",
-      onReply: () => {},
-      senderLabel: "assistant",
-    });
+    );
 
     expect(details?.replyTarget?.text).toBe("Image · Omitted from history · 12 KB");
   });
@@ -239,8 +252,7 @@ describe("message Markdown source preservation", () => {
     const source = "    *literal*";
     const message = { role: "assistant", content: source, __openclaw: cappedMeta };
     expect(extractText(message)).toBe(source);
-    const details = resolveMessageActionDetails({
-      message,
+    const details = resolveMessageActionDetails(prepareChatMessageRender(message), {
       messageId: "msg-1",
       canFetchFullMessage: true,
       getAssistantMessageExpansion: () => ({ status: "loaded", markdown: source, revision: 1 }),

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -27,6 +27,18 @@ export type MessageActionDetails = {
   replyTarget?: MessageReplyTarget;
 };
 
+// Options and action handlers outlive a render; keep this preparation separate from them.
+export function prepareChatMessageRender(message: unknown) {
+  const normalizedMessage = normalizeMessage(message);
+  return {
+    message,
+    normalizedMessage,
+    displayMarkdown: resolveMessageDisplayMarkdown(message, normalizedMessage),
+  };
+}
+
+export type ChatMessageRenderPreparation = ReturnType<typeof prepareChatMessageRender>;
+
 // An explicit Markdown value is the displayed expansion, even when it is empty.
 export function resolveMessageReplyText(
   message: unknown,
@@ -36,15 +48,19 @@ export function resolveMessageReplyText(
   return markdown || extractMessageMediaText(message, normalizedMessage.content);
 }
 
-export function resolveMessageActionDetails(params: {
-  message: unknown;
-  messageId: string;
-  canFetchFullMessage?: boolean;
-  getAssistantMessageExpansion?: (messageId: string) => AssistantMessageExpansionState | undefined;
-  onReply?: (target: MessageReplyTarget) => void;
-  senderLabel: string;
-}): MessageActionDetails | null {
-  const { message, messageId: renderMessageId, canFetchFullMessage, onReply, senderLabel } = params;
+export function resolveMessageActionDetails(
+  { message, normalizedMessage, displayMarkdown: previewMarkdown }: ChatMessageRenderPreparation,
+  params: {
+    messageId: string;
+    canFetchFullMessage?: boolean;
+    getAssistantMessageExpansion?: (
+      messageId: string,
+    ) => AssistantMessageExpansionState | undefined;
+    onReply?: (target: MessageReplyTarget) => void;
+    senderLabel: string;
+  },
+): MessageActionDetails | null {
+  const { messageId: renderMessageId, canFetchFullMessage, onReply, senderLabel } = params;
   const record = message as Record<string, unknown>;
   const transcriptMeta = asNullableRecord(record["__openclaw"]);
   const messageId =
@@ -53,10 +69,8 @@ export function resolveMessageActionDetails(params: {
       : typeof record.messageId === "string"
         ? record.messageId
         : undefined;
-  const normalizedMessage = normalizeMessage(message);
   const role = normalizeRoleForGrouping(normalizedMessage.role);
   const pendingInput = messageId?.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX) === true;
-  const previewMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
   // The Gateway records every display-cap truncation as __openclaw.truncated, so
   // that marker is the whole contract: sniffing the in-band sentinel would fetch
   // for any reply that merely contains the text. Pending user inputs share the

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -7,7 +7,11 @@ import type { ChatItem } from "../../../lib/chat/chat-types.ts";
 import { formatDurationCompact } from "../../../lib/format.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
-import { resolveMessageActionDetails, type MessageReplyTarget } from "./chat-message-markdown.ts";
+import {
+  prepareChatMessageRender,
+  resolveMessageActionDetails,
+  type MessageReplyTarget,
+} from "./chat-message-markdown.ts";
 import { renderChatTimestamp } from "./chat-message-timestamp.ts";
 import { renderChatQuestionSummary } from "./chat-question-card.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -73,21 +77,20 @@ export function renderStreamGroupParts(
       const prompt = opts.questionPrompts?.get(part.questionId);
       return prompt ? renderChatQuestionSummary(prompt) : nothing;
     }
-    const message = {
+    const source = prepareChatMessageRender({
       role: "assistant",
       content: [{ type: "text", text: part.text }],
       timestamp: part.startedAt,
-    };
+    });
     return renderGroupedMessage(
-      message,
+      source,
       part.key,
       {
         ...opts,
         isStreaming: part.isStreaming,
         showReasoning: false,
         // Settled segments can be replied to without transcript IDs or footer actions.
-        messageActions: resolveMessageActionDetails({
-          message,
+        messageActions: resolveMessageActionDetails(source, {
           messageId: part.key,
           onReply: opts.onReply,
           senderLabel: opts.assistant?.name ?? "Assistant",

--- a/ui/src/pages/chat/components/chat-tool-card-identity.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-card-identity.browser.test.ts
@@ -1,6 +1,7 @@
 import { html, nothing, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
+import { prepareChatMessageRender } from "./chat-message-markdown.ts";
 
 const containers: HTMLElement[] = [];
 afterEach(() => {
@@ -45,7 +46,7 @@ function fixture(mode: "inline" | "standalone") {
   const draw = () =>
     render(
       html`${rows.map((row) =>
-        renderGroupedMessage(row.message, row.key, {
+        renderGroupedMessage(prepareChatMessageRender(row.message), row.key, {
           isStreaming: false,
           showReasoning: false,
           showToolCalls: true,


### PR DESCRIPTION
Closes #142569

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Rerendering text-heavy Chat message groups repeats message preparation for actions and bodies. The same display and interaction results can be produced with less repeated work.

## Why This Change Was Made

This is a maintainer-requested performance cleanup. Share raw, normalized and preview facts within each synchronous render. Ordinary body paths prepare once instead of twice; completed frames keep their separate footer pass, reducing three passes to two. Four production owners grow by 11 lines, with 24 net lines in tests and fixture support.

Preparation remains local to the render and never enters a cache, retained action field or event callback. Action admission still precedes body rendering, and frame-footer actions reevaluate state afterward. The private frame-content parameter now reflects its existing array-only producer. Normalizer policy, recovery, pending/loaded-empty behavior, media and Copy/Reply semantics remain unchanged.

## User Impact

Text-heavy multi-message rerenders show lower sampled allocation in the scoped Lit/JSDOM workload. No blanket browser, streaming, small-message, latency or retained-memory improvement is claimed.

Preserving action-before-body order holds each group's prepared records until its body map completes. This temporary lifetime extension is intentional; it is not a cross-render cache.

## Evidence

- 361 original assertions passed before editing; the candidate passes 409 assertions across nine suites and both existing Chromium tool-identity cases. The full changed gate and both managed P2 review parts pass.
- 456 paired comparisons pass, including 54 exact HTML/action/footer outputs, in-place mutation, frame admission order/state/labels and scoped normalized-object collection checks.
- Two production UI builds run the same synthetic four-session flow. The declared message projection, recovery counts, Copy/Reply payloads, loaded-empty/pending behavior and eviction behavior match. Clipboard writes use a stub; this does not prove native clipboard transport or whole-UI pixel equality.
- Actual Lit rerenders with 32 text blocks per message show 38.2%/30.5%/35.4% lower sampled allocation for 1/8/32-message groups; the 32-message cohort is about 4.93 → 3.19 MB per render. These are three-trial JSDOM observations.
- Counter-results remain part of the evidence: streaming total allocation changes only −0.8%/−0.4%; short, loaded-empty and pending-user totals rise 1.4%/35.9%/12.5%, with overlapping noisy ranges. First-body forced-GC median differences of +11,688/+20,112/+62,592 bytes are noisy checkpoints, not peak or isolated normalized-object costs. Later collection checks are scoped JSDOM proof, not a universal browser-lifetime guarantee.

The retained-pane fixture exposed an existing move/reload behavior: hidden empty content is restored by a second fetch, rather than retained across movement. Both arms follow that same request sequence; the original fixture failure and separate follow-up remain recorded.

The inspected synthetic before/after pair shows the same recovered Copy/Reply state.

![Before: synthetic recovered Copy and Reply state](https://github.com/user-attachments/assets/6eddefbd-892c-4126-be32-4e1e04733f4c)

![After: preserved recovered Copy and Reply state](https://github.com/user-attachments/assets/20c17b8b-15fb-4773-9c14-fbfd700fde82)