### PR TITLE
fix(gateway): account-less web login stops every account on the channel

### DIFF
--- a/src/gateway/server-methods/web.gateway.test.ts
+++ b/src/gateway/server-methods/web.gateway.test.ts
@@ -94,13 +94,13 @@ describe("web QR login Gateway dispatch", () => {
     expect(whatsappStart).not.toHaveBeenCalled();
     expect(whatsappWait).not.toHaveBeenCalled();
     expect(weixinStart).toHaveBeenCalledWith({
-      accountId: "default",
+      accountId: undefined,
       force: false,
       timeoutMs: undefined,
       verbose: false,
     });
     expect(weixinWait).toHaveBeenCalledWith({
-      accountId: "default",
+      accountId: undefined,
       timeoutMs: undefined,
       sessionKey: "opaque-session",
       currentQrDataUrl: undefined,
@@ -175,7 +175,7 @@ describe("web QR login Gateway dispatch", () => {
 
     expect(globalWhatsappStart).not.toHaveBeenCalled();
     expect(scopedWeixinStart).toHaveBeenCalledWith({
-      accountId: "default",
+      accountId: undefined,
       force: false,
       timeoutMs: undefined,
       verbose: false,

--- a/src/gateway/server-methods/web.gateway.test.ts
+++ b/src/gateway/server-methods/web.gateway.test.ts
@@ -27,6 +27,7 @@ describe("web QR login Gateway dispatch", () => {
           source: "test",
           plugin: {
             id: "whatsapp",
+            config: { listAccountIds: () => ["default"] },
             meta: { aliases: [] },
             gatewayMethods: ["web.login.start", "web.login.wait"],
             gateway: {
@@ -40,6 +41,7 @@ describe("web QR login Gateway dispatch", () => {
           source: "test",
           plugin: {
             id: "openclaw-weixin",
+            config: { listAccountIds: () => ["default"] },
             meta: { aliases: ["weixin", "wechat"] },
             gatewayMethods: ["web.login.start", "web.login.wait"],
             gateway: {
@@ -92,13 +94,13 @@ describe("web QR login Gateway dispatch", () => {
     expect(whatsappStart).not.toHaveBeenCalled();
     expect(whatsappWait).not.toHaveBeenCalled();
     expect(weixinStart).toHaveBeenCalledWith({
-      accountId: undefined,
+      accountId: "default",
       force: false,
       timeoutMs: undefined,
       verbose: false,
     });
     expect(weixinWait).toHaveBeenCalledWith({
-      accountId: undefined,
+      accountId: "default",
       timeoutMs: undefined,
       sessionKey: "opaque-session",
       currentQrDataUrl: undefined,
@@ -124,6 +126,7 @@ describe("web QR login Gateway dispatch", () => {
         source: "test",
         plugin: {
           id: "whatsapp",
+          config: { listAccountIds: () => ["default"] },
           meta: { aliases: [] },
           gatewayMethods: ["web.login.start"],
           gateway: { loginWithQrStart: globalWhatsappStart },
@@ -136,6 +139,7 @@ describe("web QR login Gateway dispatch", () => {
         source: "test",
         plugin: {
           id: "openclaw-weixin",
+          config: { listAccountIds: () => ["default"] },
           meta: { aliases: ["wechat"] },
           gatewayMethods: ["web.login.start"],
           gateway: { loginWithQrStart: scopedWeixinStart },
@@ -171,7 +175,7 @@ describe("web QR login Gateway dispatch", () => {
 
     expect(globalWhatsappStart).not.toHaveBeenCalled();
     expect(scopedWeixinStart).toHaveBeenCalledWith({
-      accountId: undefined,
+      accountId: "default",
       force: false,
       timeoutMs: undefined,
       verbose: false,

--- a/src/gateway/server-methods/web.login-lifecycle.test.ts
+++ b/src/gateway/server-methods/web.login-lifecycle.test.ts
@@ -1,0 +1,166 @@
+/**
+ * QR-login lifecycle scoping through the real channel manager.
+ *
+ * These cases drive the real `web.login.start`/`web.login.wait` handlers against a real
+ * `createChannelManager`, so the stop/restore fan-out is observed on the lifecycle owner
+ * rather than on a spy. Only the account listener is a stand-in for the channel transport.
+ */
+import { describe, expect, it } from "vitest";
+import type { ChannelId, ChannelPlugin } from "../../channels/plugins/types.public.js";
+import {
+  createSubsystemLogger,
+  runtimeForLogger,
+  type SubsystemLogger,
+} from "../../logging/subsystem.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import {
+  requireActivePluginChannelRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+import { webHandlers } from "./web.js";
+
+const ACCOUNTS = ["arnold", "enzo", "valentina"];
+
+function createQrLoginPlugin(params: {
+  liveListeners: Set<string>;
+  pluginAccountIds: Array<string | undefined>;
+  connected: boolean;
+}): ChannelPlugin {
+  const describeAccount = (_cfg: unknown, accountId?: string) => ({
+    accountId: accountId ?? ACCOUNTS[0],
+    enabled: true,
+    configured: true,
+  });
+  return {
+    id: "whatsapp",
+    meta: {
+      id: "whatsapp",
+      label: "WhatsApp",
+      selectionLabel: "WhatsApp",
+      docsPath: "/channels/whatsapp",
+      blurb: "lifecycle test plugin",
+      aliases: [],
+    },
+    capabilities: { chatTypes: ["direct"] },
+    gatewayMethods: ["web.login.start", "web.login.wait"],
+    config: {
+      listAccountIds: () => ACCOUNTS,
+      resolveAccount: describeAccount,
+      isEnabled: () => true,
+      describeAccount,
+    },
+    gateway: {
+      // Stands in for the channel transport only: the listener stays alive until the
+      // lifecycle owner aborts it, which is what a real account listener does.
+      startAccount: async (ctx: { accountId: string; abortSignal: AbortSignal }) => {
+        params.liveListeners.add(ctx.accountId);
+        await new Promise<void>((resolve) => {
+          if (ctx.abortSignal.aborted) {
+            resolve();
+            return;
+          }
+          ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        params.liveListeners.delete(ctx.accountId);
+      },
+      loginWithQrStart: async (login: { accountId?: string }) => {
+        params.pluginAccountIds.push(login.accountId);
+        return { message: "scan the code", qrDataUrl: "data:image/png;base64,QQ==" };
+      },
+      loginWithQrWait: async (login: { accountId?: string }) => {
+        params.pluginAccountIds.push(login.accountId);
+        return {
+          connected: params.connected,
+          message: params.connected ? "linked" : "pairing timed out",
+        };
+      },
+    },
+  } as unknown as ChannelPlugin;
+}
+
+async function runAccountLessPairing(connected: boolean) {
+  const { createChannelManager } = await import("../server-channels.js");
+  const liveListeners = new Set<string>();
+  const pluginAccountIds: Array<string | undefined> = [];
+  const plugin = createQrLoginPlugin({ liveListeners, pluginAccountIds, connected });
+
+  const registry = createEmptyPluginRegistry();
+  registry.channels.push({ pluginId: plugin.id, source: "test", plugin });
+  setActivePluginRegistry(registry);
+
+  const log: SubsystemLogger = createSubsystemLogger("gateway/web-login-lifecycle-test");
+  const cfg = { channels: { whatsapp: { enabled: true } } };
+  const manager = createChannelManager({
+    getRuntimeConfig: () => cfg as never,
+    getPluginRegistry: requireActivePluginChannelRegistry,
+    channelLogs: { whatsapp: log } as unknown as Record<ChannelId, SubsystemLogger>,
+    channelRuntimeEnvs: { whatsapp: runtimeForLogger(log) } as unknown as Record<
+      ChannelId,
+      RuntimeEnv
+    >,
+  });
+
+  const options = (method: "web.login.start" | "web.login.wait") =>
+    ({
+      req: { type: "req", id: "req-1", method, params: {} },
+      params: {},
+      client: null,
+      isWebchatConnect: () => false,
+      respond: () => {},
+      context: {
+        stopChannel: (channel: ChannelId, accountId?: string) =>
+          manager.stopChannel(channel, accountId, { manual: true }),
+        startChannel: (channel: ChannelId, accountId?: string) =>
+          manager.startChannel(channel, accountId),
+        getRuntimeSnapshot: () => manager.getRuntimeSnapshot(),
+        getRuntimeConfig: () => cfg,
+      },
+    }) as unknown as GatewayRequestHandlerOptions;
+
+  const settle = () =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, 60);
+    });
+  const live = () => [...liveListeners].toSorted();
+
+  await manager.startChannel("whatsapp" as ChannelId);
+  await settle();
+  const afterStartup = live();
+
+  await webHandlers["web.login.start"]?.(options("web.login.start"));
+  await settle();
+  const duringPairing = live();
+
+  await webHandlers["web.login.wait"]?.(options("web.login.wait"));
+  await settle();
+  const afterPairing = live();
+
+  await manager.stopChannel("whatsapp" as ChannelId);
+  return { afterStartup, duringPairing, afterPairing, pluginAccountIds };
+}
+
+describe("web QR login lifecycle scoping", () => {
+  it("pairs one account and restores it without disturbing its siblings", async () => {
+    const observed = await runAccountLessPairing(true);
+
+    expect(observed.afterStartup).toEqual(ACCOUNTS);
+    // Only the account being linked leaves the air while its QR code is outstanding.
+    expect(observed.duringPairing).toEqual(["enzo", "valentina"]);
+    // The linked account comes back once pairing completes.
+    expect(observed.afterPairing).toEqual(ACCOUNTS);
+    // The plugin still resolves the omitted account itself: account ids and credential
+    // profiles are different namespaces.
+    expect(observed.pluginAccountIds).toEqual([undefined, undefined]);
+  });
+
+  it("leaves the siblings running when pairing never completes", async () => {
+    const observed = await runAccountLessPairing(false);
+
+    expect(observed.afterStartup).toEqual(ACCOUNTS);
+    expect(observed.duringPairing).toEqual(["enzo", "valentina"]);
+    // An abandoned pairing must not take the rest of the channel down with it.
+    expect(observed.afterPairing).toEqual(["enzo", "valentina"]);
+  });
+});

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -413,11 +413,45 @@ describe("webHandlers web.login.start", () => {
       'webHandlers["web.login.start"] test invariant',
     )(createOptions({}, { respond, context }));
 
-    // The pairing and the lifecycle stop must address the same concrete account, and the
-    // sibling accounts on the channel must not be swept up by a channel-wide stop.
-    expect(loginWithQrStart).toHaveBeenCalledWith(expect.objectContaining({ accountId: "arnold" }));
+    // Lifecycle control is scoped to one concrete account, so the sibling accounts on the
+    // channel are not swept up by a channel-wide stop.
     expect(stopChannel).toHaveBeenCalledWith("whatsapp", "arnold");
     expect(stopChannel).not.toHaveBeenCalledWith("whatsapp", undefined);
+    // The plugin still receives the request as sent. Account ids and credential profiles are
+    // different namespaces, and some plugins resolve an omitted account differently.
+    expect(loginWithQrStart).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: undefined }),
+    );
+  });
+
+  it("keeps an omitted account omitted for the plugin so environment-selected profiles survive", async () => {
+    // Zalo Personal resolves an omitted account through ZALOUSER_PROFILE, but returns a named
+    // account verbatim. Forwarding a resolved default here would silently repoint credential
+    // writes at another profile, so the plugin must still see the request as sent.
+    const loginWithQrStart = vi.fn().mockResolvedValue({ qrDataUrl: "data:image/png;base64,QQ==" });
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "zalouser",
+        config: {
+          listAccountIds: () => ["work"],
+          defaultAccountId: () => "work",
+        },
+        gatewayMethods: ["web.login.start"],
+        gateway: { loginWithQrStart },
+      },
+    ]);
+    const { context, stopChannel } = createRunningWhatsappContext();
+    const respond = vi.fn();
+
+    await expectDefined(
+      webHandlers["web.login.start"],
+      'webHandlers["web.login.start"] test invariant',
+    )(createOptions({ channel: "zalouser" }, { respond, context }));
+
+    expect(loginWithQrStart).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: undefined }),
+    );
+    expect(stopChannel).toHaveBeenCalledWith("zalouser", "work");
   });
 
   it("keeps the legacy first-provider fallback when channel is omitted", async () => {

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -228,6 +228,7 @@ describe("webHandlers web.login.start", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start"],
         gateway: { loginWithQrStart },
       },
@@ -275,6 +276,7 @@ describe("webHandlers web.login.start", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start"],
         gateway,
       },
@@ -319,11 +321,13 @@ describe("webHandlers web.login.start", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start", "web.login.wait"],
         gateway: { loginWithQrStart: whatsappLogin, loginWithQrWait: vi.fn() },
       },
       {
         id: "openclaw-weixin",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start", "web.login.wait"],
         gateway: { loginWithQrStart: weixinLogin, loginWithQrWait: vi.fn() },
       },
@@ -361,6 +365,7 @@ describe("webHandlers web.login.start", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start"],
         gateway: { loginWithQrStart: whatsappLogin },
       },
@@ -387,17 +392,47 @@ describe("webHandlers web.login.start", () => {
     );
   });
 
+  it("scopes an account-less login to the resolved default account on a multi-account channel", async () => {
+    const loginWithQrStart = vi.fn().mockResolvedValue({ qrDataUrl: "data:image/png;base64,QQ==" });
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "whatsapp",
+        config: {
+          listAccountIds: () => ["arnold", "valentina"],
+          defaultAccountId: () => "arnold",
+        },
+        gatewayMethods: ["web.login.start"],
+        gateway: { loginWithQrStart },
+      },
+    ]);
+    const { context, stopChannel } = createRunningWhatsappContext();
+    const respond = vi.fn();
+
+    await expectDefined(
+      webHandlers["web.login.start"],
+      'webHandlers["web.login.start"] test invariant',
+    )(createOptions({}, { respond, context }));
+
+    // The pairing and the lifecycle stop must address the same concrete account, and the
+    // sibling accounts on the channel must not be swept up by a channel-wide stop.
+    expect(loginWithQrStart).toHaveBeenCalledWith(expect.objectContaining({ accountId: "arnold" }));
+    expect(stopChannel).toHaveBeenCalledWith("whatsapp", "arnold");
+    expect(stopChannel).not.toHaveBeenCalledWith("whatsapp", undefined);
+  });
+
   it("keeps the legacy first-provider fallback when channel is omitted", async () => {
     const whatsappLogin = vi.fn().mockResolvedValue({ message: "whatsapp" });
     const weixinLogin = vi.fn();
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start"],
         gateway: { loginWithQrStart: whatsappLogin },
       },
       {
         id: "openclaw-weixin",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start"],
         gateway: { loginWithQrStart: weixinLogin },
       },
@@ -432,6 +467,7 @@ describe("webHandlers web.login.wait", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.wait"],
         gateway: { loginWithQrWait },
       },
@@ -487,11 +523,13 @@ describe("webHandlers web.login.wait", () => {
     mocks.listChannelPlugins.mockReturnValue([
       {
         id: "whatsapp",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start", "web.login.wait"],
         gateway: { loginWithQrStart: vi.fn(), loginWithQrWait: whatsappWait },
       },
       {
         id: "openclaw-weixin",
+        config: { listAccountIds: () => ["default"] },
         gatewayMethods: ["web.login.start", "web.login.wait"],
         gateway: { loginWithQrStart: vi.fn(), loginWithQrWait: weixinWait },
       },

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -117,7 +117,8 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   context: GatewayRequestContext;
   gatewayMethod: TMethod;
 }): {
-  accountId: string;
+  requestedAccountId?: string;
+  lifecycleAccountId: string;
   provider: WebLoginProvider;
   run: NonNullable<WebLoginGateway[TMethod]>;
 } | null {
@@ -137,12 +138,20 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
     respondProviderUnsupported(params.respond, provider.id);
     return null;
   }
-  // An omitted account must resolve to one concrete account before lifecycle and login
-  // calls, so the QR pairing and the stop/restore around it address the same account.
-  const accountId =
-    resolveAccountId(params.rawParams) ??
+  // Lifecycle control needs one concrete account so an omitted one does not fan out across
+  // the channel. The plugin keeps receiving the request as sent: account ids and credential
+  // profiles are not the same namespace, and some plugins resolve an omitted account
+  // differently from a named one.
+  const requestedAccountId = resolveAccountId(params.rawParams);
+  const lifecycleAccountId =
+    requestedAccountId ??
     resolveChannelDefaultAccountId({ plugin: provider, cfg: params.context.getRuntimeConfig() });
-  return { accountId, provider, run: run.bind(gateway) as NonNullable<WebLoginGateway[TMethod]> };
+  return {
+    ...(requestedAccountId === undefined ? {} : { requestedAccountId }),
+    lifecycleAccountId,
+    provider,
+    run: run.bind(gateway) as NonNullable<WebLoginGateway[TMethod]>,
+  };
 }
 
 /** Checks whether the matching channel/account should be restored after login start. */
@@ -181,34 +190,34 @@ export const webHandlers: GatewayRequestHandlers = {
       if (!request) {
         return;
       }
-      const { accountId, provider, run } = request;
+      const { requestedAccountId, lifecycleAccountId, provider, run } = request;
       const wasRunning = wasChannelRunning({
         context,
         channelId: provider.id,
-        accountId,
+        accountId: lifecycleAccountId,
       });
       const forceLogin = Boolean(params.force);
       const stoppedBeforeLogin = forceLogin || !wasRunning;
       if (stoppedBeforeLogin) {
-        await context.stopChannel(provider.id, accountId);
+        await context.stopChannel(provider.id, lifecycleAccountId);
       }
       const result = await run({
         force: forceLogin,
         timeoutMs: typeof params.timeoutMs === "number" ? params.timeoutMs : undefined,
         verbose: Boolean(params.verbose),
-        accountId,
+        accountId: requestedAccountId,
       });
       const stoppedAfterQrTakeover = !stoppedBeforeLogin && Boolean(result.qrDataUrl);
       if (stoppedAfterQrTakeover) {
-        await context.stopChannel(provider.id, accountId);
+        await context.stopChannel(provider.id, lifecycleAccountId);
       }
       const stoppedForLogin = stoppedBeforeLogin || stoppedAfterQrTakeover;
       if (result.connected && stoppedForLogin) {
-        await context.startChannel(provider.id, accountId);
+        await context.startChannel(provider.id, lifecycleAccountId);
       } else if (wasRunning && stoppedForLogin && !result.qrDataUrl) {
         // When start fails before producing a QR code, restore the previously
         // running channel/account so a transient login failure does not stop it.
-        await context.startChannel(provider.id, accountId);
+        await context.startChannel(provider.id, lifecycleAccountId);
       }
       respond(true, result, undefined);
     } catch (err) {
@@ -229,16 +238,16 @@ export const webHandlers: GatewayRequestHandlers = {
       if (!request) {
         return;
       }
-      const { accountId, provider, run } = request;
+      const { requestedAccountId, lifecycleAccountId, provider, run } = request;
       const result = await run({
         timeoutMs: typeof params.timeoutMs === "number" ? params.timeoutMs : undefined,
-        accountId,
+        accountId: requestedAccountId,
         sessionKey: typeof params.sessionKey === "string" ? params.sessionKey : undefined,
         currentQrDataUrl:
           typeof params.currentQrDataUrl === "string" ? params.currentQrDataUrl : undefined,
       });
       if (result.connected) {
-        await context.startChannel(provider.id, accountId);
+        await context.startChannel(provider.id, lifecycleAccountId);
       }
       respond(true, result, undefined);
     } catch (err) {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -8,6 +8,7 @@ import {
   validateWebLoginStartParams,
   validateWebLoginWaitParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { listChannelPlugins, normalizeChannelId } from "../../channels/plugins/index.js";
 import { listLoadedChannelPluginsForRegistry } from "../../channels/plugins/registry-loaded.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
@@ -116,11 +117,10 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   context: GatewayRequestContext;
   gatewayMethod: TMethod;
 }): {
-  accountId?: string;
+  accountId: string;
   provider: WebLoginProvider;
   run: NonNullable<WebLoginGateway[TMethod]>;
 } | null {
-  const accountId = resolveAccountId(params.rawParams);
   const provider = resolveWebLoginProvider(
     typeof params.rawParams.channel === "string" ? params.rawParams.channel : undefined,
   );
@@ -137,6 +137,11 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
     respondProviderUnsupported(params.respond, provider.id);
     return null;
   }
+  // An omitted account must resolve to one concrete account before lifecycle and login
+  // calls, so the QR pairing and the stop/restore around it address the same account.
+  const accountId =
+    resolveAccountId(params.rawParams) ??
+    resolveChannelDefaultAccountId({ plugin: provider, cfg: params.context.getRuntimeConfig() });
   return { accountId, provider, run: run.bind(gateway) as NonNullable<WebLoginGateway[TMethod]> };
 }
 


### PR DESCRIPTION
Closes #135142

## What Problem This Solves

Fixes an issue where operators running more than one account on a channel would lose the
listeners of every other account on that channel when they started a QR login from one
account's panel, and would not get them back if the pairing did not complete.

`web.login.start` treats `accountId` as optional. When it is absent the handler passed that
absent value into channel lifecycle control, which builds its stop set from every configured
account rather than one:

`src/gateway/server-channels.ts`

```ts
const configuredAccountIds =
  !accountId || optsLocal.routeHandoff ? (plugin?.config.listAccountIds(cfg) ?? []) : [];
const knownIds = new Set<string>(
  accountId ? [accountId] : [...lifecycleIds, ...configuredAccountIds],
);
```

The reporter saw exactly this: two healthy WhatsApp accounts went from `running, connected`
to `stopped, disconnected` while a QR flow held the channel, before any scan happened.

## Why This Change Was Made

The repository already has one canonical answer for "which account does an omitted account id
mean" for lifecycle purposes, and two neighbouring paths already use it: the gateway's own
runtime snapshot builder (`src/gateway/server-channels.ts`) and the CLI login path
(`src/cli/channel-auth.ts`) both call `resolveChannelDefaultAccountId`. The web login handler
did not.

This change resolves the account once, after the provider is known, and hands it to the
lifecycle calls only.

**The plugin keeps receiving the request exactly as sent.** The first revision of this PR
forwarded the resolved account to the plugin too, and review correctly flagged that as a
compatibility break: account ids and credential profiles are not the same namespace. Zalo
Personal resolves an omitted or `default` account through `ZALOUSER_PROFILE`, but returns a
named account verbatim (`extensions/zalouser/src/channel.adapters.ts`), so on a channel whose
default account is named, an account-less pairing would have started writing credentials under
a different profile. Splitting the two values keeps that provider behavior untouched.

Scope: this does not change which account a pairing writes credentials to, on any channel.
It changes only how widely the stop/restore around the pairing reaches.

## User Impact

Starting a QR login for a channel no longer stops the other accounts configured on it. Only
the account being linked is stopped and restored.

Requests that pass an explicit `accountId`, single-account channels, and channels whose
provider derives its credential profile from an omitted account all behave exactly as before.

## Evidence

### 1. Sibling listeners, through the real lifecycle owner

A real `createChannelManager` with three configured accounts, all three started through it.
The only stand-in is the listener itself: instead of opening a real WhatsApp socket it records
its account id and stays alive until its abort signal fires. The account-less
`web.login.start` request then runs through the real handler, wired to that manager's own
`stopChannel`/`startChannel`/`getRuntimeSnapshot`.

| arm | listeners before | listeners after the account-less login | manually stopped |
| --- | --- | --- | --- |
| `origin/main` | `arnold, enzo, valentina` | **none** | `arnold, enzo, valentina` |
| this branch | `arnold, enzo, valentina` | **`enzo, valentina`** | `arnold` |

```
--- origin/main ---
{"step":"after startup","liveListeners":["arnold","enzo","valentina"]}
{"step":"respond","ok":true,"result":{"qrDataUrl":"..."}}
{"step":"after account-less web.login.start","liveListeners":[],
 "manuallyStopped":["arnold","enzo","valentina"]}

--- this branch ---
{"step":"after startup","liveListeners":["arnold","enzo","valentina"]}
{"step":"respond","ok":true,"result":{"qrDataUrl":"..."}}
{"step":"after account-less web.login.start","liveListeners":["enzo","valentina"],
 "manuallyStopped":["arnold"]}
```

### 1b. Recovery after pairing, and an abandoned pairing

Review asked for the other half of the lifecycle: whether the selected account comes back
after pairing, and what happens when pairing never completes. Same real
`createChannelManager`, same real handlers, now driven through `web.login.start` **and**
`web.login.wait`, with both pairing outcomes measured on both arms.

| pairing outcome | step | `origin/main` | this branch |
| --- | --- | --- | --- |
| completes | during pairing | **none** | `enzo, valentina` |
| completes | after pairing | `arnold, enzo, valentina` | `arnold, enzo, valentina` |
| never completes | during pairing | **none** | `enzo, valentina` |
| never completes | after pairing | **none** | **`enzo, valentina`** |

```
--- origin/main ---
{"scenario":"pairing completes","afterStartup":["arnold","enzo","valentina"],
 "duringPairing":[],"afterPairing":["arnold","enzo","valentina"],
 "accountIdSeenByPlugin":{"start":[null],"wait":[null]}}
{"scenario":"pairing never completes","afterStartup":["arnold","enzo","valentina"],
 "duringPairing":[],"afterPairing":[],
 "accountIdSeenByPlugin":{"start":[null],"wait":[null]}}

--- this branch ---
{"scenario":"pairing completes","afterStartup":["arnold","enzo","valentina"],
 "duringPairing":["enzo","valentina"],"afterPairing":["arnold","enzo","valentina"],
 "accountIdSeenByPlugin":{"start":[null],"wait":[null]}}
{"scenario":"pairing never completes","afterStartup":["arnold","enzo","valentina"],
 "duringPairing":["enzo","valentina"],"afterPairing":["enzo","valentina"],
 "accountIdSeenByPlugin":{"start":[null],"wait":[null]}}
```

Two things this settles. The linked account (`arnold`) is genuinely restored on this branch
once pairing completes, so scoping the stop does not cost the account its restart. And the
reporter's second complaint - listeners that never come back when the pairing is abandoned -
only reproduces on `main`: there every listener is already down and nothing restores them,
while this branch never took the siblings off the air in the first place. `main` does end an
*answered* pairing with all three back, because its restore fans out as widely as its stop
did; the damage is the window in between, and the abandoned case.

`accountIdSeenByPlugin` is `null` (JSON for an absent `accountId`) on both arms and in both
handlers, so the plugin still resolves an omitted account itself.

**What sections 1 and 1b do not show.** The account listener there is a stand-in, so they are
lifecycle proofs, not transport proofs. Section 1c below closes that gap with a real Gateway
process and real Baileys sockets.

### 1c. Real Gateway process, real Baileys listener sockets, both arms

Review asked for the listener transport and the pairing outcome to be real rather than
simulated. I do not have a multi-account WhatsApp phone setup, so this run uses the local
WhatsApp provider server the repository already depends on for its QA lanes:
`@openclaw/crabline serve whatsapp` (0.1.21 from this checkout's `node_modules`). It
completes the Baileys Noise handshake and serves the bootstrap/prekey queries, and the
WhatsApp plugin is pointed at it through its own `OPENCLAW_WHATSAPP_WEB_SOCKET_URL`
override. Nothing in OpenClaw is substituted: a built `openclaw gateway` (Node 24.21.0,
isolated `OPENCLAW_STATE_DIR`, token auth on a loopback port) runs the real WhatsApp plugin,
whose `startAccount` opens a real Baileys socket per account through the plugin's real
monitor loop, and every request below goes over the real WebSocket RPC via
`openclaw gateway call`. Each arm is its own build of the same checkout: `origin/main` at
`56ae9cacb08`, and this branch at `cede4330ffc`.

Setup, identical on both arms: `channels.whatsapp.accounts` = `arnold`, `enzo`, `valentina`,
`newbie`; `defaultAccount: "newbie"`; `dmPolicy`/`groupPolicy` disabled. The three siblings
were linked through `web.login.start` against the local server, then the Gateway was
restarted so they come up through the normal startup path. Before every login below,
`channels.status` reports all three as `running=true connected=true lifecycle=ready` with
`lastStopAt` empty; `newbie` is the unlinked account the account-less request resolves to.

One detail that is fixture, not product: the local server pairs without a `pair-success`
node, so Baileys stores `me.lid` but no `me.id`, and the listener's next login node throws
`Cannot destructure property 'user' of 'jidDecode(...)'`. I seeded `me.id` in each linked
sibling's `creds.json` with the `selfJid` the server itself advertises so the siblings can
hold a session. `newbie` was left as the server pairs it, which is what makes its second
login fail in the third row — a convenient stand-in for a pairing that does not complete.

Each row is one account-less `web.login.start` (`{"channel":"whatsapp"}`, no `accountId`),
with `channels.status` read before, at t+4 s during the call, and after it returned.

| case | arm | siblings during the call | siblings after | `newbie` |
| --- | --- | --- | --- | --- |
| login leg completes | `origin/main` | **all stopped** (`lastStopAt` set on all three) | restarted 8.2 s later (`lastStartAt` moved) | paired, started |
| login leg completes | this branch | `running=true`, `lastStopAt` empty | unchanged (`lastStartAt` identical to before) | paired, started |
| login leg fails | `origin/main` | **all stopped** at the same millisecond | **never restored**: `running=false lifecycle=stopped` after the error | stopped |
| login leg fails | this branch | `running=true`, `lastStopAt` empty | unchanged | stopped (only it) |

`origin/main`, login leg completes — `lastStopAt` lands on every sibling, then all three are
restarted after the pairing returns:

```text
== main B: before ==
arnold:    running=True  connected=True  lifecycle=ready    lastStartAt=1789507135116 lastStopAt=
enzo:      running=True  connected=True  lifecycle=ready    lastStartAt=1789507135678 lastStopAt=
newbie:    running=False                 lifecycle=stopped  reason=not linked
valentina: running=True  connected=True  lifecycle=ready    lastStartAt=1789507135673 lastStopAt=
login => { "message": "WhatsApp recovered the existing linked session (unknown).", "connected": true }
== main B: after ==
arnold:    running=True  connected=False lifecycle=starting lastStartAt=1789507196869 lastStopAt=1789507188712
enzo:      running=True  connected=False lifecycle=starting lastStartAt=1789507196871 lastStopAt=1789507188713
valentina: running=True  connected=False lifecycle=starting lastStartAt=1789507196871 lastStopAt=1789507188712
```

Gateway log for that call — the three sibling restarts land within 10 ms of the
`web.login.start` response:

```text
00:19:56.870 [whatsapp] [arnold] starting provider (+15550000000)
00:19:56.873 [ws] ⇄ res ✓ web.login.start 8189ms
00:19:56.876 [whatsapp] [valentina] starting provider (+15550000000)
00:19:56.879 [whatsapp] [enzo] starting provider (+15550000000)
00:19:56.883 [whatsapp] [newbie] starting provider (unknown)
```

`origin/main`, login leg fails — the siblings are taken down during the call and nothing
brings them back:

```text
== main C: DURING account-less login (t+4s) ==
arnold:    running=False connected=False lifecycle=stopped lastStartAt=1789507196869 lastStopAt=1789507247606
enzo:      running=False connected=False lifecycle=stopped lastStartAt=1789507196871 lastStopAt=1789507247606
valentina: running=False connected=False lifecycle=stopped lastStartAt=1789507196871 lastStopAt=1789507247606
login => { "message": "WhatsApp login failed: Cannot destructure property 'user' of 'jidDecode(...)' as it is undefined." }
== main C: after ==
arnold:    running=False connected=False lifecycle=stopped lastStartAt=1789507196869 lastStopAt=1789507247606
enzo:      running=False connected=False lifecycle=stopped lastStartAt=1789507196871 lastStopAt=1789507247606
valentina: running=False connected=False lifecycle=stopped lastStartAt=1789507196871 lastStopAt=1789507247606
```

This branch, both cases — the siblings never leave `ready`, and their `lastStartAt` is the
value from Gateway startup:

```text
== branch B: before ==
arnold:    running=True connected=True lifecycle=ready lastStartAt=1789506553360 lastStopAt=
enzo:      running=True connected=True lifecycle=ready lastStartAt=1789506553253 lastStopAt=
valentina: running=True connected=True lifecycle=ready lastStartAt=1789506553356 lastStopAt=
login => { "message": "WhatsApp recovered the existing linked session (unknown).", "connected": true }
== branch B: after ==
arnold:    running=True connected=True lifecycle=ready lastStartAt=1789506553360 lastStopAt=
enzo:      running=True connected=True lifecycle=ready lastStartAt=1789506553253 lastStopAt=
valentina: running=True connected=True lifecycle=ready lastStartAt=1789506553356 lastStopAt=
newbie:    running=False lifecycle=recovering lastStartAt=1789506629600 lastStopAt=1789506629731

== branch C: DURING account-less login (t+4s) ==
arnold:    running=True connected=True lifecycle=ready lastStartAt=1789507992867 lastStopAt=
enzo:      running=True connected=True lifecycle=ready lastStartAt=1789507992863 lastStopAt=
newbie:    running=False lifecycle=stopped lastStopAt=1789508076460
valentina: running=True connected=True lifecycle=ready lastStartAt=1789507992871 lastStopAt=
login => { "message": "WhatsApp login failed: Cannot destructure property 'user' of 'jidDecode(...)' as it is undefined." }
== branch C: after ==   (identical to DURING)
```

The local server's recorder shows what the sibling sockets were doing in the meantime: 186
Noise-encrypted stanzas over `/ws/chat` across the runs — `iq encrypt` prekey uploads,
`passive` → `active`, `w:p` presence, `w:g2`, `blocklist` and `privacy` queries, and `ib`
frames — i.e. the plugin's real post-connect sequence, not a stub.

What this still does not show: pairing against WhatsApp's own servers, and the QR-scan
window itself (the local server pairs immediately, so the "during" snapshot covers the stop
window rather than a human scanning a code).

### 2. The Zalo compatibility finding, measured in three arms

Real handler plus the real `resolveZalouserQrProfile`, with
`channels.zalouser.defaultAccount: "work"`, a `work` account without `profile`, and
`ZALOUSER_PROFILE=personal`:

| arm | account id the plugin sees | credential profile selected | lifecycle stop scoped to |
| --- | --- | --- | --- |
| `origin/main` | `undefined` | `personal` | `undefined` (channel-wide) |
| first revision of this PR | `work` | **`work`** (the regression) | `work` |
| this branch | `undefined` | `personal` | `work` |

```
--- origin/main ---
{"accountIdSeenByPlugin":null,"credentialProfileSelected":"personal","lifecycleStopScopedTo":[null]}
--- first revision ---
{"accountIdSeenByPlugin":"work","credentialProfileSelected":"work","lifecycleStopScopedTo":["work"]}
--- this branch ---
{"accountIdSeenByPlugin":null,"credentialProfileSelected":"personal","lifecycleStopScopedTo":["work"]}
```

### 3. Tests

- `src/gateway/server-methods/web.start.test.ts` and `web.gateway.test.ts` — 15 passed. New
  cases: a multi-account channel where the stop names the resolved account and no channel-wide
  stop is issued, and a Zalo-shaped channel with a named default account where the plugin still
  receives an absent account id.
- `src/gateway/server-methods/web.login-lifecycle.test.ts` (new) - 2 passed. The measurement
  above, kept as coverage: the real handlers against a real `createChannelManager`, asserting
  sibling continuity, the linked account's return after a completed pairing, and the siblings
  surviving an abandoned one.
- Mutation: reverting only the production hunk turns exactly four unit cases red plus both
  lifecycle cases (`expected [] to deeply equal [ 'enzo', 'valentina' ]`), and the control
  cases stay green.
- The mocked channel plugins in those suites gained the `config.listAccountIds` adapter that
  every real channel plugin already carries, since the handler now reads it.
- `scripts/check-max-lines-ratchet.mts` and `scripts/check-assertion-safety-ratchet.mts`,
  both `--base origin/main` - OK. `oxlint` and `oxfmt` clean on the new file.
- Full `gateway-methods` shard — 4972 passed, 135 failed. The failures are in 27 unrelated
  suites (sessions, chat, config, projects) and reproduce identically on unmodified `main` on
  this machine; a sampled pair fails the same way with this branch's changes reverted.


