### PR TITLE
fix: avoid redundant database scans during Doctor schema repair

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4783,6 +4783,33 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
   });
 
+  it("validates each healthy doctor repair once and detects corruption after a clean repair", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        prepare.mockClear();
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({ changes: [], warnings: [] });
+        const statements = prepare.mock.calls.map(([sql]) => sql);
+        expect(statements.filter((sql) => /^PRAGMA integrity_check/iu.test(sql))).toEqual([
+          "PRAGMA integrity_check;",
+        ]);
+        expect(statements.filter((sql) => /^PRAGMA foreign_key_check/iu.test(sql))).toHaveLength(1);
+      }
+    } finally {
+      prepare.mockRestore();
+    }
+
+    createUnsafeIndexDrift(databasePath);
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: [],
+      warnings: [expect.stringMatching(/integrity_check failed.*unsafe_index_records_value/iu)],
+    });
+  });
+
   it("repairs every canonical shared-state named index", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -5107,24 +5134,50 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
   });
 
-  it("repairs physical ordinary-index drift before cold-open reads", () => {
-    const stateDir = createTempStateDir();
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    createTaskRunStatusIndexPhysicalDrift(databasePath);
+  it.each(["runtime", "doctor"])(
+    "repairs physical ordinary-index drift through %s",
+    (repairPath) => {
+      const stateDir = createTempStateDir();
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      createTaskRunStatusIndexPhysicalDrift(databasePath);
 
-    const reopened = openOpenClawStateDatabase({ env });
-    expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
-      integrity_check: "ok",
-    });
-    expect(
-      reopened.db
-        .prepare(
-          "SELECT task_id FROM task_runs INDEXED BY idx_task_runs_status WHERE status = 'running'",
-        )
-        .all(),
-    ).toEqual([{ task_id: "task-index-repair" }]);
-  });
+      if (repairPath === "doctor") {
+        const { DatabaseSync } = requireNodeSqlite();
+        const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+        try {
+          expect(repairOpenClawStateDatabaseSchema({ env })).toEqual({
+            changes: [
+              expect.stringMatching(
+                /^Rebuilt canonical shared-state SQLite indexes \([1-9]\d*\)$/u,
+              ),
+            ],
+            warnings: [],
+          });
+          const statements = prepare.mock.calls.map(([sql]) => sql);
+          expect(statements.filter((sql) => sql === "PRAGMA integrity_check;")).toHaveLength(2);
+          expect(statements.some((sql) => /^PRAGMA integrity_check\(/iu.test(sql))).toBe(true);
+          expect(statements.filter((sql) => /^PRAGMA foreign_key_check/iu.test(sql))).toHaveLength(
+            1,
+          );
+        } finally {
+          prepare.mockRestore();
+        }
+      }
+
+      const reopened = openOpenClawStateDatabase({ env });
+      expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(
+        reopened.db
+          .prepare(
+            "SELECT task_id FROM task_runs INDEXED BY idx_task_runs_status WHERE status = 'running'",
+          )
+          .all(),
+      ).toEqual([{ task_id: "task-index-repair" }]);
+    },
+  );
 
   it("rejects a missing current-schema table instead of recreating it empty", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -167,9 +167,12 @@ function repairStateSchema(
         const applied: string[] = [];
         const previousVersion = readStateSchemaContentVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
-          for (const name of repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
-            allowMissingColumns: true,
-          })) {
+          for (const name of verifyAndRepairCanonicalSqliteIndexes(
+            db,
+            pathname,
+            OPENCLAW_STATE_SCHEMA_SQL,
+            { allowMissingColumns: true },
+          )) {
             rebuiltIndexNames.add(name);
           }
           // Current-schema doctor repair may normalize recognized columns or
@@ -179,8 +182,6 @@ function repairStateSchema(
           });
         } else {
           openClawStateMigrationAssertions.get(previousVersion)?.(db, { pathname });
-        }
-        if (rebuiltIndexNames.size === 0) {
           assertSqliteIntegrity(db, pathname);
         }
         dropLegacyStateTables(db);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Doctor would wait for redundant integrity scans when repairing an already healthy shared-state database.

## Why This Change Was Made

Use the existing whole-file-first canonical index validator inside the same immediate transaction. Healthy databases need one full integrity check and one foreign-key check; damaged indexes still receive table diagnosis, canonical repair, and post-repair validation. Older-schema validation and ownership admission retain their existing boundaries.

## User Impact

Doctor avoids scanning each indexed table again on healthy shared state. Every repair still validates the database afresh. This change addresses one database cost and does not establish a fix for total update downtime.

## Evidence

- Synthetic 4,096-row, 20.7 MB shared-state fixture: three baseline repairs each performed 55 table checks, one full integrity check and one FK check. All candidate repairs perform zero table checks, one full check and one FK check, preserving payload.
- The new regression fails on the original implementation with 56 integrity calls. Seventeen focused owner tests pass, including physical index repair, unknown corruption, FK violations, missing tables and legacy migration.
- Independent source-blind validation: all seven clauses pass across 26 repair calls, including mutation after a clean repair, fresh-process reopen, real index damage and competing-writer exclusion. Existing schema metadata timestamps still advance on successful repair.
- Independent P0–P2 code review: no actionable findings. The broad local gate was stopped under the host resource boundary. [Required hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34289975707) on the exact proposed head.
- Atomic compatibility with #140339 has scoped coordinator clearance for this exact validation sequence. Thirteen database and three ownership controls passed on the isolated composed Integration source, preserving its supplied source/caller bindings. The supplied source/caller bindings remained unchanged before and after testing. Lease/handle-lifetime and media changes are excluded.

Synthetic proof artifacts: [artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publication-32b26454/20260908-231728-815695000/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260908T231732Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=dbd1edb8812226138f32ea8d6c51decb0b3c73d818e79286b802a1393a7866e0), [reproduction contract](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publication-32b26454/20260908-231728-815695000/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260908T231727Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=ba2e782cb7e1765b6b804d1102ea6663bd0284f66118e8aea69c6a56073d5772), [fixture script](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publication-32b26454/20260908-231728-815695000/shared-probe.mts?X-Amz-Expires=604800&X-Amz-Date=20260908T231727Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=eea654c4fed1fc6a52678101782b5fe8e7f412b65684304cf52e14b35eb05482), [source-blind report](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/publication-32b26454/20260908-231728-815695000/source-blind-report.md?X-Amz-Expires=604800&X-Amz-Date=20260908T231727Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=721face176d405346d867d1a6f0e2df700f11eb555296f4afe282b54e79b7883). Download links expire after seven days; the regression and safety controls remain in the test suite.

Base `037e0059e9ed1482e79cdda4b206c374157569a2`; head `32b264540d881c539d0343607a67da47e3df1b06`. The artifact manifest records the earlier measured baseline and unchanged-owner base movements.
