### PR TITLE
fix(codex): prevent 502 errors for Responses Lite requests

### DIFF
--- a/extensions/codex/src/app-server/inference-context.test.ts
+++ b/extensions/codex/src/app-server/inference-context.test.ts
@@ -22,6 +22,69 @@ function request(threadId: string, generation?: string, extra: JsonObject = {}):
 }
 
 describe("parent-local inference context", () => {
+  it("refreshes and removes overlays for native input-only requests without changing history", () => {
+    const context = createCodexInferenceContext(() => {});
+    const register = (text: string) =>
+      context.register({
+        threadId: "root",
+        text,
+        signal: new AbortController().signal,
+        assertCurrent: () => {},
+      });
+    const inputOnly = (generation: string) => {
+      const source = request("root", generation);
+      delete source.instructions;
+      source.input = [
+        { id: "at_native_tools", type: "additional_tools", role: "developer", tools: [] },
+        {
+          id: "msg_native_base",
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "native base" }],
+        },
+      ];
+      return source;
+    };
+    const first = register("persona A");
+    const source = inputOnly(first.generation);
+    const prepared = context.prepare(source);
+    expect(prepared.body).toEqual({ ...source, instructions: "persona A" });
+    expect(prepared.body.input).toBe(source.input);
+    expect(source).not.toHaveProperty("instructions");
+    const second = register("persona B");
+    expect(prepared.signal?.aborted).toBe(true);
+    expect(() => context.prepare(source)).toThrow("current admitted");
+    const continuation = {
+      ...inputOnly(second.generation),
+      input: [],
+      previous_response_id: "previous",
+    };
+    expect(context.prepare(continuation).body).toEqual({
+      ...continuation,
+      instructions: "persona B",
+    });
+    const removed = inputOnly(register("").generation);
+    expect(context.prepare(removed).body).toBe(removed);
+    context.close();
+  });
+
+  it.each([null, 42, false, [], {}].map((instructions) => ({ instructions })))(
+    "rejects explicit non-string instructions: $instructions",
+    ({ instructions }) => {
+      const context = createCodexInferenceContext(() => {});
+      const registration = context.register({
+        threadId: "root",
+        text: "persona",
+        signal: new AbortController().signal,
+        assertCurrent: () => {},
+      });
+      expect(() =>
+        context.prepare({ ...request("root", registration.generation), instructions }),
+      ).toThrow("instructions");
+      context.close();
+    },
+  );
+
   it("refreshes and removes parent instructions without rewriting native history or affecting children", () => {
     const context = createCodexInferenceContext(() => {});
     const register = (text: string) =>

--- a/extensions/codex/src/app-server/inference-context.ts
+++ b/extensions/codex/src/app-server/inference-context.ts
@@ -108,12 +108,20 @@ export function createCodexInferenceContext(assertClientCurrent: () => void) {
         throw new Error("Codex inference has no current admitted parent generation");
       }
       registration.assertCurrent();
-      if (typeof body.instructions !== "string") {
-        throw new Error("Codex inference request is missing top-level instructions");
+      // Responses Lite carries native base instructions in input and omits this optional field.
+      const instructions = body.instructions;
+      if (instructions !== undefined && typeof instructions !== "string") {
+        throw new Error("Codex inference request has invalid top-level instructions");
       }
       return {
         body: registration.text
-          ? { ...body, instructions: body.instructions + "\n\n" + registration.text }
+          ? {
+              ...body,
+              instructions:
+                instructions === undefined
+                  ? registration.text
+                  : instructions + "\n\n" + registration.text,
+            }
           : body,
         assertCurrent: registration.assertCurrent,
         signal: registration.controller.signal,

--- a/extensions/codex/src/app-server/inference-proxy.test.ts
+++ b/extensions/codex/src/app-server/inference-proxy.test.ts
@@ -91,7 +91,7 @@ async function post(
   );
 }
 
-async function fixture() {
+async function fixture(withInstructions = true) {
   const proxy = await createCodexInferenceProxy({
     upstream: new URL("https://api.openai.com/v1"),
     assertCurrent: () => {},
@@ -105,7 +105,7 @@ async function fixture() {
     assertCurrent: () => {},
   });
   const body = {
-    instructions: "native base",
+    ...(withInstructions ? { instructions: "native base" } : {}),
     input: [{ role: "developer", content: "catalog" }],
     client_metadata: {
       thread_id: "root",
@@ -120,10 +120,15 @@ async function fixture() {
 }
 
 describe("private inference HTTP relay", () => {
-  it.each([false, true])(
-    "preserves auth and native input while adding only top-level instructions (zstd=%s)",
-    async (zstd) => {
-      const { proxy, body } = await fixture();
+  it.each([
+    { zstd: false, withInstructions: true },
+    { zstd: true, withInstructions: true },
+    { zstd: false, withInstructions: false },
+    { zstd: true, withInstructions: false },
+  ])(
+    "preserves auth and native input (zstd=$zstd, top-level instructions=$withInstructions)",
+    async ({ zstd, withInstructions }) => {
+      const { proxy, body } = await fixture(withInstructions);
       let forwarded: unknown;
       transport.fetch.mockImplementation(async (args) => {
         args.beforeRequest();
@@ -154,7 +159,10 @@ describe("private inference HTTP relay", () => {
       await transport.fetch.mock.results[0]?.value;
       expect(response.status).toBe(200);
       expect(await response.text()).toBe("data: synthetic\n\n");
-      expect(forwarded).toEqual({ ...body, instructions: "native base\n\nsynthetic persona" });
+      expect(forwarded).toEqual({
+        ...body,
+        instructions: withInstructions ? "native base\n\nsynthetic persona" : "synthetic persona",
+      });
     },
   );
 
@@ -262,12 +270,14 @@ describe("private inference WebSocket relay", () => {
   );
 
   it.each([
-    { proxied: false, localDnsUnavailable: false },
-    { proxied: true, localDnsUnavailable: false },
-    { proxied: true, localDnsUnavailable: true },
+    { proxied: false, localDnsUnavailable: false, withInstructions: true },
+    { proxied: true, localDnsUnavailable: false, withInstructions: true },
+    { proxied: true, localDnsUnavailable: true, withInstructions: true },
+    { proxied: false, localDnsUnavailable: false, withInstructions: false },
+    { proxied: true, localDnsUnavailable: true, withInstructions: false },
   ])(
-    "preserves WS deltas and replies (proxy=$proxied, local DNS unavailable=$localDnsUnavailable)",
-    async ({ proxied, localDnsUnavailable }) => {
+    "preserves WS deltas (proxy=$proxied, local DNS unavailable=$localDnsUnavailable, instructions=$withInstructions)",
+    async ({ proxied, localDnsUnavailable, withInstructions }) => {
       const agent = new Agent();
       const destroy = vi.spyOn(agent, "destroy");
       transport.proxyAgent.mockReturnValue(proxied ? agent : undefined);
@@ -303,7 +313,7 @@ describe("private inference WebSocket relay", () => {
         throw new Error("fixture did not listen");
       }
       transport.upstream = "ws://127.0.0.1:" + address.port;
-      const { proxy, registration, body } = await fixture();
+      const { proxy, registration, body } = await fixture(withInstructions);
       const socket = new WebSocket(proxy.baseUrl.replace("http:", "ws:") + "/responses");
       let responseHeaders: IncomingHttpHeaders | undefined;
       socket.on("upgrade", (response) => {
@@ -317,7 +327,12 @@ describe("private inference WebSocket relay", () => {
           "openai-model": "fixture-model",
         });
         for (const input of [body.input, []]) {
-          const response = once(socket, "message");
+          const response = Promise.race([
+            once(socket, "message"),
+            once(socket, "close").then(() => {
+              throw new Error("inference relay closed before its response");
+            }),
+          ]);
           socket.send(
             JSON.stringify({
               ...body,
@@ -332,7 +347,7 @@ describe("private inference WebSocket relay", () => {
         }
         const expected = {
           ...body,
-          instructions: "native base\n\nsynthetic persona",
+          instructions: withInstructions ? "native base\n\nsynthetic persona" : "synthetic persona",
           type: "response.create",
           previous_response_id: "previous",
         };


### PR DESCRIPTION
Regression of #142276 (merge commit `8169aacdda928c4ef72954ca7f51362fb38e4d53`).

## What Problem This Solves

Fixes an issue where users running certain Codex-backed OpenAI models receive repeated local `502 Bad Gateway` errors instead of an assistant reply. Retrying on a fresh connection or restarting the Gateway does not resolve the failure.

The affected path reports:

```text
Codex parent-local inference transport failed; retry on a fresh connection.
```

## Why This Change Was Made

#142276 introduces the parent-local inference relay to restore workspace persona, skills, and memory guidance without writing that context into native conversation history. Its validator requires a top-level string `instructions` field, but native Responses Lite requests carry base instructions in developer input items and omit that field.

Accept an omitted field while continuing to reject explicitly supplied non-string values. Add the admitted parent overlay as request-level instructions, preserving existing string concatenation, native input and item IDs, metadata, `previous_response_id`, and generation/cancellation checks. An empty overlay returns the original request unchanged.

This deliberately uses an upstream-supported request-level field that native Lite requests omit. It avoids putting the overlay into retained conversation input. No model-specific branch, retry, cache, timeout, dependency, or persistent-state change is added.

## User Impact

Affected models can complete turns through the managed Codex relay while retaining parent-only workspace guidance. Standard Responses requests, native children, compaction/memory requests, and ownership boundaries retain their existing behavior.

## Evidence

### Introducing change and deployed reproduction

- Compared the raw parent `8459d9be809358c42ab040d76ff280cfc62c82b6` with merge commit `8169aacdda9`: #142276 adds both the relay and the guard rejecting omitted `instructions`.
- In the affected deployment, the earlier build `ad045d2626f8` has no relay. The checkout advances to `1d96cc3b563` (which includes #142276) at **2026-09-09 00:25:11 UTC**; the replacement Gateway starts at **00:29:05 UTC**; the first matching local 502 is logged at **00:33:57 UTC**. Both builds pin **Codex 0.153.4**, so this is not a Codex version upgrade.
- Ran that exact installed Codex binary with a temporary home, synthetic credentials, and a local mock upstream. The affected model emits correctly nested generation metadata, developer input and `additional_tools`, but no top-level `instructions`.
- Passing that request shape through an isolated instance of the deployed relay reproduces the reported 502. Its context validator throws:

```text
Codex inference request is missing top-level instructions
```

The introducing PR's HTTP and WebSocket fixtures always include `instructions: "native base"`, so they miss this native input-only shape.

### Regression tests and checks

Five regression cases fail before the repair: context preparation, plain/zstd HTTP forwarding, and direct/proxied WebSocket forwarding. After the repair, **37 tests pass across three files**, covering replacement/removal of parent overlays, explicit invalid types, unchanged native input, WebSocket deltas, cancellation, and routing/auth boundaries.

```sh
mise exec -- node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/inference-context.test.ts \
  extensions/codex/src/app-server/inference-proxy.test.ts \
  extensions/codex/src/app-server/inference-routing.test.ts

# Test Files  3 passed (3)
#      Tests  37 passed (37)

mise exec -- node scripts/check-changed.mjs -- \
  extensions/codex/src/app-server/inference-context.ts \
  extensions/codex/src/app-server/inference-context.test.ts \
  extensions/codex/src/app-server/inference-proxy.test.ts
```

Changed-scope checks pass, including formatting, extension production/test typechecks, lint, plugin boundaries, dead-export scans, and import-cycle checks. The initial nested-worktree run stops at the declaration-input isolation guard; the complete run passes from a sibling physical worktree without disabling the guard or changing dependencies. Local validation uses Node **24.19.0**.

Independent Codex autoreview reports **no accepted/actionable findings**. The published patch is identical to the reviewed and tested patch.

### Real provider proof

Ran a separate instance of the patched relay on the affected Linux host, using the deployed SDK runtime and Node **26.8.1**. It forwards a synthetic request to the real affected model with the native Lite flags, an omitted `instructions` field, and a registered parent overlay. The provider completes the request and returns the expected `OK` reply:

```json
{"status":200,"responseStatus":"completed","outputTokens":5,"inputInstructionsAbsent":true,"replyMatches":true,"elapsedMs":1301}
```

This is authenticated upstream HTTP proof, not a mocked response. Private model identifiers, credentials, host details, and private relay URLs are omitted. Live WebSocket behavior is not separately claimed; its full/delta paths are covered by the local relay tests.

The running production Gateway is **not patched or restarted**. The proof uses a separate temporary relay, so this PR does not claim production recovery or deployment.
