### PR TITLE
fix(browser): keep newer dialogs pending after earlier actions settle

### DIFF
--- a/extensions/browser/src/browser/pw-session-dialogs.ts
+++ b/extensions/browser/src/browser/pw-session-dialogs.ts
@@ -19,11 +19,17 @@ export function resolveObservedDialogTimeoutMs(timeoutMs: number | undefined): n
   return Math.max(1, Math.floor(parsed ?? OBSERVED_DIALOG_TIMEOUT_MS));
 }
 
-export function appendRecentDialog(state: PageState, record: BrowserObservedDialogRecord): void {
+export function recordClosedDialog(
+  state: PageState,
+  dialog: BrowserObservedDialogRecord,
+  closedBy: NonNullable<BrowserObservedDialogRecord["closedBy"]>,
+): BrowserObservedDialogRecord {
+  const record = { ...serializeDialogRecord(dialog), closedAt: new Date().toISOString(), closedBy };
   state.recentDialogs.push(record);
   while (state.recentDialogs.length > MAX_RECENT_DIALOGS) {
     state.recentDialogs.shift();
   }
+  return record;
 }
 
 function serializeDialogRecord(dialog: BrowserObservedDialogRecord): BrowserObservedDialogRecord {
@@ -38,14 +44,10 @@ function serializeDialogRecord(dialog: BrowserObservedDialogRecord): BrowserObse
   };
 }
 
-function serializePendingDialog(dialog: PendingObservedDialog): BrowserObservedDialogRecord {
-  return serializeDialogRecord(dialog);
-}
-
 export function serializeObservedBrowserState(state: PageState): BrowserObservedState {
   return {
     dialogs: {
-      pending: state.pendingDialogs.map(serializePendingDialog),
+      pending: state.pendingDialogs.map(serializeDialogRecord),
       recent: state.recentDialogs.map(serializeDialogRecord),
     },
   };
@@ -100,17 +102,7 @@ export async function settleObservedDialog(params: {
     closedBy = "remote";
   }
 
-  const record: BrowserObservedDialogRecord = {
-    id: pending.id,
-    type: pending.type,
-    message: pending.message,
-    ...(pending.defaultValue !== undefined ? { defaultValue: pending.defaultValue } : {}),
-    openedAt: pending.openedAt,
-    closedAt: new Date().toISOString(),
-    closedBy,
-  };
-  appendRecentDialog(state, record);
-  return record;
+  return recordClosedDialog(state, pending, closedBy);
 }
 
 export function observeDialog(pageState: PageState, dialog: Dialog): void {

--- a/extensions/browser/src/browser/pw-session-state.ts
+++ b/extensions/browser/src/browser/pw-session-state.ts
@@ -21,9 +21,9 @@ import {
   BrowserObservedDialogBlockedError,
 } from "./pw-session-contracts.js";
 import {
-  appendRecentDialog,
   clearArmedDialogResponse,
   observeDialog,
+  recordClosedDialog,
   resolveObservedDialogTimeoutMs,
   resolvePendingDialogForResponse,
   serializeObservedBrowserState,
@@ -403,20 +403,18 @@ export async function respondToObservedDialogOnPage(opts: {
 }
 
 /** Mark pending observed dialogs as handled by a remote/browser-side hook. */
-export function markObservedDialogsHandledRemotelyForPage(page: Page): BrowserObservedState {
+export function markObservedDialogsHandledRemotelyForPage(
+  page: Page,
+  dialogs: readonly BrowserObservedDialogRecord[],
+): BrowserObservedState {
   const state = ensurePageState(page);
-  const pending = state.pendingDialogs.splice(0);
-  const closedAt = new Date().toISOString();
+  // A late action completion owns only the dialogs that interrupted it. A newer
+  // dialog may already be pending while the earlier action's guard settles.
+  const ids = new Set(dialogs.map((dialog) => dialog.id));
+  const pending = state.pendingDialogs.filter((dialog) => ids.has(dialog.id));
+  state.pendingDialogs = state.pendingDialogs.filter((dialog) => !ids.has(dialog.id));
   for (const dialog of pending) {
-    appendRecentDialog(state, {
-      id: dialog.id,
-      type: dialog.type,
-      message: dialog.message,
-      ...(dialog.defaultValue !== undefined ? { defaultValue: dialog.defaultValue } : {}),
-      openedAt: dialog.openedAt,
-      closedAt,
-      closedBy: "remote",
-    });
+    recordClosedDialog(state, dialog, "remote");
   }
   return serializeObservedBrowserState(state);
 }

--- a/extensions/browser/src/browser/pw-session.dialogs.test.ts
+++ b/extensions/browser/src/browser/pw-session.dialogs.test.ts
@@ -4,6 +4,7 @@ import type { Dialog, Page } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pwAi } from "./pw-ai.js";
 import { armObservedDialogResponseOnPage } from "./pw-session.js";
+import { reconcileRemoteDialogAfterActionSettled } from "./pw-tools-core.interactions.navigation.js";
 
 const {
   createObservedDialogAbortSignalForPage,
@@ -78,6 +79,7 @@ describe("observed browser dialogs", () => {
 
     expect(dialog.accept).toHaveBeenCalledWith("yes");
     expect(closed.closedBy).toBe("agent");
+    expect(closed).not.toHaveProperty("dialog");
     expect(getObservedBrowserStateForPage(page).dialogs.pending).toEqual([]);
     expect(getObservedBrowserStateForPage(page).dialogs.recent).toMatchObject([
       { id: "d1", closedBy: "agent" },
@@ -262,11 +264,45 @@ describe("observed browser dialogs", () => {
     ensurePageState(page);
     emit("dialog", createDialog({ type: "confirm", message: "Continue?" }));
 
-    const state = markObservedDialogsHandledRemotelyForPage(page);
+    const state = markObservedDialogsHandledRemotelyForPage(
+      page,
+      getObservedBrowserStateForPage(page).dialogs.pending,
+    );
 
     expect(state.dialogs.pending).toEqual([]);
     expect(state.dialogs.recent).toMatchObject([
       { id: "d1", type: "confirm", message: "Continue?", closedBy: "remote" },
     ]);
   });
+
+  it.each(["agent", "remote"] as const)(
+    "keeps a newer dialog pending after the interrupted dialog was handled by %s",
+    async (closedBy) => {
+      const { page, emit } = createPageHarness();
+      const observed = createObservedDialogAbortSignalForPage({ page });
+      emit("dialog", createDialog({ message: "First" }));
+      if (closedBy === "agent") {
+        await respondToObservedDialogOnPage({ page, dialogId: "d1", accept: true });
+      }
+      const next = createDialog({ message: "Second" });
+      emit("dialog", next);
+
+      reconcileRemoteDialogAfterActionSettled(page, observed.signal);
+
+      expect(getObservedBrowserStateForPage(page).dialogs).toMatchObject({
+        pending: [{ id: "d2", message: "Second" }],
+        recent: [{ id: "d1", closedBy }],
+      });
+      await respondToObservedDialogOnPage({ page, dialogId: "d2", accept: false });
+      expect(next.dismiss).toHaveBeenCalledOnce();
+      expect(getObservedBrowserStateForPage(page).dialogs).toMatchObject({
+        pending: [],
+        recent: [
+          { id: "d1", closedBy },
+          { id: "d2", closedBy: "agent" },
+        ],
+      });
+      observed.cleanup();
+    },
+  );
 });

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover pw tools core ssrf guard plugin behavior.
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserObservedDialogBlockedError } from "./pw-session-contracts.js";
 
 const pageState = vi.hoisted(() => ({
   page: null as Record<string, unknown> | null,
@@ -512,12 +513,15 @@ describe("pw-tools-core browser SSRF guards", () => {
 
   it("does not start a predicate after aborting an earlier wait condition", async () => {
     const ctrl = new AbortController();
+    const dialogError = new BrowserObservedDialogBlockedError({
+      dialogs: { pending: [], recent: [] },
+    });
     sessionMocks.isBrowserObservedDialogBlockedError.mockReturnValueOnce(true);
     const waitForFunction = vi.fn(async () => {});
     pageState.page = {
       url: vi.fn(() => "https://example.com"),
       waitForTimeout: vi.fn(async () => {
-        ctrl.abort(new Error("aborted during passive wait"));
+        ctrl.abort(dialogError);
       }),
       waitForFunction,
     };
@@ -529,11 +533,12 @@ describe("pw-tools-core browser SSRF guards", () => {
         fn: "() => true",
         signal: ctrl.signal,
       }),
-    ).rejects.toThrow("aborted during passive wait");
+    ).rejects.toBe(dialogError);
     await Promise.resolve();
     expect(waitForFunction).not.toHaveBeenCalled();
     expect(sessionMocks.markObservedDialogsHandledRemotelyForPage).toHaveBeenCalledWith(
       pageState.page,
+      dialogError.browserState.dialogs.pending,
     );
   });
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
@@ -1,5 +1,6 @@
 // Browser tests cover pw tools core.interactions.evaluate.abort plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserObservedDialogBlockedError } from "./pw-session-contracts.js";
 
 let page: { evaluate: ReturnType<typeof vi.fn>; url: ReturnType<typeof vi.fn> } | null = null;
 let locator: { evaluate: ReturnType<typeof vi.fn> } | null = null;
@@ -139,15 +140,22 @@ describe("evaluateViaPlaywright (abort)", () => {
     });
 
     await pending.evalCalledPromise;
-    const err = new Error("blocked by dialog");
-    err.name = "BrowserObservedDialogBlockedError";
+    const err = new BrowserObservedDialogBlockedError({
+      dialogs: {
+        pending: [{ id: "d1", type: "alert", message: "x", openedAt: "2026-09-08T00:00:00Z" }],
+        recent: [],
+      },
+    });
     ctrl.abort(err);
 
-    await expect(p).rejects.toThrow("blocked by dialog");
+    await expect(p).rejects.toBe(err);
     expect(forceDisconnectPlaywrightForTarget).not.toHaveBeenCalled();
     resolveEval(true);
     await vi.waitFor(() => {
-      expect(markObservedDialogsHandledRemotelyForPage).toHaveBeenCalled();
+      expect(markObservedDialogsHandledRemotelyForPage).toHaveBeenCalledWith(
+        page,
+        err.browserState.dialogs.pending,
+      );
     });
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts
@@ -82,7 +82,7 @@ export function toFriendlyInteractionError(err: unknown, label: string): Error {
 
 export function reconcileRemoteDialogAfterActionSettled(page: Page, signal?: AbortSignal): void {
   if (isBrowserObservedDialogBlockedError(signal?.reason)) {
-    markObservedDialogsHandledRemotelyForPage(page);
+    markObservedDialogsHandledRemotelyForPage(page, signal.reason.browserState.dialogs.pending);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users answering sequential managed-browser dialogs could receive `Dialog "d2" is not pending` even though the second dialog remained open. This happens when the first action finishes its delayed cleanup after a new dialog has appeared.

## Why This Change Was Made

Scope late dialog reconciliation to the IDs recorded when that action was interrupted. Share closed-dialog record construction and remove the redundant pending-record serializer, deleting ten production lines. Existing external-close reconciliation remains in place; authoritative CDP close-event ownership is a separate follow-up.

## User Impact

A newly opened dialog remains pending and can be answered by its returned ID. Explicit responses, armed responses, prompt text, and externally handled dialogs retain their existing behavior. This complements the CLI presentation fix in #142480.

## Evidence

- Before: real registered `/act` and `/hooks/dialog` HTTP routes with Playwright 1.62.1 and isolated Chromium returned `d2`, then rejected its response with HTTP 500. Independent native CDP events showed only `d1` had closed while bookkeeping incorrectly recorded `d2` as remotely closed.
- After: the same sequential flow retains `d2` as pending and answers it with HTTP 200. External closure, armed dismissal, prompt text, normal evaluation, and two sequential keyboard-triggered dialogs pass.
- Two new regressions failed on the original code; all 101 tests across five focused browser test files pass after the repair.
- Required changed-scope checks passed, including production/test typechecks, lint, dead-export scans, and architecture guards. Independent P2 review found no actionable issues.

The browser proof used task-owned localhost pages and a fresh browser profile. It exercises real browser execution and dialog bookkeeping; it does not claim signed-in operator-browser or extension-relay coverage. Remote closure still uses the existing action-settlement mechanism, now scoped to the recorded dialogs.
