### PR TITLE
fix(release): keep frozen Git admission explicit

### DIFF
--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -197,7 +197,12 @@ if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]; then
   assert_package_dry_run git dev explicit --channel dev --tag beta
   assert_package_dry_run package dev stored --tag beta
   assert_package_dry_run package stable explicit --channel stable
-  dev_channel_args=()
+  # 7.33 reports a stored dev channel as a package update even though an
+  # explicit --channel dev selects Git. Keep the explicit selector for the
+  # destructive admission and actual switch probes on that frozen contract.
+  if [ "$OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT" != "1" ]; then
+    dev_channel_args=()
+  fi
 fi
 
 echo "==> ordinary untracked files still block Git admission"

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -52,6 +52,13 @@ it("projects only stored-dev frozen previews onto package reporting", () => {
   expect(run("explicit", "package").status).toBe(1);
 });
 
+it("keeps explicit dev selection for frozen stored-dev package reporters", () => {
+  const script = readFileSync("scripts/e2e/update-channel-switch-docker.sh", "utf8");
+  expect(script).toContain(
+    'if [ "$OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT" != "1" ]; then\n    dev_channel_args=()',
+  );
+});
+
 it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);


### PR DESCRIPTION
## Summary

- preserve explicit `--channel dev` for frozen candidates whose stored dev preview reports package mode
- continue proving ordinary untracked files block the actual Git admission path
- continue performing the real package-to-Git switch instead of skipping the contract

## Root cause

2026.7.33 reports only the stored dev route as a package update; an explicit dev selection still chooses Git. The prior compatibility projection corrected the dry-run assertion but then cleared the explicit selector, so the dirty-worktree probe accidentally exercised a package refresh and compared it to a Git rejection.

## Validation

- update-channel fixture suite: 5 passed
- shell syntax, Oxfmt, `git diff --check`

This addresses the duplicated update-channel failures in Full Validation run 34287144233.
