### PR TITLE
fix(models): disable Fast choices without a request mapping

### DIFF
--- a/extensions/minimax/provider-fast-mode.test.ts
+++ b/extensions/minimax/provider-fast-mode.test.ts
@@ -1,0 +1,27 @@
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it } from "vitest";
+import { resolveFastModeSupport } from "./provider-policy-api.js";
+
+const request: ProviderFastModePolicyContext = {
+  provider: "minimax",
+  modelId: "MiniMax-M2.7",
+  api: "anthropic-messages",
+  runtimeId: "openclaw",
+  requestCapabilities: { endpointClass: "custom", allowsAnthropicServiceTier: false },
+};
+
+describe("MiniMax selected Fast capability", () => {
+  it.each([
+    { change: {}, expected: true },
+    { change: { provider: "minimax-portal" }, expected: true },
+    { change: { modelId: "MiniMax-M2.5" }, expected: false },
+    { change: { modelId: "MiniMax-M2.7-highspeed" }, expected: false },
+    { change: { api: "openai-completions" }, expected: false },
+    { change: { provider: "anthropic" }, expected: false },
+    { change: { runtimeId: "codex" }, expected: undefined },
+    { change: { runtimeId: undefined }, expected: undefined },
+    { change: { api: undefined }, expected: undefined },
+  ])("resolves the request contract for $change", ({ change, expected }) => {
+    expect(resolveFastModeSupport({ ...request, ...change })).toBe(expected);
+  });
+});

--- a/extensions/minimax/provider-policy-api.ts
+++ b/extensions/minimax/provider-policy-api.ts
@@ -1,6 +1,18 @@
 // MiniMax policy module exposes static provider policy before runtime registration.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
+import { resolveMinimaxFastModelId } from "openclaw/plugin-sdk/provider-model-metadata";
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
 import { resolveMinimaxThinkingProfile } from "./thinking.js";
+
+export function resolveFastModeSupport(ctx: ProviderFastModePolicyContext): boolean | undefined {
+  if (!ctx.api || ctx.runtimeId !== "openclaw") {
+    return undefined;
+  }
+  return (
+    resolveMinimaxFastModelId({ id: ctx.modelId, provider: ctx.provider, api: ctx.api }) !==
+    undefined
+  );
+}
 
 export function resolveThinkingProfile(context: ProviderDefaultThinkingPolicyContext) {
   return resolveMinimaxThinkingProfile(context.modelId);

--- a/extensions/openai/provider-fast-mode.test.ts
+++ b/extensions/openai/provider-fast-mode.test.ts
@@ -1,0 +1,33 @@
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it } from "vitest";
+import { resolveFastModeSupport } from "./provider-policy-api.js";
+
+const request: ProviderFastModePolicyContext = {
+  provider: "openai",
+  modelId: "speed-fixture",
+  api: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  runtimeId: "openclaw",
+  requestCapabilities: { endpointClass: "openai-public", allowsAnthropicServiceTier: false },
+};
+
+describe("OpenAI selected Fast capability", () => {
+  it.each([
+    { change: {}, expected: true },
+    { change: { api: "openai-completions" }, expected: false },
+    { change: { baseUrl: "https://proxy.example/v1" }, expected: false },
+    { change: { api: "azure-openai-responses" }, expected: false },
+    { change: { params: { serviceTier: "flex" } }, expected: false },
+    { change: { params: { service_tier: " PRIORITY " } }, expected: false },
+    { change: { params: { serviceTier: "default" } }, expected: false },
+    { change: { params: { serviceTier: "auto" } }, expected: false },
+    { change: { params: { serviceTier: "invalid" } }, expected: true },
+    { change: { params: { serviceTier: 1 } }, expected: true },
+    { change: { runtimeId: "codex" }, expected: undefined },
+    { change: { runtimeId: undefined }, expected: undefined },
+    { change: { api: undefined }, expected: undefined },
+    { change: { baseUrl: undefined }, expected: undefined },
+  ])("resolves the request contract for $change", ({ change, expected }) => {
+    expect(resolveFastModeSupport({ ...request, ...change })).toBe(expected);
+  });
+});

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,8 +1,13 @@
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
 import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  normalizeOpenAIServiceTier,
+  supportsOpenAIResponsesFastMode,
+} from "openclaw/plugin-sdk/provider-model-metadata";
 import type {
   ModelApi,
   ModelProviderConfig,
+  ProviderFastModePolicyContext,
   ProviderModelRouteCandidate,
   ProviderModelRouteResolution,
   ProviderModelRouteSource,
@@ -27,6 +32,16 @@ import {
 } from "./model-route-contract.js";
 import { isOpenAIGptLiveModel, isSupportedOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 import { resolveUnifiedOpenAIThinkingProfile } from "./thinking-policy.js";
+
+export function resolveFastModeSupport(ctx: ProviderFastModePolicyContext): boolean | undefined {
+  if (!ctx.api || !ctx.baseUrl || ctx.runtimeId !== "openclaw") {
+    return undefined;
+  }
+  return (
+    normalizeOpenAIServiceTier(ctx.params?.serviceTier ?? ctx.params?.service_tier) === undefined &&
+    supportsOpenAIResponsesFastMode(ctx)
+  );
+}
 
 const OPENAI_RESPONSES_API = "openai-responses";
 const OPENAI_COMPLETIONS_API = "openai-completions";

--- a/extensions/xai/fast-mode.ts
+++ b/extensions/xai/fast-mode.ts
@@ -1,0 +1,19 @@
+import { isXaiProviderId } from "./provider-id.js";
+
+const XAI_FAST_MODEL_IDS = new Map<string, string>([
+  ["grok-3", "grok-3-fast"],
+  ["grok-3-mini", "grok-3-mini-fast"],
+  ["grok-4", "grok-4-fast"],
+  ["grok-4-0709", "grok-4-fast"],
+]);
+
+export function resolveXaiFastModelId(model: {
+  id: string;
+  provider: string;
+  api?: string;
+}): string | undefined {
+  return (model.api === "openai-completions" || model.api === "openai-responses") &&
+    isXaiProviderId(model.provider)
+    ? XAI_FAST_MODEL_IDS.get(model.id.trim())
+    : undefined;
+}

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -2,9 +2,20 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
+import { resolveXaiFastModelId } from "./fast-mode.js";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
 import { isXaiFrontierModelId, isXaiGrok46ModelId, normalizeXaiModelId } from "./model-id.js";
 import { isXaiProviderId } from "./provider-id.js";
+
+export function resolveFastModeSupport(ctx: ProviderFastModePolicyContext): boolean | undefined {
+  if (!ctx.api || ctx.runtimeId !== "openclaw") {
+    return undefined;
+  }
+  return (
+    resolveXaiFastModelId({ id: ctx.modelId, provider: ctx.provider, api: ctx.api }) !== undefined
+  );
+}
 
 export function resolveThinkingProfile(
   ctx: ProviderDefaultThinkingPolicyContext,

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -11,6 +11,7 @@ import {
 import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { XAI_BASE_URL } from "./model-definitions.js";
+import { resolveFastModeSupport } from "./provider-policy-api.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 import { wrapXaiProviderStream } from "./stream.js";
 import {
@@ -122,6 +123,25 @@ function runXaiToolPayloadWrapper(params: {
     {},
   );
 }
+
+it.each([
+  { modelId: "grok-3", target: "grok-3-fast", supported: true },
+  { modelId: "grok-4-0709", target: "grok-4-fast", supported: true },
+  { modelId: "grok-4.3", target: "grok-4.3", supported: false },
+  { modelId: "grok-3-fast", target: "grok-3-fast", supported: false },
+])("publishes the actual Fast mapping for $modelId", ({ modelId, target, supported }) => {
+  expect(
+    resolveFastModeSupport({
+      modelId,
+      provider: "xai",
+      api: "openai-responses",
+      runtimeId: "openclaw",
+      requestCapabilities: { endpointClass: "xai-native", allowsAnthropicServiceTier: false },
+    }),
+  ).toBe(supported);
+  expect(captureWrappedModelId({ modelId, fastMode: true })).toBe(target);
+  expect(captureWrappedModelId({ modelId, fastMode: false })).toBe(modelId);
+});
 
 async function captureXaiResponsesPayloadWithThinking(
   reasoning: ModelThinkingLevel = "low",

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -9,16 +9,11 @@ import {
   createToolStreamWrapper,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { asOptionalRecord, filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveXaiFastModelId } from "./fast-mode.js";
 import { XAI_BASE_URL } from "./model-definitions.js";
 import { isXaiGrokProxyBaseUrl } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 
-const XAI_FAST_MODEL_IDS = new Map<string, string>([
-  ["grok-3", "grok-3-fast"],
-  ["grok-3-mini", "grok-3-mini-fast"],
-  ["grok-4", "grok-4-fast"],
-  ["grok-4-0709", "grok-4-fast"],
-]);
 type DynamicFastMode = boolean | (() => boolean | undefined);
 
 function isXaiEndpoint(model: Parameters<StreamFn>[0], endpoint: string): boolean {
@@ -50,13 +45,6 @@ function createXaiGrokOAuthHeadersWrapper(
       headers: Object.fromEntries(headers.entries()),
     });
   };
-}
-
-function resolveXaiFastModelId(modelId: unknown): string | undefined {
-  if (typeof modelId !== "string") {
-    return undefined;
-  }
-  return XAI_FAST_MODEL_IDS.get(modelId.trim());
 }
 
 function supportsReasoningControls(model: { compat?: unknown; reasoning?: unknown }): boolean {
@@ -239,17 +227,11 @@ function createXaiFastModeWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    const supportsFastAliasTransport =
-      model.api === "openai-completions" || model.api === "openai-responses";
-    if (
-      (typeof fastMode === "function" ? fastMode() : fastMode) !== true ||
-      !supportsFastAliasTransport ||
-      !isXaiProviderId(model.provider)
-    ) {
+    if ((typeof fastMode === "function" ? fastMode() : fastMode) !== true) {
       return underlying(model, context, options);
     }
 
-    const fastModelId = resolveXaiFastModelId(model.id);
+    const fastModelId = resolveXaiFastModelId(model);
     if (!fastModelId) {
       return underlying(model, context, options);
     }

--- a/packages/ai/src/internal/openai-responses-payload-policy.ts
+++ b/packages/ai/src/internal/openai-responses-payload-policy.ts
@@ -3,4 +3,7 @@ export {
   readOpenAIResponsesCompactionWindow,
   type OpenAIResponsesCompactionOutput,
 } from "../transports/openai-responses-compaction-window.js";
-export { resolveOpenAIResponsesServerCompactionPlan } from "../transports/openai-responses-payload-policy.js";
+export {
+  resolveOpenAIResponsesPayloadPolicy,
+  resolveOpenAIResponsesServerCompactionPlan,
+} from "../transports/openai-responses-payload-policy.js";

--- a/src/agents/model-fast-mode.test.ts
+++ b/src/agents/model-fast-mode.test.ts
@@ -31,6 +31,48 @@ function resolver(cfg: OpenClawConfig = {}) {
   });
 }
 describe("private selected Fast metadata", () => {
+  it("uses each selected model's policy and effective agent parameters", () => {
+    const catalog: ModelCatalogEntry[] = [
+      {
+        id: "speed-fixture",
+        name: "Speed fixture",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      },
+      { id: "grok-3", name: "Grok 3", provider: "xai", api: "openai-responses" },
+      { id: "MiniMax-M2.7", name: "MiniMax M2.7", provider: "minimax", api: "anthropic-messages" },
+    ];
+    const resolve = createModelFastModeResolver({
+      cfg: {
+        agents: {
+          entries: {
+            main: { models: { "openai/speed-fixture": { params: { serviceTier: "flex" } } } },
+          },
+        },
+      },
+      agentId: "main",
+      catalog,
+      metadataSnapshot: createPluginMetadataSnapshotFixture({
+        plugins: ["openai", "xai", "minimax"].map((id) => ({
+          id,
+          providers: [id],
+          rootDir: path.resolve(import.meta.dirname, "../../extensions", id),
+        })),
+      }),
+    });
+    const evaluation = { availability: true, routeResolution: null, selectedAuthMode: "api_key" };
+    expect(catalog.map((entry) => resolve(entry, evaluation, "openclaw"))).toEqual([
+      false,
+      true,
+      true,
+    ]);
+    expect(catalog.map((entry) => resolve(entry, evaluation, "codex"))).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
   it("loads the provider's light policy for the exact model and auth facts", () => {
     const resolve = resolver();
     expect(

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -1072,6 +1072,7 @@ describe("models.list", () => {
                 source: "implicit",
               },
               available: false,
+              supportsFastMode: false,
               unavailableReason: "missing-auth",
               tags: ["default"],
             },

--- a/src/llm/providers/minimax-fast-mode.ts
+++ b/src/llm/providers/minimax-fast-mode.ts
@@ -1,0 +1,14 @@
+const MINIMAX_FAST_MODEL_IDS = new Map<string, string>([
+  ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+]);
+
+export function resolveMinimaxFastModelId(model: {
+  id: string;
+  api?: string;
+  provider: string;
+}): string | undefined {
+  return model.api === "anthropic-messages" &&
+    (model.provider === "minimax" || model.provider === "minimax-portal")
+    ? MINIMAX_FAST_MODEL_IDS.get(model.id.trim())
+    : undefined;
+}

--- a/src/llm/providers/openai-fast-mode.ts
+++ b/src/llm/providers/openai-fast-mode.ts
@@ -1,0 +1,28 @@
+import { resolveOpenAIResponsesPayloadPolicy } from "@openclaw/ai/internal/openai-responses-payload-policy";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+
+export type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
+
+export function normalizeOpenAIServiceTier(value: unknown): OpenAIServiceTier | undefined {
+  const normalized = normalizeOptionalLowercaseString(value);
+  return normalized === "auto" ||
+    normalized === "default" ||
+    normalized === "flex" ||
+    normalized === "priority"
+    ? normalized
+    : undefined;
+}
+
+export function supportsOpenAIResponsesFastMode(model: {
+  provider: string;
+  api?: string;
+  baseUrl?: string;
+}): boolean {
+  return (
+    model.provider === "openai" &&
+    (model.api === "openai-responses" ||
+      model.api === "openai-chatgpt-responses" ||
+      model.api === "azure-openai-responses") &&
+    resolveOpenAIResponsesPayloadPolicy(model, { storeMode: "disable" }).allowsServiceTier
+  );
+}

--- a/src/llm/providers/stream-wrappers/minimax.ts
+++ b/src/llm/providers/stream-wrappers/minimax.ts
@@ -1,18 +1,9 @@
 import type { StreamFn } from "../../../agents/runtime/index.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import { streamSimple } from "../../stream.js";
+import { resolveMinimaxFastModelId } from "../minimax-fast-mode.js";
 
-const MINIMAX_FAST_MODEL_IDS = new Map<string, string>([
-  ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
-]);
 type DynamicFastMode = boolean | (() => boolean | undefined);
-
-function resolveMinimaxFastModelId(modelId: unknown): string | undefined {
-  if (typeof modelId !== "string") {
-    return undefined;
-  }
-  return MINIMAX_FAST_MODEL_IDS.get(modelId.trim());
-}
 
 function isMinimaxAnthropicMessagesModel(model: { api?: unknown; provider?: unknown }): boolean {
   return (
@@ -69,15 +60,11 @@ export function createMinimaxFastModeWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (
-      (typeof fastMode === "function" ? fastMode() : fastMode) !== true ||
-      model.api !== "anthropic-messages" ||
-      (model.provider !== "minimax" && model.provider !== "minimax-portal")
-    ) {
+    if ((typeof fastMode === "function" ? fastMode() : fastMode) !== true) {
       return underlying(model, context, options);
     }
 
-    const fastModelId = resolveMinimaxFastModelId(model.id);
+    const fastModelId = resolveMinimaxFastModelId(model);
     if (!fastModelId) {
       return underlying(model, context, options);
     }

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -45,12 +45,16 @@ import {
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { streamSimple } from "../../stream.js";
 import type { SimpleStreamOptions } from "../../types.js";
+import {
+  normalizeOpenAIServiceTier,
+  supportsOpenAIResponsesFastMode,
+  type OpenAIServiceTier,
+} from "../openai-fast-mode.js";
 import { mapThinkingLevelToReasoningEffort } from "./reasoning-effort-utils.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 const log = createSubsystemLogger("llm/providers/stream-wrappers");
 
-type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
 type DynamicFastMode = boolean | (() => boolean | undefined);
 type OpenClawSimpleStreamOptions = SimpleStreamOptions & {
   openclawCodeModeToolSurface?: boolean;
@@ -282,22 +286,6 @@ function raiseMinimalReasoningForResponsesWebSearchPayload(params: {
   }
 }
 
-function normalizeOpenAIServiceTier(value: unknown): OpenAIServiceTier | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = normalizeOptionalLowercaseString(value);
-  if (
-    normalized === "auto" ||
-    normalized === "default" ||
-    normalized === "flex" ||
-    normalized === "priority"
-  ) {
-    return normalized;
-  }
-  return undefined;
-}
-
 /** @deprecated OpenAI provider-owned stream helper; do not use from third-party plugins. */
 export function resolveOpenAIServiceTier(
   extraParams: Record<string, unknown> | undefined,
@@ -512,13 +500,7 @@ export function createOpenAIFastModeWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (
-      normalizeOpenAIFastMode(enabled) !== true ||
-      (model.api !== "openai-responses" &&
-        model.api !== "openai-chatgpt-responses" &&
-        model.api !== "azure-openai-responses") ||
-      model.provider !== "openai"
-    ) {
+    if (normalizeOpenAIFastMode(enabled) !== true || !supportsOpenAIResponsesFastMode(model)) {
       return underlying(model, context, options);
     }
     const originalOnPayload = options?.onPayload;

--- a/src/plugin-sdk/provider-model-metadata.ts
+++ b/src/plugin-sdk/provider-model-metadata.ts
@@ -1,6 +1,11 @@
 /** Model descriptors and prompt metadata without runtime discovery or credential policy. */
 export { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 export { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+export { resolveMinimaxFastModelId } from "../llm/providers/minimax-fast-mode.js";
+export {
+  normalizeOpenAIServiceTier,
+  supportsOpenAIResponsesFastMode,
+} from "../llm/providers/openai-fast-mode.js";
 export {
   isGpt5ModelId,
   resolveGpt5PromptOverlayMode,


### PR DESCRIPTION
Related: #136257, #141852, #107378.

## What Problem This Solves

Fixes an issue where users could enable Fast for a request whose model had no Fast mapping or whose explicit service tier already controlled the request.

## Why This Change Was Made

Provider capability metadata now shares alias and service-tier rules with request construction. The selected-model capability carries that result to controls while preserving explicit-tier precedence, unknown native support and saved-preference clearing.

## User Impact

Known ineffective Fast choices are disabled; supported mappings remain available. Typed fast commands can still set or clear preferences. Capability describes request mapping, not speed, price or entitlement.

Consumers: selected-model Fast controls use request-specific support.

## Evidence

A compiled Gateway and authenticated client verified six supported/unsupported metadata cases. Forty-three focused checks passed, including aliases, selected parameters and tier precedence. These checks establish metadata and request mapping; browser clicks and external inference were not tested.
