### PR TITLE
fix(chat): prevent duplicate messages after CLI history refresh

### DIFF
--- a/packages/gateway-client/src/session-projection-conformance.test.ts
+++ b/packages/gateway-client/src/session-projection-conformance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createSessionProjection,
   readSessionMessageIdentity,
+  readSessionProjectionFinalMessageIdentity,
   reduceSessionProjection,
   type SessionProjectionEvent,
   type SessionProjectionScope,
@@ -52,6 +53,35 @@ function replayInBothClients(
 }
 
 describe("cross-client session projection conformance", () => {
+  it.each([
+    { role: "user", rawSeq: 0 },
+    { role: "assistant", rawSeq: 9 },
+  ] as const)("keeps a canonical $role row stable through CLI enrichment", ({ role, rawSeq }) => {
+    const metadata = {
+      id: "native-row",
+      seq: 1,
+      transcriptPosition: { source: "canonical-transcript", rawSeq },
+    };
+    const native = { role, content: "Persisted message", __openclaw: metadata };
+    const enriched = {
+      ...native,
+      __openclaw: {
+        ...metadata,
+        importedFrom: "claude-cli",
+        cliSessionId: "external-session",
+        externalId: "provider-row",
+      },
+    };
+    let state = createSessionProjection(sharedScope, [enriched]);
+    state = reduceSessionProjection(state, { type: "messagePersisted", message: native });
+    state = reduceSessionProjection(state, { type: "snapshotLoaded", messages: [enriched] });
+
+    expect(state.messages).toEqual([enriched]);
+    expect(readSessionProjectionFinalMessageIdentity(enriched)).toBe(
+      readSessionProjectionFinalMessageIdentity(native),
+    );
+  });
+
   it.each([
     {
       name: "persisted identity wins over conflicting Gateway envelope",

--- a/packages/gateway-client/src/session-projection-message-identity.ts
+++ b/packages/gateway-client/src/session-projection-message-identity.ts
@@ -59,6 +59,16 @@ export function readSessionMessageIdentity(
   const importedFrom = readSessionProjectionString(metadata?.importedFrom);
   const cliSessionId = readSessionProjectionString(metadata?.cliSessionId);
   const externalId = readSessionProjectionString(metadata?.externalId);
+  const position = readRecord(metadata?.transcriptPosition);
+  const positionSource = readSessionProjectionString(position?.source);
+  const hasCanonicalPosition =
+    positionSource !== null &&
+    positionSource.length <= 128 &&
+    typeof position?.rawSeq === "number" &&
+    Number.isSafeInteger(position.rawSeq) &&
+    position.rawSeq >= 0;
+  // Reader-owned placement keeps a local row native when CLI history enriches its provenance.
+  const isImported = !hasCanonicalPosition && Boolean(importedFrom || cliSessionId || externalId);
   const idempotencyKey =
     readSessionProjectionString(metadata?.idempotencyKey) ??
     readSessionProjectionString(record.idempotencyKey) ??
@@ -95,10 +105,10 @@ export function readSessionMessageIdentity(
     idempotencyKey,
     sendId: role === "user" ? (persistedRunId ?? runId) : null,
     runId,
-    isImported: Boolean(importedFrom || cliSessionId || externalId),
+    isImported,
     // Imported IDs belong to their provider and CLI session, never the native ID namespace.
     externalSource:
-      importedFrom && cliSessionId && externalId
+      isImported && importedFrom && cliSessionId && externalId
         ? JSON.stringify([importedFrom, cliSessionId, externalId])
         : null,
   };

--- a/packages/gateway-client/src/session-projection.test.ts
+++ b/packages/gateway-client/src/session-projection.test.ts
@@ -640,20 +640,24 @@ describe("session transcript projection", () => {
     expect(state.messages).toEqual([first, second]);
   });
 
-  it("does not merge native messages with colliding imported provider-local IDs", () => {
-    const native = createMessage("user", "native", { id: "provider-local", seq: 1 });
-    const imported = createMessage("user", "imported", {
-      id: "provider-local",
-      seq: 2,
-      importedFrom: "claude-cli",
-      cliSessionId: "cli-session",
-      externalId: "provider-local",
-    });
-    let state = projectLiveSessionMessage(createSessionProjection(primaryScope), native);
-    state = projectLiveSessionMessage(state, imported);
+  it.each([undefined, { source: "", rawSeq: 1 }, { source: "foreign", rawSeq: -1 }])(
+    "keeps imported ID collisions separate without valid placement (%j)",
+    (transcriptPosition) => {
+      const native = createMessage("user", "native", { id: "provider-local", seq: 1 });
+      const imported = createMessage("user", "imported", {
+        id: "provider-local",
+        seq: 2,
+        importedFrom: "claude-cli",
+        cliSessionId: "cli-session",
+        externalId: "provider-local",
+        transcriptPosition,
+      });
+      let state = projectLiveSessionMessage(createSessionProjection(primaryScope), native);
+      state = projectLiveSessionMessage(state, imported);
 
-    expect(state.messages).toEqual([native, imported]);
-  });
+      expect(state.messages).toEqual([native, imported]);
+    },
+  );
 
   it("does not merge incomplete imported source tuples", () => {
     const first = createMessage("user", "same words", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a CLI-backed chat could see the same persisted message twice after a history refresh overlaps a live message event. The history response adds CLI provenance to a local row; the live event for that same row keeps its native metadata.

## Why This Change Was Made

The shared identity reader now keeps a locally persisted message in the native identity namespace when its reader-owned transcript position is valid. CLI provenance remains available in the message, and genuine imported-only IDs remain isolated. Projection matching, pending messages, and final-message replay all use that same classification.

## User Impact

A native message remains one message as CLI history enriches it. Distinct imported messages still remain separate, even when their provider-local IDs collide with native IDs.

## Evidence

- 179 current-base package/UI owner cases passed, including terminal reconciliation, imported collisions, and canonical user/assistant enrichment. Core production/test types, targeted lint, and diff checks passed. Managed review completed both passes with no actionable findings.
- The real Gateway transcript writer, queued broadcaster, history handler, and UI reducer reproduced the duplicate with one failing case and two passing controls. All ten cases passed after the repair. This integration proof ran on main commit [127e3ffa](https://github.com/openclaw/openclaw/commit/127e3ffa3080841cef31927c57071c7ae9ae52ae); the producer code and repaired identity implementation are unchanged on the current base [306351ac](https://github.com/openclaw/openclaw/commit/306351ac3c9950a89a9873c092f835494bb982d1).
- The same synthetic prebuilt-browser driver rendered two bubbles before and one afterward, with the same session, leaf, native ID, and message data. These captures ran on [127e3ffa](https://github.com/openclaw/openclaw/commit/127e3ffa3080841cef31927c57071c7ae9ae52ae) and use the exact repaired production bytes; current-base owner tests and source review cover the subsequent carry.
- The full changed gate remains failed on an unrelated SDK compatibility record that became due at UTC midnight. That policy decision is tracked separately; no date override, waiver, or skipped-gate pass is claimed.

| Before | After |
| --- | --- |
| ![Before: the same native message appears twice](https://github.com/user-attachments/assets/677b68ed-77e1-466a-9998-8ffcb889331b) | ![After: one native message remains](https://github.com/user-attachments/assets/39817103-d264-4be9-a70b-d0a4c83a3f96) |
