### PR TITLE
fix(ci): add Android emulator diagnostic

### DIFF
--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -1,0 +1,193 @@
+name: Android Emulator Diagnostic
+
+run-name: Android emulator diagnostic (${{ inputs.target_sha }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact lowercase 40-character commit SHA to diagnose
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: macos-26-intel
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    env:
+      ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180"
+      AVD_NAME: OpenClaw_Screenshots_API36
+      DEVICE_PROFILE: pixel_2
+      SYSTEM_IMAGE: system-images;android-36;google_apis;x86_64
+    steps:
+      - name: Validate target SHA
+        shell: bash
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::target_sha must be an exact lowercase 40-character commit SHA"
+            exit 2
+          fi
+          DIAGNOSTIC_DIR="$RUNNER_TEMP/android-emulator-diagnostic"
+          echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"
+          mkdir -p "$DIAGNOSTIC_DIR"
+          {
+            printf 'target_sha=%s\n' "$TARGET_SHA"
+            printf 'runner_os=%s\n' "$RUNNER_OS"
+            printf 'runner_arch=%s\n' "$RUNNER_ARCH"
+            printf 'runner_image=%s\n' "${ImageOS:-unknown}"
+            printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
+            uname -a
+            sw_vers
+          } >"$DIAGNOSTIC_DIR/runner.txt"
+
+      - name: Checkout exact target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.target_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact target checkout
+        shell: bash
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          git status --short --branch >"$DIAGNOSTIC_DIR/checkout-status.txt"
+
+      - name: Setup Android toolchain
+        uses: ./.github/actions/setup-android-toolchain
+        with:
+          cache-mode: "off"
+          install-screenshot-emulators: "true"
+
+      - name: Run phone emulator diagnostic
+        shell: bash
+        run: |
+          set -euo pipefail
+          emulator_pid=""
+          adb_started=0
+
+          cleanup() {
+            status=$?
+            set +e
+            {
+              printf 'exit_status=%s\n' "$status"
+              printf 'finished_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              if [[ -n "$emulator_pid" ]]; then
+                ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command=
+              fi
+              adb devices -l
+            } >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
+            if [[ -n "$emulator_pid" ]] && kill -0 "$emulator_pid" 2>/dev/null; then
+              kill "$emulator_pid"
+              for _ in {1..15}; do
+                kill -0 "$emulator_pid" 2>/dev/null || break
+                sleep 1
+              done
+              if kill -0 "$emulator_pid" 2>/dev/null; then
+                kill -9 "$emulator_pid"
+              fi
+              wait "$emulator_pid" 2>/dev/null
+            fi
+            if [[ "$adb_started" == "1" ]]; then
+              adb kill-server
+            fi
+            avdmanager delete avd --name "$AVD_NAME" \
+              >>"$DIAGNOSTIC_DIR/cleanup.log" 2>&1
+            exit "$status"
+          }
+          trap cleanup EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          emulator -version >"$DIAGNOSTIC_DIR/emulator-version.txt" 2>&1
+          sdkmanager --list_installed >"$DIAGNOSTIC_DIR/sdk-packages.txt" 2>&1
+          avdmanager list device >"$DIAGNOSTIC_DIR/avd-devices.txt" 2>&1
+          adb start-server
+          adb_started=1
+          adb devices -l >"$DIAGNOSTIC_DIR/adb-before.txt"
+          if adb devices | awk 'NR > 1 && $2 != "" { found = 1 } END { exit !found }'; then
+            echo "::error::Expected no connected Android devices before diagnostic startup"
+            exit 1
+          fi
+
+          printf 'no\n' | avdmanager create avd --force --name "$AVD_NAME" --package "$SYSTEM_IMAGE" --device "$DEVICE_PROFILE"
+          cp "$HOME/.android/avd/${AVD_NAME}.avd/config.ini" "$DIAGNOSTIC_DIR/avd-config.ini"
+
+          emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim)
+          printf '%q ' "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator-args.txt"
+          printf '\n' >>"$DIAGNOSTIC_DIR/emulator-args.txt"
+          emulator "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator.log" 2>&1 &
+          emulator_pid=$!
+          printf 'emulator_pid=%s\n' "$emulator_pid" >"$DIAGNOSTIC_DIR/process-status.log"
+
+          device_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))
+          serial=""
+          while (( SECONDS < device_deadline )); do
+            {
+              printf '\n[%s] waiting for one device\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              adb devices -l
+            } >>"$DIAGNOSTIC_DIR/adb-observations.log" 2>&1
+            serials="$(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')"
+            count="$(printf '%s\n' "$serials" | sed '/^$/d' | wc -l | tr -d ' ')"
+            if [[ "$count" == "1" ]]; then
+              serial="$serials"
+              break
+            fi
+            if [[ "$count" -gt 1 ]]; then
+              echo "::error::Multiple Android devices appeared during diagnostic startup"
+              exit 1
+            fi
+            ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command= \
+              >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
+            kill -0 "$emulator_pid"
+            sleep 2
+          done
+          if [[ -z "$serial" ]]; then
+            echo "::error::Timed out waiting for exactly one Android emulator device"
+            exit 1
+          fi
+
+          adb -s "$serial" wait-for-device
+          boot_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))
+          while (( SECONDS < boot_deadline )); do
+            boot_completed="$(adb -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+            {
+              printf '\n[%s] serial=%s boot_completed=%s\n' \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$serial" "${boot_completed:-unset}"
+              adb devices -l
+            } >>"$DIAGNOSTIC_DIR/adb-observations.log" 2>&1
+            ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command= \
+              >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
+            kill -0 "$emulator_pid"
+            if [[ "$boot_completed" == "1" ]]; then
+              {
+                printf 'serial=%s\n' "$serial"
+                printf 'avd=%s\n' "$(adb -s "$serial" emu avd name 2>/dev/null | tr -d '\r' | sed -n '1p')"
+                printf 'boot_completed=1\n'
+              } >"$DIAGNOSTIC_DIR/result.txt"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "::error::Timed out waiting for Android emulator boot completion"
+          exit 1
+
+      - name: Upload Android emulator diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-emulator-diagnostic-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/android-emulator-diagnostic
+          retention-days: 7

--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -14,16 +14,11 @@ permissions:
   contents: read
 
 jobs:
-  diagnose:
-    runs-on: macos-26-intel
-    timeout-minutes: 25
+  validate-target:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: read
-    env:
-      ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180"
-      AVD_NAME: OpenClaw_Screenshots_API36
-      DEVICE_PROFILE: pixel_2
-      SYSTEM_IMAGE: system-images;android-36;google_apis;x86_64
     steps:
       - name: Validate target SHA
         shell: bash
@@ -35,18 +30,6 @@ jobs:
             echo "::error::target_sha must be an exact lowercase 40-character commit SHA"
             exit 2
           fi
-          DIAGNOSTIC_DIR="$RUNNER_TEMP/android-emulator-diagnostic"
-          echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"
-          mkdir -p "$DIAGNOSTIC_DIR"
-          {
-            printf 'target_sha=%s\n' "$TARGET_SHA"
-            printf 'runner_os=%s\n' "$RUNNER_OS"
-            printf 'runner_arch=%s\n' "$RUNNER_ARCH"
-            printf 'runner_image=%s\n' "${ImageOS:-unknown}"
-            printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
-            uname -a
-            sw_vers
-          } >"$DIAGNOSTIC_DIR/runner.txt"
 
       - name: Checkout trusted Android tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -72,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git -C candidate rev-parse HEAD)" = "$TARGET_SHA"
-          git -C candidate status --short --branch >"$DIAGNOSTIC_DIR/checkout-status.txt"
+          git -C candidate status --short --branch
 
       - name: Verify Android toolchain action parity
         shell: bash
@@ -101,6 +84,47 @@ jobs:
             echo "::error::Candidate Android toolchain action differs from trusted workflow tooling"
             exit 1
           fi
+
+  diagnose:
+    needs: validate-target
+    runs-on: macos-26-intel
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    env:
+      ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180"
+      AVD_NAME: OpenClaw_Screenshots_API36
+      DEVICE_PROFILE: pixel_2
+      SYSTEM_IMAGE: system-images;android-36;google_apis;x86_64
+    steps:
+      - name: Initialize Android emulator diagnostic
+        shell: bash
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          DIAGNOSTIC_DIR="$RUNNER_TEMP/android-emulator-diagnostic"
+          echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"
+          mkdir -p "$DIAGNOSTIC_DIR"
+          {
+            printf 'target_sha=%s\n' "$TARGET_SHA"
+            printf 'tooling_sha=%s\n' "$GITHUB_WORKFLOW_SHA"
+            printf 'runner_os=%s\n' "$RUNNER_OS"
+            printf 'runner_arch=%s\n' "$RUNNER_ARCH"
+            printf 'runner_image=%s\n' "${ImageOS:-unknown}"
+            printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
+            uname -a
+            sw_vers
+          } >"$DIAGNOSTIC_DIR/runner.txt"
+
+      - name: Checkout trusted Android tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/actions/setup-android-toolchain
+          path: .mobile-release-tooling
 
       - name: Setup Android toolchain
         uses: ./.mobile-release-tooling/.github/actions/setup-android-toolchain

--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -48,12 +48,22 @@ jobs:
             sw_vers
           } >"$DIAGNOSTIC_DIR/runner.txt"
 
+      - name: Checkout trusted Android tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/actions/setup-android-toolchain
+          path: .mobile-release-tooling
+
       - name: Checkout exact target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.target_sha }}
           fetch-depth: 1
           persist-credentials: false
+          path: candidate
 
       - name: Verify exact target checkout
         shell: bash
@@ -61,11 +71,39 @@ jobs:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
-          git status --short --branch >"$DIAGNOSTIC_DIR/checkout-status.txt"
+          test "$(git -C candidate rev-parse HEAD)" = "$TARGET_SHA"
+          git -C candidate status --short --branch >"$DIAGNOSTIC_DIR/checkout-status.txt"
+
+      - name: Verify Android toolchain action parity
+        shell: bash
+        run: |
+          set -euo pipefail
+          action_path=".github/actions/setup-android-toolchain/action.yml"
+          read -r trusted_mode trusted_type trusted_oid trusted_path < <(
+            git -C .mobile-release-tooling ls-tree HEAD -- "$action_path"
+          )
+          read -r candidate_mode candidate_type candidate_oid candidate_path < <(
+            git -C candidate ls-tree HEAD -- "$action_path"
+          )
+          if [[ "$trusted_mode" != "100644" || "$trusted_type" != "blob" || "$trusted_path" != "$action_path" ]]; then
+            echo "::error::Trusted Android toolchain action is not a regular committed file"
+            exit 1
+          fi
+          if [[ "$candidate_mode" != "100644" || "$candidate_type" != "blob" || "$candidate_path" != "$action_path" ]]; then
+            echo "::error::Candidate Android toolchain action is not a regular committed file"
+            exit 1
+          fi
+          trusted_blob="$RUNNER_TEMP/trusted-setup-android-toolchain.yml"
+          candidate_blob="$RUNNER_TEMP/candidate-setup-android-toolchain.yml"
+          git -C .mobile-release-tooling cat-file blob "$trusted_oid" >"$trusted_blob"
+          git -C candidate cat-file blob "$candidate_oid" >"$candidate_blob"
+          if ! cmp -s "$trusted_blob" "$candidate_blob"; then
+            echo "::error::Candidate Android toolchain action differs from trusted workflow tooling"
+            exit 1
+          fi
 
       - name: Setup Android toolchain
-        uses: ./.github/actions/setup-android-toolchain
+        uses: ./.mobile-release-tooling/.github/actions/setup-android-toolchain
         with:
           cache-mode: "off"
           install-screenshot-emulators: "true"

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1787,8 +1787,14 @@ describe("mobile release authority", () => {
     const job = workflow.jobs.diagnose;
     const steps = job.steps;
     const validateIndex = steps.findIndex((step) => step.name === "Validate target SHA");
+    const trustedCheckoutIndex = steps.findIndex(
+      (step) => step.name === "Checkout trusted Android tooling",
+    );
     const checkoutIndex = steps.findIndex((step) => step.name === "Checkout exact target");
     const headIndex = steps.findIndex((step) => step.name === "Verify exact target checkout");
+    const parityIndex = steps.findIndex(
+      (step) => step.name === "Verify Android toolchain action parity",
+    );
     const setupIndex = steps.findIndex((step) => step.name === "Setup Android toolchain");
     const diagnosticIndex = steps.findIndex(
       (step) => step.name === "Run phone emulator diagnostic",
@@ -1817,9 +1823,11 @@ describe("mobile release authority", () => {
     });
 
     expect(validateIndex).toBe(0);
-    expect(checkoutIndex).toBe(validateIndex + 1);
+    expect(trustedCheckoutIndex).toBe(validateIndex + 1);
+    expect(checkoutIndex).toBe(trustedCheckoutIndex + 1);
     expect(headIndex).toBe(checkoutIndex + 1);
-    expect(setupIndex).toBeGreaterThan(headIndex);
+    expect(parityIndex).toBe(headIndex + 1);
+    expect(setupIndex).toBe(parityIndex + 1);
     expect(diagnosticIndex).toBe(setupIndex + 1);
     expect(artifactIndex).toBe(diagnosticIndex + 1);
     expect(steps[validateIndex]?.env).toEqual({
@@ -1832,25 +1840,101 @@ describe("mobile release authority", () => {
     expect(steps[validateIndex]?.run).toContain(
       'echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"',
     );
+    expect(steps[trustedCheckoutIndex]).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: {
+        ref: "${{ github.workflow_sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+        "sparse-checkout": ".github/actions/setup-android-toolchain",
+        path: ".mobile-release-tooling",
+      },
+    });
     expect(steps[checkoutIndex]).toMatchObject({
       uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       with: {
         ref: "${{ inputs.target_sha }}",
         "fetch-depth": 1,
         "persist-credentials": false,
+        path: "candidate",
       },
     });
     expect(steps[headIndex]?.env).toEqual({
       TARGET_SHA: "${{ inputs.target_sha }}",
     });
-    expect(steps[headIndex]?.run).toContain('test "$(git rev-parse HEAD)" = "$TARGET_SHA"');
+    expect(steps[headIndex]?.run).toContain(
+      'test "$(git -C candidate rev-parse HEAD)" = "$TARGET_SHA"',
+    );
     expect(steps[setupIndex]).toMatchObject({
-      uses: "./.github/actions/setup-android-toolchain",
+      uses: "./.mobile-release-tooling/.github/actions/setup-android-toolchain",
       with: {
         "cache-mode": "off",
         "install-screenshot-emulators": "true",
       },
     });
+
+    const parityScript = steps[parityIndex]?.run ?? "";
+    expect(parityScript).toContain("git -C .mobile-release-tooling ls-tree");
+    expect(parityScript).toContain("git -C candidate ls-tree");
+    expect(parityScript).toContain("cat-file blob");
+    expect(parityScript).toContain("cmp -s");
+
+    const actionPath = ".github/actions/setup-android-toolchain/action.yml";
+    const trustedAction = "name: fixture\nruns:\n  using: composite\n  steps: []\n";
+    const runParityGate = (candidate: "matching" | "modified" | "symlink") => {
+      const root = tempRoots.make("openclaw-android-emulator-diagnostic-parity-");
+      const trusted = path.join(root, ".mobile-release-tooling");
+      const target = path.join(root, "candidate");
+      const runnerTemp = path.join(root, "runner-temp");
+      const sentinel = path.join(root, "setup-ran");
+      fs.mkdirSync(runnerTemp);
+      for (const repository of [trusted, target]) {
+        fs.mkdirSync(repository);
+        git(repository, "init", "-q");
+        git(repository, "config", "user.name", "OpenClaw Test");
+        git(repository, "config", "user.email", "test@openclaw.invalid");
+      }
+      writeFile(trusted, actionPath, trustedAction);
+      if (candidate === "symlink") {
+        const candidatePath = path.join(target, actionPath);
+        fs.mkdirSync(path.dirname(candidatePath), { recursive: true });
+        fs.symlinkSync(path.join(trusted, actionPath), candidatePath);
+      } else {
+        writeFile(
+          target,
+          actionPath,
+          candidate === "matching"
+            ? trustedAction
+            : trustedAction.replace("fixture", "substituted"),
+        );
+      }
+      commit(trusted, "trusted action");
+      commit(target, "candidate action");
+
+      const result = spawnSync(
+        "/bin/bash",
+        ["-c", `${parityScript}\nprintf 'setup\\n' >"$SETUP_SENTINEL"\n`],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            RUNNER_TEMP: runnerTemp,
+            SETUP_SENTINEL: sentinel,
+          },
+        },
+      );
+      return { result, sentinel };
+    };
+
+    const matching = runParityGate("matching");
+    expect(matching.result.status, matching.result.stderr).toBe(0);
+    expect(fs.readFileSync(matching.sentinel, "utf8")).toBe("setup\n");
+    for (const candidate of ["modified", "symlink"] as const) {
+      const rejected = runParityGate(candidate);
+      expect(rejected.result.status).not.toBe(0);
+      expect(fs.existsSync(rejected.sentinel)).toBe(false);
+    }
 
     const diagnostic = steps[diagnosticIndex]?.run ?? "";
     expect(diagnostic).toContain(

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1749,6 +1749,143 @@ describe("mobile release authority", () => {
     expect(source).not.toContain("extraheader");
   });
 
+  it("keeps the Android emulator diagnostic manual, exact-SHA-bound, and secretless", () => {
+    const file = ".github/workflows/android-emulator-diagnostic.yml";
+    const source = fs.readFileSync(file, "utf8");
+    const workflow = parse(source) as {
+      jobs: {
+        diagnose: {
+          env: Record<string, string>;
+          permissions: Record<string, string>;
+          "runs-on": string;
+          steps: Array<{
+            env?: Record<string, string>;
+            if?: string;
+            name: string;
+            run?: string;
+            uses?: string;
+            with?: Record<string, unknown>;
+          }>;
+          "timeout-minutes": number;
+        };
+      };
+      name: string;
+      on: {
+        workflow_dispatch: {
+          inputs: {
+            target_sha: {
+              default?: unknown;
+              description: string;
+              required: boolean;
+              type: string;
+            };
+          };
+        };
+      };
+      permissions: Record<string, string>;
+    };
+    const job = workflow.jobs.diagnose;
+    const steps = job.steps;
+    const validateIndex = steps.findIndex((step) => step.name === "Validate target SHA");
+    const checkoutIndex = steps.findIndex((step) => step.name === "Checkout exact target");
+    const headIndex = steps.findIndex((step) => step.name === "Verify exact target checkout");
+    const setupIndex = steps.findIndex((step) => step.name === "Setup Android toolchain");
+    const diagnosticIndex = steps.findIndex(
+      (step) => step.name === "Run phone emulator diagnostic",
+    );
+    const artifactIndex = steps.findIndex(
+      (step) => step.name === "Upload Android emulator diagnostic",
+    );
+
+    expect(workflow.name).toBe("Android Emulator Diagnostic");
+    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+    expect(workflow.on.workflow_dispatch.inputs.target_sha).toEqual({
+      description: "Exact lowercase 40-character commit SHA to diagnose",
+      required: true,
+      type: "string",
+    });
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(Object.keys(workflow.jobs)).toEqual(["diagnose"]);
+    expect(job.permissions).toEqual({ contents: "read" });
+    expect(job["runs-on"]).toBe("macos-26-intel");
+    expect(job["timeout-minutes"]).toBe(25);
+    expect(job.env).toEqual({
+      ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180",
+      AVD_NAME: "OpenClaw_Screenshots_API36",
+      DEVICE_PROFILE: "pixel_2",
+      SYSTEM_IMAGE: "system-images;android-36;google_apis;x86_64",
+    });
+
+    expect(validateIndex).toBe(0);
+    expect(checkoutIndex).toBe(validateIndex + 1);
+    expect(headIndex).toBe(checkoutIndex + 1);
+    expect(setupIndex).toBeGreaterThan(headIndex);
+    expect(diagnosticIndex).toBe(setupIndex + 1);
+    expect(artifactIndex).toBe(diagnosticIndex + 1);
+    expect(steps[validateIndex]?.env).toEqual({
+      TARGET_SHA: "${{ inputs.target_sha }}",
+    });
+    expect(steps[validateIndex]?.run).toContain('[[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]');
+    expect(steps[validateIndex]?.run).toContain(
+      'DIAGNOSTIC_DIR="$RUNNER_TEMP/android-emulator-diagnostic"',
+    );
+    expect(steps[validateIndex]?.run).toContain(
+      'echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"',
+    );
+    expect(steps[checkoutIndex]).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: {
+        ref: "${{ inputs.target_sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+      },
+    });
+    expect(steps[headIndex]?.env).toEqual({
+      TARGET_SHA: "${{ inputs.target_sha }}",
+    });
+    expect(steps[headIndex]?.run).toContain('test "$(git rev-parse HEAD)" = "$TARGET_SHA"');
+    expect(steps[setupIndex]).toMatchObject({
+      uses: "./.github/actions/setup-android-toolchain",
+      with: {
+        "cache-mode": "off",
+        "install-screenshot-emulators": "true",
+      },
+    });
+
+    const diagnostic = steps[diagnosticIndex]?.run ?? "";
+    expect(diagnostic).toContain(
+      'printf \'no\\n\' | avdmanager create avd --force --name "$AVD_NAME" --package "$SYSTEM_IMAGE" --device "$DEVICE_PROFILE"',
+    );
+    expect(diagnostic).toContain(
+      'emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim)',
+    );
+    expect(diagnostic).toContain(
+      "device_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))",
+    );
+    expect(diagnostic).toContain(
+      "boot_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))",
+    );
+    expect(diagnostic).toContain('>"$DIAGNOSTIC_DIR/emulator.log" 2>&1 &');
+    expect(diagnostic).toContain("adb devices -l");
+    expect(diagnostic).toContain('>>"$DIAGNOSTIC_DIR/adb-observations.log" 2>&1');
+    expect(diagnostic).toContain('ps -p "$emulator_pid"');
+    expect(diagnostic).toContain('kill "$emulator_pid"');
+    expect(diagnostic).toContain("adb kill-server");
+    expect(steps[artifactIndex]).toMatchObject({
+      if: "always()",
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      with: {
+        name: "android-emulator-diagnostic-${{ github.run_id }}-${{ github.run_attempt }}",
+        path: "${{ runner.temp }}/android-emulator-diagnostic",
+        "retention-days": 7,
+      },
+    });
+    expect(source).not.toMatch(/\$\{\{\s*secrets\./u);
+    expect(source).not.toContain("environment:");
+    expect(source).not.toMatch(/\b(?:pnpm|gradle|fastlane)\b/iu);
+    expect(source).not.toMatch(/apps-signing|MATCH_PASSWORD|GOOGLE_PLAY|upload-and-record/iu);
+  });
+
   it("keeps upload and recovery credentials inside one protected platform boundary", () => {
     const workflows = [
       {

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1754,8 +1754,21 @@ describe("mobile release authority", () => {
     const source = fs.readFileSync(file, "utf8");
     const workflow = parse(source) as {
       jobs: {
+        "validate-target": {
+          permissions: Record<string, string>;
+          "runs-on": string;
+          steps: Array<{
+            env?: Record<string, string>;
+            name: string;
+            run?: string;
+            uses?: string;
+            with?: Record<string, unknown>;
+          }>;
+          "timeout-minutes": number;
+        };
         diagnose: {
           env: Record<string, string>;
+          needs: string;
           permissions: Record<string, string>;
           "runs-on": string;
           steps: Array<{
@@ -1784,16 +1797,28 @@ describe("mobile release authority", () => {
       };
       permissions: Record<string, string>;
     };
+    const validationJob = workflow.jobs["validate-target"];
+    const validationSteps = validationJob.steps;
     const job = workflow.jobs.diagnose;
     const steps = job.steps;
-    const validateIndex = steps.findIndex((step) => step.name === "Validate target SHA");
-    const trustedCheckoutIndex = steps.findIndex(
+    const validateIndex = validationSteps.findIndex((step) => step.name === "Validate target SHA");
+    const validationTrustedCheckoutIndex = validationSteps.findIndex(
       (step) => step.name === "Checkout trusted Android tooling",
     );
-    const checkoutIndex = steps.findIndex((step) => step.name === "Checkout exact target");
-    const headIndex = steps.findIndex((step) => step.name === "Verify exact target checkout");
-    const parityIndex = steps.findIndex(
+    const checkoutIndex = validationSteps.findIndex(
+      (step) => step.name === "Checkout exact target",
+    );
+    const headIndex = validationSteps.findIndex(
+      (step) => step.name === "Verify exact target checkout",
+    );
+    const parityIndex = validationSteps.findIndex(
       (step) => step.name === "Verify Android toolchain action parity",
+    );
+    const initializeIndex = steps.findIndex(
+      (step) => step.name === "Initialize Android emulator diagnostic",
+    );
+    const trustedCheckoutIndex = steps.findIndex(
+      (step) => step.name === "Checkout trusted Android tooling",
     );
     const setupIndex = steps.findIndex((step) => step.name === "Setup Android toolchain");
     const diagnosticIndex = steps.findIndex(
@@ -1811,8 +1836,12 @@ describe("mobile release authority", () => {
       type: "string",
     });
     expect(workflow.permissions).toEqual({ contents: "read" });
-    expect(Object.keys(workflow.jobs)).toEqual(["diagnose"]);
+    expect(Object.keys(workflow.jobs)).toEqual(["validate-target", "diagnose"]);
+    expect(validationJob.permissions).toEqual({ contents: "read" });
+    expect(validationJob["runs-on"]).toBe("ubuntu-24.04");
+    expect(validationJob["timeout-minutes"]).toBe(5);
     expect(job.permissions).toEqual({ contents: "read" });
+    expect(job.needs).toBe("validate-target");
     expect(job["runs-on"]).toBe("macos-26-intel");
     expect(job["timeout-minutes"]).toBe(25);
     expect(job.env).toEqual({
@@ -1823,22 +1852,54 @@ describe("mobile release authority", () => {
     });
 
     expect(validateIndex).toBe(0);
-    expect(trustedCheckoutIndex).toBe(validateIndex + 1);
-    expect(checkoutIndex).toBe(trustedCheckoutIndex + 1);
+    expect(validationTrustedCheckoutIndex).toBe(validateIndex + 1);
+    expect(checkoutIndex).toBe(validationTrustedCheckoutIndex + 1);
     expect(headIndex).toBe(checkoutIndex + 1);
     expect(parityIndex).toBe(headIndex + 1);
-    expect(setupIndex).toBe(parityIndex + 1);
+    expect(initializeIndex).toBe(0);
+    expect(trustedCheckoutIndex).toBe(initializeIndex + 1);
+    expect(setupIndex).toBe(trustedCheckoutIndex + 1);
     expect(diagnosticIndex).toBe(setupIndex + 1);
     expect(artifactIndex).toBe(diagnosticIndex + 1);
-    expect(steps[validateIndex]?.env).toEqual({
+    expect(validationSteps[validateIndex]?.env).toEqual({
       TARGET_SHA: "${{ inputs.target_sha }}",
     });
-    expect(steps[validateIndex]?.run).toContain('[[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]');
-    expect(steps[validateIndex]?.run).toContain(
+    expect(validationSteps[validateIndex]?.run).toContain(
+      '[[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]',
+    );
+    expect(steps[initializeIndex]?.env).toEqual({
+      TARGET_SHA: "${{ inputs.target_sha }}",
+    });
+    expect(steps[initializeIndex]?.run).toContain(
       'DIAGNOSTIC_DIR="$RUNNER_TEMP/android-emulator-diagnostic"',
     );
-    expect(steps[validateIndex]?.run).toContain(
+    expect(steps[initializeIndex]?.run).toContain(
       'echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"',
+    );
+    expect(validationSteps[validationTrustedCheckoutIndex]).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: {
+        ref: "${{ github.workflow_sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+        "sparse-checkout": ".github/actions/setup-android-toolchain",
+        path: ".mobile-release-tooling",
+      },
+    });
+    expect(validationSteps[checkoutIndex]).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: {
+        ref: "${{ inputs.target_sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+        path: "candidate",
+      },
+    });
+    expect(validationSteps[headIndex]?.env).toEqual({
+      TARGET_SHA: "${{ inputs.target_sha }}",
+    });
+    expect(validationSteps[headIndex]?.run).toContain(
+      'test "$(git -C candidate rev-parse HEAD)" = "$TARGET_SHA"',
     );
     expect(steps[trustedCheckoutIndex]).toMatchObject({
       uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
@@ -1850,21 +1911,6 @@ describe("mobile release authority", () => {
         path: ".mobile-release-tooling",
       },
     });
-    expect(steps[checkoutIndex]).toMatchObject({
-      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-      with: {
-        ref: "${{ inputs.target_sha }}",
-        "fetch-depth": 1,
-        "persist-credentials": false,
-        path: "candidate",
-      },
-    });
-    expect(steps[headIndex]?.env).toEqual({
-      TARGET_SHA: "${{ inputs.target_sha }}",
-    });
-    expect(steps[headIndex]?.run).toContain(
-      'test "$(git -C candidate rev-parse HEAD)" = "$TARGET_SHA"',
-    );
     expect(steps[setupIndex]).toMatchObject({
       uses: "./.mobile-release-tooling/.github/actions/setup-android-toolchain",
       with: {
@@ -1872,8 +1918,9 @@ describe("mobile release authority", () => {
         "install-screenshot-emulators": "true",
       },
     });
+    expect(JSON.stringify(steps)).not.toContain("candidate/");
 
-    const parityScript = steps[parityIndex]?.run ?? "";
+    const parityScript = validationSteps[parityIndex]?.run ?? "";
     expect(parityScript).toContain("git -C .mobile-release-tooling ls-tree");
     expect(parityScript).toContain("git -C candidate ls-tree");
     expect(parityScript).toContain("cat-file blob");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-diagnostic gap where the Android beta screenshot emulator can fail during startup without retaining enough runner, SDK, emulator, ADB, and process evidence to distinguish a hosted-capacity problem from an app or workflow defect.

## Why This Change Was Made

Adds a manual, read-only diagnostic workflow that accepts only an exact lowercase commit SHA and reproduces the phone screenshot emulator prerequisites on `macos-26-intel`. A short Ubuntu validation job checks the selected target out under `candidate/`, verifies its exact HEAD, and requires its committed setup action to be a regular `100644` blob byte-identical to trusted `github.workflow_sha` tooling. It executes no local action. The dependent macOS diagnostic job starts fresh, receives no candidate files or paths, and checks out and executes only trusted workflow tooling. The workflow keeps caches disabled and uses the release screenshot Pixel 2/API 36 x86_64 image and boot arguments, two 180-second readiness windows, owned-process cleanup, and an always-uploaded seven-day diagnostic artifact.

The workflow has no environment, secrets, signing, package install, Gradle, Fastlane, or store access. The frozen mobile candidate is unchanged.

## User Impact

Release operators can capture bounded, reproducible evidence for Android emulator startup failures before changing release automation or retrying a store run. This diagnostic cannot publish an app or modify a release.

## Evidence

- Red regression: the original workflow failed the trusted-checkout ordering assertion because it executed the setup action from the selected target. The first same-job repair then received the exact hosted CodeQL cache-poisoning finding because the query conservatively treats a local action following any input-selected checkout as tainted.
- Isolation regression: before the job split, the focused test failed because the required `validate-target` job did not exist.
- Green owner suite: `test/scripts/mobile-release-authority.test.ts` passed 61/61. Its executable parity fixture allows matching committed bytes and rejects both a modified blob and a symlink before the setup sentinel.
- Green workflow guards: `test/scripts/ci-workflow-guards.test.ts` passed 535 with 2 skipped.
- `actionlint`, embedded Bash syntax, targeted oxlint, oxfmt, and `git diff --check` passed.
- P1 autoreview: scoped clean, 0.97 confidence.
- Production/tooling delta: +255 lines for the bounded diagnostic workflow and isolated trusted setup boundary. Test delta: +268 lines for exact input, permission, runner, setup provenance and parity, job isolation, emulator behavior, cleanup, and artifact contracts.
- Hosted runtime evidence is intentionally pending until this manual workflow exists on the default branch; a separate, explicitly authorized secretless dispatch will target the frozen candidate after landing.
