### PR TITLE
fix(ui): invalid message widths stretch the chat transcript

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -271,8 +271,9 @@ Messages forwarded by `sessions_send` render as left-aligned speech bubbles with
 Drag the side-panel divider to resize a task's **Review** transcript. Messages
 and expanded tool input reflow within the panel, keeping tool-card borders visible.
 
-Wide-monitor users can override the transcript width under **Settings → Chat →
+Wide-monitor users can override the transcript width under **Settings → Appearance → Chat →
 Message width**. The preference stays in that browser's local storage. Supported
 forms include plain lengths and percentages such as `960px` or `82%`, plus
 constrained `min(...)`, `max(...)`, `clamp(...)`, `calc(...)`, and
-`fit-content(...)` width expressions.
+`fit-content(...)` width expressions supported by your browser. Invalid input
+shows an error and keeps the last saved width. Clear the field to restore the default.

--- a/ui/src/app/settings.browser.test.ts
+++ b/ui/src/app/settings.browser.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "vitest";
+import {
+  loadSettings,
+  normalizeChatMessageMaxWidth,
+  saveSettings,
+  settingsKeyForGateway,
+} from "./settings.ts";
+
+it("normalizes and persists browser-local chat message width", () => {
+  const stored = Object.keys(localStorage).map((key) => [key, localStorage.getItem(key)!] as const);
+  try {
+    const settings = loadSettings();
+    const scopedKey = settingsKeyForGateway(settings.gatewayUrl);
+
+    expect(normalizeChatMessageMaxWidth("  min(1280px,   82%)  ")).toBe("min(1280px, 82%)");
+    expect(normalizeChatMessageMaxWidth("960px; color: red")).toBeUndefined();
+
+    saveSettings({ ...settings, chatMessageMaxWidth: "  min(1280px,   82%)  " });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatMessageMaxWidth).toBe(
+      "min(1280px, 82%)",
+    );
+    expect(loadSettings().chatMessageMaxWidth).toBe("min(1280px, 82%)");
+
+    saveSettings({ ...loadSettings(), chatMessageMaxWidth: undefined });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "chatMessageMaxWidth",
+    );
+  } finally {
+    localStorage.clear();
+    for (const [key, value] of stored) {
+      localStorage.setItem(key, value);
+    }
+  }
+});
+
+it.each([
+  "none",
+  "min-content",
+  "max-content",
+  "48rem",
+  "960px",
+  "82%",
+  ".5em",
+  "80ch",
+  "80vw",
+  "90vh",
+  "30vmin",
+  "40vmax",
+  "min(1280px, 82%)",
+  "max(30rem, 70%)",
+  "clamp(400px, 80%, 960px)",
+  "calc(100% - 2rem)",
+  "min(calc(100% - 2rem), 960px)",
+])("preserves supported message width %s", (value) => {
+  expect(normalizeChatMessageMaxWidth(value)).toBe(value);
+});
+
+it.each([
+  "calc(100%-2rem)",
+  "clamp(400px, 80%)",
+  "960px; color: red",
+  "var(--reading-width)",
+  "10cm",
+  "inherit",
+  "fit-content",
+])("rejects unsupported message width %s", (value) => {
+  expect(normalizeChatMessageMaxWidth(value)).toBeUndefined();
+});

--- a/ui/src/app/settings.preferences.node.test.ts
+++ b/ui/src/app/settings.preferences.node.test.ts
@@ -22,7 +22,6 @@ import {
   persistSessionToken,
   loadSettings,
   loadUiPreferences,
-  normalizeChatMessageMaxWidth,
   saveSettings,
 } from "./settings.ts";
 
@@ -342,26 +341,6 @@ describe("settings preference persistence", () => {
     saveSettings({ ...loadSettings(), showAdvancedSettings: false });
     expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
       "showAdvancedSettings",
-    );
-  });
-
-  it("normalizes and persists browser-local chat message width", () => {
-    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-
-    expect(normalizeChatMessageMaxWidth("  min(1280px,   82%)  ")).toBe("min(1280px, 82%)");
-    expect(normalizeChatMessageMaxWidth("960px; color: red")).toBeUndefined();
-
-    saveSettings({ ...loadSettings(), chatMessageMaxWidth: "  min(1280px,   82%)  " });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatMessageMaxWidth).toBe(
-      "min(1280px, 82%)",
-    );
-    expect(loadSettings().chatMessageMaxWidth).toBe("min(1280px, 82%)");
-
-    saveSettings({ ...loadSettings(), chatMessageMaxWidth: undefined });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "chatMessageMaxWidth",
     );
   });
 

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -69,21 +69,6 @@ const CSS_WIDTH_IDENTIFIER_RE = /[A-Za-z][A-Za-z0-9-]*/g;
 const CSS_WIDTH_SIMPLE_RE = /^(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem|em|ch|vw|vh|vmin|vmax|%)$/i;
 const CSS_WIDTH_MAX_LENGTH = 96;
 
-function hasBalancedParentheses(value: string): boolean {
-  let depth = 0;
-  for (const char of value) {
-    if (char === "(") {
-      depth++;
-    } else if (char === ")") {
-      depth--;
-      if (depth < 0) {
-        return false;
-      }
-    }
-  }
-  return depth === 0;
-}
-
 function hasAllowedWidthIdentifiers(value: string): boolean {
   for (const match of value.matchAll(CSS_WIDTH_IDENTIFIER_RE)) {
     const identifier = match[0].toLowerCase();
@@ -114,7 +99,7 @@ export function normalizeChatMessageMaxWidth(value: unknown): string | undefined
   }
   if (
     !CSS_WIDTH_ALLOWED_CHARS.test(normalized) ||
-    !hasBalancedParentheses(normalized) ||
+    !CSS.supports("max-width", normalized) ||
     !hasAllowedWidthIdentifiers(normalized)
   ) {
     return undefined;

--- a/ui/src/e2e/settings-message-width.e2e.test.ts
+++ b/ui/src/e2e/settings-message-width.e2e.test.ts
@@ -1,0 +1,92 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect as browserExpect } from "playwright/test";
+import { expect, it } from "vitest";
+import {
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionUrl,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Settings message width" });
+
+suite.define(() => {
+  it("retains the last valid reading width when CSS math is mistyped", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        historyMessages: [{ role: "assistant", content: "A comfortable reading column." }],
+      });
+      const settingsUrl = `${suite.server.baseUrl}settings/appearance#settings-appearance-chat`;
+      const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      const storedWidth = () =>
+        page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key) ?? "{}").chatMessageMaxWidth,
+          settingsKey,
+        );
+      const widthInput = page.getByRole("textbox", { name: "Message width", exact: true });
+      await page.goto(settingsUrl);
+      await widthInput.fill("  min(768px,   82%)  ");
+      await widthInput.press("Tab");
+      await browserExpect.poll(storedWidth).toBe("min(768px, 82%)");
+
+      await widthInput.fill("calc(100%-2rem)");
+      await widthInput.press("Tab");
+      const rejected = await widthInput.evaluate((input: HTMLInputElement) => ({
+        value: input.value,
+        invalid: input.validity.customError,
+        message: input.validationMessage,
+      }));
+      const storedAfterTypo = await storedWidth();
+      if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR) {
+        await page.screenshot({ path: path.join(suite.artifactDir, "settings-typo.png") });
+      }
+      await page.reload();
+      await widthInput.waitFor();
+      const restoredWidth = await widthInput.inputValue();
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      const transcript = page.locator(".chat-thread-inner");
+      await transcript.getByText("A comfortable reading column.").waitFor();
+      const rendered = await transcript.evaluate((element) => ({
+        maxWidth: getComputedStyle(element).maxWidth,
+        width: element.getBoundingClientRect().width,
+      }));
+      if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR) {
+        await page.screenshot({ path: path.join(suite.artifactDir, "chat-after-typo.png") });
+        writeFileSync(
+          path.join(suite.artifactDir, "width-outcome.json"),
+          JSON.stringify({ rejected, storedAfterTypo, restoredWidth, rendered }, null, 2),
+        );
+      }
+      expect.soft(rejected.invalid).toBe(true);
+      expect.soft(rejected.message).toContain("Enter a CSS width");
+      expect.soft(storedAfterTypo).toBe("min(768px, 82%)");
+      expect.soft(restoredWidth).toBe("min(768px, 82%)");
+      expect.soft(rendered.maxWidth).toBe("min(768px, 82%)");
+
+      await page.goto(settingsUrl);
+      await widthInput.fill("clamp(400px, 80%)");
+      await widthInput.press("Tab");
+      expect(
+        await widthInput.evaluate((input: HTMLInputElement) => input.validity.customError),
+      ).toBe(true);
+      await widthInput.fill("calc(100% - 2rem)");
+      await widthInput.press("Tab");
+      await browserExpect.poll(storedWidth).toBe("calc(100% - 2rem)");
+      await browserExpect(widthInput).toHaveJSProperty("validationMessage", "");
+      await page.reload();
+      await browserExpect(widthInput).toHaveValue("calc(100% - 2rem)");
+
+      await widthInput.fill("");
+      await widthInput.press("Tab");
+      await browserExpect.poll(storedWidth).toBeUndefined();
+      await page.reload();
+      await browserExpect(widthInput).toHaveValue("");
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      await transcript.getByText("A comfortable reading column.").waitFor();
+      expect(await transcript.evaluate((element) => getComputedStyle(element).maxWidth)).toBe(
+        "768px",
+      );
+    });
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users editing **Settings → Appearance → Chat → Message width** could save a mistyped CSS expression such as `calc(100%-2rem)`, causing the chat transcript to expand beyond their saved reading width. The invalid value survived a reload without an error.

## Why This Change Was Made

The existing width validator now uses the browser's CSS parser for expression syntax, replacing an incomplete parenthesis checker while retaining the existing allowed units and functions. This removes 15 production lines and keeps validation at the shared preference owner used by the form, saving, and loading.

## User Impact

Invalid expressions show the existing correction message and leave the last valid width in place. Corrected expressions save normally, and clearing the field restores the default width.

## Evidence

The full browser flow enters a valid width, attempts the typo, reloads Settings, and opens chat. Before the fix, the typo persisted and the transcript had no maximum width (962px in the captured viewport). After the fix, validation rejects the typo and preserves the previous 768px reading column. Native validity assertions verify the error message; the screenshots do not claim to show the browser's validation bubble.

| Before | After |
| --- | --- |
| ![Settings after entering the mistyped width, before the fix](https://github.com/user-attachments/assets/ce21bd01-4b10-4fdc-b158-85ff6fbe45c5) | ![Settings after entering the same mistyped width, after the fix](https://github.com/user-attachments/assets/0a71bcc6-2849-4ccb-94d0-0de0afc36632) |
| ![Chat after reloading the saved typo, before the fix](https://github.com/user-attachments/assets/fc629650-0a29-4427-a67c-5cb4c893547d) | ![Chat after reloading, with the last valid width preserved](https://github.com/user-attachments/assets/0e275e5a-f340-45b9-82f4-ecd97e08506f) |

- Real Chromium and Control UI with a deterministic mock Gateway; synthetic data only. The original flow failed before the repair and passed afterward, including correction and reset.
- Browser coverage retains the direct raw-whitespace `saveSettings` normalization, persistence, reload, and clear checks using native storage with cleanup, plus allowed-expression and rejection cases. Existing settings and form-control tests passed.
- Changed-file checks, UI types, focused lint/format checks, and independent P2 review passed.

This proof uses a mock Gateway and does not claim live-provider or operator-Gateway coverage.

The initial [CI run](https://github.com/openclaw/openclaw/actions/runs/34286259589) failed on an unchanged CLI-history test that still expected object identity after imported-message identity projection changed. The shared assertion correction landed in [#142618](https://github.com/openclaw/openclaw/pull/142618). This branch now includes that fix through a rebase; the message-width patch is unchanged.

The [next CI run](https://github.com/openclaw/openclaw/actions/runs/34288105356) passed all UI E2E shards but hit an unrelated, pre-existing Codex protocol file-size lint failure. The independently authored fix landed in [#142648](https://github.com/openclaw/openclaw/pull/142648). This baseline refresh includes that fix and preserves the same message-width patch and screenshots.

A [subsequent CI run](https://github.com/openclaw/openclaw/actions/runs/34290469265) passed the previous blockers but timed out after 120 seconds in `test/scripts/run-vitest-profile.test.ts`, specifically “rejects main --unknown-profile-test-option before evaluating config.” One diagnostic run of the entire, unchanged 35-case profiler file at the exact CI merge passed on Linux with Node 24.19.0, 4 CPUs, and about 15.4 GiB RAM; the affected case took 251 ms. This single pass did not reproduce the timeout and does not rule out an intermittent bug. The profiler timeout remains an unresolved follow-up; no profiler source, assertions, timeouts, or startup workaround changed in this PR.

One normal failed-job rerun of that same head completed successfully as [attempt 2](https://github.com/openclaw/openclaw/actions/runs/34290469265/attempts/2). This is an additional passing observation, not a claim that the intermittent profiler timeout is fixed.
