### PR TITLE
perf(tests): advance QA rich-observation deadlines deterministically

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
+import timersPromises from "node:timers/promises";
+import { promisify } from "node:util";
 import { createOutboundPayloadPlan } from "openclaw/plugin-sdk/channel-outbound";
+import { vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { TelegramUserbotUpdate } from "./live-transports/telegram/userbot-driver.runtime.js";
 import { waitForQaTransportCondition } from "./qa-transport.js";
@@ -353,7 +357,10 @@ export async function assertTelegramRichObservationFlow(
     markers.add(marker);
     return marker;
   };
+  vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+  const schedule = vi.spyOn(timersPromises, "setTimeout").mockImplementation(promisify(setTimeout));
   try {
+    syncBuiltinESMExports();
     const pending = runLoadedScenarioFlow("telegram-rich-inline-composition", {
       api: {
         fs,
@@ -413,7 +420,33 @@ export async function assertTelegramRichObservationFlow(
           buildAgentDelivery: () => ({ to: "123" }),
         },
         readTelegramMessages: () => structuredClone(observed),
-        waitForCondition: waitForQaTransportCondition,
+        waitForCondition: async (...args: Parameters<typeof waitForQaTransportCondition>) => {
+          const waiting = waitForQaTransportCondition(...args);
+          let settled = false;
+          const joined = waiting.then(
+            () => {
+              settled = true;
+            },
+            () => {
+              settled = true;
+            },
+          );
+          try {
+            await vi.advanceTimersByTimeAsync(0);
+            for (;;) {
+              if (settled) {
+                break;
+              }
+              await vi.advanceTimersToNextTimerAsync();
+            }
+            return await waiting;
+          } finally {
+            if (!settled) {
+              await vi.advanceTimersByTimeAsync(args[1] ?? 15_000);
+            }
+            await joined;
+          }
+        },
         runQaCli: async (_env: unknown, args: string[]) => {
           assert.deepEqual(args.slice(0, 2), ["message", "edit"]);
           const id = Number(args[args.indexOf("--message-id") + 1]);
@@ -575,6 +608,9 @@ export async function assertTelegramRichObservationFlow(
     for (const timer of timers) {
       clearTimeout(timer);
     }
+    schedule.mockRestore();
+    vi.useRealTimers();
+    syncBuiltinESMExports();
     await tempDirs.cleanup();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Six Telegram rich-observation rejection cases each spend 30 seconds waiting for observations that intentionally cannot match. This makes the QA scenario-flow test file unnecessarily slow.

## Why This Change Was Made

Advance a fixture-scoped fake clock while running the actual transport waiter and public scenario predicates. The 30000ms deadline, 100ms polling interval, and 1ms delayed observation remain unchanged. A scoped Node promise-timer bridge uses the fake timer's built-in promisified implementation; pending waits settle before timer bindings and temporary directories are restored.

## User Impact

No production behavior changes. All 48 cases and their assertions remain. The helper grows by 36 lines to remove real waiting while preserving correlation coverage.

## Evidence

- One local full-file comparison: 201.16s to 8.32s wall time; preparation was 3.509s and 2.597s respectively. This is a scoped local result, not an overall repository speedup claim.
- All 48 ordered cases pass before and after; all 20 rich-observation reports are byte-identical. The final file also passes without temporary report capture.
- Actual-waiter controls preserve the 29999/30000ms rejection boundary, 300 polls, 1ms delivery/100ms acceptance, timer counts, and restored binding identity. Initial controls caught that fake timers alone, even with ESM synchronization, did not capture Node promise timers; the explicit bridge resolves that.
- Making the wrong-edit marker valid causes the existing rejection assertion to fail, confirming correlation sensitivity.
- Mapped changed-file checks and fresh independent P2 review pass. An initial lint failure about async loop mutation was resolved with an explicit exit check, without suppression or schedule changes.
