### PR TITLE
fix(exec): stop preferential OOM targeting of sandbox transports

### DIFF
--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -370,9 +370,10 @@ Covered child process surfaces:
 - OpenClaw-launched browser/Chrome processes (via the plugin SDK process runtime)
 
 Sandbox backend launchers (such as Docker, Podman, SSH, or OpenShell transport
-processes) are spawned with exact environments and are exempt from the
-`oom_score_adj` wrapper. Workload resource policy belongs to the sandbox backend,
-preventing the local control-plane transport from being killed under host memory pressure.
+processes) are spawned with exact environments and do not apply the host
+`oom_score_adj=1000` wrapper. Workload resource limits and throttling remain
+the responsibility of the sandbox runtime, avoiding preferential OOM targeting
+of the local transport client during host memory pressure.
 
 The wrapper is Linux-only and skipped when `/bin/sh` is unavailable, or when
 the child env sets `OPENCLAW_CHILD_OOM_SCORE_ADJ` to `0`, `false`, `no`, or

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -369,6 +369,11 @@ Covered child process surfaces:
 - Managed local model and embedding service children
 - OpenClaw-launched browser/Chrome processes (via the plugin SDK process runtime)
 
+Sandbox backend launchers (such as Docker, Podman, SSH, or OpenShell transport
+processes) are spawned with exact environments and are exempt from the
+`oom_score_adj` wrapper. Workload resource policy belongs to the sandbox backend,
+preventing the local control-plane transport from being killed under host memory pressure.
+
 The wrapper is Linux-only and skipped when `/bin/sh` is unavailable, or when
 the child env sets `OPENCLAW_CHILD_OOM_SCORE_ADJ` to `0`, `false`, `no`, or
 `off`.

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -1022,96 +1022,49 @@ describe("runExecProcess PTY fallback", () => {
 });
 
 describe("runExecProcess exactEnv sandbox launcher boundary", () => {
-  it("requests exactEnv for sandbox backend launcher spawns to avoid Linux OOM score adjustment", async () => {
-    const exit = createDeferred<RunExit>();
-    let capturedSpawnInput: SpawnInput | undefined;
-    supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
-      capturedSpawnInput = input;
-      const activity = {
-        resultSettled: false,
-        isBackgroundContinuable: () => false,
-      };
-      return {
-        pid: 8881,
-        activity,
-        stdin: null,
-        waitForExit: async () => await exit.promise,
-        cancel: vi.fn(),
-      };
-    });
+  it.each([
+    { sandbox: true, expectedExactEnv: true },
+    { sandbox: false, expectedExactEnv: undefined },
+  ])(
+    "sets exactEnv=$expectedExactEnv when sandbox=$sandbox",
+    async ({ sandbox, expectedExactEnv }) => {
+      let capturedInput: SpawnInput | undefined;
+      supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => {
+        capturedInput = input;
+        return runtimeManagedRun(input);
+      });
 
-    const run = await runExecProcess({
-      command: "echo test",
-      workdir: "/tmp",
-      env: {},
-      sandbox: {
-        containerName: "sandbox-c",
-        workspaceDir: "/workspace",
-        containerWorkdir: "/workspace",
-        buildExecSpec: async () => ({
-          argv: ["docker", "exec", "-i", "sandbox-c", "/bin/sh", "-c", "echo test"],
-          env: { BACKEND_ENV: "true" },
-          stdinMode: "pipe-closed",
-          finalizeToken: "token-1",
-        }),
-        finalizeExec: vi.fn(async () => {}),
-      },
-      usePty: false,
-      warnings: [],
-      maxOutput: 1000,
-      pendingMaxOutput: 1000,
-      notifyOnExit: false,
-      sessionKey: "session-sandbox",
-      timeoutSec: null,
-    });
+      const run = await runExecProcess({
+        command: "echo test",
+        workdir: "/tmp",
+        env: {},
+        ...(sandbox
+          ? {
+              sandbox: {
+                containerName: "c1",
+                workspaceDir: "/w",
+                containerWorkdir: "/w",
+                buildExecSpec: async () => ({
+                  argv: ["docker", "exec", "c1", "echo test"],
+                  env: { BACKEND_ENV: "true" },
+                  stdinMode: "pipe-closed",
+                }),
+              },
+            }
+          : {}),
+        usePty: false,
+        warnings: [],
+        maxOutput: 1000,
+        pendingMaxOutput: 1000,
+        notifyOnExit: false,
+        timeoutSec: null,
+      });
 
-    expect(capturedSpawnInput).toBeDefined();
-    expect(capturedSpawnInput).toMatchObject({
-      mode: "child",
-      exactEnv: true,
-      argv: ["docker", "exec", "-i", "sandbox-c", "/bin/sh", "-c", "echo test"],
-    });
-
-    exit.resolve(createRunExit({ exitCode: 0 }));
-    await run.promise;
-  });
-
-  it("does not set exactEnv for ordinary host command spawns, preserving the OOM score wrapper", async () => {
-    const exit = createDeferred<RunExit>();
-    let capturedSpawnInput: SpawnInput | undefined;
-    supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
-      capturedSpawnInput = input;
-      const activity = {
-        resultSettled: false,
-        isBackgroundContinuable: () => false,
-      };
-      return {
-        pid: 8882,
-        activity,
-        stdin: null,
-        waitForExit: async () => await exit.promise,
-        cancel: vi.fn(),
-      };
-    });
-
-    const run = await runExecProcess({
-      command: "echo host-test",
-      workdir: "/tmp",
-      env: {},
-      usePty: false,
-      warnings: [],
-      maxOutput: 1000,
-      pendingMaxOutput: 1000,
-      notifyOnExit: false,
-      sessionKey: "session-host",
-      timeoutSec: null,
-    });
-
-    expect(capturedSpawnInput).toBeDefined();
-    expect(capturedSpawnInput?.mode).toBe("child");
-    expect((capturedSpawnInput as { exactEnv?: boolean }).exactEnv).toBeUndefined();
-
-    exit.resolve(createRunExit({ exitCode: 0 }));
-    await run.promise;
-  });
+      const outcome = await run.promise;
+      expect(outcome.status).toBe("completed");
+      expect(outcome.exitCode).toBe(0);
+      expect(capturedInput?.mode).toBe("child");
+      expect((capturedInput as { exactEnv?: boolean })?.exactEnv).toBe(expectedExactEnv);
+    },
+  );
 });

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -1020,3 +1020,98 @@ describe("runExecProcess PTY fallback", () => {
     }
   });
 });
+
+describe("runExecProcess exactEnv sandbox launcher boundary", () => {
+  it("requests exactEnv for sandbox backend launcher spawns to avoid Linux OOM score adjustment", async () => {
+    const exit = createDeferred<RunExit>();
+    let capturedSpawnInput: SpawnInput | undefined;
+    supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
+      capturedSpawnInput = input;
+      const activity = {
+        resultSettled: false,
+        isBackgroundContinuable: () => false,
+      };
+      return {
+        pid: 8881,
+        activity,
+        stdin: null,
+        waitForExit: async () => await exit.promise,
+        cancel: vi.fn(),
+      };
+    });
+
+    const run = await runExecProcess({
+      command: "echo test",
+      workdir: "/tmp",
+      env: {},
+      sandbox: {
+        containerName: "sandbox-c",
+        workspaceDir: "/workspace",
+        containerWorkdir: "/workspace",
+        buildExecSpec: async () => ({
+          argv: ["docker", "exec", "-i", "sandbox-c", "/bin/sh", "-c", "echo test"],
+          env: { BACKEND_ENV: "true" },
+          stdinMode: "pipe-closed",
+          finalizeToken: "token-1",
+        }),
+        finalizeExec: vi.fn(async () => {}),
+      },
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      sessionKey: "session-sandbox",
+      timeoutSec: null,
+    });
+
+    expect(capturedSpawnInput).toBeDefined();
+    expect(capturedSpawnInput).toMatchObject({
+      mode: "child",
+      exactEnv: true,
+      argv: ["docker", "exec", "-i", "sandbox-c", "/bin/sh", "-c", "echo test"],
+    });
+
+    exit.resolve(createRunExit({ exitCode: 0 }));
+    await run.promise;
+  });
+
+  it("does not set exactEnv for ordinary host command spawns, preserving the OOM score wrapper", async () => {
+    const exit = createDeferred<RunExit>();
+    let capturedSpawnInput: SpawnInput | undefined;
+    supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
+      capturedSpawnInput = input;
+      const activity = {
+        resultSettled: false,
+        isBackgroundContinuable: () => false,
+      };
+      return {
+        pid: 8882,
+        activity,
+        stdin: null,
+        waitForExit: async () => await exit.promise,
+        cancel: vi.fn(),
+      };
+    });
+
+    const run = await runExecProcess({
+      command: "echo host-test",
+      workdir: "/tmp",
+      env: {},
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      sessionKey: "session-host",
+      timeoutSec: null,
+    });
+
+    expect(capturedSpawnInput).toBeDefined();
+    expect(capturedSpawnInput?.mode).toBe("child");
+    expect((capturedSpawnInput as { exactEnv?: boolean }).exactEnv).toBeUndefined();
+
+    exit.resolve(createRunExit({ exitCode: 0 }));
+    await run.promise;
+  });
+});

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -881,6 +881,7 @@ export async function runExecProcess({
         argv: backendExecSpec.argv,
         env: backendExecSpec.env,
         stdinMode: backendExecSpec.stdinMode,
+        exactEnv: true as const,
       };
     }
     const { shell, args: shellArgs } = getShellConfig();
@@ -969,6 +970,7 @@ export async function runExecProcess({
         mode: "child",
         argv: spawnSpec.argv,
         stdinMode: spawnSpec.stdinMode,
+        ...(opts.sandbox ? { exactEnv: true as const } : {}),
       });
     }
   } catch (error) {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -909,6 +909,7 @@ export async function runExecProcess({
       argv,
       env: shellRuntimeEnv,
       stdinMode: opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const),
+      exactEnv: undefined,
     };
   };
 
@@ -970,7 +971,7 @@ export async function runExecProcess({
         mode: "child",
         argv: spawnSpec.argv,
         stdinMode: spawnSpec.stdinMode,
-        ...(opts.sandbox ? { exactEnv: true as const } : {}),
+        ...(spawnSpec.exactEnv ? { exactEnv: true as const } : {}),
       });
     }
   } catch (error) {


### PR DESCRIPTION
Closes #142481
Related: #142556

## What Problem This Solves

Fixes preferential OOM targeting of sandbox backend transports on Linux, which can sever a running command's control path under memory pressure.

## User Impact

Sandbox transports retain their inherited OOM priority and backend-prepared environments. Ordinary host commands and PTY shells keep the existing child-first OOM bias. No configuration changes or migration are required.

## Why This Change Was Made

Use the supervisor's existing exact-environment contract at the shared sandbox launch boundary. Workload resource policy and finalization remain with the backend; no backend-name exceptions or new resource-policy options are needed. Replace mocked flag-forwarding assertions with a regression that measures real Linux subprocess behavior.

## Evidence

Before/after proof ran on Linux arm64 with Node 24.19.0 in a secretless container. The supported `pnpm openclaw agent exec` command received an `exec` tool call from the repository's scripted local model server and executed it through the configured SSH backend over real OpenSSH. A same-user observer read the actual transport PID's `/proc/<pid>/oom_score_adj`.

| Observed process | Main before fix | Candidate |
| --- | ---: | ---: |
| Ordinary host command | 1000 | 1000 |
| SSH backend transport | **1000** | **0** |
| Transport's parent | 0 | 0 |
| sshd-owned sandbox workload | 0 | 0 |

Both commands completed and returned their output to the model. The transport-priority assertion failed on main and passed after the fix. No OOM was induced; this proves the policy change, not a kernel victim-selection experiment.

- Baseline: `2e7e5ef6b1c1f98091588f48791da3d1ee8a96c0`. Live main `dee738b849367a5f0885f2324a7a729896277b5b` changed only UI files, leaving all affected owner inputs identical.
- Candidate: `04ebd90b90f8a32782297ef60150452ff6847f66`; tested source hashes match the committed source.
- The new Linux regression failed before the fix: expected `0|backend-policy|pipe`, received `1000||pipe`. It passes after the fix and also verifies ordinary child and genuine PTY behavior (`isTTY=true`, score 1000, no PTY fallback).
- **144 tests passed across six focused files:** exec runtime, sandbox finalization, real PTY execution, child adapter, PTY adapter, and Linux OOM policy. The 50 affected agent tests and real SSH proof were rerun after the final ownership-policy consolidation; the unchanged process-adapter results were reused.
- Targeted type-aware Oxlint: zero warnings/errors. Targeted Oxfmt, the counted-line growth ratchet, and `git diff --check`: passed. The production owner has no net line growth.

```bash
node scripts/run-vitest.mjs \
  src/agents/bash-tools.exec.pty.test.ts \
  src/agents/bash-tools.exec-runtime.test.ts \
  src/agents/bash-tools.exec-runtime.cleanup.test.ts \
  src/process/supervisor/adapters/child.test.ts \
  src/process/supervisor/adapters/pty.test.ts \
  src/process/linux-oom-score.test.ts
```
