### PR TITLE
fix: align chat composer attachments with draft text

### DIFF
--- a/ui/src/pages/chat/chat-composer-overflow.browser.test.ts
+++ b/ui/src/pages/chat/chat-composer-overflow.browser.test.ts
@@ -30,6 +30,7 @@ describe("composer overflow presentation", () => {
     styles.textContent = [baseStyles, composerStyles, goalStyles].join("\n");
     document.head.append(styles);
     container = document.createElement("div");
+    container.className = "agent-chat__input";
     container.style.width = "760px";
     document.body.append(container);
   });

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4293,26 +4293,69 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   it.each([
     [320, 568],
     [393, 852],
+    [844, 390],
+    [1440, 1000],
   ] as const)(
-    "insets attachment previews from the composer edge at %sx%s",
+    "aligns attachment previews with draft text without clipping remove targets at %sx%s",
     async (width, height) => {
       const page = await openFixture(width, height, { composerAttachment: true });
       try {
         await expectNoHorizontalOverflow(page);
+        await page.locator(".chat-attachment-remove").focus();
+        await page.locator(".chat-attachment-remove").evaluate(finishElementAnimations);
+        await page.locator(".agent-chat__input").evaluate((node) => {
+          node.scrollTop = 0;
+        });
         const input = await getBoundingBox(
           page,
           ".agent-chat__composer-shell > .agent-chat__input",
         );
         const preview = await getBoundingBox(page, ".chat-attachments-preview");
         const attachment = await getBoundingBox(page, ".chat-attachment-thumb");
-        const previewPaddingTop = await page
-          .locator(".chat-attachments-preview")
-          .evaluate((node) => Number.parseFloat(getComputedStyle(node).paddingTop));
+        const remove = await getBoundingBox(page, ".chat-attachment-remove");
+        const topHits = await page.locator(".chat-attachment-remove").evaluate((node) => {
+          const bounds = node.getBoundingClientRect();
+          return [1, 3].map(
+            (offset) =>
+              document.elementFromPoint(bounds.x + bounds.width / 2, bounds.y + offset) === node,
+          );
+        });
+        const textStart = await page
+          .locator(".agent-chat__composer-combobox > textarea")
+          .evaluate(
+            (node) =>
+              node.getBoundingClientRect().x +
+              Number.parseFloat(getComputedStyle(node).paddingLeft),
+          );
 
         expect(attachment.x - input.x).toBeGreaterThanOrEqual(9.5);
-        expect(previewPaddingTop).toBe(18);
+        expect(Math.abs(attachment.x - textStart)).toBeLessThanOrEqual(0.5);
         expect(preview.x).toBeGreaterThanOrEqual(input.x);
-        expect(preview.x + preview.width).toBeLessThanOrEqual(input.x + input.width + 1);
+        expect(remove.y).toBeGreaterThanOrEqual(preview.y);
+        expect(remove.x + remove.width).toBeLessThanOrEqual(preview.x + preview.width);
+        expect(remove.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
+        expect(remove.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
+        expect(topHits).toEqual([true, true]);
+
+        await page.locator(".chat-attachments-preview").evaluate((node) => {
+          const firstAttachment = node.querySelector(".chat-attachment-thumb")!;
+          for (let index = 0; index < 7; index++) {
+            node.append(firstAttachment.cloneNode(true));
+          }
+          node.scrollLeft = node.scrollWidth;
+        });
+        const lastRemove = page.locator(".chat-attachment-remove").last();
+        await lastRemove.focus();
+        await lastRemove.evaluate(finishElementAnimations);
+        const rightHits = await lastRemove.evaluate((node) => {
+          const bounds = node.getBoundingClientRect();
+          return [1, 3].map(
+            (offset) =>
+              document.elementFromPoint(bounds.right - offset, bounds.y + bounds.height / 2) ===
+              node,
+          );
+        });
+        expect(rightHits).toEqual([true, true]);
       } finally {
         await closeBrowserPage(page);
       }

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -146,6 +146,7 @@
      the surface's own floor is taller than the editor plus these insets. */
   --chat-composer-editor-inset-inline: 14px;
   --chat-composer-editor-inset-block: 6px;
+  --chat-attachment-hit-slop: calc(var(--chat-composer-editor-inset-block) * 2);
   /* The editor is a reading and writing surface, not a compact form field, so it
      owns a 16px base instead of the shared control token, whose 14px base only
      reaches 16px through an iOS zoom floor — text that size by accident does not
@@ -590,7 +591,7 @@
   min-height: var(--chat-composer-control-size);
   margin-top: auto;
   margin-bottom: 4px;
-  padding-block: 6px;
+  padding-block: var(--chat-composer-editor-inset-block);
   padding-inline: 8px;
 }
 
@@ -2080,6 +2081,12 @@
     overscroll-behavior: contain;
   }
 
+  .agent-chat__input:has(.chat-attachments-preview) {
+    /* The rail's overhang must also clear this outer scrollport. */
+    padding-block-start: var(--chat-attachment-hit-slop);
+    padding-inline-end: var(--chat-attachment-hit-slop);
+  }
+
   .agent-chat__input:has(.agent-chat__attach-menu[open]) {
     overflow: visible;
   }
@@ -2297,20 +2304,36 @@
 
 .chat-attachments-preview {
   display: flex;
-  gap: 18px;
+  gap: calc(var(--chat-composer-editor-inset-block) * 3);
   flex-wrap: nowrap;
   flex-shrink: 0;
-  width: 100%;
-  max-width: 100%;
-  margin-top: 4px;
-  padding-block-start: 18px;
-  padding-block-end: 5px;
-  padding-inline: 18px;
-  margin-bottom: 2px;
+  /* Extend only the scrollport's transparent bounds for the original remove
+     target and focus ring. The extra padding cancels the overlap, so the chips
+     keep the editor's visible inset without clipping the controls. */
+  width: calc(100% + var(--chat-attachment-hit-slop));
+  max-width: calc(100% + var(--chat-attachment-hit-slop));
+  margin-block-start: calc(-1 * var(--chat-attachment-hit-slop));
+  margin-inline-end: calc(-1 * var(--chat-attachment-hit-slop));
+  padding-block: calc(var(--chat-composer-editor-inset-block) * 2 + var(--chat-attachment-hit-slop))
+    var(--chat-composer-editor-inset-block);
+  padding-inline: var(--chat-composer-editor-inset-inline)
+    calc(var(--chat-composer-editor-inset-inline) + var(--chat-attachment-hit-slop));
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-inline: contain;
   scrollbar-width: none;
+}
+
+/* The attachment rail supplies the same gap before the editor as the footer
+   supplies after it; the editor keeps its own symmetric block padding. */
+.agent-chat__input:has(.chat-attachments-preview) .agent-chat__composer-input-row {
+  padding-block-start: 0;
+}
+
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .chat-attachments-preview {
+    padding-block-end: calc(var(--chat-box-inset) / 2);
+  }
 }
 
 .chat-attachments-preview::-webkit-scrollbar {
@@ -2318,21 +2341,31 @@
 }
 
 .chat-attachments-preview[data-scrollable="true"][data-at-start="true"][data-at-end="false"] {
-  mask-image: linear-gradient(to right, black 0, black calc(100% - 18px), transparent 100%);
+  mask-image: linear-gradient(
+    to right,
+    black 0,
+    black calc(100% - var(--chat-composer-editor-inset-inline)),
+    transparent 100%
+  );
 }
 
 .chat-attachments-preview[data-scrollable="true"][data-at-start="false"][data-at-end="false"] {
   mask-image: linear-gradient(
     to right,
     transparent 0,
-    black 18px,
-    black calc(100% - 18px),
+    black var(--chat-composer-editor-inset-inline),
+    black calc(100% - var(--chat-composer-editor-inset-inline)),
     transparent 100%
   );
 }
 
 .chat-attachments-preview[data-scrollable="true"][data-at-start="false"][data-at-end="true"] {
-  mask-image: linear-gradient(to right, transparent 0, black 18px, black 100%);
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black var(--chat-composer-editor-inset-inline),
+    black 100%
+  );
 }
 
 .chat-attachment-thumb {
@@ -2466,8 +2499,8 @@
   width: 44px;
   height: 44px;
   padding: 12px;
-  border-radius: calc(12px + 7px * var(--openclaw-corner-radius-scale));
-  corner-shape: superellipse(1.5);
+  border-radius: 50%;
+  corner-shape: round;
   border: none;
   background: color-mix(in srgb, var(--bg) 82%, transparent);
   background-clip: content-box;


### PR DESCRIPTION
Closes #142650

## What Problem This Solves

Fixes an issue where users composing a message with attachments would see chips offset from the draft text, excess space above the attachment row, and a non-circular remove control.

## Why This Change Was Made

The attachment row now follows the composer's existing inset tokens and matches the draft-to-action-row spacing. The remove button keeps its existing size, colors, hover behavior, icon, and transitions; only its shape becomes circular. Transparent scrollport clearance preserves the original remove target when the visible padding is reduced.

## User Impact

Attachment chips align with the draft on desktop and mobile in both chat and New Session (`/new`), including multiple attachments and an empty draft. The remove button remains a 44 × 44 px control. The `/new` composer already uses `.agent-chat__input` and `renderAttachmentPreview`, so it inherits the canonical editor inset tokens (14 px inline / 6 px block; 12 px inline on mobile) and the shared attachment/remove styles without duplicated values or route-specific CSS.

## Evidence

Landscape (844 × 390): the composer reserves attachment overhang inside its scrollport; hit tests 1 px and 3 px from the remove button’s top and trailing edge pass in both chat and New Session, including the last item in an overflowing row.

Source-app captures use the real file picker with synthetic video bytes and wait for the bundled app fonts to load. Before: `origin/main` at `e369af82aa0b982eb665f3814d85bf3015baaa60`, served on a separate local port. After: this candidate. Viewports are 1440 × 1000 and 390 × 844 CSS pixels.

The chip/text horizontal offset changed from 4 px to 0 on desktop and from 6 px to 0 on mobile. Background, padding, and 44 × 44 px button dimensions match the baseline. The same offsets and 44 × 44 px target were confirmed on `/new`, with the shared tokens resolved on its composer in both viewports. The `/new` images show the actual remove-control focus outline. The narrow overflow case was also inspected at the end of an eight-attachment row, including focus and hit-area observations.

<table>
<thead><tr><th>Scenario</th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>1440px · dark<br>One video + text</td><td><a href="https://github.com/user-attachments/assets/34895c0d-43d0-41b3-8017-6ce0a13bf27c?raw=1"><img src="https://github.com/user-attachments/assets/230e21ee-35ad-4e65-9375-7d95fc2acb05?raw=1" alt="Before: One video + text, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/34895c0d-43d0-41b3-8017-6ce0a13bf27c?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/eb7fa841-fe08-4f3a-a69d-b28d391595e4?raw=1"><img src="https://github.com/user-attachments/assets/104dd8a4-ffbc-4d5b-b9e0-e5b8e0050665?raw=1" alt="After: One video + text, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/eb7fa841-fe08-4f3a-a69d-b28d391595e4?raw=1">Full context</a></td></tr>
<tr><td>1440px · dark<br>Two videos + text</td><td><a href="https://github.com/user-attachments/assets/0a38aa8b-b542-4b19-9519-b1ac3e08e6d1?raw=1"><img src="https://github.com/user-attachments/assets/c1cabb27-42f8-4f27-8384-de69c359bebf?raw=1" alt="Before: Two videos + text, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/0a38aa8b-b542-4b19-9519-b1ac3e08e6d1?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/985dc495-3559-4d11-b4f8-f1fb07e71567?raw=1"><img src="https://github.com/user-attachments/assets/dfdce021-6dae-4df4-8502-443da325dc8c?raw=1" alt="After: Two videos + text, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/985dc495-3559-4d11-b4f8-f1fb07e71567?raw=1">Full context</a></td></tr>
<tr><td>1440px · dark<br>One video, empty draft</td><td><a href="https://github.com/user-attachments/assets/a066c741-e0c1-443f-9168-7a156879948b?raw=1"><img src="https://github.com/user-attachments/assets/3568ca97-bcd2-4286-86fa-2038f7d5396a?raw=1" alt="Before: One video, empty draft, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/a066c741-e0c1-443f-9168-7a156879948b?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/b6dfca59-d6cc-4cea-88f3-29e3025f7bf4?raw=1"><img src="https://github.com/user-attachments/assets/9a0bafdc-35f0-4578-b11c-f7d729d1e6f4?raw=1" alt="After: One video, empty draft, 1440px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/b6dfca59-d6cc-4cea-88f3-29e3025f7bf4?raw=1">Full context</a></td></tr>
<tr><td>390px · dark<br>One video + text</td><td><a href="https://github.com/user-attachments/assets/17874b0a-5971-48fe-bad9-eb8d10d8ef2b?raw=1"><img src="https://github.com/user-attachments/assets/f06feabf-67a6-49c1-ab08-243c3a4126ca?raw=1" alt="Before: One video + text, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/17874b0a-5971-48fe-bad9-eb8d10d8ef2b?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/543776c1-c327-4420-a7b7-440b65ae47dd?raw=1"><img src="https://github.com/user-attachments/assets/58e8d4ed-c50d-44e4-8b4f-b36990e200b7?raw=1" alt="After: One video + text, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/543776c1-c327-4420-a7b7-440b65ae47dd?raw=1">Full context</a></td></tr>
<tr><td>390px · dark<br>Two videos + text</td><td><a href="https://github.com/user-attachments/assets/b97f3511-e302-4dfc-a12d-91c0cc1c95d6?raw=1"><img src="https://github.com/user-attachments/assets/040f58cc-03b0-47e2-9ac3-b95bed3f1533?raw=1" alt="Before: Two videos + text, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/b97f3511-e302-4dfc-a12d-91c0cc1c95d6?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/6d63d45d-2bbb-4c57-9191-55f67d602d8e?raw=1"><img src="https://github.com/user-attachments/assets/f798ef57-3af8-4055-9a89-524e53ed60fe?raw=1" alt="After: Two videos + text, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/6d63d45d-2bbb-4c57-9191-55f67d602d8e?raw=1">Full context</a></td></tr>
<tr><td>390px · dark<br>One video, empty draft</td><td><a href="https://github.com/user-attachments/assets/1dcb0889-eaa4-46bf-b35c-0936bffcb4bb?raw=1"><img src="https://github.com/user-attachments/assets/57bf26f9-026e-4037-a1d0-cca07c6313b0?raw=1" alt="Before: One video, empty draft, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/1dcb0889-eaa4-46bf-b35c-0936bffcb4bb?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/403c0e4e-5f21-47eb-b4a6-8266198edc0a?raw=1"><img src="https://github.com/user-attachments/assets/4aceeba4-2438-4d8d-aa4a-ae281822dad0?raw=1" alt="After: One video, empty draft, 390px, dark" width="430"></a><br><a href="https://github.com/user-attachments/assets/403c0e4e-5f21-47eb-b4a6-8266198edc0a?raw=1">Full context</a></td></tr>
<tr><td>1440px · light<br>One video + text</td><td><a href="https://github.com/user-attachments/assets/ef3172a9-eb9a-40d4-b65d-74e43171c3a5?raw=1"><img src="https://github.com/user-attachments/assets/6d052b1e-a6a5-4597-bb4e-28d8bb847e26?raw=1" alt="Before: One video + text, 1440px, light" width="430"></a><br><a href="https://github.com/user-attachments/assets/ef3172a9-eb9a-40d4-b65d-74e43171c3a5?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/ea36c6c5-7f0e-4dc2-8488-1233c73d862a?raw=1"><img src="https://github.com/user-attachments/assets/607e665a-a6c7-4e21-a468-c6e008516c41?raw=1" alt="After: One video + text, 1440px, light" width="430"></a><br><a href="https://github.com/user-attachments/assets/ea36c6c5-7f0e-4dc2-8488-1233c73d862a?raw=1">Full context</a></td></tr>
<tr><td>390px · light<br>One video + text</td><td><a href="https://github.com/user-attachments/assets/5f39cf67-af98-4a8b-8900-32e7eab6e5a7?raw=1"><img src="https://github.com/user-attachments/assets/694791aa-27ea-457f-91e2-0b812a5c2c74?raw=1" alt="Before: One video + text, 390px, light" width="430"></a><br><a href="https://github.com/user-attachments/assets/5f39cf67-af98-4a8b-8900-32e7eab6e5a7?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/744dec8c-029d-4b1f-a93b-b8ca22e26e76?raw=1"><img src="https://github.com/user-attachments/assets/15f15674-8afa-449a-b1f6-dbef42a8b98b?raw=1" alt="After: One video + text, 390px, light" width="430"></a><br><a href="https://github.com/user-attachments/assets/744dec8c-029d-4b1f-a93b-b8ca22e26e76?raw=1">Full context</a></td></tr>
<tr><td>/new · 1440px · dark<br>One video + text<br>Remove control focused</td><td><a href="https://github.com/user-attachments/assets/76361713-603a-4972-b7c3-7dcb569073fb?raw=1"><img src="https://github.com/user-attachments/assets/0f425f8e-6369-4d79-9041-7a798877b711?raw=1" alt="Before: New Session, 1440px, dark, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/76361713-603a-4972-b7c3-7dcb569073fb?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/985a8bc2-4976-4c35-a1c6-d1e3bf96255f?raw=1"><img src="https://github.com/user-attachments/assets/3f114e8b-2d4e-426c-88ce-562258c84648?raw=1" alt="After: New Session, 1440px, dark, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/985a8bc2-4976-4c35-a1c6-d1e3bf96255f?raw=1">Full context</a></td></tr>
<tr><td>/new · 390px · dark<br>One video + text<br>Remove control focused</td><td><a href="https://github.com/user-attachments/assets/73115533-dadf-4879-8f72-3a796329b8b9?raw=1"><img src="https://github.com/user-attachments/assets/c28f29ec-6811-4fc9-95ef-c692d84dc207?raw=1" alt="Before: New Session, 390px, dark, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/73115533-dadf-4879-8f72-3a796329b8b9?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/2e960c6f-cdae-4284-bd8c-a716373c52db?raw=1"><img src="https://github.com/user-attachments/assets/9c814a4f-3692-4ae9-a508-b01f3e238134?raw=1" alt="After: New Session, 390px, dark, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/2e960c6f-cdae-4284-bd8c-a716373c52db?raw=1">Full context</a></td></tr>
<tr><td>/new · 1440px · light<br>One video + text<br>Remove control focused</td><td><a href="https://github.com/user-attachments/assets/28a9b62a-c789-4c74-98ab-40691a8dd698?raw=1"><img src="https://github.com/user-attachments/assets/19b720f9-6927-4424-bae0-f427fd0162d8?raw=1" alt="Before: New Session, 1440px, light, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/28a9b62a-c789-4c74-98ab-40691a8dd698?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/ad2b84fe-181f-47ad-95c0-04945160b4e9?raw=1"><img src="https://github.com/user-attachments/assets/a0c92a31-28c7-49d9-8326-2c85ef614545?raw=1" alt="After: New Session, 1440px, light, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/ad2b84fe-181f-47ad-95c0-04945160b4e9?raw=1">Full context</a></td></tr>
<tr><td>/new · 390px · light<br>One video + text<br>Remove control focused</td><td><a href="https://github.com/user-attachments/assets/9a2ad7b9-e7ad-4d1f-ae48-5350a45bbc54?raw=1"><img src="https://github.com/user-attachments/assets/1b684bda-6698-489a-b826-3466aeb3b4b1?raw=1" alt="Before: New Session, 390px, light, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/9a2ad7b9-e7ad-4d1f-ae48-5350a45bbc54?raw=1">Full context</a></td><td><a href="https://github.com/user-attachments/assets/2bf116e9-a40b-430f-9c7d-983ff58a6d3f?raw=1"><img src="https://github.com/user-attachments/assets/d766f5d2-d23e-4e39-bcb2-6b4117c7ef70?raw=1" alt="After: New Session, 390px, light, one video and text, remove control focused" width="430"></a><br><a href="https://github.com/user-attachments/assets/2bf116e9-a40b-430f-9c7d-983ff58a6d3f?raw=1">Full context</a></td></tr>
</tbody>
</table>

Independent review through P3: no actionable findings after fixing the remove-target clearance. Formatting and whitespace checks passed.

## Risk and coverage

The production change is limited to the shared composer stylesheet. Reviewed captures cover one/two videos, a draft with no text, desktop/mobile widths, and light/dark appearance. New Session (`/new`) is additionally captured with one video and text at both widths and in both themes; its remove button is focused to show the circular shape and full focus outline. Other attachment content uses the same row and remove-button rules. The mock launcher, capture scripts, fixture, and worklog are excluded from the commit.

Linux validation passed all 127 tests in `chat-responsive.browser.test.ts`. Its attachment case now checks chip-to-text alignment and the focused remove target in mobile portrait and landscape and on desktop, replacing assertions tied to the old padding. The alignment cases fail with the baseline stylesheet; the landscape top and trailing-edge hit tests fail before their clipping repairs and pass afterward. The five overflow lifecycle tests also pass after placing their fixture inside the same composer owner used by the application, with all assertions retained.

Additional source-app checks on Linux confirmed real file selection and removal in chat and New Session at 1440 × 1000 and 390 × 844, using the bundled Instrument Sans font. Both routes also passed the narrow, eight-attachment overflow case with an empty draft: tapping outside the last thumbnail removes that attachment. The shared companion footer was inspected as another consumer of the inset token; it follows its existing 4 px block inset without changing button dimensions.

