### PR TITLE
refactor(tests): share independent replay expectations

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -1576,6 +1576,15 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 });
 
 describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
+  function expectedRetryMessages() {
+    return [
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+  }
+
   it("drops malformed assistant tool calls from outbound context before provider replay", async () => {
     const messages = [
       {
@@ -1604,12 +1613,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
     expect(seenContext.messages).not.toBe(messages);
   });
 
@@ -1778,12 +1782,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("drops signed thinking turns for bedrock claude replay when sibling tool calls are not replay-safe", async () => {
@@ -1818,12 +1817,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("drops signed thinking turns when sibling replay tool calls reuse an id", async () => {
@@ -1859,12 +1853,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("keeps signed thinking turns that reuse a mutable earlier tool id", async () => {
@@ -2009,12 +1998,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("drops signed thinking turns with non-content attachment payload fields when the result is missing", async () => {
@@ -2068,12 +2052,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = firstBaseContext(baseFn);
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("keeps signed thinking turns with sessions_spawn attachments when the tool result is present", async () => {
@@ -2432,12 +2411,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const seenContext = firstBaseContext(baseFn) as {
       messages: Array<{ role?: string }>;
     };
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("drops replayed tool calls that are no longer allowlisted", async () => {
@@ -2466,12 +2440,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const seenContext = firstBaseContext(baseFn) as {
       messages: Array<{ role?: string }>;
     };
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
   it("drops replayed tool names that are no longer allowlisted", async () => {
     const messages = [
@@ -2705,12 +2674,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const seenContext = firstBaseContext(baseFn) as {
       messages: Array<{ role?: string; content?: unknown[] }>;
     };
-    expect(seenContext.messages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-      },
-    ]);
+    expect(seenContext.messages).toEqual(expectedRetryMessages());
   });
 
   it("preserves embedded Anthropic user tool_result blocks for non-thinking turns even when immutable replay is enabled", async () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Nine replay-sanitization scenarios repeat the same complete expected message array, adding duplicate oracle maintenance within one test suite.

## Why This Change Was Made

Use one suite-local `expectedRetryMessages` constructor for those nine equality assertions. It returns fresh literal data and remains independent from every input fixture, mock result and production helper. All scenarios, wrapper calls, policies, identity checks and other assertions stay unchanged.

## User Impact

No user-visible behavior change. This removes 36 net test lines without changing production code or reducing scenario coverage.

## Evidence

- The complete `attempt.test.ts` suite passed all 121 cases before and after, with identical ordered case names.
- Full AST expansion reconstructs the original test source; all nine uses are expected-only, with four fresh object/array allocations per call and preserved values/key order.
- Mapped changed checks, diff-scoped cleanup and fresh independent P2 review passed with no findings.

No runtime improvement is claimed.
