### PR TITLE
fix(models): preserve thinking profiles across session readers

### DIFF
--- a/src/auto-reply/thinking.empty-profile.test.ts
+++ b/src/auto-reply/thinking.empty-profile.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const providerRuntimeMocks = vi.hoisted(() => ({ resolveProviderThinkingProfile: vi.fn() }));
+vi.mock("../plugins/provider-thinking.js", () => ({
+  resolveEffectiveThinkingProfile: providerRuntimeMocks.resolveProviderThinkingProfile,
+}));
+const {
+  resolveThinkingProfile,
+  listThinkingLevelOptions,
+  listThinkingLevels,
+  formatThinkingLevels,
+  isThinkingLevelSupported,
+} = await import("./thinking.js");
+beforeEach(() => {
+  providerRuntimeMocks.resolveProviderThinkingProfile.mockReset();
+  providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue(undefined);
+});
+
+describe("known-empty provider thinking profiles", () => {
+  it.each([
+    { reasoning: undefined, api: undefined },
+    { reasoning: true, api: "anthropic-messages" },
+  ])("preserves known-empty provider levels with catalog context %j", ({ reasoning, api }) => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: [],
+      defaultLevel: null,
+    });
+    const catalog = [
+      {
+        provider: "demo",
+        id: "demo-model",
+        api,
+        reasoning,
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        compat: { supportedReasoningEfforts: ["adaptive", "xhigh", "max", "ultra"] },
+      },
+    ];
+    const params = { provider: "demo", model: "demo-model", catalog, agentRuntime: "openclaw" };
+
+    expect(resolveThinkingProfile(params)).toEqual({ levels: [], defaultLevel: undefined });
+    expect(listThinkingLevelOptions("demo", "demo-model", catalog, "openclaw")).toEqual([]);
+    expect(formatThinkingLevels("demo", "demo-model", ", ", catalog, "openclaw")).toBe("");
+    expect(isThinkingLevelSupported({ ...params, level: "off" })).toBe(false);
+    expect(isThinkingLevelSupported({ ...params, level: "high" })).toBe(false);
+  });
+
+  it.each([
+    { reasoning: false, configuredReasoning: undefined, preserve: false, expected: ["off"] },
+    { reasoning: false, configuredReasoning: undefined, preserve: true, expected: [] },
+    { reasoning: true, configuredReasoning: false, preserve: false, expected: ["off"] },
+    { reasoning: true, configuredReasoning: false, preserve: true, expected: [] },
+  ])(
+    "keeps reasoning opt-out precedence for an empty profile: %j",
+    ({ reasoning, configuredReasoning, preserve, expected }) => {
+      providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+        levels: [],
+        preserveWhenCatalogReasoningFalse: preserve,
+      });
+      const profile = resolveThinkingProfile({
+        provider: "demo",
+        model: "demo-model",
+        catalog: [{ provider: "demo", id: "demo-model", reasoning }],
+        configuredReasoning,
+      });
+
+      expect(profile.levels.map(({ id }) => id)).toEqual(expected);
+      expect(profile.defaultLevel).toBe(preserve ? undefined : "off");
+    },
+  );
+
+  it.each([undefined, null])(
+    "keeps generic choices for an absent provider profile: %s",
+    (profile) => {
+      providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue(profile);
+
+      expect(
+        listThinkingLevels("demo", "demo-model", [
+          { provider: "demo", id: "demo-model", reasoning: true },
+        ]),
+      ).toEqual(["off", "minimal", "low", "medium", "high"]);
+    },
+  );
+});

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -258,14 +258,11 @@ export function resolveThinkingProfile(params: {
         })
       : undefined;
   const pluginProfile = providerProfile ?? anthropicMessagesProfile;
-  if (pluginProfile) {
-    const normalized = normalizeThinkingProfile(pluginProfile);
-    if (
-      normalized.levels.length > 0 &&
-      (context.reasoning !== false || pluginProfile.preserveWhenCatalogReasoningFalse === true)
-    ) {
-      return normalized;
-    }
+  if (
+    pluginProfile &&
+    (context.reasoning !== false || pluginProfile.preserveWhenCatalogReasoningFalse === true)
+  ) {
+    return normalizeThinkingProfile(pluginProfile);
   }
   if (context.reasoning === false) {
     return buildOffOnlyThinkingProfile();

--- a/src/gateway/server-methods/sessions-describe-catalog.test.ts
+++ b/src/gateway/server-methods/sessions-describe-catalog.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { ProviderThinkingProfile } from "../../plugins/provider-thinking.types.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { PreparedGatewayModelCatalog } from "../server-model-catalog.types.js";
+import { sessionByKeyReadHandlers } from "./sessions-read-by-key.js";
+import {
+  identifiedClient,
+  requestContext,
+  seedSessions,
+} from "./sessions-read-cache.test-support.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+
+async function describeSession(
+  context: GatewayRequestContext,
+  key: string,
+  client: GatewayClient = identifiedClient("owner@example.com"),
+) {
+  const responses: Parameters<RespondFn>[] = [];
+  await sessionByKeyReadHandlers["sessions.describe"]!({
+    req: { type: "req", id: "describe-catalog", method: "sessions.describe", params: { key } },
+    params: { key },
+    client,
+    context,
+    isWebchatConnect: () => false,
+    respond: (...response) => responses.push(response),
+  });
+  expect(responses).toHaveLength(1);
+  return responses[0];
+}
+
+function preparedCatalog(
+  profile: ProviderThinkingProfile,
+  thinkingLevelMap?: ModelCatalogEntry["thinkingLevelMap"],
+): PreparedGatewayModelCatalog {
+  const pluginRegistry = createEmptyPluginRegistry();
+  pluginRegistry.providers.push({
+    pluginId: "catalog-fixture",
+    source: "test",
+    provider: {
+      id: "catalog-fixture",
+      label: "Catalog fixture",
+      auth: [],
+      resolveThinkingProfile: () => profile,
+    },
+  });
+  const entries: ModelCatalogEntry[] = [
+    {
+      id: "reasoner",
+      provider: "catalog-fixture",
+      name: "Reasoner",
+      reasoning: true,
+      thinkingLevelMap,
+    },
+  ];
+  return { entries, pluginRegistry };
+}
+
+describe("sessions.describe catalog projection", () => {
+  it.each([
+    { agentId: "main", levels: [], defaultLevel: undefined },
+    { agentId: "work", levels: [{ id: "high", label: "Deep effort" }], defaultLevel: "high" },
+  ])(
+    "uses $agentId's completed entries and provider policy",
+    async ({ agentId, levels, defaultLevel }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const config = await seedSessions();
+        config.agents = { ...config.agents, defaults: { model: "catalog-fixture/reasoner" } };
+        const catalogs = new Map([
+          [
+            "main",
+            preparedCatalog(
+              { levels: [] },
+              {
+                off: null,
+                minimal: null,
+                low: null,
+                medium: null,
+                high: null,
+                xhigh: null,
+                max: null,
+              },
+            ),
+          ],
+          [
+            "work",
+            preparedCatalog({
+              levels: [{ id: "high", label: "Deep effort" }],
+              defaultLevel: "high",
+            }),
+          ],
+        ]);
+        const context = {
+          ...requestContext(config),
+          readPreparedGatewayModelCatalog: async (options?: { agentId?: string }) =>
+            options?.agentId ? catalogs.get(options.agentId) : undefined,
+        };
+
+        const response = await describeSession(context, `agent:${agentId}:active`);
+
+        expect(response?.[0]).toBe(true);
+        expect(response?.[1]).toMatchObject({
+          session: { agentId, thinkingLevels: levels, thinkingDefault: defaultLevel },
+        });
+      });
+    },
+  );
+
+  it("reads the current session after the catalog lookup yields", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const key = "agent:main:active";
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: async () => {
+          await upsertSessionEntryCore(
+            { agentId: "main", sessionKey: key },
+            { sessionId: "replacement-session", label: "Current conversation" },
+          );
+          return undefined;
+        },
+      };
+
+      const response = await describeSession(context, key);
+
+      expect(response?.[1]).toMatchObject({
+        session: { sessionId: "replacement-session", displayName: "Current conversation" },
+      });
+    });
+  });
+
+  it("does not expose a session made a draft during the catalog lookup", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      config.gateway = {
+        roles: {
+          default: "reader",
+          definitions: {
+            reader: { agents: "*", scopes: ["operator.read"], sessions: { others: "view" } },
+          },
+        },
+      };
+      const key = "agent:main:active";
+      const ownerId = ensureProfileForEmail("owner@example.com").id;
+      const viewerId = ensureProfileForEmail("viewer@example.com").id;
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: key },
+        { createdActor: { type: "human", source: "profile", id: ownerId } },
+      );
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: async () => {
+          await upsertSessionEntryCore(
+            { agentId: "main", sessionKey: key },
+            { visibility: "draft" },
+          );
+          return undefined;
+        },
+      };
+
+      const response = await describeSession(context, key, identifiedClient(viewerId));
+
+      expect(response?.[0]).toBe(true);
+      expect(response?.[1]).toEqual({ session: null });
+    });
+  });
+
+  it("keeps the primary read available when catalog decoration fails", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = {
+        ...requestContext(config),
+        readPreparedGatewayModelCatalog: async () => {
+          throw new Error("prepared owner retired");
+        },
+      };
+
+      const response = await describeSession(context, "agent:main:active");
+
+      expect(response?.[0]).toBe(true);
+      expect(response?.[1]).toMatchObject({ session: { sessionId: "main-active" } });
+    });
+  });
+});

--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -6,6 +6,7 @@ import { createSessionListEntryFilter } from "../session-sharing.js";
 import { readRecentSessionMessagesWithStatsAsync } from "../session-transcript-readers.js";
 import { buildSessionListRowMetadataContext } from "../session-utils-projection.js";
 import { buildGatewaySessionRow } from "../session-utils.js";
+import { readPreparedServerMethodModelCatalog } from "./optional-model-catalog.js";
 import { readSessionPlacementFields } from "./session-placement-read-projection.js";
 import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -21,7 +22,7 @@ function createRoleVisibilityFilter(
 }
 
 export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
-  "sessions.describe": ({ params, respond, context, client }) => {
+  "sessions.describe": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsDescribeParams, "sessions.describe", respond)) {
       return;
     }
@@ -29,6 +30,19 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
+    const catalogAgent = resolveRequestedSessionAgentId(
+      context.getRuntimeConfig(),
+      key,
+      params.agentId,
+    );
+    if (!catalogAgent.ok) {
+      respond(false, undefined, catalogAgent.error);
+      return;
+    }
+    const modelCatalog = await readPreparedServerMethodModelCatalog(context, {
+      agentId: catalogAgent.agentId,
+    });
+    // Resolve the visible row after the catalog read yields to configuration or session changes.
     const cfg = context.getRuntimeConfig();
     const requestedAgent = resolveRequestedSessionAgentId(cfg, key, params.agentId);
     if (!requestedAgent.ok) {
@@ -53,6 +67,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       key: target.canonicalKey,
       entry,
       agentId: target.agentId,
+      modelCatalog: new Map([[catalogAgent.agentId, modelCatalog]]),
       includeDerivedTitles: params.includeDerivedTitles,
       includeLastMessage: params.includeLastMessage,
       transcriptUsageMaxBytes: 64 * 1024,

--- a/ui/src/lib/sessions/reconcile-thinking-metadata.test.ts
+++ b/ui/src/lib/sessions/reconcile-thinking-metadata.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { resolveChatThinkingSelectState } from "../chat/thinking.ts";
+import { reconcileSessionHistory } from "./reconcile.ts";
+
+const identity = {
+  modelProvider: "catalog-fixture",
+  model: "reasoner",
+  agentRuntime: { id: "openclaw", source: "model" as const },
+};
+const row: GatewaySessionRow = {
+  ...identity,
+  key: "agent:main:main",
+  kind: "direct",
+  sessionId: "s1",
+  updatedAt: 1,
+};
+function currentResult(
+  metadata: Pick<GatewaySessionRow, "thinkingLevels" | "thinkingOptions" | "thinkingDefault">,
+): SessionsListResult {
+  return {
+    ts: 1,
+    path: "store",
+    count: 1,
+    defaults: { ...identity, ...metadata, contextTokens: null },
+    sessions: [{ ...row, ...metadata }],
+  };
+}
+
+describe("reconcileSessionHistory thinking profiles", () => {
+  it("replaces longer old choices with an explicit empty profile", () => {
+    const current = currentResult({
+      thinkingLevels: [
+        { id: "off", label: "Off" },
+        { id: "high", label: "Deep effort" },
+      ],
+      thinkingOptions: ["Off", "Deep effort"],
+      thinkingDefault: "high",
+    });
+    const empty = { thinkingLevels: [], thinkingOptions: [] };
+
+    const next = reconcileSessionHistory(
+      current,
+      { ...row, ...empty, updatedAt: 2 },
+      { ...identity, ...empty, contextTokens: null },
+    );
+
+    expect(next?.sessions[0]?.thinkingLevels).toEqual([]);
+    expect(next?.sessions[0]?.thinkingOptions).toEqual([]);
+    expect(next?.sessions[0]?.thinkingDefault).toBeUndefined();
+    expect(next?.defaults.thinkingLevels).toEqual([]);
+    expect(next?.defaults.thinkingOptions).toEqual([]);
+    expect(next?.defaults.thinkingDefault).toBeUndefined();
+    expect(
+      resolveChatThinkingSelectState({ catalog: [], sessionKey: row.key, sessionsResult: next })
+        .options,
+    ).toEqual([]);
+  });
+
+  it("accepts a narrower published profile with its own labels and default", () => {
+    const current = currentResult({
+      thinkingLevels: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High" },
+      ],
+      thinkingOptions: ["Low", "High"],
+      thinkingDefault: "high",
+    });
+    const incoming = {
+      thinkingLevels: [{ id: "low", label: "Careful" }],
+      thinkingOptions: ["Careful"],
+      thinkingDefault: "low",
+    };
+
+    const next = reconcileSessionHistory(current, { ...row, ...incoming, updatedAt: 2 }, undefined);
+
+    expect(next?.sessions[0]).toMatchObject(incoming);
+  });
+
+  it("preserves a known empty profile when history omits capability metadata", () => {
+    const current = currentResult({ thinkingLevels: [], thinkingOptions: [] });
+
+    const next = reconcileSessionHistory(
+      current,
+      { ...row, updatedAt: 2 },
+      { ...identity, contextTokens: null },
+    );
+
+    expect(next?.sessions[0]?.thinkingLevels).toEqual([]);
+    expect(next?.sessions[0]?.thinkingOptions).toEqual([]);
+    expect(next?.defaults.thinkingLevels).toEqual([]);
+    expect(next?.defaults.thinkingDefault).toBeUndefined();
+  });
+
+  it("keeps supported metadata when history has no published profile", () => {
+    const metadata = {
+      thinkingLevels: [{ id: "low", label: "Careful" }],
+      thinkingOptions: ["Careful"],
+      thinkingDefault: "low",
+    };
+    const current = currentResult(metadata);
+
+    const next = reconcileSessionHistory(
+      current,
+      { ...row, updatedAt: 2 },
+      { ...identity, contextTokens: null },
+    );
+
+    expect(next?.sessions[0]).toMatchObject(metadata);
+    expect(next?.defaults).toMatchObject(metadata);
+  });
+
+  it("does not inherit the previous model's profile", () => {
+    const current = currentResult({
+      thinkingLevels: [{ id: "high", label: "Deep effort" }],
+      thinkingOptions: ["Deep effort"],
+      thinkingDefault: "high",
+    });
+
+    const next = reconcileSessionHistory(
+      current,
+      { ...row, model: "replacement", updatedAt: 2 },
+      undefined,
+    );
+
+    expect(next?.sessions[0]?.thinkingLevels).toBeUndefined();
+    expect(next?.sessions[0]?.thinkingDefault).toBeUndefined();
+  });
+});

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -138,22 +138,26 @@ function thinkingMetadataIdentityMatches(
   );
 }
 
-function preserveRicherThinkingMetadata<T extends ThinkingMetadataCarrier>(
+function preserveMissingThinkingMetadata<T extends ThinkingMetadataCarrier>(
   incoming: T,
   existing: ThinkingMetadataCarrier | undefined,
 ): T {
-  if (existing && !thinkingMetadataIdentityMatches(incoming, existing)) {
-    return incoming;
-  }
-  const existingLevels = existing?.thinkingLevels;
-  if (!existingLevels?.length || (incoming.thinkingLevels?.length ?? 0) >= existingLevels.length) {
+  if (
+    !existing ||
+    (existing.thinkingLevels === undefined && existing.thinkingOptions === undefined) ||
+    !thinkingMetadataIdentityMatches(incoming, existing) ||
+    incoming.thinkingLevels !== undefined ||
+    incoming.thinkingOptions !== undefined
+  ) {
     return incoming;
   }
   return {
     ...incoming,
-    thinkingLevels: existingLevels,
-    ...(existing?.thinkingOptions ? { thinkingOptions: existing.thinkingOptions } : {}),
-    ...(incoming.thinkingDefault === undefined && existing?.thinkingDefault !== undefined
+    ...(existing.thinkingLevels !== undefined ? { thinkingLevels: existing.thinkingLevels } : {}),
+    ...(existing.thinkingOptions !== undefined
+      ? { thinkingOptions: existing.thinkingOptions }
+      : {}),
+    ...(incoming.thinkingDefault === undefined && existing.thinkingDefault !== undefined
       ? { thinkingDefault: existing.thinkingDefault }
       : {}),
   };
@@ -632,7 +636,7 @@ export function reconcileSessionHistory(
     matchesExistingSession(candidate, session, selectedGlobalAgentId),
   );
   const nextDefaults = defaults
-    ? preserveRicherThinkingMetadata(defaults, result.defaults)
+    ? preserveMissingThinkingMetadata(defaults, result.defaults)
     : result.defaults;
   // Lineage and repeated events can supply the current defaults. Preserve
   // result identity when nothing changes so shared subscribers stay quiet.
@@ -649,7 +653,7 @@ export function reconcileSessionHistory(
   }
   const visibleKey = existing?.key ?? session.key;
   const visibleSession = preserveRosterPresentationMetadata(
-    preserveRicherThinkingMetadata(
+    preserveMissingThinkingMetadata(
       visibleKey === session.key ? session : { ...session, key: visibleKey },
       existing,
     ),


### PR DESCRIPTION
## What Problem This Solves

Models with an explicitly empty thinking profile could regain generic effort choices during fallback, session reads, or history reconciliation.

## Why This Change Was Made

Preserve the provider’s empty result, use the selected agent’s published catalog for session descriptions, and accept current empty or narrower profiles while retaining metadata omitted by partial responses. Resolve session ownership after the catalog read.

## User Impact

Explicitly unavailable thinking choices stay unavailable. An absent profile still receives its existing fallback behavior, and reasoning opt-out remains distinct.

## Evidence

Real Gateway and CLI captures covered all-null and registered-provider empty profiles with supported-profile, missing-session, absent-profile, and opt-out controls. Eighteen focused checks reproduced baseline failures and passed after repair; required CI passed. Complete correspondence between the later build and the earlier runtime captures was not established.

Consumers: provider fallback, session descriptions, and client history retain explicitly empty or narrowed thinking profiles.
