### PR TITLE
fix(ci): hydrate release ancestry branches independently

### DIFF
--- a/.github/actions/git-owner/release-ancestry.py
+++ b/.github/actions/git-owner/release-ancestry.py
@@ -56,7 +56,7 @@ def resolve_commit(ref):
     return value
 
 
-def fetch_history(source, target, depth_argument):
+def fetch_history(depth_argument, *refspecs):
     for attempt in range(1, max_fetch_attempts + 1):
         try:
             run_git(
@@ -71,8 +71,7 @@ def fetch_history(source, target, depth_argument):
                 "--refmap=",
                 depth_argument,
                 "origin",
-                f"+{source}:{source_local_ref}",
-                target,
+                *refspecs,
                 timeout=operation_timeout(max_fetch_seconds),
                 reclaim_locks=True,
             )
@@ -189,7 +188,11 @@ def establish_ancestry():
     target_local_ref = f"refs/remotes/origin/{target_ref[len('refs/heads/') :]}"
     source_sha = resolve_commit("HEAD")
     source = source_ref or source_sha
-    fetch_history(source, f"+{target_ref}:{target_local_ref}", "--depth=64")
+    fetch_history(
+        "--depth=64",
+        f"+{source}:{source_local_ref}",
+        f"+{target_ref}:{target_local_ref}",
+    )
     # Freeze the branch after the first fetch. Later requests hydrate the live
     # branch into a separate ref: Git may not deepen a detached SHA want, while
     # every ancestry decision below remains bound to this immutable target.
@@ -205,14 +208,14 @@ def establish_ancestry():
     chunk_index = 0
     while True:
         chunk = deepen_chunks[min(chunk_index, len(deepen_chunks) - 1)]
-        fetch_history(
-            source,
+        for refspec in (
+            f"+{source}:{source_local_ref}",
             f"+{target_ref}:{target_hydration_local_ref}",
-            f"--deepen={chunk}",
-        )
-        result, current_boundaries = relation_result(mode, source_sha, target_sha)
-        if result is not None:
-            return result
+        ):
+            fetch_history(f"--deepen={chunk}", refspec)
+            result, current_boundaries = relation_result(mode, source_sha, target_sha)
+            if result is not None:
+                return result
         current_count = reachable_commit_count(source_sha, target_sha)
         if current_count < previous_count or (
             current_count == previous_count and current_boundaries == previous_boundaries

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -419,6 +419,35 @@ exec "$REAL_GIT" "$@"`,
   }
 });
 
+releasePolicyIt("hydrates each release ancestry branch independently", () => {
+  const fixture = createAncestryFixture({
+    sourceDistance: 220,
+    targetDistance: 8,
+    related: true,
+  });
+  const proxy = writeGitProxy(
+    fixture,
+    "independent-branch-hydration-git",
+    `if [[ " $* " == *" fetch "* && " $* " == *" --deepen="* && " $* " == *" +refs/heads/release-source:refs/remotes/origin/release-ancestry-source "* && " $* " == *" +refs/heads/main:refs/remotes/origin/release-ancestry-target-hydration "* ]]; then
+  exit 0
+fi
+exec "$REAL_GIT" "$@"`,
+  );
+  try {
+    const checkout = cloneAncestrySource(fixture, "checkout");
+    expectPolicySuccess(
+      runReleaseAncestry(checkout, "merge-base", {
+        PATH: `${proxy.binDir}:${process.env.PATH ?? ""}`,
+        REAL_GIT: proxy.realGit,
+        RELEASE_ANCESTRY_SOURCE_REF: "refs/heads/release-source",
+      }),
+      "merge-base",
+    );
+  } finally {
+    rmSync(fixture.root, { force: true, recursive: true });
+  }
+});
+
 releasePolicyIt("rejects fully hydrated disconnected release histories", () => {
   const fixture = createAncestryFixture({
     sourceDistance: 8,


### PR DESCRIPTION
## Summary

- deepen the frozen release source and live target branch in separate Git fetches
- re-check the frozen ancestry relation after each branch advances
- prevent unrelated movement on `main` from masking missing source-history progress

## Root cause

Full Release Validation [34281241356](https://github.com/openclaw/openclaw/actions/runs/34281241356) admitted correctly, but npm qualification [34281348106](https://github.com/openclaw/openclaw/actions/runs/34281348106) failed with exit 125. The ancestry owner fetched the canonical extended-stable source and moving `main` in one deepen request. When `main` advanced `11fab6b → a141825`, Git completed that fetch without advancing the shallow history relevant to the frozen source/target pair; the combined no-progress check then failed.

The owner now deepens each branch independently. The verdict remains bound to the initially frozen target SHA; unknown/disconnected histories still fail closed.

## Verification

- red before fix: `hydrates each release ancestry branch independently` exited 125
- green after fix: same focused regression passed
- `git diff --check`
- production/tooling: +14/-11 (net +3)
- tests: +29/-0

No candidate, package, tag, registry, or release state changes.