### PR TITLE
fix(talk): deliver final answers after repeated delegation

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -34,6 +34,7 @@ import { hasSubagentRunEnded } from "../registry/subagent-run-liveness.js";
 import {
   consumeRequesterFinalAttachment,
   revokeRequesterFinalAttachment,
+  transferRequesterFinalAttachment,
 } from "../requester-final-attachment.js";
 import { getSubagentDepthFromSessionStore } from "../spawn/subagent-depth.js";
 import {
@@ -507,6 +508,19 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
       params.transitionBatch(settledBatch, state);
     }
 
+    const directIdempotencyKey = buildAnnounceIdempotencyKey(
+      attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
+    );
+    if (requesterAgentId && state.requesterYieldBatch && state.rearmGeneration !== undefined) {
+      transferRequesterFinalAttachment({
+        requesterAgentId,
+        requesterSessionKey,
+        requesterSessionId: requesterEntry.sessionId,
+        batchRunIds,
+        rearmGeneration: state.rearmGeneration,
+        requesterTurnRunId: directIdempotencyKey,
+      });
+    }
     let delivery: Awaited<ReturnType<typeof deliverSubagentAnnouncement>>;
     try {
       delivery = await deliverSubagentAnnouncement({
@@ -525,9 +539,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
         expectsCompletionMessage: false,
         requireDirectDelivery: true,
         ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
-        directIdempotencyKey: buildAnnounceIdempotencyKey(
-          attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
-        ),
+        directIdempotencyKey,
         signal: params.signal,
         resolveGatewayContext,
       });

--- a/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionDeliveryState } from "../../../config/sessions/types.js";
 import type { CallGatewayOptions } from "../../../gateway/call.js";
 import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
-import type { AgentEventPayload } from "../../../infra/agent-events.js";
+import {
+  getAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+} from "../../../infra/agent-events.js";
 import {
   bindGatewayContextResolver,
   getGatewayContextResolver,
@@ -23,6 +26,7 @@ import { testing as subagentAnnounceDeliveryTesting } from "../announce/subagent
 import { testing as subagentAnnounceOutputTesting } from "../announce/subagent-announce-output.test-support.js";
 import { testing as subagentAnnounceTesting } from "../announce/subagent-announce.js";
 import { maybeWakeRequesterAfterAllChildrenSettled } from "../announce/subagent-announce.requester-settle-wake.js";
+import { registerRequesterFinalAttachment } from "../requester-final-attachment.js";
 import * as registry from "./subagent-registry.test-helpers.js";
 
 const MAIN_REQUESTER_SESSION_KEY = "agent:main:main";
@@ -599,12 +603,13 @@ describe("requester settle wake product flow", () => {
   });
 
   it.each([
-    { runtime: "cli", acceptNextChild: true },
-    { runtime: "cli", acceptNextChild: false },
-    { runtime: "native", acceptNextChild: true },
+    { runtime: "cli", acceptNextChild: true, attachRequesterFinal: false },
+    { runtime: "cli", acceptNextChild: false, attachRequesterFinal: false },
+    { runtime: "native", acceptNextChild: true, attachRequesterFinal: false },
+    { runtime: "cli", acceptNextChild: true, attachRequesterFinal: true },
   ] as const)(
-    "preserves serial continuation without replaying an accepted wave ($runtime, next child accepted=$acceptNextChild)",
-    async ({ runtime, acceptNextChild }) => {
+    "preserves serial continuation without replaying an accepted wave ($runtime, next child accepted=$acceptNextChild, requester final=$attachRequesterFinal)",
+    async ({ runtime, acceptNextChild, attachRequesterFinal }) => {
       vi.setSystemTime(100_000);
       const context = {} as GatewayRequestContext;
       context.resolveGatewayContext = () => context;
@@ -751,85 +756,117 @@ describe("requester settle wake product flow", () => {
       const ordinaryGatewayCall = callGatewayMock.getMockImplementation()!;
       let firstWakeReturned = false;
       let visibleFinals = 0;
-      await callGatewayMock.withImplementation(
-        async (request) => {
-          if (
-            request.method !== "agent" ||
-            !request.params?.idempotencyKey?.startsWith("announce:requester-settle:")
-          ) {
-            return await ordinaryGatewayCall(request);
-          }
-          if (!firstWakeReturned) {
-            // Gateway preflight uses this exact idempotency key as the run ID.
-            const requesterTurnRunId = request.params.idempotencyKey;
-            if (acceptNextChild) {
-              const firstEndedAt = registry.getSubagentRunByRunId(alpha.runId)?.execution.endedAt;
-              expect(firstEndedAt).toEqual(expect.any(Number));
-              vi.setSystemTime(firstEndedAt! + 1);
-              await spawnVisibleChild({ ...beta, requesterTurnRunId });
-              expect(registry.getSubagentRunByRunId(beta.runId)?.createdAt).toBeGreaterThan(
-                firstEndedAt!,
-              );
+      const initialRequesterTurnRunId = "requester-serial-initial";
+      const append = vi.fn(() => true);
+      const attachment = attachRequesterFinal
+        ? registerRequesterFinalAttachment({
+            requesterAgentId: "main",
+            requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+            requesterSessionId: "sess-main",
+            requesterTurnRunId: initialRequesterTurnRunId,
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
+            timeoutMs: 600_000,
+            append,
+          })
+        : undefined;
+      try {
+        await callGatewayMock.withImplementation(
+          async (request) => {
+            if (
+              request.method !== "agent" ||
+              !request.params?.idempotencyKey?.startsWith("announce:requester-settle:")
+            ) {
+              return await ordinaryGatewayCall(request);
             }
-            const result = await yieldTurn(requesterTurnRunId, acceptNextChild ? [beta] : []);
-            firstWakeReturned = true;
-            return { runId: requesterTurnRunId, status: "ok", result };
-          }
-          visibleFinals += 1;
-          return await ordinaryGatewayCall(request);
-        },
-        async () => {
-          const requesterTurnRunId = "requester-serial-initial";
-          await spawnVisibleChild({ ...alpha, requesterTurnRunId });
-          await yieldTurn(requesterTurnRunId, [alpha]);
-          emitCompleted(alpha.runId, alpha.childSessionKey, "alpha findings");
-          await vi.waitFor(() => expect(firstWakeReturned).toBe(true));
-          await vi.advanceTimersByTimeAsync(0);
-          expect(getRequesterWakeCalls()).toHaveLength(1);
-          expect(visibleFinals).toBe(0);
-          if (acceptNextChild) {
-            expect(registry.countActiveDescendantRuns(MAIN_REQUESTER_SESSION_KEY, "main")).toBe(1);
-            expect(registry.getSubagentRunByRunId(beta.runId)).toMatchObject({
-              requesterTurnRunId: undefined,
-              requesterSettleWake: {
-                status: "pending",
-                batchRunIds: [beta.runId],
-                requesterYieldBatch: true,
+            if (!firstWakeReturned) {
+              // Gateway preflight uses this exact idempotency key as the run ID.
+              const requesterTurnRunId = request.params.idempotencyKey;
+              if (acceptNextChild) {
+                const firstEndedAt = registry.getSubagentRunByRunId(alpha.runId)?.execution.endedAt;
+                expect(firstEndedAt).toEqual(expect.any(Number));
+                vi.setSystemTime(firstEndedAt! + 1);
+                await spawnVisibleChild({ ...beta, requesterTurnRunId });
+                expect(registry.getSubagentRunByRunId(beta.runId)?.createdAt).toBeGreaterThan(
+                  firstEndedAt!,
+                );
+              }
+              const result = await yieldTurn(requesterTurnRunId, acceptNextChild ? [beta] : []);
+              firstWakeReturned = true;
+              return { runId: requesterTurnRunId, status: "ok", result };
+            }
+            visibleFinals += 1;
+            const response = await ordinaryGatewayCall(request);
+            return attachRequesterFinal
+              ? {
+                  ...response,
+                  result: {
+                    ...response.result,
+                    meta: { durationMs: 1, finalAssistantVisibleText: "completion delivered" },
+                  },
+                }
+              : response;
+          },
+          async () => {
+            await spawnVisibleChild({ ...alpha, requesterTurnRunId: initialRequesterTurnRunId });
+            await yieldTurn(initialRequesterTurnRunId, [alpha]);
+            attachment?.releaseProvisional();
+            emitCompleted(alpha.runId, alpha.childSessionKey, "alpha findings");
+            await vi.waitFor(() => expect(firstWakeReturned).toBe(true));
+            await vi.advanceTimersByTimeAsync(0);
+            expect(getRequesterWakeCalls()).toHaveLength(1);
+            expect(visibleFinals).toBe(0);
+            expect(append).not.toHaveBeenCalled();
+            if (acceptNextChild) {
+              expect(registry.countActiveDescendantRuns(MAIN_REQUESTER_SESSION_KEY, "main")).toBe(
+                1,
+              );
+              expect(registry.getSubagentRunByRunId(beta.runId)).toMatchObject({
+                requesterTurnRunId: undefined,
+                requesterSettleWake: {
+                  status: "pending",
+                  batchRunIds: [beta.runId],
+                  requesterYieldBatch: true,
+                },
+              });
+              emitCompleted(beta.runId, beta.childSessionKey, "beta findings");
+            } else {
+              expect(registry.getSubagentRunByRunId(beta.runId)).toBeUndefined();
+            }
+            // Cross both native retry deadlines; a transferred obligation must not
+            // start an extra parent turn, while an empty failed handoff must recover.
+            await vi.advanceTimersByTimeAsync(151_000);
+            await registry.testing.sweepOnceForTests();
+            await vi.advanceTimersByTimeAsync(0);
+            for (const child of acceptNextChild ? [alpha, beta] : [alpha]) {
+              await waitForDeliveredCleanup(child.runId);
+            }
+            const wakeIdentities = getRequesterWakeCalls().map((request) => ({
+              sourceSessionKey: request.params?.inputProvenance?.sourceSessionKey,
+              idempotencyKey: request.params?.idempotencyKey,
+            }));
+            expect(wakeIdentities).toEqual([
+              {
+                sourceSessionKey: alpha.childSessionKey,
+                idempotencyKey: expect.not.stringContaining(":retry-"),
               },
-            });
-            emitCompleted(beta.runId, beta.childSessionKey, "beta findings");
-          } else {
-            expect(registry.getSubagentRunByRunId(beta.runId)).toBeUndefined();
-          }
-          // Cross both native retry deadlines; a transferred obligation must not
-          // start an extra parent turn, while an empty failed handoff must recover.
-          await vi.advanceTimersByTimeAsync(151_000);
-          await registry.testing.sweepOnceForTests();
-          await vi.advanceTimersByTimeAsync(0);
-          for (const child of acceptNextChild ? [alpha, beta] : [alpha]) {
-            await waitForDeliveredCleanup(child.runId);
-          }
-          const wakeIdentities = getRequesterWakeCalls().map((request) => ({
-            sourceSessionKey: request.params?.inputProvenance?.sourceSessionKey,
-            idempotencyKey: request.params?.idempotencyKey,
-          }));
-          expect(wakeIdentities).toEqual([
-            {
-              sourceSessionKey: alpha.childSessionKey,
-              idempotencyKey: expect.not.stringContaining(":retry-"),
-            },
-            {
-              sourceSessionKey: acceptNextChild ? beta.childSessionKey : alpha.childSessionKey,
-              idempotencyKey: acceptNextChild
-                ? expect.not.stringContaining(":retry-")
-                : expect.stringContaining(":retry-"),
-            },
-          ]);
-          expect(visibleFinals).toBe(1);
-          expect(sendMessageMock).not.toHaveBeenCalled();
-          expect(registry.countActiveDescendantRuns(MAIN_REQUESTER_SESSION_KEY, "main")).toBe(0);
-        },
-      );
+              {
+                sourceSessionKey: acceptNextChild ? beta.childSessionKey : alpha.childSessionKey,
+                idempotencyKey: acceptNextChild
+                  ? expect.not.stringContaining(":retry-")
+                  : expect.stringContaining(":retry-"),
+              },
+            ]);
+            expect(visibleFinals).toBe(1);
+            expect(sendMessageMock).not.toHaveBeenCalled();
+            expect(registry.countActiveDescendantRuns(MAIN_REQUESTER_SESSION_KEY, "main")).toBe(0);
+            if (attachRequesterFinal) {
+              expect(append).toHaveBeenCalledExactlyOnceWith("completion delivered");
+            }
+          },
+        );
+      } finally {
+        attachment?.revoke();
+      }
     },
   );
 

--- a/src/agents/subagents/requester-final-attachment.ts
+++ b/src/agents/subagents/requester-final-attachment.ts
@@ -41,11 +41,14 @@ function sameRunIds(left: readonly string[], right: readonly string[]): boolean 
   return left.length === right.length && left.every((runId, index) => runId === right[index]);
 }
 
-function getCurrentAttachment(
-  requesterAgentId: string,
-  requesterSessionKey: string,
-): RequesterFinalAttachment | undefined {
-  const key = ownerKey(requesterAgentId, requesterSessionKey);
+function getCurrentAttachment(params: {
+  requesterAgentId: string;
+  requesterSessionKey: string;
+  requesterSessionId?: string;
+  batchRunIds?: readonly string[];
+  rearmGeneration?: number;
+}): RequesterFinalAttachment | undefined {
+  const key = ownerKey(params.requesterAgentId, params.requesterSessionKey);
   const attachment = state.byOwner.get(key);
   if (!attachment) {
     return undefined;
@@ -55,6 +58,17 @@ function getCurrentAttachment(
     attachment.lifecycleGeneration !== getAgentEventLifecycleGeneration()
   ) {
     state.byOwner.delete(key);
+    return undefined;
+  }
+  if (
+    (params.requesterSessionId !== undefined &&
+      attachment.requesterSessionId !== params.requesterSessionId) ||
+    (params.batchRunIds !== undefined &&
+      (!attachment.batch ||
+        !sameRunIds(attachment.batch.batchRunIds, params.batchRunIds.toSorted()))) ||
+    (params.rearmGeneration !== undefined &&
+      attachment.batch?.rearmGeneration !== params.rearmGeneration)
+  ) {
     return undefined;
   }
   return attachment;
@@ -102,7 +116,10 @@ export function promoteRequesterFinalAttachment(params: {
   batchRunIds: readonly string[];
   rearmGeneration: number;
 }): boolean {
-  const attachment = getCurrentAttachment(params.requesterAgentId, params.requesterSessionKey);
+  const attachment = getCurrentAttachment({
+    requesterAgentId: params.requesterAgentId,
+    requesterSessionKey: params.requesterSessionKey,
+  });
   if (!attachment || attachment.requesterTurnRunId !== params.requesterTurnRunId) {
     return false;
   }
@@ -110,6 +127,23 @@ export function promoteRequesterFinalAttachment(params: {
     batchRunIds: params.batchRunIds.toSorted(),
     rearmGeneration: params.rearmGeneration,
   };
+  return true;
+}
+
+export function transferRequesterFinalAttachment(params: {
+  requesterAgentId: string;
+  requesterSessionKey: string;
+  requesterSessionId: string;
+  batchRunIds: readonly string[];
+  rearmGeneration: number;
+  requesterTurnRunId: string;
+}): boolean {
+  const attachment = getCurrentAttachment(params);
+  if (!attachment) {
+    return false;
+  }
+  // Keep this batch until its successor either finishes or durably promotes the next one.
+  attachment.requesterTurnRunId = params.requesterTurnRunId;
   return true;
 }
 
@@ -121,17 +155,7 @@ export function revokeRequesterFinalAttachment(params: {
   rearmGeneration?: number;
 }): boolean {
   const key = ownerKey(params.requesterAgentId, params.requesterSessionKey);
-  const attachment = getCurrentAttachment(params.requesterAgentId, params.requesterSessionKey);
-  if (
-    !attachment ||
-    (params.requesterSessionId !== undefined &&
-      attachment.requesterSessionId !== params.requesterSessionId) ||
-    (params.batchRunIds !== undefined &&
-      (!attachment.batch ||
-        !sameRunIds(attachment.batch.batchRunIds, params.batchRunIds.toSorted()))) ||
-    (params.rearmGeneration !== undefined &&
-      attachment.batch?.rearmGeneration !== params.rearmGeneration)
-  ) {
+  if (!getCurrentAttachment(params)) {
     return false;
   }
   state.byOwner.delete(key);
@@ -147,15 +171,8 @@ export function consumeRequesterFinalAttachment(params: {
   text: string;
 }): "appended" | "rejected" | "missing" {
   const key = ownerKey(params.requesterAgentId, params.requesterSessionKey);
-  const attachment = getCurrentAttachment(params.requesterAgentId, params.requesterSessionKey);
-  const batchRunIds = params.batchRunIds.toSorted();
-  if (
-    !attachment ||
-    attachment.requesterSessionId !== params.requesterSessionId ||
-    !attachment.batch ||
-    attachment.batch.rearmGeneration !== params.rearmGeneration ||
-    !sameRunIds(attachment.batch.batchRunIds, batchRunIds)
-  ) {
+  const attachment = getCurrentAttachment(params);
+  if (!attachment) {
     return "missing";
   }
   // Claim before invoking provider code so replay and callback failure cannot double-append.


### PR DESCRIPTION
Related: #129535

## What Problem This Solves

Fixes an issue where a Talk consult could lose its final answer after yielding through a second delegation wave. The work could finish in the requester transcript while the active voice call never received the final callback.

## Why This Change Was Made

The settlement dispatcher now transfers the current attachment to the continuation's existing run ID. A subsequent yield can bind its next batch, and completion of the previous batch leaves that attachment intact. Shared matching preserves the session, batch, generation, expiry and replacement checks; final consumption still happens once.

## User Impact

Talk can receive the final result when delegated work needs another round of subagents. Cancellation, replacement and terminal cleanup keep their existing behavior.

## Evidence

The existing serial-continuation fixture reproduces the missing append: one new case fails while two controls pass, with both delegation waves, the final response and no-replay assertions already succeeding. The same case passes after the repair. Final validation passes 73 distinct cases covering serial continuation, attachment lifetime, yield, retry, cleanup and Talk delivery, plus all 29 classified checks.

This is isolated synthetic proof through the real attachment, registry and settlement boundaries. It does not claim a live voice or model-provider run. The source fixture uses its documented focused-test path. Independent Codex review found no actionable issues.
