### PR TITLE
refactor: simplify Gateway session lifecycle test gates

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1493,15 +1493,9 @@ test("chat.send fences dashboard title persistence from concurrent session delet
     });
     scheduleTitle(params);
   });
-  let finishDispatch: (() => void) | undefined;
-  const dispatchFinished = new Promise<void>((resolve) => {
-    finishDispatch = resolve;
-  });
+  const { promise: dispatchFinished, resolve: finishDispatch } = createDeferredCore();
   let finishTitle: (() => void) | undefined;
-  let markTitleStarted = () => {};
-  const titleStarted = new Promise<void>((resolve) => {
-    markTitleStarted = resolve;
-  });
+  const { promise: titleStarted, resolve: markTitleStarted } = createDeferredCore();
   dashboardTitleGenerationMocks.generate.mockImplementationOnce(async () => {
     markTitleStarted();
     await new Promise<void>((resolve) => {
@@ -1591,11 +1585,8 @@ test("chat.send fences dashboard title persistence from concurrent session delet
 test("chat.send persists a dashboard title while the first turn is still running", async () => {
   const { storePath } = await createSessionStoreDir();
   const { ws } = await openClient();
-  let finishDispatch: (() => void) | undefined;
   let dispatchFinished = false;
-  const dispatchPending = new Promise<void>((resolve) => {
-    finishDispatch = resolve;
-  });
+  const { promise: dispatchPending, resolve: finishDispatch } = createDeferredCore();
   dispatchInboundMessageMock.mockImplementationOnce(async () => {
     await dispatchPending;
     dispatchFinished = true;
@@ -2108,14 +2099,8 @@ test("sessions.create rolls back failed provisioning before a same-key creator p
   const originalRemove = managedWorktrees.remove.bind(managedWorktrees);
   let failedWorktreeId: string | undefined;
   let successorWorktreeId: string | undefined;
-  let releaseRollback = () => {};
-  const rollbackGate = new Promise<void>((resolve) => {
-    releaseRollback = resolve;
-  });
-  let markRollbackStarted = () => {};
-  const rollbackStarted = new Promise<void>((resolve) => {
-    markRollbackStarted = resolve;
-  });
+  const { promise: rollbackGate, resolve: releaseRollback } = createDeferredCore();
+  const { promise: rollbackStarted, resolve: markRollbackStarted } = createDeferredCore();
   const removeSpy = vi.spyOn(managedWorktrees, "remove").mockImplementation(async (params) => {
     if (params.reason === "session-create-failed") {
       failedWorktreeId = params.id;
@@ -2136,7 +2121,12 @@ test("sessions.create rolls back failed provisioning before a same-key creator p
       },
       { client: adminClient },
     );
-    await rollbackStarted;
+    await Promise.race([
+      rollbackStarted,
+      failedPromise.then((result) => {
+        throw new Error(`Creation returned before rollback started: ${JSON.stringify(result)}`);
+      }),
+    ]);
     let successorSettled = false;
     const successorPromise = directSessionReq<{
       entry: {
@@ -3860,10 +3850,7 @@ test("sessions.create reset-in-place detaches the prior worktree permission boun
     const removalGate = new Promise<void>((resolve) => {
       releaseWorktreeRemoval = resolve;
     });
-    let markRemovalStarted = () => {};
-    const removalStarted = new Promise<void>((resolve) => {
-      markRemovalStarted = resolve;
-    });
+    const { promise: removalStarted, resolve: markRemovalStarted } = createDeferredCore();
     const removeIfLosslessSpy = vi
       .spyOn(managedWorktrees, "removeIfLossless")
       .mockImplementation(async (id) => {

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   readAcpSessionMeta,
   writeAcpSessionMetaForMigration,
@@ -325,10 +326,8 @@ test.each(["session id", "updated at"] as const)(
       },
     });
     let releaseBlockingMutation = () => {};
-    let markBlockingMutationStarted = () => {};
-    const blockingMutationStarted = new Promise<void>((resolve) => {
-      markBlockingMutationStarted = resolve;
-    });
+    const { promise: blockingMutationStarted, resolve: markBlockingMutationStarted } =
+      createDeferred();
     const blockingMutation = runExclusiveSessionLifecycleMutation({
       scope: storePath,
       identities: [sessionKey],
@@ -501,10 +500,7 @@ test("sessions.delete serializes a patch behind asynchronous runtime cleanup", a
   });
   await runtimeCleanupStarted;
   let patchSettled = false;
-  let markPatchPreflight = () => {};
-  const patchPreflight = new Promise<void>((resolve) => {
-    markPatchPreflight = resolve;
-  });
+  const { promise: patchPreflight, resolve: markPatchPreflight } = createDeferred();
   const patch = directSessionReq(
     "sessions.patch",
     {
@@ -548,10 +544,7 @@ test("sessions.patch waits for an in-flight session lifecycle mutation", async (
     },
   });
   let releaseMutation = () => {};
-  let markMutationStarted = () => {};
-  const mutationStarted = new Promise<void>((resolve) => {
-    markMutationStarted = resolve;
-  });
+  const { promise: mutationStarted, resolve: markMutationStarted } = createDeferred();
   const mutation = runExclusiveSessionLifecycleMutation({
     scope: storePath,
     identities: [sessionKey, sessionId],

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -359,15 +359,9 @@ test("sessions.delete keeps same-key successor worktree creation behind exact cl
     },
   } as never;
   let successorWorktreeId: string | undefined;
-  let releaseRemoval = () => {};
-  const removalGate = new Promise<void>((resolve) => {
-    releaseRemoval = resolve;
-  });
+  const { promise: removalGate, resolve: releaseRemoval } = createDeferredCore();
   const originalRemove = managedWorktrees.remove.bind(managedWorktrees);
-  let markRemovalStarted = () => {};
-  const removalStarted = new Promise<void>((resolve) => {
-    markRemovalStarted = resolve;
-  });
+  const { promise: removalStarted, resolve: markRemovalStarted } = createDeferredCore();
   const removeSpy = vi.spyOn(managedWorktrees, "remove");
   try {
     const predecessor = await directSessionReq<{

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -4,6 +4,7 @@
  */
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import * as sessionsConfig from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -207,10 +208,7 @@ test("startup prewarm fills session snapshot and title caches before the first l
       agents: { list: [{ id: "main", default: true }] },
       session: { store: storePath },
     } as never;
-    let resolveSessionPrewarm!: () => void;
-    const sessionPrewarm = new Promise<void>((resolve) => {
-      resolveSessionPrewarm = resolve;
-    });
+    const { promise: sessionPrewarm, resolve: resolveSessionPrewarm } = createDeferred();
     sidecar = scheduleGatewayHandlerPrewarm({
       cfgAtStart: cfg,
       log: { warn: vi.fn() },
@@ -282,10 +280,7 @@ test("startup skips a large session prewarm while request-time listing remains a
   let sidecar: ReturnType<typeof scheduleGatewayHandlerPrewarm> | undefined;
   vi.useFakeTimers();
   try {
-    let resolveSessionPrewarm!: () => void;
-    const sessionPrewarm = new Promise<void>((resolve) => {
-      resolveSessionPrewarm = resolve;
-    });
+    const { promise: sessionPrewarm, resolve: resolveSessionPrewarm } = createDeferred();
     sidecar = scheduleGatewayHandlerPrewarm({
       cfgAtStart: {
         agents: { list: [{ id: "main", default: true }] },

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   loadSessionEntry,
   replaceSessionEntry,
@@ -197,10 +198,7 @@ test("sessions.patch rechecks plugin ownership after waiting for lifecycle admis
     internal: { pluginRuntimeOwnerId: "memory-core" },
   } as never;
   let releaseMutation = () => {};
-  let markMutationStarted = () => {};
-  const mutationStarted = new Promise<void>((resolve) => {
-    markMutationStarted = resolve;
-  });
+  const { promise: mutationStarted, resolve: markMutationStarted } = createDeferred();
   const mutation = runExclusiveSessionLifecycleMutation({
     scope: storePath,
     identities: [sessionKey, sessionId],

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -2,6 +2,7 @@
 // hook emission, thread bindings, and browser/MCP cleanup side effects.
 import path from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   readAcpSessionMeta,
   writeAcpSessionMetaForMigration,
@@ -301,14 +302,8 @@ test("sessions.reset keeps watching a replacement registered after waiter settle
 test("sessions.reset reuses the watcher while prior MCP retirement is still disposing", async () => {
   await seedActiveMainSession();
   embeddedRunMock.waitResults.set("sess-main", false);
-  let releaseFirstRetirement = () => {};
-  const firstRetirementReleased = new Promise<void>((resolve) => {
-    releaseFirstRetirement = resolve;
-  });
-  let markFirstRetirementStarted = () => {};
-  const firstRetirementStarted = new Promise<void>((resolve) => {
-    markFirstRetirementStarted = resolve;
-  });
+  const { promise: firstRetirementReleased, resolve: releaseFirstRetirement } = createDeferred();
+  const { promise: firstRetirementStarted, resolve: markFirstRetirementStarted } = createDeferred();
   let heldFirstRetirement = false;
   bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementation(async (params) => {
     if (params.retainAcrossReuse === false && !heldFirstRetirement) {
@@ -422,10 +417,7 @@ test("sessions.reset rejects an active lifecycle mutation without interrupting a
     },
   });
   let releaseMutation = () => {};
-  let markMutationStarted = () => {};
-  const mutationStarted = new Promise<void>((resolve) => {
-    markMutationStarted = resolve;
-  });
+  const { promise: mutationStarted, resolve: markMutationStarted } = createDeferred();
   const blocker = runExclusiveSessionLifecycleMutation({
     scope: storePath,
     identities: ["agent:main:main", "sess-main"],
@@ -604,14 +596,8 @@ test("sessions.reset rejects a concurrent archive during lifecycle rotation", as
       [sessionKey]: sessionStoreEntry("sess-archive-race"),
     },
   });
-  let releaseHook = () => {};
-  const hookReleased = new Promise<void>((resolve) => {
-    releaseHook = resolve;
-  });
-  let markHookStarted = () => {};
-  const hookStarted = new Promise<void>((resolve) => {
-    markHookStarted = resolve;
-  });
+  const { promise: hookReleased, resolve: releaseHook } = createDeferred();
+  const { promise: hookStarted, resolve: markHookStarted } = createDeferred();
   sessionHookMocks.triggerInternalHook.mockImplementationOnce(async () => {
     markHookStarted();
     await hookReleased;
@@ -654,10 +640,7 @@ test("sessions.patch rejects an archive queued behind a rotated session", async 
   // Resolve the lazy handler/config imports before queue ordering begins.
   await Promise.all([getSessionsHandlers(), getGatewayConfigModule()]);
   let releaseBlocker = () => {};
-  let markBlockerStarted = () => {};
-  const blockerStarted = new Promise<void>((resolve) => {
-    markBlockerStarted = resolve;
-  });
+  const { promise: blockerStarted, resolve: markBlockerStarted } = createDeferred();
   const blocker = runExclusiveSessionLifecycle({
     scope: storePath,
     identities: [sessionKey, initialSessionId],


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Gateway session lifecycle tests repeat manual Promise resolver setup. The rollback case also waits until its 120-second timeout when creation fails before rollback begins, hiding an actionable allocation error.

## Why This Change Was Made

Reuse the existing deferred helper for 20 eager gates while preserving allocation points, resolver calls, optional guards and lifecycle assertions. Keep lazy and outer-finally gates unchanged. Race rollback startup against actual request completion so an early failure reports its result. This removes 50 net test lines, including two consequent formatter joins; no cases or production code are removed.

## User Impact

No product behavior changes. Maintainers get smaller lifecycle fixtures and a useful failure message when the rollback setup cannot complete.

## Evidence

- Healthy Linux baseline and candidate: 237 passed, 0 skipped across the same six complete suites, with identical ordered case identities.
- A low-disk diagnostic exposed the actual `UNAVAILABLE` allocation result in 533ms instead of the original 120-second barrier timeout. Capacity checks and deadlines remain unchanged.
- Final lint removed 20 redundant default type arguments; emitted JavaScript is byte-identical to the Linux-tested candidate in each file.
- Mapped changed gate passed; fresh P2 review found no actionable issues.

The original Mac baseline's disk-capacity failures are retained in the audit evidence; the healthy Linux run supplies the complete suite proof. No runtime speedup is claimed.
