### PR TITLE
test(live): avoid secret-shaped MiniMax tool probes

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -5704,13 +5704,15 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
 
     const workspaceDir = path.join(tempStateDir, "workspace-dev");
     await prepareLiveGatewayWorkspace(workspaceDir);
-    const nonceA = randomUUID();
-    const nonceB = randomUUID();
+    // Prefix the random values so provider safety heuristics do not mistake the
+    // harmless readback proof for secret material.
+    const nonceA = `tool-read-alpha-${randomUUID()}`;
+    const nonceB = `tool-read-beta-${randomUUID()}`;
     // Keep probe values out of the path: weak tool callers may echo the filename
     // instead of reading the file, turning nonceA into a false duplicate answer.
     const toolProbePath = path.join(workspaceDir, ".openclaw-live-tool-probe.txt");
     cleanupToolProbePath = toolProbePath;
-    await fs.writeFile(toolProbePath, `nonceA=${nonceA}\nnonceB=${nonceB}\n`);
+    await fs.writeFile(toolProbePath, `testMarkerA=${nonceA}\ntestMarkerB=${nonceB}\n`);
 
     const sanitizedCfg: OpenClawConfig = {
       ...params.cfg,
@@ -5980,7 +5982,8 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 });
               }
 
-              // Real tool invocation: force the agent to Read a local file and echo a nonce.
+              // Real tool invocation: force the agent to read a local file and
+              // return two harmless, uniquely generated test markers.
               phase = "tool-read";
               logProgress(`${progressLabel}: tool-read`);
               const runIdTool = randomUUID();
@@ -6004,10 +6007,10 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                     message: strictReply
                       ? "OpenClaw live tool probe (local, safe): " +
                         `use the tool named \`read\` (or \`Read\`) with JSON arguments {"path":"${toolProbePath}"}. ` +
-                        "Then reply with exactly the two nonce values from that file, separated by one space. No extra text."
+                        "Then reply with exactly the two test marker values from that file, separated by one space. No extra text."
                       : "OpenClaw live tool probe (local, safe): " +
                         `use the tool named \`read\` (or \`Read\`) with JSON arguments {"path":"${toolProbePath}"}. ` +
-                        "Then reply with the two nonce values you read (include both).",
+                        "Then reply with the two test marker values you read (include both).",
                     thinkingLevel,
                     context: `${progressLabel}: tool-read`,
                   });

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -6246,7 +6246,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   sessionKey,
                   idempotencyKey: `idem-${runId2}-2`,
                   modelKey,
-                  message: `Now answer: what are the values of nonceA and nonceB in "${toolProbePath}"? Reply with exactly: ${nonceA} ${nonceB}.`,
+                  message: `Now answer: what are the values of testMarkerA and testMarkerB in "${toolProbePath}"? Reply with exactly: ${nonceA} ${nonceB}.`,
                   thinkingLevel,
                   context: `${progressLabel}: tool-only-regression-second`,
                 });

--- a/src/gateway/live-tool-probe-utils.test.ts
+++ b/src/gateway/live-tool-probe-utils.test.ts
@@ -225,9 +225,9 @@ describe("live tool probe utils", () => {
         expected: false,
       },
       {
-        name: "retries mistral nonce marker echoes without parsed values",
+        name: "retries mistral marker echoes without parsed values",
         params: {
-          text: "nonceA= nonceB=",
+          text: "testMarkerA= testMarkerB=",
           nonceA: "nonce-a",
           nonceB: "nonce-b",
           provider: "mistral",

--- a/src/gateway/live-tool-probe.test-helpers.ts
+++ b/src/gateway/live-tool-probe.test-helpers.ts
@@ -114,7 +114,13 @@ export function shouldRetryToolReadProbe(params: {
     return true;
   }
   const lower = normalizeLowercaseStringOrEmpty(params.text);
-  if (params.provider === "mistral" && (lower.includes("noncea=") || lower.includes("nonceb="))) {
+  if (
+    params.provider === "mistral" &&
+    (lower.includes("noncea=") ||
+      lower.includes("nonceb=") ||
+      lower.includes("testmarkera=") ||
+      lower.includes("testmarkerb="))
+  ) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

- keep the gateway live tool-read proof unique and fail-closed
- present generated values as harmless test markers instead of secret-like nonce material
- retain the exact two-value readback assertion and retry budget

## Root cause

MiniMax M3 used the read tool successfully, then refused all three requests to repeat values described as nonces. Both selected MiniMax models consequently skipped and the stable live profile completed with zero successful models.

## Validation

- gateway live test file: 174 passed, 2 skipped
- Oxfmt and `git diff --check`

This addresses the MiniMax live-profile failure in Full Validation run 34287144233 / child run 34287196590.
