### PR TITLE
fix(gateway): preserve MCP App ticket authority

### DIFF
--- a/src/gateway/mcp-app-channel-action.test.ts
+++ b/src/gateway/mcp-app-channel-action.test.ts
@@ -96,6 +96,12 @@ describe("materializeMcpAppChannelPresentation", () => {
     });
 
     expect(mocks.createTicket).toHaveBeenCalledOnce();
+    expect(mocks.createTicket).toHaveBeenCalledWith({
+      sessionKey: "agent:main:do-not-emit-session",
+      view,
+      toolOperationsAuthorized: true,
+      nowMs,
+    });
     expect(presentation).toEqual({
       blocks: [
         {

--- a/src/gateway/mcp-app-channel-action.ts
+++ b/src/gateway/mcp-app-channel-action.ts
@@ -27,6 +27,7 @@ export function materializeMcpAppChannelPresentation(params: {
   const ticket = createMcpAppStandaloneTicket({
     sessionKey: params.sessionKey,
     view,
+    toolOperationsAuthorized: true,
     nowMs,
   });
   if (!ticket) {

--- a/src/gateway/mcp-app-standalone.http.test-support.ts
+++ b/src/gateway/mcp-app-standalone.http.test-support.ts
@@ -33,8 +33,15 @@ const {
   verifyMcpAppStandaloneTicket,
 } = await import("./mcp-app-standalone.js");
 
-function issueTicket(params: Parameters<typeof createMcpAppStandaloneTicket>[0]) {
-  const issued = createMcpAppStandaloneTicket(params);
+function issueTicket(
+  params: Omit<Parameters<typeof createMcpAppStandaloneTicket>[0], "toolOperationsAuthorized"> & {
+    toolOperationsAuthorized?: boolean;
+  },
+) {
+  const issued = createMcpAppStandaloneTicket({
+    ...params,
+    toolOperationsAuthorized: params.toolOperationsAuthorized ?? true,
+  });
   if (!issued) {
     throw new Error("ticket capacity unexpectedly exhausted");
   }

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -68,6 +68,7 @@ describe("MCP App standalone host", () => {
         createMcpAppStandaloneTicket({
           sessionKey: `agent:${index}`,
           view: { ...view, viewId: `mcp-app-${index}` },
+          toolOperationsAuthorized: true,
           nowMs,
           secret,
         }),
@@ -77,10 +78,49 @@ describe("MCP App standalone host", () => {
       createMcpAppStandaloneTicket({
         sessionKey: "agent:overflow",
         view: { ...view, viewId: "mcp-app-overflow" },
+        toolOperationsAuthorized: true,
         nowMs,
         secret,
       }),
     ).toBeUndefined();
+  });
+
+  it("binds tool authority and never reuses a stronger ticket for a read-only issuer", async () => {
+    const stronger = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+    const readOnly = issueTicket({
+      sessionKey: "agent:main:main",
+      view,
+      toolOperationsAuthorized: false,
+      nowMs: nowMs + 1,
+      secret,
+    });
+
+    expect(readOnly.ticket).not.toBe(stronger.ticket);
+    const payload = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${readOnly.ticket}`,
+    });
+    expect(JSON.parse(String(payload.end.mock.calls[0]?.[0]))).toMatchObject({
+      serverTools: false,
+    });
+
+    const denied = await request({
+      url: "/__openclaw__/mcp-app/view",
+      method: "POST",
+      authorization: `MCP-App ${readOnly.ticket}`,
+      body: { method: "tools/call", params: { name: "app-only", arguments: {} } },
+    });
+    expect(denied.res.statusCode).toBe(403);
+    expect(runtime.callTool).not.toHaveBeenCalled();
+
+    const allowed = await request({
+      url: "/__openclaw__/mcp-app/view",
+      method: "POST",
+      authorization: `MCP-App ${stronger.ticket}`,
+      body: { method: "tools/call", params: { name: "app-only", arguments: {} } },
+    });
+    expect(allowed.res.statusCode).toBe(200);
+    expect(runtime.callTool).toHaveBeenCalledOnce();
   });
 
   it("serves a hash-protected static shell without per-view data", async () => {

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -36,10 +36,14 @@ type StandaloneTicketBinding = {
   sessionKey: string;
   sessionId: string;
   viewId: string;
+  toolOperationsAuthorized: boolean;
   expiresAtMs: number;
 };
 
 type StandaloneTicket = { ticket: string; url: string; expiresAtMs: number };
+type StandaloneTicketActiveView = McpAppActiveView & {
+  toolOperationsAuthorized: boolean;
+};
 
 const ticketBindings = new Map<string, StandaloneTicketBinding>();
 
@@ -68,6 +72,7 @@ function formatTicket(binding: StandaloneTicketBinding, secret: Buffer): string 
 export function createMcpAppStandaloneTicket(params: {
   sessionKey: string;
   view: Pick<McpAppViewLease, "viewId" | "sessionId" | "expiresAtMs">;
+  toolOperationsAuthorized: boolean;
   nowMs?: number;
   secret?: Buffer;
 }): StandaloneTicket | undefined {
@@ -82,7 +87,8 @@ export function createMcpAppStandaloneTicket(params: {
     if (
       binding.sessionKey === params.sessionKey &&
       binding.sessionId === params.view.sessionId &&
-      binding.viewId === params.view.viewId
+      binding.viewId === params.view.viewId &&
+      binding.toolOperationsAuthorized === params.toolOperationsAuthorized
     ) {
       if (binding.expiresAtMs > params.view.expiresAtMs) {
         ticketBindings.delete(binding.nonce);
@@ -116,6 +122,7 @@ export function createMcpAppStandaloneTicket(params: {
     sessionKey: params.sessionKey,
     sessionId: params.view.sessionId,
     viewId: params.view.viewId,
+    toolOperationsAuthorized: params.toolOperationsAuthorized,
     expiresAtMs,
   };
   ticketBindings.set(nonce, binding);
@@ -174,7 +181,7 @@ function resolveTicketActiveView(
   value: string,
   nowMs: number,
   secret: Buffer,
-): McpAppActiveView | undefined {
+): StandaloneTicketActiveView | undefined {
   const binding = verifyMcpAppStandaloneTicket(value, { nowMs, secret });
   if (!binding) {
     return undefined;
@@ -193,7 +200,7 @@ function resolveTicketActiveView(
   ) {
     return undefined;
   }
-  return { runtime, view };
+  return { runtime, view, toolOperationsAuthorized: binding.toolOperationsAuthorized };
 }
 
 function ticketFromRequest(req: IncomingMessage): string | undefined {
@@ -206,11 +213,15 @@ function ticketFromRequest(req: IncomingMessage): string | undefined {
 }
 
 function supportsStandaloneToolOperations(
-  view: Pick<McpAppViewLease, "allowedAppToolNames" | "readOnly">,
+  active: Pick<StandaloneTicketActiveView, "toolOperationsAuthorized" | "view">,
 ): boolean {
-  // The ticket is the short-lived grant. Tool authority still requires the
-  // originating run's explicit allowlist and is revalidated on every request.
-  return view.allowedAppToolNames !== undefined && view.readOnly !== true;
+  // Tool authority is the intersection of the ticket issuer's Gateway scope and
+  // the originating run's live App-tool grant, revalidated on every request.
+  return (
+    active.toolOperationsAuthorized &&
+    active.view.allowedAppToolNames !== undefined &&
+    active.view.readOnly !== true
+  );
 }
 
 async function supportsStandaloneResourceOperations(view: McpAppViewLease): Promise<boolean> {
@@ -373,7 +384,7 @@ export async function handleMcpAppStandaloneHttpRequest(
         }
         if (
           (operation.method === "tools/call" || operation.method === "tools/list") &&
-          !supportsStandaloneToolOperations(current.view)
+          !supportsStandaloneToolOperations(current)
         ) {
           sendJson(res, 403, { ok: false, error: "MCP App tool bridge is unavailable" });
           return;
@@ -405,7 +416,7 @@ export async function handleMcpAppStandaloneHttpRequest(
         ...(view.csp ? { csp: view.csp } : {}),
         toolInput: view.toolInput,
         toolResult: view.toolResult,
-        serverTools: supportsStandaloneToolOperations(view),
+        serverTools: supportsStandaloneToolOperations(active),
         serverResources,
       });
       return true;

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -99,6 +99,7 @@ async function invoke(
   params: Record<string, unknown>,
   mcpAppsEnabled = true,
   config: Record<string, unknown> = {},
+  scopes: string[] = ["operator.write"],
 ) {
   const respond = vi.fn();
   await expectDefined(
@@ -107,6 +108,7 @@ async function invoke(
   )({
     respond,
     params,
+    client: { connect: { scopes } },
     context: {
       getMcpAppSandboxPort: () => 18790,
       getRuntimeConfig: () => ({
@@ -193,12 +195,25 @@ describe("MCP App gateway bridge", () => {
     expect(mocks.getMcpAppViewLease).toHaveBeenCalledWith("cv_app", expect.any(Object));
     expect(mocks.createMcpAppStandaloneTicket).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
+      toolOperationsAuthorized: true,
       view,
     });
     const activeRuntime = mocks.peekSessionMcpRuntime.mock.results[0]?.value;
     expect(activeRuntime.acquireLease).toHaveBeenCalledOnce();
     expect(activeRuntime.acquireLease.mock.results[0]?.value).toHaveBeenCalledOnce();
     expect(mocks.completeDeferredSessionMcpRuntimeRetirement).toHaveBeenCalledWith(activeRuntime);
+  });
+
+  it("mints a view-only standalone ticket for a read-scoped caller", async () => {
+    await invoke("mcp.app.view", { sessionKey: "agent:main:main", viewId: "cv_app" }, true, {}, [
+      "operator.read",
+    ]);
+
+    expect(mocks.createMcpAppStandaloneTicket).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      toolOperationsAuthorized: false,
+      view,
+    });
   });
 
   it("resolves a harness-native view through its originating session", async () => {

--- a/src/gateway/server-methods/mcp-app.ts
+++ b/src/gateway/server-methods/mcp-app.ts
@@ -17,6 +17,7 @@ import {
   withMcpAppActiveView,
 } from "../mcp-app-operations.js";
 import { createMcpAppStandaloneTicket } from "../mcp-app-standalone.js";
+import { authorizeOperatorScopesForMethod } from "../method-scopes.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
@@ -87,7 +88,7 @@ async function handle(
 }
 
 export const mcpAppHandlers: GatewayRequestHandlers = {
-  "mcp.app.view": async ({ respond, params, context }) => {
+  "mcp.app.view": async ({ respond, params, context, client }) => {
     await handle(respond, async () => {
       const active = await resolveMcpAppActiveView({
         sessionKey: requireString(params, "sessionKey"),
@@ -117,6 +118,10 @@ export const mcpAppHandlers: GatewayRequestHandlers = {
           standalone = createMcpAppStandaloneTicket({
             sessionKey: requireString(params, "sessionKey"),
             view,
+            toolOperationsAuthorized: authorizeOperatorScopesForMethod(
+              "mcp.app.callTool",
+              client?.connect?.scopes ?? [],
+            ).allowed,
           });
         } catch (error) {
           // Standalone links are additive; issuance must never break the

--- a/src/gateway/server.mcp-request-shutdown.test.ts
+++ b/src/gateway/server.mcp-request-shutdown.test.ts
@@ -6,13 +6,17 @@ import { describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager.test-support.js";
 import type { SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
-import { fetchMcpAppView } from "../agents/mcp-ui-resource.js";
+import { fetchMcpAppView, getMcpAppViewLease } from "../agents/mcp-ui-resource.js";
+import { writeConfigFile } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { issueOperatorToken } from "./device-authz.test-helpers.js";
 import {
   connectOk,
   createGatewaySuiteHarness,
   installGatewayTestHooks,
+  rpcReq,
 } from "./test-helpers.server.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -164,6 +168,212 @@ input.on("close", () => process.exit(0));
       for (const restore of restorers) {
         restore();
       }
+      if (root) {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+function ticketFromStandaloneUrl(url: string | undefined): string {
+  const ticket = url?.split("#", 2)[1];
+  if (!ticket) {
+    throw new Error("expected an MCP App standalone ticket");
+  }
+  return ticket;
+}
+
+async function connectPairedOperator(params: {
+  gateway: GatewayHarness;
+  scopes: string[];
+}): Promise<WebSocket> {
+  const issued = await issueOperatorToken({
+    name: `mcp-app-authority-${randomUUID()}`,
+    approvedScopes: params.scopes,
+    clientId: GATEWAY_CLIENT_NAMES.TEST,
+    clientMode: GATEWAY_CLIENT_MODES.TEST,
+  });
+  const ws = await params.gateway.openWs();
+  await connectOk(ws, {
+    skipDefaultAuth: true,
+    deviceIdentityPath: issued.identityPath,
+    deviceToken: issued.token,
+    scopes: params.scopes,
+  });
+  return ws;
+}
+
+async function callStandaloneTool(params: {
+  port: number;
+  ticket: string;
+  label: string;
+}): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${params.port}/__openclaw__/mcp-app/view`, {
+    method: "POST",
+    headers: {
+      Authorization: `MCP-App ${params.ticket}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      method: "tools/call",
+      params: { name: "mutate", arguments: { label: params.label } },
+    }),
+  });
+}
+
+describe("MCP App standalone ticket authority", () => {
+  it("binds paired operator scope, separates ticket strength, and revalidates live grants", async () => {
+    let gateway: GatewayHarness | undefined;
+    let runtime: SessionMcpRuntime | undefined;
+    let writer: WebSocket | undefined;
+    let reader: WebSocket | undefined;
+    let root: string | undefined;
+    try {
+      await writeConfigFile({ mcp: { apps: { enabled: true } } });
+      gateway = await createGatewaySuiteHarness({
+        serverOptions: { bind: "loopback", auth: { mode: "none" } },
+      });
+      await gateway.server.startupSettled;
+
+      root = await fs.mkdtemp(path.join(resolveStateDir(), "mcp-app-authority-"));
+      const serverPath = path.join(root, "server.mjs");
+      const markerPath = path.join(root, "tool-calls.jsonl");
+      await fs.writeFile(
+        serverPath,
+        `import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+const markerPath = ${JSON.stringify(markerPath)};
+const send = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+const input = createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.method === "initialize") {
+    send(request.id, {
+      protocolVersion: request.params.protocolVersion,
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: "authority-fixture", version: "1.0.0" },
+    });
+  } else if (request.method === "tools/list") {
+    send(request.id, { tools: [{
+      name: "mutate",
+      inputSchema: { type: "object", properties: { label: { type: "string" } } },
+      _meta: { ui: { resourceUri: "ui://authority/app", visibility: ["app"] } },
+    }] });
+  } else if (request.method === "resources/read") {
+    send(request.id, { contents: [{
+      uri: "ui://authority/app",
+      mimeType: "text/html;profile=mcp-app",
+      text: "<!doctype html><title>Authority fixture</title>",
+      _meta: { ui: {} },
+    }] });
+  } else if (request.method === "tools/call") {
+    appendFileSync(markerPath, JSON.stringify(request.params.arguments) + "\\n");
+    send(request.id, { content: [{ type: "text", text: "mutated" }] });
+  }
+});
+input.on("close", () => process.exit(0));
+`,
+      );
+
+      const sessionId = `mcp-app-authority-${randomUUID()}`;
+      const sessionKey = `agent:main:${sessionId}`;
+      runtime = await getOrCreateSessionMcpRuntime({
+        sessionId,
+        sessionKey,
+        workspaceDir: root,
+        cfg: {
+          mcp: {
+            apps: { enabled: true },
+            servers: {
+              authority: { command: process.execPath, args: [serverPath] },
+            },
+          },
+        },
+      });
+      const prepared = expectDefined(
+        await fetchMcpAppView({
+          runtime,
+          agentId: "main",
+          serverName: "authority",
+          toolName: "mutate",
+          uiResourceUri: "ui://authority/app",
+          toolInput: {},
+          toolResult: { content: [] },
+          allowedAppToolNames: new Set(["mutate"]),
+        }),
+        "prepared MCP App view",
+      );
+
+      writer = await connectPairedOperator({
+        gateway,
+        scopes: ["operator.read", "operator.write"],
+      });
+      reader = await connectPairedOperator({ gateway, scopes: ["operator.read"] });
+      const viewParams = { sessionKey, agentId: "main", viewId: prepared.viewId };
+      const writerView = await rpcReq<{ standaloneUrl?: string }>(
+        writer,
+        "mcp.app.view",
+        viewParams,
+      );
+      const readerView = await rpcReq<{ standaloneUrl?: string }>(
+        reader,
+        "mcp.app.view",
+        viewParams,
+      );
+      if (!writerView.ok) {
+        throw new Error(`writer view failed: ${JSON.stringify(writerView.error)}`);
+      }
+      if (!readerView.ok) {
+        throw new Error(`reader view failed: ${JSON.stringify(readerView.error)}`);
+      }
+      expect(writerView).toMatchObject({ ok: true });
+      expect(readerView).toMatchObject({ ok: true });
+      const writerTicket = ticketFromStandaloneUrl(writerView.payload?.standaloneUrl);
+      const readerTicket = ticketFromStandaloneUrl(readerView.payload?.standaloneUrl);
+      expect(readerTicket).not.toBe(writerTicket);
+
+      const directReaderCall = await rpcReq(reader, "mcp.app.callTool", {
+        ...viewParams,
+        toolName: "mutate",
+        arguments: { label: "direct-reader" },
+      });
+      expect(directReaderCall.ok).toBe(false);
+      expect(await fs.readFile(markerPath, "utf8").catch(() => "")).toBe("");
+
+      const readerStandaloneCall = await callStandaloneTool({
+        port: gateway.port,
+        ticket: readerTicket,
+        label: "standalone-reader",
+      });
+      expect(readerStandaloneCall.status).toBe(403);
+      expect(await fs.readFile(markerPath, "utf8").catch(() => "")).toBe("");
+
+      const writerStandaloneCall = await callStandaloneTool({
+        port: gateway.port,
+        ticket: writerTicket,
+        label: "standalone-writer",
+      });
+      expect(writerStandaloneCall.status).toBe(200);
+      expect(await writerStandaloneCall.json()).toMatchObject({ ok: true });
+      expect(await fs.readFile(markerPath, "utf8")).toBe('{"label":"standalone-writer"}\n');
+
+      const liveView = expectDefined(
+        getMcpAppViewLease(prepared.viewId, runtime),
+        "live MCP App view",
+      );
+      liveView.authorizeAppInteraction = async () => false;
+      const revokedCall = await callStandaloneTool({
+        port: gateway.port,
+        ticket: writerTicket,
+        label: "revoked-writer",
+      });
+      expect(revokedCall.status).toBe(403);
+      expect(await fs.readFile(markerPath, "utf8")).toBe('{"label":"standalone-writer"}\n');
+    } finally {
+      writer?.terminate();
+      reader?.terminate();
+      await runtime?.dispose();
+      await gateway?.close();
       if (root) {
         await fs.rm(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a paired Gateway client limited to read operations could open a standalone MCP App view and receive a ticket that still allowed App-visible tool calls.

## Why This Change Was Made

Standalone tickets now preserve whether their issuer is authorized for MCP App tool operations, and ticket reuse keeps weaker and stronger grants separate. Redemption intersects that ticket authority with the live view's existing tool allowlist, while channel-created launch actions explicitly retain their established capability.

## User Impact

Read-scoped clients can continue rendering standalone MCP App views and using permitted resources, but they can no longer execute App tools. Write-authorized clients and channel launch actions retain existing interactive behavior.

## Evidence

- Focused MCP App Gateway, standalone-host, and channel-presentation suites: 83 tests passed.
- Real Gateway integration proof on head `dd480d59f5c`: independently paired read-only and read/write device identities connect over WebSocket, receive authority-separated standalone tickets, and redeem them against a real stdio MCP server.
- The proof verifies read-only direct and standalone calls are denied without mutation, the write-authorized standalone call mutates exactly once, and revoking the live App-interaction grant blocks a later call before a second mutation.
- Exact proof command: `node scripts/run-vitest.mjs src/gateway/server.mcp-request-shutdown.test.ts` (2/2 passed).
- Scoped core and core-test changed-file checks passed, including typechecks, lint, formatting, dead-code, import-cycle, schema, and storage guards.
- Independent P1 autoreview found no accepted or actionable findings.
