### PR TITLE
refactor(tests): retire duplicate deep import memory case

### DIFF
--- a/src/commands/doctor-session-sqlite.memory.test-support.ts
+++ b/src/commands/doctor-session-sqlite.memory.test-support.ts
@@ -19,10 +19,8 @@ async function main() {
   process.env.OPENCLAW_STATE_DIR = stateDir;
   process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
   const sessionCount = scenario === "batch" ? 256 : 1;
-  const eventCount =
-    scenario === "deep" || scenario === "public" ? 100_000 : scenario === "batch" ? 64 : 8;
-  const payloadBytes =
-    scenario === "deep" || scenario === "public" ? 4096 : scenario === "batch" ? 32768 : 256;
+  const eventCount = scenario === "public" ? 100_000 : scenario === "batch" ? 64 : 8;
+  const payloadBytes = scenario === "public" ? 4096 : scenario === "batch" ? 32768 : 256;
   const sessionsDir = path.join(stateDir, "agents/main/sessions");
   const storePath = path.join(sessionsDir, "sessions.json");
   fs.mkdirSync(sessionsDir, { recursive: true });

--- a/src/commands/doctor-session-sqlite.memory.test.ts
+++ b/src/commands/doctor-session-sqlite.memory.test.ts
@@ -51,7 +51,7 @@ afterAll(() => {
   }
 });
 
-it.each(["batch", "deep", "public"])(
+it.each(["batch", "public"])(
   "imports %s transcripts and completes branch projections under a 256 MiB heap",
   async (scenario) => {
     await withOpenClawTestState({ applyEnv: false, label: "import-memory" }, async (state) => {


### PR DESCRIPTION
## What Problem This Solves

The SQLite import memory suite runs the same deep transcript twice: once through the direct importer and again through public Doctor orchestration.

## Why This Change Was Made

Retire the duplicate direct `deep` row. The public case retains the identical 100,000-event fixture, full digest and selected-ancestry checks, 256 MiB child heap limit and existing deadline through the same importer. The batch case retains 256-session breadth and positive import totals. The direct deep-specific first-import total of 100,002 is no longer asserted; independent direct-import reporting tests remain.

## User Impact

No production behavior changes. One redundant test execution and two net support lines are removed.

## Evidence

- Linux Node 24.19: original memory suite 3/3 passed; candidate 2/2 passed with identical retained cases and fixture sizes. Reporting siblings: 242 passed, two existing platform-alias skips.
- Required mapped gate passed locally after remote validation hit a missing private baseline ref, then a 15-minute budget cap. No memory tests were repeated for that recovery. Independent P2 review passed; the owned Testbox was stopped.
- One measured file pair was 88.96s before and 88.31s after. The removed deep case took 18.76s, but retained cases ran slower. No substantial wall-time or overall test-runtime improvement is claimed.
