### PR TITLE
fix(memory): align deep status with the published fallback index

### DIFF
--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
@@ -53,6 +53,63 @@ describe("memory index", () => {
     ).toBe("local");
   });
 
+  it("reports the adopted fallback provider when the published index belongs to it", async () => {
+    // A previous run fell back, so the published index carries the fallback provider's
+    // identity. Search adopts it; a deep status probe in a fresh process must describe the
+    // same provider instead of the configured primary.
+    const publishCfg = createCfg({
+      provider: "fallback-provider",
+      model: "fallback-provider-embed",
+    });
+    const publisher = await getFreshManager(publishCfg);
+    await publisher.sync({ reason: "test", force: true });
+    await publisher.close?.();
+
+    const cfg = createCfg({ model: "mock-embed", fallback: "fallback-provider" });
+
+    const searchManager = await getFreshManager(cfg);
+    const results = await searchManager.search("alpha");
+    expect(results.length).toBeGreaterThan(0);
+    expect((searchManager as unknown as { provider: { id: string } | null }).provider?.id).toBe(
+      "fallback-provider",
+    );
+    await searchManager.close?.();
+
+    const statusManager = await getFreshManager(cfg);
+    const probe = await statusManager.probeEmbeddingAvailability();
+    const status = statusManager.status() as unknown as {
+      provider?: string;
+      model?: string;
+      custom?: { providerState?: { mode?: string }; indexIdentity?: { status?: string } };
+    };
+
+    expect(probe.ok).toBe(true);
+    expect(status.provider).toBe("fallback-provider");
+    expect(status.model).toBe("fallback-provider-embed");
+    expect(status.custom?.providerState?.mode).toBe("fallback-active");
+    // The index is readable by the provider search uses, so it must not be reported as a
+    // configuration mismatch that an operator would answer with a forced rebuild.
+    expect(status.custom?.indexIdentity?.status).toBe("valid");
+  });
+
+  it("keeps probing the configured provider when the published index matches it", async () => {
+    const cfg = createCfg({ fallback: "fallback-provider" });
+    const publisher = await getFreshManager(cfg);
+    await publisher.sync({ reason: "test", force: true });
+    await publisher.close?.();
+
+    const statusManager = await getFreshManager(cfg);
+    const probe = await statusManager.probeEmbeddingAvailability();
+    const status = statusManager.status() as unknown as {
+      provider?: string;
+      custom?: { providerState?: { mode?: string } };
+    };
+
+    expect(probe.ok).toBe(true);
+    expect(status.provider).toBe("mock");
+    expect(status.custom?.providerState?.mode).toBe("active");
+  });
+
   it("rebuilds with fallback provider during explicit identity repair", async () => {
     const oldCfg = createCfg({
       model: "old-embed",

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
@@ -55,7 +55,7 @@ describe("memory index", () => {
 
   it("reports the adopted fallback provider when the published index belongs to it", async () => {
     // A previous run fell back, so the published index carries the fallback provider's
-    // identity. Search adopts it; a deep status probe in a fresh process must describe the
+    // identity. Search adopts it; a deep status probe on a fresh manager must describe the
     // same provider instead of the configured primary.
     const publishCfg = createCfg({
       provider: "fallback-provider",
@@ -70,26 +70,20 @@ describe("memory index", () => {
     const searchManager = await getFreshManager(cfg);
     const results = await searchManager.search("alpha");
     expect(results.length).toBeGreaterThan(0);
-    expect((searchManager as unknown as { provider: { id: string } | null }).provider?.id).toBe(
-      "fallback-provider",
-    );
+    expect(searchManager.status().provider).toBe("fallback-provider");
     await searchManager.close?.();
 
     const statusManager = await getFreshManager(cfg);
     const probe = await statusManager.probeEmbeddingAvailability();
-    const status = statusManager.status() as unknown as {
-      provider?: string;
-      model?: string;
-      custom?: { providerState?: { mode?: string }; indexIdentity?: { status?: string } };
-    };
+    const status = statusManager.status();
 
     expect(probe.ok).toBe(true);
     expect(status.provider).toBe("fallback-provider");
     expect(status.model).toBe("fallback-provider-embed");
-    expect(status.custom?.providerState?.mode).toBe("fallback-active");
+    expect(status.custom?.providerState).toMatchObject({ mode: "fallback-active" });
     // The index is readable by the provider search uses, so it must not be reported as a
     // configuration mismatch that an operator would answer with a forced rebuild.
-    expect(status.custom?.indexIdentity?.status).toBe("valid");
+    expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
   });
 
   it("keeps probing the configured provider when the published index matches it", async () => {
@@ -100,14 +94,11 @@ describe("memory index", () => {
 
     const statusManager = await getFreshManager(cfg);
     const probe = await statusManager.probeEmbeddingAvailability();
-    const status = statusManager.status() as unknown as {
-      provider?: string;
-      custom?: { providerState?: { mode?: string } };
-    };
+    const status = statusManager.status();
 
     expect(probe.ok).toBe(true);
     expect(status.provider).toBe("mock");
-    expect(status.custom?.providerState?.mode).toBe("active");
+    expect(status.custom?.providerState).toMatchObject({ mode: "active" });
   });
 
   it("rebuilds with fallback provider during explicit identity repair", async () => {

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -618,6 +618,10 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
         return cached;
       }
       await this.ensureProviderInitialized();
+      // Diagnostics must describe the provider search actually uses. A published index that
+      // belongs to the configured fallback is adopted on the search path, so adopt it here
+      // too instead of probing a provider this workspace's index cannot be read with.
+      await this.adoptPublishedFallbackProviderIfMatched();
       // FTS-only mode: embeddings not available but search still works
       if (!this.provider) {
         return this.cacheProbeResult({


### PR DESCRIPTION
Fresh `openclaw memory status --deep` can report a broken index even while memory search reads it successfully. This happens when the configured fallback published the index, then the primary becomes healthy again. Search adopts the matching fallback; status previously probed the primary and advised an unnecessary rebuild.

The deep probe now uses the existing published-index adoption owner before probing. It keeps full provider/model/key/provenance validation, cached-probe behavior, provider retirement, and the read-only status opening. Primary-published and incompatible indexes keep their existing outcomes. This completes the diagnostic follow-up named in #142364.

## Real CLI proof

Baseline: `a141825c9c75f75944d85ebd70a5df3793d1a71c`. Candidate: `02a09071aeeb01963296c19a8b8a90695af3604c`.

Both ran on the same isolated Linux environment through the public CLI and real bundled OpenAI/Ollama adapters. Synthetic loopback protocol peers returned vectors only; the result text came from a real `MEMORY.md` and SQLite index. No remote provider was contacted.

1. Configure OpenAI `text-embedding-3-small` plus Ollama fallback `nomic-embed-text`, with distinct destination credentials and headers.
2. Publish with `openclaw memory index --force --agent main` while the primary destination has no credential. This sends the source embedding only to Ollama.
3. Restore a healthy primary credential and response without changing the fallback identity or index.
4. Run fresh processes for search, deep JSON status, repeated deep JSON status, human deep status, then search again.
5. Separately publish a primary-owned index and probe it through the real OpenAI adapter to prove primary health.

| Observed result | Baseline | Candidate |
| --- | --- | --- |
| Both searches | Same stored marker through Ollama | Same stored marker through Ollama |
| Deep status provider/model | OpenAI / `text-embedding-3-small` | Ollama / `nomic-embed-text` |
| Lifecycle | `active` | `fallback-active` |
| Index identity | `mismatched`, model | `valid` |
| Human rebuild advice | Present | Absent |
| Primary-published control | OpenAI, valid, probe succeeds | OpenAI, valid, probe succeeds |

Selected fields copied from candidate JSON output:

```json
{
  "provider": "ollama",
  "model": "nomic-embed-text",
  "requestedProvider": "openai",
  "providerState": {
    "mode": "fallback-active",
    "providerId": "ollama",
    "fallbackFrom": "openai",
    "reason": "published memory index uses the configured fallback provider"
  },
  "indexIdentity": { "status": "valid" },
  "embeddingProbe": { "ok": true }
}
```

Candidate human output includes:

```text
Provider: ollama (requested: openai)
Model: nomic-embed-text
Indexed: 1/1 files · 1 chunks
Dirty: no
Embeddings: ready
published memory index uses the configured fallback provider
```

The original baseline instead says:

```text
Provider: openai (requested: openai)
Model: text-embedding-3-small
Index identity: index was built for model nomic-embed-text, expected text-embedding-3-small (owner: configuration, code: model)
Vector search: paused until memory is rebuilt
Fix: Run: openclaw memory status --index --agent main. Rebuilding may call the configured embedding provider and can incur provider cost.
```

Every successful fresh probe has one request to its effective provider. Destination credentials and canary headers remain separate. All CLI descendants joined before the next observation.

## Preservation and controls

- Three positive status windows and 18 additional control windows preserved the full agent database schema, all table rows, database/WAL bytes, memory source, and stable configuration. No index/fix, checkpoint, vacuum, migration, or metadata rewrite occurred inside those status windows.
- The read-only observation connection itself can create empty WAL/shared-memory sidecars. The measured windows begin after that reader closes. Original observations are retained; this proof covers empty/absent WAL, not a retained nonempty WAL.
- A neither-model index remains mismatched and requests rebuilding. A matching fallback name/model with a changed endpoint key remains `provider_settings` mismatched; search returns no stale marker.
- Absent, `none`, same-as-primary, and unknown fallback preserve conservative mismatch or missing-credential errors. A failing fallback HTTP probe exposes its real error. A failing primary probe on a primary-published index does not trigger fallback.
- Keyword-only mode still returns the indexed marker without embedding requests.

## Source validation

- 36 unique cases passed across the focused fallback, lifecycle, state, and lease suites. Unchanged results were retained; the final cleaned fallback suite and lease suite passed all 20 cases.
- Running the cleaned fallback test against baseline production gives exactly the intended provider-mismatch failure; the other nine cases pass.
- Targeted lint/format, line/assertion ratchets, actual precommit, and independent source review passed. Test cleanup uses public status results and preserves the contributor's production change and ancestry.
- The contributor's earlier broad Windows run reported 606 passes and 63 watcher failures. That historical report is retained; it is separate from the current Linux focused proof and does not certify hosted CI.

Fixed synthetic vectors prove adapter transport, stored retrieval, and diagnostic lifecycle behavior. They do not establish semantic embedding quality or live remote-provider compatibility. Full private raw captures, controls, fixtures, and preservation observations are retained for final review. Credentials and private paths/endpoints are redacted from public excerpts.

Independent source-blind acceptance also ran 62 fresh CLI commands with a different marker, `cobalt ferry ninety three`. All 16 observable clauses passed, including 17 independent database-preservation windows. The 12 expected missing-credential/unknown-provider command failures remain recorded. Source review covers implementation ownership; exact-head CI, final review, landing and cleanup remain separate delivery gates.
