### PR TITLE
fix(line): batch mixed outbound messages

### DIFF
--- a/extensions/line/src/channel.sendPayload.delivery-outcomes.test.ts
+++ b/extensions/line/src/channel.sendPayload.delivery-outcomes.test.ts
@@ -1,9 +1,12 @@
 import { HTTPFetchError } from "@line/bot-sdk";
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
-import { createRuntime } from "./channel.sendPayload.test-support.js";
+import { createRuntime, lineResult } from "./channel.sendPayload.test-support.js";
 import { lineOutboundAdapter } from "./outbound.js";
 import {
   createPendingLineResponse,
@@ -12,9 +15,18 @@ import {
 } from "./probe.test-support.js";
 import { setLineRuntime } from "./runtime.js";
 
+const ssrfMocks = vi.hoisted(() => ({
+  resolvePinnedHostnameWithPolicy: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  resolvePinnedHostnameWithPolicy: ssrfMocks.resolvePinnedHostnameWithPolicy,
+}));
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  ssrfMocks.resolvePinnedHostnameWithPolicy.mockReset();
 });
 
 describe("line outbound delivery outcomes", () => {
@@ -176,7 +188,7 @@ describe("line outbound delivery outcomes", () => {
     }
   });
 
-  it("keeps accepted media receipts without reading quota for a later text refusal", async () => {
+  it("keeps accepted media receipts without reading quota for a later batch refusal", async () => {
     const { runtime, mocks } = createRuntime();
     const rejection = new HTTPFetchError("429 - provider rejection", {
       status: 429,
@@ -184,14 +196,10 @@ describe("line outbound delivery outcomes", () => {
       headers: new Headers(),
       body: "provider rejection",
     });
-    const events: string[] = [];
-    const onDeliveryResult = vi.fn(() => {
-      events.push("media-receipt");
-    });
-    mocks.pushTextMessageWithQuickReplies.mockImplementationOnce(async () => {
-      events.push("text-refused");
-      throw rejection;
-    });
+    const onDeliveryResult = vi.fn();
+    mocks.pushMessagesLine
+      .mockResolvedValueOnce(lineResult("m-media"))
+      .mockRejectedValueOnce(rejection);
     const fetchMock = stubLineApiFetch(
       Response.json({ type: "limited", value: 200 }),
       Response.json({ totalUsage: 200 }),
@@ -204,7 +212,10 @@ describe("line outbound delivery outcomes", () => {
         text: "Caption",
         payload: {
           text: "Caption",
-          mediaUrl: "https://example.com/image.jpg",
+          mediaUrls: Array.from(
+            { length: 5 },
+            (_, index) => `https://example.com/image-${index}.jpg`,
+          ),
           channelData: { line: { quickReplies: ["Continue"] } },
         },
         ...LINE_QUOTA_ACCOUNT,
@@ -212,9 +223,9 @@ describe("line outbound delivery outcomes", () => {
       }),
     ).rejects.toBe(rejection);
 
-    expect(mocks.sendMessageLine).toHaveBeenCalledOnce();
-    expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledOnce();
-    expect(events).toEqual(["media-receipt", "text-refused"]);
+    expect(mocks.pushMessagesLine).toHaveBeenCalledTimes(2);
+    expect(mocks.sendMessageLine).not.toHaveBeenCalled();
+    expect(mocks.pushTextMessageWithQuickReplies).not.toHaveBeenCalled();
     expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         channel: "line",
@@ -249,5 +260,176 @@ describe("line outbound delivery outcomes", () => {
         cfg: { channels: { line: {} } } as OpenClawConfig,
       }),
     ).rejects.toBe(partial);
+  });
+
+  it("preserves valid mixed parts when media preparation fails", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    let caught: unknown;
+    try {
+      await lineOutboundAdapter.sendPayload!({
+        to: "line:user:media-failure",
+        text: "Caption",
+        payload: {
+          text: "Caption",
+          mediaUrl: "http://example.com/image.jpg",
+          channelData: {
+            line: {
+              flexMessage: { altText: "Card", contents: { type: "bubble" } },
+            },
+          },
+        },
+        accountId: "default",
+        cfg,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    expect(mocks.pushMessagesLine).toHaveBeenCalledOnce();
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:media-failure",
+      [
+        { type: "flex", altText: "Card", contents: { type: "bubble" } },
+        { type: "text", text: "Caption" },
+      ],
+      expect.any(Object),
+    );
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial LINE delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["m-batch"],
+      visibleReplySent: true,
+    });
+  });
+
+  it("recovers text after a definitive mixed-batch rejection", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const rejection = new HTTPFetchError("400 - invalid rich message", {
+      status: 400,
+      statusText: "Bad Request",
+      headers: new Headers(),
+      body: "invalid rich message",
+    });
+    mocks.pushMessagesLine
+      .mockRejectedValueOnce(rejection)
+      .mockResolvedValueOnce(lineResult("m-text-recovered"));
+
+    let caught: unknown;
+    try {
+      await lineOutboundAdapter.sendPayload!({
+        to: "line:user:rejected-batch",
+        text: "Caption",
+        payload: {
+          text: "Caption",
+          channelData: {
+            line: {
+              flexMessage: { altText: "Invalid card", contents: { type: "bubble" } },
+            },
+          },
+        },
+        accountId: "default",
+        cfg,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    expect(mocks.pushMessagesLine).toHaveBeenNthCalledWith(
+      1,
+      "line:user:rejected-batch",
+      [
+        { type: "flex", altText: "Invalid card", contents: { type: "bubble" } },
+        { type: "text", text: "Caption" },
+      ],
+      expect.any(Object),
+    );
+    expect(mocks.pushMessagesLine).toHaveBeenNthCalledWith(
+      2,
+      "line:user:rejected-batch",
+      [{ type: "text", text: "Caption" }],
+      expect.any(Object),
+    );
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial LINE delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["m-text-recovered"],
+      visibleReplySent: true,
+    });
+  });
+
+  it("preserves accepted fallback evidence when its receipt is unreadable", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const rejection = new HTTPFetchError("400 - invalid rich message", {
+      status: 400,
+      statusText: "Bad Request",
+      headers: new Headers(),
+      body: "invalid rich message",
+    });
+    const fallbackAccepted = createChannelPartialDeliveryError(
+      new Error("accepted response body could not be parsed"),
+      { messageIds: ["m-text-accepted"], visibleReplySent: true },
+    );
+    mocks.pushMessagesLine.mockRejectedValueOnce(rejection).mockRejectedValueOnce(fallbackAccepted);
+
+    await expect(
+      lineOutboundAdapter.sendPayload!({
+        to: "line:user:accepted-fallback",
+        text: "Caption",
+        payload: {
+          text: "Caption",
+          channelData: {
+            line: {
+              flexMessage: { altText: "Invalid card", contents: { type: "bubble" } },
+            },
+          },
+        },
+        accountId: "default",
+        cfg,
+      }),
+    ).rejects.toBe(fallbackAccepted);
+  });
+
+  it("preserves an ambiguous fallback transport failure", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const rejection = new HTTPFetchError("400 - invalid rich message", {
+      status: 400,
+      statusText: "Bad Request",
+      headers: new Headers(),
+      body: "invalid rich message",
+    });
+    const fallbackAmbiguous = new Error("connection closed after fallback request");
+    mocks.pushMessagesLine
+      .mockRejectedValueOnce(rejection)
+      .mockRejectedValueOnce(fallbackAmbiguous);
+
+    await expect(
+      lineOutboundAdapter.sendPayload!({
+        to: "line:user:ambiguous-fallback",
+        text: "Caption",
+        payload: {
+          text: "Caption",
+          channelData: {
+            line: {
+              flexMessage: { altText: "Invalid card", contents: { type: "bubble" } },
+            },
+          },
+        },
+        accountId: "default",
+        cfg,
+      }),
+    ).rejects.toBe(fallbackAmbiguous);
   });
 });

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -1,5 +1,4 @@
 // Line tests cover channel.sendPayload plugin behavior.
-import { expectDefined } from "@openclaw/normalization-core";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   verifyChannelMessageAdapterCapabilityProofs,
@@ -87,9 +86,16 @@ describe("line outbound sendPayload", () => {
         type: String(args[1]).includes("Large") ? "oversized-table-text" : "text",
       })),
       ...mocks.pushMessagesLine.mock.calls.flatMap((args, index) =>
-        args[1].map((message: { type: string; altText?: string }) => ({
+        args[1].map((message: { type: string; altText?: string; text?: string }) => ({
           position: mocks.pushMessagesLine.mock.invocationCallOrder[index],
-          type: message.altText === "Code" ? "code-card" : message.type,
+          type:
+            message.altText === "Code"
+              ? "code-card"
+              : message.altText === "Table"
+                ? "valid-table-card"
+                : message.type === "text" && message.text?.includes("Large")
+                  ? "oversized-table-text"
+                  : message.type,
         })),
       ),
     ]
@@ -102,11 +108,14 @@ describe("line outbound sendPayload", () => {
       true,
     );
     if (quickReplies.length > 0) {
-      expect(mocks.pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
+      expect(mocks.pushMessagesLine.mock.calls.at(-1)).toEqual([
         "line:user:ordered",
-        [expect.objectContaining({ altText: "Code", quickReply: { items: quickReplies } })],
+        [
+          expect.objectContaining({ type: "text", text: "After" }),
+          expect.objectContaining({ altText: "Code", quickReply: { items: quickReplies } }),
+        ],
         expect.any(Object),
-      );
+      ]);
       expect(mocks.pushTextMessageWithQuickReplies).not.toHaveBeenCalled();
     }
   });
@@ -155,14 +164,19 @@ describe("line outbound sendPayload", () => {
 
     // The pin LINE will not render still reaches the chat as the text it was
     // made of; the builder owns that degradation, so delivery must not skip it.
-    expect(mocks.pushLocationMessage).toHaveBeenCalledWith(
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
       "line:user:U123",
-      { ...location, latitude: 35.6895, longitude: 139.6917 },
-      expect.any(Object),
-    );
-    expect(mocks.pushMessageLine).toHaveBeenCalledWith(
-      "line:user:U123",
-      "Meet me there.",
+      [
+        {
+          type: "text",
+          text: [location.title, location.address]
+            .map((label) => label.trim())
+            .filter(Boolean)
+            .concat("35.6895, 139.6917")
+            .join("\n"),
+        },
+        { type: "text", text: "Meet me there." },
+      ],
       expect.any(Object),
     );
   });
@@ -272,41 +286,55 @@ describe("line outbound sendPayload", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("publishes completed Flex receipts before a later legacy text send fails", async () => {
+  it("publishes completed batch receipts before a later batch send fails", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
-    const cfg = {
-      channels: { line: { channelAccessToken: "line-fixture-token" } },
-    } as OpenClawConfig;
-    const laterFailure = new Error("second LINE Flex send failed");
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(Response.json({ sentMessages: [{ id: "m-first-flex" }] }))
-      .mockRejectedValueOnce(laterFailure);
-    vi.stubGlobal("fetch", fetch);
-    mocks.pushFlexMessage
-      .mockResolvedValueOnce(lineResult("m-first-flex"))
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const laterFailure = new Error("second LINE batch send failed");
+    mocks.pushMessagesLine
+      .mockResolvedValueOnce(lineResult("m-first-batch"))
       .mockRejectedValueOnce(laterFailure);
     const onDeliveryResult = vi.fn();
+    const text = Array.from(
+      { length: 6 },
+      (_, index) => `\`\`\`js\nmessage${index + 1}()\n\`\`\``,
+    ).join("\n\n");
 
     await expect(
       lineOutboundAdapter.sendText!({
         to: "line:user:U123",
-        text: "```js\nfirst()\n```\n\n```js\nsecond()\n```",
+        text,
         accountId: "default",
         cfg,
         onDeliveryResult,
       }),
-    ).rejects.toThrow("second LINE Flex send failed");
+    ).rejects.toThrow("second LINE batch send failed");
 
+    expect(mocks.pushMessagesLine).toHaveBeenCalledTimes(2);
+    expect(mocks.pushMessagesLine.mock.calls[0]?.[1]).toHaveLength(5);
+    expect(mocks.pushMessagesLine.mock.calls[1]?.[1]).toHaveLength(1);
     expect(onDeliveryResult).toHaveBeenCalledOnce();
     expect(onDeliveryResult).toHaveBeenCalledWith(
       expect.objectContaining({
-        messageId: "m-first-flex",
-        receipt: expect.objectContaining({ platformMessageIds: ["m-first-flex"] }),
+        messageId: "m-first-batch",
+        receipt: expect.objectContaining({ platformMessageIds: ["m-first-batch"] }),
       }),
     );
-    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("publishes a single receipt for a mixed Flex payload", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const result = await lineOutboundAdapter.sendText!({
+      to: "line:user:U123",
+      text: "```js\nfirst()\n```\n\n```js\nsecond()\n```",
+      accountId: "default",
+      cfg: { channels: { line: {} } } as OpenClawConfig,
+    });
+
+    expect(mocks.pushMessagesLine).toHaveBeenCalledOnce();
+    expect(mocks.pushMessagesLine.mock.calls[0]?.[1]).toHaveLength(2);
+    expect(result.messageId).toBe("m-batch");
   });
 
   it("sends flex message without dropping text", async () => {
@@ -334,12 +362,50 @@ describe("line outbound sendPayload", () => {
       cfg,
     });
 
-    expect(mocks.pushFlexMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:group:1", "Now playing:", {
-      verbose: false,
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:group:1",
+      [
+        { type: "flex", altText: "Now playing", contents: { type: "bubble" } },
+        { type: "text", text: "Now playing:" },
+      ],
+      { verbose: false, accountId: "default", cfg },
+    );
+  });
+
+  it("batches a card, caption, and media into one provider request", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:batch",
+      text: "Caption",
+      payload: {
+        text: "Caption",
+        mediaUrl: "https://example.com/image.jpg",
+        channelData: {
+          line: {
+            flexMessage: { altText: "Card", contents: { type: "bubble" } },
+          },
+        },
+      },
       accountId: "default",
       cfg,
     });
+
+    expect(mocks.pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
+      "line:user:batch",
+      [
+        { type: "flex", altText: "Card", contents: { type: "bubble" } },
+        { type: "text", text: "Caption" },
+        {
+          type: "image",
+          originalContentUrl: "https://example.com/image.jpg",
+          previewImageUrl: "https://example.com/image.jpg",
+        },
+      ],
+      { verbose: false, accountId: "default", cfg },
+    );
   });
 
   it("reports each platform result for text and media payloads", async () => {
@@ -360,11 +426,7 @@ describe("line outbound sendPayload", () => {
       onDeliveryResult,
     });
 
-    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
-    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
-      "m-text",
-      "m-media",
-    ]);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual(["m-batch"]);
   });
 
   it("preserves every provider receipt and conversation for an inline LINE batch", async () => {
@@ -453,12 +515,11 @@ describe("line outbound sendPayload", () => {
     });
 
     expect(mocks.buildTemplateMessageFromPayload).toHaveBeenCalledTimes(1);
-    expect(mocks.pushTemplateMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:1", "Choose one:", {
-      verbose: false,
-      accountId: "default",
-      cfg,
-    });
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:1",
+      [expect.objectContaining({ type: "template" }), { type: "text", text: "Choose one:" }],
+      { verbose: false, accountId: "default", cfg },
+    );
   });
 
   it("attaches quick replies while preserving the provider's full Flex alternative-text limit", async () => {
@@ -588,26 +649,17 @@ describe("line outbound sendPayload", () => {
       cfg,
     });
 
-    expect(mocks.sendMessageLine).toHaveBeenCalledWith("line:user:3", "", {
-      verbose: false,
-      mediaUrl: "https://example.com/img.jpg",
-      mediaKind: undefined,
-      previewImageUrl: undefined,
-      durationMs: undefined,
-      trackingId: undefined,
-      accountId: "default",
-      cfg,
-    });
-    expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
       "line:user:3",
-      "Hello",
-      ["One", "Two"],
+      [
+        {
+          type: "image",
+          originalContentUrl: "https://example.com/img.jpg",
+          previewImageUrl: "https://example.com/img.jpg",
+        },
+        { type: "text", text: "Hello", quickReply: { items: ["One", "Two"] } },
+      ],
       { verbose: false, accountId: "default", cfg },
-    );
-    const mediaOrder = mocks.sendMessageLine.mock.invocationCallOrder[0];
-    const quickReplyOrder = mocks.pushTextMessageWithQuickReplies.mock.invocationCallOrder[0];
-    expect(expectDefined(mediaOrder, "LINE media invocation")).toBeLessThan(
-      expectDefined(quickReplyOrder, "LINE quick-reply invocation"),
     );
   });
 
@@ -924,13 +976,22 @@ describe("line outbound sendPayload", () => {
             mediaUrl: "https://example.com/image.jpg",
             accountId: "primary",
           });
-          expect(mocks.sendMessageLine).toHaveBeenCalledWith("line:user:U123", "", {
-            verbose: false,
-            mediaUrl: "https://example.com/image.jpg",
-            accountId: "primary",
-            cfg,
-          });
-          expect(result?.receipt.platformMessageIds).toEqual(["m-media"]);
+          expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+            "line:user:U123",
+            [
+              {
+                type: "text",
+                text: "image",
+              },
+              {
+                type: "image",
+                originalContentUrl: "https://example.com/image.jpg",
+                previewImageUrl: "https://example.com/image.jpg",
+              },
+            ],
+            { verbose: false, accountId: "primary", cfg },
+          );
+          expect(result?.receipt.platformMessageIds).toEqual(["m-batch"]);
         },
         replyTo: async () => {
           recordLineQuoteToken({

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -34,7 +34,11 @@ import {
 } from "./rich-messages.js";
 import { getLineRuntime } from "./runtime.js";
 import { createLineSendReceipt } from "./send-receipt.js";
-import { explainLineRefusal } from "./send-retry.js";
+import {
+  explainLineRefusal,
+  findLineHttpError,
+  resolveLineNonDispatchRetryable,
+} from "./send-retry.js";
 import type { LineChannelData, LineSendResult, ResolvedLineAccount } from "./types.js";
 
 const loadLineOutboundRuntime = createLazyRuntimeModule(() => import("./outbound.runtime.js"));
@@ -123,13 +127,77 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       : quickReplies;
 
     // LINE SDK expects Message[] but we build dynamically.
-    const sendMessageBatch = async (messages: Array<Record<string, unknown>>) => {
+    const sendMessageBatch = async (
+      messages: messagingApi.Message[],
+      allowRejectedBatchRecovery = true,
+    ) => {
       if (messages.length === 0) {
         return;
       }
       for (let i = 0; i < messages.length; i += 5) {
-        const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
-        await recordResult(sendBatch(to, batch, sendOptions));
+        const batch = messages.slice(i, i + 5) as Parameters<typeof sendBatch>[1];
+        try {
+          await recordResult(sendBatch(to, batch, sendOptions));
+        } catch (error) {
+          const httpError = findLineHttpError(error);
+          if (
+            allowRejectedBatchRecovery &&
+            httpError?.status === 400 &&
+            resolveLineNonDispatchRetryable(error) !== undefined
+          ) {
+            const retryCandidates = [...batch, ...messages.slice(i + batch.length)];
+            const retryTextMessages = retryCandidates.filter(
+              (message): message is messagingApi.TextMessage => message.type === "text",
+            );
+            const quickRepliesNeedCarrier = retryCandidates.some(
+              (message) => "quickReply" in message,
+            );
+            const retryMessages: messagingApi.Message[] = retryTextMessages.length
+              ? [...retryTextMessages]
+              : quickRepliesNeedCarrier && quickReply
+                ? [
+                    {
+                      type: "text",
+                      text: buildLineQuickReplyFallbackText(quickReplyLabels),
+                      quickReply,
+                    },
+                  ]
+                : [];
+            if (quickRepliesNeedCarrier && quickReply && retryMessages.length > 0) {
+              const lastRetryMessage = retryMessages.at(-1);
+              if (lastRetryMessage && !("quickReply" in lastRetryMessage)) {
+                retryMessages[retryMessages.length - 1] = {
+                  ...lastRetryMessage,
+                  quickReply,
+                };
+              }
+            }
+            if (retryMessages.length > 0) {
+              let recoveryFailed = false;
+              let recoveryError: unknown;
+              try {
+                await sendMessageBatch(retryMessages, false);
+              } catch (recoveryFailure) {
+                recoveryFailed = true;
+                recoveryError = recoveryFailure;
+              }
+              if (recoveryFailed) {
+                // The fallback owns the latest delivery evidence. Do not replace
+                // an accepted or ambiguous fallback outcome with the first batch's
+                // definitive rejection.
+                throw recoveryError;
+              }
+              if (lastResult !== null) {
+                throw createChannelPartialDeliveryError(error, {
+                  messageIds: listMessageReceiptPlatformIds(lastResult.receipt),
+                  receipt: lastResult.receipt,
+                  visibleReplySent: true,
+                });
+              }
+            }
+          }
+          throw error;
+        }
       }
     };
 
@@ -142,6 +210,10 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       messageId: replyToId,
     });
     const sendTextWithQuickReply = async (text: string, quoteToken?: string) => {
+      if (shouldBatchMixedPayload && quickReply) {
+        pendingMessages.push({ type: "text", text, quickReply, ...quotedOption(quoteToken) });
+        return;
+      }
       if (quickReplyItems.length > 0 && quickReply) {
         await sendMessageBatch([{ type: "text", text, quickReply, ...quotedOption(quoteToken) }]);
         return;
@@ -182,47 +254,95 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       trackingId: lineData.trackingId,
     };
     const shouldSendQuickRepliesInline = chunks.length === 0 && hasQuickReplies;
+    const templateMessage = lineData.templateMessage
+      ? buildTemplate(lineData.templateMessage)
+      : undefined;
+    const richMessageCount =
+      Number(Boolean(lineData.flexMessage)) +
+      Number(Boolean(templateMessage)) +
+      Number(Boolean(location)) +
+      (orderedMessages ? 0 : processed.flexMessages.length);
+    const textMessageCount = orderedMessages?.length ?? chunks.length;
+    const mediaMessageCount = mediaUrls.filter((url) => Boolean(url?.trim())).length;
+    const shouldBatchMixedPayload =
+      !shouldSendQuickRepliesInline && richMessageCount + textMessageCount + mediaMessageCount > 1;
+    const pendingMessages: messagingApi.Message[] = [];
+    let mediaPreparationError: unknown;
     const sendMediaMessages = async () => {
       for (const url of mediaUrls) {
         const trimmed = url?.trim();
         if (!trimmed) {
           continue;
         }
-        await recordResult(
-          (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
-            ...sendOptions,
-            ...mediaOptions,
-            mediaUrl: trimmed,
-          }),
-        );
+        if (shouldBatchMixedPayload) {
+          try {
+            pendingMessages.push(await buildLineMediaMessage(trimmed, mediaOptions, to));
+          } catch (error) {
+            // Keep valid parts in the batch; report the failed media after they land.
+            mediaPreparationError ??= error;
+          }
+        } else {
+          await recordResult(
+            (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
+              ...sendOptions,
+              ...mediaOptions,
+              mediaUrl: trimmed,
+            }),
+          );
+        }
       }
     };
 
     if (!shouldSendQuickRepliesInline) {
       if (lineData.flexMessage) {
         const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-        await recordResult(sendFlex(to, lineData.flexMessage.altText, flexContents, sendOptions));
+        if (shouldBatchMixedPayload) {
+          pendingMessages.push(
+            outboundRuntime.createFlexMessage(lineData.flexMessage.altText, flexContents),
+          );
+        } else {
+          await recordResult(sendFlex(to, lineData.flexMessage.altText, flexContents, sendOptions));
+        }
       }
 
-      if (lineData.templateMessage) {
-        const template = buildTemplate(lineData.templateMessage);
+      if (templateMessage) {
+        const template = templateMessage;
         if (template?.type === "template") {
-          await recordResult(sendTemplate(to, template, sendOptions));
+          if (shouldBatchMixedPayload) {
+            pendingMessages.push(template);
+          } else {
+            await recordResult(sendTemplate(to, template, sendOptions));
+          }
         } else if (template) {
-          await recordResult(
-            sendText(to, template.text, { ...sendOptions, ...quotedOption(replyQuoteToken) }),
-          );
-          replyQuoteToken = undefined;
+          if (shouldBatchMixedPayload) {
+            pendingMessages.push({ ...template, ...quotedOption(replyQuoteToken) });
+            replyQuoteToken = undefined;
+          } else {
+            await recordResult(
+              sendText(to, template.text, { ...sendOptions, ...quotedOption(replyQuoteToken) }),
+            );
+            replyQuoteToken = undefined;
+          }
         }
       }
 
       if (location) {
-        await recordResult(sendLocation(to, location, sendOptions));
+        if (shouldBatchMixedPayload) {
+          pendingMessages.push(locationMessage!);
+        } else {
+          await recordResult(sendLocation(to, location, sendOptions));
+        }
       }
 
       if (!orderedMessages) {
         for (const flexMsg of processed.flexMessages) {
-          await recordResult(sendFlex(to, flexMsg.altText, flexMsg.contents, sendOptions));
+          if (shouldBatchMixedPayload) {
+            pendingMessages.push(
+              outboundRuntime.createFlexMessage(flexMsg.altText, flexMsg.contents),
+            );
+          } else {
+            await recordResult(sendFlex(to, flexMsg.altText, flexMsg.contents, sendOptions));
+          }
         }
       }
     }
@@ -242,12 +362,20 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         const quoteToken = index === quotedIndex ? replyQuoteToken : undefined;
         if (message.type === "flex") {
           if (isLast && quickReply) {
-            await sendMessageBatch([{ ...message, quickReply }]);
+            if (shouldBatchMixedPayload) {
+              pendingMessages.push({ ...message, quickReply });
+            } else {
+              await sendMessageBatch([{ ...message, quickReply }]);
+            }
+          } else if (shouldBatchMixedPayload) {
+            pendingMessages.push(message);
           } else {
             await recordResult(sendFlex(to, message.altText, message.contents, sendOptions));
           }
         } else if (isLast && hasQuickReplies) {
           await sendTextWithQuickReply(message.text, quoteToken);
+        } else if (shouldBatchMixedPayload) {
+          pendingMessages.push({ ...message, ...quotedOption(quoteToken) });
         } else {
           await recordResult(
             sendText(to, message.text, { ...sendOptions, ...quotedOption(quoteToken) }),
@@ -260,12 +388,14 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         const quoteToken = i === 0 ? replyQuoteToken : undefined;
         if (isLast && hasQuickReplies) {
           await sendTextWithQuickReply(chunk, quoteToken);
+        } else if (shouldBatchMixedPayload) {
+          pendingMessages.push({ type: "text", text: chunk, ...quotedOption(quoteToken) });
         } else {
           await recordResult(sendText(to, chunk, { ...sendOptions, ...quotedOption(quoteToken) }));
         }
       }
     } else if (shouldSendQuickRepliesInline) {
-      const quickReplyMessages: Array<Record<string, unknown>> = [];
+      const quickReplyMessages: messagingApi.Message[] = [];
       if (lineData.flexMessage) {
         quickReplyMessages.push(
           outboundRuntime.createFlexMessage(
@@ -276,8 +406,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           ),
         );
       }
-      if (lineData.templateMessage) {
-        const template = buildTemplate(lineData.templateMessage);
+      if (templateMessage) {
+        const template = templateMessage;
         if (template) {
           quickReplyMessages.push(
             template.type === "text" ? { ...template, ...quotedOption(replyQuoteToken) } : template,
@@ -297,16 +427,20 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         if (!trimmed) {
           continue;
         }
-        quickReplyMessages.push(await buildLineMediaMessage(trimmed, mediaOptions, to));
+        try {
+          quickReplyMessages.push(await buildLineMediaMessage(trimmed, mediaOptions, to));
+        } catch (error) {
+          mediaPreparationError ??= error;
+        }
       }
       if (quickReplyMessages.length > 0 && quickReply) {
         const lastIndex = quickReplyMessages.length - 1;
-        quickReplyMessages[lastIndex] = {
-          ...quickReplyMessages[lastIndex],
-          quickReply,
-        };
+        const lastMessage = quickReplyMessages[lastIndex];
+        if (lastMessage) {
+          quickReplyMessages[lastIndex] = { ...lastMessage, quickReply };
+        }
         await sendMessageBatch(quickReplyMessages);
-      } else if (quickReply) {
+      } else if (quickReply && mediaPreparationError === undefined) {
         await sendTextWithQuickReply(
           buildLineQuickReplyFallbackText(quickReplyLabels),
           replyQuoteToken,
@@ -318,7 +452,24 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       await sendMediaMessages();
     }
 
+    if (shouldBatchMixedPayload) {
+      await sendMessageBatch(pendingMessages);
+    }
+
     const completedResult = lastResult as LineSendResult | null;
+    if (mediaPreparationError !== undefined) {
+      if (completedResult) {
+        throw createChannelPartialDeliveryError(mediaPreparationError, {
+          messageIds: listMessageReceiptPlatformIds(completedResult.receipt),
+          receipt: completedResult.receipt,
+          visibleReplySent: true,
+        });
+      }
+      throw mediaPreparationError instanceof Error
+        ? mediaPreparationError
+        : new Error("LINE media preparation failed", { cause: mediaPreparationError });
+    }
+
     if (!completedResult) {
       throw new Error("Message must be non-empty for LINE sends");
     }

--- a/extensions/line/src/quote-reply-delivery.test.ts
+++ b/extensions/line/src/quote-reply-delivery.test.ts
@@ -1,3 +1,4 @@
+import type { messagingApi } from "@line/bot-sdk";
 // Line tests cover quoted reply delivery plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { chunkMarkdownText as chunkMarkdownTextForLine } from "openclaw/plugin-sdk/reply-runtime";
@@ -11,10 +12,15 @@ import { recordLineQuoteToken } from "./quote-tokens.js";
 import { setLineRuntime } from "./runtime.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
+const ssrfMocks = vi.hoisted(() => ({ resolvePinnedHostnameWithPolicy: vi.fn() }));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   logVerbose: logVerboseMock,
   danger: (t: string) => t,
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  resolvePinnedHostnameWithPolicy: ssrfMocks.resolvePinnedHostnameWithPolicy,
 }));
 
 // baseDeliveryParams answers on account "acc" in chat "line:user:1".
@@ -176,9 +182,14 @@ describe("the push delivery path", () => {
       cfg,
     });
 
-    expect(mocks.pushMessageLine.mock.calls.map((args) => [args[1], args[2].quoteToken])).toEqual([
-      ["first", "token-push"],
-      ["second", undefined],
+    expect(mocks.pushMessagesLine).toHaveBeenCalledOnce();
+    const messages = expectDefined(
+      mocks.pushMessagesLine.mock.calls[0]?.[1],
+      "push messages",
+    ) as messagingApi.Message[];
+    expect(messages).toEqual([
+      { type: "text", text: "first", quoteToken: "token-push" },
+      { type: "text", text: "second" },
     ]);
   });
 
@@ -256,10 +267,22 @@ describe("the push delivery path", () => {
     });
 
     // The caption is the only part LINE lets a quote ride on; the image itself cannot.
-    expect(mocks.pushMessageLine).toHaveBeenCalledExactlyOnceWith(
-      "line:group:Cmedia",
-      "here you go",
-      expect.objectContaining({ quoteToken: "token-media" }),
+    expect(mocks.pushMessagesLine).toHaveBeenCalledOnce();
+    const messages = expectDefined(
+      mocks.pushMessagesLine.mock.calls[0]?.[1],
+      "push messages",
+    ) as messagingApi.Message[];
+    expect(messages).toEqual([
+      { type: "text", text: "here you go", quoteToken: "token-media" },
+      {
+        type: "image",
+        originalContentUrl: "https://example.com/image.jpg",
+        previewImageUrl: "https://example.com/image.jpg",
+      },
+    ]);
+    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith(
+      "example.com",
+      expect.objectContaining({ policy: { allowPrivateNetwork: false } }),
     );
   });
 
@@ -290,12 +313,18 @@ describe("the push delivery path", () => {
       cfg,
     });
 
-    expect(mocks.pushFlexMessage).toHaveBeenCalledOnce();
-    expect(mocks.pushMessageLine).toHaveBeenCalledExactlyOnceWith(
-      "line:group:Cordered",
-      "After the card",
-      expect.objectContaining({ quoteToken: "token-ordered" }),
-    );
+    expect(mocks.pushMessagesLine).toHaveBeenCalledOnce();
+    const messages = expectDefined(
+      mocks.pushMessagesLine.mock.calls[0]?.[1],
+      "push messages",
+    ) as messagingApi.Message[];
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ type: "flex", altText: "Code" });
+    expect(messages[1]).toEqual({
+      type: "text",
+      text: "After the card",
+      quoteToken: "token-ordered",
+    });
   });
 
   it("sends unquoted when the push answers nothing", async () => {

--- a/extensions/line/src/template-carousel-delivery.test.ts
+++ b/extensions/line/src/template-carousel-delivery.test.ts
@@ -74,7 +74,8 @@ describe("LINE carousel fallback delivery", () => {
   it.each(["", "After"])(
     "quotes the direct carousel fallback once when the following text is %j",
     async (text) => {
-      const { runtime, pushMessageLine, pushTemplateMessage } = createOutboundRuntime();
+      const { runtime, pushMessageLine, pushMessagesLine, pushTemplateMessage } =
+        createOutboundRuntime();
       setLineRuntime(runtime);
       recordLineQuoteToken({
         accountId: "default",
@@ -93,19 +94,24 @@ describe("LINE carousel fallback delivery", () => {
       });
 
       expect(pushTemplateMessage).not.toHaveBeenCalled();
-      expect(pushMessageLine).toHaveBeenNthCalledWith(
-        1,
-        "line:user:Ucarousel",
-        fallbackText,
-        expect.objectContaining({ quoteToken: "q-carousel" }),
-      );
-      expect(pushMessageLine).toHaveBeenCalledTimes(text ? 2 : 1);
       if (text) {
-        expect(pushMessageLine).toHaveBeenNthCalledWith(
-          2,
+        expect(pushMessageLine).not.toHaveBeenCalled();
+        expect(pushMessagesLine).toHaveBeenCalledTimes(1);
+        expect(pushMessagesLine).toHaveBeenCalledWith(
           "line:user:Ucarousel",
-          text,
-          expect.not.objectContaining({ quoteToken: expect.anything() }),
+          [
+            { type: "text", text: fallbackText, quoteToken: "q-carousel" },
+            { type: "text", text },
+          ],
+          expect.any(Object),
+        );
+      } else {
+        expect(pushMessagesLine).not.toHaveBeenCalled();
+        expect(pushMessageLine).toHaveBeenCalledTimes(1);
+        expect(pushMessageLine).toHaveBeenCalledWith(
+          "line:user:Ucarousel",
+          fallbackText,
+          expect.objectContaining({ quoteToken: "q-carousel" }),
         );
       }
     },
@@ -148,7 +154,8 @@ describe("LINE carousel fallback delivery", () => {
   });
 
   it("sends direct fallback before the ordinary text without calling template delivery", async () => {
-    const { runtime, pushMessageLine, pushTemplateMessage } = createOutboundRuntime();
+    const { runtime, pushMessageLine, pushMessagesLine, pushTemplateMessage } =
+      createOutboundRuntime();
     setLineRuntime(runtime);
 
     await lineOutboundAdapter.sendPayload!({
@@ -160,7 +167,16 @@ describe("LINE carousel fallback delivery", () => {
     });
 
     expect(pushTemplateMessage).not.toHaveBeenCalled();
-    expect(pushMessageLine.mock.calls.map((call) => call[1])).toEqual([fallbackText, "After"]);
+    expect(pushMessageLine).not.toHaveBeenCalled();
+    expect(pushMessagesLine).toHaveBeenCalledTimes(1);
+    expect(pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:1",
+      [
+        { type: "text", text: fallbackText },
+        { type: "text", text: "After" },
+      ],
+      expect.any(Object),
+    );
   });
 
   it("keeps the auto-reply fallback and ordinary text in the same reply", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LINE replies containing multiple parts, such as a card, caption, and image, consumed one monthly message per part instead of using one request. It also preserves the delivery classification of a fallback request when that request is accepted but its receipt is unreadable, or when transport outcome is ambiguous.

Fixes #142734

## Why This Change Was Made

The LINE outbound adapter preserves the existing part order while collecting compatible text, Flex, template, location, and media messages into LINE's existing five-message batch boundary. A definitive mixed-batch 400 is treated as an atomic rejection: recovery retries only safe text/quick-reply content. Valid rich messages from the rejected batch are not replayed, so bounded rich-message loss is accepted to avoid duplicate delivery and keep recovery deterministic. If the fallback throws, its error is propagated instead of restoring the first batch's definitive non-dispatch rejection.

## User Impact

Mixed LINE replies use the provider's request-based quota accounting while preserving message order, quick replies, and delivery receipts. If LINE definitively rejects a mixed batch, text and quick replies are recovered while rich request-mates from that rejected batch may be lost; accepted or ambiguous fallback outcomes still retain their delivery classification.

## Evidence

- Exact-head real behavior proof (`695b70e9a9913fd1989af8cf12e1a61e724251af`) exercised the production `lineOutboundAdapter.sendPayload` -> `pushMessagesLine` -> LINE HTTP client path, including retry-key handling, response parsing, and delivery classification. Only the external `api.line.me` message endpoint was redirected to a local loopback HTTP server.
- On the exact head, the mixed Flex + location + text input made 1 provider POST containing all 3 messages in order; authorization and retry-key headers were present.
- On the exact head, a forced mixed-batch 400 followed by an accepted response with malformed JSON propagated `CHANNEL_PARTIAL_DELIVERY` with `visibleReplySent=true` and did not rethrow the original 400.
- Exact-head negative control (plain text) remained 1 provider POST with one text message.
- Changed-file focused suite: `pnpm exec vitest run extensions/line/src/channel.sendPayload.test.ts extensions/line/src/channel.sendPayload.delivery-outcomes.test.ts` — 49/49 passed.
- Quote-delivery focused suite: `pnpm exec vitest run extensions/line/src/quote-reply-delivery.test.ts` — 13/13 passed, including ordered batch contents and the single quote carrier for chunked, media, and leading-Flex replies.
- Carousel/template fallback suite: `pnpm exec vitest run extensions/line/src/template-carousel-delivery.test.ts` — 6/6 passed, including direct fallback ordering, quote carriage, and no template-sender regression.
- Combined LINE regression suite: `pnpm exec vitest run extensions/line/src/quote-reply-delivery.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/channel.sendPayload.delivery-outcomes.test.ts extensions/line/src/template-carousel-delivery.test.ts` — 68/68 passed.
- The two new regressions cover accepted-unreadable fallback evidence and ambiguous fallback transport failure.
- Canonical contract: [LINE Messaging API: Sending messages](https://developers.line.biz/en/docs/messaging-api/sending-messages/) supports up to five messages in one request; the implementation reuses that provider limit while preserving receipts.

```text
$ pnpm exec tsx proof/real-behavior-proof.ts <repo-root>
head 695b70e9a9913fd1989af8cf12e1a61e724251af:
  mixed: 1 POST /v2/bot/message/push; messages=3; types flex -> location -> text; status=200
  negative-control: 1 POST; messages=1; type text; status=200
  recovery: first POST messages=3 status=400; fallback POST messages=1 status=200 with malformed JSON
  propagated: code=CHANNEL_PARTIAL_DELIVERY; visibleReplySent=true; messageIds=[]
```

The exact-head run uses the same executable, input, production entrypoint, and loopback boundary as the earlier proof. This repair changes only the quote-delivery assertions and their SSRF test seam; the production batching and recovery path is unchanged. The recovery output demonstrates the accepted policy: a rejected mixed batch is not replayed as rich messages, while safe text recovery still preserves the fallback delivery classification.

<details>
<summary>proof/real-behavior-proof.ts</summary>

```ts
import http from "node:http";
import { execFileSync } from "node:child_process";
import path from "node:path";
import { pathToFileURL } from "node:url";

async function main() {
  const repoRoot = path.resolve(process.argv[2] ?? process.cwd());
  const { Agent, Dispatcher, getGlobalDispatcher, setGlobalDispatcher } =
    await import(pathToFileURL(path.join(repoRoot, "node_modules/undici/index.js")).href);
  const { lineOutboundAdapter } = await import(
    pathToFileURL(path.join(repoRoot, "extensions/line/src/outbound.ts")).href,
  );
  const { setLineRuntime } = await import(
    pathToFileURL(path.join(repoRoot, "extensions/line/src/runtime.ts")).href,
  );
  const { isChannelPartialDeliveryError } = await import(
    pathToFileURL(path.join(repoRoot, "src/plugin-sdk/channel-inbound.ts")).href,
  );

  const recorded: Array<{
    path: string;
    method: string;
    authPresent: boolean;
    retryKey: string | null;
    to: string | null;
    messageCount: number;
    messageTypes: string[];
    responseStatus: number;
  }> = [];
  let recoveryMode = false;
  let recoveryBatchRejected = false;
  const server = http.createServer((req, res) => {
    let body = "";
    req.on("data", (chunk) => {
      body += chunk;
    });
    req.on("end", () => {
      let parsed: { to?: string; messages?: Array<{ type?: string }> } = {};
      try {
        parsed = JSON.parse(body);
      } catch {
        // Keep malformed requests visible in the recorded transcript.
      }
      const messages = parsed.messages ?? [];
      recorded.push({
        path: req.url ?? "",
        method: req.method ?? "",
        authPresent: Boolean(req.headers.authorization),
        retryKey: req.headers["x-line-retry-key"] ? "<uuid>" : null,
        to: parsed.to ?? null,
        messageCount: messages.length,
        messageTypes: messages.map((message) => message.type ?? "unknown"),
        responseStatus: 0,
      });
      const record = recorded.at(-1)!;
      const rejectMixedBatch = recoveryMode && !recoveryBatchRejected && messages.length > 1;
      if (rejectMixedBatch) {
        recoveryBatchRejected = true;
        record.responseStatus = 400;
        res.writeHead(400, { "content-type": "text/plain" });
        res.end("invalid rich message");
        return;
      }
      const acceptedReceiptUnreadable =
        recoveryMode && recoveryBatchRejected && messages.length === 1;
      if (acceptedReceiptUnreadable) {
        record.responseStatus = 200;
        res.writeHead(200, {
          "content-type": "application/json",
          "x-line-request-id": `proof-${recorded.length}`,
        });
        res.end("not-json");
        return;
      }
      record.responseStatus = 200;
      res.writeHead(200, {
        "content-type": "application/json",
        "x-line-request-id": `proof-${recorded.length}`,
      });
      const sentMessages = Array.from({ length: Math.max(messages.length, 1) }, (_, index) => ({
        id: `proof-msg-${recorded.length}-${index + 1}`,
      }));
      res.end(JSON.stringify({ sentMessages }));
    });
  });

  class RewriteDispatcher extends Dispatcher {
    private readonly agent = new Agent();
    dispatch(options: any, handler: any): boolean {
      const origin = String(options.origin ?? "");
      const requestPath = String(options.path ?? "");
      const target =
        origin === "https://api.line.me" && requestPath.startsWith("/v2/bot/message/")
          ? `http://127.0.0.1:${(server.address() as any).port}`
          : null;
      return this.agent.dispatch(target ? { ...options, origin: target } : options, handler);
    }
    close() {
      return this.agent.close();
    }
    destroy() {
      return this.agent.destroy();
    }
  }

  const previousDispatcher = getGlobalDispatcher();
  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  const dispatcher = new RewriteDispatcher();
  setGlobalDispatcher(dispatcher);
  setLineRuntime({
    channel: {
      text: {
        chunkMarkdownText: (text: string) => [text],
        resolveTextChunkLimit: () => 5000,
      },
    },
  } as any);

  const cfg = { channels: { line: { channelAccessToken: "proof-dummy-token" } } };
  const mixedPayload = {
    text: "Caption",
    channelData: {
      line: {
        flexMessage: {
          altText: "Card",
          contents: { type: "bubble", body: { type: "box", layout: "vertical", contents: [] } },
        },
        location: { title: "OpenClaw proof", address: "Loopback", latitude: 1, longitude: 2 },
        quickReplies: ["Reply"],
      },
    },
  };

  try {
    const sourceHead = execFileSync("git", ["rev-parse", "HEAD"], {
      cwd: repoRoot,
      encoding: "utf8",
    }).trim();
    recoveryMode = false;
    recoveryBatchRejected = false;
    recorded.length = 0;
    await lineOutboundAdapter.sendPayload!({
      to: "line:user:proof-target",
      text: mixedPayload.text,
      payload: mixedPayload as any,
      cfg: cfg as any,
    });
    const mixedCalls = recorded.length;
    await lineOutboundAdapter.sendPayload!({
      to: "line:user:proof-target",
      text: "Caption",
      payload: { text: "Caption" } as any,
      cfg: cfg as any,
    });
    const mixedAndControl = {
      mixed: {
        pushRequestsToLineApi: mixedCalls,
        requests: recorded.slice(0, mixedCalls),
      },
      negativeControl: {
        pushRequestsToLineApi: recorded.length - mixedCalls,
        requests: recorded.slice(mixedCalls),
      },
    };

    recoveryMode = true;
    recoveryBatchRejected = false;
    recorded.length = 0;
    let recoveryError: unknown;
    try {
      await lineOutboundAdapter.sendPayload!({
        to: "line:user:proof-target",
        text: mixedPayload.text,
        payload: mixedPayload as any,
        cfg: cfg as any,
      });
    } catch (error) {
      recoveryError = error;
    }
    const recoveryPartial = isChannelPartialDeliveryError(recoveryError)
      ? {
          code: recoveryError.code,
          visibleReplySent: recoveryError.deliveryResult.visibleReplySent,
          messageIds: recoveryError.deliveryResult.messageIds,
        }
      : null;
    console.log(
      JSON.stringify({
        testedHead: sourceHead,
        ...mixedAndControl,
        recovery: {
          requests: recorded,
          propagatedPartialDelivery: recoveryPartial,
          errorMessage: recoveryError instanceof Error ? recoveryError.message : null,
        },
      }),
    );
  } finally {
    setGlobalDispatcher(previousDispatcher);
    await dispatcher.close();
    await new Promise<void>((resolve) => server.close(() => resolve()));
  }
}

void main().catch((error: unknown) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
