### PR TITLE
feat(plugins): define package-owned categories

### DIFF
--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -93,6 +93,7 @@ local proof.
   "id": "my-plugin",
   "name": "My Plugin",
   "description": "Adds a custom tool to OpenClaw",
+  "categories": ["tools"],
   "contracts": {
     "tools": ["my_tool"]
   },

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -261,6 +261,7 @@ The anchors from the single-page version still resolve here.
 | `name`                               | No       | `string`                     | Human-readable plugin name.                                                                                                                                                                                                                                                                                                                                                                      |
 | `description`                        | No       | `string`                     | Short summary shown in plugin surfaces.                                                                                                                                                                                                                                                                                                                                                          |
 | `catalog`                            | No       | `object`                     | Optional presentation hints for plugin catalog surfaces. This metadata does not install, enable, or grant trust to a plugin.                                                                                                                                                                                                                                                                     |
+| `categories`                         | No       | `string[]`                   | One to three controlled catalog category slugs, ordered with the primary category first. Bundled plugins must declare at least one category.                                                                                                                                                                                                                                                     |
 | `version`                            | No       | `string`                     | Informational plugin version.                                                                                                                                                                                                                                                                                                                                                                    |
 | `uiHints`                            | No       | `Record<string, object>`     | UI labels, placeholders, and sensitivity hints for config fields.                                                                                                                                                                                                                                                                                                                                |
 
@@ -269,6 +270,32 @@ An `AuthAlias` is either a provider id string or an object with `provider` and
 endpoint after trimming whitespace and trailing slashes. It does not rename
 stored credential providers or contribute a new setup provider. Existing profile
 order, explicit bindings, and plugin trust checks still apply.
+
+## Catalog categories
+
+Declare `categories` in `openclaw.plugin.json` so every catalog consumer reads the same
+package-owned classification. The array accepts one to three unique slugs. Put the plugin's
+primary category first; catalog surfaces can group it there while still matching every declared
+category in search and filters.
+
+| Slug       | Use for                                                          |
+| ---------- | ---------------------------------------------------------------- |
+| `channels` | Messaging and channel transports                                 |
+| `models`   | Model providers, inference engines, and model routing            |
+| `memory`   | Long-term memory, retrieval, and memory stores                   |
+| `context`  | Context engines, extraction, and context management              |
+| `voice`    | Speech, transcription, and calling                               |
+| `media`    | Image, video, music, and other media generation or understanding |
+| `web`      | Web search, browsing, fetching, and research                     |
+| `tools`    | Agent tools, actions, and workflows                              |
+| `runtime`  | Agent runtimes, execution backends, and development integrations |
+| `gateway`  | Gateway discovery, administration, and observability             |
+| `security` | Authentication, policy, secrets, and sandboxing                  |
+| `other`    | Plugins that do not fit a more specific controlled category      |
+
+Omission remains valid for external plugin compatibility. When an external catalog supplies a
+derived fallback, an explicit package declaration takes precedence. Bundled OpenClaw plugins must
+declare at least one category.
 
 ## JSON Schema requirements
 

--- a/extensions/a2a/openclaw.plugin.json
+++ b/extensions/a2a/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "a2a",
+  "categories": ["channels"],
   "name": "A2A",
   "description": "A2A v1.0 Agent-to-Agent protocol channel plugin.",
   "activation": {

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "acpx",
+  "categories": ["runtime", "tools"],
   "backupResources": [
     {
       "disposition": "regenerable",

--- a/extensions/active-memory/openclaw.plugin.json
+++ b/extensions/active-memory/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "active-memory",
+  "categories": ["memory"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "active-memory-session-toggles-json-to-plugin-state" }]

--- a/extensions/admin-http-rpc/openclaw.plugin.json
+++ b/extensions/admin-http-rpc/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "admin-http-rpc",
+  "categories": ["gateway"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.admin-http-rpc"]

--- a/extensions/alibaba/openclaw.plugin.json
+++ b/extensions/alibaba/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "alibaba",
+  "categories": ["media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "amazon-bedrock-mantle",
+  "categories": ["models"],
   "name": "Amazon Bedrock Mantle",
   "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "activation": {

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "amazon-bedrock",
+  "categories": ["models", "memory"],
   "name": "Amazon Bedrock",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "activation": {

--- a/extensions/anthropic-vertex/openclaw.plugin.json
+++ b/extensions/anthropic-vertex/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "anthropic-vertex",
+  "categories": ["models"],
   "name": "Anthropic Vertex",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "activation": {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "anthropic",
+  "categories": ["models", "media"],
   "doctorContract": {},
   "sessionRouteStateOwners": [
     {

--- a/extensions/arcee/openclaw.plugin.json
+++ b/extensions/arcee/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "arcee",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/azure-speech/openclaw.plugin.json
+++ b/extensions/azure-speech/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "azure-speech",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/baseten/openclaw.plugin.json
+++ b/extensions/baseten/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "baseten",
+  "categories": ["models"],
   "name": "Baseten",
   "description": "OpenClaw Baseten provider plugin.",
   "activation": {

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "beam",
+  "categories": ["runtime"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.beam"]

--- a/extensions/bonjour/openclaw.plugin.json
+++ b/extensions/bonjour/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "bonjour",
+  "categories": ["gateway"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/brave/openclaw.plugin.json
+++ b/extensions/brave/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "brave",
+  "categories": ["web"],
   "name": "Brave",
   "description": "OpenClaw Brave Search provider plugin for web search.",
   "activation": {

--- a/extensions/browser/openclaw.plugin.json
+++ b/extensions/browser/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "browser",
+  "categories": ["tools"],
   "cliCommands": [
     {
       "name": "browser",

--- a/extensions/buzz/openclaw.plugin.json
+++ b/extensions/buzz/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "buzz",
+  "categories": ["channels"],
   "name": "Buzz",
   "description": "Connect OpenClaw agents to Buzz rooms.",
   "activation": {

--- a/extensions/byteplus/openclaw.plugin.json
+++ b/extensions/byteplus/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "byteplus",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/canvas/openclaw.plugin.json
+++ b/extensions/canvas/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "canvas",
+  "categories": ["tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "canvas-custom-root-documents-to-core" }]

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "cerebras",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/chutes/openclaw.plugin.json
+++ b/extensions/chutes/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "chutes",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/clawrouter/openclaw.plugin.json
+++ b/extensions/clawrouter/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "clawrouter",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/clickclack/openclaw.plugin.json
+++ b/extensions/clickclack/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "clickclack",
+  "categories": ["channels", "tools"],
   "name": "ClickClack",
   "description": "OpenClaw ClickClack channel plugin.",
   "doctorContract": {

--- a/extensions/cloudflare-ai-gateway/openclaw.plugin.json
+++ b/extensions/cloudflare-ai-gateway/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "cloudflare-ai-gateway",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "codex",
+  "categories": ["runtime", "tools", "web"],
   "backupResources": [
     {
       "disposition": "regenerable",

--- a/extensions/cohere/openclaw.plugin.json
+++ b/extensions/cohere/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "cohere",
+  "categories": ["models"],
   "name": "Cohere",
   "description": "OpenClaw Cohere provider plugin.",
   "activation": {

--- a/extensions/comfy/openclaw.plugin.json
+++ b/extensions/comfy/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "comfy",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/copilot-proxy/openclaw.plugin.json
+++ b/extensions/copilot-proxy/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "copilot-proxy",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "copilot",
+  "categories": ["runtime"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/crabbox/openclaw.plugin.json
+++ b/extensions/crabbox/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "crabbox",
+  "categories": ["runtime", "tools"],
   "doctorContract": {
     "stateMigrations": [{ "id": "crabbox-warm-profile-v2", "doctorOnly": true }]
   },

--- a/extensions/cua-computer/openclaw.plugin.json
+++ b/extensions/cua-computer/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "cua-computer",
+  "categories": ["tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/deepgram/openclaw.plugin.json
+++ b/extensions/deepgram/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "deepgram",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "deepinfra",
+  "categories": ["models", "memory", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "deepseek",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/device-pair/openclaw.plugin.json
+++ b/extensions/device-pair/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "device-pair",
+  "categories": ["tools"],
   "doctorContract": {
     "stateMigrations": [{ "id": "device-pair-notify-json-to-plugin-state" }]
   },

--- a/extensions/diagnostics-otel/openclaw.plugin.json
+++ b/extensions/diagnostics-otel/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "diagnostics-otel",
+  "categories": ["gateway"],
   "name": "Diagnostics OpenTelemetry",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics, traces, and logs.",
   "activation": {

--- a/extensions/diagnostics-prometheus/openclaw.plugin.json
+++ b/extensions/diagnostics-prometheus/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "diagnostics-prometheus",
+  "categories": ["gateway"],
   "name": "Diagnostics Prometheus",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "activation": {

--- a/extensions/diffs-language-pack/openclaw.plugin.json
+++ b/extensions/diffs-language-pack/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "diffs-language-pack",
+  "categories": ["runtime"],
   "requiresPlugins": ["diffs"],
   "activation": {
     "onStartup": true

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "diffs",
+  "categories": ["tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "discord",
+  "categories": ["channels", "voice"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "discord-legacy-state" }]

--- a/extensions/document-extract/openclaw.plugin.json
+++ b/extensions/document-extract/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "document-extract",
+  "categories": ["context", "tools"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/duckduckgo/openclaw.plugin.json
+++ b/extensions/duckduckgo/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "duckduckgo",
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/elevenlabs/openclaw.plugin.json
+++ b/extensions/elevenlabs/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "elevenlabs",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "exa",
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/fal/openclaw.plugin.json
+++ b/extensions/fal/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "fal",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/featherless/openclaw.plugin.json
+++ b/extensions/featherless/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "featherless",
+  "categories": ["models"],
   "name": "Featherless AI",
   "description": "OpenClaw Featherless AI provider plugin.",
   "activation": {

--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "feishu",
+  "categories": ["channels", "tools"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/file-transfer/openclaw.plugin.json
+++ b/extensions/file-transfer/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "file-transfer",
+  "categories": ["tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "firecrawl",
+  "categories": ["web", "tools"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "fireworks",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/fish-audio-speech/openclaw.plugin.json
+++ b/extensions/fish-audio-speech/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "fish-audio-speech",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "legacyPluginIds": ["fish-audio"],
   "activation": {

--- a/extensions/geolocation/openclaw.plugin.json
+++ b/extensions/geolocation/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "geolocation",
+  "categories": ["tools"],
   "name": "Geolocation",
   "description": "Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database.",
   "enabledByDefault": true,

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "github-copilot",
+  "categories": ["models", "memory"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/gmi/openclaw.plugin.json
+++ b/extensions/gmi/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "gmi",
+  "categories": ["models"],
   "name": "GMI Cloud",
   "description": "OpenClaw GMI Cloud provider plugin.",
   "activation": {

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "google-meet",
+  "categories": ["voice", "tools"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "google",
+  "categories": ["models", "memory", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {},
   "sessionRouteStateOwners": [

--- a/extensions/googlechat/openclaw.plugin.json
+++ b/extensions/googlechat/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "googlechat",
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/gradium/openclaw.plugin.json
+++ b/extensions/gradium/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "gradium",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "groq",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/huggingface/openclaw.plugin.json
+++ b/extensions/huggingface/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "huggingface",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/imap/openclaw.plugin.json
+++ b/extensions/imap/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "imap",
+  "categories": ["tools"],
   "name": "IMAP email trigger",
   "description": "Watch IMAP mailboxes and dispatch authenticated incoming email to isolated agent sessions.",
   "activation": { "onStartup": true },

--- a/extensions/imessage/openclaw.plugin.json
+++ b/extensions/imessage/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "imessage",
+  "categories": ["channels"],
   "name": "iMessage",
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac.",
   "doctorContract": {

--- a/extensions/inworld/openclaw.plugin.json
+++ b/extensions/inworld/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "inworld",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/irc/openclaw.plugin.json
+++ b/extensions/irc/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "irc",
+  "categories": ["channels"],
   "name": "IRC",
   "description": "OpenClaw IRC channel plugin.",
   "doctorContract": {

--- a/extensions/kilocode/openclaw.plugin.json
+++ b/extensions/kilocode/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "kilocode",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/kimi-coding/openclaw.plugin.json
+++ b/extensions/kimi-coding/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "kimi",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/line/openclaw.plugin.json
+++ b/extensions/line/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "line",
+  "categories": ["channels"],
   "doctorContract": {
     "stateMigrations": [{ "id": "line-pre-drain-spool-rows" }]
   },

--- a/extensions/linux-node/openclaw.plugin.json
+++ b/extensions/linux-node/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "linux-node",
+  "categories": ["runtime"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/litellm/openclaw.plugin.json
+++ b/extensions/litellm/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "litellm",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/llama-cpp/openclaw.plugin.json
+++ b/extensions/llama-cpp/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "llama-cpp",
+  "categories": ["models", "memory"],
   "name": "llama.cpp Provider",
   "description": "Managed and external llama.cpp servers for GGUF chat and embeddings.",
   "activation": {

--- a/extensions/llm-task/openclaw.plugin.json
+++ b/extensions/llm-task/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "llm-task",
+  "categories": ["tools"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/lmstudio/openclaw.plugin.json
+++ b/extensions/lmstudio/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "lmstudio",
+  "categories": ["models", "memory"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/lobster/openclaw.plugin.json
+++ b/extensions/lobster/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "lobster",
+  "categories": ["tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/logbook/openclaw.plugin.json
+++ b/extensions/logbook/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "logbook",
+  "categories": ["tools"],
   "name": "Logbook",
   "description": "Automatic work journal: captures periodic screen snapshots from a paired node and turns them into a reviewable timeline of your day.",
   "enabledByDefault": false,

--- a/extensions/longcat/openclaw.plugin.json
+++ b/extensions/longcat/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "longcat",
+  "categories": ["models"],
   "name": "LongCat",
   "description": "OpenClaw LongCat provider plugin.",
   "doctorContract": {

--- a/extensions/matrix/openclaw.plugin.json
+++ b/extensions/matrix/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "matrix",
+  "categories": ["channels", "tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/mattermost/openclaw.plugin.json
+++ b/extensions/mattermost/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "mattermost",
+  "categories": ["channels"],
   "name": "Mattermost",
   "description": "OpenClaw Mattermost channel plugin.",
   "doctorContract": {

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "memory-core",
+  "categories": ["memory", "tools"],
   "doctorContract": {
     "stateMigrations": [
       { "id": "memory-core-host-events-jsonl-to-sqlite", "doctorOnly": true },

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "memory-lancedb",
+  "categories": ["memory", "tools"],
   "doctorContract": {
     "stateMigrations": [
       { "id": "memory-lancedb-agent-scope" },

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "memory-wiki",
+  "categories": ["memory", "tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "meta",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/microsoft-foundry/openclaw.plugin.json
+++ b/extensions/microsoft-foundry/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "microsoft-foundry",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/microsoft/openclaw.plugin.json
+++ b/extensions/microsoft/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "microsoft",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/migrate-claude/openclaw.plugin.json
+++ b/extensions/migrate-claude/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "migrate-claude",
+  "categories": ["runtime"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/migrate-hermes/openclaw.plugin.json
+++ b/extensions/migrate-hermes/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "migrate-hermes",
+  "categories": ["runtime"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "minimax",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "mistral",
+  "categories": ["models", "memory", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "moonshot",
+  "categories": ["models", "media", "web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/msteams/openclaw.plugin.json
+++ b/extensions/msteams/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "msteams",
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/mxc/openclaw.plugin.json
+++ b/extensions/mxc/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "mxc",
+  "categories": ["security", "runtime"],
   "name": "MXC Sandbox Execution",
   "description": "OS-level sandboxed tool execution via MXC: runs commands in a Windows ProcessContainer with configured MXC policy files.",
   "activation": {

--- a/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/extensions/nextcloud-talk/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "nextcloud-talk",
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/nostr/openclaw.plugin.json
+++ b/extensions/nostr/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "nostr",
+  "categories": ["channels"],
   "doctorContract": {
     "stateMigrations": [
       { "id": "nostr-bus-state-json-to-plugin-state" },

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "novita",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "nvidia",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/oc-path/openclaw.plugin.json
+++ b/extensions/oc-path/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "oc-path",
+  "categories": ["tools"],
   "name": "OC Path",
   "description": "Adds the openclaw path CLI for oc:// workspace file addressing.",
   "cliCommands": [

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "ollama",
+  "categories": ["models", "memory", "web"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/onepassword/openclaw.plugin.json
+++ b/extensions/onepassword/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "onepassword",
+  "categories": ["security", "tools"],
   "name": "1Password",
   "description": "1Password SecretRef resolver and curated agent broker with approval policy and SQLite audit history.",
   "cliCommands": [

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openai",
+  "categories": ["models", "memory", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "sessionRouteStateOwners": [
     {

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "opencode-go",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "opencode",
+  "categories": ["models", "media"],
   "activation": { "onStartup": true },
   "providerCatalogEntry": "./provider-discovery.ts",
   "enabledByDefault": true,

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openrouter",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openshell",
+  "categories": ["security", "runtime"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/parallel/openclaw.plugin.json
+++ b/extensions/parallel/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "parallel",
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/perplexity/openclaw.plugin.json
+++ b/extensions/perplexity/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "perplexity",
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/pixverse/openclaw.plugin.json
+++ b/extensions/pixverse/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "pixverse",
+  "categories": ["media"],
   "name": "PixVerse",
   "description": "OpenClaw PixVerse video generation provider plugin.",
   "activation": {

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "policy",
+  "categories": ["security", "tools"],
   "name": "Policy",
   "description": "Adds policy-backed doctor checks for workspace conformance.",
   "cliCommands": [

--- a/extensions/qa-channel/openclaw.plugin.json
+++ b/extensions/qa-channel/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "qa-channel",
+  "categories": ["channels"],
   "name": "QA Channel",
   "description": "OpenClaw QA synthetic channel plugin.",
   "activation": {

--- a/extensions/qa-lab/openclaw.plugin.json
+++ b/extensions/qa-lab/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "qa-lab",
+  "categories": ["tools", "web"],
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner.",
   "cliCommands": [
     {

--- a/extensions/qianfan/openclaw.plugin.json
+++ b/extensions/qianfan/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "qianfan",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "qwen",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/raft/openclaw.plugin.json
+++ b/extensions/raft/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "raft",
+  "categories": ["channels"],
   "name": "Raft",
   "description": "OpenClaw Raft channel plugin for secure CLI wake bridges.",
   "activation": {

--- a/extensions/reef/openclaw.plugin.json
+++ b/extensions/reef/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "reef",
+  "categories": ["channels", "tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/runway/openclaw.plugin.json
+++ b/extensions/runway/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "runway",
+  "categories": ["media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/searxng/openclaw.plugin.json
+++ b/extensions/searxng/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "searxng",
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/senseaudio/openclaw.plugin.json
+++ b/extensions/senseaudio/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "senseaudio",
+  "categories": ["media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/sglang/openclaw.plugin.json
+++ b/extensions/sglang/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "sglang",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/signal/openclaw.plugin.json
+++ b/extensions/signal/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "signal",
+  "categories": ["channels"],
   "name": "Signal",
   "description": "OpenClaw Signal channel plugin.",
   "doctorContract": {

--- a/extensions/slack/openclaw.plugin.json
+++ b/extensions/slack/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "slack",
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/sms/openclaw.plugin.json
+++ b/extensions/sms/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "sms",
+  "categories": ["channels"],
   "name": "SMS",
   "description": "Twilio SMS/MMS channel plugin for OpenClaw messages.",
   "activation": {

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "stepfun",
+  "categories": ["models"],
   "name": "StepFun",
   "activation": {
     "onStartup": false

--- a/extensions/synology-chat/openclaw.plugin.json
+++ b/extensions/synology-chat/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "synology-chat",
+  "categories": ["channels"],
   "doctorContract": {},
   "name": "Synology Chat",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",

--- a/extensions/synthetic/openclaw.plugin.json
+++ b/extensions/synthetic/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "synthetic",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/talk-voice/openclaw.plugin.json
+++ b/extensions/talk-voice/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "talk-voice",
+  "categories": ["voice", "tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/tavily/openclaw.plugin.json
+++ b/extensions/tavily/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "tavily",
+  "categories": ["web", "tools"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/team-reports/openclaw.plugin.json
+++ b/extensions/team-reports/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "team-reports",
   "name": "Team Reports",
   "description": "Daily, weekly, and monthly team activity reports from GitHub and Discord, with model-written summaries, served in the Control UI.",
+  "categories": ["tools"],
   "enabledByDefault": false,
   "activation": {
     "onStartup": true,

--- a/extensions/teams-meetings/openclaw.plugin.json
+++ b/extensions/teams-meetings/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "teams-meetings",
+  "categories": ["voice", "tools"],
   "name": "Microsoft Teams meetings",
   "description": "Join Microsoft Teams meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/extensions/telegram/openclaw.plugin.json
+++ b/extensions/telegram/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "telegram",
+  "categories": ["channels"],
   "name": "Telegram",
   "description": "OpenClaw Telegram channel plugin.",
   "doctorContract": {

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "tencent",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/tlon/openclaw.plugin.json
+++ b/extensions/tlon/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "tlon",
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/together/openclaw.plugin.json
+++ b/extensions/together/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "together",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "tokenjuice",
+  "categories": ["runtime"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/tts-local-cli/openclaw.plugin.json
+++ b/extensions/tts-local-cli/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "tts-local-cli",
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/twitch/openclaw.plugin.json
+++ b/extensions/twitch/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "twitch",
+  "categories": ["channels"],
   "name": "Twitch",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "activation": {

--- a/extensions/vault/openclaw.plugin.json
+++ b/extensions/vault/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "vault",
+  "categories": ["security", "tools"],
   "name": "Vault",
   "description": "HashiCorp Vault SecretRef provider integration.",
   "cliCommands": [

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "venice",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/vercel-ai-gateway/openclaw.plugin.json
+++ b/extensions/vercel-ai-gateway/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "vercel-ai-gateway",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/visitor-access/openclaw.plugin.json
+++ b/extensions/visitor-access/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "visitor-access",
+  "categories": ["tools"],
   "name": "Visitor Access",
   "description": "Manage expiring visitor grants through one Cloudflare Access email policy.",
   "activation": {

--- a/extensions/vllm/openclaw.plugin.json
+++ b/extensions/vllm/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "vllm",
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "voice-call",
+  "categories": ["voice", "tools"],
   "doctorContract": {
     "resolveSessionStoreAgentIds": true,
     "stateMigrations": [{ "id": "voice-call-calls-jsonl-to-plugin-state" }]

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "volcengine",
+  "categories": ["models", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/voyage/openclaw.plugin.json
+++ b/extensions/voyage/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "voyage",
+  "categories": ["memory"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/vydra/openclaw.plugin.json
+++ b/extensions/vydra/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "vydra",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/web-readability/openclaw.plugin.json
+++ b/extensions/web-readability/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "web-readability",
+  "categories": ["web", "context"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/webhooks/openclaw.plugin.json
+++ b/extensions/webhooks/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "webhooks",
+  "categories": ["gateway", "tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "whatsapp",
+  "categories": ["channels", "tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "whatsapp-legacy-state" }]

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
   "id": "workboard",
+  "categories": [
+    "tools"
+  ],
   "cliCommands": [
     {
       "name": "workboard",

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "xai",
+  "categories": ["models", "voice", "media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "xiaomi",
+  "categories": ["models", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "zai",
+  "categories": ["models", "media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalo/openclaw.plugin.json
+++ b/extensions/zalo/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "zalo",
+  "categories": ["channels"],
   "doctorContract": {},
   "name": "Zalo",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",

--- a/extensions/zalouser/openclaw.plugin.json
+++ b/extensions/zalouser/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "zalouser",
+  "categories": ["channels", "tools"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/zoom-meetings/openclaw.plugin.json
+++ b/extensions/zoom-meetings/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "zoom-meetings",
+  "categories": ["voice", "tools"],
   "name": "Zoom meetings",
   "description": "Join Zoom meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/packages/plugin-package-contract/src/index.test.ts
+++ b/packages/plugin-package-contract/src/index.test.ts
@@ -2,12 +2,43 @@
 import { describe, expect, it } from "vitest";
 import {
   EXTERNAL_CODE_PLUGIN_REQUIRED_FIELD_PATHS,
+  PLUGIN_CATEGORY_SLUGS,
   listMissingExternalCodePluginFieldPaths,
   normalizeExternalPluginCompatibility,
+  validatePluginCategories,
   validateExternalCodePluginPackageJson,
 } from "./index.js";
 
 describe("@openclaw/plugin-package-contract", () => {
+  it("publishes the controlled plugin category taxonomy", () => {
+    expect(PLUGIN_CATEGORY_SLUGS).toEqual([
+      "channels",
+      "models",
+      "memory",
+      "context",
+      "voice",
+      "media",
+      "web",
+      "tools",
+      "runtime",
+      "gateway",
+      "security",
+      "other",
+    ]);
+  });
+
+  it("validates ordered package-owned plugin categories", () => {
+    expect(validatePluginCategories(undefined)).toEqual({ ok: true });
+    expect(validatePluginCategories(["web", "tools", "runtime"])).toEqual({
+      ok: true,
+      categories: ["web", "tools", "runtime"],
+    });
+    expect(validatePluginCategories(["web", "web"])).toEqual({
+      ok: false,
+      error: "must not contain duplicates",
+    });
+  });
+
   it("normalizes the OpenClaw compatibility block for external plugins", () => {
     expect(
       normalizeExternalPluginCompatibility({

--- a/packages/plugin-package-contract/src/index.ts
+++ b/packages/plugin-package-contract/src/index.ts
@@ -31,6 +31,53 @@ export const EXTERNAL_CODE_PLUGIN_REQUIRED_FIELD_PATHS = [
   "openclaw.build.openclawVersion",
 ] as const;
 
+/** Controlled browse categories accepted by native OpenClaw plugin manifests. */
+export const PLUGIN_CATEGORY_SLUGS = [
+  "channels",
+  "models",
+  "memory",
+  "context",
+  "voice",
+  "media",
+  "web",
+  "tools",
+  "runtime",
+  "gateway",
+  "security",
+  "other",
+] as const;
+
+export type PluginCategorySlug = (typeof PLUGIN_CATEGORY_SLUGS)[number];
+
+export type PluginCategoriesValidationResult =
+  | { ok: true; categories?: PluginCategorySlug[] }
+  | { ok: false; error: string };
+
+/** Validate optional ordered package-owned plugin categories. */
+export function validatePluginCategories(value: unknown): PluginCategoriesValidationResult {
+  if (value === undefined) {
+    return { ok: true };
+  }
+  if (!Array.isArray(value)) {
+    return { ok: false, error: "must be an array" };
+  }
+  if (value.length < 1 || value.length > 3) {
+    return { ok: false, error: "must contain between 1 and 3 entries" };
+  }
+  const categories: PluginCategorySlug[] = [];
+  for (const entry of value) {
+    const category = PLUGIN_CATEGORY_SLUGS.find((candidate) => candidate === entry);
+    if (!category) {
+      return { ok: false, error: `contains unknown category ${JSON.stringify(entry)}` };
+    }
+    if (categories.includes(category)) {
+      return { ok: false, error: "must not contain duplicates" };
+    }
+    categories.push(category);
+  }
+  return { ok: true, categories };
+}
+
 /** Read OpenClaw package.json blocks without trusting caller input shape. */
 function readOpenClawBlock(packageJson: unknown) {
   const root = isRecord(packageJson) ? packageJson : undefined;

--- a/src/plugins/bundled-plugin-categories.test.ts
+++ b/src/plugins/bundled-plugin-categories.test.ts
@@ -1,0 +1,38 @@
+// Keeps every bundled plugin assigned to the package-owned catalog taxonomy.
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pluginTestRepoRoot as repoRoot } from "./generated-plugin-test-helpers.js";
+import { loadPluginManifest } from "./manifest.js";
+
+describe("bundled plugin categories", () => {
+  it("assigns at least one valid category to every bundled plugin", () => {
+    const extensionsRoot = path.join(repoRoot, "extensions");
+    const missing: string[] = [];
+    const invalid: string[] = [];
+    let manifestCount = 0;
+
+    for (const entry of fs.readdirSync(extensionsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const manifestPath = path.join(extensionsRoot, entry.name, "openclaw.plugin.json");
+      if (!fs.existsSync(manifestPath)) {
+        continue;
+      }
+      manifestCount += 1;
+      const result = loadPluginManifest(path.dirname(manifestPath), false);
+      if (!result.ok) {
+        invalid.push(`${entry.name}: ${result.error}`);
+        continue;
+      }
+      if (!result.manifest.categories?.length) {
+        missing.push(entry.name);
+      }
+    }
+
+    expect(manifestCount).toBeGreaterThan(0);
+    expect(invalid).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/plugins/manifest-categories.test.ts
+++ b/src/plugins/manifest-categories.test.ts
@@ -1,0 +1,59 @@
+// Verifies package-owned catalog categories at the native plugin manifest boundary.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginManifest } from "./manifest.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function loadWithCategories(categories?: unknown) {
+  const rootDir = makeTrackedTempDir("openclaw-manifest-categories", tempDirs);
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "catalog-test",
+      ...(categories === undefined ? {} : { categories }),
+      configSchema: { type: "object", additionalProperties: false },
+    }),
+  );
+  return loadPluginManifest(rootDir, false);
+}
+
+describe("plugin manifest categories", () => {
+  it("preserves one to three unique categories in declaration order", () => {
+    expect(loadWithCategories(["web", "tools", "runtime"])).toMatchObject({
+      ok: true,
+      manifest: { categories: ["web", "tools", "runtime"] },
+    });
+  });
+
+  it("allows packages to omit categories", () => {
+    const result = loadWithCategories();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest).not.toHaveProperty("categories");
+    }
+  });
+
+  it.each([
+    { categories: [], reason: "must contain between 1 and 3 entries" },
+    {
+      categories: ["web", "tools", "runtime", "other"],
+      reason: "must contain between 1 and 3 entries",
+    },
+    { categories: ["web", "web"], reason: "must not contain duplicates" },
+    { categories: ["web", "unknown"], reason: 'contains unknown category "unknown"' },
+    { categories: [" web "], reason: 'contains unknown category " web "' },
+    { categories: "web", reason: "must be an array" },
+  ])("rejects invalid categories: $reason", ({ categories, reason }) => {
+    expect(loadWithCategories(categories)).toMatchObject({
+      ok: false,
+      error: `invalid plugin manifest categories: ${reason}`,
+    });
+  });
+});

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -659,10 +659,11 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.iconPath).toBe(path.join(dir, "assets/icon.png"));
   });
 
-  it("preserves manifest catalog metadata on registry records", () => {
+  it("preserves manifest catalog metadata and categories on registry records", () => {
     const dir = makeTempDir();
     writeManifest(dir, {
       id: "catalog-demo",
+      categories: ["web", "tools"],
       catalog: { featured: true, order: 20 },
       configSchema: { type: "object" },
     });
@@ -676,6 +677,7 @@ describe("loadPluginManifestRegistry", () => {
     ]);
 
     expect(registry.plugins[0]?.catalog).toEqual({ featured: true, order: 20 });
+    expect(registry.plugins[0]?.categories).toEqual(["web", "tools"]);
   });
 
   it("keeps only the higher-precedence plugin for truly distinct duplicates", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -430,6 +430,7 @@ function buildRecord(params: {
   );
   return {
     id: pluginId,
+    categories: params.manifest.categories,
     backupResources: params.manifest.backupResources,
     doctorContract: params.manifest.doctorContract,
     doctorHealthChecks: params.manifest.doctorHealthChecks,

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -1,5 +1,6 @@
 import type { ModelPricingProvider } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import type { ModelCatalog } from "@openclaw/model-catalog-core/model-catalog-types";
+import type { PluginCategorySlug } from "../../packages/plugin-package-contract/src/index.js";
 import type { ChannelConfigRuntimeSchema } from "../channels/plugins/types.config.js";
 import type { ConfigUiPresentation } from "../shared/config-ui-hints-types.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
@@ -380,6 +381,8 @@ export type PluginManifestBackupResource = {
 export type PluginManifest = {
   id: string;
   configSchema: JsonSchemaObject;
+  /** Ordered browse categories; the first category is the plugin's primary category. */
+  categories?: PluginCategorySlug[];
   /** Static backup inclusion/exclusion declarations; resolved without loading plugin runtime. */
   backupResources?: PluginManifestBackupResource[];
   /** Plugin ids that must also be installed for this plugin to have effect. */

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
+import { validatePluginCategories } from "../../packages/plugin-package-contract/src/index.js";
 import { matchRootFileOpenFailure } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import { coerceDoctorSessionRouteStateOwners } from "./doctor-session-route-state-owner-types.js";
@@ -207,6 +208,14 @@ export function loadPluginManifest(
       diagnosticCode: "backup-resource-declaration-invalid",
     });
   }
+  const categories = validatePluginCategories(raw.categories);
+  if (!categories.ok) {
+    return cacheResult({
+      ok: false,
+      error: `invalid plugin manifest categories: ${categories.error}`,
+      manifestPath,
+    });
+  }
 
   const requiresPlugins = normalizeTrimmedStringList(raw.requiresPlugins);
   const enabledByDefaultOnPlatforms = setupNormalizers.normalizeManifestDefaultPlatforms(
@@ -235,6 +244,7 @@ export function loadPluginManifest(
   const manifestBeforeDashboard = {
     id,
     configSchema,
+    ...("categories" in categories ? { categories: categories.categories } : {}),
     ...(backupResources.resources !== undefined
       ? { backupResources: backupResources.resources }
       : {}),

--- a/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
+++ b/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
@@ -65,7 +65,7 @@ describe("PluginsPage lifecycle confirmation", () => {
           name: "Community Thing",
           family: "code-plugin",
           official: false,
-          categories: ["tools"],
+          categories: [],
         },
         local: {
           present: false,


### PR DESCRIPTION
## Summary

- define the optional ordered `categories` manifest contract and canonical taxonomy
- backfill every bundled plugin manifest with package-owned categories
- document primary-category and multi-category semantics for plugin authors

Linear: https://linear.app/my-openclaw/issue/CLAW-755/081-define-package-owned-plugin-categories-and-backfill-bundled

## Validation

- manifest schema and bundled-inventory tests
- `pnpm tsgo`
- exact stack-head build verification

## Stack

Layer 10 of https://github.com/openclaw/openclaw/stacks/139149
