### PR TITLE
fix: keep thinking choices tied to the selected model

### DIFF
--- a/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
@@ -76,7 +76,7 @@ suite.define(() => {
             highOptions,
             sliders,
             patch,
-            requests: gateway.requests,
+            requests: await gateway.getRequests(),
           }),
         );
         await page.screenshot({ path: path.join(suite.artifactDir, "partial-thinking.png") });

--- a/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
@@ -16,6 +16,74 @@ const VIEWPORTS = [
 ] as const;
 
 suite.define(() => {
+  it("keeps partial model thinking unknown and sends typed effort for server validation", async () => {
+    const key = "agent:main:main";
+    const session = { key, kind: "direct", updatedAt: 1, model: "model" };
+    const defaults = { model: "other", modelProvider: "openai", contextTokens: null };
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        agentModel: "openai/other",
+        models: [
+          {
+            id: "model",
+            name: "Model",
+            provider: "openai",
+            thinkingLevels: [{ id: "high", label: "High" }],
+            thinkingDefault: "high",
+          },
+        ],
+        methodResponses: {
+          "sessions.list": { count: 1, ts: 1, path: "", defaults, sessions: [session] },
+        },
+      });
+      let displayedStatus: string | null = null;
+      let patch: unknown;
+      let highOptions: number | undefined;
+      let sliders: number | undefined;
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        await expect.poll(() => composer.isEnabled()).toBe(true);
+        await composer.fill("/think");
+        await composer.press("Tab");
+        await expect.poll(() => composer.inputValue()).toBe("/think ");
+        await composer.press("Enter");
+        await expect
+          .poll(async () => {
+            displayedStatus = await page.getByRole("log").textContent();
+            return displayedStatus;
+          })
+          .toContain("Current thinking level: Unknown.");
+        expect(displayedStatus).toContain("Options: Unknown.");
+        highOptions = await page.locator('[data-chat-thinking-option="high"]').count();
+        sliders = await page.locator('[data-chat-thinking-slider="true"]').count();
+        expect(highOptions).toBe(0);
+        expect(sliders).toBe(0);
+        await composer.fill("/think low");
+        await composer.press("Enter");
+        patch = (await gateway.waitForRequest("sessions.patch")).params;
+        expect(patch).toMatchObject({ key, thinkingLevel: "low" });
+      } finally {
+        console.log(
+          "thinking-ui-public-observation",
+          JSON.stringify({
+            fixture: "maintained synthetic Gateway; actual Control UI browser",
+            session,
+            defaults,
+            displayedStatus,
+            highOptions,
+            sliders,
+            patch,
+            requests: gateway.requests,
+          }),
+        );
+        await page.screenshot({ path: path.join(suite.artifactDir, "partial-thinking.png") });
+      }
+    });
+  });
+
   it("executes a typed inline /elevated argument separately from the draft", async () => {
     await suite.withPage({}, async ({ page }) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/chat-thinking-metadata.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-metadata.real-gateway.e2e.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
 import {
   createOpenClawTestInstance,
@@ -37,6 +38,7 @@ const suite = createControlUiE2eSuite({
               apiKey: "synthetic-unused-key",
               baseUrl: "http://127.0.0.1:9/v1",
               models: [
+                { id: "with-effort", name: "With effort", reasoning: true },
                 {
                   id: "no-effort",
                   name: "No effort",
@@ -69,6 +71,162 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("retains saved Off through a real model change to an empty thinking profile", async () => {
+    const key = "agent:main:thinking-saved-off";
+    const commands: unknown[] = [];
+    const frames: Array<{ direction: "sent" | "received"; frame: Record<string, unknown> }> = [];
+    const observations: Record<string, unknown> = {};
+    const call = async (method: string, params: Record<string, unknown>) => {
+      const result = await instance.cli([
+        "gateway",
+        "call",
+        method,
+        "--json",
+        "--params",
+        JSON.stringify(params),
+      ]);
+      commands.push({ method, params, ...result });
+      expect(result.code, result.stderr).toBe(0);
+      return result.stdout;
+    };
+    try {
+      await call("sessions.create", {
+        key,
+        agentId: "main",
+        label: "Saved thinking override",
+        model: "with-effort",
+      });
+      await call("sessions.patch", { key, thinkingLevel: "off" });
+      const before: SessionsListResult = JSON.parse(
+        await call("sessions.list", { agentId: "main", limit: 50 }),
+      );
+      const beforeRow = before.sessions.find((row) => row.key === key);
+      expect(beforeRow).toMatchObject({
+        modelProvider: "thinking-fixture",
+        model: "with-effort",
+        thinkingLevel: "off",
+      });
+      expect(beforeRow?.thinkingLevels?.some((level) => level.id === "high")).toBe(true);
+      observations.before = before;
+      observations.agents = JSON.parse(await call("agents.list", {}));
+      const handoff = await instance.cli(["dashboard", "--json"]);
+      expect(handoff.code, handoff.stderr).toBe(0);
+      const { browserUrl }: { browserUrl: string } = JSON.parse(handoff.stdout);
+      const url = new URL(browserUrl);
+      url.pathname = "/chat/main/thinking-saved-off";
+      url.search = "?nav=collapsed";
+      await suite.withPage(
+        { locale: "en-US", serviceWorkers: "block", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          page.on("websocket", (socket) => {
+            for (const [event, direction] of [
+              ["framesent", "sent"],
+              ["framereceived", "received"],
+            ] as const) {
+              socket.on(event, ({ payload }) => {
+                const frame: Record<string, unknown> = JSON.parse(payload.toString());
+                // Authentication is outside this observation; retain all subsequent product frames.
+                if (
+                  !(frame.type === "req" && frame.method === "connect") &&
+                  frame.event !== "connect.challenge" &&
+                  !(isRecord(frame.payload) && frame.payload.type === "hello-ok")
+                ) {
+                  frames.push({ direction, frame });
+                }
+              });
+            }
+          });
+          await page.goto(url.href);
+          await waitForControlUiGatewayReady(page);
+          const composer = page.getByRole("textbox", { name: "Chat composer", exact: true });
+          await composer.waitFor({ state: "visible" });
+          await composer.fill("/model thinking-fixture/no-effort");
+          await composer.press("Enter");
+          await expect
+            .poll(async () => {
+              const listed: SessionsListResult = JSON.parse(
+                await call("sessions.list", { agentId: "main", limit: 50 }),
+              );
+              observations.after = listed;
+              return listed.sessions.find((row) => row.key === key);
+            })
+            .toMatchObject({
+              modelProvider: "thinking-fixture",
+              model: "no-effort",
+              thinkingLevel: "off",
+              thinkingLevels: [],
+            });
+          await composer.fill("/think");
+          await composer.press("Tab");
+          await expect.poll(() => composer.inputValue()).toBe("/think ");
+          await composer.press("Enter");
+          await expect
+            .poll(async () => {
+              observations.statusText = await page.getByRole("log").textContent();
+              return observations.statusText;
+            })
+            .toContain("Current thinking level: off.");
+          expect(observations.statusText).toContain("Options: none.");
+          expect(await page.locator('[data-chat-thinking-slider="true"]').count()).toBe(0);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "saved-off-empty-profile.png"),
+          });
+          await composer.fill("/think high");
+          await composer.press("Enter");
+          await expect
+            .poll(async () => {
+              observations.refusalText = await page.getByRole("log").textContent();
+              return observations.refusalText;
+            })
+            .toContain('Unsupported thinking level "high" for this model.');
+          const after: SessionsListResult = JSON.parse(
+            await call("sessions.list", { agentId: "main", limit: 50 }),
+          );
+          expect(after.sessions.find((row) => row.key === key)).toMatchObject({
+            modelProvider: "thinking-fixture",
+            model: "no-effort",
+            thinkingLevel: "off",
+            thinkingLevels: [],
+          });
+          observations.final = after;
+          const requests = frames
+            .filter(({ direction }) => direction === "sent")
+            .map(({ frame }) => frame);
+          expect(requests.some((frame) => frame.method === "chat.send")).toBe(false);
+          expect(
+            requests
+              .filter((frame) => frame.method === "sessions.patch")
+              .map((frame) => frame.params),
+          ).toEqual([{ key, model: "thinking-fixture/no-effort" }]);
+          const changes = frames
+            .filter(
+              ({ frame }) =>
+                frame.event === "sessions.changed" &&
+                isRecord(frame.payload) &&
+                frame.payload.sessionKey === key,
+            )
+            .map(({ frame }) => frame.payload)
+            .filter(isRecord);
+          expect(changes.length).toBeGreaterThan(0);
+          for (const change of changes) {
+            if (change.model !== undefined || change.modelProvider !== undefined) {
+              expect(typeof change.model).toBe("string");
+              expect(change.modelProvider).toBe("thinking-fixture");
+            }
+          }
+        },
+      );
+    } finally {
+      const serialized = JSON.stringify({ commands, frames, observations }, null, 2)
+        .replaceAll(instance.gatewayToken, "[synthetic token]")
+        .replaceAll(instance.hookToken, "[synthetic token]")
+        .replaceAll(instance.homeDir, "[fixture home]")
+        .replaceAll(instance.stateDir, "[fixture state]")
+        .replaceAll(process.cwd(), "[source checkout]");
+      await fs.writeFile(path.join(suite.artifactDir, "saved-off-public.json"), serialized);
+    }
+  }, 120_000);
+
   it("reports no thinking choices without advertising a default or changing the session", async () => {
     const commands: unknown[] = [];
     const call = async (method: string, params: Record<string, unknown>) => {

--- a/ui/src/e2e/chat-thinking-metadata.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-metadata.real-gateway.e2e.test.ts
@@ -119,22 +119,19 @@ suite.define(() => {
         { locale: "en-US", serviceWorkers: "block", viewport: { width: 1280, height: 900 } },
         async ({ page }) => {
           page.on("websocket", (socket) => {
-            for (const [event, direction] of [
-              ["framesent", "sent"],
-              ["framereceived", "received"],
-            ] as const) {
-              socket.on(event, ({ payload }) => {
-                const frame: Record<string, unknown> = JSON.parse(payload.toString());
-                // Authentication is outside this observation; retain all subsequent product frames.
-                if (
-                  !(frame.type === "req" && frame.method === "connect") &&
-                  frame.event !== "connect.challenge" &&
-                  !(isRecord(frame.payload) && frame.payload.type === "hello-ok")
-                ) {
-                  frames.push({ direction, frame });
-                }
-              });
-            }
+            const recordFrame = (direction: "sent" | "received", payload: string | Buffer) => {
+              const frame: Record<string, unknown> = JSON.parse(payload.toString());
+              // Authentication is outside this observation; retain all subsequent product frames.
+              if (
+                !(frame.type === "req" && frame.method === "connect") &&
+                frame.event !== "connect.challenge" &&
+                !(isRecord(frame.payload) && frame.payload.type === "hello-ok")
+              ) {
+                frames.push({ direction, frame });
+              }
+            };
+            socket.on("framesent", ({ payload }) => recordFrame("sent", payload));
+            socket.on("framereceived", ({ payload }) => recordFrame("received", payload));
           });
           await page.goto(url.href);
           await waitForControlUiGatewayReady(page);

--- a/ui/src/lib/chat/thinking.test.ts
+++ b/ui/src/lib/chat/thinking.test.ts
@@ -10,6 +10,51 @@ import {
 } from "./thinking.ts";
 
 describe("chat thinking helpers", () => {
+  it("keeps an explicitly empty session profile and its saved override", () => {
+    const state = resolveChatThinkingSelectState({
+      catalog: [
+        {
+          id: "model",
+          provider: "openai",
+          name: "Model",
+          thinkingLevels: [{ id: "high", label: "High" }],
+          thinkingDefault: "high",
+        },
+      ],
+      session: {
+        model: "model",
+        modelProvider: "openai",
+        thinkingLevels: [],
+        thinkingLevel: "off",
+      },
+      sessionKey: "main",
+      sessionsResult: null,
+    });
+    expect(state.options).toEqual([]);
+    expect(state.inherited.value).toBe("");
+    expect(state.selection).toMatchObject({ source: "override", value: "off" });
+  });
+
+  it("does not combine a session model with another provider from defaults", () => {
+    const state = resolveChatThinkingSelectState({
+      catalog: [
+        {
+          id: "model",
+          provider: "openai",
+          name: "Model",
+          thinkingLevels: [{ id: "high", label: "High" }],
+          thinkingDefault: "high",
+        },
+      ],
+      session: { model: "model" },
+      defaults: { model: "other", modelProvider: "openai", contextTokens: null },
+      sessionKey: "main",
+      sessionsResult: null,
+    });
+    expect(state.options).toEqual([]);
+    expect(state.inherited.value).toBe("");
+  });
+
   it("reports unknown capability without inventing thinking choices or a default", () => {
     const session = { modelProvider: "thinking-fixture", model: "unpublished" };
     const state = resolveChatThinkingSelectState({
@@ -133,7 +178,7 @@ describe("chat thinking helpers", () => {
       thinkingLevels: [{ id: "off", label: "off" }],
       thinkingDefault: "off",
     };
-    const session = { modelProvider: model.provider, model: model.id };
+    const session = { modelProvider: model.provider, model: model.id, thinkingLevel: "off" };
     const state = resolveChatThinkingSelectState({
       catalog: [model],
       session,
@@ -142,6 +187,7 @@ describe("chat thinking helpers", () => {
     });
 
     expect(state.options).toEqual([]);
+    expect(state.selection).toMatchObject({ source: "default", value: "off" });
     expect(isThinkingLevelOptionForSession(session, undefined, "off", [model])).toBe(true);
     expect(isThinkingLevelOptionForSession(session, undefined, "high", [model])).toBe(false);
   });

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -49,11 +49,12 @@ export function resolveThinkingProfileForSession(
   defaults: ThinkingSessionDefaults,
   catalog: readonly ModelCatalogEntry[],
 ): ThinkingProfile | undefined {
-  const { provider, model } = resolveThinkingTargetModel({ defaults, session });
+  // A partial session identity cannot borrow its missing half from defaults.
+  const target = session?.model || session?.modelProvider ? session : defaults;
   const catalogEntry = resolveThinkingCatalogEntry(
     catalog,
-    provider,
-    model,
+    target?.modelProvider ?? null,
+    target?.model ?? null,
     session?.agentRuntime?.id,
   );
   const candidates: Array<
@@ -202,16 +203,6 @@ function isOffOnlyThinkingLevels(levels: readonly GatewayThinkingLevelOption[]):
   return levels.every((level) => isOffThinkingOption(level.id || level.label));
 }
 
-function resolveThinkingTargetModel(params: {
-  defaults: ThinkingSessionDefaults;
-  session: ChatThinkingTarget | undefined;
-}): { provider: string | null; model: string | null } {
-  return {
-    provider: params.session?.modelProvider ?? params.defaults?.modelProvider ?? null,
-    model: params.session?.model ?? params.defaults?.model ?? null,
-  };
-}
-
 function resolveThinkingCatalogEntry(
   catalog: readonly ModelCatalogEntry[],
   provider: string | null,
@@ -250,10 +241,13 @@ export function resolveChatThinkingSelectState(params: {
   const defaults = params.defaults ?? params.sessionsResult?.defaults;
   const profile = resolveThinkingProfileForSession(session, defaults, params.catalog);
   const supportedLevels = profile?.thinkingLevels ?? [];
-  const levels =
-    profile?.reasoning === false && isOffOnlyThinkingLevels(supportedLevels) ? [] : supportedLevels;
+  const nonReasoningOffOnly =
+    profile?.reasoning === false &&
+    supportedLevels.length > 0 &&
+    isOffOnlyThinkingLevels(supportedLevels);
+  const levels = nonReasoningOffOnly ? [] : supportedLevels;
   const defaultLevel = profile?.thinkingDefault ?? "";
-  const effectiveOverride = levels.length === 0 && currentOverride === "off" ? "" : currentOverride;
+  const effectiveOverride = nonReasoningOffOnly && currentOverride === "off" ? "" : currentOverride;
   const options = buildThinkingOptions(levels);
   const defaultValue = normalizeThinkingOptionValue(defaultLevel);
   const inherited = {

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -124,6 +124,41 @@ function expectNoRequestCall(request: ReturnType<typeof vi.fn>, method: string) 
 }
 
 describe("executeSlashCommand directives", () => {
+  it("keeps unknown partial thinking support under server validation", async () => {
+    const key = "agent:main:main";
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ...createSessionsResult([row(key, { model: "model" })]),
+          defaults: { model: "other", modelProvider: "openai", contextTokens: null },
+        };
+      }
+      if (method === "sessions.patch") {
+        return { ok: true, key, entry: { thinkingLevel: "low" } };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const result = await executeSlashCommand(
+      createTestGatewayClient(request),
+      key,
+      "think",
+      "low",
+      {
+        chatModelCatalog: [
+          {
+            id: "model",
+            name: "Model",
+            provider: "openai",
+            thinkingLevels: [{ id: "high", label: "High" }],
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    );
+    expect(result.content).toBe(t("chat.commandResults.thinking.set", { level: "**low**" }));
+    expect(request).toHaveBeenCalledWith("sessions.patch", { key, thinkingLevel: "low" });
+  });
+
   it("lets the canonical row retire a slash-command selection equal to the default", async () => {
     const key = "agent:main:main";
     const request = vi.fn(async (method: string) => {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -10,6 +10,40 @@ afterEach(() => {
 });
 
 describe("new-session model runtime", () => {
+  it("does not borrow a provider for an ambiguous draft target", async () => {
+    const { context } = contextWith([
+      {
+        id: "model",
+        name: "First model",
+        provider: "openai",
+        reasoning: true,
+        thinkingLevels: [{ id: "high", label: "High" }],
+        thinkingDefault: "high",
+      },
+      { id: "model", name: "Second model", provider: "alternate-fixture", reasoning: true },
+    ]);
+    Object.assign(context.sessions.state.result!.defaults, {
+      model: "other",
+      modelProvider: "openai",
+    });
+    const agent = { id: "main", model: { primary: "model" } } satisfies GatewayAgentRow;
+    const onSelectionChange = vi.fn();
+    const control = new NewSessionModelControl(() => undefined, onSelectionChange);
+    control.load(context, "main", true, { agent });
+    await waitForFast(() =>
+      expect(
+        renderControl(control, context, "main", agent).querySelector(
+          '[data-chat-model-option="openai/model"]',
+        ),
+      ).not.toBeNull(),
+    );
+    const container = renderControl(control, context, "main", agent);
+    expect(container.querySelector('[data-chat-thinking-option="high"]')).toBeNull();
+    expect(container.querySelector('[data-chat-thinking-slider="true"]')).toBeNull();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+    control.reset();
+  });
+
   it("keeps a draft model local without exposing its internal selection target", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -570,8 +570,8 @@ export class NewSessionModelControl {
       this.catalog,
     );
     const thinkingDefaults = {
-      modelProvider: defaultTarget?.provider ?? sourceResult?.defaults.modelProvider ?? null,
-      model: defaultTarget?.model ?? agentDefaultModel ?? sourceResult?.defaults.model ?? null,
+      modelProvider: defaultTarget?.provider ?? null,
+      model: defaultTarget?.model ?? null,
       contextTokens: sourceResult?.defaults.contextTokens ?? null,
       agentRuntime: defaultThinkingProfile?.agentRuntime,
       thinkingLevels: defaultThinkingProfile?.thinkingLevels,


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Preserves a saved Off thinking override when switching to a model with no thinking choices. The internal selector could also combine a partial model identity with unrelated defaults.

## Why This Change Was Made

Keep model and provider together during profile resolution and forward the same target from New Session. Preserve saved Off in an empty-profile descriptor without adding a slider or implicit setting write.

## User Impact

An unsupported thinking profile keeps the saved Off value visible and rejects unsupported changes. Partial-identity cleanup is an internal refactor; no reachable partial-identity defect is claimed.

Consumers: shared thinking selection and New Session use one complete model target.

## Evidence

Four selector/consumer regressions failed before the change; 28 affected cases passed. A real Gateway/browser lifecycle saved Off, changed to a model with no choices, displayed Off with no options and refused High without changing state. That visible lifecycle does not independently prove the hidden descriptor change; focused source assertions cover it.
