### PR TITLE
test(ui): wait for applied config before holding refresh

### DIFF
--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   installMockGateway,
   type MockGatewayRequest,
@@ -215,11 +216,18 @@ suite.define(() => {
       );
       expect(await machineClass.getAttribute("list")).toBeNull();
       const saveButton = page.getByRole("button", { name: "Save" });
-      // The patch schedules an applied-revision poll. Let it settle before
-      // deferring config.get so the background read cannot consume the gate.
+      // Saved temporarily hides Apply changes; wait for the applied revision so
+      // its background config.get cannot consume the foreground refresh gate.
       await expect
-        .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count())
-        .toBe(0);
+        .poll(() =>
+          page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as
+              | (HTMLElement & { runtime?: { context: ApplicationContext } })
+              | null;
+            return app?.runtime?.context.runtimeConfig.state.configSnapshot?.appliedConfigHash;
+          }),
+        )
+        .toBe("cloud-workers-2");
       const configGetCount = (await gateway.getRequests("config.get")).length;
       await gateway.deferNext("config.get");
       await gateway.emitGatewayEvent("config.changed", {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the cloud-worker settings browser test fails after waiting 15 seconds for Save to disable, even though the foreground config refresh behaved correctly. This is part of the maintainer-requested CI performance and reliability work.

Related: #130168. Observed in [main CI run 34298495363](https://github.com/openclaw/openclaw/actions/runs/34298495363/job/102302557052).

## Why This Change Was Made

The test waited for the Apply changes button to disappear before deferring the next config.get. The temporary Saved indicator hides that button while the prior patch's applied-revision poll is still pending. That background read can consume the one-shot deferral; the foreground refresh then completes normally and re-enables Save.

Wait for the existing runtime config snapshot to report the expected applied revision before arming the foreground refresh gate. All profile payload, draft, reconnect, admin-access and Save-disabled assertions remain intact. Production code, deadlines and shard count are unchanged.

## User Impact

Developers avoid a false browser-test timeout and the associated CI rerun. No application behavior changes.

## Evidence

- Controlled Chromium request ordering reproduced the original failure: the background read consumed the hold at 978ms; the foreground read completed at 992ms; the original Save-disabled poll then expired. Full file: 1 failed, 7 passed, 35.20s.
- Candidate with ordinary scheduling: all 8 cases passed in 19.73s using Node 24.19.0 and pnpm 12.3.4. Original ordinary scheduling also passed, confirming the defect depends on request ordering; this is not a general 15-second speedup claim.
- Required changed-scope checks and formatting passed.
- Independent managed review: P2 scoped-clean, no actionable findings.
- Test delta +12/-4; production delta 0. Temporary diagnostic and controlled-scheduling changes were removed.
