### PR TITLE
fix: keep shipped SDK context aliases pending removal

### DIFF
--- a/docs/plugins/compatibility.md
+++ b/docs/plugins/compatibility.md
@@ -158,13 +158,16 @@ New channel plugins should use `MsgContext.ChannelPromptContext`,
 `SupplementalContextFacts.channelStructuredContext`. The older
 `UntrustedContext`, `UntrustedStructuredContext`,
 `UntrustedStructuredContextEntry`, and supplemental `untrustedContext` names
-remain as deprecated SDK aliases until 2026-09-08 (registry record
-`sdk-untrusted-context-identifier-aliases`). Inbound finalization folds those
+remain as deprecated SDK aliases. Their 2026-09-08 removal review date is
+unchanged, but registry record `sdk-untrusted-context-identifier-aliases` is now
+`removal-pending`: removal still requires verified migration of published plugin
+readers and explicit breaking-release approval. Inbound finalization folds those
 deprecated fields into the channel-named fields and removes the old keys from
 runtime context.
 
 The security runtime similarly exports `buildChannelMetadata`; the deprecated
-`buildUntrustedChannelMetadata` alias remains available on the same schedule.
+`buildUntrustedChannelMetadata` alias remains available under the same pending
+removal conditions.
 
 ### WhatsApp inbound callback retirement
 

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -282,14 +282,14 @@ export const PLUGIN_COMPAT_RECORDS = [
   },
   {
     code: "sdk-untrusted-context-identifier-aliases",
-    status: "deprecated",
+    status: "removal-pending",
     owner: "sdk",
     introduced: "2026-07-22",
     deprecated: "2026-07-22",
     warningStarts: "2026-07-22",
     removeAfter: "2026-09-08",
     replacement:
-      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`",
+      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`; retain the aliases until migration of published plugin readers is verified and explicit breaking-release approval is granted",
     docsPath: "/plugins/compatibility",
     surfaces: [
       "openclaw/plugin-sdk reply-runtime MsgContext.UntrustedContext and UntrustedStructuredContext",

--- a/test/scripts/plugin-boundary-report.test.ts
+++ b/test/scripts/plugin-boundary-report.test.ts
@@ -34,9 +34,10 @@ describe("plugin-boundary-report", () => {
 
     expect(summaryResult.exitCode).toBe(0);
     expect(summaryResult.stderr).toBe("");
-    expect(summary.compat?.removalPendingCount).toBe(8);
+    expect(summary.compat?.removalPendingCount).toBe(9);
     expect(summary.compat?.removalPendingDueCount).toEqual(expect.any(Number));
     expect(summary.compat?.removalPending?.map((record) => record.code)).toEqual([
+      "sdk-untrusted-context-identifier-aliases",
       "plugin-sdk-media-understanding-public-demotion",
       "plugin-sdk-memory-host-core-public-demotion",
       "plugin-sdk-channel-lifecycle-subpath",
@@ -46,6 +47,12 @@ describe("plugin-boundary-report", () => {
       "plugin-sdk-infra-runtime-subpath",
       "plugin-sdk-plugin-config-runtime-public-demotion",
     ]);
+    expect(summary.compat?.removalPending?.[0]).toMatchObject({
+      removeAfter: "2026-09-08",
+      blocker: expect.stringContaining(
+        "migration of published plugin readers is verified and explicit breaking-release approval is granted",
+      ),
+    });
     for (const record of summary.compat?.removalPending ?? []) {
       expect(record.removeAfter).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
       expect(record.blocker).toEqual(expect.stringMatching(/retain|replacement/iu));
@@ -76,7 +83,7 @@ describe("plugin-boundary-report", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("removalPending=8");
+    expect(result.stdout).toContain("removalPending=9");
     expect(result.stdout).not.toContain("agent-harness-sdk-alias");
     expect(result.stdout).toMatch(/blocker=.*retain the public/iu);
     expect(result.stdout).toMatch(/readerRefs=\d+ readers=/u);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the compatibility gate treated the channel prompt-context SDK aliases as ready to remove after September 8, even though published-plugin migration and breaking-release approval are still outstanding. These aliases ship in stable v2026.9.3 and v2026.9.2.

## Why This Change Was Made

Classify the existing record as `removal-pending` and state its outstanding conditions in the compatibility guide and report. Keep the original September 8 review date: the report still lists this item as due for review instead of extending its deadline or removing shipped exports.

## User Impact

Existing plugins retain the same SDK aliases and runtime behavior. Maintainers get an accurate pending-removal queue with the remaining migration and approval work visible. No API, configuration, runtime, or eligibility-guard change; net production LOC is zero.

## Evidence

- Actual boundary-report command on the base exits 1 with this sole date-eligible record; the candidate exits 0 and reports the same record as `removal-pending`, `dueForReview: true`, with its unchanged date and explicit blockers.
- All 16 existing compatibility-registry and boundary-report tests pass, including the updated pending inventory and retained-date/blocker assertion. The initial stale-inventory failures are preserved in local evidence.
- Independent full P2 autoreview: scoped-clean, no actionable findings.
- Full canonical changed-code gate passes, including core/test types, all dead-export scans, lint, docs/config checks, and boundary guards.
