### PR TITLE
fix: place user file attachments above text bubbles

### DIFF
--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -76,40 +76,68 @@ suite.define(() => {
     );
   }
 
-  it("keeps multiple files in a column with the text rhythm on mobile", async () => {
+  it("keeps user files above the painted text bubble without changing assistant cards", async () => {
     const count = 5;
-    await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
-      await installMockGateway(page, {
-        historyMessages: [
-          {
-            role: "user",
-            content: [
-              ...Array.from({ length: count }, (_, index) => attachment(index)),
-              { type: "text", text: "Reference one.\n\nReference two." },
-            ],
-          },
-        ],
-      });
-      await page.goto(`${suite.server.baseUrl}chat/main`);
-      const cards = page.locator(".chat-assistant-attachment-card");
-      const paragraphs = page.locator(".chat-text > p");
-      await paragraphs.last().waitFor();
-      await expect.poll(() => cards.count()).toBe(count);
-      const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
-      for (let index = 1; index < count; index += 1) {
+    for (const width of [1440, 390]) {
+      await suite.withPage({ viewport: { width, height: 900 } }, async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            {
+              role: "user",
+              content: [
+                ...Array.from({ length: count }, (_, index) => attachment(index)),
+                { type: "text", text: "Reference one.\n\nReference two." },
+              ],
+            },
+            {
+              role: "assistant",
+              content: [attachment(6), { type: "text", text: "Assistant reference." }],
+            },
+            { role: "user", content: [attachment(7)] },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}chat/main`);
+        const user = page.locator(".chat-group.user").first();
+        const cards = user.locator(".chat-assistant-attachment-card");
+        const paragraphs = user.locator(".chat-text > p");
+        await paragraphs.last().waitFor();
+        await expect.poll(() => cards.count()).toBe(count);
+        const shell = user.locator(".chat-bubble");
+        const text = user.locator(".chat-text");
+        const background = (element: Locator) =>
+          element.evaluate((node) => getComputedStyle(node).backgroundColor);
+        expect(await background(shell)).toBe("rgba(0, 0, 0, 0)");
+        expect(await background(text)).not.toBe("rgba(0, 0, 0, 0)");
+        const column = await user.locator(".chat-group-messages").boundingBox();
+        const card = await cards.first().boundingBox();
+        expect(column).not.toBeNull();
+        expect(card).not.toBeNull();
+        expect(Math.abs(card!.width - column!.width)).toBeLessThanOrEqual(1);
+        expect(Math.abs(card!.x + card!.width - column!.x - column!.width)).toBeLessThanOrEqual(1);
+        const assistant = page.locator(".chat-group.assistant");
+        expect(await background(assistant.locator(".chat-text"))).toBe("rgba(0, 0, 0, 0)");
         expect(
-          Math.abs((await gap(cards.nth(index - 1), cards.nth(index))) - reference),
-        ).toBeLessThanOrEqual(1);
-      }
-      expect(
-        Math.abs((await gap(cards.last(), paragraphs.first())) - reference),
-      ).toBeLessThanOrEqual(1);
-      expect(
-        await page
-          .locator(".chat-thread")
-          .evaluate((element) => element.scrollWidth <= element.clientWidth),
-      ).toBe(true);
-    });
+          await assistant
+            .locator(".chat-bubble > .chat-assistant-attachments .chat-assistant-attachment-card")
+            .count(),
+        ).toBe(1);
+        const fileOnly = page.locator(".chat-group.user").last();
+        expect(await background(fileOnly.locator(".chat-bubble"))).toBe("rgba(0, 0, 0, 0)");
+        expect(await fileOnly.locator(".chat-text").count()).toBe(0);
+        const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
+        for (let index = 1; index < count; index += 1) {
+          expect(
+            Math.abs((await gap(cards.nth(index - 1), cards.nth(index))) - reference),
+          ).toBeLessThanOrEqual(1);
+        }
+        expect(Math.abs((await gap(cards.last(), text)) - reference)).toBeLessThanOrEqual(1);
+        expect(
+          await page
+            .locator(".chat-thread")
+            .evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+      });
+    }
   });
 
   it("preserves nested user fences while sharing the top-level attachment rhythm", async () => {
@@ -138,7 +166,7 @@ suite.define(() => {
       );
       const card = page.locator(".chat-assistant-attachment-card");
       for (const [above, below] of [
-        [card, text.locator(":scope > pre")],
+        [card, text],
         [text.locator("blockquote > p").first(), nestedCode],
         [nestedCode, text.locator("blockquote > p").last()],
       ] as const) {

--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -77,229 +76,117 @@ suite.define(() => {
     );
   }
 
-  it("keeps user files above the painted text bubble without changing assistant cards", async () => {
+  it("keeps user files outside the painted text and preserves column rhythm", async () => {
     const count = 5;
-    for (const width of [1440, 390]) {
-      await suite.withPage({ viewport: { width, height: 900 } }, async ({ page }) => {
-        await installMockGateway(page, {
-          historyMessages: [
-            {
-              role: "user",
-              content: [
-                ...Array.from({ length: count }, (_, index) => attachment(index)),
-                { type: "text", text: "Reference one.\n\nReference two." },
-              ],
-            },
-            {
-              role: "assistant",
-              content: [attachment(6), { type: "text", text: "Assistant reference." }],
-            },
-            { role: "user", content: [attachment(7)] },
-          ],
-        });
-        await page.goto(`${suite.server.baseUrl}chat/main`);
-        const user = page.locator(".chat-group.user").first();
-        const cards = user.locator(".chat-assistant-attachment-card");
-        const paragraphs = user.locator(".chat-text > p");
-        await paragraphs.last().waitFor();
-        await expect.poll(() => cards.count()).toBe(count);
-        const shell = user.locator(".chat-bubble");
-        const text = user.locator(".chat-text");
-        const background = (element: Locator) =>
-          element.evaluate((node) => getComputedStyle(node).backgroundColor);
-        expect(await background(shell)).toBe("rgba(0, 0, 0, 0)");
-        expect(await background(text)).not.toBe("rgba(0, 0, 0, 0)");
-        const column = await user.locator(".chat-group-messages").boundingBox();
-        const card = await cards.first().boundingBox();
-        expect(column).not.toBeNull();
-        expect(card).not.toBeNull();
-        expect(Math.abs(card!.width - column!.width)).toBeLessThanOrEqual(1);
-        expect(Math.abs(card!.x + card!.width - column!.x - column!.width)).toBeLessThanOrEqual(1);
-        const assistant = page.locator(".chat-group.assistant");
-        expect(await background(assistant.locator(".chat-text"))).toBe("rgba(0, 0, 0, 0)");
-        expect(
-          await assistant
-            .locator(".chat-bubble > .chat-assistant-attachments .chat-assistant-attachment-card")
-            .count(),
-        ).toBe(1);
-        const fileOnly = page.locator(".chat-group.user").last();
-        expect(await background(fileOnly.locator(".chat-bubble"))).toBe("rgba(0, 0, 0, 0)");
-        expect(await fileOnly.locator(".chat-text").count()).toBe(0);
-        const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
-        for (let index = 1; index < count; index += 1) {
-          expect(
-            Math.abs((await gap(cards.nth(index - 1), cards.nth(index))) - reference),
-          ).toBeLessThanOrEqual(1);
-        }
-        expect(Math.abs((await gap(cards.last(), text)) - reference)).toBeLessThanOrEqual(1);
-        expect(
-          await page
-            .locator(".chat-thread")
-            .evaluate((element) => element.scrollWidth <= element.clientWidth),
-        ).toBe(true);
-      });
-    }
-  });
-
-  it.each([1440, 390])(
-    "aligns shared-thread media with its author's bubble at %ipx",
-    async (width) => {
-      await suite.withPage({ viewport: { width, height: 900 } }, async ({ page }) => {
-        const imageData = await page.evaluate(() => {
-          const canvas = document.createElement("canvas");
-          canvas.width = 640;
-          canvas.height = 360;
-          canvas.getContext("2d")!.fillRect(0, 0, 640, 360);
-          return canvas.toDataURL().split(",")[1];
-        });
-        await page.route("**/alignment.png*", (route) =>
-          route.fulfill({ contentType: "image/png", body: Buffer.from(imageData, "base64") }),
-        );
-        const video = readFileSync(new URL("./fixtures/video-poster.mp4", import.meta.url));
-        await page.route("**/alignment.mp4", (route) => {
-          const range = route
-            .request()
-            .headers()
-            .range?.match(/^bytes=(\d+)-(\d*)$/);
-          const start = Number(range?.[1] ?? 0);
-          const end = range?.[2] ? Number(range[2]) : video.length - 1;
-          return route.fulfill({
-            status: range ? 206 : 200,
-            contentType: "video/mp4",
-            headers: range ? { "content-range": `bytes ${start}-${end}/${video.length}` } : {},
-            body: video.subarray(start, end + 1),
-          });
-        });
-        const image = { type: "image", url: `${suite.server.baseUrl}alignment.png` };
-        const cases = [
-          { name: "Image and file", media: [image, attachment()] },
-          { name: "Image", media: [image] },
+    await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        historyMessages: [
           {
-            name: "Video",
-            media: [
-              {
-                type: "attachment",
-                attachment: {
-                  kind: "video",
-                  label: "alignment.mp4",
-                  mimeType: "video/mp4",
-                  url: `${suite.server.baseUrl}alignment.mp4`,
-                },
-              },
+            role: "user",
+            content: [
+              ...Array.from({ length: count }, (_, index) => attachment(index)),
+              { type: "text", text: "Reference one.\n\nReference two." },
             ],
           },
-          {
-            name: "Gallery",
-            media: Array.from({ length: 5 }, (_, index) => ({
-              ...image,
-              url: `${image.url}?tile=${index}`,
-            })),
-          },
-        ];
-        const users = [
-          {
-            self: true,
-            id: "profile-riley",
-            identity: { type: "profile" as const, id: "profile-riley" },
-            name: "Riley",
-          },
-          {
-            id: "profile-colin",
-            identity: { type: "profile" as const, id: "profile-colin" },
-            name: "Colin",
-          },
-        ];
-        const scenarios = users.flatMap((user) =>
-          cases.map((item) => ({
-            name: item.name,
-            media: item.media,
-            user,
-            text: `${user.name}: ${item.name}. Please compare the completed update steps with the expected release notes.`,
-          })),
-        );
-        await installMockGateway(page, {
-          presenceUsers: users,
-          historyMessages: scenarios.flatMap(({ user, media, text }) => [
-            { role: "assistant", content: [{ type: "text", text: "Share the next update." }] },
-            {
-              role: "user",
-              content: [...media, { type: "text", text }],
-              __openclaw: {
-                senderId: user.id,
-                senderIdentity: user.identity,
-                senderName: user.name,
-              },
-            },
-          ]),
-        });
-        await page.goto(`${suite.server.baseUrl}chat/main`);
-        await page.locator(".chat-group.user").last().waitFor();
-        await page.locator(".chat-thread").evaluate((node) => {
-          node.scrollTop = 0;
-        });
-        for (const { user, name, text } of scenarios) {
-          const group = page.locator(".chat-group.user").filter({ hasText: text });
-          await group.scrollIntoViewIfNeeded();
-          const previews = group.locator("img.chat-message-image");
-          await expect.poll(() => previews.count()).toBe(name === "Gallery" ? 5 : 1);
-          await expect
-            .poll(() =>
-              previews.evaluateAll((nodes) =>
-                nodes.every(
-                  (node) =>
-                    node instanceof HTMLImageElement && node.complete && node.naturalWidth > 0,
-                ),
-              ),
-            )
-            .toBe(true);
-          expect(await group.evaluate((node) => node.classList.contains("chat-group--peer"))).toBe(
-            !user.self,
-          );
-          expect(
-            await group
-              .locator(".chat-bubble")
-              .evaluate((node) => getComputedStyle(node).backgroundColor),
-          ).toBe("rgba(0, 0, 0, 0)");
-          const bubble = await group.locator(".chat-text").boundingBox();
-          const gallery = await group.locator(".chat-message-images").boundingBox();
-          expect(bubble).not.toBeNull();
-          expect(gallery).not.toBeNull();
-          const edge = user.self ? bubble!.x + bubble!.width : bubble!.x;
-          expect(
-            Math.abs((user.self ? gallery!.x + gallery!.width : gallery!.x) - edge),
-          ).toBeLessThanOrEqual(1);
-          const bounds = await previews.evaluateAll((nodes) =>
-            nodes.map((node) => ({
-              left: node.getBoundingClientRect().left,
-              right: node.getBoundingClientRect().right,
-            })),
-          );
-          const visibleEdge = user.self
-            ? Math.max(...bounds.map((rect) => rect.right))
-            : Math.min(...bounds.map((rect) => rect.left));
-          expect(Math.abs(visibleEdge - edge)).toBeLessThanOrEqual(1);
-          expect(
-            await gap(group.locator(".chat-message-images"), group.locator(".chat-text")),
-          ).toBeGreaterThan(0);
-          if (name === "Image and file") {
-            const card = await group.locator(".chat-assistant-attachment-card").boundingBox();
-            expect(card).not.toBeNull();
-            expect(
-              Math.abs((user.self ? card!.x + card!.width : card!.x) - edge),
-            ).toBeLessThanOrEqual(1);
-          }
-          const groupBox = await group.boundingBox();
-          expect(groupBox).not.toBeNull();
-          expect(Math.min(...bounds.map((rect) => rect.left))).toBeGreaterThanOrEqual(
-            groupBox!.x - 1,
-          );
-          expect(Math.max(...bounds.map((rect) => rect.right))).toBeLessThanOrEqual(
-            groupBox!.x + groupBox!.width + 1,
-          );
-        }
+        ],
       });
-    },
-  );
+      await page.goto(`${suite.server.baseUrl}chat/main`);
+      const cards = page.locator(".chat-assistant-attachment-card");
+      const paragraphs = page.locator(".chat-text > p");
+      await paragraphs.last().waitFor();
+      await expect.poll(() => cards.count()).toBe(count);
+      expect(
+        await page
+          .locator(".chat-group.user .chat-bubble")
+          .evaluate((node) => getComputedStyle(node).backgroundColor),
+      ).toBe("rgba(0, 0, 0, 0)");
+      const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
+      for (let index = 1; index < count; index += 1) {
+        expect(
+          Math.abs((await gap(cards.nth(index - 1), cards.nth(index))) - reference),
+        ).toBeLessThanOrEqual(1);
+      }
+      expect(
+        Math.abs((await gap(cards.last(), page.locator(".chat-text"))) - reference),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        await page
+          .locator(".chat-thread")
+          .evaluate((element) => element.scrollWidth <= element.clientWidth),
+      ).toBe(true);
+    });
+  });
+
+  it.each([
+    { self: true, name: "own" },
+    { self: false, name: "peer" },
+  ])("aligns visible media with the $name participant's text bubble", async ({ self }) => {
+    await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+      const url = await page.evaluate(() => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 640;
+        canvas.height = 360;
+        return canvas.toDataURL();
+      });
+      const users = ["Riley", "Colin"].map((name, index) => ({
+        id: name,
+        name,
+        self: index === 0,
+        identity: { type: "profile" as const, id: name },
+      }));
+      const sender = users[self ? 0 : 1]!;
+      await installMockGateway(page, {
+        presenceUsers: users,
+        historyMessages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", url },
+              attachment(),
+              {
+                type: "text",
+                text: "Please compare the screenshot and attached logs with the expected release notes.",
+              },
+            ],
+            __openclaw: {
+              senderId: sender.id,
+              senderIdentity: sender.identity,
+              senderName: sender.name,
+            },
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat/main`);
+      const group = page.locator(".chat-group.user");
+      await group.locator(".chat-text").waitFor();
+      await group
+        .locator("img.chat-message-image")
+        .evaluate((node: HTMLImageElement) => node.decode());
+      const layout = await group.evaluate((node) => {
+        const text = node.querySelector(".chat-text")!;
+        const rect = (element: Element) => {
+          const { left, right, top, bottom } = element.getBoundingClientRect();
+          return { left, right, top, bottom };
+        };
+        return {
+          shellPaint: getComputedStyle(node.querySelector(".chat-bubble")!).backgroundColor,
+          textPaint: getComputedStyle(text).backgroundColor,
+          text: rect(text),
+          media: [
+            ...node.querySelectorAll(".chat-message-image, .chat-assistant-attachment-card"),
+          ].map(rect),
+        };
+      });
+      expect(layout.shellPaint).toBe("rgba(0, 0, 0, 0)");
+      expect(layout.textPaint).not.toBe("rgba(0, 0, 0, 0)");
+      expect(layout.media).toHaveLength(2);
+      const edge = self ? "right" : "left";
+      for (const media of layout.media) {
+        expect(Math.abs(media[edge] - layout.text[edge])).toBeLessThanOrEqual(1);
+        expect(media.bottom).toBeLessThan(layout.text.top);
+      }
+    });
+  });
 
   it("preserves nested user fences while sharing the top-level attachment rhythm", async () => {
     await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {

--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -139,6 +140,165 @@ suite.define(() => {
       });
     }
   });
+
+  it.each([1440, 390])(
+    "aligns shared-thread media with its author's bubble at %ipx",
+    async (width) => {
+      await suite.withPage({ viewport: { width, height: 900 } }, async ({ page }) => {
+        const imageData = await page.evaluate(() => {
+          const canvas = document.createElement("canvas");
+          canvas.width = 640;
+          canvas.height = 360;
+          canvas.getContext("2d")!.fillRect(0, 0, 640, 360);
+          return canvas.toDataURL().split(",")[1];
+        });
+        await page.route("**/alignment.png*", (route) =>
+          route.fulfill({ contentType: "image/png", body: Buffer.from(imageData, "base64") }),
+        );
+        const video = readFileSync(new URL("./fixtures/video-poster.mp4", import.meta.url));
+        await page.route("**/alignment.mp4", (route) => {
+          const range = route
+            .request()
+            .headers()
+            .range?.match(/^bytes=(\d+)-(\d*)$/);
+          const start = Number(range?.[1] ?? 0);
+          const end = range?.[2] ? Number(range[2]) : video.length - 1;
+          return route.fulfill({
+            status: range ? 206 : 200,
+            contentType: "video/mp4",
+            headers: range ? { "content-range": `bytes ${start}-${end}/${video.length}` } : {},
+            body: video.subarray(start, end + 1),
+          });
+        });
+        const image = { type: "image", url: `${suite.server.baseUrl}alignment.png` };
+        const cases = [
+          { name: "Image and file", media: [image, attachment()] },
+          { name: "Image", media: [image] },
+          {
+            name: "Video",
+            media: [
+              {
+                type: "attachment",
+                attachment: {
+                  kind: "video",
+                  label: "alignment.mp4",
+                  mimeType: "video/mp4",
+                  url: `${suite.server.baseUrl}alignment.mp4`,
+                },
+              },
+            ],
+          },
+          {
+            name: "Gallery",
+            media: Array.from({ length: 5 }, (_, index) => ({
+              ...image,
+              url: `${image.url}?tile=${index}`,
+            })),
+          },
+        ];
+        const users = [
+          {
+            self: true,
+            id: "profile-riley",
+            identity: { type: "profile" as const, id: "profile-riley" },
+            name: "Riley",
+          },
+          {
+            id: "profile-colin",
+            identity: { type: "profile" as const, id: "profile-colin" },
+            name: "Colin",
+          },
+        ];
+        const scenarios = users.flatMap((user) =>
+          cases.map((item) => ({
+            ...item,
+            user,
+            text: `${user.name}: ${item.name}. Please compare the completed update steps with the expected release notes.`,
+          })),
+        );
+        await installMockGateway(page, {
+          presenceUsers: users,
+          historyMessages: scenarios.flatMap(({ user, media, text }) => [
+            { role: "assistant", content: [{ type: "text", text: "Share the next update." }] },
+            {
+              role: "user",
+              content: [...media, { type: "text", text }],
+              __openclaw: {
+                senderId: user.id,
+                senderIdentity: user.identity,
+                senderName: user.name,
+              },
+            },
+          ]),
+        });
+        await page.goto(`${suite.server.baseUrl}chat/main`);
+        await page.locator(".chat-group.user").last().waitFor();
+        await page.locator(".chat-thread").evaluate((node) => {
+          node.scrollTop = 0;
+        });
+        for (const { user, name, text } of scenarios) {
+          const group = page.locator(".chat-group.user").filter({ hasText: text });
+          await group.scrollIntoViewIfNeeded();
+          const previews = group.locator("img.chat-message-image");
+          await expect.poll(() => previews.count()).toBe(name === "Gallery" ? 5 : 1);
+          await expect
+            .poll(() =>
+              previews.evaluateAll((nodes) =>
+                nodes.every(
+                  (node) =>
+                    node instanceof HTMLImageElement && node.complete && node.naturalWidth > 0,
+                ),
+              ),
+            )
+            .toBe(true);
+          expect(await group.evaluate((node) => node.classList.contains("chat-group--peer"))).toBe(
+            !user.self,
+          );
+          expect(
+            await group
+              .locator(".chat-bubble")
+              .evaluate((node) => getComputedStyle(node).backgroundColor),
+          ).toBe("rgba(0, 0, 0, 0)");
+          const bubble = await group.locator(".chat-text").boundingBox();
+          const gallery = await group.locator(".chat-message-images").boundingBox();
+          expect(bubble).not.toBeNull();
+          expect(gallery).not.toBeNull();
+          const edge = user.self ? bubble!.x + bubble!.width : bubble!.x;
+          expect(
+            Math.abs((user.self ? gallery!.x + gallery!.width : gallery!.x) - edge),
+          ).toBeLessThanOrEqual(1);
+          const bounds = await previews.evaluateAll((nodes) =>
+            nodes.map((node) => ({
+              left: node.getBoundingClientRect().left,
+              right: node.getBoundingClientRect().right,
+            })),
+          );
+          const visibleEdge = user.self
+            ? Math.max(...bounds.map((rect) => rect.right))
+            : Math.min(...bounds.map((rect) => rect.left));
+          expect(Math.abs(visibleEdge - edge)).toBeLessThanOrEqual(1);
+          expect(
+            await gap(group.locator(".chat-message-images"), group.locator(".chat-text")),
+          ).toBeGreaterThan(0);
+          if (name === "Image and file") {
+            const card = await group.locator(".chat-assistant-attachment-card").boundingBox();
+            expect(card).not.toBeNull();
+            expect(
+              Math.abs((user.self ? card!.x + card!.width : card!.x) - edge),
+            ).toBeLessThanOrEqual(1);
+          }
+          const groupBox = await group.boundingBox();
+          expect(groupBox).not.toBeNull();
+          expect(Math.min(...bounds.map((rect) => rect.left))).toBeGreaterThanOrEqual(
+            groupBox!.x - 1,
+          );
+          expect(Math.max(...bounds.map((rect) => rect.right))).toBeLessThanOrEqual(
+            groupBox!.x + groupBox!.width + 1,
+          );
+        }
+      });
+    },
+  );
 
   it("preserves nested user fences while sharing the top-level attachment rhythm", async () => {
     await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {

--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -211,7 +211,8 @@ suite.define(() => {
         ];
         const scenarios = users.flatMap((user) =>
           cases.map((item) => ({
-            ...item,
+            name: item.name,
+            media: item.media,
             user,
             text: `${user.name}: ${item.name}. Please compare the completed update steps with the expected release notes.`,
           })),

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -287,6 +287,9 @@ export function renderGroupedMessage(
         )
       : [];
   const cardAttachments = visibleAttachments.filter((item) => !videoPreviews.includes(item));
+  const hasUserFiles =
+    normalizedRole === "user" &&
+    cardAttachments.some((item) => item.attachment.kind === "document");
   const imageRenderOptions = {
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
@@ -331,7 +334,8 @@ export function renderGroupedMessage(
 
   const bubbleClasses = [
     "chat-bubble",
-    hasImages || videoPreviews.length > 0 ? "chat-bubble--with-images" : "",
+    hasImages || videoPreviews.length > 0 || hasUserFiles ? "chat-bubble--with-images" : "",
+    hasUserFiles ? "chat-bubble--with-files" : "",
     isToolShell ? "chat-bubble--tool-shell" : "",
     opts.isStreaming ? "streaming" : "",
     opts.entryAnimated ? "chat-bubble--user-turn-enter" : "",

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -24,11 +24,13 @@
 
 /* User messages on right */
 .chat-group.user {
+  --chat-user-content-align: end;
   flex-direction: row-reverse;
   justify-content: flex-start;
 }
 
 .chat-group.user.chat-group--peer {
+  --chat-user-content-align: start;
   /* The left-aligned identity owns the leading edge while hidden details
      reserve their desktop footprint after it. */
   --chat-footer-detail-position: static;
@@ -131,13 +133,9 @@
   margin-block-start: calc(var(--chat-run-block-gap) - 2px);
 }
 
-/* User messages align content right */
+/* Content follows the same side as the participant's bubble. */
 .chat-group.user .chat-group-messages {
-  align-items: flex-end;
-}
-
-.chat-group.user.chat-group--peer .chat-group-messages {
-  align-items: flex-start;
+  align-items: var(--chat-user-content-align);
 }
 
 .chat-group.tool {
@@ -1050,19 +1048,19 @@ img.chat-avatar.chat-avatar--logo {
   color: hsl(var(--chat-sender-hue) 60% 36%);
 }
 
-/* Keep sent media outside the text surface: the image gallery remains bare,
-   while the following text retains the normal right-aligned user bubble. */
-.chat-group.user:not(.chat-group--peer) .chat-bubble--with-images {
+/* Match the sender tint's specificity so media stays outside the painted text
+   surface on either participant's side. */
+.chat-group.user .chat-bubble.chat-bubble--with-images {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: var(--chat-user-content-align);
   padding: 0;
   border: 0;
   background: transparent;
   box-shadow: none;
 }
 
-.chat-group.user:not(.chat-group--peer)
+.chat-group.user
   .chat-bubble--with-images
   > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   width: fit-content;
@@ -1073,7 +1071,7 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 :where(:root[data-theme-mode="light"])
-  .chat-group.user:not(.chat-group--peer)
+  .chat-group.user
   .chat-bubble--with-images
   > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   color: var(--text-strong);

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -491,21 +491,26 @@
   transform: scale(1.02);
 }
 
-/* Local user images sit above the text bubble. Multi-image turns use compact
-   gallery tiles; assistant and peer transcript images remain one per row. */
-.chat-group.user:not(.chat-group--peer) .chat-message-images {
+/* User media shares the text bubble's side. Multi-item turns use compact
+   gallery tiles; assistant transcript images remain one per row. */
+.chat-group.user .chat-message-images {
   --chat-user-image-grid-size: min(128px, calc((100vw - 48px) / 3));
   display: grid;
   grid-template-columns: repeat(3, var(--chat-user-image-grid-size));
-  justify-content: end;
-  justify-items: end;
+  justify-content: var(--chat-user-content-align);
+  justify-items: var(--chat-user-content-align);
   width: fit-content;
   max-width: 100%;
   gap: 4px;
   margin: 0;
 }
 
-.chat-group.user:not(.chat-group--peer) .chat-message-images--two-column {
+.chat-group.user .chat-message-images > * {
+  display: grid;
+  justify-items: var(--chat-user-content-align);
+}
+
+.chat-group.user .chat-message-images--two-column {
   grid-template-columns: repeat(2, var(--chat-user-image-grid-size));
 }
 
@@ -515,11 +520,11 @@
   grid-column: 2;
 }
 
-.chat-group.user:not(.chat-group--peer) .chat-message-images--single {
+.chat-group.user .chat-message-images--single {
   grid-template-columns: minmax(0, auto);
 }
 
-.chat-group.user:not(.chat-group--peer)
+.chat-group.user
   .chat-message-images--gallery
   :is(.chat-image-frame, .chat-message-image-button, .chat-message-image) {
   width: var(--chat-user-image-grid-size);
@@ -527,10 +532,6 @@
   height: var(--chat-user-image-grid-size);
   max-height: none;
   object-fit: cover;
-}
-
-.chat-group.user.chat-group--peer .chat-message-images {
-  align-items: flex-start;
 }
 
 .chat-assistant-attachments {
@@ -541,7 +542,7 @@
   gap: var(--chat-block-gap);
 }
 
-.chat-group.user:not(.chat-group--peer) .chat-bubble--with-files {
+.chat-group.user .chat-bubble--with-files {
   width: 100%;
 }
 

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -541,6 +541,10 @@
   gap: var(--chat-block-gap);
 }
 
+.chat-group.user:not(.chat-group--peer) .chat-bubble--with-files {
+  width: 100%;
+}
+
 .chat-group.assistant .chat-bubble:has(.chat-assistant-attachments),
 .chat-group.assistant .chat-text:has(.chat-assistant-attachments) {
   width: 100%;


### PR DESCRIPTION
Closes #142662. Related: #142593.

The dependency PRs #142623 and #142639 by @vyctorbrzezowski have merged. This branch is now rebased directly on `main`; its complete delta is four files: production +32/-25 (net +7), tests +79/-3 (net +76).

## What Problem This Solves

User file cards appeared inside the colored message bubble. In mixed image/file turns, the image could also stop short of the bubble's edge. Another participant's media in a shared session retained a separate layout from the viewer's own media.

## Why This Change Was Made

Documents now use the existing image/video media shell and canonical file cards. The existing own/peer participant classes select logical `end` or `start` alignment for the message column, bare shell, and media items. Fixing the shared item's intrinsic sizing keeps visible media on the same edge as the bubble, without a media-specific alignment rule or new DOM wrapper.

## User Impact

Images, videos, galleries, and document cards sit above text and follow its side: the viewer's own turns align to the end; another participant's turns align to the start. Multiple documents stack vertically, and file-only messages show just the cards. Open and Download actions remain available. Assistant presentation is preserved. Avatar placement remains owned by the separate alignment change.

## Evidence

All 17 cases in the remaining attachment-spacing E2E file passed after the rebase and test consolidation. Three regression witnesses were run against parent production and all failed for the intended reason: document shell still painted, the viewer's image edge offset by 108.625px, and another participant's media shell still painted.

The document invariant extends the existing mobile spacing case. Two focused desktop cases verify visible image/card edges against the own/peer text bubble using canonical sender identities. Redundant video, gallery, image-only and second-viewport permutations were removed from automated coverage; their inspected visual evidence remains below. The original spacing tests from the base retain their separate block-rhythm contract. The test delta is reduced from +220/-31 to +79/-3 without changing production behavior.

The current `check:changed` passed its policy, formatting, graph-boundary, and i18n stages, then stopped at `Declaration input escapes checkout`: the required linked dependencies are outside this nested worktree. The prior standalone UI typecheck hit the same restriction. No guard was bypassed or dependencies installed. Current scoped TypeScript lint and CSS lint passed. The unchanged production code retains the prior clean coercion and unused-export scans. Full CI and the current integrated-head review remain landing gates.

Captures use the actual Control UI with synthetic Gateway identities and attachments, and the app's Instrument Sans loaded. Each cell embeds the message crop and full viewport. The first eight pairs retain the original file-placement proof; their assistant crops are byte-for-byte identical. The remaining pairs show the alignment repair for own and shared-participant turns. The peer gallery captures use two images; the earlier browser matrix also verified five-image galleries before this test consolidation. Open ZIP/PDF, download, image preview, close, and light/dark controls were exercised in the retained mock app.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">User ZIP + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/c234b5b4-44e9-4337-9315-3098d4f9cc75"><img src="https://github.com/user-attachments/assets/327ecfc3-085d-4e6b-a115-93a245904525" alt="User ZIP + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/c234b5b4-44e9-4337-9315-3098d4f9cc75"><img src="https://github.com/user-attachments/assets/c234b5b4-44e9-4337-9315-3098d4f9cc75" alt="Full viewport: User ZIP + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/d4c18167-6706-4c22-b564-3ac87d21a62d"><img src="https://github.com/user-attachments/assets/e50b66e5-c303-46a7-b653-9dc506a3ac41" alt="User ZIP + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/d4c18167-6706-4c22-b564-3ac87d21a62d"><img src="https://github.com/user-attachments/assets/d4c18167-6706-4c22-b564-3ac87d21a62d" alt="Full viewport: User ZIP + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">User two files + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/bbb89154-c49e-4c7f-ae2b-dc03d918b317"><img src="https://github.com/user-attachments/assets/9730d505-1fc9-41d2-bd4f-825ec4dbb537" alt="User two files + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/bbb89154-c49e-4c7f-ae2b-dc03d918b317"><img src="https://github.com/user-attachments/assets/bbb89154-c49e-4c7f-ae2b-dc03d918b317" alt="Full viewport: User two files + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/dc42ff60-d027-42f9-bfe9-b94d99c8a088"><img src="https://github.com/user-attachments/assets/40dd8de7-de6f-42f3-81e6-e9c99c6e9adf" alt="User two files + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/dc42ff60-d027-42f9-bfe9-b94d99c8a088"><img src="https://github.com/user-attachments/assets/dc42ff60-d027-42f9-bfe9-b94d99c8a088" alt="Full viewport: User two files + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">User file only — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/cb3038b7-bbcc-4e7b-b782-d19ca600793f"><img src="https://github.com/user-attachments/assets/5bb25690-5eba-4e70-ac5e-405cce948c6d" alt="User file only, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/cb3038b7-bbcc-4e7b-b782-d19ca600793f"><img src="https://github.com/user-attachments/assets/cb3038b7-bbcc-4e7b-b782-d19ca600793f" alt="Full viewport: User file only, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/e02efdb8-f9b5-43a8-801f-e924c65174ce"><img src="https://github.com/user-attachments/assets/43d4b898-9628-41f6-a293-6015191a00f5" alt="User file only, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/e02efdb8-f9b5-43a8-801f-e924c65174ce"><img src="https://github.com/user-attachments/assets/e02efdb8-f9b5-43a8-801f-e924c65174ce" alt="Full viewport: User file only, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Assistant file, unchanged — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/dc6f2cad-9fb9-4004-b333-b23edffdf3cf"><img src="https://github.com/user-attachments/assets/43d18fca-0edc-45fb-a380-db6e93c65808" alt="Assistant file, unchanged, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/dc6f2cad-9fb9-4004-b333-b23edffdf3cf"><img src="https://github.com/user-attachments/assets/dc6f2cad-9fb9-4004-b333-b23edffdf3cf" alt="Full viewport: Assistant file, unchanged, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/00e12cfc-a370-44db-99f6-8c1895f9362c"><img src="https://github.com/user-attachments/assets/3f77c9d4-d0d6-4c2a-8c7e-bf6e8a485f6a" alt="Assistant file, unchanged, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/00e12cfc-a370-44db-99f6-8c1895f9362c"><img src="https://github.com/user-attachments/assets/00e12cfc-a370-44db-99f6-8c1895f9362c" alt="Full viewport: Assistant file, unchanged, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">User ZIP + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/42dc6840-04da-4610-a200-0b3998495a50"><img src="https://github.com/user-attachments/assets/44c54aca-fd1c-4232-8f12-75d410817a3e" alt="User ZIP + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/42dc6840-04da-4610-a200-0b3998495a50"><img src="https://github.com/user-attachments/assets/42dc6840-04da-4610-a200-0b3998495a50" alt="Full viewport: User ZIP + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/949b0c24-cffe-4f09-b38b-35bd022e4d59"><img src="https://github.com/user-attachments/assets/7e99e3e3-c844-4d70-98d5-20f91c017991" alt="User ZIP + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/949b0c24-cffe-4f09-b38b-35bd022e4d59"><img src="https://github.com/user-attachments/assets/949b0c24-cffe-4f09-b38b-35bd022e4d59" alt="Full viewport: User ZIP + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">User two files + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/88eb3149-3899-458b-9e9e-2219ab11467d"><img src="https://github.com/user-attachments/assets/27405f75-caf5-4c0b-9a07-ee9c84bb1ade" alt="User two files + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/88eb3149-3899-458b-9e9e-2219ab11467d"><img src="https://github.com/user-attachments/assets/88eb3149-3899-458b-9e9e-2219ab11467d" alt="Full viewport: User two files + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/da57115b-e2d3-4351-81ed-b7c216e4aa61"><img src="https://github.com/user-attachments/assets/6610c62a-e0cb-4077-a102-7b8550ddd39d" alt="User two files + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/da57115b-e2d3-4351-81ed-b7c216e4aa61"><img src="https://github.com/user-attachments/assets/da57115b-e2d3-4351-81ed-b7c216e4aa61" alt="Full viewport: User two files + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">User file only — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/b07de7b4-b5a4-457e-8404-8b93c0dfd26f"><img src="https://github.com/user-attachments/assets/dbec4ee3-cf4e-4c6d-af49-66cd781e473e" alt="User file only, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/b07de7b4-b5a4-457e-8404-8b93c0dfd26f"><img src="https://github.com/user-attachments/assets/b07de7b4-b5a4-457e-8404-8b93c0dfd26f" alt="Full viewport: User file only, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/59c6fe7a-6a46-4d9a-b650-fead9e6681ac"><img src="https://github.com/user-attachments/assets/3cd65916-07af-4e31-b71f-90da3cb90e82" alt="User file only, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/59c6fe7a-6a46-4d9a-b650-fead9e6681ac"><img src="https://github.com/user-attachments/assets/59c6fe7a-6a46-4d9a-b650-fead9e6681ac" alt="Full viewport: User file only, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Assistant file, unchanged — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/c4239320-c70c-4d41-9040-8e241f8cdea5"><img src="https://github.com/user-attachments/assets/469e7a3f-6220-4d87-9080-883392019882" alt="Assistant file, unchanged, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/c4239320-c70c-4d41-9040-8e241f8cdea5"><img src="https://github.com/user-attachments/assets/c4239320-c70c-4d41-9040-8e241f8cdea5" alt="Full viewport: Assistant file, unchanged, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/e87b6d76-ab21-4286-b183-bc5aebe73dce"><img src="https://github.com/user-attachments/assets/fb630aa9-0025-442b-aa0f-816f1f6ecf91" alt="Assistant file, unchanged, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/e87b6d76-ab21-4286-b183-bc5aebe73dce"><img src="https://github.com/user-attachments/assets/e87b6d76-ab21-4286-b183-bc5aebe73dce" alt="Full viewport: Assistant file, unchanged, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image + file + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/0efb1e9c-55b5-465b-abfb-82a9969af0e7"><img src="https://github.com/user-attachments/assets/d29a9ec4-b2be-471b-bd40-5694d076c2b0" alt="Own turn: image + file + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/0efb1e9c-55b5-465b-abfb-82a9969af0e7"><img src="https://github.com/user-attachments/assets/0efb1e9c-55b5-465b-abfb-82a9969af0e7" alt="Full viewport: Own turn: image + file + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/9244aacb-b86e-41d2-b66f-b4db9c9451e9"><img src="https://github.com/user-attachments/assets/5201b074-9232-4e28-9ff1-0a73c7392078" alt="Own turn: image + file + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/9244aacb-b86e-41d2-b66f-b4db9c9451e9"><img src="https://github.com/user-attachments/assets/9244aacb-b86e-41d2-b66f-b4db9c9451e9" alt="Full viewport: Own turn: image + file + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/1b1c3059-a020-49c8-94fd-c5d22af0b615"><img src="https://github.com/user-attachments/assets/42b8ea40-ea01-49fe-8461-d79384fa0f03" alt="Own turn: image + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/1b1c3059-a020-49c8-94fd-c5d22af0b615"><img src="https://github.com/user-attachments/assets/1b1c3059-a020-49c8-94fd-c5d22af0b615" alt="Full viewport: Own turn: image + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/951ed3db-00c3-4241-9d7a-473ff847a8fa"><img src="https://github.com/user-attachments/assets/d769ea67-5de7-4544-bc35-fcb6ab32ae98" alt="Own turn: image + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/951ed3db-00c3-4241-9d7a-473ff847a8fa"><img src="https://github.com/user-attachments/assets/951ed3db-00c3-4241-9d7a-473ff847a8fa" alt="Full viewport: Own turn: image + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: video + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/9c181779-6fff-450f-9a8f-520693b870fe"><img src="https://github.com/user-attachments/assets/bf21178a-7595-4ebc-8f19-38b5ac2a1eae" alt="Own turn: video + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/9c181779-6fff-450f-9a8f-520693b870fe"><img src="https://github.com/user-attachments/assets/9c181779-6fff-450f-9a8f-520693b870fe" alt="Full viewport: Own turn: video + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/bb19f264-617a-46a0-ba5d-80582eda5d7a"><img src="https://github.com/user-attachments/assets/bdab2596-a46a-4ecf-841d-71d6e87921f9" alt="Own turn: video + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/bb19f264-617a-46a0-ba5d-80582eda5d7a"><img src="https://github.com/user-attachments/assets/bb19f264-617a-46a0-ba5d-80582eda5d7a" alt="Full viewport: Own turn: video + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image gallery + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/16757717-f780-4d32-93a3-165756d056db"><img src="https://github.com/user-attachments/assets/76330eaa-6955-43c0-8b94-1dae3dd9e545" alt="Own turn: image gallery + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/16757717-f780-4d32-93a3-165756d056db"><img src="https://github.com/user-attachments/assets/16757717-f780-4d32-93a3-165756d056db" alt="Full viewport: Own turn: image gallery + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/59f18f09-f3d3-40de-bac2-9710fa9243c0"><img src="https://github.com/user-attachments/assets/411ca25a-8c67-4452-ab11-ba5f11dd13dd" alt="Own turn: image gallery + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/59f18f09-f3d3-40de-bac2-9710fa9243c0"><img src="https://github.com/user-attachments/assets/59f18f09-f3d3-40de-bac2-9710fa9243c0" alt="Full viewport: Own turn: image gallery + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image + file + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/2ff0e709-3abc-4284-a39a-9c85988599a9"><img src="https://github.com/user-attachments/assets/351b21a7-5137-4e4b-a479-205a7992716e" alt="Own turn: image + file + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/2ff0e709-3abc-4284-a39a-9c85988599a9"><img src="https://github.com/user-attachments/assets/2ff0e709-3abc-4284-a39a-9c85988599a9" alt="Full viewport: Own turn: image + file + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/3de04289-15f4-4d16-8cf6-7573925e5abf"><img src="https://github.com/user-attachments/assets/bfb74fc1-1769-4cea-a31c-89ea935fca09" alt="Own turn: image + file + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/3de04289-15f4-4d16-8cf6-7573925e5abf"><img src="https://github.com/user-attachments/assets/3de04289-15f4-4d16-8cf6-7573925e5abf" alt="Full viewport: Own turn: image + file + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/73c19864-9354-4ac7-8ce0-12ccdaa6a6db"><img src="https://github.com/user-attachments/assets/c709437e-145c-4d15-8447-417fb3a5673c" alt="Own turn: image + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/73c19864-9354-4ac7-8ce0-12ccdaa6a6db"><img src="https://github.com/user-attachments/assets/73c19864-9354-4ac7-8ce0-12ccdaa6a6db" alt="Full viewport: Own turn: image + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/ed895259-cb1b-4960-ae7f-bb419c2f3fe1"><img src="https://github.com/user-attachments/assets/066af505-dc91-4744-884e-c6ad42d526f2" alt="Own turn: image + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/ed895259-cb1b-4960-ae7f-bb419c2f3fe1"><img src="https://github.com/user-attachments/assets/ed895259-cb1b-4960-ae7f-bb419c2f3fe1" alt="Full viewport: Own turn: image + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: video + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/e4511507-0c70-4539-9716-da22f218893f"><img src="https://github.com/user-attachments/assets/6866376c-7804-4803-8707-eba27e935ddf" alt="Own turn: video + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/e4511507-0c70-4539-9716-da22f218893f"><img src="https://github.com/user-attachments/assets/e4511507-0c70-4539-9716-da22f218893f" alt="Full viewport: Own turn: video + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/ef7e68c2-14e6-4e7e-a9e1-c6f856457316"><img src="https://github.com/user-attachments/assets/cdb5f891-3398-4ba2-85f2-56890a8a7271" alt="Own turn: video + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/ef7e68c2-14e6-4e7e-a9e1-c6f856457316"><img src="https://github.com/user-attachments/assets/ef7e68c2-14e6-4e7e-a9e1-c6f856457316" alt="Full viewport: Own turn: video + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: image gallery + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/3a369221-b99c-4974-9f80-f363f69ba14b"><img src="https://github.com/user-attachments/assets/3c74f7e6-37c4-48f1-9a76-ce9aa1edc44a" alt="Own turn: image gallery + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/3a369221-b99c-4974-9f80-f363f69ba14b"><img src="https://github.com/user-attachments/assets/3a369221-b99c-4974-9f80-f363f69ba14b" alt="Full viewport: Own turn: image gallery + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/149d892c-dfdd-44cb-89c9-2a03b0abdf09"><img src="https://github.com/user-attachments/assets/4103861d-257c-40a5-a9ff-a7eb1d7fed1d" alt="Own turn: image gallery + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/149d892c-dfdd-44cb-89c9-2a03b0abdf09"><img src="https://github.com/user-attachments/assets/149d892c-dfdd-44cb-89c9-2a03b0abdf09" alt="Full viewport: Own turn: image gallery + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image + file + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/0e361f97-94f5-454c-817a-1104018d84fc"><img src="https://github.com/user-attachments/assets/2208eafc-3208-46ec-8373-4597fdc7f214" alt="Other participant (Colin): image + file + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/0e361f97-94f5-454c-817a-1104018d84fc"><img src="https://github.com/user-attachments/assets/0e361f97-94f5-454c-817a-1104018d84fc" alt="Full viewport: Other participant (Colin): image + file + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/f541833f-3535-4dd5-af47-b422346b20a8"><img src="https://github.com/user-attachments/assets/dfef0b1a-e729-44ed-898e-017e93f9c038" alt="Other participant (Colin): image + file + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/f541833f-3535-4dd5-af47-b422346b20a8"><img src="https://github.com/user-attachments/assets/f541833f-3535-4dd5-af47-b422346b20a8" alt="Full viewport: Other participant (Colin): image + file + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/2b841033-69ec-4c01-a4d7-310d9ddc6ce8"><img src="https://github.com/user-attachments/assets/0a8d9443-7faf-4612-83ff-dd1b3bb8ae5e" alt="Other participant (Colin): image + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/2b841033-69ec-4c01-a4d7-310d9ddc6ce8"><img src="https://github.com/user-attachments/assets/2b841033-69ec-4c01-a4d7-310d9ddc6ce8" alt="Full viewport: Other participant (Colin): image + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/9b0fa07c-1e41-446b-bb36-b253621d269a"><img src="https://github.com/user-attachments/assets/ef58dca3-1961-41f8-abe3-46f2e5ab8933" alt="Other participant (Colin): image + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/9b0fa07c-1e41-446b-bb36-b253621d269a"><img src="https://github.com/user-attachments/assets/9b0fa07c-1e41-446b-bb36-b253621d269a" alt="Full viewport: Other participant (Colin): image + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): video + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/1e40a669-6787-4b33-b49b-f165363b70ec"><img src="https://github.com/user-attachments/assets/9a9f7eb4-0eb4-4a82-86ac-08fdf86faa58" alt="Other participant (Colin): video + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/1e40a669-6787-4b33-b49b-f165363b70ec"><img src="https://github.com/user-attachments/assets/1e40a669-6787-4b33-b49b-f165363b70ec" alt="Full viewport: Other participant (Colin): video + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/5b920eaf-4717-4750-afc9-1032c957f329"><img src="https://github.com/user-attachments/assets/fb7e7550-273e-4a92-9ad8-687ebfb007fc" alt="Other participant (Colin): video + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/5b920eaf-4717-4750-afc9-1032c957f329"><img src="https://github.com/user-attachments/assets/5b920eaf-4717-4750-afc9-1032c957f329" alt="Full viewport: Other participant (Colin): video + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image gallery + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/fc5bcfd5-f9ae-4b39-839e-72f8b2da3721"><img src="https://github.com/user-attachments/assets/dc038002-c8ad-4463-8173-9ee67aad84aa" alt="Other participant (Colin): image gallery + text, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/fc5bcfd5-f9ae-4b39-839e-72f8b2da3721"><img src="https://github.com/user-attachments/assets/fc5bcfd5-f9ae-4b39-839e-72f8b2da3721" alt="Full viewport: Other participant (Colin): image gallery + text, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/a80f2a4a-20fa-46bd-be93-0117eaa6fd1a"><img src="https://github.com/user-attachments/assets/6af7b57f-6d75-49c2-a85b-ec7b1ef7266c" alt="Other participant (Colin): image gallery + text, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/a80f2a4a-20fa-46bd-be93-0117eaa6fd1a"><img src="https://github.com/user-attachments/assets/a80f2a4a-20fa-46bd-be93-0117eaa6fd1a" alt="Full viewport: Other participant (Colin): image gallery + text, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image + file + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/01d6542d-c56e-4ae7-9166-99ee96168615"><img src="https://github.com/user-attachments/assets/0df15873-a63c-45ab-b2aa-c658697dfb39" alt="Other participant (Colin): image + file + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/01d6542d-c56e-4ae7-9166-99ee96168615"><img src="https://github.com/user-attachments/assets/01d6542d-c56e-4ae7-9166-99ee96168615" alt="Full viewport: Other participant (Colin): image + file + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/cddcc9ab-d686-4ca1-98fe-457bcb5b4aa9"><img src="https://github.com/user-attachments/assets/3595a2a6-d5ad-4d89-b1a1-e16258827f1b" alt="Other participant (Colin): image + file + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/cddcc9ab-d686-4ca1-98fe-457bcb5b4aa9"><img src="https://github.com/user-attachments/assets/cddcc9ab-d686-4ca1-98fe-457bcb5b4aa9" alt="Full viewport: Other participant (Colin): image + file + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/9223815b-a35c-4964-a948-1c6fd07268b5"><img src="https://github.com/user-attachments/assets/7a806d81-2a3f-4fff-b9eb-8cfde4a77e53" alt="Other participant (Colin): image + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/9223815b-a35c-4964-a948-1c6fd07268b5"><img src="https://github.com/user-attachments/assets/9223815b-a35c-4964-a948-1c6fd07268b5" alt="Full viewport: Other participant (Colin): image + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/2fbdb971-acfa-4024-a5d9-8fa210cc893f"><img src="https://github.com/user-attachments/assets/03a996f3-1446-457d-a644-5babd42da1d6" alt="Other participant (Colin): image + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/2fbdb971-acfa-4024-a5d9-8fa210cc893f"><img src="https://github.com/user-attachments/assets/2fbdb971-acfa-4024-a5d9-8fa210cc893f" alt="Full viewport: Other participant (Colin): image + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): video + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/ce9b43d1-501a-46bf-a14b-d6cb485107bb"><img src="https://github.com/user-attachments/assets/56dbb9cf-984c-4442-b851-b4e88a61dc82" alt="Other participant (Colin): video + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/ce9b43d1-501a-46bf-a14b-d6cb485107bb"><img src="https://github.com/user-attachments/assets/ce9b43d1-501a-46bf-a14b-d6cb485107bb" alt="Full viewport: Other participant (Colin): video + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/1fe5bb61-43cd-4c74-be5a-6547f8e070c7"><img src="https://github.com/user-attachments/assets/05ae8c67-593e-48c3-8a87-3bf72c2e0fb6" alt="Other participant (Colin): video + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/1fe5bb61-43cd-4c74-be5a-6547f8e070c7"><img src="https://github.com/user-attachments/assets/1fe5bb61-43cd-4c74-be5a-6547f8e070c7" alt="Full viewport: Other participant (Colin): video + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): image gallery + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/6118772e-ff9d-4a34-b003-3e1da30b55ad"><img src="https://github.com/user-attachments/assets/075df003-521c-460a-a8b9-c48175ad1acc" alt="Other participant (Colin): image gallery + text, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/6118772e-ff9d-4a34-b003-3e1da30b55ad"><img src="https://github.com/user-attachments/assets/6118772e-ff9d-4a34-b003-3e1da30b55ad" alt="Full viewport: Other participant (Colin): image gallery + text, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/0719ce11-95f3-4699-ac90-237609f894e7"><img src="https://github.com/user-attachments/assets/707d34a5-36af-4cc7-a4f5-2898d9b44415" alt="Other participant (Colin): image gallery + text, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/0719ce11-95f3-4699-ac90-237609f894e7"><img src="https://github.com/user-attachments/assets/0719ce11-95f3-4699-ac90-237609f894e7" alt="Full viewport: Other participant (Colin): image gallery + text, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: long pasted text file + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/64ac80f1-e794-4381-8f86-a35351a1cc99"><img src="https://github.com/user-attachments/assets/21876712-a747-4186-bb97-2d672e8001c1" alt="Own turn: pasted text file, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/64ac80f1-e794-4381-8f86-a35351a1cc99"><img src="https://github.com/user-attachments/assets/64ac80f1-e794-4381-8f86-a35351a1cc99" alt="Full viewport: Own turn: pasted text file, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/fe49057a-8e4d-4333-a27e-ed650d23aa1b"><img src="https://github.com/user-attachments/assets/2ff72aec-a6d2-4f8f-aa97-a65b7f96d33c" alt="Own turn: pasted text file, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/fe49057a-8e4d-4333-a27e-ed650d23aa1b"><img src="https://github.com/user-attachments/assets/fe49057a-8e4d-4333-a27e-ed650d23aa1b" alt="Full viewport: Own turn: pasted text file, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): long pasted text file + text — 1440px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/d7055cbc-974f-4497-b623-7fffd4bdd830"><img src="https://github.com/user-attachments/assets/e206c248-2654-4ae6-8611-a4812a38ce65" alt="Other participant (Colin): pasted text file, before, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/d7055cbc-974f-4497-b623-7fffd4bdd830"><img src="https://github.com/user-attachments/assets/d7055cbc-974f-4497-b623-7fffd4bdd830" alt="Full viewport: Other participant (Colin): pasted text file, before, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/594cc79e-4af4-40bf-9145-1831fa0d532a"><img src="https://github.com/user-attachments/assets/87f52787-b0c1-4cf2-bdb6-274a87e54a02" alt="Other participant (Colin): pasted text file, after, 1440px" width="600"></a><br><a href="https://github.com/user-attachments/assets/594cc79e-4af4-40bf-9145-1831fa0d532a"><img src="https://github.com/user-attachments/assets/594cc79e-4af4-40bf-9145-1831fa0d532a" alt="Full viewport: Other participant (Colin): pasted text file, after, 1440px" width="600"></a></td></tr>
<tr><th colspan="2">Own turn: long pasted text file + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/57286bd8-a6d7-45be-b8db-c6d9623ad24a"><img src="https://github.com/user-attachments/assets/154a2442-69bb-4845-8667-785c14b5cafb" alt="Own turn: pasted text file, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/57286bd8-a6d7-45be-b8db-c6d9623ad24a"><img src="https://github.com/user-attachments/assets/57286bd8-a6d7-45be-b8db-c6d9623ad24a" alt="Full viewport: Own turn: pasted text file, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/c1fac6d7-e463-4c51-ae08-b3c858f7ed4d"><img src="https://github.com/user-attachments/assets/729bbd2c-5912-412a-9385-3d01e69463e0" alt="Own turn: pasted text file, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/c1fac6d7-e463-4c51-ae08-b3c858f7ed4d"><img src="https://github.com/user-attachments/assets/c1fac6d7-e463-4c51-ae08-b3c858f7ed4d" alt="Full viewport: Own turn: pasted text file, after, 390px" width="600"></a></td></tr>
<tr><th colspan="2">Other participant (Colin): long pasted text file + text — 390px</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/3153c24c-393e-4529-a1b2-946413e22e5d"><img src="https://github.com/user-attachments/assets/cb6f336e-90ed-4c24-8d2c-965aac2dd76a" alt="Other participant (Colin): pasted text file, before, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/3153c24c-393e-4529-a1b2-946413e22e5d"><img src="https://github.com/user-attachments/assets/3153c24c-393e-4529-a1b2-946413e22e5d" alt="Full viewport: Other participant (Colin): pasted text file, before, 390px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/28cd64bd-2fe6-4484-9f70-4dd578a355f3"><img src="https://github.com/user-attachments/assets/255d3838-5e02-4972-a91f-eff5d3319461" alt="Other participant (Colin): pasted text file, after, 390px" width="600"></a><br><a href="https://github.com/user-attachments/assets/28cd64bd-2fe6-4484-9f70-4dd578a355f3"><img src="https://github.com/user-attachments/assets/28cd64bd-2fe6-4484-9f70-4dd578a355f3" alt="Full viewport: Other participant (Colin): pasted text file, after, 390px" width="600"></a></td></tr>
</table>

A real composer paste of 1,782 bytes generated `pasted-text-1788914352304.txt`; Send preserved its exact bytes, filename and `text/plain` MIME as a file attachment. The same captured file was then replayed through canonical transcript history for the viewer and Colin. The four added pairs at 1440px/390px show its card outside the painted text, sharing the corresponding start/end edge (0px difference), with the existing 14px gap. Open, Close, and a byte-identical download were verified. This additional case needs no production change.

## Risk and coverage

Checked consumers of the shared shell and gallery: own and peer image/file/text, image/text, video/text, and multi-image/text turns; user document/text, multiple documents and document-only turns; assistant documents; and audio-only rendering. The shared alignment owner has focused decoded-image/card geometry checks for own and peer turns. Image, video, gallery and pasted-text paths retain desktop/mobile captures; decoder lifecycle coverage remains with the parent video work. Original assistant captures have pixel parity; fresh assistant content is also unchanged. Audio-only conditions and attachment actions remain unchanged. No attachment transport, storage, permission, download, preview decoder, or avatar-layout implementation changes.

Evidence uses a mock Gateway and Chromium, not authenticated live media delivery or a physical mobile device. Both dependency PRs have merged. Landing is authorized after the required checks and current review pass on the integrated head.




