### PR TITLE
feat(plugins): enrich package categories from ClawHub

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -21688,6 +21688,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
     public let hasicon: Bool?
     public let install: PluginCatalogInstallAction?
     public let error: String?
+    public let categories: [String]?
     public let category: String?
     public let removable: Bool?
 
@@ -21708,6 +21709,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         hasicon: Bool? = nil,
         install: PluginCatalogInstallAction? = nil,
         error: String? = nil,
+        categories: [String]? = nil,
         category: String? = nil,
         removable: Bool? = nil)
     {
@@ -21727,6 +21729,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         self.hasicon = hasicon
         self.install = install
         self.error = error
+        self.categories = categories
         self.category = category
         self.removable = removable
     }
@@ -21748,6 +21751,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         case hasicon = "hasIcon"
         case install
         case error
+        case categories
         case category
         case removable
     }

--- a/packages/gateway-protocol/src/plugins-validators.test.ts
+++ b/packages/gateway-protocol/src/plugins-validators.test.ts
@@ -104,6 +104,32 @@ describe("plugin lifecycle protocol validators", () => {
     ).toBe(false);
   });
 
+  it("accepts ordered plugin categories while retaining the primary compatibility field", () => {
+    const result = {
+      plugins: [
+        {
+          id: "memory-tools",
+          name: "Memory Tools",
+          installed: true,
+          enabled: true,
+          state: "enabled",
+          categories: ["memory", "tools"],
+          category: "memory",
+        },
+      ],
+      diagnostics: [],
+      mutationAllowed: true,
+    };
+
+    expect(Value.Check(PluginsListResultSchema, result)).toBe(true);
+    expect(
+      Value.Check(PluginsListResultSchema, {
+        ...result,
+        plugins: [{ ...result.plugins[0], categories: ["memory", ""] }],
+      }),
+    ).toBe(false);
+  });
+
   it("requires exactly one non-empty plugin id for inspection", () => {
     expect(validatePluginsInspectParams({ pluginId: "workboard" })).toBe(true);
     expect(validatePluginsInspectParams({ pluginId: "" })).toBe(false);

--- a/packages/gateway-protocol/src/schema/plugins.ts
+++ b/packages/gateway-protocol/src/schema/plugins.ts
@@ -163,7 +163,9 @@ export const PluginCatalogEntrySchema = closedObject({
   hasIcon: Type.Optional(Type.Boolean()),
   install: Type.Optional(PluginCatalogInstallActionSchema),
   error: Type.Optional(Type.String()),
-  /** Coarse manifest-derived grouping (channel, provider, memory, ...) for catalog UIs. */
+  /** Ordered package or registry categories; the first category is primary. */
+  categories: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, maxItems: 3 })),
+  /** Compatibility projection of the primary category. */
   category: Type.Optional(NonEmptyString),
   /** True when the plugin has an install record and can be removed via plugins.uninstall. */
   removable: Type.Optional(Type.Boolean()),

--- a/src/cli/plugins-cli.marketplace-refresh.test.ts
+++ b/src/cli/plugins-cli.marketplace-refresh.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => {
     writeJson: vi.fn(),
   };
   return {
-    clearManagedPluginOfficialCatalogCache: vi.fn(),
+    clearManagedPluginCatalogCache: vi.fn(),
     defaultRuntime,
     getRuntimeConfig: vi.fn(),
     loadConfiguredHostedOfficialExternalPluginCatalogEntries: vi.fn(),
@@ -41,7 +41,7 @@ vi.mock("../plugins/official-external-plugin-catalog.js", () => ({
 }));
 
 vi.mock("../plugins/management-catalog.js", () => ({
-  clearManagedPluginOfficialCatalogCache: mocks.clearManagedPluginOfficialCatalogCache,
+  clearManagedPluginCatalogCache: mocks.clearManagedPluginCatalogCache,
 }));
 
 vi.mock("./plugins-update-gateway-signal.js", () => ({
@@ -70,7 +70,7 @@ describe("plugins marketplace refresh", () => {
     mocks.defaultRuntime.writeJson.mockClear();
     mocks.getRuntimeConfig.mockReset();
     mocks.loadConfiguredHostedOfficialExternalPluginCatalogEntries.mockReset();
-    mocks.clearManagedPluginOfficialCatalogCache.mockReset();
+    mocks.clearManagedPluginCatalogCache.mockReset();
     mocks.notifyGatewayPluginMetadataChanged.mockReset().mockResolvedValue(true);
     vi.unstubAllEnvs();
   });

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -900,9 +900,8 @@ export async function runPluginMarketplaceRefreshCommand(
     ...(expectedSha256 ? { expectedSha256 } : {}),
     requireSnapshotWrite: true,
   });
-  const { clearManagedPluginOfficialCatalogCache } =
-    await import("../plugins/management-catalog.js");
-  clearManagedPluginOfficialCatalogCache();
+  const { clearManagedPluginCatalogCache } = await import("../plugins/management-catalog.js");
+  clearManagedPluginCatalogCache();
   let gatewayRefreshed = true;
   // Reused snapshots can lose install authority as they age, so their Gateway projection is stale too.
   if (result.source !== "bundled-fallback") {

--- a/src/gateway/server-methods/plugins.test.ts
+++ b/src/gateway/server-methods/plugins.test.ts
@@ -631,7 +631,8 @@ describe("plugin management Gateway handlers", () => {
       installed: true,
       enabled: false,
       state: "needs-setup" as const,
-      category: "tool",
+      categories: ["tools"],
+      category: "tools",
     };
     managementMocks.list.mockResolvedValue({
       plugins: [localOnly],

--- a/src/infra/clawhub-plugin-catalog.test.ts
+++ b/src/infra/clawhub-plugin-catalog.test.ts
@@ -3,6 +3,7 @@ import {
   fetchAllOfficialClawHubPlugins,
   fetchClawHubPluginCatalog,
   fetchClawHubPluginCategories,
+  fetchClawHubPluginVersionCategories,
   fetchClawHubPluginDetail,
 } from "./clawhub-plugin-catalog.js";
 
@@ -251,6 +252,41 @@ describe("ClawHub plugin catalog client", () => {
         icon: "package",
         order: 0,
       },
+    ]);
+  });
+
+  it("batch-reads categories for exact package versions", async () => {
+    let request: Request | undefined;
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      request = new Request(input, init);
+      return jsonResponse({
+        packages: [
+          { name: "@openclaw/memory", version: "1.2.3", categories: ["memory", "tools"] },
+          { name: "@openclaw/missing", version: "4.5.6", categories: null },
+        ],
+      });
+    });
+
+    const result = await fetchClawHubPluginVersionCategories({
+      baseUrl: "https://example.com",
+      packages: [
+        { name: "@openclaw/memory", version: "1.2.3" },
+        { name: "@openclaw/missing", version: "4.5.6" },
+      ],
+      fetchImpl,
+    });
+
+    expect(request?.method).toBe("POST");
+    expect(new URL(request?.url ?? "").pathname).toBe("/api/v1/packages/categories:batch");
+    await expect(request?.json()).resolves.toEqual({
+      packages: [
+        { name: "@openclaw/memory", version: "1.2.3" },
+        { name: "@openclaw/missing", version: "4.5.6" },
+      ],
+    });
+    expect(result).toEqual([
+      { name: "@openclaw/memory", version: "1.2.3", categories: ["memory", "tools"] },
+      { name: "@openclaw/missing", version: "4.5.6", categories: null },
     ]);
   });
 

--- a/src/infra/clawhub-plugin-catalog.test.ts
+++ b/src/infra/clawhub-plugin-catalog.test.ts
@@ -269,6 +269,8 @@ describe("ClawHub plugin catalog client", () => {
 
     const result = await fetchClawHubPluginVersionCategories({
       baseUrl: "https://example.com",
+      token: "private-token",
+      skipAuth: true,
       packages: [
         { name: "@openclaw/memory", version: "1.2.3" },
         { name: "@openclaw/missing", version: "4.5.6" },
@@ -277,6 +279,7 @@ describe("ClawHub plugin catalog client", () => {
     });
 
     expect(request?.method).toBe("POST");
+    expect(request?.headers.has("authorization")).toBe(false);
     expect(new URL(request?.url ?? "").pathname).toBe("/api/v1/packages/categories:batch");
     await expect(request?.json()).resolves.toEqual({
       packages: [

--- a/src/infra/clawhub-plugin-catalog.ts
+++ b/src/infra/clawhub-plugin-catalog.ts
@@ -1,5 +1,6 @@
 // ClawHub plugin discovery reads and strict remote response normalization.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { validatePluginCategories } from "../../packages/plugin-package-contract/src/index.js";
 import {
   createClawHubError,
   decodeClawHubResponseBody,
@@ -89,6 +90,12 @@ export type ClawHubPluginCategory = {
   description: string;
   icon: string;
   order: number;
+};
+
+export type ClawHubPluginVersionCategories = {
+  name: string;
+  version: string;
+  categories: string[] | null;
 };
 
 type ClawHubReadOptions = {
@@ -542,6 +549,55 @@ export async function fetchClawHubPluginCategories(
     };
   });
   return categories.toSorted((left, right) => left.order - right.order);
+}
+
+/** Read effective categories for exact installed ClawHub package versions in one request. */
+export async function fetchClawHubPluginVersionCategories(
+  params: ClawHubReadOptions & {
+    packages: ReadonlyArray<{ name: string; version: string }>;
+  },
+): Promise<ClawHubPluginVersionCategories[]> {
+  if (params.packages.length === 0) {
+    return [];
+  }
+  if (params.packages.length > 200) {
+    throw new Error("ClawHub plugin category batch cannot exceed 200 packages.");
+  }
+  const value = await fetchClawHubJson<unknown>({
+    baseUrl: params.baseUrl,
+    token: params.token,
+    timeoutMs: params.timeoutMs,
+    fetchImpl: params.fetchImpl,
+    method: "POST",
+    path: "/api/v1/packages/categories:batch",
+    json: { packages: params.packages },
+  });
+  if (!isRecord(value) || !Array.isArray(value.packages)) {
+    throw new Error(
+      "Malformed ClawHub plugin category batch response: expected packages to be an array.",
+    );
+  }
+  return value.packages.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`Malformed ClawHub plugin category batch item ${index}: expected an object.`);
+    }
+    const rawCategories = entry.categories;
+    const categories = rawCategories === null ? null : validatePluginCategories(rawCategories);
+    if (categories !== null && (!categories.ok || !categories.categories)) {
+      throw new Error(
+        `Malformed ClawHub plugin category batch item ${index}: expected categories to be a string array or null.`,
+      );
+    }
+    return {
+      name: readRequiredClawHubStringField(entry, "name", `plugin category batch item ${index}`),
+      version: readRequiredClawHubStringField(
+        entry,
+        "version",
+        `plugin category batch item ${index}`,
+      ),
+      categories: categories === null ? null : categories.categories,
+    };
+  });
 }
 
 export async function fetchClawHubPluginDetail(

--- a/src/infra/clawhub-plugin-catalog.ts
+++ b/src/infra/clawhub-plugin-catalog.ts
@@ -101,6 +101,7 @@ export type ClawHubPluginVersionCategories = {
 type ClawHubReadOptions = {
   baseUrl?: string;
   token?: string;
+  skipAuth?: boolean;
   timeoutMs?: number;
   fetchImpl?: ClawHubFetch;
 };
@@ -383,6 +384,7 @@ async function fetchOptionalReadme(
   const { response, url, hasToken } = await requestClawHub({
     baseUrl: params.baseUrl,
     token: params.token,
+    skipAuth: params.skipAuth,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
     path: `/api/v1/packages/${encodeURIComponent(params.packageName)}/file`,
@@ -566,6 +568,7 @@ export async function fetchClawHubPluginVersionCategories(
   const value = await fetchClawHubJson<unknown>({
     baseUrl: params.baseUrl,
     token: params.token,
+    skipAuth: params.skipAuth,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
     method: "POST",

--- a/src/infra/clawhub-plugin-catalog.ts
+++ b/src/infra/clawhub-plugin-catalog.ts
@@ -582,11 +582,17 @@ export async function fetchClawHubPluginVersionCategories(
       throw new Error(`Malformed ClawHub plugin category batch item ${index}: expected an object.`);
     }
     const rawCategories = entry.categories;
-    const categories = rawCategories === null ? null : validatePluginCategories(rawCategories);
-    if (categories !== null && (!categories.ok || !categories.categories)) {
-      throw new Error(
-        `Malformed ClawHub plugin category batch item ${index}: expected categories to be a string array or null.`,
-      );
+    let categories: string[] | null;
+    if (rawCategories === null) {
+      categories = null;
+    } else {
+      const validation = validatePluginCategories(rawCategories);
+      if (!validation.ok || !validation.categories) {
+        throw new Error(
+          `Malformed ClawHub plugin category batch item ${index}: expected categories to be a string array or null.`,
+        );
+      }
+      categories = validation.categories;
     }
     return {
       name: readRequiredClawHubStringField(entry, "name", `plugin category batch item ${index}`),
@@ -595,7 +601,7 @@ export async function fetchClawHubPluginVersionCategories(
         "version",
         `plugin category batch item ${index}`,
       ),
-      categories: categories === null ? null : categories.categories,
+      categories,
     };
   });
 }

--- a/src/plugins/catalog-discovery.test.ts
+++ b/src/plugins/catalog-discovery.test.ts
@@ -109,7 +109,8 @@ describe("plugin discovery identity and local join", () => {
       installed: false,
       enabled: false,
       state: "not-installed" as const,
-      category: "tool",
+      categories: ["tools", "web"],
+      category: "tools",
       install: { source: "official" as const, pluginId: "calendar-local" },
     };
     const local = { plugins: [bundledOnly], diagnostics: [], mutationAllowed: true };
@@ -125,13 +126,13 @@ describe("plugin discovery identity and local join", () => {
       includeBundledOnly: true,
       published: [remote],
       intent: "bundled",
-      category: "tools",
+      category: "web",
     });
 
     expect(all.map((item) => item.catalog.name)).toEqual(["Memory Plus"]);
     expect(tools).toHaveLength(1);
     expect(tools[0]).toMatchObject({
-      catalog: { categories: ["tools"], official: false },
+      catalog: { categories: ["tools", "web"], official: false },
       local: {
         present: true,
         action: "install",

--- a/src/plugins/catalog-discovery.ts
+++ b/src/plugins/catalog-discovery.ts
@@ -181,14 +181,14 @@ export function joinClawHubPluginCatalog(params: {
   const localOnly = params.local.plugins
     .filter((plugin) => plugin.origin === "bundled" && !publishedLocalPlugins.has(plugin))
     .filter((plugin) => {
-      const category = localDiscoveryCategory(plugin.category);
-      if (params.category && category !== params.category) {
+      const categories = localDiscoveryCategories(plugin);
+      if (params.category && !categories.includes(params.category)) {
         return false;
       }
       if (!query) {
         return true;
       }
-      return [plugin.id, plugin.packageName, plugin.name, plugin.description]
+      return [plugin.id, plugin.packageName, plugin.name, plugin.description, ...categories]
         .flatMap((value) => (value ? [value.toLowerCase()] : []))
         .some((value) => value.includes(query));
     })
@@ -197,20 +197,8 @@ export function joinClawHubPluginCatalog(params: {
   return [...localOnly, ...remote];
 }
 
-function localDiscoveryCategory(category: string | undefined): string {
-  if (category === "channel") {
-    return "channels";
-  }
-  if (category === "provider") {
-    return "models";
-  }
-  if (category === "context-engine") {
-    return "context";
-  }
-  if (category === "tool") {
-    return "tools";
-  }
-  return category || "other";
+function localDiscoveryCategories(plugin: PluginCatalogEntry): string[] {
+  return plugin.categories ?? (plugin.category ? [plugin.category] : []);
 }
 
 function localDiscoveryIdentity(plugin: PluginCatalogEntry): string {
@@ -227,7 +215,7 @@ function projectLocalDiscoveryEntry(
       name: plugin.name,
       ...(plugin.description ? { summary: plugin.description } : {}),
       official: false,
-      categories: [localDiscoveryCategory(plugin.category)],
+      categories: localDiscoveryCategories(plugin),
       publishedToClawHub: false,
       ...(plugin.version ? { latestVersion: plugin.version } : {}),
     },

--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -63,9 +63,11 @@ export function withManagedPluginCache<
   return (params) => withPluginCache(getManagedPluginCache(params.metadata), () => run(params));
 }
 
-/** Clear the process-stable hosted catalog snapshot after an explicit owner reload. */
-export function clearManagedPluginOfficialCatalogCache(): void {
-  getManagedPluginCache().officialCatalog = undefined;
+/** Clear process-stable catalog snapshots after an explicit owner reload. */
+export function clearManagedPluginCatalogCache(): void {
+  const cache = getManagedPluginCache();
+  cache.officialCatalog = undefined;
+  cache.pluginVersionCategories = undefined;
 }
 
 function mergeCatalogMetadata(

--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -229,46 +229,6 @@ export function normalizeFeaturedAt(value: unknown): number | undefined {
   return asSafeIntegerInRange(value, { min: 0 });
 }
 
-/** Coarse manifest-derived grouping so catalog UIs can shelve a large inventory. */
-export function derivePluginCategory(
-  manifest: PluginManifestRecord | undefined,
-): string | undefined {
-  if (!manifest) {
-    return undefined;
-  }
-  if (manifest.channels.length > 0 || Object.keys(manifest.channelConfigs ?? {}).length > 0) {
-    return "channel";
-  }
-  const mediaProvider =
-    Object.keys(manifest.imageGenerationProviderMetadata ?? {}).length > 0 ||
-    Object.keys(manifest.videoGenerationProviderMetadata ?? {}).length > 0 ||
-    Object.keys(manifest.musicGenerationProviderMetadata ?? {}).length > 0 ||
-    Object.keys(manifest.mediaUnderstandingProviderMetadata ?? {}).length > 0;
-  if (
-    manifest.providers.length > 0 ||
-    manifest.providerEndpoints?.length ||
-    manifest.modelCatalog ||
-    mediaProvider
-  ) {
-    return "provider";
-  }
-  const kinds = normalizeKinds(manifest.kind);
-  if (kinds?.includes("memory")) {
-    return "memory";
-  }
-  if (kinds?.includes("context-engine")) {
-    return "context-engine";
-  }
-  if (
-    manifest.contracts?.tools?.length ||
-    Object.keys(manifest.toolMetadata ?? {}).length > 0 ||
-    manifest.skills.length > 0
-  ) {
-    return "tool";
-  }
-  return undefined;
-}
-
 export function firstPluginError(
   diagnostics: readonly PluginDiagnostic[],
   pluginId: string,

--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -229,6 +229,46 @@ export function normalizeFeaturedAt(value: unknown): number | undefined {
   return asSafeIntegerInRange(value, { min: 0 });
 }
 
+/** Preserve the shipped coarse category projection for older catalog clients. */
+export function deriveLegacyPluginCategory(
+  manifest: PluginManifestRecord | undefined,
+): string | undefined {
+  if (!manifest) {
+    return undefined;
+  }
+  if (manifest.channels.length > 0 || Object.keys(manifest.channelConfigs ?? {}).length > 0) {
+    return "channel";
+  }
+  const mediaProvider =
+    Object.keys(manifest.imageGenerationProviderMetadata ?? {}).length > 0 ||
+    Object.keys(manifest.videoGenerationProviderMetadata ?? {}).length > 0 ||
+    Object.keys(manifest.musicGenerationProviderMetadata ?? {}).length > 0 ||
+    Object.keys(manifest.mediaUnderstandingProviderMetadata ?? {}).length > 0;
+  if (
+    manifest.providers.length > 0 ||
+    manifest.providerEndpoints?.length ||
+    manifest.modelCatalog ||
+    mediaProvider
+  ) {
+    return "provider";
+  }
+  const kinds = normalizeKinds(manifest.kind);
+  if (kinds?.includes("memory")) {
+    return "memory";
+  }
+  if (kinds?.includes("context-engine")) {
+    return "context-engine";
+  }
+  if (
+    manifest.contracts?.tools?.length ||
+    Object.keys(manifest.toolMetadata ?? {}).length > 0 ||
+    manifest.skills.length > 0
+  ) {
+    return "tool";
+  }
+  return undefined;
+}
+
 export function firstPluginError(
   diagnostics: readonly PluginDiagnostic[],
   pluginId: string,

--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -25,7 +25,7 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => {
   };
 });
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { listManagedPlugins, resolveManagedPluginIconSource } =
   await import("./management-service.js");
 
@@ -219,7 +219,7 @@ describe("plugin management Featured authority", () => {
 
   beforeEach(() => {
     mocks.bundledEntries = undefined;
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     mocks.metadata.mockReset();
     mocks.officialCatalog.mockReset();
     mocks.officialCatalog.mockResolvedValue(hostedCatalog([]));

--- a/src/plugins/management-service.capability-consent.test.ts
+++ b/src/plugins/management-service.capability-consent.test.ts
@@ -86,7 +86,7 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
     mocks.officialCatalog(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { inspectManagedPlugin, listManagedPlugins } = await import("./management-service.js");
 const { setManagedPluginEnabled } = await import("./management-mutations.js");
 
@@ -156,7 +156,7 @@ describe("managed plugin capability consent", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     clearPluginMetadataLifecycleCaches();
     mocks.records = {};
     mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });

--- a/src/plugins/management-service.inspect.test.ts
+++ b/src/plugins/management-service.inspect.test.ts
@@ -20,13 +20,13 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
     mocks.officialCatalog(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { inspectManagedPlugin } = await import("./management-service.js");
 
 describe("managed plugin inspection", () => {
   beforeEach(() => {
     clearPluginMetadataLifecycleCaches();
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     mocks.metadata.mockReset();
     mocks.officialCatalog.mockReset();
     mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });

--- a/src/plugins/management-service.install.test.ts
+++ b/src/plugins/management-service.install.test.ts
@@ -86,7 +86,7 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
     mocks.officialCatalog(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { installManagedPlugin, setManagedPluginEnabled } = await import("./management-mutations.js");
 
 function mockHostedOfficialCatalog(entries: unknown[]) {
@@ -126,7 +126,7 @@ describe("managed plugin installation", () => {
   beforeEach(() => {
     // Explicit empty env fixtures must never acquire a lease in the operator's home.
     vi.spyOn(os, "homedir").mockReturnValue(tempDirs.make("openclaw-managed-install-home-"));
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     for (const mock of Object.values(mocks)) {
       if (typeof mock === "function" && "mockReset" in mock) {
         mock.mockReset();

--- a/src/plugins/management-service.registry-refresh.test.ts
+++ b/src/plugins/management-service.registry-refresh.test.ts
@@ -70,7 +70,7 @@ vi.mock("./slot-selection.js", () => ({
   applySlotSelectionForPlugin: (config: unknown) => ({ config, warnings: [] }),
 }));
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { installManagedPlugin, setManagedPluginEnabled } = await import("./management-mutations.js");
 const { installManagedPluginSource } = await import("./management-install.js");
 const { inspectManagedPlugin, listManagedPlugins } = await import("./management-service.js");
@@ -181,7 +181,7 @@ describe("plugin management registry refresh", () => {
   });
 
   beforeEach(() => {
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     vi.resetAllMocks();
     mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });
   });

--- a/src/plugins/management-service.test-helpers.ts
+++ b/src/plugins/management-service.test-helpers.ts
@@ -30,6 +30,7 @@ export function metadataSnapshot(params: {
   categories?: PluginCategorySlug[];
   packageVersion?: string;
   configSchema?: PluginManifestRecord["configSchema"];
+  channels?: string[];
 }) {
   const id = params.id ?? "workboard";
   const origin = params.origin ?? "bundled";
@@ -44,7 +45,7 @@ export function metadataSnapshot(params: {
     ...(params.categories ? { categories: params.categories } : {}),
     ...(params.packageDependencies ? { packageDependencies: params.packageDependencies } : {}),
     ...(params.iconPath ? { iconPath: params.iconPath } : {}),
-    channels: [],
+    channels: params.channels ?? [],
     providers: [],
     cliBackends: [],
     skills: [],

--- a/src/plugins/management-service.test-helpers.ts
+++ b/src/plugins/management-service.test-helpers.ts
@@ -1,3 +1,4 @@
+import type { PluginCategorySlug } from "../../packages/plugin-package-contract/src/index.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 
 export function configSnapshot(config: Record<string, unknown> = {}) {
@@ -26,6 +27,8 @@ export function metadataSnapshot(params: {
   packageBuild?: { bundledDist?: boolean };
   packageDependencies?: Record<string, string>;
   iconPath?: string;
+  categories?: PluginCategorySlug[];
+  packageVersion?: string;
   configSchema?: PluginManifestRecord["configSchema"];
 }) {
   const id = params.id ?? "workboard";
@@ -38,6 +41,7 @@ export function metadataSnapshot(params: {
     name: params.name ?? "Workboard",
     description: "Coordinate agent work in a shared board.",
     catalog: { featured: true, order: 10 },
+    ...(params.categories ? { categories: params.categories } : {}),
     ...(params.packageDependencies ? { packageDependencies: params.packageDependencies } : {}),
     ...(params.iconPath ? { iconPath: params.iconPath } : {}),
     channels: [],
@@ -58,6 +62,7 @@ export function metadataSnapshot(params: {
           pluginId: id,
           ...(origin === "global" ? { installOwner: id } : {}),
           packageName: `@openclaw/${id}`,
+          ...(params.packageVersion ? { packageVersion: params.packageVersion } : {}),
           origin,
           enabled: params.enabled,
           rootDir: `/tmp/${id}`,

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -374,6 +374,7 @@ describe("plugin management service", () => {
     expect(mocks.pluginVersionCategories).toHaveBeenCalledOnce();
     expect(mocks.pluginVersionCategories).toHaveBeenCalledWith({
       baseUrl: "https://clawhub.ai",
+      skipAuth: true,
       packages: [{ name: "community/memory", version: "4.5.6" }],
     });
     expect(catalog.plugins[0]).toMatchObject({
@@ -426,12 +427,14 @@ describe("plugin management service", () => {
       [
         {
           baseUrl: "https://private.example/clawhub",
+          skipAuth: true,
           packages: [{ name: "community/memory", version: "4.5.6" }],
         },
       ],
       [
         {
           baseUrl: "https://public.example",
+          skipAuth: true,
           packages: [{ name: "community/memory", version: "4.5.6" }],
         },
       ],

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -332,8 +332,8 @@ describe("plugin management service", () => {
 
     expect(catalog.plugins[0]).toMatchObject({
       categories: ["memory", "tools"],
-      category: "memory",
     });
+    expect(catalog.plugins[0]).not.toHaveProperty("category");
     expect(mocks.pluginVersionCategories).not.toHaveBeenCalled();
   });
 
@@ -379,11 +379,35 @@ describe("plugin management service", () => {
     });
     expect(catalog.plugins[0]).toMatchObject({
       categories: ["memory", "tools"],
-      category: "memory",
     });
     expect(cached.plugins[0]).toMatchObject({
       categories: ["memory", "tools"],
-      category: "memory",
+    });
+    expect(catalog.plugins[0]).not.toHaveProperty("category");
+    expect(cached.plugins[0]).not.toHaveProperty("category");
+  });
+
+  it("preserves the shipped category projection alongside package categories", async () => {
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        enabled: true,
+        id: "chat-bridge",
+        name: "Chat Bridge",
+        origin: "global",
+        categories: ["channels", "tools"],
+        channels: ["chat-bridge"],
+      }),
+    );
+
+    const catalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    expect(catalog.plugins[0]).toMatchObject({
+      categories: ["channels", "tools"],
+      category: "channel",
     });
   });
 

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -373,6 +373,7 @@ describe("plugin management service", () => {
 
     expect(mocks.pluginVersionCategories).toHaveBeenCalledOnce();
     expect(mocks.pluginVersionCategories).toHaveBeenCalledWith({
+      baseUrl: "https://clawhub.ai",
       packages: [{ name: "community/memory", version: "4.5.6" }],
     });
     expect(catalog.plugins[0]).toMatchObject({
@@ -383,6 +384,60 @@ describe("plugin management service", () => {
       categories: ["memory", "tools"],
       category: "memory",
     });
+  });
+
+  it("keeps category enrichment scoped to the installed ClawHub registry", async () => {
+    const installedAt = (clawhubUrl: string) =>
+      metadataSnapshot({
+        enabled: true,
+        id: "community-memory",
+        name: "Community Memory",
+        origin: "global",
+        packageVersion: "4.5.6",
+        installRecord: {
+          source: "clawhub",
+          clawhubUrl,
+          clawhubPackage: "community/memory",
+          version: "4.5.6",
+        },
+      });
+    mocks.pluginVersionCategories.mockImplementation(async ({ baseUrl }: { baseUrl: string }) => [
+      {
+        name: "community/memory",
+        version: "4.5.6",
+        categories: [baseUrl.includes("private") ? "tools" : "memory"],
+      },
+    ]);
+
+    mocks.metadata.mockReturnValue(installedAt("https://private.example/clawhub/"));
+    const privateCatalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+    mocks.metadata.mockReturnValue(installedAt("https://public.example/"));
+    const publicCatalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    expect(mocks.pluginVersionCategories.mock.calls).toEqual([
+      [
+        {
+          baseUrl: "https://private.example/clawhub",
+          packages: [{ name: "community/memory", version: "4.5.6" }],
+        },
+      ],
+      [
+        {
+          baseUrl: "https://public.example",
+          packages: [{ name: "community/memory", version: "4.5.6" }],
+        },
+      ],
+    ]);
+    expect(privateCatalog.plugins[0]?.categories).toEqual(["tools"]);
+    expect(publicCatalog.plugins[0]?.categories).toEqual(["memory"]);
   });
 
   it("keeps installed plugins uncategorized when ClawHub enrichment is unavailable", async () => {

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   persistInstall: vi.fn(),
   preflight: vi.fn(),
   providerAuthChoices: vi.fn(),
+  pluginVersionCategories: vi.fn(),
   readConfig: vi.fn(),
   recommendedInstalls: vi.fn(),
   refreshRegistry: vi.fn(),
@@ -103,11 +104,17 @@ vi.mock("./provider-auth-choices.js", () => ({
   resolveManifestProviderAuthChoices: (...args: unknown[]) => mocks.providerAuthChoices(...args),
 }));
 
+vi.mock("../infra/clawhub-plugin-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/clawhub-plugin-catalog.js")>()),
+  fetchClawHubPluginVersionCategories: (...args: unknown[]) =>
+    mocks.pluginVersionCategories(...args),
+}));
+
 vi.mock("./recommended-tool-installs.js", () => ({
   listRecommendedToolInstalls: (...args: unknown[]) => mocks.recommendedInstalls(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
+const { clearManagedPluginCatalogCache } = await import("./management-catalog.js");
 const { listManagedPlugins, resolveManagedPluginIconSource, resolveManagedSetupCatalogIconUrl } =
   await import("./management-service.js");
 const { setManagedPluginEnabled } = await import("./management-mutations.js");
@@ -124,7 +131,7 @@ function mockHostedOfficialCatalog(entries: unknown[]) {
 
 describe("plugin management service", () => {
   beforeEach(() => {
-    clearManagedPluginOfficialCatalogCache();
+    clearManagedPluginCatalogCache();
     for (const mock of Object.values(mocks)) {
       if (typeof mock === "function" && "mockReset" in mock) {
         mock.mockReset();
@@ -139,6 +146,7 @@ describe("plugin management service", () => {
     mocks.installRecords.mockResolvedValue({});
     mocks.applyUninstall.mockResolvedValue({ directoryRemoved: true, warnings: [] });
     mocks.providerAuthChoices.mockReturnValue([]);
+    mocks.pluginVersionCategories.mockResolvedValue([]);
     mocks.recommendedInstalls.mockReturnValue([]);
     mocks.clawReferenceWarnings.mockReturnValue([]);
     mockHostedOfficialCatalog([]);
@@ -285,7 +293,6 @@ describe("plugin management service", () => {
       env: {},
       officialCatalog: { entries: [] },
     });
-
     expect(catalog.plugins).toEqual([
       expect.objectContaining({
         id: "workboard",
@@ -298,6 +305,117 @@ describe("plugin management service", () => {
       }),
     ]);
     expect(catalog.mutationAllowed).toBe(true);
+  });
+
+  it("projects package-declared categories without consulting ClawHub", async () => {
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        enabled: true,
+        id: "memory-tools",
+        name: "Memory Tools",
+        origin: "global",
+        categories: ["memory", "tools"],
+        packageVersion: "1.2.3",
+        installRecord: {
+          source: "clawhub",
+          clawhubPackage: "@openclaw/memory-tools",
+          version: "1.2.3",
+        },
+      }),
+    );
+
+    const catalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    expect(catalog.plugins[0]).toMatchObject({
+      categories: ["memory", "tools"],
+      category: "memory",
+    });
+    expect(mocks.pluginVersionCategories).not.toHaveBeenCalled();
+  });
+
+  it("batch-enriches missing categories from the exact installed ClawHub version", async () => {
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        enabled: true,
+        id: "community-memory",
+        name: "Community Memory",
+        origin: "global",
+        packageVersion: "4.5.6",
+        installRecord: {
+          source: "clawhub",
+          clawhubPackage: "community/memory",
+          version: "4.5.6",
+        },
+      }),
+    );
+    mocks.pluginVersionCategories.mockResolvedValue([
+      {
+        name: "community/memory",
+        version: "4.5.6",
+        categories: ["memory", "tools"],
+      },
+    ]);
+
+    const catalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+    const cached = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    expect(mocks.pluginVersionCategories).toHaveBeenCalledOnce();
+    expect(mocks.pluginVersionCategories).toHaveBeenCalledWith({
+      packages: [{ name: "community/memory", version: "4.5.6" }],
+    });
+    expect(catalog.plugins[0]).toMatchObject({
+      categories: ["memory", "tools"],
+      category: "memory",
+    });
+    expect(cached.plugins[0]).toMatchObject({
+      categories: ["memory", "tools"],
+      category: "memory",
+    });
+  });
+
+  it("keeps installed plugins uncategorized when ClawHub enrichment is unavailable", async () => {
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        enabled: true,
+        id: "community-tool",
+        name: "Community Tool",
+        origin: "global",
+        packageVersion: "1.0.0",
+        installRecord: {
+          source: "clawhub",
+          clawhubPackage: "community/tool",
+          version: "1.0.0",
+        },
+      }),
+    );
+    mocks.pluginVersionCategories.mockRejectedValue(new Error("ClawHub offline"));
+
+    const catalog = await listManagedPlugins({
+      config: {},
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    expect(catalog.plugins[0]).toMatchObject({
+      id: "community-tool",
+      installed: true,
+      enabled: true,
+      state: "enabled",
+    });
+    expect(catalog.plugins[0]).not.toHaveProperty("categories");
+    expect(catalog.plugins[0]).not.toHaveProperty("category");
   });
 
   it.each([

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -8,6 +8,7 @@ import type {
 import { resolveConfigWidePluginMetadataSnapshot } from "../config/io.plugin-metadata.js";
 import { resolveIsConfigReadOnly } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveClawHubBaseUrl } from "../infra/clawhub-client.js";
 import { fetchClawHubPluginVersionCategories } from "../infra/clawhub-plugin-catalog.js";
 import { resolvePendingPluginCapabilityReview } from "./capability-consent.js";
 import {
@@ -257,13 +258,17 @@ export const listManagedPlugins = withManagedPluginCache(
     const installedIconsById = new Map<string, ManagedPluginIconSource | undefined>();
     const installedClawHubPackages = new Set<string>();
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
-    const categoryTargets = new Map<
+    const categoryTargetsByRegistry = new Map<
       string,
-      {
-        request: { name: string; version: string };
-        plugins: ManagedPluginCatalogEntry[];
-      }
+      Map<
+        string,
+        {
+          request: { name: string; version: string };
+          plugins: ManagedPluginCatalogEntry[];
+        }
+      >
     >();
+    let categoryTargetCount = 0;
     // Hosted loading can yield; prepare this phase from the current config.
     const isEnabled = createInstalledPluginEnabledPredicate(
       metadata.index.plugins,
@@ -400,22 +405,33 @@ export const listManagedPlugins = withManagedPluginCache(
         const name = normalizeOptionalString(installRecord.clawhubPackage);
         const version = normalizeOptionalString(installRecord.version);
         if (name && version) {
+          const baseUrl = resolveClawHubBaseUrl(installRecord.clawhubUrl);
+          let categoryTargets = categoryTargetsByRegistry.get(baseUrl);
+          if (!categoryTargets) {
+            categoryTargets = new Map();
+            categoryTargetsByRegistry.set(baseUrl, categoryTargets);
+          }
           const key = pluginVersionKey(name, version);
           const target = categoryTargets.get(key);
           if (target) {
             target.plugins.push(plugin);
-          } else if (categoryTargets.size < CLAWHUB_CATEGORY_BATCH_LIMIT) {
+          } else if (categoryTargetCount < CLAWHUB_CATEGORY_BATCH_LIMIT) {
             categoryTargets.set(key, { request: { name, version }, plugins: [plugin] });
+            categoryTargetCount += 1;
           }
         }
       }
       return plugin;
     });
-    if (categoryTargets.size > 0) {
+    const cache = getManagedPluginCache();
+    const categoryCache = cache.pluginVersionCategories ?? new Map();
+    cache.pluginVersionCategories = categoryCache;
+    for (const [baseUrl, categoryTargets] of categoryTargetsByRegistry) {
       try {
-        const cache = getManagedPluginCache();
-        if (!cache.pluginVersionCategories) {
-          const load = fetchClawHubPluginVersionCategories({
+        let load = categoryCache.get(baseUrl);
+        if (!load) {
+          load = fetchClawHubPluginVersionCategories({
+            baseUrl,
             packages: [...categoryTargets.values()].map((target) => target.request),
           }).then(
             (results) =>
@@ -426,14 +442,14 @@ export const listManagedPlugins = withManagedPluginCache(
                 ),
               ),
           );
-          cache.pluginVersionCategories = load;
+          categoryCache.set(baseUrl, load);
           void load.catch(() => {
-            if (cache.pluginVersionCategories === load) {
-              cache.pluginVersionCategories = undefined;
+            if (categoryCache.get(baseUrl) === load) {
+              categoryCache.delete(baseUrl);
             }
           });
         }
-        const resolved = await cache.pluginVersionCategories;
+        const resolved = await load;
         for (const [key, target] of categoryTargets) {
           const categories = resolved.get(key);
           if (!categories?.length) {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -432,6 +432,7 @@ export const listManagedPlugins = withManagedPluginCache(
         if (!load) {
           load = fetchClawHubPluginVersionCategories({
             baseUrl,
+            skipAuth: true,
             packages: [...categoryTargets.values()].map((target) => target.request),
           }).then(
             (results) =>

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -43,6 +43,7 @@ import {
   normalizeFeaturedAt,
   firstPluginError,
   compareCatalogEntries,
+  deriveLegacyPluginCategory,
   resolveInstalledPluginPresentation,
   resolveInstalledHostedOfficialEntry,
   resolveOfficialEntryById,
@@ -334,6 +335,7 @@ export const listManagedPlugins = withManagedPluginCache(
       const error = firstPluginError(pluginDiagnostics, record.pluginId) ?? configError;
       const kind = normalizeKinds(manifest?.kind);
       const categories = manifest?.categories;
+      const legacyCategory = deriveLegacyPluginCategory(manifest);
       // Only externally installed plugins (tracked install record, non-bundled) can be removed.
       const removable = record.origin !== "bundled" && Boolean(installOwner);
       const hostedListingAuthoritative =
@@ -398,9 +400,11 @@ export const listManagedPlugins = withManagedPluginCache(
       if (error) {
         plugin.error = error;
       }
+      if (legacyCategory) {
+        plugin.category = legacyCategory;
+      }
       if (categories?.length) {
         plugin.categories = [...categories];
-        plugin.category = categories[0];
       } else if (record.origin !== "bundled" && installRecord?.source === "clawhub") {
         const name = normalizeOptionalString(installRecord.clawhubPackage);
         const version = normalizeOptionalString(installRecord.version);
@@ -458,7 +462,6 @@ export const listManagedPlugins = withManagedPluginCache(
           }
           for (const plugin of target.plugins) {
             plugin.categories = [...categories];
-            plugin.category = categories[0];
           }
         }
       } catch {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -8,6 +8,7 @@ import type {
 import { resolveConfigWidePluginMetadataSnapshot } from "../config/io.plugin-metadata.js";
 import { resolveIsConfigReadOnly } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { fetchClawHubPluginVersionCategories } from "../infra/clawhub-plugin-catalog.js";
 import { resolvePendingPluginCapabilityReview } from "./capability-consent.js";
 import {
   buildPluginCapabilitySummary,
@@ -39,7 +40,6 @@ import {
   normalizeKinds,
   normalizeCatalogMetadata,
   normalizeFeaturedAt,
-  derivePluginCategory,
   firstPluginError,
   compareCatalogEntries,
   resolveInstalledPluginPresentation,
@@ -85,6 +85,12 @@ function resolveManagedPluginState(params: {
 }
 
 export type ManagedPluginInspection = PluginsInspectResult;
+
+const CLAWHUB_CATEGORY_BATCH_LIMIT = 200;
+
+function pluginVersionKey(name: string, version: string): string {
+  return JSON.stringify([name, version]);
+}
 
 function resolveManagedPluginDiagnostics(
   snapshot: PluginMetadataSnapshot,
@@ -251,6 +257,13 @@ export const listManagedPlugins = withManagedPluginCache(
     const installedIconsById = new Map<string, ManagedPluginIconSource | undefined>();
     const installedClawHubPackages = new Set<string>();
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
+    const categoryTargets = new Map<
+      string,
+      {
+        request: { name: string; version: string };
+        plugins: ManagedPluginCatalogEntry[];
+      }
+    >();
     // Hosted loading can yield; prepare this phase from the current config.
     const isEnabled = createInstalledPluginEnabledPredicate(
       metadata.index.plugins,
@@ -315,7 +328,7 @@ export const listManagedPlugins = withManagedPluginCache(
       const configError = setup.mode === "invalid" ? setup.error : undefined;
       const error = firstPluginError(pluginDiagnostics, record.pluginId) ?? configError;
       const kind = normalizeKinds(manifest?.kind);
-      const category = derivePluginCategory(manifest);
+      const categories = manifest?.categories;
       // Only externally installed plugins (tracked install record, non-bundled) can be removed.
       const removable = record.origin !== "bundled" && Boolean(installOwner);
       const hostedListingAuthoritative =
@@ -380,11 +393,61 @@ export const listManagedPlugins = withManagedPluginCache(
       if (error) {
         plugin.error = error;
       }
-      if (category) {
-        plugin.category = category;
+      if (categories?.length) {
+        plugin.categories = [...categories];
+        plugin.category = categories[0];
+      } else if (record.origin !== "bundled" && installRecord?.source === "clawhub") {
+        const name = normalizeOptionalString(installRecord.clawhubPackage);
+        const version = normalizeOptionalString(installRecord.version);
+        if (name && version) {
+          const key = pluginVersionKey(name, version);
+          const target = categoryTargets.get(key);
+          if (target) {
+            target.plugins.push(plugin);
+          } else if (categoryTargets.size < CLAWHUB_CATEGORY_BATCH_LIMIT) {
+            categoryTargets.set(key, { request: { name, version }, plugins: [plugin] });
+          }
+        }
       }
       return plugin;
     });
+    if (categoryTargets.size > 0) {
+      try {
+        const cache = getManagedPluginCache();
+        if (!cache.pluginVersionCategories) {
+          const load = fetchClawHubPluginVersionCategories({
+            packages: [...categoryTargets.values()].map((target) => target.request),
+          }).then(
+            (results) =>
+              new Map(
+                results.map(
+                  (result) =>
+                    [pluginVersionKey(result.name, result.version), result.categories] as const,
+                ),
+              ),
+          );
+          cache.pluginVersionCategories = load;
+          void load.catch(() => {
+            if (cache.pluginVersionCategories === load) {
+              cache.pluginVersionCategories = undefined;
+            }
+          });
+        }
+        const resolved = await cache.pluginVersionCategories;
+        for (const [key, target] of categoryTargets) {
+          const categories = resolved.get(key);
+          if (!categories?.length) {
+            continue;
+          }
+          for (const plugin of target.plugins) {
+            plugin.categories = [...categories];
+            plugin.category = categories[0];
+          }
+        }
+      } catch {
+        // Registry metadata is optional presentation data. Installed plugins remain usable offline.
+      }
+    }
     const installedIds = new Set(plugins.map((plugin) => plugin.id));
     const installedPackageNames = new Set(
       plugins.flatMap((plugin) => (plugin.packageName ? [plugin.packageName] : [])),

--- a/src/plugins/plugin-cache-management.ts
+++ b/src/plugins/plugin-cache-management.ts
@@ -22,7 +22,7 @@ export type PluginCacheManagement<TCache> = {
   };
   dependencyStatus: WeakMap<PluginManifestRecord, PluginDependencyStatus>;
   officialCatalog?: Promise<OfficialCatalogResult>;
-  pluginVersionCategories?: Promise<Map<string, string[] | null>>;
+  pluginVersionCategories?: Map<string, Promise<Map<string, string[] | null>>>;
 };
 
 export function createPluginCacheManagement<TCache>(): PluginCacheManagement<TCache> {

--- a/src/plugins/plugin-cache-management.ts
+++ b/src/plugins/plugin-cache-management.ts
@@ -22,6 +22,7 @@ export type PluginCacheManagement<TCache> = {
   };
   dependencyStatus: WeakMap<PluginManifestRecord, PluginDependencyStatus>;
   officialCatalog?: Promise<OfficialCatalogResult>;
+  pluginVersionCategories?: Promise<Map<string, string[] | null>>;
 };
 
 export function createPluginCacheManagement<TCache>(): PluginCacheManagement<TCache> {


### PR DESCRIPTION
## Summary

- remove OpenClaw steady-state category inference from the catalog path
- batch-enrich missing package categories from ClawHub by canonical package identity and exact version
- preserve additive protocol compatibility and non-fatal offline behavior

Linear: https://linear.app/my-openclaw/issue/CLAW-757/084-batch-enrich-gateway-plugin-categories-and-preserve-protocol

## Validation

- Gateway management-service and exact-version catalog tests
- Gateway protocol validator tests
- `pnpm tsgo`

## Stack

Layer 11 of https://github.com/openclaw/openclaw/stacks/139149
