### PR TITLE
fix(ci): track native locale translator inputs

### DIFF
--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -16,6 +16,15 @@ on:
       - apps/.i18n/native/**
       - apps/.i18n/native-source.json
       - scripts/control-ui-i18n.ts
+      - scripts/lib/control-ui-i18n-catalog.ts
+      - scripts/lib/control-ui-i18n-catalog-values.ts
+      - ui/src/i18n/lib/config-hint-translation.ts
+      - ui/src/lib/fnv1a.ts
+      - src/config/schema*.ts
+      - src/config/zod-schema*.ts
+      - src/config/media-audio-field-metadata.ts
+      - src/config/talk-defaults.ts
+      - src/config/channel-config-keys.ts
       - scripts/android-app-i18n.ts
       - scripts/apple-app-i18n.ts
       - scripts/native-app-i18n.ts
@@ -282,6 +291,15 @@ jobs:
             apps/macos/Package.swift
             apps/shared/OpenClawKit/Sources
             scripts/control-ui-i18n.ts
+            scripts/lib/control-ui-i18n-catalog.ts
+            scripts/lib/control-ui-i18n-catalog-values.ts
+            ui/src/i18n/lib/config-hint-translation.ts
+            ui/src/lib/fnv1a.ts
+            src/config/schema*.ts
+            src/config/zod-schema*.ts
+            src/config/media-audio-field-metadata.ts
+            src/config/talk-defaults.ts
+            src/config/channel-config-keys.ts
             scripts/android-app-i18n.ts
             scripts/apple-app-i18n.ts
             scripts/native-app-i18n.ts

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3080,14 +3080,33 @@ NODE
     const controlUiPublishStep = controlUiFinalize.steps.find(
       (step: { name?: string }) => step.name === "Open or update generated locale PR",
     );
+    const sharedCatalogInputs = [
+      "scripts/lib/control-ui-i18n-catalog.ts",
+      "scripts/lib/control-ui-i18n-catalog-values.ts",
+      "ui/src/i18n/lib/config-hint-translation.ts",
+      "ui/src/lib/fnv1a.ts",
+      "src/config/schema*.ts",
+      "src/config/zod-schema*.ts",
+      "src/config/media-audio-field-metadata.ts",
+      "src/config/talk-defaults.ts",
+      "src/config/channel-config-keys.ts",
+    ];
+    const sharedCatalogInputOwners = [
+      workflow.on.push.paths,
+      nativePublishStep.with["invalidation-paths"].trim().split("\n"),
+      controlUiWorkflow.on.push.paths,
+      controlUiPublishStep.with["invalidation-paths"].trim().split("\n"),
+    ];
+    for (const catalogInput of sharedCatalogInputs) {
+      for (const ownerPaths of sharedCatalogInputOwners) {
+        expect(ownerPaths).toContain(catalogInput);
+      }
+    }
     expect(controlUiPublishStep.with["generated-paths"].trim().split("\n")).toEqual([
       "ui/src/i18n/.i18n/*.tm.jsonl",
       "ui/src/i18n/.i18n/*.meta.json",
       "ui/src/i18n/.i18n/catalog-fallbacks.json",
     ]);
-    expect(controlUiPublishStep.with["invalidation-paths"]).toContain(
-      "scripts/lib/control-ui-i18n-catalog.ts",
-    );
     expect(controlUiPublishStep.with["invalidation-paths"]).toContain(
       "scripts/lib/control-ui-i18n-sync-plan.ts",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native locale generation could miss changes to its shared Control UI translation inputs, allowing the refresh workflow to stay idle or publish output generated from stale inputs.

## Why This Change Was Made

The native locale workflow now tracks the same nine shared catalog, hash, and core configuration inputs used by the translation pipeline. The publisher's stale-run guard uses the identical set, and a workflow contract test prevents the native and Control UI owners from drifting apart again.

## User Impact

No direct user-facing change. Native locale automation now refreshes reliably when shared translation inputs change.

## Evidence

- Focused workflow guard failed before the repair and passes afterward.
- `pnpm check:workflows`
- `git diff --check`
- Independent P1 autoreview: scoped clean
