### PR TITLE
fix(ui): prevent native URL tooltips on GitHub preview links

### DIFF
--- a/ui/src/components/github-link-title-tooltip.test.ts
+++ b/ui/src/components/github-link-title-tooltip.test.ts
@@ -2,6 +2,8 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { createTestGatewayClient } from "../test-helpers/gateway-client.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
 import { installTitleTooltips } from "./tooltip-title.ts";
 
 const runtimeLoad = vi.hoisted(() => {
@@ -11,6 +13,7 @@ const runtimeLoad = vi.hoisted(() => {
   });
   return { pending, release };
 });
+
 vi.mock(import("./github-link-hovercard.runtime.ts"), async (original) => {
   await runtimeLoad.pending;
   return original();
@@ -173,4 +176,98 @@ it("reserves supported GitHub titles through cold loading, failures, recovery an
     await vi.advanceTimersByTimeAsync(0);
     observer.disconnect();
   }
+});
+
+it("keeps rendered GitHub links free of native titles across preview closure and reentry", async () => {
+  runtimeLoad.release();
+  await import("./github-link-hovercard-registration.ts");
+  const base = document.createElement("base");
+  base.href = "https://dashboard.example/";
+  document.body.append(base);
+  const provider = document.createElement(tag) as HTMLElement & { client: GatewayBrowserClient };
+  provider.client = createTestGatewayClient(async () => response);
+  provider.innerHTML = toSanitizedMarkdownHtml(
+    `${href}\n\n[the **related** issue](${href} "${href}")\n\n[![Issue icon](data:image/png;base64,x "Icon hint")](${href} "Issue details")\n\n[](${href} "Issue details")\n\n[<button>](${href} "Issue details")\n\n[\\*](${href} "Issue details")\n\n[Documentation](https://example.com "Read the documentation")`,
+  );
+  provider.innerHTML += toSanitizedMarkdownHtml(
+    `[<button>](${href} "Issue details")\n\n[<progress title="Build status" value="1" max="2">50%</progress>](${href} "Issue details")\n\n[<progress aria-label="" title="Build status">Working</progress>](${href} "Issue details")\n\n[<progress aria-valuetext="" value="1"></progress>](${href} "Issue details")\n\n[<progress aria-hidden=" TRUE " value="1"></progress>](${href} "Issue details")\n\n[<progress value=""></progress>](${href} "Issue details")\n\n[<progress>Working</progress>](${href} "Issue details")\n\n[<progress aria-labelledby="missing"></progress>](${href} "Issue details")\n\n[Relative issue](${href.replace("https:", "")} "Issue details")`,
+    { progressBars: true },
+  );
+  document.body.append(provider);
+  const links = [...provider.querySelectorAll<HTMLAnchorElement>("a")].filter(
+    (link) => link.href === href,
+  );
+  const noNativeTitles = () => {
+    for (const link of links) {
+      expect.soft(link.hasAttribute("title")).toBe(false);
+      expect(link.querySelector("[title]")).toBeNull();
+      expect(link.href).toBe(href);
+      expect(link.target).toBe("_blank");
+    }
+  };
+  expect(links).toHaveLength(15);
+  expect.soft(links[13]?.getAttribute("aria-label")).toBe("Issue details");
+  expect(links[14]?.getAttribute("href")).toBe(href.replace("https:", ""));
+  noNativeTitles();
+  const anchor = links[1]!;
+  const child = anchor.querySelector("strong")!;
+  const pointer = (target: Element, type: string, relatedTarget?: EventTarget) =>
+    target.dispatchEvent(new MouseEvent(type, { bubbles: true, composed: true, relatedTarget }));
+  pointer(anchor, "pointerover");
+  await customElements.whenDefined(tag);
+  await vi.advanceTimersByTimeAsync(1_000);
+  // The real lazy bootstrap requires browser :hover; focus supplies intent in jsdom.
+  anchor.focus();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("Preview ready");
+  noNativeTitles();
+  pointer(anchor, "pointerout", child);
+  pointer(child, "pointerover", anchor);
+  await vi.advanceTimersByTimeAsync(200);
+  expect(document.querySelector(".github-link-hovercard")).not.toBeNull();
+  anchor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  await vi.advanceTimersByTimeAsync(200);
+  expect(document.querySelector(".github-link-hovercard")).toBeNull();
+  noNativeTitles();
+  pointer(child, "pointerout", document.body);
+  pointer(anchor, "pointerleave", document.body);
+  anchor.blur();
+  await vi.advanceTimersByTimeAsync(200);
+  noNativeTitles();
+  pointer(child, "pointerover", document.body);
+  await vi.advanceTimersByTimeAsync(300);
+  expect(document.querySelector(".github-link-hovercard")).not.toBeNull();
+  noNativeTitles();
+  expect(links[0]?.textContent).toBe("#99815");
+  expect(anchor.textContent).toBe("the related issue");
+  expect(links[2]?.querySelector("img")?.alt).toBe("Issue icon");
+  expect(links[3]?.getAttribute("aria-label")).toBe("Issue details");
+  expect(links[4]?.textContent).toBe("<button>");
+  expect(links[4]?.hasAttribute("aria-label")).toBe(false);
+  expect(links[5]?.textContent).toBe("*");
+  expect.soft(links[5]?.hasAttribute("aria-label")).toBe(false);
+  expect(links[6]?.textContent).toBe("");
+  expect(links[6]?.getAttribute("aria-label")).toBe("Issue details");
+  expect(links[7]?.querySelector("progress")?.value).toBe(1);
+  expect(links[7]?.querySelector("progress")?.getAttribute("aria-label")).toBe("Build status");
+  expect.soft(links[7]?.hasAttribute("aria-label")).toBe(false);
+  expect(links[8]?.hasAttribute("aria-label")).toBe(false);
+  expect.soft(links[8]?.querySelector("progress")?.getAttribute("aria-label")).toBe("Build status");
+  expect.soft(links[9]?.getAttribute("aria-label")).toBe("Issue details");
+  expect(links[10]?.getAttribute("aria-label")).toBe("Issue details");
+  expect(links[11]?.hasAttribute("aria-label")).toBe(false);
+  expect(links[12]?.getAttribute("aria-label")).toBe("Issue details");
+  const ordinary = provider.querySelector<HTMLAnchorElement>('a[href="https://example.com"]')!;
+  pointer(child, "pointerout", ordinary);
+  pointer(anchor, "pointerleave", ordinary);
+  ordinary.focus();
+  await vi.advanceTimersByTimeAsync(200);
+  const tooltip =
+    document.querySelector<HTMLElementTagNameMap["openclaw-tooltip"]>("openclaw-tooltip");
+  expect(tooltip?.content).toBe("Read the documentation");
+  expect(
+    tooltip?.shadowRoot?.querySelector<HTMLElement & { open: boolean }>("wa-tooltip")?.open,
+  ).toBe(true);
+  ordinary.blur();
+  expect(ordinary.title).toBe("Read the documentation");
 });

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -612,7 +612,7 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(anchor?.classList.contains("markdown-github-link")).toBe(true);
       expect(anchor?.dataset.githubKind).toBe(kind);
       expect(anchor?.textContent).toBe(`#${number}`);
-      expect(anchor?.title).toBe(href);
+      expect(anchor?.hasAttribute("title")).toBe(false);
       expect(anchor?.previousSibling?.textContent ?? "").toBe(prefix);
       expect(fragment.textContent).toBe(`${input}\n`);
     });
@@ -858,7 +858,13 @@ describe("toSanitizedMarkdownHtml links", () => {
       ["bare pull request", "https://github.com/openclaw/openclaw/pull/3434", "#3434", "pull"],
       ["bare issue", "https://github.com/openclaw/openclaw/issues/3435", "#3435", "issue"],
       ["autolink", "<https://github.com/openclaw/openclaw/pull/3434>", "#3434", "pull"],
-      ["bare www item", "https://www.github.com/openclaw/openclaw/issues/3435", "#3435", "issue"],
+      [
+        "bare www item",
+        "https://www.github.com/openclaw/openclaw/issues/3435",
+        "#3435",
+        "issue",
+        true,
+      ],
       ["repository", "https://github.com/openclaw/openclaw", "openclaw/openclaw", undefined],
       [
         "repository file",
@@ -944,7 +950,7 @@ describe("toSanitizedMarkdownHtml links", () => {
         "#3434",
         undefined,
       ],
-    ])("marks %s", (_kind, input, expectedText, expectedKind) => {
+    ])("marks %s", (_kind, input, expectedText, expectedKind, keepsTitle = false) => {
       const fragment = htmlFragment(toSanitizedMarkdownHtml(input));
       const link = fragment.querySelector<HTMLAnchorElement>("a");
       expect(link?.classList.contains("markdown-github-link")).toBe(true);
@@ -952,7 +958,7 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(link?.classList.contains("markdown-github-item")).toBe(Boolean(expectedKind));
       expect(link?.getAttribute("data-github-kind")).toBe(expectedKind ?? null);
       if (expectedKind) {
-        expect(link?.getAttribute("title")).toBe(link?.getAttribute("href"));
+        expect(link?.getAttribute("title")).toBe(keepsTitle ? link?.getAttribute("href") : null);
         expect(link?.getAttribute("rel")).toBe("noreferrer noopener");
         expect(link?.getAttribute("target")).toBe("_blank");
       }
@@ -989,15 +995,18 @@ describe("toSanitizedMarkdownHtml links", () => {
       ],
       ["a review comment query", "https://github.com/openclaw/openclaw/pull/3434?tab=files"],
       ["a diff anchor", "https://github.com/openclaw/openclaw/pull/3434/files#diff-abc123"],
-    ])("keeps the specific destination in the chip href and tooltip for %s", (_kind, input) => {
-      const fragment = htmlFragment(toSanitizedMarkdownHtml(input));
-      const link = fragment.querySelector<HTMLAnchorElement>("a");
-      expect(link?.classList.contains("markdown-github-link")).toBe(true);
-      expect(link?.classList.contains("markdown-github-item")).toBe(true);
-      expect(link?.textContent).toBe("#3434");
-      expect(link?.getAttribute("href")).toBe(input);
-      expect(link?.getAttribute("title")).toBe(input);
-    });
+    ])(
+      "keeps the specific destination in the chip href without a native tooltip for %s",
+      (_kind, input) => {
+        const fragment = htmlFragment(toSanitizedMarkdownHtml(input));
+        const link = fragment.querySelector<HTMLAnchorElement>("a");
+        expect(link?.classList.contains("markdown-github-link")).toBe(true);
+        expect(link?.classList.contains("markdown-github-item")).toBe(true);
+        expect(link?.textContent).toBe("#3434");
+        expect(link?.getAttribute("href")).toBe(input);
+        expect(link?.hasAttribute("title")).toBe(false);
+      },
+    );
 
     it.each([
       ["non-github host", "[docs](https://example.com/openclaw)"],
@@ -1035,7 +1044,7 @@ describe("toSanitizedMarkdownHtml links", () => {
       const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-github-link");
       expect(link?.textContent).toBe(label);
       expect(link?.getAttribute("href")).toBe(href);
-      expect(link?.getAttribute("title")).toBe(href);
+      expect(link?.getAttribute("title")).toBe(kind ? null : href);
       expect(link?.classList.contains("markdown-bare-url")).toBe(true);
       expect(link?.classList.contains("markdown-github-item")).toBe(kind !== undefined);
       expect(link?.getAttribute("data-github-kind")).toBe(kind ?? null);

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -2,7 +2,11 @@ import MarkdownIt, { type MarkdownIt as MarkdownItParser, type Token } from "mar
 import markdownItTaskLists from "markdown-it-task-lists";
 import { t } from "../i18n/index.ts";
 import { fileKindForPath, shortestFileLabels } from "./file-kind.ts";
-import { decodeGitHubPathSegment, parseGitHubItemPath } from "./github-link-target.ts";
+import {
+  decodeGitHubPathSegment,
+  parseGitHubItemPath,
+  parseGitHubLinkTarget,
+} from "./github-link-target.ts";
 import {
   installAssistantTranscriptRoleImageRenderer,
   installAssistantTranscriptRoleMarkdown,
@@ -558,6 +562,7 @@ export function createMarkdownParser(): MarkdownItParser {
           open.markup === CODE_SPAN_LINK_MARKUP;
         const host = url.hostname.toLowerCase();
         const githubLink = isGitHubHost(host);
+        const githubPreview = githubLink ? parseGitHubLinkTarget(href) : null;
         if (generatedUrlLabel) {
           open.attrJoin("class", BARE_URL_CLASS);
         }
@@ -577,7 +582,7 @@ export function createMarkdownParser(): MarkdownItParser {
         }
         if (githubLink && labelToken) {
           open.attrJoin("class", GITHUB_LINK_CLASS);
-          const item = parseGitHubItemPath(url);
+          const item = githubPreview ?? parseGitHubItemPath(url);
           const label =
             labelToken.type === "text" &&
             children[index + 1] === labelToken &&
@@ -596,7 +601,7 @@ export function createMarkdownParser(): MarkdownItParser {
           if (generatedUrlLabel) {
             labelToken.content = item ? `#${item.number}` : formatGitHubLinkLabel(url);
           }
-          if (generatedUrlLabel || itemChip) {
+          if (!githubPreview && (generatedUrlLabel || itemChip)) {
             open.attrSet("title", href);
           }
         }

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -5,6 +5,7 @@ import { routeIdFromPath } from "../app-route-paths.ts";
 import { resolveControlUiPaths } from "../app/browser.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { truncateText } from "../lib/format.ts";
+import { parseGitHubLinkTarget } from "./github-link-target.ts";
 import { renderAssistantTranscriptPlainTextFallback } from "./markdown-assistant-transcript.ts";
 import { renderMarkdownCodeBlock } from "./markdown-code-blocks.ts";
 import { isHostLocalMarkdownFileHref } from "./markdown-file-links.ts";
@@ -435,6 +436,34 @@ function normalizeDocsRootHref(href: string): string {
   }
 }
 
+function hasMarkdownContentName(node: Node): boolean {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return Boolean(node.textContent?.trim());
+  }
+  if (
+    !(node instanceof Element) ||
+    node.getAttribute("aria-hidden")?.trim().toLowerCase() === "true"
+  ) {
+    return false;
+  }
+  if (node.matches("img[alt]")) {
+    return Boolean(node.getAttribute("alt")?.trim());
+  }
+  if (node.matches("progress")) {
+    // A progress value names its containing link; fallback text does not.
+    const valueText = node.getAttribute("aria-valuetext");
+    if (valueText !== null) {
+      return Boolean(valueText.trim());
+    }
+    return (
+      node.hasAttribute("value") ||
+      node.hasAttribute("aria-valuenow") ||
+      Boolean(node.getAttribute("aria-label")?.trim() || node.getAttribute("title")?.trim())
+    );
+  }
+  return [...node.childNodes].some(hasMarkdownContentName);
+}
+
 function installHooks() {
   if (hooksInstalled) {
     return;
@@ -462,10 +491,22 @@ function installHooks() {
 
     // Block dangerous URL schemes (javascript:, data:, vbscript:, etc.)
     try {
-      const url = new URL(normalizedHref, window.location.href);
+      const url = new URL(normalizedHref, document.baseURI);
       if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "mailto:") {
         node.removeAttribute("href");
         return;
+      }
+      if (parseGitHubLinkTarget(url.href)) {
+        for (const element of [node, ...node.querySelectorAll("[title]")]) {
+          const title = element.getAttribute("title");
+          // A progress control needs a label; its value only names an enclosing link.
+          const hasContentName = !element.matches("progress") && hasMarkdownContentName(element);
+          if (title && !hasContentName && !element.getAttribute("aria-label")?.trim()) {
+            element.setAttribute("aria-label", title);
+          }
+          // The rendered content owns the name; native hints must not survive preview closure.
+          element.removeAttribute("title");
+        }
       }
       if (url.origin === window.location.origin && isControlUiRoutePath(url.pathname)) {
         node.removeAttribute("rel");

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -540,7 +540,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await page.clock.runFor(300);
     await captureArtifact(page, "github-hovercard-title-tooltip");
     await expect.poll(() => page.locator("openclaw-tooltip[open]").count()).toBe(0);
-    expect(await pullLink.getAttribute("title")).toBe("");
+    expect(await pullLink.getAttribute("title")).toBeNull();
     await expect.poll(() => card.locator("img").count()).toBe(1);
     expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(1);
     const pullBox = await card.boundingBox();


### PR DESCRIPTION
Closes #142615.

Follow-up to #141896 by @roboclaw-bot.

## What Problem This Solves

Fixes an issue where users hovering GitHub links in chat could see a redundant plain URL tooltip after the rich preview closed. The rendered link carried a native `title`, which the shared title adapter restored when pointer or focus intent ended.

## Why This Change Was Made

Markdown links supported by the GitHub preview no longer generate or retain a native title. The existing final HTML attribute hook removes authored titles from the link and its children. It preserves names from rendered text, image alt text, and progress values; otherwise unnamed elements retain their authored title as an accessible label. Preview eligibility uses the resolved destination, including protocol-relative links on HTTPS. The destination and native navigation stay intact.

## User Impact

GitHub issue and pull request links keep their rich preview without leaving a second native title hint behind. Ordinary web links, GitHub repository/file links, and unsupported preview URLs retain their existing tooltips.

## Evidence

The regression uses the real Markdown renderer, shared title adapter, lazy registration, and hovercard runtime. It fails on the original producer because `hasAttribute("title")` is true, then passes after the repair. It checks the anchor and children before hover, while open, after dismissal with pointer intent retained, after departure, and after reentry. It also covers visible/image/empty-link names, escaped Markdown and HTML labels, retained progress values and child titles, destination attributes, and an ordinary tooltip opening and restoring normally. Native Chromium accessibility-tree checks preserve the original names and values across 16 synthetic cases. The added naming assertions failed before their corresponding repairs, including escaped labels, hidden content, empty values, and indeterminate progress labels.

Validation passed: 292 focused tests across five files, including the browser title-tooltip suite, plus all 13 tests in the bundled GitHub hovercard E2E file. The E2E now requires an absent native title rather than the previous blank attribute. Applicable repository gates passed: core-test and UI typechecks, scoped lint, formatting, styles, i18n, unused exports, coercion and repository guards, plus `git diff --check`.

Synthetic fixtures with the app's real fonts, inspected before publication. The screenshots show the preserved rich preview and transcript. Browser-native tooltips are outside these viewport captures; the DOM regression proves their title source was removed.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>Rich preview<br><a href="https://github.com/user-attachments/assets/4e428413-6fcd-43ff-b08d-4ffea8be2432"><img src="https://github.com/user-attachments/assets/4e428413-6fcd-43ff-b08d-4ffea8be2432" alt="Before: rich preview" width="440"></a></td><td>Rich preview<br><a href="https://github.com/user-attachments/assets/21fd85f3-425a-44cb-a842-116746c79ad3"><img src="https://github.com/user-attachments/assets/21fd85f3-425a-44cb-a842-116746c79ad3" alt="After: rich preview" width="440"></a></td></tr>
<tr><td>After preview closure<br><a href="https://github.com/user-attachments/assets/19aa4408-7ff2-41e6-856e-e5c3feb762f8"><img src="https://github.com/user-attachments/assets/19aa4408-7ff2-41e6-856e-e5c3feb762f8" alt="Before: after preview closure" width="440"></a></td><td>After preview closure<br><a href="https://github.com/user-attachments/assets/61d967f2-39f1-410f-8f92-5c7174a4319f"><img src="https://github.com/user-attachments/assets/61d967f2-39f1-410f-8f92-5c7174a4319f" alt="After: after preview closure" width="440"></a></td></tr>
</table>

| DOM state | Before | After |
| --- | --- | --- |
| Supported link before hover | Native URL `title` present | No `title` |
| During preview | Adapter temporarily blanks the title | No `title` |
| After pointer departure/card closure | Original URL title restored | No `title` |
| Ordinary documentation link | Hint opens and restores | Hint opens and restores |

## Risk and coverage

The change is confined to the Markdown parser, its existing final HTML attribute hook, and three test files. Naming decisions use rendered HTML rather than partially normalized Markdown tokens. It reuses the hovercard's URL eligibility parser, preserving ordinary hints for HTTP, `www.github.com`, repository/file, and other unsupported URLs. The shared adapter, rich card, request handling, silent first fetch, later skeletons, and failure backoff are unchanged; their focused tests pass. Keyboard Tab/Escape and real pointer movement across chip text/icon were also exercised through the canonical mock harness.

Source-audited consumers: `chat-message-text` (static/streaming), `chat-message-bubble` (reasoning), `chat-sidebar-content`, `chat-divider`, `chat-position-rail`, `chat-session-rail` (Markdown answers), `session-progress-card`, `skills/view`, `cron/view-runs`, `agents/memory/view`, `agents/panels-status-files`, `plugin/logbook-view`, `skill-workshop/collection-view`, and `meetings/view`. They share this parser; no dependency on the removed native URL title was found. This is a source audit, not a claim of full browser testing for every page.

Raw progress coverage follows native `progressbar` semantics and the documented inline `aria-label` contract. Arbitrary ARIA role overrides and labels resolved from external host-page IDs are outside this self-contained Markdown repair.

No live GitHub metadata fetch was needed because its contract is unchanged. The user's recording and private chat content are not included.
