### PR TITLE
fix(migrate): close provider resources after completed operations

### DIFF
--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -321,6 +321,11 @@ or replace conflicts. It reports each source's confirmed copy count and warns
 when a failure may have happened after a partial copy. Use the dedicated Import
 Memory page when you need destination selection, a file preview, or replacement.
 
+If an error says that apply completed but its result could not be returned,
+inspect the migration report and destination files before starting another
+import. Retrying the same pending request reuses its recorded outcome while
+the Gateway retains it. A plugin cleanup warning does not undo completed copies.
+
 Planning and applying require `operator.admin`. Every apply creates a verified
 OpenClaw backup when state exists, writes a redacted migration report, and keeps
 item-level backups before replacing existing destination files. See

--- a/src/commands/migrate.resources.test.ts
+++ b/src/commands/migrate.resources.test.ts
@@ -1,0 +1,405 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { clearRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { createMigrationResourceFixture } from "../plugins/migration-provider.test-support.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createNonExitingRuntime } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  detectSetupMigrationSources,
+  listSetupMigrationOptions,
+} from "../wizard/setup.migration-import.js";
+import { offerPostInstallMigrations } from "../wizard/setup.post-install-migration.js";
+import { migrateDefaultCommand } from "./migrate.js";
+
+vi.mock("../cli/prompt.js", () => ({ promptYesNo: async () => true }));
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+
+describe("migration command resources", () => {
+  it.each([false, true])(
+    "keeps native plan resources through apply and releases them after completion (failure: %s)",
+    async (failApply) => {
+      const fixture = createMigrationResourceFixture({ failApply });
+      const logs: string[] = [];
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(fixture.root, "state") }, async () => {
+        const command = migrateDefaultCommand(
+          {
+            exit: createNonExitingRuntime().exit,
+            error() {},
+            log(value) {
+              expect(fixture.state.connections.every(({ database }) => database.isOpen)).toBe(true);
+              logs.push(String(value));
+            },
+          },
+          {
+            provider: fixture.id,
+            configOverride: fixture.config,
+            yes: true,
+            json: true,
+            noBackup: true,
+            force: true,
+          },
+        );
+        // Observe early command failure as well as the provider rendezvous, so a
+        // loading regression cannot strand the test behind an unfulfilled gate.
+        const completion = command.then(
+          (result) => ({ result, error: undefined }),
+          (error: unknown) => ({ result: undefined, error }),
+        );
+        try {
+          await Promise.race([fixture.state.applying.promise, completion]);
+          expect(fixture.state.applied).toBeDefined();
+          expect(fixture.state.applied).toBe(fixture.state.planned);
+          expect(fixture.state.connections).toHaveLength(1);
+          expect(
+            fixture.state.connections[0]?.database.prepare("SELECT 42 AS value").get(),
+          ).toEqual({ value: 42 });
+          expect(fixture.state.connections[0]?.disposals).toBe(0);
+          fixture.state.resumeApply.resolve();
+          const outcome = await completion;
+          if (failApply) {
+            expect(outcome.error).toEqual(new Error("Synthetic migration apply failed"));
+            expect(logs).toEqual([]);
+          } else {
+            expect(outcome.error).toBeUndefined();
+            expect(outcome.result?.summary.migrated).toBe(1);
+            expect(outcome.result?.metadata).toBe(fixture.state.planned?.metadata);
+            expect(logs).toHaveLength(1);
+            expect(JSON.parse(logs[0] ?? "{}").summary.migrated).toBe(1);
+          }
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+        } finally {
+          fixture.state.resumeApply.resolve();
+          await completion;
+          fixture.cleanup();
+        }
+      });
+    },
+  );
+
+  it("borrows an active raw provider without disposing its connection", async () => {
+    const fixture = createMigrationResourceFixture();
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(fixture.root, "state") }, async () => {
+        const active = loadAndActivateRootPluginRegistry({ config: fixture.config });
+        expect(active.migrationProviders.map(({ provider }) => provider.id)).toContain(fixture.id);
+        fixture.state.resumeApply.resolve();
+        const result = await migrateDefaultCommand(createNonExitingRuntime(), {
+          provider: fixture.id,
+          configOverride: fixture.config,
+          yes: true,
+          json: true,
+          noBackup: true,
+          force: true,
+        });
+        expect(result.summary.migrated).toBe(1);
+        expect(fixture.state.connections).toHaveLength(1);
+        expect(fixture.state.connections[0]?.disposals).toBe(0);
+        expect(fixture.state.connections[0]?.database.prepare("SELECT 42 AS value").get()).toEqual({
+          value: 42,
+        });
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps post-install plan details alive through config projection and preparation disposal", async () => {
+    const fixture = createMigrationResourceFixture({ configPatch: true });
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    fixture.state.resumeApply.resolve();
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(fixture.root, "state") }, async () => {
+        const operation = offerPostInstallMigrations({
+          config: fixture.config,
+          runtime: createNonExitingRuntime(),
+          installedPluginIds: [fixture.id],
+          prompter: createWizardPrompter({ confirm: async () => true }),
+        });
+        const completion = operation.then(
+          (result) => ({ result, error: undefined }),
+          (error: unknown) => ({ result: undefined, error }),
+        );
+        try {
+          await Promise.race([fixture.state.preparationDisposing.promise, completion]);
+          expect(fixture.state.applied).toBe(fixture.state.planned);
+          expect(fixture.state.patchReads).toBeGreaterThan(0);
+          expect(fixture.state.connections).toHaveLength(1);
+          expect(fixture.state.connections[0]?.disposals).toBe(0);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+          fixture.state.finishPreparation.resolve();
+          const outcome = await completion;
+          expect(outcome.error).toBeUndefined();
+          expect(outcome.result?.config.agents?.defaults?.heartbeat?.every).toBe("42m");
+          expect(fixture.state.preparationDisposals).toBe(1);
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+        } finally {
+          fixture.state.finishPreparation.resolve();
+          await completion;
+        }
+      });
+    } finally {
+      if (stdinDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "isTTY");
+      }
+      fixture.cleanup();
+    }
+  });
+
+  it("prepares and disposes the selected registration after an earlier provider refreshes config", async () => {
+    const fixture = createMigrationResourceFixture({ configPatch: true, secondProvider: true });
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    fixture.state.resumeApply.resolve();
+    fixture.state.finishPreparation.resolve();
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const result = await offerPostInstallMigrations({
+            config: fixture.config,
+            runtime: createNonExitingRuntime(),
+            installedPluginIds: [fixture.id],
+            prompter: createWizardPrompter({ confirm: async () => true }),
+          });
+          expect(result.config.agents?.defaults?.heartbeat?.every).toBe("43m");
+          expect(fixture.state.preparationOwners).toHaveLength(2);
+          for (const owner of fixture.state.preparationOwners) {
+            expect(owner.prepared === owner.applied, owner.providerId).toBe(true);
+          }
+          expect(fixture.state.preparationDisposals).toBe(2);
+          expect(fixture.state.connections).toHaveLength(2);
+          expect(
+            fixture.state.connections.every(
+              ({ database, disposals }) => !database.isOpen && disposals === 1,
+            ),
+          ).toBe(true);
+        },
+      );
+    } finally {
+      if (stdinDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "isTTY");
+      }
+      fixture.cleanup();
+    }
+  });
+
+  it("logs the primary migration failure before a prepared instance disposal failure aborts onboarding", async () => {
+    const fixture = createMigrationResourceFixture({ failApply: true });
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    fixture.state.resumeApply.resolve();
+    fixture.state.finishPreparation.resolve();
+    fixture.state.failPreparationDisposal = true;
+    const messages: string[] = [];
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          await expect(
+            offerPostInstallMigrations({
+              config: fixture.config,
+              runtime: {
+                ...createNonExitingRuntime(),
+                log(message) {
+                  expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+                  expect(fixture.state.preparationDisposals).toBe(0);
+                  messages.push(String(message));
+                },
+              },
+              installedPluginIds: [fixture.id],
+              prompter: createWizardPrompter({ confirm: async () => true }),
+            }),
+          ).rejects.toBe(fixture.state.preparationError);
+          expect(messages).toHaveLength(1);
+          expect(messages[0]).toContain("Synthetic migration apply failed");
+          expect(fixture.state.preparationDisposals).toBe(1);
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+        },
+      );
+    } finally {
+      if (stdinDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "isTTY");
+      }
+      fixture.cleanup();
+    }
+  });
+
+  it("lists cold migration options without executing a full registration", async () => {
+    const fixture = createMigrationResourceFixture();
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const options = await listSetupMigrationOptions({
+            baseConfig: fixture.config,
+            detections: [],
+          });
+          expect(options.map((option) => option.providerId)).toContain(fixture.id);
+          expect(fixture.state.connections.length).toBe(0);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("carries runtime metadata for a negative detection after its native registration closes", async () => {
+    const fixture = createMigrationResourceFixture({ detectFound: false });
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const discovery = await detectSetupMigrationSources({
+            config: fixture.config,
+            runtime: createNonExitingRuntime(),
+          });
+          expect(discovery.detections).toEqual([]);
+          expect(fixture.state.connections.length).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+          const options = await listSetupMigrationOptions({
+            baseConfig: fixture.config,
+            ...discovery,
+          });
+          expect(options).toEqual([
+            {
+              providerId: fixture.id,
+              label: "Import from Native migration fixture",
+              hint: "Native source 42",
+            },
+          ]);
+          expect(
+            await listSetupMigrationOptions({ baseConfig: fixture.config, ...discovery }),
+          ).toEqual(options);
+          expect(fixture.state.connections.length).toBe(1);
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([1, 2])(
+    "preserves completed provider config patches when registration %s cleanup fails",
+    async (failedConnection) => {
+      const fixture = createMigrationResourceFixture({ configPatch: true, secondProvider: true });
+      const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+      fixture.state.resumeApply.resolve();
+      fixture.state.finishPreparation.resolve();
+      fixture.state.failCleanupOnConnection = failedConnection;
+      const messages: string[] = [];
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+          },
+          async () => {
+            const result = await offerPostInstallMigrations({
+              config: fixture.config,
+              runtime: {
+                ...createNonExitingRuntime(),
+                log: (message) => {
+                  messages.push(String(message));
+                },
+              },
+              installedPluginIds: [fixture.id],
+              prompter: createWizardPrompter({ confirm: async () => true }),
+            });
+            expect(fixture.state.applyCalls).toBe(2);
+            expect(result.config.agents?.defaults?.heartbeat?.every).toBe("43m");
+            const cleanupWarnings = messages.filter((message) =>
+              message.includes("plugin cleanup failed"),
+            );
+            expect(cleanupWarnings).toHaveLength(1);
+            expect(cleanupWarnings[0]).toContain(
+              "migration result retained, but plugin cleanup failed",
+            );
+            expect(messages.some((message) => message.includes("migration failed:"))).toBe(false);
+            expect(messages.some((message) => message.includes("Re-run with"))).toBe(false);
+            expect(fixture.state.preparationDisposals).toBe(2);
+            expect(
+              fixture.state.connections.every(
+                ({ database, disposals }) => !database.isOpen && disposals === 1,
+              ),
+            ).toBe(true);
+          },
+        );
+      } finally {
+        if (stdinDescriptor) {
+          Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+        } else {
+          Reflect.deleteProperty(process.stdin, "isTTY");
+        }
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("retains the normal no-candidates result when outer registration cleanup fails", async () => {
+    const fixture = createMigrationResourceFixture({ detectFound: false });
+    fixture.state.failCleanupOnConnection = 1;
+    const messages: string[] = [];
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const result = await offerPostInstallMigrations({
+            config: fixture.config,
+            runtime: {
+              ...createNonExitingRuntime(),
+              log: (message) => {
+                messages.push(String(message));
+              },
+            },
+            installedPluginIds: [fixture.id],
+            nonInteractive: true,
+          });
+          expect(result.config).toBe(fixture.config);
+          expect(fixture.state.applyCalls).toBe(0);
+          expect(messages).toHaveLength(1);
+          expect(messages[0]).toContain("migration result retained, but plugin cleanup failed");
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -2,7 +2,11 @@
 import fs from "node:fs/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
+import type {
+  MigrationApplyResult,
+  MigrationPlan,
+  MigrationProviderPlugin,
+} from "../plugins/types.js";
 import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -71,9 +75,10 @@ vi.mock("./migrate/skill-selection-prompt.js", () => ({
 }));
 
 vi.mock("../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded: vi.fn(),
-  resolvePluginMigrationProvider: () => mocks.provider,
-  resolvePluginMigrationProviders: () => [mocks.provider],
+  withPluginMigrationProviders: async (
+    params: { providerId?: string },
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run([{ ...mocks.provider, id: params.providerId ?? mocks.provider.id }]),
 }));
 
 vi.mock("./backup.js", () => ({

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -10,17 +10,18 @@ import { withProgress } from "../cli/progress.js";
 import { promptYesNo } from "../cli/prompt.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { redactMigrationPlan } from "../plugin-sdk/migration.js";
-import {
-  ensureStandaloneMigrationProviderRegistryLoaded,
-  resolvePluginMigrationProviders,
-} from "../plugins/migration-provider-runtime.js";
-import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
+import { withPluginMigrationProviders } from "../plugins/migration-provider-runtime.js";
+import type {
+  MigrationApplyResult,
+  MigrationPlan,
+  MigrationProviderPlugin,
+} from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { writeRuntimeJson } from "../runtime.js";
 import { runMigrationApply } from "./migrate/apply.js";
 import { applyMigrationItemSelection } from "./migrate/item-selection.js";
 import { formatMigrationPreview } from "./migrate/output.js";
-import { createMigrationPlan, resolveMigrationProvider } from "./migrate/providers.js";
+import { createMigrationPlan, withMigrationProvider } from "./migrate/providers.js";
 import {
   applyMigrationPluginSelection,
   applyMigrationSelectedPluginItemIds,
@@ -91,8 +92,10 @@ function shouldPromptForAuthCredentials(opts: MigrateCommonOptions & { yes?: boo
 async function createMigrationPlanWithProgress(
   runtime: RuntimeEnv,
   opts: MigrateCommonOptions & { provider: string },
+  provider: MigrationProviderPlugin,
 ): Promise<MigrationPlan> {
-  const createPlan = async (): Promise<MigrationPlan> => await createMigrationPlan(runtime, opts);
+  const createPlan = async (): Promise<MigrationPlan> =>
+    await createMigrationPlan(runtime, opts, provider);
   if (opts.json) {
     return selectMigrationItems(await createPlan(), opts);
   }
@@ -111,15 +114,20 @@ async function createMigrationPlanWithProgress(
 async function createInteractiveMigrationPlanWithAuthPrompt(
   runtime: RuntimeEnv,
   opts: MigrateCommonOptions & { provider: string; yes?: boolean },
+  provider: MigrationProviderPlugin,
 ): Promise<MigrationPlan> {
   if (!shouldPromptForAuthCredentials(opts)) {
-    return await migratePlanCommand(runtime, resolveDefaultIncludeSecrets(opts));
+    return await migratePlanCommand(runtime, resolveDefaultIncludeSecrets(opts), provider);
   }
-  const initialPlan = await migratePlanCommand(runtime, {
-    ...opts,
-    includeSecrets: false,
-    suppressPlanLog: true,
-  });
+  const initialPlan = await migratePlanCommand(
+    runtime,
+    {
+      ...opts,
+      includeSecrets: false,
+      suppressPlanLog: true,
+    },
+    provider,
+  );
   if (!hasAuthCredentialCandidate(initialPlan)) {
     if (!opts.suppressPlanLog) {
       log.message(formatMigrationPreview(initialPlan).join("\n"));
@@ -138,11 +146,15 @@ async function createInteractiveMigrationPlanWithAuthPrompt(
     throw new Error("unreachable");
   }
   const finalPlan = includeSecrets
-    ? await migratePlanCommand(runtime, {
-        ...opts,
-        includeSecrets: true,
-        suppressPlanLog: true,
-      })
+    ? await migratePlanCommand(
+        runtime,
+        {
+          ...opts,
+          includeSecrets: true,
+          suppressPlanLog: true,
+        },
+        provider,
+      )
     : initialPlan;
   if (!opts.suppressPlanLog) {
     log.message(formatMigrationPreview(finalPlan).join("\n"));
@@ -290,37 +302,39 @@ function logNoCodexSelection(runtime: RuntimeEnv, plan: MigrationPlan): void {
 /** Lists available migration providers as JSON or terse terminal rows. */
 export async function migrateListCommand(runtime: RuntimeEnv, opts: { json?: boolean } = {}) {
   const cfg = getRuntimeConfig();
-  ensureStandaloneMigrationProviderRegistryLoaded({ cfg });
-  const providers = resolvePluginMigrationProviders({ cfg }).map((provider) => ({
-    id: provider.id,
-    label: provider.label,
-    description: provider.description,
-  }));
-  if (opts.json) {
-    writeRuntimeJson(runtime, { providers });
-    return;
-  }
-  if (providers.length === 0) {
+  return await withPluginMigrationProviders({ cfg }, async (registered) => {
+    const providers = registered.map((provider) => ({
+      id: provider.id,
+      label: provider.label,
+      description: provider.description,
+    }));
+    if (opts.json) {
+      writeRuntimeJson(runtime, { providers });
+      return;
+    }
+    if (providers.length === 0) {
+      runtime.log(
+        `No migration providers found. Run ${formatCliCommand("openclaw plugins list")} to verify provider plugins are installed and enabled.`,
+      );
+      return;
+    }
     runtime.log(
-      `No migration providers found. Run ${formatCliCommand("openclaw plugins list")} to verify provider plugins are installed and enabled.`,
+      providers
+        .map((provider) =>
+          provider.description
+            ? `${provider.id}\t${provider.label} - ${provider.description}`
+            : `${provider.id}\t${provider.label}`,
+        )
+        .join("\n"),
     );
-    return;
-  }
-  runtime.log(
-    providers
-      .map((provider) =>
-        provider.description
-          ? `${provider.id}\t${provider.label} - ${provider.description}`
-          : `${provider.id}\t${provider.label}`,
-      )
-      .join("\n"),
-  );
+  });
 }
 
 /** Creates and prints a migration plan without applying it. */
 export async function migratePlanCommand(
   runtime: RuntimeEnv,
   opts: MigrateCommonOptions,
+  provider?: MigrationProviderPlugin,
 ): Promise<MigrationPlan> {
   const providerId = opts.provider?.trim();
   if (!providerId) {
@@ -330,10 +344,21 @@ export async function migratePlanCommand(
   }
   const resolvedOpts = resolveDefaultIncludeSecrets(opts);
   assertVerifyPluginAppsProvider(providerId, resolvedOpts);
-  const plan = await createMigrationPlanWithProgress(runtime, {
-    ...resolvedOpts,
-    provider: providerId,
-  });
+  if (!provider) {
+    return await withMigrationProvider(
+      providerId,
+      opts.configOverride,
+      async (owned) => await migratePlanCommand(runtime, opts, owned),
+    );
+  }
+  const plan = await createMigrationPlanWithProgress(
+    runtime,
+    {
+      ...resolvedOpts,
+      provider: providerId,
+    },
+    provider,
+  );
   if (resolvedOpts.json) {
     writeRuntimeJson(runtime, redactMigrationPlan(plan));
   } else if (resolvedOpts.suppressPlanLog !== true) {
@@ -346,15 +371,18 @@ export async function migratePlanCommand(
 export async function migrateApplyCommand(
   runtime: RuntimeEnv,
   opts: MigrateApplyOptions & { yes: true },
+  provider?: MigrationProviderPlugin,
 ): Promise<MigrationApplyResult>;
 /** Plans interactively when needed, prompts, then applies the selected migration. */
 export async function migrateApplyCommand(
   runtime: RuntimeEnv,
   opts: MigrateApplyOptions,
+  provider?: MigrationProviderPlugin,
 ): Promise<MigrationApplyResult | MigrationPlan>;
 export async function migrateApplyCommand(
   runtime: RuntimeEnv,
   opts: MigrateApplyOptions,
+  provider?: MigrationProviderPlugin,
 ): Promise<MigrationApplyResult | MigrationPlan> {
   const providerId = opts.provider?.trim();
   if (!providerId) {
@@ -371,13 +399,23 @@ export async function migrateApplyCommand(
       `openclaw migrate apply requires --yes in non-interactive mode. Preview first with ${formatCliCommand(`openclaw migrate plan '${providerId.replaceAll("'", "'\\''")}'`)}.`,
     );
   }
-  const provider = resolveMigrationProvider(providerId, opts.configOverride);
+  if (!provider) {
+    return await withMigrationProvider(
+      providerId,
+      opts.configOverride,
+      async (owned) => await migrateApplyCommand(runtime, opts, owned),
+    );
+  }
   if (!opts.yes) {
-    const plan = await createInteractiveMigrationPlanWithAuthPrompt(runtime, {
-      ...opts,
-      provider: providerId,
-      json: opts.json,
-    });
+    const plan = await createInteractiveMigrationPlanWithAuthPrompt(
+      runtime,
+      {
+        ...opts,
+        provider: providerId,
+        json: opts.json,
+      },
+      provider,
+    );
     if (opts.json) {
       return plan;
     }
@@ -419,6 +457,7 @@ export async function migrateApplyCommand(
 export async function migrateDefaultCommand(
   runtime: RuntimeEnv,
   opts: MigrateDefaultOptions,
+  provider?: MigrationProviderPlugin,
 ): Promise<MigrationPlan | MigrationApplyResult> {
   const providerId = opts.provider?.trim();
   if (!providerId) {
@@ -439,24 +478,39 @@ export async function migrateDefaultCommand(
     };
   }
   assertVerifyPluginAppsProvider(providerId, opts);
+  if (!provider) {
+    return await withMigrationProvider(
+      providerId,
+      opts.configOverride,
+      async (owned) => await migrateDefaultCommand(runtime, opts, owned),
+    );
+  }
   const resolvedOpts = resolveDefaultIncludeSecrets(opts);
   const plan =
     opts.json && opts.yes && !opts.dryRun
       ? selectMigrationItems(
-          await createMigrationPlan(runtime, { ...resolvedOpts, provider: providerId }),
+          await createMigrationPlan(runtime, { ...resolvedOpts, provider: providerId }, provider),
           resolvedOpts,
         )
       : !opts.yes && process.stdin.isTTY
-        ? await createInteractiveMigrationPlanWithAuthPrompt(runtime, {
-            ...opts,
-            provider: providerId,
-            json: opts.json && (opts.dryRun || !opts.yes),
-          })
-        : await migratePlanCommand(runtime, {
-            ...resolvedOpts,
-            provider: providerId,
-            json: opts.json && (opts.dryRun || !opts.yes),
-          });
+        ? await createInteractiveMigrationPlanWithAuthPrompt(
+            runtime,
+            {
+              ...opts,
+              provider: providerId,
+              json: opts.json && (opts.dryRun || !opts.yes),
+            },
+            provider,
+          )
+        : await migratePlanCommand(
+            runtime,
+            {
+              ...resolvedOpts,
+              provider: providerId,
+              json: opts.json && (opts.dryRun || !opts.yes),
+            },
+            provider,
+          );
   if (opts.dryRun) {
     return plan;
   }
@@ -481,20 +535,28 @@ export async function migrateDefaultCommand(
       runtime.log("Migration cancelled.");
       return selectedPlan;
     }
-    return await migrateApplyCommand(runtime, {
-      ...opts,
+    return await migrateApplyCommand(
+      runtime,
+      {
+        ...opts,
+        provider: providerId,
+        yes: true,
+        includeSecrets: opts.includeSecrets ?? hasPlannedAuthCredentialItem(selectedPlan),
+        json: opts.json,
+        preflightPlan: selectedPlan,
+      },
+      provider,
+    );
+  }
+  return await migrateApplyCommand(
+    runtime,
+    {
+      ...resolvedOpts,
       provider: providerId,
       yes: true,
-      includeSecrets: opts.includeSecrets ?? hasPlannedAuthCredentialItem(selectedPlan),
       json: opts.json,
-      preflightPlan: selectedPlan,
-    });
-  }
-  return await migrateApplyCommand(runtime, {
-    ...resolvedOpts,
-    provider: providerId,
-    yes: true,
-    json: opts.json,
-    preflightPlan: plan,
-  });
+      preflightPlan: plan,
+    },
+    provider,
+  );
 }

--- a/src/commands/migrate/apply.ts
+++ b/src/commands/migrate/apply.ts
@@ -53,6 +53,7 @@ export async function runMigrationApply(params: {
   opts: MigrateApplyOptions;
   providerId: string;
   provider: MigrationProviderPlugin;
+  onApplyCompleted?: () => void;
 }): Promise<MigrationApplyResult> {
   const applyMigration = async (progress?: ProgressReporter) => {
     const total = (params.opts.preflightPlan ? 0 : 1) + (params.opts.noBackup ? 0 : 1) + 1;
@@ -119,6 +120,7 @@ export async function runMigrationApply(params: {
     });
     progress?.setLabel("Applying migration…");
     const result = await params.provider.apply(ctx, selectedPlan);
+    params.onApplyCompleted?.();
     tick();
     const withBackup = {
       ...result,

--- a/src/commands/migrate/memory-import.ts
+++ b/src/commands/migrate/memory-import.ts
@@ -3,10 +3,7 @@ import { MAX_MEMORY_MIGRATION_ITEMS } from "../../../packages/gateway-protocol/s
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { bindMemoryMigrationPlanSources } from "../../plugin-sdk/memory-migration-source.js";
 import { summarizeMigrationItems } from "../../plugin-sdk/migration.js";
-import {
-  ensureStandaloneMigrationProviderRegistryLoaded,
-  resolvePluginMigrationProviders,
-} from "../../plugins/migration-provider-runtime.js";
+import { withPluginMigrationProviders } from "../../plugins/migration-provider-runtime.js";
 import type {
   MigrationApplyResult,
   MigrationDetection,
@@ -26,10 +23,16 @@ const silentRuntime: RuntimeEnv = {
   },
 };
 
-export function listMemoryMigrationProviders(config: OpenClawConfig): MigrationProviderPlugin[] {
-  ensureStandaloneMigrationProviderRegistryLoaded({ cfg: config });
-  return resolvePluginMigrationProviders({ cfg: config }).filter((provider) =>
-    provider.supportedItemKinds?.includes(MEMORY_ITEM_KIND),
+export async function withMemoryMigrationProviders<T>(
+  config: OpenClawConfig,
+  run: (providers: MigrationProviderPlugin[]) => Promise<T>,
+): Promise<T> {
+  return await withPluginMigrationProviders(
+    { cfg: config },
+    async (providers) =>
+      await run(
+        providers.filter((provider) => provider.supportedItemKinds?.includes(MEMORY_ITEM_KIND)),
+      ),
   );
 }
 
@@ -103,6 +106,7 @@ export async function applyProviderMemoryImport(params: {
   overwrite?: boolean;
   preflightPlan: MigrationPlan;
   runtime?: RuntimeEnv;
+  onApplyCompleted?: () => void;
 }): Promise<MigrationApplyResult> {
   return await runMigrationApply({
     // Default silent: embedded surfaces (wizard, gateway) render their own
@@ -110,6 +114,7 @@ export async function applyProviderMemoryImport(params: {
     runtime: params.runtime ?? silentRuntime,
     providerId: params.provider.id,
     provider: params.provider,
+    onApplyCompleted: params.onApplyCompleted,
     opts: {
       yes: true,
       json: true,

--- a/src/commands/migrate/memory-import.ts
+++ b/src/commands/migrate/memory-import.ts
@@ -26,9 +26,10 @@ const silentRuntime: RuntimeEnv = {
 export async function withMemoryMigrationProviders<T>(
   config: OpenClawConfig,
   run: (providers: MigrationProviderPlugin[]) => Promise<T>,
+  onCleanupError?: (error: unknown) => void | Promise<void>,
 ): Promise<T> {
   return await withPluginMigrationProviders(
-    { cfg: config },
+    { cfg: config, onCleanupError },
     async (providers) =>
       await run(
         providers.filter((provider) => provider.supportedItemKinds?.includes(MEMORY_ITEM_KIND)),

--- a/src/commands/migrate/providers.test.ts
+++ b/src/commands/migrate/providers.test.ts
@@ -1,40 +1,6 @@
 // Migration provider tests cover provider-specific option shaping.
-import { describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { MigrationProviderPlugin } from "../../plugins/types.js";
-
-const migrationRuntimeMocks = vi.hoisted(() => ({
-  ensureLoaded: vi.fn(),
-  resolveProvider: vi.fn(),
-  resolveProviders: vi.fn(() => []),
-}));
-
-vi.mock("../../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded: migrationRuntimeMocks.ensureLoaded,
-  resolvePluginMigrationProvider: migrationRuntimeMocks.resolveProvider,
-  resolvePluginMigrationProviders: migrationRuntimeMocks.resolveProviders,
-}));
-
-import { buildMigrationProviderOptions, resolveMigrationProvider } from "./providers.js";
-
-describe("resolveMigrationProvider", () => {
-  it("loads the requested bundled provider before resolving it", () => {
-    const config = {} as OpenClawConfig;
-    const provider = {
-      id: "hermes",
-      label: "Hermes",
-      plan: vi.fn(),
-      apply: vi.fn(),
-    } satisfies MigrationProviderPlugin;
-    migrationRuntimeMocks.resolveProvider.mockReturnValueOnce(provider);
-
-    expect(resolveMigrationProvider("hermes", config)).toBe(provider);
-    expect(migrationRuntimeMocks.ensureLoaded).toHaveBeenCalledWith({
-      cfg: config,
-      providerId: "hermes",
-    });
-  });
-});
+import { describe, expect, it } from "vitest";
+import { buildMigrationProviderOptions } from "./providers.js";
 
 describe("buildMigrationProviderOptions", () => {
   it("uses the resolved provider id for Codex options", () => {

--- a/src/commands/migrate/providers.ts
+++ b/src/commands/migrate/providers.ts
@@ -1,34 +1,33 @@
 /** Migration provider lookup, option shaping, and plan creation helpers. */
 import { getRuntimeConfig } from "../../config/config.js";
-import {
-  ensureStandaloneMigrationProviderRegistryLoaded,
-  resolvePluginMigrationProvider,
-  resolvePluginMigrationProviders,
-} from "../../plugins/migration-provider-runtime.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withPluginMigrationProviders } from "../../plugins/migration-provider-runtime.js";
 import type { MigrationPlan, MigrationProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { buildMigrationContext } from "./context.js";
 import type { MigrateCommonOptions } from "./types.js";
 
-/** Resolves a migration provider from the loaded plugin migration registry. */
-export function resolveMigrationProvider(
+/** Borrow a selected provider for the complete consuming operation. */
+export async function withMigrationProvider<T>(
   providerId: string,
-  config = getRuntimeConfig(),
-): MigrationProviderPlugin {
-  ensureStandaloneMigrationProviderRegistryLoaded({
-    cfg: config,
-    providerId,
-  });
-  const provider = resolvePluginMigrationProvider({ providerId, cfg: config });
-  if (!provider) {
-    const available = resolvePluginMigrationProviders({ cfg: config }).map((entry) => entry.id);
-    const suffix =
-      available.length > 0
-        ? ` Available providers: ${available.join(", ")}.`
-        : " No providers found.";
-    throw new Error(`Unknown migration provider "${providerId}".${suffix}`);
-  }
-  return provider;
+  config: OpenClawConfig | undefined,
+  run: (provider: MigrationProviderPlugin) => Promise<T>,
+): Promise<T> {
+  return await withPluginMigrationProviders(
+    { cfg: config ?? getRuntimeConfig(), providerId },
+    async (providers) => {
+      const provider = providers.find((entry) => entry.id === providerId);
+      if (!provider) {
+        const available = providers.map((entry) => entry.id);
+        const suffix =
+          available.length > 0
+            ? ` Available providers: ${available.join(", ")}.`
+            : " No providers found.";
+        throw new Error(`Unknown migration provider "${providerId}".${suffix}`);
+      }
+      return await run(provider);
+    },
+  );
 }
 
 /** Builds provider-specific options from shared migrate CLI flags. */
@@ -50,11 +49,11 @@ export function buildMigrationProviderOptions(
 export async function createMigrationPlan(
   runtime: RuntimeEnv,
   opts: MigrateCommonOptions & { provider: string },
+  provider: MigrationProviderPlugin,
 ): Promise<MigrationPlan> {
   if (opts.verifyPluginApps && opts.provider !== "codex") {
     throw new Error("--verify-plugin-apps is only supported for Codex migrations.");
   }
-  const provider = resolveMigrationProvider(opts.provider, opts.configOverride);
   const ctx = buildMigrationContext({
     source: opts.source,
     targetAgentId: opts.targetAgentId,

--- a/src/commands/onboard-non-interactive.migration.test.ts
+++ b/src/commands/onboard-non-interactive.migration.test.ts
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { summarizeMigrationItems } from "../plugin-sdk/migration.js";
-import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
+import type {
+  MigrationApplyResult,
+  MigrationPlan,
+  MigrationProviderPlugin,
+} from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const tempRoots = useAutoCleanupTempDirTracker(afterEach);
@@ -67,10 +71,10 @@ vi.mock("./onboard-helpers.js", () => ({
 }));
 
 vi.mock("../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded: vi.fn(),
-  resolvePluginMigrationProviders: () => [provider],
-  resolvePluginMigrationProvider: ({ providerId }: { providerId: string }) =>
-    providerId === provider.id ? provider : undefined,
+  withPluginMigrationProviders: async (
+    _params: unknown,
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run([provider]),
 }));
 
 import { runNonInteractiveSetup } from "./onboard-non-interactive.js";

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -47,14 +47,14 @@ async function runNonInteractiveMigrationImport(params: {
   }
   const { detectSetupMigrationSources, runSetupMigrationImport } =
     await import("../wizard/setup.migration-import.js");
-  const detections = await detectSetupMigrationSources({
+  const discovery = await detectSetupMigrationSources({
     config: params.baseConfig,
     runtime: params.runtime,
   });
   const outcome = await runSetupMigrationImport({
     opts: { ...params.opts, importFrom: providerId, nonInteractive: true },
     baseConfig: params.baseConfig,
-    detections,
+    ...discovery,
     prompter: createNonInteractiveLoggingPrompter(
       params.runtime,
       (message) =>

--- a/src/gateway/server-methods/migrations.resources.test.ts
+++ b/src/gateway/server-methods/migrations.resources.test.ts
@@ -1,0 +1,303 @@
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import * as loader from "../../plugins/loader.js";
+import { loadAndActivateRootPluginRegistry } from "../../plugins/loader.js";
+import { resetPluginLoaderTestStateForTest } from "../../plugins/loader.test-fixtures.js";
+import { createMigrationResourceFixture } from "../../plugins/migration-provider.test-support.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { migrationsHandlers } from "./migrations.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+
+describe("memory migration registration resources", () => {
+  it.each(["success", "cleanup failure", "encoding failure"] as const)(
+    "replays a terminal %s after native resources close without applying again",
+    async (mode) => {
+      const fixture = createMigrationResourceFixture();
+      const dedupe: GatewayRequestContext["dedupe"] = new Map();
+      const logGateway = createSubsystemLogger("migration-native-test");
+      const warn = vi.spyOn(logGateway, "warn").mockImplementation(() => {});
+      const context = {
+        getRuntimeConfig: () => fixture.config,
+        dedupe,
+        logGateway,
+      } as GatewayRequestContext;
+      const invoke = (method: keyof typeof migrationsHandlers, params: Record<string, unknown>) => {
+        const frames: string[] = [];
+        const respond: RespondFn = (ok, payload, error, meta) => {
+          frames.push(JSON.stringify({ ok, payload, error, meta }));
+        };
+        return {
+          frames,
+          run: () =>
+            expectDefined(
+              migrationsHandlers[method],
+              method,
+            )({
+              params,
+              respond,
+              context,
+              client: null,
+              req: { type: "req", id: "migration-resource-test", method },
+              isWebchatConnect: () => false,
+            }),
+        };
+      };
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+          },
+          async () => {
+            const plan = invoke("migrations.memory.plan", { agentId: "main" });
+            await plan.run();
+            expect(plan.frames).toHaveLength(1);
+            const preview = JSON.parse(plan.frames[0] ?? "{}");
+            expect(preview.ok).toBe(true);
+            const fingerprint: unknown = preview.payload.providers[0]?.planFingerprint;
+            expect(fingerprint).toEqual(expect.any(String));
+            expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+            fixture.state.failCleanup = mode === "cleanup failure";
+            fixture.state.failEncoding = mode === "encoding failure";
+            const params = {
+              agentId: "main",
+              providerId: fixture.id,
+              itemIds: ["memory:one"],
+              idempotencyKey: "native-memory-import",
+              planFingerprint: fingerprint,
+            };
+            const first = invoke("migrations.memory.apply", params);
+            const firstRun = first.run();
+            try {
+              await Promise.race([fixture.state.applying.promise, firstRun]);
+              expect(fixture.state.applyCalls).toBe(1);
+              expect(fixture.state.connections[1]?.database.isOpen).toBe(true);
+              const retry = invoke("migrations.memory.apply", params);
+              const retryRun = retry.run();
+              fixture.state.resumeApply.resolve();
+              await Promise.all([firstRun, retryRun]);
+              expect(first.frames).toHaveLength(1);
+              expect(retry.frames).toHaveLength(1);
+              const initial = JSON.parse(first.frames[0] ?? "{}");
+              const joined = JSON.parse(retry.frames[0] ?? "{}");
+              expect(joined).toEqual({ ...initial, meta: { cached: true } });
+              expect(initial.ok).toBe(mode !== "encoding failure");
+              if (mode === "encoding failure") {
+                expect(initial.error.message).toContain(
+                  "apply completed, but its result could not be returned",
+                );
+              } else {
+                expect(initial.payload.items[0].details).toEqual({ value: 42 });
+              }
+              expect(fixture.state.connections).toHaveLength(2);
+              expect(
+                fixture.state.connections.every(
+                  ({ database, disposals }) => !database.isOpen && disposals === 1,
+                ),
+              ).toBe(true);
+              const reads = fixture.state.jsonReads;
+              expect(reads).toBeGreaterThan(0);
+              const later = invoke("migrations.memory.apply", params);
+              await later.run();
+              expect(later.frames).toEqual(retry.frames);
+              expect(fixture.state.jsonReads).toBe(reads);
+              expect(fixture.state.applyCalls).toBe(1);
+              expect(warn.mock.calls.length).toBe(mode === "cleanup failure" ? 1 : 0);
+              const readback = new DatabaseSync(path.join(fixture.root, "source.sqlite"));
+              try {
+                expect(readback.prepare("SELECT count(*) AS count FROM imports").get()).toEqual({
+                  count: 1,
+                });
+              } finally {
+                readback.close();
+              }
+            } finally {
+              fixture.state.resumeApply.resolve();
+              await firstRun;
+            }
+          },
+        );
+      } finally {
+        warn.mockRestore();
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("joins fresh planning before releasing its database when a raw active provider getter rejects", async () => {
+    const active = createMigrationResourceFixture();
+    const fresh = createMigrationResourceFixture({ pausePlan: true });
+    const respond = vi.fn<RespondFn>();
+    const context = { getRuntimeConfig: () => fresh.config } as GatewayRequestContext;
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fresh.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fresh.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const raw = loadAndActivateRootPluginRegistry({ config: active.config });
+          expect(raw.migrationProviders).toHaveLength(1);
+          active.state.failLabel = true;
+          fresh.state.failPlan = true;
+          let settled = false;
+          const request = expectDefined(
+            migrationsHandlers["migrations.memory.plan"],
+            "memory plan",
+          )({
+            params: { agentId: "main" },
+            respond,
+            context,
+            client: null,
+            req: { type: "req", id: "mixed-owner-plan", method: "migrations.memory.plan" },
+            isWebchatConnect: () => false,
+          });
+          const completion = Promise.resolve(request).then(
+            () => {
+              settled = true;
+              return undefined;
+            },
+            (error: unknown) => {
+              settled = true;
+              return error;
+            },
+          );
+          try {
+            await Promise.race([fresh.state.planning.promise, completion]);
+            // Let already-issued promise reactions run without unblocking the native plan.
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(fresh.state.planCalls).toBe(1);
+            expect(fresh.state.connections).toHaveLength(1);
+            expect(fresh.state.connections[0]?.database.isOpen).toBe(true);
+            expect(settled).toBe(false);
+            fresh.state.resumePlan.resolve();
+            expect(await completion).toBe(active.state.labelError);
+            await fresh.state.planFinished.promise;
+            expect(respond).not.toHaveBeenCalled();
+            expect(fresh.state.connections[0]?.disposals).toBe(1);
+            expect(fresh.state.connections[0]?.database.isOpen).toBe(false);
+            expect(
+              active.state.connections[0]?.database.prepare("SELECT 42 AS value").get(),
+            ).toEqual({ value: 42 });
+            expect(active.state.connections[0]?.disposals).toBe(0);
+          } finally {
+            fresh.state.resumePlan.resolve();
+            await completion;
+            await fresh.state.planFinished.promise;
+          }
+        },
+      );
+    } finally {
+      fresh.cleanup();
+      active.cleanup();
+    }
+  });
+
+  it("reserves same-key requests before a real cold acquisition resolves", async () => {
+    const fixture = createMigrationResourceFixture();
+    const acquired = createDeferredCore();
+    const releaseAcquisition = createDeferredCore();
+    const dedupe: GatewayRequestContext["dedupe"] = new Map();
+    const context = { getRuntimeConfig: () => fixture.config, dedupe } as GatewayRequestContext;
+    const invoke = (method: keyof typeof migrationsHandlers, params: Record<string, unknown>) => {
+      const frames: string[] = [];
+      const respond = vi.fn<RespondFn>((ok, payload, error, meta) => {
+        frames.push(JSON.stringify({ ok, payload, error, meta }));
+      });
+      return {
+        respond,
+        frames,
+        run: () =>
+          expectDefined(
+            migrationsHandlers[method],
+            method,
+          )({
+            params,
+            respond,
+            context,
+            client: null,
+            req: { type: "req", id: "acquisition-reservation", method },
+            isWebchatConnect: () => false,
+          }),
+      };
+    };
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          const plan = invoke("migrations.memory.plan", { agentId: "main" });
+          await plan.run();
+          const preview = JSON.parse(plan.frames[0] ?? "{}").payload;
+          const params = {
+            agentId: "main",
+            providerId: fixture.id,
+            itemIds: ["memory:one"],
+            idempotencyKey: "pending-acquisition",
+            planFingerprint: preview.providers[0].planFingerprint,
+          };
+          const acquire = loader.acquirePluginRegistryForInspection;
+          const spy = vi
+            .spyOn(loader, "acquirePluginRegistryForInspection")
+            .mockImplementationOnce(async (options) => {
+              const handle = await acquire(options);
+              acquired.resolve();
+              await releaseAcquisition.promise;
+              return handle;
+            });
+          fixture.state.resumeApply.resolve();
+          const first = invoke("migrations.memory.apply", params);
+          const firstRun = Promise.resolve(first.run());
+          const runs = [firstRun];
+          try {
+            await Promise.race([acquired.promise, firstRun]);
+            expect(fixture.state.connections).toHaveLength(2);
+            expect(fixture.state.connections[1]?.database.isOpen).toBe(true);
+            const duplicate = invoke("migrations.memory.apply", params);
+            runs.push(Promise.resolve(duplicate.run()));
+            const mismatch = invoke("migrations.memory.apply", {
+              ...params,
+              itemIds: ["memory:other"],
+            });
+            await mismatch.run();
+            expect(mismatch.respond.mock.calls[0]?.[2]?.message).toContain(
+              "idempotency key was reused",
+            );
+            expect(first.respond).not.toHaveBeenCalled();
+            expect(duplicate.respond).not.toHaveBeenCalled();
+            expect(fixture.state.applyCalls).toBe(0);
+            expect(spy).toHaveBeenCalledOnce();
+            releaseAcquisition.resolve();
+            await Promise.all(runs);
+            expect(first.respond.mock.calls[0]?.[0]).toBe(true);
+            expect(duplicate.respond.mock.calls[0]?.[3]).toEqual({ cached: true });
+            expect(fixture.state.applyCalls).toBe(1);
+            expect(fixture.state.connections[1]?.disposals).toBe(1);
+          } finally {
+            releaseAcquisition.resolve();
+            await Promise.allSettled(runs);
+            spy.mockRestore();
+          }
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/src/gateway/server-methods/migrations.test.ts
+++ b/src/gateway/server-methods/migrations.test.ts
@@ -15,12 +15,20 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded: vi.fn(),
-  resolvePluginMigrationProviders: vi.fn(() => mocks.providers),
+  withPluginMigrationProviders: async (
+    _params: unknown,
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run(mocks.providers),
 }));
 
 vi.mock("../../commands/migrate/apply.js", () => ({
-  runMigrationApply: mocks.runMigrationApply,
+  runMigrationApply: async (
+    params: Parameters<typeof import("../../commands/migrate/apply.js").runMigrationApply>[0],
+  ) => {
+    const result = await mocks.runMigrationApply(params);
+    params.onApplyCompleted?.();
+    return result;
+  },
 }));
 
 import { migrationsHandlers } from "./migrations.js";

--- a/src/gateway/server-methods/migrations.ts
+++ b/src/gateway/server-methods/migrations.ts
@@ -14,7 +14,7 @@ import {
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   applyProviderMemoryImport,
-  listMemoryMigrationProviders,
+  withMemoryMigrationProviders,
   planProviderMemoryImport,
 } from "../../commands/migrate/memory-import.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -34,11 +34,11 @@ function emptySummary() {
 
 type CachedMemoryApply = {
   requestFingerprint: string;
-  result: MigrationsMemoryApplyResult;
+  outcome: MemoryApplyOutcome;
 };
 
 type MemoryApplyOutcome =
-  | { ok: true; result: MigrationsMemoryApplyResult }
+  | { ok: true; resultJson: string }
   | { ok: false; error: ReturnType<typeof errorShape> };
 
 type InFlightMemoryApply = {
@@ -78,7 +78,16 @@ function isCachedMemoryApply(value: unknown): value is CachedMemoryApply {
     return false;
   }
   const candidate = value as Partial<CachedMemoryApply>;
-  return typeof candidate.requestFingerprint === "string" && candidate.result !== undefined;
+  return typeof candidate.requestFingerprint === "string" && candidate.outcome !== undefined;
+}
+
+function respondMemoryApply(outcome: MemoryApplyOutcome, respond: RespondFn, cached = false): void {
+  const meta = cached ? { cached: true } : undefined;
+  if (outcome.ok) {
+    respond(true, JSON.parse(outcome.resultJson), undefined, meta);
+  } else {
+    respond(false, undefined, outcome.error, meta);
+  }
 }
 
 function toWireItem(item: MigrationItem): MemoryMigrationItem {
@@ -217,9 +226,8 @@ export const migrationsHandlers: GatewayRequestHandlers = {
     if (!agentId) {
       return;
     }
-    const providers = listMemoryMigrationProviders(config);
-    const planned = await Promise.all(
-      providers.map(
+    const resultJson = await withMemoryMigrationProviders(config, async (providers) => {
+      const planning = providers.map(
         async (provider) =>
           await planMemoryProvider({
             provider,
@@ -227,14 +235,23 @@ export const migrationsHandlers: GatewayRequestHandlers = {
             agentId,
             overwrite: params.overwrite,
           }),
-      ),
-    );
-    const result: MigrationsMemoryPlanResult = {
-      agentId,
-      workspace: resolveAgentWorkspaceDir(config, agentId),
-      providers: planned,
-    };
-    respond(true, result, undefined);
+      );
+      let planned: MemoryMigrationProviderPlan[];
+      try {
+        planned = await Promise.all(planning);
+      } catch (error) {
+        // Preserve the first whole-request rejection, but keep resources until every issued plan settles.
+        await Promise.allSettled(planning);
+        throw error;
+      }
+      const result: MigrationsMemoryPlanResult = {
+        agentId,
+        workspace: resolveAgentWorkspaceDir(config, agentId),
+        providers: planned,
+      };
+      return JSON.stringify(result);
+    });
+    respond(true, JSON.parse(resultJson), undefined);
   },
 
   "migrations.memory.apply": async ({ params, respond, context }) => {
@@ -271,16 +288,7 @@ export const migrationsHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      respond(true, cached.payload.result, undefined, { cached: true });
-      return;
-    }
-    const provider = findMemoryProvider(listMemoryMigrationProviders(config), params.providerId);
-    if (!provider) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "unknown memory migration provider"),
-      );
+      respondMemoryApply(cached.payload.outcome, respond, true);
       return;
     }
     const inFlightMap = memoryApplyInflightMap(context.dedupe);
@@ -294,127 +302,149 @@ export const migrationsHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      const outcome = await inFlight.completion;
-      if (outcome.ok) {
-        respond(true, outcome.result, undefined, { cached: true });
-      } else {
-        respond(false, undefined, outcome.error, { cached: true });
-      }
+      respondMemoryApply(await inFlight.completion, respond, true);
       return;
     }
     let settle!: (outcome: MemoryApplyOutcome) => void;
     const completion = new Promise<MemoryApplyOutcome>((resolve) => {
       settle = resolve;
     });
-    // Reserve before awaited planning/apply work. Success moves to the gateway dedupe cache;
-    // failure releases the key so the same frozen request can be retried.
+    // Reserve before acquisition. Once apply completes, even an unreadable result is terminal.
     inFlightMap.set(dedupeKey, { requestFingerprint, completion });
-    const complete = (outcome: MemoryApplyOutcome) => {
-      settle(outcome);
-      if (outcome.ok) {
-        respond(true, outcome.result, undefined);
-      } else {
-        respond(false, undefined, outcome.error);
+    let applyCompleted = false;
+    let producedOutcome: MemoryApplyOutcome | undefined;
+    let outcome: MemoryApplyOutcome;
+    const runApply = async (providers: MigrationProviderPlugin[]): Promise<MemoryApplyOutcome> => {
+      const provider = findMemoryProvider(providers, params.providerId);
+      if (!provider) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.INVALID_REQUEST, "unknown memory migration provider"),
+        };
+      }
+      const applyKey = `${agentId}:${provider.id}`;
+      if (activeApplies.has(applyKey)) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.UNAVAILABLE, "memory import already running", {
+            retryable: true,
+            retryAfterMs: 1000,
+          }),
+        };
+      }
+      activeApplies.add(applyKey);
+      try {
+        const { plan } = await planProviderMemoryImport({
+          provider,
+          config,
+          agentId,
+          overwrite: params.overwrite,
+        });
+        const currentFingerprint = fingerprintMemoryPlan({
+          agentId,
+          workspace: resolveAgentWorkspaceDir(config, agentId),
+          providerId: provider.id,
+          overwrite: params.overwrite,
+          plan,
+        });
+        if (currentFingerprint !== params.planFingerprint) {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "memory migration plan changed; refresh the plan before importing",
+            ),
+          };
+        }
+        const selectable = new Map(
+          plan.items
+            .filter((item) => item.status === "planned" || item.status === "conflict")
+            .map((item) => [item.id, item]),
+        );
+        const unavailable = params.itemIds.filter((id) => !selectable.has(id));
+        if (unavailable.length > 0) {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `memory migration items changed; refresh the plan (${unavailable.join(", ")})`,
+            ),
+          };
+        }
+        const selectedConflicts = params.itemIds.filter(
+          (id) => selectable.get(id)?.status === "conflict",
+        );
+        if (!params.overwrite && selectedConflicts.length > 0) {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "selected memory was already imported; enable replacement and refresh the plan",
+            ),
+          };
+        }
+        const applied = await applyProviderMemoryImport({
+          provider,
+          config,
+          agentId,
+          itemIds: params.itemIds,
+          overwrite: params.overwrite,
+          preflightPlan: plan,
+          onApplyCompleted: () => {
+            applyCompleted = true;
+          },
+        });
+        const result: MigrationsMemoryApplyResult = {
+          providerId: applied.providerId,
+          source: applied.source,
+          ...(applied.target ? { target: applied.target } : {}),
+          summary: applied.summary,
+          items: applied.items.map(toWireItem),
+          ...(applied.warnings?.length ? { warnings: applied.warnings } : {}),
+          ...(applied.backupPath ? { backupPath: applied.backupPath } : {}),
+          ...(applied.reportDir ? { reportDir: applied.reportDir } : {}),
+        };
+        // Only the projected JSON transport result crosses the registration lifetime.
+        return { ok: true, resultJson: JSON.stringify(result) };
+      } finally {
+        activeApplies.delete(applyKey);
       }
     };
-    const applyKey = `${agentId}:${provider.id}`;
-    if (activeApplies.has(applyKey)) {
-      complete({
-        ok: false,
-        error: errorShape(ErrorCodes.UNAVAILABLE, "memory import already running", {
-          retryable: true,
-          retryAfterMs: 1000,
-        }),
-      });
-      inFlightMap.delete(dedupeKey);
-      return;
-    }
-    activeApplies.add(applyKey);
     try {
-      const { plan } = await planProviderMemoryImport({
-        provider,
-        config,
-        agentId,
-        overwrite: params.overwrite,
+      outcome = await withMemoryMigrationProviders(config, async (providers) => {
+        try {
+          producedOutcome = await runApply(providers);
+        } catch (error) {
+          producedOutcome = {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.UNAVAILABLE,
+              applyCompleted
+                ? `Memory import apply completed, but its result could not be returned: ${errorMessage(error)}. Inspect the migration report before starting another import.`
+                : errorMessage(error),
+            ),
+          };
+        }
+        if (applyCompleted) {
+          context.dedupe.set(dedupeKey, {
+            ts: Date.now(),
+            ok: producedOutcome.ok,
+            payload: { requestFingerprint, outcome: producedOutcome } satisfies CachedMemoryApply,
+          });
+        }
+        return producedOutcome;
       });
-      const currentFingerprint = fingerprintMemoryPlan({
-        agentId,
-        workspace: resolveAgentWorkspaceDir(config, agentId),
-        providerId: provider.id,
-        overwrite: params.overwrite,
-        plan,
-      });
-      if (currentFingerprint !== params.planFingerprint) {
-        complete({
-          ok: false,
-          error: errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            "memory migration plan changed; refresh the plan before importing",
-          ),
-        });
-        return;
-      }
-      const selectable = new Map(
-        plan.items
-          .filter((item) => item.status === "planned" || item.status === "conflict")
-          .map((item) => [item.id, item]),
-      );
-      const unavailable = params.itemIds.filter((id) => !selectable.has(id));
-      if (unavailable.length > 0) {
-        complete({
-          ok: false,
-          error: errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `memory migration items changed; refresh the plan (${unavailable.join(", ")})`,
-          ),
-        });
-        return;
-      }
-      const selectedConflicts = params.itemIds.filter(
-        (id) => selectable.get(id)?.status === "conflict",
-      );
-      if (!params.overwrite && selectedConflicts.length > 0) {
-        complete({
-          ok: false,
-          error: errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            "selected memory was already imported; enable replacement and refresh the plan",
-          ),
-        });
-        return;
-      }
-      const applied = await applyProviderMemoryImport({
-        provider,
-        config,
-        agentId,
-        itemIds: params.itemIds,
-        overwrite: params.overwrite,
-        preflightPlan: plan,
-      });
-      const result: MigrationsMemoryApplyResult = {
-        providerId: applied.providerId,
-        source: applied.source,
-        ...(applied.target ? { target: applied.target } : {}),
-        summary: applied.summary,
-        items: applied.items.map(toWireItem),
-        ...(applied.warnings?.length ? { warnings: applied.warnings } : {}),
-        ...(applied.backupPath ? { backupPath: applied.backupPath } : {}),
-        ...(applied.reportDir ? { reportDir: applied.reportDir } : {}),
-      };
-      context.dedupe.set(dedupeKey, {
-        ts: Date.now(),
-        ok: true,
-        payload: { requestFingerprint, result } satisfies CachedMemoryApply,
-      });
-      complete({ ok: true, result });
     } catch (error) {
-      complete({
-        ok: false,
-        error: errorShape(ErrorCodes.UNAVAILABLE, errorMessage(error)),
-      });
+      if (producedOutcome) {
+        context.logGateway.warn(`Memory migration plugin cleanup failed: ${errorMessage(error)}`);
+        outcome = producedOutcome;
+      } else {
+        outcome = { ok: false, error: errorShape(ErrorCodes.UNAVAILABLE, errorMessage(error)) };
+      }
     } finally {
-      activeApplies.delete(applyKey);
       inFlightMap.delete(dedupeKey);
     }
+    settle(outcome);
+    respondMemoryApply(outcome, respond);
   },
 };

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -50,14 +50,15 @@ const mocks = vi.hoisted(() => ({
     snapshot: params?.index ?? createMockPluginIndex([]),
     diagnostics: [],
   })),
-  loadPluginRegistryHandle: vi.fn(),
+  acquirePluginRegistryForInspection: vi.fn(),
+  release: vi.fn(async () => {}),
   listBundledPluginMetadata: vi.fn(() => []),
 }));
 
 vi.mock("./loader.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./loader.js")>()),
   resolveRuntimePluginRegistry: mocks.resolveRuntimePluginRegistry,
-  loadPluginRegistryHandle: mocks.loadPluginRegistryHandle,
+  acquirePluginRegistryForInspection: mocks.acquirePluginRegistryForInspection,
 }));
 
 vi.mock("./active-runtime-registry.js", () => ({
@@ -101,9 +102,7 @@ vi.mock("./bundled-plugin-metadata.js", () => ({
   listBundledPluginMetadata: mocks.listBundledPluginMetadata,
 }));
 
-let ensureStandaloneMigrationProviderRegistryLoaded: typeof import("./migration-provider-runtime.js").ensureStandaloneMigrationProviderRegistryLoaded;
-let resolvePluginMigrationProvider: typeof import("./migration-provider-runtime.js").resolvePluginMigrationProvider;
-let resolvePluginMigrationProviders: typeof import("./migration-provider-runtime.js").resolvePluginMigrationProviders;
+let withPluginMigrationProviders: typeof import("./migration-provider-runtime.js").withPluginMigrationProviders;
 
 function createMigrationProvider(id: string) {
   return {
@@ -131,10 +130,13 @@ describe("migration provider runtime", () => {
     clearPluginMetadataLifecycleCaches();
     vi.resetModules();
     vi.clearAllMocks();
-    mocks.resolveRuntimePluginRegistry.mockReturnValue(createEmptyPluginRegistry());
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(undefined);
     mocks.loadPluginManifestRegistry.mockReturnValue(createEmptyMockManifestRegistry());
     mocks.loadPluginRegistrySnapshot.mockReturnValue(createMockPluginIndex([]));
-    mocks.loadPluginRegistryHandle.mockReturnValue(createEmptyPluginRegistry());
+    mocks.acquirePluginRegistryForInspection.mockResolvedValue({
+      registry: createEmptyPluginRegistry(),
+      release: mocks.release,
+    });
     mocks.listBundledPluginMetadata.mockReturnValue([]);
     mocks.loadPluginRegistrySnapshotWithMetadata.mockImplementation(
       (params?: MockPluginSnapshotLoadParams) => ({
@@ -144,13 +146,10 @@ describe("migration provider runtime", () => {
       }),
     );
     const runtime = await import("./migration-provider-runtime.js");
-    ensureStandaloneMigrationProviderRegistryLoaded =
-      runtime.ensureStandaloneMigrationProviderRegistryLoaded;
-    resolvePluginMigrationProvider = runtime.resolvePluginMigrationProvider;
-    resolvePluginMigrationProviders = runtime.resolvePluginMigrationProviders;
+    withPluginMigrationProviders = runtime.withPluginMigrationProviders;
   });
 
-  it("standalone-loads bundled migration providers through compat config", () => {
+  it("loads bundled migration providers through compat config", async () => {
     mocks.loadPluginRegistrySnapshot.mockReturnValue(
       createMockPluginIndex([
         {
@@ -171,19 +170,15 @@ describe("migration provider runtime", () => {
       ],
     }));
 
-    ensureStandaloneMigrationProviderRegistryLoaded({
-      cfg: { plugins: { enabled: false } } as OpenClawConfig,
-    });
+    await withPluginMigrationProviders({ cfg: { plugins: { enabled: false } } }, async () => {});
 
     const standaloneParams = requireMockCallArg(
-      mocks.loadPluginRegistryHandle,
-      "loadPluginRegistryHandle",
+      mocks.acquirePluginRegistryForInspection,
+      "acquirePluginRegistryForInspection",
     ) as {
-      activate?: unknown;
       onlyPluginIds?: unknown;
       config?: OpenClawConfig;
     };
-    expect(standaloneParams.activate).toBe(false);
     expect(standaloneParams.onlyPluginIds).toEqual(["migrate-hermes"]);
     expect(standaloneParams.config?.plugins?.enabled).toBe(true);
     expect(standaloneParams.config?.plugins?.entries).toEqual({
@@ -191,7 +186,7 @@ describe("migration provider runtime", () => {
     });
   });
 
-  it("discovers bundled migration contracts missing from a pruned persisted index", () => {
+  it("discovers bundled migration contracts missing from a pruned persisted index", async () => {
     mocks.listBundledPluginMetadata.mockReturnValue([
       {
         manifest: {
@@ -201,11 +196,11 @@ describe("migration provider runtime", () => {
       },
     ] as never);
 
-    ensureStandaloneMigrationProviderRegistryLoaded({ providerId: "hermes" });
+    await withPluginMigrationProviders({ providerId: "hermes" }, async () => {});
 
     const standaloneParams = requireMockCallArg(
-      mocks.loadPluginRegistryHandle,
-      "loadPluginRegistryHandle",
+      mocks.acquirePluginRegistryForInspection,
+      "acquirePluginRegistryForInspection",
     );
     expect(standaloneParams.onlyPluginIds).toEqual(["migrate-hermes"]);
   });
@@ -229,8 +224,12 @@ describe("migration provider runtime", () => {
       provider,
     } as never);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
-      params === undefined ? active : loaded,
+      params === undefined ? active : undefined,
     );
+    mocks.acquirePluginRegistryForInspection.mockResolvedValue({
+      registry: loaded,
+      release: mocks.release,
+    });
     mocks.loadPluginRegistrySnapshot.mockReturnValue(
       createMockPluginIndex([
         {
@@ -269,14 +268,18 @@ describe("migration provider runtime", () => {
           ],
     }));
 
-    const resolved = resolvePluginMigrationProvider({ providerId: "external-import", cfg });
-
-    expect(resolved).not.toBe(provider);
-    provider.plan.mockImplementationOnce(() => {
-      expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(loaded);
-      return {} as never;
-    });
-    await resolved?.plan({} as never);
+    await withPluginMigrationProviders(
+      { providerId: "external-import", cfg },
+      async (providers) => {
+        const resolved = providers.find((entry) => entry.id === "external-import");
+        expect(resolved).not.toBe(provider);
+        provider.plan.mockImplementationOnce(() => {
+          expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(loaded);
+          return {} as never;
+        });
+        await resolved?.plan({} as never);
+      },
+    );
     expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
       config: cfg,
       env: process.env,
@@ -303,7 +306,7 @@ describe("migration provider runtime", () => {
     });
   });
 
-  it("discovers newly bundled migration providers from current metadata", () => {
+  it("discovers newly bundled migration providers from current metadata", async () => {
     const provider = createMigrationProvider("hermes");
     const active = createEmptyPluginRegistry();
     const loaded = createEmptyPluginRegistry();
@@ -314,8 +317,12 @@ describe("migration provider runtime", () => {
       provider,
     } as never);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
-      params === undefined ? active : loaded,
+      params === undefined ? active : undefined,
     );
+    mocks.acquirePluginRegistryForInspection.mockResolvedValue({
+      registry: loaded,
+      release: mocks.release,
+    });
     mocks.listBundledPluginMetadata.mockReturnValue([
       {
         manifest: {
@@ -325,9 +332,9 @@ describe("migration provider runtime", () => {
       },
     ] as never);
 
-    const resolved = resolvePluginMigrationProvider({ providerId: "hermes" });
-
-    expect(resolved).not.toBe(provider);
+    await withPluginMigrationProviders({ providerId: "hermes" }, async (providers) => {
+      expect(providers.find((entry) => entry.id === "hermes")).not.toBe(provider);
+    });
     expect(mocks.listBundledPluginMetadata).toHaveBeenCalledWith({
       includeChannelConfigs: false,
     });
@@ -336,62 +343,7 @@ describe("migration provider runtime", () => {
     });
   });
 
-  it.each(["owner", "retired"])(
-    "does not reuse a standalone handle after %s changes",
-    async (change) => {
-      mocks.resolveRuntimePluginRegistry.mockReturnValue(undefined);
-      const cfgA = { plugins: { allow: ["migration-a"] } } as OpenClawConfig;
-      const cfgB = { plugins: { allow: ["migration-b"] } } as OpenClawConfig;
-      const provider = createMigrationProvider("shared-import");
-      const loadedA = createEmptyPluginRegistry();
-      loadedA.migrationProviders.push({
-        pluginId: "migration-a",
-        pluginName: "Migration A",
-        source: "test",
-        provider,
-      } as never);
-      mocks.loadPluginRegistryHandle.mockReturnValue(loadedA);
-      mocks.listBundledPluginMetadata.mockReturnValue([
-        {
-          manifest: {
-            id: "migration-a",
-            contracts: { migrationProviders: ["shared-import"] },
-          },
-        },
-      ] as never);
-
-      ensureStandaloneMigrationProviderRegistryLoaded({
-        cfg: cfgA,
-        providerId: "shared-import",
-      });
-      expect(
-        resolvePluginMigrationProvider({ providerId: "shared-import", cfg: cfgA }),
-      ).toBeDefined();
-      if (change === "retired") {
-        const { markPluginRegistryRetired } = await import("./registry-lifecycle.js");
-        markPluginRegistryRetired(loadedA);
-        expect(
-          resolvePluginMigrationProvider({ providerId: "shared-import", cfg: cfgA }),
-        ).toBeUndefined();
-        expect(resolvePluginMigrationProviders({ cfg: cfgA })).toEqual([]);
-        return;
-      }
-      mocks.listBundledPluginMetadata.mockReturnValue([
-        {
-          manifest: {
-            id: "migration-b",
-            contracts: { migrationProviders: ["shared-import"] },
-          },
-        },
-      ] as never);
-
-      expect(
-        resolvePluginMigrationProvider({ providerId: "shared-import", cfg: cfgB }),
-      ).toBeUndefined();
-    },
-  );
-
-  it("lists configured external migration providers alongside active providers", () => {
+  it("lists configured external migration providers alongside active providers", async () => {
     const activeProvider = createMigrationProvider("active-import");
     const externalProvider = createMigrationProvider("external-import");
     const active = createEmptyPluginRegistry();
@@ -409,8 +361,12 @@ describe("migration provider runtime", () => {
       provider: externalProvider,
     } as never);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
-      params === undefined ? active : loaded,
+      params === undefined ? active : undefined,
     );
+    mocks.acquirePluginRegistryForInspection.mockResolvedValue({
+      registry: loaded,
+      release: mocks.release,
+    });
     mocks.loadPluginRegistrySnapshot.mockReturnValue(
       createMockPluginIndex([
         {
@@ -439,9 +395,12 @@ describe("migration provider runtime", () => {
           ],
     }));
 
-    expect(resolvePluginMigrationProviders().map((provider) => provider.id)).toEqual([
-      "active-import",
-      "external-import",
-    ]);
+    await withPluginMigrationProviders({}, async (providers) => {
+      expect(providers.map((provider) => provider.id)).toEqual([
+        "active-import",
+        "external-import",
+      ]);
+      expect(providers[0]).toBe(activeProvider);
+    });
   });
 });

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -85,7 +85,12 @@ function mergeMigrationProviders(
 
 /** Keep provider callbacks and opaque plans inside the operation that owns their registration. */
 export async function withPluginMigrationProviders<T>(
-  params: { cfg?: OpenClawConfig; providerId?: string },
+  params: {
+    cfg?: OpenClawConfig;
+    providerId?: string;
+    /** Report final cleanup failure only after the consuming operation succeeded. */
+    onCleanupError?: (error: unknown) => void | Promise<void>;
+  },
   run: (providers: MigrationProviderPlugin[]) => Promise<T>,
 ): Promise<T> {
   const activeRegistry = getLoadedRuntimePluginRegistry();
@@ -133,6 +138,13 @@ export async function withPluginMigrationProviders<T>(
     }
     throw error;
   }
-  await acquisition.release();
+  try {
+    await acquisition.release();
+  } catch (error) {
+    if (!params.onCleanupError) {
+      throw error;
+    }
+    await params.onCleanupError(error);
+  }
   return result;
 }

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -3,9 +3,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
-import { loadPluginRegistryHandle } from "./loader.js";
+import { acquirePluginRegistryForInspection } from "./loader.js";
 import { resolveManifestContractRuntimePluginResolution } from "./manifest-contract-runtime.js";
-import { isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import type { MigrationProviderPlugin } from "./types.js";
@@ -14,25 +13,6 @@ type MigrationProviderPluginResolution = {
   pluginIds: string[];
   bundledCompatPluginIds: string[];
 };
-
-let standaloneMigrationRegistrySlot:
-  | {
-      config: OpenClawConfig | undefined;
-      pluginIdsKey: string;
-      registry: PluginRegistry;
-    }
-  | undefined;
-
-function migrationPluginIdsKey(pluginIds: readonly string[]): string {
-  return JSON.stringify(pluginIds);
-}
-
-function findMigrationProviderById(
-  entries: ReadonlyArray<{ provider: MigrationProviderPlugin }>,
-  providerId: string,
-): MigrationProviderPlugin | undefined {
-  return entries.find((entry) => entry.provider.id === providerId)?.provider;
-}
 
 function bindMigrationProviderToRegistry(
   provider: MigrationProviderPlugin,
@@ -54,20 +34,6 @@ function bindMigrationProviderToRegistry(
     plan: (ctx) => withPluginRuntimeRegistryScope(registry, () => provider.plan(ctx)),
     apply: (ctx, plan) => withPluginRuntimeRegistryScope(registry, () => provider.apply(ctx, plan)),
   };
-}
-
-function resolveMigrationProviderRegistry(params: { cfg?: OpenClawConfig; pluginIds: string[] }) {
-  const active = getLoadedRuntimePluginRegistry({ requiredPluginIds: params.pluginIds });
-  if (active) {
-    return active;
-  }
-  const standalone = standaloneMigrationRegistrySlot;
-  return standalone &&
-    !isPluginRegistryRetired(standalone.registry) &&
-    standalone.config === params.cfg &&
-    standalone.pluginIdsKey === migrationPluginIdsKey(params.pluginIds)
-    ? standalone.registry
-    : undefined;
 }
 
 function resolveMigrationProviderPluginResolution(params: {
@@ -117,83 +83,56 @@ function mergeMigrationProviders(
   return [...merged.values()].toSorted((a, b) => a.id.localeCompare(b.id));
 }
 
-export function ensureStandaloneMigrationProviderRegistryLoaded(
-  params: {
-    cfg?: OpenClawConfig;
-    providerId?: string;
-  } = {},
-): void {
+/** Keep provider callbacks and opaque plans inside the operation that owns their registration. */
+export async function withPluginMigrationProviders<T>(
+  params: { cfg?: OpenClawConfig; providerId?: string },
+  run: (providers: MigrationProviderPlugin[]) => Promise<T>,
+): Promise<T> {
+  const activeRegistry = getLoadedRuntimePluginRegistry();
+  const activeProviders = activeRegistry?.migrationProviders ?? [];
+  if (
+    params.providerId &&
+    activeProviders.some(({ provider }) => provider.id === params.providerId)
+  ) {
+    return await run(mergeMigrationProviders(activeProviders, []));
+  }
   const resolution = resolveMigrationProviderPluginResolution(params);
-  if (resolution.pluginIds.length === 0) {
-    return;
+  if (
+    resolution.pluginIds.length === 0 ||
+    getLoadedRuntimePluginRegistry({ requiredPluginIds: resolution.pluginIds })
+  ) {
+    return await run(mergeMigrationProviders(activeProviders, []));
   }
   const compatConfig = withBundledPluginEnablementCompat({
     config: params.cfg,
     pluginIds: resolution.bundledCompatPluginIds,
   });
-  const registry = loadPluginRegistryHandle({
+  const acquisition = await acquirePluginRegistryForInspection({
     ...(compatConfig === undefined ? {} : { config: compatConfig }),
     onlyPluginIds: resolution.pluginIds,
-    activate: false,
   });
-  standaloneMigrationRegistrySlot = registry
-    ? {
-        config: params.cfg,
-        pluginIdsKey: migrationPluginIdsKey(resolution.pluginIds),
-        registry,
-      }
-    : undefined;
-}
-
-export function resolvePluginMigrationProvider(params: {
-  providerId: string;
-  cfg?: OpenClawConfig;
-}): MigrationProviderPlugin | undefined {
-  const activeRegistry = getLoadedRuntimePluginRegistry();
-  const activeProvider = findMigrationProviderById(
-    activeRegistry?.migrationProviders ?? [],
-    params.providerId,
-  );
-  if (activeProvider) {
-    return activeProvider;
+  let result: T;
+  try {
+    const providers = acquisition.registry.migrationProviders.map(({ provider }) => ({
+      provider: bindMigrationProviderToRegistry(provider, acquisition.registry),
+    }));
+    result = await run(mergeMigrationProviders(activeProviders, providers));
+  } catch (error) {
+    const failures = [error];
+    try {
+      await acquisition.release();
+    } catch (disposalError) {
+      failures.push(disposalError);
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        "Migration failed and its plugin resources could not be disposed",
+        { cause: error },
+      );
+    }
+    throw error;
   }
-
-  const resolution = resolveMigrationProviderPluginResolution({
-    cfg: params.cfg,
-    providerId: params.providerId,
-  });
-  const pluginIds = resolution.pluginIds;
-  if (pluginIds.length === 0) {
-    return undefined;
-  }
-  const registry = resolveMigrationProviderRegistry({
-    cfg: params.cfg,
-    pluginIds,
-  });
-  const provider = findMigrationProviderById(registry?.migrationProviders ?? [], params.providerId);
-  return provider && registry ? bindMigrationProviderToRegistry(provider, registry) : undefined;
-}
-
-export function resolvePluginMigrationProviders(
-  params: {
-    cfg?: OpenClawConfig;
-  } = {},
-): MigrationProviderPlugin[] {
-  const activeRegistry = getLoadedRuntimePluginRegistry();
-  const activeProviders = activeRegistry?.migrationProviders ?? [];
-  const resolution = resolveMigrationProviderPluginResolution({ cfg: params.cfg });
-  const pluginIds = resolution.pluginIds;
-  if (pluginIds.length === 0) {
-    return mergeMigrationProviders(activeProviders, []);
-  }
-  const registry = resolveMigrationProviderRegistry({
-    cfg: params.cfg,
-    pluginIds,
-  });
-  const scopedProviders = registry
-    ? registry.migrationProviders.map(({ provider }) => ({
-        provider: bindMigrationProviderToRegistry(provider, registry),
-      }))
-    : [];
-  return mergeMigrationProviders(activeProviders, scopedProviders);
+  await acquisition.release();
+  return result;
 }

--- a/src/plugins/migration-provider.test-support.ts
+++ b/src/plugins/migration-provider.test-support.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  makePluginLoaderTempDir,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import type { MigrationPlan } from "./types.js";
+
+type Connection = { database: DatabaseSync; disposals: number };
+let fixtureId = 0;
+
+export function createMigrationResourceFixture(
+  options: {
+    failApply?: boolean;
+    configPatch?: boolean;
+    secondProvider?: boolean;
+    pausePlan?: boolean;
+    detectFound?: boolean;
+  } = {},
+) {
+  useNoBundledPlugins();
+  const id = `migration-resource-${fixtureId++}`;
+  const key = `__openclaw_${id}`;
+  const root = fs.realpathSync(makePluginLoaderTempDir());
+  const state = {
+    connections: [] as Connection[],
+    applying: createDeferredCore(),
+    planning: createDeferredCore(),
+    resumePlan: createDeferredCore(),
+    planFinished: createDeferredCore(),
+    planCalls: 0,
+    labelError: new Error("Synthetic active provider label failed"),
+    failLabel: false,
+    failPlan: false,
+    preparedConnections: new Map<string, Connection>(),
+    preparationOwners: [] as Array<{
+      providerId: string;
+      prepared: Connection | undefined;
+      applied: Connection;
+    }>,
+    resumeApply: createDeferredCore(),
+    preparationDisposing: createDeferredCore(),
+    finishPreparation: createDeferredCore(),
+    preparationDisposals: 0,
+    failPreparationDisposal: false,
+    preparationError: new Error("Synthetic preparation disposal failed"),
+    patchReads: 0,
+    jsonReads: 0,
+    applyCalls: 0,
+    failCleanup: false,
+    failCleanupOnConnection: 0,
+    failEncoding: false,
+    planned: undefined as MigrationPlan | undefined,
+    applied: undefined as MigrationPlan | undefined,
+  };
+  Object.defineProperty(globalThis, key, { value: state, configurable: true });
+  const plugin = writePlugin({
+    id,
+    dir: path.join(root, "plugin"),
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(${JSON.stringify(path.join(root, "source.sqlite"))});
+    database.exec("CREATE TABLE IF NOT EXISTS imports (id INTEGER PRIMARY KEY)");
+    const connection = { database, disposals: 0 };
+    const connectionNumber = state.connections.push(connection);
+    api.registerRuntimeLifecycle({ id: "migration-source", dispose() {
+      connection.disposals++;
+      database.close();
+      if (state.failCleanup || state.failCleanupOnConnection === connectionNumber) throw new Error("Synthetic migration cleanup failed");
+    }});
+    const metadata = { read: () => database.prepare("SELECT 42 AS value").get().value };
+    for (const providerId of ${JSON.stringify(options.secondProvider ? [id, id + "-second"] : [id])}) {
+    api.registerMigrationProvider({
+      id: providerId,
+      get label() { if (state.failLabel) throw state.labelError; return "Native migration fixture"; },
+      get description() { return "Native source " + database.prepare("SELECT 42 AS value").get().value; },
+      supportedItemKinds: ["memory"],
+      detect() { return { found: ${options.detectFound !== false}, confidence: "high", source: "synthetic-source" }; },
+      prepareApply() { state.preparedConnections.set(providerId, connection); return { async dispose() {
+        state.preparationDisposing.resolve();
+        await state.finishPreparation.promise;
+        database.prepare("SELECT 42 AS value").get();
+        state.preparationDisposals++;
+        if (state.failPreparationDisposal) throw state.preparationError;
+      }}; },
+      async plan() {
+        state.planCalls++;
+        if (${options.pausePlan === true}) {
+          state.planning.resolve();
+          try {
+            await state.resumePlan.promise;
+            database.prepare("SELECT 42 AS value").get();
+            if (state.failPlan) throw new Error("Synthetic later plan failed");
+          } finally { state.planFinished.resolve(); }
+        }
+        const plan = {
+          providerId, source: "synthetic-source",
+          summary: { total: 1, planned: 1, migrated: 0, skipped: 0, conflicts: 0, errors: 0, sensitive: 0 },
+          items: [${
+            options.configPatch
+              ? `{
+            id: "config:heartbeat", kind: "config", action: "merge", status: "planned",
+            details: { path: ["agents", "defaults", "heartbeat", "every"], get value() {
+              state.patchReads++;
+              return (database.prepare("SELECT 42 AS value").get().value + (providerId.endsWith("-second") ? 1 : 0)) + "m";
+            } },
+          }`
+              : '{ id: "memory:one", kind: "memory", action: "copy", status: "planned" }'
+          }],
+          metadata,
+        };
+        state.planned = plan;
+        return plan;
+      },
+      async apply(ctx, plan) {
+        state.applied = plan;
+        state.applyCalls++;
+        if (${options.secondProvider === true}) {
+          state.preparationOwners.push({ providerId, prepared: state.preparedConnections.get(providerId), applied: connection });
+        }
+        if (plan.metadata !== metadata || plan.metadata.read() !== 42) {
+          throw new Error("Migration lost its provider-owned plan metadata");
+        }
+        state.applying.resolve();
+        await state.resumeApply.promise;
+        database.prepare("SELECT 42 AS value").get();
+        if (${options.failApply === true}) throw new Error("Synthetic migration apply failed");
+        database.prepare("INSERT INTO imports DEFAULT VALUES").run();
+        return {
+          ...plan,
+          summary: { ...plan.summary, planned: 0, migrated: 1 },
+          items: plan.items.map(item => ({ ...item, status: "migrated",
+            ...(item.kind === "memory" ? { details: { toJSON() {
+              state.jsonReads++;
+              const row = database.prepare("SELECT 42 AS value").get();
+              if (state.failEncoding) throw new Error("Synthetic result encoding failed");
+              return { value: row.value };
+            } } } : {}),
+          })),
+        };
+      },
+    });
+    }
+  },
+};`,
+  });
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { migrationProviders: options.secondProvider ? [id, `${id}-second`] : [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  return {
+    id,
+    root,
+    state,
+    config: {
+      agents: {
+        defaults: { workspace: path.join(root, "workspace") },
+        list: [{ id: "main", default: true }],
+      },
+      plugins: {
+        allow: [id],
+        load: { paths: [plugin.file] },
+        entries: { [id]: { enabled: true } },
+        slots: { memory: "none" },
+      },
+    },
+    cleanup() {
+      for (const { database } of state.connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      state.resumePlan.resolve();
+      state.finishPreparation.resolve();
+      Reflect.deleteProperty(globalThis, key);
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -41,7 +41,7 @@ vi.mock("./setup.shared.js", async (importOriginal) => {
 });
 
 vi.mock("./setup.migration-import.js", () => ({
-  detectSetupMigrationSources: vi.fn(async () => []),
+  detectSetupMigrationSources: vi.fn(async () => ({ detections: [], providerDescriptors: [] })),
   listSetupMigrationOptions: vi.fn(async () => []),
   runSetupMigrationImport: vi.fn(),
 }));

--- a/src/wizard/setup.memory-import.test.ts
+++ b/src/wizard/setup.memory-import.test.ts
@@ -16,7 +16,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../commands/migrate/memory-import.js", () => ({
-  listMemoryMigrationProviders: () => mocks.providers,
+  withMemoryMigrationProviders: async (
+    _config: OpenClawConfig,
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run(mocks.providers),
   planProviderMemoryImport: mocks.planProviderMemoryImport,
   applyProviderMemoryImport: mocks.applyProviderMemoryImport,
 }));

--- a/src/wizard/setup.memory-import.ts
+++ b/src/wizard/setup.memory-import.ts
@@ -2,7 +2,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { createMigrationLogger } from "../commands/migrate/context.js";
 import {
   applyProviderMemoryImport,
-  listMemoryMigrationProviders,
+  withMemoryMigrationProviders,
   planProviderMemoryImport,
 } from "../commands/migrate/memory-import.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -60,201 +60,202 @@ export async function runSetupMemoryImportStep(params: {
   onProviderOutcome?: (outcome: MemoryImportProviderOutcome) => void;
 }): Promise<SetupMemoryImportOutcome> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
-  const providers = listMemoryMigrationProviders(params.config);
-  if (providers.length === 0) {
-    return { status: "nothing-to-import", providers: [] };
-  }
+  return await withMemoryMigrationProviders(params.config, async (providers) => {
+    if (providers.length === 0) {
+      return { status: "nothing-to-import", providers: [] };
+    }
 
-  const logger = createMigrationLogger(params.runtime);
-  const offers: MemoryImportOffer[] = [];
-  for (const provider of providers) {
-    try {
-      // Omit the runtime: provider plan/apply writers would print raw JSON
-      // between the wizard prompts; this page renders its own notes.
-      const { detection, plan } = await planProviderMemoryImport({
-        provider,
-        config: params.config,
-        agentId,
-        overwrite: false,
+    const logger = createMigrationLogger(params.runtime);
+    const offers: MemoryImportOffer[] = [];
+    for (const provider of providers) {
+      try {
+        // Omit the runtime: provider plan/apply writers would print raw JSON
+        // between the wizard prompts; this page renders its own notes.
+        const { detection, plan } = await planProviderMemoryImport({
+          provider,
+          config: params.config,
+          agentId,
+          overwrite: false,
+        });
+        const plannedIds = plan.items
+          .filter((item) => item.status === "planned")
+          .map((item) => item.id);
+        if (detection?.found === false || plannedIds.length === 0) {
+          continue;
+        }
+        offers.push({
+          provider,
+          plan,
+          source: detection?.source ?? plan.source,
+          plannedIds,
+          conflicts: plan.items.filter((item) => item.status === "conflict").length,
+        });
+      } catch (error) {
+        // Discovery is advisory; one broken source must not block onboarding.
+        logger.debug?.(
+          `Memory migration provider ${provider.id} planning failed: ${formatErrorMessage(error)}`,
+        );
+      }
+    }
+    if (offers.length === 0) {
+      return { status: "nothing-to-import", providers: [] };
+    }
+
+    const offerLines = offers.map((offer) => {
+      const conflictSuffix = offer.conflicts
+        ? t("wizard.memoryImport.conflictSuffix", { count: offer.conflicts })
+        : "";
+      return t("wizard.memoryImport.offerLine", {
+        label: offer.provider.label,
+        source: offer.source,
+        count: offer.plannedIds.length,
+        conflictSuffix,
       });
-      const plannedIds = plan.items
-        .filter((item) => item.status === "planned")
-        .map((item) => item.id);
-      if (detection?.found === false || plannedIds.length === 0) {
+    });
+    await params.prompter.note(offerLines.join("\n"), t("wizard.memoryImport.title"));
+
+    const confirmed = await params.prompter.confirm({
+      message: t("wizard.memoryImport.confirm"),
+      initialValue: true,
+    });
+    if (!confirmed) {
+      await showSkipHint(params.prompter);
+      return { status: "skipped", providers: [] };
+    }
+
+    const selectedIds =
+      offers.length === 1
+        ? [offers[0]!.provider.id]
+        : await params.prompter.multiselect({
+            message: t("wizard.memoryImport.selectSources"),
+            options: offers.map((offer) => ({
+              value: offer.provider.id,
+              label: offer.provider.label,
+              hint: offer.source,
+            })),
+            initialValues: offers.map((offer) => offer.provider.id),
+          });
+    const selected = new Set(selectedIds);
+    const selectedOffers = offers.filter((offer) => selected.has(offer.provider.id));
+    if (selectedOffers.length === 0) {
+      await showSkipHint(params.prompter);
+      return { status: "skipped", providers: [] };
+    }
+
+    params.prompter.disableBackNavigation?.();
+    const workspace = resolveAgentWorkspaceDir(params.config, agentId);
+    const summaryLines: string[] = [];
+    const failureLines: string[] = [];
+    const providerOutcomes: MemoryImportProviderOutcome[] = [];
+    const recordProviderOutcome = (outcome: MemoryImportProviderOutcome) => {
+      providerOutcomes.push(outcome);
+      params.onProviderOutcome?.(outcome);
+    };
+    for (const offer of selectedOffers) {
+      const progress = params.prompter.progress(
+        t("wizard.memoryImport.importing", { label: offer.provider.label }),
+      );
+      // Host authority and config-drift guards run before the apply attempt and
+      // must stop the hosted wizard rather than masquerade as copy failures.
+      try {
+        await params.beforeApply?.();
+      } catch (error) {
+        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+        throw error;
+      }
+      let result: Awaited<ReturnType<typeof applyProviderMemoryImport>>;
+      try {
+        result = await applyProviderMemoryImport({
+          provider: offer.provider,
+          config: params.config,
+          agentId,
+          itemIds: offer.plannedIds,
+          overwrite: false,
+          preflightPlan: offer.plan,
+        });
+      } catch (error) {
+        const reason = formatErrorMessage(error);
+        recordProviderOutcome({
+          providerId: offer.provider.id,
+          label: offer.provider.label,
+          failure: reason,
+          copiesIndeterminate: true,
+        });
+        // Preserve the onboarding notes: only the structured outcome distinguishes
+        // an apply throw whose partial copy count cannot be recovered.
+        summaryLines.push(
+          t("wizard.memoryImport.summaryLine", {
+            label: offer.provider.label,
+            migrated: 0,
+            skipped: 0,
+            target: offer.plan.target ?? workspace,
+          }),
+        );
+        failureLines.push(
+          t("wizard.memoryImport.failureLine", {
+            label: offer.provider.label,
+            reason,
+          }),
+        );
+        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+        await params.prompter.note(
+          t("wizard.memoryImport.applyFailed", {
+            label: offer.provider.label,
+            reason,
+          }),
+          t("wizard.memoryImport.errorTitle"),
+        );
         continue;
       }
-      offers.push({
-        provider,
-        plan,
-        source: detection?.source ?? plan.source,
-        plannedIds,
-        conflicts: plan.items.filter((item) => item.status === "conflict").length,
-      });
-    } catch (error) {
-      // Discovery is advisory; one broken source must not block onboarding.
-      logger.debug?.(
-        `Memory migration provider ${provider.id} planning failed: ${formatErrorMessage(error)}`,
-      );
-    }
-  }
-  if (offers.length === 0) {
-    return { status: "nothing-to-import", providers: [] };
-  }
-
-  const offerLines = offers.map((offer) => {
-    const conflictSuffix = offer.conflicts
-      ? t("wizard.memoryImport.conflictSuffix", { count: offer.conflicts })
-      : "";
-    return t("wizard.memoryImport.offerLine", {
-      label: offer.provider.label,
-      source: offer.source,
-      count: offer.plannedIds.length,
-      conflictSuffix,
-    });
-  });
-  await params.prompter.note(offerLines.join("\n"), t("wizard.memoryImport.title"));
-
-  const confirmed = await params.prompter.confirm({
-    message: t("wizard.memoryImport.confirm"),
-    initialValue: true,
-  });
-  if (!confirmed) {
-    await showSkipHint(params.prompter);
-    return { status: "skipped", providers: [] };
-  }
-
-  const selectedIds =
-    offers.length === 1
-      ? [offers[0]!.provider.id]
-      : await params.prompter.multiselect({
-          message: t("wizard.memoryImport.selectSources"),
-          options: offers.map((offer) => ({
-            value: offer.provider.id,
-            label: offer.provider.label,
-            hint: offer.source,
-          })),
-          initialValues: offers.map((offer) => offer.provider.id),
-        });
-  const selected = new Set(selectedIds);
-  const selectedOffers = offers.filter((offer) => selected.has(offer.provider.id));
-  if (selectedOffers.length === 0) {
-    await showSkipHint(params.prompter);
-    return { status: "skipped", providers: [] };
-  }
-
-  params.prompter.disableBackNavigation?.();
-  const workspace = resolveAgentWorkspaceDir(params.config, agentId);
-  const summaryLines: string[] = [];
-  const failureLines: string[] = [];
-  const providerOutcomes: MemoryImportProviderOutcome[] = [];
-  const recordProviderOutcome = (outcome: MemoryImportProviderOutcome) => {
-    providerOutcomes.push(outcome);
-    params.onProviderOutcome?.(outcome);
-  };
-  for (const offer of selectedOffers) {
-    const progress = params.prompter.progress(
-      t("wizard.memoryImport.importing", { label: offer.provider.label }),
-    );
-    // Host authority and config-drift guards run before the apply attempt and
-    // must stop the hosted wizard rather than masquerade as copy failures.
-    try {
-      await params.beforeApply?.();
-    } catch (error) {
-      progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-      throw error;
-    }
-    let result: Awaited<ReturnType<typeof applyProviderMemoryImport>>;
-    try {
-      result = await applyProviderMemoryImport({
-        provider: offer.provider,
-        config: params.config,
-        agentId,
-        itemIds: offer.plannedIds,
-        overwrite: false,
-        preflightPlan: offer.plan,
-      });
-    } catch (error) {
-      const reason = formatErrorMessage(error);
-      recordProviderOutcome({
-        providerId: offer.provider.id,
-        label: offer.provider.label,
-        failure: reason,
-        copiesIndeterminate: true,
-      });
-      // Preserve the onboarding notes: only the structured outcome distinguishes
-      // an apply throw whose partial copy count cannot be recovered.
       summaryLines.push(
         t("wizard.memoryImport.summaryLine", {
           label: offer.provider.label,
-          migrated: 0,
-          skipped: 0,
-          target: offer.plan.target ?? workspace,
+          migrated: result.summary.migrated,
+          skipped: result.summary.skipped,
+          target: result.target ?? offer.plan.target ?? workspace,
         }),
       );
-      failureLines.push(
-        t("wizard.memoryImport.failureLine", {
+      // Conflicts count as incomplete: a selected item was skipped because its
+      // target appeared between planning and copying.
+      const incomplete = result.summary.errors + result.summary.conflicts;
+      if (incomplete > 0) {
+        const reason = t("wizard.memoryImport.partialFailure", { count: incomplete });
+        recordProviderOutcome({
+          providerId: offer.provider.id,
           label: offer.provider.label,
-          reason,
-        }),
-      );
-      progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-      await params.prompter.note(
-        t("wizard.memoryImport.applyFailed", {
+          migrated: result.summary.migrated,
+          skipped: result.summary.skipped,
+          failure: reason,
+        });
+        failureLines.push(
+          t("wizard.memoryImport.failureLine", {
+            label: offer.provider.label,
+            reason,
+          }),
+        );
+        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+        await params.prompter.note(
+          t("wizard.memoryImport.applyFailed", {
+            label: offer.provider.label,
+            reason,
+          }),
+          t("wizard.memoryImport.errorTitle"),
+        );
+      } else {
+        recordProviderOutcome({
+          providerId: offer.provider.id,
           label: offer.provider.label,
-          reason,
-        }),
-        t("wizard.memoryImport.errorTitle"),
-      );
-      continue;
+          migrated: result.summary.migrated,
+          skipped: result.summary.skipped,
+        });
+        progress.stop(t("wizard.memoryImport.imported", { label: offer.provider.label }));
+      }
     }
-    summaryLines.push(
-      t("wizard.memoryImport.summaryLine", {
-        label: offer.provider.label,
-        migrated: result.summary.migrated,
-        skipped: result.summary.skipped,
-        target: result.target ?? offer.plan.target ?? workspace,
-      }),
-    );
-    // Conflicts count as incomplete: a selected item was skipped because its
-    // target appeared between planning and copying.
-    const incomplete = result.summary.errors + result.summary.conflicts;
-    if (incomplete > 0) {
-      const reason = t("wizard.memoryImport.partialFailure", { count: incomplete });
-      recordProviderOutcome({
-        providerId: offer.provider.id,
-        label: offer.provider.label,
-        migrated: result.summary.migrated,
-        skipped: result.summary.skipped,
-        failure: reason,
-      });
-      failureLines.push(
-        t("wizard.memoryImport.failureLine", {
-          label: offer.provider.label,
-          reason,
-        }),
-      );
-      progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-      await params.prompter.note(
-        t("wizard.memoryImport.applyFailed", {
-          label: offer.provider.label,
-          reason,
-        }),
-        t("wizard.memoryImport.errorTitle"),
-      );
-    } else {
-      recordProviderOutcome({
-        providerId: offer.provider.id,
-        label: offer.provider.label,
-        migrated: result.summary.migrated,
-        skipped: result.summary.skipped,
-      });
-      progress.stop(t("wizard.memoryImport.imported", { label: offer.provider.label }));
-    }
-  }
 
-  await params.prompter.note(
-    [...summaryLines, ...failureLines].join("\n"),
-    t("wizard.memoryImport.summaryTitle"),
-  );
-  return { status: "completed", providers: providerOutcomes };
+    await params.prompter.note(
+      [...summaryLines, ...failureLines].join("\n"),
+      t("wizard.memoryImport.summaryTitle"),
+    );
+    return { status: "completed", providers: providerOutcomes };
+  });
 }

--- a/src/wizard/setup.memory-import.ts
+++ b/src/wizard/setup.memory-import.ts
@@ -60,202 +60,210 @@ export async function runSetupMemoryImportStep(params: {
   onProviderOutcome?: (outcome: MemoryImportProviderOutcome) => void;
 }): Promise<SetupMemoryImportOutcome> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
-  return await withMemoryMigrationProviders(params.config, async (providers) => {
-    if (providers.length === 0) {
-      return { status: "nothing-to-import", providers: [] };
-    }
+  return await withMemoryMigrationProviders(
+    params.config,
+    async (providers) => {
+      if (providers.length === 0) {
+        return { status: "nothing-to-import", providers: [] };
+      }
 
-    const logger = createMigrationLogger(params.runtime);
-    const offers: MemoryImportOffer[] = [];
-    for (const provider of providers) {
-      try {
-        // Omit the runtime: provider plan/apply writers would print raw JSON
-        // between the wizard prompts; this page renders its own notes.
-        const { detection, plan } = await planProviderMemoryImport({
-          provider,
-          config: params.config,
-          agentId,
-          overwrite: false,
+      const logger = createMigrationLogger(params.runtime);
+      const offers: MemoryImportOffer[] = [];
+      for (const provider of providers) {
+        try {
+          // Omit the runtime: provider plan/apply writers would print raw JSON
+          // between the wizard prompts; this page renders its own notes.
+          const { detection, plan } = await planProviderMemoryImport({
+            provider,
+            config: params.config,
+            agentId,
+            overwrite: false,
+          });
+          const plannedIds = plan.items
+            .filter((item) => item.status === "planned")
+            .map((item) => item.id);
+          if (detection?.found === false || plannedIds.length === 0) {
+            continue;
+          }
+          offers.push({
+            provider,
+            plan,
+            source: detection?.source ?? plan.source,
+            plannedIds,
+            conflicts: plan.items.filter((item) => item.status === "conflict").length,
+          });
+        } catch (error) {
+          // Discovery is advisory; one broken source must not block onboarding.
+          logger.debug?.(
+            `Memory migration provider ${provider.id} planning failed: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+      if (offers.length === 0) {
+        return { status: "nothing-to-import", providers: [] };
+      }
+
+      const offerLines = offers.map((offer) => {
+        const conflictSuffix = offer.conflicts
+          ? t("wizard.memoryImport.conflictSuffix", { count: offer.conflicts })
+          : "";
+        return t("wizard.memoryImport.offerLine", {
+          label: offer.provider.label,
+          source: offer.source,
+          count: offer.plannedIds.length,
+          conflictSuffix,
         });
-        const plannedIds = plan.items
-          .filter((item) => item.status === "planned")
-          .map((item) => item.id);
-        if (detection?.found === false || plannedIds.length === 0) {
+      });
+      await params.prompter.note(offerLines.join("\n"), t("wizard.memoryImport.title"));
+
+      const confirmed = await params.prompter.confirm({
+        message: t("wizard.memoryImport.confirm"),
+        initialValue: true,
+      });
+      if (!confirmed) {
+        await showSkipHint(params.prompter);
+        return { status: "skipped", providers: [] };
+      }
+
+      const selectedIds =
+        offers.length === 1
+          ? [offers[0]!.provider.id]
+          : await params.prompter.multiselect({
+              message: t("wizard.memoryImport.selectSources"),
+              options: offers.map((offer) => ({
+                value: offer.provider.id,
+                label: offer.provider.label,
+                hint: offer.source,
+              })),
+              initialValues: offers.map((offer) => offer.provider.id),
+            });
+      const selected = new Set(selectedIds);
+      const selectedOffers = offers.filter((offer) => selected.has(offer.provider.id));
+      if (selectedOffers.length === 0) {
+        await showSkipHint(params.prompter);
+        return { status: "skipped", providers: [] };
+      }
+
+      params.prompter.disableBackNavigation?.();
+      const workspace = resolveAgentWorkspaceDir(params.config, agentId);
+      const summaryLines: string[] = [];
+      const failureLines: string[] = [];
+      const providerOutcomes: MemoryImportProviderOutcome[] = [];
+      const recordProviderOutcome = (outcome: MemoryImportProviderOutcome) => {
+        providerOutcomes.push(outcome);
+        params.onProviderOutcome?.(outcome);
+      };
+      for (const offer of selectedOffers) {
+        const progress = params.prompter.progress(
+          t("wizard.memoryImport.importing", { label: offer.provider.label }),
+        );
+        // Host authority and config-drift guards run before the apply attempt and
+        // must stop the hosted wizard rather than masquerade as copy failures.
+        try {
+          await params.beforeApply?.();
+        } catch (error) {
+          progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+          throw error;
+        }
+        let result: Awaited<ReturnType<typeof applyProviderMemoryImport>>;
+        try {
+          result = await applyProviderMemoryImport({
+            provider: offer.provider,
+            config: params.config,
+            agentId,
+            itemIds: offer.plannedIds,
+            overwrite: false,
+            preflightPlan: offer.plan,
+          });
+        } catch (error) {
+          const reason = formatErrorMessage(error);
+          recordProviderOutcome({
+            providerId: offer.provider.id,
+            label: offer.provider.label,
+            failure: reason,
+            copiesIndeterminate: true,
+          });
+          // Preserve the onboarding notes: only the structured outcome distinguishes
+          // an apply throw whose partial copy count cannot be recovered.
+          summaryLines.push(
+            t("wizard.memoryImport.summaryLine", {
+              label: offer.provider.label,
+              migrated: 0,
+              skipped: 0,
+              target: offer.plan.target ?? workspace,
+            }),
+          );
+          failureLines.push(
+            t("wizard.memoryImport.failureLine", {
+              label: offer.provider.label,
+              reason,
+            }),
+          );
+          progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+          await params.prompter.note(
+            t("wizard.memoryImport.applyFailed", {
+              label: offer.provider.label,
+              reason,
+            }),
+            t("wizard.memoryImport.errorTitle"),
+          );
           continue;
         }
-        offers.push({
-          provider,
-          plan,
-          source: detection?.source ?? plan.source,
-          plannedIds,
-          conflicts: plan.items.filter((item) => item.status === "conflict").length,
-        });
-      } catch (error) {
-        // Discovery is advisory; one broken source must not block onboarding.
-        logger.debug?.(
-          `Memory migration provider ${provider.id} planning failed: ${formatErrorMessage(error)}`,
-        );
-      }
-    }
-    if (offers.length === 0) {
-      return { status: "nothing-to-import", providers: [] };
-    }
-
-    const offerLines = offers.map((offer) => {
-      const conflictSuffix = offer.conflicts
-        ? t("wizard.memoryImport.conflictSuffix", { count: offer.conflicts })
-        : "";
-      return t("wizard.memoryImport.offerLine", {
-        label: offer.provider.label,
-        source: offer.source,
-        count: offer.plannedIds.length,
-        conflictSuffix,
-      });
-    });
-    await params.prompter.note(offerLines.join("\n"), t("wizard.memoryImport.title"));
-
-    const confirmed = await params.prompter.confirm({
-      message: t("wizard.memoryImport.confirm"),
-      initialValue: true,
-    });
-    if (!confirmed) {
-      await showSkipHint(params.prompter);
-      return { status: "skipped", providers: [] };
-    }
-
-    const selectedIds =
-      offers.length === 1
-        ? [offers[0]!.provider.id]
-        : await params.prompter.multiselect({
-            message: t("wizard.memoryImport.selectSources"),
-            options: offers.map((offer) => ({
-              value: offer.provider.id,
-              label: offer.provider.label,
-              hint: offer.source,
-            })),
-            initialValues: offers.map((offer) => offer.provider.id),
-          });
-    const selected = new Set(selectedIds);
-    const selectedOffers = offers.filter((offer) => selected.has(offer.provider.id));
-    if (selectedOffers.length === 0) {
-      await showSkipHint(params.prompter);
-      return { status: "skipped", providers: [] };
-    }
-
-    params.prompter.disableBackNavigation?.();
-    const workspace = resolveAgentWorkspaceDir(params.config, agentId);
-    const summaryLines: string[] = [];
-    const failureLines: string[] = [];
-    const providerOutcomes: MemoryImportProviderOutcome[] = [];
-    const recordProviderOutcome = (outcome: MemoryImportProviderOutcome) => {
-      providerOutcomes.push(outcome);
-      params.onProviderOutcome?.(outcome);
-    };
-    for (const offer of selectedOffers) {
-      const progress = params.prompter.progress(
-        t("wizard.memoryImport.importing", { label: offer.provider.label }),
-      );
-      // Host authority and config-drift guards run before the apply attempt and
-      // must stop the hosted wizard rather than masquerade as copy failures.
-      try {
-        await params.beforeApply?.();
-      } catch (error) {
-        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-        throw error;
-      }
-      let result: Awaited<ReturnType<typeof applyProviderMemoryImport>>;
-      try {
-        result = await applyProviderMemoryImport({
-          provider: offer.provider,
-          config: params.config,
-          agentId,
-          itemIds: offer.plannedIds,
-          overwrite: false,
-          preflightPlan: offer.plan,
-        });
-      } catch (error) {
-        const reason = formatErrorMessage(error);
-        recordProviderOutcome({
-          providerId: offer.provider.id,
-          label: offer.provider.label,
-          failure: reason,
-          copiesIndeterminate: true,
-        });
-        // Preserve the onboarding notes: only the structured outcome distinguishes
-        // an apply throw whose partial copy count cannot be recovered.
         summaryLines.push(
           t("wizard.memoryImport.summaryLine", {
             label: offer.provider.label,
-            migrated: 0,
-            skipped: 0,
-            target: offer.plan.target ?? workspace,
+            migrated: result.summary.migrated,
+            skipped: result.summary.skipped,
+            target: result.target ?? offer.plan.target ?? workspace,
           }),
         );
-        failureLines.push(
-          t("wizard.memoryImport.failureLine", {
+        // Conflicts count as incomplete: a selected item was skipped because its
+        // target appeared between planning and copying.
+        const incomplete = result.summary.errors + result.summary.conflicts;
+        if (incomplete > 0) {
+          const reason = t("wizard.memoryImport.partialFailure", { count: incomplete });
+          recordProviderOutcome({
+            providerId: offer.provider.id,
             label: offer.provider.label,
-            reason,
-          }),
-        );
-        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-        await params.prompter.note(
-          t("wizard.memoryImport.applyFailed", {
+            migrated: result.summary.migrated,
+            skipped: result.summary.skipped,
+            failure: reason,
+          });
+          failureLines.push(
+            t("wizard.memoryImport.failureLine", {
+              label: offer.provider.label,
+              reason,
+            }),
+          );
+          progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
+          await params.prompter.note(
+            t("wizard.memoryImport.applyFailed", {
+              label: offer.provider.label,
+              reason,
+            }),
+            t("wizard.memoryImport.errorTitle"),
+          );
+        } else {
+          recordProviderOutcome({
+            providerId: offer.provider.id,
             label: offer.provider.label,
-            reason,
-          }),
-          t("wizard.memoryImport.errorTitle"),
-        );
-        continue;
+            migrated: result.summary.migrated,
+            skipped: result.summary.skipped,
+          });
+          progress.stop(t("wizard.memoryImport.imported", { label: offer.provider.label }));
+        }
       }
-      summaryLines.push(
-        t("wizard.memoryImport.summaryLine", {
-          label: offer.provider.label,
-          migrated: result.summary.migrated,
-          skipped: result.summary.skipped,
-          target: result.target ?? offer.plan.target ?? workspace,
-        }),
-      );
-      // Conflicts count as incomplete: a selected item was skipped because its
-      // target appeared between planning and copying.
-      const incomplete = result.summary.errors + result.summary.conflicts;
-      if (incomplete > 0) {
-        const reason = t("wizard.memoryImport.partialFailure", { count: incomplete });
-        recordProviderOutcome({
-          providerId: offer.provider.id,
-          label: offer.provider.label,
-          migrated: result.summary.migrated,
-          skipped: result.summary.skipped,
-          failure: reason,
-        });
-        failureLines.push(
-          t("wizard.memoryImport.failureLine", {
-            label: offer.provider.label,
-            reason,
-          }),
-        );
-        progress.stop(t("wizard.memoryImport.importFailed", { label: offer.provider.label }));
-        await params.prompter.note(
-          t("wizard.memoryImport.applyFailed", {
-            label: offer.provider.label,
-            reason,
-          }),
-          t("wizard.memoryImport.errorTitle"),
-        );
-      } else {
-        recordProviderOutcome({
-          providerId: offer.provider.id,
-          label: offer.provider.label,
-          migrated: result.summary.migrated,
-          skipped: result.summary.skipped,
-        });
-        progress.stop(t("wizard.memoryImport.imported", { label: offer.provider.label }));
-      }
-    }
 
-    await params.prompter.note(
-      [...summaryLines, ...failureLines].join("\n"),
-      t("wizard.memoryImport.summaryTitle"),
-    );
-    return { status: "completed", providers: providerOutcomes };
-  });
+      await params.prompter.note(
+        [...summaryLines, ...failureLines].join("\n"),
+        t("wizard.memoryImport.summaryTitle"),
+      );
+      return { status: "completed", providers: providerOutcomes };
+    },
+    (error) => {
+      params.runtime.error(
+        `Memory import result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
+      );
+    },
+  );
 }

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -80,38 +80,48 @@ export async function detectSetupMigrationSources(params: {
       loadMigrationContextModule(),
       loadConfigPathsModule(),
     ]);
-  return await withPluginMigrationProviders({ cfg: params.config }, async (providers) => {
-    const stateDir = resolveStateDir();
-    const logger = createMigrationLogger(params.runtime);
-    const detections: SetupMigrationDetection[] = [];
-    for (const provider of providers) {
-      if (!provider.detect) {
-        continue;
-      }
-      try {
-        const detection = await provider.detect({
-          config: params.config,
-          stateDir,
-          logger,
-        });
-        if (detection.found) {
-          detections.push({
-            providerId: provider.id,
-            label: detection.label ?? provider.label,
-            ...(detection.source ? { source: detection.source } : {}),
-            ...(detection.message ? { message: detection.message } : {}),
-          });
-        }
-      } catch (error) {
-        // Detection is advisory; one failing provider must not prevent onboarding
-        // from offering other migration sources.
-        logger.debug?.(
-          `Migration provider ${provider.id} detection failed: ${formatErrorMessage(error)}`,
+  return await withPluginMigrationProviders(
+    {
+      cfg: params.config,
+      onCleanupError: (error) => {
+        params.runtime.error(
+          `Migration discovery result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
         );
+      },
+    },
+    async (providers) => {
+      const stateDir = resolveStateDir();
+      const logger = createMigrationLogger(params.runtime);
+      const detections: SetupMigrationDetection[] = [];
+      for (const provider of providers) {
+        if (!provider.detect) {
+          continue;
+        }
+        try {
+          const detection = await provider.detect({
+            config: params.config,
+            stateDir,
+            logger,
+          });
+          if (detection.found) {
+            detections.push({
+              providerId: provider.id,
+              label: detection.label ?? provider.label,
+              ...(detection.source ? { source: detection.source } : {}),
+              ...(detection.message ? { message: detection.message } : {}),
+            });
+          }
+        } catch (error) {
+          // Detection is advisory; one failing provider must not prevent onboarding
+          // from offering other migration sources.
+          logger.debug?.(
+            `Migration provider ${provider.id} detection failed: ${formatErrorMessage(error)}`,
+          );
+        }
       }
-    }
-    return { detections, providerDescriptors: providers.map(describeSetupMigrationProvider) };
-  });
+      return { detections, providerDescriptors: providers.map(describeSetupMigrationProvider) };
+    },
+  );
 }
 
 function describeSetupMigrationProvider(

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -3,6 +3,7 @@ import type { OnboardOptions } from "../commands/onboard-types.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { getLoadedRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import {
   listAvailableManifestContractPlugins,
   loadManifestContractSnapshot,
@@ -51,7 +52,7 @@ type SetupMigrationOption = {
   label: string;
   hint?: string;
 };
-type ManifestSetupMigrationProvider = {
+type SetupMigrationProviderDescriptor = {
   providerId: string;
   label: string;
   description?: string;
@@ -69,47 +70,54 @@ const loadConfigPathsModule = createLazyRuntimeModule(() => import("../config/pa
 export async function detectSetupMigrationSources(params: {
   config: OpenClawConfig;
   runtime: RuntimeEnv;
-}): Promise<SetupMigrationDetection[]> {
-  const [
-    { ensureStandaloneMigrationProviderRegistryLoaded, resolvePluginMigrationProviders },
-    { createMigrationLogger },
-    { resolveStateDir },
-  ] = await Promise.all([
-    loadMigrationProviderRuntimeModule(),
-    loadMigrationContextModule(),
-    loadConfigPathsModule(),
-  ]);
-  ensureStandaloneMigrationProviderRegistryLoaded({ cfg: params.config });
-  const stateDir = resolveStateDir();
-  const logger = createMigrationLogger(params.runtime);
-  const detections: SetupMigrationDetection[] = [];
-  for (const provider of resolvePluginMigrationProviders({ cfg: params.config })) {
-    if (!provider.detect) {
-      continue;
-    }
-    try {
-      const detection = await provider.detect({
-        config: params.config,
-        stateDir,
-        logger,
-      });
-      if (detection.found) {
-        detections.push({
-          providerId: provider.id,
-          label: detection.label ?? provider.label,
-          ...(detection.source ? { source: detection.source } : {}),
-          ...(detection.message ? { message: detection.message } : {}),
-        });
+}): Promise<{
+  detections: SetupMigrationDetection[];
+  providerDescriptors: SetupMigrationProviderDescriptor[];
+}> {
+  const [{ withPluginMigrationProviders }, { createMigrationLogger }, { resolveStateDir }] =
+    await Promise.all([
+      loadMigrationProviderRuntimeModule(),
+      loadMigrationContextModule(),
+      loadConfigPathsModule(),
+    ]);
+  return await withPluginMigrationProviders({ cfg: params.config }, async (providers) => {
+    const stateDir = resolveStateDir();
+    const logger = createMigrationLogger(params.runtime);
+    const detections: SetupMigrationDetection[] = [];
+    for (const provider of providers) {
+      if (!provider.detect) {
+        continue;
       }
-    } catch (error) {
-      // Detection is advisory; one failing provider must not prevent onboarding
-      // from offering other migration sources.
-      logger.debug?.(
-        `Migration provider ${provider.id} detection failed: ${formatErrorMessage(error)}`,
-      );
+      try {
+        const detection = await provider.detect({
+          config: params.config,
+          stateDir,
+          logger,
+        });
+        if (detection.found) {
+          detections.push({
+            providerId: provider.id,
+            label: detection.label ?? provider.label,
+            ...(detection.source ? { source: detection.source } : {}),
+            ...(detection.message ? { message: detection.message } : {}),
+          });
+        }
+      } catch (error) {
+        // Detection is advisory; one failing provider must not prevent onboarding
+        // from offering other migration sources.
+        logger.debug?.(
+          `Migration provider ${provider.id} detection failed: ${formatErrorMessage(error)}`,
+        );
+      }
     }
-  }
-  return detections;
+    return { detections, providerDescriptors: providers.map(describeSetupMigrationProvider) };
+  });
+}
+
+function describeSetupMigrationProvider(
+  provider: MigrationProviderPlugin,
+): SetupMigrationProviderDescriptor {
+  return { providerId: provider.id, label: provider.label, description: provider.description };
 }
 
 function resolveImportSourceDefault(params: {
@@ -143,7 +151,7 @@ function resolveManifestMigrationProviderLabel(params: {
 
 function resolveManifestSetupMigrationProviders(
   baseConfig: OpenClawConfig,
-): ManifestSetupMigrationProvider[] {
+): SetupMigrationProviderDescriptor[] {
   const snapshot = loadManifestContractSnapshot({ config: baseConfig });
   return listAvailableManifestContractPlugins({
     snapshot,
@@ -151,7 +159,7 @@ function resolveManifestSetupMigrationProviders(
     config: baseConfig,
   }).flatMap((plugin) =>
     (plugin.contracts?.migrationProviders ?? []).map((providerId) => {
-      const provider: ManifestSetupMigrationProvider = {
+      const provider: SetupMigrationProviderDescriptor = {
         providerId,
         label: resolveManifestMigrationProviderLabel({ providerId, pluginName: plugin.name }),
       };
@@ -166,9 +174,14 @@ function resolveManifestSetupMigrationProviders(
 export async function listSetupMigrationOptions(params: {
   baseConfig: OpenClawConfig;
   detections: readonly SetupMigrationDetection[];
+  providerDescriptors?: readonly SetupMigrationProviderDescriptor[];
 }): Promise<SetupMigrationOption[]> {
-  const { resolvePluginMigrationProviders } = await loadMigrationProviderRuntimeModule();
-  const providers = resolvePluginMigrationProviders({ cfg: params.baseConfig });
+  const providers = [
+    ...(getLoadedRuntimePluginRegistry()?.migrationProviders ?? []).map(({ provider }) =>
+      describeSetupMigrationProvider(provider),
+    ),
+    ...(params.providerDescriptors ?? []),
+  ].toSorted((left, right) => left.providerId.localeCompare(right.providerId));
   const options: SetupMigrationOption[] = [];
   const providerIds = new Set<string>();
   const addOption = (option: SetupMigrationOption) => {
@@ -190,7 +203,7 @@ export async function listSetupMigrationOptions(params: {
   }
   for (const provider of providers) {
     addOption({
-      providerId: provider.id,
+      providerId: provider.providerId,
       label: t("wizard.migration.importFrom", { source: provider.label }),
       hint: provider.description ?? t("wizard.migration.sourcePathHint"),
     });
@@ -210,12 +223,14 @@ async function selectSetupMigrationProvider(params: {
   opts: OnboardOptions;
   baseConfig: OpenClawConfig;
   detections: readonly SetupMigrationDetection[];
+  providerDescriptors?: readonly SetupMigrationProviderDescriptor[];
   prompter: WizardPrompter;
   allowBack: boolean;
 }): Promise<string | undefined> {
   const options = await listSetupMigrationOptions({
     baseConfig: params.baseConfig,
     detections: params.detections,
+    providerDescriptors: params.providerDescriptors,
   });
   const requestedProviderId = params.opts.importFrom?.trim();
   if (requestedProviderId) {
@@ -271,24 +286,23 @@ function assertListedMigrationProvider(
   );
 }
 
-async function resolveSetupMigrationProvider(params: {
-  providerId: string;
-  baseConfig: OpenClawConfig;
-}): Promise<{ provider: MigrationProviderPlugin; baseConfig: OpenClawConfig }> {
-  const { ensureStandaloneMigrationProviderRegistryLoaded, resolvePluginMigrationProvider } =
-    await loadMigrationProviderRuntimeModule();
-  ensureStandaloneMigrationProviderRegistryLoaded({
-    cfg: params.baseConfig,
-    providerId: params.providerId,
-  });
-  const existing = resolvePluginMigrationProvider({
-    providerId: params.providerId,
-    cfg: params.baseConfig,
-  });
-  if (existing) {
-    return { provider: existing, baseConfig: params.baseConfig };
-  }
-  throw new Error(`Migration provider "${params.providerId}" did not register after activation.`);
+async function withSetupMigrationProvider<T>(
+  params: { providerId: string; baseConfig: OpenClawConfig },
+  run: (resolved: { provider: MigrationProviderPlugin; baseConfig: OpenClawConfig }) => Promise<T>,
+): Promise<T> {
+  const { withPluginMigrationProviders } = await loadMigrationProviderRuntimeModule();
+  return await withPluginMigrationProviders(
+    { cfg: params.baseConfig, providerId: params.providerId },
+    async (providers) => {
+      const provider = providers.find((entry) => entry.id === params.providerId);
+      if (!provider) {
+        throw new Error(
+          `Migration provider "${params.providerId}" did not register after activation.`,
+        );
+      }
+      return await run({ provider, baseConfig: params.baseConfig });
+    },
+  );
 }
 
 function hasCredentialCandidate(plan: MigrationPlan): boolean {
@@ -325,6 +339,7 @@ export async function runSetupMigrationImport(params: {
   opts: OnboardOptions;
   baseConfig: OpenClawConfig;
   detections: readonly SetupMigrationDetection[];
+  providerDescriptors?: readonly SetupMigrationProviderDescriptor[];
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   readConfigFile: () => Promise<OpenClawConfig>;
@@ -352,6 +367,7 @@ export async function runSetupMigrationImport(params: {
     opts: params.opts,
     baseConfig: params.baseConfig,
     detections: params.detections,
+    providerDescriptors: params.providerDescriptors,
     prompter: params.prompter,
     allowBack: params.allowProviderBack === true,
   });
@@ -378,23 +394,27 @@ export async function runSetupMigrationImport(params: {
     });
     if (promotionResume) {
       const committedConfig = await params.readConfigFile();
-      const resolvedProvider = await resolveSetupMigrationProvider({
-        providerId,
-        baseConfig: committedConfig,
-      });
-      assertDeferredMigrationApplyContract(
-        resolvedProvider.provider,
-        promotionResume.continuation.plan,
+      return await withSetupMigrationProvider(
+        {
+          providerId,
+          baseConfig: committedConfig,
+        },
+        async (resolvedProvider) => {
+          assertDeferredMigrationApplyContract(
+            resolvedProvider.provider,
+            promotionResume.continuation.plan,
+          );
+          return await finalizeSetupMigrationPromotion({
+            provider: resolvedProvider.provider,
+            resume: promotionResume,
+            config: committedConfig,
+            stateDir,
+            logger: createMigrationLogger(params.runtime),
+            prompter: params.prompter,
+            formatMigrationResult,
+          });
+        },
       );
-      return await finalizeSetupMigrationPromotion({
-        provider: resolvedProvider.provider,
-        resume: promotionResume,
-        config: committedConfig,
-        stateDir,
-        logger: createMigrationLogger(params.runtime),
-        prompter: params.prompter,
-        formatMigrationResult,
-      });
     }
     const lockedBaseConfig = preserveSetupMigrationOnboardingConsents(
       await params.readConfigFile(),
@@ -406,214 +426,225 @@ export async function runSetupMigrationImport(params: {
       workspaceDir,
     });
     assertFreshSetupMigrationTarget(freshness);
-    const resolvedProvider = await resolveSetupMigrationProvider({
-      providerId,
-      baseConfig: lockedBaseConfig,
-    });
-    const planningBaseConfig = await params.readConfigFile();
-    const planningTargetSnapshotHash = await buildSetupMigrationTargetSnapshot({
-      config: planningBaseConfig,
-      stateDir,
-      workspaceDir,
-    });
-    const migrationLogger = createMigrationLogger(params.runtime);
-    const selectedDetections = [...params.detections];
-    if (
-      resolvedProvider.provider.detect &&
-      !selectedDetections.some((detection) => detection.providerId === providerId)
-    ) {
-      try {
-        const detection = await resolvedProvider.provider.detect({
-          config: resolvedProvider.baseConfig,
-          stateDir,
-          logger: migrationLogger,
-        });
-        if (detection.found) {
-          selectedDetections.push({
-            providerId,
-            label: detection.label ?? resolvedProvider.provider.label,
-            ...(detection.source ? { source: detection.source } : {}),
-            ...(detection.message ? { message: detection.message } : {}),
-          });
-        }
-      } catch (error) {
-        migrationLogger.debug?.(
-          `Migration provider ${providerId} detection failed: ${formatErrorMessage(error)}`,
-        );
-      }
-    }
-    const sourceDefault = resolveImportSourceDefault({
-      providerId,
-      detections: selectedDetections,
-    });
-    const sourceDir =
-      params.opts.importSource?.trim() ||
-      sourceDefault ||
-      (params.opts.nonInteractive
-        ? (() => {
-            throw new Error("--import-source is required for non-interactive migration import.");
-          })()
-        : await params.prompter.text({
-            message: t("wizard.migration.sourceAgentHome"),
-            initialValue: providerId === "hermes" ? "~/.hermes" : undefined,
-          }));
-    let targetConfig = applyLocalSetupWorkspaceConfig(resolvedProvider.baseConfig, workspaceDir);
-    if (params.opts.skipBootstrap) {
-      targetConfig = applySkipBootstrapConfig(targetConfig);
-    }
-    const initialCtx: MigrationProviderContext = {
-      config: targetConfig,
-      stateDir,
-      source: sourceDir,
-      overwrite: false,
-      logger: migrationLogger,
-    };
-    const planned = await createSetupMigrationPlan({
-      provider: resolvedProvider.provider,
-      ctx: initialCtx,
-      importSecrets: Boolean(params.opts.importSecrets),
-      nonInteractive: Boolean(params.opts.nonInteractive),
-      prompter: params.prompter,
-    });
-    const plannedSourceSnapshotHash = await buildSetupMigrationPlanSourceSnapshot(planned.plan);
-    const ctx = planned.ctx;
-    const plan = planned.plan;
-    assertDeferredMigrationApplyContract(resolvedProvider.provider, plan);
-    await params.prompter.note(
-      formatMigrationPreview(plan).join("\n"),
-      t("wizard.migration.previewTitle"),
-    );
-    assertConflictFreePlan(plan, providerId);
-
-    const confirmed =
-      params.opts.nonInteractive === true
-        ? true
-        : await params.prompter.confirm({
-            message: t("wizard.migration.apply"),
-            initialValue: true,
-          });
-    if (!confirmed) {
-      throw new WizardCancelledError(t("wizard.migration.cancelled"));
-    }
-
-    targetConfig = onboardHelpers.applyWizardMetadata(targetConfig, {
-      command: "onboard",
-      mode: "local",
-    });
-    await prepareSetupMigrationAttemptBoundary({
-      currentConfig: await params.readConfigFile(),
-      targetConfig,
-      stateDir,
-      workspaceDir,
-      plan,
-      expectedTargetSnapshotHash: planningTargetSnapshotHash,
-      expectedSourceSnapshotHash: plannedSourceSnapshotHash,
-    });
-    const reportDir = buildMigrationReportDir(providerId, stateDir);
-    const stage = await createSetupMigrationStage({
-      providerId,
-      stateDir,
-      workspaceDir,
-      reportDir,
-      targetConfig,
-    });
-    try {
-      const stagedPlan = stage.projectPlanToStage(
-        buildSetupMigrationPhasePlan(plan, "before-promotion"),
-      );
-      const stagedRuntime = ctx.runtime
-        ? {
-            ...ctx.runtime,
-            config: {
-              ...ctx.runtime.config,
-              current: stage.configRuntime.current,
-              mutateConfigFile: stage.configRuntime.mutateConfigFile,
-              replaceConfigFile: async () => {
-                throw new Error("Full config replacement is unavailable during staged migration.");
-              },
-            },
-          }
-        : undefined;
-      const stagedResult = await resolvedProvider.provider.apply(
-        {
-          ...ctx,
-          ...(stagedRuntime ? { runtime: stagedRuntime } : {}),
-          config: stage.getStagedConfig(),
-          configRuntime: stage.configRuntime,
-          stateDir: stage.staged.stateDir,
-          reportDir: stage.staged.reportDir,
-        },
-        stagedPlan,
-      );
-      assertApplySucceeded(stagedResult);
-      const projectedStagedResult = stage.projectResultToFinal(stagedResult);
-
-      let outcome: SetupMigrationPromotionOutcome = { kind: "no-imported-inference" };
-      if (resolveAgentModelPrimaryValue(stage.getStagedConfig().agents?.defaults?.model)) {
-        const verification = await offerLiveModelVerification({
-          config: stage.getStagedConfig(),
-          opts: params.opts,
-          prompter: params.prompter,
-          runtime: params.runtime,
-          workspaceDir: stage.staged.workspaceDir,
-          agentDir: stage.staged.agentDir,
-          stateDir: stage.staged.stateDir,
-          writeConfig: async (config) => {
-            stage.replaceStagedConfig(config);
-            return stage.getStagedConfig();
-          },
-          required: true,
-        });
-        if (!verification.verified || !verification.modelRef) {
-          throw new Error("Imported inference was not verified.");
-        }
-        stage.replaceStagedConfig(verification.config);
-        outcome = { kind: "verified-inference", modelRef: verification.modelRef };
-      }
-
-      const [currentTargetSnapshotHash, currentSourceSnapshotHash] = await Promise.all([
-        buildSetupMigrationTargetSnapshot({
-          config: await params.readConfigFile(),
+    return await withSetupMigrationProvider(
+      {
+        providerId,
+        baseConfig: lockedBaseConfig,
+      },
+      async (resolvedProvider) => {
+        const planningBaseConfig = await params.readConfigFile();
+        const planningTargetSnapshotHash = await buildSetupMigrationTargetSnapshot({
+          config: planningBaseConfig,
           stateDir,
           workspaceDir,
-        }),
-        buildSetupMigrationPlanSourceSnapshot(plan),
-      ]);
-      if (currentTargetSnapshotHash !== planningTargetSnapshotHash) {
-        throw new SetupMigrationTargetChangedError(
-          "Migration target changed before promotion. Review it and retry.",
+        });
+        const migrationLogger = createMigrationLogger(params.runtime);
+        const selectedDetections = [...params.detections];
+        if (
+          resolvedProvider.provider.detect &&
+          !selectedDetections.some((detection) => detection.providerId === providerId)
+        ) {
+          try {
+            const detection = await resolvedProvider.provider.detect({
+              config: resolvedProvider.baseConfig,
+              stateDir,
+              logger: migrationLogger,
+            });
+            if (detection.found) {
+              selectedDetections.push({
+                providerId,
+                label: detection.label ?? resolvedProvider.provider.label,
+                ...(detection.source ? { source: detection.source } : {}),
+                ...(detection.message ? { message: detection.message } : {}),
+              });
+            }
+          } catch (error) {
+            migrationLogger.debug?.(
+              `Migration provider ${providerId} detection failed: ${formatErrorMessage(error)}`,
+            );
+          }
+        }
+        const sourceDefault = resolveImportSourceDefault({
+          providerId,
+          detections: selectedDetections,
+        });
+        const sourceDir =
+          params.opts.importSource?.trim() ||
+          sourceDefault ||
+          (params.opts.nonInteractive
+            ? (() => {
+                throw new Error(
+                  "--import-source is required for non-interactive migration import.",
+                );
+              })()
+            : await params.prompter.text({
+                message: t("wizard.migration.sourceAgentHome"),
+                initialValue: providerId === "hermes" ? "~/.hermes" : undefined,
+              }));
+        let targetConfig = applyLocalSetupWorkspaceConfig(
+          resolvedProvider.baseConfig,
+          workspaceDir,
         );
-      }
-      if (currentSourceSnapshotHash !== plannedSourceSnapshotHash) {
-        throw new Error("Migration source changed before promotion. Review it and retry.");
-      }
+        if (params.opts.skipBootstrap) {
+          targetConfig = applySkipBootstrapConfig(targetConfig);
+        }
+        const initialCtx: MigrationProviderContext = {
+          config: targetConfig,
+          stateDir,
+          source: sourceDir,
+          overwrite: false,
+          logger: migrationLogger,
+        };
+        const planned = await createSetupMigrationPlan({
+          provider: resolvedProvider.provider,
+          ctx: initialCtx,
+          importSecrets: Boolean(params.opts.importSecrets),
+          nonInteractive: Boolean(params.opts.nonInteractive),
+          prompter: params.prompter,
+        });
+        const plannedSourceSnapshotHash = await buildSetupMigrationPlanSourceSnapshot(planned.plan);
+        const ctx = planned.ctx;
+        const plan = planned.plan;
+        assertDeferredMigrationApplyContract(resolvedProvider.provider, plan);
+        await params.prompter.note(
+          formatMigrationPreview(plan).join("\n"),
+          t("wizard.migration.previewTitle"),
+        );
+        assertConflictFreePlan(plan, providerId);
 
-      const promoted = await stage.promote({
-        expectedConfig: planningBaseConfig,
-        continuation: {
-          providerLabel: resolvedProvider.provider.label,
-          ...(ctx.source ? { source: ctx.source } : {}),
-          ...(ctx.includeSecrets !== undefined ? { includeSecrets: ctx.includeSecrets } : {}),
-          ...(ctx.providerOptions ? { providerOptions: ctx.providerOptions } : {}),
+        const confirmed =
+          params.opts.nonInteractive === true
+            ? true
+            : await params.prompter.confirm({
+                message: t("wizard.migration.apply"),
+                initialValue: true,
+              });
+        if (!confirmed) {
+          throw new WizardCancelledError(t("wizard.migration.cancelled"));
+        }
+
+        targetConfig = onboardHelpers.applyWizardMetadata(targetConfig, {
+          command: "onboard",
+          mode: "local",
+        });
+        await prepareSetupMigrationAttemptBoundary({
+          currentConfig: await params.readConfigFile(),
+          targetConfig,
+          stateDir,
+          workspaceDir,
           plan,
-          stagedResult: projectedStagedResult,
-          outcome,
-          continueOnboarding: params.continueOnboarding === true,
-        },
-        readConfigFile: params.readConfigFile,
-        commitConfigFile: params.commitConfigFile,
-      });
-      return await finalizeSetupMigrationPromotion({
-        provider: resolvedProvider.provider,
-        resume: promoted.resume,
-        config: promoted.config,
-        stateDir,
-        logger: migrationLogger,
-        prompter: params.prompter,
-        formatMigrationResult,
-      });
-    } finally {
-      await stage.cleanup();
-    }
+          expectedTargetSnapshotHash: planningTargetSnapshotHash,
+          expectedSourceSnapshotHash: plannedSourceSnapshotHash,
+        });
+        const reportDir = buildMigrationReportDir(providerId, stateDir);
+        const stage = await createSetupMigrationStage({
+          providerId,
+          stateDir,
+          workspaceDir,
+          reportDir,
+          targetConfig,
+        });
+        try {
+          const stagedPlan = stage.projectPlanToStage(
+            buildSetupMigrationPhasePlan(plan, "before-promotion"),
+          );
+          const stagedRuntime = ctx.runtime
+            ? {
+                ...ctx.runtime,
+                config: {
+                  ...ctx.runtime.config,
+                  current: stage.configRuntime.current,
+                  mutateConfigFile: stage.configRuntime.mutateConfigFile,
+                  replaceConfigFile: async () => {
+                    throw new Error(
+                      "Full config replacement is unavailable during staged migration.",
+                    );
+                  },
+                },
+              }
+            : undefined;
+          const stagedResult = await resolvedProvider.provider.apply(
+            {
+              ...ctx,
+              ...(stagedRuntime ? { runtime: stagedRuntime } : {}),
+              config: stage.getStagedConfig(),
+              configRuntime: stage.configRuntime,
+              stateDir: stage.staged.stateDir,
+              reportDir: stage.staged.reportDir,
+            },
+            stagedPlan,
+          );
+          assertApplySucceeded(stagedResult);
+          const projectedStagedResult = stage.projectResultToFinal(stagedResult);
+
+          let outcome: SetupMigrationPromotionOutcome = { kind: "no-imported-inference" };
+          if (resolveAgentModelPrimaryValue(stage.getStagedConfig().agents?.defaults?.model)) {
+            const verification = await offerLiveModelVerification({
+              config: stage.getStagedConfig(),
+              opts: params.opts,
+              prompter: params.prompter,
+              runtime: params.runtime,
+              workspaceDir: stage.staged.workspaceDir,
+              agentDir: stage.staged.agentDir,
+              stateDir: stage.staged.stateDir,
+              writeConfig: async (config) => {
+                stage.replaceStagedConfig(config);
+                return stage.getStagedConfig();
+              },
+              required: true,
+            });
+            if (!verification.verified || !verification.modelRef) {
+              throw new Error("Imported inference was not verified.");
+            }
+            stage.replaceStagedConfig(verification.config);
+            outcome = { kind: "verified-inference", modelRef: verification.modelRef };
+          }
+
+          const [currentTargetSnapshotHash, currentSourceSnapshotHash] = await Promise.all([
+            buildSetupMigrationTargetSnapshot({
+              config: await params.readConfigFile(),
+              stateDir,
+              workspaceDir,
+            }),
+            buildSetupMigrationPlanSourceSnapshot(plan),
+          ]);
+          if (currentTargetSnapshotHash !== planningTargetSnapshotHash) {
+            throw new SetupMigrationTargetChangedError(
+              "Migration target changed before promotion. Review it and retry.",
+            );
+          }
+          if (currentSourceSnapshotHash !== plannedSourceSnapshotHash) {
+            throw new Error("Migration source changed before promotion. Review it and retry.");
+          }
+
+          const promoted = await stage.promote({
+            expectedConfig: planningBaseConfig,
+            continuation: {
+              providerLabel: resolvedProvider.provider.label,
+              ...(ctx.source ? { source: ctx.source } : {}),
+              ...(ctx.includeSecrets !== undefined ? { includeSecrets: ctx.includeSecrets } : {}),
+              ...(ctx.providerOptions ? { providerOptions: ctx.providerOptions } : {}),
+              plan,
+              stagedResult: projectedStagedResult,
+              outcome,
+              continueOnboarding: params.continueOnboarding === true,
+            },
+            readConfigFile: params.readConfigFile,
+            commitConfigFile: params.commitConfigFile,
+          });
+          return await finalizeSetupMigrationPromotion({
+            provider: resolvedProvider.provider,
+            resume: promoted.resume,
+            config: promoted.config,
+            stateDir,
+            logger: migrationLogger,
+            prompter: params.prompter,
+            formatMigrationResult,
+          });
+        } finally {
+          await stage.cleanup();
+        }
+      },
+    );
   });
 }

--- a/src/wizard/setup.migration-resources.test.ts
+++ b/src/wizard/setup.migration-resources.test.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { clearRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { createMigrationResourceFixture } from "../plugins/migration-provider.test-support.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createNonExitingRuntime } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { runSetupMemoryImportStep } from "./setup.memory-import.js";
+import { detectSetupMigrationSources } from "./setup.migration-import.js";
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+
+describe("optional migration results", () => {
+  it.each(["completed", "skipped", "nothing-to-import"] as const)(
+    "retains a %s memory import outcome when native registration cleanup fails",
+    async (status) => {
+      const fixture = createMigrationResourceFixture({
+        detectFound: status !== "nothing-to-import",
+      });
+      fixture.state.failCleanupOnConnection = 1;
+      fixture.state.resumeApply.resolve();
+      const warning = vi.fn();
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+          },
+          async () => {
+            const result = await runSetupMemoryImportStep({
+              config: fixture.config,
+              runtime: { ...createNonExitingRuntime(), error: warning },
+              prompter: createWizardPrompter({ confirm: async () => status === "completed" }),
+            });
+            expect(result.status).toBe(status);
+            expect(fixture.state.applyCalls).toBe(status === "completed" ? 1 : 0);
+            if (status === "completed") {
+              expect(result.providers).toEqual([
+                {
+                  providerId: fixture.id,
+                  label: "Native migration fixture",
+                  migrated: 1,
+                  skipped: 0,
+                },
+              ]);
+            } else {
+              expect(result.providers).toEqual([]);
+            }
+            expect(warning).toHaveBeenCalledOnce();
+            expect(warning.mock.calls[0]?.[0]).toContain(
+              "Memory import result retained, but plugin cleanup failed",
+            );
+            expect(fixture.state.connections[0]?.disposals).toBe(1);
+            expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+          },
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([true, false])(
+    "retains advisory discovery metadata after native cleanup fails (found: %s)",
+    async (found) => {
+      const fixture = createMigrationResourceFixture({ detectFound: found });
+      fixture.state.failCleanupOnConnection = 1;
+      const warning = vi.fn();
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+          },
+          async () => {
+            const result = await detectSetupMigrationSources({
+              config: fixture.config,
+              runtime: { ...createNonExitingRuntime(), error: warning },
+            });
+            expect(result.detections.length).toBe(found ? 1 : 0);
+            expect(result.providerDescriptors).toEqual([
+              {
+                providerId: fixture.id,
+                label: "Native migration fixture",
+                description: "Native source 42",
+              },
+            ]);
+            expect(warning).toHaveBeenCalledOnce();
+            expect(warning.mock.calls[0]?.[0]).toContain(
+              "Migration discovery result retained, but plugin cleanup failed",
+            );
+            expect(fixture.state.applyCalls).toBe(0);
+            expect(fixture.state.connections[0]?.disposals).toBe(1);
+            expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+          },
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("preserves an authority failure even when native registration cleanup also fails", async () => {
+    const fixture = createMigrationResourceFixture();
+    fixture.state.failCleanupOnConnection = 1;
+    const authorityError = new Error("Synthetic memory import authority revoked");
+    const warning = vi.fn();
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: path.join(fixture.root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(fixture.root, "state", "openclaw.json"),
+        },
+        async () => {
+          await expect(
+            runSetupMemoryImportStep({
+              config: fixture.config,
+              runtime: { ...createNonExitingRuntime(), error: warning },
+              prompter: createWizardPrompter({ confirm: async () => true }),
+              beforeApply: async () => {
+                throw authorityError;
+              },
+            }),
+          ).rejects.toMatchObject({
+            cause: authorityError,
+            errors: [authorityError, expect.any(Error)],
+          });
+          expect(warning).not.toHaveBeenCalled();
+          expect(fixture.state.applyCalls).toBe(0);
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(false);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/src/wizard/setup.migration-transaction.test.ts
+++ b/src/wizard/setup.migration-transaction.test.ts
@@ -38,9 +38,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded: vi.fn(),
-  resolvePluginMigrationProvider: () => mocks.provider,
-  resolvePluginMigrationProviders: () => (mocks.provider ? [mocks.provider] : []),
+  withPluginMigrationProviders: async (
+    _params: unknown,
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run(mocks.provider ? [mocks.provider] : []),
 }));
 
 vi.mock("./setup.inference-verification.js", () => ({

--- a/src/wizard/setup.post-install-migration.test.ts
+++ b/src/wizard/setup.post-install-migration.test.ts
@@ -2,14 +2,16 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { MigrationProviderPlugin } from "../plugins/types.js";
 import { createNonExitingRuntime } from "../runtime.js";
 import type { WizardPrompter } from "./prompts.js";
 
-const ensureStandaloneMigrationProviderRegistryLoaded = vi.hoisted(() => vi.fn());
-const resolvePluginMigrationProviders = vi.hoisted(() => vi.fn(() => [] as unknown[]));
+const migrationProviders = vi.hoisted(() => vi.fn<() => MigrationProviderPlugin[]>(() => []));
 vi.mock("../plugins/migration-provider-runtime.js", () => ({
-  ensureStandaloneMigrationProviderRegistryLoaded,
-  resolvePluginMigrationProviders,
+  withPluginMigrationProviders: async (
+    _params: unknown,
+    run: (providers: MigrationProviderPlugin[]) => Promise<unknown>,
+  ) => await run(migrationProviders()),
 }));
 
 const resolveManifestContractRuntimePluginResolution = vi.hoisted(() =>
@@ -44,16 +46,12 @@ import { offerPostInstallMigrations } from "./setup.post-install-migration.js";
 
 const originalStdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
-type ProviderMock = {
-  id: string;
-  label: string;
-  detect: ReturnType<typeof vi.fn>;
-};
-
-function buildProvider(overrides: Partial<ProviderMock> = {}): ProviderMock {
+function buildProvider(overrides: Partial<MigrationProviderPlugin> = {}): MigrationProviderPlugin {
   return {
     id: "codex",
     label: "Codex",
+    plan: vi.fn<MigrationProviderPlugin["plan"]>(),
+    apply: vi.fn<MigrationProviderPlugin["apply"]>(),
     detect: vi.fn(async () => ({ found: true, source: "/home/user/.codex" })),
     ...overrides,
   };
@@ -68,8 +66,8 @@ function setOwnership(providerId: string, owningPluginIds: string[]): void {
   });
 }
 
-function setProviders(providers: ProviderMock[]): void {
-  resolvePluginMigrationProviders.mockReturnValue(providers as unknown[]);
+function setProviders(providers: MigrationProviderPlugin[]): void {
+  migrationProviders.mockReturnValue(providers);
 }
 
 function setTTY(isTTY: boolean): void {
@@ -95,8 +93,7 @@ describe("offerPostInstallMigrations", () => {
   beforeEach(() => {
     // clearAllMocks only resets call history; reset the implementations each
     // test would customize so prior cases don't leak across this suite.
-    ensureStandaloneMigrationProviderRegistryLoaded.mockReset();
-    resolvePluginMigrationProviders.mockReset().mockReturnValue([]);
+    migrationProviders.mockReset().mockReturnValue([]);
     resolveManifestContractRuntimePluginResolution.mockReset().mockReturnValue({
       pluginIds: [],
       bundledCompatPluginIds: [],
@@ -131,7 +128,7 @@ describe("offerPostInstallMigrations", () => {
     const result = await offerPostInstallMigrations(
       buildBaseArgs({ config, installedPluginIds: [] }),
     );
-    expect(resolvePluginMigrationProviders).not.toHaveBeenCalled();
+    expect(migrationProviders).not.toHaveBeenCalled();
     expect(migrateDefaultCommand).not.toHaveBeenCalled();
     expect(result.config).toBe(config);
   });
@@ -199,6 +196,7 @@ describe("offerPostInstallMigrations", () => {
         configPatchMode: "return",
         suppressPlanLog: true,
       }),
+      provider,
     );
     expect(result.config).toEqual({});
   });
@@ -273,6 +271,7 @@ describe("offerPostInstallMigrations", () => {
         configOverride: inputConfig,
         configPatchMode: "return",
       }),
+      provider,
     );
     expect(result.config).not.toBe(inputConfig);
     expect(result.config.plugins?.entries?.codex?.config).toEqual({

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -160,21 +160,17 @@ export async function offerPostInstallMigrations(
     return { config: params.config };
   }
   const { withPluginMigrationProviders } = await import("../plugins/migration-provider-runtime.js");
-  let completedResult: PostInstallMigrationResult | undefined;
-  try {
-    return await withPluginMigrationProviders({ cfg: params.config }, async (providers) => {
-      completedResult = await runPostInstallMigrationOffers(params, providers);
-      return completedResult;
-    });
-  } catch (error) {
-    if (!completedResult) {
-      throw error;
-    }
-    params.runtime.log(
-      `Post-install migration result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
-    );
-    return completedResult;
-  }
+  return await withPluginMigrationProviders(
+    {
+      cfg: params.config,
+      onCleanupError: (error) => {
+        params.runtime.log(
+          `Post-install migration result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
+        );
+      },
+    },
+    async (providers) => await runPostInstallMigrationOffers(params, providers),
+  );
 }
 
 async function runPostInstallMigrationOffers(

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -45,28 +45,25 @@ async function resolveCandidates(params: {
   config: OpenClawConfig;
   runtime: RuntimeEnv;
   installedPluginIds: readonly string[];
+  providers: readonly MigrationProviderPlugin[];
 }): Promise<ResolvedProviderCandidate[]> {
   if (params.installedPluginIds.length === 0) {
     return [];
   }
   const [
-    { ensureStandaloneMigrationProviderRegistryLoaded, resolvePluginMigrationProviders },
     { resolveManifestContractRuntimePluginResolution },
     { createMigrationLogger },
     { resolveStateDir },
   ] = await Promise.all([
-    import("../plugins/migration-provider-runtime.js"),
     import("../plugins/manifest-contract-runtime.js"),
     loadMigrationContextModule(),
     loadConfigPathsModule(),
   ]);
-  ensureStandaloneMigrationProviderRegistryLoaded({ cfg: params.config });
   const installedIds = new Set(params.installedPluginIds);
-  const providers = resolvePluginMigrationProviders({ cfg: params.config });
   const stateDir = resolveStateDir();
   const logger = createMigrationLogger(params.runtime);
   const candidates: ResolvedProviderCandidate[] = [];
-  for (const provider of providers) {
+  for (const provider of params.providers) {
     if (!provider.detect) {
       continue;
     }
@@ -159,7 +156,33 @@ function applyMigrationConfigPatches(
 export async function offerPostInstallMigrations(
   params: PostInstallMigrationOptions,
 ): Promise<PostInstallMigrationResult> {
+  if (params.installedPluginIds.length === 0) {
+    return { config: params.config };
+  }
+  const { withPluginMigrationProviders } = await import("../plugins/migration-provider-runtime.js");
+  let completedResult: PostInstallMigrationResult | undefined;
+  try {
+    return await withPluginMigrationProviders({ cfg: params.config }, async (providers) => {
+      completedResult = await runPostInstallMigrationOffers(params, providers);
+      return completedResult;
+    });
+  } catch (error) {
+    if (!completedResult) {
+      throw error;
+    }
+    params.runtime.log(
+      `Post-install migration result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
+    );
+    return completedResult;
+  }
+}
+
+async function runPostInstallMigrationOffers(
+  params: PostInstallMigrationOptions,
+  providers: readonly MigrationProviderPlugin[],
+): Promise<PostInstallMigrationResult> {
   const candidates = await resolveCandidates({
+    providers,
     config: params.config,
     runtime: params.runtime,
     installedPluginIds: params.installedPluginIds,
@@ -196,8 +219,14 @@ export async function offerPostInstallMigrations(
       logMigrationHint(params.runtime, candidate);
       continue;
     }
-    let preparation: Awaited<ReturnType<NonNullable<MigrationProviderPlugin["prepareApply"]>>> =
-      undefined;
+    const logFailure = (error: unknown) => {
+      params.runtime.log(
+        `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +
+          `Re-run with ${formatCliCommand(`openclaw migrate ${candidate.provider.id} --dry-run`)} to inspect.`,
+      );
+    };
+    let disposingPreparation = false;
+    let resultRetained = false;
     try {
       const [{ migrateDefaultCommand }, { createMigrationLogger }, { resolveStateDir }] =
         await Promise.all([
@@ -205,27 +234,54 @@ export async function offerPostInstallMigrations(
           loadMigrationContextModule(),
           loadConfigPathsModule(),
         ]);
-      preparation = await candidate.provider.prepareApply?.({
-        config: nextConfig,
-        stateDir: resolveStateDir(),
-        logger: createMigrationLogger(params.runtime),
-        ...(candidate.source ? { source: candidate.source } : {}),
-        providerOptions: { configPatchMode: "return" },
-      });
-      const result = await migrateDefaultCommand(params.runtime, {
-        provider: candidate.provider.id,
-        configOverride: nextConfig,
-        configPatchMode: "return",
-        suppressPlanLog: true,
-      });
-      nextConfig = applyMigrationConfigPatches(nextConfig, result);
+      const runCommand = async (provider: MigrationProviderPlugin) => {
+        let preparation: Awaited<ReturnType<NonNullable<MigrationProviderPlugin["prepareApply"]>>>;
+        try {
+          preparation = await provider.prepareApply?.({
+            config: nextConfig,
+            stateDir: resolveStateDir(),
+            logger: createMigrationLogger(params.runtime),
+            ...(candidate.source ? { source: candidate.source } : {}),
+            providerOptions: { configPatchMode: "return" },
+          });
+          const result = await migrateDefaultCommand(
+            params.runtime,
+            {
+              provider: provider.id,
+              configOverride: nextConfig,
+              configPatchMode: "return",
+              suppressPlanLog: true,
+            },
+            provider,
+          );
+          nextConfig = applyMigrationConfigPatches(nextConfig, result);
+          resultRetained = true;
+        } catch (error) {
+          logFailure(error);
+        } finally {
+          disposingPreparation = true;
+          await preparation?.dispose?.();
+          disposingPreparation = false;
+        }
+      };
+      if (nextConfig === params.config) {
+        await runCommand(candidate.provider);
+      } else {
+        const { withMigrationProvider } = await import("../commands/migrate/providers.js");
+        await withMigrationProvider(candidate.provider.id, nextConfig, runCommand);
+      }
     } catch (error) {
-      params.runtime.log(
-        `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +
-          `Re-run with ${formatCliCommand(`openclaw migrate ${candidate.provider.id} --dry-run`)} to inspect.`,
-      );
-    } finally {
-      await preparation?.dispose?.();
+      // Preparation cleanup failures must still abort the caller, not become optional-offer hints.
+      if (disposingPreparation) {
+        throw error;
+      }
+      if (resultRetained) {
+        params.runtime.log(
+          `${candidate.provider.label} migration result retained, but plugin cleanup failed: ${formatErrorMessage(error)}`,
+        );
+      } else {
+        logFailure(error);
+      }
     }
   }
   return { config: nextConfig };

--- a/src/wizard/setup.provenance.integration.test.ts
+++ b/src/wizard/setup.provenance.integration.test.ts
@@ -48,7 +48,7 @@ vi.mock("./setup.gateway-config.js", () => ({
   },
 }));
 vi.mock("./setup.migration-import.js", () => ({
-  detectSetupMigrationSources: async () => [],
+  detectSetupMigrationSources: async () => ({ detections: [], providerDescriptors: [] }),
   listSetupMigrationOptions: async () => [],
   runSetupMigrationImport: vi.fn(),
 }));

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -128,7 +128,9 @@ const finalizeSetupWizard = vi.hoisted(() =>
 const listChannelPlugins = vi.hoisted(() => vi.fn(() => []));
 const logConfigUpdated = vi.hoisted(() => vi.fn(() => {}));
 const setupInternalHooks = vi.hoisted(() => vi.fn(async (cfg) => cfg));
-const detectSetupMigrationSources = vi.hoisted(() => vi.fn(async () => []));
+const detectSetupMigrationSources = vi.hoisted(() =>
+  vi.fn(async () => ({ detections: [], providerDescriptors: [] })),
+);
 const listSetupMigrationOptions = vi.hoisted(() =>
   vi.fn<ListSetupMigrationOptions>(async () => []),
 );

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -150,10 +150,10 @@ async function runSetupWizardOnce(
   const manualHint = t("wizard.setup.flowAdvancedHint");
   const hasExistingModelConfig =
     resolveAgentModelPrimaryValue(baseConfig.agents?.defaults?.model) !== undefined;
-  const migrationDetections = await detectSetupMigrationSources({ config: baseConfig, runtime });
+  const migrationDiscovery = await detectSetupMigrationSources({ config: baseConfig, runtime });
   const migrationOptions = await listSetupMigrationOptions({
     baseConfig,
-    detections: migrationDetections,
+    ...migrationDiscovery,
   });
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;
@@ -235,7 +235,7 @@ async function runSetupWizardOnce(
           ...(importFrom ? { importFrom } : {}),
         },
         baseConfig,
-        detections: migrationDetections,
+        ...migrationDiscovery,
         prompter,
         runtime,
         readConfigFile: readValidSetupConfigFile,


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where migration commands and setup flows retained plugin database connections after finishing. Completed imports, optional onboarding results, or projected configuration could also be lost when registration cleanup failed. A Gateway result-encoding failure could allow the same completed import to run again on retry.

## Why This Change Was Made

Each cold migration operation owns its registration through planning, prompts, apply, output, and preparation cleanup. Nested callers carry the selected provider and opaque plans; setup carries plain discovery descriptors so listing choices stays inert. Active Gateway registrations keep their existing owner.

The operation owner can report cleanup failure separately after its callback succeeds. Optional discovery, Memory import, and post-install setup use that boundary to preserve completed outcomes; acquisition, operation, and authority failures still reject. Gateway apply records completion before result projection and retains either its JSON result or a terminal encoding error for the same request.

## User Impact

Migration connections close when their operation finishes. Completed imports and setup results survive registration cleanup errors, with visible cleanup diagnostics. Gateway retries reuse completed outcomes without reapplying. The Memory import documentation explains when to inspect reports and destination files before starting another import.

## Evidence

The full 27-path candidate passed fresh independent Codex review, its canonical changed gate (347 seconds), and the ordinary build (223 seconds). The final optional-flow and affected-owner sweep passed 101 tests, including five reproduced normal-outcome cleanup failures and an authority-failure control. Earlier native lifecycle, wizard, CLI, and RPC regressions also passed.

Current built CLI list/plan/apply recorded three native opens, three explicit closes, and one durable import. Three real isolated Gateway cases—success, cleanup failure after apply, and result-encoding failure after apply—each recorded two opens/two explicit closes, one durable import, and identical retry JSON after physical closure without additional provider execution. The complete live sequence took 26.7 seconds. All three Gateways stopped normally; 67 source/context files and 8,776 compiled modules stayed unchanged.

The review finding about optional onboarding cleanup is fixed and covered by native tests. The review's persisted-table warning was a classification false positive: this diff adds no SQLite schema, migration, index, or stored-data format change; replay uses the existing in-memory dedupe map.

Two earlier CI attempts failed unchanged Signal first-reply tests before the injected reply callback. The same failure was reproduced independently on main and traced to cold provider-policy loading; a separate guarded import reduction is being landed. Those failures remain recorded and are not treated as green checks. All requested tests must pass on the updated PR head before merge.
