### PR TITLE
fix(android): stabilize remote image decode regression on Linux

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -38,6 +38,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
 import java.io.ByteArrayOutputStream
 import java.net.InetAddress
 import java.net.UnknownHostException
@@ -526,6 +527,7 @@ class ChatLinkPreviewTest {
   }
 
   @Test
+  @GraphicsMode(GraphicsMode.Mode.NATIVE)
   fun imageDecodeDownsamplesLargeSource() {
     val decoded = decodeRemoteImageBitmap(pngBytes(width = 2_400, height = 1_200))
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/142714

## What Problem This Solves

Resolves a problem where Android CI could reject unrelated pull requests when the large remote-image downsampling regression ran under Robolectric's legacy graphics backend on Linux.

## Why This Change Was Made

Run only the bitmap encode/decode regression with Robolectric native graphics. This matches the existing Android image-codec test boundary, exercises the real decoder, and leaves production code and the rest of the link-preview suite unchanged.

## User Impact

No product behavior changes. Android CI can reliably validate remote-image downsampling without blocking unrelated changes.

## Evidence

- The same exact-head `android-test-third-party` job failed twice at `ChatLinkPreviewTest.imageDecodeDownsamplesLargeSource`, where `decodeRemoteImageBitmap` returned null:
  - https://github.com/openclaw/openclaw/actions/runs/34295297412/job/102290655988
  - https://github.com/openclaw/openclaw/actions/runs/34295297412/job/102295561968
- Focused patched test passed:
  - `./gradlew --no-daemon :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.ui.chat.ChatLinkPreviewTest.imageDecodeDownsamplesLargeSource' -x :app:generateMermaidAssets`
- Full `ChatLinkPreviewTest` class passed.
- `node scripts/check-changed.mjs -- apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt` passed, including Android ktlint.
- Independent autoreview reported no actionable findings.
