### PR TITLE
fix(codex): reuse completed OAuth access rotations

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -70,6 +70,21 @@ shared credential belongs to the same account. If that identity cannot be
 verified, the peer remains terminally fenced instead of inheriting another
 account.
 
+## Plugin SDK OAuth validation
+
+`resolveApiKeyForProfile`, exported from `openclaw/plugin-sdk/agent-runtime`,
+accepts an optional `validateOAuthCredential` callback. The resolver calls it
+before returning an OAuth credential and before persisting or adopting a
+refreshed credential. The callback also applies when a legacy
+`provider:default` profile falls back to a replacement OAuth profile.
+
+Throwing from the callback rejects that credential. A rejected fallback is not
+returned or refreshed, and the original selected-profile refresh failure remains
+the operator-facing error. Rejecting an active refresh or settlement generation
+fails closed and can leave that generation and its peers terminally fenced, so
+the operator must authenticate again. Callers that omit the callback retain the
+existing resolution and fallback behavior.
+
 `openclaw agent exec` preserves the original shared-store root when switching to temporary run state. Its bounded credential scope reads portable `api_key` and `token` profiles from that shared store without persisting copies; the configured agent's local profiles still win. Shared OAuth profiles are excluded from this temporary scope, even with `copyToAgents: true`, so the run does not acquire another refresh owner. `--auth-env-only` disables stored credential access entirely.
 
 Auth writes that explicitly select a state directory, including isolated QA staging, use that directory's shared store for ownership and OAuth deduplication. Their runtime publication and rollback retain the same owner; another process-local state root is not an inherited base. An unrelated outer database may be older, newer, or unreadable without blocking an isolated write, but an unreadable or newer database in the selected target still fails closed. Writes without an explicit state directory retain the normal ambient state and agent-directory configuration.

--- a/docs/plugins/sdk-runtime/agent.md
+++ b/docs/plugins/sdk-runtime/agent.md
@@ -40,6 +40,24 @@ compaction with session-store patches and harness calls. The result contains
 `compacted`, optional `reason`, and optional `tokensBefore` and `tokensAfter`
 snapshots; OpenClaw owns all persistence and lifecycle coordination.
 
+## Auth-profile resolution
+
+The experimental `openclaw/plugin-sdk/agent-runtime` entrypoint exports
+`resolveApiKeyForProfile(...)`. Its optional synchronous
+`validateOAuthCredential` callback runs for every OAuth candidate before the
+credential is used, adopted, persisted, or returned, including a legacy
+`provider:default` fallback. Return normally to accept the credential; throw to
+reject it.
+
+Stored credentials are validated before refresh, and refreshed credentials are
+validated before persistence. If fallback is allowed and every permitted
+candidate is rejected, resolution preserves the original selected-profile
+refresh failure. Rejection during active refresh settlement can terminally
+fence that credential generation and require reauthentication. Omitting the
+callback preserves existing behavior. Set `allowProfileFallback: false` when
+the selected profile represents an account boundary that must not rotate to a
+different configured profile.
+
 ## Agent and session namespaces
 
 <AccordionGroup>

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -22,6 +22,7 @@ import {
   resolveCodexAppServerPreparedAuthProfileSnapshot,
 } from "./auth-bridge.js";
 import {
+  fingerprintTokenAuthProfileCacheKey,
   resolveCodexAppServerFallbackApiKeyCacheKey,
   resolveCodexAppServerPreparedApiKeyCacheKey,
 } from "./auth-cache-key.js";
@@ -29,6 +30,10 @@ import {
   resolveCodexAppServerAuthProfileId,
   resolveCodexAppServerAuthProfileStore,
 } from "./auth-profile.js";
+import {
+  ensureCodexAppServerClientRuntime,
+  recordCodexAppServerAuthHandoff,
+} from "./client-runtime.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import { resolveMacOSDesktopCodexAppPathCandidates } from "./desktop-app-paths.js";
 import { createClientHarness } from "./test-support.js";
@@ -129,12 +134,16 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
           context: oauthCredential,
         });
         if (refreshed?.access) {
-          oauthCredential = refreshed as typeof oauthCredential;
+          const refreshedCredential = refreshed as typeof oauthCredential;
+          params.validateOAuthCredential?.(refreshedCredential);
+          oauthCredential = refreshedCredential;
           params.store.profiles[params.profileId] = oauthCredential;
           if (params.agentDir || process.env.OPENCLAW_STATE_DIR) {
             saveAuthProfileStore(params.store, params.agentDir);
           }
         }
+      } else {
+        params.validateOAuthCredential?.(oauthCredential);
       }
       const formatted = await providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin({
         provider: oauthCredential.provider,
@@ -142,9 +151,12 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       });
       const apiKey =
         typeof formatted === "string" && formatted ? formatted : oauthCredential.access;
-      return apiKey
-        ? { apiKey, provider: oauthCredential.provider, email: oauthCredential.email }
-        : null;
+      if (!apiKey) {
+        return null;
+      }
+      const result = { apiKey, provider: oauthCredential.provider, email: oauthCredential.email };
+      Object.defineProperty(result, "credential", { value: oauthCredential });
+      return result;
     },
     refreshOAuthCredentialForRuntime: async (
       params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
@@ -1538,6 +1550,52 @@ describe("bridgeCodexAppServerStartOptions", () => {
     },
   );
 
+  it("does not record native login auth after post-response lifecycle retirement", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const harness = createClientHarness({
+      onWrite: (line, send) => {
+        const message = JSON.parse(line) as { id?: string | number };
+        if (message.id !== undefined) {
+          send({ id: message.id, result: { type: "chatgptAuthTokens" } });
+        }
+      },
+    });
+    let checks = 0;
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-a",
+        },
+      });
+
+      await expect(
+        applyCodexAppServerAuthProfile({
+          client: harness.client,
+          agentDir,
+          authProfileId: "openai:work",
+          assertCurrent: () => {
+            checks += 1;
+            if (checks > 2) {
+              throw new Error("login owner retired");
+            }
+          },
+        }),
+      ).rejects.toThrow("login owner retired");
+
+      expect(harness.writes).toHaveLength(1);
+    } finally {
+      harness.client.close();
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("applies a supplied scoped OAuth profile instead of persisted credentials", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
@@ -1600,7 +1658,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "scoped-refreshed-access",
       refresh: "scoped-refreshed-refresh",
       expires: Date.now() + 60_000,
-      accountId: "scoped-refreshed-account",
+      accountId: "scoped-account",
     });
     try {
       if (persistSameId) {
@@ -1644,14 +1702,14 @@ describe("bridgeCodexAppServerStartOptions", () => {
         {
           type: "chatgptAuthTokens",
           accessToken: "scoped-refreshed-access",
-          chatgptAccountId: "scoped-refreshed-account",
+          chatgptAccountId: "scoped-account",
           chatgptPlanType: null,
         },
         { assertCurrent: undefined },
       );
       expect(authProfileStore.profiles["openai:work"]).toMatchObject({
         access: "scoped-refreshed-access",
-        accountId: "scoped-refreshed-account",
+        accountId: "scoped-account",
       });
       if (persistSameId) {
         expect(
@@ -1773,6 +1831,410 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("reuses a late persisted access rotation on the next physical-client callback", async () => {
+    vi.useFakeTimers();
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const lateRefresh = createDeferred<{
+      access: string;
+      refresh: string;
+      expires: number;
+      accountId: string;
+    }>();
+    oauthMocks.refreshOpenAICodexToken
+      .mockReturnValueOnce(lateRefresh.promise)
+      .mockResolvedValueOnce({
+        access: "duplicate-access",
+        refresh: "duplicate-refresh",
+        expires: Date.now() + 60_000,
+        accountId: "account-a",
+      });
+    const harness = createClientHarness({
+      onWrite: (line, send) => {
+        const message = JSON.parse(line) as { id?: string | number; method?: string };
+        if (message.method === "account/login/start" && message.id !== undefined) {
+          send({ id: message.id, result: { type: "chatgptAuthTokens" } });
+        }
+      },
+    });
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "initial-access",
+          refresh: "initial-refresh",
+          expires: Date.now() + 60_000,
+          accountId: "account-a",
+        },
+      });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      ensureCodexAppServerClientRuntime(harness.client, {
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+      });
+      recordCodexAppServerAuthHandoff(
+        harness.client,
+        await applyCodexAppServerAuthProfile({
+          client: harness.client,
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+        }),
+      );
+
+      harness.send({
+        id: "refresh-timeout",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: "account-a" },
+      });
+      await vi.waitFor(() => expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(9_000);
+      await vi.waitFor(() =>
+        expect(harness.writes.map((line) => JSON.parse(line) as unknown)).toContainEqual(
+          expect.objectContaining({
+            id: "refresh-timeout",
+            error: expect.objectContaining({
+              message: expect.stringContaining("token refresh timed out"),
+            }),
+          }),
+        ),
+      );
+
+      lateRefresh.resolve({
+        access: "late-access",
+        refresh: "late-refresh",
+        expires: Date.now() + 24 * 60 * 60_000,
+        accountId: "account-a",
+      });
+      await vi.waitFor(() =>
+        expect(authProfileStore.profiles["openai:work"]).toMatchObject({
+          access: "late-access",
+          refresh: "late-refresh",
+        }),
+      );
+
+      harness.send({
+        id: "refresh-retry",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: "account-a" },
+      });
+      await vi.waitFor(() =>
+        expect(harness.writes.map((line) => JSON.parse(line) as unknown)).toContainEqual({
+          id: "refresh-retry",
+          result: {
+            accessToken: "late-access",
+            chatgptAccountId: "account-a",
+            chatgptPlanType: null,
+          },
+        }),
+      );
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1);
+
+      harness.send({
+        id: "refresh-after-handoff",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: "account-a" },
+      });
+      await vi.waitFor(() =>
+        expect(harness.writes.map((line) => JSON.parse(line) as unknown)).toContainEqual({
+          id: "refresh-after-handoff",
+          result: {
+            accessToken: "duplicate-access",
+            chatgptAccountId: "account-a",
+            chatgptPlanType: null,
+          },
+        }),
+      );
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(2);
+    } finally {
+      harness.client.close();
+      vi.useRealTimers();
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses a completed access rotation from a scoped auth store", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    try {
+      const authProfileStore = {
+        version: 1 as const,
+        profiles: {
+          "openai:work": {
+            type: "oauth" as const,
+            provider: "openai",
+            access: "rotated-access",
+            refresh: "rotated-refresh",
+            expires: Date.now() + 24 * 60 * 60_000,
+            accountId: "account-a",
+          },
+        },
+      };
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey("initial-access"),
+            chatgptAccountId: "account-a",
+          },
+          previousAccountId: "account-a",
+        }),
+      ).resolves.toEqual({
+        accessToken: "rotated-access",
+        chatgptAccountId: "account-a",
+        chatgptPlanType: null,
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("forces refresh when only non-bearer OAuth material changed", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "forced-access",
+      refresh: "forced-refresh",
+      expires: Date.now() + 24 * 60 * 60_000,
+      accountId: "account-a",
+    });
+    try {
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai",
+        access: "initial-access",
+        refresh: "initial-refresh",
+        expires: Date.now() + 60 * 60_000,
+        accountId: "account-a",
+      };
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential,
+      });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          ...credential,
+          refresh: "rotated-refresh",
+          expires: credential.expires + 60_000,
+        },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+            chatgptAccountId: "account-a",
+          },
+          previousAccountId: "account-a",
+        }),
+      ).resolves.toEqual({
+        accessToken: "forced-access",
+        chatgptAccountId: "account-a",
+        chatgptPlanType: null,
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("rotated-refresh");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not commit a different workspace from a forced scoped refresh", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "initial-access",
+      refresh: "initial-refresh",
+      expires: Date.now() + 60 * 60_000,
+      accountId: "account-a",
+    };
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:work": credential },
+    };
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "other-access",
+      refresh: "other-refresh",
+      expires: Date.now() + 24 * 60 * 60_000,
+      accountId: "account-b",
+    });
+    try {
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+            chatgptAccountId: "account-a",
+          },
+          previousAccountId: "account-a",
+        }),
+      ).rejects.toThrow("ChatGPT workspace changed during Codex token refresh");
+      expect(authProfileStore.profiles["openai:work"]).toEqual(credential);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist a different workspace from a forced owner refresh", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: chatgptAccessToken("account-a"),
+      refresh: "initial-refresh",
+      expires: Date.now() + 60 * 60_000,
+    };
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: chatgptAccessToken("account-b"),
+      refresh: "other-refresh",
+      expires: Date.now() + 24 * 60 * 60_000,
+      accountId: "account-b",
+    });
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential,
+      });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+            chatgptAccountId: "account-a",
+          },
+          previousAccountId: "account-a",
+        }),
+      ).rejects.toThrow("ChatGPT workspace changed during Codex token refresh");
+      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:work"]).toEqual(
+        credential,
+      );
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects conflicting callback workspace identities before refreshing", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "opaque-access",
+      refresh: "opaque-refresh",
+      expires: Date.now() + 60 * 60_000,
+    };
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:work": credential },
+    };
+    try {
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+            chatgptAccountId: "account-a",
+          },
+          previousAccountId: "account-b",
+        }),
+      ).rejects.toThrow("ChatGPT workspace changed before Codex token refresh");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+      expect(authProfileStore.profiles["openai:work"]).toEqual(credential);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let a stale client refresh a newly selected scoped workspace", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "workspace-b-access",
+      refresh: "workspace-b-refresh",
+      expires: Date.now() + 60 * 60_000,
+      accountId: "account-b",
+    };
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:work": credential },
+    };
+    try {
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey("workspace-a-access"),
+            chatgptAccountId: "account-a",
+          },
+        }),
+      ).rejects.toThrow("ChatGPT workspace changed before Codex token refresh");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+      expect(authProfileStore.profiles["openai:work"]).toEqual(credential);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not switch a scoped workspace during startup refresh", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "expired-access",
+      refresh: "expired-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "account-a",
+    };
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:work": credential },
+    };
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "other-access",
+      refresh: "other-refresh",
+      expires: Date.now() + 24 * 60 * 60_000,
+      accountId: "account-b",
+    });
+    try {
+      await expect(
+        applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+        }),
+      ).rejects.toThrow("ChatGPT workspace changed during Codex token refresh");
+      expect(request).not.toHaveBeenCalled();
+      expect(authProfileStore.profiles["openai:work"]).toEqual(credential);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not replace a prepared persisted store changed during refresh", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     let resolveRefresh:
@@ -1825,6 +2287,71 @@ describe("bridgeCodexAppServerStartOptions", () => {
         refresh: "replacement-refresh",
         accountId: "replacement-account",
       });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the validated refresh generation across a concurrent persisted workspace switch", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const initialAccess = chatgptAccessToken("workspace-a", "initial");
+    const refreshedAccess = chatgptAccessToken("workspace-a", "refreshed");
+    const replacementAccess = chatgptAccessToken("workspace-b", "replacement");
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: refreshedAccess,
+      refresh: "refreshed-refresh",
+      expires: Date.now() + 60_000,
+    });
+    providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockImplementationOnce(
+      async ({ context }) => {
+        upsertAuthProfile({
+          agentDir,
+          profileId: "openai:work",
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: replacementAccess,
+            refresh: "replacement-refresh",
+            expires: Date.now() + 60_000,
+          },
+        });
+        return context.access;
+      },
+    );
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: initialAccess,
+          refresh: "initial-refresh",
+          expires: Date.now() - 60_000,
+        },
+      });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+
+      const refreshed = await refreshCodexAppServerAuthTokens({
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+      });
+
+      expect(refreshed).toMatchObject({
+        accessToken: refreshedAccess,
+        chatgptAccountId: "workspace-a",
+      });
+      expect(authProfileStore.profiles["openai:work"]).toMatchObject({
+        access: refreshedAccess,
+        refresh: "refreshed-refresh",
+      });
+      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:work"]).toMatchObject(
+        {
+          access: replacementAccess,
+          refresh: "replacement-refresh",
+        },
+      );
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -2152,7 +2679,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         access: "scoped-refreshed-access",
         refresh: "scoped-refreshed-refresh",
         expires: Date.now() + 60_000,
-        accountId: "scoped-refreshed-account",
+        accountId: "scoped-account",
       });
       await Promise.all([first, second]);
 
@@ -2164,7 +2691,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         {
           type: "chatgptAuthTokens",
           accessToken: "scoped-refreshed-access",
-          chatgptAccountId: "scoped-refreshed-account",
+          chatgptAccountId: "scoped-account",
           chatgptPlanType: null,
         },
         { assertCurrent: undefined },
@@ -2175,7 +2702,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         {
           type: "chatgptAuthTokens",
           accessToken: "scoped-refreshed-access",
-          chatgptAccountId: "scoped-refreshed-account",
+          chatgptAccountId: "scoped-account",
           chatgptPlanType: null,
         },
         { assertCurrent: undefined },
@@ -2187,6 +2714,68 @@ describe("bridgeCodexAppServerStartOptions", () => {
         expires: Date.now() + 60_000,
         accountId: "cleanup-account",
       });
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("validates each waiter on a coalesced scoped refresh", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const refresh = createDeferred<{
+      access: string;
+      refresh: string;
+      expires: number;
+      accountId: string;
+    }>();
+    oauthMocks.refreshOpenAICodexToken.mockReturnValueOnce(refresh.promise);
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "expired-access",
+      refresh: "expired-refresh",
+      expires: Date.now() - 60_000,
+    };
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:work": credential },
+    };
+    try {
+      const first = refreshCodexAppServerAuthTokens({
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+        authHandoff: {
+          accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+          chatgptAccountId: "account-a",
+        },
+        previousAccountId: "account-a",
+      });
+      const incompatibleWaiter = refreshCodexAppServerAuthTokens({
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+        authHandoff: {
+          accessFingerprint: fingerprintTokenAuthProfileCacheKey(credential.access),
+          chatgptAccountId: "account-b",
+        },
+      });
+      await vi.waitFor(() => expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1));
+
+      refresh.resolve({
+        access: "refreshed-access",
+        refresh: "refreshed-refresh",
+        expires: Date.now() + 60_000,
+        accountId: "account-a",
+      });
+
+      await expect(first).resolves.toMatchObject({
+        accessToken: "refreshed-access",
+        chatgptAccountId: "account-a",
+      });
+      await expect(incompatibleWaiter).rejects.toThrow(
+        "ChatGPT workspace changed during Codex token refresh",
+      );
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1);
+    } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });
@@ -2527,7 +3116,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "refreshed-ref-backed-access-token",
       refresh: "refreshed-ref-backed-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-ref-backed-refreshed",
+      accountId: "account-ref-backed",
     });
     try {
       upsertAuthProfile({
@@ -2546,7 +3135,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
         accessToken: "refreshed-ref-backed-access-token",
-        chatgptAccountId: "account-ref-backed-refreshed",
+        chatgptAccountId: "account-ref-backed",
         chatgptPlanType: null,
       });
 
@@ -2631,18 +3220,53 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "fresh-cli-access-token",
       refresh: "fresh-cli-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-cli-refreshed",
+      accountId: "account-cli",
     });
     try {
       await writeCodexCliAuthFile(codexHome);
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
         accessToken: "fresh-cli-access-token",
-        chatgptAccountId: "account-cli-refreshed",
+        chatgptAccountId: "account-cli",
         chatgptPlanType: null,
       });
 
       await expectPathMissing(authProfileStorePath);
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reuse a stale native Codex CLI token as a completed rotation", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "codex-cli");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "next-cli-access-token",
+      refresh: "next-cli-refresh-token",
+      expires: Date.now() + 60_000,
+      accountId: "account-cli",
+    });
+    try {
+      await writeCodexCliAuthFile(codexHome);
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authHandoff: {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey("fresh-cli-access-token"),
+            chatgptAccountId: "account-cli",
+          },
+          previousAccountId: "account-cli",
+        }),
+      ).resolves.toEqual({
+        accessToken: "next-cli-access-token",
+        chatgptAccountId: "account-cli",
+        chatgptPlanType: null,
+      });
+
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -2749,7 +3373,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "fresh-access-token",
       refresh: "fresh-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-456",
+      accountId: "account-123",
     });
     try {
       upsertAuthProfile({
@@ -2778,7 +3402,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         {
           type: "chatgptAuthTokens",
           accessToken: "fresh-access-token",
-          chatgptAccountId: "account-456",
+          chatgptAccountId: "account-123",
           chatgptPlanType: null,
         },
         { assertCurrent: undefined },
@@ -3337,7 +3961,10 @@ describe("bridgeCodexAppServerStartOptions", () => {
           agentDir,
           authProfileId: "openai:work",
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({
+        accessFingerprint: fingerprintTokenAuthProfileCacheKey(access),
+        chatgptAccountId: "token-profile-account",
+      });
 
       expect(request).toHaveBeenCalledWith(
         "account/login/start",
@@ -3441,7 +4068,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "refreshed-access-token",
       refresh: "refreshed-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-789",
+      accountId: "account-123",
     });
     try {
       upsertAuthProfile({
@@ -3465,7 +4092,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         }),
       ).resolves.toEqual({
         accessToken: "refreshed-access-token",
-        chatgptAccountId: "account-789",
+        chatgptAccountId: "account-123",
         chatgptPlanType: null,
       });
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("refresh-token");
@@ -3532,7 +4159,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         access: "refreshed-access-token",
         refresh: "refreshed-refresh-token",
         expires: Date.now() + 60_000,
-        accountId: "account-789",
+        accountId: "account-123",
       };
     });
     try {
@@ -3557,7 +4184,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         }),
       ).resolves.toEqual({
         accessToken: "refreshed-access-token",
-        chatgptAccountId: "account-789",
+        chatgptAccountId: "account-123",
         chatgptPlanType: null,
       });
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("refresh-token");
@@ -3582,7 +4209,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "main-refreshed-access-token",
       refresh: "main-refreshed-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-main-refreshed",
+      accountId: "account-main",
     });
     try {
       upsertAuthProfile({
@@ -3605,7 +4232,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         }),
       ).resolves.toEqual({
         accessToken: "main-refreshed-access-token",
-        chatgptAccountId: "account-main-refreshed",
+        chatgptAccountId: "account-main",
         chatgptPlanType: null,
       });
 
@@ -3632,7 +4259,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       access: "main-refreshed-access-token",
       refresh: "main-refreshed-refresh-token",
       expires: Date.now() + 60_000,
-      accountId: "account-main-refreshed",
+      accountId: "account-main",
     });
     try {
       await fs.mkdir(childAgentDir, { recursive: true });
@@ -3674,7 +4301,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         }),
       ).resolves.toEqual({
         accessToken: "main-refreshed-access-token",
-        chatgptAccountId: "account-main-refreshed",
+        chatgptAccountId: "account-main",
         chatgptPlanType: null,
       });
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -12,7 +12,6 @@ import {
 import {
   ensureAuthProfileStore,
   findPersistedAuthProfileCredential,
-  loadAuthProfileStoreForSecretsRuntime,
   refreshOAuthCredentialForRuntime,
   resolveApiKeyForProfile,
   resolvePersistedAuthProfileOwnerAgentDir,
@@ -24,7 +23,6 @@ import {
   hasUsableOAuthCredential,
   resolveOpenAICodexAuthIdentity,
 } from "openclaw/plugin-sdk/provider-auth";
-import { resolveProviderIdForAuth } from "openclaw/plugin-sdk/provider-auth-aliases";
 import {
   CODEX_AUTH_JSON_FILENAME,
   CODEX_APP_SERVER_API_KEY_ENV_VARS,
@@ -90,6 +88,10 @@ const activeComputerUseArtifactReconciliations = new Map<
 >();
 type AuthProfileOrderConfig = Parameters<typeof resolveCodexAppServerAuthProfileId>[0]["config"];
 export type CodexAppServerAuthRequirement = "api-key" | "subscription";
+export type CodexAppServerAuthHandoff = Readonly<{
+  accessFingerprint: string;
+  chatgptAccountId: string;
+}>;
 const scopedOAuthRefreshQueues = new WeakMap<
   AuthProfileStore,
   Map<string, Promise<OAuthCredential>>
@@ -664,7 +666,7 @@ export async function applyCodexAppServerAuthProfile(params: {
   startOptions?: CodexAppServerStartOptions;
   config?: AuthProfileOrderConfig;
   assertCurrent?: () => void;
-}): Promise<void> {
+}): Promise<CodexAppServerAuthHandoff | undefined> {
   params.assertCurrent?.();
   if (!params.preparedAuth && params.authProfileId === null) {
     await assertNativeCodexAccountMatchesRoute(
@@ -672,9 +674,9 @@ export async function applyCodexAppServerAuthProfile(params: {
       params.authRequirement,
       params.assertCurrent,
     );
-    return;
+    return undefined;
   }
-  let loginParams =
+  let loginParams: CodexLoginAccountParams | undefined =
     params.preparedAuth?.kind === "profile"
       ? params.preparedAuth.snapshot.loginParams
       : params.preparedAuth?.kind === "api-key"
@@ -708,7 +710,15 @@ export async function applyCodexAppServerAuthProfile(params: {
     await params.client.request("account/login/start", loginParams, {
       assertCurrent: params.assertCurrent,
     });
+    if (loginParams.type === "chatgptAuthTokens") {
+      params.assertCurrent?.();
+      return {
+        accessFingerprint: fingerprintTokenAuthProfileCacheKey(loginParams.accessToken),
+        chatgptAccountId: loginParams.chatgptAccountId,
+      };
+    }
   }
+  return undefined;
 }
 
 /**
@@ -790,10 +800,17 @@ export async function refreshCodexAppServerAuthTokens(params: {
   agentDir: string;
   authProfileId?: string;
   authProfileStore?: AuthProfileStore;
+  authHandoff?: CodexAppServerAuthHandoff;
   previousAccountId?: string | null;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexChatgptAuthTokensRefreshResponse> {
   const previousAccountId = params.previousAccountId?.trim();
+  const handoffAccountId = params.authHandoff?.chatgptAccountId.trim();
+  if (previousAccountId && handoffAccountId && previousAccountId !== handoffAccountId) {
+    throw new Error(
+      "ChatGPT workspace changed before Codex token refresh. Retry to start a client for the selected workspace.",
+    );
+  }
   if (previousAccountId) {
     const store = resolveCodexAppServerAuthProfileStore(params);
     const profileId = resolveCodexAppServerAuthProfileId({
@@ -828,6 +845,11 @@ export async function refreshCodexAppServerAuthTokens(params: {
       "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
     );
   }
+  if (params.authHandoff && loginParams.chatgptAccountId !== params.authHandoff.chatgptAccountId) {
+    throw new Error(
+      "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
+    );
+  }
   return {
     accessToken: loginParams.accessToken,
     chatgptAccountId: loginParams.chatgptAccountId,
@@ -839,6 +861,8 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   agentDir: string;
   authProfileId?: string;
   authProfileStore?: AuthProfileStore;
+  authHandoff?: CodexAppServerAuthHandoff;
+  previousAccountId?: string | null;
   forceOAuthRefresh?: boolean;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexLoginAccountParams | undefined> {
@@ -872,6 +896,8 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
     store,
     preferStoreCredential: Boolean(params.authProfileStore?.profiles[profileId]),
     forceOAuthRefresh: params.forceOAuthRefresh === true,
+    authHandoff: params.authHandoff,
+    previousAccountId: params.previousAccountId,
     config: params.config,
   });
   if (!loginParams) {
@@ -913,6 +939,8 @@ async function resolveLoginParamsForCredential(
     store: AuthProfileStore;
     preferStoreCredential: boolean;
     forceOAuthRefresh: boolean;
+    authHandoff?: CodexAppServerAuthHandoff;
+    previousAccountId?: string | null;
     config?: AuthProfileOrderConfig;
   },
 ): Promise<CodexLoginAccountParams | undefined> {
@@ -951,6 +979,8 @@ async function resolveLoginParamsForCredential(
     store: params.store,
     preferStoreCredential: params.preferStoreCredential,
     forceRefresh: params.forceOAuthRefresh,
+    authHandoff: params.authHandoff,
+    previousAccountId: params.previousAccountId,
     config: params.config,
   });
   const accessToken = resolvedCredential.access?.trim();
@@ -967,6 +997,8 @@ async function resolveOAuthCredentialForCodexAppServer(
     store: AuthProfileStore;
     preferStoreCredential: boolean;
     forceRefresh: boolean;
+    authHandoff?: CodexAppServerAuthHandoff;
+    previousAccountId?: string | null;
     config?: AuthProfileOrderConfig;
   },
 ): Promise<OAuthCredential> {
@@ -985,8 +1017,17 @@ async function resolveOAuthCredentialForCodexAppServer(
       profileId,
       persistedCredential,
       suppliedCredential: credential,
-      config: params.config,
     });
+  if (
+    params.preferStoreCredential &&
+    params.store.runtimePersistedProfileIds?.includes(profileId) &&
+    (persistedCredential?.type !== "oauth" ||
+      !isCodexAppServerAuthProvider(persistedCredential.provider))
+  ) {
+    throw new CodexAppServerAuthProfileUnavailableError(
+      `Codex app-server auth profile "${profileId}" is no longer available. Sign in again with OpenClaw, then retry.`,
+    );
+  }
   const store = useScopedCredential
     ? params.store
     : resolveCodexAppServerAuthProfileStore({
@@ -1005,15 +1046,42 @@ async function resolveOAuthCredentialForCodexAppServer(
     ownerCredential?.type === "oauth" && isCodexAppServerAuthProvider(ownerCredential.provider)
       ? ownerCredential
       : undefined;
+  const currentCredential =
+    useScopedCredential || !persistedOAuthCredential
+      ? overlaidOAuthCredential
+      : persistedOAuthCredential;
+  const reuseCompletedRotation =
+    params.forceRefresh &&
+    (Boolean(persistedOAuthCredential) || params.preferStoreCredential) &&
+    shouldReuseCompletedCodexOAuthRotation({
+      credential: currentCredential,
+      authHandoff: params.authHandoff,
+      previousAccountId: params.previousAccountId,
+    });
+  const selectedAccountId = currentCredential
+    ? resolveOpenAICodexAuthIdentity(currentCredential).accountId?.trim()
+    : undefined;
+  const callbackAccountId =
+    params.authHandoff?.chatgptAccountId.trim() ?? params.previousAccountId?.trim() ?? undefined;
+  if (callbackAccountId && selectedAccountId && callbackAccountId !== selectedAccountId) {
+    throw new Error(
+      "ChatGPT workspace changed before Codex token refresh. Retry to start a client for the selected workspace.",
+    );
+  }
+  const expectedAccountId = callbackAccountId ?? selectedAccountId;
   if (useScopedCredential && overlaidOAuthCredential) {
     return await resolveScopedOAuthCredential({
       store,
       profileId,
       credential: overlaidOAuthCredential,
-      forceRefresh: params.forceRefresh,
+      forceRefresh: params.forceRefresh && !reuseCompletedRotation,
+      expectedAccountId,
     });
   }
   if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
+    if (reuseCompletedRotation) {
+      return overlaidOAuthCredential;
+    }
     const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
       credential: overlaidOAuthCredential,
     });
@@ -1022,6 +1090,7 @@ async function resolveOAuthCredentialForCodexAppServer(
         `Codex app-server auth profile "${profileId}" could not refresh. Sign in again with OpenClaw, then retry.`,
       );
     }
+    assertCodexOAuthRefreshWorkspace(profileId, refreshedRuntimeCredential, expectedAccountId);
     store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
   }
@@ -1029,27 +1098,56 @@ async function resolveOAuthCredentialForCodexAppServer(
     store,
     profileId,
     agentDir: ownerAgentDir,
-    forceRefresh: params.forceRefresh && Boolean(persistedOAuthCredential),
+    forceRefresh:
+      params.forceRefresh && Boolean(persistedOAuthCredential) && !reuseCompletedRotation,
+    allowProfileFallback: false,
+    ...(expectedAccountId
+      ? {
+          validateOAuthCredential: (candidate: OAuthCredential) =>
+            assertCodexOAuthRefreshWorkspace(profileId, candidate, expectedAccountId),
+        }
+      : {}),
   });
-  const refreshed = useScopedCredential
-    ? undefined
-    : loadAuthProfileStoreForSecretsRuntime(ownerAgentDir, { profileId }).profiles[profileId];
-  const refreshedOAuthCredential =
-    refreshed?.type === "oauth" && isCodexAppServerAuthProvider(refreshed.provider)
-      ? refreshed
-      : undefined;
-  if (refreshedOAuthCredential && isDeepStrictEqual(params.store.profiles[profileId], credential)) {
+  if (
+    !resolved ||
+    resolved.credential?.type !== "oauth" ||
+    !isCodexAppServerAuthProvider(resolved.credential.provider) ||
+    !resolved.apiKey.trim()
+  ) {
+    throw new CodexAppServerAuthProfileUnavailableError(
+      `Codex app-server auth profile "${profileId}" is no longer available. Sign in again with OpenClaw, then retry.`,
+    );
+  }
+  const candidate = { ...resolved.credential, access: resolved.apiKey };
+  if (isDeepStrictEqual(params.store.profiles[profileId], credential)) {
     // Persisted refreshes rotate refresh tokens. Keep an isolated prepared
     // store aligned without reverting a concurrent caller-owned replacement.
-    params.store.profiles[profileId] = refreshedOAuthCredential;
+    params.store.profiles[profileId] = candidate;
   }
-  const storedCredential = store.profiles[profileId];
-  const candidate = refreshedOAuthCredential
-    ? refreshedOAuthCredential
-    : storedCredential?.type === "oauth" && isCodexAppServerAuthProvider(storedCredential.provider)
-      ? storedCredential
-      : credential;
-  return resolved?.apiKey ? { ...candidate, access: resolved.apiKey } : candidate;
+  return candidate;
+}
+
+function shouldReuseCompletedCodexOAuthRotation(params: {
+  credential: OAuthCredential | undefined;
+  authHandoff: CodexAppServerAuthHandoff | undefined;
+  previousAccountId?: string | null;
+}): boolean {
+  const handoff = params.authHandoff;
+  const credential = params.credential;
+  if (
+    !handoff ||
+    !credential ||
+    !hasUsableOAuthCredential(credential) ||
+    fingerprintTokenAuthProfileCacheKey(credential.access.trim()) === handoff.accessFingerprint
+  ) {
+    return false;
+  }
+  const accountId = resolveOpenAICodexAuthIdentity(credential).accountId?.trim();
+  const previousAccountId = params.previousAccountId?.trim();
+  return (
+    accountId === handoff.chatgptAccountId &&
+    (!previousAccountId || previousAccountId === handoff.chatgptAccountId)
+  );
 }
 
 function shouldUseScopedOAuthCredential(params: {
@@ -1057,20 +1155,13 @@ function shouldUseScopedOAuthCredential(params: {
   profileId: string;
   persistedCredential: AuthProfileCredential | undefined;
   suppliedCredential: OAuthCredential;
-  config?: AuthProfileOrderConfig;
 }): boolean {
   if (!params.store.runtimePersistedProfileIds?.includes(params.profileId)) {
     return true;
   }
   const persisted = params.persistedCredential;
-  if (persisted?.type !== "oauth") {
-    return true;
-  }
-  if (
-    resolveProviderIdForAuth(persisted.provider, { config: params.config }) !==
-    resolveProviderIdForAuth(params.suppliedCredential.provider, { config: params.config })
-  ) {
-    return true;
+  if (persisted?.type !== "oauth" || !isCodexAppServerAuthProvider(persisted.provider)) {
+    return false;
   }
   return (
     !isDeepStrictEqual(persisted, params.suppliedCredential) &&
@@ -1096,10 +1187,13 @@ async function resolveScopedOAuthCredential(params: {
   profileId: string;
   credential: OAuthCredential;
   forceRefresh: boolean;
+  expectedAccountId?: string;
 }): Promise<OAuthCredential> {
   const existingRefresh = scopedOAuthRefreshQueues.get(params.store)?.get(params.profileId);
   if (existingRefresh) {
-    return await existingRefresh;
+    const refreshed = await existingRefresh;
+    assertCodexOAuthRefreshWorkspace(params.profileId, refreshed, params.expectedAccountId);
+    return refreshed;
   }
   if (!params.forceRefresh && hasUsableOAuthCredential(params.credential)) {
     return params.credential;
@@ -1119,6 +1213,7 @@ async function resolveScopedOAuthCredential(params: {
         `Codex app-server auth profile "${params.profileId}" could not refresh. Sign in again with OpenClaw, then retry.`,
       );
     }
+    assertCodexOAuthRefreshWorkspace(params.profileId, refreshed, params.expectedAccountId);
     if (!isDeepStrictEqual(params.store.profiles[params.profileId], credential)) {
       throw new Error(
         `Codex app-server auth profile "${params.profileId}" changed while refreshing. Retry with the newly selected OpenAI profile.`,
@@ -1136,6 +1231,25 @@ async function resolveScopedOAuthCredential(params: {
     if (storeRefreshes.get(params.profileId) === refresh) {
       storeRefreshes.delete(params.profileId);
     }
+  }
+}
+
+function assertCodexOAuthRefreshWorkspace(
+  profileId: string,
+  credential: OAuthCredential,
+  expectedAccountId: string | undefined,
+): void {
+  if (!expectedAccountId) {
+    return;
+  }
+  const loginParams = buildChatgptAuthTokensParams(profileId, credential, credential.access.trim());
+  if (
+    loginParams.type !== "chatgptAuthTokens" ||
+    loginParams.chatgptAccountId !== expectedAccountId
+  ) {
+    throw new Error(
+      "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
+    );
   }
 }
 

--- a/extensions/codex/src/app-server/auth-refresh-authority.integration.test.ts
+++ b/extensions/codex/src/app-server/auth-refresh-authority.integration.test.ts
@@ -1,0 +1,306 @@
+import path from "node:path";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  loadAuthProfileStoreForSecretsRuntime,
+  saveAuthProfileStore,
+  type AuthProfileCredential,
+  type OAuthCredential,
+} from "openclaw/plugin-sdk/agent-runtime";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginRegistry,
+  createPluginRecord,
+  createPluginRuntimeMock,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
+import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { fingerprintTokenAuthProfileCacheKey } from "./auth-cache-key.js";
+import {
+  ensureCodexAppServerClientRuntime,
+  recordCodexAppServerAuthHandoff,
+} from "./client-runtime.js";
+import { createClientHarness } from "./test-support.js";
+
+const PROFILE_ID = "openai:work";
+const ACCOUNT_ID = "account-a";
+const INITIAL_ACCESS = "initial-access";
+
+type Harness = ReturnType<typeof createClientHarness>;
+type JsonRpcResponse = {
+  id?: string | number;
+  result?: unknown;
+  error?: { code?: number; message?: string };
+};
+
+async function waitForResponse(harness: Harness, id: string): Promise<JsonRpcResponse> {
+  let response: JsonRpcResponse | undefined;
+  await vi.waitFor(
+    () => {
+      response = harness.writes
+        .map((line) => JSON.parse(line) as JsonRpcResponse)
+        .find((message) => message.id === id);
+      expect(response, `observed wire output: ${JSON.stringify(harness.writes)}`).toBeDefined();
+    },
+    { timeout: 15_000 },
+  );
+  return response as JsonRpcResponse;
+}
+
+async function withAuthRefreshHarness(
+  refreshOAuth: (credential: OAuthCredential) => Promise<OAuthCredential>,
+  run: (fixture: {
+    agentDir: string;
+    harness: Harness;
+    otherProviderRefresh: ReturnType<typeof vi.fn>;
+    retainedStore: ReturnType<typeof loadAuthProfileStoreForSecretsRuntime>;
+  }) => Promise<void>,
+): Promise<void> {
+  await withStateDirEnv("openclaw-codex-auth-refresh-authority-", async ({ stateDir }) => {
+    const previousRegistry = getActivePluginRegistry();
+    const pluginRoot = path.join(process.cwd(), "extensions", "openai");
+    const registration = createPluginRegistry({
+      runtime: createPluginRuntimeMock(),
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      activateGlobalSideEffects: false,
+    });
+    const record = createPluginRecord({
+      id: "openai",
+      source: path.join(pluginRoot, "index.ts"),
+      rootDir: pluginRoot,
+      origin: "bundled",
+      format: "bundle",
+      enabled: true,
+      providerIds: ["openai"],
+      configSchema: true,
+    });
+    const otherProviderRecord = createPluginRecord({
+      id: "anthropic",
+      source: path.join(pluginRoot, "anthropic.ts"),
+      rootDir: pluginRoot,
+      origin: "bundled",
+      format: "bundle",
+      enabled: true,
+      providerIds: ["anthropic"],
+      configSchema: true,
+    });
+    registration.registry.plugins.push(record, otherProviderRecord);
+    const api = registration.createApi(record, { config: {} });
+    const otherProviderRefresh = vi.fn(async (credential: OAuthCredential) => credential);
+    api.registerProvider({
+      id: "openai",
+      label: "OpenAI",
+      auth: [],
+      refreshOAuth,
+    });
+    registration.createApi(otherProviderRecord, { config: {} }).registerProvider({
+      id: "anthropic",
+      label: "Anthropic",
+      auth: [],
+      refreshOAuth: otherProviderRefresh,
+    });
+    setActivePluginRegistry(registration.registry, undefined, "default", process.cwd());
+
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    upsertAuthProfile({
+      agentDir,
+      profileId: PROFILE_ID,
+      credential: {
+        type: "oauth",
+        provider: "openai",
+        access: INITIAL_ACCESS,
+        refresh: "initial-refresh",
+        expires: Date.now() + 60_000,
+        accountId: ACCOUNT_ID,
+      },
+    });
+    const retainedStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+    const harness = createClientHarness();
+    ensureCodexAppServerClientRuntime(harness.client, {
+      agentDir,
+      authProfileId: PROFILE_ID,
+      authProfileStore: retainedStore,
+    });
+    recordCodexAppServerAuthHandoff(harness.client, {
+      accessFingerprint: fingerprintTokenAuthProfileCacheKey(INITIAL_ACCESS),
+      chatgptAccountId: ACCOUNT_ID,
+    });
+
+    try {
+      await run({ agentDir, harness, otherProviderRefresh, retainedStore });
+    } finally {
+      harness.client.close();
+      clearRuntimeAuthProfileStoreSnapshots();
+      closeOpenClawStateDatabaseForTest();
+      if (previousRegistry) {
+        setActivePluginRegistry(previousRegistry);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
+    }
+  });
+}
+
+describe("Codex app-server auth refresh authority", () => {
+  it.each([
+    { name: "is deleted", credential: undefined },
+    {
+      name: "becomes an OpenAI API key",
+      credential: {
+        type: "api_key",
+        provider: "openai",
+        key: "replacement-api-key",
+      },
+    },
+    {
+      name: "becomes an OpenAI token",
+      credential: {
+        type: "token",
+        provider: "openai",
+        token: "replacement-token",
+      },
+    },
+    {
+      name: "becomes another provider's OAuth credential",
+      credential: {
+        type: "oauth",
+        provider: "anthropic",
+        access: "other-provider-access",
+        refresh: "other-provider-refresh",
+        expires: Date.now() + 24 * 60 * 60_000,
+        accountId: ACCOUNT_ID,
+      },
+    },
+  ] satisfies Array<{ name: string; credential: AuthProfileCredential | undefined }>)(
+    "rejects a retained persisted OAuth profile when canonical authority $name",
+    async ({ credential }) => {
+      const refreshOAuth = vi.fn(async (current: OAuthCredential) => ({
+        ...current,
+        access: "retired-profile-rotated-access",
+        refresh: "retired-profile-rotated-refresh",
+        expires: Date.now() + 60_000,
+        accountId: ACCOUNT_ID,
+      }));
+
+      await withAuthRefreshHarness(
+        refreshOAuth,
+        async ({ agentDir, harness, otherProviderRefresh, retainedStore }) => {
+          saveAuthProfileStore(
+            {
+              version: 1,
+              profiles: credential ? { [PROFILE_ID]: credential } : {},
+            },
+            agentDir,
+            {
+              filterExternalAuthProfiles: false,
+              sharedStoreWrite: true,
+              syncExternalCli: false,
+            },
+          );
+          expect(retainedStore.profiles[PROFILE_ID]).toMatchObject({
+            type: "oauth",
+            access: INITIAL_ACCESS,
+          });
+
+          harness.send({
+            id: "refresh-authority-lost",
+            method: "account/chatgptAuthTokens/refresh",
+            params: { reason: "unauthorized", previousAccountId: ACCOUNT_ID },
+          });
+          const response = await waitForResponse(harness, "refresh-authority-lost");
+          expect(response).toMatchObject({
+            error: { code: -32603, message: expect.stringMatching(/no longer available/i) },
+          });
+          expect(response.result).toBeUndefined();
+          expect(refreshOAuth).not.toHaveBeenCalled();
+          expect(otherProviderRefresh).not.toHaveBeenCalled();
+
+          const serialized = JSON.stringify(response);
+          expect(serialized).not.toContain(INITIAL_ACCESS);
+          expect(serialized).not.toContain("retired-profile-rotated-access");
+        },
+      );
+    },
+  );
+
+  it("keeps a retained client fenced after a rejected account rotation", async () => {
+    const refreshOAuth = vi.fn(async (credential: OAuthCredential) => ({
+      ...credential,
+      access: "other-account-access",
+      refresh: "other-account-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "account-b",
+    }));
+
+    await withAuthRefreshHarness(refreshOAuth, async ({ harness }) => {
+      harness.send({
+        id: "refresh-rejected",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: ACCOUNT_ID },
+      });
+      const rejected = await waitForResponse(harness, "refresh-rejected");
+      expect(rejected).toMatchObject({
+        error: { code: -32603, message: expect.stringMatching(/different OAuth account/i) },
+      });
+      expect(rejected.result).toBeUndefined();
+
+      harness.send({
+        id: "refresh-after-fence",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: ACCOUNT_ID },
+      });
+      const afterFence = await waitForResponse(harness, "refresh-after-fence");
+      expect(afterFence).toMatchObject({
+        error: { code: -32603, message: expect.stringMatching(/sign in again/i) },
+      });
+      expect(afterFence.result).toBeUndefined();
+      expect(refreshOAuth).toHaveBeenCalledTimes(1);
+
+      const responses = JSON.stringify([rejected, afterFence]);
+      expect(responses).not.toContain(INITIAL_ACCESS);
+      expect(responses).not.toContain("other-account-access");
+    });
+  });
+
+  it("returns and persists an accepted same-account rotation", async () => {
+    const refreshOAuth = vi.fn(async (credential: OAuthCredential) => ({
+      ...credential,
+      access: "rotated-access",
+      refresh: "rotated-refresh",
+      expires: Date.now() + 60_000,
+      accountId: ACCOUNT_ID,
+    }));
+
+    await withAuthRefreshHarness(refreshOAuth, async ({ agentDir, harness, retainedStore }) => {
+      harness.send({
+        id: "refresh-accepted",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: ACCOUNT_ID },
+      });
+      await expect(waitForResponse(harness, "refresh-accepted")).resolves.toEqual({
+        id: "refresh-accepted",
+        result: {
+          accessToken: "rotated-access",
+          chatgptAccountId: ACCOUNT_ID,
+          chatgptPlanType: null,
+        },
+      });
+      expect(refreshOAuth).toHaveBeenCalledTimes(1);
+      expect(retainedStore.profiles[PROFILE_ID]).toMatchObject({
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        accountId: ACCOUNT_ID,
+      });
+
+      clearRuntimeAuthProfileStoreSnapshots();
+      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles[PROFILE_ID]).toMatchObject({
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        accountId: ACCOUNT_ID,
+      });
+    });
+  });
+});

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -162,7 +162,7 @@ describe("Codex app-server client runtime", () => {
     });
   });
 
-  it("rejects a refreshed token from a different ChatGPT workspace", async () => {
+  it("rejects a refreshed token from a different previous ChatGPT workspace", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);
     ensureCodexAppServerClientRuntime(harness.client, {
@@ -173,7 +173,10 @@ describe("Codex app-server client runtime", () => {
     harness.send({
       id: "refresh-other-workspace",
       method: "account/chatgptAuthTokens/refresh",
-      params: { reason: "unauthorized", previousAccountId: "original-workspace" },
+      params: {
+        reason: "unauthorized",
+        previousAccountId: "original-workspace",
+      },
     });
 
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThan(0));

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -3,7 +3,8 @@ import { createHash } from "node:crypto";
 import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { readCodexSessionMeta } from "../session-catalog-provenance.js";
-import { refreshCodexAppServerAuthTokens } from "./auth-bridge.js";
+import { refreshCodexAppServerAuthTokens, type CodexAppServerAuthHandoff } from "./auth-bridge.js";
+import { fingerprintTokenAuthProfileCacheKey } from "./auth-cache-key.js";
 import type { CodexAppServerAuthProfileLookup } from "./auth-profile.js";
 import type { CodexAppServerClient } from "./client.js";
 import { isJsonObject, type CodexServiceTier, type JsonObject } from "./protocol.js";
@@ -18,6 +19,7 @@ type ClientRuntimeContext = Omit<CodexAppServerAuthProfileLookup, "agentDir"> & 
 
 type ClientRuntime = {
   context: ClientRuntimeContext;
+  authHandoff?: CodexAppServerAuthHandoff;
   closed: boolean;
   retainedThreads: Map<string, RetainedLiveThread>;
   claimedThreads: Map<string, symbol>;
@@ -72,6 +74,16 @@ const claimedThreadReleaseTokens = new WeakMap<
 export function isCodexAppServerClientRuntimeLive(client: CodexAppServerClient): boolean {
   const runtime = configuredClients.get(client);
   return runtime !== undefined && !runtime.closed;
+}
+
+export function recordCodexAppServerAuthHandoff(
+  client: CodexAppServerClient,
+  handoff: CodexAppServerAuthHandoff | undefined,
+): void {
+  const runtime = configuredClients.get(client);
+  if (runtime && !runtime.closed && handoff) {
+    runtime.authHandoff = handoff;
+  }
 }
 
 /** Reference history is only trusted while this native subscription stays warm. */
@@ -197,11 +209,13 @@ export function ensureCodexAppServerClientRuntime(
       isJsonObject(request.params) && typeof request.params.previousAccountId === "string"
         ? request.params.previousAccountId.trim() || undefined
         : undefined;
+    const authHandoff = runtime.authHandoff;
     try {
       const tokens = await withTimeout(
         refreshCodexAppServerAuthTokens({
           agentDir: runtime.context.agentDir,
           authProfileId: runtime.context.authProfileId,
+          ...(authHandoff ? { authHandoff } : {}),
           ...(previousAccountId ? { previousAccountId } : {}),
           ...(runtime.context.authProfileStore
             ? { authProfileStore: runtime.context.authProfileStore }
@@ -216,6 +230,13 @@ export function ensureCodexAppServerClientRuntime(
           "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
         );
       }
+      if (runtime.closed) {
+        throw new Error("Codex app-server client closed during ChatGPT token refresh.");
+      }
+      runtime.authHandoff = {
+        accessFingerprint: fingerprintTokenAuthProfileCacheKey(tokens.accessToken),
+        chatgptAccountId: tokens.chatgptAccountId,
+      };
       return { ...tokens };
     } catch (error) {
       // Failed refresh leaves Codex holding its old account. Detach the cached

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -8,7 +8,7 @@ import { SemVer } from "semver";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
 import { createCodexAppServerAgentHarness } from "../../harness.js";
-import type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
+import type { CodexAppServerAuthHandoff, CodexAppServerPreparedAuth } from "./auth-bridge.js";
 import { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
@@ -36,7 +36,7 @@ const mocks = vi.hoisted(() => ({
       agentDir?: string;
       authProfileId?: string;
       config?: unknown;
-    }): Promise<void> => undefined,
+    }): Promise<CodexAppServerAuthHandoff | undefined> => undefined,
   ),
   resolveCodexAppServerAuthProfileIdForAgent: vi.fn(
     (params?: { authProfileId?: string }) => params?.authProfileId,
@@ -90,6 +90,7 @@ vi.mock("./auth-profile.js", () => ({
 }));
 
 vi.mock("./auth-cache-key.js", () => ({
+  fingerprintTokenAuthProfileCacheKey: (accessToken: string) => `token:${accessToken}`,
   resolveCodexAppServerFallbackApiKeyCacheKey: mocks.resolveCodexAppServerFallbackApiKeyCacheKey,
   resolveCodexAppServerPreparedApiKeyCacheKey: mocks.resolveCodexAppServerPreparedApiKeyCacheKey,
 }));
@@ -240,8 +241,8 @@ function clientStartCall(startSpy: unknown) {
 
 function deferNextAuthProfileApplication(): () => void {
   let release: () => void = () => {};
-  const gate = new Promise<void>((resolve) => {
-    release = () => resolve();
+  const gate = new Promise<CodexAppServerAuthHandoff | undefined>((resolve) => {
+    release = () => resolve(undefined);
   });
   mocks.applyCodexAppServerAuthProfile.mockReturnValueOnce(gate);
   return release;
@@ -1957,6 +1958,11 @@ describe("shared Codex app-server client", () => {
   it("registers persisted profile refresh for isolated app-server startup", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+    const authHandoff = {
+      accessFingerprint: "token:startup-access",
+      chatgptAccountId: "persisted-account",
+    };
+    mocks.applyCodexAppServerAuthProfile.mockResolvedValueOnce(authHandoff);
 
     const clientPromise = createIsolatedCodexAppServerClient({
       timeoutMs: 1000,
@@ -1982,6 +1988,7 @@ describe("shared Codex app-server client", () => {
     expect(mocks.refreshCodexAppServerAuthTokens).toHaveBeenCalledWith({
       agentDir: "/tmp/openclaw-persisted-agent",
       authProfileId: "openai:persisted",
+      authHandoff,
       previousAccountId: "persisted-account",
       config: undefined,
     });

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -32,7 +32,10 @@ import {
   resolveCodexAppServerAuthProfileStore,
 } from "./auth-profile.js";
 import { resolveCodexAppServerUserHomeDir } from "./auth-start-options.js";
-import { ensureCodexAppServerClientRuntime } from "./client-runtime.js";
+import {
+  ensureCodexAppServerClientRuntime,
+  recordCodexAppServerAuthHandoff,
+} from "./client-runtime.js";
 import { CodexAppServerClient, isUnsupportedCodexAppServerVersionError } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config-contracts.js";
 import {
@@ -1144,7 +1147,7 @@ async function startInitializedCodexAppServerClient(
       });
 
       assertStartupCurrent();
-      await waitForStartup(() =>
+      const authHandoff = await waitForStartup(() =>
         applyCodexAppServerAuthProfile({
           client,
           agentDir: params.agentDir,
@@ -1166,6 +1169,7 @@ async function startInitializedCodexAppServerClient(
       ) {
         ownCodexInferenceClient(client);
       }
+      recordCodexAppServerAuthHandoff(client, authHandoff);
       if (runtimeArtifactModule && runtimeArtifact) {
         runtimeArtifactModule.bindCodexAppServerRuntimeArtifact(client, runtimeArtifact);
       }

--- a/src/agents/auth-profiles/oauth-manager.settlement-validation.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.settlement-validation.test.ts
@@ -1,0 +1,494 @@
+/** Tests credential validation during cross-agent OAuth settlement. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import {
+  detectSharedAuthStoreMigration,
+  migrateSharedAuthStore,
+} from "../../infra/state-migrations.shared-auth-store.js";
+import { resolveOpenAICodexAuthIdentity } from "../../plugin-sdk/provider-openai-chatgpt-auth.js";
+import { captureEnv } from "../../test-utils/env.js";
+import "./oauth-external-auth-passthrough.test-support.js";
+import { getOAuthProviderRuntimeMocks } from "./oauth-common-mocks.test-support.js";
+import { isOAuthRefreshFence, isPendingOAuthRefreshFence } from "./oauth-refresh-marker.js";
+import {
+  OAUTH_AGENT_ENV_KEYS,
+  createOAuthMainAgentDir,
+  createOAuthTestTempRoot,
+  createExpiredOauthStore,
+  removeOAuthTestTempRoot,
+  resolveApiKeyForProfileInTest,
+  resetOAuthProviderRuntimeMocks,
+} from "./oauth-test-utils.js";
+import { loadPersistedAuthProfileStore, loadPersistedSharedAuthProfileStore } from "./persisted.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import { writePersistedAuthProfileStoreRaw } from "./sqlite.js";
+import { ensureAuthProfileStore, saveAuthProfileStore } from "./store-runtime.js";
+import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+
+const {
+  refreshProviderOAuthCredentialWithPluginMock,
+  formatProviderAuthProfileApiKeyWithPluginMock,
+} = getOAuthProviderRuntimeMocks();
+
+function createWorkspaceAccessToken(accountId: string, rotation: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    }),
+  ).toString("base64url");
+  return `e30.${payload}.${rotation}`;
+}
+
+let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
+let resetOAuthRefreshQueuesForTest: typeof import("./oauth.test-support.js").resetOAuthRefreshQueuesForTest;
+
+async function loadOAuthModuleForTest() {
+  ({ resolveApiKeyForProfile } = await import("./oauth.js"));
+  ({ resetOAuthRefreshQueuesForTest } = await import("./oauth.test-support.js"));
+  resetOAuthRefreshQueuesForTest();
+}
+
+vi.mock("../../llm/oauth.js", () => ({
+  getOAuthApiKey: vi.fn(async () => null),
+  getOAuthProviders: () => [{ id: "openai" }],
+}));
+
+describe("createOAuthManager settlement credential validation", () => {
+  it.each([{ storage: "fresh" as const }, { storage: "upgraded" as const }])(
+    "preserves an independent local rotation with $storage shared storage",
+    async ({ storage }) => {
+      const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+      let tempRoot = "";
+
+      try {
+        resetFileLockStateForTest();
+        resetOAuthProviderRuntimeMocks({
+          refreshProviderOAuthCredentialWithPluginMock,
+          formatProviderAuthProfileApiKeyWithPluginMock,
+        });
+        clearRuntimeAuthProfileStoreSnapshots();
+        tempRoot = await createOAuthTestTempRoot("openclaw-oauth-independent-validator-");
+        const mainAgentDir = await createOAuthMainAgentDir(tempRoot);
+        await loadOAuthModuleForTest();
+        const profileId = "openai:default";
+        const provider = "openai";
+        const localAgentDir = path.join(tempRoot, "agents", "independent", "agent");
+        await fs.mkdir(localAgentDir, { recursive: true });
+        const local = createExpiredOauthStore({
+          profileId,
+          provider,
+          access: createWorkspaceAccessToken("workspace-a", "original"),
+          accountId: "workspace-a",
+          email: "same@example.test",
+        });
+        const shared = createExpiredOauthStore({
+          profileId,
+          provider,
+          access: createWorkspaceAccessToken("workspace-b", "shared"),
+          accountId: "workspace-b",
+          email: "same@example.test",
+        });
+        const sharedCredential = shared.profiles[profileId];
+        if (sharedCredential?.type !== "oauth") {
+          throw new Error("expected shared OAuth credential");
+        }
+        sharedCredential.refresh = "workspace-b-refresh";
+        sharedCredential.expires = Date.now() + 60 * 60 * 1000;
+        saveAuthProfileStore(local, localAgentDir);
+        if (storage === "fresh") {
+          saveAuthProfileStore(shared);
+        } else {
+          writePersistedAuthProfileStoreRaw(shared, mainAgentDir);
+          const detected = detectSharedAuthStoreMigration({
+            stateDir: tempRoot,
+            env: process.env,
+            doctorOnlyStateMigrations: true,
+          });
+          expect(detected.hasLegacy).toBe(true);
+          await migrateSharedAuthStore({ detected, stateDir: tempRoot, env: process.env });
+        }
+        expect(loadPersistedAuthProfileStore(mainAgentDir)).toBeNull();
+
+        refreshProviderOAuthCredentialWithPluginMock.mockResolvedValue({
+          type: "oauth",
+          provider,
+          access: createWorkspaceAccessToken("workspace-a", "rotated"),
+          refresh: "workspace-a-rotated-refresh",
+          expires: Date.now() + 60 * 60 * 1000,
+          accountId: "workspace-a",
+        } as never);
+        const validatedWorkspaceIds: Array<string | undefined> = [];
+
+        await expect(
+          resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+            store: ensureAuthProfileStore(localAgentDir),
+            profileId,
+            agentDir: localAgentDir,
+            validateOAuthCredential: (credential) => {
+              const accountId = resolveOpenAICodexAuthIdentity({
+                access: credential.access,
+              }).accountId;
+              validatedWorkspaceIds.push(accountId);
+              if (accountId !== "workspace-a") {
+                throw new Error("credential owner mismatch");
+              }
+            },
+          }),
+        ).resolves.toEqual(
+          expect.objectContaining({
+            apiKey: createWorkspaceAccessToken("workspace-a", "rotated"),
+          }),
+        );
+
+        expect(
+          validatedWorkspaceIds.filter((accountId) => accountId === "workspace-b"),
+        ).toHaveLength(0);
+        expect(loadPersistedAuthProfileStore(localAgentDir)?.profiles[profileId]).toMatchObject({
+          access: createWorkspaceAccessToken("workspace-a", "rotated"),
+          refresh: "workspace-a-rotated-refresh",
+        });
+        expect(loadPersistedSharedAuthProfileStore(process.env)?.profiles[profileId]).toMatchObject(
+          {
+            access: createWorkspaceAccessToken("workspace-b", "shared"),
+            refresh: "workspace-b-refresh",
+          },
+        );
+      } finally {
+        envSnapshot.restore();
+        resetFileLockStateForTest();
+        clearRuntimeAuthProfileStoreSnapshots();
+        await removeOAuthTestTempRoot(tempRoot);
+      }
+    },
+  );
+
+  it("keeps a newer same-account shared credential authoritative for historical peers", async () => {
+    const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+    let tempRoot = "";
+
+    try {
+      resetFileLockStateForTest();
+      resetOAuthProviderRuntimeMocks({
+        refreshProviderOAuthCredentialWithPluginMock,
+        formatProviderAuthProfileApiKeyWithPluginMock,
+      });
+      clearRuntimeAuthProfileStoreSnapshots();
+      tempRoot = await createOAuthTestTempRoot("openclaw-oauth-newer-shared-validator-");
+      await createOAuthMainAgentDir(tempRoot);
+      await loadOAuthModuleForTest();
+      const profileId = "openai:default";
+      const provider = "openai";
+      const ownerAgentDir = path.join(tempRoot, "agents", "owner", "agent");
+      const peerAgentDir = path.join(tempRoot, "agents", "peer", "agent");
+      await Promise.all([
+        fs.mkdir(ownerAgentDir, { recursive: true }),
+        fs.mkdir(peerAgentDir, { recursive: true }),
+      ]);
+      const local = createExpiredOauthStore({
+        profileId,
+        provider,
+        access: createWorkspaceAccessToken("workspace-a", "original"),
+        accountId: "workspace-a",
+      });
+      const olderShared = createExpiredOauthStore({
+        profileId,
+        provider,
+        access: createWorkspaceAccessToken("workspace-a", "older-shared"),
+        refresh: "older-shared-refresh",
+        accountId: "workspace-a",
+      });
+      const olderSharedCredential = olderShared.profiles[profileId];
+      if (olderSharedCredential?.type !== "oauth") {
+        throw new Error("expected shared OAuth credential");
+      }
+      olderSharedCredential.expires = Date.now() - 120_000;
+      saveAuthProfileStore(local, ownerAgentDir);
+      saveAuthProfileStore(local, peerAgentDir);
+      saveAuthProfileStore(olderShared);
+
+      let finishRefresh: (() => void) | undefined;
+      let markStarted: (() => void) | undefined;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+        markStarted?.();
+        await new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        });
+        return {
+          type: "oauth",
+          provider,
+          access: createWorkspaceAccessToken("workspace-a", "local-rotation"),
+          refresh: "local-rotation-refresh",
+          expires: Date.now() + 30 * 60 * 1000,
+          accountId: "workspace-a",
+        } as never;
+      });
+      const validatedRotations: string[] = [];
+      const resolving = resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(ownerAgentDir),
+        profileId,
+        agentDir: ownerAgentDir,
+        validateOAuthCredential: (credential) => {
+          const accountId = resolveOpenAICodexAuthIdentity({
+            access: credential.access,
+          }).accountId;
+          if (accountId !== "workspace-a") {
+            throw new Error("credential owner mismatch");
+          }
+          validatedRotations.push(credential.access);
+        },
+      });
+      await started;
+      const newerShared = {
+        type: "oauth" as const,
+        provider,
+        access: createWorkspaceAccessToken("workspace-a", "newer-shared"),
+        refresh: "newer-shared-refresh",
+        expires: Date.now() + 60 * 60 * 1000,
+        accountId: "workspace-a",
+      };
+      await persistAuthProfileBatch({
+        profiles: [{ profileId, credential: newerShared }],
+        resetFailureState: true,
+        allowOAuthGenerationReplacement: true,
+      });
+      finishRefresh?.();
+
+      await expect(resolving).resolves.toEqual(
+        expect.objectContaining({
+          apiKey: createWorkspaceAccessToken("workspace-a", "local-rotation"),
+        }),
+      );
+      expect(validatedRotations).toContain(
+        createWorkspaceAccessToken("workspace-a", "newer-shared"),
+      );
+      expect(loadPersistedSharedAuthProfileStore(process.env)?.profiles[profileId]).toEqual(
+        newerShared,
+      );
+      expect(loadPersistedAuthProfileStore(peerAgentDir)?.profiles[profileId]).toBeUndefined();
+      expect(loadPersistedAuthProfileStore(ownerAgentDir)?.profiles[profileId]).toMatchObject({
+        access: createWorkspaceAccessToken("workspace-a", "local-rotation"),
+        refresh: "local-rotation-refresh",
+      });
+    } finally {
+      envSnapshot.restore();
+      resetFileLockStateForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      await removeOAuthTestTempRoot(tempRoot);
+    }
+  });
+
+  it("preserves an upgraded local owner and fences its historical peer beside another account", async () => {
+    const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+    let tempRoot = "";
+
+    try {
+      resetFileLockStateForTest();
+      resetOAuthProviderRuntimeMocks({
+        refreshProviderOAuthCredentialWithPluginMock,
+        formatProviderAuthProfileApiKeyWithPluginMock,
+      });
+      clearRuntimeAuthProfileStoreSnapshots();
+      tempRoot = await createOAuthTestTempRoot("openclaw-oauth-relogin-validator-");
+      const mainAgentDir = await createOAuthMainAgentDir(tempRoot);
+      await loadOAuthModuleForTest();
+      const profileId = "openai:default";
+      const provider = "openai";
+      const original = createExpiredOauthStore({
+        profileId,
+        provider,
+        access: createWorkspaceAccessToken("workspace-a", "original"),
+        email: "shared@example.test",
+      });
+      const peers = await Promise.all(
+        Array.from({ length: 2 }, async (_, index) => {
+          const agentDir = path.join(tempRoot, "agents", `peer-${index}`, "agent");
+          await fs.mkdir(agentDir, { recursive: true });
+          saveAuthProfileStore(original, agentDir);
+          return agentDir;
+        }),
+      );
+
+      let finishRefresh: (() => void) | undefined;
+      let markStarted: (() => void) | undefined;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+        markStarted?.();
+        await new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        });
+        return {
+          type: "oauth",
+          provider,
+          access: createWorkspaceAccessToken("workspace-a", "stale-rotation"),
+          refresh: "stale-rotation-refresh",
+          expires: Date.now() + 60 * 60 * 1000,
+          email: "shared@example.test",
+        } as never;
+      });
+
+      const validatedWorkspaceIds: Array<string | undefined> = [];
+      const resolving = resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(peers[0]),
+        profileId,
+        agentDir: peers[0],
+        validateOAuthCredential: (credential) => {
+          const accountId = resolveOpenAICodexAuthIdentity({
+            access: credential.access,
+          }).accountId;
+          validatedWorkspaceIds.push(accountId);
+          if (accountId !== "workspace-a") {
+            throw new Error("credential owner mismatch");
+          }
+        },
+      });
+      await started;
+      await persistAuthProfileBatch({
+        agentDir: mainAgentDir,
+        profiles: [
+          {
+            profileId,
+            credential: {
+              type: "oauth",
+              provider,
+              access: createWorkspaceAccessToken("workspace-b", "relogin"),
+              refresh: "relogin-other-workspace-refresh",
+              expires: Date.now() + 10 * 60 * 1000,
+              email: "shared@example.test",
+            },
+          },
+        ],
+        resetFailureState: true,
+        allowOAuthGenerationReplacement: true,
+      });
+      finishRefresh?.();
+
+      await expect(resolving).resolves.toEqual(
+        expect.objectContaining({
+          apiKey: createWorkspaceAccessToken("workspace-a", "stale-rotation"),
+        }),
+      );
+      expect(validatedWorkspaceIds.filter((accountId) => accountId === "workspace-b")).toHaveLength(
+        1,
+      );
+      expect(loadPersistedSharedAuthProfileStore(process.env)?.profiles[profileId]).toMatchObject({
+        access: createWorkspaceAccessToken("workspace-b", "relogin"),
+        refresh: "relogin-other-workspace-refresh",
+      });
+      expect(loadPersistedAuthProfileStore(peers[0])?.profiles[profileId]).toMatchObject({
+        access: createWorkspaceAccessToken("workspace-a", "stale-rotation"),
+        refresh: "stale-rotation-refresh",
+      });
+      const peer = loadPersistedAuthProfileStore(peers[1])?.profiles[profileId];
+      expect(peer?.type === "oauth" && isOAuthRefreshFence(peer)).toBe(true);
+      expect(peer?.type === "oauth" && isPendingOAuthRefreshFence(peer)).toBe(false);
+      expect(peer).not.toMatchObject({
+        access: createWorkspaceAccessToken("workspace-b", "relogin"),
+      });
+    } finally {
+      envSnapshot.restore();
+      resetFileLockStateForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      await removeOAuthTestTempRoot(tempRoot);
+    }
+  });
+
+  it("does not recover a conflicting owner after provider refresh failure", async () => {
+    const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+    let tempRoot = "";
+
+    try {
+      resetFileLockStateForTest();
+      resetOAuthProviderRuntimeMocks({
+        refreshProviderOAuthCredentialWithPluginMock,
+        formatProviderAuthProfileApiKeyWithPluginMock,
+      });
+      clearRuntimeAuthProfileStoreSnapshots();
+      tempRoot = await createOAuthTestTempRoot("openclaw-oauth-failed-relogin-validator-");
+      await createOAuthMainAgentDir(tempRoot);
+      await loadOAuthModuleForTest();
+      const profileId = "openai:default";
+      const provider = "openai";
+      const original = createExpiredOauthStore({
+        profileId,
+        provider,
+        access: createWorkspaceAccessToken("workspace-a", "original"),
+        email: "shared@example.test",
+      });
+      const peers = await Promise.all(
+        Array.from({ length: 2 }, async (_, index) => {
+          const agentDir = path.join(tempRoot, "agents", `peer-${index}`, "agent");
+          await fs.mkdir(agentDir, { recursive: true });
+          saveAuthProfileStore(original, agentDir);
+          return agentDir;
+        }),
+      );
+
+      let rejectRefresh: ((error: Error) => void) | undefined;
+      let markStarted: (() => void) | undefined;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+        markStarted?.();
+        return await new Promise<never>((_, reject) => {
+          rejectRefresh = reject;
+        });
+      });
+
+      const validatedWorkspaceIds: Array<string | undefined> = [];
+      const resolving = resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(peers[0]),
+        profileId,
+        agentDir: peers[0],
+        validateOAuthCredential: (credential) => {
+          const accountId = resolveOpenAICodexAuthIdentity({
+            access: credential.access,
+          }).accountId;
+          validatedWorkspaceIds.push(accountId);
+          if (accountId !== "workspace-a") {
+            throw new Error("credential owner mismatch");
+          }
+        },
+      });
+      await started;
+      const conflictingOwner = {
+        type: "oauth" as const,
+        provider,
+        access: createWorkspaceAccessToken("workspace-b", "relogin"),
+        refresh: "relogin-other-workspace-refresh",
+        expires: Date.now() + 60 * 60 * 1000,
+        email: "shared@example.test",
+      };
+      await persistAuthProfileBatch({
+        agentDir: peers[0],
+        profiles: [{ profileId, credential: conflictingOwner }],
+        resetFailureState: true,
+        allowOAuthGenerationReplacement: true,
+      });
+      rejectRefresh?.(new Error("provider refresh failed"));
+
+      await expect(resolving).rejects.toThrow("credential owner mismatch");
+      expect(validatedWorkspaceIds.filter((accountId) => accountId === "workspace-b")).toHaveLength(
+        1,
+      );
+      expect(loadPersistedAuthProfileStore(peers[0])?.profiles[profileId]).toEqual(
+        conflictingOwner,
+      );
+      const peer = loadPersistedAuthProfileStore(peers[1])?.profiles[profileId];
+      expect(peer?.type === "oauth" && isOAuthRefreshFence(peer)).toBe(true);
+      expect(peer?.type === "oauth" && isPendingOAuthRefreshFence(peer)).toBe(false);
+    } finally {
+      envSnapshot.restore();
+      resetFileLockStateForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      await removeOAuthTestTempRoot(tempRoot);
+    }
+  });
+});

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -389,12 +389,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         (localExpires === undefined || mainExpires > localExpires) &&
         isSafeToAdoptMainStoreOAuthIdentity(params.credential, mainCred)
       ) {
-        params.store.profiles[params.profileId] = { ...mainCred };
-        authProfilesLog.info("adopted newer OAuth credentials from main agent", {
-          profileId: params.profileId,
-          agentDir: params.agentDir,
-          expires: new Date(mainCred.expires).toISOString(),
-        });
         return mainCred;
       }
     } catch (err) {
@@ -412,13 +406,50 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return `${provider}\u0000${profileId}`;
   }
 
+  class OAuthSettlementCredentialValidationError extends Error {
+    constructor(cause: unknown, cleanupErrors: readonly unknown[] = []) {
+      const error = toErrorObject(cause, "OAuth credential validation failed");
+      super(error.message, { cause: appendOAuthRefreshCleanupErrors(error, cleanupErrors) });
+      this.name = "OAuthSettlementCredentialValidationError";
+    }
+  }
+
+  function validateSettlementCredential(
+    validateCredential: ((credential: OAuthCredential) => void) | undefined,
+    credential: OAuthCredential,
+  ): void {
+    try {
+      validateCredential?.(credential);
+    } catch (error) {
+      throw new OAuthSettlementCredentialValidationError(error);
+    }
+  }
+
   async function resolveAuthoritativeSharedOAuthCredentialUnderLock(params: {
     profileId: string;
     candidate: OAuthCredential;
+    validateCredential?: (credential: OAuthCredential) => void;
   }): Promise<OAuthCredential | undefined> {
+    let validatedAuthoritative = false;
+    const acceptAuthoritative = (credential: OAuthCredential): boolean => {
+      try {
+        validateSettlementCredential(params.validateCredential, credential);
+        validatedAuthoritative = true;
+        return true;
+      } catch {
+        authProfilesLog.warn(
+          "refused shared OAuth credential during settlement: credential validation failed",
+          {
+            profileId: params.profileId,
+          },
+        );
+        return false;
+      }
+    };
     const updated = await updateAuthProfileStoreWithLock({
       agentDir: undefined,
       profileId: params.profileId,
+      sharedStoreWrite: true,
       updater: (store) => {
         const existing = store.profiles[params.profileId];
         const decision = shouldMirrorRefreshedOAuthCredential({
@@ -434,9 +465,16 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               },
             );
           }
+          if (decision.reason === "incoming-not-fresher" && existing?.type === "oauth") {
+            acceptAuthoritative(existing);
+          }
+          return false;
+        }
+        if (existing?.type === "oauth" && !acceptAuthoritative(existing)) {
           return false;
         }
         store.profiles[params.profileId] = { ...params.candidate };
+        validatedAuthoritative = true;
         authProfilesLog.debug("mirrored refreshed OAuth credential to main agent store", {
           profileId: params.profileId,
           expires: Number.isFinite(params.candidate.expires)
@@ -449,6 +487,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     if (updated === null) {
       throw new Error("Failed to read authoritative shared OAuth credential");
     }
+    if (!validatedAuthoritative) {
+      return undefined;
+    }
     const authoritative = updated.profiles[params.profileId];
     return authoritative?.type === "oauth" ? authoritative : undefined;
   }
@@ -457,13 +498,16 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     claim: Extract<OAuthRefreshClaim, { kind: "claimed" }>;
     claims: readonly OAuthRefreshPeerClaim[];
     replacement: OAuthCredential;
+    validateCredential?: (credential: OAuthCredential) => void;
   }): Promise<void> {
+    validateSettlementCredential(params.validateCredential, params.replacement);
     const authoritativeSharedCredential =
       params.claim.authPath === resolveSharedAuthStorePath()
         ? params.replacement
         : await resolveAuthoritativeSharedOAuthCredentialUnderLock({
             profileId: params.claim.profileId,
             candidate: params.replacement,
+            validateCredential: params.validateCredential,
           });
     settleOAuthRefreshPeerClaims({
       profileId: params.claim.profileId,
@@ -539,6 +583,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     profileId: string;
     fence: OAuthCredential;
+    settledCredential?: OAuthCredential;
   }): Promise<void> {
     const updated = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
@@ -546,7 +591,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       updater: (store) => {
         const existing = store.profiles[params.profileId];
         if (
-          !isExactOAuthCredential(existing?.type === "oauth" ? existing : undefined, params.fence)
+          !isExactOAuthCredential(
+            existing?.type === "oauth" ? existing : undefined,
+            params.settledCredential ?? params.fence,
+          )
         ) {
           return false;
         }
@@ -614,6 +662,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     attemptedCredential: OAuthCredential;
     bootstrapCredential?: OAuthCredential | null;
     bootstrapBaseCredential?: OAuthCredential;
+    validateCredential?: (credential: OAuthCredential) => void;
   }): Promise<OAuthRefreshClaim> {
     const personalProfile = isUserModelAuthProfileId(params.profileId);
     const ownerAgentDir = personalProfile
@@ -635,6 +684,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             return { kind: "unavailable" };
           }
           const storedFence = isOAuthRefreshFence(cred);
+          if (!storedFence) {
+            params.validateCredential?.(cred);
+          }
           let credentialToRefresh = cred;
           if (
             !storedFence &&
@@ -693,6 +745,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 !params.forceRefresh &&
                 isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
               ) {
+                params.validateCredential?.(mainCred);
                 authProfilesLog.info(
                   "adopted fresh OAuth credential from main store (under refresh lock)",
                   {
@@ -756,6 +809,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               );
             } else {
               credentialToRefresh = externallyManaged;
+              params.validateCredential?.(credentialToRefresh);
               if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
                 return { kind: "use", credential: externallyManaged };
               }
@@ -820,6 +874,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             ];
             if (current?.type !== "oauth" || current.provider !== params.provider) {
               return { kind: "unavailable" };
+            }
+            if (!isOAuthRefreshFence(current)) {
+              params.validateCredential?.(current);
             }
             if (isPendingOAuthRefreshFence(current)) {
               return {
@@ -929,6 +986,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     attemptedCredentials?: OAuthCredential[];
     bootstrapCredential?: OAuthCredential | null;
     bootstrapBaseCredential?: OAuthCredential;
+    validateCredential?: (credential: OAuthCredential) => void;
   }): Promise<ResolvedOAuthAccess | null> {
     const claim = await claimOAuthRefresh(params);
     if (claim.kind === "unavailable") {
@@ -953,6 +1011,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           ) {
             return null;
           }
+          params.validateCredential?.(credential);
           return {
             apiKey: await adapter.buildApiKey(credential.provider, credential, {
               cfg: params.cfg,
@@ -965,6 +1024,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       return observed;
     }
     if (claim.kind === "use") {
+      params.validateCredential?.(claim.credential);
       return {
         apiKey: await adapter.buildApiKey(claim.credential.provider, claim.credential, {
           cfg: params.cfg,
@@ -980,17 +1040,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
     type FailureSettlement = {
       supersedingOwner: OAuthCredential | null;
+      validationError: OAuthSettlementCredentialValidationError | null;
       cleanupErrors: unknown[];
     };
 
     const failClaim = async (): Promise<FailureSettlement> => {
-      let result: FailureSettlement = { supersedingOwner: null, cleanupErrors: [] };
+      let result: FailureSettlement = {
+        supersedingOwner: null,
+        validationError: null,
+        cleanupErrors: [],
+      };
       try {
         await withOAuthProfileLock(
           { provider: params.provider, profileId: params.profileId },
           async () => {
             const cleanupErrors: unknown[] = [];
             let supersedingOwner: OAuthCredential | null = null;
+            let validationError: OAuthSettlementCredentialValidationError | null = null;
             try {
               const owner = loadStoredOAuthRefreshStore(claim.ownerAgentDir, params.profileId)
                 .profiles[params.profileId];
@@ -1034,11 +1100,16 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                   claim,
                   claims: activePeerClaims,
                   replacement: supersedingOwner,
+                  validateCredential: params.validateCredential,
                 });
-                result = { supersedingOwner, cleanupErrors };
+                result = { supersedingOwner, validationError, cleanupErrors };
                 return;
               } catch (error) {
-                cleanupErrors.push(error);
+                if (error instanceof OAuthSettlementCredentialValidationError) {
+                  validationError = error;
+                } else {
+                  cleanupErrors.push(error);
+                }
               }
             }
             try {
@@ -1059,13 +1130,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             } catch (error) {
               cleanupErrors.push(error);
             }
-            result = { supersedingOwner: null, cleanupErrors };
+            result = { supersedingOwner: null, validationError, cleanupErrors };
           },
         );
         return result;
       } catch (error) {
         return {
           supersedingOwner: null,
+          validationError: result.validationError,
           cleanupErrors: [...result.cleanupErrors, error],
         };
       }
@@ -1077,9 +1149,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       const initiatingError = failure
         ? toErrorObject(failure.error, "OAuth refresh failed")
         : undefined;
-      const { supersedingOwner, cleanupErrors } = await failClaim();
+      const { supersedingOwner, validationError, cleanupErrors } = await failClaim();
+      if (validationError) {
+        throw new OAuthSettlementCredentialValidationError(validationError, cleanupErrors);
+      }
       if (supersedingOwner) {
         try {
+          params.validateCredential?.(supersedingOwner);
           return {
             apiKey: await adapter.buildApiKey(supersedingOwner.provider, supersedingOwner, {
               cfg: params.cfg,
@@ -1130,6 +1206,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         if (!isSafeOAuthOwnerRefreshResult(claim.credential, rotated)) {
           throw new Error("OAuth refresh returned credentials for a different OAuth account");
         }
+        params.validateCredential?.(rotated);
         const settled = await withOAuthProfileLock(
           { provider: params.provider, profileId: params.profileId },
           async () => {
@@ -1168,8 +1245,37 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 claim,
                 claims: activePeerClaims,
                 replacement: claimSettlement.credential,
+                validateCredential: params.validateCredential,
               });
             } catch (peerSettlementError) {
+              if (peerSettlementError instanceof OAuthSettlementCredentialValidationError) {
+                const cleanupErrors: unknown[] = [];
+                try {
+                  failOAuthRefreshPeerClaims({
+                    profileId: params.profileId,
+                    fence: claim.fence,
+                    claims: activePeerClaims,
+                  });
+                } catch (error) {
+                  cleanupErrors.push(error);
+                }
+                if (claimSettlement.persisted) {
+                  try {
+                    await markOAuthRefreshClaimFailed({
+                      agentDir: claim.ownerAgentDir,
+                      profileId: params.profileId,
+                      fence: claim.fence,
+                      settledCredential: claimSettlement.credential,
+                    });
+                  } catch (error) {
+                    cleanupErrors.push(error);
+                  }
+                }
+                throw new OAuthSettlementCredentialValidationError(
+                  peerSettlementError,
+                  cleanupErrors,
+                );
+              }
               try {
                 failOAuthRefreshPeerClaims({
                   profileId: params.profileId,
@@ -1193,6 +1299,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         if (!settled) {
           throw new Error("Failed to persist refreshed OAuth credential");
         }
+        params.validateCredential?.(settled.credential);
         return {
           apiKey: await adapter.buildApiKey(settled.credential.provider, settled.credential, {
             cfg: params.cfg,
@@ -1201,6 +1308,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           credential: settled.credential,
         };
       } catch (error) {
+        if (error instanceof OAuthSettlementCredentialValidationError) {
+          throw error;
+        }
         return await settleFailure({ error });
       }
     })();
@@ -1228,6 +1338,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    validateCredential?: (credential: OAuthCredential) => void;
   }): Promise<ResolvedOAuthAccess | null> {
     const personalProfile = isUserModelAuthProfileId(params.profileId);
     let credential = params.credential;
@@ -1240,13 +1351,22 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       }
       credential = owned;
     }
-    const adoptedCredential =
-      adoptNewerMainOAuthCredential({
-        store: params.store,
+    const newerMainCredential = adoptNewerMainOAuthCredential({
+      store: params.store,
+      profileId: params.profileId,
+      agentDir: params.agentDir,
+      credential,
+    });
+    if (newerMainCredential) {
+      params.validateCredential?.(newerMainCredential);
+      params.store.profiles[params.profileId] = { ...newerMainCredential };
+      authProfilesLog.info("adopted newer OAuth credentials from main agent", {
         profileId: params.profileId,
         agentDir: params.agentDir,
-        credential,
-      }) ?? credential;
+        expires: new Date(newerMainCredential.expires).toISOString(),
+      });
+    }
+    const adoptedCredential = newerMainCredential ?? credential;
     const bootstrapCredential = personalProfile
       ? null
       : adapter.readBootstrapCredential({
@@ -1267,6 +1387,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       !isOAuthRefreshFence(adoptedCredential) &&
       hasUsableOAuthCredential(effectiveCredential)
     ) {
+      params.validateCredential?.(effectiveCredential);
       return {
         apiKey: await adapter.buildApiKey(effectiveCredential.provider, effectiveCredential, {
           cfg: params.cfg,
@@ -1287,18 +1408,21 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         attemptedCredentials,
         bootstrapCredential,
         bootstrapBaseCredential: adoptedCredential,
+        validateCredential: params.validateCredential,
       });
       return refreshed;
     } catch (error) {
       let refreshError: unknown = error;
       let recoveryBuildFailed =
-        refreshError instanceof Error && oauthRefreshRecoveryBuildFailures.has(refreshError);
+        refreshError instanceof OAuthSettlementCredentialValidationError ||
+        (refreshError instanceof Error && oauthRefreshRecoveryBuildFailures.has(refreshError));
       let refreshedStore = params.store;
       let recoveryStoreLoaded = false;
       const buildRecoveryAccess = async (
         candidate: OAuthCredential,
       ): Promise<ResolvedOAuthAccess | null> => {
         try {
+          params.validateCredential?.(candidate);
           return {
             apiKey: await adapter.buildApiKey(candidate.provider, candidate, {
               cfg: params.cfg,
@@ -1351,6 +1475,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               candidate: mainCred,
             })
           ) {
+            params.validateCredential?.(mainCred);
             refreshedStore.profiles[params.profileId] = { ...mainCred };
             authProfilesLog.info("inherited fresh OAuth credentials from main agent", {
               profileId: params.profileId,

--- a/src/agents/auth-profiles/oauth-manager.validation.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.validation.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { testing as externalAuthTesting } from "./external-auth.test-support.js";
+import { createOAuthManager } from "./oauth-manager.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import {
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "./store-runtime.js";
+import type { OAuthCredential } from "./types.js";
+
+function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "openai",
+    access: "access-token",
+    refresh: "refresh-token",
+    expires: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+const tempDirs: string[] = [];
+
+async function withMainAgentDir(
+  prefix: string,
+  run: (mainAgentDir: string) => Promise<void>,
+): Promise<void> {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempRoot);
+  const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+  await fs.mkdir(mainAgentDir, { recursive: true });
+  await withEnvAsync(
+    {
+      OPENCLAW_STATE_DIR: tempRoot,
+      OPENCLAW_AGENT_DIR: mainAgentDir,
+    },
+    async () => await run(mainAgentDir),
+  );
+}
+
+beforeEach(() => {
+  externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+  clearRuntimeAuthProfileStoreSnapshots();
+});
+
+afterEach(async () => {
+  externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+  clearRuntimeAuthProfileStoreSnapshots();
+  closeOpenClawStateDatabaseForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("createOAuthManager credential validation", () => {
+  it("validates a refreshed credential before persisting it", async () => {
+    await withMainAgentDir("oauth-manager-refresh-validator-", async (mainAgentDir) => {
+      const profileId = "openai:oauth";
+      const credential = createCredential({
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+      });
+      saveAuthProfileStore({ version: 1, profiles: { [profileId]: credential } }, mainAgentDir, {
+        filterExternalAuthProfiles: false,
+      });
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, value) => value.access,
+        canRefreshCredential: async () => true,
+        refreshCredential: async () => ({
+          access: "wrong-account-access",
+          refresh: "wrong-account-refresh",
+          expires: Date.now() + 600_000,
+          accountId: "wrong-account",
+        }),
+        readBootstrapCredential: () => null,
+      });
+
+      await expect(
+        manager.resolveOAuthAccess({
+          store: ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir),
+          profileId,
+          credential,
+          agentDir: mainAgentDir,
+          forceRefresh: true,
+          validateCredential: (candidate) => {
+            if (candidate.accountId === "wrong-account") {
+              throw new Error("credential owner mismatch");
+            }
+          },
+        }),
+      ).rejects.toThrow("credential owner mismatch");
+
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir).profiles[profileId],
+      ).not.toMatchObject({
+        access: "wrong-account-access",
+        accountId: "wrong-account",
+      });
+    });
+  });
+
+  it("validates the authoritative credential before claiming refresh ownership", async () => {
+    await withMainAgentDir("oauth-manager-claim-validator-", async (mainAgentDir) => {
+      const profileId = "openai:oauth";
+      const original = createCredential({
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+        accountId: "expected-account",
+      });
+      const replacement = createCredential({
+        access: "replacement-access",
+        refresh: "replacement-refresh",
+        expires: Date.now() - 30_000,
+        accountId: "other-account",
+      });
+      saveAuthProfileStore({ version: 1, profiles: { [profileId]: original } }, mainAgentDir, {
+        filterExternalAuthProfiles: false,
+      });
+      let replaced = false;
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, value) => value.access,
+        canRefreshCredential: async () => {
+          if (!replaced) {
+            replaced = true;
+            saveAuthProfileStore(
+              { version: 1, profiles: { [profileId]: replacement } },
+              mainAgentDir,
+              { filterExternalAuthProfiles: false },
+            );
+          }
+          return true;
+        },
+        refreshCredential: async () => ({
+          access: "refreshed-access",
+          refresh: "refreshed-refresh",
+          expires: Date.now() + 600_000,
+          accountId: "expected-account",
+        }),
+        readBootstrapCredential: () => null,
+      });
+
+      await expect(
+        manager.resolveOAuthAccess({
+          store: ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir),
+          profileId,
+          credential: original,
+          agentDir: mainAgentDir,
+          forceRefresh: true,
+          validateCredential: (candidate) => {
+            if (candidate.accountId !== "expected-account") {
+              throw new Error("credential owner mismatch");
+            }
+          },
+        }),
+      ).rejects.toThrow("credential owner mismatch");
+
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir).profiles[profileId],
+      ).toEqual(replacement);
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -186,6 +186,8 @@ type ResolveApiKeyForProfileParams = {
   agentDir?: string;
   forceRefresh?: boolean;
   allowProfileFallback?: boolean;
+  /** Reject an OAuth credential before the resolver persists, adopts, or returns it. */
+  validateOAuthCredential?: (credential: OAuthCredential) => void;
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
@@ -302,6 +304,7 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
     cfg,
     forceRefresh: params.forceRefresh,
+    validateCredential: params.validateOAuthCredential,
   });
   if (!resolved) {
     return null;
@@ -516,6 +519,7 @@ export async function resolveApiKeyForProfile(
       credential: cred,
       cfg,
       forceRefresh: params.forceRefresh,
+      validateCredential: params.validateOAuthCredential,
     });
     if (!resolved) {
       return null;
@@ -589,6 +593,7 @@ export async function resolveApiKeyForProfile(
           profileId: fallbackProfileId,
           agentDir: params.agentDir,
           forceRefresh: params.forceRefresh,
+          validateOAuthCredential: params.validateOAuthCredential,
         });
         if (fallbackResolved) {
           return fallbackResolved;

--- a/src/agents/auth-profiles/oauth.validator-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.validator-fallback.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests credential validation across legacy OAuth profile fallback.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { captureEnv } from "../../test-utils/env.js";
+import "./oauth-external-auth-passthrough.test-support.js";
+import {
+  OAUTH_AGENT_ENV_KEYS,
+  createOAuthMainAgentDir,
+  createOAuthTestTempRoot,
+  removeOAuthTestTempRoot,
+} from "./oauth-test-utils.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import {
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "./store-runtime.js";
+import type { OAuthCredential } from "./types.js";
+
+const refreshProviderOAuthCredentialWithPluginMock = vi.hoisted(() =>
+  vi.fn(async (_credential: OAuthCredential): Promise<OAuthCredential | undefined> => undefined),
+);
+
+vi.mock("../../llm/oauth.js", () => ({
+  getOAuthApiKey: vi.fn(async () => null),
+  getOAuthProviders: () => [{ id: "openai" }],
+}));
+
+vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
+  buildProviderAuthDoctorHintWithPlugin: async () => undefined,
+  formatProviderAuthProfileApiKeyWithPlugin: async (params: { context?: OAuthCredential }) =>
+    params.context?.access,
+  resolveProviderOAuthCredentialWithPlugin: async (params: { credential: OAuthCredential }) => {
+    const credential = await refreshProviderOAuthCredentialWithPluginMock(params.credential);
+    return credential
+      ? { status: "available" as const, credential, apiKey: credential.access }
+      : { status: "unhandled" as const };
+  },
+  resolveProviderOAuthRefreshCapabilityWithPlugin: async () => ({
+    status: "available" as const,
+  }),
+}));
+
+function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "openai",
+    access: "access-token",
+    refresh: "refresh-token",
+    expires: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe("resolveApiKeyForProfile fallback credential validation", () => {
+  it.each([
+    { name: "returns an accepted fallback", reject: false },
+    { name: "rejects an invalid fallback", reject: true },
+  ])("$name", async ({ reject }) => {
+    const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+    let tempRoot = "";
+
+    try {
+      resetFileLockStateForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      refreshProviderOAuthCredentialWithPluginMock.mockReset();
+      tempRoot = await createOAuthTestTempRoot("openclaw-oauth-validator-fallback-");
+      const mainAgentDir = await createOAuthMainAgentDir(tempRoot);
+      const legacyProfileId = "openai:default";
+      const fallbackProfileId = "openai:alternate";
+      const fallbackCredential = createCredential({
+        access: "fallback-access",
+        refresh: "fallback-refresh",
+        expires: Date.now() + 600_000,
+        accountId: "fallback-account",
+      });
+      const legacyCredential = createCredential({
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+        accountId: "legacy-account",
+      });
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [legacyProfileId]: legacyCredential,
+            [fallbackProfileId]: fallbackCredential,
+          },
+        },
+        mainAgentDir,
+        { filterExternalAuthProfiles: false },
+      );
+      refreshProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
+        new Error("primary refresh failed"),
+      );
+      const validateOAuthCredential = vi.fn((credential: OAuthCredential) => {
+        if (reject && credential.accountId === fallbackCredential.accountId) {
+          throw new Error(`rejected ${credential.accountId}`);
+        }
+      });
+      const { resolveApiKeyForProfile } = await import("./oauth.js");
+
+      const resolution = resolveApiKeyForProfile({
+        cfg: {
+          auth: {
+            profiles: {
+              [legacyProfileId]: { provider: "openai", mode: "oauth" },
+              [fallbackProfileId]: { provider: "openai", mode: "oauth" },
+            },
+          },
+        },
+        store: ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir),
+        profileId: legacyProfileId,
+        agentDir: mainAgentDir,
+        validateOAuthCredential,
+      });
+
+      if (reject) {
+        await expect(resolution).rejects.toThrow(
+          "OAuth token refresh failed for openai: primary refresh failed",
+        );
+      } else {
+        const result = await resolution;
+        expect(result).toMatchObject({
+          apiKey: "fallback-access",
+          provider: "openai",
+        });
+        expect(result?.profileId).toBe(fallbackProfileId);
+      }
+      expect(validateOAuthCredential).toHaveBeenCalledTimes(2);
+      expect(validateOAuthCredential).toHaveBeenNthCalledWith(1, legacyCredential);
+      expect(validateOAuthCredential).toHaveBeenNthCalledWith(2, fallbackCredential);
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledOnce();
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(mainAgentDir).profiles[fallbackProfileId],
+      ).toEqual(fallbackCredential);
+    } finally {
+      envSnapshot.restore();
+      resetFileLockStateForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      await removeOAuthTestTempRoot(tempRoot);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Related: #89278
Supersedes: #122566

Codex external auth waits 10 seconds for OpenClaw's refresh callback. A provider rotation can complete and persist after that callback has already timed out, so the next request previously forced another refresh instead of reusing the completed same-workspace access rotation.

This replacement keeps the repair inside the existing auth-profile and physical Codex client owners:

- records a secret-free access fingerprint plus exact ChatGPT account ID only after successful Codex login
- reuses only a usable persisted/scoped credential whose access bearer changed for that exact account
- keeps metadata-only, refresh-token-only, and expiry-only changes on the normal forced-refresh path
- excludes transient native-CLI auth from completed-rotation reuse
- validates the exact resolved workspace credential before persistence, mutation, or use
- terminally fences an invalid exact rotation and its peers while preserving a concurrent replacement
- refuses an unrelated shared account without terminally fencing a still-valid local account
- carries the resolver-validated credential across the await instead of rereading unchecked mutable persistence

The public Plugin SDK refresh-context proposal from #121764 is intentionally not revived. #141477 already landed the late-settlement/CAS ownership repair in the auth-profile layer; this PR adds the private Codex handoff and an optional validator on the existing experimental `agent-runtime` credential resolver.

## Root cause and ownership

The callback deadline is owned by upstream Codex, while refresh settlement and credential persistence are owned by OpenClaw's auth-profile manager. The missing fact was whether this physical Codex client had already installed a specific same-account access generation. Without that owner-held fact, a later callback could not distinguish a completed late access rotation from metadata-only persistence changes or a workspace switch.

The canonical fix records that fact at successful Codex login, advances it only after a timely successful callback, and lets the auth-profile owner validate/fence the exact credential generation before it can be persisted or returned.

## Upstream contract proof

Directly inspected sibling `openai/codex` at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`:

- `codex-rs/app-server/src/external_auth.rs:18` sets the callback deadline to 10 seconds
- `codex-rs/app-server/src/external_auth.rs:37-45` forwards `previous_account_id`
- `codex-rs/app-server/src/external_auth.rs:46-63` cancels and errors on timeout
- `codex-rs/app-server/src/external_auth.rs:66-81` installs auth only after a valid successful response
- `codex-rs/app-server-protocol/src/protocol/common.rs:2856-2865` proves the wire field is `previousAccountId`

An exact live callback trace is not available without a provider rotation that exceeds Codex's fixed deadline. The source contract plus deterministic owner-boundary timeout, concurrency, workspace-switch, and settlement regressions exercise that path without exposing credentials.

## Validation

- refreshed-head Codex app-server suite: 3 files / 279 tests passed
- final-head real JSON-RPC authority matrix: 6 tests passed; the pre-fix candidate failed 4 authority-loss cases and passed the 2 valid rotation cases
- final-head auth-profile settlement validation: 5 tests passed
- reconstructed changed-surface gate passed every reached stage, then stopped only at the stale September 8 compatibility-removal deadline on base `5734578`; current `main` already marks that record `removal-pending`
- pre-final-repair full Codex extension suite: 231 test files / 5,479 tests passed across all 20 chunks
- two independent implementation audits: no actionable findings
- mandatory high-reasoning autoreview on the final staged candidate: no P0-P2 findings; patch-correct confidence 0.9
- privacy scan and `git diff --check`: passed
- mechanically rebased onto current `main` after #142775 landed; the patch ID is unchanged and the focused Codex authority suites pass on the refreshed head

The newest settlement regressions were confirmed red against the pre-fix helper and green afterward:

- fresh canonical shared-store bootstrap preserves a valid unrelated local account
- real legacy-main-to-state-db Doctor migration preserves a valid unrelated local account
- a newer same-account shared credential becomes authoritative
- an unrelated historical peer is fenced without poisoning the valid local account
- a conflicting superseding owner is validated exactly once and invalid peers are terminally fenced
- a resolver-validated refresh generation is returned and synchronized despite a concurrent persisted workspace switch
- accepted legacy-profile fallback credentials pass the same validator and are returned
- rejected legacy-profile fallback credentials are neither refreshed nor returned, while the original selected-profile failure remains visible
- a retained physical client cannot emit its old bearer after canonical authority is deleted, changed to an API key or token, or transferred to another provider
- a rejected account rotation terminally fences the retained client, while an accepted same-account rotation still returns and persists through the real transport boundary

## Surface and risk

Production: `+325/-56` (net `+269`)
Tests: `+1781/-31` (net `+1750`)
Docs: `+33/-0`

The positive production delta is intentional owner-boundary capability, not a consumer guard: it adds cross-agent credential validation/fencing and a per-physical-client late-rotation handoff. Folding this into the existing owners avoids a second refresh path, public SDK churn, or runtime compatibility fallback.

No config, environment, protocol, or database schema changes. The existing experimental `openclaw/plugin-sdk/agent-runtime` resolver gains an optional synchronous `validateOAuthCredential` parameter; callers that omit it retain existing behavior, and the contract is documented in the Plugin SDK runtime and auth-semantics references.

## User impact

Cron, heartbeat, and reused Codex clients can recover on the next callback after a late successful same-workspace access rotation without repeating provider refresh. Workspace changes and invalid credentials remain fail-closed.

The revoked-token diagnostics and inline reauthentication portion of #89278 remains separate, so this PR intentionally uses `Related` rather than closing the issue.
