### PR TITLE
test(doctor): isolate auth and workspace migration fixtures

### DIFF
--- a/src/infra/state-migrations.shared-auth-store.test.ts
+++ b/src/infra/state-migrations.shared-auth-store.test.ts
@@ -593,6 +593,8 @@ describe("shared auth store relocation", () => {
               OPENCLAW_AGENT_DIR: undefined,
               PI_CODING_AGENT_DIR: undefined,
               OPENCLAW_OAUTH_DIR: undefined,
+              // These auth owners have no plugin inventory; keep discovery inside the fixture.
+              OPENCLAW_BUNDLED_PLUGINS_DIR: tempDirs.make("openclaw-shared-auth-bundled-"),
             },
           });
           ownerStates.push(owner);

--- a/src/infra/state-migrations.workspace-move-order.test.ts
+++ b/src/infra/state-migrations.workspace-move-order.test.ts
@@ -17,7 +17,14 @@ describe("Doctor workspace move ordering", () => {
   const { setup, detect, migrate } = useWorkspaceMigrationTestFixture();
 
   it("repairs the workspace owner before importing a carried legacy setup generation", async () => {
-    const context = setup();
+    const fixture = setup();
+    // This core workspace-ordering fixture has no plugin-owned migration inputs.
+    const bundledRoot = path.join(fixture.homeDir, "bundled-plugins");
+    fs.mkdirSync(bundledRoot);
+    const context = {
+      ...fixture,
+      env: { ...fixture.env, OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot },
+    };
     const alias = path.join(context.homeDir, "workspace-alias");
     const moved = path.join(context.homeDir, "moved-workspace");
     const symlinkType = process.platform === "win32" ? "junction" : "dir";


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable cold plugin loading in shared-auth and workspace migration tests. The slowest Node job in [successful main CI 34298388636](https://github.com/openclaw/openclaw/actions/runs/34298388636/job/102300061878) spent 12.728s in the first selected-auth-owner case and 10.815s in workspace move ordering. These fixtures have no plugin-owned inputs, but inherited the repository's entire bundled-plugin inventory.

Part of the maintainer-requested test performance work; follows #142777 for the related core storage fixture.

## Why This Change Was Made

Give each selected/ambient auth owner a separately tracked empty plugin directory, and give the workspace fixture an empty directory within its tracked home. Both use the existing bundled-directory selector and existing Vitest trust setup. Real Doctor discovery and core migration execution remain enabled against the fixture's actual inventory.

Global plugin disablement intentionally keeps bundled non-channel Doctor migrations available. That production behavior is unchanged and remains covered by the existing registry tests. All auth contents, owner separation, symlink movement, migration ordering, receipt assertions, and cleanup remain intact.

## User Impact

Faster CI and local test feedback. No production code, schema, configuration surface, timeout, assertion, or shard-count change.

## Evidence

Old prebuilt plugin outputs initially masked the cold cost locally. We temporarily moved those task-owned generated directories aside, ran unchanged source-only tests matching fresh CI, and restored the original directories after joining every consumer. Passive shared-auth profiling attributed 12.488s to Doctor detection transforming 11 source plugin modules; migration and cleanup took 59ms and 43ms, and the plugin scan found no work.

Source-only case timings on Node 24.19.0 / pnpm 12.3.4:

| Case | Original | Restored original | Final candidate |
| --- | ---: | ---: | ---: |
| Selected absolute auth owner | 13.441s | 12.357s | 0.263s |
| Workspace move ordering | 12.906s | 14.617s | 0.605s |

An intermediate neutral-package auth fixture measured 0.268s between the original runs; the final empty-directory fixture simplifies that inventory further. Workspace's intermediate runtime-equivalent fixture measured 0.661s between the original runs; its final context construction also passes the inferred environment typecheck. Timing differences are per case, not additive whole-CI guarantees.

- Final combined source-only proof: 32 passed, one unchanged Linux-only POSIX-lock skip, across shared-auth, workspace ordering, and recreated-workspace cases.
- Final auth fixture with existing caller-inventory and Doctor registry siblings: 56 passed, the same Linux-only skip. This includes the explicit globally-disabled bundled non-channel migration contract.
- Required changed checks, formatting and diff checks passed. The initial workspace environment assignment hit TS2339; explicit context construction repaired that before final validation.
- Independent managed P2 review: scoped-clean, no actionable findings.
- Test delta +10/-1; production delta 0. No cases removed.
