### PR TITLE
fix: continue memory recall after optional trigger lookup times out

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -751,11 +751,11 @@ budget:
 }
 ```
 
-Worst-case blocking time is `timeoutMs + setupGraceTimeoutMs + 4500` ms (the
-configured recall-work budget, plus up to 1500 ms preflight, up to 1500 ms
-for optional trigger lookup, and a fixed 1500 ms post-recall completion
-allowance). A trigger lookup timeout skips that optional context and lets
-model recall continue. The embedded recall runner uses
+Worst-case blocking time is `timeoutMs + setupGraceTimeoutMs + 3000` ms (the
+configured recall-work budget, plus up to 1500 ms preflight, plus a fixed
+1500 ms post-recall completion allowance). Optional trigger lookup uses only
+the remaining preflight allowance; its timeout skips optional context and
+lets eligible model recall continue. The embedded recall runner uses
 the same effective timeout budget, so `setupGraceTimeoutMs` covers both the
 outer prompt-build watchdog and the inner blocking recall run.
 

--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -751,9 +751,11 @@ budget:
 }
 ```
 
-Worst-case blocking time is `timeoutMs + setupGraceTimeoutMs + 3000` ms (the
-configured recall-work budget, plus up to 1500 ms preflight, plus a fixed
-1500 ms post-recall completion allowance). The embedded recall runner uses
+Worst-case blocking time is `timeoutMs + setupGraceTimeoutMs + 4500` ms (the
+configured recall-work budget, plus up to 1500 ms preflight, up to 1500 ms
+for optional trigger lookup, and a fixed 1500 ms post-recall completion
+allowance). A trigger lookup timeout skips that optional context and lets
+model recall continue. The embedded recall runner uses
 the same effective timeout budget, so `setupGraceTimeoutMs` covers both the
 outer prompt-build watchdog and the inner blocking recall run.
 

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -767,8 +767,8 @@ describe("active-memory plugin", () => {
     const [hookName, handler, options] = firstHookRegistration();
     expect(hookName).toBe("before_prompt_build");
     expect(typeof handler).toBe("function");
-    expect(options).toEqual({ timeoutMs: 153_000, requiresToolAuthority: true });
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
+    expect(options).toEqual({ timeoutMs: 154_500, requiresToolAuthority: true });
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
     expect(hooks.before_model_resolve).toBeUndefined();
     expect(typeof hooks.agent_end).toBe("function");
   });
@@ -834,13 +834,13 @@ describe("active-memory plugin", () => {
   it("keeps the outer hook timeout at the live-config ceiling", () => {
     registerPluginConfig({ timeoutMs: 90_000 });
 
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
   });
 
   it("covers the maximum recall and setup-grace budgets", () => {
     registerPluginConfig({ timeoutMs: 90_000, setupGraceTimeoutMs: 30_000 });
 
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
   });
 
   it("runs recall without recording shared auth-profile failures", async () => {
@@ -2073,6 +2073,41 @@ describe("active-memory plugin", () => {
     );
     expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
   });
+
+  it.each([0, 1_490])(
+    "continues model recall after %d ms preflight when trigger lookup times out",
+    async (preflightMs) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(new Error("trigger lookup timeout")), delay);
+        return controller.signal;
+      });
+      vi.spyOn(api.runtime.state, "openKeyedStore").mockReturnValue({
+        lookup: async () =>
+          await new Promise<undefined>((resolve) => {
+            setTimeout(() => resolve(undefined), preflightMs);
+          }),
+      });
+      hoisted.getActiveMemorySearchManager.mockImplementationOnce(
+        () => new Promise<never>(() => {}),
+      );
+
+      const result = runPromptBuild(
+        { prompt: "what did we decide?" },
+        {
+          sessionKey: "agent:main:telegram:direct:owner",
+          messageProvider: "telegram",
+          channelId: "owner",
+        },
+      );
+      await vi.advanceTimersByTimeAsync(preflightMs + 1_500);
+
+      expectPrependContextResult(await result);
+      expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      expect(hasWarnLine("preflight timed out")).toBe(false);
+    },
+  );
 
   it("frames the blocking memory subagent as a memory search agent for another model", async () => {
     await runPromptBuild({

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -767,8 +767,8 @@ describe("active-memory plugin", () => {
     const [hookName, handler, options] = firstHookRegistration();
     expect(hookName).toBe("before_prompt_build");
     expect(typeof handler).toBe("function");
-    expect(options).toEqual({ timeoutMs: 154_500, requiresToolAuthority: true });
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
+    expect(options).toEqual({ timeoutMs: 153_000, requiresToolAuthority: true });
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
     expect(hooks.before_model_resolve).toBeUndefined();
     expect(typeof hooks.agent_end).toBe("function");
   });
@@ -834,13 +834,13 @@ describe("active-memory plugin", () => {
   it("keeps the outer hook timeout at the live-config ceiling", () => {
     registerPluginConfig({ timeoutMs: 90_000 });
 
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
   });
 
   it("covers the maximum recall and setup-grace budgets", () => {
     registerPluginConfig({ timeoutMs: 90_000, setupGraceTimeoutMs: 30_000 });
 
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(154_500);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
   });
 
   it("runs recall without recording shared auth-profile failures", async () => {
@@ -2092,6 +2092,16 @@ describe("active-memory plugin", () => {
       hoisted.getActiveMemorySearchManager.mockImplementationOnce(
         () => new Promise<never>(() => {}),
       );
+      const startedAt = Date.now();
+      let recallStartedAt: number | undefined;
+      runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
+        recallStartedAt = Date.now();
+        await writeUsableMemoryTranscript(
+          params.sessionFile,
+          "lemon pepper wings with blue cheese",
+        );
+        return { payloads: [{ text: "- lemon pepper wings\n- blue cheese" }] };
+      });
 
       const result = runPromptBuild(
         { prompt: "what did we decide?" },
@@ -2105,6 +2115,7 @@ describe("active-memory plugin", () => {
 
       expectPrependContextResult(await result);
       expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      expect(recallStartedAt).toBe(startedAt + 1_500);
       expect(hasWarnLine("preflight timed out")).toBe(false);
     },
   );

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2074,10 +2074,15 @@ describe("active-memory plugin", () => {
     expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
   });
 
-  it.each([0, 1_490])(
-    "continues model recall after %d ms preflight when trigger lookup times out",
-    async (preflightMs) => {
-      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+  it.each([
+    [0, 0],
+    [1_490, 0],
+    [1_490, -60_000],
+    [1_490, 60_000],
+  ])(
+    "continues model recall after %d ms preflight with a %d ms wall-clock shift",
+    async (preflightMs, wallClockShiftMs) => {
+      vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
       vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
         const controller = new AbortController();
         setTimeout(() => controller.abort(new Error("trigger lookup timeout")), delay);
@@ -2086,16 +2091,19 @@ describe("active-memory plugin", () => {
       vi.spyOn(api.runtime.state, "openKeyedStore").mockReturnValue({
         lookup: async () =>
           await new Promise<undefined>((resolve) => {
-            setTimeout(() => resolve(undefined), preflightMs);
+            setTimeout(() => {
+              vi.setSystemTime(Date.now() + wallClockShiftMs);
+              resolve(undefined);
+            }, preflightMs);
           }),
       });
       hoisted.getActiveMemorySearchManager.mockImplementationOnce(
         () => new Promise<never>(() => {}),
       );
-      const startedAt = Date.now();
+      const startedAt = performance.now();
       let recallStartedAt: number | undefined;
       runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
-        recallStartedAt = Date.now();
+        recallStartedAt = performance.now();
         await writeUsableMemoryTranscript(
           params.sessionFile,
           "lemon pepper wings with blue cheese",
@@ -2113,8 +2121,8 @@ describe("active-memory plugin", () => {
       );
       await vi.advanceTimersByTimeAsync(preflightMs + 1_500);
 
-      expectPrependContextResult(await result);
       expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      expectPrependContextResult(await result);
       expect(recallStartedAt).toBe(startedAt + 1_500);
       expect(hasWarnLine("preflight timed out")).toBe(false);
     },
@@ -4633,7 +4641,7 @@ describe("active-memory plugin", () => {
   });
 
   it("preserves recall settlement time after near-limit preflight latency", async () => {
-    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
     testing.setTimeoutPartialDataGraceMsForTests(100);

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -197,10 +197,10 @@ export default definePluginEntry({
       },
     });
 
-    // Preflight and recall own separate deadlines. Reserve enough hook time for
-    // both maxima so preflight latency cannot consume recall settlement time.
+    // Preflight, optional trigger lookup, and recall own separate deadlines.
+    // Reserve their maxima without consuming recall settlement time.
     const beforePromptBuildTimeoutMs =
-      MAX_TIMEOUT_MS + MAX_SETUP_GRACE_TIMEOUT_MS + HOOK_TIMEOUT_RECOVERY_GRACE_MS * 2;
+      MAX_TIMEOUT_MS + MAX_SETUP_GRACE_TIMEOUT_MS + HOOK_TIMEOUT_RECOVERY_GRACE_MS * 3;
     // Names the exit taken when recall is configured off for this session, so
     // "no relevant memory found" and "recall never ran" stop being
     // indistinguishable at info level. Reserved for states an operator can act
@@ -275,6 +275,7 @@ export default definePluginEntry({
             );
           });
         };
+        const preflightDeadlineAt = Date.now() + HOOK_TIMEOUT_RECOVERY_GRACE_MS;
         armHookDeadline(HOOK_TIMEOUT_RECOVERY_GRACE_MS, "preflight");
         const handlerPromise = (async () => {
           try {
@@ -375,6 +376,10 @@ export default definePluginEntry({
               chatIdAllowed
             ) {
               toolAuthority.assertActive();
+              // Trigger lookup is optional and owns its own bounded deadline.
+              // Pause preflight so its timeout can fall through to model recall.
+              const remainingPreflightMs = Math.max(0, preflightDeadlineAt - Date.now());
+              hookDeadline.stop();
               laneOne = await resolveTriggerRecall({
                 cfg: liveConfig,
                 agentId: effectiveAgentId,
@@ -390,6 +395,7 @@ export default definePluginEntry({
                 );
                 return { hasStrongHit: false, injectedCount: 0 };
               });
+              armHookDeadline(remainingPreflightMs, "preflight");
               toolAuthority.assertActive();
               if (laneOne.context && laneOne.injectedCount > 0 && invocationConfig.logging) {
                 api.logger.info?.(

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -197,10 +197,10 @@ export default definePluginEntry({
       },
     });
 
-    // Preflight, optional trigger lookup, and recall own separate deadlines.
-    // Reserve their maxima without consuming recall settlement time.
+    // Preflight and recall own separate deadlines. Reserve enough hook time for
+    // both maxima so preflight latency cannot consume recall settlement time.
     const beforePromptBuildTimeoutMs =
-      MAX_TIMEOUT_MS + MAX_SETUP_GRACE_TIMEOUT_MS + HOOK_TIMEOUT_RECOVERY_GRACE_MS * 3;
+      MAX_TIMEOUT_MS + MAX_SETUP_GRACE_TIMEOUT_MS + HOOK_TIMEOUT_RECOVERY_GRACE_MS * 2;
     // Names the exit taken when recall is configured off for this session, so
     // "no relevant memory found" and "recall never ran" stop being
     // indistinguishable at info level. Reserved for states an operator can act
@@ -376,8 +376,8 @@ export default definePluginEntry({
               chatIdAllowed
             ) {
               toolAuthority.assertActive();
-              // Trigger lookup is optional and owns its own bounded deadline.
-              // Pause preflight so its timeout can fall through to model recall.
+              // Optional lookup owns the remaining preflight allowance. Its
+              // deadline must end lookup without aborting eligible model recall.
               const remainingPreflightMs = Math.max(0, preflightDeadlineAt - Date.now());
               hookDeadline.stop();
               laneOne = await resolveTriggerRecall({
@@ -386,7 +386,7 @@ export default definePluginEntry({
                 query: searchQuery,
                 message: event.prompt,
                 activeProjectKeys: ctx.activeProjectKeys,
-                signal: AbortSignal.timeout(HOOK_TIMEOUT_RECOVERY_GRACE_MS),
+                signal: AbortSignal.timeout(remainingPreflightMs),
                 runId: ctx.runId,
                 authorityFingerprint: toolAuthority.fingerprint,
               }).catch((error: unknown) => {
@@ -395,7 +395,7 @@ export default definePluginEntry({
                 );
                 return { hasStrongHit: false, injectedCount: 0 };
               });
-              armHookDeadline(remainingPreflightMs, "preflight");
+              armHookDeadline(Math.max(0, preflightDeadlineAt - Date.now()), "preflight");
               toolAuthority.assertActive();
               if (laneOne.context && laneOne.injectedCount > 0 && invocationConfig.logging) {
                 api.logger.info?.(

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -275,7 +275,7 @@ export default definePluginEntry({
             );
           });
         };
-        const preflightDeadlineAt = Date.now() + HOOK_TIMEOUT_RECOVERY_GRACE_MS;
+        const preflightDeadlineAt = performance.now() + HOOK_TIMEOUT_RECOVERY_GRACE_MS;
         armHookDeadline(HOOK_TIMEOUT_RECOVERY_GRACE_MS, "preflight");
         const handlerPromise = (async () => {
           try {
@@ -378,7 +378,10 @@ export default definePluginEntry({
               toolAuthority.assertActive();
               // Optional lookup owns the remaining preflight allowance. Its
               // deadline must end lookup without aborting eligible model recall.
-              const remainingPreflightMs = Math.max(0, preflightDeadlineAt - Date.now());
+              const remainingPreflightMs = Math.max(
+                0,
+                Math.ceil(preflightDeadlineAt - performance.now()),
+              );
               hookDeadline.stop();
               laneOne = await resolveTriggerRecall({
                 cfg: liveConfig,
@@ -395,7 +398,10 @@ export default definePluginEntry({
                 );
                 return { hasStrongHit: false, injectedCount: 0 };
               });
-              armHookDeadline(Math.max(0, preflightDeadlineAt - Date.now()), "preflight");
+              armHookDeadline(
+                Math.max(0, Math.ceil(preflightDeadlineAt - performance.now())),
+                "preflight",
+              );
               toolAuthority.assertActive();
               if (laneOne.context && laneOne.injectedCount > 0 && invocationConfig.logging) {
                 api.logger.info?.(


### PR DESCRIPTION
Closes #142479

## What Problem This Solves

Fixes an issue where users asking for remembered context could have model recall skipped when the optional trigger lookup reaches its deadline.

## Why This Change Was Made

The optional lookup and enclosing preflight timer each had a 1500 ms limit, but the enclosing timer started first and aborted the entire hook. Carry the authoritative remaining preflight allowance into optional lookup, suspending the enclosing watchdog only while that bounded lookup owns the deadline. Re-arm the watchdog with any remaining allowance afterward. Model recall retains its own full budget, and the existing total allowance is unchanged.

This revision follows the prior maintainer guidance in https://github.com/openclaw/openclaw/pull/117534#issuecomment-5159725254 and removes the first revision's additional 1500 ms allowance.

## User Impact

A slow or unavailable optional trigger lookup can fall through to model recall, as an immediate lookup failure already does. Session-state stalls still stop preflight at its existing deadline.

## Evidence

- The added focused reproduction failed before the source change with undefined recalled context.
- 229 Active Memory hook and trigger tests pass, including lookup exhaustion after both immediate and near-limit preflight, stalled session state, and recall settlement. The timing regression verifies recall starts at the original 1500 ms deadline after 1490 ms of setup; it failed the initial revision, which started recall at 2990 ms.
- The same 229 tests pass after backporting only this repair to v2026.9.3.
- Extension production and test typechecks pass. Formatting, plugin boundary and contract checks pass.
- Independent autoreview through P2 inspected both the prior index and revised working tree. All five findings concerned the prior index and explicitly identified the working-tree revision as corrected; that exact reviewed revision is now committed. No unresolved findings remain in the submitted source.
- All checks selected by check:changed completed successfully: the initial run stopped at a registry failure; the dead-export scan, lint and remaining guards then passed separately. No live behavior claim is made from these tests.
