### PR TITLE
improve: speed up checks for larger core and UI changes

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -84,6 +84,7 @@ type TargetedOxlintCommandOptions = TargetedLintOptions & {
   neutralPathRe: RegExp;
   paths: string[];
   tsconfig: string;
+  maxPaths?: number;
 };
 
 type NpmLockPackageDirsResolver = (changedPaths: string[]) => string[];
@@ -121,6 +122,7 @@ const EXTENSIONS_OXLINT_TS_CONFIG = "extensions/tsconfig.json";
 const SCRIPTS_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.scripts.json";
 const ROOT_TEST_TS_CONFIG = "test/tsconfig/tsconfig.test.root.json";
 const TARGETED_LINT_PATH_LIMIT = 8;
+const CORE_LINT_ARGV_BYTES = 24 * 1024;
 const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_SCRIPT_PATH_RE = /^scripts\/.+\.[cm]?[jt]sx?$/u;
@@ -863,14 +865,16 @@ export function createChangedCheckPlan(
         !LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath)
       );
     });
-    addTargetedLint(
-      createTargetedCoreLintCommand,
-      LINTABLE_CORE_PATH_RE,
-      "lint core",
-      ["lint:core"],
-      undefined,
-      fallbackWithoutTargets,
-    );
+    const coreLint = createTargetedCoreLintCommands(result.paths, baseEnv, {
+      platform: options.platform,
+    });
+    if (coreLint) {
+      for (const command of coreLint) {
+        addCommand(command.name, command.bin, command.args, command.env);
+      }
+    } else if (fallbackWithoutTargets) {
+      addLint("lint core", ["lint:core"]);
+    }
   }
   if (lanes.ui) {
     const targets = result.paths
@@ -996,13 +1000,13 @@ export function createChangedCheckPlan(
   );
 }
 
-export function createTargetedCoreLintCommand(
+export function createTargetedCoreLintCommands(
   paths: string[],
   env: NodeJS.ProcessEnv = process.env,
-  options: TargetedLintOptions = {},
+  options: TargetedLintOptions & { platform?: NodeJS.Platform } = {},
 ) {
-  return createTargetedOxlintCommand({
-    env,
+  const command = createTargetedOxlintCommand({
+    env: createChangedCheckChildEnv(env),
     label: "core",
     lintablePathRe: LINTABLE_CORE_PATH_RE,
     neutralPathRe: CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
@@ -1010,6 +1014,44 @@ export function createTargetedCoreLintCommand(
     tsconfig: CORE_OXLINT_TS_CONFIG,
     ...options,
   });
+  return command ? batchCoreLintCommand(command, options.platform ?? process.platform) : null;
+}
+
+function batchCoreLintCommand(command: TargetedLintCommand, platform: NodeJS.Platform) {
+  const prefix = command.args.slice(0, 3);
+  const windows = platform === "win32";
+  // POSIX uses the formatter's conservative argv budget. Keep Windows batches
+  // unchanged until the installed cmd/pnpm shim chain has its own budget.
+  const maxBytes = windows ? Infinity : CORE_LINT_ARGV_BYTES;
+  const maxPaths = windows ? TARGETED_LINT_PATH_LIMIT : Infinity;
+  const argumentBytes = (args: string[]) =>
+    args.reduce((bytes, arg) => bytes + Buffer.byteLength(arg, "utf8") + 1, 0);
+  const prefixBytes = argumentBytes([command.bin, ...prefix]);
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let bytes = prefixBytes;
+  for (const file of command.args.slice(3)) {
+    const fileBytes = argumentBytes([file]);
+    if (prefixBytes + fileBytes > maxBytes) {
+      throw new Error(`Core lint target exceeds the command-line budget: ${file}`);
+    }
+    if (batch.length === maxPaths || bytes + fileBytes > maxBytes) {
+      batches.push(batch);
+      batch = [];
+      bytes = prefixBytes;
+    }
+    batch.push(file);
+    bytes += fileBytes;
+  }
+  if (batch.length) {
+    batches.push(batch);
+  }
+  return batches.map((files) => ({
+    name: files.length === 1 ? "lint core changed file" : "lint core changed files",
+    bin: command.bin,
+    args: [...prefix, ...files],
+    env: command.env,
+  }));
 }
 
 export function createTargetedExtensionLintCommand(
@@ -1024,6 +1066,7 @@ export function createTargetedExtensionLintCommand(
     neutralPathRe: TOOLING_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
     paths,
     tsconfig: EXTENSIONS_OXLINT_TS_CONFIG,
+    maxPaths: TARGETED_LINT_PATH_LIMIT,
     ...options,
   });
 }
@@ -1040,6 +1083,7 @@ export function createTargetedScriptLintCommand(
     neutralPathRe: TOOLING_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
     paths,
     tsconfig: SCRIPTS_OXLINT_TS_CONFIG,
+    maxPaths: TARGETED_LINT_PATH_LIMIT,
     ...options,
   });
 }
@@ -1052,6 +1096,7 @@ function createTargetedOxlintCommand({
   neutralPathRe,
   paths,
   tsconfig,
+  maxPaths,
 }: TargetedOxlintCommandOptions) {
   if (
     paths.some(
@@ -1070,7 +1115,7 @@ function createTargetedOxlintCommand({
   const targets = paths
     .filter((changedPath) => lintablePathRe.test(changedPath))
     .toSorted((left, right) => left.localeCompare(right));
-  if (targets.length === 0 || targets.length > TARGETED_LINT_PATH_LIMIT) {
+  if (targets.length === 0 || (maxPaths !== undefined && targets.length > maxPaths)) {
     return null;
   }
   if (!targets.every((target) => fileExists(target))) {

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -28,7 +28,7 @@ import {
   cleanupCorepackPnpmShimDir,
   createChangedCheckPlan,
   createPnpmManagedCommand,
-  createTargetedCoreLintCommand,
+  createTargetedCoreLintCommands,
   createTargetedExtensionLintCommand,
   createTargetedScriptLintCommand,
   shouldDelegateChangedCheckToCrabbox,
@@ -1461,55 +1461,66 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it.each([
-    {
-      owner: "core",
-      paths: [
-        "src/gateway/node-registry.ts",
-        "src/gateway/node-registry.invoke-stream.ts",
-        "src/gateway/server-methods/nodes.invoke.ts",
-        "src/gateway/server-methods/nodes.ts",
-        "src/node-host/runtime.ts",
-        "src/node-host/runner.ts",
-        "src/plugins/provider-self-hosted-setup.ts",
-        "packages/gateway-client/src/timeouts.ts",
-        "packages/normalization-core/src/number-coercion.ts",
-      ],
-      pluralName: "lint core changed files",
-      singularName: "lint core changed file",
-      fullLane: "lint:core",
-    },
-    {
-      owner: "extension",
-      paths: [
-        "extensions/lmstudio/src/embedding-provider.ts",
-        "extensions/lmstudio/src/stream.ts",
-        "extensions/lmstudio/src/model-reasoning.ts",
-        "extensions/lmstudio/src/models.fetch.ts",
-        "extensions/lmstudio/src/setup.ts",
-        "extensions/lmstudio/src/defaults.ts",
-        "extensions/lmstudio/src/provider-auth.ts",
-        "extensions/lmstudio/src/runtime.ts",
-        "extensions/lmstudio/src/models.ts",
-      ],
-      pluralName: "lint extension changed files",
-      singularName: "lint extension changed file",
-      fullLane: "lint:extensions",
-    },
-  ])("batches broad $owner changes without falling back to full lint", (testCase) => {
-    const result = detectChangedLanes(testCase.paths);
-    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
-    const commands = plan.commands.filter(
-      (command) => command.name === testCase.pluralName || command.name === testCase.singularName,
-    );
+  it.each(
+    [
+      {
+        owner: "core",
+        paths: [
+          "src/gateway/node-registry.ts",
+          "src/gateway/node-registry.invoke-stream.ts",
+          "src/gateway/server-methods/nodes.invoke.ts",
+          "src/gateway/server-methods/nodes.ts",
+          "src/node-host/runtime.ts",
+          "src/node-host/runner.ts",
+          "src/plugins/provider-self-hosted-setup.ts",
+          "packages/gateway-client/src/timeouts.ts",
+          "packages/normalization-core/src/number-coercion.ts",
+        ],
+        pluralName: "lint core changed files",
+        singularName: "lint core changed file",
+        fullLane: "lint:core",
+      },
+      {
+        owner: "extension",
+        paths: [
+          "extensions/lmstudio/src/embedding-provider.ts",
+          "extensions/lmstudio/src/stream.ts",
+          "extensions/lmstudio/src/model-reasoning.ts",
+          "extensions/lmstudio/src/models.fetch.ts",
+          "extensions/lmstudio/src/setup.ts",
+          "extensions/lmstudio/src/defaults.ts",
+          "extensions/lmstudio/src/provider-auth.ts",
+          "extensions/lmstudio/src/runtime.ts",
+          "extensions/lmstudio/src/models.ts",
+        ],
+        pluralName: "lint extension changed files",
+        singularName: "lint extension changed file",
+        fullLane: "lint:extensions",
+      },
+    ].flatMap((testCase) =>
+      (["darwin", "win32"] as const).map((platform) => ({ testCase, platform })),
+    ),
+  )(
+    "batches broad $testCase.owner changes on $platform without falling back to full lint",
+    ({ testCase, platform }) => {
+      const result = detectChangedLanes(testCase.paths);
+      const plan = createChangedCheckPlan(result, {
+        env: { PATH: "/usr/bin" },
+        platform,
+      });
+      const commands = plan.commands.filter(
+        (command) => command.name === testCase.pluralName || command.name === testCase.singularName,
+      );
 
-    expect(commands).toHaveLength(2);
-    expect(commands.map((command) => command.args.slice(3).length)).toEqual([8, 1]);
-    expect(commands.flatMap((command) => command.args.slice(3)).toSorted()).toEqual(
-      testCase.paths.toSorted(),
-    );
-    expect(plan.commands.map((command) => command.args[0])).not.toContain(testCase.fullLane);
-  });
+      const batchSizes = testCase.owner === "core" && platform !== "win32" ? [9] : [8, 1];
+      expect(commands).toHaveLength(batchSizes.length);
+      expect(commands.map((command) => command.args.slice(3).length)).toEqual(batchSizes);
+      expect(commands.flatMap((command) => command.args.slice(3)).toSorted()).toEqual(
+        testCase.paths.toSorted(),
+      );
+      expect(plan.commands.map((command) => command.args[0])).not.toContain(testCase.fullLane);
+    },
+  );
 
   it.each([
     {
@@ -1681,12 +1692,79 @@ describe("scripts/changed-lanes", () => {
     },
   );
 
-  it("falls back to full core lint for broad core diffs", () => {
-    const targets = Array.from({ length: 9 }, (_, index) => `src/shared/file-${index}.ts`);
-    const command = createTargetedCoreLintCommand(targets, { PATH: "/usr/bin" });
+  it.each(["darwin", "linux", "win32"] as const)(
+    "preserves core/UI lint coverage and platform batching for 83 targets on %s",
+    (platform) => {
+      const targets = Array.from(
+        { length: 83 },
+        (_, index) => `${index % 2 ? "ui/src" : "src/shared"}/file-${index}.ts`,
+      ).toReversed();
+      const commands = expectDefined(
+        createTargetedCoreLintCommands(
+          targets,
+          { PATH: "/usr/bin" },
+          { fileExists: () => true, platform },
+        ),
+        "core lint commands",
+      );
 
-    expect(command).toBeNull();
-  });
+      expect(commands.map((command) => command.args.slice(3).length)).toEqual(
+        platform === "win32" ? [...Array<number>(10).fill(8), 3] : [83],
+      );
+      expect(commands.flatMap((command) => command.args.slice(3))).toEqual(
+        targets.toSorted((left, right) => left.localeCompare(right)),
+      );
+      for (const command of commands) {
+        expect(command.args.slice(0, 3)).toEqual([
+          "scripts/run-oxlint.mjs",
+          "--tsconfig",
+          "config/tsconfig/oxlint.core.json",
+        ]);
+      }
+    },
+  );
+
+  it.each(["darwin", "linux"] as const)(
+    "bounds encoded core lint commands without dropping long Unicode paths on %s",
+    (platform) => {
+      const targets = Array.from(
+        { length: 160 },
+        (_, index) => `src/shared/${"nested folder/".repeat(20)}界😀^-${index}.ts`,
+      );
+      const env = { PATH: "/usr/bin", OPENCLAW_LOCAL_CHECK: "0" };
+      const commands = expectDefined(
+        createTargetedCoreLintCommands(targets, env, { fileExists: () => true, platform }),
+        "core lint commands",
+      );
+      expect(commands.length).toBeGreaterThan(1);
+      expect(commands[0]?.args.slice(3).length).toBeGreaterThan(8);
+      expect(commands.flatMap((command) => command.args.slice(3))).toEqual(
+        targets.toSorted((left, right) => left.localeCompare(right)),
+      );
+      for (const command of commands) {
+        expect(command.env).toMatchObject({ OPENCLAW_LOCAL_CHECK: "1" });
+        expect(
+          [command.bin, ...command.args].reduce(
+            (size, arg) => size + Buffer.byteLength(arg, "utf8") + 1,
+            0,
+          ),
+        ).toBeLessThanOrEqual(24 * 1024);
+      }
+    },
+  );
+
+  it.each(["darwin", "linux"] as const)(
+    "rejects an oversized core target instead of omitting it on %s",
+    (platform) => {
+      expect(() =>
+        createTargetedCoreLintCommands(
+          [`src/shared/${"long/".repeat(6000)}file.ts`],
+          { PATH: "/usr/bin" },
+          { fileExists: () => true, platform },
+        ),
+      ).toThrow("Core lint target exceeds the command-line budget");
+    },
+  );
 
   it("falls back to full extension lint for broad extension diffs", () => {
     const targets = Array.from(
@@ -1700,7 +1778,7 @@ describe("scripts/changed-lanes", () => {
 
   it("falls back to full core lint when a changed core target was deleted", () => {
     expect(
-      createTargetedCoreLintCommand(
+      createTargetedCoreLintCommands(
         ["src/shared/deleted.ts"],
         { PATH: "/usr/bin" },
         {
@@ -1712,7 +1790,7 @@ describe("scripts/changed-lanes", () => {
 
   it("falls back to full core lint for mixed core lint configuration diffs", () => {
     expect(
-      createTargetedCoreLintCommand(
+      createTargetedCoreLintCommands(
         [
           "config/assertion-safety-baseline.txt",
           "config/tsconfig/oxlint.core.json",
@@ -1727,7 +1805,7 @@ describe("scripts/changed-lanes", () => {
   it.each([
     {
       name: "targets small core lint diffs",
-      create: createTargetedCoreLintCommand,
+      create: createTargetedCoreLintCommands,
       targets: [
         "config/assertion-safety-baseline.txt",
         ".github/workflows/ci.yml",
@@ -1770,7 +1848,11 @@ describe("scripts/changed-lanes", () => {
       },
     },
   ])("$name", ({ create, targets, expected }) => {
-    expect(create(targets, { PATH: "/usr/bin" }, { fileExists: () => true })).toEqual({
+    const result = create(targets, { PATH: "/usr/bin" }, { fileExists: () => true });
+    if (Array.isArray(result)) {
+      expect(result).toHaveLength(1);
+    }
+    expect(Array.isArray(result) ? result[0] : result).toEqual({
       name: expected.name,
       bin: "node",
       args: ["scripts/run-oxlint.mjs", "--tsconfig", expected.tsconfig, expected.path],
@@ -1789,6 +1871,12 @@ describe("scripts/changed-lanes", () => {
       OPENCLAW_TSGO_SPARSE_SKIP: "1",
       PATH: "/usr/bin",
     });
+    expect(plan.commands.find((command) => command.name === "lint core changed file")?.env).toEqual(
+      {
+        OPENCLAW_LOCAL_CHECK: "1",
+        PATH: "/usr/bin",
+      },
+    );
   });
 
   it("runs CI changed-check children through Corepack pnpm", () => {
@@ -2171,7 +2259,7 @@ describe("scripts/changed-lanes", () => {
       paths: ["assets/avatar-placeholder.svg", "assets/chrome-extension/icons/icon128.png"],
       excludesTests: false,
     },
-  ])("$name", ({ paths, excludesTests, broad = false }) => {
+  ])("$name", ({ paths, excludesTests, broad }) => {
     const result = detectChangedLanes(paths);
     const commands = createChangedCheckPlan(result).commands.map((command) => command.args[0]);
 


### PR DESCRIPTION
Closes #142689

## What Problem This Solves

Fixes an issue where developers running `check:changed` on larger core or Control UI changes repeatedly wait for the same typed-lint project to initialize. The old eight-file batches caused eleven lint invocations for an 83-file change.

## Why This Change Was Made

Select and validate the eligible core/UI files once, then group Mac/Linux invocations under a conservative 24 KiB argument budget. The existing wrapper continues to own resource limits, type-aware options, and failure handling; missing-file and configuration fallbacks retain their coverage. Windows keeps its eight-file schedule, as do the separately owned extension and script paths.

## User Impact

Larger core/UI changes finish the lint portion of local checks sooner without dropping targets or adding concurrency. A controlled 83-file macOS sample took 20.0–20.3 seconds with one invocation, versus 202.9–215.0 seconds with eleven. This measures the lint portion on one machine, not a universal whole-gate speedup.

## Evidence

- All 336 owner cases passed, covering batching, complete target coverage, Unicode argument bounds, environment policy, and fallback behavior. A final table-only lint correction passed all four affected cases again.
- The canonical changed gate passed 21 stages, then caught that table's object-spread lint violation. After correction, test-root types, lint, formatting, and the affected cases passed. The earlier gate is not represented as a fresh full run on the corrected test bytes.
- Controlled old/new/new/old scheduling used identical source, wrapper, configuration, dependencies, and resource policy; all 24 lint invocations passed. Maximum per-command resident memory was 8.90–8.94 GB before and 9.02 GB after. Final command and input continuity were verified.
- Linux and Windows scheduling are covered by planner tests; runtime timing was measured on macOS.
