### PR TITLE
test(live): backport unavailable-model drift to 7.33

### DIFF
--- a/src/agents/live-test-provider-drift.test.ts
+++ b/src/agents/live-test-provider-drift.test.ts
@@ -49,6 +49,11 @@ describe("live test provider drift", () => {
         "Service temporarily unavailable. The model is at capacity and currently cannot serve this request.",
       ),
     ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "400 Error from provider (Console Go): Upstream request failed: Model is unavailable.",
+      ),
+    ).toBe(true);
   });
 
   it("returns explicit skip labels only for enabled drift classes", () => {

--- a/src/agents/live-test-provider-drift.ts
+++ b/src/agents/live-test-provider-drift.ts
@@ -96,6 +96,7 @@ export function isLiveProviderUnavailableDrift(error: unknown): boolean {
     msg.includes("unable to access non-serverless model") ||
     msg.includes("create and start a new dedicated endpoint") ||
     msg.includes("no available capacity was found for the model") ||
+    msg.includes("upstream request failed: model is unavailable") ||
     (msg.includes("502") && msg.includes("internal server error"))
   );
 }


### PR DESCRIPTION
## Summary

- backport the upstream-unavailable live-model classifier from #142561 to `extended-stable/2026.7.33`
- classify the exact OpenCode Go `Model is unavailable` response as moving provider drift
- retain failures for unexpected provider and candidate errors

## Why

Full Validation run 34294189135 selected `opencode-go/hy3-preview`, which returned `400 Error from provider (Console Go): Upstream request failed: Model is unavailable.` The current classifier already handles this moving provider response, but the frozen candidate owns and executes the older classifier in Docker live-model validation.

## Verification

- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/opencode-drift-vitest-patterns.txt node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts`
- 1 file passed, 4 tests passed

