### PR TITLE
fix(release): preserve frozen update compatibility

### DIFF
--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -11,6 +11,14 @@ export function legacyPackageAcceptanceCompat(version) {
   );
 }
 
+export function updateChannelDryRunReportsPackageCompat(version) {
+  const match = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:[-+].*)?/.exec(version || "");
+  const [year, month, day] = match?.slice(1, 4).map(Number) ?? [];
+  return (
+    Boolean(match) && (year < 2026 || (year === 2026 && (month < 7 || (month === 7 && day <= 33))))
+  );
+}
+
 // Candidates on either side of consent enforcement can share a package version.
 // Only successful command help establishes support; callers own probe failures.
 export function fixtureCapabilityConsentArgs(help) {
@@ -23,8 +31,12 @@ if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   console.log(
     process.argv[2] === "fixture-consent"
       ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
-      : legacyPackageAcceptanceCompat(process.argv[2])
-        ? "1"
-        : "0",
+      : process.argv[2] === "update-channel-dry-run"
+        ? updateChannelDryRunReportsPackageCompat(process.argv[3])
+          ? "1"
+          : "0"
+        : legacyPackageAcceptanceCompat(process.argv[2])
+          ? "1"
+          : "0",
   );
 }

--- a/scripts/e2e/lib/update-channel-switch/assertions.mjs
+++ b/scripts/e2e/lib/update-channel-switch/assertions.mjs
@@ -236,13 +236,17 @@ function assertConfigChannel(channel) {
 
 function assertDryRun(kind, channel) {
   const preview = JSON.parse(process.env.UPDATE_JSON ?? "");
+  const reportedKind =
+    kind === "git" && process.env.OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT === "1"
+      ? "package"
+      : kind;
   assert.equal(preview.dryRun, true);
   assert.equal(preview.installKind, "package");
   assert.equal(preview.storedChannel, "dev");
   assert.equal(preview.effectiveChannel, channel);
-  assert.equal(preview.updateInstallKind, kind);
-  assert.equal(preview.mode, kind === "git" ? "git" : "npm");
-  assert.equal(preview.switchToGit, kind === "git");
+  assert.equal(preview.updateInstallKind, reportedKind);
+  assert.equal(preview.mode, reportedKind === "git" ? "git" : "npm");
+  assert.equal(preview.switchToGit, reportedKind === "git");
   assert.equal(preview.switchToPackage, false);
 }
 

--- a/scripts/e2e/lib/update-channel-switch/assertions.mjs
+++ b/scripts/e2e/lib/update-channel-switch/assertions.mjs
@@ -234,10 +234,12 @@ function assertConfigChannel(channel) {
   );
 }
 
-function assertDryRun(kind, channel) {
+function assertDryRun(kind, channel, selection) {
   const preview = JSON.parse(process.env.UPDATE_JSON ?? "");
   const reportedKind =
-    kind === "git" && process.env.OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT === "1"
+    kind === "git" &&
+    selection === "stored" &&
+    process.env.OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT === "1"
       ? "package"
       : kind;
   assert.equal(preview.dryRun, true);
@@ -286,7 +288,7 @@ switch (command) {
     assertConfigChannel(args[0]);
     break;
   case "assert-dry-run":
-    assertDryRun(args[0], args[1]);
+    assertDryRun(args[0], args[1], args[2]);
     break;
   case "assert-status-kind":
     assertStatusKind(args[0]);

--- a/scripts/e2e/lib/upgrade-survivor/config-parking.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/config-parking.mjs
@@ -41,8 +41,10 @@ function parkRestartProbe(configPath, snapshotPath, rawPort) {
     throw new Error("park-restart-probe requires a valid port");
   }
   const authoredConfig = fs.readFileSync(configPath);
-  requireObject(JSON.parse(authoredConfig.toString("utf8")), "restart probe config");
+  const parsedConfig = JSON.parse(authoredConfig.toString("utf8"));
+  requireObject(parsedConfig, "restart probe config");
   snapshotAndReplace(configPath, snapshotPath, authoredConfig, {
+    ...parsedConfig,
     plugins: { enabled: false },
     gateway: {
       port,

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -107,6 +107,10 @@ OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
   node scripts/e2e/lib/package-compat.mjs "$package_version"
 )"
 export OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT
+OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="$(
+  node scripts/e2e/lib/package-compat.mjs update-channel-dry-run "$package_version"
+)"
+export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT
 command -v openclaw >/dev/null
 openclaw_e2e_enable_openclaw_cli_timeout
 

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -178,13 +178,13 @@ printf "%s\n" "$status_json"
 STATUS_JSON="$status_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-status-kind package
 
 assert_package_dry_run() {
-  local expected_kind="$1" expected_channel="$2"
-  shift 2
+  local expected_kind="$1" expected_channel="$2" selection="$3"
+  shift 3
   local preview
   preview="$(openclaw update --dry-run --json --no-restart "$@")"
   printf "%s\n" "$preview"
   UPDATE_JSON="$preview" node scripts/e2e/lib/update-channel-switch/assertions.mjs \
-    assert-dry-run "$expected_kind" "$expected_channel"
+    assert-dry-run "$expected_kind" "$expected_channel" "$selection"
   node scripts/e2e/lib/update-channel-switch/assertions.mjs assert-config-channel dev
 }
 dev_channel_args=(--channel dev)
@@ -192,11 +192,11 @@ dev_channel_args=(--channel dev)
 if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]; then
   echo "==> package dry-run channel and one-off tag precedence"
   openclaw config set update.channel dev
-  assert_package_dry_run git dev
-  assert_package_dry_run git dev --channel dev
-  assert_package_dry_run git dev --channel dev --tag beta
-  assert_package_dry_run package dev --tag beta
-  assert_package_dry_run package stable --channel stable
+  assert_package_dry_run git dev stored
+  assert_package_dry_run git dev explicit --channel dev
+  assert_package_dry_run git dev explicit --channel dev --tag beta
+  assert_package_dry_run package dev stored --tag beta
+  assert_package_dry_run package stable explicit --channel stable
   dev_channel_args=()
 fi
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3872,6 +3872,7 @@ printf '%s\n' "$status" >"$TMPDIR/status"
     expect(readFileSync(join(workDir, "status"), "utf8")).toBe("57\n");
     expect(existsSync(join(workDir, "gateway.log.authored-config"))).toBe(true);
     expect(JSON.parse(readFileSync(join(workDir, "state", "openclaw.json"), "utf8"))).toEqual({
+      channels: { discord: { dm: { policy: "allowlist" } } },
       plugins: { enabled: false },
       gateway: expect.objectContaining({ reload: { mode: "off" } }),
     });

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -2,7 +2,10 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { fixtureCapabilityConsentArgs } from "../../scripts/e2e/lib/package-compat.mjs";
+import {
+  fixtureCapabilityConsentArgs,
+  updateChannelDryRunReportsPackageCompat,
+} from "../../scripts/e2e/lib/package-compat.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -356,5 +359,13 @@ ${fixtureCommand} plugins install fixture`,
     });
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(output);
+  });
+
+  it.each([
+    ["2026.7.33", true],
+    ["2026.7.33-1", true],
+    ["2026.8.1", false],
+  ])("scopes package-reported dev dry runs for %s", (version, expected) => {
+    expect(updateChannelDryRunReportsPackageCompat(version)).toBe(expected);
   });
 });

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -16,6 +16,42 @@ it("keeps the frozen legacy dev status on its shipped package contract", () => {
   expect(script).toContain("assert-status-kind package");
 });
 
+it("projects only stored-dev frozen previews onto package reporting", () => {
+  const run = (selection: "stored" | "explicit", updateInstallKind: "git" | "package") =>
+    spawnSync(
+      process.execPath,
+      [
+        "scripts/e2e/lib/update-channel-switch/assertions.mjs",
+        "assert-dry-run",
+        "git",
+        "dev",
+        selection,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT: "1",
+          UPDATE_JSON: JSON.stringify({
+            dryRun: true,
+            installKind: "package",
+            storedChannel: "dev",
+            effectiveChannel: "dev",
+            updateInstallKind,
+            mode: updateInstallKind === "git" ? "git" : "npm",
+            switchToGit: updateInstallKind === "git",
+            switchToPackage: false,
+          }),
+        },
+      },
+    );
+
+  expect(run("stored", "package").status).toBe(0);
+  expect(run("explicit", "git").status).toBe(0);
+  expect(run("stored", "git").status).toBe(1);
+  expect(run("explicit", "package").status).toBe(1);
+});
+
 it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -125,6 +125,8 @@ exit "$probe_status"
       );
       expect(existsSync(path.join(root, "installed"))).toBe(true);
       expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual({
+        agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+        channels: { discord: { enabled: true }, whatsapp: { enabled: true } },
         plugins: { enabled: false },
         gateway: {
           port: 18789,
@@ -425,13 +427,15 @@ ${conditional ? 'probe_status=0; phase preparation handler || probe_status=$?; e
     const configPath = path.join(root, "openclaw.json");
     const snapshotPath = path.join(root, "openclaw.authored.json");
     const authoredConfig =
-      '{"channels":{"discord":{"dm":{"policy":"allowlist","allowFrom":["123"]}}}}\n';
+      '{"meta":{"lastTouchedVersion":"2026.7.1-2"},"channels":{"discord":{"dm":{"policy":"allowlist","allowFrom":["123"]}}},"plugins":{"entries":{"matrix":{"enabled":true}}}}\n';
     writeFileSync(configPath, authoredConfig);
 
     const park = run("park-restart-probe", configPath, snapshotPath, "19876");
     expect(park.status, park.stderr).toBe(0);
     expect(readFileSync(snapshotPath, "utf8")).toBe(authoredConfig);
     expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+      meta: { lastTouchedVersion: "2026.7.1-2" },
+      channels: { discord: { dm: { policy: "allowlist", allowFrom: ["123"] } } },
       plugins: { enabled: false },
       gateway: {
         port: 19876,


### PR DESCRIPTION
## Summary

- capability-bind 7.33 package dry-run reporting in the update-channel assertion
- retain authored non-plugin config while parking restart probes with plugins disabled
- preserve config metadata and size so a frozen baseline cannot auto-restore plugin entries from `.last-good`

## Root causes

1. 2026.7.33 stores and resolves the `dev` channel correctly but reports the dry-run install kind as `package`/`npm` rather than current tooling's expected `git` switch. The compatibility projection is version-scoped and fail-closed unless the runner sets it.
2. The restart-auth probe replaced a full authored config with a tiny config lacking `meta`. Baseline recovery treated that as corruption, restored plugin entries, then Doctor installed 7.33-era fixtures into a 2026.7.1-2 runtime and refused startup. Parking now preserves all authored non-plugin fields while replacing plugins and gateway probe settings.

## Validation

- tooling Docker contracts: 285 passed, 2 skipped
- package compatibility/config parking: 54 passed
- shell syntax, Oxfmt, `git diff --check`

This covers the duplicated update-channel and update-restart-auth failures in the 2026.7.33 Full Validation run.