### PR TITLE
refactor(plugins): unify startup contract membership checks

### DIFF
--- a/src/plugins/gateway-startup-plugin-activation.ts
+++ b/src/plugins/gateway-startup-plugin-activation.ts
@@ -15,11 +15,7 @@ import type {
   ConfiguredVoiceProviderIds,
   NormalizedPluginsConfig,
 } from "./gateway-startup-plugin-contracts.js";
-import {
-  manifestOwnsConfiguredModelProvider,
-  manifestOwnsConfiguredSpeechProvider,
-  manifestOwnsConfiguredWebSearchProvider,
-} from "./gateway-startup-plugin-providers.js";
+import { manifestOwnsConfiguredModelProvider } from "./gateway-startup-plugin-providers.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { manifestOwnsWorkerProvider } from "./worker-provider-manifest.js";
@@ -57,7 +53,8 @@ type StartupActivationPolicy =
 type StartupContractKey =
   | keyof ConfiguredGenerationProviderIds
   | keyof ConfiguredVoiceProviderIds
-  | "embeddingProviders";
+  | "embeddingProviders"
+  | "webSearchProviders";
 
 export function addRequiredAgentHarnessPluginIds(
   target: Set<string>,
@@ -247,12 +244,16 @@ const GATEWAY_STARTUP_ACTIVATION_POLICIES: readonly {
   {
     policy: "speech",
     matches: ({ manifest, configuredSpeechProviderIds }) =>
-      manifestOwnsConfiguredSpeechProvider({ manifest, configuredSpeechProviderIds }),
+      manifestOwnsConfiguredContract(manifest, "speechProviders", configuredSpeechProviderIds),
   },
   {
     policy: "implicit-external",
     matches: ({ manifest, configuredWebSearchProviderIds }) =>
-      manifestOwnsConfiguredWebSearchProvider({ manifest, configuredWebSearchProviderIds }),
+      manifestOwnsConfiguredContract(
+        manifest,
+        "webSearchProviders",
+        configuredWebSearchProviderIds,
+      ),
   },
   {
     policy: "provider",

--- a/src/plugins/gateway-startup-plugin-providers.ts
+++ b/src/plugins/gateway-startup-plugin-providers.ts
@@ -24,19 +24,6 @@ import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-re
 import { CORE_BUILT_IN_MODEL_APIS } from "./provider-config-owner.js";
 import type { PluginRegistry } from "./registry-types.js";
 
-export function manifestOwnsConfiguredSpeechProvider(params: {
-  manifest: PluginManifestRecord | undefined;
-  configuredSpeechProviderIds: ReadonlySet<string>;
-}): boolean {
-  if (params.configuredSpeechProviderIds.size === 0) {
-    return false;
-  }
-  return (params.manifest?.contracts?.speechProviders ?? []).some((providerId) => {
-    const normalized = normalizeOptionalLowercaseString(providerId);
-    return normalized ? params.configuredSpeechProviderIds.has(normalized) : false;
-  });
-}
-
 export function collectConfiguredWebSearchProviderIds(config: OpenClawConfig): ReadonlySet<string> {
   const search = config.tools?.web?.search;
   if (search?.enabled === false || typeof search?.provider !== "string") {
@@ -44,19 +31,6 @@ export function collectConfiguredWebSearchProviderIds(config: OpenClawConfig): R
   }
   const providerId = normalizeOptionalLowercaseString(search.provider);
   return providerId ? new Set([providerId]) : new Set();
-}
-
-export function manifestOwnsConfiguredWebSearchProvider(params: {
-  manifest: PluginManifestRecord | undefined;
-  configuredWebSearchProviderIds: ReadonlySet<string>;
-}): boolean {
-  if (params.configuredWebSearchProviderIds.size === 0) {
-    return false;
-  }
-  return (params.manifest?.contracts?.webSearchProviders ?? []).some((providerId) => {
-    const normalized = normalizeOptionalLowercaseString(providerId);
-    return normalized ? params.configuredWebSearchProviderIds.has(normalized) : false;
-  });
 }
 
 function listModelProviderRefParts(value: unknown): Array<{ providerId: string; modelId: string }> {


### PR DESCRIPTION
## What Problem This Solves

Startup plugin selection has separate speech and web-search membership checks alongside an existing shared contract-membership path. Maintaining the same normalization and membership rules in three places creates avoidable drift risk.

## Why This Change Was Made

This maintainer-requested refactor routes the two descriptors through the existing private helper and removes their unused wrappers. It preserves descriptor order, captured provider sets, short-circuiting, normalization, and the distinct speech and external-plugin activation policies.

## User Impact

No intended behavior or public API change. No new configuration, dependencies, storage, exports, or tests.

## Evidence

- Before and after the change, separate clean physical Testboxes passed the same 41 selected startup-planner cases and 2 provider-ownership cases: 43 distinct cases. The selection intentionally skipped 129 other cases in each run.
- Full tracked source contents and modes were verified before and after execution and bound to the baseline or candidate commit and tree.
- Candidate explicit two-path changed-file dry-run and actual gate passed, including core and core-test typechecking, formatting, targeted lint, dead-export scans, and all selected guards.
- Independent review found no actionable P0-P2 issue in the patch.
- Exact-head CI passed for `f9446aa2a7b9e5cbdbab4a5ab3ffa7453324b4a5`: https://github.com/openclaw/openclaw/actions/runs/34279203676.
- No full repository test suite, build, profiler, or live Gateway proof is claimed.
