### PR TITLE
fix(gateway): report truncated Responses replies as incomplete

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -243,11 +243,11 @@ Set `stream: true` to receive Server-Sent Events:
 - Each event line is `event: <type>` and `data: <json>`
 - Stream ends with `data: [DONE]`
 
-Event types currently emitted: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `response.failed` (on error).
+Event types currently emitted: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `response.incomplete` (on output-budget truncation), `response.failed` (on error).
 
 Failed agent runs, including whole-agent timeouts, return a failed response. Streaming failures emit `response.failed` followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
 
-A reply that ends because the agent reached its output-token budget is returned with `status: "incomplete"` and `incomplete_details: { "reason": "max_output_tokens" }`, and its final message item carries `status: "incomplete"`. Streaming delivers the same fields on the terminal `response.completed` event. This mirrors the `finish_reason: "length"` projection on `/v1/chat/completions`.
+A reply that ends because the agent reached its output-token budget is returned with `status: "incomplete"` and `incomplete_details: { "reason": "max_output_tokens" }`, and its final message item carries `status: "incomplete"`. Streaming emits these fields on the terminal `response.incomplete` event, so clients dispatching by event type also observe the truncation. This mirrors the `finish_reason: "length"` projection on `/v1/chat/completions`.
 
 Disconnecting the HTTP client cancels active source-URL downloads and the agent run. If cancellation happens while preparing input, the Gateway releases that download and does not start another input download or the agent run. This applies to both streaming and non-streaming requests.
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -247,6 +247,8 @@ Event types currently emitted: `response.created`, `response.in_progress`, `resp
 
 Failed agent runs, including whole-agent timeouts, return a failed response. Streaming failures emit `response.failed` followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
 
+A reply that ends because the agent reached its output-token budget is returned with `status: "incomplete"` and `incomplete_details: { "reason": "max_output_tokens" }`, and its final message item carries `status: "incomplete"`. Streaming delivers the same fields on the terminal `response.completed` event. This mirrors the `finish_reason: "length"` projection on `/v1/chat/completions`.
+
 Disconnecting the HTTP client cancels active source-URL downloads and the agent run. If cancellation happens while preparing input, the Gateway releases that download and does not start another input download or the agent run. This applies to both streaming and non-streaming requests.
 
 ## Usage

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -243,11 +243,11 @@ Set `stream: true` to receive Server-Sent Events:
 - Each event line is `event: <type>` and `data: <json>`
 - Stream ends with `data: [DONE]`
 
-Event types currently emitted: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `response.failed` (on error).
+Event types currently emitted: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `response.incomplete` (on output-token exhaustion), `response.failed` (on error).
 
 Failed agent runs, including whole-agent timeouts, return a failed response. Streaming failures emit `response.failed` followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
 
-A reply that ends because the agent reached its output-token budget is returned with `status: "incomplete"` and `incomplete_details: { "reason": "max_output_tokens" }`, and its final message item carries `status: "incomplete"`. Streaming delivers the same fields on the terminal `response.completed` event. This mirrors the `finish_reason: "length"` projection on `/v1/chat/completions`.
+A reply that ends because the agent reached its output-token budget is returned with `status: "incomplete"` and `incomplete_details: { "reason": "max_output_tokens" }`, and its final message item carries `status: "incomplete"`. Streaming delivers the same fields on the terminal `response.incomplete` event. This mirrors the `finish_reason: "length"` projection on `/v1/chat/completions`.
 
 Disconnecting the HTTP client cancels active source-URL downloads and the agent run. If cancellation happens while preparing input, the Gateway releases that download and does not start another input download or the agent run. This applies to both streaming and non-streaming requests.
 

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -236,7 +236,6 @@ export type CreateResponseBody = z.infer<typeof CreateResponseBodySchema>;
 // ─────────────────────────────────────────────────────────────────────────────
 
 type OutputTextContentPart = Extract<ContentPart, { type: "output_text" }>;
-// Output items may end incomplete when the response hit its output-token budget.
 type OutputStatus = "in_progress" | "completed" | "incomplete";
 
 export type OutputItem =
@@ -270,9 +269,7 @@ export type ResponseResource = {
   output: OutputItem[];
   usage: Usage;
   error?: { code: string; message: string } | undefined;
-  // Mirrors the OpenAI Responses incomplete_details contract; only
-  // max_output_tokens is reachable because provider content_filter outcomes
-  // map to failed responses instead.
+  // Provider content filters are failures, not incomplete output.
   incomplete_details?: { reason: "max_output_tokens" } | undefined;
 };
 
@@ -290,6 +287,7 @@ export type StreamingEvent =
   | { type: "response.created"; response: ResponseResource }
   | { type: "response.in_progress"; response: ResponseResource }
   | { type: "response.completed"; response: ResponseResource }
+  | { type: "response.incomplete"; response: ResponseResource }
   | { type: "response.failed"; response: ResponseResource }
   | { type: "response.output_item.added"; output_index: number; item: OutputItem }
   | { type: "response.output_item.done"; output_index: number; item: OutputItem }

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -290,6 +290,7 @@ export type StreamingEvent =
   | { type: "response.created"; response: ResponseResource }
   | { type: "response.in_progress"; response: ResponseResource }
   | { type: "response.completed"; response: ResponseResource }
+  | { type: "response.incomplete"; response: ResponseResource }
   | { type: "response.failed"; response: ResponseResource }
   | { type: "response.output_item.added"; output_index: number; item: OutputItem }
   | { type: "response.output_item.done"; output_index: number; item: OutputItem }

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -236,7 +236,8 @@ export type CreateResponseBody = z.infer<typeof CreateResponseBodySchema>;
 // ─────────────────────────────────────────────────────────────────────────────
 
 type OutputTextContentPart = Extract<ContentPart, { type: "output_text" }>;
-type OutputStatus = "in_progress" | "completed";
+// Output items may end incomplete when the response hit its output-token budget.
+type OutputStatus = "in_progress" | "completed" | "incomplete";
 
 export type OutputItem =
   | (Omit<Extract<ItemParam, { type: "message" }>, "id" | "role" | "content" | "status"> & {
@@ -269,6 +270,10 @@ export type ResponseResource = {
   output: OutputItem[];
   usage: Usage;
   error?: { code: string; message: string } | undefined;
+  // Mirrors the OpenAI Responses incomplete_details contract; only
+  // max_output_tokens is reachable because provider content_filter outcomes
+  // map to failed responses instead.
+  incomplete_details?: { reason: "max_output_tokens" } | undefined;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1979,64 +1979,69 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
-  it("fails an official SDK stream when an error lifecycle precedes a resolved run", async () => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string }).runId;
-      if (!runId) {
-        throw new Error("expected a streaming response run ID");
-      }
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "partial answer" } });
-      emitAgentEvent({
-        runId,
-        stream: "lifecycle",
-        data: { phase: "error", error: "All model fallback candidates failed" },
-      });
-      emitAgentEvent({
-        runId,
-        stream: "lifecycle",
-        data: { phase: "error", error: "A later lifecycle event must not replace the failure" },
-      });
-      return {
-        payloads: [{ text: "partial answer" }],
-        meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
-      };
-    }) as never);
+  it.each(["stop", "length"])(
+    "keeps a failed SDK stream failed when the run stops with %s",
+    async (stopReason) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "partial answer" } });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "error", error: "All model fallback candidates failed" },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "error", error: "A later lifecycle event must not replace the failure" },
+        });
+        return {
+          payloads: [{ text: "partial answer" }],
+          meta: { stopReason, agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
+        };
+      }) as never);
 
-    const client = new OpenAI({
-      apiKey: "test",
-      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
-      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
-      maxRetries: 0,
-    });
-    const stream = client.responses.stream({
-      model: "openclaw",
-      input: "Report the provider failure.",
-    });
-    let completedEvents = 0;
-    let failedEvents = 0;
-    stream.on("response.completed", () => {
-      completedEvents += 1;
-    });
-    stream.on("response.failed", () => {
-      failedEvents += 1;
-    });
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const stream = client.responses.stream({
+        model: "openclaw",
+        input: "Report the provider failure.",
+      });
+      let completedEvents = 0;
+      let failedEvents = 0;
+      stream.on("response.completed", () => {
+        completedEvents += 1;
+      });
+      stream.on("response.failed", () => {
+        failedEvents += 1;
+      });
 
-    const response = await stream.finalResponse();
-    expect(completedEvents).toBe(0);
-    expect(failedEvents).toBe(1);
-    expect(response.status).toBe("failed");
-    expect(response.error).toEqual({
-      code: "server_error",
-      message: "All model fallback candidates failed",
-    });
-    expect(response.usage).toMatchObject({
-      input_tokens: 11,
-      output_tokens: 7,
-      total_tokens: 18,
-    });
-    expect(agentCommandMock).toHaveBeenCalledTimes(1);
-  });
+      const response = await stream.finalResponse();
+      expect(completedEvents).toBe(0);
+      expect(failedEvents).toBe(1);
+      expect(response.status).toBe("failed");
+      expect(response.incomplete_details).toBeUndefined();
+      expect(response.output[0]).toMatchObject({ type: "message", status: "completed" });
+      expect(response.error).toEqual({
+        code: "server_error",
+        message: "All model fallback candidates failed",
+      });
+      expect(response.usage).toMatchObject({
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+      });
+      expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([
     {
@@ -2858,19 +2863,29 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(res.status).toBe(200);
     const text = await res.text();
     const events = parseSseEvents(text);
-    const completed = events.find((event) => event.event === "response.completed");
-    expect(completed).toBeDefined();
-    const completedPayload = JSON.parse(completed?.data ?? "{}") as {
-      response?: {
-        status?: string;
-        incomplete_details?: { reason?: string };
-        output?: Array<Record<string, unknown>>;
-      };
+    expect(
+      events
+        .filter((event) =>
+          ["response.completed", "response.incomplete", "response.failed"].includes(event.event),
+        )
+        .map((event) => event.event),
+    ).toEqual(["response.incomplete"]);
+    expect(text.split("data: [DONE]")).toHaveLength(2);
+    const incomplete = parseSseData(findSseEvent(events, "response.incomplete")) as {
+      type: string;
+      response: ResponseResource;
     };
-    expect(completedPayload.response?.status).toBe("incomplete");
-    expect(completedPayload.response?.incomplete_details?.reason).toBe("max_output_tokens");
-    expect(completedPayload.response?.output?.[0]?.status).toBe("incomplete");
-    expect(completedPayload.response?.output?.[0]?.phase).toBe("final_answer");
+    expect(incomplete.type).toBe("response.incomplete");
+    expect(incomplete.response.status).toBe("incomplete");
+    expect(incomplete.response.incomplete_details?.reason).toBe("max_output_tokens");
+    expect(incomplete.response.output[0]).toMatchObject({
+      type: "message",
+      status: "incomplete",
+      phase: "final_answer",
+    });
+    expect(parseSseData(findSseEvent(events, "response.output_item.done"))).toMatchObject({
+      item: incomplete.response.output[0],
+    });
   });
 
   it("rejects an unsatisfied function tool_choice on the non-streaming path", async () => {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2858,9 +2858,13 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(res.status).toBe(200);
     const text = await res.text();
     const events = parseSseEvents(text);
-    const completed = events.find((event) => event.event === "response.completed");
-    expect(completed).toBeDefined();
-    const completedPayload = JSON.parse(completed?.data ?? "{}") as {
+    // The terminal event type must carry the truncation outcome, not only the
+    // nested resource fields: event-dispatching clients never see status otherwise.
+    const terminal = events.find(
+      (event) => event.event === "response.incomplete" || event.event === "response.completed",
+    );
+    expect(terminal?.event).toBe("response.incomplete");
+    const completedPayload = JSON.parse(terminal?.data ?? "{}") as {
       response?: {
         status?: string;
         incomplete_details?: { reason?: string };

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2813,6 +2813,66 @@ describe("OpenResponses HTTP API (e2e)", () => {
     await ensureResponseConsumed(res);
   });
 
+  it("reports output-budget truncation as incomplete on the non-streaming path", async () => {
+    const port = enabledPort;
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "A partial answer cut off by the output token budget mid-sent" }],
+      meta: { stopReason: "length" },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "write a long story",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status?: string;
+      incomplete_details?: { reason?: string };
+      output?: Array<Record<string, unknown>>;
+    };
+    expect(json.status).toBe("incomplete");
+    expect(json.incomplete_details?.reason).toBe("max_output_tokens");
+    expect(json.output?.map((item) => item.type)).toEqual(["message"]);
+    expect(json.output?.[0]?.status).toBe("incomplete");
+    expect(json.output?.[0]?.phase).toBe("final_answer");
+    await ensureResponseConsumed(res);
+  });
+
+  it("carries output-budget truncation as incomplete on the streaming path", async () => {
+    const port = enabledPort;
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "A streamed partial answer cut off by the output token budget mid-" }],
+      meta: { stopReason: "length" },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "write another long story",
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+    const completed = events.find((event) => event.event === "response.completed");
+    expect(completed).toBeDefined();
+    const completedPayload = JSON.parse(completed?.data ?? "{}") as {
+      response?: {
+        status?: string;
+        incomplete_details?: { reason?: string };
+        output?: Array<Record<string, unknown>>;
+      };
+    };
+    expect(completedPayload.response?.status).toBe("incomplete");
+    expect(completedPayload.response?.incomplete_details?.reason).toBe("max_output_tokens");
+    expect(completedPayload.response?.output?.[0]?.status).toBe("incomplete");
+    expect(completedPayload.response?.output?.[0]?.phase).toBe("final_answer");
+  });
+
   it("rejects an unsatisfied function tool_choice on the non-streaming path", async () => {
     const port = enabledPort;
     agentCommandMock.mockClear();

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2864,11 +2864,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const text = await res.text();
     const events = parseSseEvents(text);
     expect(
-      events
-        .filter((event) =>
-          ["response.completed", "response.incomplete", "response.failed"].includes(event.event),
-        )
-        .map((event) => event.event),
+      collectSseEventTypes(events).filter((type) =>
+        ["response.completed", "response.incomplete", "response.failed"].includes(type),
+      ),
     ).toEqual(["response.incomplete"]);
     expect(text.split("data: [DONE]")).toHaveLength(2);
     const incomplete = parseSseData(findSseEvent(events, "response.incomplete")) as {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -360,6 +360,7 @@ function createResponseResource(params: {
   output: OutputItem[];
   usage?: Usage;
   error?: { code: string; message: string };
+  incomplete?: boolean;
 }): ResponseResource {
   return {
     id: params.id,
@@ -370,6 +371,7 @@ function createResponseResource(params: {
     output: params.output,
     usage: params.usage ?? createEmptyUsage(),
     error: params.error,
+    ...(params.incomplete ? { incomplete_details: { reason: "max_output_tokens" as const } } : {}),
   };
 }
 
@@ -801,16 +803,21 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
+      // Preserve the agent's authoritative output-budget outcome: a reply that
+      // ended on stopReason "length" is partial, so the response must say
+      // incomplete instead of claiming a completed answer.
+      const truncatedByOutputBudget = stopReason === "length";
       const response = createResponseResource({
         ...responseIdentity,
         model,
-        status: "completed",
+        status: truncatedByOutputBudget ? "incomplete" : "completed",
+        incomplete: truncatedByOutputBudget,
         output: [
           createAssistantOutputItem({
             id: outputItemId,
             text: assistantText || "No response from OpenClaw.",
             phase: "final_answer",
-            status: "completed",
+            status: truncatedByOutputBudget ? "incomplete" : "completed",
           }),
         ],
         usage,
@@ -862,6 +869,9 @@ export async function handleOpenResponsesHttpRequest(
   let closed = false;
   let unsubscribe = () => {};
   let finalUsage: Usage | undefined;
+  // Mirrors the chat-completions finalFinishReason capture: true when the agent
+  // turn ended on stopReason "length" and the streamed answer is partial.
+  let finalTruncatedByOutputBudget = false;
   let finalizeRequested: { status: ResponseResource["status"]; errorMessage?: string } | null =
     null;
   let finalizeScheduled = false;
@@ -937,7 +947,7 @@ export async function handleOpenResponsesHttpRequest(
           finalizeRequested.status === "completed" && !finalToolCalls
             ? "final_answer"
             : "commentary",
-        status: "completed",
+        status: finalTruncatedByOutputBudget ? "incomplete" : "completed",
       });
 
       writeSseEvent(res, {
@@ -971,7 +981,13 @@ export async function handleOpenResponsesHttpRequest(
       const finalResponse = createResponseResource({
         ...responseIdentity,
         model,
-        status: finalizeRequested.status,
+        status:
+          finalizeRequested.status === "failed"
+            ? "failed"
+            : finalTruncatedByOutputBudget
+              ? "incomplete"
+              : "completed",
+        incomplete: finalizeRequested.status !== "failed" && finalTruncatedByOutputBudget,
         output,
         usage,
         ...(finalizeRequested.status === "failed"
@@ -1218,6 +1234,7 @@ export async function handleOpenResponsesHttpRequest(
       }
 
       finalResultText = resultPayloadText;
+      finalTruncatedByOutputBudget = stopReason === "length";
       finalToolCalls =
         stopReason === "tool_calls" && pendingToolCalls?.length ? pendingToolCalls : undefined;
       maybeFinalize();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -360,7 +360,6 @@ function createResponseResource(params: {
   output: OutputItem[];
   usage?: Usage;
   error?: { code: string; message: string };
-  incomplete?: boolean;
 }): ResponseResource {
   return {
     id: params.id,
@@ -371,7 +370,9 @@ function createResponseResource(params: {
     output: params.output,
     usage: params.usage ?? createEmptyUsage(),
     error: params.error,
-    ...(params.incomplete ? { incomplete_details: { reason: "max_output_tokens" as const } } : {}),
+    ...(params.status === "incomplete"
+      ? { incomplete_details: { reason: "max_output_tokens" as const } }
+      : {}),
   };
 }
 
@@ -803,21 +804,17 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
-      // Preserve the agent's authoritative output-budget outcome: a reply that
-      // ended on stopReason "length" is partial, so the response must say
-      // incomplete instead of claiming a completed answer.
-      const truncatedByOutputBudget = stopReason === "length";
+      const status = stopReason === "length" ? "incomplete" : "completed";
       const response = createResponseResource({
         ...responseIdentity,
         model,
-        status: truncatedByOutputBudget ? "incomplete" : "completed",
-        incomplete: truncatedByOutputBudget,
+        status,
         output: [
           createAssistantOutputItem({
             id: outputItemId,
             text: assistantText || "No response from OpenClaw.",
             phase: "final_answer",
-            status: truncatedByOutputBudget ? "incomplete" : "completed",
+            status,
           }),
         ],
         usage,
@@ -869,11 +866,8 @@ export async function handleOpenResponsesHttpRequest(
   let closed = false;
   let unsubscribe = () => {};
   let finalUsage: Usage | undefined;
-  // Mirrors the chat-completions finalFinishReason capture: true when the agent
-  // turn ended on stopReason "length" and the streamed answer is partial.
-  let finalTruncatedByOutputBudget = false;
-  let finalizeRequested: { status: ResponseResource["status"]; errorMessage?: string } | null =
-    null;
+  let finalOutputStatus: "completed" | "incomplete" = "completed";
+  let finalizeRequested: { status: "completed" | "failed"; errorMessage?: string } | null = null;
   let finalizeScheduled = false;
   let terminalLifecyclePhase: "end" | "error" = "end";
 
@@ -899,6 +893,7 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
       const usage = finalUsage;
+      const status = finalizeRequested.status === "failed" ? "failed" : finalOutputStatus;
       const finalText = resolveAssistantTextCompletion({
         assistantText,
         pending: pendingAssistantText,
@@ -947,7 +942,7 @@ export async function handleOpenResponsesHttpRequest(
           finalizeRequested.status === "completed" && !finalToolCalls
             ? "final_answer"
             : "commentary",
-        status: finalTruncatedByOutputBudget ? "incomplete" : "completed",
+        status: status === "incomplete" ? "incomplete" : "completed",
       });
 
       writeSseEvent(res, {
@@ -981,13 +976,7 @@ export async function handleOpenResponsesHttpRequest(
       const finalResponse = createResponseResource({
         ...responseIdentity,
         model,
-        status:
-          finalizeRequested.status === "failed"
-            ? "failed"
-            : finalTruncatedByOutputBudget
-              ? "incomplete"
-              : "completed",
-        incomplete: finalizeRequested.status !== "failed" && finalTruncatedByOutputBudget,
+        status,
         output,
         usage,
         ...(finalizeRequested.status === "failed"
@@ -1002,7 +991,7 @@ export async function handleOpenResponsesHttpRequest(
 
       rememberResponseSession();
       writeSseEvent(res, {
-        type: finalizeRequested.status === "failed" ? "response.failed" : "response.completed",
+        type: `response.${status}`,
         response: finalResponse,
       });
       writeDone(res);
@@ -1010,7 +999,7 @@ export async function handleOpenResponsesHttpRequest(
     });
   };
 
-  const requestFinalize = (status: ResponseResource["status"], errorMessage?: string) => {
+  const requestFinalize = (status: "completed" | "failed", errorMessage?: string) => {
     if (finalizeRequested) {
       return;
     }
@@ -1234,7 +1223,7 @@ export async function handleOpenResponsesHttpRequest(
       }
 
       finalResultText = resultPayloadText;
-      finalTruncatedByOutputBudget = stopReason === "length";
+      finalOutputStatus = stopReason === "length" ? "incomplete" : "completed";
       finalToolCalls =
         stopReason === "tool_calls" && pendingToolCalls?.length ? pendingToolCalls : undefined;
       maybeFinalize();

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1001,8 +1001,15 @@ export async function handleOpenResponsesHttpRequest(
       });
 
       rememberResponseSession();
+      // Event-dispatching clients select their terminal handler by event type,
+      // so the terminal event must carry the response's own outcome.
       writeSseEvent(res, {
-        type: finalizeRequested.status === "failed" ? "response.failed" : "response.completed",
+        type:
+          finalResponse.status === "failed"
+            ? "response.failed"
+            : finalResponse.status === "incomplete"
+              ? "response.incomplete"
+              : "response.completed",
         response: finalResponse,
       });
       writeDone(res);

--- a/src/gateway/openresponses-shape.ts
+++ b/src/gateway/openresponses-shape.ts
@@ -9,7 +9,7 @@ export function createAssistantOutputItem(params: {
   id: string;
   text: string;
   phase?: "commentary" | "final_answer";
-  status?: "in_progress" | "completed";
+  status?: "in_progress" | "completed" | "incomplete";
 }): Extract<OutputItem, { type: "message" }> {
   return {
     type: "message",


### PR DESCRIPTION
Related: #141264, #141268

## What Problem This Solves

Fixes an issue where clients calling `POST /v1/responses` would treat an output-token-limited partial reply as a completed answer.

## Why This Change Was Made

The endpoint preserves the agent's authoritative length outcome as an incomplete response and final message, with `incomplete_details.reason: "max_output_tokens"`. Streaming sends `response.incomplete` and the existing `[DONE]` marker. Failure and tool-choice checks retain priority over truncation.

This retains the contributor's repair and aligns the terminal event with the public Open Responses protocol. One final status supplies the message, response, and event; output budgets and provider behavior stay unchanged.

## User Impact

JSON clients can detect a partial answer from its response status. Streaming clients receive the matching incomplete event, including SDK event listeners. Normal completions and failures retain their current behavior.

## Evidence

- Real authenticated Gateway requests through a controlled local provider: main reported completed in both JSON and streaming after authoritative length termination; the candidate reports incomplete, `max_output_tokens`, an incomplete final message, and exactly one `response.incomplete` event plus one `[DONE]` marker.
- Matching before/after controls preserve normal completion, provider failures, content filtering, whole-agent timeout, client cancellation and recovery, required-tool rejection, ordered client calls, usage, response identity, and same-runtime session history. Both Chat Completions length modes remain correct.
- Fresh source-blind acceptance exercised 19 additional public HTTP cases, including identical text with different termination reasons, misleading truncation wording, required-tool precedence, and continuation after an incomplete response. No behavioral findings.
- The actual installed OpenAI SDK receives exactly one incomplete callback for the length case and one completed callback for its normal control; both accumulated final responses retain the correct status and text.
- Focused Responses and Chat Completions suites: 257 passed. Updated regressions fail on main for completed status/event, and on the original contributor implementation for the terminal event and failed-message status.
- Targeted formatting, lint, and diff checks passed. Full hosted checks and the exact-head landing review gate are required before merge.

The runtime proof uses a synthetic provider through normal agent transport. Cancellation proves disconnection and upstream teardown; no stored cancellation result is claimed. History proof covers a same-runtime continuation. Raw prompts, credentials, identifiers, and infrastructure metadata remain private.
