### PR TITLE
fix(plugin-sdk): allow gateway handlers to return responses

### DIFF
--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -41,10 +41,12 @@ export function registerWorkboardResultMethods(
     api.registerGatewayMethod(
       method,
       (context) =>
-        Promise.resolve(handler(context)).then(
-          (result) => context.respond(true, result),
-          (error: unknown) => respondError(context.respond, error),
-        ),
+        Promise.resolve()
+          .then(() => handler(context))
+          .then(
+            (result) => context.respond(true, result),
+            (error: unknown) => respondError(context.respond, error),
+          ),
       { scope },
     );
   }

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -1,7 +1,6 @@
 import { WORKBOARD_STATUSES, type WorkboardCard } from "@openclaw/workboard-contract";
 // Workboard plugin module implements shared gateway request helpers.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { GatewayRequestHandler } from "openclaw/plugin-sdk/gateway-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { OpenClawPluginApi } from "../api.js";
 import {
@@ -20,9 +19,7 @@ export type GatewayMethodContext = Parameters<
   Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
 >[0];
 type GatewayRespond = GatewayMethodContext["respond"];
-type WorkboardGatewayResultHandler =
-  | GatewayRequestHandler
-  | ((context: GatewayMethodContext) => Promise<unknown>);
+type WorkboardGatewayResultHandler = (context: GatewayMethodContext) => Promise<unknown> | void;
 type WorkboardGatewayScope = NonNullable<
   NonNullable<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2]>["scope"]
 >;

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -40,14 +40,11 @@ export function registerWorkboardResultMethods(
   for (const [method, scope, handler] of methods) {
     api.registerGatewayMethod(
       method,
-      async (context) => {
-        try {
-          context.respond(true, await handler(context));
-          return;
-        } catch (error) {
-          respondError(context.respond, error);
-        }
-      },
+      (context) =>
+        Promise.resolve(handler(context)).then(
+          (result) => context.respond(true, result),
+          (error: unknown) => respondError(context.respond, error),
+        ),
       { scope },
     );
   }

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -1,6 +1,7 @@
 import { WORKBOARD_STATUSES, type WorkboardCard } from "@openclaw/workboard-contract";
 // Workboard plugin module implements shared gateway request helpers.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { GatewayRequestHandler } from "openclaw/plugin-sdk/gateway-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { OpenClawPluginApi } from "../api.js";
 import {
@@ -19,7 +20,9 @@ export type GatewayMethodContext = Parameters<
   Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
 >[0];
 type GatewayRespond = GatewayMethodContext["respond"];
-type WorkboardGatewayResultHandler = (context: GatewayMethodContext) => unknown;
+type WorkboardGatewayResultHandler =
+  | GatewayRequestHandler
+  | ((context: GatewayMethodContext) => Promise<unknown>);
 type WorkboardGatewayScope = NonNullable<
   NonNullable<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2]>["scope"]
 >;

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -43,6 +43,7 @@ export function registerWorkboardResultMethods(
       async (context) => {
         try {
           context.respond(true, await handler(context));
+          return;
         } catch (error) {
           respondError(context.respond, error);
         }

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -59,7 +59,7 @@ export function registerWorkboardGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "workboard.cards.start",
-    async (context) => await dispatchCards(context, { supportsMaxStarts: false, directCard: true }),
+    (context) => dispatchCards(context, { supportsMaxStarts: false, directCard: true }),
     { scope: WRITE_SCOPE },
   );
 
@@ -187,13 +187,13 @@ export function registerWorkboardGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "workboard.cards.dispatch",
-    async (context) => await dispatchCards(context, { supportsMaxStarts: false }),
+    (context) => dispatchCards(context, { supportsMaxStarts: false }),
     { scope: WRITE_SCOPE },
   );
 
   api.registerGatewayMethod(
     "workboard.cards.dispatchWithOptions",
-    async (context) => await dispatchCards(context, { supportsMaxStarts: true }),
+    (context) => dispatchCards(context, { supportsMaxStarts: true }),
     { scope: WRITE_SCOPE },
   );
 

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -50,9 +50,8 @@ export function registerWorkboardGatewayMethods(params: {
     [
       "workboard.cards.list",
       READ_SCOPE,
-      async ({ params: requestParams }): Promise<unknown> => {
-        return await listWorkboardCards(store, requestParams.boardId, redactClaimToken);
-      },
+      ({ params: requestParams }) =>
+        listWorkboardCards(store, requestParams.boardId, redactClaimToken),
     ],
   ]);
 

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -50,8 +50,9 @@ export function registerWorkboardGatewayMethods(params: {
     [
       "workboard.cards.list",
       READ_SCOPE,
-      async ({ params: requestParams }) =>
-        await listWorkboardCards(store, requestParams.boardId, redactClaimToken),
+      async ({ params: requestParams }): Promise<unknown> => {
+        return await listWorkboardCards(store, requestParams.boardId, redactClaimToken);
+      },
     ],
   ]);
 

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -329,7 +329,7 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      4353,
+      4355,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -427,9 +427,9 @@ export type GatewayRequestHandlerOptions = {
 export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
 
 /** Plugin-facing handler; the registration adapter turns returned values into responses. */
-export type PluginGatewayRequestHandler = (
-  opts: GatewayRequestHandlerOptions,
-) => Promise<unknown> | void;
+export type PluginGatewayRequestHandler =
+  | GatewayRequestHandler
+  | ((opts: GatewayRequestHandlerOptions) => Promise<unknown>);
 
 /** Registry fragment keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -428,9 +428,7 @@ export type GatewayRequestHandlerOptions = {
  * return a value for an implicit success response. Keep the result visible in
  * the public type so plugin authors can use that form without casts.
  */
-export type GatewayRequestHandler = (
-  opts: GatewayRequestHandlerOptions,
-) => Promise<unknown> | unknown;
+export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<unknown> | void;
 
 /** Registry fragment keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -423,12 +423,13 @@ export type GatewayRequestHandlerOptions = {
   signal?: AbortSignal;
 };
 
-/**
- * Single gateway method implementation. Handlers may either call `respond` or
- * return a value for an implicit success response. Keep the result visible in
- * the public type so plugin authors can use that form without casts.
- */
-export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<unknown> | void;
+/** Single core gateway method implementation. */
+export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
+
+/** Plugin-facing handler; the registration adapter turns returned values into responses. */
+export type PluginGatewayRequestHandler = (
+  opts: GatewayRequestHandlerOptions,
+) => Promise<unknown> | void;
 
 /** Registry fragment keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -423,8 +423,14 @@ export type GatewayRequestHandlerOptions = {
   signal?: AbortSignal;
 };
 
-/** Single gateway method implementation. */
-export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
+/**
+ * Single gateway method implementation. Handlers may either call `respond` or
+ * return a value for an implicit success response. Keep the result visible in
+ * the public type so plugin authors can use that form without casts.
+ */
+export type GatewayRequestHandler = (
+  opts: GatewayRequestHandlerOptions,
+) => Promise<unknown> | unknown;
 
 /** Registry fragment keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -32,7 +32,11 @@ export {
   parseGatewayPayload as safeParseJson,
   respondUnavailableOnNodeInvokeError,
 } from "../gateway/server-methods/nodes.helpers.js";
-export type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
+export type {
+  GatewayRequestHandler,
+  GatewayRequestHandlers,
+  PluginGatewayRequestHandler,
+} from "../gateway/server-methods/types.js";
 export { ensureGatewayStartupAuth } from "../gateway/startup-auth.js";
 export { resolveGatewayAuth } from "../gateway/auth.js";
 

--- a/src/plugins/contracts/scheduled-turns.contract.test.ts
+++ b/src/plugins/contracts/scheduled-turns.contract.test.ts
@@ -34,7 +34,8 @@ import type { OpenClawPluginApi } from "../types.js";
 
 // Return-value gateway handlers are part of the public SDK contract. This
 // assignment must remain valid for plugins that return an implicit response.
-const returnedGatewayHandlerResult: Awaited<ReturnType<GatewayRequestHandler>> = {
+type PluginGatewayMethodHandler = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+const returnedGatewayHandlerResult: Awaited<ReturnType<PluginGatewayMethodHandler>> = {
   ok: true,
 };
 void returnedGatewayHandlerResult;

--- a/src/plugins/contracts/scheduled-turns.contract.test.ts
+++ b/src/plugins/contracts/scheduled-turns.contract.test.ts
@@ -32,6 +32,13 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../runt
 import { createPluginRecord } from "../status.test-helpers.js";
 import type { OpenClawPluginApi } from "../types.js";
 
+// Return-value gateway handlers are part of the public SDK contract. This
+// assignment must remain valid for plugins that return an implicit response.
+const returnedGatewayHandlerResult: Awaited<ReturnType<GatewayRequestHandler>> = {
+  ok: true,
+};
+void returnedGatewayHandlerResult;
+
 const workflowMocks = vi.hoisted(() => ({
   cronAdd: vi.fn(),
   cronListPage: vi.fn(),

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -2,7 +2,7 @@ import type { AgentHarness, AgentHarnessRegistrationOptions } from "../agents/ha
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
-import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import type { PluginGatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hook-types.js";
 import type { DetachedTaskLifecycleRuntime } from "../tasks/detached-task-runtime-contract.js";
 import type {
@@ -229,7 +229,7 @@ export type OpenClawPluginApi = {
    */
   registerGatewayMethod: (
     method: string,
-    handler: GatewayRequestHandler,
+    handler: PluginGatewayRequestHandler,
     opts?: {
       scope?: OperatorScope;
       profileAccess?: "independent" | "required";

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -5,7 +5,11 @@ import {
   type GatewayMethodProfileAccess,
 } from "../gateway/methods/descriptor.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
-import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
+import type {
+  GatewayRequestHandler,
+  PluginGatewayRequestHandler,
+  RespondFn,
+} from "../gateway/server-methods/types.js";
 import { normalizePluginGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -30,7 +34,9 @@ import type {
 
 const GATEWAY_METHOD_DISPATCH_CONTRACT = "authenticated-request";
 
-function adaptPluginGatewayMethodHandler(handler: GatewayRequestHandler): GatewayRequestHandler {
+function adaptPluginGatewayMethodHandler(
+  handler: PluginGatewayRequestHandler,
+): GatewayRequestHandler {
   return async (opts) => {
     let responded = false;
     const respond: RespondFn = (ok, payload, error, meta) => {
@@ -58,7 +64,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
   const registerGatewayMethod = (
     record: PluginRecord,
     method: string,
-    handler: GatewayRequestHandler,
+    handler: PluginGatewayRequestHandler,
     opts?: { scope?: OperatorScope; profileAccess?: GatewayMethodProfileAccess },
   ) => {
     const trimmed = method.trim();

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import {
   disconnectGatewayClient,
@@ -68,11 +68,19 @@ describe("plugin Gateway returned values", () => {
         source: "typescript",
       });
     } finally {
-      if (gateway) await disconnectGatewayClient(gateway.client);
-      if (previous.HOME === undefined) delete process.env.HOME;
-      else process.env.HOME = previous.HOME;
-      if (previous.OPENCLAW_STATE_DIR === undefined) delete process.env.OPENCLAW_STATE_DIR;
-      else process.env.OPENCLAW_STATE_DIR = previous.OPENCLAW_STATE_DIR;
+      if (gateway) {
+        await disconnectGatewayClient(gateway.client);
+      }
+      if (previous.HOME === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previous.HOME;
+      }
+      if (previous.OPENCLAW_STATE_DIR === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previous.OPENCLAW_STATE_DIR;
+      }
     }
   }, 120_000);
 });

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
+
+describe("plugin Gateway returned values", () => {
+  it("loads a cast-free TypeScript plugin and returns its payload through Gateway RPC", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-gateway-return-"));
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const pluginDir = path.join(root, "plugin");
+    await Promise.all([
+      fs.mkdir(stateDir, { recursive: true }),
+      fs.mkdir(workspaceDir, { recursive: true }),
+      fs.mkdir(pluginDir, { recursive: true }),
+    ]);
+    await fs.writeFile(path.join(pluginDir, "package.json"), '{"type":"module"}\n');
+    await fs.writeFile(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "ts-gateway-return", configSchema: { type: "object" } }),
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "index.ts"),
+      `export default {
+  id: "ts-gateway-return",
+  register(api: import("../../../../src/plugins/plugin-api.types.js").OpenClawPluginApi) {
+    api.registerGatewayMethod("ts-gateway-return.echo", async () => ({ ok: true, source: "typescript" }));
+  },
+};
+`,
+    );
+    const token = "plugin-gateway-return-test-token";
+    const config = {
+      agents: {
+        defaults: { workspace: workspaceDir, skipBootstrap: true },
+        entries: { main: { default: true } },
+      },
+      gateway: { auth: { mode: "token", token } },
+      plugins: {
+        enabled: true,
+        allow: ["ts-gateway-return"],
+        load: { paths: [pluginDir] },
+        entries: { "ts-gateway-return": { enabled: true } },
+        slots: { memory: "none" },
+      },
+    } satisfies OpenClawConfig;
+    const previous = { HOME: process.env.HOME, OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR };
+    process.env.HOME = root;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+    try {
+      gateway = await startGatewayWithClient({
+        cfg: config,
+        configPath: path.join(stateDir, "openclaw.json"),
+        token,
+        clientDisplayName: "plugin-gateway-return-proof",
+      });
+      await expect(gateway.client.request("ts-gateway-return.echo", {})).resolves.toEqual({
+        ok: true,
+        source: "typescript",
+      });
+    } finally {
+      if (gateway) await disconnectGatewayClient(gateway.client);
+      if (previous.HOME === undefined) delete process.env.HOME;
+      else process.env.HOME = previous.HOME;
+      if (previous.OPENCLAW_STATE_DIR === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = previous.OPENCLAW_STATE_DIR;
+    }
+  }, 120_000);
+});

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   disconnectGatewayClient,
   startGatewayWithClient,
 } from "../../../../src/gateway/test-helpers.e2e.js";
+import pluginFixture from "./plugin-gateway-return.fixture.js";
 
 describe("plugin Gateway returned values", () => {
   it("loads a cast-free TypeScript plugin and returns its payload through Gateway RPC", async () => {
@@ -27,16 +28,11 @@ describe("plugin Gateway returned values", () => {
       path.join(pluginDir, "openclaw.plugin.json"),
       JSON.stringify({ id: "ts-gateway-return", configSchema: { type: "object" } }),
     );
-    await fs.writeFile(
+    await fs.copyFile(
+      new URL("./plugin-gateway-return.fixture.ts", import.meta.url),
       path.join(pluginDir, "index.ts"),
-      `export default {
-  id: "ts-gateway-return",
-  register(api: import("../../../../src/plugins/plugin-api.types.js").OpenClawPluginApi) {
-    api.registerGatewayMethod("ts-gateway-return.echo", async () => ({ ok: true, source: "typescript" }));
-  },
-};
-`,
     );
+    expect(pluginFixture.id).toBe("ts-gateway-return");
     const token = "plugin-gateway-return-test-token";
     const config = {
       agents: {

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
@@ -69,7 +69,11 @@ describe("plugin Gateway returned values", () => {
       });
     } finally {
       if (gateway) {
-        await disconnectGatewayClient(gateway.client);
+        try {
+          await disconnectGatewayClient(gateway.client);
+        } finally {
+          await gateway.server.close({ reason: "plugin Gateway returned-value proof complete" });
+        }
       }
       if (previous.HOME === undefined) {
         delete process.env.HOME;

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts
@@ -19,7 +19,10 @@ describe("plugin Gateway returned values", () => {
       fs.mkdir(workspaceDir, { recursive: true }),
       fs.mkdir(pluginDir, { recursive: true }),
     ]);
-    await fs.writeFile(path.join(pluginDir, "package.json"), '{"type":"module"}\n');
+    await fs.writeFile(
+      path.join(pluginDir, "package.json"),
+      '{"type":"module","main":"index.ts"}\n',
+    );
     await fs.writeFile(
       path.join(pluginDir, "openclaw.plugin.json"),
       JSON.stringify({ id: "ts-gateway-return", configSchema: { type: "object" } }),

--- a/test/e2e/qa-lab/runtime/plugin-gateway-return.fixture.ts
+++ b/test/e2e/qa-lab/runtime/plugin-gateway-return.fixture.ts
@@ -1,0 +1,13 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+const plugin = {
+  id: "ts-gateway-return",
+  register(api: OpenClawPluginApi) {
+    api.registerGatewayMethod("ts-gateway-return.echo", async () => ({
+      ok: true,
+      source: "typescript",
+    }));
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
## What Problem This Solves

Issue #142718: `registerGatewayMethod` already supports returning a value that becomes the Gateway response, but the exported plugin handler type describes handlers as returning only `void`. TypeScript plugin authors cannot express the supported return-value contract cleanly.

## Why This Change Was Made

The plugin gateway adapter has converted non-`undefined` handler results into successful responses since #85785. The public plugin registration input is the remaining stale contract. This change widens only that plugin-facing input type and keeps core Gateway handlers callback-only.

## User Impact

TypeScript plugins can return a Gateway response from `registerGatewayMethod` without a cast. Existing core handlers, explicit `respond(...)` handlers, and runtime dispatch behavior are unchanged.

## Evidence

- `PluginGatewayRequestHandler` is used at the plugin registration boundary; the adapter converts its returned value and exposes a core `GatewayRequestHandler` afterward.
- Core `GatewayRequestHandler` remains `Promise<void> | void`; the plugin SDK exports both public handler contracts from `gateway-runtime`.
- The Workboard shared result wrapper now explicitly returns `void`, preserving no-return callback inference under the widened plugin input.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:extensions` passed.
- `pnpm tsgo:test:root` passed.
- Exact-head runtime contract test under Node 24.18.0 passed: `src/plugins/contracts/scheduled-turns.contract.test.ts` (26 tests), including real plugin registration lifecycle coverage and returned Gateway method behavior.
- `git diff --check` passed.


## Added exact-head proof (44e7bcdc96b)

- Added `test/e2e/qa-lab/runtime/plugin-gateway-return.e2e.test.ts`.
- The fixture is a TypeScript plugin whose `register(api)` calls `api.registerGatewayMethod("ts-gateway-return.echo", async () => ({ ok: true, source: "typescript" }))` with no cast and no explicit `respond` call.
- The test starts an isolated Gateway with the plugin loaded through `plugins.load.paths`, connects with the real `GatewayClient`, invokes `ts-gateway-return.echo`, and asserts the RPC payload is `{ ok: true, source: "typescript" }`.
- This exercises the public plugin registration type, the plugin loader, registration adapter, authenticated Gateway dispatch, and the client response path together.

## Public handler-union compatibility

The widened `PluginGatewayRequestHandler` is confined to the plugin registration boundary. Existing callback handlers remain valid because the union retains the original `(opts) => void | Promise<void>` shape; the adapter still supplies the same `respond` callback and preserves explicit responses. Core `GatewayRequestHandler` remains callback-only, so core dispatch does not acquire an implicit-return contract. The new test covers the cast-free implicit-return branch, while the existing contract fixtures cover explicit-response and callback-only handlers. Contextual typing can expose a downstream plugin that depended on an inferred callback-only return type, so this is an additive public-input compatibility risk limited to TypeScript plugin authors; runtime dispatch semantics and existing callback registrations are unchanged.


## CI follow-up on exact head

The previous CI run exposed two contract fallout errors from the widened plugin handler type: Workboard callbacks had inconsistent return paths (`extensions/workboard/src/gateway.ts` and `gateway-helpers.ts`). They now return one canonical Promise path while preserving explicit `respond` behavior. The plugin SDK surface budget was refreshed from 4,353 to 4,355 to account for the two intentional public type exports; unrelated tooling shard failures were rechecked against the exact head.


## Follow-up fixes (975638accf2)

- Wrapped Workboard handler invocation in a deferred Promise boundary so synchronous validation throws and rejected promises both reach `respondError`.
- Closed the Gateway server in the RPC proof test before restoring the test environment.
- Focused checks: `oxlint` passed for touched files; `plugin-sdk-surface-report.mts --check` passed; Workboard gateway tests were run with Node 24.15.0 (the repository-required SQLite-safe runtime).


## Follow-up proof and fixes (93b878309f4)

- Workboard handler invocation is deferred before `Promise.resolve`, so synchronous validation throws and rejected promises share the `respondError` boundary.
- The Gateway RPC proof closes the returned server before restoring the test environment.
- The proof plugin is now a committed TypeScript fixture importing `OpenClawPluginApi` from the public `openclaw/plugin-sdk/plugin-entry` entrypoint. `pnpm tsgo:test:root` passes with the fixture, and the E2E test loads that same TypeScript entry through the real plugin loader and invokes it through `GatewayClient`.
