### PR TITLE
fix(release): source-qualify settled Telegram recovery

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -343,6 +343,7 @@ jobs:
           sparse-checkout: |
             extensions/telegram/src/bot-message-dispatch.ts
             extensions/telegram/src/draft-stream.ts
+            qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
             src/agents/embedded-agent-subscribe.ts
 
       - name: Resolve frozen package Telegram scenarios

--- a/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
+++ b/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
@@ -3,7 +3,8 @@ import { appendFileSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-const CURRENT_ONLY_SCENARIO = "telegram-partial-failure-recovery";
+const PARTIAL_FAILURE_RECOVERY_SCENARIO = "telegram-partial-failure-recovery";
+const SETTLED_EMPTY_RESPONSE_SCENARIO = "telegram-empty-response-after-write-recovery";
 
 function readSource(sourceRoot: string, relativePath: string): string | undefined {
   try {
@@ -26,6 +27,22 @@ export function isPrePartialFailureRecoveryTarget(sourceRoot: string): boolean {
   );
 }
 
+export function isPreSettledEmptyResponseTarget(sourceRoot: string): boolean {
+  return (
+    readSource(
+      sourceRoot,
+      "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
+    ) === undefined
+  );
+}
+
+export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): string[] {
+  return [
+    ...(isPrePartialFailureRecoveryTarget(sourceRoot) ? [PARTIAL_FAILURE_RECOVERY_SCENARIO] : []),
+    ...(isPreSettledEmptyResponseTarget(sourceRoot) ? [SETTLED_EMPTY_RESPONSE_SCENARIO] : []),
+  ];
+}
+
 function main(): void {
   const sourceRoot = process.argv[2];
   const selectedSha = process.env.OPENCLAW_SELECTED_SHA;
@@ -39,10 +56,11 @@ function main(): void {
   if (actualSha !== selectedSha) {
     throw new Error("frozen Telegram source checkout does not match package source SHA");
   }
-  if (isPrePartialFailureRecoveryTarget(sourceRoot)) {
+  const omittedScenarios = resolveFrozenTelegramScenarioOmissions(sourceRoot);
+  if (omittedScenarios.length > 0) {
     appendFileSync(
       output,
-      `OPENCLAW_NPM_TELEGRAM_OMIT_DEFAULT_SCENARIOS=${CURRENT_ONLY_SCENARIO}\n`,
+      `OPENCLAW_NPM_TELEGRAM_OMIT_DEFAULT_SCENARIOS=${omittedScenarios.join(",")}\n`,
     );
   }
 }

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { isPrePartialFailureRecoveryTarget } from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
+import {
+  isPrePartialFailureRecoveryTarget,
+  isPreSettledEmptyResponseTarget,
+  resolveFrozenTelegramScenarioOmissions,
+} from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
 import { testing } from "../../scripts/e2e/npm-telegram-live-runner.ts";
 import { privateLocalOnlyPluginSdkEntrypoints } from "../../scripts/lib/plugin-sdk-entries.mts";
 
@@ -428,6 +432,48 @@ describe("package Telegram live Docker E2E", () => {
     expect(isPrePartialFailureRecoveryTarget(root)).toBe(true);
     writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
     expect(isPrePartialFailureRecoveryTarget(root)).toBe(false);
+  });
+
+  it("omits settled empty-response recovery until the frozen source owns its scenario", () => {
+    const root = mkTempRoot();
+    const scenario = path.join(
+      root,
+      "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
+    );
+
+    expect(isPreSettledEmptyResponseTarget(root)).toBe(true);
+    mkdirSync(path.dirname(scenario), { recursive: true });
+    writeFileSync(scenario, "id: telegram-empty-response-after-write-recovery\n");
+    expect(isPreSettledEmptyResponseTarget(root)).toBe(false);
+  });
+
+  it("combines only the unsupported frozen Telegram scenario contracts", () => {
+    const root = mkTempRoot();
+    const writeOwner = (relativePath: string, source: string) => {
+      const file = path.join(root, relativePath);
+      mkdirSync(path.dirname(file), { recursive: true });
+      writeFileSync(file, source);
+    };
+    writeOwner("src/agents/embedded-agent-subscribe.ts", "void params.onPartialReply(data);");
+    writeOwner("extensions/telegram/src/draft-stream.ts", "flush: loop.flush,");
+    writeOwner(
+      "extensions/telegram/src/bot-message-dispatch.ts",
+      "enqueueDraftLaneEvent(async () => {});",
+    );
+
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-partial-failure-recovery",
+      "telegram-empty-response-after-write-recovery",
+    ]);
+    writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-empty-response-after-write-recovery",
+    ]);
+    writeOwner(
+      "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
+      "id: telegram-empty-response-after-write-recovery\n",
+    );
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([]);
   });
 
   it("rejects multiple explicit RTT scenario ids", () => {


### PR DESCRIPTION
## Summary

- source-qualify the settled empty-response Telegram scenario for frozen candidates
- omit it from default package QA only when the frozen source does not own the scenario contract
- preserve explicit scenario selection and all supported default Telegram coverage

## Root cause

`telegram-empty-response-after-write-recovery` and its settled post-tool continuation behavior landed after the 2026.7.33 branch. Current private QA selected that scenario by default against the frozen package, which correctly surfaced its older incomplete-turn behavior after the write rather than replaying a side effect.

## Validation

- package Telegram/workflow suites: 469 passed
- focused Telegram suite after final aggregation test: 51 passed
- actual 7.33 source resolves exactly the partial-failure and settled-empty-response omissions
- Oxfmt and `git diff --check`

This addresses the package Telegram failure in Full Validation run 34287144233.
