### PR TITLE
fix(windows): keep process-start probe budget monotonic

### DIFF
--- a/src/infra/windows-process-start.test.ts
+++ b/src/infra/windows-process-start.test.ts
@@ -69,7 +69,7 @@ describe("readWindowsProcessStartTimeSync", () => {
   });
 
   it("does not start WMIC once PowerShell has spent the whole budget", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       spawnSyncMock.mockImplementationOnce(() => {
         vi.advanceTimersByTime(1000);
@@ -86,7 +86,7 @@ describe("readWindowsProcessStartTimeSync", () => {
   });
 
   it("gives WMIC only the time left on the caller's budget", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       spawnSyncMock
         .mockImplementationOnce(() => {
@@ -108,7 +108,7 @@ describe("readWindowsProcessStartTimeSync", () => {
   });
 
   it("preserves the default WMIC fallback after PowerShell spends five seconds", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       spawnSyncMock
         .mockImplementationOnce(() => {
@@ -125,6 +125,59 @@ describe("readWindowsProcessStartTimeSync", () => {
       expect(spawnSyncMock.mock.calls[1]?.[2]).toMatchObject({ timeout: 5000 });
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("keeps the WMIC fallback budget bounded across a wall-clock rollback", () => {
+    // A wall-clock step backward while the PowerShell probe runs must not inflate
+    // the fallback timeout beyond the caller's end-to-end budget. The budget is
+    // elapsed monotonic time, not wall-clock delta.
+    const realNow = Date.now;
+    let offset = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => realNow() + offset);
+    try {
+      spawnSyncMock
+        .mockImplementationOnce(() => {
+          offset -= 60_000;
+          return { status: 1, stdout: "" };
+        })
+        .mockReturnValueOnce({
+          status: 0,
+          stdout: Buffer.from("CreationDate=20260713092049.123456+120\r\n"),
+        } as never);
+
+      expect(readWindowsProcessStartTimeSync(654, 1000)).toBe(
+        Date.parse("2026-07-13T07:20:49.123Z"),
+      );
+      expect(spawnSyncMock.mock.calls[1]?.[2]?.timeout).toBeLessThanOrEqual(1000);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("still runs the WMIC fallback after a wall-clock jump forward", () => {
+    // A wall-clock jump forward must not silently skip the WMIC fallback while
+    // real time still remains on the caller's budget.
+    const realNow = Date.now;
+    let offset = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => realNow() + offset);
+    try {
+      spawnSyncMock
+        .mockImplementationOnce(() => {
+          offset += 60_000;
+          return { status: 1, stdout: "" };
+        })
+        .mockReturnValueOnce({
+          status: 0,
+          stdout: Buffer.from("CreationDate=20260713092049.123456+120\r\n"),
+        } as never);
+
+      expect(readWindowsProcessStartTimeSync(654, 1000)).toBe(
+        Date.parse("2026-07-13T07:20:49.123Z"),
+      );
+      expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
     }
   });
 

--- a/src/infra/windows-process-start.ts
+++ b/src/infra/windows-process-start.ts
@@ -87,8 +87,11 @@ export function readWindowsProcessStartTimeSync(
     return null;
   }
   // Preserve both former 5s attempts inside one deadline. Explicit callers
-  // still keep their smaller end-to-end budget.
-  const deadline = Date.now() + timeoutMs;
+  // still keep their smaller end-to-end budget. Measure the budget on a
+  // monotonic clock: a wall-clock step while the PowerShell probe runs must
+  // neither inflate the WMIC timeout past the caller's budget nor drop the
+  // fallback while real time remains.
+  const startedAtMs = performance.now();
   const powershell = spawnSync(
     windowsPowerShellPath(env),
     [
@@ -112,7 +115,7 @@ export function readWindowsProcessStartTimeSync(
       return startTime;
     }
   }
-  const remainingMs = deadline - Date.now();
+  const remainingMs = Math.max(0, timeoutMs - Math.round(performance.now() - startedAtMs));
   if (remainingMs <= 0) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a Windows system clock step during a lock-owner / PID-reuse identity probe breaks the probe's shared time budget.

The Windows start-time probe runs two synchronous probes (PowerShell, then a WMIC fallback) against one deadline measured on the wall clock. When the system clock is stepped while the PowerShell probe runs:

- **Rollback** (NTP adjustment, manual set-back, VM clock sync): the WMIC fallback timeout inflates by the full rollback, so the probe blocks the synchronous caller far longer than its end-to-end budget — a 60s step adds ~60s to every such probe (a 1s budget probe returns a ~61s timeout).
- **Jump forward** past the remaining budget: the WMIC fallback is silently skipped and the probe returns "unknown" even though real time remains, losing the stronger process-start-time identity check that guards against recycled-PID misidentification of the running Gateway.

These checks run on Windows whenever OpenClaw verifies that a process/lock it owns is still the same process (gateway lock ownership, process-tree kill verification).

## Why This Change Was Made

The shared budget is now measured as elapsed monotonic time (`performance.now()` since the probe started) instead of a wall-clock delta, so a clock step can neither inflate the WMIC timeout nor drop the fallback. This mirrors the systemd service budgets, which already keep their deadlines monotonic across wall-clock steps.

The two-probe PowerShell-then-WMIC structure, the 5s/10s attempt bounds, the caller's end-to-end budget, and the function's `number | null` contract are all preserved; only the clock used to measure the shared budget changed.

## User Impact

Windows operators no longer see multi-second-to-minute stalls on gateway lock-owner or process identity checks after their system clock is stepped (NTP sync, manual change, VM clock jump), and the stronger process-start-time identity check is no longer silently dropped during a clock jump forward. Behavior is unchanged when the clock does not step.

## Evidence

- Qualified as a merge with current main while preserving the original contributor commits and the native ancestry implementation. The minimal test-fixup publication reproduces the complete tested merge tree exactly.
- Four deterministic wall-clock-step cases on unchanged production: three reproduced failures and one stable exhausted-budget control. The same complete candidate fixture passes **19/19** after the fix.
- Native Windows / Node 24.16.0: real PowerShell identity, repeated identity and baseline equality, owned-child identity/CIM ancestry, invalid PID, unavailable executables, and exhausted native query checks passed; the owned child exited and was joined.
- Native Windows limitation: this host has no WMIC, and its operating-system clock was not changed. Successful real WMIC fallback and actual host-clock stepping are not claimed.
- PID-identity sibling tests: **30/30**; native-Node source-closure test: **1/1**. All affected changed-file checks passed, including production/test types, lint, dead exports and source guards.
- Independent P0–P2 review: scoped-clean. No dependency, configuration, protocol, process-killing policy, or timestamp-format changes.

### Real subprocess clock-step proof (Windows)

The exact production probe was run on native Windows / Node 24.16.0 against two task-private, compiled .NET executable fixtures under its supported `SystemRoot` input. The primary executable sleeps 200 ms and fails; the fallback prints a valid creation timestamp after a chosen real delay. These are **protocol fixtures, not the host PowerShell or WMIC binaries**. `spawnSync` always delegates to the original native implementation, records its actual status/error and timeout, and steps only the parent process's `Date.now` after the first child returns. `performance.now`, production source, parsing and timeout enforcement are unchanged. No OS clock change or subprocess return-value stub is used.

Budget: **1,000 ms**; injected clock step: **±1 hour**.

| Case | Baseline | Fixed production |
| --- | --- | --- |
| Forward, 100 ms fallback work | Skips fallback; unknown after 255 ms | Launches fallback with 765 ms remaining; valid fixture identity after 392 ms |
| Backward, 1,400 ms fallback work | Grants 3,600,769 ms; succeeds after 1,671 ms, beyond the caller budget | Grants 768 ms; native child ends with `ETIMEDOUT`, unknown after 1,009 ms |

All four paired outcomes matched the expected behavior. Synchronous children joined, and the process-local clock/spawn hooks were restored. Fixed owner SHA-256: `7e6df825bb173629528ced517a5ba83aa6290e98e31874508f687ed2a289ee34`.

This proves the changed production fallback decision and real Windows child timeout boundary under injected clock steps. Native PowerShell identity/CIM behavior is covered separately above; **successful native WMIC remains unverified because WMIC is not installed**.

Both hosted native Windows jobs passed for signed head `50d8eb0bdd731c799096cf8d0113106249c514b2`, including all 19 owner cases and the native-Node import case: [Windows test-1](https://github.com/openclaw/openclaw/actions/runs/34922566746/job/104233875876), [Windows test-2](https://github.com/openclaw/openclaw/actions/runs/34922566746/job/104233876051).

Required CI is not green: the Linux `models-manual-policy.integration.test.ts:120` default-reset assertion failed. A single focused run on unchanged CI main base `dd3383345724424da5139473addcf247f0c9afbd`, without this PR, reproduced the authenticated timeout (the unauthenticated case passed). This is evidence of a separate baseline failure, not a CI waiver or a claim that both cases fail deterministically. No blind rerun or unrelated model-policy change was made in this PR.

Original fix and contributor credit: **tzy-17**. The follow-up expands the regression matrix without changing the production approach.
