### PR TITLE
fix(ui): align configuration fields and collection actions

### DIFF
--- a/ui/src/components/config-form-layout.browser.test.ts
+++ b/ui/src/components/config-form-layout.browser.test.ts
@@ -1,0 +1,101 @@
+import { html, render } from "lit";
+import { afterEach, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import "../styles.css";
+import "../styles/settings.css";
+import "../styles/config.css";
+import { renderNode, type JsonSchema } from "./config-form.ts";
+import { renderSettingsGroup, renderSettingsPage } from "./settings-ui.ts";
+
+afterEach(() => document.body.replaceChildren());
+
+it.each([390, 768, 1440])(
+  "aligns config controls and keeps collection actions beside their labels at %ipx",
+  async (width) => {
+    await page.viewport(width, 1200);
+    const host = document.createElement("main");
+    host.className = "shell--settings";
+    document.body.append(host);
+    const fields: Array<[string, JsonSchema, unknown]> = [
+      ["Name", { type: "string" }, "example"],
+      ["Mode", { type: "string", enum: ["a", "b", "c", "d", "e", "f"] }, "a"],
+      ["Payload", { anyOf: [{ type: "object" }, { type: "array" }] }, { enabled: true }],
+      ["Retries", { type: "integer" }, 2],
+      ["Collection", { type: "array", items: { type: "string" } }, ["item"]],
+      [
+        "Nested collections",
+        { type: "array", items: { type: "array", items: { type: "string" } } },
+        [["nested item"]],
+      ],
+      ["Draft", { type: "array", items: { type: "string", pattern: "^[A-Z]+$" } }, []],
+    ];
+    render(
+      renderSettingsPage(
+        renderSettingsGroup(
+          html`${fields.map(([title, schema, value]) =>
+            renderNode({
+              schema: { ...schema, title },
+              value,
+              path: [title],
+              hints: {},
+              unsupported: new Set(),
+              disabled: false,
+              onPatch: () => {},
+            }),
+          )}`,
+        ),
+      ),
+      host,
+    );
+    await document.fonts.ready;
+    const rect = (selector: string) => {
+      const element = host.querySelector(selector);
+      expect(element, selector).not.toBeNull();
+      return element!.getBoundingClientRect();
+    };
+    const nameControl = rect('[aria-label="Name"]');
+    const nameLabel = rect(".settings-group > .settings-row > .settings-row__text");
+    for (const label of ["Mode", "Payload"]) {
+      const control = rect(`[aria-label="${label}"]`);
+      expect(control.left).toBeCloseTo(nameControl.left, 0);
+      expect(control.right).toBeCloseTo(nameControl.right, 0);
+    }
+    const rows = [...host.querySelectorAll(".settings-group > .settings-row")];
+    const gaps = rows.map((row) => {
+      const text = row.querySelector(".settings-row__text")!.getBoundingClientRect();
+      const control = row.querySelector(".settings-row__control")!.getBoundingClientRect();
+      if (width < 768) {
+        expect(control.top).toBeGreaterThan(text.bottom);
+      } else {
+        expect(control.left).toBeGreaterThan(text.right);
+        expect(control.left).toBeCloseTo(nameControl.left, 0);
+        expect(control.right).toBeCloseTo(nameControl.right, 0);
+      }
+      return control.top - text.bottom;
+    });
+    if (width < 768) {
+      for (const gap of gaps.slice(1)) {
+        expect(gap).toBeCloseTo(nameControl.top - nameLabel.bottom, 0);
+      }
+    }
+    for (const header of host.querySelectorAll(".cfg-array .settings-row:has(button)")) {
+      const text = header.querySelector(".settings-row__text")!.getBoundingClientRect();
+      const actions = header.querySelector(".settings-row__control")!.getBoundingClientRect();
+      expect(actions.left).toBeGreaterThan(text.right);
+      expect(actions.top).toBeLessThan(text.bottom);
+      expect(text.top).toBeLessThan(actions.bottom);
+    }
+    const item = rect(".cfg-array input");
+    expect(item.right).toBeCloseTo(nameControl.right, 0);
+    const nestedHeader = rect(".cfg-array .cfg-array .settings-row__text");
+    const nestedItem = rect(".cfg-array .cfg-array input");
+    expect(nestedHeader.left).toBeLessThanOrEqual(nestedItem.left);
+    const draftArray = host.querySelector(".settings-group > .cfg-array:last-child")!;
+    await page.elementLocator(draftArray.querySelector("button")!).click();
+    await expect.element(host.querySelector<HTMLElement>(".cfg-collection-draft")!).toBeVisible();
+    const draftInput = rect(".cfg-collection-draft input");
+    expect(draftInput.left).toBeCloseTo(nameLabel.left, 0);
+    expect(draftInput.right).toBeCloseTo(nameControl.right, 0);
+    expect(host.scrollWidth).toBeLessThanOrEqual(host.clientWidth);
+  },
+);

--- a/ui/src/components/config-form.node.collection-map.ts
+++ b/ui/src/components/config-form.node.collection-map.ts
@@ -76,7 +76,7 @@ export function renderMapField(
 
   return html`
     <div class="cfg-block cfg-map">
-      <div class="settings-row">
+      <div class="settings-row cfg-collection-header">
         <div class="settings-row__text">
           <span class="settings-row__title">${t("configForm.customEntries")}</span>
         </div>
@@ -139,7 +139,7 @@ export function renderMapField(
                     isSensitivePathRevealed,
                   });
                   return html`
-                    <div class="settings-row">
+                    <div class="settings-row cfg-collection-header">
                       <div class="settings-row__text">
                         <input
                           type="text"
@@ -189,7 +189,6 @@ export function renderMapField(
                           <button
                             type="button"
                             class="btn btn--icon"
-                            style="width:28px;height:28px;padding:0;"
                             aria-label=${t("configForm.removeEntry")}
                             ?disabled=${disabled}
                             @click=${() => {
@@ -209,7 +208,6 @@ export function renderMapField(
                             label: key,
                             tags: [],
                             showLabel: false,
-                            stacked: true,
                             control: renderJsonTextareaControl({
                               schema,
                               path: valuePath,

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -338,7 +338,7 @@ export function renderArray(
 
   return html`
     <div class="cfg-block cfg-array">
-      <div class="settings-row">
+      <div class="settings-row cfg-collection-header">
         <div class="settings-row__text">
           ${showLabel ? html`<span class="settings-row__title">${label}</span>` : nothing}
           ${
@@ -419,7 +419,7 @@ export function renderArray(
                 ${arrayValue.map((item, index) => {
                   const itemSchema = itemSchemaAt(index);
                   return html`
-                    <div class="settings-row">
+                    <div class="settings-row cfg-collection-header">
                       <div class="settings-row__text">
                         <span class="settings-row__title">#${index + 1}</span>
                       </div>
@@ -428,7 +428,6 @@ export function renderArray(
                           <button
                             type="button"
                             class="btn btn--icon"
-                            style="width:28px;height:28px;padding:0;"
                             aria-label=${t("configForm.removeItem")}
                             ?disabled=${
                               disabled ||

--- a/ui/src/components/config-form.node.json.ts
+++ b/ui/src/components/config-form.node.json.ts
@@ -49,7 +49,6 @@ export function renderJsonTextarea(params: ConfigNodeRenderParams): TemplateResu
       : renderSchemaDefaultDescription(schema, value),
     tags,
     showLabel,
-    stacked: true,
     control,
   });
 }

--- a/ui/src/components/config-form.node.shared.ts
+++ b/ui/src/components/config-form.node.shared.ts
@@ -219,7 +219,6 @@ export function renderFieldRow(params: {
   tags: string[];
   showLabel: boolean;
   control: TemplateResult | typeof nothing;
-  stacked?: boolean;
   error?: unknown;
 }): TemplateResult {
   // Array/map item rows resolve their meta from the parent path (numeric and
@@ -233,11 +232,8 @@ export function renderFieldRow(params: {
     Boolean(defaultDescription) ||
     params.tags.length > 0 ||
     Boolean(params.error);
-  // Control-only rows (array/map item values) stack so the control gets full width.
-  const stacked = params.stacked || !hasText;
-  const className = stacked ? "settings-row settings-row--stacked" : "settings-row";
   return html`
-    <div class=${className}>
+    <div class="settings-row settings-row--stacked cfg-field">
       ${
         hasText
           ? html`

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -828,15 +828,6 @@
   width: 100%;
 }
 
-.cfg-array .settings-row--stacked .settings-row__control {
-  width: 100%;
-}
-
-.cfg-array .settings-row--stacked .settings-row__control > input[type="number"] {
-  flex: 1 1 auto;
-  width: auto;
-}
-
 .cfg-collection-draft__controls {
   display: grid;
   gap: 8px;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -481,6 +481,66 @@
   border-top: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
 }
 
+/* Schema fields share a control column; collection headers keep their actions inline. */
+.settings-row.cfg-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-2) var(--space-4);
+}
+
+:is(.cfg-field, .cfg-collection-draft) > .settings-row__control {
+  width: 100%;
+  max-width: none;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+}
+
+.cfg-field > .settings-row__control:only-child {
+  grid-column: 1 / -1;
+}
+
+.cfg-field
+  > .settings-row__control
+  > :is(
+    .settings-input,
+    .settings-select,
+    .settings-secret,
+    .settings-phone-presentation,
+    .settings-segmented
+  ) {
+  flex: 1 1 0;
+  width: 100%;
+  min-width: 0;
+}
+
+@media (width >= 768px) {
+  .settings-row.cfg-field {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.settings-row.cfg-collection-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+}
+
+.cfg-collection-header > .settings-row__control {
+  width: auto;
+  max-width: none;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.cfg-block > .settings-subrows {
+  padding-inline: var(--space-4);
+}
+
+.cfg-block > .settings-subrows > .settings-row,
+.settings-subrows .cfg-block > .settings-row {
+  padding-inline: 0;
+}
+
 /* ── Controls ── */
 
 /* One control height inside settings clusters. Buttons, inputs, selects, and


### PR DESCRIPTION
Closes #142515

Related: #142143 (general alignment pass by @roboclaw-bot), #124362 (broader modal consistency), #124365 (broader input/focus consistency).

## What Problem This Solves

Fixes an issue where users editing configuration saw inconsistent field widths and spacing, with collection count/Add and item remove actions split onto separate lines on phones.

## Why This Change Was Made

Schema fields now share one control column at 768px and above and one stacked gap below that breakpoint. Collection headings and item actions stay together, nested items use a consistent inset, and remove buttons use existing Settings sizing. New-item editors retain their full width.

## User Impact

Text, select, JSON, and numeric controls align consistently. Collections take less vertical space on phones while preserving editing, validation, and autosave behavior.

## Evidence

Fresh dark-theme captures at 390px and 1440px. The Config captures use the real Advanced page with the existing configuration-defaults fixture and the mock Gateway's stateful write flow.

<table>
<tr><th>Surface</th><th>Before</th><th>After</th></tr>
<tr><td>Config page, 390px</td><td><a href="https://github.com/user-attachments/assets/9baa0fea-6edc-4b5a-8a52-411fa13f54d9"><img src="https://github.com/user-attachments/assets/9baa0fea-6edc-4b5a-8a52-411fa13f54d9" width="480" alt="Config page, 390px, before"></a></td><td><a href="https://github.com/user-attachments/assets/0a38cfed-3b22-438b-9124-11f0dab6221d"><img src="https://github.com/user-attachments/assets/0a38cfed-3b22-438b-9124-11f0dab6221d" width="480" alt="Config page, 390px, after"></a></td></tr>
<tr><td>Config page, 1440px</td><td><a href="https://github.com/user-attachments/assets/06c35b12-0d7b-43dc-9b94-d5734d8daa24"><img src="https://github.com/user-attachments/assets/06c35b12-0d7b-43dc-9b94-d5734d8daa24" width="480" alt="Config page, 1440px, before"></a></td><td><a href="https://github.com/user-attachments/assets/24876c5b-6065-4363-ac99-02856817042a"><img src="https://github.com/user-attachments/assets/24876c5b-6065-4363-ac99-02856817042a" width="480" alt="Config page, 1440px, after"></a></td></tr>
<tr><td>Form controls fixture, 390px</td><td><a href="https://github.com/user-attachments/assets/2ea1fe61-b559-4ce7-adb8-7525a5ed661c"><img src="https://github.com/user-attachments/assets/2ea1fe61-b559-4ce7-adb8-7525a5ed661c" width="480" alt="Form controls fixture, 390px, before"></a></td><td><a href="https://github.com/user-attachments/assets/1490b434-282d-42f1-9f03-6a3e887a4d77"><img src="https://github.com/user-attachments/assets/1490b434-282d-42f1-9f03-6a3e887a4d77" width="480" alt="Form controls fixture, 390px, after"></a></td></tr>
<tr><td>Form controls fixture, 1440px</td><td><a href="https://github.com/user-attachments/assets/60d14576-d600-4f0f-8663-b1f32d738b8f"><img src="https://github.com/user-attachments/assets/60d14576-d600-4f0f-8663-b1f32d738b8f" width="480" alt="Form controls fixture, 1440px, before"></a></td><td><a href="https://github.com/user-attachments/assets/e7fb6c81-3875-4ee6-b667-7be8a9f7ce00"><img src="https://github.com/user-attachments/assets/e7fb6c81-3875-4ee6-b667-7be8a9f7ce00" width="480" alt="Form controls fixture, 1440px, after"></a></td></tr>
</table>

- 52 focused browser tests passed across form layout, rendering, array integrity, and map integrity. The geometry regression failed on the original code at 390px, 768px, and 1440px; it also covers nested collections and new-item editor width.
- Config: text/select/JSON edits and collection add/remove persisted through the mocked config.set flow.
- Channels: direct entry into WhatsApp settings retained inline collection actions and working add/remove at 390px and 1440px.
- Setup: discovery-access selection remained visible and persisted at 390px and 1440px.
- Targeted formatting, UI production/test typechecks, Oxlint, Stylelint, coercion and unused-export guards passed. The three geometry cases passed again after the final CSS/test cleanup.
- The general changed-check guards passed; its expansion into unrelated agent-test typechecks was stopped, and the owning UI type projects were checked directly.

## Risk and coverage

The shared schema-form styles are used by Config, Channels, and Setup; all three consumers were checked. Existing behavior tests cover scalar edits, invalid drafts, and collection identity. Proof uses synthetic configuration data and a mocked Gateway; no live Gateway or external provider was exercised. Local preview files and screenshots are excluded from the commit.
