### PR TITLE
fix(ci): reduce shard planner work when test inventories grow

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -881,6 +881,13 @@ function listTestFiles(rootDir: string): string[] {
   return listTrackedTestFiles(rootDir);
 }
 
+function resolveTestFilesBuildMode(files: readonly string[]): NodeTestPretestBuildMode | undefined {
+  // Planner inventories contain resolved paths. Preserve their exact membership
+  // instead of reparsing every file as a glob against the runtime consumers.
+  const selectedFiles = new Set(files);
+  return resolveVitestPretestBuildMode([{ matchesFile: (file) => selectedFiles.has(file) }]);
+}
+
 function createAutoReplyReplySplitShards(): NodeTestSplitShard[] {
   const files = listTestFiles("src/auto-reply/reply");
   const groups = {
@@ -1657,12 +1664,7 @@ function createUnitFastSplitShards(): NodeTestSplitShard[] {
 function createToolingSplitShards(): NodeTestSplitShard[] {
   const files = listCompactToolingTestFiles();
   // Resolve file ownership once; batch scoring reuses those prepared facts.
-  const buildModes = new Map(
-    files.map((file) => [
-      file,
-      resolveVitestPretestBuildMode([{ configs: [TOOLING_CONFIG], includePatterns: [file] }]),
-    ]),
-  );
+  const buildModes = new Map(files.map((file) => [file, resolveTestFilesBuildMode([file])]));
   const toolingBatchWeight = (batch: string[]) => {
     const mode = mergeVitestPretestBuildModes(batch.map((file) => buildModes.get(file)));
     return (
@@ -2046,9 +2048,9 @@ export function createNodeTestShards(options: NodeTestPlanOptions = {}): NodeTes
           }
         }
 
-        const pretestBuildMode = resolveVitestPretestBuildMode([
-          { configs: splitConfigs, includePatterns },
-        ]);
+        const pretestBuildMode = includePatterns
+          ? resolveTestFilesBuildMode(includePatterns)
+          : resolveVitestPretestBuildMode([{ configs: splitConfigs }]);
 
         return [
           {
@@ -2449,6 +2451,9 @@ function splitOversizedCompactGroup(
   }
   const includePatterns =
     group.includePatterns ?? WHOLE_CONFIG_SPLIT_FILE_LISTERS.get(group.shard_name)?.();
+  const buildModes = new Map(
+    includePatterns?.map((file) => [file, resolveTestFilesBuildMode([file])]) ?? [],
+  );
   const isTooling = /^core-tooling-\d+$/u.test(group.shard_name);
   const packTooling = isTooling && runnerBackend === "github";
   const weightForFile = isTooling ? toolingFileWeight : stripeFileWeight;
@@ -2459,7 +2464,7 @@ function splitOversizedCompactGroup(
   const profileSeconds = Math.max(measuredProfileSeconds, isCliProcess ? totalWeight : 0);
   const splitBuildMode =
     isCliProcess && !runtimePartition
-      ? resolveVitestPretestBuildMode([{ configs: group.configs, includePatterns }])
+      ? mergeVitestPretestBuildModes([...buildModes.values()])
       : undefined;
   const splitBuildSeconds = splitBuildMode ? VITEST_PRETEST_BUILD_SECONDS[splitBuildMode] : 0;
   const hostedProfileSeconds = Math.max(measuredHostedSeconds, isCliProcess ? totalWeight : 0);
@@ -2473,17 +2478,6 @@ function splitOversizedCompactGroup(
 
   // The prerequisite is charged once per emitted job. Include it in placement
   // so a balanced test stripe still leaves room for its runtime build.
-  const buildModes = new Map(
-    isCliProcess || packTooling
-      ? includePatterns.map(
-          (file) =>
-            [
-              file,
-              resolveVitestPretestBuildMode([{ configs: group.configs, includePatterns: [file] }]),
-            ] as const,
-        )
-      : [],
-  );
   const createStripes = (seconds: number) => {
     const files = runtimePartition?.otherFiles ?? includePatterns;
     const batchWeight = (patterns: readonly string[]) => {
@@ -2596,9 +2590,7 @@ function splitOversizedCompactGroup(
     group: {
       ...group,
       includePatterns: patterns,
-      pretestBuildMode: resolveVitestPretestBuildMode([
-        { configs: group.configs, includePatterns: patterns },
-      ]),
+      pretestBuildMode: mergeVitestPretestBuildModes(patterns.map((file) => buildModes.get(file))),
       shard_name: `${group.shard_name}-hosted-${index + 1}`,
       timing_key: timingGeneration.timingKeys[index]!,
     },

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -162,8 +162,6 @@ export function resolveVitestPretestBuildMode(
 ): VitestPretestBuildMode | undefined {
   const preparedSelections = selections.map((selection) => {
     const includedFiles = new Set<string>();
-    // Keep each pattern hot in Node's bounded glob cache across the small consumer list.
-    // Consumer-first traversal recompiles large include inventories for every file.
     for (const pattern of selection.includePatterns ?? []) {
       for (const { file } of runtimeConsumers) {
         if (!includedFiles.has(file) && path.matchesGlob(file, pattern)) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CI shard-planner inventory-growth checks spend most of their time matching already resolved test filenames as glob patterns. The existing growth check exceeded its 120-second timeout in [CI job 102224566660](https://github.com/openclaw/openclaw/actions/runs/34274584954/job/102224566660), which tested merge commit `4e35df96c1233f2644611e6f63090b9bb68e41fa`.

## Why This Change Was Made

Pass resolved file membership through the existing prerequisite selector and reuse per-file build modes during stripe scoring and emission. The canonical runtime-consumer owner still selects the strongest prerequisite; general glob, config, and custom-selector behavior remains intact. Remove the inaccurate comment claiming Node caches these glob matchers.

This preserves #140680’s balanced-tail, alternate-packing, and recursive overflow handling. No dependencies, custom matcher, cache, runner capacity, job caps, timeouts, or test assertions change. The two-file tooling change is net −10 lines.

## User Impact

Developers get faster CI planning and more headroom for the existing inventory-growth check. There is no product runtime behavior change.

## Evidence

- On the exact original CI merge, the same unchanged named test and profiler on the same macOS host improved from **46.110s to 7.545s** (83.64%). Total profile wall time improved from 57.27s to 15.92s. This is local profiling, not a Linux CI timing claim.
- Sampled CPU beneath prerequisite resolution fell from 39.053s to 0.0105s. Direct inspection of Node 24.19.0 confirms `path.matchesGlob` constructs a new minimatch instance for each call; the existing unit-fast and tracked-file discovery caches are retained.
- On publication base `fd285cc6826a69e627b8fe2149148e7c1b3c5acf`, the expanded twelve-snapshot growth test passed once in **9.218s**, including #140680’s new inventory case. This verifies the newer context separately from the ten-snapshot before/after comparison.
- 118 planner and prerequisite semantic checks passed across three files on the original merge plus this identical patch. Scoped type, lint, format, and guard checks passed. Native preinstall planning succeeded with `node_modules` reads denied.
- Fresh independent P2 review passed on the publication base. Hosted CI for this PR will provide the final integration result.

The separate subagent-announcement failure from the original CI run remains unreproduced; this PR does not claim to repair it.
