### PR TITLE
fix(models): retain captured rows in passive catalogs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1848,7 +1848,6 @@ src/agents/memory-write-provenance.ts	1
 src/agents/minimax-vlm.ts	1
 src/agents/model-auth-label.ts	1
 src/agents/model-auth-model.ts	2
-src/agents/model-catalog.ts	1
 src/agents/model-fallback-attempt.ts	1
 src/agents/model-fallback-runner.ts	2
 src/agents/model-provider-auth.ts	1
@@ -1869,7 +1868,7 @@ src/agents/plugin-model-catalog.ts	3
 src/agents/plugin-text-transforms.ts	5
 src/agents/prepared-model-catalog.ts	1
 src/agents/prepared-model-catalog.worker.ts	1
-src/agents/prepared-model-runtime.configured.ts	2
+src/agents/prepared-model-runtime.configured.ts	1
 src/agents/prepared-model-runtime.facts.ts	1
 src/agents/prepared-model-runtime.ts	1
 src/agents/provider-attribution.ts	14

--- a/src/agents/model-catalog-entry.test.ts
+++ b/src/agents/model-catalog-entry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
+
+describe("model catalog metadata projection", () => {
+  it("retains runtime capabilities without exporting request credentials", () => {
+    const model: ProviderRuntimeModel = {
+      id: "configured-model",
+      name: "Configured model",
+      provider: "custom",
+      api: "openai-responses",
+      baseUrl: "https://example.test/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      maxTokens: 4096,
+      contextWindow: 96_000,
+      contextTokens: 48_000,
+      contextWindows: [{ id: "large", label: "Large", contextWindow: 96_000 }],
+      contextWindowDefault: "large",
+      thinkingLevelMap: { off: null, high: "high" },
+      params: { platformOnly: true },
+      compat: { supportsTools: false },
+      headers: { Authorization: "synthetic-unused" },
+      authHeader: true,
+      requestTimeoutMs: 12_000,
+    };
+
+    const entry = modelCatalogRowToEntry(model);
+
+    expect(entry).toMatchObject({
+      id: "configured-model",
+      name: "Configured model",
+      provider: "custom",
+      api: "openai-responses",
+      contextWindow: 96_000,
+      contextTokens: 48_000,
+      contextWindows: [{ id: "large", label: "Large", contextWindow: 96_000 }],
+      contextWindowDefault: "large",
+      reasoning: true,
+      input: ["text", "image"],
+      thinkingLevelMap: { off: null, high: "high" },
+      params: { platformOnly: true },
+      compat: { supportsTools: false },
+    });
+    expect(entry).not.toHaveProperty("headers");
+    expect(entry).not.toHaveProperty("authHeader");
+    expect(entry).not.toHaveProperty("requestTimeoutMs");
+  });
+});

--- a/src/agents/model-catalog-entry.ts
+++ b/src/agents/model-catalog-entry.ts
@@ -4,7 +4,7 @@ import type { ModelCatalogEntry } from "./model-catalog.types.js";
 function isCatalogModelApi(
   value: string | undefined,
 ): value is NonNullable<ModelCatalogEntry["api"]> {
-  return value !== undefined && (MODEL_APIS as readonly string[]).includes(value);
+  return value !== undefined && MODEL_APIS.some((api) => api === value);
 }
 
 /** Shared metadata projection; keep transport headers and authoring fields out of catalog entries. */

--- a/src/agents/model-catalog-entry.ts
+++ b/src/agents/model-catalog-entry.ts
@@ -1,14 +1,22 @@
-import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
+import { MODEL_APIS } from "../config/types.models.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 
+function isCatalogModelApi(
+  value: string | undefined,
+): value is NonNullable<ModelCatalogEntry["api"]> {
+  return value !== undefined && (MODEL_APIS as readonly string[]).includes(value);
+}
+
 /** Shared metadata projection; keep transport headers and authoring fields out of catalog entries. */
-export function modelCatalogRowToEntry(row: NormalizedModelCatalogRow): ModelCatalogEntry {
+export function modelCatalogRowToEntry(
+  row: Omit<ModelCatalogEntry, "api"> & { api?: string },
+): ModelCatalogEntry {
   const contextWindow = row.contextWindow ?? row.contextTokens;
   return {
     id: row.id,
     name: row.name,
     provider: row.provider,
-    api: row.api,
+    ...(isCatalogModelApi(row.api) ? { api: row.api } : {}),
     ...(row.baseUrl ? { baseUrl: row.baseUrl } : {}),
     ...(contextWindow !== undefined ? { contextWindow } : {}),
     ...(row.contextWindows
@@ -18,7 +26,8 @@ export function modelCatalogRowToEntry(row: NormalizedModelCatalogRow): ModelCat
     ...(row.contextTokens !== undefined ? { contextTokens: row.contextTokens } : {}),
     reasoning: row.reasoning,
     ...(row.thinkingLevelMap ? { thinkingLevelMap: { ...row.thinkingLevelMap } } : {}),
-    input: [...row.input],
+    ...(row.input ? { input: [...row.input] } : {}),
+    ...(row.params ? { params: { ...row.params } } : {}),
     ...(row.compat ? { compat: row.compat } : {}),
     ...(row.mediaInput ? { mediaInput: row.mediaInput } : {}),
     status: row.status,

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -731,6 +731,7 @@ describe("prepared model catalog builder", () => {
       });
 
       const selectedRoute = {
+        name: retarget ? "Earlier Route A" : "Route A",
         api: "openai-responses",
         baseUrl: "https://route-a.example.test/v1",
         thinkingLevelMap: retarget ? { xhigh: "high", max: "max" } : { xhigh: null, max: null },

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -4,7 +4,6 @@
 import { resolveClaudeFable5ModelIdentity } from "@openclaw/llm-core";
 import { buildModelCatalogMergeKey } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -20,11 +19,7 @@ import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
 import { assignProviderModelOrder, compareModelCatalogEntries } from "./model-catalog-order.js";
 import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
-import type {
-  ModelCatalogEntry,
-  ModelCatalogSnapshot,
-  ModelInputType,
-} from "./model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
@@ -43,21 +38,6 @@ export {
   findModelInCatalog,
   modelSupportsInput,
 } from "./model-catalog-lookup.js";
-
-type DiscoveredModel = {
-  id: string;
-  name?: string;
-  provider: string;
-  api?: ModelCatalogEntry["api"];
-  contextWindow?: number;
-  contextTokens?: number;
-  reasoning?: boolean;
-  thinkingLevelMap?: ModelCatalogEntry["thinkingLevelMap"];
-  input?: ModelInputType[];
-  params?: ModelCatalogEntry["params"];
-  compat?: ModelCatalogEntry["compat"];
-  baseUrl?: string;
-};
 
 export type BuildPreparedModelCatalogParams = {
   agentDir: string;
@@ -161,9 +141,7 @@ function overlayCatalogMetadata(
   base: ModelCatalogEntry,
   overlay: ModelCatalogEntry,
   options?: {
-    catalogRoute?: ModelCatalogEntry;
     preserveBaseCompat?: boolean;
-    preserveBaseName?: boolean;
   },
 ): ModelCatalogEntry {
   // Catalog rows with one logical provider/id may describe different physical
@@ -172,7 +150,7 @@ function overlayCatalogMetadata(
   const routeChanged = catalogRouteChanges(base, overlay);
   const routeBase = routeChanged ? clearRouteBoundCatalogMetadata(base) : base;
   const params = mergeCatalogParams(routeBase.params, overlay.params);
-  const thinkingLevelMap = overlay.thinkingLevelMap ?? options?.catalogRoute?.thinkingLevelMap;
+  const thinkingLevelMap = overlay.thinkingLevelMap ?? routeBase.thinkingLevelMap;
   // Options + default are one normalized unit (default ∈ options): an overlay
   // that replaces the options list must also own the default, or a base default
   // absent from the new list would leak through the field-by-field merge.
@@ -203,7 +181,7 @@ function overlayCatalogMetadata(
   return {
     ...selectionNeutralBase,
     ...contextWindowSelection,
-    ...(routeChanged && !options?.preserveBaseName ? { name: overlay.name } : {}),
+    ...(routeChanged ? { name: overlay.name } : {}),
     ...(overlay.api !== undefined ? { api: overlay.api } : {}),
     ...(overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
     ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
@@ -223,8 +201,8 @@ function overlayCatalogMetadata(
     ...(overlay.replacedBy !== undefined ? { replacedBy: overlay.replacedBy } : {}),
     compat: options?.preserveBaseCompat
       ? resolveCatalogOwnedModelCompat({
-          catalogRoute: options.catalogRoute ?? base,
-          catalogCompat: (options.catalogRoute ?? base).compat,
+          catalogRoute: base,
+          catalogCompat: base.compat,
           configuredRoute: {
             api: overlay.api ?? base.api,
             baseUrl: overlay.baseUrl ?? base.baseUrl,
@@ -251,7 +229,6 @@ function mergeCatalogEntries(
   options?: {
     catalogRoutes?: ModelCatalogRouteVariantCollector;
     preserveBaseCompat?: boolean;
-    preserveBaseName?: boolean;
   },
 ): void {
   const indexByKey = new Map(
@@ -274,10 +251,7 @@ function mergeCatalogEntries(
         ? routes?.indexByKey.get(catalogRouteVariantKey(entry))
         : undefined;
       const catalogRoute = routeIndex === undefined ? undefined : routes?.entries[routeIndex];
-      models[existingIndex] = overlayCatalogMetadata(existing, entry, {
-        ...options,
-        catalogRoute,
-      });
+      models[existingIndex] = overlayCatalogMetadata(catalogRoute ?? existing, entry, options);
     }
   }
 }
@@ -441,7 +415,7 @@ export async function buildPreparedModelCatalogSnapshot(
     );
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
     logStage("catalog-deps-ready");
-    const entries = params.modelRegistry.getAll() as DiscoveredModel[];
+    const entries = params.modelRegistry.getAll();
     const declaredManifestModels = loadManifestModelCatalog({
       config: cfg,
       env,
@@ -453,49 +427,27 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("suppress-resolver-ready");
 
     for (const entry of entries) {
-      const rawId = normalizeOptionalString(entry?.id) ?? "";
+      const rawId = entry.id.trim();
       if (!rawId) {
         continue;
       }
-      const rawProvider = normalizeOptionalString(entry?.provider) ?? "";
+      const rawProvider = entry.provider.trim();
       if (!rawProvider) {
         continue;
       }
       const provider = normalizeProvider(rawProvider);
       const id = normalizeModelId(provider, rawId);
-      const baseUrl = normalizeOptionalString(entry?.baseUrl);
+      const baseUrl = entry.baseUrl?.trim();
       if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
         continue;
       }
-      const name = normalizeOptionalString(entry?.name ?? id) || id;
-      const contextWindow =
-        typeof entry?.contextWindow === "number" && entry.contextWindow > 0
-          ? entry.contextWindow
-          : undefined;
-      const contextTokens =
-        typeof entry?.contextTokens === "number" && entry.contextTokens > 0
-          ? entry.contextTokens
-          : undefined;
-      const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
-      const api = typeof entry?.api === "string" ? entry.api : undefined;
-      const input = Array.isArray(entry?.input) ? entry.input : undefined;
-      const modelParams =
-        entry?.params && typeof entry.params === "object" ? entry.params : undefined;
-      const compat = entry?.compat && typeof entry.compat === "object" ? entry.compat : undefined;
-      const model = {
+      const model = modelCatalogRowToEntry({
+        ...entry,
         id,
-        name,
+        name: entry.name.trim() || id,
         provider,
-        ...(api ? { api } : {}),
-        ...(baseUrl ? { baseUrl } : {}),
-        contextWindow,
-        ...(contextTokens !== undefined ? { contextTokens } : {}),
-        reasoning,
-        ...(entry.thinkingLevelMap ? { thinkingLevelMap: entry.thinkingLevelMap } : {}),
-        input,
-        ...(modelParams ? { params: modelParams } : {}),
-        compat,
-      } satisfies ModelCatalogEntry;
+        baseUrl,
+      });
       models.push(model);
     }
     // Gateway startup may publish registry rows without runtime augmentation.
@@ -548,7 +500,6 @@ export async function buildPreparedModelCatalogSnapshot(
         mergeCatalogEntries(augmentEntries, configuredModels, {
           catalogRoutes: routeVariants,
           preserveBaseCompat: true,
-          preserveBaseName: true,
         });
       }
       const { createProviderApiKeyResolverFromPreparedCredentials } =
@@ -628,9 +579,8 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("plugin-models-merged", `entries=${models.length}`);
 
     if (configuredModels.length > 0) {
-      mergeCatalogRouteVariants(routeVariants, configuredModels, { preserveBaseCompat: true });
-      // Augmentation may mutate borrowed rows. Reindex after the final merge so
-      // route lookup keeps the first current match, including duplicate keys.
+      // Augmentation may mutate borrowed rows. Reindex before configured overlays so
+      // route lookup keeps the first current donor, including duplicate keys.
       routeVariants.indexByKey.clear();
       routeVariants.entries.forEach((entry, index) => {
         const key = catalogRouteVariantKey(entry);
@@ -641,8 +591,8 @@ export async function buildPreparedModelCatalogSnapshot(
       mergeCatalogEntries(models, configuredModels, {
         catalogRoutes: routeVariants,
         preserveBaseCompat: true,
-        preserveBaseName: true,
       });
+      mergeCatalogRouteVariants(routeVariants, configuredModels, { preserveBaseCompat: true });
     }
     logStage("configured-models-finalized", `entries=${models.length}`);
 

--- a/src/agents/prepared-model-runtime.captured-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.captured-refresh.test.ts
@@ -1,0 +1,78 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  cleanupPreparedModelRuntimeHarness,
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import {
+  getPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
+async function prepareCatalogOwner(
+  config: OpenClawConfig,
+  catalogs: readonly ModelCatalogSnapshot[],
+) {
+  mocks.configuredAgentIds = ["pro"];
+  for (const catalog of catalogs) {
+    mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
+  }
+  await refreshPreparedModelRuntimeSnapshots(config, {
+    gatewayLifecycle: true,
+    catalogMode: "static",
+    allowGatewaySubagentBinding: true,
+  });
+  return getPreparedModelRuntimeSnapshot({
+    config,
+    agentId: "pro",
+    agentDir: state.agentDir("pro"),
+  })!;
+}
+
+describe("captured startup inventory refresh", () => {
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "captured-model-runtime" });
+    await resetPreparedModelRuntimeHarness(state);
+  });
+  afterEach(async ({ task }) => {
+    await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
+  });
+
+  it("does not refill a successful empty refresh from the captured startup registry", async () => {
+    const captured = {
+      provider: "custom",
+      id: "removed",
+      name: "Previously discovered",
+      api: "openai-completions" as const,
+      baseUrl: "https://custom.example.test/v1",
+    };
+    mocks.modelRegistry.getAll.mockReturnValue([captured]);
+    const owner = await prepareCatalogOwner(
+      { models: { mode: "merge" }, agents: { entries: { pro: {} } } },
+      [
+        {
+          entries: [],
+          routeVariants: [],
+          providerOutcomes: [{ provider: "custom", status: "ready" }],
+        },
+      ],
+    );
+    expect(owner.modelCatalog.entries).toContainEqual(expect.objectContaining({ id: "removed" }));
+
+    const refreshed = await owner.loadFullModelCatalog!({ refresh: true });
+
+    expect(refreshed.entries).toEqual([]);
+    expect(refreshed.routeVariants).toEqual([]);
+    expect(refreshed.providerOutcomes).toEqual([{ provider: "custom", status: "ready" }]);
+  });
+});

--- a/src/agents/prepared-model-runtime.configured-catalog.test.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { prepareConfiguredRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+
+describe("configured catalog registry composition", () => {
+  it.each([
+    { mode: "merge", expectedIds: ["selected", "retained-only"] },
+    { mode: "replace", expectedIds: ["selected"] },
+  ] as const)("keeps the $mode row set and configured fields", ({ mode, expectedIds }) => {
+    const config: OpenClawConfig = {
+      models: { mode },
+    };
+    const configured: ModelCatalogEntry = {
+      provider: "donor-fixture",
+      id: "selected",
+      name: "Configured selected",
+      api: "openai-completions",
+      baseUrl: "https://fixture.invalid/v1",
+      contextWindow: 32_000,
+      reasoning: true,
+      configuredReasoning: true,
+      input: ["text"],
+    };
+    const registry = ModelRegistry.create(AuthStorage.inMemory({}), "captured:models.json", {
+      config,
+      includePluginCatalogs: false,
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+      modelsJsonContents: JSON.stringify({
+        providers: {
+          "donor-fixture": {
+            api: "openai-completions",
+            baseUrl: "https://fixture.invalid/v1",
+            models: [
+              {
+                id: "selected",
+                name: "Earlier selected",
+                contextWindow: 64_000,
+                maxTokens: 4096,
+                reasoning: false,
+                input: ["text", "image"],
+              },
+              {
+                id: "retained-only",
+                name: "Retained authored row",
+                contextWindow: 48_000,
+                maxTokens: 4096,
+                reasoning: false,
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const agentFacts = {
+      input: { config },
+      configuredModelRefs: [{ provider: "donor-fixture", modelId: "selected" }],
+    };
+    const { modelCatalog } = prepareConfiguredRuntimeFacts({
+      agentFacts,
+      workspaceFacts: { configuredCatalogEntries: [configured], inlineProviderModels: [] },
+      templateModelRegistry: registry,
+      configuredRuntimeModels: [],
+    });
+
+    expect(modelCatalog.entries.map((entry) => entry.id)).toEqual(expectedIds);
+    expect(modelCatalog.entries[0]).toEqual(configured);
+    expect(modelCatalog.routeVariants).toEqual(modelCatalog.entries);
+  });
+});

--- a/src/agents/prepared-model-runtime.configured-catalog.test.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import { prepareConfiguredRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
+import { prepareCapturedRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 
 describe("configured catalog registry composition", () => {
@@ -59,7 +59,7 @@ describe("configured catalog registry composition", () => {
       input: { config },
       configuredModelRefs: [{ provider: "donor-fixture", modelId: "selected" }],
     };
-    const { modelCatalog } = prepareConfiguredRuntimeFacts({
+    const { modelCatalog } = prepareCapturedRuntimeFacts({
       agentFacts,
       workspaceFacts: { configuredCatalogEntries: [configured], inlineProviderModels: [] },
       templateModelRegistry: registry,

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -1,16 +1,16 @@
 import type { ModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
+import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import type { PreparedModelRuntimeCatalogFacts } from "./prepared-model-runtime.catalog-contract.js";
-import {
-  toStaticCatalogEntry,
-  type PreparedConfiguredRuntimeModel,
-} from "./prepared-model-runtime.configured.js";
+import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
 type ConfiguredCatalogAgentFacts = {
+  input: { config: OpenClawConfig };
   configuredModelRefs: readonly ModelCatalogRef[];
 };
 
@@ -36,17 +36,23 @@ function createConfiguredModelCatalogSnapshot(params: {
     addEntry(entry);
   }
   for (const configured of params.configuredRuntimeModels) {
-    addEntry(toStaticCatalogEntry(configured.model));
+    addEntry(modelCatalogRowToEntry(configured.model));
   }
   for (const { provider, modelId } of params.agentFacts.configuredModelRefs) {
     const model = params.templateModelRegistry.find(provider, modelId);
     if (model) {
-      addEntry(toStaticCatalogEntry(model));
+      addEntry(modelCatalogRowToEntry(model));
+    }
+  }
+  // Configured fields remain authoritative; merge mode also exposes already captured rows.
+  if (params.agentFacts.input.config.models?.mode !== "replace") {
+    for (const model of params.templateModelRegistry.getAll()) {
+      addEntry(modelCatalogRowToEntry(model));
     }
   }
   const configuredEntries = [...entries.values()];
   const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
-    toStaticCatalogEntry(model),
+    modelCatalogRowToEntry(model),
   );
   return {
     entries: configuredEntries,

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -1,5 +1,6 @@
 import type { ModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
@@ -44,12 +45,6 @@ function createConfiguredModelCatalogSnapshot(params: {
       addEntry(modelCatalogRowToEntry(model));
     }
   }
-  // Configured fields remain authoritative; merge mode also exposes already captured rows.
-  if (params.agentFacts.input.config.models?.mode !== "replace") {
-    for (const model of params.templateModelRegistry.getAll()) {
-      addEntry(modelCatalogRowToEntry(model));
-    }
-  }
   const configuredEntries = [...entries.values()];
   const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
     modelCatalogRowToEntry(model),
@@ -73,4 +68,22 @@ export function prepareConfiguredRuntimeFacts(params: {
     configuredRuntimeModels: params.configuredRuntimeModels,
     inlineProviderModels: params.workspaceFacts.inlineProviderModels,
   };
+}
+
+/** Startup can expose captured rows; full refresh overlays only configured membership. */
+export function prepareCapturedRuntimeFacts(
+  params: Parameters<typeof prepareConfiguredRuntimeFacts>[0],
+): PreparedModelRuntimeCatalogFacts {
+  const facts = prepareConfiguredRuntimeFacts(params);
+  if (params.agentFacts.input.config.models?.mode === "replace") {
+    return facts;
+  }
+  const entries = dedupeByKey(
+    [
+      ...facts.modelCatalog.entries,
+      ...params.templateModelRegistry.getAll().map(modelCatalogRowToEntry),
+    ],
+    resolveModelCatalogIdentityKey,
+  );
+  return { ...facts, modelCatalog: { ...facts.modelCatalog, entries, routeVariants: entries } };
 }

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -11,7 +11,6 @@ import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
-import { MODEL_APIS } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
@@ -27,7 +26,6 @@ import {
 } from "./embedded-agent-runner/model.inline-provider.js";
 import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { resolveConfiguredModelHarnessRuntime } from "./harness-runtimes.js";
-import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 import { resolveEffectiveAgentRuntime } from "./thinking-runtime.js";
 
@@ -60,36 +58,6 @@ export function collectPreparedModelRuntimeConfiguredRefs(
       list: entry ? [entry] : [],
     },
   });
-}
-
-function isCatalogModelApi(
-  value: string | undefined,
-): value is NonNullable<ModelCatalogEntry["api"]> {
-  return value !== undefined && (MODEL_APIS as readonly string[]).includes(value);
-}
-
-export function toStaticCatalogEntry(model: ProviderRuntimeModel): ModelCatalogEntry {
-  return {
-    id: model.id,
-    name: model.name ?? model.id,
-    provider: model.provider,
-    ...(isCatalogModelApi(model.api) ? { api: model.api } : {}),
-    ...(model.baseUrl ? { baseUrl: model.baseUrl } : {}),
-    ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
-    ...(model.contextWindows
-      ? {
-          contextWindows: model.contextWindows.map((option) => ({ ...option })),
-        }
-      : {}),
-    ...(model.contextWindowDefault ? { contextWindowDefault: model.contextWindowDefault } : {}),
-    ...(model.contextTokens ? { contextTokens: model.contextTokens } : {}),
-    ...(model.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
-    ...(model.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
-    ...(model.input ? { input: model.input } : {}),
-    ...(model.params ? { params: model.params } : {}),
-    ...(model.compat ? { compat: model.compat } : {}),
-    ...(model.mediaInput ? { mediaInput: model.mediaInput } : {}),
-  };
 }
 
 export function collectPreparedModelRuntimeProviderIds(

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -26,6 +26,7 @@ import {
 } from "./embedded-agent-runner/model.inline-provider.js";
 import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { resolveConfiguredModelHarnessRuntime } from "./harness-runtimes.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 import { resolveEffectiveAgentRuntime } from "./thinking-runtime.js";
 

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -49,7 +49,7 @@ import type {
   PreparedModelRuntimeAgentFacts,
   PreparedModelRuntimeCatalogFacts,
 } from "./prepared-model-runtime.catalog-contract.js";
-import { prepareConfiguredRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
+import { prepareCapturedRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
 import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
 import {
   collectPreparedModelRuntimeConfiguredRefs,
@@ -609,7 +609,7 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
       );
       catalogs.set(
         facts.input,
-        prepareConfiguredRuntimeFacts({
+        prepareCapturedRuntimeFacts({
           agentFacts: facts,
           workspaceFacts: params.pluginGeneration,
           templateModelRegistry,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -31,6 +31,7 @@ import {
   loadBundledProviderStaticCatalogContextModels,
 } from "./embedded-agent-runner/model.static-catalog.js";
 import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
+import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import {
   buildConfiguredModelCatalog,
   parseConfiguredModelVisibilityEntries,
@@ -56,7 +57,6 @@ import {
   collectPreparedModelRuntimeProviderIds,
   prepareConfiguredRuntimeModels,
   prepareRuntimeCapabilityModels,
-  toStaticCatalogEntry,
 } from "./prepared-model-runtime.configured.js";
 import {
   prepareWorkspacePluginRegistries,
@@ -407,7 +407,7 @@ export async function prepareWorkspaceBuildGroup(
         candidates: [
           ...configuredCatalogEntries,
           ...configuredRuntimeModels.map(({ model, modelId, provider }) => ({
-            ...toStaticCatalogEntry(model),
+            ...modelCatalogRowToEntry(model),
             id: modelId,
             provider,
           })),

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -6,6 +6,7 @@ import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { discoverModels } from "./agent-model-discovery.js";
 import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-materializations.js";
 import { loadBundledProviderStaticCatalogContextModels } from "./embedded-agent-runner/model.static-catalog.js";
+import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import { compareModelCatalogEntries } from "./model-catalog-order.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
@@ -25,10 +26,9 @@ import type {
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
 import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
-import {
-  toStaticCatalogEntry,
-  type PreparedConfiguredRuntimeModel,
-  type PreparedRuntimeCapabilityModel,
+import type {
+  PreparedConfiguredRuntimeModel,
+  PreparedRuntimeCapabilityModel,
 } from "./prepared-model-runtime.configured.js";
 import { buildPreparedPluginModelCatalog } from "./prepared-model-runtime.plugin-generation.js";
 import type {
@@ -90,7 +90,7 @@ export async function prepareFullCatalogFacts(
   const completeModelCatalog = {
     ...modelCatalog,
     staticEntries: dedupeByKey(providerStaticModels, resolveModelCatalogIdentityKey).map(
-      toStaticCatalogEntry,
+      modelCatalogRowToEntry,
     ),
     ...(providerOutcomes.length > 0 ? { providerOutcomes } : {}),
   };
@@ -234,7 +234,7 @@ export function materializePreparedModelCatalog(
   const runtimeByKey = new Map(
     runtimeCapabilityModels.map(({ provider, modelId, model }) => [
       resolveModelCatalogIdentityKey({ provider, id: modelId }),
-      toStaticCatalogEntry(model),
+      modelCatalogRowToEntry(model),
     ]),
   );
   const project = (entries: ModelCatalogSnapshot["entries"]) =>
@@ -265,7 +265,7 @@ export function materializePreparedModelCatalog(
     materialized.staticEntries = project(
       dedupeByKey(
         [
-          ...configuredRuntimeModels.map(({ model }) => toStaticCatalogEntry(model)),
+          ...configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
           ...(snapshot.staticEntries ?? []),
         ],
         resolveModelCatalogIdentityKey,

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -47,7 +47,7 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
   },
   modelRegistry: {
     fork: vi.fn((authStorage: unknown) => ({ authStorage })),
-    getAll: vi.fn(() => []),
+    getAll: vi.fn<() => ModelCatalogSnapshot["entries"]>(() => []),
     find: vi.fn(() => null),
   },
   buildPreparedModelCatalogSnapshot: vi.fn<BuildPreparedModelCatalogSnapshot>(async () => ({

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -924,7 +924,12 @@ describe("gateway server chat", () => {
     let webchatWs: WebSocket | undefined;
     agentDiscoveryMock.enabled = true;
     agentDiscoveryMock.models = [
-      { id: "claude-opus-4-6", provider: "anthropic", input: ["text", "image"] },
+      {
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        provider: "anthropic",
+        input: ["text", "image"],
+      },
     ];
 
     try {
@@ -2506,7 +2511,9 @@ describe("gateway server chat", () => {
         },
       });
       agentDiscoveryMock.enabled = true;
-      agentDiscoveryMock.models = [{ id: "gpt-5", provider: "openai", reasoning: true }];
+      agentDiscoveryMock.models = [
+        { id: "gpt-5", name: "GPT-5", provider: "openai", reasoning: true },
+      ];
       await prepareGatewayReplyRuntimeForTest({ force: true });
 
       const historyRes = await rpcReq<{


### PR DESCRIPTION
## What Problem This Solves

Gateway startup could omit an authored model from passive model lists in merge mode even though its saved row remained present.

## Why This Change Was Made

Retain captured rows after configured rows so explicit settings win. Keep startup retention separate from Refresh membership, and share metadata conversion using the exact donor row. Replace mode still excludes unconfigured rows.

## User Impact

Authored merge-mode models remain visible at startup without restoring removed models during fresh discovery.

## Evidence

Compiled Gateway merge/replace checks reproduced the missing row before the fix and passed afterward, preserving explicit fields and saved data. The captured-registry-to-empty-refresh regression failed before the correction and passed afterward; 14 affected checks and required CI passed. Empty Refresh was verified by the owner regression, not a successful public restart flow. Persistent inventory across restart and inference were not established.
