### PR TITLE
fix(release): derive frozen target harness contracts

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1606,6 +1606,8 @@ jobs:
             OPENCLAW_SKIP_DOCKER_BUILD=0 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" bash .release-harness/scripts/test-live-build-docker.sh
           fi
 
+          source .release-harness/scripts/lib/frozen-target-compat.sh
+          openclaw_resolve_frozen_update_channel_dry_run_mode "$GITHUB_WORKSPACE"
           node .release-harness/scripts/test-docker-all.mjs
 
       - name: Summarize Docker E2E chunk
@@ -1994,6 +1996,8 @@ jobs:
           fi
           export OPENCLAW_DOCKER_ALL_BUILD=0
 
+          source .release-harness/scripts/lib/frozen-target-compat.sh
+          openclaw_resolve_frozen_update_channel_dry_run_mode "$GITHUB_WORKSPACE"
           node .release-harness/scripts/test-docker-all.mjs
 
       - name: Summarize targeted Docker E2E lanes

--- a/scripts/e2e/agent-bundle-mcp-tools-docker.sh
+++ b/scripts/e2e/agent-bundle-mcp-tools-docker.sh
@@ -29,7 +29,7 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 agent-bundle-m
 CLIENT_PATH="test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
 CLIENT_MOUNT_ARGS=()
 if [ "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" = "legacy" ]; then
-  # The selected release's client imports a trusted E2E helper and ../../../../dist.
+  # The selected release's client imports a trusted E2E helper and ../../dist.
   # Materialize its committed source tree outside the trusted read-only harness.
   LEGACY_CLIENT_SOURCE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-frozen-agent-bundle-mcp-tools.XXXXXX")"
   # Preserve its root package.json so tsx retains the selected release's ESM scope,
@@ -37,10 +37,10 @@ if [ "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" = "legacy" ]; then
   git -C "$SOURCE_ROOT" archive "$OPENCLAW_SELECTED_SHA" -- \
     package.json \
     scripts/e2e/lib/temp-state-dir.ts \
-    test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts |
+    scripts/e2e/agent-bundle-mcp-tools-docker-client.ts |
     tar -x -C "$LEGACY_CLIENT_SOURCE_ROOT"
   LEGACY_CLIENT_ROOT="/tmp/openclaw-frozen-agent-bundle-mcp-tools"
-  CLIENT_PATH="$LEGACY_CLIENT_ROOT/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
+  CLIENT_PATH="$LEGACY_CLIENT_ROOT/scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"
   ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"
   ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"
   # The functional image runs as UID 1001 and must traverse this host-owned staging root.

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -11,14 +11,6 @@ export function legacyPackageAcceptanceCompat(version) {
   );
 }
 
-export function updateChannelDryRunReportsPackageCompat(version) {
-  const match = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:[-+].*)?/.exec(version || "");
-  const [year, month, day] = match?.slice(1, 4).map(Number) ?? [];
-  return (
-    Boolean(match) && (year < 2026 || (year === 2026 && (month < 7 || (month === 7 && day <= 33))))
-  );
-}
-
 // Candidates on either side of consent enforcement can share a package version.
 // Only successful command help establishes support; callers own probe failures.
 export function fixtureCapabilityConsentArgs(help) {
@@ -31,12 +23,8 @@ if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   console.log(
     process.argv[2] === "fixture-consent"
       ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
-      : process.argv[2] === "update-channel-dry-run"
-        ? updateChannelDryRunReportsPackageCompat(process.argv[3])
-          ? "1"
-          : "0"
-        : legacyPackageAcceptanceCompat(process.argv[2])
-          ? "1"
-          : "0",
+      : legacyPackageAcceptanceCompat(process.argv[2])
+        ? "1"
+        : "0",
   );
 }

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -37,6 +37,7 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_SKIP_CHANNELS=1 \
   -e OPENCLAW_SKIP_PROVIDERS=1 \
   -e OPENCLAW_FS_SAFE_NATIVE_CONTRACT \
+  -e OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "$IMAGE_NAME" \
@@ -107,9 +108,7 @@ OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
   node scripts/e2e/lib/package-compat.mjs "$package_version"
 )"
 export OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT
-OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="$(
-  node scripts/e2e/lib/package-compat.mjs update-channel-dry-run "$package_version"
-)"
+OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="${OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT:-0}"
 export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT
 command -v openclaw >/dev/null
 openclaw_e2e_enable_openclaw_cli_timeout

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -107,6 +107,26 @@ openclaw_resolve_frozen_live_cli_backend_package_mode() {
   fi
 }
 
+openclaw_resolve_frozen_update_channel_dry_run_mode() {
+  local source_root="${1:?missing selected source root}" authorization_status=0
+
+  export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="0"
+  openclaw_prepare_frozen_target_context "$source_root" || authorization_status=$?
+  [ "$authorization_status" -eq 1 ] && return 0
+  [ "$authorization_status" -eq 0 ] || return "$authorization_status"
+
+  # The old CLI routed only an explicit dev request to Git. Recognize that
+  # exact historical owner shape; backports and unknown future shapes stay strict.
+  if openclaw_frozen_target_source_contains \
+    "$source_root" src/cli/update-cli/update-command.ts \
+    'const switchToGit = requestedChannel === "dev" && installKind !== "git";' &&
+    ! openclaw_frozen_target_source_contains \
+      "$source_root" src/cli/update-cli/update-command.ts \
+      'selectedChannel === "dev" && explicitTag === null'; then
+    export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="1"
+  fi
+}
+
 openclaw_resolve_frozen_plugin_harness_capabilities() {
   local source_root="${1:?missing selected source root}" authorization_status=0
 
@@ -214,7 +234,7 @@ openclaw_resolve_frozen_core_harness_capabilities() {
   # new dist entry the release cannot contain.
   if ! git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-manager-api.ts" 2>/dev/null &&
     git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-runtime.ts" 2>/dev/null &&
-    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts" 2>/dev/null; then
+    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:scripts/e2e/agent-bundle-mcp-tools-docker-client.ts" 2>/dev/null; then
     export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="legacy"
   fi
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6541,8 +6541,8 @@ process.exit(73);
 
     expectTextToIncludeAll(runner, [
       "scripts/e2e/lib/temp-state-dir.ts \\",
-      "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts |",
-      'CLIENT_PATH="$LEGACY_CLIENT_ROOT/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"',
+      "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts |",
+      'CLIENT_PATH="$LEGACY_CLIENT_ROOT/scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"',
       'ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"',
       'ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"',
       '-v "$LEGACY_CLIENT_SOURCE_ROOT:$LEGACY_CLIENT_ROOT:ro"',

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -438,6 +438,61 @@ export function parseRegistryNpmSpec(spec: string) {
     expect(result.status, result.stderr).toBe(0);
   });
 
+  it("derives stored-dev preview compatibility from the selected source", () => {
+    const root = tempDirs.make("openclaw-frozen-update-channel-");
+    const sourcePath = path.join(root, "src/cli/update-cli/update-command.ts");
+    mkdirSync(path.dirname(sourcePath), { recursive: true });
+    writeFileSync(
+      sourcePath,
+      'const switchToGit = requestedChannel === "dev" && installKind !== "git";\n',
+    );
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    execFileSync("git", ["config", "user.email", "test@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-qm", "legacy"], { cwd: root });
+    const legacySha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    writeFileSync(
+      sourcePath,
+      'const switchToGit = installKind !== "git" &&\n  (requestedChannel === "dev" || (selectedChannel === "dev" && explicitTag === null));\n',
+    );
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-qm", "current"], { cwd: root });
+    const currentSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    const run = (selectedSha: string, authorized = true) => {
+      execFileSync("git", ["checkout", "-q", selectedSha], { cwd: root });
+      return spawnSync(
+        "bash",
+        [
+          "-c",
+          'set -euo pipefail; source "$1"; openclaw_resolve_frozen_update_channel_dry_run_mode "$2"; printf "%s\\n" "$OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT"',
+          "test",
+          stageScriptPath,
+          root,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: authorized ? "1" : "0",
+            OPENCLAW_SELECTED_SHA: selectedSha,
+            OPENCLAW_TOOLING_SHA: "f".repeat(40),
+          },
+        },
+      );
+    };
+
+    expect(run(legacySha).stdout).toBe("1\n");
+    expect(run(currentSha).stdout).toBe("0\n");
+    expect(run(legacySha, false).stdout).toBe("0\n");
+  });
+
   it("derives frozen harness capabilities only from an authorized selected source", () => {
     const root = tempDirs.make("openclaw-frozen-target-core-dialects-");
     mkdirSync(path.join(root, "src/agents"), { recursive: true });
@@ -445,14 +500,14 @@ export function parseRegistryNpmSpec(spec: string) {
     mkdirSync(path.join(root, "src/commands"), { recursive: true });
     mkdirSync(path.join(root, "scripts"), { recursive: true });
     mkdirSync(path.join(root, "src/config"), { recursive: true });
-    mkdirSync(path.join(root, "test/e2e/qa-lab/runtime"), { recursive: true });
+    mkdirSync(path.join(root, "scripts/e2e"), { recursive: true });
     writeFileSync(
       path.join(root, "src/agents/code-mode-namespaces.ts"),
       'export const globals = ["ALL_TOOLS"];\n',
     );
     writeFileSync(path.join(root, "src/agents/agent-bundle-mcp-runtime.ts"), "export {};\n");
     writeFileSync(
-      path.join(root, "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"),
+      path.join(root, "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"),
       "export {};\n",
     );
     writeFileSync(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6152,6 +6152,7 @@ describe("package artifact reuse", () => {
         step.run?.includes("export OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR="),
       );
       expect(runStep).toBeDefined();
+      expect(runStep?.run).toContain("openclaw_resolve_frozen_update_channel_dry_run_mode");
       expect(`${runStep?.run}\n${JSON.stringify(runStep?.env)}`).toContain(
         "steps.plan.outputs.needs_package",
       );

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -2,10 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  fixtureCapabilityConsentArgs,
-  updateChannelDryRunReportsPackageCompat,
-} from "../../scripts/e2e/lib/package-compat.mjs";
+import { fixtureCapabilityConsentArgs } from "../../scripts/e2e/lib/package-compat.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -359,13 +356,5 @@ ${fixtureCommand} plugins install fixture`,
     });
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(output);
-  });
-
-  it.each([
-    ["2026.7.33", true],
-    ["2026.7.33-1", true],
-    ["2026.8.1", false],
-  ])("scopes package-reported dev dry runs for %s", (version, expected) => {
-    expect(updateChannelDryRunReportsPackageCompat(version)).toBe(expected);
   });
 });

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -59,6 +59,14 @@ it("keeps explicit dev selection for frozen stored-dev package reporters", () =>
   );
 });
 
+it("preserves a source-derived dry-run mode supplied by the workflow", () => {
+  const script = readFileSync("scripts/e2e/update-channel-switch-docker.sh", "utf8");
+  expect(script).toContain(
+    'OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="${OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT:-0}"',
+  );
+  expect(script).toContain("-e OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT \\");
+});
+
 it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);


### PR DESCRIPTION
## Summary

- replace the frozen update-preview version cutoff with selected-source capability resolution
- recognize the shipped bundle-MCP client at its historical scripts/e2e path
- keep current, unauthorized, unknown, and future targets on strict current assertions

## Root cause

Full Release Validation [34288884747](https://github.com/openclaw/openclaw/actions/runs/34288884747) exposed two trusted-harness classification defects:

1. #142573 classified every 2026.6.35 package as pre-routing-fix. This candidate already contains the stored-dev-to-Git backport, so it correctly reported updateInstallKind git while the version-based harness expected package.
2. The bundle-MCP resolver looked for the historical client under its current test/e2e path. The candidate ships it under scripts/e2e, so the harness selected its current client and imported a manager API absent from the frozen package.

The candidate product behavior is correct in both cases; these belong to the trusted harness, not candidate backports.

## Validation

- original update-channel failures: actual git, expected package; plugins-offline sibling passed
- original core failure: current client imported absent dist/agents/agent-bundle-mcp-manager-api.js
- exact candidate c283867d7cdd resolves update strict/current (0) and bundle MCP legacy
- focused update/workflow tests passed before the follow-up; the bundle-path regression is covered by the existing core capability fixture
- bash syntax, Actionlint, Oxfmt, OXLint, and git diff check pass

Application runtime delta: 0. The follow-up replaces one incorrect path and its fixture path without production growth.