### PR TITLE
fix(release): admit frozen dirty-block exit contract

### DIFF
--- a/scripts/e2e/lib/update-channel-switch/assertions.mjs
+++ b/scripts/e2e/lib/update-channel-switch/assertions.mjs
@@ -10,7 +10,7 @@ const controlUiHtml = "<!doctype html><title>fixture</title>\n";
 
 function usage() {
   console.error(
-    "usage: assertions.mjs <prepare-git-fixture|write-control-ui|assert-update|assert-dry-run|assert-config-channel|assert-status-kind|assert-installed-version|assert-runtime-staging-clean|assert-dirty-update> [...]",
+    "usage: assertions.mjs <prepare-git-fixture|write-control-ui|assert-update|assert-dry-run|assert-config-channel|assert-status-kind|assert-installed-version|assert-runtime-staging-clean|assert-dirty-exit|assert-dirty-update> [...]",
   );
   process.exit(2);
 }
@@ -268,6 +268,17 @@ function assertInstalledVersion(root, expectedVersion) {
   }
 }
 
+function assertDirtyExit(statusRaw, legacyCompat, frozenCompat) {
+  const status = Number(statusRaw);
+  const acceptsZero = legacyCompat === "1" || frozenCompat === "1";
+  if (status === 1 || (status === 0 && acceptsZero)) {
+    return;
+  }
+  throw new Error(
+    `unexpected dirty-worktree update exit ${statusRaw}; expected ${acceptsZero ? "0 or 1" : "1"}`,
+  );
+}
+
 switch (command) {
   case "prepare-git-fixture":
     prepareGitFixture(args[0] ?? "/tmp/openclaw-git");
@@ -283,6 +294,9 @@ switch (command) {
     break;
   case "assert-dirty-update":
     assertDirtyUpdate(args[0], args[1]);
+    break;
+  case "assert-dirty-exit":
+    assertDirtyExit(args[0], args[1], args[2]);
     break;
   case "assert-config-channel":
     assertConfigChannel(args[0]);

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -38,6 +38,7 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_SKIP_PROVIDERS=1 \
   -e OPENCLAW_FS_SAFE_NATIVE_CONTRACT \
   -e OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT \
+  -e OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "$IMAGE_NAME" \
@@ -110,6 +111,8 @@ OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
 export OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT
 OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="${OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT:-0}"
 export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT
+OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT="${OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT:-0}"
+export OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT
 command -v openclaw >/dev/null
 openclaw_e2e_enable_openclaw_cli_timeout
 
@@ -211,11 +214,13 @@ dirty_json="$(openclaw update "${dev_channel_args[@]}" --yes --json --no-restart
 dirty_status=$?
 set -e
 # Historical update CLIs can report a blocked structured result with exit zero.
-# The assertion proves the update was rejected and no checkout state changed.
-if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ] && [ "$dirty_status" -ne 1 ]; then
-  echo "expected current dirty-worktree update to exit 1, got $dirty_status" >&2
-  exit 1
-fi
+# Admit only that exact legacy status; timeouts, signals, and other failures stay fatal.
+node scripts/e2e/lib/update-channel-switch/assertions.mjs \
+  assert-dirty-exit \
+  "$dirty_status" \
+  "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" \
+  "$OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT"
+# The payload assertion proves the update was rejected and no checkout state changed.
 UPDATE_JSON="$dirty_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs \
   assert-dirty-update "$git_root" "$fixture_sha"
 node -e "require(\"node:fs\").unlinkSync(process.argv[1])" "$git_root/operator-update-notes.tmp"

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -110,7 +110,8 @@ openclaw_resolve_frozen_live_cli_backend_package_mode() {
 openclaw_resolve_frozen_update_channel_dry_run_mode() {
   local source_root="${1:?missing selected source root}" authorization_status=0
 
-  export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="0"
+  export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="0" \
+    OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT="0"
   openclaw_prepare_frozen_target_context "$source_root" || authorization_status=$?
   [ "$authorization_status" -eq 1 ] && return 0
   [ "$authorization_status" -eq 0 ] || return "$authorization_status"
@@ -123,7 +124,8 @@ openclaw_resolve_frozen_update_channel_dry_run_mode() {
     ! openclaw_frozen_target_source_contains \
       "$source_root" src/cli/update-cli/update-command.ts \
       'selectedChannel === "dev" && explicitTag === null'; then
-    export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="1"
+    export OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT="1" \
+      OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT="1"
   fi
 }
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5997,7 +5997,8 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     const updateRunner = readFileSync(UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH, "utf8");
     expect(updateRunner).toContain('assert-dirty-update "$git_root" "$fixture_sha"');
     expect(updateRunner).toContain('[ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]');
-    expect(updateRunner).toContain('[ "$dirty_status" -ne 1 ]');
+    expect(updateRunner).toContain("assert-dirty-exit \\");
+    expect(updateRunner).toContain('"$OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT"');
   });
 
   it("serves the version-matched Codex candidate during package onboarding", () => {

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -471,7 +471,7 @@ export function parseRegistryNpmSpec(spec: string) {
         "bash",
         [
           "-c",
-          'set -euo pipefail; source "$1"; openclaw_resolve_frozen_update_channel_dry_run_mode "$2"; printf "%s\\n" "$OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT"',
+          'set -euo pipefail; source "$1"; openclaw_resolve_frozen_update_channel_dry_run_mode "$2"; printf "%s:%s\\n" "$OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT" "$OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT"',
           "test",
           stageScriptPath,
           root,
@@ -488,9 +488,9 @@ export function parseRegistryNpmSpec(spec: string) {
       );
     };
 
-    expect(run(legacySha).stdout).toBe("1\n");
-    expect(run(currentSha).stdout).toBe("0\n");
-    expect(run(legacySha, false).stdout).toBe("0\n");
+    expect(run(legacySha).stdout).toBe("1:1\n");
+    expect(run(currentSha).stdout).toBe("0:0\n");
+    expect(run(legacySha, false).stdout).toBe("0:0\n");
   });
 
   it("derives frozen harness capabilities only from an authorized selected source", () => {

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -67,6 +67,32 @@ it("preserves a source-derived dry-run mode supplied by the workflow", () => {
   expect(script).toContain("-e OPENCLAW_UPDATE_CHANNEL_DRY_RUN_PACKAGE_COMPAT \\");
 });
 
+it("admits the frozen structured dirty block without weakening its payload assertion", () => {
+  const script = readFileSync("scripts/e2e/update-channel-switch-docker.sh", "utf8");
+  const assertExit = (status: number, legacyCompat: boolean, frozenCompat: boolean) =>
+    spawnSync(
+      process.execPath,
+      [
+        "scripts/e2e/lib/update-channel-switch/assertions.mjs",
+        "assert-dirty-exit",
+        String(status),
+        legacyCompat ? "1" : "0",
+        frozenCompat ? "1" : "0",
+      ],
+      { encoding: "utf8" },
+    );
+
+  expect(assertExit(1, false, false).status).toBe(0);
+  expect(assertExit(0, true, false).status).toBe(0);
+  expect(assertExit(0, false, true).status).toBe(0);
+  expect(assertExit(0, false, false).status).toBe(1);
+  expect(assertExit(124, false, true).status).toBe(1);
+  expect(assertExit(2, true, false).status).toBe(1);
+  expect(script).toContain("-e OPENCLAW_UPDATE_CHANNEL_DIRTY_BLOCK_EXIT_ZERO_COMPAT \\");
+  expect(script).toContain("assert-dirty-exit \\");
+  expect(script).toContain('assert-dirty-update "$git_root" "$fixture_sha"');
+});
+
 it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);


### PR DESCRIPTION
## Summary

- derive the frozen dirty-worktree exit contract from the selected source
- accept exit zero only for that exact frozen contract
- retain the structured rejection and unchanged-checkout assertions

## Root cause

2026.7.33 rejects an untracked-file Git update with a structured blocked result but exits zero. Current tooling required exit 1 for every non-legacy package, so both update-channel diagnostic lanes failed after the actual rejection succeeded.

The compatibility flag is derived from the selected source owner shape, defaults closed, and is separate from the preview-reporting flag. Current and unknown candidates remain strict.

## Validation

- tooling compatibility: 34 passed
- shell syntax
- Oxfmt
- `git diff --check`

This covers both `update-channel-switch` failures in Full Validation 34294189135.