### PR TITLE
fix: finish opening the mobile sidebar after a swipe

### DIFF
--- a/ui/src/app/navigation-surface.ts
+++ b/ui/src/app/navigation-surface.ts
@@ -90,7 +90,7 @@ export function moveToastToNavDrawer(host: HTMLElement): void {
   const drawer = host.querySelector<HTMLElement>(".shell-nav");
   const toastHost = host.querySelector<HTMLElement>("openclaw-toast-host");
   if (drawer && toastHost && toastHost.parentElement !== drawer) {
-    drawer.moveBefore(toastHost, null);
+    drawer.append(toastHost);
   }
 }
 
@@ -98,7 +98,7 @@ export function restoreToastFromNavDrawer(host: HTMLElement): void {
   const shell = host.querySelector<HTMLElement>(".shell");
   const toastHost = host.querySelector<HTMLElement>("openclaw-toast-host");
   if (shell && toastHost?.parentElement?.classList.contains("shell-nav")) {
-    shell.moveBefore(toastHost, null);
+    shell.append(toastHost);
   }
 }
 

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -156,29 +156,34 @@ describe("openclaw-modal-dialog", () => {
     expect(dialog.open).toBe(true);
   });
 
-  it("hands an active toast back to the app layer when it closes", async () => {
-    const shell = document.createElement("div");
-    shell.className = "shell";
-    const appHost = document.createElement("openclaw-toast-host");
-    shell.append(appHost);
-    document.body.append(shell);
-    try {
-      const { modal } = await renderModal();
-      const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
+  it.each(["hide", "remove"] as const)(
+    "hands an active toast back to the app layer on %s",
+    async (action) => {
+      const shell = document.createElement("div");
+      shell.className = "shell";
+      const appHost = document.createElement("openclaw-toast-host");
+      shell.append(appHost);
+      document.body.append(shell);
+      try {
+        const { modal } = await renderModal();
 
-      showToast({ message: "Saved" });
-      modal.hide();
-      await modal.updateComplete;
-      await appHost.updateComplete;
+        showToast({ message: "Saved" });
+        expect(appHost.parentElement).toBe(modal);
+        modal[action]();
+        await modal.updateComplete;
+        if (action === "hide") {
+          modal.dispatchEvent(new Event("wa-after-hide"));
+        }
+        await appHost.updateComplete;
 
-      expect(moveBefore).toHaveBeenCalledWith(appHost, null);
-      expect(moveBefore.mock.contexts).toContain(modal);
-      expect(appHost.querySelector(".app-toast__message")?.textContent).toBe("Saved");
-      expect(modal.querySelector(".app-toast")).toBeNull();
-    } finally {
-      shell.remove();
-    }
-  });
+        expect(appHost.parentElement).toBe(shell);
+        expect(appHost.querySelector(".app-toast__message")?.textContent).toBe("Saved");
+        expect(modal.querySelector(".app-toast")).toBeNull();
+      } finally {
+        shell.remove();
+      }
+    },
+  );
 
   it("assigns overlay motion by interaction type", () => {
     const styles = OpenClawModalDialog.styles.cssText;

--- a/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
+++ b/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
@@ -250,51 +250,77 @@ suite.define(() => {
       .toEqual(["32px", "32px"]);
   });
 
-  it("opens the mobile drawer by swipe across the full mobile-layout range", async () => {
-    const page = await openPage({ hasTouch: true, height: 393, width: 852 });
-    const shell = page.locator(".shell");
-    await expect.poll(() => shell.getAttribute("class")).toContain("shell--mobile-nav");
-
-    await page.locator(".content").evaluate((content) => {
-      const touch = (clientX: number, clientY: number) =>
-        new Touch({
-          identifier: 1,
-          target: content,
-          clientX,
-          clientY,
-          pageX: clientX,
-          pageY: clientY,
-          screenX: clientX,
-          screenY: clientY,
+  it.each([
+    { width: 852, height: 393, atomicMoves: true },
+    { width: 393, height: 852, atomicMoves: false },
+  ])(
+    "fully opens and closes the mobile drawer by swipe ($width px, atomic moves: $atomicMoves)",
+    async ({ width, height, atomicMoves }) => {
+      const page = await openPage({ hasTouch: true, height, width });
+      if (!atomicMoves) {
+        // Safari does not implement atomic DOM moves; drawer completion must not depend on them.
+        await page.evaluate(() => {
+          Object.defineProperty(Element.prototype, "moveBefore", {
+            configurable: true,
+            value: undefined,
+          });
         });
-      content.dispatchEvent(
-        new TouchEvent("touchstart", {
-          bubbles: true,
-          composed: true,
-          touches: [touch(24, 180)],
-          changedTouches: [touch(24, 180)],
-        }),
-      );
-      content.dispatchEvent(
-        new TouchEvent("touchmove", {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          touches: [touch(210, 184)],
-          changedTouches: [touch(210, 184)],
-        }),
-      );
-      content.dispatchEvent(
-        new TouchEvent("touchend", {
-          bubbles: true,
-          composed: true,
-          touches: [],
-          changedTouches: [touch(210, 184)],
-        }),
-      );
-    });
+      }
+      const errors: string[] = [];
+      page.on("pageerror", (error) => errors.push(error.message));
+      const shell = page.locator(".shell");
+      await expect.poll(() => shell.getAttribute("class")).toContain("shell--mobile-nav");
 
-    await expect.poll(() => shell.getAttribute("class")).toContain("shell--nav-drawer-open");
-    await expect.poll(() => page.locator(".shell-nav.nav-drawer").isVisible()).toBe(true);
-  });
+      await page.locator(".content").evaluate((content) => {
+        const touch = (clientX: number, clientY: number) =>
+          new Touch({
+            identifier: 1,
+            target: content,
+            clientX,
+            clientY,
+            pageX: clientX,
+            pageY: clientY,
+            screenX: clientX,
+            screenY: clientY,
+          });
+        content.dispatchEvent(
+          new TouchEvent("touchstart", {
+            bubbles: true,
+            composed: true,
+            touches: [touch(24, 180)],
+            changedTouches: [touch(24, 180)],
+          }),
+        );
+        content.dispatchEvent(
+          new TouchEvent("touchmove", {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            touches: [touch(210, 184)],
+            changedTouches: [touch(210, 184)],
+          }),
+        );
+        content.dispatchEvent(
+          new TouchEvent("touchend", {
+            bubbles: true,
+            composed: true,
+            touches: [],
+            changedTouches: [touch(210, 184)],
+          }),
+        );
+      });
+
+      await expect.poll(() => shell.getAttribute("class")).toContain("shell--nav-drawer-open");
+      const drawer = page.locator(".shell-nav.nav-drawer");
+      await expect.poll(async () => (await drawer.boundingBox())?.x).toBe(0);
+      await expect.poll(() => drawer.evaluate((element) => element.style.transform)).toBe("");
+      await expect.poll(() => drawer.locator("openclaw-toast-host").count()).toBe(1);
+      await page.locator(".shell-nav-backdrop").click({ position: { x: width - 10, y: 100 } });
+      await expect.poll(() => shell.getAttribute("class")).not.toContain("shell--nav-drawer-open");
+      await expect.poll(() => shell.locator(":scope > openclaw-toast-host").count()).toBe(1);
+      await page.getByRole("button", { name: "Expand sidebar" }).click();
+      await expect.poll(async () => (await drawer.boundingBox())?.x).toBe(0);
+      expect(errors).toEqual([]);
+    },
+  );
 });

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "../components/modal-dialog.ts";
+import { moveToastToNavDrawer, restoreToastFromNavDrawer } from "../app/navigation-surface.ts";
 import { showToast } from "./toast.ts";
 
 async function mountHost() {
@@ -57,13 +58,11 @@ describe("shared toast", () => {
     modal.open = true;
     document.body.append(modal);
     await modal.updateComplete;
-    const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
     showToast({ message: "Above overlay" });
     await appHost.updateComplete;
 
-    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
-    expect(moveBefore.mock.contexts).toContain(modal);
+    expect(appHost.parentElement).toBe(modal);
     expect(appHost.textContent).toContain("Above overlay");
   });
 
@@ -76,14 +75,47 @@ describe("shared toast", () => {
     shadowRoot.append(modal);
     document.body.append(shadowOwner);
     await modal.updateComplete;
-    const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
     showToast({ message: "Critical session notice" });
     await appHost.updateComplete;
 
-    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
-    expect(moveBefore.mock.contexts).toContain(modal);
+    expect(appHost.parentElement).toBe(modal);
     expect(appHost.textContent).toContain("Critical session notice");
+  });
+
+  it("preserves queued outcomes, placement, and the deadline across drawer handoffs", async () => {
+    vi.useFakeTimers();
+    const app = document.createElement("div");
+    const shell = document.createElement("div");
+    shell.className = "shell";
+    const drawer = document.createElement("nav");
+    drawer.className = "shell-nav";
+    const host = document.createElement("openclaw-toast-host");
+    shell.append(drawer, host);
+    app.append(shell);
+    document.body.append(app);
+    const onDismiss = vi.fn();
+    showToast({ message: "First", durationMs: 100, onDismiss });
+    showToast({ message: "Queued", fifo: true });
+    await vi.advanceTimersByTimeAsync(40);
+
+    moveToastToNavDrawer(app);
+    await host.updateComplete;
+    expect(host.parentElement).toBe(drawer);
+    expect(host.dataset.toastPlacement).toBe("overlay");
+    expect(host.textContent).toContain("First");
+    await vi.advanceTimersByTimeAsync(40);
+    restoreToastFromNavDrawer(app);
+    await host.updateComplete;
+    expect(host.parentElement).toBe(shell);
+    expect(host.dataset.toastPlacement).toBe("shell");
+    expect(host.textContent).toContain("First");
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(20);
+    await host.updateComplete;
+    expect(onDismiss).toHaveBeenCalledExactlyOnceWith("timeout");
+    expect(host.textContent).toContain("Queued");
   });
 
   it("auto-dismisses after the configured duration", async () => {

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -67,18 +67,18 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
   }
 
   override disconnectedCallback() {
+    super.disconnectedCallback();
+    // append() relocations reconnect before reactions run. Keep the notification
+    // and its deadline; only a real removal dismisses or returns it from a modal.
+    if (this.isConnected) {
+      return;
+    }
     const target = activeModalToastLayer() ?? restingToastLayer();
-    if (!this.isConnected && this.parentElement?.localName === "openclaw-modal-dialog" && target) {
+    if (this.parentElement?.localName === "openclaw-modal-dialog" && target) {
       target.append(this);
     } else {
       this.dismiss("disconnected");
     }
-    super.disconnectedCallback();
-  }
-
-  /** Keep the outcome intact and refresh ancestor-owned placement across moveBefore() handoffs. */
-  connectedMoveCallback() {
-    this.syncPlacement();
   }
 
   show(options: ToastOptions) {
@@ -233,15 +233,13 @@ export function showToast(options: ToastOptions): boolean {
   }
   const modal = activeModalToastLayer();
   if (modal && host.parentElement !== modal) {
-    modal.moveBefore(host, null);
+    modal.append(host);
     const handoff = (event: Event) => {
       if (event.target !== modal) {
         return;
       }
       modal.removeEventListener("wa-after-hide", handoff);
-      queueMicrotask(() =>
-        (activeModalToastLayer() ?? restingToastLayer())?.moveBefore(host, null),
-      );
+      queueMicrotask(() => (activeModalToastLayer() ?? restingToastLayer())?.append(host));
     };
     modal.addEventListener("wa-after-hide", handoff);
   }

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -39,14 +39,6 @@ if (typeof Element !== "undefined" && !("getAnimations" in Element.prototype)) {
   });
 }
 
-// jsdom does not yet expose the browser's state-preserving DOM move primitive.
-if (typeof Element !== "undefined" && !("moveBefore" in Element.prototype)) {
-  Object.defineProperty(Element.prototype, "moveBefore", {
-    configurable: true,
-    value: () => {},
-  });
-}
-
 // JSDOM exposes partial ElementInternals. Web Awesome form controls require
 // the form-associated methods even when tests do not mount them in a form.
 // Browser tests need native CustomStateSet so CSS :state() observes real state.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users swiping right to open the Control UI sidebar would leave it stuck halfway open on browsers without atomic DOM moves. The drawer follows the finger, but releasing the gesture fails to reveal the rest of the navigation.

## Why This Change Was Made

Swipe completion sets the drawer's open state and moves its notification container before clearing the inline drag transform. That move called `Element.moveBefore()`, which is unavailable in the reproduced WebKit environment; the exception interrupted completion. The same dependency affected closing the drawer and moving notifications into and out of dialogs.

Use `append()` for all four notification handoffs, with the toast lifecycle preserving the message, queue, and expiration deadline during connected relocation. Real removal still dismisses the notification or returns it from a removed dialog. This removes the obsolete atomic-move callback and the no-op test shim that masked the unsupported API. Swipe thresholds and gesture behavior are unchanged.

## User Impact

- A completed right swipe fully opens the mobile sidebar.
- Closing and reopening navigation continues to work.
- Notifications remain visible, actionable, and correctly positioned across drawer/dialog handoffs without restarting their lifetime.
- No configuration, dependency, database, or protocol changes.

## Evidence

### Reproduction and visual proof

Playwright WebKit 26.5 against the running Control UI preview, with synthetic backend data and a programmatic touch sequence from x=30 to x=180 at a 393-pixel viewport:

| Before | After |
| --- | --- |
| 320-pixel drawer remains at x=-170 after release; `drawer.moveBefore is not a function` | Drawer reaches x=0, inline drag transform clears, no page errors; close/reopen also passes |
| ![Before: mobile sidebar stuck halfway open after releasing a swipe](https://github.com/user-attachments/assets/b2766000-a2ab-4656-87c1-fd14a12aa900) | ![After: mobile sidebar fully open after releasing the same swipe](https://github.com/user-attachments/assets/52bba16e-85d7-4344-8883-fa72a6504aca) |

The strengthened browser regression failed before the production fix (`expected x=0, received x=-134`) and passes afterward. It checks full drawer geometry, cleared drag styles, notification ownership, backdrop dismissal, reopen, and absence of page errors, with and without atomic DOM move support.

This is browser-engine proof, not a physical-device or production-gateway test. The report also mentioned Brave; [Brave uses WebKit on iOS and Chromium on Android/desktop](https://brave.com/about/), but the reporter's platform was not confirmed. No Android Brave reproduction is claimed. [WebKit API tracking](https://bugs.webkit.org/show_bug.cgi?id=281223).

### Validation

```sh
node scripts/run-vitest.mjs ui/src/lib/toast.test.ts ui/src/components/modal-dialog.test.ts ui/src/app/app-host.test.ts ui/src/app/app-host-native-shell.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-responsive-layout.e2e.test.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
git diff --check
```

- Rebased candidate: 95 focused tests and all 26 current browser scenarios pass; the E2E run builds the production UI bundle.
- Original candidate: 27 browser scenarios and the complete changed-file check pass, including core/UI type checks, formatting, i18n, dependency guards, dead-export scans, and lint.
- Clean rebase onto current `main`; production patch ID unchanged. Changed-file formatting and whitespace checks pass after rebase.
- Fresh authenticated autoreview of the rebased branch: `scoped-clean`, no findings at the default P0 threshold.
- Production: +11/-13 (net -2). Tests: +137/-74. Test support: -8.

Sibling coverage includes portrait/landscape navigation, keyboard focus, notification placement on mobile/desktop, queued notification deadlines, and dialog hide/removal.
