### PR TITLE
fix(codex): backport nonfatal optional app availability

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -357,12 +357,13 @@ allowed app can be installed and authenticated before it becomes callable.
 OpenClaw provisionally admits only ownership-proven, policy-approved apps,
 creates the thread with `_default.enabled = false` and explicit app overrides,
 then calls `app/installed` once with that thread's ID and `forceRefresh: false`.
-It exposes an app only when Codex confirms the app is enabled and callable for
-the actual thread. Managed restrictions, workspace policy, missing metadata,
-revoked auth, and unavailable tools still fail closed.
+If that snapshot reports missing, disabled, or non-callable apps, OpenClaw logs
+one warning and continues with the remaining tools. Codex still enforces
+managed restrictions, workspace policy, and app/tool permissions; unavailable
+apps gain no access.
 
-Attestation completes before OpenClaw injects history, starts a turn, or
-persists the native thread binding. On failure, OpenClaw deletes a persistent
+The check completes before OpenClaw injects history, starts a turn, or
+persists the native thread binding. If the snapshot request fails, OpenClaw deletes a persistent
 provisional thread with `thread/delete` or unsubscribes an ephemeral thread
 with `thread/unsubscribe`. If safe cleanup cannot be confirmed, it retires the
 owning app-server connection. Supervised branches also clean up their temporary

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -23,12 +23,13 @@ policy. OpenClaw caches a runtime-and-workspace-scoped `plugin/installed`
 snapshot, reads exact configured plugin details, provisionally admits only
 explicitly allowed, ownership-proven apps, and creates a deny-by-default
 native thread. One `app/installed` request verifies the actual thread ID
-without forcing an inventory refresh. Native app execution begins only after
-Codex confirms the app is enabled and callable for that thread.
+without forcing an inventory refresh. Missing, disabled, or non-callable apps
+produce one warning; the conversation continues with the remaining tools.
+Codex still enforces app and tool permissions for the actual thread.
 
 This check finishes before OpenClaw injects history, starts a turn, or commits a
-thread binding. Failed persistent provisional threads are deleted; ephemeral
-threads are unsubscribed. OpenClaw retires the app-server connection when safe
+thread binding. If the snapshot request fails, persistent provisional threads
+are deleted and ephemeral threads are unsubscribed. OpenClaw retires the app-server connection when safe
 cleanup cannot be confirmed. Supervised branches also clean up their temporary
 probe and preserve recovery state if cleanup fails.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1136,14 +1136,14 @@ An authorized app can initially appear disabled or non-callable because Codex
 has not yet applied the target thread's restrictive app configuration.
 OpenClaw provisionally admits only explicitly allowed, ownership-proven apps,
 starts the thread with `_default.enabled = false`, and reads `app/installed`
-once with that thread's ID and `forceRefresh: false`. An app is exposed only
-after Codex confirms it is enabled and callable for the actual thread. Missing
-metadata, revoked auth, managed restrictions, workspace policy, and unavailable
-tools remain fail-closed.
+once with that thread's ID and `forceRefresh: false`. Missing, disabled, or
+non-callable apps produce one warning without blocking unrelated chat or
+heartbeat runs. Codex still enforces app/tool permissions, managed restrictions,
+and workspace policy; continuing the conversation does not enable an unavailable app.
 
-The check runs before OpenClaw starts a turn or commits a thread binding. A
-failed persistent provisional thread is deleted; an ephemeral thread is
-unsubscribed. If cleanup cannot be confirmed, OpenClaw retires the app-server
+The check runs before OpenClaw starts a turn or commits a thread binding. If the
+snapshot request fails, a persistent provisional thread is deleted and an
+ephemeral thread is unsubscribed. If cleanup cannot be confirmed, OpenClaw retires the app-server
 connection instead of reusing an unsafe thread.
 
 Account-wide app access never overrides an explicitly disabled configured

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -391,12 +391,16 @@ An app can be installed and authenticated but non-callable in the account-wide
 snapshot while `_default` is disabled. OpenClaw provisionally admits only
 ownership-proven, policy-allowed apps, creates the restrictive thread, and then
 rereads `app/installed` once with the resulting thread ID and
-`forceRefresh: false`. Codex must confirm each admitted app is enabled and
-callable under the thread's effective app, managed, workspace, and tool
-policies before the turn proceeds. If that attestation fails, the provisional
-thread is never bound or used. OpenClaw deletes a failed persistent provisional
-thread, unsubscribes a failed ephemeral thread, and retires the app-server
-connection if safe cleanup cannot be confirmed.
+`forceRefresh: false`. If the snapshot reports an app missing, disabled, or
+non-callable, OpenClaw logs one warning listing the unavailable apps and
+continues with the remaining tools. Codex still enforces the thread's effective
+app, managed, workspace, and tool policies. An unavailable optional app does
+not block unrelated chat or heartbeat runs.
+
+If the snapshot request itself fails, the provisional thread is never bound
+or used. OpenClaw deletes a failed persistent provisional thread, unsubscribes
+a failed ephemeral thread, and retires the app-server connection if safe
+cleanup cannot be confirmed.
 
 `destructive_enabled` on each app comes from the effective global or
 per-plugin `allow_destructive_actions` policy; `true`, `"auto"`, and `"ask"`

--- a/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
@@ -1,119 +1,104 @@
-import { describe, expect, it, vi } from "vitest";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  attestCodexPluginThreadApps,
+  checkCodexThreadAppAvailability,
   discardUnattestedCodexPluginThread,
 } from "./plugin-thread-attestation.js";
 import type { v2 } from "./protocol.js";
 
-describe("Codex plugin thread app attestation", () => {
-  it("reads the committed snapshot with the started thread's effective policy", async () => {
-    const request = vi.fn(async () => installedApps(["linear-app"]));
+describe("Codex thread app availability", () => {
+  afterEach(() => vi.restoreAllMocks());
 
-    await attestCodexPluginThreadApps({
-      client: { request } as never,
-      threadId: "thread-linear",
-      appIds: ["linear-app", "linear-app"],
-    });
-
-    expect(request).toHaveBeenCalledExactlyOnceWith(
-      "app/installed",
-      { threadId: "thread-linear", forceRefresh: false },
-      { signal: undefined },
-    );
-  });
-
-  it("attests configured plugin and account apps against one thread snapshot", async () => {
+  it("checks configured and account apps once using the thread policy", async () => {
     const request = vi.fn(async () => installedApps(["plugin-app", "account-app"]));
-
-    await attestCodexPluginThreadApps({
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    await checkCodexThreadAppAvailability({
       client: { request } as never,
-      threadId: "thread-mixed-apps",
+      threadId: "thread-mixed",
       appIds: ["plugin-app", "account-app", "plugin-app"],
     });
-
     expect(request).toHaveBeenCalledExactlyOnceWith(
       "app/installed",
-      { threadId: "thread-mixed-apps", forceRefresh: false },
+      { threadId: "thread-mixed", forceRefresh: false },
       { signal: undefined },
     );
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("rejects a mixed snapshot when the thread denies its account-wide app", async () => {
-    const request = vi.fn(async () => installedApps(["plugin-app"]));
-
-    await expect(
-      attestCodexPluginThreadApps({
-        client: { request } as never,
-        threadId: "thread-mixed-apps",
-        appIds: ["plugin-app", "account-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      message: expect.stringContaining("account-app:missing"),
+  it("records unavailable apps without blocking the remaining tools", async () => {
+    const request = vi.fn(async () => ({
+      apps: [
+        ...installedApps(["working"]).apps,
+        ...installedApps(["disabled"], { enabled: false, callable: false }).apps,
+        ...installedApps(["readonly"], { callable: false }).apps,
+      ],
+    }));
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    await checkCodexThreadAppAvailability({
+      client: { request } as never,
+      threadId: "thread-mixed",
+      appIds: ["working", "readonly", "missing", "disabled", "missing"],
     });
-
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      "codex apps unavailable; continuing with remaining tools",
+      {
+        threadId: "thread-mixed",
+        failures: ["disabled:disabled", "missing:missing", "readonly:not-callable"],
+      },
+    );
     expect(request).toHaveBeenCalledOnce();
   });
 
-  it("does not read the app snapshot when no apps need attestation", async () => {
+  it("does not read the app snapshot when no apps are configured", async () => {
     const request = vi.fn();
-
-    await attestCodexPluginThreadApps({
+    await checkCodexThreadAppAvailability({
       client: { request } as never,
-      threadId: "thread-linear",
+      threadId: "thread-empty",
       appIds: [],
     });
-
     expect(request).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      state: "missing",
-      response: installedApps([]),
-      failure: "linear-app:missing",
-    },
-    {
-      state: "disabled",
-      response: installedApps(["linear-app"], { enabled: false, callable: false }),
-      failure: "linear-app:disabled",
-    },
-    {
-      state: "not callable",
-      response: installedApps(["linear-app"], { callable: false }),
-      failure: "linear-app:not-callable",
-    },
-  ])("fails closed when an admitted app is $state", async ({ response, failure }) => {
-    await expect(
-      attestCodexPluginThreadApps({
-        client: { request: vi.fn(async () => response) } as never,
-        threadId: "thread-linear",
-        appIds: ["linear-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      message: expect.stringContaining(failure),
+  it("preserves snapshot request failures and their cause", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    const cause = new Error("app inventory offline");
+    const request = vi.fn(async () => {
+      throw cause;
     });
+    await expect(
+      checkCodexThreadAppAvailability({
+        client: { request } as never,
+        threadId: "thread-unavailable",
+        appIds: ["plugin-app"],
+      }),
+    ).rejects.toMatchObject({ name: "CodexPluginThreadAppAttestationError", cause });
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("preserves the original cause when thread-scoped discovery fails", async () => {
-    const cause = new Error("committed app snapshot unavailable");
-
-    await expect(
-      attestCodexPluginThreadApps({
-        client: {
-          request: vi.fn(async () => {
-            throw cause;
-          }),
-        } as never,
-        threadId: "thread-linear",
-        appIds: ["linear-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      cause,
-    });
-  });
+  it.each(["resolve", "reject"])(
+    "preserves cancellation when discovery will %s",
+    async (outcome) => {
+      const abort = new AbortController();
+      const cause = new Error("turn cancelled");
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+      const request = vi.fn(async () => {
+        abort.abort(cause);
+        if (outcome === "reject") {
+          throw cause;
+        }
+        return installedApps([]);
+      });
+      await expect(
+        checkCodexThreadAppAvailability({
+          client: { request } as never,
+          threadId: "thread-cancelled",
+          appIds: ["plugin-app"],
+          signal: abort.signal,
+        }),
+      ).rejects.toBe(cause);
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe("unattested Codex plugin thread cleanup", () => {

--- a/extensions/codex/src/app-server/plugin-thread-attestation.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.ts
@@ -1,6 +1,5 @@
 /**
- * Confirms admitted plugin and account apps against their actual Codex thread before
- * OpenClaw commits a binding or starts a turn.
+ * Checks app availability against the effective Codex thread policy.
  */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -18,7 +17,7 @@ class CodexPluginThreadAppAttestationError extends Error {
 }
 
 /** Reads the existing runtime snapshot with the started thread's effective app policy. */
-export async function attestCodexPluginThreadApps(params: {
+export async function checkCodexThreadAppAvailability(params: {
   client: CodexAppServerClient;
   threadId: string;
   appIds: readonly string[];
@@ -37,11 +36,13 @@ export async function attestCodexPluginThreadApps(params: {
       { signal: params.signal },
     );
   } catch (error) {
+    params.signal?.throwIfAborted();
     throw new CodexPluginThreadAppAttestationError(
       `Codex could not confirm admitted apps for thread ${params.threadId}`,
       { cause: error },
     );
   }
+  params.signal?.throwIfAborted();
 
   const installedById = new Map(response.apps.map((app) => [app.id, app] as const));
   const failures = appIds.flatMap((appId): string[] => {
@@ -55,9 +56,12 @@ export async function attestCodexPluginThreadApps(params: {
     return app.callable ? [] : [`${appId}:not-callable`];
   });
   if (failures.length > 0) {
-    throw new CodexPluginThreadAppAttestationError(
-      `Codex thread ${params.threadId} did not expose admitted apps: ${failures.join(", ")}`,
-    );
+    // Availability is not authorization: Codex still filters and checks each tool.
+    // An optional app with no allowed tools must not prevent unrelated chat or heartbeats.
+    embeddedAgentLog.warn("codex apps unavailable; continuing with remaining tools", {
+      threadId: params.threadId,
+      failures,
+    });
   }
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -20,7 +20,7 @@ import { markStartedCodexManagedThread } from "./managed-thread-store.js";
 import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
-  attestCodexPluginThreadApps,
+  checkCodexThreadAppAvailability,
   discardUnattestedCodexPluginThread,
 } from "./plugin-thread-attestation.js";
 import {
@@ -219,7 +219,7 @@ export async function resumeExistingCodexThread(
       (params.pluginThreadConfig?.enabled
         ? Object.keys(resumeBinding.pluginAppPolicyContext?.apps ?? {})
         : []);
-    await attestCodexPluginThreadApps({
+    await checkCodexThreadAppAvailability({
       client: params.client,
       threadId: response.thread.id,
       appIds: provisionalAppIds,
@@ -500,12 +500,12 @@ export async function startFreshCodexThread(
   });
   const response = assertCodexThreadStartResponse(threadStartResponse);
   const provisionalAppIds = pluginThreadConfig?.provisionalAppIds;
-  // A deny-by-default app becomes callable only under this exact thread's
-  // allowlist. Never persist or run the thread before Codex confirms it.
+  // Check the effective thread snapshot before persisting the binding.
+  // Unavailable optional apps are diagnostic; snapshot RPC failures still fail closed.
   if (provisionalAppIds?.length) {
     try {
       await lifecycleTiming.measure("plugin-app-attestation", () =>
-        attestCodexPluginThreadApps({
+        checkCodexThreadAppAvailability({
           client: params.client,
           threadId: response.thread.id,
           appIds: provisionalAppIds,

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -3127,61 +3127,54 @@ describe("Codex thread-effective app attestation", () => {
     },
   );
 
-  it.each([
-    {
-      state: "missing",
-      apps: [],
-      failure: "linear-app:missing",
-    },
-    {
-      state: "disabled by managed or workspace policy",
-      apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
-    },
-    {
-      state: "not callable under thread policy",
-      apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
-    },
-  ])("deletes the unbound persistent thread when its app is $state", async ({ apps, failure }) => {
+  it.each(
+    ["chat", "heartbeat", "incognito"].flatMap((source) =>
+      ["missing", "disabled", "not-callable"].map((state) => ({ source, state })),
+    ),
+  )("keeps the $source binding when its optional app is $state", async ({ source, state }) => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.sessionKey =
+      source === "heartbeat"
+        ? "agent:main:main"
+        : source === "incognito"
+          ? "agent:main:internal-session-effects:incognito-app-unavailable"
+          : "agent:main:dashboard:app-unavailable";
+    const provider = createProvisionalPluginThreadConfigProvider("linear-app");
+    const expectedConfig = (await provider.build()).configPatch;
     const abandonClient = vi.fn(async () => undefined);
-    const request = vi.fn(
-      async (method: string, _requestParams?: unknown, _requestOptions?: unknown) => {
-        if (method === "thread/start") {
-          return threadStartResult("thread-linear-blocked");
-        }
-        if (method === "app/installed") {
-          return { apps };
-        }
-        if (method === "thread/delete") {
-          return {};
-        }
-        throw new Error(`unexpected method: ${method}`);
-      },
-    );
-
-    await expect(
-      startOrResumeThread({
-        client: { request } as never,
-        abandonClient,
-        params,
-        cwd: workspaceDir,
-        dynamicTools: [],
-        appServer: createThreadLifecycleAppServerOptions(),
-        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
-      }),
-    ).rejects.toThrow(failure);
-
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/start",
-      "app/installed",
-      "thread/delete",
-    ]);
-    expect(request.mock.calls[2]?.[1]).toEqual({ threadId: "thread-linear-blocked" });
-    expect(request.mock.calls[2]?.[2]).toEqual({ timeoutMs: 5_000 });
-    expect(abandonClient).not.toHaveBeenCalled();
+    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "thread/start") {
+        expect(requestParams).toMatchObject({ config: expectedConfig });
+        return threadStartResult("thread-app-unavailable");
+      }
+      if (method === "app/installed") {
+        return {
+          apps:
+            state === "missing"
+              ? []
+              : [
+                  {
+                    id: "linear-app",
+                    runtimeName: "Linear",
+                    enabled: state !== "disabled",
+                    callable: false,
+                  },
+                ],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const result = await startOrResumeThread({
+      client: { request } as never,
+      abandonClient,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      pluginThreadConfig: provider,
+    });
+    expect(result.threadId).toBe("thread-app-unavailable");
     await expect(
       testCodexAppServerBindingStore.read(
         sessionBindingIdentity({
@@ -3191,7 +3184,9 @@ describe("Codex thread-effective app attestation", () => {
           config: params.config,
         }),
       ),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ threadId: result.threadId });
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "app/installed"]);
+    expect(abandonClient).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -3201,7 +3196,6 @@ describe("Codex thread-effective app attestation", () => {
       state: "disabled by thread policy",
       enabled: false,
       callable: false,
-      failure: "global-ready-app:disabled",
     },
     {
       source: "globally ready account-wide app",
@@ -3209,7 +3203,6 @@ describe("Codex thread-effective app attestation", () => {
       state: "disabled by thread policy",
       enabled: false,
       callable: false,
-      failure: "global-ready-app:disabled",
     },
     {
       source: "globally ready configured plugin",
@@ -3217,7 +3210,6 @@ describe("Codex thread-effective app attestation", () => {
       state: "not callable under thread policy",
       enabled: true,
       callable: false,
-      failure: "global-ready-app:not-callable",
     },
     {
       source: "globally ready account-wide app",
@@ -3225,11 +3217,10 @@ describe("Codex thread-effective app attestation", () => {
       state: "not callable under thread policy",
       enabled: true,
       callable: false,
-      failure: "global-ready-app:not-callable",
     },
   ])(
-    "rejects a $source when it is $state in the actual thread",
-    async ({ createProvider, enabled, callable, failure }) => {
+    "keeps a $source when it is $state in the actual thread",
+    async ({ createProvider, enabled, callable }) => {
       const workspaceDir = path.join(tempDir, "workspace");
       const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
       const abandonClient = vi.fn(async () => undefined);
@@ -3259,12 +3250,11 @@ describe("Codex thread-effective app attestation", () => {
           appServer: createThreadLifecycleAppServerOptions(),
           pluginThreadConfig: createProvider("global-ready-app"),
         }),
-      ).rejects.toThrow(failure);
+      ).resolves.toMatchObject({ threadId: "thread-global-ready" });
 
       expect(request.mock.calls.map(([method]) => method)).toEqual([
         "thread/start",
         "app/installed",
-        "thread/delete",
       ]);
       expect(abandonClient).not.toHaveBeenCalled();
       await expect(
@@ -3276,7 +3266,7 @@ describe("Codex thread-effective app attestation", () => {
             config: params.config,
           }),
         ),
-      ).resolves.toBeUndefined();
+      ).resolves.toMatchObject({ threadId: "thread-global-ready" });
     },
   );
 
@@ -3289,7 +3279,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-unsafe");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/delete") {
         throw new Error("delete unavailable");
@@ -3361,7 +3351,7 @@ describe("Codex thread-effective app attestation", () => {
     expect(abandonClient).not.toHaveBeenCalled();
   });
 
-  it("unsubscribes an ephemeral thread when its app cannot be attested", async () => {
+  it("unsubscribes an ephemeral thread when its app snapshot request fails", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.sessionKey = "agent:main:internal-session-effects:incognito-plugin-attestation";
@@ -3372,7 +3362,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-ephemeral");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/unsubscribe") {
         return {};
@@ -3390,7 +3380,7 @@ describe("Codex thread-effective app attestation", () => {
         appServer: createThreadLifecycleAppServerOptions(),
         pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
       }),
-    ).rejects.toThrow("linear-app:missing");
+    ).rejects.toThrow("Codex could not confirm admitted apps");
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
@@ -3410,7 +3400,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-ephemeral-unsafe");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/unsubscribe") {
         throw new Error("unsubscribe unavailable");
@@ -4253,46 +4243,40 @@ describe("Codex app-server supervised branch lifecycle", () => {
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "missing from the effective thread",
       apps: [],
-      failure: "linear-app:missing",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "missing from the effective thread",
       apps: [],
-      failure: "linear-app:missing",
     },
     {
       source: "configured plugin",
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "disabled by managed or workspace policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "disabled by managed or workspace policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
     },
     {
       source: "configured plugin",
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "not callable under thread policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "not callable under thread policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
     },
   ])(
-    "cleans both supervised branches when a $source app is $state",
-    async ({ createProvider, apps, failure }) => {
+    "keeps the supervised branch when a $source app is $state",
+    async ({ createProvider, apps }) => {
       const sourceThreadId = "thread-source";
       const probeThreadId = "thread-probe";
       const finalThreadId = "thread-final";
@@ -4337,7 +4321,7 @@ describe("Codex app-server supervised branch lifecycle", () => {
           appServer: createThreadLifecycleAppServerOptions(),
           pluginThreadConfig: createProvider("linear-app"),
         }),
-      ).rejects.toThrow(failure);
+      ).resolves.toMatchObject({ threadId: finalThreadId, lifecycle: { action: "forked" } });
 
       expect(request.mock.calls.map(([method]) => method)).toEqual([
         "thread/read",
@@ -4345,18 +4329,15 @@ describe("Codex app-server supervised branch lifecycle", () => {
         "thread/unsubscribe",
         "thread/start",
         "app/installed",
-        "thread/delete",
       ]);
       expect(request.mock.calls[2]?.[1]).toEqual({ threadId: probeThreadId });
-      expect(request.mock.calls[5]?.[1]).toEqual({ threadId: finalThreadId });
       expect(abandonClient).not.toHaveBeenCalled();
       await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
-        pendingSupervisionBranch: { sourceThreadId },
+        threadId: finalThreadId,
       });
       expect(
-        (await testCodexAppServerBindingStore.read(identity))?.pendingSupervisionBranch
-          ?.cleanupThreadIds ?? [],
-      ).toEqual([]);
+        (await testCodexAppServerBindingStore.read(identity))?.pendingSupervisionBranch,
+      ).toBeUndefined();
     },
   );
 
@@ -4383,7 +4364,7 @@ describe("Codex app-server supervised branch lifecycle", () => {
         return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/delete") {
         throw new Error("delete unavailable");

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -16,7 +16,7 @@ import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
-  attestCodexPluginThreadApps,
+  checkCodexThreadAppAvailability,
   discardUnattestedCodexPluginThread,
 } from "./plugin-thread-attestation.js";
 import {
@@ -299,7 +299,7 @@ export async function materializePendingSupervisionBranch(
     if (params.provisionalAppIds?.length) {
       try {
         await params.lifecycleTiming.measure("plugin-app-attestation", () =>
-          attestCodexPluginThreadApps({
+          checkCodexThreadAppAvailability({
             client: params.client,
             threadId: finalThreadId,
             appIds: params.provisionalAppIds ?? [],


### PR DESCRIPTION
## What Problem This Solves

Backports #138687 to `sjf_openclaw_2026-09-01`: an unavailable optional Codex app prevents unrelated conversations and heartbeats from starting.

## Why This Change Was Made

A successful thread snapshot reporting missing, disabled, or non-callable optional apps produces one warning and allows use of the remaining tools. Snapshot RPC errors, cancellation, restricted MCP checks, and scheduled authority retain their existing enforcement.

The release adaptation updates the existing lifecycle-io callers and asynchronous binding-store tests. It preserves the release-only configured/account-app matrix and omits main-only lifecycle refactors.

## User Impact

Unavailable optional apps no longer block unrelated conversations or heartbeats, while Codex continues to enforce each tool's policy.

## Evidence

- Release base: `6096144077ff1f28b09a7f47dbcd45c965685475`.
- Upstream fix: `7b1795acc6783273c4218a511011bc1f7f13bd65` (#138687).
- Four focused app-availability/lifecycle/fork suites: 221 tests passed.
- Native formatting, syntax lint, MDX and diff checks passed.
- Fresh autoreview of this standalone backport: no actionable P0 findings (default scope).
- Codex source inspected directly: installed app callability reflects policy-allowed visible tools; dispatch independently enforces app policy.
- No new configuration, persistence schema, dependency, retry, or runtime version change. No new live-provider acceptance claim; this carries the already-merged fix with release-specific regression coverage.

Related independent backport: #142566 (Slack heartbeat workspace repair).
