### PR TITLE
refactor(apple): centralize gateway error overrides

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
@@ -176,8 +176,7 @@ public enum GatewayConnectionProblemMapper {
         let message: String
         let actionLabel: String?
         let actionCommand: String?
-        let docsURL: URL?
-        let requestId: String?
+        let docsURLString: String?
         let retryable: Bool
         let pauseReconnect: Bool
     }
@@ -263,15 +262,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .tailscaleIdentityMissing,
                     owner: .network,
-                    title: authError.titleOverride ?? "Tailscale identity check failed",
-                    message: authError.userMessageOverride
-                        ?? "This connection expected Tailscale identity headers, but they were not available.",
-                    actionLabel: authError.actionLabel ?? "Turn on Tailscale",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/tailscale"),
-                    requestId: authError.requestId,
+                    title: "Tailscale identity check failed",
+                    message: "This connection expected Tailscale identity headers, but they were not available.",
+                    actionLabel: "Turn on Tailscale",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/tailscale",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -280,15 +275,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .tailscaleProxyMissing,
                     owner: .network,
-                    title: authError.titleOverride ?? "Tailscale identity check failed",
-                    message: authError.userMessageOverride
-                        ?? "The gateway expected a Tailscale auth proxy, but it was not configured.",
-                    actionLabel: authError.actionLabel ?? "Review Tailscale setup",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/tailscale"),
-                    requestId: authError.requestId,
+                    title: "Tailscale identity check failed",
+                    message: "The gateway expected a Tailscale auth proxy, but it was not configured.",
+                    actionLabel: "Review Tailscale setup",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/tailscale",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -297,15 +288,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .tailscaleWhoisFailed,
                     owner: .network,
-                    title: authError.titleOverride ?? "Tailscale identity check failed",
-                    message: authError.userMessageOverride
-                        ?? "The gateway could not verify this Tailscale client identity.",
-                    actionLabel: authError.actionLabel ?? "Review Tailscale setup",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/tailscale"),
-                    requestId: authError.requestId,
+                    title: "Tailscale identity check failed",
+                    message: "The gateway could not verify this Tailscale client identity.",
+                    actionLabel: "Review Tailscale setup",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/tailscale",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -314,15 +301,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .tailscaleIdentityMismatch,
                     owner: .network,
-                    title: authError.titleOverride ?? "Tailscale identity check failed",
-                    message: authError.userMessageOverride
-                        ?? "The forwarded Tailscale identity did not match the verified identity.",
-                    actionLabel: authError.actionLabel ?? "Review Tailscale setup",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/tailscale"),
-                    requestId: authError.requestId,
+                    title: "Tailscale identity check failed",
+                    message: "The forwarded Tailscale identity did not match the verified identity.",
+                    actionLabel: "Review Tailscale setup",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/tailscale",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -331,15 +314,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .authRateLimited,
                     owner: .gateway,
-                    title: authError.titleOverride ?? "Too many failed attempts",
-                    message: authError.userMessageOverride
-                        ?? "The gateway is temporarily refusing new auth attempts after repeated failures.",
-                    actionLabel: authError.actionLabel ?? "Wait and retry",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
-                    requestId: authError.requestId,
+                    title: "Too many failed attempts",
+                    message: "The gateway is temporarily refusing new auth attempts after repeated failures.",
+                    actionLabel: "Wait and retry",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/troubleshooting",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -347,13 +326,12 @@ public enum GatewayConnectionProblemMapper {
             self.problem(
                 .init(
                     kind: .unknown,
-                    owner: authError.ownerRaw.flatMap { self.owner(from: $0) } ?? .unknown,
-                    title: authError.titleOverride ?? "Gateway rejected the connection",
-                    message: authError.userMessageOverride ?? authError.message,
-                    actionLabel: authError.actionLabel,
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(authError.docsURLString, fallback: nil),
-                    requestId: authError.requestId,
+                    owner: .unknown,
+                    title: "Gateway rejected the connection",
+                    message: authError.message,
+                    actionLabel: nil,
+                    actionCommand: nil,
+                    docsURLString: nil,
                     retryable: false,
                     pauseReconnect: authError.isNonRecoverable),
                 authError: authError)
@@ -369,15 +347,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthTokenMissing,
                     owner: .both,
-                    title: authError.titleOverride ?? "Gateway token required",
-                    message: authError.userMessageOverride
-                        ?? "This gateway requires an auth token, but this device did not send one.",
-                    actionLabel: authError.actionLabel ?? "Open Settings",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway token required",
+                    message: "This gateway requires an auth token, but this device did not send one.",
+                    actionLabel: "Open Settings",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -386,16 +360,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthTokenMismatch,
                     owner: .both,
-                    title: authError.titleOverride ?? "Gateway token is out of date",
-                    message: authError.userMessageOverride
-                        ?? "The token on this device does not match the gateway token.",
-                    actionLabel: authError.actionLabel
-                        ?? (authError.canRetryWithDeviceToken ? "Retry once" : "Update gateway token"),
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway token is out of date",
+                    message: "The token on this device does not match the gateway token.",
+                    actionLabel: authError.canRetryWithDeviceToken ? "Retry once" : "Update gateway token",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: authError.canRetryWithDeviceToken,
                     pauseReconnect: !authError.canRetryWithDeviceToken),
                 authError: authError)
@@ -404,16 +373,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthTokenNotConfigured,
                     owner: .gateway,
-                    title: authError.titleOverride ?? "Gateway token is not configured",
-                    message: authError.userMessageOverride
-                        ?? "This gateway is set to token auth, but no gateway token is configured on the gateway.",
-                    actionLabel: authError.actionLabel ?? "Fix on gateway",
-                    actionCommand: authError.actionCommand
-                        ?? "openclaw config set gateway.auth.token <new-token>",
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway token is not configured",
+                    message: "This gateway is set to token auth, but no gateway token is configured on the gateway.",
+                    actionLabel: "Fix on gateway",
+                    actionCommand: "openclaw config set gateway.auth.token <new-token>",
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -422,15 +386,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthPasswordMissing,
                     owner: .both,
-                    title: authError.titleOverride ?? "Gateway password required",
-                    message: authError.userMessageOverride
-                        ?? "This gateway requires a password, but this device did not send one.",
-                    actionLabel: authError.actionLabel ?? "Open Settings",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway password required",
+                    message: "This gateway requires a password, but this device did not send one.",
+                    actionLabel: "Open Settings",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -439,15 +399,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthPasswordMismatch,
                     owner: .both,
-                    title: authError.titleOverride ?? "Gateway password is out of date",
-                    message: authError.userMessageOverride
-                        ?? "The saved password on this device does not match the gateway password.",
-                    actionLabel: authError.actionLabel ?? "Update password",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway password is out of date",
+                    message: "The saved password on this device does not match the gateway password.",
+                    actionLabel: "Update password",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -456,17 +412,12 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .gatewayAuthPasswordNotConfigured,
                     owner: .gateway,
-                    title: authError.titleOverride ?? "Gateway password is not configured",
-                    message: authError.userMessageOverride
-                        ??
-                        "This gateway is set to password auth, but no gateway password is configured on the gateway.",
-                    actionLabel: authError.actionLabel ?? "Fix on gateway",
-                    actionCommand: authError.actionCommand
-                        ?? "openclaw config set gateway.auth.password <new-password>",
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/authentication"),
-                    requestId: authError.requestId,
+                    title: "Gateway password is not configured",
+                    message:
+                    "This gateway is set to password auth, but no gateway password is configured on the gateway.",
+                    actionLabel: "Fix on gateway",
+                    actionCommand: "openclaw config set gateway.auth.password <new-password>",
+                    docsURLString: "https://docs.openclaw.ai/gateway/authentication",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -487,15 +438,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .bootstrapTokenInvalid,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "Setup code expired",
-                    message: authError.userMessageOverride
-                        ?? "The setup QR or bootstrap token is no longer valid.",
-                    actionLabel: authError.actionLabel ?? "Scan QR again",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/platforms/ios"),
-                    requestId: authError.requestId,
+                    title: "Setup code expired",
+                    message: "The setup QR or bootstrap token is no longer valid.",
+                    actionLabel: "Scan QR again",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/platforms/ios",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -504,15 +451,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceTokenMismatch,
                     owner: .both,
-                    title: authError.titleOverride ?? "This device's saved device token is no longer valid",
-                    message: authError.userMessageOverride
-                        ?? "The gateway rejected the stored device token for this role.",
-                    actionLabel: authError.actionLabel ?? "Repair pairing",
-                    actionCommand: authError.actionCommand ?? pairingCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                    requestId: authError.requestId,
+                    title: "This device's saved device token is no longer valid",
+                    message: "The gateway rejected the stored device token for this role.",
+                    actionLabel: "Repair pairing",
+                    actionCommand: pairingCommand,
+                    docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -521,15 +464,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceTokenScopeMismatch,
                     owner: .both,
-                    title: authError.titleOverride ?? "Device permissions need approval",
-                    message: authError.userMessageOverride
-                        ?? "The gateway accepted this device token but rejected the requested operator scopes.",
-                    actionLabel: authError.actionLabel ?? "Review pairing",
-                    actionCommand: authError.actionCommand ?? pairingCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                    requestId: authError.requestId,
+                    title: "Device permissions need approval",
+                    message: "The gateway accepted this device token but rejected the requested operator scopes.",
+                    actionLabel: "Review pairing",
+                    actionCommand: pairingCommand,
+                    docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -548,16 +487,12 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceIdentityRequired,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "Secure device identity is required",
-                    message: authError.userMessageOverride
-                        ?? "This connection must include a signed device identity before the gateway can bind "
+                    title: "Secure device identity is required",
+                    message: "This connection must include a signed device identity before the gateway can bind "
                         + "permissions to this device.",
-                    actionLabel: authError.actionLabel ?? "Retry from the app",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/platforms/ios"),
-                    requestId: authError.requestId,
+                    actionLabel: "Retry from the app",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/platforms/ios",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -566,14 +501,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceSignatureExpired,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "Secure handshake expired",
-                    message: authError.userMessageOverride ?? "The device signature is too old to use.",
-                    actionLabel: authError.actionLabel ?? "Check device time",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
-                    requestId: authError.requestId,
+                    title: "Secure handshake expired",
+                    message: "The device signature is too old to use.",
+                    actionLabel: "Check device time",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/troubleshooting",
                     retryable: true,
                     pauseReconnect: true),
                 authError: authError)
@@ -582,15 +514,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceNonceRequired,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "Secure handshake is incomplete",
-                    message: authError.userMessageOverride
-                        ?? "The gateway expected a one-time challenge response, but the nonce was missing.",
-                    actionLabel: authError.actionLabel ?? "Retry",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
-                    requestId: authError.requestId,
+                    title: "Secure handshake is incomplete",
+                    message: "The gateway expected a one-time challenge response, but the nonce was missing.",
+                    actionLabel: "Retry",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/troubleshooting",
                     retryable: true,
                     pauseReconnect: true),
                 authError: authError)
@@ -599,14 +527,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceNonceMismatch,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "Secure handshake did not match",
-                    message: authError.userMessageOverride ?? "The challenge response was stale or mismatched.",
-                    actionLabel: authError.actionLabel ?? "Retry",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
-                    requestId: authError.requestId,
+                    title: "Secure handshake did not match",
+                    message: "The challenge response was stale or mismatched.",
+                    actionLabel: "Retry",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/troubleshooting",
                     retryable: true,
                     pauseReconnect: true),
                 authError: authError)
@@ -615,15 +540,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceSignatureInvalid,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "This device identity could not be verified",
-                    message: authError.userMessageOverride
-                        ?? "The gateway could not verify the identity this device presented.",
-                    actionLabel: authError.actionLabel ?? "Re-pair this device",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                    requestId: authError.requestId,
+                    title: "This device identity could not be verified",
+                    message: "The gateway could not verify the identity this device presented.",
+                    actionLabel: "Re-pair this device",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -632,15 +553,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .devicePublicKeyInvalid,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "This device identity could not be verified",
-                    message: authError.userMessageOverride
-                        ?? "The gateway could not verify the public key this device presented.",
-                    actionLabel: authError.actionLabel ?? "Re-pair this device",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                    requestId: authError.requestId,
+                    title: "This device identity could not be verified",
+                    message: "The gateway could not verify the public key this device presented.",
+                    actionLabel: "Re-pair this device",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -649,15 +566,11 @@ public enum GatewayConnectionProblemMapper {
                 .init(
                     kind: .deviceIdMismatch,
                     owner: .iphone,
-                    title: authError.titleOverride ?? "This device identity could not be verified",
-                    message: authError.userMessageOverride
-                        ?? "The gateway rejected the device identity because the device ID did not match.",
-                    actionLabel: authError.actionLabel ?? "Re-pair this device",
-                    actionCommand: authError.actionCommand,
-                    docsURL: self.docsURL(
-                        authError.docsURLString,
-                        fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                    requestId: authError.requestId,
+                    title: "This device identity could not be verified",
+                    message: "The gateway rejected the device identity because the device ID did not match.",
+                    actionLabel: "Re-pair this device",
+                    actionCommand: nil,
+                    docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                     retryable: false,
                     pauseReconnect: true),
                 authError: authError)
@@ -888,14 +801,11 @@ extension GatewayConnectionProblemMapper {
             .init(
                 kind: kind,
                 owner: .gateway,
-                title: authError.titleOverride ?? title,
-                message: authError.userMessageOverride ?? message,
-                actionLabel: authError.actionLabel ?? "Approve on gateway",
-                actionCommand: authError.actionCommand ?? self.approvalCommand(requestId: authError.requestId),
-                docsURL: self.docsURL(
-                    authError.docsURLString,
-                    fallback: "https://docs.openclaw.ai/gateway/pairing"),
-                requestId: authError.requestId,
+                title: title,
+                message: message,
+                actionLabel: "Approve on gateway",
+                actionCommand: self.approvalCommand(requestId: authError.requestId),
+                docsURLString: "https://docs.openclaw.ai/gateway/pairing",
                 retryable: false,
                 pauseReconnect: true),
             authError: authError)
@@ -911,29 +821,26 @@ extension GatewayConnectionProblemMapper {
            let expected = authError.expectedProtocol,
            clientMax < expected
         {
-            title = authError.titleOverride ?? "App update required"
-            message = authError.userMessageOverride
-                ?? "This app is older than the gateway. Update OpenClaw on this device, then retry."
+            title = "App update required"
+            message = "This app is older than the gateway. Update OpenClaw on this device, then retry."
             owner = .iphone
-            actionLabel = authError.actionLabel ?? "Update app"
-            actionCommand = authError.actionCommand
+            actionLabel = "Update app"
+            actionCommand = nil
         } else if let clientMin = authError.clientMinProtocol,
                   let expected = authError.expectedProtocol,
                   clientMin > expected
         {
-            title = authError.titleOverride ?? "Gateway update required"
-            message = authError.userMessageOverride
-                ?? "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
+            title = "Gateway update required"
+            message = "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
             owner = .gateway
-            actionLabel = authError.actionLabel ?? "Copy update command"
-            actionCommand = authError.actionCommand ?? "openclaw update"
+            actionLabel = "Copy update command"
+            actionCommand = "openclaw update"
         } else {
-            title = authError.titleOverride ?? "OpenClaw update required"
-            message = authError.userMessageOverride
-                ?? "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
+            title = "OpenClaw update required"
+            message = "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
             owner = .both
-            actionLabel = authError.actionLabel ?? "Update OpenClaw"
-            actionCommand = authError.actionCommand
+            actionLabel = "Update OpenClaw"
+            actionCommand = nil
         }
         return self.problem(
             .init(
@@ -943,10 +850,7 @@ extension GatewayConnectionProblemMapper {
                 message: message,
                 actionLabel: actionLabel,
                 actionCommand: actionCommand,
-                docsURL: self.docsURL(
-                    authError.docsURLString,
-                    fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
-                requestId: authError.requestId,
+                docsURLString: "https://docs.openclaw.ai/gateway/troubleshooting",
                 retryable: false,
                 pauseReconnect: true),
             authError: authError)
@@ -957,25 +861,28 @@ extension GatewayConnectionProblemMapper {
         authError: GatewayConnectAuthError)
         -> GatewayConnectionProblem
     {
-        GatewayConnectionProblem(
+        let title = authError.titleOverride ?? defaults.title
+        let message = authError.userMessageOverride ?? defaults.message
+        let actionLabel = authError.actionLabel ?? defaults.actionLabel
+        return GatewayConnectionProblem(
             kind: defaults.kind,
             owner: authError.ownerRaw.flatMap(self.owner(from:)) ?? defaults.owner,
-            title: defaults.title,
-            message: defaults.message,
-            actionLabel: defaults.actionLabel,
+            title: title,
+            message: message,
+            actionLabel: actionLabel,
             titlePresentation: authError.titleOverride == nil
-                ? .localized(defaults.title)
-                : .verbatim(defaults.title),
+                ? .localized(title)
+                : .verbatim(title),
             messagePresentation: authError.userMessageOverride == nil
-                && defaults.message != authError.message
-                ? .localized(defaults.message)
-                : .verbatim(defaults.message),
+                && message != authError.message
+                ? .localized(message)
+                : .verbatim(message),
             actionLabelPresentation: authError.actionLabel == nil
-                ? defaults.actionLabel.map(GatewayConnectionProblem.PresentationText.localized)
-                : defaults.actionLabel.map(GatewayConnectionProblem.PresentationText.verbatim),
-            actionCommand: defaults.actionCommand,
-            docsURL: defaults.docsURL,
-            requestId: defaults.requestId,
+                ? actionLabel.map(GatewayConnectionProblem.PresentationText.localized)
+                : actionLabel.map(GatewayConnectionProblem.PresentationText.verbatim),
+            actionCommand: authError.actionCommand ?? defaults.actionCommand,
+            docsURL: self.docsURL(authError.docsURLString, fallback: defaults.docsURLString),
+            requestId: authError.requestId,
             retryable: authError.retryableOverride ?? defaults.retryable,
             pauseReconnect: authError.pauseReconnectOverride ?? defaults.pauseReconnect,
             technicalDetails: self.technicalDetails(for: authError))


### PR DESCRIPTION
Closes #142594

## What Problem This Solves

Apple Gateway connection errors repeat the same presentation-override policy in 24 case constructions. Maintaining that policy in each case makes future changes harder to keep consistent.

## Why This Change Was Made

Move override selection and output shaping into the existing private problem factory. Each case retains its own fallback values. Public fields, string literals, localized/verbatim handling, pairing/protocol variants, URL fallback, owner hints and retry/reconnect flags are preserved.

## User Impact

Existing Gateway messages, actions and diagnostics stay the same. The complete one-file change removes 93 production code/physical lines and introduces no helper, adapter, public API, resource or dependency change.

## Evidence

- The actual shared Swift package and tests compile. All 22 unchanged GatewayErrorsTests, the real GatewayNodeSession protocol-error case and the differential characterization pass: 24 tests in exactly three audited suites.
- The characterization executes the original mapper and candidate and compares 8,775 complete Equatable outputs across 39 scenarios and override combinations, including false flags, owner aliases, invalid URLs and equal-copy localization cases.
- Native localization check: 3,783 entries, changed=false. Apple catalogs and the required changed gate pass; no retained generated/test/tooling changes.
- Fresh P2 review reported one owner-override regression. It is rejected against the [original factory](https://github.com/openclaw/openclaw/blob/83c609b0365dc349e580f203879891127b9bff00/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift#L962): both old and new code already use `owner: authError.ownerRaw.flatMap(self.owner(from:)) ?? defaults.owner`. The complete-output comparisons include its claimed case. No accepted findings remain; the raw review is preserved with its separate source-backed rejection.
- Native tests ran inside an OS sandbox denying access to operator files, network, credential/preferences/window services and external process/service control. An earlier unfiltered launcher probe aborted inside that sandbox and has zero passing credit. The exact filtered launch was then verified with separate synthetic selector canaries before the successful product run.

Related #118107 is the already-merged shared-construction predecessor; its public contracts and ownership boundaries remain.
