### PR TITLE
refactor(tests): share independent Gateway scope expectations

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -19,6 +19,7 @@ import {
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
   pickPrimaryTailnetIPv4Mock as pickPrimaryTailnetIPv4,
 } from "./gateway-connection.test-mocks.js";
+import { createExpectedBroadOperatorScopes } from "./scope-expectations.test-support.js";
 
 const TLS_FINGERPRINT = "ab".repeat(32);
 
@@ -982,15 +983,7 @@ describe("callGateway url resolution", () => {
 
     await callGatewayCli({ method: "plugin.custom.unclassified" });
 
-    expect(lastClientOptions?.scopes).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    expect(lastClientOptions?.scopes).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("falls back to broad operator scopes for unresolved plugin session actions", async () => {
@@ -1005,15 +998,7 @@ describe("callGateway url resolution", () => {
       },
     });
 
-    expect(lastClientOptions?.scopes).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    expect(lastClientOptions?.scopes).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("passes explicit scopes through, including empty arrays", async () => {

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -13,6 +13,7 @@ import {
   resolveTrustedHttpOperatorScopes,
 } from "./http-utils.js";
 import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+import { createExpectedBroadOperatorScopes } from "./scope-expectations.test-support.js";
 
 const sessionEntries = vi.hoisted(() => new Map<string, Record<string, unknown>>());
 
@@ -324,15 +325,7 @@ describe("resolveOpenAiCompatibleHttpOperatorScopes", () => {
       { authMethod: "token", trustDeclaredOperatorScopes: false },
     );
 
-    expect(scopes).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    expect(scopes).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("keeps declared scopes for trusted HTTP identity-bearing requests", () => {

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -10,6 +10,7 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
 } from "./method-scopes.js";
 import { createPluginGatewayMethodDescriptor } from "./methods/descriptor.js";
+import { createExpectedBroadOperatorScopes } from "./scope-expectations.test-support.js";
 import { listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
@@ -337,15 +338,7 @@ describe("method scope resolution", () => {
         pluginId: "scope-plugin",
         actionId: "missing",
       }),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual(createExpectedBroadOperatorScopes());
     expect(
       authorizeOperatorScopesForMethod("plugins.sessionAction", ["operator.approvals"], {
         pluginId: "scope-plugin",
@@ -775,15 +768,7 @@ describe("method scope resolution", () => {
         pluginId: "remote-plugin",
         actionId: "approve",
       }),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("returns empty scopes for unknown methods", () => {

--- a/src/gateway/scope-expectations.test-support.ts
+++ b/src/gateway/scope-expectations.test-support.ts
@@ -1,0 +1,11 @@
+export function createExpectedBroadOperatorScopes() {
+  return [
+    "operator.admin",
+    "operator.read",
+    "operator.write",
+    "operator.approvals",
+    "operator.questions",
+    "operator.pairing",
+    "operator.talk.secrets",
+  ];
+}

--- a/src/gateway/server/plugin-route-runtime-scopes.test.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.test.ts
@@ -3,6 +3,7 @@
  */
 import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
+import { createExpectedBroadOperatorScopes } from "../scope-expectations.test-support.js";
 import { resolvePluginRouteRuntimeOperatorScopes } from "./plugin-route-runtime-scopes.js";
 
 function createReq(headers: Record<string, string> = {}): IncomingMessage {
@@ -58,15 +59,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
         { authMethod: "token", trustDeclaredOperatorScopes: false },
         "trusted-operator",
       ),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("restores trusted default operator scopes for trusted-proxy routes opting into trusted-operator when scopes header is absent", () => {
@@ -76,15 +69,7 @@ describe("resolvePluginRouteRuntimeOperatorScopes", () => {
         { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
         "trusted-operator",
       ),
-    ).toEqual([
-      "operator.admin",
-      "operator.read",
-      "operator.write",
-      "operator.approvals",
-      "operator.questions",
-      "operator.pairing",
-      "operator.talk.secrets",
-    ]);
+    ).toEqual(createExpectedBroadOperatorScopes());
   });
 
   it("preserves trusted-proxy declared scopes for routes opting into trusted-operator surface", () => {


### PR DESCRIPTION
## What Problem This Solves

Seven Gateway assertions repeat the same broad operator-scope expectation across CLI, plugin-action and HTTP tests, making that independently authored policy list harder to maintain.

## Why This Change Was Made

Share the expected list through a narrow test-only constructor that returns a fresh array each time. The helper contains explicit literals and never imports the production scope constant or supplies an input fixture. All seven actual expressions, scenarios, smaller-scope expectations and hooks remain unchanged.

## User Impact

No runtime or user-facing behavior changes. This maintainer-requested test consolidation removes 41 net test/support lines without removing cases.

## Evidence

- All four complete consumer suites passed before and after: 374 cases, zero pending, with identical ordered case names and statuses.
- Expanding every helper call restores the original full-file test syntax after removing the added imports. All seven references are expected arguments; fresh arrays and mutation isolation were checked.
- The mapped changed gate and fresh P2 review passed. No overall test-runtime improvement is claimed.
