### PR TITLE
fix(plugins): retain registration work through final resource cleanup

### DIFF
--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -114,7 +114,15 @@ export function runPluginRegisterSyncInRegistry(
   withPluginRegistrationContext(
     registry,
     pluginId,
-    () => runPluginRegisterSync(register, api, registry),
+    () => {
+      const inspection = getPluginRegistryInspectionResources(registry);
+      const run = () => runPluginRegisterSync(register, api, registry);
+      if (inspection) {
+        inspection.runRegistration(pluginId, run);
+      } else {
+        run();
+      }
+    },
     {
       registerMemoryCapability: api.registerMemoryCapability,
     },

--- a/src/plugins/registry-inspection-resources.ts
+++ b/src/plugins/registry-inspection-resources.ts
@@ -38,6 +38,10 @@ export class PluginRegistryInspectionResources {
     this.#source.register(pluginId, disposer);
   }
 
+  runRegistration(pluginId: string, run: () => void): void {
+    this.#source.runRegistration(pluginId, run);
+  }
+
   trackRegistration(pending: Promise<unknown>): void {
     this.#source.trackRegistration(pending);
   }

--- a/src/plugins/registry-lifecycle.test.ts
+++ b/src/plugins/registry-lifecycle.test.ts
@@ -1,5 +1,12 @@
+import { readFile } from "node:fs/promises";
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "./loader.js";
 import {
@@ -224,10 +231,12 @@ type InspectionConnection = { database: DatabaseSync; disposals: number; cleanup
 let inspectionFixtureId = 0;
 
 function createInspectionFixture(options?: {
-  registration?: "throw" | "async-resolve" | "async-reject";
+  registration?: "throw" | "async-resolve" | "async-reject" | "thenable" | "tracked";
   pauseDisposal?: boolean;
   disposalFailure?: boolean;
   contextEngine?: boolean;
+  capturedDisposal?: "async-context" | "work-tracker" | "sibling-tracker";
+  queuedAbortCleanup?: boolean;
 }) {
   useNoBundledPlugins();
   const id = `owned-inspection-${inspectionFixtureId++}`;
@@ -237,7 +246,19 @@ function createInspectionFixture(options?: {
   const finishDisposal = createDeferredCore();
   const disposalStarted = createDeferredCore();
   const disposed = createDeferredCore();
-  const sibling: { read?: () => unknown; result?: unknown } = {};
+  const sibling: {
+    read?: () => unknown;
+    result?: unknown;
+    track?: (run: () => Promise<void>) => Promise<void>;
+  } = {};
+  const captured: {
+    registrationSignal?: AbortSignal;
+    disposalSignal?: AbortSignal;
+    read?: unknown;
+    abortCleanup?: Promise<void>;
+    abortRead?: unknown;
+    tracker?: ReturnType<typeof captureAsyncWorkTracker>;
+  } = {};
   const state = {
     connections,
     resume,
@@ -245,8 +266,13 @@ function createInspectionFixture(options?: {
     disposalStarted,
     disposed,
     sibling,
+    captured,
+    captureAsyncWorkTracker,
+    getAsyncWorkSignal,
+    trackAsyncWork,
     lateRead: 0,
     factoryCalls: 0,
+    thenCalls: 0,
   };
   Object.defineProperty(globalThis, key, { value: state, configurable: true });
   const plugin = writePlugin({
@@ -259,13 +285,17 @@ module.exports = {
     const database = new DatabaseSync(":memory:");
     const connection = { database, disposals: 0, cleanups: 0 };
     state.connections.push(connection);
+    const captureMode = ${JSON.stringify(options?.capturedDisposal)};
     class NativeLifecycle {
       id = " native-resource ";
       #database = database;
       async dispose() {
         connection.disposals++;
+        if (captureMode) state.captured.disposalSignal = state.getAsyncWorkSignal();
         state.disposalStarted.resolve();
         if (${options?.pauseDisposal === true}) await state.finishDisposal.promise;
+        if (captureMode === "sibling-tracker") state.sibling.result = state.sibling.read();
+        if (captureMode) state.captured.read = this.#database.prepare("SELECT 42 AS value").get();
         this.#database.close();
         state.disposed.resolve();
         if (${options?.disposalFailure === true}) throw new Error("fixture disposal failed");
@@ -275,7 +305,27 @@ module.exports = {
         if (database.isOpen) database.close();
       };
     }
-    api.registerRuntimeLifecycle(new NativeLifecycle());
+    const lifecycle = new NativeLifecycle();
+    if (${options?.queuedAbortCleanup === true}) {
+      const track = state.captureAsyncWorkTracker();
+      state.getAsyncWorkSignal().addEventListener("abort", () => queueMicrotask(() => {
+        state.captured.abortCleanup = track(async () => {
+          await require("node:fs/promises").readFile(__filename);
+          state.captured.abortRead = database.prepare("SELECT 42 AS value").get();
+          state.sibling.result = state.sibling.read?.();
+        });
+        void state.captured.abortCleanup.catch(() => {});
+      }), { once: true });
+    }
+    if (captureMode) {
+      state.captured.registrationSignal = state.getAsyncWorkSignal();
+      const dispose = lifecycle.dispose.bind(lifecycle);
+      const track = state.captured.tracker = state.captureAsyncWorkTracker();
+      lifecycle.dispose = captureMode === "async-context"
+        ? require("node:async_hooks").AsyncLocalStorage.bind(() => state.trackAsyncWork(dispose))
+        : captureMode === "sibling-tracker" ? () => state.sibling.track(dispose) : () => track(dispose);
+    }
+    api.registerRuntimeLifecycle(lifecycle);
     if (${options?.contextEngine === true}) {
       api.registerContextEngine(${JSON.stringify(id)}, () => {
         state.factoryCalls++;
@@ -284,12 +334,19 @@ module.exports = {
     }
     const mode = ${JSON.stringify(options?.registration)};
     if (mode === "throw") throw new Error("fixture registration failed");
-    if (mode?.startsWith("async")) return (async () => {
+    const finishRegistration = async () => {
       await state.resume.promise;
       state.lateRead = database.prepare("SELECT 42 AS value").get().value;
       state.sibling.result = state.sibling.read?.();
       if (mode === "async-reject") throw new Error("late registration failure");
-    })();
+    };
+    if (mode === "thenable") return { then(resolve, reject) {
+      state.thenCalls++;
+      finishRegistration().then(resolve, reject);
+    } };
+    if (mode === "tracked") {
+      void state.trackAsyncWork(finishRegistration);
+    } else if (mode?.startsWith("async")) return finishRegistration();
   },
 };`,
   });
@@ -329,7 +386,97 @@ module.exports = {
   };
 }
 
+function acquireFixtureInspection(fixtures: Array<ReturnType<typeof createInspectionFixture>>) {
+  return acquirePluginRegistryForInspection({
+    config: {
+      plugins: {
+        allow: fixtures.map((fixture) => fixture.plugin.id),
+        load: { paths: fixtures.map((fixture) => fixture.plugin.file) },
+        slots: { memory: "none" },
+      },
+    },
+  });
+}
+
 describe("owned plugin inspections", () => {
+  it.each([
+    { capturedDisposal: "async-context", disposalFailure: false },
+    { capturedDisposal: "work-tracker", disposalFailure: true },
+  ] as const)(
+    "keeps registration cleanup captured by $capturedDisposal after its caller closes",
+    async ({ capturedDisposal, disposalFailure }) => {
+      const fixture = createInspectionFixture({
+        capturedDisposal,
+        disposalFailure,
+        pauseDisposal: true,
+      });
+      const caller = new AsyncWorkScope();
+      const closer = new AsyncWorkScope();
+      let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+      let borrowed: { release: () => Promise<void> } | undefined;
+      try {
+        inspection = await caller.track(() =>
+          acquirePluginRegistryForInspection({ config: fixture.config }),
+        );
+        borrowed = getPluginRegistryInspectionResources(inspection.registry)!.retain();
+        const authority = capturePluginLifecycleAuthority(inspection.registry, undefined, {
+          scopedRuntime: true,
+        })!;
+        await inspection.release();
+        await caller.drain();
+        expect(caller.signal.aborted).toBe(true);
+        expect(authority()).toBe(false);
+        expect(fixture.connection().database.prepare("SELECT 42 AS value").get()).toEqual({
+          value: 42,
+        });
+        const registrationSignalAborted = fixture.state.captured.registrationSignal?.aborted;
+        const released = closer
+          .track(() => borrowed!.release())
+          .then(
+            () => ({ phase: "released", error: undefined }),
+            (error: unknown) => ({ phase: "released", error }),
+          );
+        expect(
+          await Promise.race([
+            fixture.state.disposalStarted.promise.then(() => ({
+              phase: "disposing",
+              error: undefined,
+            })),
+            released,
+          ]),
+        ).toEqual({ phase: "disposing", error: undefined });
+        expect(registrationSignalAborted).toBe(false);
+        expect(fixture.state.captured.registrationSignal).not.toBe(caller.signal);
+        expect(fixture.state.captured.disposalSignal).toBe(
+          fixture.state.captured.registrationSignal,
+        );
+        expect(fixture.connection().database.isOpen).toBe(true);
+        expect(authority()).toBe(false);
+        fixture.state.finishDisposal.resolve();
+        const outcome = await released;
+        if (disposalFailure) {
+          expect(outcome.error).toMatchObject({
+            errors: [
+              expect.objectContaining({
+                message: `Plugin inspection disposal failed: ${fixture.plugin.id}:native-resource`,
+                cause: expect.objectContaining({ message: "fixture disposal failed" }),
+              }),
+            ],
+          });
+        } else {
+          expect(outcome.error).toBeUndefined();
+        }
+        expect(fixture.state.captured.read).toEqual({ value: 42 });
+        expect(fixture.connection().disposals).toBe(1);
+        expect(fixture.connection().database.isOpen).toBe(false);
+        expect(fixture.connection().cleanups).toBe(0);
+      } finally {
+        await fixture.cleanup(inspection, borrowed);
+        await Promise.all([caller.drain(), closer.drain()]);
+      }
+    },
+  );
+
   it("releases an uncached inspection without disposing or changing the raw loader value", async () => {
     const fixture = createInspectionFixture({ pauseDisposal: true });
     const active = createEmptyPluginRegistry();
@@ -444,15 +591,7 @@ describe("owned plugin inspections", () => {
       let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
       let borrowed: { release: () => Promise<void> } | undefined;
       try {
-        inspection = await acquirePluginRegistryForInspection({
-          config: {
-            plugins: {
-              allow: [failed.plugin.id, successful.plugin.id],
-              load: { paths: [failed.plugin.file, successful.plugin.file] },
-              slots: { memory: "none" },
-            },
-          },
-        });
+        inspection = await acquireFixtureInspection([failed, successful]);
         if (retainSibling) {
           borrowed = getPluginRegistryInspectionResources(inspection.registry)!.retain();
         }
@@ -619,8 +758,8 @@ describe("owned plugin inspections", () => {
     },
   );
 
-  it.each(["async-resolve", "async-reject"] as const)(
-    "waits for actual invalid registration work before disposal (%s)",
+  it.each(["async-resolve", "async-reject", "thenable", "tracked"] as const)(
+    "waits for actual registration work before disposal (%s)",
     async (registration) => {
       const sibling = createInspectionFixture();
       const fixture = createInspectionFixture({ registration });
@@ -628,19 +767,16 @@ describe("owned plugin inspections", () => {
         sibling.connection().database.prepare("SELECT 42 AS value").get()?.value;
       let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
       try {
-        inspection = await acquirePluginRegistryForInspection({
-          config: {
-            plugins: {
-              allow: [sibling.plugin.id, fixture.plugin.id],
-              load: { paths: [sibling.plugin.file, fixture.plugin.file] },
-              slots: { memory: "none" },
-            },
-          },
-        });
-        expect(
-          inspection.registry.plugins.find((entry) => entry.id === fixture.plugin.id)?.error,
-        ).toContain("plugin register must be synchronous");
-        expect(inspection.registry.runtimeLifecycles).toHaveLength(1);
+        inspection = await acquireFixtureInspection([sibling, fixture]);
+        const record = inspection.registry.plugins.find((entry) => entry.id === fixture.plugin.id);
+        if (registration === "tracked") {
+          expect(record?.status).toBe("loaded");
+        } else {
+          expect(record?.error).toContain("plugin register must be synchronous");
+        }
+        expect(inspection.registry.runtimeLifecycles).toHaveLength(
+          registration === "tracked" ? 2 : 1,
+        );
         let released = false;
         const release = inspection.release().then(() => {
           released = true;
@@ -652,6 +788,9 @@ describe("owned plugin inspections", () => {
         await release;
         expect(fixture.state.lateRead).toBe(42);
         expect(fixture.state.sibling.result).toBe(42);
+        if (registration === "thenable") {
+          expect(fixture.state.thenCalls).toBe(1);
+        }
         expect(sibling.connection().database.isOpen).toBe(false);
         expect(fixture.connection().disposals).toBe(1);
         expect(fixture.connection().database.isOpen).toBe(false);
@@ -662,6 +801,147 @@ describe("owned plugin inspections", () => {
     },
   );
 
+  it("joins queued registration-signal cleanup before disposing native resources", async () => {
+    const fixture = createInspectionFixture({ queuedAbortCleanup: true });
+    let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+    try {
+      inspection = await acquirePluginRegistryForInspection({ config: fixture.config });
+      await inspection.release();
+      await expect(fixture.state.captured.abortCleanup).resolves.toBeUndefined();
+      expect(fixture.state.captured.abortRead).toEqual({ value: 42 });
+      expect(fixture.connection().disposals).toBe(1);
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().cleanups).toBe(0);
+    } finally {
+      await fixture.cleanup(inspection);
+    }
+  });
+
+  it.each([false, true])(
+    "joins cross-registration abort work before last-borrower disposal (descendant: %s)",
+    async (descendant) => {
+      const first = createInspectionFixture({ queuedAbortCleanup: true });
+      const sibling = createInspectionFixture(
+        descendant ? { capturedDisposal: "work-tracker" } : undefined,
+      );
+      let siblingWork: Promise<void> | undefined;
+      let siblingReads: unknown;
+      first.state.sibling.read = descendant
+        ? () => {
+            siblingWork = sibling.state.captured.tracker!(async () => {
+              await readFile(sibling.plugin.file);
+              siblingReads = {
+                first: first.connection().database.prepare("SELECT 42 AS value").get()?.value,
+                sibling: sibling.connection().database.prepare("SELECT 42 AS value").get()?.value,
+              };
+            });
+            // A deliberately returns before B's admitted descendant settles.
+            void siblingWork.catch(() => undefined);
+          }
+        : () => sibling.connection().database.prepare("SELECT 42 AS value").get()?.value;
+      let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+      let borrowed: { release: () => Promise<void> } | undefined;
+      try {
+        inspection = await acquireFixtureInspection([first, sibling]);
+        borrowed = getPluginRegistryInspectionResources(inspection.registry)!.retain();
+        await inspection.release();
+        expect(first.connection().disposals).toBe(0);
+        expect(sibling.connection().disposals).toBe(0);
+        await borrowed.release();
+        expect(first.state.captured.abortRead).toEqual({ value: 42 });
+        await expect(first.state.captured.abortCleanup).resolves.toBeUndefined();
+        if (descendant) {
+          await expect(siblingWork).resolves.toBeUndefined();
+          expect(siblingReads).toEqual({ first: 42, sibling: 42 });
+        } else {
+          expect(first.state.sibling.result).toBe(42);
+        }
+        for (const fixture of [first, sibling]) {
+          expect(fixture.connection().disposals).toBe(1);
+          expect(fixture.connection().database.isOpen).toBe(false);
+          expect(fixture.connection().cleanups).toBe(0);
+        }
+      } finally {
+        await first.cleanup(inspection, borrowed);
+        await siblingWork?.catch(() => undefined);
+        await sibling.cleanup();
+      }
+    },
+  );
+
+  it("joins rollback abort work handed to an open retained sibling", async () => {
+    const sibling = createInspectionFixture({ capturedDisposal: "work-tracker" });
+    const failed = createInspectionFixture({ registration: "throw", queuedAbortCleanup: true });
+    const handedOff = createDeferredCore();
+    let siblingWork: Promise<void> | undefined;
+    let reads: unknown;
+    failed.state.sibling.read = () => {
+      siblingWork = sibling.state.captured.tracker!(async () => {
+        await readFile(sibling.plugin.file);
+        reads = {
+          failed: failed.connection().database.prepare("SELECT 42 AS value").get()?.value,
+          sibling: sibling.connection().database.prepare("SELECT 42 AS value").get()?.value,
+        };
+      });
+      void siblingWork.catch(() => undefined);
+      handedOff.resolve();
+    };
+    let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+    let borrowed: { release: () => Promise<void> } | undefined;
+    try {
+      inspection = await acquireFixtureInspection([sibling, failed]);
+      borrowed = getPluginRegistryInspectionResources(inspection.registry)!.retain();
+      await handedOff.promise;
+      await expect(siblingWork).resolves.toBeUndefined();
+      expect(reads).toEqual({ failed: 42, sibling: 42 });
+      await failed.state.disposed.promise;
+      expect(failed.connection().disposals).toBe(1);
+      expect(sibling.connection().disposals).toBe(0);
+      expect(sibling.state.captured.registrationSignal?.aborted).toBe(false);
+      await inspection.release();
+      expect(sibling.connection().database.isOpen).toBe(true);
+      await borrowed.release();
+      expect(sibling.connection().database.isOpen).toBe(false);
+      expect(sibling.connection().disposals).toBe(1);
+    } finally {
+      await failed.cleanup(inspection, borrowed);
+      await siblingWork?.catch(() => undefined);
+      await sibling.cleanup();
+    }
+  });
+
+  it("keeps a sibling resource alive while a disposer explicitly uses its work owner", async () => {
+    const first = createInspectionFixture({
+      capturedDisposal: "sibling-tracker",
+      pauseDisposal: true,
+    });
+    const sibling = createInspectionFixture({ capturedDisposal: "work-tracker" });
+    first.state.sibling.track = (run) => sibling.state.captured.tracker!(run);
+    first.state.sibling.read = () =>
+      sibling.connection().database.prepare("SELECT 42 AS value").get()?.value;
+    let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+    try {
+      inspection = await acquireFixtureInspection([first, sibling]);
+      const released = inspection.release();
+      await first.state.disposalStarted.promise;
+      await readFile(first.plugin.file);
+      expect(first.connection().database.isOpen).toBe(true);
+      expect(sibling.connection().database.isOpen).toBe(true);
+      expect(sibling.connection().disposals).toBe(0);
+      first.state.finishDisposal.resolve();
+      await released;
+      expect(first.state.sibling.result).toBe(42);
+      for (const fixture of [first, sibling]) {
+        expect(fixture.connection().disposals).toBe(1);
+        expect(fixture.connection().database.isOpen).toBe(false);
+        expect(fixture.connection().cleanups).toBe(0);
+      }
+    } finally {
+      await first.cleanup(inspection);
+      await sibling.cleanup();
+    }
+  });
+
   it("joins invalid registration work before releasing an inspection with a retained sibling", async () => {
     const sibling = createInspectionFixture();
     const fixture = createInspectionFixture({ registration: "async-reject" });
@@ -670,15 +950,7 @@ describe("owned plugin inspections", () => {
     let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
     let borrowed: { release: () => Promise<void> } | undefined;
     try {
-      inspection = await acquirePluginRegistryForInspection({
-        config: {
-          plugins: {
-            allow: [sibling.plugin.id, fixture.plugin.id],
-            load: { paths: [sibling.plugin.file, fixture.plugin.file] },
-            slots: { memory: "none" },
-          },
-        },
-      });
+      inspection = await acquireFixtureInspection([sibling, fixture]);
       borrowed = getPluginRegistryInspectionResources(inspection.registry)!.retain();
       let released = false;
       const release = inspection.release().then(() => {

--- a/src/plugins/registry-registration-resources.ts
+++ b/src/plugins/registry-registration-resources.ts
@@ -1,8 +1,12 @@
+import { AsyncWorkScope, trackAsyncWork } from "../shared/async-work-scope.js";
+
 export type RegistrationDisposer = { id: string; dispose: () => void | Promise<void> };
 type RegistrationResources = {
   disposers: RegistrationDisposer[];
+  work: AsyncWorkScope;
   rolledBack?: boolean;
   disposal?: Promise<Error[]>;
+  disposalStarted?: boolean;
 };
 
 /** Physical registration custody, independent of registry execution authority. */
@@ -24,13 +28,16 @@ export class PluginRegistrationResourceSource {
           const last = --this.#claims === 0;
           this.#closed = last;
           release = Promise.resolve().then(async () => {
+            const entries = [...this.#registrations]
+              // Construction owns rollback failures; the last claim owns successful entries.
+              .filter(([, entry]) => (entry.rolledBack ? owner === "inspection" : last));
+            // Signal the entire closing batch before scheduling any disposal idle gate.
+            for (const [, entry] of entries) {
+              entry.work.beginClose();
+            }
+            const disposals = entries.map(([pluginId, entry]) => this.#dispose(pluginId, entry));
             await this.#waitForRegistrations();
-            const results = await Promise.all(
-              [...this.#registrations]
-                // Construction owns rollback failures; the last claim owns successful entries.
-                .filter(([, entry]) => (entry.rolledBack ? owner === "inspection" : last))
-                .map(([pluginId, entry]) => this.#dispose(pluginId, entry)),
-            );
+            const results = await Promise.all(disposals);
             return results.flat();
           });
         }
@@ -39,16 +46,34 @@ export class PluginRegistrationResourceSource {
     };
   }
 
-  register(pluginId: string, disposer: RegistrationDisposer): void {
+  #registration(pluginId: string): RegistrationResources {
     let entry = this.#registrations.get(pluginId);
     if (!entry) {
-      entry = { disposers: [] };
+      entry = { disposers: [], work: new AsyncWorkScope() };
       this.#registrations.set(pluginId, entry);
     }
-    entry.disposers.push(disposer);
+    return entry;
+  }
+
+  runRegistration(pluginId: string, run: () => void): void {
+    const entry = this.#registration(pluginId);
+    try {
+      entry.work.run(run);
+    } finally {
+      // This fence includes registration descendants, never the later disposal phase.
+      this.#trackRegistration(entry.work.runWhenIdle(() => undefined));
+    }
+  }
+
+  register(pluginId: string, disposer: RegistrationDisposer): void {
+    this.#registration(pluginId).disposers.push(disposer);
   }
 
   trackRegistration(pending: Promise<unknown>): void {
+    this.#trackRegistration(trackAsyncWork(() => pending));
+  }
+
+  #trackRegistration(pending: Promise<unknown>): void {
     const completion = pending.then(
       () => undefined,
       () => undefined,
@@ -73,20 +98,36 @@ export class PluginRegistrationResourceSource {
 
   #dispose(pluginId: string, entry: RegistrationResources): Promise<Error[]> {
     return (entry.disposal ??= Promise.resolve().then(async () => {
+      entry.work.beginClose();
       // Invalid async registration can still use a successful sibling's resources.
       await this.#waitForRegistrations();
-      const failures: Error[] = [];
-      const disposers = entry.disposers.splice(0);
-      for (const { id, dispose } of disposers) {
-        try {
-          await dispose();
-        } catch (cause) {
-          failures.push(
-            new Error(`Plugin inspection disposal failed: ${pluginId}:${id}`, { cause }),
-          );
-        }
+      try {
+        return await AsyncWorkScope.runWhenAllIdle(
+          () =>
+            [...this.#registrations.values()]
+              .filter((candidate) => !candidate.disposalStarted)
+              .map((candidate) => candidate.work),
+          () =>
+            entry.work.track(async () => {
+              entry.disposalStarted = true;
+              const failures: Error[] = [];
+              const disposers = entry.disposers.splice(0);
+              for (const { id, dispose } of disposers) {
+                try {
+                  await dispose();
+                } catch (cause) {
+                  failures.push(
+                    new Error(`Plugin inspection disposal failed: ${pluginId}:${id}`, { cause }),
+                  );
+                }
+              }
+              return failures;
+            }),
+        );
+      } finally {
+        // Draining inside the tracked disposal callback would wait on itself.
+        await entry.work.drain();
       }
-      return failures;
     }));
   }
 }

--- a/src/shared/async-work-scope.test.ts
+++ b/src/shared/async-work-scope.test.ts
@@ -10,6 +10,98 @@ import {
 import { createDeferredCore } from "./deferred.js";
 
 describe("async work scope", () => {
+  it("excludes newly admitted disposal work while another owner enters its next phase", async () => {
+    const first = new AsyncWorkScope();
+    const second = new AsyncWorkScope();
+    const finishAbort = createDeferredCore();
+    const finishDisposal = createDeferredCore();
+    const disposalStarted = createDeferredCore();
+    let disposing = false;
+    let disposed = false;
+    let secondStarted = false;
+    const abortWork = first.track(() => finishAbort.promise);
+    const selectScopes = () => (disposing ? [second] : [first, second]);
+    const disposal = AsyncWorkScope.runWhenAllIdle(selectScopes, () =>
+      first.track(async () => {
+        disposing = true;
+        disposalStarted.resolve();
+        await finishDisposal.promise;
+        disposed = true;
+      }),
+    );
+    const nextPhase = AsyncWorkScope.runWhenAllIdle(selectScopes, () =>
+      second.track(() => {
+        secondStarted = true;
+      }),
+    );
+    finishAbort.resolve();
+    try {
+      await disposalStarted.promise;
+      await nextTurn();
+      expect(secondStarted).toBe(true);
+      expect(disposed).toBe(false);
+    } finally {
+      finishDisposal.resolve();
+      await Promise.all([abortWork, disposal, nextPhase]);
+      await Promise.all([first.drain(), second.drain()]);
+    }
+  });
+
+  it("preserves synchronous returns and throws without inspecting a thenable", async () => {
+    const scope = new AsyncWorkScope();
+    const readThen = vi.fn(() => {
+      throw new Error("The synchronous caller owns thenable inspection");
+    });
+    const thenable = {
+      // oxlint-disable-next-line unicorn/no-thenable -- The synchronous entry must leave this thenable untouched.
+      get then() {
+        return readThen();
+      },
+    };
+    const value = scope.run(() => {
+      expect(getAsyncWorkSignal()).toBe(scope.signal);
+      return thenable;
+    });
+    expect(value === thenable).toBe(true);
+    const failure = new Error("synchronous failure");
+    let caught: unknown;
+    try {
+      scope.run(() => {
+        throw failure;
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(failure);
+    await scope.drain();
+    expect(readThen).not.toHaveBeenCalled();
+  });
+
+  it("admits synchronous work before a reentrant drain and joins its descendant", async () => {
+    const scope = new AsyncWorkScope();
+    const gate = createDeferredCore();
+    let closing: Promise<void> | undefined;
+    let child: Promise<void> | undefined;
+    let drained = false;
+    scope.run(() => {
+      closing = scope.drain().then(() => {
+        drained = true;
+      });
+      child = trackAsyncWork(() => gate.promise);
+    });
+    try {
+      await nextTurn();
+      expect(drained).toBe(false);
+    } finally {
+      gate.resolve();
+      await child;
+      await closing;
+    }
+    const late = vi.fn();
+    expect(() => scope.run(late)).toThrow("Async work scope is closed");
+    expect(late).not.toHaveBeenCalled();
+  });
+
   it("settles work for cleanup without closing its captured tracker, then fences final drain", async () => {
     const scope = new AsyncWorkScope();
     const track = await scope.track(captureAsyncWorkTracker);

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -22,24 +22,42 @@ export class AsyncWorkScope {
     return this.phase !== "open";
   }
 
+  /** Enters synchronous work without inspecting or assimilating its return value. */
+  run<T>(run: () => T): T {
+    if (this.phase === "closed") {
+      throw new Error("Async work scope is closed");
+    }
+    const operation = this.registerWork<void>();
+    try {
+      return currentWorkScope.run(this, run);
+    } finally {
+      operation.resolve();
+    }
+  }
+
   track<T>(run: () => T | Promise<T>): Promise<T> {
     if (this.phase === "closed") {
       return Promise.reject(new Error("Async work scope is closed"));
     }
     // Register before invoking without delaying received node results behind
     // a subsequent socket-close event. Async descendants inherit this exact owner.
-    const operation = createDeferredCore<T>();
-    this.pending.add(operation.promise);
-    void operation.promise.then(
-      () => this.pending.delete(operation.promise),
-      () => this.pending.delete(operation.promise),
-    );
+    const operation = this.registerWork<T>();
     try {
       operation.resolve(currentWorkScope.run(this, run));
     } catch (error) {
       operation.reject(error);
     }
     return operation.promise;
+  }
+
+  private registerWork<T>() {
+    const operation = createDeferredCore<T>();
+    this.pending.add(operation.promise);
+    void operation.promise.then(
+      () => this.pending.delete(operation.promise),
+      () => this.pending.delete(operation.promise),
+    );
+    return operation;
   }
 
   beginClose(reason?: unknown): void {
@@ -51,11 +69,24 @@ export class AsyncWorkScope {
   }
 
   /** Starts the next phase in the same continuation that observes settled pending work. */
-  async runWhenIdle<T>(run: () => T | Promise<T>): Promise<T> {
+  runWhenIdle<T>(run: () => T | Promise<T>): Promise<T> {
+    return AsyncWorkScope.runWhenAllIdle(
+      () => [this],
+      () => this.track(run),
+    );
+  }
+
+  /** Reselects owners so work admitted into a later phase is not mistaken for earlier work. */
+  static async runWhenAllIdle<T>(
+    selectScopes: () => readonly AsyncWorkScope[],
+    run: () => T | Promise<T>,
+  ): Promise<T> {
+    let scopes = selectScopes();
     do {
-      await Promise.allSettled(this.pending);
-    } while (this.pending.size > 0);
-    return this.track(run);
+      await Promise.allSettled(scopes.flatMap((scope) => [...scope.pending]));
+      scopes = selectScopes();
+    } while (scopes.some((scope) => scope.pending.size > 0));
+    return run();
   }
 
   async drain(): Promise<void> {


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where plugin resource cleanup captured during registration could inherit a caller's already-closed work context. A later resource owner could retain the database but still fail to run its disposer. Registration abort work could also outlive the database it was cleaning up.

## Why This Change Was Made

Owned registration now has its own work context through final disposal. Construction and abort work settle before physical cleanup starts; rollback preserves successful siblings, and the final resource claim joins actual cleanup. The existing work-scope helper handles synchronous registration without inspecting its return value.

## User Impact

Releasing an inspection still retires its authority immediately. Retained resources remain usable by their existing owners, and cleanup can finish in its original registration context before the last claim closes it. Independent cleanup remains concurrent; work explicitly owned by a sibling retains that sibling until it finishes.

## Evidence

- Native regressions reproduced closed captured contexts, cross-registration abort work, and rollback while a successful sibling remained active. All 31 final native lifecycle cases pass; nine shared-work and 59 loader controls also passed on the same production.
- The final six-file changed gate passed in 227 seconds. The ordinary build passed in 205 seconds; the only later source change added native test coverage and consolidated its fixture setup.
- Eight isolated compiled scenarios passed using the actual built loader, real registration claims, native SQLite, and readonly reopen checks. These cover retained context/tracker cleanup, disposal errors, ordinary and raw controls, cross-registration aborts, rollback, and explicit sibling dependencies. All 13,707 build artifacts remained unchanged.
- Independent Codex review completed. Reproduced defects were repaired; follow-up dependency reports were adjudicated against real callers and native/compiled evidence. A captured tracker owns its captured scope, so callers must also await or track work that uses their own resources; the implementation does not infer dependencies from arbitrary closures.
- All six reviewed source files are unchanged after integration with main, including the already-landed CLI work-scope helper.
