### PR TITLE
test(signal): await canonical ingress idle

### DIFF
--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, vi } from "vitest";
 import type { SignalDaemonHandle } from "./daemon.js";
 import { setSignalRuntime } from "./runtime.js";
 import { clearSignalRuntimeForTest } from "./runtime.test-support.js";
+import type { SignalIngressMonitor } from "./signal-ingress.js";
 
 type SignalDaemonExitEvent = Awaited<SignalDaemonHandle["exited"]>;
 
@@ -44,6 +45,9 @@ const signalRpcRequestMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const assertSignalDaemonEndpointAvailableMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const spawnSignalDaemonMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalToolResultSessionStore = vi.hoisted(() => ({ path: "" }));
+const signalToolResultIngressMonitor = vi.hoisted(() => ({
+  current: undefined as SignalIngressMonitor | undefined,
+}));
 let signalToolResultStateDir: string | undefined;
 let signalToolResultIngressQueue: ReturnType<typeof createChannelIngressQueueForTests> | undefined;
 
@@ -53,13 +57,15 @@ export function toSignalToolResultTestError(value: unknown, fallbackMessage: str
 
 export async function waitForSignalToolResultIngressIdle() {
   const queue = signalToolResultIngressQueue;
-  if (!queue) {
-    throw new Error("Signal tool-result ingress queue is not initialized");
+  const monitor = signalToolResultIngressMonitor.current;
+  if (!queue || !monitor) {
+    throw new Error("Signal tool-result ingress monitor is not initialized");
   }
+  await monitor.waitForIdle();
+  // Canonical idle owns active delivery synchronization. Deferred debounce claims
+  // settle later at turn adoption, so retain a bounded queue drain assertion.
   await vi.waitFor(
     async () => {
-      // Pending must be read before claims so a pending→claimed transition cannot
-      // disappear between two concurrent snapshots and produce a false idle.
       const pending = await queue.listPending({ limit: "all" });
       const claims = await queue.listClaims();
       if (pending.length > 0 || claims.length > 0) {
@@ -289,6 +295,20 @@ vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
   waitForTransportReady: (...args: unknown[]) => waitForTransportReadyMock(...args),
 }));
 
+vi.mock("./signal-ingress.js", async () => {
+  const actual = await vi.importActual<typeof import("./signal-ingress.js")>("./signal-ingress.js");
+  return {
+    ...actual,
+    startSignalIngressMonitor: async (
+      ...args: Parameters<typeof actual.startSignalIngressMonitor>
+    ) => {
+      const monitor = await actual.startSignalIngressMonitor(...args);
+      signalToolResultIngressMonitor.current = monitor;
+      return monitor;
+    },
+  };
+});
+
 export function installSignalToolResultTestHooks() {
   beforeEach(async () => {
     const [{ resetInboundDedupe }, { resetSystemEventsForTest }] = await Promise.all([
@@ -302,6 +322,7 @@ export function installSignalToolResultTestHooks() {
     const stateDir = await fs.realpath(createdStateDir);
     signalToolResultStateDir = stateDir;
     signalToolResultSessionStore.path = path.join(stateDir, "sessions.json");
+    signalToolResultIngressMonitor.current = undefined;
     signalToolResultIngressQueue = undefined;
     setSignalRuntime({
       logging: {
@@ -360,6 +381,7 @@ export function installSignalToolResultTestHooks() {
 
   afterEach(async () => {
     clearSignalRuntimeForTest();
+    signalToolResultIngressMonitor.current = undefined;
     signalToolResultIngressQueue = undefined;
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Signal extension test failure where the harness could observe `0 pending, 1 claimed` while an accepted ingress delivery was still completing. The race blocked unrelated pull requests, including #142628, on the shared Signal shard.

## Why This Change Was Made

The harness now captures the real `SignalIngressMonitor` returned by `startSignalIngressMonitor()` and awaits its canonical `waitForIdle()` lifecycle boundary before checking durable queue state. The existing bounded queue wait remains because debounced claims can settle later at turn adoption.

This changes test support only. It does not serialize production Signal ingress or increase the existing queue timeout.

## User Impact

No runtime behavior changes. Signal monitor coverage stops racing valid claimed deliveries in CI.

## Evidence

- Hosted pre-fix failure: https://github.com/openclaw/openclaw/actions/runs/34298811260/job/102301282817
- Independent failed-job rerun with the same `0 pending, 1 claimed` state: https://github.com/openclaw/openclaw/actions/runs/34298811260/job/102304080968
- Focused Signal monitor tests: 2 files, 51 tests passed
- Full Signal extension suite: 48 files, 863 tests passed
- Final diff: test support `+26/-4`; production `+0/-0`
