### PR TITLE
fix(models): isolate catalog refresh failures across source changes

### DIFF
--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -70,7 +70,7 @@ const limitFullModelCatalogBuild = pLimit(MAX_CONCURRENT_FULL_MODEL_CATALOG_BUIL
 export type PreparedModelRuntimeBuildCandidate = Readonly<{
   input: PreparedModelRuntimeInput;
   catalogOwner: PreparedModelRuntimeSnapshot["catalogOwner"];
-  inventoryOwner?: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttemptError">;
+  inventoryOwner?: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttempt">;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;
   prepareInboundPluginRegistry?: boolean;
   isGenerationCurrent?: () => boolean;
@@ -138,7 +138,7 @@ function createFullModelCatalogAccess(params: {
   pluginGeneration: PreparedModelRuntimePluginGeneration;
   agentBuildCompletions: Map<string, Promise<void>>;
   isCurrent: () => boolean;
-  inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttemptError">;
+  inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttempt">;
 }): PreparedModelRuntimeCatalogAccess {
   // Retain discovery, not the retired worker or its runtime capability projection.
   const project = (
@@ -189,9 +189,13 @@ function createFullModelCatalogAccess(params: {
     params.agentFacts.env,
   );
   const previousInventory = params.inventoryOwner.catalogInventory;
-  const attempt = createCatalogAttemptReporter(params.inventoryOwner, params.isCurrent);
   const pluginFingerprint = resolveInstalledManifestRegistryIndexFingerprint(
     params.pluginGeneration.pluginMetadataSnapshot.index,
+  );
+  const attempt = createCatalogAttemptReporter(
+    params.inventoryOwner,
+    { key: inventoryKey, pluginFingerprint, credentials: params.agentFacts.credentials },
+    params.isCurrent,
   );
   let inventory =
     previousInventory?.key === inventoryKey &&

--- a/src/agents/prepared-model-runtime.publication-events.ts
+++ b/src/agents/prepared-model-runtime.publication-events.ts
@@ -1,8 +1,12 @@
+import { isDeepStrictEqual } from "node:util";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
-import type { PreparedModelRuntimeOwner } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelCatalogAttempt,
+  PreparedModelRuntimeOwner,
+} from "./prepared-model-runtime.types.js";
 
 const log = createSubsystemLogger("agents/prepared-model-runtime");
 
@@ -14,33 +18,41 @@ const publicationListeners = new Set<(event: PreparedModelRuntimePublicationEven
 
 /** Completes catalog attempts without withdrawing their prepared turn runtime. */
 export function createCatalogAttemptReporter(
-  owner: Pick<PreparedModelRuntimeOwner, "catalogAttemptError">,
+  owner: Pick<PreparedModelRuntimeOwner, "catalogAttempt">,
+  source: PreparedModelCatalogAttempt["source"],
   isCurrent: () => boolean,
 ): {
   published: () => void;
   failed: (error: unknown) => never;
   withRefreshStatus: (catalog: ModelCatalogSnapshot) => ModelCatalogSnapshot;
 } {
+  // Compatible reloads share live status; replacement sources start without the old error.
+  const attempt: PreparedModelCatalogAttempt =
+    owner.catalogAttempt && isDeepStrictEqual(owner.catalogAttempt.source, source)
+      ? owner.catalogAttempt
+      : { source };
   return {
     withRefreshStatus: (catalog) => {
       // Keep the status live on retained inventory without copying an error into its successor.
       Object.defineProperty(catalog, "refreshFailed", {
         enumerable: true,
         get: () =>
-          owner.catalogAttemptError !== undefined ||
+          attempt.error !== undefined ||
           catalog.providerOutcomes?.some((outcome) => outcome.status !== "ready") ||
           undefined,
       });
       return catalog;
     },
     published: () => {
-      delete owner.catalogAttemptError;
+      delete attempt.error;
+      owner.catalogAttempt = attempt;
       notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
     },
     failed: (error) => {
       if (isCurrent() && !(error instanceof PreparedModelRuntimePublicationSupersededError)) {
         const attemptError = toStringifiedError(error);
-        owner.catalogAttemptError = attemptError;
+        attempt.error = attemptError;
+        owner.catalogAttempt = attempt;
         notifyPreparedModelRuntimePublication({ phase: "catalog-failed", error: attemptError });
       }
       throw error;

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -33,6 +33,53 @@ describe("prepared model runtime reload auth adoption", () => {
     await resetPreparedModelRuntimeHarness(state);
   });
 
+  it("keeps catalog failure status when a neutral reload retains the same source", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://first.invalid/v1",
+            api: "openai-completions" as const,
+            models: [],
+          },
+        },
+      },
+    };
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config,
+    };
+    const original = await prepareModelRuntimeSnapshot(input);
+    if (!original.loadFullModelCatalog) {
+      throw new Error("catalog source diagnostic requires a full catalog loader");
+    }
+    await original.loadFullModelCatalog();
+    const failure = new Error("same source failed to refresh");
+    mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
+    await expect(original.loadFullModelCatalog({ refresh: true })).rejects.toBe(failure);
+    const replacementConfig = { ...config, logging: { level: "debug" as const } };
+    await refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const replacement = await prepareModelRuntimeSnapshot({ ...input, config: replacementConfig });
+    expect(replacement.isCurrent()).toBe(true);
+    expect(replacement.modelCatalog.refreshFailed).toBe(true);
+    if (!replacement.loadFullModelCatalog) {
+      throw new Error("expected the replacement catalog loader");
+    }
+    await replacement.loadFullModelCatalog({ refresh: true });
+    expect(replacement.modelCatalog.refreshFailed).toBeUndefined();
+    expect(original.modelCatalog.refreshFailed).toBeUndefined();
+  });
+
   it("records failed catalog attempts without withdrawing published runtime", async () => {
     mocks.configuredAgentIds = ["default"];
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
@@ -75,7 +122,7 @@ describe("prepared model runtime reload auth adoption", () => {
       expect
         .soft(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))
         .toBe(dispatch);
-      expect.soft(owner.catalogAttemptError).toBe(failure);
+      expect.soft(owner.catalogAttempt?.error).toBe(failure);
       expect.soft(snapshot.modelCatalog.refreshFailed).toBe(true);
       expect.soft(original.refreshFailed).toBe(true);
       expect.soft(events).toContainEqual({ phase: "catalog-failed", error: failure });
@@ -117,7 +164,7 @@ describe("prepared model runtime reload auth adoption", () => {
       if (!owner.catalogInventory) {
         throw new Error("catalog attempt test lost its internal inventory after recovery");
       }
-      expect.soft(owner.catalogAttemptError).toBeUndefined();
+      expect.soft(owner.catalogAttempt?.error).toBeUndefined();
       expect.soft(snapshot.modelCatalog.refreshFailed).toBeUndefined();
       expect.soft(snapshot.readFullModelCatalog()?.refreshFailed).toBeUndefined();
     } finally {
@@ -148,13 +195,13 @@ describe("prepared model runtime reload auth adoption", () => {
     const failure = new Error("first catalog attempt failed");
     mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
     await expect(snapshot.loadFullModelCatalog()).rejects.toBe(failure);
-    expect(owner.catalogAttemptError).toBe(failure);
+    expect(owner.catalogAttempt?.error).toBe(failure);
     expect(snapshot.modelCatalog.refreshFailed).toBe(true);
     expect(owner.catalogInventory).toBeUndefined();
     expect(snapshot.readFullModelCatalog()).toBeUndefined();
     expect(snapshot.isCurrent()).toBe(true);
     await snapshot.loadFullModelCatalog();
-    expect(owner.catalogAttemptError).toBeUndefined();
+    expect(owner.catalogAttempt?.error).toBeUndefined();
     expect(snapshot.modelCatalog.refreshFailed).toBeUndefined();
     expect(snapshot.readFullModelCatalog()).toBeDefined();
   });
@@ -203,7 +250,7 @@ describe("prepared model runtime reload auth adoption", () => {
       result.reject(failure);
       await rejected;
       await replacement;
-      expect(owner.catalogAttemptError).toBeUndefined();
+      expect(owner.catalogAttempt?.error).toBeUndefined();
       expect(events).not.toContain("catalog-failed");
     } finally {
       result.reject(failure);

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -27,6 +27,7 @@ import {
 import { markPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import {
   getPreparedModelRuntimeSnapshot,
+  prepareModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
 
@@ -58,6 +59,113 @@ describe("prepared model runtime scoped refresh", () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
     await resetPreparedModelRuntimeHarness(state);
   });
+
+  it.each(["warm", "cold"] as const)(
+    "does not carry catalog failure status from a %s source into its replacement",
+    async (inventoryState) => {
+      mocks.configuredAgentIds = ["default"];
+      const config = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://first.invalid/v1",
+              api: "openai-completions" as const,
+              models: [],
+            },
+          },
+        },
+      };
+      await refreshPreparedModelRuntimeSnapshots(config, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+      });
+      const input = {
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
+        config,
+      };
+      const original = await prepareModelRuntimeSnapshot(input);
+      if (!original.loadFullModelCatalog) {
+        throw new Error("catalog source diagnostic requires a full catalog loader");
+      }
+      if (inventoryState === "warm") {
+        await original.loadFullModelCatalog();
+      }
+      const failure = new Error("previous source failed to refresh");
+      mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
+      await expect(original.loadFullModelCatalog({ refresh: true })).rejects.toBe(failure);
+      expect(original.modelCatalog.refreshFailed).toBe(true);
+
+      const replacementConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://second.invalid/v1",
+              api: "openai-completions" as const,
+              models: [],
+            },
+          },
+        },
+      };
+      await refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+      });
+      const replacement = await prepareModelRuntimeSnapshot({
+        ...input,
+        config: replacementConfig,
+      });
+      expect(replacement).not.toBe(original);
+      expect(replacement.isCurrent()).toBe(true);
+      expect(replacement.modelCatalog.refreshFailed).toBeUndefined();
+    },
+  );
+
+  it.each(["credentials", "plugins"] as const)(
+    "does not carry a cold catalog failure into replacement %s",
+    async (change) => {
+      mocks.configuredAgentIds = ["default"];
+      const originalIndex = mocks.pluginMetadataSnapshot.index;
+      mocks.pluginMetadataSnapshot.index = { ...originalIndex };
+      const input = {
+        agentId: "default",
+        agentDir: state.agentDir("default"),
+        inheritedAuthDir: state.agentDir("default"),
+        config: {},
+      };
+      const options = { gatewayLifecycle: true, catalogMode: "static" as const };
+      try {
+        await refreshPreparedModelRuntimeSnapshots(input.config, options);
+        const original = await prepareModelRuntimeSnapshot(input);
+        if (!original.loadFullModelCatalog) {
+          throw new Error("expected the original catalog loader");
+        }
+        const failure = new Error("first catalog attempt failed");
+        mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
+        await expect(original.loadFullModelCatalog()).rejects.toBe(failure);
+        expect(original.modelCatalog.refreshFailed).toBe(true);
+        expect(original.readFullModelCatalog?.()).toBeUndefined();
+
+        if (change === "credentials") {
+          mocks.authStorage.getAll.mockReturnValue({
+            custom: { type: "api_key", key: "replacement-key" },
+          });
+        } else {
+          Object.assign(mocks.pluginMetadataSnapshot.index, {
+            hostContractVersion: "replacement",
+          });
+        }
+        await refreshPreparedModelRuntimeSnapshots(input.config, options);
+        const replacement = await prepareModelRuntimeSnapshot(input);
+        expect(replacement.isCurrent()).toBe(true);
+        expect(replacement.modelCatalog.refreshFailed).toBeUndefined();
+        expect(replacement.readFullModelCatalog?.()).toBeUndefined();
+      } finally {
+        mocks.pluginMetadataSnapshot.index = originalIndex;
+      }
+    },
+  );
 
   it.each([undefined, "provider-a:default"])(
     "retains failed-provider inventory and variants until authoritative recovery (%s)",

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -7,6 +7,7 @@ import type { PreparedProviderStaticCatalog } from "../plugins/provider-discover
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
+import type { AgentCredentialMap } from "./agent-auth-credentials.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import type { AgentHarnessPluginSelection } from "./harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
@@ -174,6 +175,15 @@ export type PreparedModelCatalogInventory = {
   discoveryOrigins: readonly { provider: string; profileId?: string }[];
 };
 
+export type PreparedModelCatalogAttempt = {
+  source: {
+    key: string;
+    pluginFingerprint: string;
+    credentials: Readonly<AgentCredentialMap>;
+  };
+  error?: Error;
+};
+
 export type PreparedModelRuntimeOwner = {
   input: PreparedModelRuntimeInput;
   catalogOwner: PublishedModelCatalogOwnerCandidate["catalogOwner"];
@@ -185,8 +195,8 @@ export type PreparedModelRuntimeOwner = {
   catalogStale: boolean;
   /** Completed discovery facts; runtime capability projection belongs to each generation. */
   catalogInventory?: PreparedModelCatalogInventory;
-  /** Last failed catalog attempt; it does not withdraw the published turn runtime. */
-  catalogAttemptError?: Error;
+  /** Source-bound attempt status, including failure before any inventory was published. */
+  catalogAttempt?: PreparedModelCatalogAttempt;
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -7,13 +7,12 @@ import type { PreparedProviderStaticCatalog } from "../plugins/provider-discover
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
-import type { AgentCredentialMap } from "./agent-auth-credentials.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import type { AgentHarnessPluginSelection } from "./harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import type { PublishedModelCatalogOwnerCandidate } from "./prepared-model-catalog.types.js";
 import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
-import type { AuthStorage } from "./sessions/auth-storage.js";
+import type { AuthStorage, AuthStorageData } from "./sessions/auth-storage.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
 export type PreparedModelRuntimeCatalogMode = "live" | "static";
@@ -179,7 +178,7 @@ export type PreparedModelCatalogAttempt = {
   source: {
     key: string;
     pluginFingerprint: string;
-    credentials: Readonly<AgentCredentialMap>;
+    credentials: Readonly<AuthStorageData>;
   };
   error?: Error;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a catalog refresh failure remained visible after changing the provider endpoint. The replacement catalog dropped the previous source's learned models but still reported `refreshFailed: true` until another refresh succeeded.

## Why This Change Was Made

Catalog attempt status now belongs to its captured source, plugin generation and prepared credentials. Compatible reloads share that status; a replacement source starts without the previous error. This replaces the unscoped error field while preserving failed first attempts, retained inventory, current-generation checks and the original error value.

## User Impact

A new catalog source no longer inherits an unrelated refresh warning. A logging-only reload keeps the warning for the same source until a successful refresh clears it.

## Evidence

- The public baseline reproduced the stale warning after an endpoint-only hot reload on the same Gateway.
- The compiled candidate passes warm failure, neutral reload, source replacement and recovery through the public Gateway interface. Independent source-blind acceptance passes all six clauses, including one fresh cold first-attempt failure and recovery sequence.
- All 45 focused runtime reload and scoped-refresh tests passed. The five added scenarios passed again after placement in the existing suites. Formatting and scoped lint passed.
- [Required CI passed](https://github.com/openclaw/openclaw/actions/runs/34285022508) for `b41792da7118a37137071607aef27fd39e269755`. Public proof used its actual CI merge build, `1b284af37e091fab9fc58297e4478a0f701ed6fd`.

Proof uses synthetic backend fixtures. It does not claim native-client, browser, account-policy or inference coverage.

AI-assisted.
