### PR TITLE
fix(ci): prevent candidate refs from controlling live workflow setup

### DIFF
--- a/.github/actions/setup-node-env-uncached/action.yml
+++ b/.github/actions/setup-node-env-uncached/action.yml
@@ -1,0 +1,137 @@
+name: Setup Node environment without caches
+description: Install the pinned Node and pnpm toolchain without reading or writing shared caches.
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: "24.x"
+  install-bun:
+    description: Whether to install Bun alongside Node.
+    required: false
+    default: "true"
+  install-deps:
+    description: Whether to run pnpm install after environment setup.
+    required: false
+    default: "true"
+  frozen-lockfile:
+    description: Whether to use --frozen-lockfile for install.
+    required: false
+    default: "true"
+  cache-mode:
+    description: Must remain off; this action has no cache authority.
+    required: false
+    default: "off"
+runs:
+  using: composite
+  steps:
+    - name: Revalidate current maintainer authority
+      if: github.triggering_actor != 'github-actions[bot]'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+      run: |
+        set -euo pipefail
+        role_name="$(gh api \
+          "repos/${GITHUB_REPOSITORY}/collaborators/${TRIGGERING_ACTOR}/permission" \
+          --jq .role_name)"
+        case "$role_name" in
+          admin|maintain) ;;
+          *)
+            echo "::error::Current triggering actor ${TRIGGERING_ACTOR} no longer has maintain/admin authority."
+            exit 1
+            ;;
+        esac
+
+    - name: Validate cache isolation
+      shell: bash
+      env:
+        CACHE_MODE: ${{ inputs.cache-mode }}
+      run: |
+        if [[ "$CACHE_MODE" != "off" ]]; then
+          echo "::error::setup-node-env-uncached requires cache-mode=off"
+          exit 2
+        fi
+
+    - name: Normalize container toolcache
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -d /__t && ! -e /opt/hostedtoolcache ]]; then
+          mkdir -p /opt
+          ln -s /__t /opt/hostedtoolcache
+        fi
+
+    - name: Setup Node.js
+      shell: bash
+      env:
+        REQUESTED_NODE_VERSION: ${{ inputs.node-version }}
+      run: |
+        set -euo pipefail
+        source "$GITHUB_ACTION_PATH/../setup-pnpm-store-cache/ensure-node.sh"
+        openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
+    - name: Setup pnpm from packageManager
+      shell: bash
+      env:
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      run: |
+        set -euo pipefail
+        package_manager="$(node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); process.stdout.write(pkg.packageManager || '')")"
+        case "$package_manager" in
+          pnpm@*) ;;
+          *)
+            echo "::error::Expected packageManager to pin pnpm, got '${package_manager:-<empty>}'"
+            exit 1
+            ;;
+        esac
+        if [[ -n "${PNPM_HOME:-}" ]]; then
+          mkdir -p "$PNPM_HOME"
+          corepack enable --install-directory "$PNPM_HOME"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+        else
+          corepack enable
+        fi
+        for attempt in 1 2 3; do
+          if corepack prepare "$package_manager" --activate; then
+            break
+          fi
+          if [[ "$attempt" -eq 3 ]]; then
+            exit 1
+          fi
+          sleep $((attempt * 5))
+        done
+
+    - name: Setup Bun
+      if: inputs.install-bun == 'true'
+      shell: bash
+      run: npm install -g bun@1.4.0
+
+    - name: Runtime versions
+      shell: bash
+      run: |
+        node -v
+        npm -v
+        pnpm -v
+        if command -v bun &>/dev/null; then bun -v; fi
+
+    - name: Capture node path
+      shell: bash
+      run: |
+        node_bin="$(dirname "$(node -p 'process.execPath')")"
+        if command -v cygpath >/dev/null 2>&1; then
+          node_bin="$(cygpath -u "$node_bin")"
+        fi
+        echo "NODE_BIN=$node_bin" >> "$GITHUB_ENV"
+        echo "$node_bin" >> "$GITHUB_PATH"
+
+    - name: Install dependencies
+      if: inputs.install-deps == 'true'
+      shell: bash
+      env:
+        CI: "true"
+        DEPENDENCY_CACHE: "false"
+        DEPENDENCY_CACHE_HIT: "false"
+        FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
+      run: bash "$GITHUB_ACTION_PATH/../setup-node-env/install-dependencies.sh"

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Ref, tag, or SHA to validate
+        description: Default-branch workflow ref only; arbitrary candidates require AWS Crabbox
         required: true
         type: string
       include_repo_e2e:
@@ -586,10 +586,85 @@ env:
   OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: ${{ github.workspace }}
 
 jobs:
+  authorize_actor:
+    name: Authorize workflow actor
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      authorized: ${{ steps.permission.outputs.authorized }}
+    steps:
+      - name: Require maintainer-level repository access
+        id: permission
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        with:
+          script: |
+            const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+            const callerWorkflowRef = process.env.CALLER_WORKFLOW_REF ?? "";
+            const defaultBranch = process.env.DEFAULT_BRANCH ?? "";
+            const triggeringActor = process.env.TRIGGERING_ACTOR ?? "";
+            if (!triggeringActor) {
+              core.setOutput("authorized", "false");
+              core.setFailed("github.triggering_actor is required for authority validation.");
+              return;
+            }
+            const directDispatch = callerWorkflowRef === job.workflow_ref;
+            const callerPrefix = "openclaw/openclaw/.github/workflows/";
+            const calledPrefix =
+              `${callerPrefix}openclaw-live-and-e2e-checks-reusable.yml@refs/heads/`;
+            const callerMatch = callerWorkflowRef.match(
+              /^openclaw\/openclaw\/\.github\/workflows\/([A-Za-z0-9_.-]+)\.yml@refs\/heads\/(.+)$/u,
+            );
+            const calledRef = job.workflow_ref.startsWith(calledPrefix)
+              ? job.workflow_ref.slice(calledPrefix.length)
+              : "";
+            const releaseCiMatch = calledRef.match(/^release-ci\/([0-9a-f]{12})-[1-9][0-9]*$/u);
+            const trustedCoordinatorRef =
+              calledRef === defaultBranch ||
+              (releaseCiMatch !== null && job.workflow_sha.startsWith(releaseCiMatch[1]));
+            const trustedCaller =
+              !directDispatch &&
+              callerMatch !== null &&
+              callerMatch[2] === calledRef &&
+              trustedCoordinatorRef &&
+              job.workflow_repository === "openclaw/openclaw" &&
+              job.workflow_ref.startsWith(calledPrefix);
+            if (triggeringActor === "github-actions[bot]") {
+              core.setOutput("authorized", trustedCaller ? "true" : "false");
+              if (!trustedCaller) {
+                core.setFailed("Bot invocation is not bound to a trusted release coordinator.");
+              }
+              return;
+            }
+            const allowedRoles = new Set(["admin", "maintain"]);
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: triggeringActor,
+            });
+            const roleName = data.role_name;
+            const authorized =
+              allowedRoles.has(roleName) && (directDispatch || trustedCaller);
+            core.info(`Triggering actor ${triggeringActor} repository role: ${roleName}`);
+            core.setOutput("authorized", authorized ? "true" : "false");
+            if (!authorized) {
+              core.setFailed(
+                `Workflow requires maintain/admin access and reusable calls must originate from a trusted coordinator. Triggering actor "${triggeringActor}" has role "${roleName}".`,
+              );
+            }
+
   validate_selected_ref:
+    needs: authorize_actor
+    if: needs.authorize_actor.outputs.authorized == 'true'
     runs-on: ${{ !inputs.use_github_hosted_runners && github.repository == 'openclaw/openclaw' && vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
     timeout-minutes: 30
     outputs:
+      direct_dispatch: ${{ steps.workflow.outputs.direct_dispatch }}
       fs_safe_native_contract: ${{ steps.validate.outputs.fs_safe_native_contract }}
       package_artifact_present: ${{ steps.validate.outputs.package_artifact_present }}
       selected_sha: ${{ steps.validate.outputs.selected_sha }}
@@ -602,6 +677,7 @@ jobs:
       - name: Resolve job workflow identity
         id: workflow
         env:
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
           JOB_CONTEXT: ${{ toJSON(job) }}
         shell: bash
         run: |
@@ -610,6 +686,7 @@ jobs:
           import fs from "node:fs";
 
           const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+          const callerWorkflowRef = process.env.CALLER_WORKFLOW_REF ?? "";
           if (
             typeof job.workflow_repository !== "string" ||
             !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(job.workflow_repository)
@@ -619,13 +696,21 @@ jobs:
           if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
             throw new Error("job.workflow_sha must be a full lowercase commit SHA");
           }
+          if (typeof job.workflow_ref !== "string" || job.workflow_ref.length === 0) {
+            throw new Error("job.workflow_ref is required");
+          }
           const outputPath = process.env.GITHUB_OUTPUT;
           if (!outputPath) {
             throw new Error("GITHUB_OUTPUT is required");
           }
           fs.appendFileSync(
             outputPath,
-            `workflow_repository=${job.workflow_repository}\nworkflow_sha=${job.workflow_sha}\n`,
+            [
+              `direct_dispatch=${callerWorkflowRef === job.workflow_ref}`,
+              `workflow_repository=${job.workflow_repository}`,
+              `workflow_sha=${job.workflow_sha}`,
+              "",
+            ].join("\n"),
           );
           NODE
 
@@ -653,6 +738,9 @@ jobs:
         id: validate
         env:
           ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
+          COORDINATOR_REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DIRECT_DISPATCH: ${{ steps.workflow.outputs.direct_dispatch }}
           INPUT_REF: ${{ inputs.ref }}
           PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
           PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id }}
@@ -695,19 +783,41 @@ jobs:
             exit 1
           fi
 
-          if git merge-base --is-ancestor "$selected_sha" refs/remotes/origin/main; then
+          if [[ "$DIRECT_DISPATCH" == "true" ]]; then
+            [[ "$COORDINATOR_REF" == "refs/heads/${DEFAULT_BRANCH}" ]] || {
+              echo "Manual live/E2E dispatches must use the default-branch workflow coordinator." >&2
+              exit 1
+            }
+            [[ "$selected_sha" == "$TRUSTED_WORKFLOW_SHA" ]] || {
+              echo "Manual live/E2E dispatches may validate only the exact default-branch workflow SHA." >&2
+              echo "Run arbitrary candidates in a fresh secretless, cacheless AWS Crabbox instead." >&2
+              exit 1
+            }
+            trusted_reason="default-branch-workflow-sha"
+          elif git merge-base --is-ancestor "$selected_sha" refs/remotes/origin/main; then
             trusted_reason="main-ancestor"
           elif git tag --points-at "$selected_sha" | grep -Eq '^v'; then
             trusted_reason="release-tag"
-          elif git for-each-ref --format='%(refname:short)' --contains "$selected_sha" refs/remotes/origin | grep -Eq '^origin/'; then
-            trusted_reason="repository-branch-history"
+          elif git for-each-ref --format='%(objectname) %(refname:short)' refs/remotes/origin |
+            awk -v sha="$selected_sha" '
+              $1 == sha && (
+                $2 ~ /^origin\/release\// ||
+                $2 ~ /^origin\/extended-stable\/[0-9][0-9][0-9][0-9]\.([1-9]|1[0-2])\.33$/ ||
+                $2 ~ /^origin\/tideclaw\/alpha\//
+              ) {
+                found = 1
+              }
+              END { exit(found ? 0 : 1) }
+            '; then
+            trusted_reason="release-branch-head"
           else
             trusted_reason=""
           fi
 
           if [[ -z "$trusted_reason" ]]; then
             echo "Ref '${INPUT_REF}' resolved to $selected_sha, which is not trusted for secret-bearing live/E2E checks." >&2
-            echo "Allowed refs must be reachable from an OpenClaw branch or release tag." >&2
+            echo "Allowed refs must be on main, a release tag, or an exact release automation branch head." >&2
+            echo "Run arbitrary candidates in a fresh secretless, cacheless AWS Crabbox instead." >&2
             exit 1
           fi
 
@@ -1045,10 +1155,50 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: &prepare_trusted_harness_destination |
+          set -euo pipefail
+          harness="$GITHUB_WORKSPACE/.release-harness"
+          rm -rf -- "$harness"
+          mkdir -p -- "$harness"
+
+      - name: Checkout trusted workflow harness
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          cache-mode: restore
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
+          persist-credentials: false
+
+      - name: Stage trusted setup action graph
+        shell: bash
+        run: &stage_trusted_setup_action |
+          set -euo pipefail
+          github_dir="$GITHUB_WORKSPACE/.github"
+          actions_dir="$github_dir/actions"
+          trusted_action="$GITHUB_WORKSPACE/.release-harness/.github/actions/setup-pnpm-store-cache"
+
+          test -f "$trusted_action/action.yml"
+          test -f "$trusted_action/ensure-node.sh"
+          if [[ -L "$github_dir" || ( -e "$github_dir" && ! -d "$github_dir" ) ]]; then
+            rm -rf -- "$github_dir"
+          fi
+          mkdir -p "$github_dir"
+          if [[ -L "$actions_dir" || ( -e "$actions_dir" && ! -d "$actions_dir" ) ]]; then
+            rm -rf -- "$actions_dir"
+          fi
+          mkdir -p "$actions_dir"
+          rm -rf -- "$actions_dir/setup-pnpm-store-cache"
+          cp -R -- "$trusted_action" "$actions_dir/setup-pnpm-store-cache"
+          cmp "$trusted_action/action.yml" "$actions_dir/setup-pnpm-store-cache/action.yml"
+          cmp "$trusted_action/ensure-node.sh" "$actions_dir/setup-pnpm-store-cache/ensure-node.sh"
+
+      - name: Setup Node environment
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
+        with:
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -1145,13 +1295,29 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
+      - name: Checkout trusted workflow harness
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          cache-mode: restore
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
+          persist-credentials: false
+
+      - name: Stage trusted setup action graph
+        shell: bash
+        run: *stage_trusted_setup_action
+
+      - name: Setup Node environment
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
+        with:
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
-          build-all-cache-scope: full
 
       - name: Build dist for special E2E
         if: |
@@ -1360,6 +1526,10 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted release harness
         if: contains(matrix.profiles, inputs.release_test_profile)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1383,11 +1553,16 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Stage trusted setup action graph
+        if: contains(matrix.profiles, inputs.release_test_profile)
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -1750,6 +1925,10 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted release harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1771,10 +1950,14 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Stage trusted setup action graph
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -2047,6 +2230,10 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted release harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -2068,8 +2255,12 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Stage trusted setup action graph
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
           cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
@@ -2341,6 +2532,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted release harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -2501,11 +2696,16 @@ jobs:
           fi
           node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
 
+      - name: Stage trusted setup action graph
+        if: (steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: (steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -3693,6 +3893,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted live Docker harness
         if: contains(matrix.profiles, inputs.release_test_profile)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -3745,11 +3949,16 @@ jobs:
             bash .release-harness/scripts/docker/shared-image-artifact.sh \
             load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
+      - name: Stage trusted setup action graph
+        if: contains(matrix.profiles, inputs.release_test_profile)
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -3864,6 +4073,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted live Docker harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -3915,10 +4128,14 @@ jobs:
             bash .release-harness/scripts/docker/shared-image-artifact.sh \
             load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
+      - name: Stage trusted setup action graph
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -4301,6 +4518,10 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted live shard harness
         if: steps.selection.outputs.run == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -4311,11 +4532,16 @@ jobs:
           fetch-depth: 1
           path: .release-harness
 
+      - name: Stage trusted setup action graph
+        if: steps.selection.outputs.run == 'true'
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: steps.selection.outputs.run == 'true'
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -4586,6 +4812,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -4648,11 +4878,16 @@ jobs:
             bash .release-harness/scripts/docker/shared-image-artifact.sh \
             load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
+      - name: Stage trusted setup action graph
+        if: steps.codex_compat.outputs.run_lane != 'false' && contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: steps.codex_compat.outputs.run_lane != 'false' && contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -4864,6 +5099,10 @@ jobs:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
+      - name: Prepare trusted harness destination
+        shell: bash
+        run: *prepare_trusted_harness_destination
+
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -4882,11 +5121,16 @@ jobs:
           ffmpeg -version | head -1
           ffprobe -version | head -1
 
+      - name: Stage trusted setup action graph
+        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
+        shell: bash
+        run: *stage_trusted_setup_action
+
       - name: Setup Node environment
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env-uncached
         with:
-          cache-mode: restore
+          cache-mode: off
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7457,6 +7457,118 @@ server.listen(0, "127.0.0.1", () => {
     });
   });
 
+  it("keeps privileged live dispatch on the trusted default-branch control plane", () => {
+    const source = readFileSync(
+      ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
+      "utf8",
+    );
+    const workflow = parse(source);
+    const authorize = workflow.jobs.authorize_actor;
+    const validate = workflow.jobs.validate_selected_ref;
+    const validateStep = validate.steps.find(
+      (step: WorkflowStep) => step.name === "Validate selected ref",
+    );
+
+    expect(authorize.steps[0].uses).toBe(
+      "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+    );
+    expect(authorize.steps[0].with.script).toContain('new Set(["admin", "maintain"])');
+    expect(authorize.steps[0].with.script).toContain("data.role_name");
+    expect(authorize.steps[0].with.script).not.toContain("data.permission");
+    expect(authorize.steps[0].with.script).toContain("trustedCaller");
+    expect(authorize.steps[0].with.script).toContain("^release-ci\\/");
+    expect(authorize.steps[0].with.script).toContain("core.setFailed");
+    expect(authorize.steps[0].env.TRIGGERING_ACTOR).toBe("${{ github.triggering_actor }}");
+    expect(authorize.steps[0].with.script).toContain("username: triggeringActor");
+    expect(authorize.steps[0].with.script).not.toContain("username: context.actor");
+    expect(authorize.steps[0].with.script).toContain(
+      "allowedRoles.has(roleName) && (directDispatch || trustedCaller)",
+    );
+    expect(validate.needs).toBe("authorize_actor");
+    expect(validate.if).toBe("needs.authorize_actor.outputs.authorized == 'true'");
+    expect(validateStep.run).toContain(
+      '[[ "$COORDINATOR_REF" == "refs/heads/${DEFAULT_BRANCH}" ]]',
+    );
+    expect(validateStep.run).toContain('[[ "$selected_sha" == "$TRUSTED_WORKFLOW_SHA" ]]');
+    expect(validateStep.run).toContain("fresh secretless, cacheless AWS Crabbox");
+    expect(validateStep.run).toContain('trusted_reason="release-branch-head"');
+    expect(validateStep.run).toContain("origin\\/extended-stable\\/");
+    expect(source).not.toContain('trusted_reason="repository-branch-history"');
+
+    const setupJobs = Object.entries(workflow.jobs).filter(([, job]) =>
+      (job as { steps?: WorkflowStep[] }).steps?.some(
+        (step) => step.name === "Setup Node environment",
+      ),
+    );
+    expect(setupJobs).toHaveLength(11);
+    for (const [jobName, job] of setupJobs) {
+      const steps = (job as { steps: WorkflowStep[] }).steps;
+      const setupIndex = steps.findIndex((step) => step.name === "Setup Node environment");
+      const stageIndex = steps.findIndex(
+        (step) => step.name === "Stage trusted setup action graph",
+      );
+      const trustedCheckoutIndex = steps.findIndex(
+        (step) =>
+          step.uses === "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" &&
+          step.with?.path === ".release-harness" &&
+          step.with?.ref === "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+      );
+      const prepareHarnessIndex = steps.findIndex(
+        (step) => step.name === "Prepare trusted harness destination",
+      );
+      expect(steps[setupIndex]?.uses, `${jobName} setup action source`).toBe(
+        "./.release-harness/.github/actions/setup-node-env-uncached",
+      );
+      expect(steps[setupIndex]?.with?.["cache-mode"], `${jobName} cache authority`).toBe("off");
+      expect(stageIndex, `${jobName} trusted action graph stage`).toBeGreaterThanOrEqual(0);
+      expect(stageIndex, `${jobName} trusted action graph ordering`).toBe(setupIndex - 1);
+      expect(steps[stageIndex]?.if, `${jobName} trusted action graph condition`).toBe(
+        steps[setupIndex]?.if,
+      );
+      expect(trustedCheckoutIndex, `${jobName} trusted harness checkout`).toBeGreaterThanOrEqual(0);
+      expect(prepareHarnessIndex, `${jobName} trusted harness destination`).toBe(
+        trustedCheckoutIndex - 1,
+      );
+      expect(steps[prepareHarnessIndex]?.run, `${jobName} trusted harness cleanup`).toContain(
+        'rm -rf -- "$harness"',
+      );
+      expect(trustedCheckoutIndex, `${jobName} trusted harness ordering`).toBeLessThan(setupIndex);
+    }
+    const stageSteps = Object.values(workflow.jobs).flatMap((job) =>
+      ((job as { steps?: WorkflowStep[] }).steps ?? []).filter(
+        (step) => step.name === "Stage trusted setup action graph",
+      ),
+    );
+    expect(stageSteps).toHaveLength(11);
+    const cachelessSetup = readFileSync(
+      ".github/actions/setup-node-env-uncached/action.yml",
+      "utf8",
+    );
+    expect(cachelessSetup).not.toContain("actions/cache");
+    expect(cachelessSetup).toContain("Revalidate current maintainer authority");
+    expect(cachelessSetup).toContain("github.triggering_actor != 'github-actions[bot]'");
+    expect(cachelessSetup).toContain("TRIGGERING_ACTOR: ${{ github.triggering_actor }}");
+    expect(cachelessSetup).toContain("collaborators/${TRIGGERING_ACTOR}/permission");
+    expect(cachelessSetup).not.toContain("collaborators/${GITHUB_ACTOR}/permission");
+    expect(cachelessSetup).toContain("admin|maintain");
+    const stageScript = stageSteps.find((step) => typeof step.run === "string")?.run ?? "";
+    expect(stageScript).toContain(
+      'trusted_action="$GITHUB_WORKSPACE/.release-harness/.github/actions/setup-pnpm-store-cache"',
+    );
+    expect(stageScript).toContain('[[ -L "$github_dir"');
+    expect(stageScript).toContain('[[ -L "$actions_dir"');
+    expect(stageScript).toContain('rm -rf -- "$actions_dir/setup-pnpm-store-cache"');
+    expect(stageScript).toContain(
+      'cp -R -- "$trusted_action" "$actions_dir/setup-pnpm-store-cache"',
+    );
+    expect(stageScript).toContain(
+      'cmp "$trusted_action/action.yml" "$actions_dir/setup-pnpm-store-cache/action.yml"',
+    );
+    expect(stageScript).toContain(
+      'cmp "$trusted_action/ensure-node.sh" "$actions_dir/setup-pnpm-store-cache/ensure-node.sh"',
+    );
+  });
+
   it("fingerprints dependency install inputs without ordinary script churn", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-dependency-fingerprint-"));
     try {

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -94,14 +94,23 @@ function runSourceRequirement(step: WorkflowStep, env: Record<string, string>) {
   }
 }
 
-function runLiveArtifactTupleValidation(packageEnv: Record<string, string>) {
+function runLiveArtifactTupleValidation(
+  packageEnv: Record<string, string>,
+  options: {
+    coordinatorRef?: string;
+    directDispatch?: boolean;
+    selectedSha?: string;
+    trustedWorkflowSha?: string;
+  } = {},
+) {
   const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
   const step = workflowStep(workflow, "validate_selected_ref", "Validate selected ref");
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-live-artifact-tuple-"));
   const fakeBin = path.join(tempDir, "bin");
   const outputPath = path.join(tempDir, "output");
   const summaryPath = path.join(tempDir, "summary");
-  const selectedSha = "a".repeat(40);
+  const selectedSha = options.selectedSha ?? "a".repeat(40);
+  const trustedWorkflowSha = options.trustedWorkflowSha ?? selectedSha;
   mkdirSync(fakeBin);
   mkdirSync(path.join(tempDir, ".release-harness", "scripts"), { recursive: true });
   copyFileSync(
@@ -133,12 +142,15 @@ exit 64
         ...stepEnv,
         GITHUB_OUTPUT: outputPath,
         GITHUB_STEP_SUMMARY: summaryPath,
+        COORDINATOR_REF: options.coordinatorRef ?? "refs/heads/main",
+        DEFAULT_BRANCH: "main",
+        DIRECT_DISPATCH: options.directDispatch ? "true" : "false",
         INPUT_REF: "main",
         PATH: `${fakeBin}:${process.env.PATH}`,
         PROVIDED_BARE_IMAGE: "ghcr.io/openclaw/openclaw:test",
         SELECTED_SHA: selectedSha,
         SHARED_IMAGE_POLICY: "existing-only",
-        TRUSTED_WORKFLOW_SHA: selectedSha,
+        TRUSTED_WORKFLOW_SHA: trustedWorkflowSha,
         ...packageEnv,
       },
     });
@@ -639,6 +651,33 @@ describe("package source preflight", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(output.package_artifact_present).toBe("false");
+  });
+
+  it("rejects hostile manual live dispatches before privileged setup", () => {
+    const offMain = runLiveArtifactTupleValidation(
+      {},
+      {
+        coordinatorRef: "refs/heads/feature/hostile",
+        directDispatch: true,
+      },
+    );
+    expect(offMain.result.status).toBe(1);
+    expect(offMain.result.stderr).toContain("must use the default-branch workflow coordinator");
+
+    const arbitraryCandidate = runLiveArtifactTupleValidation(
+      {},
+      {
+        directDispatch: true,
+        selectedSha: "b".repeat(40),
+        trustedWorkflowSha: "a".repeat(40),
+      },
+    );
+    expect(arbitraryCandidate.result.status).toBe(1);
+    expect(arbitraryCandidate.result.stderr).toContain("fresh secretless, cacheless AWS Crabbox");
+
+    const canonical = runLiveArtifactTupleValidation({}, { directDispatch: true });
+    expect(canonical.result.status, canonical.result.stderr).toBe(0);
+    expect(canonical.output.trusted_reason).toBe("default-branch-workflow-sha");
   });
 
   it("keeps a whitespace-only artifact tuple in source mode through Docker reports", async () => {


### PR DESCRIPTION
## What Problem This Solves

Hardens privileged live and E2E validation so candidate-controlled workflow code cannot reach secret-bearing setup or mutable shared-image execution.

## Current Status

Draft and intentionally not being pushed. The public PR branch remains at `75c7437dcbfb8db78f9314a25f3d8307d88edcb6`. A stronger signed local candidate exists at `6010b6ebeb3a6876f6888e142fe78886d67c70b3`, but review proved it is not landable within this PR's approved file boundary.

## Exact Blocker

Frozen `release-ci/*` reruns cannot be securely authorized from payload fields or branch naming alone. They must enter through a canonical trusted release dispatcher that binds the candidate SHA and release context. That seam is owned by `.github/workflows/openclaw-release-checks.yml` and related release paths, which are explicitly excluded from this PR. A release owner must provide or approve that trusted dispatcher seam before this branch can continue.

## Remaining Scope-Compatible Findings

- The manual wrapper must be a secret-bearing default-branch `repository_dispatch` control plane only; branch-selectable `workflow_dispatch` is unsafe.
- Scheduled live checks and plugin prerelease need narrowly constrained caller admission tied to exact canonical ref/SHA and immutable candidate evidence.
- `existing-only` package images must be derived from the package digest, then resolved and used by immutable OCI digest rather than a mutable tag.

## Completed Proof

- Uncached GitHub identity/repository gate passed for the authenticated admin against the public repository.
- The signed local candidate was rebased onto recorded `main` `b13971bdcc4580760029fb474d0e7021360455f2` with a clean 12-file scoped diff.
- Focused workflow/script tests passed: 1,297 passed and 2 skipped across seven files.
- `actionlint`, `git diff --check`, script erasability/type checks, targeted lint, shell syntax checks, and Docker scheduler dry-run passed.
- An earlier full `pnpm check:changed` passed; the exact-head rerun later stalled in the unchanged tsgo graph inventory under host contention, so targeted owner gates were used instead of another retry.
- Independent autoreview, security, and release-manager reviews all blocked publication on the release-owned dispatcher seam and the remaining findings above.
