### PR TITLE
fix(meeting-bot): acquire root-work admission before agent consults

### DIFF
--- a/src/meeting-bot/agent-consult.test.ts
+++ b/src/meeting-bot/agent-consult.test.ts
@@ -1,10 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
 
-const consultRealtimeVoiceAgent = vi.hoisted(() => vi.fn(async () => ({ text: "done" })));
+// Mirrors the real entry point's first substantive act: reject subordinate
+// work while the inherited root-work admission is closed (issue #141279).
+const consultRealtimeVoiceAgent = vi.hoisted(() =>
+  vi.fn(async () => {
+    const { GatewayDrainingError, isGatewaySubordinateWorkAdmissionClosed } =
+      await import("../process/gateway-work-admission.js");
+    if (isGatewaySubordinateWorkAdmissionClosed()) {
+      throw new GatewayDrainingError();
+    }
+    return { text: "done" };
+  }),
+);
 
 vi.mock("../talk/agent-consult-runtime.js", () => ({ consultRealtimeVoiceAgent }));
 
+import { tryBeginGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { createMeetingRealtimeEngineBindings } from "./agent-consult.js";
 import type {
   MeetingAgentConsultSurface,
@@ -179,5 +191,43 @@ describe("createMeetingRealtimeEngineBindings", () => {
     expect(consultRealtimeVoiceAgent).toHaveBeenCalledTimes(1);
     expect(submitToolResult).toHaveBeenCalledTimes(1);
     expect(events.map((event) => event.type)).toEqual(["tool.progress"]);
+  });
+
+  it("consults successfully from a released root-work context (issue #142610)", async () => {
+    const lease = tryBeginGatewayRootWorkAdmission("test-meeting-consult");
+    if (!lease) {
+      throw new Error("root-work admission unavailable in test");
+    }
+    let resume: () => void = () => {};
+    let insideReleasedContext: Promise<void> = Promise.resolve();
+
+    const insideChain = lease.run(async () => {
+      insideReleasedContext = (async () => {
+        // Pause inside the request's async chain, then let the test release
+        // the admission; the continuation still carries the (now released)
+        // context, exactly like the meeting-bot callback from issue #142610.
+        await new Promise<void>((resolve) => {
+          resume = resolve;
+        });
+        await createBindings("Support").consultAgent({
+          meetingSessionId: "meeting-released",
+          args: { question: "What should I say?" },
+          transcript: [],
+        });
+      })();
+      await insideReleasedContext;
+    });
+    // Releasing only works while the chain is paused; resuming after release
+    // runs the consult inside the released context.
+    lease.release();
+    resume();
+
+    await expect(insideReleasedContext).resolves.toBeUndefined();
+    await expect(insideChain).resolves.toBeUndefined();
+    expect(consultRealtimeVoiceAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:support:subagent:test-meeting:meeting-released",
+      }),
+    );
   });
 });

--- a/src/meeting-bot/agent-consult.ts
+++ b/src/meeting-bot/agent-consult.ts
@@ -3,6 +3,11 @@ import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
+import {
+  GatewayDrainingError,
+  runOutsideGatewayRootWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
 import {
@@ -129,27 +134,38 @@ async function consultMeetingAgent(params: {
   const requesterSessionKey =
     normalizeOptionalString(params.requesterSessionKey) ?? `agent:${agentId}:main`;
   const sessionKey = `agent:${agentId}:subagent:${params.surface.id}:${params.meetingSessionId}`;
-  return await consultRealtimeVoiceAgent({
-    cfg: params.config,
-    agentRuntime: params.runtime.agent,
-    logger: params.logger,
-    agentId,
-    sessionKey,
-    messageProvider: params.surface.provider,
-    lane: params.surface.lane,
-    runIdPrefix: `${params.surface.id}:${params.meetingSessionId}`,
-    spawnedBy: requesterSessionKey,
-    contextMode: "fork",
-    args: params.args,
-    transcript: params.transcript,
-    surface: params.surface.surface,
-    userLabel: params.surface.userLabel,
-    assistantLabel: params.surface.assistantLabel,
-    questionSourceLabel: params.surface.questionSourceLabel,
-    toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(params.toolPolicy),
-    extraSystemPrompt: params.surface.extraSystemPrompt,
-    abortSignal: params.abortSignal,
-  });
+  // The consult must not inherit the root-work admission of the long-finished
+  // request that created the meeting: that context is already released, so
+  // enqueueCommandInLane would reject the consult with a misleading "Gateway
+  // is draining" error. Acquire a fresh admission, exactly like the browser
+  // Talk path does.
+  const admission = runOutsideGatewayRootWorkAdmission(tryBeginGatewayRootWorkAdmission);
+  if (!admission) {
+    throw new GatewayDrainingError();
+  }
+  return await admission.run(() =>
+    consultRealtimeVoiceAgent({
+      cfg: params.config,
+      agentRuntime: params.runtime.agent,
+      logger: params.logger,
+      agentId,
+      sessionKey,
+      messageProvider: params.surface.provider,
+      lane: params.surface.lane,
+      runIdPrefix: `${params.surface.id}:${params.meetingSessionId}`,
+      spawnedBy: requesterSessionKey,
+      contextMode: "fork",
+      args: params.args,
+      transcript: params.transcript,
+      surface: params.surface.surface,
+      userLabel: params.surface.userLabel,
+      assistantLabel: params.surface.assistantLabel,
+      questionSourceLabel: params.surface.questionSourceLabel,
+      toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(params.toolPolicy),
+      extraSystemPrompt: params.surface.extraSystemPrompt,
+      abortSignal: params.abortSignal,
+    }),
+  );
 }
 
 async function handleMeetingRealtimeConsultToolCall(params: {


### PR DESCRIPTION
## What Problem This Solves

Every spoken question in a meeting agent session fails with a misleading drain error:

```
node agent consult failed: elapsedMs=5 Gateway is draining; new tasks are not accepted
```

The gateway is not draining. `consultMeetingAgent()` invoked `consultRealtimeVoiceAgent()` directly, inheriting the AsyncLocalStorage root-work admission of the `googlemeet.create` request that started the meeting — an admission that is already released by consult time. `enqueueCommandInLane()` → `isGatewaySubordinateWorkAdmissionClosed()` then rejects with `GatewayDrainingError` (issue #142610, which includes reporter instrumentation: `subordinate-closed reason=rootWorkReleased refs=0`).

## What This Changes

`consultMeetingAgent` now acquires its own root-work admission via the same `runOutsideGatewayRootWorkAdmission(tryBeginGatewayRootWorkAdmission)` pattern the browser Talk path already uses (`talk-client-agent-consult.ts:205`), throwing `GatewayDrainingError` only when admission is genuinely closed.

## Evidence

Regression test in `src/meeting-bot/agent-consult.test.ts` (6/6 passing):

- The consult-path mock now mirrors the real entry point's first substantive act — rejecting when `isGatewaySubordinateWorkAdmissionClosed()` is true.
- The new case pauses inside a real root-work admission's async chain, releases the admission, then resumes the consult inside the (now released) context — exactly the reported scenario. It asserts the consult succeeds with the expected session key.
- **Red/green verified**: reverting the fix reproduces the reported failure (`promise rejected "GatewayDrainingError: Gateway is draining…"`); the fix turns it green.

Fixes #142610