### PR TITLE
refactor(skills): unify package spec normalization

### DIFF
--- a/src/skills/loading/frontmatter.ts
+++ b/src/skills/loading/frontmatter.ts
@@ -65,37 +65,18 @@ function normalizeSafeNpmSpec(raw: unknown): string | undefined {
   return spec;
 }
 
-function normalizeSafeGoModule(raw: unknown): string | undefined {
+function normalizeSafePackageSpec(raw: unknown, pattern: RegExp): string | undefined {
   if (typeof raw !== "string") {
     return undefined;
   }
-  const moduleSpec = raw.trim();
-  if (
-    !moduleSpec ||
-    moduleSpec.startsWith("-") ||
-    moduleSpec.includes("\\") ||
-    moduleSpec.includes("://")
-  ) {
+  const value = raw.trim();
+  if (!value || value.startsWith("-") || value.includes("\\") || value.includes("://")) {
     return undefined;
   }
-  if (!GO_MODULE_PATTERN.test(moduleSpec)) {
+  if (!pattern.test(value)) {
     return undefined;
   }
-  return moduleSpec;
-}
-
-function normalizeSafeUvPackage(raw: unknown): string | undefined {
-  if (typeof raw !== "string") {
-    return undefined;
-  }
-  const pkg = raw.trim();
-  if (!pkg || pkg.startsWith("-") || pkg.includes("\\") || pkg.includes("://")) {
-    return undefined;
-  }
-  if (!UV_PACKAGE_PATTERN.test(pkg)) {
-    return undefined;
-  }
-  return pkg;
+  return value;
 }
 
 function normalizeSafeDownloadUrl(raw: unknown): string | undefined {
@@ -147,12 +128,12 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
       spec.package = pkg;
     }
   } else if (spec.kind === "uv") {
-    const pkg = normalizeSafeUvPackage(raw.package);
+    const pkg = normalizeSafePackageSpec(raw.package, UV_PACKAGE_PATTERN);
     if (pkg) {
       spec.package = pkg;
     }
   }
-  const moduleSpec = normalizeSafeGoModule(raw.module);
+  const moduleSpec = normalizeSafePackageSpec(raw.module, GO_MODULE_PATTERN);
   if (moduleSpec) {
     spec.module = moduleSpec;
   }


### PR DESCRIPTION
## What Problem This Solves

Skill install metadata repeats the same safety checks for Go module and UV package specifications. Keeping those guards separate creates avoidable maintenance drift.

## Why This Change Was Made

This maintainer-requested refactor uses one private normalizer with the existing, distinct Go and UV patterns. It preserves guard order, trimming, required fields, and installer selection. Other installer grammars and invocation policy are unchanged.

## User Impact

No intended behavior or public API change. No new configuration, storage, dependencies, exports, or tests.

## Evidence

- The same grouped command passed 61 distinct selected cases both before and after the change: 27 frontmatter cases and 34 lifecycle cases, with no skips. Baseline and candidate used separate physical Testbox leases.
- Candidate source `2e5159ad9dcfcba11fdb1dd7b948e47854eba7ed` was verified against its full tracked tree and file modes before and after execution.
- The actual changed-file gate passed for `src/skills/loading/frontmatter.ts`, including core and core-test typechecks, dead-code scans, targeted lint, import-cycle checks, and the selected guards.
- Targeted formatting, diff checks, and changed-file dry-run passed. Independent review found no actionable P0-P2 issue in the exact patch.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34284347141
- Candidate Testbox run: https://github.com/openclaw/openclaw/actions/runs/34284316241
- Lifecycle fallback/cache cases inject metadata and provide downstream smoke, not parser or live-install proof. UV-negative and explicit nonstring/trim coverage gaps remain. No standalone build or live installation is claimed.
