### PR TITLE
fix(progress): stop command exits from crowding out active work

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -358,6 +358,12 @@ Limit how many lines stay visible (default 8):
 }
 ```
 
+With `toolProgress: true`, command exit rows use ordinary tool-log capacity,
+including exits with a code other than `0`. Older exits scroll out as newer
+activity arrives and do not reduce the plan's line budget. Approval requests
+and explicit `failed`, `error`, or `blocked` states still take priority. With
+the tool log hidden, non-zero exits remain visible as attention lines.
+
 Progress lines are compacted automatically to reduce chat-bubble reflow while
 the draft is edited, and OpenClaw truncates long lines so repeated draft edits
 do not wrap differently on every update. The default per-line budget is 120

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -96,6 +96,7 @@ export function createProgressState(
       draftState.answerLane.finalized = false;
       draftState.answerLane.stream?.updatePreview(
         renderTelegramProgressDraftPreview(options.snapshot, {
+          toolProgress: progressCompositor.previewToolProgressEnabled,
           richMessages: config.telegramCfg.richMessages === true,
           maxLines: resolveChannelProgressDraftMaxLines(config.telegramCfg),
           maxLineChars: resolveChannelProgressDraftMaxLineChars(config.telegramCfg),

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -90,6 +90,34 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(preview.text).toContain("1/4 done");
     expect(preview.text).not.toContain("Read files");
   });
+
+  it("keeps the full plan when non-zero exits fill the activity window", () => {
+    const preview = renderTelegramProgressDraftPreview(
+      {
+        lines: Array.from({ length: 8 }, (_, index) => ({
+          id: `command:${index}`,
+          kind: "command-output" as const,
+          label: "Exec",
+          text: `🛠️ exit ${index + 1}`,
+          status: `exit ${index + 1}`,
+        })),
+        plan: [
+          { step: "Inspect", status: "completed" },
+          { step: "Repair", status: "in_progress" },
+          { step: "Verify", status: "pending" },
+          { step: "Audit", status: "pending" },
+          { step: "Ship", status: "pending" },
+        ],
+      },
+      { ...options, maxLines: 8 },
+    );
+    const text = telegramHtmlToPlainTextFallback(preview.text);
+    for (const step of ["Inspect", "Repair", "Verify", "Audit", "Ship"]) {
+      expect(text).toContain(step);
+    }
+    expect(text).toContain("exit 8");
+    expect(text).not.toContain("exit 1");
+  });
   it.each([true, false])(
     "renders retained edit totals without a plan (rich=%s)",
     (richMessages) => {

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { telegramHtmlToPlainTextFallback } from "./format.js";
 import { renderTelegramProgressDraftPreview } from "./progress-draft-preview.js";
 
-const options = { richMessages: false, maxLines: 8, maxLineChars: 300 };
+const options = { richMessages: false, toolProgress: true, maxLines: 8, maxLineChars: 300 };
 
 describe("renderTelegramProgressDraftPreview", () => {
   it.each(["Bash", "bash", "exec", "Read"])("prints one tool icon for %s", (name) => {
@@ -67,29 +67,59 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(rich.complete).toBe(true);
   });
 
-  it("keeps attention and the active step within the configured window", () => {
-    const preview = renderTelegramProgressDraftPreview(
-      {
-        lines: [
-          { kind: "tool", label: "Read", text: "Read files" },
-          { kind: "approval", label: "Approval", text: "Approval", detail: "Confirm access" },
-        ],
-        diffStat: { files: 1, added: 2, removed: 1 },
-        plan: [
-          { step: "Inspect", status: "completed" },
-          { step: "Repair", status: "in_progress" },
-          { step: "Verify", status: "pending" },
-          { step: "Ship", status: "pending" },
-        ],
-      },
-      { ...options, richMessages: true, maxLines: 3 },
-    );
-    expect(preview.text.split("\n")).toHaveLength(3);
-    expect(preview.text).toContain("Confirm access");
-    expect(preview.text).toContain("Repair (in progress)");
-    expect(preview.text).toContain("1/4 done");
-    expect(preview.text).not.toContain("Read files");
-  });
+  it.each([undefined, "exit 1", "exit 0"])(
+    "keeps approval and the active step within the window regardless of status (%s)",
+    (status) => {
+      const preview = renderTelegramProgressDraftPreview(
+        {
+          lines: [
+            { kind: "tool", label: "Read", text: "Read files" },
+            {
+              kind: "approval",
+              label: "Approval",
+              text: "Approval",
+              detail: "Confirm access",
+              status,
+            },
+          ],
+          diffStat: { files: 1, added: 2, removed: 1 },
+          plan: [
+            { step: "Inspect", status: "completed" },
+            { step: "Repair", status: "in_progress" },
+            { step: "Verify", status: "pending" },
+            { step: "Ship", status: "pending" },
+          ],
+        },
+        { ...options, richMessages: true, maxLines: 3 },
+      );
+      expect(preview.text.split("\n")).toHaveLength(3);
+      expect(preview.text).toContain("Confirm access");
+      expect(preview.text).toContain("Repair (in progress)");
+      expect(preview.text).toContain("1/4 done");
+      expect(preview.text).not.toContain("Read files");
+    },
+  );
+
+  it.each([true, false])(
+    "keeps quiet non-zero exits visible above a full plan (rich=%s)",
+    (richMessages) => {
+      const preview = renderTelegramProgressDraftPreview(
+        {
+          lines: [{ kind: "command-output", label: "Exec", text: "🛠️ exit 1", status: "exit 1" }],
+          plan: [
+            { step: "Inspect", status: "completed" },
+            { step: "Repair", status: "in_progress" },
+            { step: "Verify", status: "pending" },
+          ],
+        },
+        { ...options, richMessages, toolProgress: false, maxLines: 3 },
+      );
+      const text = telegramHtmlToPlainTextFallback(preview.text);
+      expect(text).toContain("exit 1");
+      expect(text).toContain("Repair (in progress)");
+      expect(text.split("\n")).toHaveLength(3);
+    },
+  );
 
   it("keeps the full plan when non-zero exits fill the activity window", () => {
     const preview = renderTelegramProgressDraftPreview(

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -19,11 +19,13 @@ import { markdownToTelegramRichBlocks } from "./rich-blocks.js";
 import { buildTelegramRichBlocksPlan } from "./rich-message.js";
 
 function isTelegramProgressPriorityLine(line: ChannelProgressDraftCompositorLine): boolean {
-  if (!isChannelProgressAttentionLine(line) || typeof line === "string") {
+  if (typeof line === "string") {
     return false;
   }
   const status = line.status?.toLowerCase();
-  return status?.startsWith("exit ") !== true || status === "exit 0";
+  return (
+    line.kind === "approval" || status === "failed" || status === "error" || status === "blocked"
+  );
 }
 
 // Each row has one content decision; both Telegram transports use that row.
@@ -79,7 +81,7 @@ function progressLineText(
 
 export function renderTelegramProgressDraftPreview(
   snapshot: ChannelProgressDraftCompositorSnapshot,
-  options: { richMessages: boolean; maxLines: number; maxLineChars: number },
+  options: { richMessages: boolean; maxLines: number; maxLineChars: number; toolProgress: boolean },
 ): TelegramDraftPreview {
   const { maxLines, maxLineChars } = options;
   const activity =
@@ -91,13 +93,16 @@ export function renderTelegramProgressDraftPreview(
             !line.id?.startsWith("commentary:"),
         )
       : snapshot.lines;
-  const attention = activity.filter(isTelegramProgressPriorityLine);
+  const isPriorityLine = options.toolProgress
+    ? isTelegramProgressPriorityLine
+    : isChannelProgressAttentionLine;
+  const attention = activity.filter(isPriorityLine);
   const checklist = selectPlanChecklistSteps(snapshot.plan ?? [], {
     maxLines: maxLines - attention.length,
   });
   const checklistLines = checklist.steps.length + (checklist.summary ? 1 : 0);
   const lineBudget = Math.max(0, maxLines - checklistLines);
-  const lines = [...activity.filter((line) => !isTelegramProgressPriorityLine(line)), ...attention];
+  const lines = [...activity.filter((line) => !isPriorityLine(line)), ...attention];
   const visibleLines = lineBudget ? lines.slice(-lineBudget) : [];
   const diffStat =
     visibleLines.length + checklistLines < maxLines

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -18,6 +18,14 @@ import {
 import { markdownToTelegramRichBlocks } from "./rich-blocks.js";
 import { buildTelegramRichBlocksPlan } from "./rich-message.js";
 
+function isTelegramProgressPriorityLine(line: ChannelProgressDraftCompositorLine): boolean {
+  if (!isChannelProgressAttentionLine(line) || typeof line === "string") {
+    return false;
+  }
+  const status = line.status?.toLowerCase();
+  return status?.startsWith("exit ") !== true || status === "exit 0";
+}
+
 // Each row has one content decision; both Telegram transports use that row.
 type ProgressText = { html: string; rich: RichText };
 
@@ -83,13 +91,13 @@ export function renderTelegramProgressDraftPreview(
             !line.id?.startsWith("commentary:"),
         )
       : snapshot.lines;
-  const attention = activity.filter(isChannelProgressAttentionLine);
+  const attention = activity.filter(isTelegramProgressPriorityLine);
   const checklist = selectPlanChecklistSteps(snapshot.plan ?? [], {
     maxLines: maxLines - attention.length,
   });
   const checklistLines = checklist.steps.length + (checklist.summary ? 1 : 0);
   const lineBudget = Math.max(0, maxLines - checklistLines);
-  const lines = [...activity.filter((line) => !isChannelProgressAttentionLine(line)), ...attention];
+  const lines = [...activity.filter((line) => !isTelegramProgressPriorityLine(line)), ...attention];
   const visibleLines = lineBudget ? lines.slice(-lineBudget) : [];
   const diffStat =
     visibleLines.length + checklistLines < maxLines

--- a/src/channels/progress-draft-compositor.quiet.test.ts
+++ b/src/channels/progress-draft-compositor.quiet.test.ts
@@ -177,8 +177,16 @@ describe("createChannelProgressDraftCompositor quiet drafts", () => {
           toolCallId: "failed-command",
           exitCode: 1,
         });
-        expect(update.mock.lastCall?.[0]).toContain("exit 1");
-        expect(update.mock.lastCall?.[1]).toMatchObject({ flush: true });
+        // Non-zero exits stay eligible for quiet-mode display but do not take
+        // capacity from a full plan or receive attention-only immediate flushes.
+        expect(
+          progress
+            .getSnapshot()
+            .lines.some(
+              (line) => typeof line === "object" && "text" in line && line.text.includes("exit 1"),
+            ),
+        ).toBe(true);
+        expect(update.mock.lastCall?.[1]).not.toMatchObject({ flush: true });
         await progress.pushCommandOutputEvent({
           phase: "end",
           toolCallId: "failed-command",
@@ -190,4 +198,69 @@ describe("createChannelProgressDraftCompositor quiet drafts", () => {
       }
     },
   );
+
+  it("keeps a non-zero exit visible when the quiet draft has room", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "progress",
+          progress: { toolProgress: false, maxLines: 3, label: false },
+        },
+      },
+      update,
+    });
+    try {
+      await progress.start();
+      await progress.pushCommandOutputEvent({
+        phase: "end",
+        toolCallId: "failed-command",
+        exitCode: 1,
+      });
+      expect(update.mock.lastCall?.[0]).toContain("exit 1");
+      expect(update.mock.lastCall?.[1]).not.toMatchObject({ flush: true });
+    } finally {
+      progress.cancel();
+    }
+  });
+
+  it("lets new activity replace old non-zero exits without collapsing the plan", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "progress",
+          progress: { toolProgress: true, maxLines: 8, commentary: true, label: false },
+        },
+      },
+      update,
+    });
+    try {
+      await progress.pushPlanProgress([
+        { step: "Inspect", status: "completed" },
+        { step: "Repair", status: "in_progress" },
+        { step: "Verify", status: "pending" },
+        { step: "Audit", status: "pending" },
+        { step: "Ship", status: "pending" },
+      ]);
+      for (let index = 1; index <= 8; index++) {
+        await progress.pushCommandOutputEvent({
+          phase: "end",
+          toolCallId: `failed-${index}`,
+          exitCode: index,
+        });
+      }
+      await progress.pushToolEvent({ name: "read", toolCallId: "new-work", phase: "start" });
+
+      const rendered = update.mock.lastCall?.[0] ?? "";
+      for (const step of ["Inspect", "Repair", "Verify", "Audit", "Ship"]) {
+        expect(rendered).toContain(step);
+      }
+      expect(rendered).toContain("Read");
+      expect(rendered).not.toContain("exit 1");
+      expect(progress.getSnapshot().lines).toHaveLength(8);
+    } finally {
+      progress.cancel();
+    }
+  });
 });

--- a/src/channels/progress-draft-compositor.quiet.test.ts
+++ b/src/channels/progress-draft-compositor.quiet.test.ts
@@ -172,21 +172,85 @@ describe("createChannelProgressDraftCompositor quiet drafts", () => {
         );
         await progress.pushApprovalEvent({ phase: "resolved", approvalId: "approval-1" });
         expect(update.mock.lastCall?.[0]).not.toContain("Run checks");
+      } finally {
+        progress.cancel();
+      }
+    },
+  );
+
+  it("starts and flushes a quiet draft for a non-zero exit", async () => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "progress",
+          progress: { toolProgress: false, maxLines: 3, label: false },
+        },
+      },
+      update,
+    });
+    try {
+      await progress.pushCommandOutputEvent({
+        phase: "end",
+        toolCallId: "failed-command",
+        exitCode: 1,
+      });
+      expect(progress.hasStarted).toBe(true);
+      expect(update.mock.lastCall?.[0]).toContain("exit 1");
+      expect(update.mock.lastCall?.[1]).toMatchObject({ flush: true });
+    } finally {
+      progress.cancel();
+    }
+  });
+
+  it.each([
+    { presentation: undefined, toolProgress: false, maxLines: 1 },
+    { presentation: undefined, toolProgress: false, maxLines: 3 },
+    { presentation: "summary" as const, toolProgress: false, maxLines: 1 },
+    { presentation: "summary" as const, toolProgress: true, maxLines: 3 },
+  ])(
+    "keeps exits above a full quiet plan through reasoning and commentary ($presentation, $toolProgress, $maxLines)",
+    async ({ presentation, toolProgress, maxLines }) => {
+      const update = vi.fn();
+      const progress = createTestProgressDraftCompositor({
+        presentation,
+        entry: {
+          streaming: {
+            mode: "progress",
+            progress: { toolProgress, maxLines, commentary: true, label: false },
+          },
+        },
+        update,
+      });
+      try {
+        await progress.pushPlanProgress([
+          { step: "Inspect", status: "completed" },
+          { step: "Repair", status: "in_progress" },
+          { step: "Verify", status: "pending" },
+        ]);
         await progress.pushCommandOutputEvent({
           phase: "end",
           toolCallId: "failed-command",
           exitCode: 1,
         });
-        // Non-zero exits stay eligible for quiet-mode display but do not take
-        // capacity from a full plan or receive attention-only immediate flushes.
-        expect(
-          progress
-            .getSnapshot()
-            .lines.some(
-              (line) => typeof line === "object" && "text" in line && line.text.includes("exit 1"),
-            ),
-        ).toBe(true);
-        expect(update.mock.lastCall?.[1]).not.toMatchObject({ flush: true });
+        expect(update.mock.lastCall?.[0]).toContain("exit 1");
+        expect(update.mock.lastCall?.[1]).toMatchObject({ flush: true });
+        for (let index = 0; index < 5; index++) {
+          await progress.pushToolEvent({
+            name: "read",
+            toolCallId: `read-${index}`,
+            phase: "start",
+          });
+          await progress.pushReasoningProgress(`Thinking ${index}`, { snapshot: true });
+          expect(update.mock.lastCall?.[0]).toContain("exit 1");
+          await progress.pushCommentaryProgress(`Inspecting file ${index}`, {
+            itemId: `comment-${index}`,
+          });
+          expect(update.mock.lastCall?.[0]).toContain("exit 1");
+        }
+        expect(update.mock.lastCall?.[0].split("\n").filter(Boolean).length).toBeLessThanOrEqual(
+          maxLines,
+        );
         await progress.pushCommandOutputEvent({
           phase: "end",
           toolCallId: "failed-command",
@@ -199,30 +263,51 @@ describe("createChannelProgressDraftCompositor quiet drafts", () => {
     },
   );
 
-  it("keeps a non-zero exit visible when the quiet draft has room", async () => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: {
-        streaming: {
-          mode: "progress",
-          progress: { toolProgress: false, maxLines: 3, label: false },
+  it.each(["failed", "error", "blocked"])(
+    "flushes and retains explicit %s status while tool progress is enabled",
+    async (status) => {
+      const update = vi.fn();
+      const progress = createTestProgressDraftCompositor({
+        entry: {
+          streaming: {
+            mode: "progress",
+            progress: { toolProgress: true, maxLines: 3, commentary: true, label: false },
+          },
         },
-      },
-      update,
-    });
-    try {
-      await progress.start();
-      await progress.pushCommandOutputEvent({
-        phase: "end",
-        toolCallId: "failed-command",
-        exitCode: 1,
+        update,
       });
-      expect(update.mock.lastCall?.[0]).toContain("exit 1");
-      expect(update.mock.lastCall?.[1]).not.toMatchObject({ flush: true });
-    } finally {
-      progress.cancel();
-    }
-  });
+      try {
+        await progress.pushPlanProgress([
+          { step: "Inspect", status: "completed" },
+          { step: "Repair", status: "in_progress" },
+          { step: "Verify", status: "pending" },
+        ]);
+        await progress.pushItemEvent({
+          itemId: "attention-item",
+          kind: "tool",
+          name: "read",
+          status,
+          progressText: "Check access",
+        });
+        expect(update.mock.lastCall?.[0]).toContain("Check access");
+        expect(update.mock.lastCall?.[1]).toMatchObject({ flush: true });
+        for (let index = 0; index < 5; index++) {
+          await progress.pushToolEvent({
+            name: "read",
+            toolCallId: `read-${index}`,
+            phase: "start",
+          });
+          await progress.pushCommentaryProgress(`Inspecting file ${index}`, {
+            itemId: `comment-${index}`,
+          });
+        }
+        expect(update.mock.lastCall?.[0]).toContain("Check access");
+        expect(update.mock.lastCall?.[0].split("\n").filter(Boolean).length).toBeLessThanOrEqual(3);
+      } finally {
+        progress.cancel();
+      }
+    },
+  );
 
   it("lets new activity replace old non-zero exits without collapsing the plan", async () => {
     const update = vi.fn();

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -22,6 +22,7 @@ import {
   type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressAttentionLine,
+  isChannelProgressPriorityLine,
   isChannelProgressDraftWorkToolName,
   mergeChannelProgressDraftLine,
   normalizeChannelProgressDraftLineIdentity,
@@ -404,8 +405,9 @@ export function createChannelProgressDraftCompositor(params: {
     }
     const progressLine = typeof line === "object" && line !== undefined ? line : normalized;
     // Approvals and failures stay visible even when the rolling tool log is off.
-    const needsAttention = isChannelProgressAttentionLine(progressLine);
-    const shouldStoreLine = !quietProgress || needsAttention;
+    const needsAttention = isChannelProgressPriorityLine(progressLine);
+    const shouldStartImmediately = isChannelProgressAttentionLine(progressLine);
+    const shouldStoreLine = !quietProgress || isChannelProgressAttentionLine(progressLine);
     const nextLines = shouldStoreLine
       ? mergeChannelProgressDraftLine(lines, progressLine, {
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
@@ -442,7 +444,7 @@ export function createChannelProgressDraftCompositor(params: {
       return shouldStoreLine ? await publish() : false;
     }
     // Attention bypasses startup delay and adapter batching even with the tool log enabled.
-    if (options?.startImmediately || params.shouldStartNow?.(line) || needsAttention) {
+    if (options?.startImmediately || params.shouldStartNow?.(line) || shouldStartImmediately) {
       const flush = options?.flush === true || needsAttention;
       return await startAndRender(flush ? { flush: true } : undefined);
     }

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -20,11 +20,11 @@ import {
   createChannelProgressDraftGate,
   type AgentPlanStep,
   type ChannelProgressDraftLine,
-  formatChannelProgressDraftText,
+  formatChannelProgressDraftTextForStreaming,
   isChannelProgressAttentionLine,
   isChannelProgressPriorityLine,
   isChannelProgressDraftWorkToolName,
-  mergeChannelProgressDraftLine,
+  mergeChannelProgressDraftLineForStreaming,
   normalizeChannelProgressDraftLineIdentity,
   resolveChannelProgressDraftLabel,
   resolveChannelProgressDraftMaxLineChars,
@@ -187,7 +187,8 @@ export function createChannelProgressDraftCompositor(params: {
     // `lines`) would print them twice if they also appeared in this text.
     const linesRenderedByChannel =
       params.rendersRollingLinesNatively === true && Boolean(narration || planSteps?.length);
-    return formatChannelProgressDraftText({
+    return formatChannelProgressDraftTextForStreaming({
+      toolProgress: !quietProgress,
       presentation: params.presentation,
       entry: params.entry,
       lines: linesRenderedByChannel ? [] : draftLines,
@@ -405,11 +406,14 @@ export function createChannelProgressDraftCompositor(params: {
     }
     const progressLine = typeof line === "object" && line !== undefined ? line : normalized;
     // Approvals and failures stay visible even when the rolling tool log is off.
-    const needsAttention = isChannelProgressPriorityLine(progressLine);
+    const needsAttention = quietProgress
+      ? isChannelProgressAttentionLine(progressLine)
+      : isChannelProgressPriorityLine(progressLine);
     const shouldStartImmediately = isChannelProgressAttentionLine(progressLine);
     const shouldStoreLine = !quietProgress || isChannelProgressAttentionLine(progressLine);
     const nextLines = shouldStoreLine
-      ? mergeChannelProgressDraftLine(lines, progressLine, {
+      ? mergeChannelProgressDraftLineForStreaming(lines, progressLine, {
+          toolProgress: !quietProgress,
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
         })
       : typeof line === "object" && line.id
@@ -687,7 +691,7 @@ export function createChannelProgressDraftCompositor(params: {
       const priorIndex =
         lastReasoningLine === undefined ? -1 : lines.lastIndexOf(lastReasoningLine);
       if (params.presentation === "summary") {
-        lines = mergeChannelProgressDraftLine(
+        lines = mergeChannelProgressDraftLineForStreaming(
           lines,
           {
             id: "reasoning",
@@ -696,13 +700,17 @@ export function createChannelProgressDraftCompositor(params: {
             label: "Reasoning",
             prefix: false,
           },
-          { maxLines: resolveChannelProgressDraftMaxLines(params.entry) },
+          {
+            maxLines: resolveChannelProgressDraftMaxLines(params.entry),
+            toolProgress: !quietProgress,
+          },
         );
       } else if (priorIndex >= 0) {
         lines = [...lines];
         lines[priorIndex] = displayLine;
       } else {
-        lines = mergeChannelProgressDraftLine(lines, displayLine, {
+        lines = mergeChannelProgressDraftLineForStreaming(lines, displayLine, {
+          toolProgress: !quietProgress,
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
         });
       }
@@ -746,7 +754,8 @@ export function createChannelProgressDraftCompositor(params: {
         label: "Commentary",
         prefix: false,
       };
-      lines = mergeChannelProgressDraftLine(lines, line, {
+      lines = mergeChannelProgressDraftLineForStreaming(lines, line, {
+        toolProgress: !quietProgress,
         maxLines: resolveChannelProgressDraftMaxLines(params.entry),
       });
       if (!itemId) {

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -6,8 +6,6 @@ import {
   buildChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   formatPlanChecklistLines,
-  isChannelProgressAttentionLine,
-  isChannelProgressPriorityLine,
   normalizeAgentPlanSteps,
   isChannelProgressDraftWorkToolName,
   mergeChannelProgressDraftLine,
@@ -22,25 +20,6 @@ import {
 } from "./streaming.js";
 
 describe("buildChannelProgressDraftLine", () => {
-  it("does not reserve attention capacity for non-zero command exits", () => {
-    const exitLine = {
-      kind: "command-output" as const,
-      label: "Exec",
-      text: "🛠️ exit 1",
-      status: "exit 1",
-    };
-    expect(isChannelProgressAttentionLine(exitLine)).toBe(true);
-    expect(isChannelProgressPriorityLine(exitLine)).toBe(false);
-    expect(
-      isChannelProgressAttentionLine({
-        kind: "tool",
-        label: "Deploy",
-        text: "Deploy failed",
-        status: "failed",
-      }),
-    ).toBe(true);
-  });
-
   it("keeps non-zero exits in the legacy quiet summary", () => {
     expect(
       formatChannelProgressDraftText({
@@ -299,6 +278,23 @@ describe("backend tool-name casing", () => {
 });
 
 describe("mergeChannelProgressDraftLine", () => {
+  it("preserves SDK default retention of non-zero exits over newer activity", () => {
+    const exit = {
+      id: "command-1",
+      kind: "command-output" as const,
+      label: "Exec",
+      text: "🛠️ exit 1",
+      status: "exit 1",
+    };
+    const lines = mergeChannelProgressDraftLine(
+      [exit, { id: "read-1", kind: "tool", label: "Read", text: "Read first file" }],
+      { id: "read-2", kind: "tool", label: "Read", text: "Read second file" },
+      { maxLines: 2 },
+    );
+
+    expect(lines.map((line) => line.text)).toEqual(["🛠️ exit 1", "Read second file"]);
+  });
+
   it("keeps identical visible lines distinct when their stable ids differ", () => {
     const first = { id: "tool-1", kind: "tool" as const, text: "bash", label: "bash" };
     const second = { id: "tool-2", kind: "tool" as const, text: "bash", label: "bash" };
@@ -418,6 +414,31 @@ describe("streaming config resolution", () => {
 });
 
 describe("progress narration", () => {
+  it.each([undefined, "summary"] as const)(
+    "preserves SDK default exit priority over a full plan (presentation=%s)",
+    (presentation) => {
+      const text = formatChannelProgressDraftText({
+        presentation,
+        entry: {
+          streaming: {
+            mode: "progress",
+            progress: { toolProgress: true, label: false, maxLines: 3 },
+          },
+        },
+        lines: [{ kind: "command-output", label: "Exec", text: "🛠️ exit 1", status: "exit 1" }],
+        plan: [
+          { step: "Inspect", status: "completed" },
+          { step: "Repair", status: "in_progress" },
+          { step: "Verify", status: "pending" },
+        ],
+      });
+
+      expect(text).toContain("exit 1");
+      expect(text).toContain("Repair");
+      expect(text.split("\n").filter(Boolean)).toHaveLength(3);
+    },
+  );
+
   it("preserves the shipped plain checklist option", () => {
     expect(
       formatPlanChecklistLines(

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -6,6 +6,8 @@ import {
   buildChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   formatPlanChecklistLines,
+  isChannelProgressAttentionLine,
+  isChannelProgressPriorityLine,
   normalizeAgentPlanSteps,
   isChannelProgressDraftWorkToolName,
   mergeChannelProgressDraftLine,
@@ -20,6 +22,42 @@ import {
 } from "./streaming.js";
 
 describe("buildChannelProgressDraftLine", () => {
+  it("does not reserve attention capacity for non-zero command exits", () => {
+    const exitLine = {
+      kind: "command-output" as const,
+      label: "Exec",
+      text: "🛠️ exit 1",
+      status: "exit 1",
+    };
+    expect(isChannelProgressAttentionLine(exitLine)).toBe(true);
+    expect(isChannelProgressPriorityLine(exitLine)).toBe(false);
+    expect(
+      isChannelProgressAttentionLine({
+        kind: "tool",
+        label: "Deploy",
+        text: "Deploy failed",
+        status: "failed",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-zero exits in the legacy quiet summary", () => {
+    expect(
+      formatChannelProgressDraftText({
+        presentation: "summary",
+        entry: { streaming: { mode: "progress", progress: { label: false } } },
+        lines: [
+          {
+            kind: "command-output",
+            label: "Exec",
+            text: "🛠️ exit 1",
+            status: "exit 1",
+          },
+        ],
+      }),
+    ).toBe("Exec — exit 1");
+  });
+
   it("suppresses status tools from generic work-tool progress", () => {
     expect(isChannelProgressDraftWorkToolName("progress_card")).toBe(false);
     expect(isChannelProgressDraftWorkToolName("update_plan")).toBe(false);

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1228,11 +1228,32 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
   /** Merge limits for rolling progress drafts. */
   params: { maxLines: number },
 ): TLine[] {
+  // The shipped SDK lacks the compositor's effective preview mode and keeps its attention policy.
+  return mergeProgressDraftLine(lines, line, params.maxLines, isChannelProgressAttentionLine);
+}
+
+export function mergeChannelProgressDraftLineForStreaming<
+  TLine extends string | ChannelProgressDraftLine,
+>(lines: TLine[], line: TLine, params: { maxLines: number; toolProgress: boolean }): TLine[] {
+  return mergeProgressDraftLine(
+    lines,
+    line,
+    params.maxLines,
+    params.toolProgress ? isChannelProgressPriorityLine : isChannelProgressAttentionLine,
+  );
+}
+
+function mergeProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(
+  lines: TLine[],
+  line: TLine,
+  limit: number,
+  isPriorityLine: typeof isChannelProgressAttentionLine,
+): TLine[] {
   const normalized = normalizeChannelProgressDraftLineIdentity(line);
   if (!normalized) {
     return lines;
   }
-  const maxLines = Math.max(1, params.maxLines);
+  const maxLines = Math.max(1, limit);
   const lineKeys = resolveProgressDraftLineMergeKeys(line);
   if (lineKeys.length > 0) {
     const existingIndex = lines.findIndex((entry) =>
@@ -1248,7 +1269,7 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
       }
       const next = [...lines];
       next[existingIndex] = replacement;
-      return limitProgressDraftLines(next, maxLines);
+      return limitProgressDraftLines(next, maxLines, isPriorityLine);
     }
   } else {
     const previous = lines.at(-1);
@@ -1256,21 +1277,20 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
       return lines;
     }
   }
-  return limitProgressDraftLines([...lines, line], maxLines);
+  return limitProgressDraftLines([...lines, line], maxLines, isPriorityLine);
 }
 
 function limitProgressDraftLines<TLine extends string | ChannelProgressDraftLine>(
   lines: TLine[],
   maxLines: number,
+  isPriorityLine: typeof isChannelProgressAttentionLine,
 ): TLine[] {
   let attentionSlots = maxLines;
-  let ordinarySlots = Math.max(0, maxLines - lines.filter(isChannelProgressPriorityLine).length);
+  let ordinarySlots = Math.max(0, maxLines - lines.filter(isPriorityLine).length);
   // Keep attention through tool/commentary bursts without changing arrival order.
   return lines
     .toReversed()
-    .filter((line) =>
-      isChannelProgressPriorityLine(line) ? attentionSlots-- > 0 : ordinarySlots-- > 0,
-    )
+    .filter((line) => (isPriorityLine(line) ? attentionSlots-- > 0 : ordinarySlots-- > 0))
     .toReversed();
 }
 
@@ -1318,7 +1338,7 @@ function resolveProgressDraftLineMergeKeys(line: string | ChannelProgressDraftLi
   return [...new Set(keys)];
 }
 
-export function formatChannelProgressDraftText(params: {
+type ChannelProgressDraftTextParams = {
   /** @deprecated v2026.9.1 SDK presentation; retain until a breaking SDK release. */
   presentation?: "summary";
   /** Channel streaming config source for progress label and bounds. */
@@ -1338,7 +1358,27 @@ export function formatChannelProgressDraftText(params: {
   /** Latest full plan snapshot, rendered independently from rolling tool lines. */
   plan?: readonly AgentPlanStep[];
   diffStat?: ChannelProgressDraftDiffStat;
-}): string {
+};
+
+export function formatChannelProgressDraftText(params: ChannelProgressDraftTextParams): string {
+  return formatProgressDraftText(params, isChannelProgressAttentionLine);
+}
+
+export function formatChannelProgressDraftTextForStreaming(
+  params: ChannelProgressDraftTextParams & { toolProgress: boolean },
+): string {
+  return formatProgressDraftText(
+    params,
+    params.toolProgress && params.presentation !== "summary"
+      ? isChannelProgressPriorityLine
+      : isChannelProgressAttentionLine,
+  );
+}
+
+function formatProgressDraftText(
+  params: ChannelProgressDraftTextParams,
+  isPriorityLine: typeof isChannelProgressAttentionLine,
+): string {
   const narration = compactProgressText(
     params.narration?.replace(/\s+/g, " ").trim() ?? "",
     PROGRESS_DRAFT_NARRATION_MAX_CHARS,
@@ -1346,7 +1386,7 @@ export function formatChannelProgressDraftText(params: {
   const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
   const maxLineChars = resolveChannelProgressDraftMaxLineChars(params.entry);
   const formatLine = params.formatLine ?? ((line: string) => line);
-  const attention = params.lines.filter(isChannelProgressPriorityLine);
+  const attention = params.lines.filter(isPriorityLine);
   const planLines = formatPlanChecklistLines(params.plan ?? [], {
     maxLines: maxLines - attention.length,
     maxLineChars,
@@ -1364,10 +1404,7 @@ export function formatChannelProgressDraftText(params: {
   const bullet = params.bullet ?? "•";
   const toolLineBudget = planLines.length > 0 ? Math.max(0, maxLines - planLines.length) : maxLines;
   // Attention owns capacity before plans and routine progress consume the window.
-  const visibleLines = [
-    ...params.lines.filter((line) => !isChannelProgressPriorityLine(line)),
-    ...attention,
-  ];
+  const visibleLines = [...params.lines.filter((line) => !isPriorityLine(line)), ...attention];
   const renderedToolLines = visibleLines
     .map((line) => {
       if (params.presentation === "summary") {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -317,6 +317,17 @@ export function isChannelProgressAttentionLine(line: string | ChannelProgressDra
   );
 }
 
+/** Lines that reserve bounded progress capacity. */
+export function isChannelProgressPriorityLine(line: string | ChannelProgressDraftLine): boolean {
+  if (typeof line === "string") {
+    return false;
+  }
+  const status = line.status?.toLowerCase();
+  return (
+    line.kind === "approval" || status === "failed" || status === "error" || status === "blocked"
+  );
+}
+
 const progressDraftLineCorrelationKeys = new WeakMap<ChannelProgressDraftLine, string>();
 
 function compactStrings(values: readonly (string | undefined | null)[]): string[] {
@@ -1253,12 +1264,12 @@ function limitProgressDraftLines<TLine extends string | ChannelProgressDraftLine
   maxLines: number,
 ): TLine[] {
   let attentionSlots = maxLines;
-  let ordinarySlots = Math.max(0, maxLines - lines.filter(isChannelProgressAttentionLine).length);
+  let ordinarySlots = Math.max(0, maxLines - lines.filter(isChannelProgressPriorityLine).length);
   // Keep attention through tool/commentary bursts without changing arrival order.
   return lines
     .toReversed()
     .filter((line) =>
-      isChannelProgressAttentionLine(line) ? attentionSlots-- > 0 : ordinarySlots-- > 0,
+      isChannelProgressPriorityLine(line) ? attentionSlots-- > 0 : ordinarySlots-- > 0,
     )
     .toReversed();
 }
@@ -1335,7 +1346,7 @@ export function formatChannelProgressDraftText(params: {
   const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
   const maxLineChars = resolveChannelProgressDraftMaxLineChars(params.entry);
   const formatLine = params.formatLine ?? ((line: string) => line);
-  const attention = params.lines.filter(isChannelProgressAttentionLine);
+  const attention = params.lines.filter(isChannelProgressPriorityLine);
   const planLines = formatPlanChecklistLines(params.plan ?? [], {
     maxLines: maxLines - attention.length,
     maxLineChars,
@@ -1354,7 +1365,7 @@ export function formatChannelProgressDraftText(params: {
   const toolLineBudget = planLines.length > 0 ? Math.max(0, maxLines - planLines.length) : maxLines;
   // Attention owns capacity before plans and routine progress consume the window.
   const visibleLines = [
-    ...params.lines.filter((line) => !isChannelProgressAttentionLine(line)),
+    ...params.lines.filter((line) => !isChannelProgressPriorityLine(line)),
     ...attention,
   ];
   const renderedToolLines = visibleLines


### PR DESCRIPTION
## What Problem This Solves

With the rolling tool log enabled, repeated non-zero command exits could pin old activity in a bounded progress preview. A five-step plan collapsed, and newer successful work stayed hidden while the turn continued.

## Why This Change Was Made

Keep ordinary command exits in the rolling activity window so newer work can replace them. Reserve protected capacity for approvals and explicit `failed`, `error`, and `blocked` states.

Preserve quiet-mode and legacy summary behavior: non-zero exits remain visible and receive immediate updates when routine tool progress is hidden. The compositor carries its effective mode through retention, formatting, and flush decisions. Telegram uses that same mode and protects approval rows independently of their optional status.

The existing plugin SDK exports, argument shapes, and default attention behavior remain unchanged. Shared internal implementations handle both policies.

## User Impact

Active previews retain the available plan rows and show newer work. Quiet previews still show command failures. Command execution, exit codes, final replies, and delivery ownership remain unchanged.

## Evidence

- Real Telegram Test Server direct-message comparison: baseline `87cd7d1c21d4` versus candidate `b36a4f8c29d7`, using the built Gateway, `toolProgress: true`, and `maxLines: 10`.
- The baseline retained eight exits, hid four of five plan rows, and omitted three later successful activities. The candidate retained all five plan rows and replaced older exits with all three newer activities.
- A separate full-plan quiet comparison reproduced the incoming branch's hidden exit and verified that this candidate restores its visibility. Final replies and preview cleanup were observed on both versions.
- Independent validation exercised the candidate through Telegram and the public SDK. SDK controls covered summary visibility, retention through later activity, explicit failure priority, and approval start, retention, and resolution. These SDK controls do not claim live approval authorization or delivery.
- **199 focused and sibling tests passed**, including shared composition, Telegram rendering, Discord final delivery, and progress visibility. Ten regression cases failed on the incoming implementation for the intended reasons.
- Formatting, syntax lint, size/assertion ratchets, the changed-page MDX check, and `git diff --check` passed. Fresh independent source review found no actionable findings. Hosted CI remains required before merge.

Complete runtime evidence is retained privately because it contains account and execution data. The contributor's earlier screenshots remain historical evidence for the original active-progress repair.
