### PR TITLE
fix: HTML-only email stalls packaged IMAP delivery

### DIFF
--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -201,6 +201,75 @@ describe("tsdown config", () => {
     },
   );
 
+  it("parses HTML-only IMAP mail from the bundled runtime", async () => {
+    const entryName = "extensions/imap/index";
+    const selected = configs.find((config) =>
+      hasWorkerEntry(config, entryName, "extensions/imap/index.ts"),
+    );
+    expect(selected).toBeDefined();
+
+    const root = fs.realpathSync(createTempDir("openclaw-tsdown-imap-"));
+    fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}');
+    // Mirror the packaged layout: the bundled plugin runs beside root production dependencies.
+    fs.symlinkSync(fs.realpathSync("node_modules"), path.join(root, "node_modules"), "dir");
+
+    const bundles = await build({
+      ...selected,
+      config: false,
+      entry: { [entryName]: "extensions/imap/index.ts" },
+      outDir: path.join(root, "dist"),
+      dts: false,
+      logLevel: "silent",
+    });
+    try {
+      const artifact = path.join(root, "dist", `${entryName}.js`);
+      const proofArtifact = path.join(root, "dist", `${entryName}-proof.js`);
+      const artifactSource = fs.readFileSync(artifact, "utf8");
+      const defaultExport = "export { imap_default as default };";
+      expect(artifactSource).toContain(defaultExport);
+      // Expose the parser binding from the actual plugin artifact; its bundled code is unchanged.
+      fs.writeFileSync(
+        proofArtifact,
+        artifactSource.replace(
+          defaultExport,
+          "export { imap_default as default, import_mailparser as __mailparser };",
+        ),
+      );
+      const script = `
+        import assert from "node:assert/strict";
+        import { pathToFileURL } from "node:url";
+        const [entry] = process.argv.slice(1);
+        const { __mailparser } = await import(pathToFileURL(entry).href);
+        const mail = await __mailparser.simpleParser(Buffer.from(
+          "From: sender@example.com\\r\\n" +
+          "To: recipient@example.com\\r\\n" +
+          "Subject: Bundled HTML\\r\\n" +
+          "Content-Type: text/html\\r\\n" +
+          "\\r\\n" +
+          "<p>Sheena&apos;s expert advice.</p>\\r\\n"
+        ), { skipImageLinks: true, skipTextToHtml: true });
+        assert.equal(mail.text?.trim(), "Sheena's expert advice.");
+        console.log("bundled IMAP parser decoded HTML entities");
+      `;
+      const result = await new Promise<{ error: Error | null; stdout: string; stderr: string }>(
+        (resolve) => {
+          execFile(
+            process.execPath,
+            ["--input-type=module", "-e", script, proofArtifact],
+            { cwd: root, timeout: 30_000 },
+            (error, stdout, stderr) => resolve({ error, stdout, stderr }),
+          );
+        },
+      );
+      expect(result.error, result.stderr).toBeNull();
+      expect(result.stdout.trim()).toBe("bundled IMAP parser decoded HTML entities");
+    } finally {
+      for (const bundle of bundles) {
+        await bundle[Symbol.asyncDispose]();
+      }
+    }
+  });
+
   it("builds retained config repairs without plugin runtime or state migration closures", async () => {
     const selected = configs.find((config) => config.outDir === "dist/config-doctor");
     expect(selected?.name).toBe(TSDOWN_UNIFIED_CONFIG_GROUP);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -353,6 +353,8 @@ function shouldNeverBundleDeclarationDependency(id: string): boolean {
 
 function shouldAlwaysBundleDependency(id: string): boolean {
   return (
+    // Keep htmlparser2's decoder version intact instead of binding it to the root major.
+    id === "entities/decode" ||
     id === "openclaw/plugin-sdk/ssrf-runtime-internal" ||
     id === "@openclaw/normalization-core" ||
     id.startsWith("@openclaw/normalization-core/") ||


### PR DESCRIPTION
Closes #142574

## What Problem This Solves
HTML-only mail containing `&apos;` can stop packaged IMAP delivery and leave later mail queued.

## Why This Change Was Made
The decision to bundle the parser's decoder has one owner: `shouldAlwaysBundleDependency` in `tsdown.config.ts`. It now retains `entities/decode` from the parser's compatible dependency. The watcher remains the sole cursor writer.

## User Impact
HTML and later mail dispatch in order without resetting mailbox state.

## Evidence
`pnpm build` passes on main and the candidate.
`node scripts/run-vitest.mjs run test/scripts/tsdown-config.test.ts -t 'packaged imap-watch'` fails on main and passes with this change.
The unchanged generated plugin connects to a local synthetic mailbox: main stops at message 3; the fix decodes the apostrophe, dispatches later mail, and reaches message 5. Restart dispatches no duplicates. No external account or recipient delivery is claimed.

## Compatibility
No dependency versions, configuration, sender policy, or stored data formats change.

## Consumers
Packaged IMAP uses its existing parser and sender checks.

## Invalidation
Rebuild the package; no mailbox reset is needed.

## Tests
57 build checks and 53 IMAP checks pass. Plain, multipart, denied-sender, ordering, cursor, and restart controls are retained.
The subprocess fixture uses a module-relative URL so dependency analysis follows the same file that the test executes.
