### PR TITLE
fix(release): source-qualify Telegram progress scenario

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -344,6 +344,7 @@ jobs:
             extensions/telegram/src/bot-message-dispatch.ts
             extensions/telegram/src/draft-stream.ts
             qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
+            qa/scenarios/channels/telegram-progress-tool-visibility.yaml
             src/agents/embedded-agent-subscribe.ts
 
       - name: Resolve frozen package Telegram scenarios

--- a/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
+++ b/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 const PARTIAL_FAILURE_RECOVERY_SCENARIO = "telegram-partial-failure-recovery";
 const SETTLED_EMPTY_RESPONSE_SCENARIO = "telegram-empty-response-after-write-recovery";
+const PROGRESS_TOOL_VISIBILITY_SCENARIO = "telegram-progress-tool-visibility";
 
 function readSource(sourceRoot: string, relativePath: string): string | undefined {
   try {
@@ -36,10 +37,18 @@ export function isPreSettledEmptyResponseTarget(sourceRoot: string): boolean {
   );
 }
 
+export function isPreProgressToolVisibilityTarget(sourceRoot: string): boolean {
+  return (
+    readSource(sourceRoot, "qa/scenarios/channels/telegram-progress-tool-visibility.yaml") ===
+    undefined
+  );
+}
+
 export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): string[] {
   return [
     ...(isPrePartialFailureRecoveryTarget(sourceRoot) ? [PARTIAL_FAILURE_RECOVERY_SCENARIO] : []),
     ...(isPreSettledEmptyResponseTarget(sourceRoot) ? [SETTLED_EMPTY_RESPONSE_SCENARIO] : []),
+    ...(isPreProgressToolVisibilityTarget(sourceRoot) ? [PROGRESS_TOOL_VISIBILITY_SCENARIO] : []),
   ];
 }
 

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   isPrePartialFailureRecoveryTarget,
+  isPreProgressToolVisibilityTarget,
   isPreSettledEmptyResponseTarget,
   resolveFrozenTelegramScenarioOmissions,
 } from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
@@ -447,6 +448,19 @@ describe("package Telegram live Docker E2E", () => {
     expect(isPreSettledEmptyResponseTarget(root)).toBe(false);
   });
 
+  it("omits progress visibility until the frozen source owns its scenario", () => {
+    const root = mkTempRoot();
+    const scenario = path.join(
+      root,
+      "qa/scenarios/channels/telegram-progress-tool-visibility.yaml",
+    );
+
+    expect(isPreProgressToolVisibilityTarget(root)).toBe(true);
+    mkdirSync(path.dirname(scenario), { recursive: true });
+    writeFileSync(scenario, "id: telegram-progress-tool-visibility\n");
+    expect(isPreProgressToolVisibilityTarget(root)).toBe(false);
+  });
+
   it("combines only the unsupported frozen Telegram scenario contracts", () => {
     const root = mkTempRoot();
     const writeOwner = (relativePath: string, source: string) => {
@@ -464,14 +478,23 @@ describe("package Telegram live Docker E2E", () => {
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-partial-failure-recovery",
       "telegram-empty-response-after-write-recovery",
+      "telegram-progress-tool-visibility",
     ]);
     writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-empty-response-after-write-recovery",
+      "telegram-progress-tool-visibility",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
       "id: telegram-empty-response-after-write-recovery\n",
+    );
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-progress-tool-visibility",
+    ]);
+    writeOwner(
+      "qa/scenarios/channels/telegram-progress-tool-visibility.yaml",
+      "id: telegram-progress-tool-visibility\n",
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- include the progress-visibility scenario in the frozen-source capability checkout
- omit that default scenario when the selected package source does not own it
- preserve explicit scenario selection and current-package coverage

## Root cause

The Telegram package lane for 2026.7.33 correctly omitted two later recovery scenarios, but still ran `telegram-progress-tool-visibility`. That scenario was introduced with #137342 after the frozen release and asserts the later progress-compositor contract, so 7.33 failed at the expected one-progress-message settlement boundary.

This change follows the existing source-owned scenario mechanism: absence from the immutable selected source omits it only from the default frozen catalog. Explicit requests remain unchanged.

## Validation

- package Telegram harness: 52 passed
- package acceptance workflow contracts: 419 passed
- Oxfmt
- `git diff --check`

Local actionlint was unavailable; CI owns that check.