### PR TITLE
refactor(ai): keep model policy parsing independent of transport host

### DIFF
--- a/extensions/openai/model-construction.imports.test.ts
+++ b/extensions/openai/model-construction.imports.test.ts
@@ -2,6 +2,14 @@ import { findSourceImportBackedges } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 
 describe("OpenAI model construction imports", () => {
+  it("loads model route policy without the transport host", async () => {
+    expect(
+      await findSourceImportBackedges("extensions/openai/provider-policy-api.ts", [
+        "packages/ai/src/host.ts",
+      ]),
+    ).toEqual([]);
+  });
+
   it("constructs auth descriptors without loading credential stores", async () => {
     expect(
       await findSourceImportBackedges("extensions/openai/openai-provider.ts", [

--- a/packages/ai/src/transports/openai-responses-payload-policy.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.test.ts
@@ -29,6 +29,30 @@ describe("OpenAI Responses compact threshold", () => {
       model: {},
       expected: 80_000,
     },
+    {
+      name: "floors a positive numeric threshold",
+      model: {},
+      extraParams: { responsesCompactThreshold: 123_456.9 },
+      expected: 123_456,
+    },
+    {
+      name: "accepts a strict positive integer string threshold",
+      model: {},
+      extraParams: { responsesCompactThreshold: "123456" },
+      expected: 123_456,
+    },
+    {
+      name: "rejects a fractional string threshold",
+      model: {},
+      extraParams: { responsesCompactThreshold: "123456.9" },
+      expected: 80_000,
+    },
+    {
+      name: "rejects a nonfinite threshold",
+      model: {},
+      extraParams: { responsesCompactThreshold: Number.POSITIVE_INFINITY },
+      expected: 80_000,
+    },
   ])("$name", ({ model, extraParams, expected }) => {
     expect(
       resolveOpenAIResponsesServerCompactionPlan(

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -10,7 +10,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { supportsOpenAIReasoningEffort } from "../providers/openai-reasoning-effort.js";
 import { OPENAI_RESPONSES_APIS } from "./openai-responses-contracts.js";
-import { parsePositiveInteger } from "./transport-utils.js";
+import { parsePositiveInteger } from "./positive-integer.js";
 
 type OpenAIResponsesPayloadModel = {
   api?: unknown;

--- a/packages/ai/src/transports/positive-integer.ts
+++ b/packages/ai/src/transports/positive-integer.ts
@@ -1,0 +1,8 @@
+import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
+
+export function parsePositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return typeof value === "string" ? parseStrictPositiveInteger(value) : undefined;
+}

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -1,10 +1,10 @@
 import type { Model } from "@openclaw/llm-core";
 import { consumeResponseBytes } from "@openclaw/normalization-core";
-import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getAiTransportHost } from "../host.js";
 export { redactIdentifier, sha256Hex } from "@openclaw/normalization-core/node-crypto";
 export { parseRetryAfterHeadersSeconds as parseRetryAfterSeconds } from "../internal/retry-after.js";
+export { parsePositiveInteger } from "./positive-integer.js";
 
 export const MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE =
   "OpenClaw transport error: malformed_streaming_fragment";
@@ -12,13 +12,6 @@ export const CHARS_PER_TOKEN_ESTIMATE = 4;
 const NON_LATIN_RE =
   /[\u2E80-\u9FFF\uA000-\uA4FF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60\uFFE0-\uFFE6\u{20000}-\u{2FA1F}]/gu;
 const CJK_SURROGATE_HIGH_RE = /[\uD840-\uD87E][\uDC00-\uDFFF]/g;
-
-export function parsePositiveInteger(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-    return Math.floor(value);
-  }
-  return typeof value === "string" ? parseStrictPositiveInteger(value) : undefined;
-}
 
 export function redactSensitiveText(text: string, _options?: unknown): string {
   return getAiTransportHost().redactToolPayloadText(text);


### PR DESCRIPTION
Related: #142682, #142738

## What Problem This Solves

Resolves a problem where reading OpenAI model policy pulls in the AI transport host solely to parse a positive integer. The unnecessary dependency was found while investigating cold first-reply Signal test failures.

## Why This Change Was Made

Move the exact existing parser into a private leaf module and have Responses payload policy import that leaf. The old transport-utils export remains available. An import-boundary regression prevents model-policy loading from depending on the transport host again.

## User Impact

Model-policy inspection has a narrower dependency graph. Fast choices, model routes, numeric coercion, and existing public exports retain their behavior. No package exports, dependencies, versions, or configuration change.

## Evidence

The import-boundary test failed on the original graph and passes after the change. The canonical five-path gate, ordinary build, and independent Codex review passed. Sixty-six focused tests cover the import boundary, Fast and route policy, Responses handling, and coercion. Rebuilt AI package exports and four native threshold cases also passed.

The original Signal CI shard passed on Linux with fresh caches and three workers: 48 files and 863 tests, without changing its assertions, timeouts, fixtures, or routing. The previously failing prefix case took 4.228 seconds; the cancellation case took 0.447 seconds. All temporary profiling changes were removed.

A causal comparison confirmed that the earlier Fast metadata import increased cold source-loader work. This patch removes a verified transport-host dependency, but residual source-test startup cost remains; these measurements do not establish a production latency improvement. The remote test runtime was Node 24.19, while the original CI failure used Node 24.20; the failure was also reproduced independently on the remote runtime.
