### PR TITLE
fix(doctor): avoid installing unselected search providers

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.ids.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ids.ts
@@ -108,15 +108,14 @@ export function collectConfiguredPluginIds(
     }
     addConfiguredPluginId(ids, pluginId);
   }
-  const searchProvider = cfg.tools?.web?.search?.provider;
-  if (cfg.tools?.web?.search?.enabled !== false && typeof searchProvider === "string") {
+  const searchProvider = normalizeOptionalLowercaseString(cfg.tools?.web?.search?.provider);
+  if (cfg.tools?.web?.search?.enabled !== false && searchProvider) {
     const installEntry = resolveWebSearchInstallCatalogEntry({ providerId: searchProvider });
     if (installEntry?.pluginId) {
       ids.add(installEntry.pluginId);
     }
-  }
-  if (cfg.tools?.web?.search?.enabled !== false) {
-    // Env-only web providers are valid auto-detect inputs and need their manifest installed first.
+  } else if (cfg.tools?.web?.search?.enabled !== false) {
+    // Only auto-detect from environment credentials when no provider was selected.
     for (const entry of resolveWebSearchInstallCatalogEntriesForEnv(env ?? process.env)) {
       ids.add(entry.pluginId);
     }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -4765,10 +4765,76 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     ]);
   });
 
-  it("installs env-only web provider plugins before auto-detection", async () => {
+  it.each([
+    {
+      name: "installs env-only providers before auto-detection",
+      cfg: {},
+      env: { BRAVE_API_KEY: "brave-key", PERPLEXITY_API_KEY: "perplexity-key" },
+      installedIds: ["brave", "perplexity"],
+    },
+    {
+      name: "auto-detects providers for a whitespace-only selection",
+      cfg: { tools: { web: { search: { provider: " \t " } } } },
+      env: { BRAVE_API_KEY: "brave-key", PERPLEXITY_API_KEY: "perplexity-key" },
+      installedIds: ["brave", "perplexity"],
+    },
+    {
+      name: "installs only the selected provider despite another provider's env key",
+      cfg: { tools: { web: { search: { provider: "perplexity" } } } },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: ["perplexity"],
+    },
+    {
+      name: "normalizes a padded mixed-case explicit provider",
+      cfg: { tools: { web: { search: { provider: " PeRpLeXiTy " } } } },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: ["perplexity"],
+    },
+    {
+      name: "does not auto-detect providers for an unknown explicit selection",
+      cfg: { tools: { web: { search: { provider: "custom-search" } } } },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: [],
+    },
+    {
+      name: "retains independently configured plugins with an explicit search provider",
+      cfg: {
+        tools: { web: { search: { provider: "perplexity" } } },
+        plugins: { entries: { brave: { enabled: true } } },
+      },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: ["brave", "perplexity"],
+    },
+    {
+      name: "does not install an env-selected disabled plugin",
+      cfg: { plugins: { entries: { brave: { enabled: false } } } },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: [],
+    },
+    {
+      name: "does not install an env-selected denied plugin",
+      cfg: { plugins: { deny: ["brave"] } },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: [],
+    },
+    {
+      name: "does not install search providers when plugins are globally disabled",
+      cfg: {
+        tools: { web: { search: { provider: "perplexity" } } },
+        plugins: { enabled: false, entries: { brave: { enabled: true } } },
+      },
+      env: { BRAVE_API_KEY: "brave-key" },
+      installedIds: [],
+    },
+  ] satisfies Array<{
+    name: string;
+    cfg: OpenClawConfig;
+    env: Record<string, string>;
+    installedIds: string[];
+  }>)("search plugin installation intent: $name", async ({ cfg, env, installedIds }) => {
     const packages = [
-      ["exa", "@openclaw/exa-plugin", "EXA_API_KEY"],
-      ["firecrawl", "@openclaw/firecrawl-plugin", "FIRECRAWL_API_KEY"],
+      ["brave", "@openclaw/brave-plugin", "BRAVE_API_KEY"],
+      ["perplexity", "@openclaw/perplexity-plugin", "PERPLEXITY_API_KEY"],
     ] as const;
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue(
       packages.map(([id, npmSpec, envVar]) =>
@@ -4780,31 +4846,38 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         }),
       ),
     );
-    for (const [pluginId, npmSpec] of packages) {
-      mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-        successfulInstall({ pluginId, npmSpec }),
-      );
-    }
-
-    const result = await repairConfiguredPlugins(
-      {},
-      {
-        EXA_API_KEY: "exa-key",
-        FIRECRAWL_API_KEY: "firecrawl-key",
-      },
+    mocks.installPluginFromNpmSpec.mockImplementation(
+      async ({ expectedPluginId }: { expectedPluginId: string }) =>
+        successfulInstall({
+          pluginId: expectedPluginId,
+          npmSpec: expectDefined(
+            packages.find(([id]) => id === expectedPluginId),
+            "expected search plugin package",
+          )[1],
+        }),
     );
+
+    const result = await repairConfiguredPlugins(cfg, env);
 
     expect(
       mocks.installPluginFromNpmSpec.mock.calls.map(
         ([params]) => (params as { expectedPluginId?: string }).expectedPluginId,
       ),
-    ).toEqual(["exa", "firecrawl"]);
+    ).toEqual(installedIds);
+    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(Object.keys(result.records)).toEqual(installedIds);
     expect(result.changes).toEqual(
-      packages.map(
-        ([pluginId, npmSpec]) =>
-          `Installed missing configured plugin "${pluginId}" from ${expectedNpmInstallSpec(npmSpec)}.`,
-      ),
+      packages
+        .filter(([pluginId]) => installedIds.some((id) => id === pluginId))
+        .map(
+          ([pluginId, npmSpec]) =>
+            `Installed missing configured plugin "${pluginId}" from ${expectedNpmInstallSpec(npmSpec)}.`,
+        ),
     );
+    expect(result.warnings).toEqual([]);
+    if (installedIds.length === 0) {
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    }
   });
 
   it("installs env-only provider plugins before model discovery", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running doctor repair could get an additional search plugin installed from an unrelated API-key environment variable after explicitly selecting a different web-search provider. For example, selecting Perplexity could still trigger a Brave Search plugin installation when `BRAVE_API_KEY` was present.

## Why This Change Was Made

Doctor now normalizes the explicit search-provider selection and only uses environment-based discovery when no provider is selected, matching runtime selection behavior. This applies to all catalog-backed search providers; it does not special-case Brave or add configuration.

## User Impact

Explicit search-provider choice is respected during plugin repair. Unset or whitespace-only selection retains environment-based discovery, and independently configured plugins, disabled/denied plugins, global plugin disable, existing install/upgrade records, and independent web-fetch behavior remain unchanged. Already installed plugins are not removed.

Release-note context: doctor no longer installs unrelated search-provider plugins merely because their API keys are present when another search provider is explicitly selected.

## Evidence

- Regression proof on cached source base `e0c230789b33d4a59a8cda1f7b0858c4af0d5e7a`: before the production fix, three expected assertion failures reproduced explicit, padded/mixed-case, and unknown-provider over-installation; six other intent cases passed.
- After the production fix: all nine intent cases passed. Four owner/sibling suites passed, 184 tests total: missing configured plugin repair, post-core plugin convergence, the search install catalog, and search runtime.
- Formatting and scoped lint passed before the final fixture-only corrections. The command-test type shard then identified a missing `expectDefined` message and an inferred-`never` `.includes()` argument; both have been corrected without changing assertions or production behavior. Final fixture-focused, type-shard, and formatting retries remain pending. The initial pull-request-event substantive test/type checks were skipped because this PR is a draft.
- Normal manual exact-head CI is now running for `3d07bf8eb9cbf5cda6ce8cbc6dbebd790714cb62`: https://github.com/openclaw/openclaw/actions/runs/34287485937. Results are pending; no CI success is claimed.
- Testbox materialization left the tracked `pnpm-lock.yaml` absent, so the hydrated dependencies could not be qualified against the source dependency inputs. The 184 source-matched passing tests remain behavior evidence with this unresolved dependency-qualification gap, not proof of a qualified exact dependency environment.
- Fresh autoreview after those corrections: scoped-clean. `git diff --check` and the diff privacy scan pass.
- Per-file three-way compatibility against immutable main `81d8b17414b900f47cbaba0af3c259f8bd1cf436` passes, preserving the newer native-session opt-out guard. This is compatibility evidence, not a current-main full-suite claim; exact-head validation remains outstanding.
- Production delta: +4/-5 lines. Test delta: +93/-20 lines. No new config, environment variable, dependency, SDK surface, or migration.

Draft pending final validation.
