### PR TITLE
chore(plugins): record blocked SDK alias retirement

### DIFF
--- a/docs/plugins/compatibility.md
+++ b/docs/plugins/compatibility.md
@@ -158,13 +158,20 @@ New channel plugins should use `MsgContext.ChannelPromptContext`,
 `SupplementalContextFacts.channelStructuredContext`. The older
 `UntrustedContext`, `UntrustedStructuredContext`,
 `UntrustedStructuredContextEntry`, and supplemental `untrustedContext` names
-remain as deprecated SDK aliases until 2026-09-08 (registry record
-`sdk-untrusted-context-identifier-aliases`). Inbound finalization folds those
-deprecated fields into the channel-named fields and removes the old keys from
-runtime context.
+remain as deprecated SDK aliases (registry record
+`sdk-untrusted-context-identifier-aliases`). The announced migration window ended
+on 2026-09-08. Removal is `removal-pending` until a published-plugin artifact
+sweep verifies reader migration and SDK/security owners explicitly approve
+removal in a breaking SDK major release. The original `removeAfter` date remains
+2026-09-08, and the boundary report keeps this record due for review; this is not
+a deadline renewal.
+
+Inbound finalization still folds those deprecated fields into the channel-named
+fields and removes the old keys from runtime context.
 
 The security runtime similarly exports `buildChannelMetadata`; the deprecated
-`buildUntrustedChannelMetadata` alias remains available on the same schedule.
+`buildUntrustedChannelMetadata` alias remains available under the same pending
+removal conditions.
 
 ### WhatsApp inbound callback retirement
 

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -282,14 +282,14 @@ export const PLUGIN_COMPAT_RECORDS = [
   },
   {
     code: "sdk-untrusted-context-identifier-aliases",
-    status: "deprecated",
+    status: "removal-pending",
     owner: "sdk",
     introduced: "2026-07-22",
     deprecated: "2026-07-22",
     warningStarts: "2026-07-22",
     removeAfter: "2026-09-08",
     replacement:
-      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`",
+      "`MsgContext.ChannelPromptContext`, `MsgContext.ChannelStructuredContext`, `ChannelStructuredContextEntry`, `SupplementalContextFacts.channelStructuredContext`, and `buildChannelMetadata`; retain the shipped aliases until a published-plugin artifact sweep verifies reader migration and SDK/security owners explicitly approve removal in a breaking SDK major release",
     docsPath: "/plugins/compatibility",
     surfaces: [
       "openclaw/plugin-sdk reply-runtime MsgContext.UntrustedContext and UntrustedStructuredContext",
@@ -300,7 +300,7 @@ export const PLUGIN_COMPAT_RECORDS = [
     diagnostics: ["TypeScript deprecated SDK alias annotations"],
     tests: ["src/auto-reply/reply/inbound-context.test.ts"],
     releaseNote:
-      "Untrusted-named prompt-context SDK identifiers remain wired as deprecated aliases of the channel-named fields while plugins migrate.",
+      "Channel prompt-context SDK alias removal is pending published-plugin reader verification and breaking-release approval; the aliases and runtime normalization remain unchanged.",
   },
   {
     code: "bundled-channel-sdk-compat-facades",

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -87,6 +87,21 @@ describe("plugin compatibility registry", () => {
     );
 
     expect(staleRemovalWindows).toEqual([]);
+    const contextAliases = records.get("sdk-untrusted-context-identifier-aliases");
+    expect(contextAliases).toMatchObject({
+      status: "removal-pending",
+      introduced: "2026-07-22",
+      deprecated: "2026-07-22",
+      warningStarts: "2026-07-22",
+      removeAfter: "2026-09-08",
+      docsPath: "/plugins/compatibility",
+    });
+    expect(contextAliases?.replacement).toContain(
+      "published-plugin artifact sweep verifies reader migration",
+    );
+    expect(contextAliases?.replacement).toContain(
+      "SDK/security owners explicitly approve removal in a breaking SDK major release",
+    );
     for (const code of [
       "plugin-sdk-config-runtime-subpath",
       "plugin-sdk-channel-reply-pipeline-subpath",

--- a/test/scripts/plugin-boundary-report.test.ts
+++ b/test/scripts/plugin-boundary-report.test.ts
@@ -34,9 +34,10 @@ describe("plugin-boundary-report", () => {
 
     expect(summaryResult.exitCode).toBe(0);
     expect(summaryResult.stderr).toBe("");
-    expect(summary.compat?.removalPendingCount).toBe(8);
+    expect(summary.compat?.removalPendingCount).toBe(9);
     expect(summary.compat?.removalPendingDueCount).toEqual(expect.any(Number));
     expect(summary.compat?.removalPending?.map((record) => record.code)).toEqual([
+      "sdk-untrusted-context-identifier-aliases",
       "plugin-sdk-media-understanding-public-demotion",
       "plugin-sdk-memory-host-core-public-demotion",
       "plugin-sdk-channel-lifecycle-subpath",
@@ -46,6 +47,19 @@ describe("plugin-boundary-report", () => {
       "plugin-sdk-infra-runtime-subpath",
       "plugin-sdk-plugin-config-runtime-public-demotion",
     ]);
+    const contextAliases = summary.compat?.removalPending?.find(
+      (record) => record.code === "sdk-untrusted-context-identifier-aliases",
+    );
+    expect(contextAliases).toMatchObject({
+      removeAfter: "2026-09-08",
+      dueForReview: true,
+      blocker: expect.stringContaining("published-plugin artifact sweep verifies reader migration"),
+    });
+    expect(contextAliases?.blocker).toEqual(
+      expect.stringContaining(
+        "SDK/security owners explicitly approve removal in a breaking SDK major release",
+      ),
+    );
     for (const record of summary.compat?.removalPending ?? []) {
       expect(record.removeAfter).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
       expect(record.blocker).toEqual(expect.stringMatching(/retain|replacement/iu));
@@ -76,7 +90,7 @@ describe("plugin-boundary-report", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("removalPending=8");
+    expect(result.stdout).toContain("removalPending=9");
     expect(result.stdout).not.toContain("agent-harness-sdk-alias");
     expect(result.stdout).toMatch(/blocker=.*retain the public/iu);
     expect(result.stdout).toMatch(/readerRefs=\d+ readers=/u);


### PR DESCRIPTION
Related: #114414

## What Problem This Solves

Resolves a problem where the compatibility check treats channel-context SDK aliases as ready for removal after their September 8 window, although the required published-plugin reader verification and breaking-release approval have not happened.

## Why This Change Was Made

The existing compatibility registry now marks this record as removal-pending and states the missing prerequisites. Its original dates remain unchanged, and the boundary report continues to show it as due for review with reader references. This uses the existing pending-removal policy; the reporter, eligibility logic, and enforcement remain unchanged.

## User Impact

Plugin authors retain the shipped aliases and inbound normalization while retirement is reviewed. Maintainers can see the overdue work and its blockers without treating an unapproved breaking API removal as routine cleanup.

## Evidence

At the real UTC date, the same boundary-report command failed before this change with one eligible deprecated record and passed afterward with zero eligible deprecated records, nine removal-pending records, and one still due for review. No clock or deadline override was used. The September 8 date and both blockers remain visible.

The existing registry, report, inbound normalization, and security metadata suites passed 56 tests. The canonical four-path changed gate also passed. Independent Codex review found no actionable findings. No runtime, security framing, SDK exports, aliases, or report guard code changed. Broad source reader references are triage data; they do not substitute for the still-required published-plugin artifact verification.
