### PR TITLE
fix(ui): settings search loses phrases with middle tag filters

### DIFF
--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -10,6 +10,8 @@ sidebarTitle: "Settings"
 
 Everything under Settings, plus the settings-owned pages the sidebar links to.
 
+Use **Search settings** to find pages and configuration fields. Add `tag:storage`, for example, to filter configuration fields by tag. Tags can appear before, within, or after a text phrase: `Log File tag:storage` and `Log tag:storage File` both find **Log File Path**. Multiple tags require a field to match every tag.
+
 Model menus with more than eight choices include search. Filter by model name or provider/model reference, then choose a result to apply it. Typing or dismissing the menu leaves the current selection unchanged. Short menus stay compact, and custom model entry remains available where the setting supports it.
 
 ## Environment identity

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -24,10 +24,17 @@ const schema = {
 };
 
 describe("config form search", () => {
-  it("parses tag-prefixed query terms", () => {
-    const parsed = parseConfigSearchQuery("token tag:security tag:Auth");
-    expect(parsed.text).toBe("token");
-    expect(parsed.tags).toEqual(["security", "auth"]);
+  it.each([
+    ["token tag:security tag:Auth", "token", ["security", "auth"]],
+    ["Café tag:storage 文書", "café 文書", ["storage"]],
+    ["Log tag:storage tag:STORAGE File", "log file", ["storage"]],
+    ["", "", []],
+    ["  ", "", []],
+    ["tag:storage", "", ["storage"]],
+    ["Log  File", "log  file", []],
+    ["path:tag:storage", "path:tag:storage", []],
+  ])("parses search query %j", (query, text, tags) => {
+    expect(parseConfigSearchQuery(query)).toEqual({ text, tags });
   });
 
   it("matches fields by tag through ui hints", () => {
@@ -44,28 +51,24 @@ describe("config form search", () => {
     expect(matched).toBe(true);
   });
 
-  it("requires text and tag when combined", () => {
-    const positive = matchesNodeSearch({
-      schema: schema.properties.gateway,
-      value: {},
-      path: ["gateway"],
-      hints: {
-        "gateway.auth.token": { tags: ["security"] },
-      },
-      criteria: parseConfigSearchQuery("token tag:security"),
-    });
-    expect(positive).toBe(true);
-
-    const negative = matchesNodeSearch({
-      schema: schema.properties.gateway,
-      value: {},
-      path: ["gateway"],
-      hints: {
-        "gateway.auth.token": { tags: ["security"] },
-      },
-      criteria: parseConfigSearchQuery("mode tag:security"),
-    });
-    expect(negative).toBe(false);
+  it.each([
+    ["access token tag:security", true],
+    ["tag:security access token", true],
+    ["access tag:security token", true],
+    ["mode tag:security", false],
+    ["access token tag:storage", false],
+  ])("requires text and tag when combined in %j", (query, expected) => {
+    expect(
+      matchesNodeSearch({
+        schema: schema.properties.gateway,
+        value: {},
+        path: ["gateway"],
+        hints: {
+          "gateway.auth.token": { label: "Access Token", tags: ["security"] },
+        },
+        criteria: parseConfigSearchQuery(query),
+      }),
+    ).toBe(expected);
   });
 
   it("searches array item schemas before entries exist", () => {

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -23,14 +23,13 @@ export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefin
 export function parseConfigSearchQuery(query: string): ConfigSearchCriteria {
   const tags: string[] = [];
   const seen = new Set<string>();
-  const raw = query.trim();
-  const stripped = raw.replace(/(^|\s)tag:([^\s]+)/gi, (_, leading: string, token: string) => {
+  const stripped = query.replace(/(?:^|\s)tag:([^\s]+)/gi, (_, token: string) => {
     const normalized = normalizeLowercaseStringOrEmpty(token);
     if (normalized && !seen.has(normalized)) {
       seen.add(normalized);
       tags.push(normalized);
     }
-    return leading;
+    return "";
   });
   return {
     text: normalizeLowercaseStringOrEmpty(stripped),

--- a/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
+++ b/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
@@ -71,7 +71,14 @@ suite.define(() => {
       }).messages;
 
       expect(mergedMessages).toHaveLength(2);
-      expect(mergedMessages[0]).toBe(localUserMessage);
+      expect(mergedMessages[0]).toEqual({
+        ...localUserMessage,
+        __openclaw: {
+          cliSessionId,
+          externalId: "control-ui-claude-user-copy",
+          importedFrom: "claude-cli",
+        },
+      });
       expect(requireRecord(requireRecord(mergedMessages[1])["__openclaw"])).toMatchObject({
         cliSessionId,
         externalId: "control-ui-claude-imported-assistant",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The branch is in `openclaw/openclaw` and is editable by repository maintainers.

</details>

## What Problem This Solves

Fixes an issue where users searching Settings would lose matching configuration fields when a `tag:` filter appeared between words. `Log File tag:storage` finds Logging, but `Log tag:storage File` incorrectly shows “No matching settings.”

## Why This Change Was Made

The query parser retained the separator before each removed tag, leaving two spaces inside the literal phrase. Remove the complete tag span and the redundant preliminary trim. Both Settings navigation search and configuration-field filtering use this owner; tag matching, deduplication, Unicode text, and ordinary literal whitespace retain their existing semantics. Production code decreases by one line.

## User Impact

Tag filters work before, within, or after search phrases. Clicking the result opens the matching field. The Settings guide now includes the example and explains that multiple tags must all match.

## Evidence

- Three regression assertions failed with the original parser. The final focused parser and Settings-search caller suites pass all 58 tests, including tag position, empty/tag-only queries, Unicode, duplicate tags, wrong tags, embedded nonoperator text, and literal double spaces.
- `node scripts/check-changed.mjs -- ui/src/components/config-form.search.ts ui/src/components/config-form.search.node.test.ts ui/src/e2e/chat-cli-history-redaction.e2e.test.ts docs/web/control-ui/settings.md` passed, including typechecks, formatting, i18n, guards, dead-export scans, and targeted lint.
- The first CI run exposed an unrelated stale CLI-history E2E assertion after main #130494 began retaining native identity on deduplicated messages. After refreshing the base, the untouched E2E reproduced the failure. Its assertion now checks the exact local message plus the expected native identity; the complete bundled Chromium E2E passes with all redaction, on-disk preservation, message-count, and rendering assertions retained. No runtime behavior changed for this maintenance correction.
- Independent review through P2 is clean. Current-main qualification found the affected owner, callers, label/tag producer, and dependencies unchanged.
- Real Chromium against the source UI and a synthetic mock Gateway reproduces the missing result before the fix and the matching result/click-through afterward. Deferred schema loading, an unmatched tag, and clearing search also complete. These captures contain synthetic data only; no live operator Gateway or provider traffic was used.

Before: the middle tag hides the matching setting.

![Before: Settings search has no match for the middle-tag phrase](https://github.com/user-attachments/assets/59098e63-3bda-43f0-ae86-f88deed58406)

After: the same phrase finds Logging.

![After: Settings search finds Logging with the middle-tag phrase](https://github.com/user-attachments/assets/f27d1641-cabe-4c3e-958c-06ebdc66e70e)

Clicking the result opens Log File Path.

![The search result opens Log File Path with its storage and observability tags](https://github.com/user-attachments/assets/399d26a4-6bcb-4a19-8934-cdc2bd272206)
