### PR TITLE
fix(security): preserve existing WhatsApp group allowlists

### DIFF
--- a/extensions/whatsapp/src/security-fix.test.ts
+++ b/extensions/whatsapp/src/security-fix.test.ts
@@ -1,0 +1,86 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readChannelAllowFromStoreMock } = vi.hoisted(() => ({
+  readChannelAllowFromStoreMock: vi.fn(async () => [] as string[]),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-pairing", () => ({
+  readChannelAllowFromStore: readChannelAllowFromStoreMock,
+}));
+
+import { applyWhatsAppSecurityConfigFixes } from "./security-fix.js";
+
+describe("applyWhatsAppSecurityConfigFixes", () => {
+  beforeEach(() => {
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue(["+15550000001"]);
+  });
+
+  it("seeds only holders whose open group policy is awaiting conversion", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "open",
+          accounts: {
+            default: { groupPolicy: "open" },
+            alreadyRestricted: { groupPolicy: "allowlist" },
+            disabled: { groupPolicy: "disabled" },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await applyWhatsAppSecurityConfigFixes({ cfg, env: process.env });
+
+    expect(result.changes).toEqual([
+      "channels.whatsapp.groupAllowFrom=pairing-store",
+      "channels.whatsapp.accounts.default.groupAllowFrom=pairing-store",
+    ]);
+    expect(result.config.channels?.whatsapp?.groupAllowFrom).toEqual(["+15550000001"]);
+    expect(result.config.channels?.whatsapp?.accounts?.default?.groupAllowFrom).toEqual([
+      "+15550000001",
+    ]);
+    expect(
+      result.config.channels?.whatsapp?.accounts?.alreadyRestricted?.groupAllowFrom,
+    ).toBeUndefined();
+    expect(result.config.channels?.whatsapp?.accounts?.disabled?.groupAllowFrom).toBeUndefined();
+  });
+
+  it("does not modify an existing empty allowlist", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          accounts: {
+            default: { groupPolicy: "allowlist" },
+            work: { groupPolicy: "allowlist" },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await applyWhatsAppSecurityConfigFixes({ cfg, env: process.env });
+
+    expect(result.config).toBe(cfg);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("preserves explicit allowlists while an open policy is converted", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "open",
+          allowFrom: ["+15550000002"],
+          accounts: {
+            work: { groupPolicy: "open", groupAllowFrom: ["+15550000003"] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await applyWhatsAppSecurityConfigFixes({ cfg, env: process.env });
+
+    expect(result.config).toBe(cfg);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/extensions/whatsapp/src/security-fix.ts
+++ b/extensions/whatsapp/src/security-fix.ts
@@ -18,7 +18,7 @@ function applyGroupAllowFromFromStore(params: {
 
   let changed = false;
   const maybeApply = (prefix: string, holder: Record<string, unknown>) => {
-    if (holder.groupPolicy !== "allowlist") {
+    if (holder.groupPolicy !== "open") {
       return;
     }
     const allowFrom = Array.isArray(holder.allowFrom) ? holder.allowFrom : [];

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -84,7 +84,7 @@ describe("security fix", () => {
         const changes: string[] = [];
         let changed = false;
         const maybeApply = (prefix: string, holder: Record<string, unknown>) => {
-          if (holder.groupPolicy !== "allowlist") {
+          if (holder.groupPolicy !== "open") {
             return;
           }
           const allowFrom = Array.isArray(holder.allowFrom) ? holder.allowFrom : [];
@@ -237,6 +237,31 @@ describe("security fix", () => {
     expect(expectDefined(accounts.a1, "accounts.a1 test invariant").groupAllowFrom).toEqual([
       "+15550001111",
     ]);
+  });
+
+  it("does not seed WhatsApp accounts that were already allowlisted", async () => {
+    const { res, channels } = await fixWhatsAppConfigScenario({
+      whatsapp: {
+        groupPolicy: "allowlist",
+        accounts: {
+          default: { groupPolicy: "allowlist" },
+          work: { groupPolicy: "allowlist" },
+        },
+      },
+      allowFromStore: ["+15550001111"],
+    });
+
+    expect(res.configWritten).toBe(false);
+    expect(res.changes).toEqual([]);
+    const whatsapp = expectDefined(channels.whatsapp, "channels.whatsapp test invariant");
+    expect(whatsapp.groupAllowFrom).toBeUndefined();
+    const accounts = whatsapp.accounts as Record<string, Record<string, unknown>>;
+    expect(
+      expectDefined(accounts.default, "accounts.default test invariant").groupAllowFrom,
+    ).toBeUndefined();
+    expect(
+      expectDefined(accounts.work, "accounts.work test invariant").groupAllowFrom,
+    ).toBeUndefined();
   });
 
   it("does not seed WhatsApp groupAllowFrom if allowFrom is set", async () => {

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -255,14 +255,14 @@ async function applySecurityFixConfigMutations(params: {
   cfg: OpenClawConfig;
   changes: string[];
 }> {
-  const fixed = applyConfigFixes({ cfg: params.cfg, env: params.env });
   const channelFixes = await collectChannelSecurityConfigFixMutation({
-    cfg: fixed.cfg,
+    cfg: params.cfg,
     env: params.env,
     channelPlugins: params.channelPlugins,
   });
+  const fixed = applyConfigFixes({ cfg: channelFixes.cfg, env: params.env });
   return {
-    cfg: channelFixes.cfg,
+    cfg: fixed.cfg,
     changes: [...fixed.changes, ...channelFixes.changes],
   };
 }


### PR DESCRIPTION
## What changed

`openclaw security audit --fix` changes an open WhatsApp group policy to an allowlist. When it does that, it copies existing pairing approvals into `groupAllowFrom` so the operator is not accidentally locked out.

The command currently changes the policy first. By the time the WhatsApp-specific repair runs, it cannot tell the difference between:

- a policy that was open and was just converted; and
- a policy the user had already configured as an allowlist.

As a result, running the command can add paired users to an existing group allowlist even though that policy was not changed by the command.

This fix runs the WhatsApp-specific step while the original policy is still visible. Pairing approvals are copied only when that policy is actually being converted from `open` to `allowlist`. Existing allowlists, disabled policies, explicit sender lists, and account-default inheritance are left unchanged.

## Tests

- Focused tests cover both paths: converting an open policy still seeds the list, while an existing allowlist is not modified.
- Full WhatsApp extension test suite: 1,411 tests passed.
- Full repository checks passed.
