### PR TITLE
fix(markdown): own generated table delimiters against bare cell markdown

### DIFF
--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -315,6 +315,21 @@ describe("convertMarkdownTables", () => {
     expect(rendered).not.toContain("\\*");
   });
 
+  it("preserves angle-bracket autolink destinations in bullet cells", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | <first_last@example.com> |\n| Other | <https://example.com/a_b> |",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The autolink text is the destination; escaping its underscore breaks
+    // markdown-it's autolink grammar and kills the link.
+    expect(rendered).toContain("<first_last@example.com>");
+    expect(rendered).toContain("<https://example.com/a_b>");
+    expect(parsed).toContain('<a href="mailto:first_last@example.com">');
+    expect(parsed).toContain('<a href="https://example.com/a_b">');
+  });
+
   it("preserves CRLF source around a table", () => {
     const before = "Keep \\*literal\\*.\r\n\r\n";
     const after = "\r\n\r\nAfter.\r\n";

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -189,6 +189,26 @@ describe("convertMarkdownTables", () => {
     expect(rendered.endsWith(references)).toBe(true);
   });
 
+  it("preserves delimiter-bearing reference labels against document definitions in bullets", () => {
+    const references = "\n\n[api_v1]: https://example.com";
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api_v1] |" + references,
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The reference label keeps its underscore so the definition still matches.
+    expect(rendered).toContain("[manual][api_v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+    // Bracket text without a matching definition is still delimiter-isolated.
+    const unlabeled = convertMarkdownTables(
+      "| A | B |\n| --- | --- |\n| x | [a_b] stays literal |",
+      "bullets",
+    );
+
+    expect(unlabeled).toContain("[a\\_b]");
+  });
+
   it("preserves CRLF source around a table", () => {
     const before = "Keep \\*literal\\*.\r\n\r\n";
     const after = "\r\n\r\nAfter.\r\n";

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -235,6 +235,47 @@ describe("convertMarkdownTables", () => {
     expect(parsed).toContain('<a href="https://example.com">manual</a>');
   });
 
+  it("preserves references whose definition label spans lines", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api_ v1] |\n\n[api_\nv1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The renderer folds the definition's newline to a space, so the reference
+    // resolves; the label must keep its underscore for the link to survive.
+    expect(rendered).toContain("[manual][api_ v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+  });
+
+  it("preserves shortcut references with whitespace-padded labels", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [ api_v1 ] |\n\n[api_v1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The renderer trims labels during lookup, so the padded shortcut is a
+    // valid reference and its underscore must not be escaped.
+    expect(rendered).toContain("[ api_v1 ]");
+    expect(parsed).toContain('<a href="https://example.com">');
+  });
+
+  it("preserves references that differ from definitions by Unicode whitespace", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api_ v1] |\n| Other | [guide][docs_\u00a0v2] |\n\n[api_\u00a0v1]: https://example.com/api\n\n[docs_ v2]: https://example.com/docs",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // markdown-it folds identifiers with Unicode `\s`, so a nonbreaking space in
+    // either the reference or the definition still matches an ordinary space.
+    expect(rendered).toContain("[manual][api_ v1]");
+    expect(rendered).toContain("[guide][docs_\u00a0v2]");
+    expect(parsed).toContain('<a href="https://example.com/api">manual</a>');
+    expect(parsed).toContain('<a href="https://example.com/docs">guide</a>');
+  });
+
   it("preserves CRLF source around a table", () => {
     const before = "Keep \\*literal\\*.\r\n\r\n";
     const after = "\r\n\r\nAfter.\r\n";

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -81,6 +81,40 @@ describe("convertMarkdownTables", () => {
     expect(html).toContain(mode === "bullets" ? "<code>x`y</code>" : "x`y");
   });
 
+  it.each([
+    {
+      name: "row label stray delimiter binds through the generated bold markers",
+      input: "| Name | Value |\n| --- | --- |\n| `tick | more` |",
+      // A bare label backtick must not own the generated `**`; otherwise the
+      // code span swallows the bullet line (`**<code>tick** • V: more</code>`).
+      notHtml: ["<code>tick**"],
+      html: ["• Value: more`"],
+    },
+    {
+      name: "value cell stray delimiters bind across the bullet line",
+      input: "| A | B |\n| --- | --- |\n| a * | b * |",
+      // Bare stars must stay literal instead of pairing across the bullet line
+      // boundary (`*<em>a ***\n• V: b</em>` once emphasis misbinds).
+      notHtml: ["<em>"],
+      html: ["• B: b *"],
+    },
+  ])(
+    "keeps unescaped stray cell delimiters literal in bullet output: $name",
+    ({ input, notHtml, html }) => {
+      const rendered = convertMarkdownTables(input, "bullets");
+      const parsed = new MarkdownIt().render(rendered);
+
+      for (const forbidden of notHtml) {
+        expect(parsed).not.toContain(forbidden);
+      }
+      for (const literal of html) {
+        expect(parsed).toContain(literal);
+      }
+      // Row labels stay bold and no delimiter leaks outside its own cell text.
+      expect(parsed).toContain("<strong>");
+    },
+  );
+
   it("chooses a code fence that contains literal backtick runs", () => {
     const rendered = convertMarkdownTables(
       "| A | B |\n| --- | --- |\n| 1 | ````a```b```` |",

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -209,6 +209,32 @@ describe("convertMarkdownTables", () => {
     expect(unlabeled).toContain("[a\\_b]");
   });
 
+  it("preserves reference labels whose only definition lives in a block quote", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api_v1] |\n\n> [api_v1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The block-quoted definition still backs the reference, so the label must
+    // keep its underscore for the link to resolve.
+    expect(rendered).toContain("[manual][api_v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+  });
+
+  it("preserves reference labels that differ from definitions by Unicode case folding", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][straße_v1] |\n\n[straße_v1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // micromark folds identifiers with lower+uppercase (ß → SS), so matching
+    // must use the same fold or the underscore gets escaped and the link dies.
+    expect(rendered).toContain("[manual][straße_v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+  });
+
   it("preserves CRLF source around a table", () => {
     const before = "Keep \\*literal\\*.\r\n\r\n";
     const after = "\r\n\r\nAfter.\r\n";

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -276,6 +276,45 @@ describe("convertMarkdownTables", () => {
     expect(parsed).toContain('<a href="https://example.com/docs">guide</a>');
   });
 
+  it("preserves references backed by a continued block-quote definition", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api_ v1] |\n\n> [api_\n> v1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The definition's continuation lines belong to the block quote; the cell
+    // passes through untouched so the renderer's own label folding resolves it.
+    expect(rendered).toContain("[manual][api_ v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+  });
+
+  it("preserves references whose label contains an escaped closing bracket", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][api\\]_v1] |\n\n[api\\]_v1]: https://example.com",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    // The renderer skips the escaped `]` while reading the label; the cell must
+    // keep its exact source bytes for the definition match to survive.
+    expect(rendered).toContain("[manual][api\\]_v1]");
+    expect(parsed).toContain('<a href="https://example.com">manual</a>');
+  });
+
+  it("passes bracket-bearing cells through untouched while definitions exist", () => {
+    const rendered = convertMarkdownTables(
+      "| A | B |\n| --- | --- |\n| x | [not a ref * stray] |\n\n[other]: https://example.com",
+      "bullets",
+    );
+
+    // A stray `*` in a bracket cell would normally be delimiter-isolated, but
+    // any `[` cell might be a reference while definitions exist; the cell keeps
+    // main's exact bytes by design instead of approximating reference grammar.
+    expect(rendered).toContain("[not a ref * stray]");
+    expect(rendered).not.toContain("\\*");
+  });
+
   it("preserves CRLF source around a table", () => {
     const before = "Keep \\*literal\\*.\r\n\r\n";
     const after = "\r\n\r\nAfter.\r\n";

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -115,6 +115,32 @@ describe("convertMarkdownTables", () => {
     },
   );
 
+  it("preserves authored emphasis across bullet cells", () => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | **bold** and _italic_ |",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    expect(parsed).toContain("<strong>bold</strong>");
+    expect(parsed).toContain("<em>italic</em>");
+    expect(parsed).not.toContain("\\*");
+    expect(parsed).not.toContain("\\_");
+  });
+
+  it("preserves escaped backticks followed by real code spans in bullet cells", () => {
+    const rendered = convertMarkdownTables(
+      "| A | B |\n| --- | --- |\n| a | \\` literal and `code` |",
+      "bullets",
+    );
+    const parsed = new MarkdownIt().render(rendered);
+
+    expect(parsed).toContain("<code>code</code>");
+    expect(parsed).toContain("` literal and ");
+    // The escaped backtick stays a literal and must not consume the code closer.
+    expect(parsed).not.toContain("code\\`");
+  });
+
   it("chooses a code fence that contains literal backtick runs", () => {
     const rendered = convertMarkdownTables(
       "| A | B |\n| --- | --- |\n| 1 | ````a```b```` |",

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -1,53 +1,70 @@
 import { expectDefined } from "@openclaw/normalization-core/expect";
-import { buildCodeSpanIndex } from "./code-spans.js";
+import { fromMarkdown } from "mdast-util-from-markdown";
 import { getMarkdownTableSource, markdownToIRWithMeta, type MarkdownTableMeta } from "./ir.js";
 import { renderMarkdownCodeTable, renderMarkdownTableBullets } from "./table-layout.js";
 import type { MarkdownTableMode } from "./types.js";
 
 // The bullets render path reassembles raw cell Markdown next to generated `**` markers
-// and `• ` prefixes. A bare emphasis or code delimiter inside one cell can then pair
-// with those generated markers or with a delimiter in a later cell, shifting emphasis
-// and code-span boundaries across the whole bullet block (inline code and emphasis
-// both span softbreaks within the rendered paragraph). Escaping bare delimiters in the
-// source cell markdown keeps every stray delimiter literal at its own position. Authored
-// spans are already parsed into the IR at this point and authored escapes keep their
-// backslash, so ordinary cells stay byte-identical.
-const BARE_CELL_DELIMITERS = /(?<!\\)[*_`]/gu;
+// and `• ` prefixes. A delimiter left literal in one cell can pair with those generated
+// markers or with a delimiter in a later cell, shifting emphasis and code-span boundaries
+// across the whole bullet block (both span softbreaks within the rendered paragraph).
+// The inline parser decides which delimiters are literal: authored emphasis, code spans,
+// and links keep their delimiters (their syntax lives in non-text nodes), while text
+// nodes own the literal `*`/`_`/`` ` `` runs. Escaping only those keeps authored markup
+// rendering while strays stay confined to their own cell.
+const CELL_DELIMITER_CANDIDATES = /[*_`]/u;
+
+type PositionedNode = {
+  type?: string;
+  position?: { start?: { offset?: number }; end?: { offset?: number } };
+  children?: PositionedNode[];
+};
 
 /**
- * Finds code-span coverage that only includes closed spans: the scanner reports an
- * open-at-EOF run as covered, but that run has no closer in this markdown, so it is a
- * stray whose delimiters must still be escaped.
+ * Ranges of cell source that the inline parser owns as literal text. Delimiters inside
+ * them are orphans on this embedded surface; delimiters outside them belong to parsed
+ * emphasis, code spans, or links and must survive rendering.
  */
-function closedCodeSpanLookup(markdown: string): (offset: number) => boolean {
-  const { isInside, inlineState } = buildCodeSpanIndex(markdown);
-  const spans: Array<[number, number]> = [];
-  let start: number | undefined;
-  for (let offset = 0; offset <= markdown.length; offset += 1) {
-    const inside = offset < markdown.length && isInside(offset);
-    if (inside && start === undefined) {
-      start = offset;
+function literalTextRanges(markdown: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const visit = (node: PositionedNode): void => {
+    const start = node.position?.start?.offset;
+    const end = node.position?.end?.offset;
+    if (node.type === "text" && start !== undefined && end !== undefined) {
+      ranges.push([start, end]);
+      return;
     }
-    if (!inside && start !== undefined) {
-      spans.push([start, offset]);
-      start = undefined;
+    for (const child of node.children ?? []) {
+      visit(child);
     }
-  }
-  const last = spans.at(-1);
-  const kept = inlineState.open && last && last[1] === markdown.length ? spans.slice(0, -1) : spans;
-  return (offset) => kept.some(([from, to]) => offset >= from && offset < to);
+  };
+  visit(fromMarkdown(markdown) as PositionedNode);
+  return ranges;
 }
 
 function ownCellDelimiters(markdown: string): string {
-  if (!/[*_`]/.test(markdown)) {
+  if (!CELL_DELIMITER_CANDIDATES.test(markdown)) {
     return markdown;
   }
-  // Closed code spans own their delimiters, and `\\*` or `` \` `` are not delimiters at
-  // all. Everything else is an orphan on this embedded surface.
-  const isInsideClosedSpan = closedCodeSpanLookup(markdown);
-  return markdown.replaceAll(BARE_CELL_DELIMITERS, (delimiter, offset: number) =>
-    isInsideClosedSpan(offset) ? delimiter : `\\${delimiter}`,
-  );
+  const ranges = literalTextRanges(markdown);
+  const isLiteral = (offset: number): boolean =>
+    ranges.some(([from, to]) => offset >= from && offset < to);
+  let owned = "";
+  let offset = 0;
+  while (offset < markdown.length) {
+    const char = markdown[offset];
+    if (char === "\\") {
+      // A backslash escapes the following byte; keep the pair verbatim so
+      // already-escaped delimiters and literal backslashes stay untouched.
+      owned += markdown.slice(offset, offset + 2);
+      offset += 2;
+      continue;
+    }
+    const isDelimiter = char === "*" || char === "_" || char === "`";
+    owned += isDelimiter && isLiteral(offset) ? `\\${char}` : char;
+    offset += 1;
+  }
+  return owned;
 }
 
 function renderTableSource(

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -1,7 +1,54 @@
 import { expectDefined } from "@openclaw/normalization-core/expect";
+import { buildCodeSpanIndex } from "./code-spans.js";
 import { getMarkdownTableSource, markdownToIRWithMeta, type MarkdownTableMeta } from "./ir.js";
 import { renderMarkdownCodeTable, renderMarkdownTableBullets } from "./table-layout.js";
 import type { MarkdownTableMode } from "./types.js";
+
+// The bullets render path reassembles raw cell Markdown next to generated `**` markers
+// and `• ` prefixes. A bare emphasis or code delimiter inside one cell can then pair
+// with those generated markers or with a delimiter in a later cell, shifting emphasis
+// and code-span boundaries across the whole bullet block (inline code and emphasis
+// both span softbreaks within the rendered paragraph). Escaping bare delimiters in the
+// source cell markdown keeps every stray delimiter literal at its own position. Authored
+// spans are already parsed into the IR at this point and authored escapes keep their
+// backslash, so ordinary cells stay byte-identical.
+const BARE_CELL_DELIMITERS = /(?<!\\)[*_`]/gu;
+
+/**
+ * Finds code-span coverage that only includes closed spans: the scanner reports an
+ * open-at-EOF run as covered, but that run has no closer in this markdown, so it is a
+ * stray whose delimiters must still be escaped.
+ */
+function closedCodeSpanLookup(markdown: string): (offset: number) => boolean {
+  const { isInside, inlineState } = buildCodeSpanIndex(markdown);
+  const spans: Array<[number, number]> = [];
+  let start: number | undefined;
+  for (let offset = 0; offset <= markdown.length; offset += 1) {
+    const inside = offset < markdown.length && isInside(offset);
+    if (inside && start === undefined) {
+      start = offset;
+    }
+    if (!inside && start !== undefined) {
+      spans.push([start, offset]);
+      start = undefined;
+    }
+  }
+  const last = spans.at(-1);
+  const kept = inlineState.open && last && last[1] === markdown.length ? spans.slice(0, -1) : spans;
+  return (offset) => kept.some(([from, to]) => offset >= from && offset < to);
+}
+
+function ownCellDelimiters(markdown: string): string {
+  if (!/[*_`]/.test(markdown)) {
+    return markdown;
+  }
+  // Closed code spans own their delimiters, and `\\*` or `` \` `` are not delimiters at
+  // all. Everything else is an orphan on this embedded surface.
+  const isInsideClosedSpan = closedCodeSpanLookup(markdown);
+  return markdown.replaceAll(BARE_CELL_DELIMITERS, (delimiter, offset: number) =>
+    isInsideClosedSpan(offset) ? delimiter : `\\${delimiter}`,
+  );
+}
 
 function renderTableSource(
   table: MarkdownTableMeta,
@@ -17,9 +64,15 @@ function renderTableSource(
     return `${fence}\n${text}${fence}`;
   }
   const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
-  const headers = table.headers.map((text, column) => ({ text, markdown: source.headers[column] }));
+  const headers = table.headers.map((text, column) => ({
+    text,
+    markdown: ownCellDelimiters(source.headers[column] ?? ""),
+  }));
   const rows = table.rows.map((row, index) =>
-    row.map((text, column) => ({ text, markdown: source.rows[index]?.[column] })),
+    row.map((text, column) => ({
+      text,
+      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? ""),
+    })),
   );
   let rendered = "";
   renderMarkdownTableBullets(

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -37,6 +37,13 @@ function literalTextRanges(markdown: string): Array<[number, number]> {
   const visit = (node: PositionedNode): void => {
     const start = node.position?.start?.offset;
     const end = node.position?.end?.offset;
+    // An autolink's text child carries the destination itself, so escaping a
+    // delimiter there rewrites the URL or email the renderer matches against.
+    // Autolinks are the only link form whose source starts with `<`; inline
+    // and reference links keep prose text and stay escapable.
+    if (node.type === "link" && start !== undefined && markdown[start] === "<") {
+      return;
+    }
     if (node.type === "text" && start !== undefined && end !== undefined) {
       ranges.push([start, end]);
       return;

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -41,8 +41,25 @@ function literalTextRanges(markdown: string): Array<[number, number]> {
       visit(child);
     }
   };
+  // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
   visit(fromMarkdown(markdown) as PositionedNode);
   return ranges;
+}
+
+/**
+ * Canonical form for reference identifiers, mirroring micromark's
+ * `normalizeIdentifier` (which markdown-it's normalizeReference matches):
+ * collapse Markdown whitespace, trim, then lower- AND uppercase. The double
+ * case fold is required — `ß`.toLowerCase() stays `ß` while its definition
+ * identifier was already folded to `SS`, so lowercasing alone misses valid
+ * references.
+ */
+function normalizeReferenceIdentifier(value: string): string {
+  return value
+    .replace(/[\t\n\r ]+/gu, " ")
+    .replace(/^ | $/gu, "")
+    .toLowerCase()
+    .toUpperCase();
 }
 
 /** Collects the identifiers of reference definitions declared anywhere in the document. */
@@ -50,13 +67,13 @@ function collectReferenceIdentifiers(markdown: string): Set<string> {
   const identifiers = new Set<string>();
   const visit = (node: PositionedNode): void => {
     if (node.type === "definition" && typeof node.identifier === "string") {
-      // Mirror markdown-it's normalizeReference: fold whitespace, case-fold.
-      identifiers.add(node.identifier.trim().replace(/\s+/gu, " ").toLowerCase());
+      identifiers.add(normalizeReferenceIdentifier(node.identifier));
     }
     for (const child of node.children ?? []) {
       visit(child);
     }
   };
+  // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
   visit(fromMarkdown(markdown) as PositionedNode);
   return identifiers;
 }
@@ -77,7 +94,7 @@ function referenceSpans(markdown: string, identifiers: Set<string>): ReferenceSp
   for (const match of markdown.matchAll(reference)) {
     const start = match.index ?? 0;
     const [source, label = "", ref = ""] = match;
-    const identifier = (ref === "" ? label : ref).trim().replace(/\s+/gu, " ").toLowerCase();
+    const identifier = normalizeReferenceIdentifier(ref === "" ? label : ref);
     if (!identifiers.has(identifier)) {
       continue;
     }
@@ -165,7 +182,10 @@ export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode)
     autolink: false,
     tableMode: "block",
   });
-  const referenceIdentifiers = /(^|\n)\s*\[[^\]]+\]:\s*/u.test(markdown)
+  // Gate the definition-collecting parse on any `[…]:` shape: definitions may be
+  // nested in block quotes or list items, so a line-anchored precheck would miss
+  // documents whose only definitions live inside a container.
+  const referenceIdentifiers = /\[[^\]\n]+\]:/u.test(markdown)
     ? collectReferenceIdentifiers(markdown)
     : new Set<string>();
   let cursor = 0;

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -11,14 +11,17 @@ import type { MarkdownTableMode } from "./types.js";
 // The inline parser decides which delimiters are literal: authored emphasis, code spans,
 // and links keep their delimiters (their syntax lives in non-text nodes), while text
 // nodes own the literal `*`/`_`/`` ` `` runs. Escaping only those keeps authored markup
-// rendering while strays stay confined to their own cell. Reference links keep their
-// source too: cells parse in isolation, so the document's reference definitions are
-// appended to the parse input and the parser itself resolves each reference into a
-// link node whose delimiters live outside text ranges.
+// rendering while strays stay confined to their own cell.
+//
+// Reference links are the one exception: the renderer matches their labels against the
+// document's definitions by identifier, and an escaped delimiter inside a label breaks
+// that match. Approximating the parser's reference grammar locally (label folding,
+// containers, multiline labels) keeps leaking edge cases, so cells that could contain
+// a reference pass through byte-identical to main instead; the stray-delimiter defect
+// stays open in those cells by design.
 const CELL_DELIMITER_CANDIDATES = /[*_`]/u;
 
 type PositionedNode = {
-  identifier?: string;
   type?: string;
   position?: { start?: { offset?: number }; end?: { offset?: number } };
   children?: PositionedNode[];
@@ -28,26 +31,10 @@ type PositionedNode = {
  * Ranges of cell source that the inline parser owns as literal text. Delimiters inside
  * them are orphans on this embedded surface; delimiters outside them belong to parsed
  * emphasis, code spans, or links and must survive rendering.
- *
- * `definitionSuffix` carries the document's reference definitions (whitespace-flattened,
- * joined by newlines) so references resolve exactly as the channel renderer resolves
- * them — multiline labels, padded labels, and Unicode-whitespace variants included —
- * instead of approximating the parser's reference grammar with a local scanner.
- * Whitespace is flattened to ordinary spaces in the parse copy only; the substitution
- * preserves UTF-16 offsets 1:1, keeps whitespace semantics for emphasis flanking, and
- * matches markdown-it's `\s`-based identifier folding. Classification always applies
- * to the original cell bytes.
  */
-function literalTextRanges(markdown: string, definitionSuffix: string): Array<[number, number]> {
+function literalTextRanges(markdown: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   const visit = (node: PositionedNode): void => {
-    // Reference labels must keep their exact source bytes: the renderer matches
-    // them against definition identifiers, and an escaped delimiter inside the
-    // label text breaks that match. Inline links/images stay escapable — their
-    // label text renders identically whether or not a delimiter is escaped.
-    if (node.type === "linkReference" || node.type === "imageReference") {
-      return;
-    }
     const start = node.position?.start?.offset;
     const end = node.position?.end?.offset;
     if (node.type === "text" && start !== undefined && end !== undefined) {
@@ -58,45 +45,26 @@ function literalTextRanges(markdown: string, definitionSuffix: string): Array<[n
       visit(child);
     }
   };
-  const source = markdown.replace(/\s/gu, " ");
-  const input = definitionSuffix === "" ? source : `${source}\n\n${definitionSuffix}`;
   // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
-  visit(fromMarkdown(input) as PositionedNode);
-  // The appended definitions start beyond the cell source; their ranges never apply.
-  return ranges.filter(([, to]) => to <= markdown.length);
+  visit(fromMarkdown(markdown) as PositionedNode);
+  return ranges;
 }
 
 /**
- * Source slices of every reference definition in the document. Definitions may nest
- * in block quotes or list items and their labels may span lines, so the mdast parse —
- * not a line-anchored precheck — decides what is a definition; keeping the exact
- * source lets the cell parse re-resolve references with the parser's own grammar.
+ * Owns literal cell delimiters, except when the cell could hold a reference link.
+ * A reference needs `[` in the cell and a definition (`[label]: destination`, which
+ * always contains `]:`) somewhere in the document; either one missing proves the
+ * cell is reference-free. Matching that grammar more precisely is the renderer's
+ * job, so possible-reference cells keep their exact source bytes.
  */
-function collectReferenceDefinitions(markdown: string): string[] {
-  const definitions: string[] = [];
-  const visit = (node: PositionedNode): void => {
-    if (node.type === "definition") {
-      const start = node.position?.start?.offset;
-      const end = node.position?.end?.offset;
-      if (start !== undefined && end !== undefined) {
-        definitions.push(markdown.slice(start, end));
-      }
-      return;
-    }
-    for (const child of node.children ?? []) {
-      visit(child);
-    }
-  };
-  // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
-  visit(fromMarkdown(markdown) as PositionedNode);
-  return definitions;
-}
-
-function ownCellDelimiters(markdown: string, definitionSuffix: string): string {
+function ownCellDelimiters(markdown: string, referencesPossible: boolean): string {
   if (!CELL_DELIMITER_CANDIDATES.test(markdown)) {
     return markdown;
   }
-  const ranges = literalTextRanges(markdown, definitionSuffix);
+  if (referencesPossible && markdown.includes("[")) {
+    return markdown;
+  }
+  const ranges = literalTextRanges(markdown);
   const isLiteral = (offset: number): boolean =>
     ranges.some(([from, to]) => offset >= from && offset < to);
   let owned = "";
@@ -120,7 +88,7 @@ function ownCellDelimiters(markdown: string, definitionSuffix: string): string {
 function renderTableSource(
   table: MarkdownTableMeta,
   mode: Exclude<MarkdownTableMode, "off">,
-  definitionSuffix: string,
+  referencesPossible: boolean,
 ): string {
   if (mode !== "bullets") {
     const text = renderMarkdownCodeTable(table.headers, table.rows);
@@ -134,12 +102,12 @@ function renderTableSource(
   const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
   const headers = table.headers.map((text, column) => ({
     text,
-    markdown: ownCellDelimiters(source.headers[column] ?? "", definitionSuffix),
+    markdown: ownCellDelimiters(source.headers[column] ?? "", referencesPossible),
   }));
   const rows = table.rows.map((row, index) =>
     row.map((text, column) => ({
       text,
-      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? "", definitionSuffix),
+      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? "", referencesPossible),
     })),
   );
   let rendered = "";
@@ -166,20 +134,14 @@ export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode)
     autolink: false,
     tableMode: "block",
   });
-  // Gate the definition-collecting parse on any `[…]:` shape: labels may span lines
-  // (so the brackets may contain newlines) and definitions may nest in block quotes
-  // or list items (so no line anchoring). A false positive only costs one parse.
-  // The suffix is prepared once and reused for every cell parse on this document.
-  const definitionSuffix = /\[[^\]]+\]:/u.test(markdown)
-    ? collectReferenceDefinitions(markdown)
-        .map((definition) => definition.replace(/\s/gu, " "))
-        .join("\n")
-    : "";
+  // Every reference definition contains `]:`; without that shape no reference in
+  // any cell can resolve, so bracket-bearing cells are provably reference-free.
+  const referencesPossible = /\]:/u.test(markdown);
   let cursor = 0;
   let result = "";
   for (const table of tables) {
     const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
-    const rendered = renderTableSource(table, mode, definitionSuffix).replaceAll(
+    const rendered = renderTableSource(table, mode, referencesPossible).replaceAll(
       "\n",
       "\n" + source.prefix,
     );

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -11,10 +11,13 @@ import type { MarkdownTableMode } from "./types.js";
 // The inline parser decides which delimiters are literal: authored emphasis, code spans,
 // and links keep their delimiters (their syntax lives in non-text nodes), while text
 // nodes own the literal `*`/`_`/`` ` `` runs. Escaping only those keeps authored markup
-// rendering while strays stay confined to their own cell.
+// rendering while strays stay confined to their own cell. Reference links keep their
+// source too: cells parse without the document's definitions, so a reference label
+// looks like text unless it is matched against the definitions collected up front.
 const CELL_DELIMITER_CANDIDATES = /[*_`]/u;
 
 type PositionedNode = {
+  identifier?: string;
   type?: string;
   position?: { start?: { offset?: number }; end?: { offset?: number } };
   children?: PositionedNode[];
@@ -42,13 +45,59 @@ function literalTextRanges(markdown: string): Array<[number, number]> {
   return ranges;
 }
 
-function ownCellDelimiters(markdown: string): string {
+/** Collects the identifiers of reference definitions declared anywhere in the document. */
+function collectReferenceIdentifiers(markdown: string): Set<string> {
+  const identifiers = new Set<string>();
+  const visit = (node: PositionedNode): void => {
+    if (node.type === "definition" && typeof node.identifier === "string") {
+      // Mirror markdown-it's normalizeReference: fold whitespace, case-fold.
+      identifiers.add(node.identifier.trim().replace(/\s+/gu, " ").toLowerCase());
+    }
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(fromMarkdown(markdown) as PositionedNode);
+  return identifiers;
+}
+
+type ReferenceSpan = { end: number; label: string; start: number };
+
+/**
+ * Scans cell source for reference-link syntax: `full` `[label][ref]`, `collapsed`
+ * `[ref][]`, and `shortcut` `[ref]`. Only spans whose identifier matches a document
+ * definition are returned so literal bracket text is never mistaken for a reference.
+ */
+function referenceSpans(markdown: string, identifiers: Set<string>): ReferenceSpan[] {
+  if (identifiers.size === 0) {
+    return [];
+  }
+  const spans: ReferenceSpan[] = [];
+  const reference = /\[([^\][\s](?:[^\][]*?)?)\](?:\[([^\][]*)\])?/gu;
+  for (const match of markdown.matchAll(reference)) {
+    const start = match.index ?? 0;
+    const [source, label = "", ref = ""] = match;
+    const identifier = (ref === "" ? label : ref).trim().replace(/\s+/gu, " ").toLowerCase();
+    if (!identifiers.has(identifier)) {
+      continue;
+    }
+    spans.push({ start, end: start + source.length, label });
+  }
+  return spans;
+}
+
+function ownCellDelimiters(markdown: string, identifiers: Set<string>): string {
   if (!CELL_DELIMITER_CANDIDATES.test(markdown)) {
     return markdown;
   }
   const ranges = literalTextRanges(markdown);
-  const isLiteral = (offset: number): boolean =>
-    ranges.some(([from, to]) => offset >= from && offset < to);
+  const references = referenceSpans(markdown, identifiers);
+  const isLiteral = (offset: number): boolean => {
+    if (references.some(({ start, end }) => offset >= start && offset < end)) {
+      return false;
+    }
+    return ranges.some(([from, to]) => offset >= from && offset < to);
+  };
   let owned = "";
   let offset = 0;
   while (offset < markdown.length) {
@@ -70,6 +119,7 @@ function ownCellDelimiters(markdown: string): string {
 function renderTableSource(
   table: MarkdownTableMeta,
   mode: Exclude<MarkdownTableMode, "off">,
+  identifiers: Set<string>,
 ): string {
   if (mode !== "bullets") {
     const text = renderMarkdownCodeTable(table.headers, table.rows);
@@ -83,12 +133,12 @@ function renderTableSource(
   const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
   const headers = table.headers.map((text, column) => ({
     text,
-    markdown: ownCellDelimiters(source.headers[column] ?? ""),
+    markdown: ownCellDelimiters(source.headers[column] ?? "", identifiers),
   }));
   const rows = table.rows.map((row, index) =>
     row.map((text, column) => ({
       text,
-      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? ""),
+      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? "", identifiers),
     })),
   );
   let rendered = "";
@@ -115,11 +165,17 @@ export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode)
     autolink: false,
     tableMode: "block",
   });
+  const referenceIdentifiers = /(^|\n)\s*\[[^\]]+\]:\s*/u.test(markdown)
+    ? collectReferenceIdentifiers(markdown)
+    : new Set<string>();
   let cursor = 0;
   let result = "";
   for (const table of tables) {
     const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
-    const rendered = renderTableSource(table, mode).replaceAll("\n", "\n" + source.prefix);
+    const rendered = renderTableSource(table, mode, referenceIdentifiers).replaceAll(
+      "\n",
+      "\n" + source.prefix,
+    );
     result += markdown.slice(cursor, source.start) + rendered;
     cursor = source.end;
   }

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -12,8 +12,9 @@ import type { MarkdownTableMode } from "./types.js";
 // and links keep their delimiters (their syntax lives in non-text nodes), while text
 // nodes own the literal `*`/`_`/`` ` `` runs. Escaping only those keeps authored markup
 // rendering while strays stay confined to their own cell. Reference links keep their
-// source too: cells parse without the document's definitions, so a reference label
-// looks like text unless it is matched against the definitions collected up front.
+// source too: cells parse in isolation, so the document's reference definitions are
+// appended to the parse input and the parser itself resolves each reference into a
+// link node whose delimiters live outside text ranges.
 const CELL_DELIMITER_CANDIDATES = /[*_`]/u;
 
 type PositionedNode = {
@@ -27,10 +28,26 @@ type PositionedNode = {
  * Ranges of cell source that the inline parser owns as literal text. Delimiters inside
  * them are orphans on this embedded surface; delimiters outside them belong to parsed
  * emphasis, code spans, or links and must survive rendering.
+ *
+ * `definitionSuffix` carries the document's reference definitions (whitespace-flattened,
+ * joined by newlines) so references resolve exactly as the channel renderer resolves
+ * them — multiline labels, padded labels, and Unicode-whitespace variants included —
+ * instead of approximating the parser's reference grammar with a local scanner.
+ * Whitespace is flattened to ordinary spaces in the parse copy only; the substitution
+ * preserves UTF-16 offsets 1:1, keeps whitespace semantics for emphasis flanking, and
+ * matches markdown-it's `\s`-based identifier folding. Classification always applies
+ * to the original cell bytes.
  */
-function literalTextRanges(markdown: string): Array<[number, number]> {
+function literalTextRanges(markdown: string, definitionSuffix: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   const visit = (node: PositionedNode): void => {
+    // Reference labels must keep their exact source bytes: the renderer matches
+    // them against definition identifiers, and an escaped delimiter inside the
+    // label text breaks that match. Inline links/images stay escapable — their
+    // label text renders identically whether or not a delimiter is escaped.
+    if (node.type === "linkReference" || node.type === "imageReference") {
+      return;
+    }
     const start = node.position?.start?.offset;
     const end = node.position?.end?.offset;
     if (node.type === "text" && start !== undefined && end !== undefined) {
@@ -41,33 +58,30 @@ function literalTextRanges(markdown: string): Array<[number, number]> {
       visit(child);
     }
   };
+  const source = markdown.replace(/\s/gu, " ");
+  const input = definitionSuffix === "" ? source : `${source}\n\n${definitionSuffix}`;
   // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
-  visit(fromMarkdown(markdown) as PositionedNode);
-  return ranges;
+  visit(fromMarkdown(input) as PositionedNode);
+  // The appended definitions start beyond the cell source; their ranges never apply.
+  return ranges.filter(([, to]) => to <= markdown.length);
 }
 
 /**
- * Canonical form for reference identifiers, mirroring micromark's
- * `normalizeIdentifier` (which markdown-it's normalizeReference matches):
- * collapse Markdown whitespace, trim, then lower- AND uppercase. The double
- * case fold is required — `ß`.toLowerCase() stays `ß` while its definition
- * identifier was already folded to `SS`, so lowercasing alone misses valid
- * references.
+ * Source slices of every reference definition in the document. Definitions may nest
+ * in block quotes or list items and their labels may span lines, so the mdast parse —
+ * not a line-anchored precheck — decides what is a definition; keeping the exact
+ * source lets the cell parse re-resolve references with the parser's own grammar.
  */
-function normalizeReferenceIdentifier(value: string): string {
-  return value
-    .replace(/[\t\n\r ]+/gu, " ")
-    .replace(/^ | $/gu, "")
-    .toLowerCase()
-    .toUpperCase();
-}
-
-/** Collects the identifiers of reference definitions declared anywhere in the document. */
-function collectReferenceIdentifiers(markdown: string): Set<string> {
-  const identifiers = new Set<string>();
+function collectReferenceDefinitions(markdown: string): string[] {
+  const definitions: string[] = [];
   const visit = (node: PositionedNode): void => {
-    if (node.type === "definition" && typeof node.identifier === "string") {
-      identifiers.add(normalizeReferenceIdentifier(node.identifier));
+    if (node.type === "definition") {
+      const start = node.position?.start?.offset;
+      const end = node.position?.end?.offset;
+      if (start !== undefined && end !== undefined) {
+        definitions.push(markdown.slice(start, end));
+      }
+      return;
     }
     for (const child of node.children ?? []) {
       visit(child);
@@ -75,46 +89,16 @@ function collectReferenceIdentifiers(markdown: string): Set<string> {
   };
   // SAFETY: fromMarkdown returns the mdast Root; nodes structurally match PositionedNode.
   visit(fromMarkdown(markdown) as PositionedNode);
-  return identifiers;
+  return definitions;
 }
 
-type ReferenceSpan = { end: number; label: string; start: number };
-
-/**
- * Scans cell source for reference-link syntax: `full` `[label][ref]`, `collapsed`
- * `[ref][]`, and `shortcut` `[ref]`. Only spans whose identifier matches a document
- * definition are returned so literal bracket text is never mistaken for a reference.
- */
-function referenceSpans(markdown: string, identifiers: Set<string>): ReferenceSpan[] {
-  if (identifiers.size === 0) {
-    return [];
-  }
-  const spans: ReferenceSpan[] = [];
-  const reference = /\[([^\][\s](?:[^\][]*?)?)\](?:\[([^\][]*)\])?/gu;
-  for (const match of markdown.matchAll(reference)) {
-    const start = match.index ?? 0;
-    const [source, label = "", ref = ""] = match;
-    const identifier = normalizeReferenceIdentifier(ref === "" ? label : ref);
-    if (!identifiers.has(identifier)) {
-      continue;
-    }
-    spans.push({ start, end: start + source.length, label });
-  }
-  return spans;
-}
-
-function ownCellDelimiters(markdown: string, identifiers: Set<string>): string {
+function ownCellDelimiters(markdown: string, definitionSuffix: string): string {
   if (!CELL_DELIMITER_CANDIDATES.test(markdown)) {
     return markdown;
   }
-  const ranges = literalTextRanges(markdown);
-  const references = referenceSpans(markdown, identifiers);
-  const isLiteral = (offset: number): boolean => {
-    if (references.some(({ start, end }) => offset >= start && offset < end)) {
-      return false;
-    }
-    return ranges.some(([from, to]) => offset >= from && offset < to);
-  };
+  const ranges = literalTextRanges(markdown, definitionSuffix);
+  const isLiteral = (offset: number): boolean =>
+    ranges.some(([from, to]) => offset >= from && offset < to);
   let owned = "";
   let offset = 0;
   while (offset < markdown.length) {
@@ -136,7 +120,7 @@ function ownCellDelimiters(markdown: string, identifiers: Set<string>): string {
 function renderTableSource(
   table: MarkdownTableMeta,
   mode: Exclude<MarkdownTableMode, "off">,
-  identifiers: Set<string>,
+  definitionSuffix: string,
 ): string {
   if (mode !== "bullets") {
     const text = renderMarkdownCodeTable(table.headers, table.rows);
@@ -150,12 +134,12 @@ function renderTableSource(
   const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
   const headers = table.headers.map((text, column) => ({
     text,
-    markdown: ownCellDelimiters(source.headers[column] ?? "", identifiers),
+    markdown: ownCellDelimiters(source.headers[column] ?? "", definitionSuffix),
   }));
   const rows = table.rows.map((row, index) =>
     row.map((text, column) => ({
       text,
-      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? "", identifiers),
+      markdown: ownCellDelimiters(source.rows[index]?.[column] ?? "", definitionSuffix),
     })),
   );
   let rendered = "";
@@ -182,17 +166,20 @@ export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode)
     autolink: false,
     tableMode: "block",
   });
-  // Gate the definition-collecting parse on any `[…]:` shape: definitions may be
-  // nested in block quotes or list items, so a line-anchored precheck would miss
-  // documents whose only definitions live inside a container.
-  const referenceIdentifiers = /\[[^\]\n]+\]:/u.test(markdown)
-    ? collectReferenceIdentifiers(markdown)
-    : new Set<string>();
+  // Gate the definition-collecting parse on any `[…]:` shape: labels may span lines
+  // (so the brackets may contain newlines) and definitions may nest in block quotes
+  // or list items (so no line anchoring). A false positive only costs one parse.
+  // The suffix is prepared once and reused for every cell parse on this document.
+  const definitionSuffix = /\[[^\]]+\]:/u.test(markdown)
+    ? collectReferenceDefinitions(markdown)
+        .map((definition) => definition.replace(/\s/gu, " "))
+        .join("\n")
+    : "";
   let cursor = 0;
   let result = "";
   for (const table of tables) {
     const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
-    const rendered = renderTableSource(table, mode, referenceIdentifiers).replaceAll(
+    const rendered = renderTableSource(table, mode, definitionSuffix).replaceAll(
       "\n",
       "\n" + source.prefix,
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users chatting through channels that render tables with
`convertMarkdownTables` in `bullets` mode (Discord, Feishu, IRC, Mattermost,
and others; resolved per channel config) would see table content silently
misrepresented when a cell contained a stray `*`, `_`, or backtick: the bare
delimiter could pair with the generated `**` row-label markers or with a
delimiter in a neighboring cell, swallowing the row boundary, leaking later
cells into a code span, or emitting stray `<em>` markup.

## Why This Change Was Made

The bullets formatter is the only table surface that mixes raw cell markdown
with generated markup without separating ownership: the generated `**` belongs
to the formatter, while delimiters inside `cell.markdown` belong to the cell
author. Inline markdown-it parsing runs over the joined string, so an unpaired
cell delimiter can pair with (or consume) the generated marker.

The fix lets the inline parser decide which delimiters are literal. Each cell
is parsed with `fromMarkdown` (an existing dependency), and only delimiters
inside parsed text nodes — the parser's literal-text regions — are escaped
with a backslash. Delimiters that belong to authored emphasis, inline code, or
links live in non-text nodes and survive untouched, so valid markup keeps
rendering while strays stay confined to their own cell. Escape-aware scanning
keeps authored backslash pairs (`\*`, `` \` ``, `\\`) verbatim.

Reference links are the one exception, and they are handled by non-
intervention rather than approximation: the renderer matches reference labels
against document definitions by identifier, an escaped delimiter inside a
label breaks that match, and every local approximation of the reference
grammar (scanners, definition slicing, label prechecks) leaks another edge
case — label folding, containers, multiline labels, escaped brackets. So a
cell that could contain a reference — any `[` while the document holds a
definition shape (`]:`, which every reference definition contains) — passes
through byte-identical to main. Cells without `[`, or any cell when the
document has no `]:`, are provably reference-free and get full delimiter
isolation. The stray-delimiter defect stays open in possible-reference cells
by design; that intersection is rare and this PR chooses zero reference
regressions over covering it. Angle-bracket autolinks get the same protection
structurally: their parsed text child *is* the destination, so autolink
subtrees (the only link form starting with `<`) are exempt from escaping.

**Fix classification: behavior-completing** — #139892 (merged as
`5d1a4193ef8`) preserved table literals by routing only parsed table ranges
through this formatter, but the formatter itself still mixes generated and
authored delimiters. This PR completes that boundary at the cell level.

Related: #139892, fixes #142647

## User Impact

Table output in bullets mode now renders as authored: deliberate `**bold**`,
`_italic_`, and `` `code` `` keep their formatting, escaped characters stay
literal, document reference links keep resolving exactly as on main (their
cells are byte-identical), and a stray delimiter in one cell can no longer
corrupt the rendering of later cells or swallow the generated bullet markers.
One disclosure: a cell delimiter that previously paired across the cell
boundary (misrepresenting the table) now renders literally at its own
position, and the underlying bytes gain a `\`; rendered glyphs are otherwise
unchanged, and cells with valid markup are byte-identical.

## Evidence

Reproduction through the real Discord outbound formatter
(`renderDiscordMarkdown`, extensions/discord/src/markdown.ts:324 — the
`convertMarkdownTables` call at outbound-text.ts:19), run under the
extension-discord vitest project so `openclaw/plugin-sdk/*` resolves exactly
like production. BEFORE is main itself (no cell delimiter isolation), so main
already renders valid emphasis, code spans, and reference links correctly;
the defect is the stray-delimiter rows:

| Input | BEFORE (main) | AFTER (this branch) |
|---|---|---|
| `a *` and `b *` in adjacent cells | stray `<em>` spans cells | each `*` stays literal |
| `` `tick `` in row label | code span swallows the row boundary | row label stays bold, backtick literal |
| `**bold** and _italic_` | renders correctly on main | still renders `<strong>`/`<em>` (no regression) |
| `` \` literal and `code` `` | renders correctly on main | still renders literal backtick + `<code>` (no regression) |
| `[manual][api_v1]` + `[api_v1]:` definition | renders correctly on main | byte-identical cell; still resolves `<a>` |
| `[manual][api\]_v1]` + escaped-bracket definition | renders correctly on main | byte-identical cell; still resolves `<a>` |
| `[manual][api_ v1]` + continued block-quote definition | renders correctly on main | byte-identical cell; still resolves `<a>` |
| `<first_last@example.com>` / `<https://example.com/a_b>` | autolinks resolve on main | destinations untouched; autolinks still resolve |

Red/green proof: the reference pass-through cases (continued
block-quote definition, escaped-bracket label) fail on revision
`f9ac6ba0134` exactly on their assertions, and the autolink destination case
fails on `982ad77c54a` (escaped underscore kills the email/URL autolink);
all pass on this head. Full
`tables.test.ts` passes 36/36 and the markdown-core suite passes 27 files /
396 tests; `extensions/discord/src/markdown.test.ts` passes 2/2. All test
runs executed in an isolated Docker environment on a remote test host;
`oxfmt` clean (re-verified 2026-09-09 UTC after the pass-through reslice and
the autolink guard).

<details>
<summary>Details maintainers may want to adjust</summary>

- The issue text, reproduction rows, and classification wording can be edited
  freely to match house style.
- The regression cases live in the existing `convertMarkdownTables`
  `it.each` block neighborhood; maintainers may prefer them split or renamed.
- If maintainers prefer ownership handled further upstream (at table parse
  time), the same escape can move there — this patch keeps it at the formatter
  because `code`/`block` modes must stay byte-faithful.

</details>

<details>
<summary>Alternatives considered / land-ready rationale</summary>

- **Reject and close** as `wontfix` if bullets-mode fidelity is considered
  acceptable drift — but the converter is the bullets fallback for a dozen
  channels (discord, feishu, irc, matrix, mattermost, msteams, nextcloud-talk,
  nostr, zalo, and more), so real chat output hits this.
- **Behavior-altering alternative**: render row labels as plain text instead
  of `**` — rejected, it changes deliberate output for all tables.
- **Escape everything outside closed code spans** (first revision): rejected
  after review — it degraded authored emphasis and broke escaped-backtick +
  code-span cells. The parser-owned text-node rule replaces it.
- **Reconstruct reference context locally** (revisions 2–5): rejected after
  five review rounds — scanning, definition slicing, and label prechecks each
  leaked another renderer-grammar edge case (containers, Unicode folds,
  multiline labels, escaped brackets). Byte-identical pass-through for
  possible-reference cells removes the whole regression class instead of
  approximating one more corner of it.
- **Parse-time ownership**: escape at table parse instead of render — kept out
  of scope; render-time is the only place that knows `code`/`block` modes do
  not need it.
- This patch is land-ready: no config/schema changes, no dependency changes,
  one file plus tests, `oxfmt` clean, and it reuses the existing
  `fromMarkdown` dependency rather than adding a new scanner.

</details>
