### PR TITLE
fix(cron): prevent Gateway hangs on stalled reservations

### DIFF
--- a/src/cron/service.cross-tick-admission.test.ts
+++ b/src/cron/service.cross-tick-admission.test.ts
@@ -308,6 +308,77 @@ describe("cron service cross-tick bounded admission", () => {
     stop(state);
   });
 
+  it("retires an empty tick when a receipt conflict leaves the same jobs due", async () => {
+    const store = fixtures.makeStorePath();
+    const t0 = Date.parse("2026-02-06T10:07:00.000Z");
+    const conflicted = createDueIsolatedJob({
+      id: "unchanged-conflict",
+      nowMs: t0,
+      nextRunAtMs: t0,
+    });
+    const pending = createDueIsolatedJob({
+      id: "after-unchanged-conflict",
+      nowMs: t0,
+      nextRunAtMs: t0,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [conflicted, pending] });
+    const prepared = prepareCronRunReceiptClaim({
+      storePath: store.storePath,
+      job: conflicted,
+      agentId: conflicted.agentId ?? "main",
+      startedAtMs: t0,
+    });
+    const receipt = runOpenClawStateWriteTransaction(({ db }) =>
+      claimCronRunReceiptInDatabase({
+        database: db,
+        prepared,
+        resolveAgentId: (job) => job.agentId ?? "main",
+      }),
+    );
+    let peakTicks = 0;
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state: ReturnType<typeof createCronRegressionState> = createCronRegressionState({
+      storePath: store.storePath,
+      nowMs: () => {
+        peakTicks = Math.max(peakTicks, state.activeTimerTicks);
+        // A timer cannot stop a microtask livelock; bound the pre-fix failure here.
+        if (peakTicks >= 5) {
+          stop(state);
+        }
+        return t0;
+      },
+      runIsolatedAgentJob,
+    });
+    state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1;
+
+    try {
+      await onTimer(state);
+
+      expect(peakTicks).toBe(1);
+      expect(state.stopped).toBe(false);
+      expect(state.activeTimerTicks).toBe(0);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+      expect(state.runAdmission.active).toBe(DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1);
+      expect(state.queuedRunReservationsByJobId.size).toBe(0);
+      expect(state.timer).not.toBeNull();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+
+      finishCronRunReceipt({ handle: receipt, status: "skipped", finishedAtMs: t0 });
+      await onTimer(state);
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+      expect(state.activeTimerTicks).toBe(0);
+      expect(
+        (await loadCronStore(store.storePath)).jobs.every(
+          (job) => job.state.lastRunStatus === "ok",
+        ),
+      ).toBe(true);
+    } finally {
+      finishCronRunReceipt({ handle: receipt, status: "skipped", finishedAtMs: t0 });
+      stop(state);
+    }
+  });
+
   it("rechecks a partial batch immediately when its only reservation conflicts", async () => {
     const store = fixtures.makeStorePath();
     const t0 = Date.parse("2026-02-06T10:07:30.000Z");

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -258,6 +258,15 @@ async function onAdmittedTimer(state: CronServiceState) {
           }),
           releaseAdmission: admissionReleases[index]!,
         }));
+        if (reservedDue.length === 0 && allowEmptyCapacityRecheck) {
+          // Releasing an unused slot is not progress. Retry immediately only
+          // when the refreshed store removed a candidate from the due set;
+          // otherwise child ticks retain their parents and starve the event loop.
+          const stillDue = new Set(
+            collectRunnableJobs(state, state.deps.nowMs()).map((job) => job.id),
+          );
+          allowEmptyCapacityRecheck = admittedDue.some((job) => !stillDue.has(job.id));
+        }
         for (const releaseAdmission of admissionReleases.slice(reservedDue.length)) {
           releaseAdmission();
         }

--- a/src/infra/sqlite-wal.connection-pragmas.test.ts
+++ b/src/infra/sqlite-wal.connection-pragmas.test.ts
@@ -1,0 +1,108 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { configureSqliteConnectionPragmas } from "./sqlite-wal.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("SQLite connection pragma acquisition", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it.each(["synchronous = NORMAL", "foreign_keys = ON"])(
+    "releases unpublished maintenance when PRAGMA %s fails",
+    (pragma) => {
+      vi.useFakeTimers();
+      const dbPath = path.join(tempDirs.make("openclaw-sqlite-pragma-failure-"), "state.sqlite");
+      const { DatabaseSync } = requireNodeSqlite();
+      const db = new DatabaseSync(dbPath);
+      const failure = new Error("connection pragma failed");
+      try {
+        db.exec("CREATE TABLE payload (value TEXT); INSERT INTO payload VALUES ('committed');");
+        const exec = db.exec.bind(db);
+        const execSpy = vi.spyOn(db, "exec").mockImplementation((sql) => {
+          if (sql === `PRAGMA ${pragma};`) {
+            expect(vi.getTimerCount()).toBe(1);
+            throw failure;
+          }
+          exec(sql);
+        });
+        for (let attempt = 0; attempt < 3; attempt++) {
+          expect(() =>
+            configureSqliteConnectionPragmas(db, {
+              databasePath: dbPath,
+              foreignKeys: true,
+              synchronous: "NORMAL",
+            }),
+          ).toThrow(failure);
+          expect(vi.getTimerCount()).toBe(0);
+          expect(db.isOpen).toBe(true);
+        }
+        execSpy.mockRestore();
+        const maintenance = configureSqliteConnectionPragmas(db, {
+          databasePath: dbPath,
+          foreignKeys: true,
+          synchronous: "NORMAL",
+        });
+        try {
+          expect(db.prepare("SELECT value FROM payload").all()).toEqual([{ value: "committed" }]);
+          expect(vi.getTimerCount()).toBe(1);
+        } finally {
+          maintenance.close();
+        }
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        db.close();
+        vi.clearAllTimers();
+      }
+    },
+  );
+
+  it("retains the pragma failure when maintenance cleanup also throws", () => {
+    vi.useFakeTimers();
+    const dbPath = path.join(tempDirs.make("openclaw-sqlite-pragma-cleanup-"), "state.sqlite");
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    const failure = new Error("connection pragma failed");
+    const checkpointFailure = new Error("checkpoint failed");
+    const reportFailure = new Error("checkpoint error reporting failed");
+    try {
+      const exec = db.exec.bind(db);
+      vi.spyOn(db, "exec").mockImplementation((sql) => {
+        if (sql === "PRAGMA foreign_keys = ON;") {
+          throw failure;
+        }
+        exec(sql);
+      });
+      const prepare = db.prepare.bind(db);
+      vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        if (sql.startsWith("PRAGMA wal_checkpoint")) {
+          throw checkpointFailure;
+        }
+        return prepare(sql);
+      });
+      let caught: unknown;
+      try {
+        configureSqliteConnectionPragmas(db, {
+          databasePath: dbPath,
+          foreignKeys: true,
+          onCheckpointError: () => {
+            throw reportFailure;
+          },
+        });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(AggregateError);
+      expect(caught).toMatchObject({ cause: failure, errors: [failure, reportFailure] });
+      expect(vi.getTimerCount()).toBe(0);
+      expect(db.isOpen).toBe(true);
+    } finally {
+      db.close();
+      vi.clearAllTimers();
+    }
+  });
+});

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -10,6 +10,7 @@ import type { Result } from "@openclaw/normalization-core/result";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hasErrnoCode } from "./errno.js";
 import { normalizeSqliteNonNegativeInteger } from "./sqlite-busy-timeout.js";
+import { createSqliteLifecycleAggregateError } from "./sqlite-coordinator.js";
 import { isSqliteLockError, runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
 // WAL maintenance configures SQLite write-ahead logging and schedules bounded
@@ -738,11 +739,25 @@ export function configureSqliteConnectionPragmas(
 ): SqliteWalMaintenance {
   const { foreignKeys, synchronous, ...walOptions } = options;
   const maintenance = configureSqliteWalMaintenance(db, walOptions);
-  if (synchronous) {
-    db.exec(`PRAGMA synchronous = ${synchronous};`);
+  try {
+    if (synchronous) {
+      db.exec(`PRAGMA synchronous = ${synchronous};`);
+    }
+    if (foreignKeys) {
+      db.exec("PRAGMA foreign_keys = ON;");
+    }
+    return maintenance;
+  } catch (error) {
+    // The caller cannot dispose maintenance until this function returns it.
+    try {
+      maintenance.close();
+    } catch (closeError) {
+      throw createSqliteLifecycleAggregateError(
+        [error, closeError],
+        "SQLite connection pragma configuration and WAL maintenance cleanup both failed.",
+        error,
+      );
+    }
+    throw error;
   }
-  if (foreignKeys) {
-    db.exec("PRAGMA foreign_keys = ON;");
-  }
-  return maintenance;
 }

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -4,10 +4,12 @@ import {
   clearNodeSqliteKyselyCacheForDatabase,
   registerNodeSqliteKyselyQueryErrorHandler,
 } from "../infra/kysely-sync-cache-state.js";
+import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
+import { registerSqliteCacheExitClose } from "../infra/sqlite-wal.js";
 import {
   createOpenClawDatabaseVerificationError,
   readOpenClawDatabaseQuarantine,
@@ -16,6 +18,11 @@ import type { OpenClawStateDatabase } from "./openclaw-state-db-contract.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
+type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
+  Partial<Pick<OpenClawStateDatabase, "walMaintenance">>;
+// Failed native closes stay disposal-owned, never eligible for a successful cache hit.
+const retainedDatabaseHandles = new Map<DatabaseSync, StateDatabaseHandle>();
+let unregisterRetainedExitClose: (() => void) | undefined;
 // Statements retain their native database; key by the plain lifecycle owner so
 // removing that owner releases the statement instead of rooting its own weak key.
 const cachedDataVersionStatements = new WeakMap<
@@ -64,16 +71,20 @@ export function registerOpenClawStateDatabaseLifecycleListener(
 
 /** Close both physical-handle owners while retaining every cleanup failure. */
 function closeOpenClawStateDatabaseHandle(
-  database: OpenClawStateDatabase,
+  database: StateDatabaseHandle,
   options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
 ): unknown[] {
   const errors: unknown[] = [];
   try {
-    database.walMaintenance.close(options);
+    database.walMaintenance?.close(options);
   } catch (error) {
     errors.push(error);
   }
-  clearNodeSqliteKyselyCacheForDatabase(database.db);
+  try {
+    clearNodeSqliteKyselyCacheForDatabase(database.db);
+  } catch (error) {
+    errors.push(error);
+  }
   try {
     if (database.db.isOpen) {
       database.db.close();
@@ -81,7 +92,32 @@ function closeOpenClawStateDatabaseHandle(
   } catch (error) {
     errors.push(error);
   }
+  if (database.db.isOpen) {
+    retainedDatabaseHandles.set(database.db, database);
+    unregisterRetainedExitClose ??= registerSqliteCacheExitClose(closeOpenClawStateDatabase);
+  } else {
+    retainedDatabaseHandles.delete(database.db);
+    if (retainedDatabaseHandles.size === 0) {
+      unregisterRetainedExitClose?.();
+      unregisterRetainedExitClose = undefined;
+    }
+  }
   return errors;
+}
+
+function closeRetainedStateDatabaseHandles(
+  pathname?: string,
+  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
+): { closed: boolean; errors: unknown[] } {
+  let closed = false;
+  const errors: unknown[] = [];
+  for (const database of retainedDatabaseHandles.values()) {
+    if (pathname === undefined || database.path === pathname) {
+      errors.push(...closeOpenClawStateDatabaseHandle(database, options));
+      closed = true;
+    }
+  }
+  return { closed, errors };
 }
 
 function evictCachedOpenClawStateDatabase(database: OpenClawStateDatabase): boolean {
@@ -248,31 +284,40 @@ function assertOpenClawStateDatabaseFreshOpenAllowedAtPath(
 /** Close one cached shared state database handle by exact pathname. */
 export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
   const resolvedPath = path.resolve(pathname);
+  const retained = closeRetainedStateDatabaseHandles(resolvedPath);
   const database = cachedDatabases.get(resolvedPath);
-  if (!database) {
-    return false;
+  if (database) {
+    cachedDatabases.delete(resolvedPath);
+    retained.errors.push(...closeOpenClawStateDatabaseHandle(database));
+    notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: resolvedPath });
   }
-  database.walMaintenance.close();
-  if (database.db.isOpen) {
-    database.db.close();
+  if (retained.errors.length > 0) {
+    throw createSqliteLifecycleAggregateError(
+      retained.errors,
+      `OpenClaw state database cleanup failed for ${resolvedPath}.`,
+      retained.errors[0],
+    );
   }
-  cachedDatabases.delete(resolvedPath);
-  notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: resolvedPath });
-  return true;
+  return Boolean(database) || retained.closed;
 }
 
 /** Close all cached shared state database handles. */
 export function closeOpenClawStateDatabase(
   options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
 ): void {
+  const { errors } = closeRetainedStateDatabaseHandles(undefined, options);
   for (const database of cachedDatabases.values()) {
-    database.walMaintenance.close(options);
-    if (database.db.isOpen) {
-      database.db.close();
-    }
+    cachedDatabases.delete(database.path);
+    errors.push(...closeOpenClawStateDatabaseHandle(database, options));
     notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
   }
-  cachedDatabases.clear();
+  if (errors.length > 0) {
+    throw createSqliteLifecycleAggregateError(
+      errors,
+      "OpenClaw state database cleanup failed.",
+      errors[0],
+    );
+  }
 }
 
 /** Test whether a cached shared state database handle is still open, optionally at one path. */

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -291,7 +291,10 @@ export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
     retained.errors.push(...closeOpenClawStateDatabaseHandle(database));
     notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: resolvedPath });
   }
-  if (retained.errors.length > 0) {
+  if (retained.errors.length === 1) {
+    throw retained.errors[0];
+  }
+  if (retained.errors.length > 1) {
     throw createSqliteLifecycleAggregateError(
       retained.errors,
       `OpenClaw state database cleanup failed for ${resolvedPath}.`,
@@ -311,7 +314,10 @@ export function closeOpenClawStateDatabase(
     errors.push(...closeOpenClawStateDatabaseHandle(database, options));
     notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
   }
-  if (errors.length > 0) {
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
     throw createSqliteLifecycleAggregateError(
       errors,
       "OpenClaw state database cleanup failed.",

--- a/src/state/openclaw-state-db-open.test.ts
+++ b/src/state/openclaw-state-db-open.test.ts
@@ -1,0 +1,240 @@
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { kyselyByDatabase } from "../infra/kysely-sync-cache-state.js";
+import * as kyselySync from "../infra/kysely-sync.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
+import * as busyTimeout from "../infra/sqlite-busy-timeout.js";
+import * as sqliteWal from "../infra/sqlite-wal.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
+import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
+import * as permissions from "./openclaw-state-db-permissions.js";
+
+describe("unpublished state database acquisition", () => {
+  const databases = new Set<DatabaseSync>();
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      openClawStateDatabaseCache.closeOpenClawStateDatabaseForTest();
+      for (const db of databases) {
+        if (db.isOpen) {
+          db.close();
+        }
+      }
+      databases.clear();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      cleanup();
+    });
+  });
+
+  function acquisitionFixture() {
+    vi.useFakeTimers();
+    const pathname = path.join(tempDirs.make("openclaw-state-acquisition-"), "state.sqlite");
+    const params = {
+      pathname,
+      env: {},
+      busyTimeoutMs: 50,
+      lockFailureReporting: "report" as const,
+      ensureSchema: (db: DatabaseSync) => {
+        db.exec("CREATE TABLE IF NOT EXISTS payload (value TEXT);");
+        const query = kyselySync.getNodeSqliteKysely<{ payload: { value: string } }>(db);
+        kyselySync.executeSqliteQuerySync(db, query.selectFrom("payload").selectAll());
+      },
+      recordOpenFailure: vi.fn(),
+    };
+    const seed = openUnpublishedStateDatabase(params);
+    seed.db.exec("INSERT INTO payload VALUES ('committed');");
+    seed.walMaintenance.close();
+    seed.db.close();
+    const openNative = nodeSqlite.openNodeSqliteDatabase;
+    const open = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase").mockImplementation((...args) => {
+      const db = openNative(...args);
+      databases.add(db);
+      return db;
+    });
+    return { params, open, openNative };
+  }
+
+  function expectSuccessfulReopen(params: Parameters<typeof openUnpublishedStateDatabase>[0]) {
+    const reopened = openUnpublishedStateDatabase(params);
+    try {
+      expect(reopened.db.prepare("SELECT value FROM payload").all()).toEqual([
+        { value: "committed" },
+      ]);
+      expect(reopened.db.isOpen).toBe(true);
+      expect(vi.getTimerCount()).toBe(1);
+    } finally {
+      reopened.walMaintenance.close();
+      reopened.db.close();
+    }
+    expect(vi.getTimerCount()).toBe(0);
+  }
+
+  it.each([
+    "statement cache",
+    "initial busy timeout",
+    "busy timeout read",
+    "busy timeout finalization",
+    "schema",
+    "hardening",
+  ])("releases every acquisition after failed %s and preserves committed state", (phase) => {
+    const { params, open, openNative } = acquisitionFixture();
+    const failure = new Error(`${phase} failed`);
+    if (phase === "statement cache") {
+      vi.spyOn(kyselySync, "enableNodeSqliteKyselyStatementCache").mockImplementation(() => {
+        throw failure;
+      });
+    } else if (phase === "busy timeout finalization") {
+      const run = busyTimeout.runWithSqliteBusyTimeout;
+      vi.spyOn(busyTimeout, "runWithSqliteBusyTimeout").mockImplementation((...args) => {
+        run(...args);
+        throw failure;
+      });
+    } else if (phase === "hardening") {
+      const harden = permissions.ensureOpenClawStatePermissions;
+      let calls = 0;
+      vi.spyOn(permissions, "ensureOpenClawStatePermissions").mockImplementation((...args) => {
+        harden(...args);
+        if (++calls % 2 === 0) {
+          throw failure;
+        }
+      });
+    } else if (phase === "schema") {
+      const ensureSchema = params.ensureSchema;
+      params.ensureSchema = (db) => {
+        ensureSchema(db);
+        throw failure;
+      };
+    } else {
+      open.mockImplementation((...args) => {
+        const db = openNative(...args);
+        databases.add(db);
+        if (phase === "initial busy timeout") {
+          vi.spyOn(db, "exec").mockImplementationOnce(() => {
+            throw failure;
+          });
+        } else {
+          const prepare = db.prepare.bind(db);
+          vi.spyOn(db, "prepare").mockImplementation((sql) => {
+            if (sql === "PRAGMA busy_timeout") {
+              throw failure;
+            }
+            return prepare(sql);
+          });
+        }
+        return db;
+      });
+    }
+    for (let attempt = 0; attempt < 3; attempt++) {
+      expect(() => openUnpublishedStateDatabase(params)).toThrow(failure);
+      const db = expectDefined([...databases].at(-1), "failed acquisition");
+      expect(db.isOpen).toBe(false);
+      expect(kyselyByDatabase.has(db)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+    expect(params.recordOpenFailure).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+    expectSuccessfulReopen({
+      ...params,
+      ensureSchema: (db) => {
+        expect(db.prepare("SELECT value FROM payload").get()).toEqual({ value: "committed" });
+      },
+    });
+  });
+
+  it.each(
+    ["schema", "hardening"].flatMap((phase) =>
+      ["maintenance", "native", "both"].map((cleanupFailure) => ({ phase, cleanupFailure })),
+    ),
+  )(
+    "preserves the $phase error and $cleanupFailure cleanup failures with a disposal-only owner",
+    ({ phase, cleanupFailure }) => {
+      const { params } = acquisitionFixture();
+      const failure = new Error(`${phase} failed`);
+      const maintenanceFailure = new Error("maintenance close failed");
+      const nativeFailure = new Error("native close failed");
+      const configure = sqliteWal.configureSqliteConnectionPragmas;
+      const maintenanceFails = cleanupFailure !== "native";
+      const nativeFails = cleanupFailure !== "maintenance";
+      vi.spyOn(sqliteWal, "configureSqliteConnectionPragmas").mockImplementation((...args) => {
+        const maintenance = configure(...args);
+        const close = maintenance.close;
+        vi.spyOn(maintenance, "close").mockImplementation((options) => {
+          close(options);
+          if (maintenanceFails) {
+            throw maintenanceFailure;
+          }
+          return true;
+        });
+        return maintenance;
+      });
+      const harden = permissions.ensureOpenClawStatePermissions;
+      let calls = 0;
+      vi.spyOn(permissions, "ensureOpenClawStatePermissions").mockImplementation((...args) => {
+        harden(...args);
+        if (++calls === 2 && phase === "hardening") {
+          throw failure;
+        }
+      });
+      const ensureSchema = params.ensureSchema;
+      params.ensureSchema = (db) => {
+        ensureSchema(db);
+        if (nativeFails) {
+          vi.spyOn(db, "close").mockImplementation(() => {
+            throw nativeFailure;
+          });
+        }
+        if (phase === "schema") {
+          throw failure;
+        }
+      };
+      let caught: unknown;
+      try {
+        openUnpublishedStateDatabase(params);
+      } catch (error) {
+        caught = error;
+      }
+      const db = expectDefined([...databases].at(-1), "failed acquisition");
+      expect(caught).toBeInstanceOf(AggregateError);
+      expect(caught).toMatchObject({
+        cause: failure,
+        errors: [
+          failure,
+          ...(maintenanceFails ? [maintenanceFailure] : []),
+          ...(nativeFails ? [nativeFailure] : []),
+        ],
+      });
+      expect(db.isOpen).toBe(nativeFails);
+      expect(kyselyByDatabase.has(db)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(
+        openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(params.pathname),
+      ).toBeUndefined();
+      if (nativeFails) {
+        const healthy = openUnpublishedStateDatabase({
+          ...params,
+          pathname: path.join(path.dirname(params.pathname), "healthy.sqlite"),
+          ensureSchema,
+        });
+        openClawStateDatabaseCache.publishOpenClawStateDatabase(healthy);
+        expect(() => openClawStateDatabaseCache.closeOpenClawStateDatabase()).toThrow(
+          AggregateError,
+        );
+        expect(healthy.db.isOpen).toBe(false);
+        expect(openClawStateDatabaseCache.isOpenClawStateDatabaseOpen()).toBe(false);
+        expect(db.isOpen).toBe(true);
+      }
+      vi.restoreAllMocks();
+      expectSuccessfulReopen({
+        ...params,
+        ensureSchema: () => {},
+      });
+      // Failed close remains discoverable only to disposal, never ordinary acquisition.
+      openClawStateDatabaseCache.closeOpenClawStateDatabaseByPath(params.pathname);
+      expect(db.isOpen).toBe(false);
+    },
+  );
+});

--- a/src/state/openclaw-state-db-open.test.ts
+++ b/src/state/openclaw-state-db-open.test.ts
@@ -221,7 +221,7 @@ describe("unpublished state database acquisition", () => {
         });
         openClawStateDatabaseCache.publishOpenClawStateDatabase(healthy);
         expect(() => openClawStateDatabaseCache.closeOpenClawStateDatabase()).toThrow(
-          AggregateError,
+          maintenanceFails ? AggregateError : nativeFailure,
         );
         expect(healthy.db.isOpen).toBe(false);
         expect(openClawStateDatabaseCache.isOpenClawStateDatabaseOpen()).toBe(false);

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -6,6 +6,7 @@ import {
   setSqliteBusyTimeout,
   type SqliteLockFailureReporting,
 } from "../infra/sqlite-busy-timeout.js";
+import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
 import {
   assertSqliteIntegrity,
   isTerminalSqliteIntegrityError,
@@ -17,6 +18,7 @@ import {
   type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabase,
@@ -64,18 +66,18 @@ export function openUnpublishedStateDatabase(params: {
   const { busyTimeoutMs, lockFailureReporting } = params;
   ensureOpenClawStatePermissions(params.pathname, params.env);
   const db = openNodeSqliteDatabase(params.pathname);
-  enableNodeSqliteKyselyStatementCache(db);
-  setSqliteBusyTimeout(db, busyTimeoutMs);
-  const walMaintenance = runWithSqliteBusyTimeout(
-    db,
-    busyTimeoutMs,
-    () => {
-      let maintenance: SqliteWalMaintenance | undefined;
-      try {
+  let walMaintenance: SqliteWalMaintenance | undefined;
+  try {
+    enableNodeSqliteKyselyStatementCache(db);
+    setSqliteBusyTimeout(db, busyTimeoutMs);
+    const maintenance = runWithSqliteBusyTimeout(
+      db,
+      busyTimeoutMs,
+      () => {
         assertSupportedStateSchemaVersion(db, params.pathname);
         assertStateDatabaseIntegrityBeforeMutation(db, params.pathname);
         configureSqlitePreSchemaPragmas(db, { busyTimeoutMs });
-        maintenance = configureSqliteConnectionPragmas(db, {
+        walMaintenance = configureSqliteConnectionPragmas(db, {
           busyTimeoutMs,
           databaseLabel: "openclaw-state",
           databasePath: params.pathname,
@@ -83,21 +85,32 @@ export function openUnpublishedStateDatabase(params: {
           synchronous: "NORMAL",
         });
         params.ensureSchema(db);
-        return maintenance;
-      } catch (error) {
-        maintenance?.close();
-        db.close();
-        if (
-          error instanceof Error &&
-          (isSqliteSchemaVersionError(error) || isTerminalSqliteIntegrityError(error))
-        ) {
-          params.recordOpenFailure(params.pathname, error);
-        }
-        throw error;
-      }
-    },
-    { lockFailureReporting },
-  );
-  ensureOpenClawStatePermissions(params.pathname, params.env);
-  return { db, path: params.pathname, walMaintenance };
+        return walMaintenance;
+      },
+      { lockFailureReporting },
+    );
+    ensureOpenClawStatePermissions(params.pathname, params.env);
+    return { db, path: params.pathname, walMaintenance: maintenance };
+  } catch (error) {
+    // Acquisition owns the native handle until every setup and hardening step returns.
+    const errors = openClawStateDatabaseCache.closeOpenClawStateDatabaseHandle({
+      db,
+      path: params.pathname,
+      walMaintenance,
+    });
+    if (
+      error instanceof Error &&
+      (isSqliteSchemaVersionError(error) || isTerminalSqliteIntegrityError(error))
+    ) {
+      params.recordOpenFailure(params.pathname, error);
+    }
+    if (errors.length > 0) {
+      throw createSqliteLifecycleAggregateError(
+        [error, ...errors],
+        `OpenClaw state database acquisition and cleanup failed for ${params.pathname}.`,
+        error,
+      );
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
Closes #142737

## What Problem This Solves

Fixes an issue where operators running scheduled jobs could lose Gateway responsiveness and see growing memory use when a partially admitted cron batch could not reserve any durable jobs and the same candidates remained due.

A read-only analysis of a Windows full-memory dump found 595,870 unfinished scheduler ticks with only seven occupied execution slots. Strong promise references repeatedly linked child scheduler invocations to parents waiting in capacity-recheck finalization. The raw dump and operational state remain private.

The investigation also reproduced separate SQLite initialization failures that could leave native handles, statement caches, or maintenance timers undisposed. Those failures are not claimed as the cause of the captured cron retaining chain.

## Why This Change Was Made

An unused execution-slot release is no longer treated as sufficient progress to immediately repeat an empty reservation attempt. An empty batch rechecks immediately only when refreshed runnable state shows that a selected candidate is no longer due; unchanged conflicts retire the tick and keep normal timer scheduling. Real capacity releases and concurrent-owner progress retain their immediate wake behavior.

The SQLite change keeps disposal ownership through cache setup, connection pragmas, timeout-wrapper finalization, schema initialization, and final permission hardening. Cleanup attempts independent resources, preserves primary and cleanup errors, and keeps a failed native close available for explicit disposal without publishing it as a healthy cache entry.

Single cleanup failures are rethrown unchanged in both by-path and global retirement. Only multiple failures are aggregated. This preserves actionable top-level messages for QA diagnostics without inspecting or exposing potentially sensitive nested causes.

These are separate commits. No schema, configuration option, dependency, permission-policy, or timeout changes are included.

## User Impact

The Gateway no longer continuously creates and retains scheduler invocations for this no-progress condition. Pending work can recover when its conflicting receipt retires, and existing capacity-release behavior is preserved.

Failed database initialization releases acquired resources instead of silently leaving background maintenance and native handles behind. Failures remain visible rather than being converted into successful opens.

## Evidence

The full-build and isolated-Gateway smoke evidence below predates the rebase. The P2-specific cleanup coverage was rerun on the rebased branch.

- P2 diagnostics follow-up: the existing shared-store QA cleanup case and two global-retirement cases failed before the repair because the actual close reason was hidden. All 22 acquisition, wrapper-retention, and QA artifact-cleanup cases pass afterward, including secret redaction, nested-cause exclusion, and cleanup retry. Focused P0/P1/P2 autoreview found no accepted/actionable issues.
- The file-backed cron regression fails on the original scheduler: an in-band guard observes five nested ticks instead of one. The repaired scheduler retires after one tick, releases Gateway work admission, keeps its timer armed, and completes both jobs after the conflicting receipt retires.
- Cron admission, cross-tick lifecycle, and timer regression suites: 75 passing tests.
- SQLite acquisition, WAL, busy-timeout, and Kysely suites: 103 passing tests. The original acquisition implementation fails 11 owner cases; the original pragma handoff fails three cases.
- Integrated cron, shared/agent permission, closed-wrapper retention, and plugin-state SDK coverage: 93 passing tests across seven files. These overlap the focused groups above; counts are not additive.
- Core production/test typechecking, scoped lint and formatting, database-schema guards, and runtime import-cycle checks passed.
- Independent P0/P1 autoreview of the combined changes: no accepted/actionable findings.
- `pnpm build` passed. The normal CLI also rebuilt the committed candidate before the isolated runtime started.
- An isolated loopback Gateway accepted authenticated RPC, ran a scheduled model-free command, persisted a successful run-history entry, returned ten successful readiness responses, and removed the synthetic job. After startup, readiness reported no failing components and `eventLoop.degraded=false`. The task-owned Gateway was then stopped; no external provider or channel traffic was used.

Local executable coverage uses Linux and Node 24.19.0; the captured Windows process used Node 24.18.0. The dump establishes the runaway promise-retention mechanism, not a complete retained-size accounting of every process allocation.

No live deployment or 48-hour soak is claimed. The incident's separate WAL checkpoint backlog still requires attribution to its reader/connection owner; this PR does not delete WAL files or claim that backlog is independently repaired.
