### PR TITLE
fix(ui/chat): persist the background-tasks rail collapse across restarts

### DIFF
--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -156,6 +156,7 @@ it("renders task-shaped placeholders while the initial task list loads", async (
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
+  localStorage.removeItem("openclaw.chat.backgroundTasks.collapsed");
 });
 
 describe("background tasks rail state", () => {
@@ -356,6 +357,19 @@ describe("background tasks rail state", () => {
     expect(request.mock.calls.at(-1)?.[1]).toMatchObject({
       sessionKey: "agent:main:another-thread",
     });
+  });
+
+  it("persists the collapsed toggle and restores it when the pane remounts", async () => {
+    const { host } = createHost();
+
+    createBackgroundTasksProps(host).onToggleCollapsed();
+    expect(createBackgroundTasksProps(host).collapsed).toBe(false);
+
+    // Simulate a gateway restart / pane reload: the in-memory host state is gone.
+    const freshHost = createHost().host;
+    freshHost.client = null;
+    freshHost.connected = false;
+    expect(createBackgroundTasksProps(freshHost).collapsed).toBe(false);
   });
 
   it("surfaces cancellation refusals through the rail props", async () => {

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -25,6 +25,7 @@ import {
   taskTimestampMs,
 } from "../../../lib/tasks/data.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
+import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { newestTaskSnapshot } from "./chat-background-tasks-shared.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import { deriveSubagentActivity } from "./chat-subagent-activity.ts";
@@ -65,6 +66,26 @@ type BackgroundTasksState = {
   taskDetailErrors: Map<string, string>;
   taskDetailLoadingIds: Set<string>;
 };
+
+const BACKGROUND_TASKS_COLLAPSED_STORAGE_KEY = "openclaw.chat.backgroundTasks.collapsed";
+
+function loadBackgroundTasksCollapsedPreference(): boolean {
+  try {
+    // Default is collapsed; only "0" means the user expanded the rail and wants
+    // that choice restored across restarts.
+    return getSafeLocalStorage()?.getItem(BACKGROUND_TASKS_COLLAPSED_STORAGE_KEY) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+function storeBackgroundTasksCollapsedPreference(collapsed: boolean): void {
+  try {
+    getSafeLocalStorage()?.setItem(BACKGROUND_TASKS_COLLAPSED_STORAGE_KEY, collapsed ? "1" : "0");
+  } catch {
+    // Privacy mode can make localStorage unavailable; the in-memory choice still works.
+  }
+}
 
 export type BackgroundTasksHost = {
   sessionKey: string;
@@ -110,8 +131,10 @@ function getBackgroundTasksState(host: BackgroundTasksHost): BackgroundTasksStat
   const next: BackgroundTasksState = {
     cancellingTaskIds: new Set(),
     // Keep presentation choices across thread switches while discarding all
-    // task data and private details from the previous session scope.
-    collapsed: current?.collapsed ?? true,
+    // task data and private details from the previous session scope. Falling
+    // back to the persisted preference keeps the toggle stable across gateway
+    // restarts; the in-memory value still wins when the pane is remounted.
+    collapsed: current?.collapsed ?? loadBackgroundTasksCollapsedPreference(),
     // The pane increments this epoch even when a reconnect reuses its client.
     // Old snapshots and private task details must never enter the new scope.
     connectionClient: host.client,
@@ -640,6 +663,7 @@ async function cancelBackgroundTask(
 function toggleBackgroundTasks(host: BackgroundTasksHost) {
   const state = getBackgroundTasksState(host);
   state.collapsed = !state.collapsed;
+  storeBackgroundTasksCollapsedPreference(state.collapsed);
   host.requestUpdate?.();
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI background-tasks rail toggle ("show background") reset to collapsed every gateway restart or pane reload, so operators had to re-enable it each session. The choice was kept purely in memory.

Fixes #142611.

## Why This Change Was Made

`BackgroundTasksState.collapsed` defaulted to `true` on every scope reset with no persistence. Persist the preference in `localStorage` through a safe get/set helper (mirroring the existing `chat-observer-display` pattern), restoring the expanded choice on pane init.

## User Impact

The toggle now survives gateway restarts. The default remains collapsed for first-time users; only an explicit expansion is remembered. The in-memory value still wins across thread switches within a session. Privacy mode (unavailable `localStorage`) degrades to the prior in-memory-only behavior.

## Evidence

- New test: toggling open persists the expansion and restores it when the pane remounts with no in-memory state.
- `chat-background-tasks.test.ts` 36/36 pass; `ui/src/pages/chat/components/` 1271 tests pass.
- `oxlint` clean; `git diff --check` clean.

## Approach (non-obvious)

- Storage protocol: default collapsed; only `"0"` means expanded, so any missing/corrupt value (or `localStorage` throwing) falls back to the collapsed default instead of accidentally expanding.