### PR TITLE
refactor(codex): keep protocol maps within lint budget

### DIFF
--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -1,6 +1,17 @@
 import type { JsonObject, JsonValue } from "./protocol-json.js";
 
 /** Current Codex marketplace, app, skill, hook, and config wire contracts. */
+export type CodexExperimentalFeatureListParams = {
+  cursor?: string | null;
+  limit?: number | null;
+  threadId?: string | null;
+};
+
+export type CodexExperimentalFeatureListResponse = {
+  data: Array<{ name: string; enabled: boolean }>;
+  nextCursor?: string | null;
+};
+
 export type CodexPluginSummary = {
   id: string;
   remotePluginId?: string | null;

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -15,6 +15,8 @@ import type {
   CodexConfigRequirementsReadResponse,
   CodexConfigValueWriteParams,
   CodexConfigWriteResponse,
+  CodexExperimentalFeatureListParams,
+  CodexExperimentalFeatureListResponse,
   CodexHooksListParams,
   CodexHooksListResponse,
   CodexInstalledApp,
@@ -691,11 +693,7 @@ type CodexAppServerRequestParamsOverride = {
   "config/read": CodexConfigReadParams;
   "config/value/write": CodexConfigValueWriteParams;
   "environment/add": { environmentId: string; execServerUrl: string };
-  "experimentalFeature/list": {
-    cursor?: string | null;
-    limit?: number | null;
-    threadId?: string | null;
-  };
+  "experimentalFeature/list": CodexExperimentalFeatureListParams;
   "plugin/installed": CodexPluginInstalledParams;
   "plugin/install": CodexPluginInstallParams;
   "plugin/list": CodexPluginListParams;
@@ -739,10 +737,7 @@ type CodexAppServerRequestResultMap = {
   "configRequirements/read": CodexConfigRequirementsReadResponse;
   "config/value/write": CodexConfigWriteResponse;
   "environment/add": JsonValue;
-  "experimentalFeature/list": {
-    data: Array<{ name: string; enabled: boolean }>;
-    nextCursor?: string | null;
-  };
+  "experimentalFeature/list": CodexExperimentalFeatureListResponse;
   "experimentalFeature/enablement/set": JsonValue;
   "feedback/upload": JsonValue;
   "hooks/list": CodexHooksListResponse;


### PR DESCRIPTION
## Summary

- move the experimental-feature list request/response shapes into the existing Codex control-plane protocol owner
- keep the app-server request maps typed without growing the already-full central protocol module

## Root cause

#137485 added the new `experimentalFeature/list` wire shapes inline to `protocol.ts`, taking the file to 701 lint-counted lines and breaking `check-lint` for subsequent PRs, including #142643.

## Proof

- red: `check-lint` on #142643 reports `protocol.ts:785:2 File has too many lines (701)`
- green: direct Oxlint on both affected files
- green: Oxfmt check and `git diff --check`
- upstream contract inspected directly in `../codex/codex-rs/app-server-protocol/src/protocol/v2/experimental_feature.rs`, `protocol/common.rs`, and `app-server/src/request_processors/catalog_processor.rs`

## LOC

- production: +15/-9, net +6; no runtime behavior change
- tests: 0 (the failing owner is the lint rule itself)