### PR TITLE
improve(plugins): avoid rebuilding provider ownership metadata

### DIFF
--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -1,4 +1,3 @@
-// Covers provider plugin registration and runtime composition.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -20,6 +19,8 @@ type LoadPluginManifestRegistry =
 type LoadPluginMetadataSnapshot =
   typeof import("./plugin-metadata-snapshot.js").loadPluginMetadataSnapshot;
 type LoadPluginRegistrySnapshot = typeof import("./plugin-registry.js").loadPluginRegistrySnapshot;
+type LoadPluginRegistrySnapshotWithMetadata =
+  typeof import("./plugin-registry.js").loadPluginRegistrySnapshotWithMetadata;
 type ApplyPluginAutoEnable = typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable;
 type SetActivePluginRegistry = typeof import("./runtime.js").setActivePluginRegistry;
 
@@ -30,6 +31,7 @@ const isPluginRegistryLoadInFlightMock = vi.fn<IsPluginRegistryLoadInFlight>((_o
 const loadPluginManifestRegistryMock = vi.fn<LoadPluginManifestRegistry>();
 const loadPluginMetadataSnapshotMock = vi.fn<LoadPluginMetadataSnapshot>();
 const loadPluginRegistrySnapshotMock = vi.fn<LoadPluginRegistrySnapshot>();
+const loadPluginRegistrySnapshotWithMetadataMock = vi.fn<LoadPluginRegistrySnapshotWithMetadata>();
 const getCurrentPluginMetadataSnapshotMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 
@@ -507,6 +509,9 @@ describe("resolvePluginProviders", () => {
         ...actual,
         loadPluginRegistrySnapshot: (...args: Parameters<LoadPluginRegistrySnapshot>) =>
           loadPluginRegistrySnapshotMock(...args),
+        loadPluginRegistrySnapshotWithMetadata: (
+          ...args: Parameters<LoadPluginRegistrySnapshotWithMetadata>
+        ) => loadPluginRegistrySnapshotWithMetadataMock(...args),
         resolvePluginContributionOwners: resolvePluginContributionOwnersFixture,
         resolveProviderOwners: resolveProviderOwnersFixture,
       };
@@ -603,12 +608,12 @@ describe("resolvePluginProviders", () => {
 
     expectOwningPluginIds("setup-only-cli");
     loadPluginMetadataSnapshotMock.mockClear();
-    loadPluginRegistrySnapshotMock.mockClear();
+    loadPluginRegistrySnapshotWithMetadataMock.mockClear();
     expect(resolveOwningPluginIdsForProviderRef({ provider: "setup-only-cli" })).toEqual([
       "setup-only-backend-owner",
     ]);
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
-    expect(loadPluginRegistrySnapshotMock).toHaveBeenCalledOnce();
+    expect(loadPluginRegistrySnapshotWithMetadataMock).toHaveBeenCalledOnce();
   });
 
   it("maps explicit provider refs to provider or cli-backend owners", () => {
@@ -620,6 +625,59 @@ describe("resolvePluginProviders", () => {
       pluginIds: ["anthropic"],
     });
   });
+
+  it.each([true, false])(
+    "resolves installed owners with prepared manifest metadata: %s",
+    (prepared) => {
+      const plugins = [
+        createManifestProviderPlugin({
+          id: "first-owner",
+          providerIds: ["direct-provider"],
+          cliBackends: ["shared-cli"],
+        }),
+        createManifestProviderPlugin({
+          id: "second-owner",
+          providerIds: [],
+          setup: { cliBackends: ["SHARED-CLI"] },
+          enabledByDefault: false,
+        }),
+      ];
+      setManifestPlugins(plugins);
+      const snapshot = createProviderRegistrySnapshotFixture();
+      loadPluginRegistrySnapshotMock.mockReturnValue(snapshot);
+      loadPluginRegistrySnapshotWithMetadataMock.mockReturnValue({
+        snapshot,
+        source: "derived",
+        diagnostics: [],
+        ...(prepared
+          ? {
+              manifestRegistry: {
+                plugins: [
+                  ...plugins,
+                  createManifestProviderPlugin({
+                    id: "not-installed",
+                    providerIds: ["direct-provider"],
+                    cliBackends: ["shared-cli"],
+                  }),
+                ],
+                diagnostics: [],
+              },
+            }
+          : {}),
+      });
+      loadPluginManifestRegistryMock.mockClear();
+
+      expect(resolveProviderRefOwnership({ provider: " DIRECT-PROVIDER " })).toEqual({
+        status: "owned",
+        pluginIds: ["first-owner"],
+      });
+      expect(resolveProviderRefOwnership({ provider: " Shared-CLI " })).toEqual({
+        status: "ambiguous",
+        pluginIds: ["first-owner", "second-owner"],
+      });
+      expect(loadPluginManifestRegistryMock).toHaveBeenCalledTimes(prepared ? 0 : 2);
+    },
+  );
 
   it("marks explicit provider refs with multiple owners as ambiguous", () => {
     setManifestPlugins([
@@ -689,6 +747,7 @@ describe("resolvePluginProviders", () => {
     expectOwningPluginIds("openai", ["openai"]);
 
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(loadPluginRegistrySnapshotWithMetadataMock).not.toHaveBeenCalled();
     expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       config: undefined,
       env: undefined,
@@ -696,20 +755,32 @@ describe("resolvePluginProviders", () => {
     });
   });
 
-  it("uses current metadata owner maps for cli backend provider refs", () => {
-    const plugins = [
-      createManifestProviderPlugin({
-        id: "anthropic",
-        providerIds: [],
-        cliBackends: ["claude-cli"],
-      }),
-    ];
-    getCurrentPluginMetadataSnapshotMock.mockReturnValue(createMetadataSnapshotFixture(plugins));
+  it.each(["current", "supplied"])(
+    "uses %s metadata owner maps for cli backend provider refs",
+    (source) => {
+      const plugins = [
+        createManifestProviderPlugin({
+          id: "anthropic",
+          providerIds: [],
+          cliBackends: ["claude-cli"],
+        }),
+      ];
+      const metadataSnapshot = createMetadataSnapshotFixture(plugins);
+      if (source === "current") {
+        getCurrentPluginMetadataSnapshotMock.mockReturnValue(metadataSnapshot);
+      }
 
-    expect(resolveOwningPluginIdsForProviderRef({ provider: "claude-cli" })).toEqual(["anthropic"]);
+      expect(
+        resolveOwningPluginIdsForProviderRef({
+          provider: "claude-cli",
+          ...(source === "supplied" ? { metadataSnapshot } : {}),
+        }),
+      ).toEqual(["anthropic"]);
 
-    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
-  });
+      expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+      expect(loadPluginRegistrySnapshotWithMetadataMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps normalized case-variant owners from current metadata maps", () => {
     const plugins = [
@@ -765,6 +836,7 @@ describe("resolvePluginProviders", () => {
     ).toEqual(["fresh-owner"]);
 
     expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(loadPluginRegistrySnapshotWithMetadataMock).not.toHaveBeenCalled();
   });
 
   it("maps manifest provider auth aliases to the target provider owner", () => {
@@ -808,6 +880,12 @@ describe("resolvePluginProviders", () => {
     loadPluginRegistrySnapshotMock.mockImplementation(() =>
       createProviderRegistrySnapshotFixture(),
     );
+    loadPluginRegistrySnapshotWithMetadataMock.mockReset();
+    loadPluginRegistrySnapshotWithMetadataMock.mockImplementation(() => ({
+      snapshot: createProviderRegistrySnapshotFixture(),
+      source: "derived",
+      diagnostics: [],
+    }));
     getCurrentPluginMetadataSnapshotMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
     const provider: ProviderPlugin = {

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -1,4 +1,3 @@
-// Registers provider plugins into the provider registry.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
@@ -16,6 +15,7 @@ import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-re
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import {
   loadPluginRegistrySnapshot,
+  loadPluginRegistrySnapshotWithMetadata,
   normalizePluginsConfigWithRegistry,
   type PluginRegistryRecord,
   type PluginRegistrySnapshot,
@@ -564,25 +564,23 @@ function resolveProviderOwnershipContext(
           ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
           allowWorkspaceScopedSnapshot: true,
         }));
-  const config = params.config ?? {};
-  const env = params.env ?? process.env;
-  const manifestRegistry =
-    params.manifestRegistry ??
-    metadataSnapshot?.manifestRegistry ??
-    resolveManifestRegistry({
-      config,
-      workspaceDir: params.workspaceDir,
-      env,
-      registry: loadProviderRegistrySnapshot({
-        config,
-        workspaceDir: params.workspaceDir,
-        env,
-      }),
-      includeDisabled: true,
-    });
+  const manifestRegistry = params.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
+  if (manifestRegistry) {
+    return { manifestRegistry, ...(metadataSnapshot ? { metadataSnapshot } : {}) };
+  }
+  const registryParams = {
+    config: params.config ?? {},
+    workspaceDir: params.workspaceDir,
+    env: params.env ?? process.env,
+  };
+  const loaded = loadPluginRegistrySnapshotWithMetadata(registryParams);
   return {
-    manifestRegistry,
-    ...(metadataSnapshot ? { metadataSnapshot } : {}),
+    manifestRegistry: loadPluginManifestRegistryForInstalledIndex({
+      ...registryParams,
+      index: loaded.snapshot,
+      manifestRegistry: loaded.manifestRegistry,
+      includeDisabled: true,
+    }),
   };
 }
 


### PR DESCRIPTION
Related: #127178

## What Problem This Solves

Provider ownership lookup could rebuild plugin manifests even when the registry loader had already prepared compatible metadata. This repeated work affects the cold lookup used to identify a provider or CLI backend's owning plugin.

## Why This Change Was Made

The ownership lookup now keeps the loader's paired manifest metadata and passes it through the existing installed-plugin adapter. Explicit and current metadata keep their precedence; the adapter still owns installed filtering, disabled-plugin ownership, normalization, and reconstruction when prepared metadata is absent.

## User Impact

Provider and CLI backend selection keep their existing results while avoiding redundant manifest reconstruction. No configuration or plugin API changes are required.

## Evidence

The new regression fails on unchanged production because prepared metadata triggers two unnecessary reconstructions; the absent-metadata control and existing ownership cases pass. After the repair, 137 tests pass across the provider, snapshot, installed-adapter, and current-runtime-metadata suites. All 29 canonical changed-file checks pass, including core and test types, lint, and architecture guards.

The two-file patch and its inspected dependencies carry unchanged to main `3f0f98ef7ef`. Production shrinks by two lines. These are synthetic metadata tests through the real adapter; no live-provider or elapsed-time claim is made. Independent Codex review found no actionable issues.
