### PR TITLE
fix(auth): show the Claude CLI re-auth step when the login expires

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -252,6 +252,35 @@ describe("oauth refresh failure hints", () => {
     });
   });
 
+  it("classifies structured claude-cli 410 session expiry as a provider refresh failure", () => {
+    const error = new FailoverError(
+      "Failed to authenticate: OAuth session expired and could not be refreshed",
+      {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-opus-5",
+        status: 410,
+        rawError: "Failed to authenticate: OAuth session expired and could not be refreshed",
+      },
+    );
+
+    expect(classifyOAuthRefreshFailureError(error)).toEqual({
+      provider: "claude-cli",
+      reason: "revoked",
+    });
+  });
+
+  it("keeps an expired claude-cli conversation session out of the login recovery path", () => {
+    const error = new FailoverError("HTTP 404: session not found", {
+      reason: "session_expired",
+      provider: "claude-cli",
+      model: "claude-opus-5",
+      status: 410,
+    });
+
+    expect(classifyOAuthRefreshFailureError(error)).toBeNull();
+  });
+
   it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {
     // A generic 401 from another provider should NOT be treated as an OAuth
     // refresh failure — it lacks the "claude-cli" provider prefix.

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -146,12 +146,18 @@ function readStructuredClaudeCliAuthFailure(err: unknown): StructuredClaudeCliAu
     return null;
   }
   const candidate = err as StructuredClaudeCliAuthFailure & { name?: unknown };
-  if (
-    candidate.name !== "FailoverError" ||
-    candidate.provider !== "claude-cli" ||
-    candidate.reason !== "auth" ||
-    candidate.status !== 401
-  ) {
+  if (candidate.name !== "FailoverError" || candidate.provider !== "claude-cli") {
+    return null;
+  }
+  // The claude subprocess reports an expired native login either as the
+  // classified 401 auth failure or, when the CLI runner keeps its own expiry
+  // status, as session_expired/410. Both carry the same login recovery. The
+  // caller still requires the expiry wording, so an ordinary expired CLI
+  // conversation session does not turn into a re-auth hint.
+  const isStructuredLoginFailure =
+    (candidate.reason === "auth" && candidate.status === 401) ||
+    (candidate.reason === "session_expired" && candidate.status === 410);
+  if (!isStructuredLoginFailure) {
     return null;
   }
   return candidate;
@@ -343,6 +349,24 @@ export function buildOAuthRefreshFailureLoginCommand(
           : `openclaw models auth login --provider ${sanitizedProvider}`,
       )
     : formatCliCommand("openclaw models auth login");
+}
+
+/**
+ * One-line recovery text for a classified OAuth login expiry. Shared by channel
+ * failure replies and the persisted terminal-run error the Control UI renders,
+ * so both surfaces name the same re-authentication step. The Codex pairing
+ * variant (with a button presentation) stays in the reply layer.
+ */
+export function buildOAuthRefreshFailureRecoveryText(
+  failure: Pick<OAuthRefreshFailure, "provider" | "profileId">,
+  options?: { includeProfileId?: boolean },
+): string {
+  const loginCommand = buildOAuthRefreshFailureLoginCommand(failure.provider, {
+    profileId: options?.includeProfileId ? failure.profileId : undefined,
+  });
+  const loginCommandMarkdown = formatOAuthRefreshFailureLoginCommandMarkdown(loginCommand);
+  const providerText = failure.provider ? ` for ${failure.provider}` : "";
+  return `⚠️ Model login expired on the gateway${providerText}. Re-auth with ${loginCommandMarkdown} in a terminal, then try again.`;
 }
 
 /** Build operator guidance for an active profile cooldown or disable window. */

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -44,6 +44,41 @@ describe("createAgentLifecycleTerminalBackstop", () => {
     expect(JSON.stringify(event)).not.toContain(rawDiagnostic);
   });
 
+  it.each([
+    { reason: "auth", status: 401 },
+    { reason: "session_expired", status: 410 },
+  ] as const)(
+    "publishes claude-cli re-auth recovery text for a %o login expiry",
+    ({ reason, status }) => {
+      emitAgentEvent.mockClear();
+      const raw = "Failed to authenticate: OAuth session expired and could not be refreshed";
+      const error = new FailoverError(raw, {
+        reason,
+        provider: "claude-cli",
+        model: "claude-opus-5",
+        status,
+        rawError: raw,
+      });
+      const terminal = createAgentLifecycleTerminalBackstop({
+        runId: "claude-cli-login-expired",
+        getLifecycleGeneration: () => "test-generation",
+        resolveTerminationFields: () => ({}),
+      });
+
+      terminal.emit("error", error);
+
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data.error).toBe(
+        "\u26a0\ufe0f Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
+      );
+      expect(event.data.errorObservation).toMatchObject({
+        provider: "claude-cli",
+        providerRuntimeFailureKind: "auth_refresh",
+      });
+      expect(event.data.error).not.toBe(raw);
+    },
+  );
+
   it.each(["typed", "raw"] as const)(
     "publishes bounded selected-profile recovery from %s failures without discovering providers",
     (kind) => {

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -44,6 +44,38 @@ describe("createAgentLifecycleTerminalBackstop", () => {
     expect(JSON.stringify(event)).not.toContain(rawDiagnostic);
   });
 
+  it("keeps the auth-refresh observation for a summary-only OAuth failure", () => {
+    emitAgentEvent.mockClear();
+    // An OpenAI non-JSON HTTP 401 refresh response yields a bounded summary and
+    // status with no recognized reason; OAuthRefreshFailureError preserves that
+    // shape. The Control UI still needs the observation to classify the error
+    // and render provider/status details.
+    const summary = "OpenAI Codex token refresh failed (HTTP 401).";
+    const oauthError = new OAuthRefreshFailureError({
+      provider: "openai",
+      message: `OAuth token refresh failed for openai: ${summary}`,
+      reason: null,
+      status: 401,
+      summary,
+    });
+    const error = new Error("wrapped OAuth refresh failure", { cause: oauthError });
+    const terminal = createAgentLifecycleTerminalBackstop({
+      runId: "oauth-refresh-failure-summary-only",
+      getLifecycleGeneration: () => "test-generation",
+      resolveTerminationFields: () => ({}),
+    });
+
+    terminal.emit("error", error);
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data.error).toBe(`⚠️ ${summary}`);
+    expect(event.data.errorObservation).toEqual({
+      provider: "openai",
+      providerRuntimeFailureKind: "auth_refresh",
+      httpStatus: 401,
+    });
+  });
+
   it.each([
     { reason: "auth", status: 401 },
     { reason: "session_expired", status: 410 },

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -124,12 +124,16 @@ export function createAgentLifecycleTerminalBackstop(params: {
       // providers (claude-cli) carry a reason but no summary, so fall through to
       // the shared recovery text rather than the raw provider error string; this
       // is what the persisted lastRunError the Control UI renders inherits.
+      // Others (an OpenAI non-JSON 401 refresh response) carry a bounded
+      // summary and status but no recognized reason. Both shapes are auth
+      // refresh failures, so both keep the observation the Control UI uses to
+      // classify the error and render provider/status details.
       data.error =
         renderFailoverCodeUserCopy(getFailoverErrorCode(resultOrError)) ??
         (oauthFailure?.summary ? `⚠️ ${oauthFailure.summary}` : undefined) ??
         (oauthFailure?.reason ? buildOAuthRefreshFailureRecoveryText(oauthFailure) : undefined) ??
         formatErrorMessage(resultOrError);
-      if (oauthFailure?.reason) {
+      if (oauthFailure?.summary || oauthFailure?.reason) {
         data.errorObservation = {
           ...(oauthFailure.provider ? { provider: oauthFailure.provider } : {}),
           ...(oauthFailure.reason ? { failoverReason: oauthFailure.reason } : {}),

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -1,5 +1,8 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { classifyOAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import {
+  buildOAuthRefreshFailureRecoveryText,
+  classifyOAuthRefreshFailureError,
+} from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { getFailoverErrorCode } from "../../agents/failover/error.js";
 import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
@@ -117,11 +120,16 @@ export function createAgentLifecycleTerminalBackstop(params: {
       data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
     } else if (phase === "error") {
       const oauthFailure = classifyOAuthRefreshFailureError(resultOrError);
+      // A classified login expiry becomes actionable recovery copy. Some
+      // providers (claude-cli) carry a reason but no summary, so fall through to
+      // the shared recovery text rather than the raw provider error string; this
+      // is what the persisted lastRunError the Control UI renders inherits.
       data.error =
         renderFailoverCodeUserCopy(getFailoverErrorCode(resultOrError)) ??
         (oauthFailure?.summary ? `⚠️ ${oauthFailure.summary}` : undefined) ??
+        (oauthFailure?.reason ? buildOAuthRefreshFailureRecoveryText(oauthFailure) : undefined) ??
         formatErrorMessage(resultOrError);
-      if (oauthFailure?.summary) {
+      if (oauthFailure?.reason) {
         data.errorObservation = {
           ...(oauthFailure.provider ? { provider: oauthFailure.provider } : {}),
           ...(oauthFailure.reason ? { failoverReason: oauthFailure.reason } : {}),

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   buildOAuthRefreshFailureLoginCommand,
+  buildOAuthRefreshFailureRecoveryText,
   classifyOAuthRefreshFailure,
   classifyOAuthRefreshFailureError,
   formatOAuthRefreshFailureLoginCommandMarkdown,
@@ -319,7 +320,9 @@ export function buildExternalRunFailureReply(
       return {
         text: providerLoginRecovery
           ? `⚠️ ${providerLoginRecovery.hint} You can also re-auth with ${loginCommandMarkdown} on the gateway.`
-          : `⚠️ Model login expired on the gateway${providerText}. Re-auth with ${loginCommandMarkdown} in a terminal, then try again.`,
+          : buildOAuthRefreshFailureRecoveryText(oauthRefreshFailure, {
+              includeProfileId: options?.includeAuthProfileId,
+            }),
         ...(providerLoginRecovery ? { presentation: providerLoginRecovery.presentation } : {}),
         isGenericRunnerFailure: false,
       };


### PR DESCRIPTION
Closes #135519

## What Problem This Solves

Fixes an issue where Control UI users on a canonical `anthropic/*` model routed through `agentRuntime.id: "claude-cli"` saw only a raw failure when the native Claude Code login had expired: `Error: Failed to authenticate: OAuth session expired and could not be refreshed`, with no re-authentication step. It appeared in the live chat bubble and again after reload, and retrying or starting a new session could not repair the login. Discord and other channels already answered the same failure with the targeted `claude auth login …` recovery text.

## Why This Change Was Made

The lifecycle terminal event substituted recovery copy for the persisted run error only when the classified OAuth failure carried a `summary`. The claude-cli classifier returns a `provider` and `reason` but no `summary`, so the run error fell through to the raw provider string. That string is stored as the session row's `lastRunError` and written into the failed-run transcript marker, and the Control UI renders `lastRunError`. Channel replies were unaffected because they build their copy from the reply payload, not from `lastRunError`.

The fix falls through to the shared recovery text for any classified login expiry that has a `reason` (not only ones with a `summary`), and emits the structured `errorObservation` for it as well. The recovery copy is extracted into one helper shared by channel replies and this path, so both surfaces stay in sync. Provider-summary failures (e.g. OpenAI) keep their existing copy, and an expired CLI conversation session is still not treated as a login expiry.

## User Impact

When a `claude-cli` route's login expires, the Control UI now shows the same actionable reply as other channels — `⚠️ Model login expired on the gateway for claude-cli. Re-auth with \`claude auth login && openclaw models auth login --provider anthropic --method cli\` in a terminal, then try again.` — in the live bubble, after reload, and in the transcript. The raw error stays in the Gateway logs.

## Evidence

### Real Control UI turn, before and after

Gateway built from this branch on Linux, a canonical `anthropic/claude-opus-5` model with `agentRuntime.id: "claude-cli"`, real Claude Code CLI `2.1.265` on `PATH`, and a subscription login whose OAuth token was expired (an isolated copy selected via `CLAUDE_CONFIG_DIR`; no credential values involved). Turns sent from the Control UI chat.

The claude subprocess returns the reported failure (`is_error: true`, `result: "Failed to authenticate: OAuth session expired and could not be refreshed"`), and the Gateway records `cli terminal failure: provider=claude-cli … reason=auth status=401`.

Persisted `lastRunError` (what the Control UI bubble renders) and the transcript marker, read back over `sessions.list` / `chat.history`:

Before (current `main`, `1a06c2f`):
```
lastRunError: Failed to authenticate: OAuth session expired and could not be refreshed
transcript:  This turn ended before a reply: Failed to authenticate: OAuth session expired and could not be refreshed
```

After (this branch):
```
lastRunError: ⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.
transcript:  This turn ended before a reply: ⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.
```

**Before** (current `main`, `1a06c2f`) — the Control UI bubble shows the raw error:

![Control UI before: raw authentication error](https://raw.githubusercontent.com/ylcn91/openclaw/pr-135519-proof/135519-before.png)

**After** (this branch, fresh session on reload) — the bubble shows the actionable re-auth step, and the live error banner carries it with a **Details** expander:

![Control UI after: re-auth recovery text](https://raw.githubusercontent.com/ylcn91/openclaw/pr-135519-proof/135519-after.png)

One Control UI session showing both: the earlier turns (built from `main`) render the raw error; the turn on this branch renders the recovery text, and the live error bubble carries it with a **Details** expander (the structured `errorObservation`).

Note on the reported shape: on current `main` this classifies as `reason=auth status=410` in `2026.9.1-beta.1`, and as `reason=auth status=401` today; both shapes are covered.

### Regressions (red on `main`, green here)

- `src/auto-reply/reply/agent-lifecycle-terminal.test.ts`: a claude-cli `auth`/`401` and a `session_expired`/`410` login expiry publish the recovery text as `data.error` (the source of `lastRunError`) and set `errorObservation`. The existing OpenAI-summary and selected-profile cases are unchanged.
- `src/agents/auth-profiles/oauth-refresh-failure.test.ts`: the structured claude-cli `session_expired`/`410` shape classifies as a provider refresh failure, and an expired CLI conversation session stays out of the login recovery path.

### Checks

- `node scripts/run-vitest.mjs run` on the changed test files plus `agent-runner-failure-reply.test.ts`: all passed.
- `pnpm check:changed`: lint (oxlint) clean, typecheck clean, and the changed-file test lanes pass locally; the draft PR also runs the full CI gate.
