### PR TITLE
fix(agents): preserve HTTP conversations with uppercase keys

### DIFF
--- a/src/agents/command/session.exact-target.test.ts
+++ b/src/agents/command/session.exact-target.test.ts
@@ -79,6 +79,32 @@ it.each(["work", "dashboard:incognito-work"])(
   },
 );
 
+it("reuses the persisted session when an explicit key's opaque tail is uppercase", async () => {
+  await withOpenClawTestState({ label: "command-uppercase-tail-session" }, async (state) => {
+    const storePath = state.path("sessions.sqlite");
+    // Client-generated opaque tails (a ULID, for example) carry uppercase, while
+    // persisted store rows always hold the canonical store-folded key.
+    const sessionKey = "agent:main:assist:01M21F31SCNCCQQ3N4X43AY420";
+    const cfg = {
+      agents: { defaults: {} },
+      session: { store: storePath, reset: { mode: "idle", idleMinutes: 60 } },
+    } satisfies OpenClawConfig;
+
+    const first = resolveSession({ cfg, sessionKey });
+    expect(first.sessionEntry).toBeUndefined();
+    expect(first.isNewSession).toBe(true);
+    await sessionAccessor.replaceSessionEntry(
+      { sessionKey: first.sessionKey, storePath },
+      { sessionId: first.sessionId, updatedAt: Date.now(), sessionStartedAt: Date.now() },
+    );
+
+    const second = resolveSession({ cfg, sessionKey });
+    expect(second.sessionId).toBe(first.sessionId);
+    expect(second.isNewSession).toBe(false);
+    expect(second.sessionEntry?.sessionId).toBe(first.sessionId);
+  });
+});
+
 it("does not provision a missing incognito lookup or select a hidden run-owned entry", async () => {
   await withOpenClawTestState({ label: "command-private-session" }, async (state) => {
     const storePath = state.path("sessions.sqlite");

--- a/src/agents/command/session.exact-target.test.ts
+++ b/src/agents/command/session.exact-target.test.ts
@@ -79,12 +79,17 @@ it.each(["work", "dashboard:incognito-work"])(
   },
 );
 
-it("reuses the persisted session when an explicit key's opaque tail is uppercase", async () => {
+it.each([
+  "agent:main:assist:01M21F31SCNCCQQ3N4X43AY420",
+  "agent:main:assist:prefix-01M21F31SCNCCQQ3N4X43AY420",
+  "agent:main:assist:lowercaseletters",
+  "agent:main:assist:abcdef0123456789",
+  "agent:main:assist:ordinary-42",
+  "agent:main:signal:group:AbCdEf123",
+  "agent:main:matrix:channel:!Room:Example.org:thread:$Event",
+])("reuses the persisted session for explicit key %s", async (sessionKey) => {
   await withOpenClawTestState({ label: "command-uppercase-tail-session" }, async (state) => {
     const storePath = state.path("sessions.sqlite");
-    // Client-generated opaque tails (a ULID, for example) carry uppercase, while
-    // persisted store rows always hold the canonical store-folded key.
-    const sessionKey = "agent:main:assist:01M21F31SCNCCQQ3N4X43AY420";
     const cfg = {
       agents: { defaults: {} },
       session: { store: storePath, reset: { mode: "idle", idleMinutes: 60 } },
@@ -99,6 +104,7 @@ it("reuses the persisted session when an explicit key's opaque tail is uppercase
     );
 
     const second = resolveSession({ cfg, sessionKey });
+    expect(second.sessionKey).toBe(sessionKey);
     expect(second.sessionId).toBe(first.sessionId);
     expect(second.isNewSession).toBe(false);
     expect(second.sessionEntry?.sessionId).toBe(first.sessionId);
@@ -124,6 +130,10 @@ it("does not provision a missing incognito lookup or select a hidden run-owned e
     );
     expect(
       resolveSessionKeyForRequestCore({ cfg, sessionKey: hidden.sessionKey }).sessionEntry,
+    ).toBeUndefined();
+    expect(
+      resolveSessionKeyForRequestCore({ cfg, sessionKey: hidden.sessionKey.toUpperCase() })
+        .sessionEntry,
     ).toBeUndefined();
   });
 });

--- a/src/agents/command/session.exact-target.test.ts
+++ b/src/agents/command/session.exact-target.test.ts
@@ -94,7 +94,7 @@ it("reuses the persisted session when an explicit key's opaque tail is uppercase
     expect(first.sessionEntry).toBeUndefined();
     expect(first.isNewSession).toBe(true);
     await sessionAccessor.replaceSessionEntry(
-      { sessionKey: first.sessionKey, storePath },
+      { sessionKey, storePath },
       { sessionId: first.sessionId, updatedAt: Date.now(), sessionStartedAt: Date.now() },
     );
 

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -38,6 +38,7 @@ import {
   resolvePersistedSessionStoreOwner,
   resolvePersistedSessionStoreOwnerForKey,
 } from "../../config/sessions/session-store-owner.js";
+import { normalizeStoreSessionKey } from "../../config/sessions/store-entry.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -485,9 +486,17 @@ function resolveSessionKeyForRequestInternal(opts: {
 
   // Command preparation needs one owned entry. Exact reads preserve the SQLite target and
   // Doctor guards without enumerating the agent store or exposing hidden run-owned rows.
+  // Exact row locators are not canonicalized, but persisted rows always hold the canonical
+  // store-folded key, so the read must use that form: a request key carrying an opaque
+  // uppercase tail (a client ULID, for example) would otherwise miss the row its previous
+  // turn created and remint the session id, tripping the admission fence.
   const sessionEntry =
     sessionKey && !isInternalSessionEffectsKey(sessionKey)
-      ? loadExactSessionEntryReadOnly({ agentId: storeAgentId, storePath, sessionKey })?.entry
+      ? loadExactSessionEntryReadOnly({
+          agentId: storeAgentId,
+          storePath,
+          sessionKey: normalizeStoreSessionKey(sessionKey),
+        })?.entry
       : undefined;
 
   // If a session id was provided, prefer to re-use its existing entry (by id) even when no key was

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -486,16 +486,14 @@ function resolveSessionKeyForRequestInternal(opts: {
 
   // Command preparation needs one owned entry. Exact reads preserve the SQLite target and
   // Doctor guards without enumerating the agent store or exposing hidden run-owned rows.
-  // Exact row locators are not canonicalized, but persisted rows always hold the canonical
-  // store-folded key, so the read must use that form: a request key carrying an opaque
-  // uppercase tail (a client ULID, for example) would otherwise miss the row its previous
-  // turn created and remint the session id, tripping the admission fence.
+  // Exclusion and lookup share the persisted locator; routing keeps the request key.
+  const storeSessionKey = sessionKey ? normalizeStoreSessionKey(sessionKey) : undefined;
   const sessionEntry =
-    sessionKey && !isInternalSessionEffectsKey(sessionKey)
+    storeSessionKey && !isInternalSessionEffectsKey(storeSessionKey)
       ? loadExactSessionEntryReadOnly({
           agentId: storeAgentId,
           storePath,
-          sessionKey: normalizeStoreSessionKey(sessionKey),
+          sessionKey: storeSessionKey,
         })?.entry
       : undefined;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where applications using uppercase conversation keys could send one chat completion, then receive HTTP 500 on every follow-up.

Closes #142616.

## Why This Change Was Made

Command preparation now uses the existing canonical store key for both hidden-session exclusion and exact lookup. The original request key remains available for routing, and existing case-sensitive peer identities remain intact.

## User Impact

Applications can continue the same conversation without replacing or lowercasing their keys. Internal run-owned sessions remain inaccessible through alternate-case keys.

## Evidence

- Real Gateway baseline: first HTTP turn succeeded; the second failed with a session identity mismatch while the original persisted row remained intact.
- Repaired Gateway: 33 successful HTTP turns across 11 conversations, including separate agents and case-sensitive peer keys. The hidden-session probe started no model work and left its row unchanged.
- 120 focused tests passed. The added hidden-session regression failed against the incoming patch and passed after correction.
- Targeted formatting, lint, runtime build, and fresh code review passed.

Original continuation repair by @ruel225. Raw fixture data and credentials remain private.

Observed HTTP results, with fixture identifiers removed:

```text
Uppercase conversation, baseline:  200 -> 500
Uppercase conversation, repaired:  200 -> 200 -> 200
Hidden conversation probe:        rejected; no model request; row unchanged
```

Independent acceptance confirmed complete prior conversation inputs, separate case-sensitive conversations, incognito behavior, command history, and a working reset followed by a fresh turn. The hosted [CI run](https://github.com/openclaw/openclaw/actions/runs/34301715119) checks the published revision.
