### PR TITLE
test(ui): settle attachment geometry before comparison

### DIFF
--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -1,6 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { waitForControlUiProofSurface } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureUiProofEnabled,
   copiedViaExec,
@@ -267,6 +268,8 @@ suite.define(() => {
         ".chat-assistant-attachment-card__action-skeleton.skeleton",
       );
       expect(await actionSkeletons.count()).toBe(4);
+      // Ancestor entrance animations must settle before comparing viewport rectangles.
+      await waitForControlUiProofSurface(checkingCards.first(), [actionSkeletons.first()]);
       const actionSkeletonSize = await actionSkeletons.first().evaluate((element) => {
         const rect = element.getBoundingClientRect();
         return { x: rect.x, y: rect.y, height: rect.height, width: rect.width };


### PR DESCRIPTION
## What Problem This Solves

The managed-document browser test can compare the loading action and final Open button while their page ancestors are still moving. CI failed on a 0.009px Y-coordinate difference even though the pill's X position, width and height matched.

## Why This Change Was Made

Reuse the existing presentation-surface helper before recording the loading rectangle, while the artifact download responses are still held. It waits for fonts and finite ancestor animations, including shadow hosts. The loading shimmer continues, and the original exact rectangle equality, card counts, metadata, shimmer and deferred-response assertions remain unchanged.

Production delta: zero. One test file gains three lines; no runtime, CSS, dependency, timeout or precision change.

## User Impact

Prevents a timing-dependent CI failure without changing how attachments render.

## Evidence

The unchanged full Chromium file reproduced the failure: 8 passed, 1 failed. Temporary measurements inside the existing rectangle callbacks also reproduced it and identified the motion: the card ancestor's `rise` and the shell's `dashboard-enter` animations were running. Their translations explain the measured offsets; ancestor scroll positions stayed zero. Diagnostics were removed before final validation.

With the existing presentation wait, the complete original file passes all 9 cases in 12.04 seconds. Required changed-file checks passed, including formatting, UI E2E type checking, lint and guards. The exact geometry assertion and active-shimmer checks pass together.

Independent P0–P2 review found no actionable findings.
