### PR TITLE
fix(git): use Git-openable null paths for GIT_CONFIG_GLOBAL/SYSTEM on Windows

### DIFF
--- a/src/gateway/github-publication-executor.ts
+++ b/src/gateway/github-publication-executor.ts
@@ -1,10 +1,10 @@
-import os from "node:os";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionGitHubPublicationResult } from "../../packages/gateway-protocol/src/schema/session-github-publication.js";
 import { resolveGitCoauthorAttribution } from "../agents/git-coauthor-attribution.js";
 import type { PreparedGitHubPublicationIdentity } from "../agents/github-tool-identity.js";
 import { resolveControlUiSessionUrl } from "../config/control-ui-link-base.js";
+import { gitNullConfigPath } from "../infra/git-exec.js";
 import {
   currentGitHubPublicationConfig,
   resolveLocalGitHubPublicationWorktreeOwner,
@@ -189,8 +189,8 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
     identity = await refreshIdentity();
     const baseTransportEnv = {
       ...identity.env,
-      GIT_CONFIG_GLOBAL: os.devNull,
-      GIT_CONFIG_SYSTEM: os.devNull,
+      GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+      GIT_CONFIG_SYSTEM: gitNullConfigPath(),
     };
     const baseFetched = await run(githubPublicationBaseFetchArgs(repository, remoteBaseSha), {
       cwd: worktree.path,
@@ -350,8 +350,8 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
     identity = await refreshIdentity();
     let transportEnv = {
       ...identity.env,
-      GIT_CONFIG_GLOBAL: os.devNull,
-      GIT_CONFIG_SYSTEM: os.devNull,
+      GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+      GIT_CONFIG_SYSTEM: gitNullConfigPath(),
     };
     const pushArgs = githubPublicationPushArgs(httpsRemote, headCommit, branch);
     const observeRemoteHead = async () => {
@@ -372,8 +372,8 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
       identity = await refreshIdentity();
       transportEnv = {
         ...identity.env,
-        GIT_CONFIG_GLOBAL: os.devNull,
-        GIT_CONFIG_SYSTEM: os.devNull,
+        GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+        GIT_CONFIG_SYSTEM: gitNullConfigPath(),
       };
       remoteHead = await step(observeRemoteHead);
       if (remoteHead !== headCommit) {

--- a/src/gateway/github-publication-git-index.ts
+++ b/src/gateway/github-publication-git-index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gitNullConfigPath } from "../infra/git-exec.js";
 import { GitHubPublicationWorkspaceChangedError } from "./github-publication-failure.js";
 
 type GitCommandOptions = { cwd?: string; env?: NodeJS.ProcessEnv; input?: string };
@@ -206,8 +207,8 @@ export async function updateGitHubPublicationBranchAndIndex(params: {
     recoveryPath = publicationRecoveryPath(indexPath, params.requestId);
     const gitEnv = {
       ...params.env,
-      GIT_CONFIG_GLOBAL: os.devNull,
-      GIT_CONFIG_SYSTEM: os.devNull,
+      GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+      GIT_CONFIG_SYSTEM: gitNullConfigPath(),
     };
     await params.run([...HARDENED_GIT, "read-tree", params.headCommit], {
       cwd: params.cwd,

--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gitNullConfigPath } from "../infra/git-exec.js";
 import { runCommandBuffered } from "../process/exec.js";
 import { githubPublicationUnsafeConfigArgs } from "./github-publication-base.js";
 
@@ -68,7 +69,10 @@ export async function assertSafeGitPublicationWorkspace(
   cwd: string,
   run: (argv: string[], options?: GitCommandOptions) => Promise<GitCommandResult>,
 ): Promise<void> {
-  const isolatedConfig = { GIT_CONFIG_GLOBAL: os.devNull, GIT_CONFIG_SYSTEM: os.devNull };
+  const isolatedConfig = {
+    GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+    GIT_CONFIG_SYSTEM: gitNullConfigPath(),
+  };
   const [localUnsafe, worktreeConfig] = await Promise.all([
     run(githubPublicationUnsafeConfigArgs("--local"), { cwd, env: isolatedConfig }),
     run(
@@ -228,8 +232,8 @@ export async function captureGitHubPublicationWorkspaceSnapshot(params: {
   try {
     const env = {
       GIT_ATTR_NOSYSTEM: "1",
-      GIT_CONFIG_GLOBAL: os.devNull,
-      GIT_CONFIG_SYSTEM: os.devNull,
+      GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+      GIT_CONFIG_SYSTEM: gitNullConfigPath(),
       GIT_INDEX_FILE: path.join(tempDir, "index"),
     };
     // Preserve staged path inventory, and keep write-tree cache updates off the real index.

--- a/src/gateway/session-repository-materialization.ts
+++ b/src/gateway/session-repository-materialization.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { gitNullConfigPath } from "../infra/git-exec.js";
 import {
   readProjectCheckoutRemoteHead,
   ProjectCloneError,
@@ -180,7 +181,7 @@ export async function materializeSessionRepositoryWorkspaceOnGateway(params: {
   const git = (args: string[]) =>
     command(["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", ...args], {
       cwd: root,
-      env: { GIT_CONFIG_GLOBAL: os.devNull, GIT_CONFIG_SYSTEM: os.devNull },
+      env: { GIT_CONFIG_GLOBAL: gitNullConfigPath(), GIT_CONFIG_SYSTEM: gitNullConfigPath() },
     });
   const alignPublication = async () => {
     if (published?.pushed_head_commit) {

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as execRunner from "../process/exec-runner.js";
 import * as processExec from "../process/exec.js";
@@ -6,6 +10,7 @@ import { withTestDir } from "../test-helpers/temp-dir.js";
 import {
   createGitCommandError,
   executeGitCommand,
+  gitNullConfigPath,
   normalizeGitPathForFilesystem,
   requireGitCommand,
   requireGitCommandBuffer,
@@ -288,4 +293,67 @@ describe("required Git output", () => {
     await expect(requireGitCommandRaw("/repo", ["status"])).resolves.toBe("complete\n");
     await expect(requireGitCommand("/repo", ["status"])).resolves.toBe("complete");
   });
+});
+
+describe("gitNullConfigPath", () => {
+  it("returns the Git-openable null path for the execution host", () => {
+    const originalPlatform = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      // Git for Windows cannot open the device-namespace path that
+      // os.devNull returns; "NUL" is the path it understands.
+      expect(gitNullConfigPath()).toBe("NUL");
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      expect(gitNullConfigPath()).toBe("/dev/null");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("is accepted by the real git binary as GIT_CONFIG_GLOBAL on this host", () => {
+    const repo = fsSync.mkdtempSync(path.join(os.tmpdir(), "git-null-config-"));
+    try {
+      fsSync.writeFileSync(path.join(repo, "file.txt"), "x");
+      const baseEnv = {
+        ...process.env,
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_COUNT: "0",
+        GIT_CONFIG_GLOBAL: gitNullConfigPath(),
+      };
+      const init = spawnSync("git", ["init", "-q", repo], { env: baseEnv, encoding: "utf8" });
+      expect(init.status).toBe(0);
+      const log = spawnSync("git", ["-C", repo, "log", "--oneline", "-1"], {
+        env: baseEnv,
+        encoding: "utf8",
+      });
+      // Empty repo: git may exit non-zero for "no commits", but config parsing
+      // must not fail with the device-namespace access error (exit 128).
+      expect(log.stderr).not.toContain("unable to access");
+    } finally {
+      fsSync.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "documents the defect: os.devNull as GIT_CONFIG_GLOBAL exits 128 on Windows",
+    () => {
+      const repo = fsSync.mkdtempSync(path.join(os.tmpdir(), "git-null-config-"));
+      try {
+        const result = spawnSync("git", ["-C", repo, "log", "--oneline", "-1"], {
+          env: {
+            ...process.env,
+            GIT_CONFIG_NOSYSTEM: "1",
+            GIT_CONFIG_COUNT: "0",
+            GIT_CONFIG_GLOBAL: os.devNull,
+          },
+          encoding: "utf8",
+        });
+        // Red evidence for issue #141279: the device-namespace path that
+        // os.devNull returns is rejected by Git for Windows.
+        expect(result.stderr).toContain("unable to access");
+      } finally {
+        fsSync.rmSync(repo, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -135,3 +135,16 @@ export async function requireGitCommandBuffer(
   }
   return result.stdout;
 }
+
+/**
+ * Null device path that Git for Windows can open as a config file.
+ *
+ * `os.devNull` returns `\.\nul` on Windows, which Git rejects with
+ * "unable to access '\.\nul': Invalid argument" (exit 128) when passed via
+ * `GIT_CONFIG_GLOBAL` or `GIT_CONFIG_SYSTEM` — it must open and parse those
+ * files. "NUL" is the path Git for Windows understands. Config *values* such
+ * as `core.hooksPath` accept the device path and need no change.
+ */
+export function gitNullConfigPath(): string {
+  return process.platform === "win32" ? "NUL" : "/dev/null";
+}

--- a/src/infra/update-runner-git-target.ts
+++ b/src/infra/update-runner-git-target.ts
@@ -6,6 +6,7 @@ import {
   parsePackageOpenClawSchemaVersions,
   type OpenClawSchemaVersions,
 } from "../state/openclaw-schema-versions.js";
+import { gitNullConfigPath } from "./git-exec.js";
 import { isBetaTag, isStableTag, type UpdateChannel } from "./update-channels.js";
 import { compareSemverStrings } from "./update-check.js";
 import { runGitCandidatePreflight } from "./update-runner-git-preflight.js";
@@ -96,7 +97,7 @@ export async function withGitTargetInspectionRoot<T>(
               env: {
                 ...options.env,
                 GIT_CONFIG_NOSYSTEM: "1",
-                GIT_CONFIG_GLOBAL: os.devNull,
+                GIT_CONFIG_GLOBAL: gitNullConfigPath(),
                 GIT_CONFIG_COUNT: "0",
               },
             }

--- a/src/projects/project-clone-runtime.ts
+++ b/src/projects/project-clone-runtime.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ProjectCloneFailureCause } from "../../packages/gateway-protocol/src/index.js";
-import { executeGitCommand, requireGitCommandOutput } from "../infra/git-exec.js";
+import {
+  executeGitCommand,
+  gitNullConfigPath,
+  requireGitCommandOutput,
+} from "../infra/git-exec.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 
 const PROJECT_CLONE_TIMEOUT_MS = 10 * 60_000;
@@ -30,7 +34,7 @@ function cloneCommandEnv(token: string | undefined, env: NodeJS.ProcessEnv): Nod
     ...env,
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_NOSYSTEM: "1",
-    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_GLOBAL: gitNullConfigPath(),
     GIT_TEMPLATE_DIR: "",
     GIT_EDITOR: "",
     GIT_SEQUENCE_EDITOR: "",


### PR DESCRIPTION
> Successor to #141365, closed during branch reorganization. The original contributor commits were retained when rebasing this PR; the sole conflict combined the existing Git helper imports with the new null-path helper. See #141365 for the original review trail.

## What Problem This Solves

On Windows, `os.devNull` returns the device-namespace path `\.\nul`. Git for Windows must open and parse `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM`, and rejects that path with exit 128 (`fatal: unable to access '\.\nul': Invalid argument`). #140803 fixed the worker/publication helpers, but the same pattern remained in the gateway publication/transport/index paths, session repository materialization, update-runner git target inspection, and project cloning — so every `openclaw update` on a Windows git checkout still fails with `fetch-failed` at `git target inspection fetch` (#141279).

## What This Changes

Adds `gitNullConfigPath()` to `src/infra/git-exec.ts` (`"NUL"` on win32, `/dev/null` otherwise — matching the precedent already in `node-worker-workspace.ts:217`) and applies it to the 16 remaining `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` sites across 6 files (`github-publication-executor` ×6, `github-publication-git-transport` ×4, `github-publication-git-index` ×2, `session-repository-materialization` ×2, `update-runner-git-target` ×1, `project-clone-runtime` ×1).

**Intentionally unchanged** (scope verified against Git for Windows 2.55): `core.hooksPath` and `core.attributesFile` accept the device path (exit 0), literal "/dev/null" strings work on Git for Windows, and `project-seed-script.ts` emits into a Linux shell heredoc where `os.devNull` is always `/dev/null`.

## Evidence

### Contributor evidence (before maintainer rebase)

All reproduction is network-free — plain git invocations carrying the config env, run on Windows 11 / Git for Windows 2.55:

```
GIT_CONFIG_GLOBAL='\.\nul' git log -1   -> exit 128: fatal: unable to access '\.\nul': Invalid argument
GIT_CONFIG_GLOBAL='NUL'      git log -1   -> exit 0
```

Regression tests in `src/infra/git-exec.test.ts` (68/68 passing on Windows):

- Platform mapping: `NUL` on win32, `/dev/null` otherwise.
- **Real git binary integration**: `git init` + `git log` in a temp repo with `GIT_CONFIG_GLOBAL` set to the helper's path — config parsing must not fail with the device-namespace access error.
- Windows-only red-evidence case documenting the defect: the same invocation with `GIT_CONFIG_GLOBAL` set to `os.devNull` fails with `unable to access`.

Fixes #141279

### Maintainer Windows boundary proof

Verified head: `936bee8014b3cd67deb385251ac6f32a0aa163be`.

[Sanitized AWS Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_aba2e80f2368) completed successfully on native Windows build 20348 with Git for Windows 2.52.0. The fresh PR checkout matched this head, and the source helper blob was `7d62932ace786c1e996e698232b7ddebfaf570e0`. The IMDSv2 IAM credential endpoint returned 404; the lease used no hydration or Tailscale.

A trusted, network-free Git harness created a synthetic committed repository and tested each configuration environment variable independently:

| Variable | Null path | Exit | Observed result |
| --- | --- | --- | --- |
| `GIT_CONFIG_GLOBAL` | `\\.\nul` | 128 | `unable to access`, invalid argument |
| `GIT_CONFIG_GLOBAL` | `NUL` | 0 | Expected commit subject, empty stderr |
| `GIT_CONFIG_SYSTEM` | `\\.\nul` | 128 | `unable to access`, invalid argument |
| `GIT_CONFIG_SYSTEM` | `NUL` | 0 | Expected commit subject, empty stderr |

This proves the Git config-file boundary repaired by the source-verified helper mapping. It does **not** claim a full updater, clone, or publication flow, and the harness did not execute contributor modules. Fresh-head repository tests remain tracked by [CI](https://github.com/openclaw/openclaw/actions/runs/34382354142).

The complete rebased patch received a fresh independent autoreview with no actionable P0–P2 findings. Both contributor commits and their authorship were preserved.
