### PR TITLE
fix(plugins): retain context aliases pending approved removal

### DIFF
--- a/docs/plugins/compatibility.md
+++ b/docs/plugins/compatibility.md
@@ -158,13 +158,14 @@ New channel plugins should use `MsgContext.ChannelPromptContext`,
 `SupplementalContextFacts.channelStructuredContext`. The older
 `UntrustedContext`, `UntrustedStructuredContext`,
 `UntrustedStructuredContextEntry`, and supplemental `untrustedContext` names
-remain as deprecated SDK aliases until 2026-09-08 (registry record
-`sdk-untrusted-context-identifier-aliases`). Inbound finalization folds those
-deprecated fields into the channel-named fields and removes the old keys from
-runtime context.
+remain available as deprecated SDK aliases. Their original removal window ended
+on 2026-09-08; registry record `sdk-untrusted-context-identifier-aliases` is
+`removal-pending` until published-plugin reader migration is verified and removal
+has explicit breaking-release approval. Inbound finalization folds those deprecated
+fields into the channel-named fields and removes the old keys from runtime context.
 
 The security runtime similarly exports `buildChannelMetadata`; the deprecated
-`buildUntrustedChannelMetadata` alias remains available on the same schedule.
+`buildUntrustedChannelMetadata` alias remains available under the same removal conditions.
 
 ### WhatsApp inbound callback retirement
 

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -282,14 +282,14 @@ export const PLUGIN_COMPAT_RECORDS = [
   },
   {
     code: "sdk-untrusted-context-identifier-aliases",
-    status: "deprecated",
+    status: "removal-pending",
     owner: "sdk",
     introduced: "2026-07-22",
     deprecated: "2026-07-22",
     warningStarts: "2026-07-22",
     removeAfter: "2026-09-08",
     replacement:
-      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`",
+      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`; retain until published-plugin reader migration is verified and removal has explicit breaking-release approval",
     docsPath: "/plugins/compatibility",
     surfaces: [
       "openclaw/plugin-sdk reply-runtime MsgContext.UntrustedContext and UntrustedStructuredContext",

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -87,6 +87,13 @@ describe("plugin compatibility registry", () => {
     );
 
     expect(staleRemovalWindows).toEqual([]);
+    const contextAliases = records.get("sdk-untrusted-context-identifier-aliases");
+    expect(contextAliases).toMatchObject({
+      status: "removal-pending",
+      removeAfter: "2026-09-08",
+    });
+    expect(contextAliases?.replacement).toContain("published-plugin reader migration is verified");
+    expect(contextAliases?.replacement).toContain("explicit breaking-release approval");
     for (const code of [
       "plugin-sdk-config-runtime-subpath",
       "plugin-sdk-channel-reply-pipeline-subpath",

--- a/test/scripts/plugin-boundary-report.test.ts
+++ b/test/scripts/plugin-boundary-report.test.ts
@@ -34,9 +34,10 @@ describe("plugin-boundary-report", () => {
 
     expect(summaryResult.exitCode).toBe(0);
     expect(summaryResult.stderr).toBe("");
-    expect(summary.compat?.removalPendingCount).toBe(8);
+    expect(summary.compat?.removalPendingCount).toBe(9);
     expect(summary.compat?.removalPendingDueCount).toEqual(expect.any(Number));
     expect(summary.compat?.removalPending?.map((record) => record.code)).toEqual([
+      "sdk-untrusted-context-identifier-aliases",
       "plugin-sdk-media-understanding-public-demotion",
       "plugin-sdk-memory-host-core-public-demotion",
       "plugin-sdk-channel-lifecycle-subpath",
@@ -76,7 +77,7 @@ describe("plugin-boundary-report", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("removalPending=8");
+    expect(result.stdout).toContain("removalPending=9");
     expect(result.stdout).not.toContain("agent-harness-sdk-alias");
     expect(result.stdout).toMatch(/blocker=.*retain the public/iu);
     expect(result.stdout).toMatch(/readerRefs=\d+ readers=/u);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The channel-context SDK alias migration window ended on September 8, but removal still requires verified published-plugin migration and explicit breaking-release approval. Keeping the record classified as eligible deprecated debt made the boundary guard fail at UTC midnight even though removing the public aliases was not authorized.

## Why This Change Was Made

Move only `sdk-untrusted-context-identifier-aliases` into the existing `removal-pending` review queue and state both blockers. Preserve its original `2026-09-08` date so it remains overdue and visible; update the compatibility guide and existing registry/report assertions.

## User Impact

The public aliases, deprecation annotations, canonical-field precedence, and inbound normalization are unchanged. This does not renew the deadline or approve a breaking removal. The boundary guard is unchanged, and the pending record still exposes its blocker and reader references.

## Evidence

- Original guard failed with one eligible record. Afterward the same guard passes with zero eligible records, nine pending records and one due review. The other eight pending records are identical.
- The record retains `2026-09-08`, `dueForReview: true`, its explicit blocker, and nonempty reader references. Those references are existing surface-token triage matches, not verified external-plugin usage.
- All 56 tests across the existing registry, boundary-report, inbound-context and channel-metadata suites passed.
- Public alias, normalization and gate source files are byte-identical to the base.

Required changed-file checks and independent P2 review passed. This maintenance change adds eight test lines; it claims no test removal or runtime improvement.
