### PR TITLE
fix(e2e): show frozen onboarding failure diagnostics

### DIFF
--- a/scripts/e2e/release-typed-onboarding-docker.sh
+++ b/scripts/e2e/release-typed-onboarding-docker.sh
@@ -71,7 +71,7 @@ if ! docker_e2e_run_with_harness \
   -v "$SCENARIO_PATH:/app/scripts/e2e/lib/release-typed-onboarding/scenario.sh:ro" \
   -v "$ONBOARD_ASSERTIONS:/app/scripts/e2e/lib/release-scenarios/assertions.mjs:ro" \
   -v "$ONBOARD_MOCK_OPENAI_CONFIG:/app/scripts/e2e/lib/fixtures/mock-openai-config.mjs:ro" \
-  -i "$IMAGE_NAME" bash scripts/e2e/lib/release-typed-onboarding/scenario.sh >"$run_log" 2>&1; then
+  -i "$IMAGE_NAME" bash -E scripts/e2e/lib/release-typed-onboarding/scenario.sh >"$run_log" 2>&1; then
   docker_e2e_print_log "$run_log"
   exit 1
 fi

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3016,6 +3016,27 @@ docker_e2e_docker_run_cmd run demo
     );
   });
 
+  it("propagates frozen typed-onboarding ERR traps through nested helpers", () => {
+    const runner = readFileSync(RELEASE_TYPED_ONBOARDING_DOCKER_E2E_PATH, "utf8");
+    const invocation = runner.match(
+      /-i "\$IMAGE_NAME" bash(?<flags>(?: +-[A-Za-z]+)*) scripts\/e2e\/lib\/release-typed-onboarding\/scenario\.sh/u,
+    );
+    expect(invocation?.groups?.flags).toBeDefined();
+    const bashFlags = invocation?.groups?.flags?.trim().split(/ +/u).filter(Boolean) ?? [];
+    const diagnostic = "typed-onboarding diagnostic status=23";
+    const script = `set -euo pipefail
+trap 'status=$?; printf "typed-onboarding diagnostic status=%s\\n" "$status" >&2' ERR
+inner() { return 23; }
+outer() { inner; }
+outer
+`;
+
+    const result = spawnSync("bash", [...bashFlags, "-c", script], { encoding: "utf8" });
+
+    expect(result.status).toBe(23);
+    expect(result.stderr.trim().split("\n")).toEqual([diagnostic]);
+  });
+
   it("prints channel-add failures through the shared E2E logger", () => {
     const script = readFileSync(NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH, "utf8");
     expect(script).toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where frozen Full Release Validation typed-onboarding failures inside shell helpers could exit with only a bare container exit code, hiding the bounded scenario diagnostics needed to identify the failure.

## Why This Change Was Made

The earlier configuration compatibility repair in https://github.com/openclaw/openclaw/pull/142467 fixed the concrete frozen-package failure. This follow-up launches the selected frozen scenario with Bash error tracing so its existing `ERR` trap also runs inside nested helpers, without changing the scenario or adding another diagnostic path.

## User Impact

Release operators now get the existing secret-safe typed-onboarding failure diagnostics for nested helper failures instead of an opaque `ExitCode=1`.

## Evidence

- Pre-fix behavior: plain `bash` exits 1 with no diagnostic for a failing nested helper; `bash -E` exits with the helper status and invokes the existing trap.
- Focused Vitest: 1 passed, 287 skipped.
- Exact-head PR CI: https://github.com/openclaw/openclaw/actions/runs/34291227101.
- Exact-head Testbox changed-file gate: provider `blacksmith-testbox`, lease `tbx_01m21p79rhykfqg9rsfppsq8ae`, https://github.com/openclaw/openclaw/actions/runs/34291590510. Frozen install, strict test typecheck, script lint, changed-test lint, formatting, and guards passed.
- Exact frozen-target comparison:
  - Before: https://github.com/openclaw/openclaw/actions/runs/34265621268 produced a 23-line lane log ending with only `ExitCode=1`.
  - Candidate: https://github.com/openclaw/openclaw/actions/runs/34291591481 ran tooling SHA `45c94cf07066fd8b542782acd9b1311efeb5e0ac` against frozen target `659df8107ce37c07a4cd4364c76ece55a7124e22`. The 275-line lane log emitted the scenario failure message and bounded install, onboarding, and mock-provider logs before container state.
- `bash -n scripts/e2e/release-typed-onboarding-docker.sh` passed.
- `git diff --check` passed.
- Final autoreview through standalone Codex on the patch-identical pre-rebase head: scoped clean through P3, confidence 0.98.

The historical target still fails in its old interactive onboarding path. That behavior is outside this diagnostics repair; the candidate run proves the previously opaque failure is now observable.

The rebase preserved the exact stable patch ID `3e1bf6fca0dc678b73e8c4e32099ea73a84cf16b`.

Tooling LOC is net zero; regression coverage adds 21 test lines. No production runtime behavior changes.

Related: https://github.com/openclaw/openclaw/pull/142405
Related: https://github.com/openclaw/openclaw/pull/142467

@clawsweeper review
