### PR TITLE
test(reply): keep scoped thinking on the fixture catalog

### DIFF
--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -86,7 +86,8 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         throw new Error("native command attempted synchronous CLI setup discovery");
       },
     });
-    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalogSnapshot").mockResolvedValue({
+    // Keep scoped thinking reads on the same catalog fixture as model selection.
+    const catalogSnapshot: ModelCatalogSnapshot = {
       entries: [
         {
           id: "gpt-5.5",
@@ -104,7 +105,13 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         },
       ],
       routeVariants: [],
-    });
+    };
+    vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalogSnapshot").mockResolvedValue(
+      catalogSnapshot,
+    );
+    vi.spyOn(preparedModelCatalog, "loadProviderScopedThinkingCatalog").mockResolvedValue(
+      catalogSnapshot.entries,
+    );
     handleCommandsMock.mockReset();
     buildStatusReplyMock.mockReset();
     buildStatusReplyMock.mockResolvedValue({ text: "selected model status" });
@@ -298,6 +305,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       loadExactSessionEntry({ sessionKey: "agent:main:telegram:123", storePath })?.entry,
     ).toMatchObject({ providerOverride: "ollama", modelOverride: "picker-secondary" });
     expect(preparedModelCatalog.loadPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
+    expect(preparedModelCatalog.loadProviderScopedThinkingCatalog).not.toHaveBeenCalled();
   });
 
   it("marks native /compact terminal replies for delivery under message_tool_only (#90185)", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a minute of unintended provider-catalog setup in the native-command unit tests. The first case took 56.115s in [main CI 34303070633](https://github.com/openclaw/openclaw/actions/runs/34303070633), and 66–69s in unchanged source-only local runs. It only needs the suite's existing test catalog to verify command handling and persisted session selections.

Part of the maintainer-requested test performance work.

## Why This Change Was Made

The suite already supplies two controlled model rows through the snapshot loader. Current thinking resolution uses a separate scoped loader, bypassing that fixture and acquiring real runtime metadata. Supply the same fresh catalog through both existing metadata boundaries.

Real command parsing, session writes and all 53 cases remain. The admitted-catalog case additionally checks that the scoped loader is not called, so this fixture cannot hide forbidden rediscovery. Separate thinking-catalog, harness and worker integration tests retain the real catalog-owner contracts. Production thinking defaults, stored-level remapping, visibility and ownership are unchanged.

## User Impact

Faster CI and local unit-test feedback. No production, timeout, configuration, dependency or shard-count change.

## Evidence

Source-only full-file original/candidate/restored-original, Node 24.19.0 and pnpm 12.3.4:

| Source | First case | Whole command |
| --- | ---: | ---: |
| Original | 67.058s | 89.87s |
| Candidate | 2.966s | 22.79s |
| Restored original | 68.607s | 96.26s |

All 53 cases pass in identical order. Conservative saving: 64.092s in the first case and 67.08s for the invocation. Profiled original work spent 65.063s resolving thinking metadata, versus 137ms persisting the session and 8ms applying the directive.

- Final native-command + scoped-thinking + harness catalog proof: 69/69 passed; native case 3.853s in the combined run.
- All original assertions retained; one no-rediscovery assertion added.
- Required changed checks, formatter and diff checks passed.
- Independent managed P2 review: scoped-clean, no actionable findings.
- Test delta +10/-2; production delta 0.

Old generated outputs were temporarily moved aside for source-only proof and restored after all consumers joined. A prior snapshot-input-only experiment did not improve timings and was fully reverted; no config seeding or catalog-visibility change was retained.
