### PR TITLE
refactor(tests): avoid idle wait after profiled fork cleanup

### DIFF
--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -390,6 +390,18 @@ export default {
         `
 const { subscribe } = require("node:diagnostics_channel");
 const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const schedule = globalThis.setTimeout;
+const cancel = globalThis.clearTimeout;
+const deadlines = new Map();
+globalThis.setTimeout = (callback, delay, ...args) => {
+  if (delay !== 60000) return schedule(callback, delay, ...args);
+  const invoke = () => callback(...args);
+  const timer = schedule(() => { deadlines.delete(timer); invoke(); }, delay);
+  deadlines.set(timer, invoke);
+  return timer;
+};
+globalThis.clearTimeout = timer => { deadlines.delete(timer); return cancel(timer); };
 const isVitestFork = arg => typeof arg === "string" && arg.replaceAll("\\\\", "/").endsWith("/vitest/dist/workers/forks.js");
 if (isVitestFork(process.argv[1]) && process.send) {
   const send = process.send;
@@ -410,14 +422,41 @@ if (isVitestFork(process.argv[1]) && process.send) {
 subscribe("child_process", ({ process: child }) => {
   let selected = false;
   let acknowledged = false;
+  let poll;
+  const deadline = { delay: 60000, liveTimers: 0, stopped: false, advanced: 0, error: null };
   child.once("spawn", () => {
     selected = child.spawnargs.some(isVitestFork);
   });
   child.on("message", message => {
-    if (selected && message?.__vitest_worker_response__ === true && message.type === "stopped") acknowledged = true;
+    if (!selected || message?.__vitest_worker_response__ !== true || message.type !== "stopped" || message.willExit !== true) return;
+    acknowledged = true;
+    // Let Vitest consume the acknowledgement before observing the child stopped in send's callback.
+    setImmediate(() => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      poll = setInterval(() => {
+        try {
+          const state = execFileSync("ps", ["-o", "stat=", "-p", String(child.pid)], { encoding: "utf8", timeout: 1000, maxBuffer: 1024 }).trim();
+          if (!state.startsWith("T")) return;
+          clearInterval(poll);
+          deadline.stopped = true;
+          deadline.liveTimers = deadlines.size;
+          if (deadlines.size !== 1) { deadline.error = "expected one live stop deadline"; return; }
+          const [timer, invoke] = deadlines.entries().next().value;
+          cancel(timer);
+          deadlines.delete(timer);
+          deadline.advanced++;
+          invoke();
+        } catch (error) {
+          clearInterval(poll);
+          deadline.error = String(error);
+        }
+      }, 5);
+      poll.unref();
+    });
   });
   child.once("exit", (code, signal) => {
-    if (selected) fs.writeFileSync(${JSON.stringify(pauseReceipt)}, JSON.stringify({ acknowledged, code, signal }));
+    clearInterval(poll);
+    if (selected) fs.writeFileSync(${JSON.stringify(pauseReceipt)}, JSON.stringify({ acknowledged, code, signal, deadline }));
   });
 });
 `,
@@ -498,6 +537,7 @@ process.exitCode = (await completion).code ?? 1;`,
           acknowledged: true,
           code: null,
           signal: "SIGKILL",
+          deadline: { delay: 60_000, liveTimers: 1, stopped: true, advanced: 1, error: null },
         });
       }
       const receipt = JSON.parse(fs.readFileSync(receiptPath, "utf8")) as {


### PR DESCRIPTION
## What Problem This Solves

The paused profile-fork cleanup test spends a minute waiting after the real worker has already flushed its teardown acknowledgement and been stopped. That wait slows validation without adding another observation to the cleanup contract.

## Why This Change Was Made

The existing generated preload now observes the selected fork's stopped state after Vitest has consumed its acknowledgement, requires exactly one live 60-second stop timer, and advances that timer's callback. The real fork, awaited CPU/heap profile writes, native 500 ms kill escalation, exit receipt, namespace cleanup, and independent inner test verdicts remain exercised. The production timeout values are unchanged.

## User Impact

This is a test-only change with 40 net lines added. In one local paired run, the focused case fell from 62.529 seconds to 2.411 seconds (native shard wall time: 63.88 to 3.37 seconds). It avoids the controlled 60-second wait in that measured case; this is not a claim of an overall 30% suite improvement.

## Evidence

- Complete cleanup and fork-shutdown suites: 93 passed (76 + 17); all existing cleanup case names remain in order.
- Separate capture-only run retained the exact acknowledgement/SIGKILL/deadline receipt, valid CPU/heap profiles, namespace/config receipts, and the intended one-passed/one-failed inner verdict.
- Removing awaited profile finalization fails the existing profile-file assertion. Suppressing worker termination fails the existing exit-receipt check; the supervisor's original cleanup leaves the recorded group and both PIDs dead. These controls were restored before final validation.
- Fresh independent review and the normal full changed gate passed. The patch and relevant test/dependency inputs remained byte-identical across the upstream metadata-fix refresh.
