### PR TITLE
fix(ui): smooth scroll-to-latest button dismissal

### DIFF
--- a/ui/src/e2e/chat-scroll.e2e.test.ts
+++ b/ui/src/e2e/chat-scroll.e2e.test.ts
@@ -246,10 +246,14 @@ suite.define(() => {
         });
 
       const before = await readLayout();
-      expect(before.buttonBottom).toBeNull();
+      const button = page.locator(".chat-scroll-to-bottom");
+      expect(await button.isVisible()).toBe(false);
+      expect(await button.getAttribute("aria-hidden")).toBe("true");
+      expect(await button.evaluate((element: HTMLButtonElement) => element.inert)).toBe(true);
 
       await scrollChatThreadToTop(page);
       await page.getByRole("button", { name: "Scroll to latest" }).waitFor({ timeout: 10_000 });
+      expect(await button.evaluate((element: HTMLButtonElement) => element.inert)).toBe(false);
       const after = await readLayout();
 
       expect(after.threadBottom).toBe(before.threadBottom);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2496,11 +2496,25 @@ describe("chat scroll-to-bottom affordance", () => {
     expect(queue.compareDocumentPosition(composer)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it("hides the scroll-to-bottom button when the transcript is already latest", () => {
-    const container = renderChatView({ showNewMessages: false });
+  it.each([false, true])(
+    "keeps the latest action inactive while hidden and reuses it on reentry (initially visible: %s)",
+    (showNewMessages) => {
+      const container = renderChatView({ showNewMessages });
+      const button = requireElement(container, ".chat-scroll-to-bottom", "scroll affordance");
 
-    expect(container.querySelector(".chat-scroll-to-bottom")).toBeNull();
-  });
+      renderChatInto(container, { showNewMessages: false });
+
+      expect(container.querySelector(".chat-scroll-to-bottom")).toBe(button);
+      expect(button.getAttribute("aria-hidden")).toBe("true");
+      expect(button.hasAttribute("inert")).toBe(true);
+
+      renderChatInto(container, { showNewMessages: true });
+
+      expect(container.querySelector(".chat-scroll-to-bottom")).toBe(button);
+      expect(button.getAttribute("aria-hidden")).toBe("false");
+      expect(button.hasAttribute("inert")).toBe(false);
+    },
+  );
 });
 
 describe("chat composer workbench", () => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -961,7 +961,9 @@ describe("inline approval card", () => {
     const inlineSurface = requireElement(container, ".chat-inline-approval", "inline approval");
     const shell = requireElement(container, ".agent-chat__composer-shell", "composer shell");
     expect(card?.getAttribute("data-approval-id")).toBe("approval-inline");
-    expect(inlineSurface.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
+    const scrollAnchor = inlineSurface.previousElementSibling;
+    expect(scrollAnchor?.classList.contains("chat-scroll-to-bottom-wrap")).toBe(true);
+    expect(scrollAnchor?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
     expect(inlineSurface.parentElement).toBe(shell.parentElement);
     expect(inlineSurface.compareDocumentPosition(shell)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     const countdown = expectDefined(

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -255,21 +255,24 @@ export function renderChat(props: ChatProps) {
     taskSuggestionTray === nothing
       ? nothing
       : html`<div class="chat-gutter-stack">${taskSuggestionTray}</div>`;
-  const scrollToBottomButton =
-    props.showNewMessages && props.onScrollToBottom
-      ? html`
-          <div class="chat-scroll-to-bottom-wrap">
-            <button
-              class="chat-scroll-to-bottom"
-              type="button"
-              @click=${() => props.onScrollToBottom?.({ smooth: true })}
-              aria-label=${t("chat.actions.scrollToLatest")}
-            >
-              ${icons.arrowDown}
-            </button>
-          </div>
-        `
-      : nothing;
+  // Keep the affordance mounted so visibility changes can finish their exit transition.
+  const scrollToBottomButton = props.onScrollToBottom
+    ? html`
+        <div class="chat-scroll-to-bottom-wrap">
+          <button
+            class="chat-scroll-to-bottom"
+            data-visible=${Boolean(props.showNewMessages)}
+            type="button"
+            ?inert=${!props.showNewMessages}
+            aria-hidden=${!props.showNewMessages}
+            @click=${() => props.onScrollToBottom?.({ smooth: true })}
+            aria-label=${t("chat.actions.scrollToLatest")}
+          >
+            ${icons.arrowDown}
+          </button>
+        </div>
+      `
+    : nothing;
   const historyState = props.historyState;
   const historyLoadState = historyState ? getChatHistoryLoadState(historyState) : undefined;
   const historyFailed =

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -795,8 +795,48 @@ openclaw-chat-page {
   border-radius: var(--radius-full);
   box-shadow: var(--shadow-sm);
   cursor: var(--cursor-action);
+  pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
+  transform: translate(-50%, 8px) scale(0.9);
+  transition:
+    transform var(--duration-slow) var(--ease-in-out),
+    opacity var(--duration-slow) var(--ease-in-out),
+    visibility 0s linear var(--duration-slow);
+}
+
+.chat-scroll-to-bottom[data-visible="true"] {
   pointer-events: auto;
-  transform: translateX(-50%);
+  visibility: visible;
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    opacity var(--duration-normal) var(--ease-out),
+    visibility 0s;
+}
+
+@starting-style {
+  .chat-scroll-to-bottom[data-visible="true"] {
+    opacity: 0;
+    transform: translate(-50%, 8px) scale(0.9);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-scroll-to-bottom,
+  .chat-scroll-to-bottom[data-visible="true"] {
+    transform: translateX(-50%);
+    transition-property: opacity, visibility;
+    transition-timing-function: linear;
+    transition-delay: 0s, var(--duration-fast);
+    /* Keep the short fade despite the global reduced-motion duration reset. */
+    transition-duration: var(--duration-fast), 0s !important;
+  }
+
+  .chat-scroll-to-bottom[data-visible="true"] {
+    transition-delay: 0s;
+  }
 }
 
 .chat-scroll-to-bottom:focus-visible {


### PR DESCRIPTION
Quick fix, bigger pass later.

Closes #142716

## What Problem This Solves

Fixes an issue where users returning to the end of a Control UI chat would see the Scroll to latest button disappear abruptly, either after clicking it or scrolling manually.

## Why This Change Was Made

Keep the button mounted and drive its transition from the existing visibility state. It moves down 8 px, scales to 0.90, and fades out over 300 ms; entry follows the inverse path over 180 ms. The hidden action becomes inert immediately, and reduced motion uses only a 100 ms fade.

## User Impact

Moving between earlier messages and the latest message now has a smooth visual transition. The button's appearance, composer position, and scroll behavior stay the same.

## Evidence

Same long synthetic chat and interaction sequence before/after: scroll upward, click Scroll to latest, then repeat with manual scrolling to the end. Both recordings show dark followed by light, at 1280 × 800 with the UI's real font loaded. Captures were inspected before upload.

Before: source `22cba86bc30c6e02323d1e9a88e5ce9838587ca4`.

https://github.com/user-attachments/assets/4d536a38-0986-4f41-a529-b7ac96a0ab4a

After: production source matching `628b77a9d5e9af7d5a169e158c39f2fc0119f94d`.

https://github.com/user-attachments/assets/7c33f53a-a7f8-4e81-80cb-49d12113a012

<table>
<thead><tr><th>State</th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>Dark — Context: button visible</td><td><a href="https://github.com/user-attachments/assets/6d3e2642-1051-441c-9e2d-be2d55e216b0"><img src="https://github.com/user-attachments/assets/6d3e2642-1051-441c-9e2d-be2d55e216b0" alt="Before: dark Context: button visible" width="520"></a></td><td><a href="https://github.com/user-attachments/assets/ecbb8008-76c1-4776-93c5-ba77e8ce08e2"><img src="https://github.com/user-attachments/assets/ecbb8008-76c1-4776-93c5-ba77e8ce08e2" alt="After: dark Context: button visible" width="520"></a></td></tr>
<tr><td>Dark — Exit detail: immediate removal vs. transition</td><td><a href="https://github.com/user-attachments/assets/f1ee5485-4876-4f4b-b0f9-567ebc8454af"><img src="https://github.com/user-attachments/assets/f1ee5485-4876-4f4b-b0f9-567ebc8454af" alt="Before: dark Exit detail: immediate removal vs. transition" width="520"></a></td><td><a href="https://github.com/user-attachments/assets/21833793-7f85-454e-9cfe-e7fbbc81cbc4"><img src="https://github.com/user-attachments/assets/21833793-7f85-454e-9cfe-e7fbbc81cbc4" alt="After: dark Exit detail: immediate removal vs. transition" width="520"></a></td></tr>
<tr><td>Light — Context: button visible</td><td><a href="https://github.com/user-attachments/assets/6e73dbf4-7900-47a1-b84f-c9d587c4a2ae"><img src="https://github.com/user-attachments/assets/6e73dbf4-7900-47a1-b84f-c9d587c4a2ae" alt="Before: light Context: button visible" width="520"></a></td><td><a href="https://github.com/user-attachments/assets/708e2c51-0a89-4ee8-8ae7-301f5b506dbf"><img src="https://github.com/user-attachments/assets/708e2c51-0a89-4ee8-8ae7-301f5b506dbf" alt="After: light Context: button visible" width="520"></a></td></tr>
<tr><td>Light — Exit detail: immediate removal vs. transition</td><td><a href="https://github.com/user-attachments/assets/d8f98c68-a070-408b-a720-84b996815a06"><img src="https://github.com/user-attachments/assets/d8f98c68-a070-408b-a720-84b996815a06" alt="Before: light Exit detail: immediate removal vs. transition" width="520"></a></td><td><a href="https://github.com/user-attachments/assets/3918b585-070d-4e37-a119-c648b6a8fb0b"><img src="https://github.com/user-attachments/assets/3918b585-070d-4e37-a119-c648b6a8fb0b" alt="After: light Exit detail: immediate removal vs. transition" width="520"></a></td></tr>
</tbody>
</table>

Independent review returned no actionable P0–P3 findings. The render regression coverage checks that the hidden action is inert and accessibility-hidden, and that hiding/reentry retains the same button for its transition. Existing approval-order and scroll-overlay tests now account for the mounted hidden button while retaining their ordering and layout checks.

## Risk and coverage

The button remains mounted while its scroll callback exists, so interaction and accessibility must track visibility independently of DOM presence. Existing scroll-state ownership is unchanged; CSS delays final visibility hiding until the exit completes and allows reversal from the current transition value.

Focused render and scroll tests passed (412 cases). All three scroll browser scenarios passed against both source and production bundles, covering overlay geometry, composer growth, and sending. The new render regression fails against the original renderer. Browser inspection confirmed click/manual dismissal, reentry, immediate focus and pointer exclusion while hidden, and the reduced-motion fade. No fixtures or mock-server changes are included. Cross-browser and screen-reader execution were not performed.

