### PR TITLE
docs(active-memory): explain scoped Lossless Claw tool grants

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -470,6 +470,18 @@ call for advanced Active Memory. Defaults depend on the current memory provider:
 | Built-in memory | `["memory_search", "memory_get"]` |
 | LanceDB         | `["memory_recall"]`               |
 
+`toolsAllow` is a limit, not a permission grant. Before starting recall, Active
+Memory filters these names through the parent agent's finalized tool policy.
+A plugin can register a tool that the parent agent's selected profile excludes.
+Use explicit `tools.alsoAllow` entries to extend a restrictive profile, as in
+the [Lossless Claw example](/concepts/active-memory#lossless-claw). These grants also give the parent
+agent access to the named tools; they are not recall-only permissions. Explicit
+denies and provider, agent, and sandbox restrictions still apply, and recall
+cannot continue after the parent turn's tool authority expires.
+If only some configured tools are allowed, recall can still run with that
+smaller set. For example, `memory_search` may remain available even when the
+Lossless Claw tools are excluded.
+
 If none of the configured tools are available, or the sub-agent run fails,
 active memory skips recall for that turn and the main reply continues
 without memory context. For custom recall tools, non-empty model-visible
@@ -532,10 +544,28 @@ configuration above when LanceDB is the active memory provider.
 external context-engine plugin (`openclaw plugins install
 @martian-engineering/lossless-claw`) with its own recall tools. Set it up as
 a context engine first; see [Context engine](/concepts/context-engine). Then
-point active memory at its tools:
+grant its recall tools to the parent agent and point Active Memory at them.
+This example keeps the `main` agent on the restrictive `coding` profile and
+adds only the three named Lossless Claw tools through
+`agents.entries.main.tools.alsoAllow`. Merge these entries into that agent's
+existing tool configuration. Keep your selected profile and any other required
+grants and denies. This example assumes that agent scope does not also define
+`tools.allow`: `allow` and `alsoAllow` cannot be combined in the same scope.
+A later allowlist cannot restore tools excluded by a profile. See
+[Tool policy](/gateway/config-tools) before adapting an existing layered allowlist:
 
 ```json5
 {
+  agents: {
+    entries: {
+      main: {
+        tools: {
+          profile: "coding",
+          alsoAllow: ["lcm_grep", "lcm_describe", "lcm_expand_query"],
+        },
+      },
+    },
+  },
   plugins: {
     slots: {
       contextEngine: "lossless-claw",
@@ -794,6 +824,27 @@ provider must support OpenClaw's protected same-agent/private-session recall
 path.
 
 <AccordionGroup>
+  <Accordion title="Registered recall tools return `status=policy-disabled`">
+    This status means none of the configured recall tools remain in the parent
+    agent's authorized tool surface. Active Memory skips the blocking sub-agent
+    and the main reply continues without recalled context.
+
+    - Check the selected agent's profile and explicit `tools.alsoAllow` grants.
+      Under a restrictive profile, listing plugin tools in `config.toolsAllow`
+      alone does not authorize them. Use the scoped [Lossless Claw example](/concepts/active-memory#lossless-claw).
+    - Check explicit denies and provider, agent, and sandbox tool policies.
+      `alsoAllow` extends the profile; it does not override those restrictions.
+      Provider-specific profiles have their own `alsoAllow` configuration.
+    - Confirm that `config.toolsAllow` contains the intended concrete recall
+      names. Active Memory can use only the intersection of this list and the
+      parent agent's effective tools. Keep `memory_search` when using Remember
+      across conversations.
+    - Use `openclaw plugins inspect lossless-claw --runtime --json` to check
+      registration. A tool listed there is registered, but that output does not
+      prove the parent agent or Active Memory is authorized to call it.
+
+  </Accordion>
+
   <Accordion title="Embedding provider switched or stopped working">
     If `memory.search.provider` is unset, OpenClaw uses OpenAI embeddings. Set
     `memory.search.provider` explicitly for Bedrock, DeepInfra, Gemini, GitHub


### PR DESCRIPTION
Closes #100537

## What Problem This Solves

Fixes an incomplete Lossless Claw recipe: operators using a restrictive parent tool profile were told to configure Active Memory's `toolsAllow` without the explicit parent-tool grants that recall requires. Plugin registration alone does not establish permission to use those tools.

## Why This Change Was Made

The recipe now grants the three configured `lcm_*` tools through the existing per-agent `tools.alsoAllow` setting and explains that the parent agent gains access too. It documents partial and empty authorized tool sets, `status=policy-disabled`, and registration-only inspection. Existing deny, provider, agent, sandbox, and authority-lifetime restrictions still apply.

This documentation-only revision replaces the proposed runtime allowance change and its mocked test. Runtime limits remain limits; no authorization code changes. The `memory_search` transcript guidance and top-level `lcm_expand` exclusion are preserved.

## User Impact

Operators can configure scoped parent access while keeping their selected profile and diagnose policy filtering separately from plugin registration or embedding errors. This documents existing configuration behavior; it does not claim current external Lossless Claw compatibility or a new successful runtime recall test.

## Evidence

- Pinned main `dbab7f74c235723ae2b6c9968724f0b08c24c418`: the old recipe listed the three `lcm_*` tools only in `config.toolsAllow`. Active Memory filters that list through the parent tool authority before recall; an empty result records `policy-disabled`.
- Independent source audit and source-blind document acceptance cover the original 18-clause documentation contract, including all three matching grants and parent access consequences.
- Documentation checks on the candidate:

```text
docs:list                         PASS
docs:check-config-examples        PASS (1218 examples validated)
docs:check-mdx                    PASS (974 files)
docs:check-links                  PASS (10156 links; 0 broken)
format:docs:check                 PASS (961 files)
git diff --check                  PASS
```

- Extra anchor audit with the upstream ClawHub docs finds the same three missing `windows-app-node` anchors in generated maturity pages on both pinned main and candidate. The added links pass. These pre-existing generated-page failures are outside this repair; the required standard link check is green.
- Thanks to @MasterSwords1 for the original contribution and to the issue reporters for isolating the profile prerequisite.
