### PR TITLE
fix(feishu): preserve native rich-text inline styles

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2653,6 +2653,33 @@ describe("handleFeishuMessage command authorization", () => {
     expect(parseFeishuMessageEvent(event).content).toBe("Direct task\nStatus\nOpen");
   });
 
+  it("preserves native post inline styles in the agent body", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const event = createFeishuTestEvent({
+      messageId: "msg-post-styles",
+      senderOpenId: "ou-styles",
+      messageType: "post",
+      content: JSON.stringify({
+        content: [
+          [
+            { tag: "text", text: "Urgent", style: ["bold"] },
+            { tag: "text", text: " " },
+            { tag: "a", text: "Docs", href: "https://example.com", style: ["italic"] },
+            { tag: "text", text: " " },
+            { tag: "at", user_name: "Bob", user_id: "ou_bob", style: ["underline"] },
+          ],
+        ],
+      }),
+    });
+
+    await dispatchMessage({ cfg: createFeishuTestConfig({ dmPolicy: "open" }), event });
+
+    const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.BodyForAgent).toContain(
+      "ou-styles: **Urgent** *[Docs](https://example.com)* <u>@Bob</u>",
+    );
+  });
+
   it("expands merge_forward content from API sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockGetMessageFeishu.mockResolvedValueOnce({

--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -1,5 +1,6 @@
 // Feishu tests cover post plugin behavior.
 import { describe, expect, it } from "vitest";
+import { parseFeishuMarkdown } from "./markdown.js";
 import { parsePostContent } from "./post.js";
 
 describe("parsePostContent", () => {
@@ -8,15 +9,15 @@ describe("parsePostContent", () => {
       title: "Daily *Plan*",
       content: [
         [
-          { tag: "text", text: "Bold", style: { bold: true } },
+          { tag: "text", text: "Bold", style: ["bold"] },
           { tag: "text", text: " " },
-          { tag: "text", text: "Italic", style: { italic: true } },
+          { tag: "text", text: "Italic", style: ["italic"] },
           { tag: "text", text: " " },
-          { tag: "text", text: "Underline", style: { underline: true } },
+          { tag: "text", text: "Underline", style: ["underline"] },
           { tag: "text", text: " " },
-          { tag: "text", text: "Strike", style: { strikethrough: true } },
+          { tag: "text", text: "Strike", style: ["lineThrough"] },
           { tag: "text", text: " " },
-          { tag: "text", text: "Code", style: { code: true, bold: true } },
+          { tag: "code", text: "Code" },
         ],
       ],
     });
@@ -28,6 +29,69 @@ describe("parsePostContent", () => {
     );
     expect(result.attachments).toStrictEqual([]);
     expect(result.mentionedOpenIds).toStrictEqual([]);
+  });
+
+  it.each([
+    { style: ["bold"], expected: "**x \\* y** **[Docs](https://example.com)** **@Alice**" },
+    { style: ["italic"], expected: "*x \\* y* *[Docs](https://example.com)* *@Alice*" },
+    {
+      style: ["underline"],
+      expected: "<u>x \\* y</u> <u>[Docs](https://example.com)</u> <u>@Alice</u>",
+    },
+    { style: ["lineThrough"], expected: "~~x \\* y~~ ~~[Docs](https://example.com)~~ ~~@Alice~~" },
+    {
+      style: ["lineThrough", "bold", "italic"],
+      expected: "~~***x \\* y***~~ ~~***[Docs](https://example.com)***~~ ~~***@Alice***~~",
+    },
+    { style: [], expected: "x \\* y [Docs](https://example.com) @Alice" },
+  ])("preserves native inline styles $style", ({ style, expected }) => {
+    const result = parsePostContent(
+      JSON.stringify({
+        content: [
+          [
+            { tag: "text", text: "x * y", style },
+            { tag: "text", text: " " },
+            { tag: "a", text: "Docs", href: "https://example.com", style },
+            { tag: "text", text: " " },
+            { tag: "at", user_name: "Alice", user_id: "ou_alice", style },
+          ],
+        ],
+      }),
+    );
+
+    expect(result.textContent).toBe(expected);
+    expect(result.mentionedOpenIds).toEqual(["ou_alice"]);
+    expect(result.attachments).toEqual([]);
+  });
+
+  it.each([
+    { style: "bold", nodeType: "strong" },
+    { style: "italic", nodeType: "emphasis" },
+  ])("keeps boundary whitespace outside $style delimiters", ({ style, nodeType }) => {
+    const result = parsePostContent(
+      JSON.stringify({
+        content: [
+          [
+            { tag: "text", text: "Before" },
+            { tag: "text", text: " styled ", style: [style] },
+            { tag: "text", text: "after" },
+          ],
+        ],
+      }),
+    );
+
+    expect(parseFeishuMarkdown(result.textContent)).toMatchObject({
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            { type: "text", value: "Before " },
+            { type: nodeType, children: [{ type: "text", value: "styled" }] },
+            { type: "text", value: " after" },
+          ],
+        },
+      ],
+    });
   });
 
   it("renders links and mentions", () => {

--- a/extensions/feishu/src/post.ts
+++ b/extensions/feishu/src/post.ts
@@ -29,17 +29,6 @@ function escapeMarkdownText(text: string): string {
   return text.replace(MARKDOWN_SPECIAL_CHARS, "\\$1");
 }
 
-function toBoolean(value: unknown): boolean {
-  return value === true || value === 1 || value === "true";
-}
-
-function isStyleEnabled(style: Record<string, unknown> | undefined, key: string): boolean {
-  if (!style) {
-    return false;
-  }
-  return toBoolean(style[key]);
-}
-
 function wrapInlineCode(text: string): string {
   const maxRun = Math.max(0, ...(text.match(/`+/g) ?? []).map((run) => run.length));
   const fence = "`".repeat(maxRun + 1);
@@ -52,36 +41,26 @@ function sanitizeFenceLanguage(language: string): string {
   return language.trim().replace(/[^A-Za-z0-9_+#.-]/g, "");
 }
 
-function renderTextElement(element: Record<string, unknown>): string {
-  const text = toStringOrEmpty(element.text);
-  const style = isRecord(element.style) ? element.style : undefined;
-
-  if (isStyleEnabled(style, "code")) {
-    return wrapInlineCode(text);
+function applyInlineStyles(text: string, style: unknown): string {
+  // Keep boundary whitespace outside Markdown emphasis delimiters.
+  const content = text.trim();
+  if (!content || !Array.isArray(style)) {
+    return text;
   }
-
-  let rendered = escapeMarkdownText(text);
-  if (!rendered) {
-    return "";
-  }
-
-  if (isStyleEnabled(style, "bold")) {
+  let rendered = content;
+  if (style.includes("bold")) {
     rendered = `**${rendered}**`;
   }
-  if (isStyleEnabled(style, "italic")) {
+  if (style.includes("italic")) {
     rendered = `*${rendered}*`;
   }
-  if (isStyleEnabled(style, "underline")) {
+  if (style.includes("underline")) {
     rendered = `<u>${rendered}</u>`;
   }
-  if (
-    isStyleEnabled(style, "strikethrough") ||
-    isStyleEnabled(style, "line_through") ||
-    isStyleEnabled(style, "lineThrough")
-  ) {
+  if (style.includes("lineThrough")) {
     rendered = `~~${rendered}~~`;
   }
-  return rendered;
+  return text.replace(content, () => rendered);
 }
 
 function renderLinkElement(element: Record<string, unknown>): string {
@@ -141,9 +120,9 @@ function renderElement(
   const tag = normalizeLowercaseStringOrEmpty(toStringOrEmpty(element.tag));
   switch (tag) {
     case "text":
-      return renderTextElement(element);
+      return applyInlineStyles(escapeMarkdownText(toStringOrEmpty(element.text)), element.style);
     case "a":
-      return renderLinkElement(element);
+      return applyInlineStyles(renderLinkElement(element), element.style);
     case "at":
       {
         const mentioned = toStringOrEmpty(element.open_id) || toStringOrEmpty(element.user_id);
@@ -152,7 +131,7 @@ function renderElement(
           mentionedOpenIds.push(normalizedMention);
         }
       }
-      return renderMentionElement(element);
+      return applyInlineStyles(renderMentionElement(element), element.style);
     case "img": {
       const imageKey = normalizeFeishuExternalKey(toStringOrEmpty(element.image_key));
       if (imageKey) {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -490,7 +490,13 @@ describe("getMessageFeishu", () => {
               content: JSON.stringify({
                 zh_cn: {
                   title: "Summary",
-                  content: [[{ tag: "text", text: "post body" }]],
+                  content: [
+                    [
+                      { tag: "text", text: "post body", style: ["bold"] },
+                      { tag: "text", text: " " },
+                      { tag: "a", text: "Docs", href: "https://example.com", style: ["italic"] },
+                    ],
+                  ],
                 },
               }),
             },
@@ -507,7 +513,7 @@ describe("getMessageFeishu", () => {
     expectParsedMessage(result, {
       messageId: "om_post",
       chatId: "oc_post",
-      content: "Summary\n\npost body",
+      content: "Summary\n\n**post body** *[Docs](https://example.com)*",
       contentType: "post",
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending formatted Feishu rich-text posts would lose bold, italic, underline, and strikethrough in the text passed to the agent or returned by message reads. Native styles on links and mentions were also ignored. For example, a text element with `style: ["bold"]` arrived as plain `Urgent` instead of `**Urgent**`.

## Why This Change Was Made

Use one local style projection for text, links, and mentions, following Feishu's documented string-array contract and replacing the unsupported map/boolean handling. It keeps surrounding whitespace outside Markdown emphasis delimiters while preserving escaping, link destinations, mention IDs, media collection, and existing code tags. Production code decreases by 21 lines; no SDK, API, dependency, configuration, or host-version changes are needed.

## User Impact

Native formatting remains visible in agent input and retrieved conversation text, including styled links and mentions. Text selected with surrounding spaces produces valid emphasis rather than literal Markdown markers.

## Evidence

- Feishu's [official received-message content contract](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/events/message_content.md) defines `style` as a string array for `text`, `a`, and `at`, with `bold`, `italic`, `underline`, and `lineThrough`. Current callers and implementation history contain no named producer for the removed map-shaped style fixtures.
- Original-code regressions failed in the native post parser, actual `handleFeishuMessage` to `BodyForAgent` path, and `getMessageFeishu` read path. Plain text, media ordering, mention ID collection, and locale controls remain covered.
- **153 focused tests passed** across the post parser, full bot, send/read, and interactive-card parser suites. The real Feishu Markdown parser verifies bold/italic nodes when styled text has surrounding whitespace.
- Ingress proof uses the real parser, handler, and shared inbound context builder; the existing test runtime replaces external SDK/provider/reply and persistence boundaries. Read-path proof uses a synthetic SDK response. This does not claim live Feishu-client rendering or real-account traffic.
- Full scoped `check-changed` passed, including production/test extension typechecks, lint, package-boundary output and selected guards. Independent P2 review found no actionable P0–P2 issues. Validation used Node 24.19.0 and pnpm 12.3.4.
- The owner/caller/contract source is unchanged on main at `9a209e0a18de9b37576c68468e40d23330e01aa3`; the reviewed source and proof remain unchanged.

Focused command:

```sh
node scripts/run-vitest.mjs extensions/feishu/src/post.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/interactive-message-content.test.ts
```
