### PR TITLE
fix(line): batch proactive reply parts into as few push requests as possible

### DIFF
--- a/extensions/line/src/outbound.batch.test.ts
+++ b/extensions/line/src/outbound.batch.test.ts
@@ -1,0 +1,110 @@
+// Line tests cover outbound payload batching (issue #142734).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeStub = vi.hoisted(() => {
+  const sendResult = () => ({ messageId: "m1", messageIds: ["m1"] });
+  return {
+    pushMessageLine: vi.fn(sendResult),
+    pushMessagesLine: vi.fn(sendResult),
+    pushFlexMessage: vi.fn(sendResult),
+    pushTemplateMessage: vi.fn(sendResult),
+    pushLocationMessage: vi.fn(sendResult),
+    pushTextMessageWithQuickReplies: vi.fn(sendResult),
+    createQuickReplyItems: vi.fn(() => []),
+    createFlexMessage: vi.fn((altText: string, contents: unknown) => ({
+      type: "flex",
+      altText,
+      contents,
+    })),
+    createLocationMessage: vi.fn(() => ({ type: "location", title: "loc", address: "addr" })),
+    sendMessageLine: vi.fn(sendResult),
+  };
+});
+
+const outboundRuntimeStub = vi.hoisted(() => ({
+  processLineMessage: vi.fn((text: string) => ({ text, flexMessages: [] })),
+  createFlexMessage: vi.fn((altText: string, contents: unknown) => ({
+    type: "flex",
+    altText,
+    contents,
+  })),
+  createLocationMessage: vi.fn(() => ({ type: "location", title: "loc", address: "addr" })),
+  createQuickReplyItems: vi.fn(() => []),
+  pushMessageLine: vi.fn(() => ({ messageId: "om", messageIds: ["om"] })),
+  pushMessagesLine: vi.fn(() => ({ messageId: "om", messageIds: ["om"] })),
+  pushFlexMessage: vi.fn(() => ({ messageId: "of", messageIds: ["of"] })),
+  pushTemplateMessage: vi.fn(() => ({ messageId: "ot", messageIds: ["ot"] })),
+  pushLocationMessage: vi.fn(() => ({ messageId: "ol", messageIds: ["ol"] })),
+  pushTextMessageWithQuickReplies: vi.fn(() => ({ messageId: "oq", messageIds: ["oq"] })),
+  sendMessageLine: vi.fn(() => ({ messageId: "os", messageIds: ["os"] })),
+  buildTemplateMessageFromPayload: vi.fn(() => undefined),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getLineRuntime: () => ({
+    channel: {
+      line: runtimeStub,
+      text: {
+        chunkMarkdownText: (text: string) => text.split(String.fromCharCode(10).repeat(2)),
+        resolveTextChunkLimit: undefined,
+      },
+    },
+  }),
+}));
+
+vi.mock("./outbound.runtime.js", () => outboundRuntimeStub);
+
+import { lineOutboundAdapter } from "./outbound.js";
+
+const CFG = { channels: { line: { accounts: { acc: {} } } } };
+
+describe("lineOutboundAdapter.sendPayload batching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("batches a card, its caption, and an image into one push request", async () => {
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:Uabc",
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://example.com/image.jpg"],
+        channelData: {
+          line: {
+            card: { type: "bubble", body: { type: "box", contents: [] } },
+          },
+        },
+      },
+      accountId: "acc",
+      cfg: CFG,
+    });
+
+    // One request carries the card, its caption, and the image — exactly the
+    // three parts the issue measured as three monthly messages before.
+    expect(runtimeStub.pushMessagesLine).toHaveBeenCalledTimes(1);
+    const [, messages] = runtimeStub.pushMessagesLine.mock.calls[0] as unknown as [
+      string,
+      Array<{ type: string }>,
+    ];
+    expect(messages.map((message) => message.type)).toEqual(["flex", "text", "image"]);
+    expect(runtimeStub.pushFlexMessage).not.toHaveBeenCalled();
+    expect(runtimeStub.pushMessageLine).not.toHaveBeenCalled();
+  });
+
+  it("keeps per-request batches within the five-message Reply limit", async () => {
+    const longText = Array.from({ length: 7 }, (_, i) => `chunk ${i}`).join("\n\n");
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:Uabc",
+      payload: { text: longText },
+      accountId: "acc",
+      cfg: CFG,
+    });
+
+    expect(runtimeStub.pushMessagesLine).toHaveBeenCalledTimes(2);
+    const firstBatch = runtimeStub.pushMessagesLine.mock.calls[0] as unknown as [
+      string,
+      Array<{ type: string }>,
+    ];
+    expect(firstBatch[1]).toHaveLength(5);
+  });
+});

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -52,11 +52,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     const lineRuntime = runtime.channel.line;
     const location = lineData.location;
     const locationMessage = location ? outboundRuntime.createLocationMessage(location) : null;
-    const sendText = lineRuntime?.pushMessageLine ?? outboundRuntime.pushMessageLine;
     const sendBatch = lineRuntime?.pushMessagesLine ?? outboundRuntime.pushMessagesLine;
-    const sendFlex = lineRuntime?.pushFlexMessage ?? outboundRuntime.pushFlexMessage;
-    const sendTemplate = lineRuntime?.pushTemplateMessage ?? outboundRuntime.pushTemplateMessage;
-    const sendLocation = lineRuntime?.pushLocationMessage ?? outboundRuntime.pushLocationMessage;
     const sendQuickReplies =
       lineRuntime?.pushTextMessageWithQuickReplies ??
       outboundRuntime.pushTextMessageWithQuickReplies;
@@ -123,6 +119,19 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       }
     };
 
+    const batchedMessages: Array<Record<string, unknown>> = [];
+    const buildMediaBatch = async () => {
+      const mediaBatch: Array<Record<string, unknown>> = [];
+      for (const url of mediaUrls) {
+        const trimmed = url?.trim();
+        if (!trimmed) {
+          continue;
+        }
+        mediaBatch.push(await buildLineMediaMessage(trimmed, mediaOptions, to));
+      }
+      return mediaBatch;
+    };
+
     const sendTextWithQuickReply = async (text: string) => {
       if (quickReplyItems.length > 0 && quickReply) {
         await sendMessageBatch([{ type: "text", text, quickReply }]);
@@ -162,76 +171,70 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       trackingId: lineData.trackingId,
     };
     const shouldSendQuickRepliesInline = chunks.length === 0 && hasQuickReplies;
-    const sendMediaMessages = async () => {
-      for (const url of mediaUrls) {
-        const trimmed = url?.trim();
-        if (!trimmed) {
-          continue;
-        }
-        await recordResult(
-          (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
-            ...sendOptions,
-            ...mediaOptions,
-            mediaUrl: trimmed,
-          }),
-        );
-      }
-    };
 
     if (!shouldSendQuickRepliesInline) {
+      // LINE bills one message per request per recipient no matter how many
+      // message objects a request carries, so the reply's parts (card, its
+      // caption, images, ...) are batched into as few push requests as
+      // possible — 5 objects per request — instead of one request per part
+      // (issue #142734). Quick replies stay attached to the final message.
       if (lineData.flexMessage) {
-        const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-        await recordResult(sendFlex(to, lineData.flexMessage.altText, flexContents, sendOptions));
+        batchedMessages.push(
+          outboundRuntime.createFlexMessage(
+            lineData.flexMessage.altText,
+            lineData.flexMessage.contents as Parameters<
+              typeof outboundRuntime.createFlexMessage
+            >[1],
+          ),
+        );
       }
 
       if (lineData.templateMessage) {
         const template = buildTemplate(lineData.templateMessage);
         if (template) {
-          await recordResult(sendTemplate(to, template, sendOptions));
+          batchedMessages.push(template);
         }
       }
 
-      if (location) {
-        await recordResult(sendLocation(to, location, sendOptions));
+      if (locationMessage) {
+        batchedMessages.push(locationMessage);
       }
 
       if (!orderedMessages) {
         for (const flexMsg of processed.flexMessages) {
-          await recordResult(sendFlex(to, flexMsg.altText, flexMsg.contents, sendOptions));
+          batchedMessages.push(
+            outboundRuntime.createFlexMessage(flexMsg.altText, flexMsg.contents),
+          );
         }
       }
-    }
 
-    const sendMediaAfterText = !(hasQuickReplies && chunks.length > 0);
-    if (mediaUrls.length > 0 && !shouldSendQuickRepliesInline && !sendMediaAfterText) {
-      await sendMediaMessages();
-    }
+      const sendMediaAfterText = !(hasQuickReplies && chunks.length > 0);
+      if (!sendMediaAfterText) {
+        batchedMessages.push(...(await buildMediaBatch()));
+      }
 
-    if (orderedMessages && !shouldSendQuickRepliesInline) {
-      for (const [index, message] of orderedMessages.entries()) {
-        const isLast = index === orderedMessages.length - 1;
-        if (message.type === "flex") {
-          if (isLast && quickReply) {
-            await sendMessageBatch([{ ...message, quickReply }]);
-          } else {
-            await recordResult(sendFlex(to, message.altText, message.contents, sendOptions));
-          }
-        } else if (isLast && hasQuickReplies) {
-          await sendTextWithQuickReply(message.text);
-        } else {
-          await recordResult(sendText(to, message.text, sendOptions));
+      if (orderedMessages) {
+        batchedMessages.push(...orderedMessages);
+      } else {
+        for (const chunk of chunks) {
+          batchedMessages.push({ type: "text", text: chunk });
         }
       }
-    } else if (chunks.length > 0) {
-      for (const [i, chunk] of chunks.entries()) {
-        const isLast = i === chunks.length - 1;
-        if (isLast && hasQuickReplies) {
-          await sendTextWithQuickReply(chunk);
-        } else {
-          await recordResult(sendText(to, chunk, sendOptions));
-        }
+
+      if (sendMediaAfterText) {
+        batchedMessages.push(...(await buildMediaBatch()));
       }
-    } else if (shouldSendQuickRepliesInline) {
+
+      if (batchedMessages.length > 0 && quickReply) {
+        const lastIndex = batchedMessages.length - 1;
+        batchedMessages[lastIndex] = {
+          ...batchedMessages[lastIndex],
+          quickReply,
+        };
+      }
+
+      await sendMessageBatch(batchedMessages);
+    } else {
       const quickReplyMessages: Array<Record<string, unknown>> = [];
       if (lineData.flexMessage) {
         quickReplyMessages.push(
@@ -274,10 +277,6 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       } else if (quickReply) {
         await sendTextWithQuickReply(buildLineQuickReplyFallbackText(quickReplyLabels));
       }
-    }
-
-    if (mediaUrls.length > 0 && !shouldSendQuickRepliesInline && sendMediaAfterText) {
-      await sendMediaMessages();
     }
 
     const completedResult = lastResult as LineSendResult | null;


### PR DESCRIPTION
## What Problem This Solves

LINE bills one message per request per recipient, regardless of how many message objects a request carries. The LINE plugin's proactive send path (`sendPayload`) issued one request per part, so a reply carrying a card, its caption, and an image spent **three** of the account's monthly messages instead of one (issue #142734: measured `totalUsage 111 -> 114` on a real channel) — multiplied again for every group member. LINE's free plan includes 200 messages/month, and an exhausted allowance leaves the bot silent for the rest of the billing cycle.

## What This Changes

The non-quick-reply path of `sendPayload` now collects the reply's parts — channelData flex card, template, location, markdown-derived flex/text segments, media — into one ordered message array (same part precedence and quick-reply-on-final-message attachment as before) and sends it through the existing `sendMessageBatch` helper (5 objects per request, receipts recorded per chunk) that the quick-reply path already used. Text chunking and the media-before/after-text ordering rule are preserved.

## Evidence

Regression tests in `extensions/line/src/outbound.batch.test.ts` (mocked LINE runtime, no network):

- **One request for three parts**: a payload of card + caption text + image produces exactly **one** `pushMessagesLine` call carrying `[flex, text, image]` — and neither `pushFlexMessage` nor `pushMessageLine` is invoked. Verified **red** on the per-part path (two+ separate sends).
- **Chunking**: a seven-segment reply produces two push requests of 5 + 2 messages.

Full `extensions/line/src/` suite note: this branch's upstream base moved fast today and several untouched suites (`bot-message-context` etc.) fail identically on unmodified upstream HEAD locally (verified) — CI Linux is authoritative.

Fixes #142734