### PR TITLE
fix(qa): backport Matrix live stability fixes

### DIFF
--- a/extensions/qa-matrix/src/adapter.runtime.ts
+++ b/extensions/qa-matrix/src/adapter.runtime.ts
@@ -199,6 +199,21 @@ export async function createMatrixQaTransportAdapter(
         if (!logicalConversation) {
           continue;
         }
+        const replacedMessageId = event.replacesEventId
+          ? busMessageIds.get(event.replacesEventId)
+          : undefined;
+        if (replacedMessageId) {
+          const outbound = await context.messages.editMessage({
+            accountId,
+            messageId: replacedMessageId,
+            text,
+            timestamp: event.originServerTs,
+          });
+          // Replacements update the logical message but relations still target
+          // the original Matrix event; only the reverse replacement map changes.
+          busMessageIds.set(event.eventId, outbound.id);
+          continue;
+        }
         const outbound = await context.messages.addOutboundMessage({
           accountId,
           to: buildQaTarget({

--- a/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
@@ -424,6 +424,12 @@ export const MATRIX_QA_SCENARIOS: MatrixQaScenarioDefinition[] = [
     title: "Matrix generated images deliver as real image attachments while streaming",
     topology: MATRIX_QA_MEDIA_ROOM_TOPOLOGY,
     configOverrides: {
+      agentDefaults: {
+        imageGenerationModel: {
+          primary: "openai/gpt-image-1",
+        },
+      },
+      requiredPluginIds: ["openai"],
       streaming: "quiet",
     },
   },

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts
@@ -393,39 +393,42 @@ export async function runGeneratedImageDeliveryScenario(context: MatrixQaScenari
   const roomId = resolveMatrixQaScenarioRoomId(context, MATRIX_QA_MEDIA_ROOM_KEY);
   const { client, startSince } = await primeMatrixQaDriverMediaClient(context);
   const triggerBody = buildMatrixQaImageGenerationPrompt(context.sutUserId);
-  const driverEventIds: string[] = [];
+  const triggerSentAt = Date.now();
+  const driverEventId = await client.sendTextMessage({
+    body: triggerBody,
+    mentionUserIds: [context.sutUserId],
+    roomId,
+  });
   const isGeneratedImageEvent = (event: MatrixQaObservedEvent) =>
     event.roomId === roomId &&
     event.sender === context.sutUserId &&
     event.type === "m.room.message" &&
     event.relatesTo === undefined &&
     event.msgtype === "m.image" &&
-    event.attachment?.kind === "image";
-  let matched = await client.waitForOptionalRoomEvent({
+    event.attachment?.kind === "image" &&
+    typeof event.originServerTs === "number" &&
+    event.originServerTs >= triggerSentAt;
+  const matched = await client.waitForOptionalRoomEvent({
     observedEvents: context.observedEvents,
     predicate: isGeneratedImageEvent,
     roomId,
     since: startSince,
-    timeoutMs: 0,
+    timeoutMs: context.timeoutMs,
   });
-  for (let attempt = 1; !matched.matched && attempt <= 2; attempt += 1) {
-    const driverEventId = await client.sendTextMessage({
-      body: triggerBody,
-      mentionUserIds: [context.sutUserId],
-      roomId,
-    });
-    driverEventIds.push(driverEventId);
-    matched = await client.waitForOptionalRoomEvent({
-      observedEvents: context.observedEvents,
-      predicate: isGeneratedImageEvent,
-      roomId,
-      since: matched.since ?? startSince,
-      timeoutMs: context.timeoutMs,
-    });
-  }
   if (!matched.matched) {
+    const recentRoomEvents = context.observedEvents
+      .filter((event) => event.roomId === roomId)
+      .slice(-8)
+      .map((event) => ({
+        body: event.body?.slice(0, 200),
+        eventId: event.eventId,
+        kind: event.kind,
+        msgtype: event.msgtype,
+        sender: event.sender,
+        type: event.type,
+      }));
     throw new Error(
-      `timed out after ${context.timeoutMs}ms waiting for Matrix generated image after ${driverEventIds.length} attempt(s)`,
+      `timed out after ${context.timeoutMs}ms waiting for Matrix generated image; recent room events: ${JSON.stringify(recentRoomEvents)}`,
     );
   }
   const matchedEvent = matched.event;
@@ -446,14 +449,13 @@ export async function runGeneratedImageDeliveryScenario(context: MatrixQaScenari
       attachmentFilename: attachment.filename,
       attachmentKind: attachment.kind,
       attachmentMsgtype: matchedEvent.msgtype,
-      driverEventId: driverEventIds[0],
-      driverEventIds,
+      driverEventId,
       roomId,
       triggerBody,
     },
     details: [
       `room id: ${roomId}`,
-      `driver events: ${driverEventIds.join(", ")}`,
+      `driver event: ${driverEventId}`,
       ...buildMatrixQaAttachmentDetailLines({
         attachmentEvent: matchedEvent,
         label: "generated image",

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -330,8 +330,7 @@ async function runMatrixStreamingPreviewScenario(
       event.roomId === context.roomId &&
       event.sender === context.sutUserId &&
       isMatrixQaMessageLikeKind(event.kind) &&
-      event.relatesTo?.relType === "m.replace" &&
-      event.relatesTo.eventId === preview.event.eventId &&
+      event.replacesEventId === preview.event.eventId &&
       event.body === params.finalText,
     roomId: context.roomId,
     since: preview.since,
@@ -385,7 +384,7 @@ function findMatrixQaUnexpectedWorkingEvents(params: {
     if (event.eventId === params.previewEventId || event.eventId === params.finalEventId) {
       return false;
     }
-    return event.relatesTo?.eventId !== params.previewEventId;
+    return event.replacesEventId !== params.previewEventId;
   });
 }
 
@@ -517,7 +516,7 @@ function buildMatrixQaToolProgressFinalTimeoutMessage(params: {
       ) {
         return false;
       }
-      return event.relatesTo?.eventId === params.previewEventId;
+      return event.replacesEventId === params.previewEventId;
     })
     .slice(-8);
   const candidateDetails =
@@ -565,9 +564,7 @@ async function runMatrixToolProgressScenario(
     params.progressPattern.test(body ?? "") ||
     (params.allowGenericProgressLine === true && hasMatrixQaToolProgressPreviewLine(body));
   const getPreviewRootEventId = (event: MatrixQaObservedEvent) =>
-    event.relatesTo?.relType === "m.replace" && event.relatesTo.eventId
-      ? event.relatesTo.eventId
-      : event.eventId;
+    event.replacesEventId ?? event.eventId;
   const isFinalReply = (event: MatrixQaObservedEvent) =>
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
@@ -594,15 +591,13 @@ async function runMatrixToolProgressScenario(
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     event.kind === params.expectedPreviewKind &&
-    event.relatesTo?.relType === "m.replace" &&
-    event.relatesTo.eventId === previewRootEventId &&
+    event.replacesEventId === previewRootEventId &&
     matchesExpectedProgress(event.body);
   const isFinalReplacement = (event: MatrixQaObservedEvent, previewRootEventId: string) =>
     event.roomId === context.roomId &&
     event.sender === context.sutUserId &&
     isMatrixQaMessageLikeKind(event.kind) &&
-    event.relatesTo?.relType === "m.replace" &&
-    event.relatesTo.eventId === previewRootEventId &&
+    event.replacesEventId === previewRootEventId &&
     doesMatrixQaReplyBodyMatchToken(event, params.finalText);
   const throwProgressTimeout = (err: unknown, previewEventId: string): never => {
     throw new Error(
@@ -794,8 +789,7 @@ async function runMatrixToolProgressScenario(
           event.sender === context.sutUserId &&
           isMatrixQaMessageLikeKind(event.kind) &&
           doesMatrixQaReplyBodyMatchToken(event, params.finalText) &&
-          ((event.relatesTo?.relType === "m.replace" &&
-            event.relatesTo.eventId === previewRootEventId) ||
+          (event.replacesEventId === previewRootEventId ||
             (params.allowTopLevelFinalWithProgress === true && event.relatesTo === undefined)),
         roomId: context.roomId,
         since: progress.since,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -193,6 +193,7 @@ export function buildMatrixReplyArtifact(
     eventId: event.eventId,
     mentions: event.mentions,
     relatesTo: event.relatesTo,
+    replacesEventId: event.replacesEventId,
     sender: event.sender,
     ...(token ? { tokenMatched: doesMatrixQaReplyBodyMatchToken(event, token) } : {}),
   };
@@ -205,6 +206,7 @@ export function buildMatrixReplyDetails(label: string, artifact: MatrixQaReplyAr
       artifact.tokenMatched === undefined ? "n/a" : artifact.tokenMatched ? "yes" : "no"
     }`,
     `${label} rel_type: ${artifact.relatesTo?.relType ?? "<none>"}`,
+    `${label} replaces: ${artifact.replacesEventId ?? "<none>"}`,
     `${label} in_reply_to: ${artifact.relatesTo?.inReplyToId ?? "<none>"}`,
     `${label} is_falling_back: ${artifact.relatesTo?.isFallingBack === true ? "true" : "false"}`,
   ];

--- a/extensions/qa-matrix/src/runners/contract/scenario-types.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-types.ts
@@ -6,6 +6,7 @@ export type MatrixQaReplyArtifact = {
   eventId: string;
   mentions?: MatrixQaObservedEvent["mentions"];
   relatesTo?: MatrixQaObservedEvent["relatesTo"];
+  replacesEventId?: string;
   sender?: string;
   tokenMatched?: boolean;
 };

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -55,7 +55,10 @@ import {
   LIVE_TRANSPORT_BASELINE_STANDARD_SCENARIO_IDS,
   findMissingLiveTransportStandardScenarios,
 } from "../../shared/live-transport-scenarios.js";
-import type { MatrixQaObservedEvent } from "../../substrate/events.js";
+import {
+  normalizeMatrixQaObservedEvent,
+  type MatrixQaObservedEvent,
+} from "../../substrate/events.js";
 import {
   MATRIX_QA_MEDIA_TYPE_COVERAGE_CASES,
   MATRIX_QA_VOICE_PREFLIGHT_FILENAME,
@@ -840,6 +843,23 @@ describe("matrix live qa scenarios", () => {
         .findMatrixQaScenarios(["matrix-room-generated-image-delivery"], "fast")
         .map((scenario) => scenario.id),
     ).toEqual(["matrix-room-generated-image-delivery"]);
+  });
+
+  it("scopes image-provider setup to generated-image delivery", () => {
+    const scenarios = new Map(MATRIX_QA_SCENARIOS.map((scenario) => [scenario.id, scenario]));
+
+    expect(scenarios.get("matrix-room-quiet-streaming-preview")?.configOverrides).toEqual({
+      streaming: "quiet",
+    });
+    expect(scenarios.get("matrix-room-generated-image-delivery")?.configOverrides).toEqual({
+      agentDefaults: {
+        imageGenerationModel: {
+          primary: "openai/gpt-image-1",
+        },
+      },
+      requiredPluginIds: ["openai"],
+      streaming: "quiet",
+    });
   });
 
   it("fails when the Matrix profile is unknown", () => {
@@ -2291,21 +2311,32 @@ describe("matrix live qa scenarios", () => {
         },
         since: "driver-sync-preview",
       }))
-      .mockImplementationOnce(async () => ({
-        event: {
-          kind: "message",
-          roomId: "!main:matrix-qa.test",
-          eventId: "$quiet-final",
+      .mockImplementationOnce(async () => {
+        const normalizedFinalEvent = normalizeMatrixQaObservedEvent("!main:matrix-qa.test", {
+          event_id: "$quiet-final",
           sender: "@sut:matrix-qa.test",
           type: "m.room.message",
-          body: readFinalText(),
-          relatesTo: {
-            relType: "m.replace",
-            eventId: "$quiet-preview",
+          content: {
+            body: "* finalized",
+            msgtype: "m.text",
+            "m.new_content": {
+              body: readFinalText(),
+              msgtype: "m.text",
+            },
+            "m.relates_to": {
+              rel_type: "m.replace",
+              event_id: "$quiet-preview",
+            },
           },
-        },
-        since: "driver-sync-next",
-      }));
+        });
+        if (!normalizedFinalEvent) {
+          throw new Error("expected normalized Matrix replacement event");
+        }
+        return {
+          event: normalizedFinalEvent,
+          since: "driver-sync-next",
+        };
+      });
 
     createMatrixQaClient.mockReturnValue({
       primeRoom,
@@ -2378,10 +2409,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessageItem, "sendTextMessage"),
                 fallbackFinalText,
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-next",
         },
@@ -2515,10 +2543,7 @@ describe("matrix live qa scenarios", () => {
                 kind: "notice",
                 eventId: "$tool-progress-final",
                 body: token,
-                relatesTo: {
-                  relType: "m.replace",
-                  eventId: previewEventId,
-                },
+                replacesEventId: previewEventId,
               });
             },
             since: "driver-sync-next",
@@ -2578,10 +2603,7 @@ describe("matrix live qa scenarios", () => {
             kind: "notice",
             eventId: "$tool-progress-generic-update",
             body: "- `tool: exec_command`",
-            relatesTo: {
-              relType: "m.replace",
-              eventId: previewEventId,
-            },
+            replacesEventId: previewEventId,
           }),
           since: "driver-sync-progress",
         },
@@ -2594,10 +2616,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessage, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_FIXED",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-next",
         },
@@ -2637,10 +2656,7 @@ describe("matrix live qa scenarios", () => {
             kind: "notice",
             eventId: "$tool-progress-command-update",
             body: "Working\n`🔧 Exec: matrix-command-progress-start`\n`🔧 Exec: completed`",
-            relatesTo: {
-              relType: "m.replace",
-              eventId: previewEventId,
-            },
+            replacesEventId: previewEventId,
           }),
           since: "driver-sync-progress",
         },
@@ -2672,10 +2688,7 @@ describe("matrix live qa scenarios", () => {
             kind: "notice",
             eventId: "$tool-progress-command-clean-update",
             body: "Working\n`🔧 Exec: completed`",
-            relatesTo: {
-              relType: "m.replace",
-              eventId: previewEventId,
-            },
+            replacesEventId: previewEventId,
           }),
           since: "driver-sync-progress",
         },
@@ -2688,10 +2701,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessage, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_COMMAND",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-final",
         },
@@ -2734,10 +2744,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessage, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_COMMAND",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-final",
         },
@@ -2768,10 +2775,7 @@ describe("matrix live qa scenarios", () => {
       kind: "notice",
       eventId: "$tool-progress-timeout-update",
       body: "Working...\nstill deciding",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEvent.eventId,
-      },
+      replacesEventId: previewEvent.eventId,
     });
     const context = matrixQaScenarioContext();
     const primeRoom = vi.fn().mockResolvedValue("driver-sync-start");
@@ -2984,6 +2988,7 @@ describe("matrix live qa scenarios", () => {
       previewEventId?: unknown;
       reply?: {
         eventId?: unknown;
+        replacesEventId?: unknown;
         relatesTo?: {
           eventId?: unknown;
           relType?: unknown;
@@ -3027,10 +3032,7 @@ describe("matrix live qa scenarios", () => {
       kind: "notice",
       eventId: "$tool-progress-error-final-first-progress",
       body: "Working...\n`📖 Read: from /tmp/qa/workspace/missing-matrix-tool-progress-target.txt`",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEventId,
-      },
+      replacesEventId: previewEventId,
     });
     const context = matrixQaScenarioContext();
     const primeRoom = vi.fn().mockResolvedValue("driver-sync-start");
@@ -3067,6 +3069,7 @@ describe("matrix live qa scenarios", () => {
       previewEventId?: unknown;
       reply?: {
         eventId?: unknown;
+        replacesEventId?: unknown;
         relatesTo?: {
           eventId?: unknown;
           relType?: unknown;
@@ -3089,10 +3092,7 @@ describe("matrix live qa scenarios", () => {
       kind: "notice",
       eventId: "$tool-progress-error-placeholder-progress",
       body: "Working...\n`📖 Read: from /tmp/qa/workspace/missing-matrix-tool-progress-target.txt`",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEventId,
-      },
+      replacesEventId: previewEventId,
     });
     const { waitForRoomEvent } = mockMatrixQaRoomClient({
       driverEventId: "$tool-progress-error-placeholder-trigger",
@@ -3203,19 +3203,13 @@ describe("matrix live qa scenarios", () => {
       kind: "notice",
       eventId: "$tool-progress-final-timeout-update",
       body: "Working...\n- `tool: read`",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEvent.eventId,
-      },
+      replacesEventId: previewEvent.eventId,
     });
     const finalCandidate = matrixQaMessageEvent({
       kind: "message",
       eventId: "$tool-progress-final-timeout-candidate",
       body: "I read the file, but missed the exact marker.",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEvent.eventId,
-      },
+      replacesEventId: previewEvent.eventId,
     });
     const context = matrixQaScenarioContext();
     const primeRoom = vi.fn().mockResolvedValue("driver-sync-start");
@@ -3285,10 +3279,7 @@ describe("matrix live qa scenarios", () => {
       kind: "notice",
       eventId: "$tool-progress-error-progress",
       body: "Pearling...\n`📖 Read: from /tmp/qa/workspace/missing-matrix-tool-progress-target.txt`",
-      relatesTo: {
-        relType: "m.replace",
-        eventId: previewEventId,
-      },
+      replacesEventId: previewEventId,
     });
     const { sendTextMessage, waitForRoomEvent } = mockMatrixQaRoomClient({
       driverEventId: "$tool-progress-error-trigger",
@@ -3306,10 +3297,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessageResult, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_ERROR_FIXED",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-next",
         },
@@ -3325,6 +3313,7 @@ describe("matrix live qa scenarios", () => {
       previewEventId?: unknown;
       reply?: {
         eventId?: unknown;
+        replacesEventId?: unknown;
         relatesTo?: {
           eventId?: unknown;
           relType?: unknown;
@@ -3337,8 +3326,8 @@ describe("matrix live qa scenarios", () => {
     );
     expect(artifacts.previewEventId).toBe("$tool-progress-error-preview");
     expect(artifacts.reply?.eventId).toBe("$tool-progress-error-final");
-    expect(artifacts.reply?.relatesTo?.eventId).toBe("$tool-progress-error-preview");
-    expect(artifacts.reply?.relatesTo?.relType).toBe("m.replace");
+    expect(artifacts.reply?.replacesEventId).toBe("$tool-progress-error-preview");
+    expect(artifacts.reply?.relatesTo).toBeUndefined();
 
     const progressWait = mockObjectArg(waitForRoomEvent, "waitForRoomEvent");
     expect(
@@ -3374,10 +3363,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessage, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_ERROR_SHORT_FIXED",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-next",
         },
@@ -3392,6 +3378,7 @@ describe("matrix live qa scenarios", () => {
       previewEventId?: unknown;
       reply?: {
         eventId?: unknown;
+        replacesEventId?: unknown;
         relatesTo?: {
           eventId?: unknown;
           relType?: unknown;
@@ -3403,8 +3390,8 @@ describe("matrix live qa scenarios", () => {
     );
     expect(artifacts.previewEventId).toBe(previewEventId);
     expect(artifacts.reply?.eventId).toBe("$tool-progress-error-short-final");
-    expect(artifacts.reply?.relatesTo?.eventId).toBe(previewEventId);
-    expect(artifacts.reply?.relatesTo?.relType).toBe("m.replace");
+    expect(artifacts.reply?.replacesEventId).toBe(previewEventId);
+    expect(artifacts.reply?.relatesTo).toBeUndefined();
 
     expect(waitForRoomEvent).toHaveBeenCalledTimes(2);
   });
@@ -3430,10 +3417,7 @@ describe("matrix live qa scenarios", () => {
             formattedBody:
               "Working...<br><ul><li><code>read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt failed</code></li></ul>",
             mentions: {},
-            relatesTo: {
-              relType: "m.replace",
-              eventId: previewEventId,
-            },
+            replacesEventId: previewEventId,
           }),
           since: "driver-sync-progress",
         },
@@ -3446,10 +3430,7 @@ describe("matrix live qa scenarios", () => {
                 mockMessageBody(sendTextMessageValue, "sendTextMessage"),
                 "MATRIX_QA_TOOL_PROGRESS_MENTION_SAFE_FIXED",
               ),
-              relatesTo: {
-                relType: "m.replace",
-                eventId: previewEventId,
-              },
+              replacesEventId: previewEventId,
             }),
           since: "driver-sync-next",
         },
@@ -3817,29 +3798,24 @@ describe("matrix live qa scenarios", () => {
   it("waits for a real Matrix image attachment after image generation", async () => {
     const primeRoom = vi.fn().mockResolvedValue("driver-sync-start");
     const sendTextMessage = vi.fn().mockResolvedValue("$image-generate-trigger");
-    const waitForOptionalRoomEvent = vi
-      .fn()
-      .mockResolvedValueOnce({
-        matched: false,
-        since: "driver-sync-start",
-      })
-      .mockResolvedValueOnce({
-        event: {
-          kind: "message",
-          roomId: "!media:matrix-qa.test",
-          eventId: "$sut-image",
-          sender: "@sut:matrix-qa.test",
-          type: "m.room.message",
-          body: "Protocol note: generated the QA lighthouse image successfully.",
-          msgtype: "m.image",
-          attachment: {
-            kind: "image",
-            filename: "qa-lighthouse.png",
-          },
+    const waitForOptionalRoomEvent = vi.fn().mockResolvedValueOnce({
+      event: {
+        kind: "message",
+        roomId: "!media:matrix-qa.test",
+        eventId: "$sut-image",
+        sender: "@sut:matrix-qa.test",
+        type: "m.room.message",
+        body: "Protocol note: generated the QA lighthouse image successfully.",
+        originServerTs: Date.now() + 1_000,
+        msgtype: "m.image",
+        attachment: {
+          kind: "image",
+          filename: "qa-lighthouse.png",
         },
-        matched: true,
-        since: "driver-sync-next",
-      });
+      },
+      matched: true,
+      since: "driver-sync-next",
+    });
 
     createMatrixQaClient.mockReturnValue({
       primeRoom,
@@ -3895,6 +3871,7 @@ describe("matrix live qa scenarios", () => {
     expect(artifacts.attachmentKind).toBe("image");
     expect(artifacts.attachmentMsgtype).toBe("m.image");
     expect(artifacts.driverEventId).toBe("$image-generate-trigger");
+    expect(waitForOptionalRoomEvent).toHaveBeenCalledTimes(1);
 
     expectSentTextMessage(sendTextMessage, {
       bodyIncludes: "/tool image_generate action=generate",

--- a/extensions/qa-matrix/src/substrate/config.test.ts
+++ b/extensions/qa-matrix/src/substrate/config.test.ts
@@ -100,6 +100,9 @@ describe("matrix qa config", () => {
             maxChars: 48,
             minChars: 1,
           },
+          imageGenerationModel: {
+            primary: "openai/gpt-image-1",
+          },
         },
         blockStreaming: true,
         dm: {
@@ -121,6 +124,7 @@ describe("matrix qa config", () => {
           },
         },
         replyToMode: "all",
+        requiredPluginIds: ["openai"],
         streaming: "quiet",
         threadBindings: {
           enabled: true,
@@ -151,6 +155,11 @@ describe("matrix qa config", () => {
       maxChars: 48,
       minChars: 1,
     });
+    expect(next.agents?.defaults?.imageGenerationModel).toEqual({
+      primary: "openai/gpt-image-1",
+    });
+    expect(next.plugins?.allow).toEqual(["matrix", "openai"]);
+    expect(next.plugins?.entries?.openai).toEqual({ enabled: true });
     expect(next.tools?.profile).toBe("coding");
     expect(next.tools?.media?.audio).toEqual({
       echoTranscript: false,

--- a/extensions/qa-matrix/src/substrate/config.ts
+++ b/extensions/qa-matrix/src/substrate/config.ts
@@ -33,6 +33,9 @@ type MatrixQaAgentDefaultsOverrides = {
     maxChars?: number;
     minChars?: number;
   };
+  imageGenerationModel?: {
+    primary: string;
+  };
 };
 
 type MatrixQaToolConfigOverrides = {
@@ -100,6 +103,7 @@ export type MatrixQaConfigOverrides = {
   configuredBotRoles?: MatrixQaActorRole[];
   groupsByKey?: Record<string, MatrixQaGroupConfigOverrides>;
   replyToMode?: MatrixQaReplyToMode;
+  requiredPluginIds?: string[];
   startupVerification?: "if-unverified" | "off";
   streaming?: MatrixQaStreamingMode | MatrixQaStreamingConfig | boolean;
   textChunkLimit?: number;
@@ -581,7 +585,11 @@ export function buildMatrixQaConfig(
     topology: MatrixQaProvisionedTopology;
   },
 ): OpenClawConfig {
-  const pluginAllow = uniqueStrings([...(baseCfg.plugins?.allow ?? []), "matrix"]);
+  const pluginAllow = uniqueStrings([
+    ...(baseCfg.plugins?.allow ?? []),
+    "matrix",
+    ...(params.overrides?.requiredPluginIds ?? []),
+  ]);
   const snapshot = buildMatrixQaConfigSnapshot({
     driverUserId: params.driverUserId,
     observerUserId: params.observerUserId,
@@ -673,6 +681,12 @@ export function buildMatrixQaConfig(
       entries: {
         ...baseCfg.plugins?.entries,
         matrix: { enabled: true },
+        ...Object.fromEntries(
+          (params.overrides?.requiredPluginIds ?? []).map((pluginId) => [
+            pluginId,
+            { enabled: true },
+          ]),
+        ),
       },
     },
     messages: {

--- a/extensions/qa-matrix/src/substrate/e2ee-client.test.ts
+++ b/extensions/qa-matrix/src/substrate/e2ee-client.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { testing } from "./e2ee-client.js";
+import { findMatrixQaObservedEventMatch } from "./events.js";
 
 describe("matrix qa e2ee client storage", () => {
   it("filters receipt noise without suppressing room state or timeline events", () => {
@@ -72,5 +73,123 @@ describe("matrix qa e2ee client storage", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  it("inherits replacement relations when the encrypted target arrives first", () => {
+    const localEvents: Parameters<
+      typeof testing.recordMatrixQaE2eeObservedEvent
+    >[0]["localEvents"] = [];
+    const observedEvents: typeof localEvents = [];
+    const observedEventsById = new Map<string, (typeof localEvents)[number]>();
+    const pendingReplacementIds = new Set<string>();
+    const record = (
+      event: Parameters<typeof testing.recordMatrixQaE2eeObservedEvent>[0]["event"],
+    ) =>
+      testing.recordMatrixQaE2eeObservedEvent({
+        event,
+        localEvents,
+        observedEvents,
+        observedEventsById,
+        pendingReplacementIds,
+        roomId: "!room:matrix-qa.test",
+      });
+
+    record({
+      event_id: "$preview",
+      origin_server_ts: 1,
+      sender: "@bot:matrix-qa.test",
+      type: "m.room.message",
+      content: {
+        body: "preview",
+        msgtype: "m.text",
+        "m.relates_to": { rel_type: "m.thread", event_id: "$thread-root" },
+      },
+    });
+    const replacement = record({
+      event_id: "$final",
+      origin_server_ts: 2,
+      sender: "@bot:matrix-qa.test",
+      type: "m.room.message",
+      content: {
+        body: "* final",
+        msgtype: "m.text",
+        "m.new_content": { body: "final", msgtype: "m.text" },
+        "m.relates_to": { rel_type: "m.replace", event_id: "$preview" },
+      },
+    });
+
+    expect(replacement?.relatesTo).toEqual({ relType: "m.thread", eventId: "$thread-root" });
+  });
+
+  it("enriches an encrypted replacement when its target arrives late", () => {
+    const localEvents: Parameters<
+      typeof testing.recordMatrixQaE2eeObservedEvent
+    >[0]["localEvents"] = [];
+    const observedEvents: typeof localEvents = [];
+    const observedEventsById = new Map<string, (typeof localEvents)[number]>();
+    const pendingReplacementIds = new Set<string>();
+    const record = (
+      event: Parameters<typeof testing.recordMatrixQaE2eeObservedEvent>[0]["event"],
+    ) =>
+      testing.recordMatrixQaE2eeObservedEvent({
+        event,
+        localEvents,
+        observedEvents,
+        observedEventsById,
+        pendingReplacementIds,
+        roomId: "!room:matrix-qa.test",
+      });
+
+    const replacement = record({
+      event_id: "$final",
+      origin_server_ts: 1,
+      sender: "@bot:matrix-qa.test",
+      type: "m.room.message",
+      content: {
+        body: "* final",
+        msgtype: "m.text",
+        "m.new_content": { body: "final", msgtype: "m.text" },
+        "m.relates_to": { rel_type: "m.replace", event_id: "$preview" },
+      },
+    });
+    expect(replacement?.relatesTo).toBeUndefined();
+    expect(localEvents).toEqual([]);
+    const waiterCursor = localEvents.length;
+    expect(
+      findMatrixQaObservedEventMatch({
+        cursorIndex: waiterCursor,
+        events: localEvents,
+        predicate: (event) => event.body === "final" && event.relatesTo === undefined,
+        roomId: "!room:matrix-qa.test",
+      }),
+    ).toBeUndefined();
+
+    record({
+      event_id: "$preview",
+      origin_server_ts: 2,
+      sender: "@bot:matrix-qa.test",
+      type: "m.room.message",
+      content: {
+        body: "preview",
+        msgtype: "m.text",
+        "m.relates_to": { rel_type: "m.thread", event_id: "$thread-root" },
+      },
+    });
+
+    expect(localEvents).toHaveLength(2);
+    expect(localEvents[1]).toMatchObject({
+      eventId: "$final",
+      relatesTo: { relType: "m.thread", eventId: "$thread-root" },
+    });
+    expect(observedEvents).toEqual(localEvents);
+    expect(pendingReplacementIds.size).toBe(0);
+    expect(
+      findMatrixQaObservedEventMatch({
+        cursorIndex: waiterCursor,
+        events: localEvents,
+        predicate: (event) => event.body === "final" && event.relatesTo?.eventId === "$thread-root",
+        roomId: "!room:matrix-qa.test",
+      })?.event.eventId,
+    ).toBe("$final");
   });
 });

--- a/extensions/qa-matrix/src/substrate/e2ee-client.ts
+++ b/extensions/qa-matrix/src/substrate/e2ee-client.ts
@@ -24,7 +24,11 @@ import type {
   PluginStateSyncKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { buildMatrixQaMessageContent } from "./client.js";
-import { findMatrixQaObservedEventMatch, normalizeMatrixQaObservedEvent } from "./events.js";
+import {
+  findMatrixQaObservedEventMatch,
+  inheritMatrixQaReplacementRelation,
+  normalizeMatrixQaObservedEvent,
+} from "./events.js";
 import type { MatrixQaObservedEvent } from "./events.js";
 import type { MatrixQaRoomEventWaitResult } from "./sync.js";
 
@@ -206,6 +210,81 @@ function shouldRecordMatrixQaObservedEventUpdate(params: {
   );
 }
 
+function recordMatrixQaE2eeObservedEvent(params: {
+  event: MatrixRawEvent;
+  localEvents: MatrixQaObservedEvent[];
+  observedEvents: MatrixQaObservedEvent[];
+  observedEventsById: Map<string, MatrixQaObservedEvent>;
+  pendingReplacementIds: Set<string>;
+  roomId: string;
+}): MatrixQaObservedEvent | null {
+  const normalized = normalizeMatrixQaObservedEvent(params.roomId, params.event);
+  if (!normalized) {
+    return null;
+  }
+  const observed = inheritMatrixQaReplacementRelation({
+    event: normalized,
+    replacedEvent: normalized.replacesEventId
+      ? params.observedEventsById.get(normalized.replacesEventId)
+      : undefined,
+  });
+  if (
+    !shouldRecordMatrixQaObservedEventUpdate({
+      next: observed,
+      previous: params.observedEventsById.get(observed.eventId),
+    })
+  ) {
+    return null;
+  }
+  params.observedEventsById.set(observed.eventId, observed);
+  const append = (event: MatrixQaObservedEvent) => {
+    params.observedEventsById.set(event.eventId, event);
+    params.localEvents.push(event);
+    params.observedEvents.push(event);
+  };
+
+  if (observed.replacesEventId && !params.observedEventsById.has(observed.replacesEventId)) {
+    // Until the encrypted target arrives, this edit's logical relation is
+    // unknown. Do not expose it to top-level waiters as relation-free.
+    params.pendingReplacementIds.add(observed.eventId);
+    return observed;
+  }
+  append(observed);
+
+  for (const replacementId of params.pendingReplacementIds) {
+    const candidate = params.observedEventsById.get(replacementId);
+    if (!candidate || candidate.replacesEventId !== observed.eventId) {
+      continue;
+    }
+    const enriched = inheritMatrixQaReplacementRelation({
+      event: candidate,
+      replacedEvent: observed,
+    });
+    append(enriched);
+    params.pendingReplacementIds.delete(replacementId);
+  }
+
+  if (observed.relatesTo) {
+    for (const candidate of params.observedEventsById.values()) {
+      if (
+        candidate.replacesEventId !== observed.eventId ||
+        candidate.relatesTo ||
+        params.pendingReplacementIds.has(candidate.eventId)
+      ) {
+        continue;
+      }
+      const enriched = inheritMatrixQaReplacementRelation({
+        event: candidate,
+        replacedEvent: observed,
+      });
+      if (enriched !== candidate) {
+        append(enriched);
+      }
+    }
+  }
+  return observed;
+}
+
 export type MatrixQaE2eeScenarioClient = {
   acceptVerification(id: string): Promise<MatrixVerificationSummary>;
   bootstrapOwnDeviceVerification(params?: {
@@ -376,22 +455,18 @@ export async function createMatrixQaE2eeScenarioClient(
   const localEvents: MatrixQaObservedEvent[] = [];
   const verificationSummaries: MatrixVerificationSummary[] = [];
   const observedEventsById = new Map<string, MatrixQaObservedEvent>();
+  const pendingReplacementIds = new Set<string>();
   let cursorIndex = 0;
 
   const recordEvent = (roomId: string, event: MatrixRawEvent) => {
-    const normalized = normalizeMatrixQaObservedEvent(roomId, event);
-    if (
-      !normalized ||
-      !shouldRecordMatrixQaObservedEventUpdate({
-        next: normalized,
-        previous: observedEventsById.get(normalized.eventId),
-      })
-    ) {
-      return;
-    }
-    observedEventsById.set(normalized.eventId, normalized);
-    localEvents.push(normalized);
-    params.observedEvents.push(normalized);
+    recordMatrixQaE2eeObservedEvent({
+      event,
+      localEvents,
+      observedEvents: params.observedEvents,
+      observedEventsById,
+      pendingReplacementIds,
+      roomId,
+    });
   };
   client.on("room.message", recordEvent);
   const recordVerificationSummary = (summary: MatrixVerificationSummary) => {
@@ -583,6 +658,7 @@ export const testing = {
   MATRIX_QA_E2EE_SYNC_FILTER,
   buildMatrixQaE2eeStoragePaths,
   findMatrixQaObservedEventMatch,
+  recordMatrixQaE2eeObservedEvent,
   shouldRecordMatrixQaObservedEventUpdate,
 };
 export { testing as __testing };

--- a/extensions/qa-matrix/src/substrate/events.test.ts
+++ b/extensions/qa-matrix/src/substrate/events.test.ts
@@ -85,6 +85,12 @@ describe("matrix observed event normalization", () => {
           "m.new_content": {
             body: "finalized",
             msgtype: "m.text",
+            // Matrix ignores relations inside replacement content. The
+            // observer inherits the original event's relation separately.
+            "m.relates_to": {
+              rel_type: "m.thread",
+              event_id: "$wrong-root",
+            },
           },
           "m.relates_to": {
             rel_type: "m.replace",
@@ -104,12 +110,7 @@ describe("matrix observed event normalization", () => {
       formattedBody: undefined,
       msgtype: "m.text",
       membership: undefined,
-      relatesTo: {
-        eventId: "$draft",
-        inReplyToId: undefined,
-        isFallingBack: undefined,
-        relType: "m.replace",
-      },
+      replacesEventId: "$draft",
     });
   });
 
@@ -336,6 +337,7 @@ describe("matrix observed event normalization", () => {
         event_id: "$redaction",
         sender: "@driver:matrix-qa.test",
         type: "m.room.redaction",
+        redacts: "$top-level-target",
         content: {},
       }),
     ).toEqual({
@@ -350,6 +352,33 @@ describe("matrix observed event normalization", () => {
       formattedBody: undefined,
       msgtype: undefined,
       membership: undefined,
+      redactsEventId: "$top-level-target",
+    });
+  });
+
+  it("normalizes legacy content-level Matrix redaction targets", () => {
+    expect(
+      normalizeMatrixQaObservedEvent("!room:matrix-qa.test", {
+        event_id: "$legacy-redaction",
+        sender: "@driver:matrix-qa.test",
+        type: "m.room.redaction",
+        content: {
+          redacts: "$content-target",
+        },
+      }),
+    ).toEqual({
+      kind: "redaction",
+      roomId: "!room:matrix-qa.test",
+      eventId: "$legacy-redaction",
+      sender: "@driver:matrix-qa.test",
+      stateKey: undefined,
+      type: "m.room.redaction",
+      originServerTs: undefined,
+      body: undefined,
+      formattedBody: undefined,
+      msgtype: undefined,
+      membership: undefined,
+      redactsEventId: "$content-target",
     });
   });
 });

--- a/extensions/qa-matrix/src/substrate/events.ts
+++ b/extensions/qa-matrix/src/substrate/events.ts
@@ -3,6 +3,7 @@ export type MatrixQaRoomEvent = {
   content?: Record<string, unknown>;
   event_id?: string;
   origin_server_ts?: number;
+  redacts?: string;
   sender?: string;
   state_key?: string;
   type?: string;
@@ -63,6 +64,8 @@ export type MatrixQaObservedEvent = {
     eventId?: string;
     key?: string;
   };
+  replacesEventId?: string;
+  redactsEventId?: string;
   attachment?: MatrixQaObservedEventAttachment;
   approval?: MatrixQaObservedApproval;
 };
@@ -89,6 +92,25 @@ function resolveMatrixQaMessageContent(
     return newContent;
   }
   return content;
+}
+
+function normalizeMatrixQaRelation(value: unknown) {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const relation = value as Record<string, unknown>;
+  const inReplyToRaw = relation["m.in_reply_to"];
+  const inReplyTo =
+    typeof inReplyToRaw === "object" && inReplyToRaw !== null
+      ? (inReplyToRaw as Record<string, unknown>)
+      : null;
+  return {
+    eventId: typeof relation.event_id === "string" ? relation.event_id : undefined,
+    inReplyToId: typeof inReplyTo?.event_id === "string" ? inReplyTo.event_id : undefined,
+    isFallingBack:
+      typeof relation.is_falling_back === "boolean" ? relation.is_falling_back : undefined,
+    relType: typeof relation.rel_type === "string" ? relation.rel_type : undefined,
+  };
 }
 
 function resolveMatrixQaObservedEventKind(params: { msgtype?: string; type: string }) {
@@ -214,12 +236,15 @@ export function normalizeMatrixQaObservedEvent(
     typeof relatesToRaw === "object" && relatesToRaw !== null
       ? (relatesToRaw as Record<string, unknown>)
       : null;
-  const inReplyToRaw = relatesTo?.["m.in_reply_to"];
-  const inReplyTo =
-    typeof inReplyToRaw === "object" && inReplyToRaw !== null
-      ? (inReplyToRaw as Record<string, unknown>)
-      : null;
   const messageContent = resolveMatrixQaMessageContent(content, relatesTo);
+  const replacesEventId =
+    relatesTo?.rel_type === "m.replace" && typeof relatesTo.event_id === "string"
+      ? relatesTo.event_id
+      : undefined;
+  // An edit's outer m.replace relation describes wire delivery, not the
+  // logical relation of the edited message. Matrix ignores relations inside
+  // m.new_content, so the observer must inherit the original event's relation.
+  const logicalRelation = replacesEventId ? undefined : normalizeMatrixQaRelation(relatesToRaw);
   const normalizedMsgtype =
     typeof messageContent.msgtype === "string" ? messageContent.msgtype : msgtype;
   const normalizedFilename =
@@ -248,6 +273,14 @@ export function normalizeMatrixQaObservedEvent(
   const approval = normalizeMatrixQaApprovalMetadata(
     messageContent[MATRIX_QA_APPROVAL_METADATA_KEY] ?? content[MATRIX_QA_APPROVAL_METADATA_KEY],
   );
+  const redactsEventId =
+    type === "m.room.redaction"
+      ? typeof event.redacts === "string"
+        ? event.redacts
+        : typeof content.redacts === "string"
+          ? content.redacts
+          : undefined
+      : undefined;
 
   return {
     kind: resolveMatrixQaObservedEventKind({ msgtype: normalizedMsgtype, type }),
@@ -263,19 +296,7 @@ export function normalizeMatrixQaObservedEvent(
       typeof messageContent.formatted_body === "string" ? messageContent.formatted_body : undefined,
     msgtype: normalizedMsgtype,
     membership: typeof content.membership === "string" ? content.membership : undefined,
-    ...(relatesTo
-      ? {
-          relatesTo: {
-            eventId: typeof relatesTo.event_id === "string" ? relatesTo.event_id : undefined,
-            inReplyToId: typeof inReplyTo?.event_id === "string" ? inReplyTo.event_id : undefined,
-            isFallingBack:
-              typeof relatesTo.is_falling_back === "boolean"
-                ? relatesTo.is_falling_back
-                : undefined,
-            relType: typeof relatesTo.rel_type === "string" ? relatesTo.rel_type : undefined,
-          },
-        }
-      : {}),
+    ...(logicalRelation ? { relatesTo: logicalRelation } : {}),
     ...(mentions
       ? {
           mentions: {
@@ -292,9 +313,21 @@ export function normalizeMatrixQaObservedEvent(
           },
         }
       : {}),
+    ...(redactsEventId ? { redactsEventId } : {}),
+    ...(replacesEventId ? { replacesEventId } : {}),
     ...(attachment ? { attachment } : {}),
     ...(approval ? { approval } : {}),
   };
+}
+
+export function inheritMatrixQaReplacementRelation(params: {
+  event: MatrixQaObservedEvent;
+  replacedEvent?: MatrixQaObservedEvent;
+}) {
+  if (!params.event.replacesEventId || params.event.relatesTo || !params.replacedEvent?.relatesTo) {
+    return params.event;
+  }
+  return { ...params.event, relatesTo: params.replacedEvent.relatesTo };
 }
 
 export function findMatrixQaObservedEventMatch(params: {

--- a/extensions/qa-matrix/src/substrate/sync.test.ts
+++ b/extensions/qa-matrix/src/substrate/sync.test.ts
@@ -196,7 +196,16 @@ describe("matrix sync helpers", () => {
                       event_id: "$preview",
                       sender: "@sut:matrix-qa.test",
                       type: "m.room.message",
-                      content: { body: "preview", msgtype: "m.notice" },
+                      content: {
+                        body: "preview",
+                        msgtype: "m.notice",
+                        "m.relates_to": {
+                          rel_type: "m.thread",
+                          event_id: "$root",
+                          is_falling_back: true,
+                          "m.in_reply_to": { event_id: "$driver" },
+                        },
+                      },
                     },
                     {
                       event_id: "$final",
@@ -205,10 +214,10 @@ describe("matrix sync helpers", () => {
                       content: {
                         body: "final",
                         msgtype: "m.text",
+                        "m.new_content": { body: "final", msgtype: "m.text" },
                         "m.relates_to": {
                           rel_type: "m.replace",
                           event_id: "$preview",
-                          "m.new_content": { body: "final", msgtype: "m.text" },
                         },
                       },
                     },
@@ -242,7 +251,17 @@ describe("matrix sync helpers", () => {
     });
 
     expect(preview.event.eventId).toBe("$preview");
-    expect(finalized.event.eventId).toBe("$final");
+    expect(finalized.event).toMatchObject({
+      body: "final",
+      eventId: "$final",
+      replacesEventId: "$preview",
+      relatesTo: {
+        eventId: "$root",
+        inReplyToId: "$driver",
+        isFallingBack: true,
+        relType: "m.thread",
+      },
+    });
     expect(calls).toBe(1);
   });
 

--- a/extensions/qa-matrix/src/substrate/sync.ts
+++ b/extensions/qa-matrix/src/substrate/sync.ts
@@ -1,6 +1,7 @@
 // Qa Matrix plugin module implements sync behavior.
 import {
   findMatrixQaObservedEventMatch,
+  inheritMatrixQaReplacementRelation,
   normalizeMatrixQaObservedEvent,
   type MatrixQaObservedEvent,
   type MatrixQaRoomEvent,
@@ -57,6 +58,7 @@ export type MatrixQaRoomObserver = {
 
 type MatrixQaRoomObserverState = {
   cursorIndexes: Map<string, number>;
+  eventsById: Map<string, MatrixQaObservedEvent>;
   events: MatrixQaObservedEvent[];
   pollPromise?: Promise<void>;
   since?: string;
@@ -108,8 +110,15 @@ async function pollMatrixQaRoomObserver(
         if (!normalized) {
           continue;
         }
-        params.observedEvents.push(normalized);
-        params.roomObserver.events.push(normalized);
+        const observed = inheritMatrixQaReplacementRelation({
+          event: normalized,
+          replacedEvent: normalized.replacesEventId
+            ? params.roomObserver.eventsById.get(normalized.replacesEventId)
+            : undefined,
+        });
+        params.roomObserver.eventsById.set(observed.eventId, observed);
+        params.observedEvents.push(observed);
+        params.roomObserver.events.push(observed);
       }
     }
   })();
@@ -129,6 +138,7 @@ export function createMatrixQaRoomObserver(
 ): MatrixQaRoomObserver {
   const roomObserver: MatrixQaRoomObserverState = {
     cursorIndexes: new Map(),
+    eventsById: new Map(),
     events: [],
     since: params.since,
   };


### PR DESCRIPTION
## Summary
- preserve Matrix replacement identity in the frozen observer and edit the existing logical outbound message
- inherit original reply/thread relations across edits
- configure the OpenAI image-generation provider for the frozen generated-image scenario
- run one causally bounded image trigger with useful recent-event diagnostics

Backports the relevant QA semantics from #117390 and #119150 into the 2026.7.33 private Matrix runner. This addresses the repeatable tool-progress preview/opt-out timeouts and the generated-image timeout from Full Validation.

## Evidence
- the exact candidate repeated the core Matrix failures in two independent live runs
- focused private Matrix QA suite: 100 passed
- diff check clean

This PR changes private QA only; production Matrix transport behavior is unchanged. The separate E2EE restart lifecycle failure remains under production backport investigation.