### PR TITLE
fix(talk): allow independent voice consults from locked requesters

### DIFF
--- a/src/talk/agent-consult-runtime.test.ts
+++ b/src/talk/agent-consult-runtime.test.ts
@@ -561,6 +561,37 @@ describe("realtime voice agent consult runtime", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("allows an independent consult when only the requester session is locked", async () => {
+    const { runtime, runEmbeddedAgent, sessionStore } = createAgentRuntime();
+    sessionStore["agent:main:main"] = {
+      sessionId: "locked-requester",
+      updatedAt: 1,
+      agentHarnessId: "codex",
+      modelSelectionLocked: true,
+    };
+
+    await expect(
+      consultRealtimeVoiceAgent({
+        cfg: {} as never,
+        agentRuntime: runtime as never,
+        logger: { warn: vi.fn() },
+        agentId: "meet-consult",
+        sessionKey: "agent:meet-consult:subagent:google-meet:meet-independent",
+        spawnedBy: "agent:main:main",
+        contextMode: "fork",
+        messageProvider: "google-meet",
+        lane: "google-meet",
+        runIdPrefix: "google-meet:meet-independent",
+        args: { question: "Check the meeting." },
+        transcript: [],
+        surface: "a private Google Meet",
+        userLabel: "Participant",
+      }),
+    ).resolves.toEqual({ text: "Speak this." });
+    expect(sessionForkMocks.forkSessionEntryFromParent).not.toHaveBeenCalled();
+    expect(requireEmbeddedAgentCall(runEmbeddedAgent).agentId).toBe("meet-consult");
+  });
+
   it("fresh-checks archive state after a queued lifecycle mutation", async () => {
     const { runtime, runEmbeddedAgent, sessionStore } = createAgentRuntime();
     const sessionKey = "voice:archive-race";

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -92,12 +92,14 @@ export function assertRealtimeVoiceAgentConsultModelSelectionUnlocked(params: {
 
   remember(params.sessionKey, params.agentId, params.storePath);
   const requesterSessionKey = params.spawnedBy?.trim();
-  if (requesterSessionKey) {
-    const requesterAgentId = parseAgentSessionKey(requesterSessionKey)?.agentId ?? params.agentId;
-    remember(requesterSessionKey, requesterAgentId);
+  const requesterAgentId = parseAgentSessionKey(requesterSessionKey)?.agentId;
+  const targetAgentId = parseAgentSessionKey(params.sessionKey)?.agentId ?? params.agentId;
+  if (requesterSessionKey && (!requesterAgentId || requesterAgentId === targetAgentId)) {
+    const requesterAgent = requesterAgentId ?? params.agentId;
+    remember(requesterSessionKey, requesterAgent);
     const { baseSessionKey } = parseSessionThreadInfoFast(requesterSessionKey);
     if (baseSessionKey && baseSessionKey !== requesterSessionKey) {
-      remember(baseSessionKey, requesterAgentId);
+      remember(baseSessionKey, requesterAgent);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a realtime voice or Google Meet consultation from a model-selection-locked requester session was rejected even when the consultation targeted a separate agent.

Fixes #142483

## Why This Change Was Made

The consult now checks the target agent's session and only reuses requester lock state when the requester and target belong to the same agent. Locked target sessions and same-agent forks remain fail-closed.

## User Impact

Independent realtime voice consultations can run from locked requester sessions without weakening model-selection protection for the target or same-agent fork.

## Evidence

### Maintainer-hosted proof at `9970e2f3231ac89bd8be890259aee717efe7f14f`

<!-- maintainer-proof-142736:9970e2f3231ac89bd8be890259aee717efe7f14f -->

[Sanitized AWS Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_f72aeeff3545) completed with exit 0 on this exact head. The patch-identical rebase incorporates the Signal fixture repairs in #142775 and #142796.

- 887 tests passed: 21 consult-runtime, 3 consult-storage, and 863 Signal tests. The previously failing response-prefix test passed.
- The complete changed-file validation gate passed, including formatting, lint, typechecks, and repository guards.
- The real Google Meet production binding called `consultMeetingAgent`, `consultRealtimeVoiceAgent`, and the embedded agent runner. An independent target answered a locked requester with exactly one model request and no requester-history fork. Locked-target and same-agent controls both rejected with `ModelSelectionLockedError`.

The host used the trusted exact-head bootstrap, frozen dependencies, isolated state, no instance role, no credential hydration, and no Tailscale. Its lease is released.

```sh
pnpm test src/talk/agent-consult-runtime.test.ts src/talk/agent-consult-runtime.storage.test.ts extensions/signal
node scripts/check-changed.mjs -- src/talk/agent-consult-runtime.ts src/talk/agent-consult-runtime.test.ts
node --import ./scripts/tsx.mjs proof-live-142736.mts 9970e2f3231ac89bd8be890259aee717efe7f14f
```

```json
{"head":"9970e2f3231ac89bd8be890259aee717efe7f14f","modelRequests":1,"noRequesterFork":true,"result":"Independent consultation proof passed.","lockedTarget":"rejected","sameAgentRequester":"rejected"}
```

Only the external model endpoint was replaced with a localhost OpenAI-compatible fixture. This proves the production consultation path, not live Meet media or a paid model service. Hosted validation does not replace the required GitHub CI gate.

### Original submission evidence (pre-rebase `b0829b5ff0eb75c09db7664b6baf0f4456b96934`)

- Real call-chain proof: `node --import ./scripts/tsx.mjs proof-live-142736.mts` exercised the Google Meet production binding through `consultMeetingAgent`, `consultRealtimeVoiceAgent`, and the embedded agent runner. The model dependency was replaced only at the network boundary with a localhost OpenAI-compatible fixture; no consult or agent-run method was mocked.
- Regression tests: `pnpm exec vitest run src/talk/agent-consult-runtime.test.ts src/talk/agent-consult-runtime.storage.test.ts` — 2 files, 23 tests passed.
- Canonical precedent: `resolveRealtimeVoiceAgentConsultSessionEntry` already limits fork reuse to an unscoped requester or the same agent; this change aligns the early lock assertion with that production routing boundary.

```text
$ node --import ./scripts/tsx.mjs proof-live-142736.mts
entrypoint: Google Meet production binding -> consultMeetingAgent -> consultRealtimeVoiceAgent -> embedded agent runner
dependency-boundary: localhost OpenAI-compatible model fixture
head: b0829b5ff0eb75c09db7664b6baf0f4456b96934
requester: locked model-selection session
target: independent meet-consult agent
model-requests: 1
result: Independent consultation proof passed.
locked-target: rejected
same-agent-requester: rejected
```

The live Meet/browser and paid model service were unavailable in this task-owned checkout, so the production call chain used a localhost model fixture at the external network boundary. The returned answer and both lock-protection negative controls came from the real production path.

<details>
<summary>Testing proof source</summary>

```ts
import { createServer } from "node:http";
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";

const [
  { createMeetingRealtimeEngineBindings },
  { GOOGLE_MEET_PLATFORM_ADAPTER },
  { createPluginRuntime },
  { createEmptyPluginRegistry },
  { setActivePluginRegistry },
  { withPluginRuntimeGatewayRequestScope },
] = await Promise.all([
  import("./src/meeting-bot/agent-consult.js"),
  import("./extensions/google-meet/src/transports/google-meet-platform-adapter.js"),
  import("./src/plugins/runtime/index.js"),
  import("./src/plugins/registry-empty.js"),
  import("./src/plugins/runtime.js"),
  import("./src/plugins/runtime/gateway-request-scope.js"),
]);

const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pr-142736-"));
process.env.OPENCLAW_STATE_DIR = tempRoot;
process.env.OPENCLAW_CONFIG_PATH = path.join(tempRoot, "openclaw.json");
const serverRequests: Array<{ method?: string; path?: string; stream?: boolean }> = [];
const server = createServer(async (request, response) => {
  let body = "";
  for await (const chunk of request) {
    body += String(chunk);
  }
  let parsed: any = {};
  try {
    parsed = JSON.parse(body);
  } catch {
    // The production provider client will report malformed responses if this happens.
  }
  serverRequests.push({ method: request.method, path: request.url, stream: parsed.stream === true });
  const id = "chatcmpl-pr-142736-proof";
  const text = "Independent consultation proof passed.";
  if (parsed.stream === true) {
    response.writeHead(200, { "content-type": "text/event-stream" });
    response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant", content: text }, finish_reason: null }] })}\n\n`);
    response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
    response.end("data: [DONE]\n\n");
    return;
  }
  response.writeHead(200, { "content-type": "application/json" });
  response.end(JSON.stringify({ id, object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }] }));
});
await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("loopback proof server did not expose a TCP port");
}

const providerId = "loopback-proof";
const cfg: any = {
  models: {
    mode: "merge",
    providers: {
      [providerId]: {
        api: "openai-completions",
        apiKey: "loopback-proof",
        baseUrl: `http://127.0.0.1:${address.port}`,
        models: [{
          id: "loopback-model",
          name: "Loopback proof model",
          input: ["text"],
          contextWindow: 128000,
          maxTokens: 4096,
        }],
      },
    },
  },
  session: {
    store: path.join(tempRoot, "agents", "{agentId}", "sessions", "sessions.json"),
  },
  agents: {
    list: [{ id: "main", default: true }, { id: "meet-consult" }],
    defaults: {
      model: { primary: `${providerId}/loopback-model` },
      workspace: path.join(tempRoot, "workspace"),
    },
  },
};

const pluginRegistry = createEmptyPluginRegistry();
setActivePluginRegistry(pluginRegistry);
const runtime = createPluginRuntime();
const bindings = createMeetingRealtimeEngineBindings({
  platform: GOOGLE_MEET_PLATFORM_ADAPTER,
  config: { realtime: { agentId: "meet-consult", toolPolicy: "safe-read-only" } },
  fullConfig: cfg,
  runtime,
  logger: { warn: (...args: unknown[]) => console.error(...args) } as any,
});

async function seedLockedSession(agentId: string, sessionKey: string, sessionId: string) {
  const storePath = runtime.agent.session.resolveStorePath(cfg.session.store, { agentId });
  await runtime.agent.session.patchSessionEntry({
    agentId,
    storePath,
    sessionKey,
    fallbackEntry: {
      sessionId,
      updatedAt: Date.now(),
      agentHarnessId: "codex",
      modelSelectionLocked: true,
    },
    update: (entry) => entry,
  });
}

const requesterSessionKey = "agent:main:main";
await seedLockedSession("main", requesterSessionKey, "locked-requester");

async function consult(meetingSessionId: string, requester: string) {
  return await withPluginRuntimeGatewayRequestScope(
    { isWebchatConnect: false, pluginId: "google-meet", pluginSource: "bundled", pluginRegistry },
    async () =>
      await bindings.consultAgent({
        meetingSessionId,
        requesterSessionKey: requester,
        args: { question: "What should the meeting agent say?" },
        transcript: [{ role: "user", text: "Please answer the participant." }],
      }),
  );
}

const positive = await consult("independent-agent", requesterSessionKey);
await seedLockedSession(
  "meet-consult",
  "agent:meet-consult:subagent:google-meet:locked-target",
  "locked-target",
);
let lockedTarget = "admitted";
try {
  await consult("locked-target", requesterSessionKey);
} catch {
  lockedTarget = "rejected";
}

await seedLockedSession("meet-consult", "agent:meet-consult:main", "locked-same-agent-requester");
let sameAgentRequester = "admitted";
try {
  await consult("same-agent", "agent:meet-consult:main");
} catch {
  sameAgentRequester = "rejected";
}

await new Promise<void>((resolve) => server.close(() => resolve()));
console.log(JSON.stringify({
  entrypoint: "Google Meet production binding -> consultMeetingAgent -> consultRealtimeVoiceAgent -> embedded agent runner",
  dependencyBoundary: "localhost OpenAI-compatible model fixture",
  requester: "locked model-selection session",
  target: "independent meet-consult agent",
  modelRequests: serverRequests.length,
  result: positive.text,
  lockedTarget,
  sameAgentRequester,
}));
```

</details>

AI-assisted: built with Codex
