### PR TITLE
fix(ci): capture Android emulator boot telemetry

### DIFF
--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -1,6 +1,6 @@
 name: Android Emulator Diagnostic
 
-run-name: Android emulator diagnostic (${{ inputs.target_sha }})
+run-name: Android emulator diagnostic instrumented (${{ inputs.target_sha }})
 
 on:
   workflow_dispatch:
@@ -113,6 +113,9 @@ jobs:
             printf 'runner_arch=%s\n' "$RUNNER_ARCH"
             printf 'runner_image=%s\n' "${ImageOS:-unknown}"
             printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
+            printf 'host_cpu=%s\n' "$(sysctl -n machdep.cpu.brand_string)"
+            printf 'host_logical_cpus=%s\n' "$(sysctl -n hw.logicalcpu)"
+            printf 'host_memory_bytes=%s\n' "$(sysctl -n hw.memsize)"
             uname -a
             sw_vers
           } >"$DIAGNOSTIC_DIR/runner.txt"
@@ -138,6 +141,57 @@ jobs:
           set -euo pipefail
           emulator_pid=""
           adb_started=0
+
+          capture_accel_check() {
+            local accel_raw="$DIAGNOSTIC_DIR/emulator-accel-check.raw"
+            local accel_check_timeout_seconds=10
+            local accel_deadline
+            local accel_pid
+            local accel_status
+            local accel_timed_out=false
+
+            emulator -accel-check >"$accel_raw" 2>&1 &
+            accel_pid=$!
+            accel_deadline=$((SECONDS + accel_check_timeout_seconds))
+            while kill -0 "$accel_pid" 2>/dev/null; do
+              if (( SECONDS >= accel_deadline )); then
+                accel_timed_out=true
+                if kill "$accel_pid" 2>/dev/null; then
+                  :
+                fi
+                if kill -0 "$accel_pid" 2>/dev/null && kill -9 "$accel_pid" 2>/dev/null; then
+                  :
+                fi
+                break
+              fi
+              sleep 1
+            done
+            if wait "$accel_pid"; then
+              accel_status=0
+            else
+              accel_status=$?
+            fi
+            if [[ "$accel_timed_out" == "true" ]]; then
+              accel_status=124
+            fi
+            head -c 16384 "$accel_raw" >"$DIAGNOSTIC_DIR/emulator-accel-check.txt"
+            rm -f "$accel_raw"
+            printf 'exit_status=%s\n' "$accel_status" >>"$DIAGNOSTIC_DIR/emulator-accel-check.txt"
+            printf 'timed_out=%s\n' "$accel_timed_out" >>"$DIAGNOSTIC_DIR/emulator-accel-check.txt"
+          }
+
+          sample_owned_qemu() {
+            sample_status=0
+            {
+              printf '\n[%s] owned_emulator_pid=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$emulator_pid"
+              ps -p "$emulator_pid" -o pid=,ppid=,%cpu=,rss=,stat=,etime=,command=
+            } >>"$DIAGNOSTIC_DIR/owned-qemu-samples.log" 2>&1 || sample_status=$?
+            if [[ "$sample_status" -ne 0 ]]; then
+              printf 'sample_status=%s\n' "$sample_status" \
+                >>"$DIAGNOSTIC_DIR/owned-qemu-samples.log"
+            fi
+            return 0
+          }
 
           cleanup() {
             status=$?
@@ -173,6 +227,7 @@ jobs:
           trap 'exit 143' TERM
 
           emulator -version >"$DIAGNOSTIC_DIR/emulator-version.txt" 2>&1
+          capture_accel_check
           sdkmanager --list_installed >"$DIAGNOSTIC_DIR/sdk-packages.txt" 2>&1
           avdmanager list device >"$DIAGNOSTIC_DIR/avd-devices.txt" 2>&1
           adb start-server
@@ -186,12 +241,13 @@ jobs:
           printf 'no\n' | avdmanager create avd --force --name "$AVD_NAME" --package "$SYSTEM_IMAGE" --device "$DEVICE_PROFILE"
           cp "$HOME/.android/avd/${AVD_NAME}.avd/config.ini" "$DIAGNOSTIC_DIR/avd-config.ini"
 
-          emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim)
+          emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim -verbose -show-kernel)
           printf '%q ' "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator-args.txt"
           printf '\n' >>"$DIAGNOSTIC_DIR/emulator-args.txt"
           emulator "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator.log" 2>&1 &
           emulator_pid=$!
           printf 'emulator_pid=%s\n' "$emulator_pid" >"$DIAGNOSTIC_DIR/process-status.log"
+          sample_owned_qemu
 
           device_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))
           serial=""
@@ -210,6 +266,7 @@ jobs:
               echo "::error::Multiple Android devices appeared during diagnostic startup"
               exit 1
             fi
+            sample_owned_qemu
             ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command= \
               >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
             kill -0 "$emulator_pid"
@@ -229,6 +286,7 @@ jobs:
                 "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$serial" "${boot_completed:-unset}"
               adb devices -l
             } >>"$DIAGNOSTIC_DIR/adb-observations.log" 2>&1
+            sample_owned_qemu
             ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command= \
               >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
             kill -0 "$emulator_pid"

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1796,6 +1796,7 @@ describe("mobile release authority", () => {
         };
       };
       permissions: Record<string, string>;
+      "run-name": string;
     };
     const validationJob = workflow.jobs["validate-target"];
     const validationSteps = validationJob.steps;
@@ -1829,6 +1830,9 @@ describe("mobile release authority", () => {
     );
 
     expect(workflow.name).toBe("Android Emulator Diagnostic");
+    expect(workflow["run-name"]).toBe(
+      "Android emulator diagnostic instrumented (${{ inputs.target_sha }})",
+    );
     expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
     expect(workflow.on.workflow_dispatch.inputs.target_sha).toEqual({
       description: "Exact lowercase 40-character commit SHA to diagnose",
@@ -1875,6 +1879,15 @@ describe("mobile release authority", () => {
     );
     expect(steps[initializeIndex]?.run).toContain(
       'echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"',
+    );
+    expect(steps[initializeIndex]?.run).toContain(
+      "printf 'host_cpu=%s\\n' \"$(sysctl -n machdep.cpu.brand_string)\"",
+    );
+    expect(steps[initializeIndex]?.run).toContain(
+      "printf 'host_logical_cpus=%s\\n' \"$(sysctl -n hw.logicalcpu)\"",
+    );
+    expect(steps[initializeIndex]?.run).toContain(
+      "printf 'host_memory_bytes=%s\\n' \"$(sysctl -n hw.memsize)\"",
     );
     expect(validationSteps[validationTrustedCheckoutIndex]).toMatchObject({
       uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
@@ -1988,8 +2001,73 @@ describe("mobile release authority", () => {
       'printf \'no\\n\' | avdmanager create avd --force --name "$AVD_NAME" --package "$SYSTEM_IMAGE" --device "$DEVICE_PROFILE"',
     );
     expect(diagnostic).toContain(
-      'emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim)',
+      'emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim -verbose -show-kernel)',
     );
+    expect(diagnostic).toContain("capture_accel_check() {");
+    expect(diagnostic).toContain("accel_check_timeout_seconds=10");
+    expect(diagnostic).toContain('emulator -accel-check >"$accel_raw" 2>&1 &');
+    expect(diagnostic).toContain(
+      'head -c 16384 "$accel_raw" >"$DIAGNOSTIC_DIR/emulator-accel-check.txt"',
+    );
+    expect(diagnostic).toContain(
+      'printf \'exit_status=%s\\n\' "$accel_status" >>"$DIAGNOSTIC_DIR/emulator-accel-check.txt"',
+    );
+    expect(diagnostic).toContain(
+      'printf \'timed_out=%s\\n\' "$accel_timed_out" >>"$DIAGNOSTIC_DIR/emulator-accel-check.txt"',
+    );
+    expect(diagnostic).toContain("sample_owned_qemu() {");
+    expect(diagnostic).toContain(
+      'printf \'\\n[%s] owned_emulator_pid=%s\\n\' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$emulator_pid"',
+    );
+    expect(diagnostic).toContain(
+      'ps -p "$emulator_pid" -o pid=,ppid=,%cpu=,rss=,stat=,etime=,command=',
+    );
+    expect(diagnostic).toContain('>>"$DIAGNOSTIC_DIR/owned-qemu-samples.log" 2>&1');
+    expect(diagnostic.match(/\bsample_owned_qemu\b/gu)).toHaveLength(4);
+
+    const accelFunctionStart = diagnostic.indexOf("capture_accel_check() {");
+    const accelFunctionEnd = diagnostic.indexOf("\n\nsample_owned_qemu()", accelFunctionStart);
+    expect(accelFunctionStart).toBeGreaterThanOrEqual(0);
+    expect(accelFunctionEnd).toBeGreaterThan(accelFunctionStart);
+    const accelFunction = diagnostic
+      .slice(accelFunctionStart, accelFunctionEnd)
+      .replace("accel_check_timeout_seconds=10", "accel_check_timeout_seconds=1");
+    const runAccelCheck = (emulatorSource: string) => {
+      const root = tempRoots.make("openclaw-android-emulator-accel-check-");
+      const bin = path.join(root, "bin");
+      const diagnosticDir = path.join(root, "diagnostic");
+      fs.mkdirSync(bin);
+      fs.mkdirSync(diagnosticDir);
+      fs.writeFileSync(path.join(bin, "emulator"), emulatorSource, { mode: 0o755 });
+      const result = spawnSync(
+        "/bin/bash",
+        ["-c", `set -euo pipefail\n${accelFunction}\ncapture_accel_check\n`],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DIAGNOSTIC_DIR: diagnosticDir,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+          timeout: 5_000,
+        },
+      );
+      return {
+        output: fs.readFileSync(path.join(diagnosticDir, "emulator-accel-check.txt"), "utf8"),
+        result,
+      };
+    };
+
+    const nonzeroAccel = runAccelCheck("#!/bin/bash\nprintf 'unavailable\\n'\nexit 7\n");
+    expect(nonzeroAccel.result.status, nonzeroAccel.result.stderr).toBe(0);
+    expect(nonzeroAccel.output).toContain("unavailable");
+    expect(nonzeroAccel.output).toContain("exit_status=7");
+    expect(nonzeroAccel.output).toContain("timed_out=false");
+
+    const timedOutAccel = runAccelCheck("#!/bin/bash\nexec sleep 30\n");
+    expect(timedOutAccel.result.status, timedOutAccel.result.stderr).toBe(0);
+    expect(timedOutAccel.output).toContain("exit_status=124");
+    expect(timedOutAccel.output).toContain("timed_out=true");
     expect(diagnostic).toContain(
       "device_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))",
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the secretless Android emulator diagnostic could prove that the fixed phone emulator stayed offline for 180 seconds, but did not retain enough bounded host, acceleration-capability, kernel, and owned-process telemetry to distinguish guest boot progress from runner-capacity or emulator-runtime failure.

## Why This Change Was Made

The diagnostic remains manual, exact-SHA-bound, read-only, and candidate-inert. It adds supported verbose/kernel emulator logging, bounded accelerator-capability capture with a 10-second deadline, fixed host CPU/memory facts, and timestamped CPU/RSS samples for the exact emulator PID. None of this telemetry changes either existing 180-second readiness decision.

## User Impact

Release operators get a more useful failure artifact from the next secretless phone-emulator qualification run. This change does not modify release authority, credentials, candidate bytes, signing, store destinations, App Review, or production promotion.

## Evidence

- Before: the exact diagnostic run https://github.com/openclaw/openclaw/actions/runs/34305338368 timed out waiting for one online emulator while QEMU remained alive; the retained artifact could not establish the underlying cause.
- Red: the focused owner test failed on the missing instrumented diagnostic contract before the workflow change.
- Green: `test/scripts/mobile-release-authority.test.ts` passed 62/62.
- Executable boundary proof: nonzero `emulator -accel-check` status is retained without blocking startup; a hung check is terminated at the bounded deadline and recorded as timeout status 124.
- Static proof: Actionlint, Bash syntax, Oxfmt, Oxlint, workflow parsing, privacy scan, and `git diff --check` passed.
- Independent P1 autoreview: clean, confidence 0.94.
- Delta: workflow production/tooling +60/-2; focused tests +79/-1. Production growth is the bounded telemetry and exact-PID timeout/cleanup path required to diagnose the observed failure without weakening readiness.
- Limitation: no new emulator runtime claim is made by this PR. One fresh original secretless diagnostic is conditionally authorized only after exact-head CI and native landing; the actual hosted result remains required.

## Maintainer Decision

ClawSweeper's requested hosted telemetry trace is intentionally deferred until after landing. The one-shot diagnostic must execute the exact trusted workflow from `main`; running a branch variant before merge would weaken that evidence identity. Parent and independent review accepted this bounded defer: merge only after exact-head CI, then run one original secretless diagnostic against the frozen candidate and stop at its first terminal result.

Punchcard-Session: calm-meadow-summit-7q
