### PR TITLE
refactor(tests): share scoped Discord action expectations

### DIFF
--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -4,6 +4,44 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { withEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 
+function expectedScopedDiscordActionsWithoutPolls(): string[] {
+  return [
+    "send",
+    "react",
+    "reactions",
+    "emoji-list",
+    "upload-file",
+    "read",
+    "edit",
+    "delete",
+    "pin",
+    "unpin",
+    "list-pins",
+    "permissions",
+    "thread-create",
+    "thread-list",
+    "thread-reply",
+    "search",
+    "sticker",
+    "member-info",
+    "role-info",
+    "emoji-upload",
+    "sticker-upload",
+    "channel-info",
+    "channel-list",
+    "channel-create",
+    "channel-edit",
+    "channel-delete",
+    "channel-move",
+    "category-create",
+    "category-edit",
+    "category-delete",
+    "voice-status",
+    "event-list",
+    "event-create",
+  ];
+}
+
 const handleDiscordMessageActionMock = vi.hoisted(() =>
   vi.fn(async () => ({ content: [], details: { ok: true } })),
 );
@@ -199,41 +237,7 @@ describe("discordMessageActions", () => {
       accountId: "ops",
     });
 
-    expect(discovery?.actions).toEqual([
-      "send",
-      "react",
-      "reactions",
-      "emoji-list",
-      "upload-file",
-      "read",
-      "edit",
-      "delete",
-      "pin",
-      "unpin",
-      "list-pins",
-      "permissions",
-      "thread-create",
-      "thread-list",
-      "thread-reply",
-      "search",
-      "sticker",
-      "member-info",
-      "role-info",
-      "emoji-upload",
-      "sticker-upload",
-      "channel-info",
-      "channel-list",
-      "channel-create",
-      "channel-edit",
-      "channel-delete",
-      "channel-move",
-      "category-create",
-      "category-edit",
-      "category-delete",
-      "voice-status",
-      "event-list",
-      "event-create",
-    ]);
+    expect(discovery?.actions).toEqual(expectedScopedDiscordActionsWithoutPolls());
   });
 
   it("honors account-scoped action gates during discovery", () => {
@@ -300,41 +304,7 @@ describe("discordMessageActions", () => {
       "event-list",
       "event-create",
     ]);
-    expect(workDiscovery?.actions).toEqual([
-      "send",
-      "react",
-      "reactions",
-      "emoji-list",
-      "upload-file",
-      "read",
-      "edit",
-      "delete",
-      "pin",
-      "unpin",
-      "list-pins",
-      "permissions",
-      "thread-create",
-      "thread-list",
-      "thread-reply",
-      "search",
-      "sticker",
-      "member-info",
-      "role-info",
-      "emoji-upload",
-      "sticker-upload",
-      "channel-info",
-      "channel-list",
-      "channel-create",
-      "channel-edit",
-      "channel-delete",
-      "channel-move",
-      "category-create",
-      "category-edit",
-      "category-delete",
-      "voice-status",
-      "event-list",
-      "event-create",
-    ]);
+    expect(workDiscovery?.actions).toEqual(expectedScopedDiscordActionsWithoutPolls());
     expect(schemaForAction(defaultDiscovery, "send")).toMatchObject({
       actions: ["send"],
       properties: {


### PR DESCRIPTION
## What Problem This Solves

Two Discord action-discovery regressions repeat the same 33-item expected action list, making the independent expectations harder to maintain consistently.

## Why This Change Was Made

Share only those two literal expected arrays through a private helper that returns a fresh array each time. Account configuration, SecretRef inputs, discovery calls, the distinct default-account list, and schema assertions remain explicit. Expectations are not derived from production data or input configuration.

## User Impact

No production behavior changes. This removes 30 net test lines while retaining every case and assertion; no runtime improvement is claimed.

## Evidence

- Complete action-discovery and public plugin contract suites pass all 32 cases before and after, with identical ordered names and results.
- Expanding the two helper calls reconstructs the entire original test AST. The 33 strings retain their order, and separate calls produce independent mutable arrays.
- Mapped changed-file checks and fresh independent P2 review pass.
- Rebased onto current main containing the existing lint repair; reviewed test bytes, relevant action/account owners, package manifest, and lockfile are unchanged.
