### PR TITLE
fix(gateway): preserve restored-version verification across update restart

### DIFF
--- a/src/gateway/server-restart-update-run.test.ts
+++ b/src/gateway/server-restart-update-run.test.ts
@@ -1,15 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildUpdateRestartSentinelPayload } from "../infra/update-restart-sentinel-payload.js";
-import { createUpdateRun, recordUpdateRunPhase } from "../infra/update-run-ledger.js";
+import {
+  createUpdateRun,
+  recordUpdateRunPhase,
+  recordUpdateRunVerification,
+} from "../infra/update-run-ledger.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { finalizeRestartUpdateRun } from "./server-restart-update-run.js";
+
+// The runtime build ID is a process-level constant resolved from packaged
+// build info; vary it per test through this mutable override instead.
+let runtimeBuildId: string | null = null;
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
+  resolveRuntimeServiceBuildId: () => runtimeBuildId,
+}));
 
 const directories = createTempDirTracker();
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   vi.unstubAllEnvs();
+  runtimeBuildId = null;
   directories.cleanup();
 });
 
@@ -53,6 +66,175 @@ describe("update restart verification ownership", () => {
       });
     },
   );
+
+  it.each(["api", "chat", "control-ui", "campaign"] as const)(
+    "preserves the restored-version verification for a failed managed %s update",
+    async (trigger) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-managed-restore-"));
+      const restoredVersion = "1.2.3";
+      const targetVersion = "2.0.0";
+      vi.stubEnv("OPENCLAW_VERSION", restoredVersion);
+      runtimeBuildId = "build-restored";
+      // The failed update booting the old version records the target, not the
+      // restored disk version: after.version stays empty (staged-install
+      // verification failed), so the helper's restore verification is the only
+      // versionMatch fact. It compares the restored gateway against the
+      // restored disk version, not against the update target.
+      const run = createUpdateRun({ trigger, target: { version: targetVersion } });
+      recordUpdateRunPhase(run.runId, "restarting");
+      recordUpdateRunPhase(run.runId, "verifying", { after: {} });
+      recordUpdateRunVerification(run.runId, {
+        serviceRunning: true,
+        runningVersion: restoredVersion,
+        runningBuildId: "build-restored",
+        versionMatch: true,
+        settled: true,
+        channelsReady: true,
+        pluginErrors: [],
+      });
+      const payload = buildUpdateRestartSentinelPayload({
+        result: {
+          status: "error",
+          mode: "npm",
+          reason: "managed-service-handoff-failed",
+          steps: [],
+          durationMs: 1,
+        },
+        meta: { runId: run.runId, handoffId: "managed-update-handoff" },
+      });
+      const observed = await finalizeRestartUpdateRun(payload, true);
+      // The restored gateway booted on the restored version. The helper already
+      // verified that identity; the boot must not regrade it against the
+      // update target.
+      expect(observed?.verification.versionMatch).toBe(true);
+      expect(observed?.verification.runningVersion).toBe(restoredVersion);
+      expect(observed).toMatchObject({ status: "running", phase: "verifying" });
+    },
+  );
+
+  it("regrades a restored-version boot reporting a different build against the update target", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-managed-restore-build-mismatch-"));
+    const restoredVersion = "1.2.3";
+    vi.stubEnv("OPENCLAW_VERSION", restoredVersion);
+    runtimeBuildId = "build-other";
+    // The restore helper verified version 1.2.3/build-restored. A later boot
+    // serving 1.2.3/build-other is a different binary; reusing the recorded
+    // verification would publish a false verified result.
+    const run = createUpdateRun({ trigger: "api", target: { version: "2.0.0" } });
+    recordUpdateRunPhase(run.runId, "restarting");
+    recordUpdateRunPhase(run.runId, "verifying", { after: {} });
+    recordUpdateRunVerification(run.runId, {
+      serviceRunning: true,
+      runningVersion: restoredVersion,
+      runningBuildId: "build-restored",
+      versionMatch: true,
+      settled: true,
+      channelsReady: true,
+      pluginErrors: [],
+    });
+    const payload = buildUpdateRestartSentinelPayload({
+      result: {
+        status: "error",
+        mode: "npm",
+        reason: "managed-service-handoff-failed",
+        steps: [],
+        durationMs: 1,
+      },
+      meta: { runId: run.runId, handoffId: "managed-update-handoff" },
+    });
+    const observed = await finalizeRestartUpdateRun(payload, true);
+    expect(observed?.verification.versionMatch).toBe(false);
+    expect(observed?.verification.runningVersion).toBe(restoredVersion);
+  });
+
+  it("regrades a restored-version boot whose build cannot be resolved when a build was recorded", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-managed-restore-build-missing-"));
+    const restoredVersion = "1.2.3";
+    vi.stubEnv("OPENCLAW_VERSION", restoredVersion);
+    runtimeBuildId = null;
+    const run = createUpdateRun({ trigger: "api", target: { version: "2.0.0" } });
+    recordUpdateRunPhase(run.runId, "restarting");
+    recordUpdateRunPhase(run.runId, "verifying", { after: {} });
+    recordUpdateRunVerification(run.runId, {
+      serviceRunning: true,
+      runningVersion: restoredVersion,
+      runningBuildId: "build-restored",
+      versionMatch: true,
+      settled: true,
+      channelsReady: true,
+      pluginErrors: [],
+    });
+    const payload = buildUpdateRestartSentinelPayload({
+      result: {
+        status: "error",
+        mode: "npm",
+        reason: "managed-service-handoff-failed",
+        steps: [],
+        durationMs: 1,
+      },
+      meta: { runId: run.runId, handoffId: "managed-update-handoff" },
+    });
+    const observed = await finalizeRestartUpdateRun(payload, true);
+    expect(observed?.verification.versionMatch).toBe(false);
+  });
+
+  it("reuses a restored-version verification recorded without build identity", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-managed-restore-build-unrecorded-"));
+    const restoredVersion = "1.2.3";
+    vi.stubEnv("OPENCLAW_VERSION", restoredVersion);
+    runtimeBuildId = "build-other";
+    // The recorder never learned the restored build, so no stronger identity
+    // check is possible; version equality is all the verification recorded.
+    const run = createUpdateRun({ trigger: "api", target: { version: "2.0.0" } });
+    recordUpdateRunPhase(run.runId, "restarting");
+    recordUpdateRunPhase(run.runId, "verifying", { after: {} });
+    recordUpdateRunVerification(run.runId, {
+      serviceRunning: true,
+      runningVersion: restoredVersion,
+      versionMatch: true,
+      settled: true,
+      channelsReady: true,
+      pluginErrors: [],
+    });
+    const payload = buildUpdateRestartSentinelPayload({
+      result: {
+        status: "error",
+        mode: "npm",
+        reason: "managed-service-handoff-failed",
+        steps: [],
+        durationMs: 1,
+      },
+      meta: { runId: run.runId, handoffId: "managed-update-handoff" },
+    });
+    const observed = await finalizeRestartUpdateRun(payload, true);
+    expect(observed?.verification.versionMatch).toBe(true);
+  });
+
+  it("keeps ordinary expected-build checks when target verification already succeeded", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-ordinary-build-check-"));
+    const version = resolveRuntimeServiceVersion();
+    runtimeBuildId = "build-running";
+    // after.version is set, so target verification succeeded: the recorded
+    // versionMatch is an ordinary verification, not a restore, and the
+    // expected build must still be enforced even for the same binary.
+    const run = createUpdateRun({ trigger: "api", target: { version } });
+    recordUpdateRunPhase(run.runId, "restarting");
+    recordUpdateRunPhase(run.runId, "verifying", {
+      after: { version, buildId: "build-expected" },
+    });
+    recordUpdateRunVerification(run.runId, {
+      serviceRunning: true,
+      runningVersion: version,
+      runningBuildId: "build-running",
+      versionMatch: true,
+    });
+    const payload = buildUpdateRestartSentinelPayload({
+      result: { status: "ok", mode: "npm", after: { version }, steps: [], durationMs: 1 },
+      meta: { runId: run.runId },
+    });
+    const observed = await finalizeRestartUpdateRun(payload);
+    expect(observed?.verification.versionMatch).toBe(false);
+  });
 
   it("fails an expired unmanaged pending restart", async () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", directories.make("update-unmanaged-expiry-"));

--- a/src/gateway/server-restart-update-run.ts
+++ b/src/gateway/server-restart-update-run.ts
@@ -40,8 +40,29 @@ export async function finalizeRestartUpdateRun(
     }
     const runningVersion = resolveRuntimeServiceVersion();
     const runningBuildId = resolveRuntimeServiceBuildId();
-    const expectedVersion = updateRun.after.version ?? updateRun.target.version;
-    const expectedBuildId = updateRun.after.buildId;
+    // A failed update's restored boot serves the previous version. The restore
+    // owner already verified that identity against the restored disk state and
+    // recorded it; regrading this boot against the update target would
+    // overwrite the verified fact with a version mismatch. An empty
+    // after.version marks that path: target verification never succeeded, so
+    // the recorded versionMatch could only have come from the restore. Reuse
+    // it only for the exact binary the recorder verified — a boot serving the
+    // recorded version under a different (or unverifiable) build is another
+    // binary and must be regraded against the update target.
+    const recordedBuildId =
+      typeof updateRun.verification.runningBuildId === "string"
+        ? updateRun.verification.runningBuildId
+        : undefined;
+    const restoredVerification =
+      updateRun.verification.versionMatch === true &&
+      !updateRun.after.version &&
+      typeof updateRun.verification.runningVersion === "string" &&
+      updateRun.verification.runningVersion === runningVersion &&
+      (recordedBuildId === undefined || recordedBuildId === runningBuildId);
+    const expectedVersion = restoredVerification
+      ? runningVersion
+      : (updateRun.after.version ?? updateRun.target.version);
+    const expectedBuildId = restoredVerification ? undefined : updateRun.after.buildId;
     const pluginErrors = getActivePluginRegistry()
       ?.diagnostics.filter((entry) => entry.level === "error")
       .map((entry) => entry.message);


### PR DESCRIPTION
## What Problem This Solves

When a managed `/update` fails and the handoff restores the previous Gateway version, the restored boot reports **"version mismatch"** in the update report — even though the restore itself succeeded and the service is healthy on the previous version.

### Defect chain

1. `src/infra/package-update-steps.ts` records `afterVersion` **only** when the failure is a staged-install verification failure (`failedVerification && stagedInstall`). For every other managed-update failure path, `updateRun.after.version` is empty.
2. The restore owner (`src/infra/update-managed-service-handoff.ts`) then correctly restores the previous service generation. It knows the running (previous) version, verifies readiness against it, and records a **correct** `versionMatch=true` in the update-run ledger.
3. When the restored Gateway boots, `finalizeRestartUpdateRun` in `src/gateway/server-restart-update-run.ts` recomputes the comparison as `expectedVersion = updateRun.after.version ?? updateRun.target.version`. With `after.version` empty this resolves to the **update target** (the new version), so `runningVersion (old) !== expected (new)` → `versionMatch=false`, overwriting the helper's verified ledger fact.
4. The user sees a healthy restored boot reported as a version mismatch; the waiting orchestrator would grade the run `restart-unhealthy` off that corrupted fact.

### Impact

- Incorrect outcome presentation: the update report claims a version mismatch for a boot that is verifiably healthy on the restored version (see real-run before/after below).
- Ledger corruption: the boot-time regrade overwrites the restore owner's verified verification record.

This is a behavior-completing follow-up from #139393 (listed by the maintainer when closing that issue).

## Solution

A failed update's restored boot serves the previous version. The restore owner already verified that identity against the restored disk state and recorded it. The boot-time verification must not regrade that boot against the update target.

In `finalizeRestartUpdateRun`, when the recorded verification already says `versionMatch === true` with a `runningVersion` that matches the version booting now **and `after.version` is empty** (the restore-path marker: target verification never succeeded), treat that running version as the expected version (and skip the stale `after.buildId` comparison). Otherwise the existing `after.version ?? target.version` logic is unchanged.

The reuse is additionally gated on build identity: when the recorder stored a `runningBuildId`, the recorded verification is only reused if the booting process resolves to that same build. A same-version boot serving a different build (or one whose build cannot be resolved) is still regraded against the update target, so the ledger can never publish a verified result for a binary the restore owner did not verify.

- Normal successful updates: unaffected — the recorded verification is not `true` with a matching version until after this code runs, so the primary path is untouched.
- Genuine version mismatches on boot: unaffected — the recorded `versionMatch` would not be `true`, so the regrade still happens.

## Evidence

### Real managed-update recovery run (2026-09-09, built dist gateway, isolated state dir)

End-to-end with the real packaged gateway booting against a real state DB. Seed uses only the real producer APIs in the same order as production: `createUpdateRun(api → target 2026.9.3)` → `recordUpdateRunPhase(restarting, verifying {after:{}})` → the restore owner's `recordUpdateRunVerification({serviceRunning, runningVersion: 2026.9.2, runningBuildId: <dist buildId>, versionMatch: true, settled, channelsReady, pluginErrors: []})` → `finishUpdateRun(failed, managed-service-handoff-failed)` (the handoff's `finishManagedUpdateRun`) → `writeRestartSentinel(buildUpdateRestartSentinelPayload({status: "error", reason: "managed-service-handoff-failed"}, {runId, handoffId}))`. Then `node dist/index.js gateway run` boots for real (post-ready sidecar `sidecars.restart-sentinel` → `finalizeRestartUpdateRun`), and the final ledger + rendered report are read back from the same DB. The restored-version environment runs with `OPENCLAW_VERSION=2026.9.2` (the version resolution path the service itself uses).

Ledger BEFORE the restored boot (both variants, recorded by the restore owner):

```json
"verification": {
  "runningVersion": "2026.9.2",
  "runningBuildId": "2026.9.3-2026-09-09T13-22-18.261Z",
  "serviceRunning": true,
  "versionMatch": true,
  "channelsReady": true,
  "settled": true
}
```

**Before fix (parent commit `1c576b0a0fa` dist)** — the restored boot regrades against the update target and overwrites the verified fact:

```json
"verification": {
  "booted": true,
  "runningVersion": "2026.9.2",
  "runningBuildId": "2026.9.3-2026-09-09T13-22-18.261Z",
  "serviceRunning": true,
  "pid": 115,
  "versionMatch": false,
  ...
}
```

Report the user is shown:

```
⚠️ OpenClaw update failed: managed-service-handoff-failed. The gateway is running 2026.9.2.
Verification: gateway booted; service running; version mismatch; channels ready.
```

**After fix (PR head `ba53a17386e` dist)** — the boot preserves the restore owner's verified identity; the original update failure stands on its own:

```json
"verification": {
  "booted": true,
  "runningVersion": "2026.9.2",
  "runningBuildId": "2026.9.3-2026-09-09T13-25-40.675Z",
  "serviceRunning": true,
  "pid": 115,
  "versionMatch": true,
  ...
}
```

Report:

```
⚠️ OpenClaw update failed: managed-service-handoff-failed. The gateway is running 2026.9.2.
Verification: gateway booted; service running; version verified; channels ready.
```

The booting gateway's own build ID (`dist/build-info.json`) was recorded by the restore owner and matches the booting process, so the preserved verdict exercises the build-identity gate, not the legacy no-build fallback.

### Tests (exact PR head)

- `src/gateway/server-restart-update-run.test.ts`: 24/24 green (`vitest run`, 40.9s), including `it.each` over `api`/`chat`/`control-ui`/`campaign` for restore preservation and the four build-identity branches (different build → regraded; unresolvable build → regraded; legacy record without build → reused; ordinary expected-build check retained when target verification succeeded).
- Red evidence: on the original implementation the restore-preservation tests fail exactly on the `versionMatch` assertion (`expected true, received false`).
- `tsgo` typecheck of the `src/gateway/*.test.ts` shard exits 0; `oxfmt --check` clean; CI green on `ba53a17386e` (including `check-test-types-core-2` and `PR context and evidence`).

Fixes #143204
Related #139393
