### PR TITLE
fix(signal): preserve final reply quotes after failed streamed sends

### DIFF
--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -1,6 +1,8 @@
 // Signal tests cover monitor.tool result.sends tool summaries responseprefix plugin behavior.
 import { expectPairingReplyText } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -186,6 +188,71 @@ describe("monitorSignalProvider tool results", () => {
       replyToBody: "quote me",
     });
   });
+
+  it.each([
+    { mode: "first", failed: true, media: false, finalQuoted: true },
+    { mode: "first", failed: true, media: true, finalQuoted: true },
+    { mode: "first", failed: false, media: false, finalQuoted: false },
+    { mode: "first", failed: false, media: true, finalQuoted: false },
+    { mode: "all", failed: true, media: false, finalQuoted: true },
+    { mode: "all", failed: false, media: false, finalQuoted: true },
+    { mode: "batched", failed: true, media: false, finalQuoted: false },
+    { mode: "batched", failed: false, media: false, finalQuoted: false },
+  ] as const)(
+    "quotes final replies after a block: mode=$mode failed=$failed media=$media",
+    async ({ mode, failed, media, finalQuoted }) => {
+      setSignalToolResultTestConfig(
+        createSignalToolResultConfig({
+          autoStart: false,
+          replyToMode: mode,
+          streaming: { block: { enabled: true } },
+        }),
+      );
+      sendMock.mockResolvedValue({ messageId: "1700000000002" });
+      if (failed) {
+        sendMock.mockRejectedValueOnce(
+          new PlatformMessageNotDispatchedError("not dispatched", { cause: new Error("offline") }),
+        );
+      }
+      replyMock.mockImplementation(async (_ctx, options: GetReplyOptions) => {
+        await options.onBlockReply?.({
+          text: "Streamed block",
+          ...(media ? { mediaUrl: "https://example.com/block.png" } : {}),
+        });
+        return { text: "Final answer" };
+      });
+
+      await receiveSingleEnvelope({
+        ...makeBaseEnvelope({ timestamp: 1700000000001 }),
+        dataMessage: { message: "quote me" },
+      });
+
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      expect(sendMock.mock.calls.map((call) => call[1])).toEqual([
+        "PFX Streamed block",
+        "PFX Final answer",
+      ]);
+      const quote = {
+        replyToId: "1700000000001",
+        replyToAuthor: "+15550001111",
+        replyToBody: "quote me",
+      };
+      if (mode !== "batched") {
+        expect(sendMock.mock.calls[0]?.[2]).toMatchObject(quote);
+      }
+      if (media) {
+        expect(sendMock.mock.calls[0]?.[2]).toHaveProperty(
+          "mediaUrl",
+          "https://example.com/block.png",
+        );
+      }
+      if (finalQuoted) {
+        expect(sendMock.mock.calls[1]?.[2]).toMatchObject(quote);
+      } else {
+        expect(sendMock.mock.calls[1]?.[2]).not.toHaveProperty("replyToId");
+      }
+    },
+  );
 
   it("passes UUID-only inbound Signal quote metadata to final replies", async () => {
     replyMock.mockResolvedValue({ text: "final reply" });

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -5,7 +5,6 @@ import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import type {
   OpenClawConfig,
-  ReplyToMode,
   SignalReactionNotificationMode,
 } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -62,7 +61,7 @@ import type {
   SignalReactionMessage,
   SignalReactionTarget,
 } from "./monitor/event-handler.types.js";
-import { createSignalNativeReplyIdResolver } from "./native-reply.js";
+import { createSignalNativeReplyIdPlan } from "./native-reply.js";
 import { materializeSignalPresentationFallback } from "./presentation-fallback.js";
 import { registerSignalReactionTargetsForDeliveredPayload } from "./reaction-targets.js";
 import { sendMessageSignal } from "./send.js";
@@ -310,6 +309,7 @@ export async function deliverReplies(params: {
     accountId,
     chatType: params.chatType,
   });
+  const replyToAuthor = normalizeOptionalString(params.replyContext?.author);
   for (const payload of replies) {
     const deliveryResults: Array<{
       channel: "signal";
@@ -327,15 +327,31 @@ export async function deliverReplies(params: {
         targetAuthorUuid: accountUuid,
       }) ?? presentationPayload;
     const reply = resolveSendableOutboundReplyParts(deliveredPayload);
-    const nextNativeReply = createSignalNativeReplyResolver({
+    const replyPlan = createSignalNativeReplyIdPlan({
       payload: deliveredPayload,
       replyContext: params.replyContext,
       replyToMode,
     });
-    const recordDeliveryResult = (
-      result: Awaited<ReturnType<typeof sendMessageSignal>>,
-      visibleText: string,
-    ) => {
+    const send = async (visibleText: string, mediaUrl?: string) => {
+      const replyToId = replyPlan.peek();
+      const result = await sendMessageSignal(target, visibleText, {
+        cfg: params.cfg,
+        baseUrl,
+        account,
+        maxBytes,
+        accountId,
+        ...(mediaUrl ? { mediaUrl } : {}),
+        ...(replyToId
+          ? {
+              replyToId,
+              ...(replyToAuthor
+                ? { replyToAuthor, replyToBody: params.replyContext?.body ?? "" }
+                : {}),
+            }
+          : {}),
+      });
+      // Failed blocks must leave the shared first-reply slot available to the final reply.
+      replyPlan.markSent();
       const messageId =
         typeof result?.messageId === "string" && result.messageId.trim()
           ? result.messageId.trim()
@@ -352,34 +368,8 @@ export async function deliverReplies(params: {
       payload: deliveredPayload,
       text: reply.text,
       chunkText: (value) => chunkTextWithMode(value, textLimit, chunkMode),
-      sendText: async (chunk) => {
-        recordDeliveryResult(
-          await sendMessageSignal(target, chunk, {
-            cfg: params.cfg,
-            baseUrl,
-            account,
-            maxBytes,
-            accountId,
-            ...nextNativeReply(),
-          }),
-          chunk,
-        );
-      },
-      sendMedia: async ({ mediaUrl, caption }) => {
-        const visibleText = caption ?? "";
-        recordDeliveryResult(
-          await sendMessageSignal(target, visibleText, {
-            cfg: params.cfg,
-            baseUrl,
-            account,
-            mediaUrl,
-            maxBytes,
-            accountId,
-            ...nextNativeReply(),
-          }),
-          visibleText,
-        );
-      },
+      sendText: send,
+      sendMedia: ({ mediaUrl, caption }) => send(caption ?? "", mediaUrl),
     });
     if (delivered !== "empty") {
       registerSignalReactionTargetsForDeliveredPayload({
@@ -397,28 +387,6 @@ export async function deliverReplies(params: {
       runtime.log?.(`delivered reply to ${target}`);
     }
   }
-}
-
-function createSignalNativeReplyResolver(params: {
-  payload: ReplyPayload;
-  replyContext?: SignalNativeReplyContext;
-  replyToMode: ReplyToMode;
-}): () => Pick<
-  Parameters<typeof sendMessageSignal>[2],
-  "replyToId" | "replyToAuthor" | "replyToBody"
-> {
-  const nextReplyToId = createSignalNativeReplyIdResolver(params);
-  return () => {
-    const replyToId = nextReplyToId();
-    if (!replyToId) {
-      return {};
-    }
-    const replyToAuthor = normalizeOptionalString(params.replyContext?.author);
-    return {
-      replyToId,
-      ...(replyToAuthor ? { replyToAuthor, replyToBody: params.replyContext?.body ?? "" } : {}),
-    };
-  };
 }
 
 export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promise<void> {

--- a/extensions/signal/src/native-reply.ts
+++ b/extensions/signal/src/native-reply.ts
@@ -6,7 +6,6 @@ import type { SignalNativeReplyContext } from "./monitor/event-handler.types.js"
 
 type SignalNativeReplyIdPlan = {
   peek: () => string | undefined;
-  use: () => string | undefined;
   markSent: () => void;
 };
 
@@ -45,48 +44,30 @@ export function createSignalNativeReplyIdPlan(params: {
 }): SignalNativeReplyIdPlan {
   const replyToId = resolveSignalNativeReplyId(params);
   if (!replyToId) {
-    return { peek: () => undefined, use: () => undefined, markSent: () => undefined };
+    return { peek: () => undefined, markSent: () => undefined };
   }
   const isExplicitReply =
     params.payload.replyToTag === true || params.payload.replyToCurrent === true;
   const isStatusNotice = isSignalStatusNoticePayload(params.payload);
   if (isStatusNotice) {
     const resolve = params.replyToMode === "off" ? () => undefined : () => replyToId;
-    return { peek: resolve, use: resolve, markSent: () => undefined };
+    return { peek: resolve, markSent: () => undefined };
   }
   if (isExplicitReply) {
-    const resolve = () => replyToId;
-    return { peek: resolve, use: resolve, markSent: () => undefined };
+    return { peek: () => replyToId, markSent: () => undefined };
   }
   const planner = createReplyReferencePlanner({
     replyToMode: params.replyToMode,
     existingId: replyToId,
     hasReplied: params.replyContext?.state?.hasReplied,
   });
-  const syncState = () => {
-    if (params.replyContext?.state) {
-      params.replyContext.state.hasReplied = planner.hasReplied();
-    }
-  };
   return {
     peek: () => planner.peek(),
-    use: () => {
-      const nextReplyToId = planner.use();
-      syncState();
-      return nextReplyToId;
-    },
     markSent: () => {
       planner.markSent();
-      syncState();
+      if (params.replyContext?.state) {
+        params.replyContext.state.hasReplied = planner.hasReplied();
+      }
     },
   };
-}
-
-export function createSignalNativeReplyIdResolver(params: {
-  payload: ReplyPayload;
-  replyContext?: SignalNativeReplyContext;
-  replyToMode: ReplyToMode;
-}): () => string | undefined {
-  const plan = createSignalNativeReplyIdPlan(params);
-  return plan.use;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Signal users with `replyToMode: first` received an unquoted final answer when an earlier streamed text or media block failed to send. The successful final answer lost its link to the incoming message even though the earlier reply never reached the recipient.

## Why This Change Was Made

The monitor now uses the same quote plan as durable final delivery: inspect the next quote before sending and consume the slot only after the send succeeds. One shared text/media send path replaces duplicated option and result assembly, removing the consume-on-attempt resolver and 51 production lines.

## User Impact

The first successful reply retains the incoming message's quote after a streamed block fails. Successful first replies still consume their slot; `all`, `batched`, explicit replies, and status notices retain their existing behavior.

## Evidence

- Before the production edit, the actual monitor regression table failed both first-mode cases (failed text and failed media) and passed six original-order controls. After the repair, all eight pass, including a rerun against the final reviewed source.
- 57 tests passed across the monitor reply suite, partial-final-delivery suite, and approval/presentation delivery suite. Coverage includes successful text/media blocks, quote modes, chunking, UUID/group/account overrides, notices, and existing partial-delivery handling.
- The complete changed gate passed for all three changed paths, including extension and test typechecks, lint, dead exports, and repository guards. A mechanical unbound-method lint finding in the first run was corrected before the passing run.
- Independent P2 review is clean. An initial concern about post-send persistence rejection was resolved by inspecting the existing registration owner and executing five synthetic store-failure/success cases. That owner catches opening, update, and lookup failures; no persistence change was needed.

The monitor proof uses the real monitor, isolated ingress, dispatcher, and durable final delivery with synthetic messages and mocked Signal transport/model replies. It verifies outgoing text order and quote metadata. It does not exercise a live Signal account, external provider, or mobile app rendering. Batched single-message behavior is a preservation control, not a separate defect.

The quoted-reply owners, callers, planner, and dependency lock were also compared with main at `63943fffb46c5fc1714d46f7aa5ef53170b492cd`; their contracts are unchanged.
