### PR TITLE
fix(mcp): drain admitted tool work before shutdown cleanup

### DIFF
--- a/src/mcp/plugin-tools-handlers.cancel.test.ts
+++ b/src/mcp/plugin-tools-handlers.cancel.test.ts
@@ -1,9 +1,14 @@
 // Plugin MCP cancellation tests cover cancellation of in-flight plugin tool calls.
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { consumeTrackedToolExecutionStarted } from "../agents/agent-tools.before-tool-call.state.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { createToolsMcpServer } from "./tools-stdio-server.js";
 
 describe("plugin tools MCP cancellation", () => {
@@ -73,6 +78,163 @@ describe("plugin tools MCP cancellation", () => {
     } finally {
       await client.close();
       await server.close();
+    }
+  });
+
+  it.each(["handler", "descendant"] as const)(
+    "joins native %s work before close releases its database and permits reconnect",
+    async (mode) => {
+      let database = new DatabaseSync(":memory:");
+      const started = createDeferred();
+      const finish = createDeferred();
+      const reads: unknown[] = [];
+      let queryError: unknown;
+      let signal: AbortSignal | undefined;
+      let pendingWork: ReturnType<AnyAgentTool["execute"]> | undefined;
+      const runNativeWork = async (): ReturnType<AnyAgentTool["execute"]> => {
+        started.resolve();
+        await finish.promise;
+        try {
+          reads.push(database.prepare("SELECT 42 AS value").get());
+        } catch (error) {
+          queryError = error;
+          throw error;
+        }
+        return { content: [{ type: "text", text: "done" }], details: {} };
+      };
+      const tool: AnyAgentTool = {
+        name: "native_cleanup",
+        label: "Native cleanup",
+        description: "Keeps accepted database work alive through cancellation",
+        parameters: Type.Object({}),
+        execute: async (_id, _params, requestSignal) => {
+          signal = requestSignal;
+          pendingWork = mode === "handler" ? runNativeWork() : trackAsyncWork(runNativeWork);
+          if (mode === "handler") {
+            return await pendingWork;
+          }
+          void pendingWork.catch(() => {});
+          return { content: [{ type: "text", text: "accepted" }], details: {} };
+        },
+      };
+      const server = createToolsMcpServer({ name: "native-drain", tools: [tool] });
+      const clients: Client[] = [];
+      const connect = async () => {
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        const client = new Client(
+          { name: "native-client", version: "0.0.0" },
+          { capabilities: {} },
+        );
+        clients.push(client);
+        await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+        return client;
+      };
+      let closing: Promise<void> | undefined;
+      let siblingClose: Promise<void> | undefined;
+      try {
+        const client = await connect();
+        const call = client.callTool({ name: tool.name, arguments: {} });
+        const callResult = call.then(
+          (result) => ({ result }),
+          (error: unknown) => ({ error }),
+        );
+        await Promise.race([
+          started.promise,
+          call.then(() => {
+            throw new Error("Tool completed before native work started");
+          }),
+        ]);
+        if (mode === "descendant") {
+          expect(await callResult).toMatchObject({
+            result: { content: [{ type: "text", text: "accepted" }] },
+          });
+        }
+        let transportClosed = false;
+        let released = false;
+        let siblingSettled = false;
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes callback properties, not EventTarget.
+        server.onclose = () => {
+          transportClosed = true;
+        };
+        closing = server.close().then(() => {
+          database.close();
+          released = true;
+        });
+        siblingClose = server.close().then(() => {
+          siblingSettled = true;
+        });
+        await nextTurn();
+        expect(transportClosed).toBe(true);
+        if (mode === "handler") {
+          expect(signal?.aborted).toBe(true);
+          expect(await callResult).toHaveProperty("error");
+        }
+        expect.soft(released).toBe(false);
+        expect.soft(siblingSettled).toBe(false);
+        expect.soft(database.isOpen).toBe(true);
+        finish.resolve();
+        await pendingWork?.catch(() => {});
+        await Promise.all([closing, siblingClose]);
+        expect.soft(queryError).toBeUndefined();
+        expect.soft(reads).toEqual([{ value: 42 }]);
+        expect(database.isOpen).toBe(false);
+
+        // The SDK Server supports a new connection after its preceding close settles.
+        database = new DatabaseSync(":memory:");
+        const nextClient = await connect();
+        await expect(
+          nextClient.callTool({ name: tool.name, arguments: {} }),
+        ).resolves.toMatchObject({
+          content: [{ type: "text", text: mode === "handler" ? "done" : "accepted" }],
+        });
+        await pendingWork;
+        expect(reads.at(-1)).toEqual({ value: 42 });
+      } finally {
+        finish.resolve();
+        await pendingWork?.catch(() => {});
+        await closing;
+        await siblingClose;
+        await Promise.all(clients.map((client) => client.close()));
+        await server.close();
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+    },
+  );
+
+  it("does not execute a request queued in SDK microtasks when close starts", async () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec("CREATE TABLE calls (value INTEGER)");
+    const tool: AnyAgentTool = {
+      name: "queued_write",
+      label: "Queued write",
+      description: "Records actual tool admission",
+      parameters: Type.Object({}),
+      execute: async () => {
+        database.prepare("INSERT INTO calls VALUES (1)").run();
+        return { content: [{ type: "text", text: "done" }], details: {} };
+      },
+    };
+    const server = createToolsMcpServer({ name: "queued-admission", tools: [tool] });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "queued-client", version: "0.0.0" }, { capabilities: {} });
+    try {
+      await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+      const sent = clientTransport.send({
+        jsonrpc: "2.0",
+        id: "queued-before-close",
+        method: "tools/call",
+        params: { name: tool.name, arguments: {} },
+      });
+      await server.close();
+      await sent;
+      await nextTurn();
+      expect(database.prepare("SELECT count(*) AS count FROM calls").get()).toEqual({ count: 0 });
+    } finally {
+      await client.close();
+      await server.close();
+      database.close();
     }
   });
 });

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -1,23 +1,70 @@
 // MCP stdio server exposes OpenClaw tools over the MCP stdio transport.
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { VERSION } from "../version.js";
 import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
 
+class ToolsMcpServer extends Server {
+  #work = new AsyncWorkScope();
+  #closing: Promise<void> | undefined;
+
+  runRequest<T>(run: () => Promise<T>, signal: AbortSignal): Promise<T> {
+    // SDK request callbacks are queued in microtasks and may enter after transport closure.
+    if (this.#closing || !this.transport) {
+      return Promise.reject(McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed"));
+    }
+    signal.throwIfAborted();
+    return this.#work.track(run);
+  }
+
+  override close(): Promise<void> {
+    if (this.#closing) {
+      return this.#closing;
+    }
+    const closed = createDeferredCore();
+    this.#closing = closed.promise;
+    const work = this.#work;
+    void (async () => {
+      try {
+        // Native close delivers cancellation; it does not join accepted tool work.
+        await super.close();
+      } finally {
+        await work.drain();
+        // The same SDK Server can connect again after this close has fully settled.
+        this.#work = new AsyncWorkScope();
+        this.#closing = undefined;
+      }
+    })().then(closed.resolve, closed.reject);
+    return closed.promise;
+  }
+}
+
 export function createToolsMcpServer(params: { name: string; tools: AnyAgentTool[] }): Server {
   const handlers = createPluginToolsMcpHandlers(params.tools);
-  const server = new Server(
+  const server = new ToolsMcpServer(
     { name: params.name, version: VERSION },
     { capabilities: { tools: {} } },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, handlers.listTools);
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
+    return await server.runRequest(handlers.listTools, extra.signal);
+  });
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    return await handlers.callTool(request.params, extra.signal);
+    return await server.runRequest(
+      async () => await handlers.callTool(request.params, extra.signal),
+      extra.signal,
+    );
   });
 
   return server;
@@ -70,7 +117,13 @@ export async function connectToolsMcpServerToStdio(
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
 
-  await server.connect(transport);
+  try {
+    await server.connect(transport);
+  } catch (error) {
+    shutdown();
+    await shutdownComplete;
+    throw error;
+  }
   if (options.onShutdown) {
     await shutdownComplete;
   }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where MCP tool-server shutdown could release resources while canceled tool calls or their cooperating cleanup were still using them. Native SQLite queries could then fail with a closed-database error. A failed stdio connection also skipped the shutdown callback.

## Why This Change Was Made

The factory's server now joins admitted handler work after closing the transport. Concurrent close calls share that completion, and the server remains reusable after an awaited close. The stdio connector performs shutdown after connection failure and preserves the original connection error.

## User Impact

Tool bridges finish accepted cleanup before their shutdown owner releases dependencies. Transport cancellation remains prompt. External force-kills can still interrupt cleanup.

## Evidence

- Four native SDK/SQLite cases pass, including both reproduced early-close failures, cancellation, and reconnect controls.
- The exact changed-file gate passed in 344 seconds; the ordinary build passed in 244 seconds.
- Compiled stdio proof ran real JSON-RPC initialize/list/call, sent SIGTERM, and verified the final SQLite read completed before shutdown closed the database. The child exited successfully.
- Compiled connection-failure proof preserved the actual SDK error, joined native cleanup, and restored process listeners. A separate control preserved return-after-connect behavior without a shutdown callback.
- The optional control initially sampled before signal delivery; its fixture was corrected to await the actual signal, and only that control was rerun. All three accepted cases use the same production and compiled artifacts.
- Independent Codex review found no actionable findings. Both source files remain identical after rebasing onto current main.
