### PR TITLE
fix(ui): match loading attachment action to Open pill

### DIFF
--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -269,10 +269,9 @@ suite.define(() => {
       expect(await actionSkeletons.count()).toBe(4);
       const actionSkeletonSize = await actionSkeletons.first().evaluate((element) => {
         const rect = element.getBoundingClientRect();
-        return { height: rect.height, width: rect.width };
+        return { x: rect.x, y: rect.y, height: rect.height, width: rect.width };
       });
       expect(actionSkeletonSize.height).toBeCloseTo(30, 3);
-      expect(actionSkeletonSize.width).toBeCloseTo(30, 3);
       expect(
         await actionSkeletons
           .first()
@@ -295,6 +294,14 @@ suite.define(() => {
         .toBe(4);
       expect(await checkingCards.count()).toBe(0);
       expect(await page.locator(".chat-assistant-attachment-card .skeleton").count()).toBe(0);
+      const openButtonSize = await page
+        .locator(".chat-assistant-attachment-card__expand")
+        .first()
+        .evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return { x: rect.x, y: rect.y, height: rect.height, width: rect.width };
+        });
+      expect(actionSkeletonSize).toEqual(openButtonSize);
       const finalActionWidths = await page
         .locator(
           ".chat-assistant-attachment-card--compact .chat-assistant-attachment-card__actions",

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -727,7 +727,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-end: 0;
-  width: var(--chat-attachment-action-size);
+  width: calc(100% - 38px);
   height: var(--chat-attachment-action-size);
   border-radius: var(--radius-full);
 }


### PR DESCRIPTION
Quick fix, bigger pass later.

## What Problem This Solves

Fixes an issue where loading attachment cards in the chat transcript show a circular action placeholder instead of the Open button's pill shape and width.

## Why This Change Was Made

Use the existing localized Open label's reserved width for the skeleton. Its 30px height, full radius, right alignment, and the download-action space remain unchanged.

## User Impact

The loading action now occupies the same box as Open, eliminating the action's size and position jump when the attachment resolves.

## Evidence

- Existing managed-document transition test fails before the fix (30px skeleton versus 57.27px Open) and passes afterward, comparing x/y/width/height. It also checks PDF, CSV, text, and archive cards and their loading metadata.
- Chromium captures below use the app's real Instrument Sans at 1440px and 390px viewports; each image was inspected. Crops show the actual transcript. The synthetic image attachment's loading and resolved action boxes match exactly at both widths.
- Targeted CSS lint, UI typecheck, and the UI E2E typecheck passed.
- No new test was added for this CSS-only production change; the existing transition test replaces its obsolete 30px width assertion.

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>1440px</td><td><a href="https://github.com/user-attachments/assets/b6c42552-87d0-4a76-9ee9-09d2c08f3731"><img src="https://github.com/user-attachments/assets/b6c42552-87d0-4a76-9ee9-09d2c08f3731" alt="Before: loading attachment action at 1440px" width="560"></a></td><td><a href="https://github.com/user-attachments/assets/2a9e3778-b090-4037-8bf4-9b776b15bf69"><img src="https://github.com/user-attachments/assets/2a9e3778-b090-4037-8bf4-9b776b15bf69" alt="After: loading attachment action at 1440px" width="560"></a></td></tr>
<tr><td>390px</td><td><a href="https://github.com/user-attachments/assets/2733c066-542a-469a-9a35-2d8398cf284a"><img src="https://github.com/user-attachments/assets/2733c066-542a-469a-9a35-2d8398cf284a" alt="Before: loading attachment action at 390px" width="560"></a></td><td><a href="https://github.com/user-attachments/assets/bc5a0c08-7cc0-4039-bb8e-fe5072d19bb7"><img src="https://github.com/user-attachments/assets/bc5a0c08-7cc0-4039-bb8e-fe5072d19bb7" alt="After: loading attachment action at 390px" width="560"></a></td></tr>
</table>

## Risk and coverage

One CSS declaration changes the shared loading-action width. Checked consumers: Image-labeled attachment and its Open file panel, managed PDF, CSV, plain-text, and ZIP cards. The metadata-line skeleton is unchanged. Browser evidence uses a mocked Gateway; no live provider or attachment transport behavior changes.
