### PR TITLE
fix(ui): align user avatars with attachment text bubbles

### DIFF
--- a/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
@@ -6,7 +6,7 @@ const suite = createControlUiE2eSuite({ name: "User avatar alignment" });
 
 suite.define(() => {
   it.each(["Review this image.\n\nKeep the sender beside this message.", '{"ok":true}'])(
-    "anchors the sender to the text surface below media and keeps mobile avatars hidden: %s",
+    "keeps each shared-session sender and media on the text bubble side: %s",
     async (message) => {
       await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
         const imageUrl = "/api/chat/media/outgoing/avatar-alignment/image.svg";
@@ -16,61 +16,71 @@ suite.define(() => {
             body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="teal"/></svg>',
           }),
         );
+        const participants = [
+          { id: "avatar-sender", name: "Alex", self: true },
+          { id: "avatar-peer", name: "Riley", self: false },
+        ];
         await installMockGateway(page, {
-          presenceUsers: [
-            {
-              self: true,
-              id: "avatar-sender",
-              identity: { type: "profile", id: "avatar-sender" },
-              name: "Alex",
-              avatarUrl: imageUrl,
+          hasMultipleSessionSharingIdentities: true,
+          sessions: [{ key: "agent:main:main", visibility: "shared", sharingRole: "owner" }],
+          presenceUsers: participants.map((participant) => ({
+            ...participant,
+            identity: { type: "profile", id: participant.id },
+            avatarUrl: imageUrl,
+          })),
+          historyMessages: participants.map((participant) => ({
+            role: "user",
+            __openclaw: {
+              senderId: participant.id,
+              senderIdentity: { type: "profile", id: participant.id },
+              senderName: participant.name,
             },
-          ],
-          historyMessages: [
-            {
-              role: "user",
-              __openclaw: {
-                senderId: "avatar-sender",
-                senderIdentity: { type: "profile", id: "avatar-sender" },
-                senderName: "Alex",
-              },
-              content: [
-                { type: "image", url: imageUrl, alt: "Attached image" },
-                { type: "text", text: message },
-              ],
-            },
-          ],
+            content: [
+              { type: "image", url: imageUrl, alt: "Attached image" },
+              { type: "text", text: message },
+            ],
+          })),
         });
         await page.goto(`${suite.server.baseUrl}chat`);
-        const group = page.locator(".chat-group.user");
-        const media = group.locator(".chat-message-image");
-        await media.waitFor();
-        await media.evaluate((image: HTMLImageElement) => image.decode());
-        const avatar = group.locator(".chat-avatar:visible");
-        await avatar.waitFor();
-        const text = group.locator(".chat-text, .chat-json-collapse");
-        const textBox = (await text.boundingBox())!;
-        const surfaceTop = await text.evaluate((element) => {
-          let surface = element;
-          while (getComputedStyle(surface).backgroundColor === "rgba(0, 0, 0, 0)") {
-            surface = surface.parentElement!;
+        for (const width of [1440, 390]) {
+          await page.setViewportSize({ width, height: 900 });
+          for (const [index, participant] of participants.entries()) {
+            const group = page.locator(".chat-group.user").nth(index);
+            const media = group.locator(".chat-message-image");
+            await media.waitFor();
+            await media.evaluate((image: HTMLImageElement) => image.decode());
+            const text = group.locator(".chat-text, .chat-json-collapse");
+            const surface = await text.evaluate((element) => {
+              let painted = element;
+              while (getComputedStyle(painted).backgroundColor === "rgba(0, 0, 0, 0)") {
+                painted = painted.parentElement!;
+              }
+              const { x, y, width: surfaceWidth, height } = painted.getBoundingClientRect();
+              return { x, y, width: surfaceWidth, height };
+            });
+            const mediaBox = (await media.boundingBox())!;
+            const mediaEdge = participant.self ? mediaBox.x + mediaBox.width : mediaBox.x;
+            const textEdge = participant.self ? surface.x + surface.width : surface.x;
+            expect(Math.abs(mediaEdge - textEdge)).toBeLessThanOrEqual(1);
+            expect(surface.y).toBeGreaterThan(mediaBox.y + mediaBox.height);
+            const avatar = group.locator(".chat-avatar:visible");
+            if (width === 390) {
+              await expect.poll(() => avatar.count()).toBe(0);
+              expect(mediaBox.x).toBeGreaterThanOrEqual(0);
+              expect(mediaBox.x + mediaBox.width).toBeLessThanOrEqual(width);
+            } else {
+              await avatar.waitFor();
+              const avatarBox = (await avatar.boundingBox())!;
+              expect(Math.abs(avatarBox.y - surface.y)).toBeLessThanOrEqual(1);
+              if (participant.self) {
+                expect(avatarBox.x).toBeGreaterThan(surface.x + surface.width);
+              } else {
+                expect(avatarBox.x + avatarBox.width).toBeLessThan(surface.x);
+              }
+              expect(await avatar.count()).toBe(1);
+            }
           }
-          return surface.getBoundingClientRect().top;
-        });
-        const avatarBox = (await avatar.boundingBox())!;
-        const mediaBox = (await media.boundingBox())!;
-        expect(Math.abs(avatarBox.y - surfaceTop)).toBeLessThanOrEqual(1);
-        expect(avatarBox.x).toBeGreaterThan(textBox.x + textBox.width);
-        expect(avatarBox.y).toBeGreaterThan(mediaBox.y + mediaBox.height);
-        expect(await avatar.count()).toBe(1);
-
-        await page.setViewportSize({ width: 390, height: 844 });
-        await expect.poll(() => avatar.count()).toBe(0);
-        const mobileMedia = (await media.boundingBox())!;
-        const mobileText = (await text.boundingBox())!;
-        expect(mobileText.y).toBeGreaterThan(mobileMedia.y + mobileMedia.height);
-        expect(mobileMedia.x).toBeGreaterThanOrEqual(0);
-        expect(mobileMedia.x + mobileMedia.width).toBeLessThanOrEqual(390);
+        }
       });
     },
   );

--- a/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
@@ -37,8 +37,8 @@ suite.define(() => {
       const [offset, leftGap, rightGap, height] = await visibleAvatar.evaluate((node) => {
         const group = node.closest(".chat-group")!;
         const body = group.querySelector(".chat-text")!.getBoundingClientRect();
-        const avatar = node.getBoundingClientRect();
-        return [avatar.y - body.y, body.x - avatar.right, avatar.x - body.right, body.height];
+        const box = node.getBoundingClientRect();
+        return [box.y - body.y, body.x - box.right, box.x - body.right, body.height] as const;
       });
       expect(Math.abs(offset)).toBeLessThanOrEqual(1);
       expect(self ? rightGap : leftGap).toBeGreaterThan(0);

--- a/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
@@ -33,17 +33,17 @@ suite.define(() => {
         ],
       });
       await page.goto(`${suite.server.baseUrl}chat`);
-      const group = page.locator(".chat-group.user");
-      const avatar = group.locator(".chat-avatar:visible");
-      await avatar.waitFor();
-      const bubble = (await group.locator(".chat-text").boundingBox())!;
-      const avatarBox = (await avatar.boundingBox())!;
-      expect(Math.abs(avatarBox.y - bubble.y)).toBeLessThanOrEqual(1);
-      expect(
-        self ? avatarBox.x > bubble.x + bubble.width : avatarBox.x + avatarBox.width < bubble.x,
-      ).toBe(true);
+      const visibleAvatar = page.locator(".chat-group.user .chat-avatar:visible");
+      const [offset, leftGap, rightGap, height] = await visibleAvatar.evaluate((node) => {
+        const group = node.closest(".chat-group")!;
+        const body = group.querySelector(".chat-text")!.getBoundingClientRect();
+        const avatar = node.getBoundingClientRect();
+        return [avatar.y - body.y, body.x - avatar.right, avatar.x - body.right, body.height];
+      });
+      expect(Math.abs(offset)).toBeLessThanOrEqual(1);
+      expect(self ? rightGap : leftGap).toBeGreaterThan(0);
       if (text.includes("\n")) {
-        expect(bubble.height).toBeGreaterThan(100);
+        expect(height).toBeGreaterThan(100);
       }
     });
   });

--- a/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
@@ -2,86 +2,49 @@ import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
+const imageUrl =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='teal'/%3E%3C/svg%3E";
+const viewer = { type: "profile" as const, id: "alex" };
 const suite = createControlUiE2eSuite({ name: "User avatar alignment" });
 
 suite.define(() => {
-  it.each(["Review this image.\n\nKeep the sender beside this message.", '{"ok":true}'])(
-    "keeps each shared-session sender and media on the text bubble side: %s",
-    async (message) => {
-      await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
-        const imageUrl = "/api/chat/media/outgoing/avatar-alignment/image.svg";
-        await page.route(`**${imageUrl}`, (route) =>
-          route.fulfill({
-            contentType: "image/svg+xml",
-            body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="teal"/></svg>',
-          }),
-        );
-        const participants = [
-          { id: "avatar-sender", name: "Alex", self: true },
-          { id: "avatar-peer", name: "Riley", self: false },
-        ];
-        await installMockGateway(page, {
-          hasMultipleSessionSharingIdentities: true,
-          sessions: [{ key: "agent:main:main", visibility: "shared", sharingRole: "owner" }],
-          presenceUsers: participants.map((participant) => ({
-            ...participant,
-            identity: { type: "profile", id: participant.id },
-            avatarUrl: imageUrl,
-          })),
-          historyMessages: participants.map((participant) => ({
+  it.each([
+    [true, "Review this image."],
+    [false, "Review this image."],
+    [true, "Review image.\nCheck heading.\nKeep spacing.\nShare notes.\nSend update."],
+  ])("anchors the avatar beside the bubble (own=%s): %s", async (self, text) => {
+    await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        hasMultipleSessionSharingIdentities: true,
+        sessions: [{ key: "agent:main:main", visibility: "shared", sharingRole: "owner" }],
+        presenceUsers: [{ ...viewer, identity: viewer, self: true }],
+        historyMessages: [
+          {
             role: "user",
             __openclaw: {
-              senderId: participant.id,
-              senderIdentity: { type: "profile", id: participant.id },
-              senderName: participant.name,
+              senderIdentity: { type: "profile", id: self ? "alex" : "riley" },
+              senderName: self ? "Alex" : "Riley",
             },
             content: [
-              { type: "image", url: imageUrl, alt: "Attached image" },
-              { type: "text", text: message },
+              { type: "image", url: imageUrl },
+              { type: "text", text },
             ],
-          })),
-        });
-        await page.goto(`${suite.server.baseUrl}chat`);
-        for (const width of [1440, 390]) {
-          await page.setViewportSize({ width, height: 900 });
-          for (const [index, participant] of participants.entries()) {
-            const group = page.locator(".chat-group.user").nth(index);
-            const media = group.locator(".chat-message-image");
-            await media.waitFor();
-            await media.evaluate((image: HTMLImageElement) => image.decode());
-            const text = group.locator(".chat-text, .chat-json-collapse");
-            const surface = await text.evaluate((element) => {
-              let painted = element;
-              while (getComputedStyle(painted).backgroundColor === "rgba(0, 0, 0, 0)") {
-                painted = painted.parentElement!;
-              }
-              const { x, y, width: surfaceWidth, height } = painted.getBoundingClientRect();
-              return { x, y, width: surfaceWidth, height };
-            });
-            const mediaBox = (await media.boundingBox())!;
-            const mediaEdge = participant.self ? mediaBox.x + mediaBox.width : mediaBox.x;
-            const textEdge = participant.self ? surface.x + surface.width : surface.x;
-            expect(Math.abs(mediaEdge - textEdge)).toBeLessThanOrEqual(1);
-            expect(surface.y).toBeGreaterThan(mediaBox.y + mediaBox.height);
-            const avatar = group.locator(".chat-avatar:visible");
-            if (width === 390) {
-              await expect.poll(() => avatar.count()).toBe(0);
-              expect(mediaBox.x).toBeGreaterThanOrEqual(0);
-              expect(mediaBox.x + mediaBox.width).toBeLessThanOrEqual(width);
-            } else {
-              await avatar.waitFor();
-              const avatarBox = (await avatar.boundingBox())!;
-              expect(Math.abs(avatarBox.y - surface.y)).toBeLessThanOrEqual(1);
-              if (participant.self) {
-                expect(avatarBox.x).toBeGreaterThan(surface.x + surface.width);
-              } else {
-                expect(avatarBox.x + avatarBox.width).toBeLessThan(surface.x);
-              }
-              expect(await avatar.count()).toBe(1);
-            }
-          }
-        }
+          },
+        ],
       });
-    },
-  );
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const group = page.locator(".chat-group.user");
+      const avatar = group.locator(".chat-avatar:visible");
+      await avatar.waitFor();
+      const bubble = (await group.locator(".chat-text").boundingBox())!;
+      const avatarBox = (await avatar.boundingBox())!;
+      expect(Math.abs(avatarBox.y - bubble.y)).toBeLessThanOrEqual(1);
+      expect(
+        self ? avatarBox.x > bubble.x + bubble.width : avatarBox.x + avatarBox.width < bubble.x,
+      ).toBe(true);
+      if (text.includes("\n")) {
+        expect(bubble.height).toBeGreaterThan(100);
+      }
+    });
+  });
 });

--- a/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-user-avatar-alignment.e2e.test.ts
@@ -1,0 +1,77 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "User avatar alignment" });
+
+suite.define(() => {
+  it.each(["Review this image.\n\nKeep the sender beside this message.", '{"ok":true}'])(
+    "anchors the sender to the text surface below media and keeps mobile avatars hidden: %s",
+    async (message) => {
+      await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+        const imageUrl = "/api/chat/media/outgoing/avatar-alignment/image.svg";
+        await page.route(`**${imageUrl}`, (route) =>
+          route.fulfill({
+            contentType: "image/svg+xml",
+            body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="teal"/></svg>',
+          }),
+        );
+        await installMockGateway(page, {
+          presenceUsers: [
+            {
+              self: true,
+              id: "avatar-sender",
+              identity: { type: "profile", id: "avatar-sender" },
+              name: "Alex",
+              avatarUrl: imageUrl,
+            },
+          ],
+          historyMessages: [
+            {
+              role: "user",
+              __openclaw: {
+                senderId: "avatar-sender",
+                senderIdentity: { type: "profile", id: "avatar-sender" },
+                senderName: "Alex",
+              },
+              content: [
+                { type: "image", url: imageUrl, alt: "Attached image" },
+                { type: "text", text: message },
+              ],
+            },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const group = page.locator(".chat-group.user");
+        const media = group.locator(".chat-message-image");
+        await media.waitFor();
+        await media.evaluate((image: HTMLImageElement) => image.decode());
+        const avatar = group.locator(".chat-avatar:visible");
+        await avatar.waitFor();
+        const text = group.locator(".chat-text, .chat-json-collapse");
+        const textBox = (await text.boundingBox())!;
+        const surfaceTop = await text.evaluate((element) => {
+          let surface = element;
+          while (getComputedStyle(surface).backgroundColor === "rgba(0, 0, 0, 0)") {
+            surface = surface.parentElement!;
+          }
+          return surface.getBoundingClientRect().top;
+        });
+        const avatarBox = (await avatar.boundingBox())!;
+        const mediaBox = (await media.boundingBox())!;
+        expect(Math.abs(avatarBox.y - surfaceTop)).toBeLessThanOrEqual(1);
+        expect(avatarBox.x).toBeGreaterThan(textBox.x + textBox.width);
+        expect(avatarBox.y).toBeGreaterThan(mediaBox.y + mediaBox.height);
+        expect(await avatar.count()).toBe(1);
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await expect.poll(() => avatar.count()).toBe(0);
+        const mobileMedia = (await media.boundingBox())!;
+        const mobileText = (await text.boundingBox())!;
+        expect(mobileText.y).toBeGreaterThan(mobileMedia.y + mobileMedia.height);
+        expect(mobileMedia.x).toBeGreaterThanOrEqual(0);
+        expect(mobileMedia.x + mobileMedia.width).toBeLessThanOrEqual(390);
+      });
+    },
+  );
+});

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -1,6 +1,6 @@
 import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
@@ -249,6 +249,7 @@ export function renderGroupedMessage(
     fetchLinkFavicon?: LinkFaviconFetcher;
     githubRepo?: MarkdownRenderOptions["githubRepo"];
     onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
+    avatar?: TemplateResult | typeof nothing;
     entryId?: string;
     /** Freshly submitted user turn: play the one-shot composer entry animation. */
     entryAnimated?: boolean;
@@ -453,6 +454,18 @@ export function renderGroupedMessage(
     !reasoningMarkdown;
 
   const toolRenderOptions = { ...opts, messageKey, onOpenSidebar };
+  const renderText = () =>
+    jsonResult
+      ? renderMessageJson(jsonResult, isStandaloneToolMessage && Boolean(opts.autoExpandToolCalls))
+      : bodyMarkdown
+        ? renderMessageMarkdown(
+            bodyMarkdown,
+            messageKey,
+            { ...opts, role: isStandaloneToolMessage ? "tool" : normalizedRole },
+            markdownRenderOptions,
+            duplicateSuffix,
+          )
+        : nothing;
   // Collapsed tool results must not load attachments or render hidden markdown.
   // Retained panes use opacity, so hidden transcripts must unmount video previews.
   const renderBody = () => html`
@@ -490,20 +503,9 @@ export function renderGroupedMessage(
     }
     ${isStandaloneToolMessage ? nothing : assistantViewContent}
     ${
-      jsonResult
-        ? renderMessageJson(
-            jsonResult,
-            isStandaloneToolMessage && Boolean(opts.autoExpandToolCalls),
-          )
-        : bodyMarkdown
-          ? renderMessageMarkdown(
-              bodyMarkdown,
-              messageKey,
-              { ...opts, role: isStandaloneToolMessage ? "tool" : normalizedRole },
-              markdownRenderOptions,
-              duplicateSuffix,
-            )
-          : nothing
+      opts.avatar
+        ? html`<div class="chat-message-avatar-anchor">${renderText()}${opts.avatar}</div>`
+        : renderText()
     }
     ${
       hasToolCards

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -432,6 +432,26 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     normalizedRole === "assistant" ? formatSenderLabel(group.replyToSender) : null;
   const replyToTitle = replyToLabel ? t("chat.messages.replyingTo", { name: replyToLabel }) : null;
 
+  const inlineUserAvatar =
+    normalizedRole === "user" &&
+    !isPeerGroup &&
+    avatarPlacement === "gutter" &&
+    Boolean(preparedMessages[lastMessageIndex]?.source.displayMarkdown);
+  const avatar =
+    normalizedRole !== "tool" &&
+    avatarPlacement === "gutter" &&
+    (isForwarded || normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
+      ? isForwarded
+        ? renderForwardedAvatar(group.senderSession?.agentId, opts)
+        : renderChatAvatar(
+            group.role,
+            { name: assistantName, avatar: opts.assistantAvatar ?? null },
+            { name: opts.userName ?? null, avatar: opts.userAvatar ?? null },
+            opts.resourceBasePath,
+            group.sender,
+          )
+      : nothing;
+
   return html`
     <div
       class="chat-group ${roleClass} chat-group--with-footer${
@@ -442,21 +462,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
-      ${
-        normalizedRole !== "tool" &&
-        avatarPlacement === "gutter" &&
-        (isForwarded || normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
-          ? isForwarded
-            ? renderForwardedAvatar(group.senderSession?.agentId, opts)
-            : renderChatAvatar(
-                group.role,
-                { name: assistantName, avatar: opts.assistantAvatar ?? null },
-                { name: opts.userName ?? null, avatar: opts.userAvatar ?? null },
-                opts.resourceBasePath,
-                group.sender,
-              )
-          : nothing
-      }
+      ${inlineUserAvatar ? nothing : avatar}
       <div class="chat-group-messages">
         ${isForwarded ? renderForwardedAttribution(group, opts) : nothing}
         ${
@@ -480,7 +486,15 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           preparedMessages.map((prepared, index) => {
             const { item, actions: actionDetails } = prepared;
             return html`
-              ${renderPreparedGroupMessage(group, index, opts, prepared)}
+              ${renderPreparedGroupMessage(
+                group,
+                index,
+                {
+                  ...opts,
+                  avatar: inlineUserAvatar && index === lastMessageIndex ? avatar : undefined,
+                },
+                prepared,
+              )}
               ${
                 actionDetails && index < lastMessageIndex && !ownsRunFrame
                   ? html`

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -434,7 +434,6 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
 
   const inlineUserAvatar =
     normalizedRole === "user" &&
-    !isPeerGroup &&
     avatarPlacement === "gutter" &&
     Boolean(preparedMessages[lastMessageIndex]?.source.displayMarkdown);
   const avatar =

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1048,6 +1048,23 @@ img.chat-avatar.chat-avatar--logo {
   color: hsl(var(--chat-sender-hue) 60% 36%);
 }
 
+.chat-message-avatar-anchor {
+  display: contents;
+}
+
+.chat-message-avatar-anchor > :is(.chat-avatar, .chat-avatar-slot) {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: calc(100% + var(--chat-avatar-gap));
+}
+
+.chat-group.user:not(.chat-group--peer) .chat-bubble--with-images > .chat-message-avatar-anchor {
+  position: relative;
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+}
+
 /* Match the sender tint's specificity so media stays outside the painted text
    surface on either participant's side. */
 .chat-group.user .chat-bubble.chat-bubble--with-images {
@@ -1061,7 +1078,7 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-group.user
-  .chat-bubble--with-images
+  :is(.chat-bubble--with-images, .chat-bubble--with-images > .chat-message-avatar-anchor)
   > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   width: fit-content;
   max-width: 100%;
@@ -1072,7 +1089,7 @@ img.chat-avatar.chat-avatar--logo {
 
 :where(:root[data-theme-mode="light"])
   .chat-group.user
-  .chat-bubble--with-images
+  :is(.chat-bubble--with-images, .chat-bubble--with-images > .chat-message-avatar-anchor)
   > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   color: var(--text-strong);
 }
@@ -1276,7 +1293,7 @@ img.chat-avatar.chat-avatar--logo {
     margin-inline: 0;
   }
 
-  .chat-group > :is(.chat-avatar, .chat-avatar-slot) {
+  .chat-group :is(.chat-avatar, .chat-avatar-slot) {
     display: none;
   }
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1058,7 +1058,12 @@ img.chat-avatar.chat-avatar--logo {
   inset-inline-start: calc(100% + var(--chat-avatar-gap));
 }
 
-.chat-group.user:not(.chat-group--peer) .chat-bubble--with-images > .chat-message-avatar-anchor {
+.chat-group--peer .chat-message-avatar-anchor > :is(.chat-avatar, .chat-avatar-slot) {
+  inset-inline-start: auto;
+  inset-inline-end: calc(100% + var(--chat-avatar-gap));
+}
+
+.chat-group.user .chat-bubble--with-images > .chat-message-avatar-anchor {
   position: relative;
   display: block;
   width: fit-content;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -1183,7 +1183,7 @@
 }
 
 /* renderBody is shared by normal bubbles and expanded tool output. */
-:is(.chat-bubble, .chat-tool-msg-body) {
+:is(.chat-bubble, .chat-tool-msg-body, .chat-message-avatar-anchor) {
   > :is(
     .chat-message-images,
     .chat-assistant-attachments,
@@ -1194,6 +1194,7 @@
     .chat-text,
     .chat-json-collapse,
     .chat-message-disclosure,
+    .chat-message-avatar-anchor,
     .chat-tools-inline
   ) {
     margin-block: 0;
@@ -1208,6 +1209,7 @@
       .chat-text,
       .chat-json-collapse,
       .chat-message-disclosure,
+      .chat-message-avatar-anchor,
       .chat-tools-inline
     ) {
       margin-block-start: var(--chat-block-gap);

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -1217,6 +1217,11 @@
   }
 }
 
+/* A display-contents anchor transfers its block gap to the first rendered box. */
+.chat-bubble:not(.chat-bubble--with-images) > .chat-message-avatar-anchor > :first-child {
+  margin-block-start: inherit;
+}
+
 .chat-text > * + *,
 .chat-text > * + .markdown-external-image {
   margin-block-start: var(--chat-block-gap);


### PR DESCRIPTION
Built on the now-merged #142623, #142639, and #142671 by @vyctorbrzezowski. This branch is rebased onto `main` at `8b0d79936ae9498155ed859b4594e7ff9460f8d7`.

Closes #142688

## What Problem This Solves

A user message with media above its text leaves the sender avatar beside the top of the media. This separates the avatar from both short and tall text bubbles, including messages from another participant in a shared session.

## Why This Change Was Made

The rendered text surface now owns the single sender avatar’s vertical position. The existing peer class places the avatar in the corresponding reserved gutter through logical insets. Media keeps the base’s shared participant-alignment rule: own turns use inline end and other participants use inline start. No media-height measurement or attachment-specific avatar selector is introduced.

## User Impact

At desktop widths, the avatar aligns with the top of the text bubble beside image, video, gallery, or file content. Media-only messages intentionally retain their avatar beside the media. Assistant rendering and the existing hidden-avatar layout at 390px remain unchanged.

## Evidence

The refreshed pairs below use the complete #142671 base at `2fe7c10041644508e5939f75dcd0d944ca8372ae` before the fix and candidate `8a2fbfb1708db982a9966b101c871764fb6c5670` after it. Both sides render the canonical Control UI with the same synthetic shared-session history and real Instrument Sans fonts. File placement is supplied by the complete sibling base in both captures. The final main rebase preserves these source paths; the additional audio-gap repair below excludes these detached media shells.

Each sheet contains: (a) own five-line text with an image; (b) own five-line text with a text file; (c) own one-line text with an image; (d) the long and short image cases for Riley, the other participant. All 40 targets were inspected. Desktop avatar/text top difference is **0px** after the fix, versus **239px** for images and **88px** for files before it. Mobile avatars stay hidden without overlap.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td colspan="2"><strong>Dark, 1440px — all five scenarios</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/463e7f23-e008-48c7-85d3-ad8cd88295c1"><img src="https://github.com/user-attachments/assets/463e7f23-e008-48c7-85d3-ad8cd88295c1" alt="before: dark, 1440px; own and peer long/short image, own long text file" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/50df97a3-32d2-4f8c-93fd-2fe4b8ebb45c"><img src="https://github.com/user-attachments/assets/50df97a3-32d2-4f8c-93fd-2fe4b8ebb45c" alt="after: dark, 1440px; own and peer long/short image, own long text file" width="600"></a></td></tr>
<tr><td colspan="2"><strong>Dark, 390px — all five scenarios</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/b8a71eb1-7e9f-4d75-9252-de7b9cb35156"><img src="https://github.com/user-attachments/assets/b8a71eb1-7e9f-4d75-9252-de7b9cb35156" alt="before: dark, 390px; own and peer long/short image, own long text file" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/37ef9bc9-2a27-45e7-ba07-a07b2d7bef2e"><img src="https://github.com/user-attachments/assets/37ef9bc9-2a27-45e7-ba07-a07b2d7bef2e" alt="after: dark, 390px; own and peer long/short image, own long text file" width="600"></a></td></tr>
<tr><td colspan="2"><strong>Light, 1440px — all five scenarios</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/46c6486b-ad9e-48dd-98f5-a8059a397a3f"><img src="https://github.com/user-attachments/assets/46c6486b-ad9e-48dd-98f5-a8059a397a3f" alt="before: light, 1440px; own and peer long/short image, own long text file" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/1d5466f3-f979-44be-9271-ab8b0a519859"><img src="https://github.com/user-attachments/assets/1d5466f3-f979-44be-9271-ab8b0a519859" alt="after: light, 1440px; own and peer long/short image, own long text file" width="600"></a></td></tr>
<tr><td colspan="2"><strong>Light, 390px — all five scenarios</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/524be9c2-3b17-455e-8040-9deb315b5c7c"><img src="https://github.com/user-attachments/assets/524be9c2-3b17-455e-8040-9deb315b5c7c" alt="before: light, 390px; own and peer long/short image, own long text file" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/ee0b18b6-c5d5-40fb-adaf-09ec5cc50608"><img src="https://github.com/user-attachments/assets/ee0b18b6-c5d5-40fb-adaf-09ec5cc50608" alt="after: light, 390px; own and peer long/short image, own long text file" width="600"></a></td></tr>
</table>

- Focused browser regression: **3 passed**, one case each for own avatar, peer avatar, and a tall bubble. All three fail on the pre-fix source for the intended avatar/text top mismatch.
- The E2E file remains **50 lines**, reduced from 87. Removed Markdown/JSON and viewport permutations plus repeated media/count checks; no test-only production helper.
- The four existing gallery theme/tint assertions pass unchanged after integration with the sibling’s canonical alignment variable. This resolves the earlier `textRightAligned` CI failure without altering the fixture or weakening its assertions.
- The current integrated candidate passed **233 renderer tests** and the existing **image-handoff continuity test**. The continuity check addresses the prior review concern about an image disappearing during canonical-history loading.
- The existing 17 attachment-spacing tests pass unchanged. Avatar geometry is now read synchronously from the visible avatar and text, retaining the 1px tolerance and all three cases.
- Formatting and diff checks passed. Prior targeted lint passed; the changed-check limitation is recorded below.

Additional shared-session audio regression check at 1440px: the normal painted bubble keeps its avatar at the bubble top. The card-to-text gap was 0px through the boxless anchor and is restored to the existing 14px paragraph rhythm. The same spacing assertion failed before this repair and passed after it. This used a temporary audio adaptation of the existing browser harness; the committed test remains the requested three avatar invariants in 50 lines, without another permutation. The selector excludes detached media shells, preserving the image/file layouts above.

<table>
<tr><th>Before gap repair</th><th>After gap repair</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/2772bffc-19ab-4534-9042-aa3fb9b53091"><img src="https://github.com/user-attachments/assets/2772bffc-19ab-4534-9042-aa3fb9b53091" alt="audio-gap-before: shared-session audio card and following text, 1440px" width="600"></a></td><td><a href="https://github.com/user-attachments/assets/eb4e6ac9-9e70-4740-8bcb-f5b6f85ad865"><img src="https://github.com/user-attachments/assets/eb4e6ac9-9e70-4740-8bcb-f5b6f85ad865" alt="audio-gap-after: shared-session audio card and following text, 1440px" width="600"></a></td></tr>
</table>

Original single-user before/after, including preserved media-only and assistant paths:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td colspan="2"><strong>1440px: image (with text-only reference), video, gallery</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/34e25d94-b6e4-4897-95ee-79b92156f66e"><img src="https://github.com/user-attachments/assets/34e25d94-b6e4-4897-95ee-79b92156f66e" alt="before: 1440px: image (with text-only reference), video, gallery" width="620"></a></td><td><a href="https://github.com/user-attachments/assets/8736bf70-b1a6-400d-a11c-5e22f413c240"><img src="https://github.com/user-attachments/assets/8736bf70-b1a6-400d-a11c-5e22f413c240" alt="after: 1440px: image (with text-only reference), video, gallery" width="620"></a></td></tr>
<tr><td colspan="2"><strong>1440px: media-only and assistant (preserved)</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/7e7ca4e4-4935-4824-9453-f04688ce01b3"><img src="https://github.com/user-attachments/assets/7e7ca4e4-4935-4824-9453-f04688ce01b3" alt="before: 1440px: media-only and assistant (preserved)" width="620"></a></td><td><a href="https://github.com/user-attachments/assets/7f538710-b753-4915-b8ee-d5e065e47ab5"><img src="https://github.com/user-attachments/assets/7f538710-b753-4915-b8ee-d5e065e47ab5" alt="after: 1440px: media-only and assistant (preserved)" width="620"></a></td></tr>
<tr><td colspan="2"><strong>390px: image (with text-only reference), video, gallery</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/86c606b5-f4b2-4d25-bd26-d7ca13a156a5"><img src="https://github.com/user-attachments/assets/86c606b5-f4b2-4d25-bd26-d7ca13a156a5" alt="before: 390px: image (with text-only reference), video, gallery" width="620"></a></td><td><a href="https://github.com/user-attachments/assets/15c14872-9d3c-4535-8545-002a8355f7af"><img src="https://github.com/user-attachments/assets/15c14872-9d3c-4535-8545-002a8355f7af" alt="after: 390px: image (with text-only reference), video, gallery" width="620"></a></td></tr>
<tr><td colspan="2"><strong>390px: media-only and assistant (preserved)</strong></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/3fb3dc45-fa96-4bc2-8459-85fe09d73104"><img src="https://github.com/user-attachments/assets/3fb3dc45-fa96-4bc2-8459-85fe09d73104" alt="before: 390px: media-only and assistant (preserved)" width="620"></a></td><td><a href="https://github.com/user-attachments/assets/ef1bbe9c-2f31-4446-9a36-8efc55745323"><img src="https://github.com/user-attachments/assets/ef1bbe9c-2f31-4446-9a36-8efc55745323" alt="after: 390px: media-only and assistant (preserved)" width="620"></a></td></tr>
</table>

## Risk and coverage

The real Control UI renders synthetic attributed history through the normal shared-session, message-group, text, image, file, and avatar paths. The refreshed visual set covers own/peer turns, tall/short bubbles, both themes and both widths. Earlier image/video/gallery/media-only and assistant captures remain above. JSON and mobile geometry are no longer automatic permutations of the focused avatar test; renderer coverage remains in place. Other browser engines and a real Gateway were not exercised.

Moving files and aligning the shared media slot remain owned by #142671 by @vyctorbrzezowski. This PR adds the generic text-owned avatar anchor on that base. Own production delta is +79/−35, including five lines that preserve the existing audio-card spacing through a boxless anchor. A fresh cleanup pass found no further safe reduction without changing behavior.

Local type validation remains incomplete: the canonical core-test/UI wrappers reject the task’s donor `node_modules` symlinks with “Declaration input escapes checkout”. No guard was bypassed or dependency installation changed. Landing requires green hosted CI on the final head.

The complete five-file avatar layer at `4aeeb317179da745c42844357498214ec6fccd26` received a fresh independent review with no actionable findings after the audio-spacing repair and test measurement/type corrections. The existing gallery policy, file producer, media handlers, and logical participant-side variable remain owned by the sibling base.


The latest reviewed attachment-spacing and integration requests are addressed: audio retains the original 14px rhythm; the complete file-placement base is merged; the group-owned alignment variable and four gallery assertions are preserved. The image-handoff continuity test also passes.

Final candidate: `4aeeb317179da745c42844357498214ec6fccd26`. Exact-head hosted CI is [green](https://github.com/openclaw/openclaw/actions/runs/34310880535); no CI rerun was used. The latest review of this same head has no remaining before-merge items.
