### PR TITLE
fix(telegram): download inbound animations as media

### DIFF
--- a/extensions/telegram/src/bot-handlers.media.ts
+++ b/extensions/telegram/src/bot-handlers.media.ts
@@ -64,7 +64,15 @@ export function hasInboundMedia(msg: Message): boolean {
   return (
     Boolean(msg.media_group_id) ||
     (Array.isArray(msg.photo) && msg.photo.length > 0) ||
-    Boolean(msg.video ?? msg.video_note ?? msg.document ?? msg.audio ?? msg.voice ?? msg.sticker)
+    Boolean(
+      msg.video ??
+      msg.video_note ??
+      msg.animation ??
+      msg.document ??
+      msg.audio ??
+      msg.voice ??
+      msg.sticker,
+    )
   );
 }
 
@@ -74,6 +82,7 @@ export function resolveInboundMediaFileId(msg: Message): string | undefined {
     msg.photo?.[msg.photo.length - 1]?.file_id ??
     msg.video?.file_id ??
     msg.video_note?.file_id ??
+    msg.animation?.file_id ??
     msg.document?.file_id ??
     msg.audio?.file_id ??
     msg.voice?.file_id

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -23,6 +23,11 @@ type ReplyPayload = {
   ChannelStructuredContext?: unknown[];
 } & Record<string, unknown>;
 type MockWithCalls = { mock: { calls: unknown[][] } };
+type InboundMediaAssertionParams = {
+  fetchSpy: ReturnType<typeof vi.spyOn>;
+  replySpy: ReturnType<typeof vi.fn>;
+  runtimeError: ReturnType<typeof vi.fn>;
+};
 
 function mockCall(mock: MockWithCalls, index: number): unknown[] {
   const resolvedIndex = index < 0 ? mock.mock.calls.length + index : index;
@@ -140,7 +145,6 @@ describe("telegram inbound media", () => {
 
       for (const scenario of [
         {
-          name: "downloads via file_path",
           messageId: 1,
           getFile: async () => ({ file_path: "photos/1.jpg" }),
           setupFetch: () =>
@@ -148,11 +152,7 @@ describe("telegram inbound media", () => {
               contentType: "image/jpeg",
               bytes: new Uint8Array([0xff, 0xd8, 0xff, 0x00]),
             }),
-          assert: (params: {
-            fetchSpy: ReturnType<typeof vi.spyOn>;
-            replySpy: ReturnType<typeof vi.fn>;
-            runtimeError: ReturnType<typeof vi.fn>;
-          }) => {
+          assert: (params: InboundMediaAssertionParams) => {
             expect(params.runtimeError).not.toHaveBeenCalled();
             const request = downloadRequest(params.fetchSpy, -1);
             expect(request.url).toBe("https://api.telegram.org/file/bottok/photos/1.jpg");
@@ -167,15 +167,10 @@ describe("telegram inbound media", () => {
           },
         },
         {
-          name: "reports unavailable media when file_path is missing",
           messageId: 2,
           getFile: async () => ({}),
           setupFetch: () => watchTelegramFetch(),
-          assert: (params: {
-            fetchSpy: ReturnType<typeof vi.spyOn>;
-            replySpy: ReturnType<typeof vi.fn>;
-            runtimeError: ReturnType<typeof vi.fn>;
-          }) => {
+          assert: (params: InboundMediaAssertionParams) => {
             expect(params.fetchSpy).not.toHaveBeenCalled();
             expect(params.replySpy).toHaveBeenCalledTimes(1);
             expect(replyPayload(params.replySpy)).toMatchObject({
@@ -186,24 +181,54 @@ describe("telegram inbound media", () => {
             expect(params.runtimeError).not.toHaveBeenCalled();
           },
         },
+        {
+          messageId: 3,
+          media: {
+            animation: {
+              file_id: "animation-file-id",
+              file_unique_id: "animation-unique-id",
+              width: 320,
+              height: 240,
+              duration: 2,
+            },
+          },
+          getFile: async () => ({ file_path: "animations/animation.mp4" }),
+          setupFetch: () =>
+            mockTelegramFileDownload({
+              contentType: "video/mp4",
+              bytes: new Uint8Array([0x00, 0x00, 0x00, 0x18]),
+            }),
+          assert: (params: InboundMediaAssertionParams) => {
+            expect(params.runtimeError).not.toHaveBeenCalled();
+            expect(downloadRequest(params.fetchSpy, -1).filePathHint).toBe(
+              "animations/animation.mp4",
+            );
+            expect(replyPayload(params.replySpy)).toMatchObject({
+              MediaTypes: ["video/mp4"],
+              media: [expect.objectContaining({ kind: "video" })],
+            });
+          },
+        },
       ]) {
         replySpy.mockClear();
         replySpy.mockResolvedValueOnce({ text: "ack" });
         runtimeError.mockClear();
         const fetchSpy = scenario.setupFetch();
 
+        const getFile = vi.fn(scenario.getFile);
         await handler({
           message: {
             message_id: scenario.messageId,
             chat: { id: 1234, type: "private" },
             from: { id: 777, is_bot: false, first_name: "Ada" },
-            photo: [{ file_id: "fid" }],
+            ...("media" in scenario ? scenario.media : { photo: [{ file_id: "fid" }] }),
             date: 1736380800, // 2025-01-09T00:00:00Z
           },
           me: { username: "openclaw_bot" },
-          getFile: scenario.getFile,
+          getFile,
         });
 
+        expect(getFile).toHaveBeenCalledTimes(1);
         scenario.assert({ fetchSpy, replySpy, runtimeError });
         fetchSpy.mockRestore();
       }

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -21,13 +21,14 @@ import { renderTelegramTextEntities } from "./inbound-text-entities.js";
 
 type TelegramMediaMessage = Pick<
   Message,
-  "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker"
+  "photo" | "video" | "video_note" | "animation" | "audio" | "voice" | "document" | "sticker"
 >;
 
 type TelegramMediaFileRef =
   | NonNullable<Message["photo"]>[number]
   | NonNullable<Message["video"]>
   | NonNullable<Message["video_note"]>
+  | NonNullable<Message["animation"]>
   | NonNullable<Message["audio"]>
   | NonNullable<Message["voice"]>
   | NonNullable<Message["document"]>
@@ -62,6 +63,9 @@ export function resolveTelegramPrimaryMedia(
   }
   if (msg.video_note) {
     return { kind: "video", fileRef: msg.video_note };
+  }
+  if (msg.animation) {
+    return { kind: "video", fileRef: msg.animation };
   }
   if (msg.audio) {
     return { kind: "audio", fileRef: msg.audio };

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -88,6 +88,7 @@ interface MediaMetadata {
     | NonNullable<TelegramContext["message"]["photo"]>[number]
     | TelegramContext["message"]["video"]
     | TelegramContext["message"]["video_note"]
+    | TelegramContext["message"]["animation"]
     | TelegramContext["message"]["document"]
     | TelegramContext["message"]["audio"]
     | TelegramContext["message"]["voice"];
@@ -101,6 +102,7 @@ function resolveMediaMetadata(msg: TelegramContext["message"]): MediaMetadata {
       msg.photo?.[msg.photo.length - 1] ??
       msg.video ??
       msg.video_note ??
+      msg.animation ??
       msg.document ??
       msg.audio ??
       msg.voice,


### PR DESCRIPTION
Closes #56312

## What Problem This Solves

Fixes an issue where users sending Telegram animations or GIFs would have their
media omitted from the inbound message because animation attachments never
entered the media download flow.

## Why This Change Was Made

Telegram can represent an animation as both `animation` and `document`. The
inbound selectors now recognize and prefer the animation field consistently,
then classify it as video media. Prior investigation: #56336 by @manus-pi.

## User Impact

Telegram animations and GIFs are now downloaded and delivered to the agent as
video media instead of arriving without their attachment.

## Evidence

- The regression scenario failed before the production change because
  `getFile()` was never called; after the fix, it downloads the animation and
  verifies `video/mp4` plus video-kind structured media.
- `tsgo:extensions:test`
- Scoped extension oxlint and formatting
- Media-download helper roundtrip and test temp-creation report
- `git diff --check`
- On Windows, the existing E2E teardown still reports an `EPERM` while deleting
  its temporary state after the assertions; the unchanged photo sibling test
  reproduces the same harness cleanup failure.
