### PR TITLE
improve: speed up Signal delivery tests

### DIFF
--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -1,4 +1,3 @@
-// Signal tests cover monitor.tool result.pairs uuid only senders uuid allowlist entry plugin behavior.
 import { Buffer } from "node:buffer";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -177,6 +176,7 @@ describe("monitorSignalProvider tool results", () => {
   it("drains an inline inbound message accepted before the monitor stops", async () => {
     const abortController = new AbortController();
     setSignalToolResultTestConfig({
+      messages: { visibleReplies: "automatic" },
       channels: { signal: { autoStart: false, dmPolicy: "open", allowFrom: ["*"] } },
     });
     replyMock.mockResolvedValue({ text: "accepted reply" });
@@ -249,6 +249,7 @@ describe("monitorSignalProvider tool results", () => {
     const maxBytes = 2 * 1024 * 1024;
     const expectedMaxResponseBytes = Math.ceil((maxBytes * 4) / 3) + 64 * 1024;
     setSignalToolResultTestConfig({
+      messages: { visibleReplies: "automatic" },
       channels: {
         signal: {
           transport: { kind: "container", url: "http://container:8080" },

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -1,4 +1,3 @@
-// Signal tests cover monitor.tool result.sends tool summaries responseprefix plugin behavior.
 import { expectPairingReplyText } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
@@ -597,7 +596,7 @@ describe("monitorSignalProvider tool results", () => {
         autoStart: false,
         replyToMode: "batched",
       }),
-      messages: { inbound: { debounceMs: 10 } },
+      messages: { visibleReplies: "automatic", inbound: { debounceMs: 10 } },
     });
     replyMock.mockResolvedValue({ text: "reply" });
     const abortController = new AbortController();

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -1,4 +1,3 @@
-// Signal plugin module implements monitor.tool result harness behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -352,7 +351,8 @@ export function installSignalToolResultTestHooks() {
       },
     } as unknown as PluginRuntime);
     config = {
-      messages: { responsePrefix: "PFX" },
+      // Mocked final replies exercise transport behavior independently of harness defaults.
+      messages: { responsePrefix: "PFX", visibleReplies: "automatic" },
       session: { store: signalToolResultSessionStore.path },
       channels: {
         signal: {


### PR DESCRIPTION
Related: #142775

## What Problem This Solves

Signal transport fixtures return mocked final replies and expect automatic delivery, but leave visible-reply policy implicit. Their first dispatch can spend several seconds selecting unused harness defaults before reaching the delivery assertions.

## Why This Change Was Made

Declare the existing automatic-delivery policy in the shared fixture and the three complete configuration overrides that dispatch mocked replies. The real ingress, adoption, dispatcher, queue assertions, and timeouts remain in place. Three generic file-header comments are removed, leaving total LOC unchanged. Main's canonical idle synchronization from #142775 is preserved.

## User Impact

Signal delivery tests reach their intended assertions faster and keep their policy expectations explicit. Core harness-default selection retains its separate regression coverage.

## Evidence

On the original CI merge, an isolated Linux diagnostic reproduced the failure and measured 5,112 ms in visible-reply policy selection. The matched fixture diagnostic measured 0.053 ms with all 863 Signal cases passing; the clean Linux run also passed all 863 cases. These measurements are from Node 24.19.0 with two workers and the observed two-CPU CI budget, not a claim about every host.

After carrying the patch onto main `ee2d54f0dc8`, all 48 Signal test files / 863 cases and the complete changed-file gate passed, including extension production/test types and lint. Four existing core implicit-default/explicit-override guards passed separately. No test name or assertion changed. Independent review completed with no actionable findings.
