### PR TITLE
fix(cli): correct misleading uninstall guidance

### DIFF
--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -84,7 +84,7 @@ export const CORE_CLI_COMMAND_DESCRIPTORS = [
   },
   {
     name: "uninstall",
-    description: "Uninstall the gateway service + local data (CLI remains)",
+    description: "Uninstall the gateway service + local data",
     hasSubcommands: false,
   },
   {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -318,7 +318,7 @@ export function registerMaintenanceCommands(program: Command) {
 
   program
     .command("uninstall")
-    .description("Uninstall the gateway service + local data (CLI remains)")
+    .description("Uninstall the gateway service + local data")
     .addHelpText(
       "after",
       () =>

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -75,7 +75,7 @@ describe("uninstallCommand", () => {
     expect(removeStateAndLinkedPaths).not.toHaveBeenCalled();
     expect(removeWorkspaceDirs).not.toHaveBeenCalled();
     expect(cleanupCommandLogMessages(runtime)).not.toContain(
-      "CLI still installed. Remove via npm/pnpm if desired.",
+      "CLI removal instructions: https://docs.openclaw.ai/install/uninstall",
     );
   });
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -248,7 +248,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
   }
 
   if (!failed) {
-    runtime.log("CLI still installed. Remove via npm/pnpm if desired.");
+    runtime.log("CLI removal instructions: https://docs.openclaw.ai/install/uninstall");
   }
 
   if (scopes.has("state") && !scopes.has("workspace") && cleanupPlan) {


### PR DESCRIPTION
Related: #127250

## What Problem This Solves

`openclaw uninstall` promises that the CLI remains installed and should be removed through npm/pnpm. Supported prefix installs can live inside the selected state directory, and CLI removal depends on the installation method.

## Why This Change Was Made

Successful cleanup now points to the installation-specific guide updated in #127254. Root and command help drop the unsupported promise. The success-only condition and cleanup behavior stay unchanged; production and test LOC are both neutral.

## User Impact

Operators receive removal guidance appropriate to their installation instead of an unverified claim about what remains installed.

## Evidence

- [Baseline/candidate proof](https://github.com/steipete/openclaw/actions/runs/34271071455): both normal builds passed on Node 24.20.0/pnpm 12.3.4. Root help, uninstall help, and a service-only dry run showed the exact intended output change, preserved authored inputs, and completed process cleanup. This exercised output, without service or state deletion.
- Full committed-head source autoreview and separate direct review: no actionable P0–P2 findings.
- [Remaining validation](https://github.com/steipete/openclaw/actions/runs/34279816009): three existing mocked failure cases passed (19 other cases filtered), and all 29 canonical changed-file checks completed with exit zero. The workflow failed afterward at the proof harness's incidental-file inventory limit. Native results, authored-input hashes, and cleanup were independently verified; the complete incidental inventory is unavailable.
- Required PR CI and native landing gates remain pending.
