### PR TITLE
refactor(tests): assert live meeting capture drafts

### DIFF
--- a/ui/src/pages/config/meeting-capture.test.ts
+++ b/ui/src/pages/config/meeting-capture.test.ts
@@ -166,6 +166,7 @@ describe("curated meeting capture", () => {
       await page.updateComplete;
       const control = page.querySelector<HTMLInputElement>(`input[name="${field}"]`)!;
       const fields = [...page.querySelectorAll("input")].map((item) => item.name);
+      input(page, "title", "Not yet submitted");
       const refresh = startedRefresh ?? (await beginRefresh());
       try {
         if (health === "error") {
@@ -185,6 +186,9 @@ describe("curated meeting capture", () => {
         if (health !== "pending") {
           await vi.waitFor(() => expect(refresh.disabled).toBe(false));
         }
+        expect(page.querySelector<HTMLInputElement>('input[name="title"]')?.value).toBe(
+          "Not yet submitted",
+        );
         expect(page.querySelector<HTMLSelectElement>('select[name="providerId"]')?.value).toBe(
           original.providerId,
         );
@@ -889,18 +893,6 @@ describe("curated meeting capture", () => {
     ).toBe(true);
     expect(page.querySelector("wa-switch")?.hasAttribute("disabled")).toBe(true);
     expect(runtimeConfig.state.configFormDirty).toBe(false);
-  });
-
-  it("keeps source form edits intact through a health refresh", async () => {
-    const { page } = await mount();
-    click(page, "Edit source 1");
-    await page.updateComplete;
-    const title = page.querySelector<HTMLInputElement>('input[name="title"]')!;
-    title.value = "Not yet submitted";
-    click(page, "Refresh");
-    await vi.waitFor(() => expect(page.textContent).toContain("Not active"));
-    await page.updateComplete;
-    expect(title.value).toBe("Not yet submitted");
   });
 
   it("retains newly entered locators while a health refresh is pending", async () => {


### PR DESCRIPTION
## What Problem This Solves

A meeting-capture test could pass after the visible title input lost an edit because it checked a cached DOM element and did not wait for a controlled health-refresh transition.

## Why This Change Was Made

Enter the title through an input event in the existing saved-source validation cases, then re-query the live control after the controlled refresh state. Remove the weaker standalone test while retaining every validation row and its save assertions. Removes 8 net test lines.

## User Impact

Stronger regression coverage for unsaved source titles; no production behavior change.

## Evidence

- Full file passes: 37 cases before, 36 retained cases after, with unchanged retained names and statuses.
- A test-only control confirms the old assertion passes with a detached cached input and reset live value. The strengthened assertion detects that fault in all 8 validation rows.
- Diagnostic edits removed; full changed checks and independent P2 review pass.

No runtime improvement claimed.
