### PR TITLE
fix(cli): finish pending cleanup before automatic macOS exit

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -166,6 +166,8 @@ Each plugin service startup attempt owns one cleanup operation, including failed
 
 Gateway shutdown also joins actual harness, MCP, LSP, embedding, and media cleanup after their initial grace periods. When clearing the active registry, plugin host cleanup can advance to later hooks after a timeout, but registry resets and shared database closure wait for its actual completion. These waits preserve resources for cleanup; they do not restore a retired plugin's runtime authority.
 
+Executable CLI cleanup reports each disposer that exceeds five seconds and proceeds with later cleanup without canceling the pending work. On macOS with Node's system CA support enabled, automatic exit after command completion waits for this pending cleanup to finish. Explicit command exit requests and the update exit watchdog retain their bounded behavior.
+
 Hot registry publication does not wait for retired host cleanup; terminal shutdown also joins cleanup already started by earlier registry replacements before resetting shared state. Activation and rollback apply only to their captured registry version. An activation superseded by a lifecycle callback reports an error.
 
 The cache rule is documented in [Plugin architecture internals](/plugins/architecture-internals#plugin-cache-boundary): Gateway retains one cache generation, while explicit management operations use isolated generations of the same cache. There are no wall-clock TTLs for Gateway metadata.

--- a/src/cli/one-shot-exit.cleanup.process.test.ts
+++ b/src/cli/one-shot-exit.cleanup.process.test.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it } from "vitest";
+
+it.each([
+  { mode: "automatic", exitCode: 0, disposed: true },
+  { mode: "requested", exitCode: 7, disposed: false },
+  { mode: "deferred", exitCode: 7, disposed: false },
+  { mode: "failure", exitCode: 9, disposed: false },
+  { mode: "worker", exitCode: 0, disposed: true },
+])("preserves native cleanup and the $mode exit policy", ({ mode, exitCode, disposed }) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-cleanup-exit-"));
+  const databasePath = path.join(directory, "observations.sqlite");
+  const exitPath = path.join(directory, "exit.json");
+  const oneShotExitUrl = new URL("./one-shot-exit.ts", import.meta.url).href;
+  const cleanupUrl = new URL("./runtime-cleanup.ts", import.meta.url).href;
+  const runtimeUrl = new URL("../runtime.ts", import.meta.url).href;
+  const script = `
+    import fs from "node:fs";
+    import { DatabaseSync } from "node:sqlite";
+    import { setTimeout as delay } from "node:timers/promises";
+    import { runCliDisposer } from ${JSON.stringify(cleanupUrl)};
+    import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from ${JSON.stringify(oneShotExitUrl)};
+    import { defaultRuntime, ExitError } from ${JSON.stringify(runtimeUrl)};
+
+    const mode = ${JSON.stringify(mode)};
+    const database = new DatabaseSync(${JSON.stringify(databasePath)});
+    database.exec("CREATE TABLE observations(value INTEGER); INSERT INTO observations VALUES (42)");
+    let disposals = 0;
+    let returnedBeforeCleanup = false;
+    let finalizationReturnedBeforeCleanup = false;
+    let reportedErrors = 0;
+    process.on("exit", code => {
+      fs.writeFileSync(${JSON.stringify(exitPath)}, JSON.stringify({
+        code, disposals, nativeOpen: database.isOpen, returnedBeforeCleanup,
+        finalizationReturnedBeforeCleanup, reportedErrors,
+      }));
+    });
+    await runCliWithExitFinalization({
+      run: async () => {
+        try {
+          defaultRuntime.writeJson({ mode, outcome: "recorded" });
+          if (mode === "requested") requestExitAfterOneShotOutput(defaultRuntime, 7);
+          if (mode === "deferred") throw new ExitError(7);
+          if (mode === "failure") throw new Error("synthetic command failure");
+        } finally {
+          await runCliDisposer("native-write", async () => {
+            // The referenced timer is the actual cleanup, beyond its reporting grace.
+            await delay(6_000);
+            database.exec("INSERT INTO observations VALUES (99)");
+            database.close();
+            disposals++;
+          });
+          returnedBeforeCleanup = database.isOpen && disposals === 0;
+        }
+      },
+      onError: error => {
+        if (error.message !== "synthetic command failure") throw error;
+        reportedErrors++;
+        process.exitCode = 9;
+      },
+      env: { NODE_USE_SYSTEM_CA: "1", ...(mode === "worker" ? { VITEST: "1" } : {}) },
+      execArgv: [],
+      platform: "darwin",
+      markers: mode === "worker" ? { tinypoolState: {} } : {},
+    });
+    finalizationReturnedBeforeCleanup = database.isOpen;
+  `;
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--disable-warning=ExperimentalWarning",
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "--eval",
+        script,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          SystemRoot: process.env.SystemRoot,
+          HOME: directory,
+          USERPROFILE: directory,
+          TERM: "dumb",
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          TSX_DISABLE_CACHE: "1",
+        },
+        timeout: 20_000,
+      },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(exitCode);
+    expect(JSON.parse(result.stdout)).toEqual({ mode, outcome: "recorded" });
+    expect(result.stderr).toContain("CLI cleanup timed out: native-write after 5000ms");
+    expect(JSON.parse(fs.readFileSync(exitPath, "utf8"))).toEqual({
+      code: exitCode,
+      disposals: disposed ? 1 : 0,
+      nativeOpen: !disposed,
+      returnedBeforeCleanup: true,
+      finalizationReturnedBeforeCleanup: mode !== "automatic",
+      reportedErrors: mode === "failure" ? 1 : 0,
+    });
+    const database = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(database.prepare("SELECT value FROM observations ORDER BY value").all()).toEqual(
+        (disposed ? [42, 99] : [42]).map((value) => ({ value })),
+      );
+    } finally {
+      database.close();
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/cli/one-shot-exit.ts
+++ b/src/cli/one-shot-exit.ts
@@ -1,6 +1,7 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime, ExitError } from "../runtime.js";
 import { drainOneShotOutput } from "./one-shot-output.js";
+import { waitForPendingCliDisposers } from "./runtime-cleanup.js";
 
 type VitestWorkerMarkers = {
   tinypoolState?: unknown;
@@ -79,9 +80,10 @@ function requestExitAfterSystemCaCliCompletion(
   if (platform !== "darwin" || !usesSystemCa || runtime !== defaultRuntime) {
     return false;
   }
-  if (requestedExitCode === undefined) {
-    requestedExitCode = params.exitCode ?? "process";
+  if (requestedExitCode !== undefined) {
+    return false;
   }
+  requestedExitCode = params.exitCode ?? "process";
   return true;
 }
 
@@ -107,11 +109,14 @@ export async function runCliWithExitFinalization(params: {
       requestExitAfterOneShotOutput(runtime, resolveProcessExitCode(1));
     }
   } finally {
-    requestExitAfterSystemCaCliCompletion(runtime, {
+    const automaticExit = requestExitAfterSystemCaCliCompletion(runtime, {
       env: params.env,
       execArgv: params.execArgv,
       platform: params.platform,
     });
+    if (automaticExit && !isVitestWorker(params.env ?? process.env, params.markers)) {
+      await waitForPendingCliDisposers();
+    }
     flushExitAfterOneShotOutput(runtime, params.env, params.markers);
   }
 }

--- a/src/cli/runtime-cleanup.ts
+++ b/src/cli/runtime-cleanup.ts
@@ -3,10 +3,17 @@ import type { CliHarnessCleanup } from "./runtime-cleanup-scope.js";
 // Match Gateway's harness/MCP shutdown grace; local-provider TERM/KILL already
 // consumes at most two 2-second waits. Keep command teardown bounded independently.
 const DISPOSER_TIMEOUT_MS = 5_000;
-const pendingDisposers = new Map<symbol, string>();
+const pendingDisposers = new Map<symbol, { name: string; operation: Promise<void> }>();
 
 export function getPendingCliDisposers(): string[] {
-  return [...pendingDisposers.values()];
+  return [...pendingDisposers.values()].map(({ name }) => name);
+}
+
+/** Automatic process exit must join cleanup that outlived its reporting grace. */
+export async function waitForPendingCliDisposers(): Promise<void> {
+  while (pendingDisposers.size > 0) {
+    await Promise.allSettled([...pendingDisposers.values()].map(({ operation }) => operation));
+  }
 }
 
 export async function runCliDisposer(
@@ -15,11 +22,11 @@ export async function runCliDisposer(
   runCleanup?: (dispose: () => Promise<void>) => Promise<void>,
 ): Promise<void> {
   const token = Symbol(name);
-  pendingDisposers.set(token, name);
   let timer: ReturnType<typeof setTimeout> | undefined;
   const operation = Promise.resolve()
     .then(() => (runCleanup ? runCleanup(dispose) : dispose()))
     .finally(() => pendingDisposers.delete(token));
+  pendingDisposers.set(token, { name, operation });
   try {
     await Promise.race([
       operation,


### PR DESCRIPTION
Related: #140674, #142388

## What Problem This Solves

Fixes an issue where automatic macOS CLI exit with Node system-CA support enabled could terminate pending plugin cleanup after its five-second reporting grace. The command exited successfully while a delayed database write and physical close were still pending.

## Why This Change Was Made

The existing pending-disposer owner now retains each actual operation as well as its diagnostic name. Automatic system-CA completion joins those operations before draining output and exiting. The disposer reporting race remains bounded, and explicit exit requests, command-error outcomes, Vitest exit suppression, and the existing update watchdog retain their behavior.

## User Impact

Automatic macOS completion allows admitted cleanup to finish, including writes and connection closure. Plugin-author documentation explains the distinction between the reporting grace and actual cleanup completion.

## Evidence

An unchanged-source native process regression exited with SQLite still open and only its initial row. The repaired automatic case waits for the delayed write, closes once, and retains both rows. Four controls preserve explicit, deferred, error, and test-worker behavior. All 42 focused tests, the canonical changed-file gate, documentation checks, and fresh independent Codex review passed.

The ordinary build passed in 216.5 seconds. Two actual `node openclaw.mjs` launcher cases used a plain synthetic plugin with an asynchronous lifecycle disposer—no preload, SDK helper, or exit override. Ordinary execution took 7.60 seconds and system-CA execution 7.28 seconds; both registered once, wrote the delayed row, disposed once, and exited zero with SQLite closed. Independent read-only checks ran after actual process exit. Source and build seals stayed unchanged, and all owned processes joined.

The initial regression run also exposed a fixture expectation about asynchronous output draining; that expectation was corrected before the unchanged-source baseline was repeated. Runtime timers and exit policy were not altered to make the proof pass.
