### PR TITLE
fix: reduce cold presence work when viewing multiple sessions

### DIFF
--- a/src/gateway/presence-projection.ts
+++ b/src/gateway/presence-projection.ts
@@ -1,3 +1,5 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SystemPresence } from "../infra/system-presence.js";
@@ -6,42 +8,60 @@ import { authorizeOperatorScopesForRequiredScope, READ_SCOPE } from "./method-sc
 import { isGatewayClientProfilePending } from "./server-methods/gateway-client-identity.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { isGatewayAdmin, prepareSessionSharing } from "./session-sharing.js";
-import {
-  resolveGatewaySessionStoreTargetWithStore,
-  type GatewaySessionStoreDiscoveryCache,
-} from "./session-utils-store-lookup.js";
+import { prepareGatewaySessionStoreTargetsReadOnly } from "./session-utils-store-lookup.js";
 import { resolveCanonicalSessionStoreMatchFromStoreKeys } from "./session-utils-store.js";
+
+type PresenceTarget = { canonicalKey: string; entry: SessionEntry } | undefined;
 
 /** One synchronous snapshot/fanout owns these reads; never reuse them across broadcasts. */
 export function createPresenceRecipientProjection(params: {
   cfg: OpenClawConfig;
   presence: SystemPresence[];
 }): (client: GatewayClient | null) => SystemPresence[] {
-  const targets = new Map<string, { canonicalKey: string; entry: SessionEntry } | undefined>();
-  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+  let targets: Map<string, Result<PresenceTarget, unknown>> | undefined;
+  const prepareTargets = () => {
+    const keys = [...new Set(params.presence.flatMap((row) => row.watchedSessions ?? []))];
+    const prepared = prepareGatewaySessionStoreTargetsReadOnly({
+      cfg: params.cfg,
+      projection: "full",
+      targets: keys.map((sessionKey) => {
+        const parsed = parseAgentSessionKey(sessionKey);
+        // Viewer declarations qualify sentinels; their stored keys remain global/unknown.
+        return {
+          key: parsed?.rest === "global" || parsed?.rest === "unknown" ? parsed.rest : sessionKey,
+          agentId: parsed?.agentId,
+        };
+      }),
+    });
+    return new Map<string, Result<PresenceTarget, unknown>>(
+      keys.map((sessionKey, index) => {
+        const result = expectDefined(prepared[index], "prepared presence target");
+        if (!result.ok) {
+          return [sessionKey, result];
+        }
+        try {
+          const target = result.value;
+          const match = resolveCanonicalSessionStoreMatchFromStoreKeys(
+            target.store,
+            target.storeKeys,
+          );
+          return [
+            sessionKey,
+            ok(match ? { canonicalKey: target.canonicalKey, entry: match.entry } : undefined),
+          ];
+        } catch (error) {
+          return [sessionKey, err(error)];
+        }
+      }),
+    );
+  };
   const resolveTarget = (sessionKey: string) => {
-    if (!targets.has(sessionKey)) {
-      const parsed = parseAgentSessionKey(sessionKey);
-      // Viewer declarations wrap sentinel keys with their agent. The stored key
-      // remains global/unknown in that agent's store, not a literal prefixed row.
-      const key =
-        parsed?.rest === "global" || parsed?.rest === "unknown" ? parsed.rest : sessionKey;
-      const target = resolveGatewaySessionStoreTargetWithStore({
-        cfg: params.cfg,
-        key,
-        agentId: parsed?.agentId,
-        readOnly: true,
-        exactRead: true,
-        clone: false,
-        targetDiscoveryCache,
-      });
-      const match = resolveCanonicalSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
-      targets.set(
-        sessionKey,
-        match ? { canonicalKey: target.canonicalKey, entry: match.entry } : undefined,
-      );
+    // Dormant until an eligible recipient visits a watch; errors retain visitor order.
+    const result = expectDefined((targets ??= prepareTargets()).get(sessionKey), "presence target");
+    if (!result.ok) {
+      throw result.error;
     }
-    return targets.get(sessionKey);
+    return result.value;
   };
   return (client) => {
     // Match system-presence RPC access before projecting any rows: even idle

--- a/src/gateway/session-utils-store-lookup.test.ts
+++ b/src/gateway/session-utils-store-lookup.test.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -10,6 +11,7 @@ import { prepareCurrentGitHubPublicationIdentity } from "./github-publication-av
 import { handleGatewayRequest } from "./server-methods.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 import {
+  prepareGatewaySessionStoreTargetsReadOnly,
   resolveGatewaySessionStoreTargetWithStore,
   resolveGatewaySessionStoreTargetsReadOnly,
 } from "./session-utils-store-lookup.js";
@@ -52,6 +54,103 @@ async function withGlobalSessions(mainKey: string, run: (cfg: OpenClawConfig) =>
 }
 
 describe("global session lookup ownership", () => {
+  it("prepares full selected entries while retaining an independent target error", async () => {
+    await withGlobalSessions("main", async (cfg) => {
+      await replaceSessionEntry(
+        { agentId: "research", sessionKey: "global" },
+        {
+          sessionId: "research-global",
+          updatedAt: 1,
+          skillsSnapshot: { prompt: "selected synthetic prompt", skills: [] },
+        },
+      );
+      const results = prepareGatewaySessionStoreTargetsReadOnly({
+        cfg,
+        projection: "full",
+        targets: [{ key: "agent:research:main" }, { key: "agent:main:main", agentId: "research" }],
+      });
+      expect(results).toMatchObject([
+        {
+          ok: true,
+          value: {
+            agentId: "research",
+            store: { global: { skillsSnapshot: { prompt: "selected synthetic prompt" } } },
+          },
+        },
+        { ok: false, error: { message: expect.stringContaining('belongs to "main"') } },
+      ]);
+    });
+  });
+
+  it("keeps deferred errors in visitor order without changing eager batch failure order", async () => {
+    await withStateDirEnv("gateway-deferred-lookup-errors-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {}, research: {} } },
+        session: { store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json") },
+      };
+      for (const directory of ["Retired Agent", "retired-agent"]) {
+        const storePath = path.join(stateDir, "agents", directory, "sessions", "sessions.json");
+        mkdirSync(path.dirname(storePath), { recursive: true });
+        await replaceSessionEntry(
+          { agentId: "retired-agent", sessionKey: "agent:retired-agent:main", storePath },
+          {
+            sessionId: directory === "Retired Agent" ? "retired-first" : "retired-second",
+            updatedAt: 1,
+          },
+        );
+      }
+      const targets = [
+        { key: "agent:retired-agent:main" },
+        { key: "agent:main:main", agentId: "research" },
+      ];
+      expect(() => resolveGatewaySessionStoreTargetsReadOnly({ cfg, targets })).toThrow(
+        'belongs to "main"',
+      );
+      const results = prepareGatewaySessionStoreTargetsReadOnly({
+        cfg,
+        targets,
+        projection: "full",
+      });
+      expect(results).toMatchObject([
+        { ok: false, error: { message: expect.stringContaining("duplicate rows") } },
+        { ok: false, error: { message: expect.stringContaining('belongs to "main"') } },
+      ]);
+    });
+  });
+
+  it.each([false, true])(
+    "does not plan a replacement after a deleted-main match or selection error (duplicate: %s)",
+    async (duplicate) => {
+      await withStateDirEnv("gateway-prepared-legacy-owner-", async ({ stateDir }) => {
+        const cfg: OpenClawConfig = {
+          agents: { ownership: "explicit", entries: { research: {} } },
+          session: {
+            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+          },
+        };
+        const key = "agent:main:retained";
+        for (const sessionKey of duplicate ? [key, "agent:main:main"] : [key]) {
+          await replaceSessionEntry(
+            { agentId: "main", sessionKey },
+            { sessionId: sessionKey, updatedAt: 1 },
+          );
+        }
+        // Normal planning rejects this explicit replacement owner. Legacy success
+        // and duplicate selection errors must both finish before that boundary.
+        const results = prepareGatewaySessionStoreTargetsReadOnly({
+          cfg,
+          targets: [{ key, agentId: "research" }],
+          projection: "full",
+        });
+        expect(results).toMatchObject(
+          duplicate
+            ? [{ ok: false, error: { message: expect.stringContaining("duplicate rows") } }]
+            : [{ ok: true, value: { agentId: "main", store: { [key]: { sessionId: key } } } }],
+        );
+      });
+    },
+  );
+
   it.each(["single", "batch", "read-only"] as const)(
     "preserves qualified main aliases and ordinary global keys through %s reads",
     async (mode) => {

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentIds } from "../agents/agent-scope.js";
 import {
@@ -446,6 +447,63 @@ export function resolveGatewaySessionStoreTargetsReadOnly(params: {
     (selection) =>
       selection.target ??
       expectDefined(selection.plan, "unresolved logical session plan").resolve(),
+  );
+}
+
+function captureSessionStoreTargetResult<T>(resolve: () => T): Result<T, unknown> {
+  try {
+    return ok(resolve());
+  } catch (error) {
+    return err(error);
+  }
+}
+
+/** Read exact groups now, retaining logical errors for the caller's ordered visitor. */
+export function prepareGatewaySessionStoreTargetsReadOnly(params: {
+  cfg: OpenClawConfig;
+  targets: readonly { key: string; agentId?: string }[];
+  projection: SessionEntryListScope["projection"];
+}): Array<Result<GatewaySessionStoreTargetWithStore, unknown>> {
+  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+  const requests = params.targets.map((target) =>
+    captureSessionStoreTargetResult(() => {
+      const lookup: GatewaySessionStoreLookupParams = {
+        ...target,
+        key: normalizeOptionalString(target.key) ?? "",
+        cfg: params.cfg,
+        clone: false,
+        readOnly: true,
+        exactRead: true,
+        projection: params.projection,
+        targetDiscoveryCache,
+      };
+      return { lookup, legacy: prepareExplicitDeletedLegacyMainStoreTarget(lookup) };
+    }),
+  );
+  loadGatewaySessionStoreReads(
+    requests.flatMap((request) => (request.ok ? (request.value.legacy?.reads ?? []) : [])),
+  );
+  const selected = requests.map((request) => {
+    if (!request.ok) {
+      return request;
+    }
+    return captureSessionStoreTargetResult(() => {
+      // Only a legacy miss permits fallback; a logical error must stay with its target.
+      const target = request.value.legacy?.resolve();
+      return target ? { target } : { plan: prepareGatewaySessionStoreTarget(request.value.lookup) };
+    });
+  });
+  loadGatewaySessionStoreReads(
+    selected.flatMap((selection) => (selection.ok ? (selection.value.plan?.reads ?? []) : [])),
+  );
+  return selected.map((selection) =>
+    selection.ok
+      ? captureSessionStoreTargetResult(
+          () =>
+            selection.value.target ??
+            expectDefined(selection.value.plan, "unresolved logical session plan").resolve(),
+        )
+      : selection,
   );
 }
 

--- a/src/gateway/session-viewer-presence.test.ts
+++ b/src/gateway/session-viewer-presence.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listSystemPresence } from "../infra/system-presence.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  resolveOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createPresenceRecipientProjection } from "./presence-projection.js";
+import type { GatewayClient } from "./server-methods/types.js";
 import { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { createSessionViewerPresenceDeclarations } from "./session-viewer-presence.js";
@@ -97,5 +106,101 @@ describe("session viewer presence declarations", () => {
     declarations.stop();
     expect(declarations.replace("conn-a", ["alpha"])).toEqual([]);
     expect(broadcast).not.toHaveBeenCalled();
+  });
+});
+
+function recipient(scopes = ["operator.admin"]): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      role: "operator",
+      scopes,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+    },
+  };
+}
+
+async function seedColdStore(count: number): Promise<string[]> {
+  const keys = Array.from({ length: count }, (_, index) => `agent:main:presence-${index}`);
+  for (const [index, sessionKey] of keys.entries()) {
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      { sessionId: `presence-${index}`, updatedAt: 1, visibility: "shared" },
+    );
+  }
+  // Fresh read-only handles expose repeated admission work hidden by a warm writer.
+  expect(
+    closeOpenClawAgentDatabaseByPath(resolveOpenClawAgentSqlitePath({ agentId: "main" })),
+  ).toBe(true);
+  return keys;
+}
+
+describe("presence projection store admission", () => {
+  it("bounds a cold fanout to one metadata census per store, including repeated watches and recipients", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const watchedSessions = (await seedColdStore(64)).slice(0, 8);
+      const presence = [
+        { text: "first watcher", ts: 1, watchedSessions },
+        { text: "second watcher", ts: 2, watchedSessions: [...watchedSessions] },
+      ];
+      const { DatabaseSync } = requireNodeSqlite();
+      const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+      try {
+        const project = createPresenceRecipientProjection({ cfg: {}, presence });
+        expect(project(recipient())).toEqual(presence);
+        // Observe real unbounded session reads, without replacing the canonical
+        // validator or exact reader. Selected-row queries contain a WHERE clause.
+        const censuses = prepare.mock.calls.filter(([sql]) => {
+          const normalized = sql.toLowerCase().replaceAll(/\s+/g, " ");
+          return normalized.includes('from "session_nodes"') && !normalized.includes(" where ");
+        });
+        expect(censuses).toHaveLength(1);
+        const preparedQueries = prepare.mock.calls.length;
+        expect(project(recipient())).toEqual(presence);
+        expect(prepare).toHaveBeenCalledTimes(preparedQueries);
+      } finally {
+        prepare.mockRestore();
+      }
+    });
+  });
+
+  it("does not admit stores until an eligible recipient demands a watched key", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const watchedSessions = await seedColdStore(1);
+      const person = { text: "watcher", ts: 1 };
+      const presence = [{ ...person, watchedSessions }];
+      const pending = recipient(["operator.read"]);
+      pending.authenticatedGitHubIdentitySync = async () => ({
+        profileId: "pending",
+        updatedAt: 1,
+      });
+      const node = recipient();
+      node.connect.role = "node";
+      const { DatabaseSync } = requireNodeSqlite();
+      const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+      try {
+        const project = createPresenceRecipientProjection({ cfg: {}, presence });
+        expect(project(pending)).toEqual([person]);
+        for (const denied of [recipient([]), node, null]) {
+          expect(project(denied)).toEqual([]);
+        }
+        expect(createPresenceRecipientProjection({ cfg: {}, presence: [] })(recipient())).toEqual(
+          [],
+        );
+        expect(
+          createPresenceRecipientProjection({
+            cfg: {},
+            presence: [person, { ...person, watchedSessions: [] }],
+          })(recipient()),
+        ).toEqual([person, person]);
+        expect(prepare).not.toHaveBeenCalled();
+
+        expect(project(recipient())).toEqual(presence);
+        expect(prepare).toHaveBeenCalled();
+      } finally {
+        prepare.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where viewing several sessions could slow presence updates when their session store had no retained database handle. Each distinct watched session could repeat validation of every session metadata row in the store.

## Why This Change Was Made

Presence now prepares exact watched-session reads through the existing grouped reader after the first eligible recipient requests a watched reference. It retains each logical result or error and exposes errors in the original visitor order. Full selected-entry decoding, canonical corruption refusal, recipient visibility checks, and deleted-main fallback rules remain intact. Existing eager batch callers keep their failure ordering.

The change uses the existing grouped admission boundary: read-only work can happen earlier, and an admission or close failure affects its store group. It adds no schema, transaction, configuration, or handle-cache API.

## User Impact

Presence updates avoid repeated cold metadata validation when users view multiple sessions. Pending or unauthorized recipients still trigger no session reads, and each recipient retains the existing visibility filtering.

## Evidence

- The regression failed on the unchanged baseline with eight metadata censuses for eight watched sessions over 64 rows; the candidate requires and performs one. Repeated watcher rows and recipients reuse those results.
- 308 focused tests passed across presence, store lookup, serialization, session utilities, and read-only accessors. After consolidating the two new cases into the existing viewer-presence suite to preserve the test-root budget, all six cases there passed.
- Tests cover full selected-entry projection, independent logical errors, deferred visitor order versus existing eager failure order, and legacy success/error suppression of replacement planning.
- Changed-file checks passed, including typechecks and the existing test-root limits. Independent autoreview is clear through P2.

- Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34282710781) for `a38d161dcde174b53783b6a2380eb5bffad2b226`. Current ClawSweeper review reports no concrete code defect.
- Linux Node 24.19.0 proof used `blacksmith-testbox`, lease `tbx_01m21gz22cjv2rz64c6apb90gn` ([run](https://github.com/openclaw/openclaw/actions/runs/34284230537)), comparing exact baseline `8cca96e1185994165a4e475679f6d16874392c25` and candidate. Both frozen installs and builds passed. All ten measurement pairs produced identical output. For 1,024 rows and eight watched sessions, instrumented canonical censuses fell from eight to one, rows visited from 8,192 to 1,024, and exact reads remained eight; every observed handle closed. The uninstrumented cold projection observations were 69.97 → 14.84 ms for eight watches and 183.60 → 15.14 ms for 32 watches. These are bounded single-cell observations, not production latency estimates.
- The ordinary package-bin `node openclaw.mjs gateway run` flow passed on both revisions with fresh isolated state, 30 sampled presence RPCs each, matching declaration ACK/event/RPC output at 1/8/32 watches, creator/draft/incognito filtering, fresh visibility changes, and declaration clearing. The serving PID was the directly spawned process with respawn disabled; both Gateways exited zero with no signal, all sockets/process groups closed, and the exact listeners refused connection.

Two initial dispatches were rejected before workload execution because of unsupported delegated transport flags. The first runtime attempt preserved all successful measurements but failed its synthetic Control UI handshake because the client omitted the built ID; the Gateway correctly rejected it. A separately reviewed Gateway-only follow-up supplied each revision's real build ID and verified the server echoed it. The original failure remains retained; no assertion or deadline was relaxed. Full synthetic state evidence is retained privately rather than published. This PR does not attribute historical stalls to this specific path.
