### PR TITLE
refactor: simplify outbound reply mirroring

### DIFF
--- a/src/infra/outbound/payloads.mirror.test.ts
+++ b/src/infra/outbound/payloads.mirror.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import { adaptMessagePresentationForChannel } from "../../channels/plugins/outbound/presentation-limits.js";
+import { renderMessagePresentationFallbackText } from "../../interactive/payload.js";
+import { createOutboundPayloadPlan, projectOutboundPayloadPlanForMirror } from "./payloads.js";
+
+describe("outbound mirror text", () => {
+  it("preserves normalized control order and plain-text precedence", () => {
+    const payload: ReplyPayload = {
+      presentation: {
+        title: "  Card  ",
+        blocks: [
+          { type: "context", text: " context " },
+          { type: "text", text: " body " },
+          {
+            type: "buttons",
+            buttons: [
+              { label: " Same ", value: "first" },
+              { label: "Same", value: "second" },
+              { label: " \t ", value: "ignored" },
+            ],
+          },
+          {
+            type: "select",
+            placeholder: " Select ",
+            options: [
+              { label: " Choice ", value: "choice" },
+              { label: "  ", value: "ignored" },
+            ],
+          },
+        ],
+      },
+      interactive: {
+        blocks: [
+          { type: "text", text: " Legacy " },
+          { type: "buttons", buttons: [{ label: " Accept ", value: "accept" }] },
+          { type: "select", placeholder: " Old ", options: [{ label: " One ", value: "one" }] },
+        ],
+      },
+    };
+    const before = structuredClone(payload);
+
+    expect(projectOutboundPayloadPlanForMirror(createOutboundPayloadPlan([payload]))).toEqual({
+      text: "Card\ncontext\nbody\nSame\nSame\nSelect\nChoice\nLegacy\nAccept\nOld\nOne",
+      mediaUrls: [],
+    });
+    expect(
+      projectOutboundPayloadPlanForMirror(
+        createOutboundPayloadPlan([{ ...payload, text: "Caption" }]),
+      ),
+    ).toEqual({ text: "Caption", mediaUrls: [] });
+    expect(payload).toEqual(before);
+  });
+
+  it("trims adapted continuation fragments and drops blank continuation context", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        title: "Head    Tail",
+        blocks: [{ type: "context", text: "body        tail" }],
+      },
+      capabilities: { limits: { text: { maxLength: 6, encoding: "characters" } } },
+    });
+    const before = renderMessagePresentationFallbackText({ presentation });
+
+    expect(
+      projectOutboundPayloadPlanForMirror(createOutboundPayloadPlan([{ presentation }])),
+    ).toEqual({ text: "Head\nTail\nbody\ntail", mediaUrls: [] });
+    expect(renderMessagePresentationFallbackText({ presentation })).toBe(before);
+  });
+});

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -87,24 +87,15 @@ type MirrorTextBlock =
   | MessagePresentation["blocks"][number]
   | LegacyInteractiveReply["blocks"][number];
 
-function collectBlockMirrorText(
-  blocks: readonly MirrorTextBlock[],
-  options: { includeContext?: boolean } = {},
-): string[] {
-  const lines: string[] = [];
+function appendBlockMirrorText(lines: string[], blocks: readonly MirrorTextBlock[]): void {
   for (const block of blocks) {
-    if (
-      (block.type === "text" || (options.includeContext === true && block.type === "context")) &&
-      block.text.trim()
-    ) {
+    if ((block.type === "text" || block.type === "context") && block.text.trim()) {
       lines.push(block.text.trim());
       continue;
     }
     if (block.type === "buttons") {
       for (const button of block.buttons) {
-        if (button.label.trim()) {
-          lines.push(button.label.trim());
-        }
+        lines.push(button.label);
       }
       continue;
     }
@@ -117,29 +108,14 @@ function collectBlockMirrorText(
       continue;
     }
     if (block.type === "select") {
-      if (block.placeholder?.trim()) {
-        lines.push(block.placeholder.trim());
+      if (block.placeholder) {
+        lines.push(block.placeholder);
       }
       for (const option of block.options) {
-        if (option.label.trim()) {
-          lines.push(option.label.trim());
-        }
+        lines.push(option.label);
       }
     }
   }
-  return lines;
-}
-
-function collectPresentationMirrorText(presentation: MessagePresentation | undefined): string[] {
-  if (!presentation) {
-    return [];
-  }
-  const lines: string[] = [];
-  if (presentation.title?.trim()) {
-    lines.push(presentation.title.trim());
-  }
-  lines.push(...collectBlockMirrorText(presentation.blocks, { includeContext: true }));
-  return lines;
 }
 
 /** Renders user-visible payload content safely for every outbound transcript mirror. */
@@ -149,18 +125,28 @@ export function resolveOutboundPayloadMirrorText(payload: ReplyPayload): string 
     : payload.location && formatLocationText(payload.location);
   const presentation = normalizeMessagePresentation(payload.presentation);
   if (text?.trim()) {
-    const structuredDataText = presentation
-      ? collectBlockMirrorText(
-          presentation.blocks.filter((block) => block.type === "chart" || block.type === "table"),
-        )
-      : [];
-    return [text, ...structuredDataText].join("\n");
+    if (!presentation) {
+      return text;
+    }
+    const lines = [text];
+    appendBlockMirrorText(
+      lines,
+      presentation.blocks.filter((block) => block.type === "chart" || block.type === "table"),
+    );
+    return lines.join("\n");
   }
+  const lines: string[] = [];
   const interactive = normalizeLegacyInteractiveReply(payload.interactive);
-  return [
-    ...collectPresentationMirrorText(presentation),
-    ...collectBlockMirrorText(interactive?.blocks ?? []),
-  ].join("\n");
+  if (presentation?.title?.trim()) {
+    lines.push(presentation.title.trim());
+  }
+  if (presentation) {
+    appendBlockMirrorText(lines, presentation.blocks);
+  }
+  if (interactive) {
+    appendBlockMirrorText(lines, interactive.blocks);
+  }
+  return lines.join("\n");
 }
 
 function isSuppressedRelayStatusText(text: string): boolean {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Maintaining mirrored replies across plain text, interactive controls, charts, and tables requires keeping several equivalent text assembly paths in sync. This simplifies that shared outbound path while preserving the resulting reply text and media order.

## Why This Change Was Made

Use one private block appender and consume control labels/placeholders already prepared by the canonical normalizers. Return the selected primitive text directly when the existing presentation normalization and text checks finish without a presentation. All property reads, normalization and throws, rich-content precedence, and no-text interactive fallback remain in place.

The change removes **14 production lines overall**. Title/text/context trimming remains because canonical continuation fragments preserve authored whitespace. Two preservation tests cover the real plan-to-mirror composition, duplicate/blank controls, plaintext precedence, and canonical adapted continuation fragments; no production test seam is added.

## User Impact

No intended user-visible behavior change. Mirrored text, Unicode, duplicate labels, presentation-before-legacy order, chart/table fallback, and ordered media references remain the same. This is a maintenance cleanup with mixed measured effects; it does **not** establish a general mirror or Gateway speedup.

## Evidence

Fresh validation of the final candidate:

- Check-only `oxfmt` passed without changing source.
- The normal repository test wrapper passed **112 tests across four whole files**: outbound payloads, the focused mirror suite, interactive payloads, and interactive fallback.
- Independent Codex **P2 review: scoped-clean, no findings, 0.98 confidence**.
- The complete changed-scope dry plan selected **29 commands**. A dry plan is not execution of those checks; **all 22 matching-head CI obligations passed** in [CI run34309935469](https://github.com/openclaw/openclaw/actions/runs/34309935469), with the complete lint and typecheck partitions.

The original baseline's **112/112 tests in the same four files**, with identical preservation tests, and the successful owned dependency installation/readiness are **reused historical evidence**, not a fresh baseline run or installation. Six supplementary guards passed. The unchanged compatibility-calendar guard **failed** in this checkout. [Upstream PR #142708](https://github.com/openclaw/openclaw/pull/142708) separately marks the relevant record removal-pending while retaining migration-verification and breaking-release requirements. That upstream change was not copied into this author checkout, and the historical failure was not rerun, relabeled as passed, or waived. Native preparation and merge completed; the exact reviewed head landed as [894b8032de5](https://github.com/openclaw/openclaw/commit/894b8032de5103b7c4fe131c93d27fecfdef0f7e), and the resulting source was verified on clean main.

### Fixed full-boundary measurements

Measured the actual `projectOutboundPayloadPlanForMirror(createOutboundPayloadPlan(payloads))` composition, with no product substitutions. The final candidate (R2) used the **exact same eight-profile corpus and apparatus** as the earlier R1 experiment: B0/C0/C1/B1, one timed first call, one untimed warmup, and 24 timed samples per row in six groups of four. **832 complete R2 outputs and captured inputs matched the literal contract**; the independent audit checked every event and batch sum. R1 and R2 are separate cohorts and were never pooled.

All 16 median comparisons follow. Values are **nanoseconds per call**, measured as the median of six four-call batch means. Positive percentages mean slower. Forward compares B0→C0; reverse compares B1→C1.

| Profile | Forward baseline → candidate | Change | Reverse baseline → candidate | Change |
|---|---:|---:|---:|---:|
| Empty | 682.25 → 557.375 | −18.30% | 994.625 → 1000 | +0.54% |
| Ordinary text | 9448 → 10620 | +12.40% | 9672 → 8349 | −13.68% |
| Mixed rich controls | 18442.625 → 13015.75 | −29.43% | 13677.125 → 12922 | −5.52% |
| Plaintext with chart | 8521 → 8906.125 | +4.52% | 10416.75 → 9208.375 | −11.60% |
| Table only | 8323 → 8166.625 | −1.88% | 8843.875 → 8973.875 | +1.47% |
| Plaintext and media | 4656.25 → 4479.125 | −3.80% | 4286.5 → 4250.125 | −0.85% |
| Large text | 20401.125 → 21218.875 | +4.01% | 20791.375 → 21823.125 | +4.96% |
| Large controls | 27145.875 → 25656.125 | −5.49% | 26911.5 → 27765.875 | +3.17% |

**Adverse totals:** 7/16 medians, 23/64 min/median/mean/max statistics, 141/384 indexed samples, 7/16 first calls, and 2/10 resource comparisons. Ordinary text's forward mean increased **46.67%** and maximum **113.57%**; its reverse mean increased **4.09%** despite the favorable median. Large text's medians increased **4.01%/4.96%**. All adverse samples remain retained.

Whole-child wall time decreased 11.23%/0.93%; kernel peak RSS decreased 6.64%/4.65% and sampled tree peak RSS decreased 7.29%/4.22%. The adverse resources were forward user CPU (+0.72%) and reverse system CPU (+0.68%). These whole-child readings include imports, fixtures, capture, assertions, and startup/completion; RSS is not an allocation count.

The earlier **R1** cohort also preserved all 832 outputs/inputs but had **9/16 adverse medians**, including table-only **+72.94%/+38.88%** and ordinary text **+29.21%/+7.53%**. Its raw records and independent audit remain unchanged. R2 compares against the original baseline, not against R1; these measurements cannot attribute the earlier regressions to a particular operation or quantify a causal R1→R2 improvement.

These are descriptive fixed-cohort measurements, not statistical-significance or population-tail claims. Setup, capture, and checks are outside the narrow call timer but can affect subsequent samples. First-call measurements are row-first after earlier rows, not cold startup. No network, delivery transport, transcript persistence, allocation, or whole-Gateway performance was measured. No third variant, calibration, or extra samples were added.
