### PR TITLE
refactor(ui): share bridged route location restoration

### DIFF
--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -17,6 +17,7 @@ import {
   pathForPluginsHubTab,
   pathForWorkboardBoard,
   pluginsHubTabFromPath,
+  restoreBridgedRouteLocation,
   routeIdFromPath,
   routePageSpec,
   type RouteId,
@@ -440,6 +441,42 @@ describe("Dynamic route startup bridge", () => {
       route.component = originalComponent;
     }
   });
+});
+
+describe("Bridged route locations", () => {
+  it.each([
+    ["absent", "?", "/ui/activity", ""],
+    ["empty", "?bridge=&bridge=%2Fignored&q=release", "", "?q=release"],
+    [
+      "repeated",
+      "?q=first&bridge=%2Fui%2Factivity%2Fada-12345678&q=second&bridge=%2Fignored",
+      "/ui/activity/ada-12345678",
+      "?q=first&q=second",
+    ],
+    ["bridge-only", "?bridge=%2Fui%2Factivity%2Fada-12345678", "/ui/activity/ada-12345678", ""],
+    [
+      "other namespace",
+      "?other=%2Fui%2Fworkboard&q=release",
+      "/ui/activity",
+      "?other=%2Fui%2Fworkboard&q=release",
+    ],
+    [
+      "encoded query",
+      "?bridge=%2Fui%2Factivity%2Fa%252Fb&q=hello%20world&q=a%2Bb",
+      "/ui/activity/a%2Fb",
+      "?q=hello+world&q=a%2Bb",
+    ],
+  ])(
+    "restores %s bridge input without changing the source",
+    (_label, search, pathname, nextSearch) => {
+      const location = Object.freeze({ pathname: "/ui/activity", search, hash: "#sessions" });
+      const restored = restoreBridgedRouteLocation(location, "bridge");
+
+      expect(restored).toEqual({ pathname, search: nextSearch, hash: "#sessions" });
+      expect(restored).not.toBe(location);
+      expect(location).toEqual({ pathname: "/ui/activity", search, hash: "#sessions" });
+    },
+  );
 });
 
 describe("Agent panel route paths", () => {

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -418,3 +418,18 @@ export function locationForRoute(routeId: RouteId, basePath: string): RouteLocat
     hash: "",
   };
 }
+
+export function restoreBridgedRouteLocation(
+  location: RouteLocation,
+  pathParam: string,
+): RouteLocation {
+  const params = new URLSearchParams(location.search);
+  const pathname = params.get(pathParam) ?? location.pathname;
+  params.delete(pathParam);
+  const search = params.toString();
+  return {
+    pathname,
+    search: search ? `?${search}` : "",
+    hash: location.hash,
+  };
+}

--- a/ui/src/pages/activity/route.test.ts
+++ b/ui/src/pages/activity/route.test.ts
@@ -49,12 +49,12 @@ describe("resolveActivityRouteData", () => {
   });
 
   it("scopes readable person paths independently of query filters and mounted prefixes", () => {
-    for (const [pathname, search] of [
-      ["/ui/activity/ada-12345678", "?person=ignored&time=30d&q=release"],
-      [
-        "/ui/activity",
-        `?${INTERNAL_ACTIVITY_PATH_PARAM}=%2Fui%2Factivity%2Fada-12345678&person=ignored&time=30d&q=release`,
-      ],
+    for (const { pathname, search } of [
+      { pathname: "/ui/activity/ada-12345678", search: "?person=ignored&time=30d&q=release" },
+      {
+        pathname: "/ui/activity",
+        search: `?${INTERNAL_ACTIVITY_PATH_PARAM}=%2Fui%2Factivity%2Fada-12345678&person=ignored&time=30d&q=release`,
+      },
     ]) {
       expect(loadRoute(search, pathname, "/ui")).toEqual({
         mode: "sessions",

--- a/ui/src/pages/activity/route.test.ts
+++ b/ui/src/pages/activity/route.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import type { RouteLoaderOptions, RouteLocation } from "@openclaw/uirouter";
 import { describe, expect, it } from "vitest";
-import { activityPersonFromPath } from "../../app-route-paths.ts";
+import { activityPersonFromPath, INTERNAL_ACTIVITY_PATH_PARAM } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { page } from "./route.ts";
 import { resolveActivityRouteData, type ActivityRouteData } from "./run-inspector-model.ts";
@@ -49,13 +49,19 @@ describe("resolveActivityRouteData", () => {
   });
 
   it("scopes readable person paths independently of query filters and mounted prefixes", () => {
-    expect(
-      loadRoute("?person=ignored&time=30d&q=release", "/ui/activity/ada-12345678", "/ui"),
-    ).toEqual({
-      mode: "sessions",
-      filters: { personId: "12345678", time: "30d", query: "release" },
-      selector: null,
-    });
+    for (const [pathname, search] of [
+      ["/ui/activity/ada-12345678", "?person=ignored&time=30d&q=release"],
+      [
+        "/ui/activity",
+        `?${INTERNAL_ACTIVITY_PATH_PARAM}=%2Fui%2Factivity%2Fada-12345678&person=ignored&time=30d&q=release`,
+      ],
+    ]) {
+      expect(loadRoute(search, pathname, "/ui")).toEqual({
+        mode: "sessions",
+        filters: { personId: "12345678", time: "30d", query: "release" },
+        selector: null,
+      });
+    }
     expect(loadRoute("?view=live", "/activity/ada-12345678")).toEqual({
       mode: "live",
       selector: null,

--- a/ui/src/pages/activity/route.ts
+++ b/ui/src/pages/activity/route.ts
@@ -1,12 +1,12 @@
 import { definePage, type RouteLocation } from "@openclaw/uirouter";
-import { INTERNAL_ACTIVITY_PATH_PARAM, routePageSpec } from "../../app-route-paths.ts";
+import {
+  INTERNAL_ACTIVITY_PATH_PARAM,
+  restoreBridgedRouteLocation,
+  routePageSpec,
+} from "../../app-route-paths.ts";
 
 function sessionActivityRouteLocation(location: RouteLocation): RouteLocation {
-  const params = new URLSearchParams(location.search);
-  const pathname = params.get(INTERNAL_ACTIVITY_PATH_PARAM) ?? location.pathname;
-  params.delete(INTERNAL_ACTIVITY_PATH_PARAM);
-  const search = params.toString();
-  return { pathname, search: search ? `?${search}` : "", hash: location.hash };
+  return restoreBridgedRouteLocation(location, INTERNAL_ACTIVITY_PATH_PARAM);
 }
 
 export const page = definePage({

--- a/ui/src/pages/agents/route-location.ts
+++ b/ui/src/pages/agents/route-location.ts
@@ -4,6 +4,7 @@ import {
   INTERNAL_AGENT_PATH_PARAM,
   pathForAgentPanel,
   pathForRoute,
+  restoreBridgedRouteLocation,
 } from "../../app-route-paths.ts";
 import { DEFAULT_AGENT_PANEL, type AgentsPanel } from "../../lib/agents/panels.ts";
 
@@ -15,15 +16,7 @@ export type AgentsRouteLocation = {
 };
 
 function routeLocation(location: RouteLocation): RouteLocation {
-  const params = new URLSearchParams(location.search);
-  const pathname = params.get(INTERNAL_AGENT_PATH_PARAM) ?? location.pathname;
-  params.delete(INTERNAL_AGENT_PATH_PARAM);
-  const search = params.toString();
-  return {
-    pathname,
-    search: search ? `?${search}` : "",
-    hash: location.hash,
-  };
+  return restoreBridgedRouteLocation(location, INTERNAL_AGENT_PATH_PARAM);
 }
 
 function legacyAgentId(params: URLSearchParams): string | null {

--- a/ui/src/pages/plugins/route-data.ts
+++ b/ui/src/pages/plugins/route-data.ts
@@ -3,19 +3,12 @@ import {
   INTERNAL_PLUGINS_PATH_PARAM,
   pathForPluginsHubTab,
   pluginsHubTabFromPath,
+  restoreBridgedRouteLocation,
   type PluginsHubRouteTab,
 } from "../../app-route-paths.ts";
 
 export function pluginsRouteLocation(location: RouteLocation): RouteLocation {
-  const searchParams = new URLSearchParams(location.search);
-  const pathname = searchParams.get(INTERNAL_PLUGINS_PATH_PARAM) ?? location.pathname;
-  searchParams.delete(INTERNAL_PLUGINS_PATH_PARAM);
-  const search = searchParams.toString();
-  return {
-    pathname,
-    search: search ? `?${search}` : "",
-    hash: location.hash,
-  };
+  return restoreBridgedRouteLocation(location, INTERNAL_PLUGINS_PATH_PARAM);
 }
 
 export function pluginsHubTabForRoute(location: RouteLocation, basePath = ""): PluginsHubRouteTab {

--- a/ui/src/pages/workboard/route-location.ts
+++ b/ui/src/pages/workboard/route-location.ts
@@ -4,6 +4,7 @@ import {
   INTERNAL_WORKBOARD_PATH_PARAM,
   pathForRoute,
   pathForWorkboardBoard,
+  restoreBridgedRouteLocation,
   workboardBoardIdFromPath,
 } from "../../app-route-paths.ts";
 // Existing Workboard URLs persist this value for the all-boards route.
@@ -16,17 +17,9 @@ export type WorkboardRouteData = {
 };
 
 export function workboardRouteLocation(location: RouteLocation): RouteLocation {
-  const params = new URLSearchParams(location.search);
   // The router's private bridge must not masquerade as the public legacy
   // `board` query, or its canonical redirect survives after the real path wins.
-  const pathname = params.get(INTERNAL_WORKBOARD_PATH_PARAM) ?? location.pathname;
-  params.delete(INTERNAL_WORKBOARD_PATH_PARAM);
-  const search = params.toString();
-  return {
-    pathname,
-    search: search ? `?${search}` : "",
-    hash: location.hash,
-  };
+  return restoreBridgedRouteLocation(location, INTERNAL_WORKBOARD_PATH_PARAM);
 }
 
 export function resolveWorkboardRouteLocation(


### PR DESCRIPTION
Closes #142704

## What Problem This Solves

Activity, Agents, Plugins, and Workboard duplicate private route bridge
restoration. This maintainer-requested cleanup keeps their query handling from
drifting during future route changes. It is not a fix for a reproduced
user-facing defect.

## Why This Change Was Made

Share the unchanged operation in the existing route paths owner while retaining
all four wrappers and namespace constants. Preserve first-value/nullish
precedence, removal of every selected bridge key, unrelated query ordering and
encoding, hashes, defaults, and public URL canonicalization.

## User Impact

No visible behavior change is intended. Deep links, filters, reconnects,
Workboard pins, and reload persistence should continue to work as before.
There are no router, configuration, SDK, or storage changes.

## Evidence

Candidate: `aaf1a52c4e49fd9e35352acc3d68da1af6f88c15`.

- Complete seven-path changed check passed, including the full core-test
  typecheck, UI typecheck, formatting, dead-export scans, and lint.
- Five focused unit files passed all 99 cases. All three real Chromium/mock
  Gateway flows in `identity-activity-links` and `dynamic-route-loader-count`
  passed, covering filters, reloads, pretty URLs, and Plugins reconnect.
- Normal `pnpm ui:build` passed, including 840 finalized precompressed sidecars
  and performance gates.
- The Activity fixture typing failure is repaired without casts or weaker
  assertions. Independent P0-P2 autoreview reported only the stale indexed
  tuple fixtures, explicitly confirmed the object-fixture repair, and found
  no other issues. The reviewed repair was staged and then passed the full
  core-test typecheck.
- Baseline proof previously passed 97 focused cases, three Chromium/mock
  Gateway flows, and the normal UI build. Six query-characterization cases
  cover the shared helper; the mounted Activity case exercises its real
  bridged loader.
- Exact-head hosted CI is green:
  https://github.com/openclaw/openclaw/actions/runs/34316757077
- Independent Blacksmith Testbox browser proof passed all three flows with no
  skips and wrapper exit 0:
  https://github.com/openclaw/openclaw/actions/runs/34318752043
  Native source verification matched the candidate, followed by exact raw Git
  blob checks for all seven changed files before browser invocation. The new
  proof lease was stopped with native completed verification.
- Earlier remote attempts stopped before browser execution because of a
  readiness TLS failure, an incorrect operating guard comparing the carrier
  commit to the source commit, and an HTTP 500 during pinned TruffleHog
  hydration. The guard was corrected and positive/negative checked; dependency
  recovery was verified against the complete archive checksum before the
  successful bounded same-provider attempt. No product tests or setup checks
  were weakened. The earlier hydration-failed lease reported already stopped;
  its retained local claim/key remain untouched.

This PR makes no live Gateway claim.
