### PR TITLE
fix(ci): install Watch Rust toolchain for iOS beta

### DIFF
--- a/.github/workflows/ios-beta-release.yml
+++ b/.github/workflows/ios-beta-release.yml
@@ -229,6 +229,16 @@ jobs:
           ./scripts/install-swift-tools.sh "$swift_tools_dir"
           echo "$swift_tools_dir" >> "$GITHUB_PATH"
 
+      - name: Install Watch Rust toolchain
+        if: hashFiles('apps/shared/OpenClawWatchRTC/Cargo.toml') != ''
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.cargo/bin:$PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          watch_toolchain="$(awk -F '"' '/^channel =/ { print $2; exit }' apps/shared/OpenClawWatchRTC/rust-toolchain.toml)"
+          test -n "$watch_toolchain"
+          rustup toolchain install "$watch_toolchain" --profile minimal --component rust-src
+
       - name: Refresh trusted authority before store access
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -2241,4 +2241,45 @@ describe("mobile release authority", () => {
       },
     ]);
   });
+
+  it("installs the pinned Watch Rust toolchain before iOS store access", () => {
+    const source = fs.readFileSync(".github/workflows/ios-beta-release.yml", "utf8");
+    const workflow = parse(source) as {
+      jobs: {
+        release: {
+          steps: Array<{
+            if?: string;
+            name: string;
+            run?: string;
+          }>;
+        };
+      };
+    };
+    const releaseSteps = workflow.jobs.release.steps;
+    const xcodeIndex = releaseSteps.findIndex((step) => step.name === "Select Xcode 26");
+    const rustIndex = releaseSteps.findIndex(
+      (step) => step.name === "Install Watch Rust toolchain",
+    );
+    const storeAccessIndex = releaseSteps.findIndex(
+      (step) => step.name === "Refresh trusted authority before store access",
+    );
+    const uploadIndex = releaseSteps.findIndex(
+      (step) => step.name === "Upload and distribute iOS beta",
+    );
+    const rustStep = releaseSteps[rustIndex];
+
+    expect(xcodeIndex).toBeGreaterThanOrEqual(0);
+    expect(rustIndex).toBeGreaterThan(xcodeIndex);
+    expect(storeAccessIndex).toBeGreaterThan(rustIndex);
+    expect(uploadIndex).toBeGreaterThan(storeAccessIndex);
+    expect(rustStep?.if).toBe("hashFiles('apps/shared/OpenClawWatchRTC/Cargo.toml') != ''");
+    expect(rustStep?.run).toContain(
+      `watch_toolchain="$(awk -F '"' '/^channel =/ { print $2; exit }' apps/shared/OpenClawWatchRTC/rust-toolchain.toml)"`,
+    );
+    expect(rustStep?.run).toContain('test -n "$watch_toolchain"');
+    expect(rustStep?.run).toContain(
+      'rustup toolchain install "$watch_toolchain" --profile minimal --component rust-src',
+    );
+    expect(rustStep?.run).toContain('echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"');
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the protected iOS beta workflow could reach the Watch RTC build without installing the Rust toolchain and `rust-src` component selected by the candidate source.

## Why This Change Was Made

The workflow now mirrors the existing CI contract: when Watch RTC is present, it reads the channel from its pinned `rust-toolchain.toml`, installs that exact toolchain with `rust-src`, and persists Cargo's binary directory before trusted store-access staging. Release authority, credentials, destinations, and the frozen candidate remain unchanged.

## User Impact

Maintainers can run the guarded iOS beta workflow with the Watch RTC build prerequisites available. TestFlight distribution behavior, App Review policy, and production promotion are unchanged.

## Evidence

- Red regression: the parsed workflow test failed because the Watch Rust setup step was absent (`rustIndex = -1`).
- Green regression: focused workflow contract test passed.
- Full focused authority/workflow suite: 61/61 passed.
- `actionlint .github/workflows/ios-beta-release.yml`
- Targeted `oxfmt` and `oxlint`
- `git diff --check` and private-data scrub
- P1 autoreview: clean, confidence 0.95.

Hosted exact-head CI remains the required clean-runner proof. No release workflow was dispatched, no credentials were accessed, and no store operation occurred during this repair.
