### PR TITLE
refactor(tests): remove stale skills CLI terminal mocks

### DIFF
--- a/src/cli/skills-cli.curator.test.ts
+++ b/src/cli/skills-cli.curator.test.ts
@@ -50,17 +50,6 @@ vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => mocks.config,
   resetConfigRuntimeState: () => undefined,
 }));
-vi.mock("../terminal/links.js", () => ({ formatDocsLink: () => "docs.openclaw.ai/cli/skills" }));
-vi.mock("../terminal/theme.js", () => ({
-  theme: {
-    command: (value: string) => value,
-    error: (value: string) => value,
-    heading: (value: string) => value,
-    muted: (value: string) => value,
-    success: (value: string) => value,
-    warn: (value: string) => value,
-  },
-}));
 
 const status = {
   lastAttemptAtMs: 1,

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -77,21 +77,6 @@ vi.mock("../infra/gateway-lock.js", () => ({
   })),
 }));
 
-vi.mock("../terminal/links.js", () => ({
-  formatDocsLink: () => "docs.openclaw.ai/cli/skills",
-}));
-
-vi.mock("../terminal/theme.js", () => ({
-  theme: {
-    command: (value: string) => value,
-    error: (value: string) => value,
-    heading: (value: string) => value,
-    muted: (value: string) => value,
-    success: (value: string) => value,
-    warn: (value: string) => value,
-  },
-}));
-
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => mocks.config,
   resetConfigRuntimeState: () => undefined,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The skills curator and workshop tests retained four mock registrations for terminal modules that no longer exist at those paths. They made the fixtures appear to control formatting even though the real package implementations were already being used.

## Why This Change Was Made

Remove the copied obsolete links/theme registrations. Both suites introduced those paths after the CLI had moved to `packages/terminal-core`; no mock paths, output assertions, or runtime behavior are changed.

## User Impact

No user-visible change. The tests keep all existing scenarios and assertions with 26 fewer lines of dead setup, including blank separators.

## Evidence

- Original factory counters: each suite’s retained runtime factory ran once; both obsolete terminal factories ran zero times. Counter assertions and all 33 cases passed.
- After removal, all 33 cases passed in the same per-file order. Remaining ASTs equal the originals with exactly the four registrations removed.
- Mapped `check-changed` gate, deslop, and fresh P2 review passed with no findings.

No runtime improvement is claimed.
