### PR TITLE
feat(onboard): surface optional web search setup

### DIFF
--- a/src/commands/onboard-guided.quickstart.test.ts
+++ b/src/commands/onboard-guided.quickstart.test.ts
@@ -77,6 +77,12 @@ describe("runGuidedOnboarding quick start", () => {
       );
       expect(prompter.confirm).not.toHaveBeenCalled();
       expect(prompter.text).not.toHaveBeenCalled();
+      expect(prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining("Web search setup is optional."),
+        "Search",
+      );
+      expect(localOnboarding.persisted.config?.tools?.web?.search).toBeUndefined();
+      expect(localOnboarding.persisted.config?.plugins?.installs).toBeUndefined();
       expect(localOnboarding.persisted.config?.telemetry).toBeUndefined();
       expect(localOnboarding.persisted.config?.wizard?.securityAcknowledgedAt).toEqual(
         acknowledgedAt ?? expect.any(String),

--- a/src/commands/onboard-guided.search.test.ts
+++ b/src/commands/onboard-guided.search.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { setupGuidedCustodianTestSuite } from "./onboard-guided.custodian.test-support.js";
+
+const runSearchSetupFlow = vi.hoisted(() => vi.fn());
+vi.mock("../flows/search-setup.js", () => ({ runSearchSetupFlow }));
+
+describe("guided onboarding optional search", () => {
+  const {
+    detection,
+    localOnboarding,
+    makeRuntime,
+    promptAuthChoiceGrouped,
+    runGuidedOnboarding,
+    setupApplyResult,
+    setupDeps,
+  } = setupGuidedCustodianTestSuite();
+
+  beforeEach(() => {
+    runSearchSetupFlow.mockClear();
+    promptAuthChoiceGrouped.mockResolvedValue("candidate:claude-cli");
+  });
+
+  it.each([
+    { label: "browser", opts: {}, selectValues: ["custom", "full", "use"] },
+    { label: "TUI", opts: { tui: true }, selectValues: ["full", "use"] },
+    { label: "no UI", opts: { skipUi: true }, selectValues: ["full", "use"] },
+  ])("offers search after fresh setup with $label", async ({ opts, selectValues }) => {
+    const prompter = createWizardPrompter(undefined, { selectValues });
+    const deps = setupDeps({
+      prompter,
+      runBrowserHandoff: vi.fn(async () => ({ handedOff: true as const })),
+    });
+
+    await runGuidedOnboarding({ acceptRisk: true, ...opts }, makeRuntime(), deps);
+
+    expect(deps.applySetup).toHaveBeenCalledOnce();
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw configure --section web"),
+      "Search",
+    );
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("`configure search` in Settings > Ask OpenClaw"),
+      "Search",
+    );
+    expect(prompter.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Search provider" }),
+    );
+    expect(deps.detect).toHaveBeenCalledOnce();
+    expect(runSearchSetupFlow).not.toHaveBeenCalled();
+    expect(localOnboarding.persisted.config?.tools?.web?.search).toBeUndefined();
+    expect(localOnboarding.persisted.config?.plugins?.installs).toBeUndefined();
+    expect(localOnboarding.states.get("/tmp/openclaw.json")?.status).toBe("completed");
+  });
+
+  it.each(["configured rerun", "skipped inference", "failed setup"])(
+    "does not offer search after %s",
+    async (scenario) => {
+      if (scenario === "configured rerun") {
+        localOnboarding.persisted.config = {
+          gateway: { mode: "local" },
+          agents: { defaults: { workspace: "/tmp/openclaw-workspace" } },
+        };
+      }
+      if (scenario === "skipped inference") {
+        promptAuthChoiceGrouped.mockResolvedValueOnce("skip");
+      }
+      const prompter = createWizardPrompter(undefined, { selectValues: ["full", "use"] });
+      const deps = setupDeps({
+        prompter,
+        detect: vi.fn(async () =>
+          detection({
+            ...(scenario === "skipped inference" ? { candidates: [] } : {}),
+            setupComplete: scenario === "configured rerun",
+          }),
+        ),
+        applySetup: vi.fn(async () => ({
+          ...setupApplyResult(),
+          ...(scenario === "failed setup"
+            ? { gateway: { status: "failed" as const, error: "test setup failure" } }
+            : {}),
+        })),
+      });
+
+      await runGuidedOnboarding({ acceptRisk: true, skipUi: true }, makeRuntime(), deps);
+
+      expect(prompter.note).not.toHaveBeenCalledWith(expect.any(String), "Search");
+      expect(runSearchSetupFlow).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -657,6 +657,14 @@ async function runGuidedOnboardingFlow(
     }
     recommendationOutcome.commitResult();
   }
+  if (!alreadyConfigured) {
+    await prompter.note(
+      t("wizard.guided.optionalSearch", {
+        command: formatCliCommand("openclaw configure --section web"),
+      }),
+      t("wizard.setup.searchTitle"),
+    );
+  }
   const hatchWorkspace = alreadyConfigured
     ? resolveUserPath(
         existingConfig.agents?.defaults?.workspace?.trim() || onboardHelpers.DEFAULT_WORKSPACE,

--- a/src/flows/search-setup.test.ts
+++ b/src/flows/search-setup.test.ts
@@ -254,16 +254,21 @@ describe("runSearchSetupFlow", () => {
     });
 
     webSearchProviderMocks.resolvePluginWebSearchProviders.mockReturnValue([mockGrokProvider]);
+    const beforePersistentEffect = vi.fn(async () => {});
     const skipped = await runSearchSetupFlow(
       original,
       createNonExitingRuntime(),
       createWizardPrompter({ select: vi.fn(async () => "__skip__") as never }),
+      { beforePersistentEffect },
     );
     expect(skipped).toEqual({
       outcome: "kept-current",
       config: original,
       reason: "user-skipped",
     });
+    expect(skipped.config).toBe(original);
+    expect(beforePersistentEffect).not.toHaveBeenCalled();
+    expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
   });
 
   it("localizes setup copy for web search provider selection", async () => {

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawConfig,
   type WizardPrompter,
 } from "./chat-engine.test-support.js";
+import { buildOnboardingWelcome } from "./onboarding-welcome.js";
 
 describe("SystemAgentChatEngine runtime", () => {
   it("hosts a channel setup wizard as chat turns", async () => {
@@ -362,9 +363,25 @@ describe("SystemAgentChatEngine runtime", () => {
     expect(handoff.handoff).toEqual({ kind: "open-setup", target: "gateway" });
   });
 
-  it("reports a failed hosted search-provider install without writing or auditing", async () => {
-    const baseConfig: OpenClawConfig = {};
+  it.each([
+    {
+      label: "user skip",
+      answer: "Skip for now",
+      expected: "Web search setup kept the current configuration. Nothing was changed.",
+    },
+    {
+      label: "failed provider install",
+      answer: "Brave",
+      expected: "Web search setup stopped: Error: web search provider brave installation failed",
+    },
+  ])("keeps completed onboarding unchanged after search $label", async ({ answer, expected }) => {
+    const baseConfig: OpenClawConfig = {
+      ...structuredClone(sharedVerifiedInferenceConfig),
+      wizard: { securityAcknowledgedAt: "2026-08-01T00:00:00.000Z" },
+    };
+    const original = structuredClone(baseConfig);
     const appendAuditEntry = vi.fn(async () => "state/openclaw.sqlite");
+    mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot(baseConfig) as never);
     mocks.readSetupConfigFileSnapshot.mockResolvedValue({
       exists: true,
       valid: true,
@@ -372,28 +389,51 @@ describe("SystemAgentChatEngine runtime", () => {
       config: baseConfig,
       sourceConfig: baseConfig,
     });
-    mocks.runSearchSetupFlow.mockResolvedValue({
-      outcome: "install-failed",
-      config: baseConfig,
-      providerId: "brave",
-      reason: "failed",
-    });
+    mocks.runSearchSetupFlow.mockImplementation(
+      async (config: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
+        const provider = await prompter.select({
+          message: "Search provider",
+          options: [
+            { value: "brave", label: "Brave" },
+            { value: "__skip__", label: "Skip for now" },
+          ],
+          initialValue: "__skip__",
+        });
+        return provider === "__skip__"
+          ? { outcome: "kept-current", config, reason: "user-skipped" }
+          : { outcome: "install-failed", config, providerId: provider, reason: "failed" };
+      },
+    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       runAgentTurn: async () => null,
-      planWithAssistant: async () => null,
       appendAuditEntry,
-      deps: { loadOverview: fakeOverviewLoader() },
+      deps: {
+        loadOverview: async () =>
+          ({
+            config: { path: "/tmp/openclaw.json", exists: true, valid: true },
+            defaultModel: "example/test-model",
+            gateway: { reachable: true, url: "ws://127.0.0.1:18789" },
+          }) as never,
+      },
     });
+    const propose = vi.spyOn(engine, "propose");
+    const welcome = await buildOnboardingWelcome({ engine });
+    const search = welcome.question.options.find(({ label }) => label === "Set up web search");
+    expect(search?.reply).toBeTypeOf("string");
+    expect(propose).not.toHaveBeenCalled();
+    expect(mocks.runSearchSetupFlow).not.toHaveBeenCalled();
 
-    const reply = await engine.handle("configure search");
+    const providerStep = await engine.handle(search!.reply!);
+    expect(providerStep.question?.question).toBe("Search provider");
+    expect(mocks.runSearchSetupFlow).toHaveBeenCalledOnce();
+    const reply = await engine.handle(answer);
 
-    expect(reply.text).toContain(
-      "Web search setup stopped: Error: web search provider brave installation failed",
-    );
+    expect(reply.text).toContain(expected);
     expect(reply.text).not.toContain("Done — web search setup is complete");
     expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
     expect(appendAuditEntry).not.toHaveBeenCalled();
+    expect(baseConfig).toEqual(original);
   });
 
   it("hands CLI search credentials to the masked terminal wizard", async () => {

--- a/src/system-agent/onboarding-welcome.test.ts
+++ b/src/system-agent/onboarding-welcome.test.ts
@@ -143,7 +143,7 @@ describe("buildOnboardingWelcome", () => {
       completedAtMs: 2,
     });
     const propose = vi.fn();
-    const { question } = await buildOnboardingWelcome({
+    const { text, question } = await buildOnboardingWelcome({
       engine: {
         loadOverview: vi.fn(async () => ({
           config: { path: "/tmp/openclaw.json", exists: true, valid: true },
@@ -162,6 +162,16 @@ describe("buildOnboardingWelcome", () => {
     );
     expect(propose).not.toHaveBeenCalled();
     expect(question.id).toBe("onboarding-next-step");
+    expect(question.options).toEqual([
+      expect.objectContaining({ reply: "talk to agent", recommended: true }),
+      expect.objectContaining({ label: "Set up web search", reply: "configure search" }),
+      { label: "See all channels", reply: "channels" },
+    ]);
+    expect(question.options.length).toBeLessThanOrEqual(4);
+    expect(question.isOther).toBe(true);
+    expect(question.skipAction).toBe("exit");
+    expect(text).toContain("`configure search` to choose a provider, or skip for now");
+    expect(text).toContain("`connect whatsapp`, `connect telegram`");
   });
 
   it("ignores a pending receipt from a replaced configuration", async () => {

--- a/src/system-agent/onboarding-welcome.ts
+++ b/src/system-agent/onboarding-welcome.ts
@@ -21,8 +21,11 @@ const READY_WELCOME_QUESTION: SystemAgentChatQuestion = {
       recommended: true,
       description: "Meet your agent right here.",
     },
-    { label: "Connect WhatsApp", reply: "connect whatsapp" },
-    { label: "Connect Telegram", reply: "connect telegram" },
+    {
+      label: "Set up web search",
+      reply: "configure search",
+      description: "Choose a provider, or skip for now.",
+    },
     { label: "See all channels", reply: "channels" },
   ],
   isOther: true,

--- a/src/system-agent/overview.ts
+++ b/src/system-agent/overview.ts
@@ -330,6 +330,7 @@ export function formatSystemAgentOnboardingWelcome(overview: SystemAgentOverview
     `- ${overview.gateway.reachable ? `Gateway: running at ${overview.gateway.url}.` : "Gateway: not configured or reachable yet."}`,
     "- I can now finish your workspace, Gateway, channels, agents, plugins, and other optional setup.",
     "- Connect how you want to talk: say `connect whatsapp`, `connect telegram`, `connect slack`, `connect discord` — or `channels` for the full list.",
+    "- Web search setup is optional: say `configure search` to choose a provider, or skip for now.",
     "",
     "Say `talk to agent` to meet your agent right here, or `help` for everything I can do.",
   ].join("\n");

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -328,6 +328,8 @@ export const en = {
       failedOptionsIntro: "These didn't work just now:",
       findMeLater:
         "You can always find me later — run `openclaw` in a terminal, or open Settings in the dashboard.",
+      optionalSearch:
+        "Web search setup is optional. Choose a provider with `{command}`, or say `configure search` in Settings > Ask OpenClaw. You can skip without changing your setup.",
       hatchingNow: "Hatching your agent now…",
       keepingCurrent: "Keeping the working AI you already have.",
       lookAroundManual: "No — I'll configure it manually",


### PR DESCRIPTION
## What Problem This Solves

Users can finish guided onboarding without seeing how to choose a web-search provider. Provider choice already exists, but the default onboarding path does not make that optional setup easy to find.

## Why This Change Was Made

Surface the existing search setup flow after successful guided setup and in the ready onboarding chat. Quick start stays focused on working inference: there is no added provider questionnaire, automatic search setup, or change to search defaults or config schema.

The completion note points to `openclaw configure --section web` and **Settings > Ask OpenClaw**. The chat action uses the existing `configure search` route, including its provider picker and skip behavior.

## User Impact

- Fresh guided setup shows an optional web-search setup note before completion. Configured reruns, skipped inference, and setup failures do not show it.
- The ready onboarding card offers **Talk to my agent** (recommended), **Set up web search**, and **See all channels**, with free text and exit preserved.
- Skipping search leaves the completed setup unchanged. Search installation failures remain visible and do not produce a success audit.
- WhatsApp and Telegram card shortcuts now require one extra click through **See all channels**. Their existing text commands remain available.

## Evidence

- Added regression coverage for quickstart, browser/TUI and no-UI completion, configured reruns, skipped inference, setup failures, the returned chat action, and search skip/failure outcomes.
- `git diff --check` passes. Independent source review and fresh autoreview completed with no actionable P0-P2 findings.
- Actual three-way merge checks passed for all nine files against main at `3623c1ff0080c37a5af88de0f56d91bf9dca6084`. The merged search note remains after the skipped-inference return and before all completion handoffs.
- Production LOC: +16/-2 (net +14) for the two optional discovery surfaces. Tests: +167/-15.

Validation is incomplete; this PR is intentionally a draft:

- Qualified runtime regression results are pending. Testbox has an unresolved source/dependency materialization gap: `pnpm-lock.yaml` is absent, so source-identity verification stopped before test execution. The hydrated environment does not qualify the changed dependency inputs.
- Pinned-version formatting qualification is pending: the available formatter is 0.60.0, while the source pins 0.65.0. The normal commit hook passed without changing reviewed source bytes; that is not pinned-version proof. No dependency installation or reconciliation was performed.
- Type-check results and real UI capture remain pending. The available Testbox runtime environment is not yet qualified for this candidate. The initial pull-request-event substantive test/type checks were skipped because this PR is a draft.
- Normal manual exact-head CI is now running for `ecc7d8792e7fad0d1ecd44fd29d9a62af60336d9`: https://github.com/openclaw/openclaw/actions/runs/34287497518. Results are pending; no CI success is claimed.
- The branch uses cached base `e0c230789b33d4a59a8cda1f7b0858c4af0d5e7a`. Static integration checks do not claim current-main runtime or CI qualification.
