### PR TITLE
fix(plugin-sdk): restore writable catalog loader defaults

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -96,11 +96,12 @@ validation also use the published inventory. Missing capability facts do not
 start another provider discovery. Native runtime observations keep their separate
 owner and authentication requirements.
 
-Programmatic catalog loads, including the public SDK loader, also default to
-passive reads. Without a published owner they use existing read-only facts. Callers
-that explicitly request a full refresh keep inventory acquisition; an explicit
-read-only request keeps its narrower refresh scope. Runtime callers can retain
-explicit writable ownership when needed.
+Internal catalog loads default to passive reads. Without a published owner they
+use existing read-only facts. The public SDK's `loadPreparedModelCatalog` and legacy
+`loadModelCatalog` keep their writable default for compatibility and can acquire
+provider inventory. Pass `readOnly: true` for a passive SDK read. Explicit full
+refreshes keep inventory acquisition; explicit read-only requests keep their
+narrower refresh scope.
 
 For models configured to use a CLI runtime, channel picker availability follows that
 runtime's prepared authentication; a provider API key does not substitute for its

--- a/src/agents/model-catalog.runtime.ts
+++ b/src/agents/model-catalog.runtime.ts
@@ -1,7 +1,7 @@
 /** Runtime barrel for lifecycle-owned model catalog helpers. */
 export { loadManifestModelCatalog } from "./model-catalog.js";
 export {
-  loadPreparedModelCatalog,
+  readPreparedModelCatalog,
   loadPreparedModelCatalogSnapshot,
   loadProviderScopedThinkingCatalog,
 } from "./prepared-model-catalog.js";

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -51,7 +51,7 @@ vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal)
 vi.mock("./model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: () => [],
   loadProviderScopedThinkingCatalog: async () => [],
-  loadPreparedModelCatalog: async () => [],
+  readPreparedModelCatalog: async () => [],
   loadPreparedModelCatalogSnapshot: loadPreparedModelCatalogSnapshotMock,
 }));
 

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -208,7 +208,7 @@ function createModelCatalogModuleMock() {
     loadProviderScopedThinkingCatalog: async () => [],
     // A run's captured config goes stale after any Gateway config republish; the exact
     // loader then throws, and session_status must read the published owner instead.
-    loadPreparedModelCatalog: async () => {
+    readPreparedModelCatalog: async () => {
       throw new Error("prepared model catalog owner config was replaced during the read (/tmp)");
     },
     loadPublishedPreparedModelCatalog: async () => [

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -451,7 +451,7 @@ export async function loadPreparedModelCatalogSnapshot(
   return (await loadPreparedModelCatalogOwnerSnapshot(params)).modelCatalog;
 }
 
-export async function loadPreparedModelCatalog(
+export async function readPreparedModelCatalog(
   params: LoadPreparedModelCatalogParams = {},
 ): Promise<ModelCatalogEntry[]> {
   return (await loadPreparedModelCatalogSnapshot(params)).entries;

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -70,7 +70,7 @@ async function resolveSpawnModelError(params: {
   const provider = selected.provider ?? defaults.provider;
   let catalog: ModelCatalogEntry[];
   try {
-    catalog = await getSubagentSpawnDeps().loadPreparedModelCatalog({
+    catalog = await getSubagentSpawnDeps().readPreparedModelCatalog({
       config: params.cfg,
       agentDir: params.targetAgentDir,
       workspaceDir: params.workspaceDir,

--- a/src/agents/subagents/spawn/subagent-spawn-deps.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-deps.ts
@@ -7,7 +7,7 @@ import {
   getGlobalHookRunner,
   getRuntimeConfig,
   hasInProcessGatewayContext,
-  loadPreparedModelCatalog,
+  readPreparedModelCatalog,
   resolveProviderRefOwnership,
   resolveContextEngine,
 } from "./subagent-spawn.runtime.js";
@@ -20,7 +20,7 @@ type SubagentSpawnDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
   hasInProcessGatewayContext: typeof hasInProcessGatewayContext;
   ensureContextEnginesInitialized: typeof ensureContextEnginesInitialized;
-  loadPreparedModelCatalog: typeof loadPreparedModelCatalog;
+  readPreparedModelCatalog: typeof readPreparedModelCatalog;
   resolveProviderRefOwnership: typeof resolveProviderRefOwnership;
   resolveContextEngine: typeof resolveContextEngine;
 };
@@ -33,7 +33,7 @@ const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
   getRuntimeConfig,
   hasInProcessGatewayContext,
   ensureContextEnginesInitialized,
-  loadPreparedModelCatalog,
+  readPreparedModelCatalog,
   resolveProviderRefOwnership,
   resolveContextEngine,
 };

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
@@ -16,7 +16,7 @@ vi.mock("./subagent-spawn.runtime.js", async () => {
     forkSessionEntryFromParent: vi.fn(),
     getGlobalHookRunner: vi.fn(),
     getRuntimeConfig: vi.fn(),
-    loadPreparedModelCatalog: vi.fn(),
+    readPreparedModelCatalog: vi.fn(),
     resolveProviderRefOwnership: vi.fn(),
     resolveContextEngine: vi.fn(),
   };

--- a/src/agents/subagents/spawn/subagent-spawn.runtime.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.runtime.ts
@@ -31,7 +31,7 @@ export {
 } from "../../../utils/delivery-context.shared.js";
 export { resolveAgentConfig } from "../../agent-scope.js";
 export { AGENT_LANE_SUBAGENT } from "../../lanes.js";
-export { loadPreparedModelCatalog } from "../../prepared-model-catalog.js";
+export { readPreparedModelCatalog } from "../../prepared-model-catalog.js";
 export { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 export {
   resolveInternalSessionKey,

--- a/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
@@ -265,7 +265,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
     getRuntimeConfig: () =>
       params.getRuntimeConfig?.() ??
       createSubagentSpawnTestConfig(params.workspaceDir ?? os.tmpdir()),
-    loadPreparedModelCatalog: (...args: unknown[]) =>
+    readPreparedModelCatalog: (...args: unknown[]) =>
       params.loadPreparedModelCatalogMock?.(...args) ?? [],
     resolveProviderRefOwnership: (...args: unknown[]) =>
       params.resolveProviderRefOwnershipMock?.(...args) ?? {

--- a/src/agents/subagents/spawn/subagent-spawn.test-support.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test-support.ts
@@ -11,7 +11,7 @@ type SpawnDeps = Omit<
     | "getGlobalHookRunner"
     | "getRuntimeConfig"
     | "hasInProcessGatewayContext"
-    | "loadPreparedModelCatalog"
+    | "readPreparedModelCatalog"
     | "resolveContextEngine"
   >,
   "getGlobalHookRunner"

--- a/src/agents/tools/swarm-tools.integration.test.ts
+++ b/src/agents/tools/swarm-tools.integration.test.ts
@@ -117,7 +117,7 @@ describe("swarm tools integration", () => {
         getRuntimeConfig: () => config,
         hasInProcessGatewayContext: () => false,
         ensureContextEnginesInitialized: vi.fn(),
-        loadPreparedModelCatalog: vi.fn(async () => []),
+        readPreparedModelCatalog: vi.fn(async () => []),
         resolveContextEngine: vi.fn(async () => ({
           info: { id: "test", name: "Test", version: "0.0.1" },
           ingest: vi.fn(async () => ({ ingested: false })),

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
@@ -106,7 +106,7 @@ vi.mock("../agents/embedded-agent.runtime.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: loadModelCatalogMock,
+  readPreparedModelCatalog: loadModelCatalogMock,
 }));
 
 vi.mock("../agents/thinking-runtime.js", async (importOriginal) => {

--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -34,7 +34,7 @@ vi.mock("../agents/embedded-agent.js", () => ({
 
 vi.mock("../agents/model-catalog.runtime.js", () => ({
   loadProviderScopedThinkingCatalog: async () => [],
-  loadPreparedModelCatalog: (...args: unknown[]) =>
+  readPreparedModelCatalog: (...args: unknown[]) =>
     replyRuntimeMockState.mocks.loadModelCatalog(...args),
 }));
 

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -383,7 +383,7 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
   ];
   const loadModelCatalog = vi.fn(async () => entries);
   return {
-    loadPreparedModelCatalog: loadModelCatalog,
+    readPreparedModelCatalog: loadModelCatalog,
     loadProviderScopedThinkingCatalog: loadModelCatalog,
     getPublishedPreparedModelCatalogOwnerSnapshot: (params: { config: OpenClawConfig }) => ({
       config: params.config,

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -30,7 +30,7 @@ type HandleDirectiveOnlyCoreParams = {
   allowedModelKeys: Set<string>;
   modelPolicy?: ModelVisibilityPolicy;
   allowedModelCatalog: Awaited<
-    ReturnType<typeof import("../../agents/prepared-model-catalog.js").loadPreparedModelCatalog>
+    ReturnType<typeof import("../../agents/prepared-model-catalog.js").readPreparedModelCatalog>
   >;
   thinkingCatalog?: ModelCatalogEntry[];
   resetModelOverride: boolean;

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts
@@ -55,7 +55,7 @@ describe("native /status channel model routing", () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createSessionConversationTestRegistry());
-    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalog").mockResolvedValue([
+    vi.spyOn(preparedModelCatalog, "readPreparedModelCatalog").mockResolvedValue([
       {
         id: "gpt-5.5",
         name: "GPT",

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -612,7 +612,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     { selection: "automatic fallback", source: "auto" as const },
     { selection: "channel override", source: undefined },
   ])("preserves canonical native /status $selection", async (testCase) => {
-    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalog").mockResolvedValueOnce([]);
+    vi.spyOn(preparedModelCatalog, "readPreparedModelCatalog").mockResolvedValueOnce([]);
     const targetSessionKey = "agent:main:main";
     const storePath = path.join(tempDirs.make("openclaw-native-status-"), "sessions.json");
     await replaceSessionEntry(

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -7,7 +7,7 @@ import {
   resolveThinkingDefaultWithRuntimeCatalogCore,
   type ModelAliasIndex,
 } from "../../agents/model-selection.js";
-import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { isModelSelectionLocked } from "../../sessions/model-overrides.js";
@@ -111,7 +111,7 @@ async function resolveNativeSlashDefaultThinkingLevel(params: {
     provider: params.provider,
     model: params.model,
     loadRuntimeCatalog: () =>
-      loadPreparedModelCatalog({
+      readPreparedModelCatalog({
         config: params.cfg,
         agentId: params.agentId,
         agentDir: params.agentDir,
@@ -288,7 +288,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     };
     const resolvedThinkLevel = normalizeThinkLevel(targetSessionEntry?.thinkingLevel);
     // This fast path has no model-state owner; prepare side-effect-free catalog facts directly.
-    const thinkingCatalog = await loadPreparedModelCatalog({
+    const thinkingCatalog = await readPreparedModelCatalog({
       config: params.cfg,
       agentId: params.agentId,
       agentDir: params.agentDir,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.turn-model-differential.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.turn-model-differential.test.ts
@@ -142,7 +142,7 @@ describe("turn model selection status-path differential", () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createSessionConversationTestRegistry());
-    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalog").mockResolvedValue([]);
+    vi.spyOn(preparedModelCatalog, "readPreparedModelCatalog").mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -44,7 +44,7 @@ import "./get-reply.test-runtime-mocks.js";
 registerGetReplyBaselineBypass();
 
 type LoadModelCatalogFn =
-  typeof import("../../agents/prepared-model-catalog.js").loadPreparedModelCatalog;
+  typeof import("../../agents/prepared-model-catalog.js").readPreparedModelCatalog;
 
 const mocks = vi.hoisted(() => ({
   buildStatusReply: vi.fn(),
@@ -66,7 +66,7 @@ vi.mock("./commands-status.js", () => ({
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: mocks.loadModelCatalog,
+  readPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
 vi.mock("../../agents/workspace.js", () => ({

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -7,7 +7,7 @@ import {
 import {
   loadManifestModelCatalog,
   loadProviderScopedThinkingCatalog,
-  loadPreparedModelCatalog as loadModelCatalogLocal,
+  readPreparedModelCatalog as loadModelCatalogLocal,
 } from "../../agents/model-catalog.runtime.js";
 import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -62,7 +62,7 @@ vi.mock("../../agents/cli-backends.js", () => ({
 vi.mock("../../agents/model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: vi.fn(() => []),
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: catalogRuntimeMocks.loadModelCatalog,
+  readPreparedModelCatalog: catalogRuntimeMocks.loadModelCatalog,
   loadPreparedModelCatalogSnapshot: catalogRuntimeMocks.loadModelCatalogSnapshot,
 }));
 

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -12,12 +12,12 @@ import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/ses
 import { clearSessionStoreCacheForTest } from "../../config/sessions/store-writer-state.js";
 import type { ModelAliasIndex } from "./model-selection-directive.js";
 
-const loadPreparedModelCatalog = vi.hoisted(() => vi.fn(async () => modelCatalog));
+const readPreparedModelCatalog = vi.hoisted(() => vi.fn(async () => modelCatalog));
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog,
+  readPreparedModelCatalog,
 }));
 
 import { applyResetModelOverride } from "./session-reset-model.js";
@@ -216,7 +216,7 @@ describe("applyResetModelOverride", () => {
       aliasIndex: fixture.aliasIndex,
     });
 
-    expect(loadPreparedModelCatalog).toHaveBeenCalledWith({
+    expect(readPreparedModelCatalog).toHaveBeenCalledWith({
       config: fixture.cfg,
       agentId: "worker",
       agentDir: "/tmp/shared-agent",

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -37,8 +37,8 @@ async function loadResetModelCatalog(params: {
   agentDir?: string;
   workspaceDir?: string;
 }): Promise<ModelCatalogEntry[]> {
-  const { loadPreparedModelCatalog } = await import("../../agents/prepared-model-catalog.js");
-  return loadPreparedModelCatalog({
+  const { readPreparedModelCatalog } = await import("../../agents/prepared-model-catalog.js");
+  return readPreparedModelCatalog({
     config: params.cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -135,7 +135,7 @@ vi.mock("../../infra/channel-summary.js", () => ({
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: vi.fn(async () => [
+  readPreparedModelCatalog: vi.fn(async () => [
     { provider: "minimax", id: "m2.7", name: "M2.7" },
     { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
   ]),

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -106,7 +106,7 @@ const mocks = vi.hoisted(() => ({
     typeof import("../agents/memory-search.js").resolveMemorySearchConfig
   >(() => null),
   loadModelCatalog: vi.fn<
-    typeof import("../agents/prepared-model-catalog.js").loadPreparedModelCatalog
+    typeof import("../agents/prepared-model-catalog.js").readPreparedModelCatalog
   >(async () => []),
   prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
     selection: {
@@ -343,8 +343,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog:
-    mocks.loadModelCatalog as typeof import("../agents/prepared-model-catalog.js").loadPreparedModelCatalog,
+  readPreparedModelCatalog:
+    mocks.loadModelCatalog as typeof import("../agents/prepared-model-catalog.js").readPreparedModelCatalog,
 }));
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -20,7 +20,7 @@ import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store
 import { buildExplicitSessionIdSessionKey } from "../../agents/command/session.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../../agents/model-selection.js";
-import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import {
   completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
@@ -59,7 +59,7 @@ const HEIC_MODEL_RUN_MIMES = new Set([
 async function loadModelCatalogForInspection(cfg: OpenClawConfig, rawAgentId?: string) {
   const agentId =
     rawAgentId === undefined ? undefined : resolveCapabilityProviderAgentId(cfg, rawAgentId);
-  const prepared = await loadPreparedModelCatalog({ config: cfg, agentId, readOnly: true });
+  const prepared = await readPreparedModelCatalog({ config: cfg, agentId, readOnly: true });
   return prepared.toSorted(
     (a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id),
   );
@@ -76,7 +76,7 @@ async function canonicalizeModelRunRef(params: {
     raw: params.raw,
     defaultProvider: DEFAULT_PROVIDER,
     loadCatalog: () =>
-      loadPreparedModelCatalog({ config: params.cfg, agentId: params.agentId, readOnly: true }),
+      readPreparedModelCatalog({ config: params.cfg, agentId: params.agentId, readOnly: true }),
     preserveAuthProfile: params.preserveAuthProfile,
   });
 }

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -68,7 +68,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: vi.fn(),
+  readPreparedModelCatalog: vi.fn(),
   loadPreparedModelCatalogSnapshot: vi.fn(async () => ({
     entries: [],
     routeVariants: [],

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -17,7 +17,7 @@ import { prepareAgentCommandExecution } from "../agents/command/prepare.js";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
 import { loadManifestModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
-import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import { callInProcessGatewayTool } from "../agents/tools/in-process-gateway.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
@@ -543,7 +543,7 @@ async function runAgentWithSessionKey(sessionKey: string): Promise<void> {
 
 function mockModelCatalogOnce(entries: ReturnType<typeof loadManifestModelCatalog>): void {
   vi.mocked(loadManifestModelCatalog).mockReturnValueOnce(entries);
-  vi.mocked(loadPreparedModelCatalog).mockResolvedValueOnce(entries);
+  vi.mocked(readPreparedModelCatalog).mockResolvedValueOnce(entries);
 }
 
 function installThinkingTestProviders(channels: Parameters<typeof createTestRegistry>[0] = []) {
@@ -598,7 +598,7 @@ beforeEach(() => {
   runtimeSnapshotModule.clearRuntimeConfigSnapshot();
   vi.mocked(runEmbeddedAgent).mockResolvedValue(createDefaultAgentResult());
   vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
-  vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
+  vi.mocked(readPreparedModelCatalog).mockResolvedValue([]);
   vi.mocked(loadEnabledClaudeBundleCommands).mockReturnValue([]);
   vi.mocked(modelSelectionModule.isCliProvider).mockImplementation(() => false);
   configIoMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
@@ -1782,7 +1782,7 @@ describe("agentCommand", () => {
         runtime,
       );
 
-      expect(loadPreparedModelCatalog).not.toHaveBeenCalled();
+      expect(readPreparedModelCatalog).not.toHaveBeenCalled();
       expectLastRunProviderModel("openrouter", "openrouter/auto");
       const thinkingDefaultCall = vi.mocked(modelSelectionModule.resolveThinkingDefault).mock
         .calls[0]?.[0];

--- a/src/commands/models/list.probe.ollama.test.ts
+++ b/src/commands/models/list.probe.ollama.test.ts
@@ -4,14 +4,14 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildProbeCandidateMap, selectProbeModel } from "./list.probe.models.js";
 
-const loadPreparedModelCatalog = vi.fn(
+const readPreparedModelCatalog = vi.fn(
   async (): Promise<Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>> => [
     { provider: "ollama", id: "llama3.2:latest" },
     { provider: "ollama", id: "gemma4:latest" },
   ],
 );
 
-vi.mock("../../agents/prepared-model-catalog.js", () => ({ loadPreparedModelCatalog }));
+vi.mock("../../agents/prepared-model-catalog.js", () => ({ readPreparedModelCatalog }));
 vi.mock("../../agents/auth-profiles.js", () => ({
   externalCliDiscoveryScoped: () => undefined,
   ensureAuthProfileStore: () => ({ version: 1, profiles: {}, order: {} }),
@@ -73,7 +73,7 @@ const options = {
 };
 
 describe("Ollama probe targets", () => {
-  beforeEach(() => loadPreparedModelCatalog.mockClear());
+  beforeEach(() => readPreparedModelCatalog.mockClear());
 
   it("builds a runtime-auth target for a configured keyless local provider", async () => {
     const cfg = {
@@ -96,7 +96,7 @@ describe("Ollama probe targets", () => {
     });
 
     expect(plan.results).toEqual([]);
-    expect(loadPreparedModelCatalog).toHaveBeenCalledWith(
+    expect(readPreparedModelCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
         readOnly: true,
       }),
@@ -147,7 +147,7 @@ describe("Ollama probe targets", () => {
   });
 
   it("builds an automatic Ollama probe with the first non-retired catalog model", async () => {
-    loadPreparedModelCatalog.mockResolvedValueOnce([
+    readPreparedModelCatalog.mockResolvedValueOnce([
       { provider: "ollama", id: "kimi-k2.5", status: "deprecated" },
       { provider: "ollama", id: "kimi-k2.6" },
     ]);

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -23,7 +23,7 @@ const resolveSecretRefStringMock = vi.fn(async () => "resolved-secret");
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: loadModelCatalogMock,
+  readPreparedModelCatalog: loadModelCatalogMock,
 }));
 vi.mock("../../agents/model-auth.js", () => ({
   hasSyntheticLocalProviderAuthConfig: () => false,

--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -219,7 +219,7 @@ describe("runAuthProbes", () => {
       resolveProviderEntryApiKeyProfileReference: () => ({ kind: "none" }),
     }));
     vi.doMock("../../agents/prepared-model-catalog.js", () => ({
-      loadPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
+      readPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
     }));
     try {
       const module = await importFreshModule<typeof import("./list.probe.js")>(
@@ -356,7 +356,7 @@ describe("runAuthProbes", () => {
       }),
     }));
     vi.doMock("../../agents/prepared-model-catalog.js", () => ({
-      loadPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
+      readPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
     }));
     const providerConfig = {
       baseUrl: "https://api.openai.com/v1",
@@ -459,7 +459,7 @@ describe("runAuthProbes", () => {
       }),
     }));
     vi.doMock("../../agents/prepared-model-catalog.js", () => ({
-      loadPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
+      readPreparedModelCatalog: async () => [{ provider: "openai", id: "gpt-5.5" }],
     }));
     const cfg = {
       models: {

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -45,7 +45,7 @@ import {
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../../agents/model-selection.js";
-import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -385,7 +385,7 @@ export async function buildProbeTargets(params: {
   const providerFilterKey = providerFilter ? normalizeProviderId(providerFilter) : null;
   const profileFilter = new Set(normalizeUniqueStringEntries(options.profileIds));
   const refResolveCache: SecretRefResolveCache = {};
-  const catalog = await loadPreparedModelCatalog({
+  const catalog = await readPreparedModelCatalog({
     config: cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(agentDir ? { agentDir } : {}),

--- a/src/cron/isolated-agent.hook-content-wrapping.test.ts
+++ b/src/cron/isolated-agent.hook-content-wrapping.test.ts
@@ -2,7 +2,7 @@
 import "./isolated-agent.mocks.js";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
-import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { makeCfg } from "./isolated-agent.test-harness.js";
 import {
   DEFAULT_MESSAGE,
@@ -27,7 +27,7 @@ describe("runCronIsolatedAgentTurn hook content wrapping", () => {
   beforeAll(async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.spyOn(isolatedAgentRunRuntime, "resolveThinkingDefault").mockReturnValue("off");
-    vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
+    vi.mocked(readPreparedModelCatalog).mockResolvedValue([]);
     await withTempHome(async (home) => {
       await runCronTurn(home, {
         jobPayload: { kind: "agentTurn", message: "warm runtime" },
@@ -41,7 +41,7 @@ describe("runCronIsolatedAgentTurn hook content wrapping", () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.spyOn(isolatedAgentRunRuntime, "resolveThinkingDefault").mockReturnValue("off");
     vi.mocked(runEmbeddedAgent).mockClear();
-    vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
+    vi.mocked(readPreparedModelCatalog).mockResolvedValue([]);
   });
 
   it("wraps external hook content by default", async () => {

--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -4,7 +4,7 @@
 import "../utils/usage-format.js";
 import { vi } from "vitest";
 
-const loadPreparedModelCatalog = vi.hoisted(() => vi.fn());
+const readPreparedModelCatalog = vi.hoisted(() => vi.fn());
 
 vi.mock("../agents/embedded-agent.js", () => ({
   abortEmbeddedAgentRun: vi.fn().mockReturnValue(false),
@@ -16,15 +16,15 @@ vi.mock("../agents/prepared-model-catalog.js", async () => {
   const { resolveAgentDir, resolveAgentWorkspaceDir, resolveDefaultAgentId } =
     await vi.importActual<typeof import("../agents/agent-scope.js")>("../agents/agent-scope.js");
   return {
-    loadPreparedModelCatalog,
+    readPreparedModelCatalog,
     loadPreparedModelCatalogSnapshot: vi.fn(async (params) => ({
-      entries: (await loadPreparedModelCatalog(params)) ?? [],
+      entries: (await readPreparedModelCatalog(params)) ?? [],
       routeVariants: [],
     })),
     loadProviderScopedThinkingCatalog: vi.fn(
-      async (params) => (await loadPreparedModelCatalog(params)) ?? [],
+      async (params) => (await readPreparedModelCatalog(params)) ?? [],
     ),
-    loadPublishedPreparedModelCatalog: loadPreparedModelCatalog,
+    loadPublishedPreparedModelCatalog: readPreparedModelCatalog,
     publishedModelCatalogOwnerMatchesAgent: (owner: { agentId: string }, agentId: string) =>
       owner.agentId === agentId.trim().toLowerCase(),
     loadResolvedPublishedModelCatalogOwner: vi.fn(
@@ -42,7 +42,7 @@ vi.mock("../agents/prepared-model-catalog.js", async () => {
           workspaceDir: params.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId),
           config,
           modelCatalog: {
-            entries: (await loadPreparedModelCatalog(params)) ?? [],
+            entries: (await readPreparedModelCatalog(params)) ?? [],
             routeVariants: [],
           },
         };

--- a/src/cron/isolated-agent.test-setup.ts
+++ b/src/cron/isolated-agent.test-setup.ts
@@ -2,7 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Isolated agent test setup centralizes common mocks for cron agent tests.
 import { vi } from "vitest";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
-import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { runSubagentAnnounceFlow } from "../agents/subagents/announce/subagent-announce.js";
 import type {
   ChannelOutboundAdapter,
@@ -168,7 +168,7 @@ export function setupIsolatedAgentTurnMocks(params?: { fast?: boolean }): void {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
   }
   vi.mocked(runEmbeddedAgent).mockReset();
-  vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
+  vi.mocked(readPreparedModelCatalog).mockResolvedValue([]);
   vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue("delivered");
   vi.mocked(callGateway).mockReset().mockResolvedValue({ ok: true, deleted: true });
   setActivePluginRegistry(

--- a/src/flows/doctor-core-checks.runtime-errors.test.ts
+++ b/src/flows/doctor-core-checks.runtime-errors.test.ts
@@ -22,7 +22,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: mocks.loadModelCatalog,
+  readPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
 vi.mock("../agents/model-selection.js", async (importOriginal) => ({

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -35,7 +35,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: mocks.loadModelCatalog,
+  readPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
 vi.mock("../agents/model-selection.js", async (importOriginal) => ({

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -24,7 +24,7 @@ import { partitionMcpServersByConnectionScope } from "../agents/mcp-connection-r
 import { findModelInCatalog, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { supportsModelTools } from "../agents/model-tool-support.js";
-import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
+import { readPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { normalizeAgentRuntimeTools } from "../agents/runtime-plan/tools.js";
 import { collectExplicitAllowlist, normalizeToolPolicyName } from "../agents/tool-policy.js";
 import {
@@ -1155,7 +1155,7 @@ export async function collectRuntimeToolSchemaFindings(
       const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
       const collectForAgent = async () => {
         const agentDir = resolveAgentDir(cfg, agentId);
-        const catalog = await loadPreparedModelCatalog({
+        const catalog = await readPreparedModelCatalog({
           config: cfg,
           agentId,
           agentDir,

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -36,7 +36,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: mocks.loadModelCatalog,
+  readPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
 vi.mock("../commands/doctor-gateway-services.js", () => ({

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -512,7 +512,7 @@ const hooksModelCheck: HealthCheck = {
       return [];
     }
     const { DEFAULT_MODEL, DEFAULT_PROVIDER } = await import("../agents/defaults.js");
-    const { loadPreparedModelCatalog } = await import("../agents/prepared-model-catalog.js");
+    const { readPreparedModelCatalog } = await import("../agents/prepared-model-catalog.js");
     const { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel } =
       await import("../agents/model-selection.js");
     const hooksModelRef = resolveHooksGmailModel({
@@ -534,7 +534,7 @@ const hooksModelCheck: HealthCheck = {
       defaultProvider: DEFAULT_PROVIDER,
       defaultModel: DEFAULT_MODEL,
     });
-    const catalog = await loadPreparedModelCatalog({
+    const catalog = await readPreparedModelCatalog({
       config: ctx.cfg,
       readOnly: true,
       providerDiscoveryProviderIds: [],

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -40,7 +40,7 @@ export async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise
     return;
   }
   const { DEFAULT_MODEL, DEFAULT_PROVIDER } = await import("../agents/defaults.js");
-  const { loadPreparedModelCatalog } = await import("../agents/prepared-model-catalog.js");
+  const { readPreparedModelCatalog } = await import("../agents/prepared-model-catalog.js");
   const { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel } =
     await import("../agents/model-selection.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
@@ -54,7 +54,7 @@ export async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const catalog = await loadPreparedModelCatalog({
+  const catalog = await readPreparedModelCatalog({
     config: ctx.cfg,
     readOnly: true,
     providerDiscoveryProviderIds: [],

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -485,7 +485,7 @@ vi.mock("../agents/model-catalog.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: mocks.loadModelCatalog,
+  readPreparedModelCatalog: mocks.loadModelCatalog,
 }));
 
 vi.mock("../agents/model-selection.js", () => ({

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -233,7 +233,7 @@ vi.mock("../infra/update-startup.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: hoisted.loadModelCatalog,
+  readPreparedModelCatalog: hoisted.loadModelCatalog,
 }));
 
 vi.mock("../agents/model-selection.js", () => ({

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -968,7 +968,7 @@ export async function startGatewaySidecars(params: {
         run: async (isStopped) => {
           const [
             { DEFAULT_MODEL, DEFAULT_PROVIDER },
-            { loadPreparedModelCatalog },
+            { readPreparedModelCatalog },
             { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel },
           ] = await Promise.all([
             loadAgentDefaultsModule(),
@@ -989,7 +989,7 @@ export async function startGatewaySidecars(params: {
                 defaultProvider: DEFAULT_PROVIDER,
                 defaultModel: DEFAULT_MODEL,
               });
-            const catalog = await loadPreparedModelCatalog({
+            const catalog = await readPreparedModelCatalog({
               config: params.cfg,
               readOnly: true,
             });

--- a/src/media-understanding/runner.auto-selection.test.ts
+++ b/src/media-understanding/runner.auto-selection.test.ts
@@ -29,7 +29,7 @@ vi.mock("../plugins/capability-provider-runtime.js", () => ({
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: async () => [],
-  loadPreparedModelCatalog: async () => [],
+  readPreparedModelCatalog: async () => [],
 }));
 
 beforeEach(() => {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -83,7 +83,7 @@ export {
 type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 type ModelCatalogApi = typeof import("../agents/model-catalog.js") &
   typeof import("../agents/prepared-model-catalog.js");
-type ModelCatalog = Awaited<ReturnType<ModelCatalogApi["loadPreparedModelCatalog"]>>;
+type ModelCatalog = Awaited<ReturnType<ModelCatalogApi["readPreparedModelCatalog"]>>;
 
 type RunCapabilityResult = {
   outputs: MediaUnderstandingOutput[];
@@ -219,9 +219,9 @@ async function explicitImageModelVisionStatus(params: {
   if (configured?.id?.trim() === params.model && configured.input?.includes("image")) {
     return "supported";
   }
-  const { findModelInCatalog, loadPreparedModelCatalog, modelSupportsVision } =
+  const { findModelInCatalog, readPreparedModelCatalog, modelSupportsVision } =
     await loadPreparedModelCatalogApi();
-  const catalog = await loadPreparedModelCatalog({
+  const catalog = await readPreparedModelCatalog({
     config: params.cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
@@ -282,8 +282,8 @@ async function resolveAutoImageModelId(params: {
   if (bundledDefaultModel) {
     return bundledDefaultModel;
   }
-  const { loadPreparedModelCatalog, modelSupportsVision } = await loadPreparedModelCatalogApi();
-  const catalog = await loadPreparedModelCatalog({
+  const { readPreparedModelCatalog, modelSupportsVision } = await loadPreparedModelCatalogApi();
+  const catalog = await readPreparedModelCatalog({
     config: params.cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
@@ -449,9 +449,9 @@ async function activeModelSupportsNativeVision(params: {
   ) {
     return false;
   }
-  const { findModelInCatalog, loadPreparedModelCatalog, modelSupportsVision } =
+  const { findModelInCatalog, readPreparedModelCatalog, modelSupportsVision } =
     await loadPreparedModelCatalogApi();
-  const catalog = await loadPreparedModelCatalog({
+  const catalog = await readPreparedModelCatalog({
     config: params.cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -62,7 +62,7 @@ vi.mock("../agents/model-catalog.js", async () => {
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: loadModelCatalog,
+  readPreparedModelCatalog: loadModelCatalog,
 }));
 
 let buildProviderRegistry: typeof import("./runner.js").buildProviderRegistry;
@@ -105,7 +105,7 @@ function setCompatibleActiveMediaUnderstandingRegistry(
 describe("runCapability image skip", () => {
   beforeAll(async () => {
     vi.doMock("../agents/prepared-model-catalog.js", () => {
-      return { loadPreparedModelCatalog: loadModelCatalog };
+      return { readPreparedModelCatalog: loadModelCatalog };
     });
     ({ buildProviderRegistry, resolveAutoImageModel, runCapability } = await import("./runner.js"));
     ({ applyMediaUnderstanding } = await import("./apply.js"));

--- a/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
+++ b/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   getPreparedModelCatalogSnapshot: (...args: unknown[]) => mocks.getSnapshot(...args),
-  loadPreparedModelCatalog: (...args: unknown[]) => mocks.loadCatalog(...args),
+  readPreparedModelCatalog: (...args: unknown[]) => mocks.loadCatalog(...args),
 }));
 
 import {

--- a/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
+++ b/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
@@ -14,6 +14,7 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
 
 import {
   loadModelCatalog,
+  loadPreparedModelCatalog,
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "openclaw/plugin-sdk/agent-runtime";
 
@@ -52,6 +53,27 @@ describe("agent-runtime model catalog compatibility", () => {
     ).rejects.toBe(failure);
   });
 
+  it.each([
+    ["prepared", loadPreparedModelCatalog],
+    ["legacy", loadModelCatalog],
+  ] as const)("preserves the writable default of the %s SDK loader", async (_name, load) => {
+    const entries = [{ provider: "test", id: "discovered", name: "Discovered" }];
+    mocks.loadCatalog.mockResolvedValue(entries);
+
+    await expect(load()).resolves.toBe(entries);
+    expect(mocks.loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+    expect(mocks.getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("preserves explicit readOnly:%s in the SDK loader", async (readOnly) => {
+    const config = {};
+    const entries = [{ provider: "test", id: "selected", name: "Selected" }];
+    mocks.loadCatalog.mockResolvedValue(entries);
+
+    await expect(loadPreparedModelCatalog({ config, readOnly })).resolves.toBe(entries);
+    expect(mocks.loadCatalog).toHaveBeenCalledExactlyOnceWith({ config, readOnly });
+  });
+
   it("keeps legacy cache-only reads nonblocking", async () => {
     mocks.getSnapshot.mockReturnValue({
       entries: [{ provider: "test", id: "cached", name: "Cached" }],
@@ -69,7 +91,10 @@ describe("agent-runtime model catalog compatibility", () => {
     mocks.loadCatalog.mockResolvedValue(entries);
 
     await expect(loadModelCatalog({ refreshFullCatalog: true })).resolves.toBe(entries);
-    expect(mocks.loadCatalog).toHaveBeenCalledExactlyOnceWith({ refreshFullCatalog: true });
+    expect(mocks.loadCatalog).toHaveBeenCalledExactlyOnceWith({
+      readOnly: false,
+      refreshFullCatalog: true,
+    });
     expect(mocks.getSnapshot).not.toHaveBeenCalled();
   });
 

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -1,7 +1,7 @@
 import { resolveThinkingDefaultWithRuntimeCatalogCore } from "../agents/model-thinking-default.js";
 import {
   getPreparedModelCatalogSnapshot,
-  loadPreparedModelCatalog,
+  loadPreparedModelCatalog as readPreparedModelCatalog,
   type LoadPreparedModelCatalogParams,
 } from "../agents/prepared-model-catalog.js";
 /**
@@ -34,7 +34,12 @@ export {
 export { resolveApiKeyForProviderCore as resolveApiKeyForProvider } from "../agents/model-auth.js";
 export { findModelInCatalog, modelSupportsVision } from "../agents/model-catalog.js";
 export type { ModelCatalogEntry } from "../agents/model-catalog.js";
-export { getPreparedModelCatalogSnapshot, loadPreparedModelCatalog };
+export { getPreparedModelCatalogSnapshot };
+
+/** Preserves the public SDK's writable default while internal catalog reads stay passive. */
+export async function loadPreparedModelCatalog(params: LoadPreparedModelCatalogParams = {}) {
+  return await readPreparedModelCatalog({ ...params, readOnly: params.readOnly ?? false });
+}
 
 type LoadModelCatalogCompatibilityParams = LoadPreparedModelCatalogParams & {
   /** @deprecated Lifecycle publication owns refreshes; retained for source compatibility. */

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -1,7 +1,7 @@
 import { resolveThinkingDefaultWithRuntimeCatalogCore } from "../agents/model-thinking-default.js";
 import {
   getPreparedModelCatalogSnapshot,
-  loadPreparedModelCatalog as readPreparedModelCatalog,
+  readPreparedModelCatalog,
   type LoadPreparedModelCatalogParams,
 } from "../agents/prepared-model-catalog.js";
 /**

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -23,7 +23,7 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   // These tests exercise the TUI boundary, not filesystem-backed catalog discovery.
   getPreparedModelCatalogSnapshot: vi.fn(() => undefined),
-  loadPreparedModelCatalog: vi.fn(async () => []),
+  readPreparedModelCatalog: vi.fn(async () => []),
 }));
 
 vi.mock("./verified-inference.js", async (importOriginal) => {
@@ -256,7 +256,7 @@ describe("runSystemAgentTui", () => {
 
   it("opens the verified setup shell without preparing an unpublished model catalog", async () => {
     const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
-    const catalogPreparation = vi.mocked(preparedModelCatalog.loadPreparedModelCatalog);
+    const catalogPreparation = vi.mocked(preparedModelCatalog.readPreparedModelCatalog);
     const publishedSnapshot = vi
       .spyOn(preparedModelCatalog, "getPreparedModelCatalogSnapshot")
       .mockReturnValue(undefined);

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -244,7 +244,7 @@ vi.mock("../agents/model-selection.js", () => ({
 }));
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalog: (params?: LoadPreparedModelCatalogParams) =>
+  readPreparedModelCatalog: (params?: LoadPreparedModelCatalogParams) =>
     loadPreparedModelCatalogMock(params),
   withPreparedModelCatalogOwner: (...args: Parameters<typeof withPreparedModelCatalogOwnerMock>) =>
     withPreparedModelCatalogOwnerMock(...args),

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -25,7 +25,7 @@ import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-questi
 import { resolveThinkingDefault } from "../agents/model-selection.js";
 import { resolvePublishedModelCatalogOwner } from "../agents/prepared-model-catalog-owner.js";
 import {
-  loadPreparedModelCatalog,
+  readPreparedModelCatalog,
   withPreparedModelCatalogOwner,
 } from "../agents/prepared-model-catalog.js";
 import { getPreparedModelRuntimeAuthMaterializations } from "../agents/prepared-model-runtime-auth.js";
@@ -664,7 +664,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const catalog = await loadPreparedModelCatalog({
+      const catalog = await readPreparedModelCatalog({
         config: cfg,
         agentId: sessionAgentId,
         readOnly: true,
@@ -756,7 +756,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           agentId: target.agentId,
           patch: opts,
           loadGatewayModelCatalog: () =>
-            loadPreparedModelCatalog({ config: cfg, agentId: target.agentId, readOnly: true }),
+            readPreparedModelCatalog({ config: cfg, agentId: target.agentId, readOnly: true }),
         }),
     });
     if (!applied.ok) {
@@ -808,7 +808,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       emitCommandHooks: Boolean(opts.parentSessionKey),
       commandSource: "tui:embedded",
       loadGatewayModelCatalog: () =>
-        loadPreparedModelCatalog({
+        readPreparedModelCatalog({
           config: cfg,
           agentId: resolveSessionAgentId({
             sessionKey: opts.key,

--- a/test/e2e/qa-lab/media/vision-routing-core.e2e.test.ts
+++ b/test/e2e/qa-lab/media/vision-routing-core.e2e.test.ts
@@ -29,7 +29,7 @@ const preparedVisionCatalog = vi.hoisted(() => [
 
 vi.mock("../../../../src/agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: vi.fn(async () => preparedVisionCatalog),
+  readPreparedModelCatalog: vi.fn(async () => preparedVisionCatalog),
 }));
 
 vi.mock("../../../../src/plugins/capability-provider-runtime.js", () => ({

--- a/test/helpers/auto-reply/trigger-handling-test-harness.ts
+++ b/test/helpers/auto-reply/trigger-handling-test-harness.ts
@@ -122,7 +122,7 @@ const DEFAULT_MODEL_CATALOG = [
 
 const modelCatalogMocks = getSharedMocks("openclaw.trigger-handling.model-catalog-mocks", () => ({
   loadManifestModelCatalog: vi.fn(() => DEFAULT_MODEL_CATALOG),
-  loadPreparedModelCatalog: vi.fn().mockResolvedValue(DEFAULT_MODEL_CATALOG),
+  readPreparedModelCatalog: vi.fn().mockResolvedValue(DEFAULT_MODEL_CATALOG),
 }));
 
 const installModelCatalogMock = () =>
@@ -131,24 +131,24 @@ const installModelCatalogMock = () =>
 installModelCatalogMock();
 
 vi.doMock("../../../src/agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalog: (...args: unknown[]) =>
-    modelCatalogMocks.loadPreparedModelCatalog(...args),
+  readPreparedModelCatalog: (...args: unknown[]) =>
+    modelCatalogMocks.readPreparedModelCatalog(...args),
   loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
-    const entries = await modelCatalogMocks.loadPreparedModelCatalog(...args);
+    const entries = await modelCatalogMocks.readPreparedModelCatalog(...args);
     return { entries, routeVariants: entries, authoritative: true };
   },
 }));
 
 vi.doMock("../../../src/agents/model-catalog.runtime.js", () => ({
   loadManifestModelCatalog: () => modelCatalogMocks.loadManifestModelCatalog(),
-  loadPreparedModelCatalog: (...args: unknown[]) =>
-    modelCatalogMocks.loadPreparedModelCatalog(...args),
+  readPreparedModelCatalog: (...args: unknown[]) =>
+    modelCatalogMocks.readPreparedModelCatalog(...args),
   loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
-    const entries = await modelCatalogMocks.loadPreparedModelCatalog(...args);
+    const entries = await modelCatalogMocks.readPreparedModelCatalog(...args);
     return { entries, routeVariants: entries, authoritative: true };
   },
   loadProviderScopedThinkingCatalog: async (...args: unknown[]) =>
-    await modelCatalogMocks.loadPreparedModelCatalog(...args),
+    await modelCatalogMocks.readPreparedModelCatalog(...args),
 }));
 
 vi.doMock("../../../src/plugins/provider-runtime.runtime.js", () => ({


### PR DESCRIPTION
Related: #142557.

## What Problem This Solves

Fixes a public developer-interface regression from #142557 where ordinary catalog loads became passive and existing plugins stopped receiving discovered models.

## Why This Change Was Made

Restore the writable default at one public wrapper shared by the preferred and legacy loaders. Explicit read-only values pass through, internal reads remain passive, and refresh and cache-only behavior are preserved. Rename the internal reader and update its callers.

## User Impact

Existing plugin catalog calls discover models again when options are omitted. Explicit passive reads still avoid discovery. No credential policy or stored-format change.

Consumers: preferred and legacy public catalog loaders regain their writable default; internal readers stay passive.

## Evidence

Six focused public-interface checks passed. Compiled package exports made no requests for explicit read-only calls, then discovered the model for omitted options in both warm and cold cases. Configuration and defaults were unchanged. An unrelated native-command timeout remained; no full release-upgrade run was performed.
