### PR TITLE
fix: allow independent worker and CLI runs to start from parent tools

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1296,6 +1296,7 @@ export function runAgentAttempt(params: {
         return result;
       },
       {
+        preparedRunAdmission: params.preparedRunAdmission,
         lifecycleGeneration: params.lifecycleGeneration,
         abortSignal: params.deferredLifecycle?.signal ?? params.opts.abortSignal,
         trigger: "user",

--- a/src/agents/session-placement-admission.caller-scope.test.ts
+++ b/src/agents/session-placement-admission.caller-scope.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  placements,
+  seedActivePlacement,
+  SESSION_ID,
+  SESSION_KEY,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+} from "../gateway/worker-environments/worker-turn-launcher.test-support.js";
+import {
+  createOperationalRunInstanceRef,
+  prepareAgentRunAdmission,
+  type AdmittedRunContext,
+  type PreparedAgentRunAdmission,
+} from "./admitted-run-context.js";
+import { createDeferredEmbeddedRunLifecycleManager } from "./embedded-agent-runner/run/deferred-lifecycle-owner.js";
+import {
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunHandleActive,
+  resolveActiveEmbeddedRunOwner,
+  setActiveEmbeddedRun,
+} from "./embedded-agent-runner/runs.js";
+import { createEmbeddedRunHandle } from "./embedded-agent-runner/runs.test-support.js";
+import { withPreparedEmbeddedRunToolAuthority } from "./harness/tool-authority.runtime.js";
+import {
+  installSessionPlacementAdmissionProvider,
+  withLocalSessionPlacementTurnSettlement,
+  withSessionPlacementTurnAdmission,
+} from "./session-placement-admission.js";
+import { getGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
+
+let uninstall: (() => void) | undefined;
+
+// Enter a real live parent attempt, as an in-process sessions tool does.
+async function fromParent(
+  run: (owner: {
+    admittedRunContext: AdmittedRunContext;
+    preparedRunAdmission: PreparedAgentRunAdmission;
+    register: () => void;
+  }) => Promise<void>,
+) {
+  const parent = {
+    sessionId: "parent-session",
+    sessionKey: "agent:main:parent",
+    sessionFile: "agent:main:parent",
+    agentId: "main",
+    runId: "parent-run",
+    workspaceDir: "/unused-parent-workspace",
+    config: {},
+    provider: "openai",
+    modelId: "gpt-test",
+  };
+  const admission = prepareAgentRunAdmission({
+    cfg: {},
+    operationalRunInstance: createOperationalRunInstanceRef(parent.runId),
+    facts: {
+      agentId: parent.agentId,
+      runId: parent.runId,
+      ingress: { kind: "system", state: "present", boundary: "caller-scope-test" },
+    },
+  });
+  const admittedRunContext = await admission.admit("embedded");
+  const handle = createEmbeddedRunHandle({ runId: parent.runId });
+  try {
+    await withPreparedEmbeddedRunToolAuthority(
+      { admittedRunContext },
+      parent,
+      undefined,
+      async (prepared) => {
+        const caller = getGatewayToolCallerIdentity()!;
+        handle.toolAuthorityFingerprint = prepared.toolAuthorityFingerprint;
+        await run({
+          admittedRunContext,
+          preparedRunAdmission: admission,
+          register: () =>
+            setActiveEmbeddedRun(
+              parent.sessionId,
+              handle,
+              parent.sessionKey,
+              parent.sessionFile,
+              parent.agentId,
+            ),
+        });
+        expect(getGatewayToolCallerIdentity()).toBe(caller);
+      },
+    );
+  } finally {
+    clearActiveEmbeddedRun(parent.sessionId, handle, parent.sessionKey, parent.sessionFile);
+    admission.close();
+  }
+}
+
+describe("independent placement caller scope", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(async () => {
+    uninstall?.();
+    uninstall = undefined;
+    await cleanupWorkerTurnLauncherTest();
+  });
+
+  it.each(["live parent", "closed parent", "reused run id"])(
+    "registers a worker proxy without consuming authority from a %s",
+    async (scenario) => {
+      seedActivePlacement();
+      const input = turn(scenario === "reused run id" ? "parent-run" : "child-worker-run");
+      const reachedWorkerExecution = new Error("test worker execution reached");
+      const get = vi.fn(() => {
+        expect(resolveActiveEmbeddedRunOwner(SESSION_ID)?.runId).toBe(input.runId);
+        throw reachedWorkerExecution;
+      });
+      uninstall = installSessionPlacementAdmissionProvider(
+        createWorkerSessionTurnPlacementProvider({
+          placements,
+          environments: { ...unusedEnvironments(), get },
+        }),
+      );
+      try {
+        let queued: Promise<void> | undefined;
+        let release!: () => void;
+        const ready = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        await fromParent(async () => {
+          const execute = async () => {
+            await expect(
+              withSessionPlacementTurnAdmission(
+                {
+                  sessionId: SESSION_ID,
+                  sessionKey: SESSION_KEY,
+                  agentId: "main",
+                  runId: input.runId,
+                },
+                input,
+                vi.fn(),
+              ),
+            ).rejects.toBe(reachedWorkerExecution);
+          };
+          if (scenario === "closed parent") {
+            // Queue while parent ALS is active, then let its attempt close first.
+            queued = ready.then(execute);
+          } else {
+            await execute();
+          }
+        });
+        release();
+        await queued;
+        expect(get).toHaveBeenCalledOnce();
+        expect(isEmbeddedAgentRunHandleActive(SESSION_ID)).toBe(false);
+        expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+      } finally {
+        input.preparedRunAdmission.close();
+      }
+    },
+  );
+
+  it("registers the direct CLI handoff under its own placement lifecycle", async () => {
+    const input = turn("child-cli-run");
+    const lifecycle = createDeferredEmbeddedRunLifecycleManager(input);
+    uninstall = installSessionPlacementAdmissionProvider(
+      createWorkerSessionTurnPlacementProvider({
+        placements,
+        environments: unusedEnvironments(),
+      }),
+    );
+    try {
+      await fromParent(async () => {
+        await withLocalSessionPlacementTurnSettlement(
+          {
+            sessionId: SESSION_ID,
+            sessionKey: SESSION_KEY,
+            agentId: "main",
+            runId: input.runId,
+          },
+          async (assertCurrent) => {
+            assertCurrent();
+            lifecycle.handoffToCli();
+            expect(resolveActiveEmbeddedRunOwner(SESSION_ID)?.runId).toBe(input.runId);
+            await lifecycle.complete();
+            return { meta: { durationMs: 0 } };
+          },
+          { preparedRunAdmission: input.preparedRunAdmission },
+        );
+      });
+      expect(isEmbeddedAgentRunHandleActive(SESSION_ID)).toBe(false);
+      expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+    } finally {
+      await lifecycle.complete();
+      input.preparedRunAdmission.close();
+    }
+  });
+
+  it.each([
+    { path: "embedded", carrier: "prepared" },
+    { path: "embedded", carrier: "admitted" },
+    { path: "cli", carrier: "prepared" },
+    { path: "cli", carrier: "admitted" },
+  ] as const)(
+    "retains exact $carrier $path authority and rejects registration after closure",
+    async ({ path, carrier }) => {
+      await fromParent(async (owner) => {
+        const admission =
+          carrier === "prepared"
+            ? { preparedRunAdmission: owner.preparedRunAdmission }
+            : { admittedRunContext: owner.admittedRunContext };
+        const claim = {
+          sessionId: "parent-session",
+          sessionKey: "agent:main:parent",
+          agentId: "main",
+          runId: "parent-run",
+        };
+        const execute = async () => {
+          owner.register();
+          expect(resolveActiveEmbeddedRunOwner(claim.sessionId)?.runId).toBe(claim.runId);
+          await Promise.resolve();
+          owner.preparedRunAdmission.close();
+          expect(owner.register).toThrow(/no longer active/);
+          return { meta: { durationMs: 0 } };
+        };
+        const input = {
+          ...claim,
+          ...admission,
+          sessionFile: claim.sessionKey,
+          workspaceDir: "/unused-parent-workspace",
+          prompt: "test",
+          timeoutMs: 1000,
+        };
+        if (path === "embedded") {
+          await withSessionPlacementTurnAdmission(claim, input, execute);
+        } else {
+          await withLocalSessionPlacementTurnSettlement(claim, execute, admission);
+        }
+      });
+    },
+  );
+});

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -22,6 +22,10 @@ import {
   withoutSessionPlacementForcedTerminalSettlement,
 } from "./session-placement-forced-terminal-settlement.js";
 import { settleRequesterAfterSessionSpawns } from "./subagents/registry/subagent-registry.js";
+import {
+  getGatewayToolCallerIdentity,
+  withoutGatewayToolCallerIdentity,
+} from "./tools/gateway-caller-context.js";
 
 export type LocalTurnPlacementClaim = {
   sessionId: string;
@@ -91,6 +95,21 @@ export function captureSessionPlacementCompactionSuccessorAssertion(): SessionPl
   };
 }
 
+// Placement can register a cancellation proxy before runtime/tool preparation.
+// Only an exact continuation retains caller fences; independently admitted work
+// must enter its own runtime scope instead of borrowing its launching tool's.
+function withPlacementTurnCallerScope<T>(
+  params: Pick<RunEmbeddedAgentParams, "admittedRunContext" | "preparedRunAdmission">,
+  task: () => T,
+): T {
+  const instance =
+    params.admittedRunContext?.operationalRunInstance ??
+    params.preparedRunAdmission?.operationalRunInstance;
+  return instance && getGatewayToolCallerIdentity()?.operationalRunInstance === instance
+    ? task()
+    : withoutGatewayToolCallerIdentity(task);
+}
+
 export async function withSessionPlacementTurnAdmission(
   claim: LocalTurnPlacementClaim,
   params: SessionPlacementTurnParams,
@@ -128,10 +147,12 @@ export async function withSessionPlacementTurnAdmission(
     return result;
   };
   const provider = state.provider;
-  const result = await withoutSessionPlacementForcedTerminalSettlement(() =>
-    provider
-      ? provider.executeTurn(claim, params, runAdmittedLocalTurn, admitTurn)
-      : runAdmittedLocalTurn(),
+  const result = await withPlacementTurnCallerScope(params, () =>
+    withoutSessionPlacementForcedTerminalSettlement(() =>
+      provider
+        ? provider.executeTurn(claim, params, runAdmittedLocalTurn, admitTurn)
+        : runAdmittedLocalTurn(),
+    ),
   );
   if (result.meta.executionTrace?.runner === "cli") {
     settleYieldedRequesterAfterPlacementRelease(claim, result);
@@ -145,7 +166,12 @@ export async function withLocalSessionPlacementTurnSettlement(
   task: (assertSettlementCurrent: () => void) => Promise<EmbeddedAgentRunResult>,
   options: Pick<
     RunEmbeddedAgentParams,
-    "abortSignal" | "lifecycleGeneration" | "trigger" | "inputProvenance"
+    | "abortSignal"
+    | "lifecycleGeneration"
+    | "trigger"
+    | "inputProvenance"
+    | "admittedRunContext"
+    | "preparedRunAdmission"
   > = {},
 ): Promise<EmbeddedAgentRunResult> {
   const provider = state.provider;
@@ -201,8 +227,10 @@ export async function withLocalSessionPlacementTurnSettlement(
             open = false;
           }
         };
-        const result = await withoutSessionPlacementForcedTerminalSettlement(() =>
-          provider ? provider.executeLocalTurn(claim, runLocal) : runLocal(),
+        const result = await withPlacementTurnCallerScope(options, () =>
+          withoutSessionPlacementForcedTerminalSettlement(() =>
+            provider ? provider.executeLocalTurn(claim, runLocal) : runLocal(),
+          ),
         );
         settleYieldedRequesterAfterPlacementRelease(claim, result);
         return result;

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -474,6 +474,7 @@ export async function runCliFallbackCandidate(
         return candidateResult;
       },
       {
+        preparedRunAdmission: params.preparedRunAdmission,
         lifecycleGeneration: params.lifecycleGeneration,
         abortSignal: params.runAbortSignal,
         trigger: turn.isHeartbeat ? "heartbeat" : "user",

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -730,7 +730,7 @@ function createCronPromptExecutor(
               }
               return candidateResult;
             },
-            { abortSignal: params.abortSignal, trigger: "cron" },
+            { preparedRunAdmission, abortSignal: params.abortSignal, trigger: "cron" },
           );
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting independent worker or CLI runs from a parent agent tool could see the child rejected during active-run registration, before its own runtime started.

## Why This Change Was Made

Placement orchestration could inherit the parent attempt's asynchronous tool-authority context. Its early cancellation proxy was then checked against the parent's session, run, and fingerprint. Scope placement to the requested prepared/admitted operational instance: exact-instance continuations retain their existing fences, while independently admitted work leaves the parent caller context before registering its own lifecycle owner. Forward the existing admission through all three direct CLI placement paths.

Strict registration validation stays unchanged. No parent fingerprint is copied, new authority minted, or schema, configuration, protocol, or dependency changed.

## User Impact

Independent worker and CLI child runs can register their own lifecycle without consuming the launching parent's authority. Same-instance continuations still reject operations after their admission closes.

## Evidence

### Regression and sibling coverage

Validated the patch on base `b689bf06a7e5e92895cadcbe1e7acb0d539306ef`; published as `565921193f7936fea028efc88e7e003b0c990096`.

- **Before:** replaying the final eight-case regression with the original placement owner produced **4 failures / 4 passes**. Failing cases: live parent, queued work after parent closure, reused run ID with a different instance, and direct CLI handoff. The four exact-instance closure cases already passed.
- **After:** **284 tests passed** across the selected suites: worker/Gateway boundaries (40), cron (24), auto-reply (11), placement/finalization (11), deferred lifecycle (2), CLI/tool authority (180), caller context (12), and Codex steering authority (4).
- Full `pnpm build` passed.
- Changed-file validation completed across the initial run and serialized continuation: core/core-test typechecks, formatting, lint, and planned guards passed. The initial run exited 143 during concurrent build/typecheck contention; only its missing stages were rerun serially, successfully.
- Fresh independent autoreview of the final five-file patch: **scoped-clean at P0/P1**.
- `git diff --cached --check` passed before commit.

Focused regression command:

```sh
node scripts/run-vitest.mjs src/agents/session-placement-admission.caller-scope.test.ts
```

### Clean-machine worker boundary evidence — partial E2E

Provider: **Blacksmith Testbox**, lease `tbx_01m21k5sdae9t5x4vknhjh4ks2` ([run 34287502316](https://github.com/openclaw/openclaw/actions/runs/34287502316)). The Testbox workflow provisions the environment; its GitHub status is not a passing test result. The task patch was synced into the prepared checkout and built on Linux / Node 24.19.0.

The existing `test/e2e/qa-lab/runtime/subagent-lineage-inspection.ts` scenario used an isolated Gateway, an actual paired device worker, and a loopback mock model provider:

1. A worker-hosted parent model issued `sessions_spawn`.
2. The Gateway reported a linked child with `createdVia: spawn` and `spawnDepth: 1`.
3. That child reached `placement.state: active` on a distinct device-worker environment, with `status: running` and `hasActiveRun: true`.

This establishes progress through independent child placement/registration. It does **not** establish completed child execution or a passing full lineage scenario. The captured request list does not independently establish a child model call.

**Known proof gap:** the broader scenario exited 1 when workspace result reconciliation returned `WORKSPACE_TRANSFER_FAILED`. Full nested-worker completion, lineage persistence/restart assertions, and successful result reconciliation therefore remain unproved by this run. No assertion was weakened, and no temporary diagnostic changes were retained.

Separately, the local wire E2E could not pass QA auth bootstrap because the installed operator Gateway and temporary QA state diverged. Clean Testbox isolation avoided that local precondition; no credential/store guard was bypassed and no live operator Gateway was changed.

The QA bootstrap isolation and worker workspace reconciliation problems are recorded as separate local follow-ups. Raw captures are omitted because they include environment/session details; the observations above are sanitized.
