### PR TITLE
fix(channels): hold draining ingress claims before release

### DIFF
--- a/src/channels/message/ingress-drain.draining-hold.test.ts
+++ b/src/channels/message/ingress-drain.draining-hold.test.ts
@@ -1,0 +1,61 @@
+// Gateway draining hold: keep the claim until the backoff elapses.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+describe("channel ingress drain draining hold", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("holds a GatewayDrainingError claim before release so the next pump cannot re-claim instantly", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-draining", { text: "x" }, { laneKey: "l1" });
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        dispatchClaimedEvent: async (event) => {
+          dispatches.push(event.id);
+          throw new GatewayDrainingError();
+        },
+      });
+
+      const idle = drain.waitForIdle();
+      await drain.drainOnce();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(dispatches).toEqual(["evt-draining"]);
+      expect(await queue.listClaims()).toEqual([
+        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
+      ]);
+      expect(await queue.listPending()).toEqual([]);
+      // Still claimed, so the next pump iteration cannot spin the same row.
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(await queue.listClaims()).toHaveLength(1);
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+
+      await vi.advanceTimersByTimeAsync(1);
+      await idle;
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
+      ]);
+      expect(await queue.listFailed?.()).toEqual([]);
+      drain.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -1,7 +1,6 @@
 // Durable ingress drain contract tests for lifecycle reliability invariants.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   createChannelIngressDrain,
@@ -167,46 +166,6 @@ describe("channel ingress drain", () => {
         expect(pending).toHaveLength(1);
         expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
       });
-      drain.dispose();
-    });
-  });
-
-  it("holds a GatewayDrainingError claim before release so the next pump cannot re-claim instantly", async () => {
-    await withTempState(async (stateDir) => {
-      const queue = createTestIngressQueue(stateDir);
-      await queue.enqueue("evt-draining", { text: "x" }, { laneKey: "l1" });
-      const dispatches: string[] = [];
-      const drain = createChannelIngressDrain<Payload>({
-        queue,
-        dispatchClaimedEvent: async (event) => {
-          dispatches.push(event.id);
-          throw new GatewayDrainingError();
-        },
-      });
-
-      const idle = drain.waitForIdle();
-      await drain.drainOnce();
-      await vi.advanceTimersByTimeAsync(0);
-
-      expect(dispatches).toEqual(["evt-draining"]);
-      expect(await queue.listClaims()).toEqual([
-        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
-      ]);
-      expect(await queue.listPending()).toEqual([]);
-      // Still claimed, so the next pump iteration cannot spin the same row.
-      expect(await drain.drainOnce()).toEqual({ started: 0 });
-
-      await vi.advanceTimersByTimeAsync(4_999);
-      expect(await queue.listClaims()).toHaveLength(1);
-      expect(await drain.drainOnce()).toEqual({ started: 0 });
-
-      await vi.advanceTimersByTimeAsync(1);
-      await idle;
-      expect(await queue.listClaims()).toEqual([]);
-      expect(await queue.listPending()).toEqual([
-        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
-      ]);
-      expect(await queue.listFailed?.()).toEqual([]);
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -1,6 +1,7 @@
 // Durable ingress drain contract tests for lifecycle reliability invariants.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   createChannelIngressDrain,
@@ -166,6 +167,46 @@ describe("channel ingress drain", () => {
         expect(pending).toHaveLength(1);
         expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
       });
+      drain.dispose();
+    });
+  });
+
+  it("holds a GatewayDrainingError claim before release so the next pump cannot re-claim instantly", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("evt-draining", { text: "x" }, { laneKey: "l1" });
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        dispatchClaimedEvent: async (event) => {
+          dispatches.push(event.id);
+          throw new GatewayDrainingError();
+        },
+      });
+
+      const idle = drain.waitForIdle();
+      await drain.drainOnce();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(dispatches).toEqual(["evt-draining"]);
+      expect(await queue.listClaims()).toEqual([
+        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
+      ]);
+      expect(await queue.listPending()).toEqual([]);
+      // Still claimed, so the next pump iteration cannot spin the same row.
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(await queue.listClaims()).toHaveLength(1);
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+
+      await vi.advanceTimersByTimeAsync(1);
+      await idle;
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({ id: "evt-draining", attempts: 0 }),
+      ]);
+      expect(await queue.listFailed?.()).toEqual([]);
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -10,6 +10,7 @@ import {
   retainGatewayRootWorkAdmissionContinuation,
   runOutsideGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
+import { sleep } from "../../utils/sleep.js";
 import {
   createIngressDrainOwnerId,
   deregisterLiveIngressDrainInstance,
@@ -47,6 +48,9 @@ export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 
 /** Default claim→adoption stall before applying the shared retry disposition. */
 export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
+
+/** Hold a draining claim before release so the pump cannot re-claim it immediately. */
+export const INGRESS_DRAINING_RELEASE_HOLD_MS = 5_000;
 
 type DeferredLaneOccupancy = "hold" | "release";
 
@@ -235,8 +239,12 @@ export function createChannelIngressDrain<
   ) => {
     if (err instanceof GatewayDrainingError) {
       // Root dispatch closes before durable transport admission during restart.
-      // Preserve the row for the successor without spending its failure budget.
-      await releaseClaim(claim, { recordAttempt: false });
+      // Hold the claim so the pump cannot re-dispatch the same row every ~40ms,
+      // then release without spending the failure budget.
+      await sleep(INGRESS_DRAINING_RELEASE_HOLD_MS, options.abortSignal);
+      if (!isStopped()) {
+        await releaseClaim(claim, { recordAttempt: false });
+      }
       return;
     }
     const disposition = resolveIngressFailureDisposition({

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -50,7 +50,7 @@ export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 
 /** Hold a draining claim before release so the pump cannot re-claim it immediately. */
-export const INGRESS_DRAINING_RELEASE_HOLD_MS = 5_000;
+const INGRESS_DRAINING_RELEASE_HOLD_MS = 5_000;
 
 type DeferredLaneOccupancy = "hold" | "release";
 


### PR DESCRIPTION
Closes #142013.

## What Problem This Solves

Fixes an issue where users sending Discord (or any channel) messages while the Gateway is draining would have the same inbound claim released and immediately re-claimed, producing thousands of `GatewayDrainingError` log lines until an external restart. Observed on 2026.9.2: 7,098 failures in three minutes for one message.

The follow-up queue drain already holds on this error (#136684 / #136713). Channel ingress still released with `recordAttempt: false`, so the pump spun at ~40ms.

## Why This Change Was Made

Hold the claimed row for 5 seconds before release, still without spending the failure budget. The next pump cannot re-dispatch the same event while it is held. Stop/abort skips the release so a successor drain can recover the claim.

No change to retry accounting, dead-letter policy, or non-draining failures.

## User Impact

A draining Gateway no longer storms the same inbound message. The row stays pending for the successor process. Operators do not need to restart to stop the loop.

## Evidence

Baseline: `03497256f95`.

```
node scripts/run-vitest.mjs run src/channels/message/ingress-drain.test.ts
```

29 passed, including `holds a GatewayDrainingError claim before release so the next pump cannot re-claim instantly`. Fake timers: still claimed at 4999ms (`drainOnce` starts 0), released at 5000ms with `attempts: 0`.
