### PR TITLE
fix(channels): preserve 7.33 Telegram workspace media access

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1153,7 +1153,12 @@ describe("handleTelegramAction", () => {
         content: "Hello with local media",
       },
       telegramConfig(),
-      { mediaLocalRoots: ["/tmp/agent-root"] },
+      {
+        mediaAccess: {
+          localRoots: ["/tmp/agent-root"],
+          workspaceDir: "/tmp/agent-root/workspace",
+        },
+      },
     );
     const call = mockCall(sendMessageTelegram, 0, "local media roots");
     expect(call[0]).toBe("@testchannel");
@@ -1161,6 +1166,15 @@ describe("handleTelegramAction", () => {
     expect(requireRecord(call[2], "local media roots options").mediaLocalRoots).toEqual([
       "/tmp/agent-root",
     ]);
+    expect(
+      requireRecord(
+        requireRecord(
+          mockCall(sendDurableMessageBatch, 0, "workspace media delivery")[0],
+          "workspace media delivery",
+        ).mediaAccess,
+        "workspace media access",
+      ).workspaceDir,
+    ).toBe("/tmp/agent-root/workspace");
   });
 
   it("forwards gateway client scopes into Telegram send target resolution", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -11,6 +11,7 @@ import {
   resolvePollMaxSelections,
   resolveReactionMessageId,
 } from "openclaw/plugin-sdk/channel-actions";
+import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   buildOutboundSessionContext,
   sendDurableMessageBatch,
@@ -319,6 +320,7 @@ export async function handleTelegramAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
   options?: {
+    mediaAccess?: ChannelMessageActionContext["mediaAccess"];
     mediaLocalRoots?: readonly string[];
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
     sessionKey?: string | null;
@@ -511,12 +513,13 @@ export async function handleTelegramAction(
       quoteText,
     });
     const mediaAccess =
-      options?.mediaLocalRoots || options?.mediaReadFile
+      options?.mediaAccess ??
+      (options?.mediaLocalRoots || options?.mediaReadFile
         ? {
             ...(options.mediaLocalRoots ? { localRoots: options.mediaLocalRoots } : {}),
             ...(options.mediaReadFile ? { readFile: options.mediaReadFile } : {}),
           }
-        : undefined;
+        : undefined);
     const outboundSession = buildOutboundSessionContext({
       cfg,
       sessionKey: options?.sessionKey,

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -52,6 +52,7 @@ describe("telegramMessageActions", () => {
       },
       cfg: {} as never,
       accountId: "default",
+      mediaAccess: { localRoots: [], workspaceDir: "/tmp/workspace" },
       mediaLocalRoots: [],
       sessionKey: "telegram-session",
     } as never);
@@ -72,6 +73,7 @@ describe("telegramMessageActions", () => {
       },
       {},
       {
+        mediaAccess: { localRoots: [], workspaceDir: "/tmp/workspace" },
         mediaLocalRoots: [],
         mediaReadFile: undefined,
         sessionKey: "telegram-session",

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -201,6 +201,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     params,
     cfg,
     accountId,
+    mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
     sessionKey,
@@ -224,7 +225,14 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           : {}),
       },
       cfg,
-      { mediaLocalRoots, mediaReadFile, sessionKey, inboundEventKind, gatewayClientScopes },
+      {
+        ...(mediaAccess !== undefined ? { mediaAccess } : {}),
+        mediaLocalRoots,
+        mediaReadFile,
+        sessionKey,
+        inboundEventKind,
+        gatewayClientScopes,
+      },
     );
   },
 };

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -69,12 +69,17 @@ describe("telegramOutbound", () => {
 
   it("forwards mediaLocalRoots in direct media sends", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-media" });
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-root"],
+      workspaceDir: "/tmp/agent-root/workspace",
+    };
 
     const result = await telegramOutbound.sendMedia!({
       cfg: {} as never,
       to: "12345",
       text: "hello",
       mediaUrl: "/tmp/image.png",
+      mediaAccess,
       mediaLocalRoots: ["/tmp/agent-root"],
       accountId: "ops",
       replyToId: "900",
@@ -91,6 +96,7 @@ describe("telegramOutbound", () => {
       silent: undefined,
       gatewayClientScopes: undefined,
       mediaUrl: "/tmp/image.png",
+      mediaAccess,
       mediaLocalRoots: ["/tmp/agent-root"],
       mediaReadFile: undefined,
       forceDocument: false,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -333,6 +333,7 @@ export function createTelegramOutboundAdapter(
         return await send(outboundTo, params.text, {
           ...baseOpts,
           mediaUrl: params.mediaUrl,
+          ...(params.mediaAccess !== undefined ? { mediaAccess: params.mediaAccess } : {}),
           mediaLocalRoots: params.mediaLocalRoots,
           mediaReadFile: params.mediaReadFile,
           forceDocument: params.forceDocument ?? false,
@@ -352,6 +353,7 @@ export function createTelegramOutboundAdapter(
         payload: params.payload,
         baseOpts: {
           ...baseOpts,
+          ...(params.mediaAccess !== undefined ? { mediaAccess: params.mediaAccess } : {}),
           mediaLocalRoots: params.mediaLocalRoots,
           mediaReadFile: params.mediaReadFile,
           forceDocument: params.forceDocument ?? false,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3269,6 +3269,10 @@ describe("sendMessageTelegram", () => {
 
   it("defaults outbound media uploads to 100MB", async () => {
     const chatId = "123";
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-root"],
+      workspaceDir: "/tmp/agent-root/workspace",
+    };
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 60,
       chat: { id: chatId },
@@ -3287,15 +3291,19 @@ describe("sendMessageTelegram", () => {
       cfg: TELEGRAM_TEST_CFG,
       token: "tok",
       api,
-      mediaUrl: "https://example.com/photo.jpg",
+      mediaUrl: "chart.png",
+      mediaAccess,
     });
 
     const [mediaUrl, options] = requireMockCall(
       firstMockCall(loadWebMedia, "loadWebMedia call"),
       "load web media call",
     );
-    expect(mediaUrl).toBe("https://example.com/photo.jpg");
-    expect(requireRecord(options, "load web media options").maxBytes).toBe(100 * 1024 * 1024);
+    expect(mediaUrl).toBe("chart.png");
+    const loadOptions = requireRecord(options, "load web media options");
+    expect(loadOptions.maxBytes).toBe(100 * 1024 * 1024);
+    expect(loadOptions.localRoots).toEqual(mediaAccess.localRoots);
+    expect(loadOptions.workspaceDir).toBe(mediaAccess.workspaceDir);
   });
 
   it("uses configured telegram mediaMaxMb for outbound uploads", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -11,6 +11,7 @@ import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import type { OutboundMediaAccess } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
@@ -114,6 +115,7 @@ type TelegramSendOpts = {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
+  mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   gatewayClientScopes?: readonly string[];
@@ -1195,6 +1197,7 @@ export async function sendMessageTelegram(
       mediaUrl,
       buildOutboundMediaLoadOptions({
         maxBytes: mediaMaxBytes,
+        mediaAccess: opts.mediaAccess,
         mediaLocalRoots: opts.mediaLocalRoots,
         mediaReadFile: opts.mediaReadFile,
         optimizeImages: opts.forceDocument ? false : undefined,

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -84,6 +84,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
     agentId?: string;
   }) => resolveAgentIdFromSessionKeyForTests({ sessionKey }),
   resolveDefaultAgentId: () => "main",
+  resolveAgentConfig: () => undefined,
   resolveAgentWorkspaceDir: () => TEST_AGENT_WORKSPACE,
 }));
 
@@ -2610,8 +2611,8 @@ describe("gateway send mirroring", () => {
         isConfigured: () => true,
       },
       actions: {
-        describeMessageTool: () => ({ actions: ["sendAttachment"] }),
-        supportsAction: ({ action }) => action === "sendAttachment",
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
         handleAction: async () => jsonResult({ ok: true }),
       },
     };
@@ -2624,7 +2625,7 @@ describe("gateway send mirroring", () => {
     const { respond } = await runMessageActionRequest(
       {
         channel: "telegram",
-        action: "sendAttachment",
+        action: "send",
         params: { chatId: "123", mediaUrl: `${TEST_AGENT_WORKSPACE}/render.png` },
         agentId: "work",
         idempotencyKey: "idem-message-action-media-roots",
@@ -2635,6 +2636,10 @@ describe("gateway send mirroring", () => {
     expect(firstRespondCall(respond)[0]).toBe(true);
     const actionCall = lastDispatchChannelMessageActionCall();
     expect(actionCall?.mediaLocalRoots).toContain(TEST_AGENT_WORKSPACE);
+    expect(actionCall?.mediaAccess).toMatchObject({
+      localRoots: expect.arrayContaining([TEST_AGENT_WORKSPACE]),
+      workspaceDir: TEST_AGENT_WORKSPACE,
+    });
     expect(actionCall?.gatewayClientScopes).toEqual(["operator.write"]);
   });
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -43,6 +43,7 @@ import { mirrorDeliveredSourceReplyToTranscript } from "../../infra/outbound/sou
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -541,6 +542,26 @@ export const sendHandlers: GatewayRequestHandlers = {
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
         const accountId = normalizeOptionalString(request.accountId) ?? undefined;
+        const resolvedMediaAccess =
+          request.action === "send"
+            ? resolveAgentScopedOutboundMediaAccess({
+                cfg,
+                agentId,
+                sessionKey,
+                messageProvider: sessionKey ? undefined : channel,
+                accountId,
+              })
+            : undefined;
+        // Gateway identities omit trusted sender aliases; expose roots/workspace
+        // only so a host reader cannot bypass alias-based group read policy.
+        const mediaAccess = resolvedMediaAccess
+          ? {
+              localRoots: resolvedMediaAccess.localRoots,
+              ...(resolvedMediaAccess.workspaceDir
+                ? { workspaceDir: resolvedMediaAccess.workspaceDir }
+                : {}),
+            }
+          : undefined;
         if (request.action === "send") {
           await hydrateAttachmentParamsForAction({
             cfg,
@@ -548,9 +569,11 @@ export const sendHandlers: GatewayRequestHandlers = {
             accountId,
             args: request.params,
             action: "send",
-            mediaPolicy: resolveAttachmentMediaPolicy({
-              mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
-            }),
+            mediaPolicy: resolveAttachmentMediaPolicy(
+              mediaAccess
+                ? { mediaAccess, mediaLocalRoots: mediaAccess.localRoots }
+                : { mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId) },
+            ),
           });
         }
         const gatewayClientScopes = client?.connect?.scopes ?? [];
@@ -592,7 +615,9 @@ export const sendHandlers: GatewayRequestHandlers = {
               sessionId: normalizeOptionalString(request.sessionId) ?? undefined,
               inboundEventKind: request.inboundTurnKind,
               agentId,
-              mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
+              ...(mediaAccess
+                ? { mediaAccess, mediaLocalRoots: mediaAccess.localRoots }
+                : { mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId) }),
               toolContext: request.toolContext,
               dryRun: false,
               gatewayClientScopes: dispatchGatewayClientScopes,


### PR DESCRIPTION
## Summary

- build the agent-scoped outbound media authority at the Gateway message-action boundary
- preserve that complete `mediaAccess` contract through Telegram action and outbound adapters
- pass `workspaceDir` into the final media loader so relative attachments resolve under the same authority as direct sends
- add regressions across Gateway, adapter, action runtime, outbound adapter, and final loader boundaries

## Root cause

The 7.33 candidate reduced the Gateway-owned media authority to `mediaLocalRoots` and `mediaReadFile` at multiple handoffs. That discarded `workspaceDir`, so direct Gateway sends succeeded while `message.action` rejected the same relative attachment as missing.

## Verification

- Gateway suites: 126/126
- Telegram suites: 275/275
- production TypeScript: core + extensions green
- Oxfmt and `git diff --check`

This is the complete 7.33 port of the already-proven media authority correction; it does not weaken the package acceptance scenario.