### PR TITLE
fix(meeting): own a fresh root admission for agent consults

### DIFF
--- a/src/meeting-bot/agent-consult.test.ts
+++ b/src/meeting-bot/agent-consult.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isGatewaySubordinateWorkAdmissionClosed,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
 
 const consultRealtimeVoiceAgent = vi.hoisted(() => vi.fn(async () => ({ text: "done" })));
@@ -82,6 +86,42 @@ describe("createMeetingRealtimeEngineBindings", () => {
         spawnedBy: "agent:operator:main",
       }),
     );
+  });
+
+  it("consults successfully under a fresh admission after the meeting's creation-request root released", async () => {
+    const creationRoot = tryBeginGatewayRootWorkAdmission("ws:googlemeet.create");
+    expect(creationRoot).not.toBeNull();
+    let admissionClosedDuringConsult: boolean | undefined;
+    consultRealtimeVoiceAgent.mockImplementationOnce(async () => {
+      admissionClosedDuringConsult = isGatewaySubordinateWorkAdmissionClosed();
+      return { text: "done" };
+    });
+
+    let continueConsult = () => {};
+    const gate = new Promise<void>((resolve) => {
+      continueConsult = resolve;
+    });
+    let consultResult: Promise<{ text: string }> | undefined;
+    // Mirrors the real bug: the transcript callback that triggers a consult is
+    // registered during the meeting-creation request and only fires later, so
+    // it inherits that request's AsyncLocalStorage root via Node's automatic
+    // async context propagation, not a lexical reference to it.
+    await creationRoot?.run(async () => {
+      consultResult = (async () => {
+        await gate;
+        return createBindings(undefined).consultAgent({
+          meetingSessionId: "meeting-1",
+          args: { question: "What should I say?" },
+          transcript: [],
+        });
+      })();
+    });
+
+    creationRoot?.release();
+    continueConsult();
+
+    await expect(consultResult).resolves.toEqual({ text: "done" });
+    expect(admissionClosedDuringConsult).toBe(false);
   });
 
   it("keeps an explicit agentId ahead of the configured default", async () => {

--- a/src/meeting-bot/agent-consult.ts
+++ b/src/meeting-bot/agent-consult.ts
@@ -3,6 +3,11 @@ import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
+import {
+  GatewayDrainingError,
+  runOutsideGatewayRootWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
 import {
@@ -129,27 +134,40 @@ async function consultMeetingAgent(params: {
   const requesterSessionKey =
     normalizeOptionalString(params.requesterSessionKey) ?? `agent:${agentId}:main`;
   const sessionKey = `agent:${agentId}:subagent:${params.surface.id}:${params.meetingSessionId}`;
-  return await consultRealtimeVoiceAgent({
-    cfg: params.config,
-    agentRuntime: params.runtime.agent,
-    logger: params.logger,
-    agentId,
-    sessionKey,
-    messageProvider: params.surface.provider,
-    lane: params.surface.lane,
-    runIdPrefix: `${params.surface.id}:${params.meetingSessionId}`,
-    spawnedBy: requesterSessionKey,
-    contextMode: "fork",
-    args: params.args,
-    transcript: params.transcript,
-    surface: params.surface.surface,
-    userLabel: params.surface.userLabel,
-    assistantLabel: params.surface.assistantLabel,
-    questionSourceLabel: params.surface.questionSourceLabel,
-    toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(params.toolPolicy),
-    extraSystemPrompt: params.surface.extraSystemPrompt,
-    abortSignal: params.abortSignal,
-  });
+  // The meeting session's creation-request root is long released by the time a
+  // spoken question arrives; inheriting it makes admission reject every consult
+  // as "draining". Own a fresh root, mirroring the browser Talk consult path.
+  const admission = runOutsideGatewayRootWorkAdmission(() =>
+    tryBeginGatewayRootWorkAdmission(`meeting:${params.surface.id}:consult`),
+  );
+  if (!admission) {
+    throw new GatewayDrainingError();
+  }
+  return await admission
+    .run(() =>
+      consultRealtimeVoiceAgent({
+        cfg: params.config,
+        agentRuntime: params.runtime.agent,
+        logger: params.logger,
+        agentId,
+        sessionKey,
+        messageProvider: params.surface.provider,
+        lane: params.surface.lane,
+        runIdPrefix: `${params.surface.id}:${params.meetingSessionId}`,
+        spawnedBy: requesterSessionKey,
+        contextMode: "fork",
+        args: params.args,
+        transcript: params.transcript,
+        surface: params.surface.surface,
+        userLabel: params.surface.userLabel,
+        assistantLabel: params.surface.assistantLabel,
+        questionSourceLabel: params.surface.questionSourceLabel,
+        toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(params.toolPolicy),
+        extraSystemPrompt: params.surface.extraSystemPrompt,
+        abortSignal: params.abortSignal,
+      }),
+    )
+    .finally(admission.release);
 }
 
 async function handleMeetingRealtimeConsultToolCall(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes #142610.

Every spoken question in a Google Meet agent-mode session fails with a misleading
`Gateway is draining; new tasks are not accepted` error, even though the gateway is
healthy. `consultMeetingAgent()` in `src/meeting-bot/agent-consult.ts` calls
`consultRealtimeVoiceAgent()` directly, without acquiring its own root-work
admission. Because the consult runs inside the same async chain that handled the
`googlemeet.create` request, it inherits that request's AsyncLocalStorage
root-work context — a context that is already `released` by the time a
participant actually asks a question minutes later. `enqueueCommandInLane()`
then rejects the consult via `isGatewaySubordinateWorkAdmissionClosed()`,
which returns `true` for a released inherited root.

The browser Talk path (`src/gateway/talk-client-agent-consult.ts`) already
handles this correctly by acquiring an independent root admission with
`runOutsideGatewayRootWorkAdmission(tryBeginGatewayRootWorkAdmission)` before
running the consult, and releasing it in a `finally`. The meeting path omitted
this step.

## Fix

`consultMeetingAgent()` now acquires its own root-work admission outside the
inherited (possibly-released) context before calling
`consultRealtimeVoiceAgent()`, mirroring the Talk path exactly, and releases it
once the consult settles. If admission is refused (a genuine drain/suspension),
it now throws `GatewayDrainingError` from an accurate state instead of from a
stale one.

## Evidence

Added a regression test that reproduces the real bug shape: it opens a root
admission (simulating the `googlemeet.create` request), schedules the consult
call as an async descendant of that root's callback (so it inherits the store
via Node's AsyncLocalStorage propagation, exactly like a transcript-triggered
callback registered during meeting creation), releases the root (simulating the
finished creation request), and only then lets the consult proceed. It asserts
that `isGatewaySubordinateWorkAdmissionClosed()` is `false` at the point the
consult actually runs — i.e. a fresh, open admission was acquired instead of the
stale released one.

Confirmed the test fails without the fix, for the intended reason:

```
$ git checkout HEAD~1 -- src/meeting-bot/agent-consult.ts
$ node scripts/run-vitest.mjs src/meeting-bot/agent-consult.test.ts

 × |unit| ... > consults successfully under a fresh admission after the meeting's creation-request root released
   → expected true to be false // Object.is equality
 Tests  1 failed | 5 passed (6)
```

And passes with the fix restored:

```
$ git checkout HEAD -- src/meeting-bot/agent-consult.ts
$ node scripts/run-vitest.mjs src/meeting-bot/agent-consult.test.ts

 ✓ |unit| ... > consults successfully under a fresh admission after the meeting's creation-request root released
 Tests  6 passed (6)
```

Also ran the acceptance-criteria suites named in triage, all green:

```
$ node scripts/run-vitest.mjs src/meeting-bot/agent-consult.test.ts \
    src/process/gateway-work-admission.test.ts src/process/command-queue.test.ts \
    src/gateway/talk-client-gateway-control.agent-consult.test.ts

 RUN  v5.0.0 ...
 Test Files  1 passed (1)
      Tests  6 passed (6)
 RUN  v5.0.0 ...
 Test Files  1 passed (1)
      Tests  23 passed (23)
 RUN  v5.0.0 ...
 Test Files  2 passed (2)
      Tests  70 passed (70)
[test] passed 3 Vitest shards in 24.75s
```

(The runner splits the four files across three shards; `gateway-work-admission.test.ts`
and `command-queue.test.ts` land in the same shard, so that shard's 70 already
includes the admission file's tests. Total: 6 + 23 + 70 = 99 tests, all passing.)

Typecheck and lint on the changed files:

```
$ pnpm tsgo:core                                   # passes clean
$ node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '[...]'  # exit 0
$ node_modules/.bin/oxlint src/meeting-bot/agent-consult.ts src/meeting-bot/agent-consult.test.ts   # no findings
$ npx oxfmt --check src/meeting-bot/agent-consult.ts src/meeting-bot/agent-consult.test.ts          # correctly formatted
```

`pnpm check:changed`'s max-lines ratchet step fails against this fork's stale
`origin/main` (last synced at #114884, far behind `upstream/main` at #142632) —
reproduced identically on an unmodified checkout with no relation to this diff,
and passes cleanly with `--base upstream/main`.

## Real-meeting proof (community-supplied)

This sandbox still has no Google Meet OAuth credentials or live meeting to join, so it
cannot generate first-party live-meeting proof (see the 2026-09-09 comment on this PR).

The reporter of #142610, @jai-assistant, independently arrived at a functionally
identical fix and ran this exact change in production since 2026-09-08. They posted
real Google Meet before/after evidence and root-cause diagnostics in a
[PR comment](https://github.com/openclaw/openclaw/pull/142692#issuecomment-5671310635):

- Before the patch: 27/27 spoken consults failed with `Gateway is draining; new tasks
  are not accepted`, each rejected in 5-19 ms.
- After the patch: 47 consults, 0 failures, across a continuous 21-minute session,
  still running six days later.
- Instrumentation of `isGatewaySubordinateWorkAdmissionClosed()` during the failure
  showed `reason=rootWorkReleased origin=ws:googlemeet.create refs=0`, matching this
  PR's diagnosis of a consult inheriting an already-released creation-request root.

This is third-party evidence from the reporter's own environment, not proof generated
in this session.

AI assistance disclosure: this patch was authored by an autonomous Claude Code
agent.

