### PR TITLE
fix(active-memory): show skipped recall when logging is enabled

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1700,8 +1700,8 @@ describe("active-memory plugin", () => {
     },
   );
 
-  it("records why default escalation skips an ordinary turn", async () => {
-    registerPluginConfig({ mode: undefined });
+  it("logs why default escalation skips an ordinary turn when logging is enabled", async () => {
+    registerPluginConfig({ mode: undefined, logging: true });
 
     const result = await runPromptBuild(
       { prompt: "Explain the current configuration" },
@@ -1714,8 +1714,8 @@ describe("active-memory plugin", () => {
 
     expectPrependContextContains(result, skippedRecallContext);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
-    expect(hasDebugLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
-    expect(hasInfoLine("active-memory: recall skipped reason=no-recall-intent")).toBe(false);
+    expect(hasDebugLine("active-memory: recall skipped reason=no-recall-intent")).toBe(false);
+    expect(hasInfoLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
   });
 
   it("does not run deep recall when the live active-memory plugin entry is removed", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -443,10 +443,15 @@ export default definePluginEntry({
               hasStrongLaneOneHit: laneOne.hasStrongHit,
             });
             if (escalationDecision !== "recall") {
-              // Stays at debug: escalate is the default mode and ordinary
-              // prompts resolve to no-recall-intent, so this is the healthy
-              // path rather than an actionable skip.
-              api.logger.debug?.(`active-memory: recall skipped reason=${escalationDecision}`);
+              const logLine = `active-memory: recall skipped reason=${escalationDecision}`;
+              if (invocationConfig.logging) {
+                api.logger.info?.(logLine);
+              } else {
+                // Escalate is the default mode and ordinary prompts resolve to
+                // no-recall-intent, so keep the healthy path at debug unless
+                // the operator explicitly enables Active Memory logging.
+                api.logger.debug?.(logLine);
+              }
               const outcomeContext =
                 escalationDecision === "no-recall-intent"
                   ? buildRecallOutcomePrefix("skipped-no-recall-intent")


### PR DESCRIPTION
Related: #138561

## What Problem This Solves

Fixes an issue where operators who enable Active Memory logging receive no
info-level outcome when an ordinary turn is intentionally skipped because it has
no recall intent. This makes a healthy skip indistinguishable from a missing
plugin invocation at the configured log level.

## Why This Change Was Made

The existing bounded skip result now follows the plugin's established `logging`
setting: it is emitted at info level when logging is enabled and remains a debug
message otherwise. The broader upgrade-specific recall report remains outside
this focused observability repair.

## User Impact

Operators with Active Memory logging enabled can now see that recall ran far
enough to make an intentional `no-recall-intent` decision. Default installations
retain the existing quiet debug-level behavior.

## Evidence

- The focused regression assertion failed against the original production code
  because no info-level skip message was emitted.
- The focused regression passes with the fix (1 passed, 207 skipped).
- The complete Active Memory test file passed 207 of 208 tests. The remaining
  failure is an unrelated existing Windows-only fixture expecting a POSIX `/tmp`
  path while the runtime returns the equivalent `C:\tmp` path.
- Targeted `oxlint`, formatting, extension typechecks, test typechecks, plugin
  boundary checks, doctor contract tests (6 passed), and `git diff --check`
  passed.
- Independent `gpt-6-astra` high-reasoning review found no actionable P0-P3
  findings in commit `b21f1f6ab8`.
