### PR TITLE
ci(labeler): label the child pages created by docs splits

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,7 @@
           - "extensions/file-transfer/**"
           - "docs/nodes/index.md"
           - "docs/plugins/sdk-runtime.md"
+          - "docs/plugins/sdk-runtime/**"
 "plugin: linux-node":
   - changed-files:
       - any-glob-to-any-file:
@@ -41,6 +42,7 @@
       - any-glob-to-any-file:
           - "extensions/discord/**"
           - "docs/channels/discord.md"
+          - "docs/channels/discord/**"
 "channel: irc":
   - changed-files:
       - any-glob-to-any-file:
@@ -191,6 +193,7 @@
           - "qa/scenarios/**"
           - "docs/maturity/**"
           - "docs/concepts/qa-e2e-automation.md"
+          - "docs/concepts/qa-e2e-automation/**"
           - "docs/concepts/personal-agent-benchmark-pack.md"
           - "docs/channels/qa-channel.md"
 "channel: signal":
@@ -203,6 +206,7 @@
       - any-glob-to-any-file:
           - "extensions/slack/**"
           - "docs/channels/slack.md"
+          - "docs/channels/slack/**"
 "channel: sms":
   - changed-files:
       - any-glob-to-any-file:
@@ -597,6 +601,7 @@
       - any-glob-to-any-file:
           - "extensions/codex/**"
           - "docs/plugins/codex-harness.md"
+          - "docs/plugins/codex-harness/**"
           - "docs/plugins/codex-harness-reference.md"
           - "docs/plugins/codex-harness-runtime.md"
           - "docs/plugins/codex-supervision.md"


### PR DESCRIPTION
## What

Adds a child-directory glob to five labeler rules whose docs page has been split into a directory.

```
channel: discord      docs/channels/discord/**
channel: slack        docs/channels/slack/**
qa                    docs/concepts/qa-e2e-automation/**
plugins codex         docs/plugins/codex-harness/**
plugins sdk-runtime   docs/plugins/sdk-runtime/**
```

## Why

Each rule globs one page — for example `docs/channels/discord.md`. After a split that file is a short index and the substance lives in `docs/channels/discord/`. The rule keeps matching the index while the content it exists to label has moved, so a PR touching only the children gets no label.

## How it was found

While splitting the Discord page. That agent spotted the gap for its own page and deliberately left it out of the docs-only PR — fixing it there would have turned a documentation change into a `.github` change, and would have diverged from the Slack sibling, which had the identical gap. It flagged it for a follow-up instead, which was the right call.

Checking every rule in the file rather than just that one turned two gaps into five. The three beyond Slack and Discord have been silently unlabelled since their own splits landed.

## Validation

```
5 rules updated, 5 insertions, no other change
every "docs/<page>.md" glob whose page now has a sibling directory is covered
structural check on the file: no malformed lines
```

Kept separate from the documentation PRs deliberately: this is CI configuration spanning five unrelated areas.