### PR TITLE
ci(labeler): complete the google-meet and plugin reference globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,7 @@
       - any-glob-to-any-file:
           - "extensions/geolocation/**"
           - "docs/plugins/geolocation.md"
+          - "docs/plugins/reference/geolocation.md"
 "plugin: file-transfer":
   - changed-files:
       - any-glob-to-any-file:
@@ -68,6 +69,7 @@
       - any-glob-to-any-file:
           - "extensions/logbook/**"
           - "docs/plugins/logbook.md"
+          - "docs/plugins/reference/logbook.md"
 "plugin: imap":
   - changed-files:
       - any-glob-to-any-file:
@@ -78,6 +80,8 @@
       - any-glob-to-any-file:
           - "extensions/google-meet/**"
           - "docs/plugins/google-meet.md"
+          - "docs/plugins/google-meet/**"
+          - "docs/plugins/reference/google-meet.md"
 "plugin: teams-meetings":
   - changed-files:
       - any-glob-to-any-file:
@@ -611,6 +615,7 @@
       - any-glob-to-any-file:
           - "extensions/copilot/**"
           - "docs/plugins/copilot.md"
+          - "docs/plugins/reference/copilot.md"
 "extensions: kimi-coding":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## What

Five glob lines across four labeler rules.

- `plugin: google-meet` gains `docs/plugins/google-meet/**` and `docs/plugins/reference/google-meet.md`
- `copilot`, `geolocation` and `logbook` gain their existing `docs/plugins/reference/<id>.md`

## Why

**Child glob.** The Google Meet split ([#142729](https://github.com/openclaw/openclaw/pull/142729)) moves most of that page into `docs/plugins/google-meet/`. The rule matches only the single file, so a later child-only PR would silently lose the label. Adding the glob now means it keeps working the moment that split lands.

**Reference pages.** The same rule omitted `docs/plugins/reference/google-meet.md`, which exists. Its siblings `teams-meetings` and `zoom` both list theirs, so this was an inconsistency rather than a choice. Checking every reference page against its globbed sibling found three more: `copilot`, `geolocation`, `logbook`.

## Why it is separate from the docs PR

ClawSweeper raised the child-glob half as a finding on #142729 and is right on the facts. It is still the wrong place to fix it: adding a `.github` file there flips that PR from `docs-only: true` to `lanes: docs, tooling`, pulling the tooling lane into CI for a pure content move. That was measured with a probe commit, then reverted — not assumed.

One correction to the finding for the record: the label loss is **prospective**, not current. #142729 also edits the index, which the existing glob still matches, so that PR is labelled correctly today.

This follows [#142677](https://github.com/openclaw/openclaw/pull/142677), which closed the same class of gap for five other split pages.

## Validation

```
5 insertions, no other change
every docs/plugins/reference/<id>.md whose sibling is globbed is now globbed
structural check on the file: no malformed lines
```