### PR TITLE
fix(ci): retain measured costs when split test inventories change

### DIFF
--- a/.github/workflows/ci-test-timings-refit.yml
+++ b/.github/workflows/ci-test-timings-refit.yml
@@ -77,6 +77,7 @@ jobs:
             scripts/ci-run-timings.mjs
             scripts/lib/ci-test-timings-refit.mts
             scripts/lib/ci-test-timings-schema.mts
+            scripts/lib/vitest-shard-metadata.mts
             scripts/lib/direct-run.mjs
             scripts/lib/numeric-options.mjs
             scripts/lib/plain-gh.mjs

--- a/docs/ci/capacity.md
+++ b/docs/ci/capacity.md
@@ -95,6 +95,15 @@ jobs retain `planConcurrency: 1`. The refit preserves each complete child span,
 including contention, without subtracting setup or rewriting historical costs. Runner-profile
 calibration remains a separate admission policy.
 
+For split compact groups, the refit also records the parent cost from a complete
+generation within one run and runner profile. It sums each part's median span,
+takes the largest complete generation or direct parent measurement in that run,
+and applies the same two-run minimum and median rules. The stable parent estimate
+survives file additions and repartitioning, while exact child keys continue to
+describe only their original inventory. Partial generations cannot create or
+lower a parent estimate; observing a child preserves an existing parent during
+pruning. Parts from different runs, profiles, or generations never form a total.
+
 Gateway E2E uses the same greedy partition owner as UI E2E. Measured file durations
 include suite hooks; new files use source bytes scaled by the discovered files'
 measured seconds per byte. Without measurements, Gateway partitions use source

--- a/scripts/lib/ci-test-timings-refit.mts
+++ b/scripts/lib/ci-test-timings-refit.mts
@@ -1,5 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
 import type { CiTestTimings } from "./ci-test-timings-schema.mts";
+import { parseCompactSplitTimingKey } from "./vitest-shard-metadata.mts";
 
 export type CiTimingRun = {
   id: number;
@@ -101,10 +102,47 @@ function readCompactLog(
   }
 }
 
-function refitMap(samples: Samples, previous: Record<string, number> = {}, contributingRuns = 0) {
+function recordCompleteParentSamples(samples: Samples, observedParents: Set<string>) {
+  const generations = new Map<
+    string,
+    { parent: string; expected: number; parts: Map<number, number> }
+  >();
+  for (const [key, values] of samples) {
+    const parsed = parseCompactSplitTimingKey(key);
+    if (!parsed) {
+      continue;
+    }
+    observedParents.add(parsed.parentShardName);
+    const generation = generations.get(parsed.generationKey) ?? {
+      parent: parsed.parentShardName,
+      expected: parsed.expectedParts,
+      parts: new Map<number, number>(),
+    };
+    generation.parts.set(parsed.part, median(values));
+    generations.set(parsed.generationKey, generation);
+  }
+  for (const { parent, expected, parts } of generations.values()) {
+    if (parts.size !== expected) {
+      continue;
+    }
+    // Inventory-specific child keys expire when files move. Retain the full
+    // measured cost at its parent so the next inventory has a measured floor.
+    // One run/profile supplies one sample, even after retries or repartitioning.
+    const total = [...parts.values()].reduce((sum, duration) => sum + duration, 0);
+    const direct = samples.get(parent);
+    samples.set(parent, [Math.max(total, direct ? median(direct) : 0)]);
+  }
+}
+
+function refitMap(
+  samples: Samples,
+  previous: Record<string, number> = {},
+  contributingRuns = 0,
+  observedParents?: Set<string>,
+) {
   const next = Object.fromEntries(
     Object.entries(previous).filter(
-      ([key]) => contributingRuns < MIN_PRUNE_RUNS || samples.has(key),
+      ([key]) => contributingRuns < MIN_PRUNE_RUNS || samples.has(key) || observedParents?.has(key),
     ),
   );
   for (const [key, values] of samples) {
@@ -139,6 +177,7 @@ export function refitTestTimings(runs: CiTimingRun[], previous?: CiTestTimings) 
     github: new Set<number>(),
   };
   const overhead: number[] = [];
+  const observedParents = { blacksmith: new Set<string>(), github: new Set<string>() };
   for (const run of runs) {
     const current = {
       uiE2e: new Map<string, number[]>(),
@@ -153,6 +192,9 @@ export function refitTestTimings(runs: CiTimingRun[], previous?: CiTestTimings) 
       } else {
         readE2eLog(text, current[log.kind], log.kind === "uiE2e" ? overhead : undefined);
       }
+    }
+    for (const profile of ["blacksmith", "github"] as const) {
+      recordCompleteParentSamples(current[profile], observedParents[profile]);
     }
     // Retries or duplicate reporter lines in one run must not satisfy the two-run minimum.
     for (const profile of ["uiE2e", "repoE2e", "blacksmith", "github"] as const) {
@@ -179,11 +221,13 @@ export function refitTestTimings(runs: CiTimingRun[], previous?: CiTestTimings) 
         samples.blacksmith,
         previous?.compactGroupSeconds.blacksmith,
         contributingRuns.blacksmith.size,
+        observedParents.blacksmith,
       ),
       github: refitMap(
         samples.github,
         previous?.compactGroupSeconds.github,
         contributingRuns.github.size,
+        observedParents.github,
       ),
     },
     repoE2eFileSeconds: refitMap(

--- a/scripts/lib/vitest-shard-metadata.mts
+++ b/scripts/lib/vitest-shard-metadata.mts
@@ -39,6 +39,7 @@ type CompactSplitTimingGenerationSpec = {
 export type CompactSplitTimingKey = {
   expectedParts: number;
   generationKey: string;
+  parentShardName: string;
   part: number;
   selectorKey: string;
 };
@@ -59,6 +60,7 @@ export function parseCompactSplitTimingKey(value: string): CompactSplitTimingKey
   return {
     expectedParts,
     generationKey: `${match[1]}#generation-${match[2]}#parts-${expectedParts}`,
+    parentShardName: match[1]!.slice(0, match[1]!.lastIndexOf("#selector-")),
     part,
     selectorKey: match[1]!,
   };

--- a/test/scripts/ci-test-timings.test.ts
+++ b/test/scripts/ci-test-timings.test.ts
@@ -18,6 +18,7 @@ import {
   ciTestTimingsSchema,
   type CiTestTimings,
 } from "../../scripts/lib/ci-test-timings-schema.mts";
+import { createCompactSplitTimingGeneration } from "../../scripts/lib/vitest-shard-metadata.mts";
 
 function uiLog(files: Record<string, number>, overhead = 0.6) {
   const body = Object.values(files).reduce((sum, value) => sum + value, 0);
@@ -309,6 +310,146 @@ it.todo("retains todo coverage");
       github: { "core-unit-src-security-2": 50 },
     });
   });
+
+  it("retains measured parent costs across split inventory changes without double-counting retries", () => {
+    const parentShardName = "agentic-control-plane-agent-chat";
+    const generations = [0, 1, 2].map((index) =>
+      createCompactSplitTimingGeneration({
+        parentShardName,
+        configs: ["test/vitest/vitest.gateway-server.config.ts"],
+        stripes: [["a.test.ts"], [`added-${index}.test.ts`]],
+      }),
+    );
+    const runs = generations.map((generation, index) =>
+      timingRun(
+        index + 1,
+        generation.timingKeys.flatMap((key, part) => [
+          {
+            kind: "compact" as const,
+            labels: ["blacksmith-32vcpu-ubuntu-2404"],
+            text: compactLog(100 + part * 100 + index * 10, key),
+          },
+          {
+            kind: "compact" as const,
+            labels: ["blacksmith-32vcpu-ubuntu-2404"],
+            text: compactLog(100 + part * 100 + index * 10, key),
+          },
+          {
+            kind: "compact" as const,
+            labels: ["ubuntu-24.04"],
+            text: compactLog(300 + part * 100, key),
+          },
+        ]),
+      ),
+    );
+    const previous = {
+      ...baseline,
+      compactGroupSeconds: { blacksmith: { [parentShardName]: 167 }, github: {} },
+    };
+    // No child key has two independent run samples, but every run covers its
+    // complete parent. Inventory growth must not erase that measured baseline.
+    expect(refitTestTimings(runs, previous).timings.compactGroupSeconds).toEqual({
+      blacksmith: { [parentShardName]: 320 },
+      github: { [parentShardName]: 700 },
+    });
+    expect(refitTestTimings([runs[0]!]).timings.compactGroupSeconds).toEqual({
+      blacksmith: {},
+      github: {},
+    });
+  });
+
+  it.each(["missing part", "different generation", "different profile", "different run"])(
+    "does not invent a complete parent measurement from %s",
+    (condition) => {
+      const common = {
+        parentShardName: "agentic-control-plane-agent-chat",
+        configs: ["test/vitest/vitest.gateway-server.config.ts"],
+      };
+      const first = createCompactSplitTimingGeneration({
+        ...common,
+        stripes: [["a.test.ts"], ["b.test.ts"]],
+      });
+      const second = createCompactSplitTimingGeneration({
+        ...common,
+        stripes: [["b.test.ts"], ["a.test.ts"]],
+      });
+      const runs = [1, 2, 3].map((id) => {
+        const logs: CiTimingRun["logs"] = [
+          {
+            kind: "compact",
+            labels: ["blacksmith-32vcpu-ubuntu-2404"],
+            text: compactLog(
+              100,
+              first.timingKeys[condition === "different run" ? (id - 1) % 2 : 0]!,
+            ),
+          },
+        ];
+        if (condition === "different generation" || condition === "different profile") {
+          logs.push({
+            kind: "compact",
+            labels: [
+              condition === "different profile" ? "ubuntu-24.04" : "blacksmith-32vcpu-ubuntu-2404",
+            ],
+            text: compactLog(
+              200,
+              (condition === "different generation" ? second : first).timingKeys[1]!,
+            ),
+          });
+        }
+        return timingRun(id, logs);
+      });
+      const result = refitTestTimings(runs).timings.compactGroupSeconds;
+      expect(result.blacksmith).not.toHaveProperty(common.parentShardName);
+      expect(result.github).not.toHaveProperty(common.parentShardName);
+      const previous = {
+        ...baseline,
+        compactGroupSeconds: { blacksmith: { [common.parentShardName]: 500 }, github: {} },
+      };
+      expect(
+        refitTestTimings(runs, previous).timings.compactGroupSeconds.blacksmith[
+          common.parentShardName
+        ],
+      ).toBe(500);
+    },
+  );
+
+  it.each([undefined, 900])(
+    "counts complete repartitions as one parent sample alongside direct cost %s",
+    (directSeconds) => {
+      const parentShardName = "agentic-control-plane-agent-chat";
+      const generations = [
+        [["a.test.ts"], ["b.test.ts"]],
+        [["b.test.ts"], ["a.test.ts"]],
+      ].map((stripes) =>
+        createCompactSplitTimingGeneration({
+          parentShardName,
+          configs: ["test/vitest/vitest.gateway-server.config.ts"],
+          stripes,
+        }),
+      );
+      const logs: CiTimingRun["logs"] = generations.flatMap((generation, index) =>
+        generation.timingKeys.map((key) => ({
+          kind: "compact" as const,
+          labels: ["blacksmith-32vcpu-ubuntu-2404"],
+          text: compactLog(index === 0 ? 150 : 350, key),
+        })),
+      );
+      if (directSeconds !== undefined) {
+        logs.push({
+          kind: "compact",
+          labels: ["blacksmith-32vcpu-ubuntu-2404"],
+          text: compactLog(directSeconds, parentShardName),
+        });
+      }
+      const runs = [timingRun(1, logs), timingRun(2, logs)];
+      expect(refitTestTimings(runs).timings.compactGroupSeconds.blacksmith[parentShardName]).toBe(
+        directSeconds ?? 700,
+      );
+      expect(
+        refitTestTimings([runs[0]!]).timings.compactGroupSeconds.blacksmith,
+      ).not.toHaveProperty(parentShardName);
+    },
+  );
 
   it.each([0, 1, 2, 3])(
     "prunes absent keys only after at least three contributing runs per profile (%s)",


### PR DESCRIPTION
## What Problem This Solves

CI loses measured costs when a split test group gains or moves files. In [PR #142685’s CI job](https://github.com/openclaw/openclaw/actions/runs/34291896788/job/102280287184), seven groups budgeted at 360 aggregate seconds consumed about 2,340 seconds and held the job open for 21m 27s.

## Why This Change Was Made

The refit records split children under exact inventory keys, which become unusable after inventory changes. It can also prune the stable parent estimate, sending the planner back to stale cold-start hints.

Preserve a stable parent cost from each complete split generation within one run and runner profile. Duplicate child observations use their median; complete repartitions and direct parent measurements contribute one maximum cost per run. Existing two-run minimum, median, and write-threshold rules still apply. Partial generations preserve existing parent estimates without inventing measurements. The planner already consumes this parent fallback.

Also include the shared timing-key parser in the generated-PR publisher’s input invalidation paths.

## User Impact

Future timing refreshes retain learned costs across inventory changes. This fixes the measurement producer without manually redistributing tests or changing runners, concurrency, timeouts, or coverage. Existing committed weights remain unchanged; the repair takes effect when a subsequent timing refit lands.

## Evidence

- The new regression failed before repair: three complete runs with different inventories erased the parent estimate. It passes after repair.
- `node scripts/run-vitest.mjs test/scripts/ci-test-timings.test.ts test/scripts/ci-node-test-plan.test.ts test/scripts/ci-workflow-guards.test.ts`: 691 passed, 2 skipped. Covers incomplete generations, profile/run separation, retries, multiple complete generations, and existing planner/workflow policy.
- Changed-file checks, docs inventory, and `git diff --check` passed.
- Independent autoreview found no actionable P0–P2 issues.

A live native refit successfully recovered stable Blacksmith parent costs of 515s for Gateway agent/chat and 258s for config. The full generated refresh is deliberately excluded: it exposed separate Gateway CLI process singleton estimates of 237s against their existing 200s budget, and additional hybrid CLI budget failures. No assertion or budget was relaxed. Regenerating the standing timing PR #136235 after this fix lands needs to address those process-test costs before landing its data. This PR does not claim a measured wall-time improvement or fix every source of test runtime.
