### PR TITLE
test(live): backport safe MiniMax probes to 7.33

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -4318,13 +4318,15 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
       )}\n`,
     );
     await fs.rm(path.join(workspaceDir, "BOOTSTRAP.md"), { force: true });
-    const nonceA = randomUUID();
-    const nonceB = randomUUID();
+    // Prefix the random values so provider safety heuristics do not mistake the
+    // harmless readback proof for secret material.
+    const nonceA = `tool-read-alpha-${randomUUID()}`;
+    const nonceB = `tool-read-beta-${randomUUID()}`;
     // Keep probe values out of the path: weak tool callers may echo the filename
     // instead of reading the file, turning nonceA into a false duplicate answer.
     const toolProbePath = path.join(workspaceDir, ".openclaw-live-tool-probe.txt");
     cleanupToolProbePath = toolProbePath;
-    await fs.writeFile(toolProbePath, `nonceA=${nonceA}\nnonceB=${nonceB}\n`);
+    await fs.writeFile(toolProbePath, `testMarkerA=${nonceA}\ntestMarkerB=${nonceB}\n`);
 
     const agentDir = resolveDefaultAgentDir(params.cfg);
     const sanitizedCfg: OpenClawConfig = {
@@ -4594,7 +4596,8 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 });
               }
 
-              // Real tool invocation: force the agent to Read a local file and echo a nonce.
+              // Real tool invocation: force the agent to read a local file and
+              // return two harmless, uniquely generated test markers.
               logProgress(`${progressLabel}: tool-read`);
               const runIdTool = randomUUID();
               const maxToolReadAttempts = 3;
@@ -4617,10 +4620,10 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                     message: strictReply
                       ? "OpenClaw live tool probe (local, safe): " +
                         `use the tool named \`read\` (or \`Read\`) with JSON arguments {"path":"${toolProbePath}"}. ` +
-                        "Then reply with exactly the two nonce values from that file, separated by one space. No extra text."
+                        "Then reply with exactly the two test marker values from that file, separated by one space. No extra text."
                       : "OpenClaw live tool probe (local, safe): " +
                         `use the tool named \`read\` (or \`Read\`) with JSON arguments {"path":"${toolProbePath}"}. ` +
-                        "Then reply with the two nonce values you read (include both).",
+                        "Then reply with the two test marker values you read (include both).",
                     thinkingLevel,
                     context: `${progressLabel}: tool-read`,
                   });
@@ -4852,7 +4855,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   sessionKey,
                   idempotencyKey: `idem-${runId2}-2`,
                   modelKey,
-                  message: `Now answer: what are the values of nonceA and nonceB in "${toolProbePath}"? Reply with exactly: ${nonceA} ${nonceB}.`,
+                  message: `Now answer: what are the values of testMarkerA and testMarkerB in "${toolProbePath}"? Reply with exactly: ${nonceA} ${nonceB}.`,
                   thinkingLevel,
                   context: `${progressLabel}: tool-only-regression-second`,
                 });

--- a/src/gateway/live-tool-probe-utils.test.ts
+++ b/src/gateway/live-tool-probe-utils.test.ts
@@ -225,9 +225,9 @@ describe("live tool probe utils", () => {
         expected: false,
       },
       {
-        name: "retries mistral nonce marker echoes without parsed values",
+        name: "retries mistral marker echoes without parsed values",
         params: {
-          text: "nonceA= nonceB=",
+          text: "testMarkerA= testMarkerB=",
           nonceA: "nonce-a",
           nonceB: "nonce-b",
           provider: "mistral",

--- a/src/gateway/live-tool-probe.test-helpers.ts
+++ b/src/gateway/live-tool-probe.test-helpers.ts
@@ -114,7 +114,13 @@ export function shouldRetryToolReadProbe(params: {
     return true;
   }
   const lower = normalizeLowercaseStringOrEmpty(params.text);
-  if (params.provider === "mistral" && (lower.includes("noncea=") || lower.includes("nonceb="))) {
+  if (
+    params.provider === "mistral" &&
+    (lower.includes("noncea=") ||
+      lower.includes("nonceb=") ||
+      lower.includes("testmarkera=") ||
+      lower.includes("testmarkerb="))
+  ) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

- backport the harmless test-marker wording from #142685 to `extended-stable/2026.7.33`
- retain the frozen branch's live-harness control flow
- keep the Mistral retry matcher compatible with both legacy nonce labels and the new marker labels

## Why

Full Validation run 34294189135 executes the candidate-owned live profile test. The trusted `main` merge of #142685 therefore could not change the frozen candidate's `nonceA`/`nonceB` probe, and both MiniMax profiles skipped after reading the file successfully but returning values the harness did not accept.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/live-tool-probe-utils.test.ts src/gateway/gateway-models.profiles.live.test.ts`
- 3 files passed, 120 tests passed

