### PR TITLE
feat(plugins): assign one purpose category to every bundled plugin

### DIFF
--- a/extensions/a2a/openclaw.plugin.json
+++ b/extensions/a2a/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "a2a",
-  "categories": ["channels"],
+  "categories": ["channels", "agent-orchestration"],
   "name": "A2A",
   "description": "A2A v1.0 Agent-to-Agent protocol channel plugin.",
   "activation": {

--- a/extensions/a2a/openclaw.plugin.json
+++ b/extensions/a2a/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "a2a",
-  "categories": ["channels", "agent-orchestration"],
+  "categories": ["agent-orchestration"],
   "name": "A2A",
   "description": "A2A v1.0 Agent-to-Agent protocol channel plugin.",
   "activation": {

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "acpx",
-  "categories": ["developer-tools"],
+  "categories": ["agent-runtimes"],
   "backupResources": [
     {
       "disposition": "regenerable",

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "acpx",
-  "categories": ["runtime", "tools"],
+  "categories": ["developer-tools", "agent-orchestration"],
   "backupResources": [
     {
       "disposition": "regenerable",

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "acpx",
-  "categories": ["developer-tools", "agent-orchestration"],
+  "categories": ["developer-tools"],
   "backupResources": [
     {
       "disposition": "regenerable",

--- a/extensions/admin-http-rpc/openclaw.plugin.json
+++ b/extensions/admin-http-rpc/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "admin-http-rpc",
-  "categories": ["gateway"],
+  "categories": ["infrastructure", "integrations"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.admin-http-rpc"]

--- a/extensions/admin-http-rpc/openclaw.plugin.json
+++ b/extensions/admin-http-rpc/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "admin-http-rpc",
-  "categories": ["infrastructure", "integrations"],
+  "categories": ["infrastructure"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.admin-http-rpc"]

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "amazon-bedrock",
-  "categories": ["models", "memory"],
+  "categories": ["models"],
   "name": "Amazon Bedrock",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "activation": {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "anthropic",
-  "categories": ["models", "media", "developer-tools"],
+  "categories": ["models"],
   "doctorContract": {},
   "sessionRouteStateOwners": [
     {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "anthropic",
-  "categories": ["models", "media"],
+  "categories": ["models", "media", "developer-tools"],
   "doctorContract": {},
   "sessionRouteStateOwners": [
     {

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "beam",
-  "categories": ["developer-tools", "inbox-collaboration"],
+  "categories": ["developer-tools"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.beam"]

--- a/extensions/beam/openclaw.plugin.json
+++ b/extensions/beam/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "beam",
-  "categories": ["runtime"],
+  "categories": ["developer-tools", "inbox-collaboration"],
   "activation": {
     "onStartup": false,
     "onConfigPaths": ["plugins.entries.beam"]

--- a/extensions/bonjour/openclaw.plugin.json
+++ b/extensions/bonjour/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "bonjour",
-  "categories": ["gateway"],
+  "categories": ["infrastructure"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/browser/openclaw.plugin.json
+++ b/extensions/browser/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "browser",
-  "categories": ["tools"],
+  "categories": ["web"],
   "cliCommands": [
     {
       "name": "browser",

--- a/extensions/byteplus/openclaw.plugin.json
+++ b/extensions/byteplus/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "byteplus",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/canvas/openclaw.plugin.json
+++ b/extensions/canvas/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "canvas",
-  "categories": ["productivity"],
+  "categories": ["documents-files"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "canvas-custom-root-documents-to-core" }]

--- a/extensions/canvas/openclaw.plugin.json
+++ b/extensions/canvas/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "canvas",
-  "categories": ["tools"],
+  "categories": ["productivity"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "canvas-custom-root-documents-to-core" }]

--- a/extensions/clickclack/openclaw.plugin.json
+++ b/extensions/clickclack/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "clickclack",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "name": "ClickClack",
   "description": "OpenClaw ClickClack channel plugin.",
   "doctorContract": {

--- a/extensions/clickclack/openclaw.plugin.json
+++ b/extensions/clickclack/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "clickclack",
-  "categories": ["channels", "tools"],
+  "categories": ["channels", "inbox-collaboration"],
   "name": "ClickClack",
   "description": "OpenClaw ClickClack channel plugin.",
   "doctorContract": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "codex",
-  "categories": ["runtime", "tools", "web"],
+  "categories": ["developer-tools", "agent-orchestration", "web"],
   "providers": ["codex"],
   "syntheticAuthRefs": ["codex"],
   "providerCatalogEntry": "./provider-discovery.ts",

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "codex",
-  "categories": ["developer-tools", "agent-orchestration", "web"],
+  "categories": ["developer-tools"],
   "providers": ["codex"],
   "syntheticAuthRefs": ["codex"],
   "providerCatalogEntry": "./provider-discovery.ts",

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "codex",
-  "categories": ["developer-tools"],
+  "categories": ["agent-runtimes"],
   "providers": ["codex"],
   "syntheticAuthRefs": ["codex"],
   "providerCatalogEntry": "./provider-discovery.ts",

--- a/extensions/comfy/openclaw.plugin.json
+++ b/extensions/comfy/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "comfy",
-  "categories": ["models", "media"],
+  "categories": ["media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "categories": ["runtime"],
+  "categories": ["developer-tools", "agent-orchestration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "categories": ["developer-tools", "agent-orchestration"],
+  "categories": ["developer-tools"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "categories": ["developer-tools"],
+  "categories": ["agent-runtimes"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/crabbox/openclaw.plugin.json
+++ b/extensions/crabbox/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "crabbox",
-  "categories": ["infrastructure", "agent-orchestration"],
+  "categories": ["infrastructure"],
   "doctorContract": {
     "stateMigrations": [{ "id": "crabbox-warm-profile-v3", "doctorOnly": true }]
   },

--- a/extensions/crabbox/openclaw.plugin.json
+++ b/extensions/crabbox/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "crabbox",
-  "categories": ["runtime", "tools"],
+  "categories": ["infrastructure", "agent-orchestration"],
   "doctorContract": {
     "stateMigrations": [{ "id": "crabbox-warm-profile-v3", "doctorOnly": true }]
   },

--- a/extensions/cua-computer/openclaw.plugin.json
+++ b/extensions/cua-computer/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "cua-computer",
-  "categories": ["productivity"],
+  "categories": ["infrastructure"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/cua-computer/openclaw.plugin.json
+++ b/extensions/cua-computer/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "cua-computer",
-  "categories": ["tools"],
+  "categories": ["productivity"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/deepgram/openclaw.plugin.json
+++ b/extensions/deepgram/openclaw.plugin.json
@@ -1,10 +1,6 @@
 {
   "id": "deepgram",
-  "categories": [
-    "models",
-    "voice",
-    "media"
-  ],
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "deepinfra",
-  "categories": ["models", "memory", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/device-pair/openclaw.plugin.json
+++ b/extensions/device-pair/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "device-pair",
-  "categories": ["tools"],
+  "categories": ["security"],
   "doctorContract": {
     "stateMigrations": [{ "id": "device-pair-notify-json-to-plugin-state" }]
   },

--- a/extensions/diagnostics-otel/openclaw.plugin.json
+++ b/extensions/diagnostics-otel/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "diagnostics-otel",
-  "categories": ["gateway"],
+  "categories": ["infrastructure"],
   "name": "Diagnostics OpenTelemetry",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics, traces, and logs.",
   "activation": {

--- a/extensions/diagnostics-prometheus/openclaw.plugin.json
+++ b/extensions/diagnostics-prometheus/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "diagnostics-prometheus",
-  "categories": ["gateway"],
+  "categories": ["infrastructure"],
   "name": "Diagnostics Prometheus",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "activation": {

--- a/extensions/diffs-language-pack/openclaw.plugin.json
+++ b/extensions/diffs-language-pack/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "diffs-language-pack",
-  "categories": ["runtime"],
+  "categories": ["developer-tools"],
   "requiresPlugins": ["diffs"],
   "activation": {
     "onStartup": true

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "diffs",
-  "categories": ["developer-tools", "documents-files"],
+  "categories": ["developer-tools"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "diffs",
-  "categories": ["tools"],
+  "categories": ["developer-tools", "documents-files"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "discord",
-  "categories": ["channels", "voice"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "discord-legacy-state" }]

--- a/extensions/document-extract/openclaw.plugin.json
+++ b/extensions/document-extract/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "document-extract",
-  "categories": ["context", "tools"],
+  "categories": ["context", "documents-files"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/document-extract/openclaw.plugin.json
+++ b/extensions/document-extract/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "document-extract",
-  "categories": ["context", "documents-files"],
+  "categories": ["documents-files"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/elevenlabs/openclaw.plugin.json
+++ b/extensions/elevenlabs/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "elevenlabs",
-  "categories": ["models", "voice", "media"],
+  "categories": ["voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/fal/openclaw.plugin.json
+++ b/extensions/fal/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "fal",
-  "categories": ["models", "media"],
+  "categories": ["media"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "feishu",
-  "categories": ["channels", "tools"],
+  "categories": ["channels", "documents-files", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "feishu",
-  "categories": ["channels", "documents-files", "inbox-collaboration"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/file-transfer/openclaw.plugin.json
+++ b/extensions/file-transfer/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "file-transfer",
-  "categories": ["tools"],
+  "categories": ["documents-files"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "firecrawl",
-  "categories": ["web", "tools"],
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/geolocation/openclaw.plugin.json
+++ b/extensions/geolocation/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "geolocation",
-  "categories": ["tools"],
+  "categories": ["infrastructure"],
   "name": "Geolocation",
   "description": "Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database.",
   "enabledByDefault": true,

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "github-copilot",
-  "categories": ["models", "memory"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "google-meet",
-  "categories": ["voice", "inbox-collaboration"],
+  "categories": ["voice"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "google-meet",
-  "categories": ["voice", "tools"],
+  "categories": ["voice", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "google",
-  "categories": ["models", "memory", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {},
   "sessionRouteStateOwners": [

--- a/extensions/googlechat/openclaw.plugin.json
+++ b/extensions/googlechat/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "googlechat",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/googlechat/openclaw.plugin.json
+++ b/extensions/googlechat/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "googlechat",
-  "categories": ["channels"],
+  "categories": ["channels", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "groq",
-  "categories": ["models", "media"],
+  "categories": ["models", "voice"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "groq",
-  "categories": ["models", "voice"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/imap/openclaw.plugin.json
+++ b/extensions/imap/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "imap",
-  "categories": ["tools"],
+  "categories": ["inbox-collaboration"],
   "name": "IMAP email trigger",
   "description": "Watch IMAP mailboxes and dispatch authenticated incoming email to isolated agent sessions.",
   "activation": { "onStartup": true },

--- a/extensions/linux-node/openclaw.plugin.json
+++ b/extensions/linux-node/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "linux-node",
-  "categories": ["runtime"],
+  "categories": ["infrastructure"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/litellm/openclaw.plugin.json
+++ b/extensions/litellm/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "litellm",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/llama-cpp/openclaw.plugin.json
+++ b/extensions/llama-cpp/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "llama-cpp",
-  "categories": ["models", "memory"],
+  "categories": ["models"],
   "name": "llama.cpp Provider",
   "description": "Managed and external llama.cpp servers for GGUF chat and embeddings.",
   "activation": {

--- a/extensions/llm-task/openclaw.plugin.json
+++ b/extensions/llm-task/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "llm-task",
-  "categories": ["tools"],
+  "categories": ["agent-orchestration", "developer-tools"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/llm-task/openclaw.plugin.json
+++ b/extensions/llm-task/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "llm-task",
-  "categories": ["agent-orchestration", "developer-tools"],
+  "categories": ["agent-orchestration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/lmstudio/openclaw.plugin.json
+++ b/extensions/lmstudio/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "lmstudio",
-  "categories": ["models", "memory"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/lobster/openclaw.plugin.json
+++ b/extensions/lobster/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "lobster",
-  "categories": ["tools"],
+  "categories": ["agent-orchestration"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/logbook/openclaw.plugin.json
+++ b/extensions/logbook/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "logbook",
-  "categories": ["tools"],
+  "categories": ["productivity"],
   "name": "Logbook",
   "description": "Automatic work journal: captures periodic screen snapshots from a paired node and turns them into a reviewable timeline of your day.",
   "enabledByDefault": false,

--- a/extensions/matrix/openclaw.plugin.json
+++ b/extensions/matrix/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "matrix",
-  "categories": ["channels", "tools"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/mattermost/openclaw.plugin.json
+++ b/extensions/mattermost/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mattermost",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "name": "Mattermost",
   "description": "OpenClaw Mattermost channel plugin.",
   "doctorContract": {

--- a/extensions/mattermost/openclaw.plugin.json
+++ b/extensions/mattermost/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mattermost",
-  "categories": ["channels"],
+  "categories": ["channels", "inbox-collaboration"],
   "name": "Mattermost",
   "description": "OpenClaw Mattermost channel plugin.",
   "doctorContract": {

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-core",
-  "categories": ["memory", "tools"],
+  "categories": ["memory"],
   "doctorContract": {
     "stateMigrations": [
       { "id": "memory-core-host-events-jsonl-to-sqlite", "doctorOnly": true },

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-lancedb",
-  "categories": ["memory", "tools"],
+  "categories": ["memory"],
   "doctorContract": {
     "stateMigrations": [
       { "id": "memory-lancedb-agent-scope" },

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-wiki",
-  "categories": ["memory", "documents-files"],
+  "categories": ["memory"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-wiki",
-  "categories": ["memory", "tools"],
+  "categories": ["memory", "documents-files"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/microsoft-foundry/openclaw.plugin.json
+++ b/extensions/microsoft-foundry/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "microsoft-foundry",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/migrate-claude/openclaw.plugin.json
+++ b/extensions/migrate-claude/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "migrate-claude",
-  "categories": ["integrations", "developer-tools"],
+  "categories": ["integrations"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/migrate-claude/openclaw.plugin.json
+++ b/extensions/migrate-claude/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "migrate-claude",
-  "categories": ["runtime"],
+  "categories": ["integrations", "developer-tools"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/migrate-hermes/openclaw.plugin.json
+++ b/extensions/migrate-hermes/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "migrate-hermes",
-  "categories": ["runtime"],
+  "categories": ["integrations"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "minimax",
-  "categories": ["models", "voice", "media"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mistral",
-  "categories": ["models", "memory", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "moonshot",
-  "categories": ["models", "media", "web"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/msteams/openclaw.plugin.json
+++ b/extensions/msteams/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "msteams",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/msteams/openclaw.plugin.json
+++ b/extensions/msteams/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "msteams",
-  "categories": ["channels"],
+  "categories": ["channels", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/mxc/openclaw.plugin.json
+++ b/extensions/mxc/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mxc",
-  "categories": ["security", "runtime"],
+  "categories": ["security", "infrastructure"],
   "name": "MXC Sandbox Execution",
   "description": "OS-level sandboxed tool execution via MXC: runs commands in a Windows ProcessContainer with configured MXC policy files.",
   "activation": {

--- a/extensions/mxc/openclaw.plugin.json
+++ b/extensions/mxc/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mxc",
-  "categories": ["security", "infrastructure"],
+  "categories": ["security"],
   "name": "MXC Sandbox Execution",
   "description": "OS-level sandboxed tool execution via MXC: runs commands in a Windows ProcessContainer with configured MXC policy files.",
   "activation": {

--- a/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/extensions/nextcloud-talk/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nextcloud-talk",
-  "categories": ["channels"],
+  "categories": ["channels", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/nextcloud-talk/openclaw.plugin.json
+++ b/extensions/nextcloud-talk/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "nextcloud-talk",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/oc-path/openclaw.plugin.json
+++ b/extensions/oc-path/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "oc-path",
-  "categories": ["documents-files", "developer-tools"],
+  "categories": ["documents-files"],
   "name": "OC Path",
   "description": "Adds the openclaw path CLI for oc:// workspace file addressing.",
   "cliCommands": [

--- a/extensions/oc-path/openclaw.plugin.json
+++ b/extensions/oc-path/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "oc-path",
-  "categories": ["tools"],
+  "categories": ["documents-files", "developer-tools"],
   "name": "OC Path",
   "description": "Adds the openclaw path CLI for oc:// workspace file addressing.",
   "cliCommands": [

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "ollama",
-  "categories": ["models", "memory", "web"],
+  "categories": ["models"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/onepassword/openclaw.plugin.json
+++ b/extensions/onepassword/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "onepassword",
-  "categories": ["security", "tools"],
+  "categories": ["security"],
   "name": "1Password",
   "description": "1Password SecretRef resolver and curated agent broker with approval policy and SQLite audit history.",
   "cliCommands": [

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openai",
-  "categories": ["models", "memory", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "sessionRouteStateOwners": [
     {

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode-go",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": { "onStartup": true },
   "providerCatalogEntry": "./provider-discovery.ts",
   "enabledByDefault": true,

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openrouter",
-  "categories": ["models", "voice", "media"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openshell",
-  "categories": ["security", "infrastructure"],
+  "categories": ["security"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openshell",
-  "categories": ["security", "runtime"],
+  "categories": ["security", "infrastructure"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "policy",
-  "categories": ["security", "tools"],
+  "categories": ["security"],
   "name": "Policy",
   "description": "Adds policy-backed doctor checks for workspace conformance.",
   "cliCommands": [

--- a/extensions/qa-channel/openclaw.plugin.json
+++ b/extensions/qa-channel/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qa-channel",
-  "categories": ["developer-tools", "channels"],
+  "categories": ["developer-tools"],
   "name": "QA Channel",
   "description": "OpenClaw QA synthetic channel plugin.",
   "activation": {

--- a/extensions/qa-channel/openclaw.plugin.json
+++ b/extensions/qa-channel/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qa-channel",
-  "categories": ["channels"],
+  "categories": ["developer-tools", "channels"],
   "name": "QA Channel",
   "description": "OpenClaw QA synthetic channel plugin.",
   "activation": {

--- a/extensions/qa-lab/openclaw.plugin.json
+++ b/extensions/qa-lab/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qa-lab",
-  "categories": ["tools", "web"],
+  "categories": ["developer-tools"],
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner.",
   "cliCommands": [
     {

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "qwen",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/reef/openclaw.plugin.json
+++ b/extensions/reef/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "reef",
-  "categories": ["channels", "tools"],
+  "categories": ["channels", "agent-orchestration"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/reef/openclaw.plugin.json
+++ b/extensions/reef/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "reef",
-  "categories": ["channels", "agent-orchestration"],
+  "categories": ["agent-orchestration"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/senseaudio/openclaw.plugin.json
+++ b/extensions/senseaudio/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "senseaudio",
-  "categories": ["media"],
+  "categories": ["voice"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/slack/openclaw.plugin.json
+++ b/extensions/slack/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "slack",
-  "categories": ["channels"],
+  "categories": ["channels", "inbox-collaboration"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/slack/openclaw.plugin.json
+++ b/extensions/slack/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "slack",
-  "categories": ["channels", "inbox-collaboration"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true
   },

--- a/extensions/talk-voice/openclaw.plugin.json
+++ b/extensions/talk-voice/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "talk-voice",
-  "categories": ["voice", "tools"],
+  "categories": ["voice"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/tavily/openclaw.plugin.json
+++ b/extensions/tavily/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "tavily",
-  "categories": ["web", "tools"],
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/team-reports/openclaw.plugin.json
+++ b/extensions/team-reports/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "team-reports",
   "name": "Team Reports",
   "description": "Daily, weekly, and monthly team activity reports from GitHub and Discord, with model-written summaries, served in the Control UI.",
-  "categories": ["data-analytics", "productivity", "inbox-collaboration"],
+  "categories": ["data-analytics"],
   "enabledByDefault": false,
   "activation": {
     "onStartup": true,

--- a/extensions/team-reports/openclaw.plugin.json
+++ b/extensions/team-reports/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "team-reports",
   "name": "Team Reports",
   "description": "Daily, weekly, and monthly team activity reports from GitHub and Discord, with model-written summaries, served in the Control UI.",
-  "categories": ["tools"],
+  "categories": ["data-analytics", "productivity", "inbox-collaboration"],
   "enabledByDefault": false,
   "activation": {
     "onStartup": true,

--- a/extensions/teams-meetings/openclaw.plugin.json
+++ b/extensions/teams-meetings/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "teams-meetings",
-  "categories": ["voice", "inbox-collaboration"],
+  "categories": ["voice"],
   "name": "Microsoft Teams meetings",
   "description": "Join Microsoft Teams meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/extensions/teams-meetings/openclaw.plugin.json
+++ b/extensions/teams-meetings/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "teams-meetings",
-  "categories": ["voice", "tools"],
+  "categories": ["voice", "inbox-collaboration"],
   "name": "Microsoft Teams meetings",
   "description": "Join Microsoft Teams meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/extensions/together/openclaw.plugin.json
+++ b/extensions/together/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "together",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "tokenjuice",
-  "categories": ["runtime"],
+  "categories": ["context", "developer-tools"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "tokenjuice",
-  "categories": ["context", "developer-tools"],
+  "categories": ["context"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/vault/openclaw.plugin.json
+++ b/extensions/vault/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "vault",
-  "categories": ["security", "tools"],
+  "categories": ["security"],
   "name": "Vault",
   "description": "HashiCorp Vault SecretRef provider integration.",
   "cliCommands": [

--- a/extensions/visitor-access/openclaw.plugin.json
+++ b/extensions/visitor-access/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "visitor-access",
-  "categories": ["tools"],
+  "categories": ["security"],
   "name": "Visitor Access",
   "description": "Manage expiring visitor grants through one Cloudflare Access email policy.",
   "activation": {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "voice-call",
-  "categories": ["voice", "tools"],
+  "categories": ["voice"],
   "doctorContract": {
     "resolveSessionStoreAgentIds": true,
     "stateMigrations": [{ "id": "voice-call-calls-jsonl-to-plugin-state" }]

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "volcengine",
-  "categories": ["models", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/vydra/openclaw.plugin.json
+++ b/extensions/vydra/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "vydra",
-  "categories": ["models", "voice", "media"],
+  "categories": ["media", "voice"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/vydra/openclaw.plugin.json
+++ b/extensions/vydra/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "vydra",
-  "categories": ["media", "voice"],
+  "categories": ["media"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/web-readability/openclaw.plugin.json
+++ b/extensions/web-readability/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "web-readability",
-  "categories": ["web", "context"],
+  "categories": ["web"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/webhooks/openclaw.plugin.json
+++ b/extensions/webhooks/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "webhooks",
-  "categories": ["gateway", "tools"],
+  "categories": ["integrations", "agent-orchestration"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/webhooks/openclaw.plugin.json
+++ b/extensions/webhooks/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "webhooks",
-  "categories": ["integrations", "agent-orchestration"],
+  "categories": ["integrations"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "whatsapp",
-  "categories": ["channels", "voice"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "whatsapp-legacy-state" }]

--- a/extensions/whatsapp/openclaw.plugin.json
+++ b/extensions/whatsapp/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "whatsapp",
-  "categories": ["channels", "tools"],
+  "categories": ["channels", "voice"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [{ "id": "whatsapp-legacy-state" }]

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -1,6 +1,8 @@
 {
   "id": "workboard",
-  "categories": ["productivity", "agent-orchestration"],
+  "categories": [
+    "productivity"
+  ],
   "cliCommands": [
     {
       "name": "workboard",

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -1,8 +1,6 @@
 {
   "id": "workboard",
-  "categories": [
-    "tools"
-  ],
+  "categories": ["productivity", "agent-orchestration"],
   "cliCommands": [
     {
       "name": "workboard",

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "xai",
-  "categories": ["models", "voice", "media"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "doctorContract": {
     "configRepair": true

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "xiaomi",
-  "categories": ["models", "voice"],
+  "categories": ["models"],
   "capabilityCatalogEntry": "./capability-catalog.ts",
   "activation": {
     "onStartup": false

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "zai",
-  "categories": ["models", "media"],
+  "categories": ["models"],
   "activation": {
     "onStartup": false
   },

--- a/extensions/zalouser/openclaw.plugin.json
+++ b/extensions/zalouser/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "zalouser",
-  "categories": ["channels", "tools"],
+  "categories": ["channels"],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [

--- a/extensions/zoom-meetings/openclaw.plugin.json
+++ b/extensions/zoom-meetings/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "zoom-meetings",
-  "categories": ["voice", "inbox-collaboration"],
+  "categories": ["voice"],
   "name": "Zoom meetings",
   "description": "Join Zoom meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/extensions/zoom-meetings/openclaw.plugin.json
+++ b/extensions/zoom-meetings/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "zoom-meetings",
-  "categories": ["voice", "tools"],
+  "categories": ["voice", "inbox-collaboration"],
   "name": "Zoom meetings",
   "description": "Join Zoom meetings as a Chrome browser guest.",
   "cliCommands": [

--- a/src/plugins/bundled-plugin-categories.test.ts
+++ b/src/plugins/bundled-plugin-categories.test.ts
@@ -41,7 +41,12 @@ describe("bundled plugin categories", () => {
   });
 
   it.each([
-    { pluginId: "codex", category: "developer-tools", purpose: "coding harness" },
+    { pluginId: "codex", category: "agent-runtimes", purpose: "native agent executor" },
+    { pluginId: "acpx", category: "agent-runtimes", purpose: "ACP execution backend" },
+    { pluginId: "copilot", category: "agent-runtimes", purpose: "native agent executor" },
+    { pluginId: "beam", category: "developer-tools", purpose: "coding-session review" },
+    { pluginId: "anthropic", category: "models", purpose: "model access despite a CLI backend" },
+    { pluginId: "opencode", category: "models", purpose: "model access despite session tools" },
     { pluginId: "a2a", category: "agent-orchestration", purpose: "agent-to-agent delegation" },
     {
       pluginId: "feishu",

--- a/src/plugins/bundled-plugin-categories.test.ts
+++ b/src/plugins/bundled-plugin-categories.test.ts
@@ -7,9 +7,8 @@ import { pluginTestRepoRoot as repoRoot } from "./generated-plugin-test-helpers.
 import { loadPluginManifest } from "./manifest.js";
 
 describe("bundled plugin categories", () => {
-  it("assigns active categories to every bundled plugin", () => {
+  it("assigns exactly one active purpose category to every bundled plugin", () => {
     const extensionsRoot = path.join(repoRoot, "extensions");
-    const missing: string[] = [];
     const invalid: string[] = [];
     let manifestCount = 0;
 
@@ -27,8 +26,8 @@ describe("bundled plugin categories", () => {
         invalid.push(`${entry.name}: ${result.error}`);
         continue;
       }
-      if (!result.manifest.categories?.length) {
-        missing.push(entry.name);
+      if (result.manifest.categories?.length !== 1) {
+        invalid.push(`${entry.name}: expected exactly one purpose category`);
       }
       for (const category of result.manifest.categories ?? []) {
         if (!PLUGIN_CATEGORY_SLUGS.some((activeCategory) => activeCategory === category)) {
@@ -39,6 +38,23 @@ describe("bundled plugin categories", () => {
 
     expect(manifestCount).toBeGreaterThan(0);
     expect(invalid).toEqual([]);
-    expect(missing).toEqual([]);
+  });
+
+  it.each([
+    { pluginId: "codex", category: "developer-tools", purpose: "coding harness" },
+    { pluginId: "a2a", category: "agent-orchestration", purpose: "agent-to-agent delegation" },
+    {
+      pluginId: "feishu",
+      category: "channels",
+      purpose: "human-agent messaging despite workspace tools",
+    },
+    { pluginId: "document-extract", category: "documents-files", purpose: "document extraction" },
+    { pluginId: "google-meet", category: "voice", purpose: "live spoken participation" },
+    { pluginId: "tokenjuice", category: "context", purpose: "active-context compaction" },
+    { pluginId: "team-reports", category: "data-analytics", purpose: "team activity reporting" },
+    { pluginId: "diagnostics-otel", category: "infrastructure", purpose: "operational telemetry" },
+  ])("classifies $pluginId by its $purpose", ({ pluginId, category }) => {
+    const result = loadPluginManifest(path.join(repoRoot, "extensions", pluginId), false);
+    expect(result).toMatchObject({ ok: true, manifest: { categories: [category] } });
   });
 });

--- a/src/plugins/bundled-plugin-categories.test.ts
+++ b/src/plugins/bundled-plugin-categories.test.ts
@@ -2,11 +2,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { PLUGIN_CATEGORY_SLUGS } from "../../packages/plugin-package-contract/src/index.js";
 import { pluginTestRepoRoot as repoRoot } from "./generated-plugin-test-helpers.js";
 import { loadPluginManifest } from "./manifest.js";
 
 describe("bundled plugin categories", () => {
-  it("assigns at least one valid category to every bundled plugin", () => {
+  it("assigns active categories to every bundled plugin", () => {
     const extensionsRoot = path.join(repoRoot, "extensions");
     const missing: string[] = [];
     const invalid: string[] = [];
@@ -28,6 +29,11 @@ describe("bundled plugin categories", () => {
       }
       if (!result.manifest.categories?.length) {
         missing.push(entry.name);
+      }
+      for (const category of result.manifest.categories ?? []) {
+        if (!PLUGIN_CATEGORY_SLUGS.some((activeCategory) => activeCategory === category)) {
+          invalid.push(`${entry.name}: retired category ${category}`);
+        }
       }
     }
 


### PR DESCRIPTION
Assign one category to each of the 152 bundled plugins using its main install purpose. ACPX, Codex, and Copilot declare `"categories": ["agent-runtimes"]`.

This layer changes 88 manifests relative to the [taxonomy layer](https://github.com/openclaw/openclaw/pull/142759) and updates the bundled-category regression test. All 152 assignments exactly match the approved inventory at `3bf34b0570d3e55ad16f7c4cb25249797a59042b`. Non-category manifest fields match the rebase base `ad6b2678445365bedb0c4704f1578bfaa77b612c`, including newer provider metadata. Original inventory source hashes remain historical provenance.

## Validation

- 14 bundled-category regression tests passed after the final rebase.
- Inventory audit: 152 single-category manifests, zero assignment drift, and zero non-category metadata drift.
- The combined stack passed 23 browser scenarios, 23 catalog/controller tests, 26 ClawHub client tests, scoped static/type/lint checks, and independent review. See [current UI and performance proof](https://github.com/openclaw/openclaw/pull/142759).

## Full-stack proof and rollout

The reviewed ClawHub latest-release backfill is already complete; this stack preserves its approved assignments. [Production verification](https://github.com/openclaw/clawhub/pull/3637#issuecomment-5598749483) · [152 bundled rationales and runtime evidence](https://raw.githubusercontent.com/openclaw/openclaw/qa-artifacts/plugin-categories/2026-09-08/agent-runtimes/openclaw/summary.json).

The retained [ClawHub rehearsal](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/plugin-categories/2026-09-08/agent-runtimes/clawhub/report.md) and [OpenClaw comparison](https://raw.githubusercontent.com/openclaw/openclaw/qa-artifacts/plugin-categories/2026-09-08/agent-runtimes/openclaw/report.md) cover the real 100-plugin, 190-release local snapshot, including 93 applied latest releases and 90 unchanged historical releases.
