### PR TITLE
fix(music): close registration resources after generation

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -45,6 +45,15 @@ still does not invoke a discovery-only engine factory. `dispose()` must not dele
 durable state or disable another registration. Existing raw loader and Gateway
 lifetimes do not gain automatic disposal: keep their `cleanup(ctx)` behavior.
 
+Music generation also owns fresh registrations acquired by
+`api.runtime.musicGeneration.generate(...)`. It waits for the provider's complete
+audio buffers and tracked operation cleanup, then awaits registration disposal
+before resolving or rejecting. Existing managed registrations are retained for
+the operation; raw host registrations and caller-supplied providers retain their
+existing owner. Provider listing still returns caller-owned callbacks and does
+not acquire a generation lifetime. Return asynchronous provider work and have
+`dispose()` stop and join any additional background work it owns.
+
 Executable CLI command registration also uses an owned, uncached registry. Its
 resources remain available through asynchronous registration, command actions,
 and their tracked cleanup, then `dispose()` runs. Closing command preparation

--- a/src/media-generation/registry.ts
+++ b/src/media-generation/registry.ts
@@ -1,3 +1,6 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { MusicGenerationProvider } from "../music-generation/types.js";
+import { withAcquiredPluginCapabilityProviders } from "../plugins/capability-provider-acquisition.js";
 import { createMediaProviderRegistry } from "./provider-registry.js";
 
 /** Registry for image-generation providers contributed by plugin capabilities. */
@@ -17,3 +20,11 @@ export const {
   listProviders: listVideoGenerationProviders,
   getProvider: getVideoGenerationProvider,
 } = createMediaProviderRegistry("videoGenerationProviders");
+
+/** Owns providers loaded for one buffered music-generation operation. */
+export function withMusicGenerationProviders<T>(
+  cfg: OpenClawConfig,
+  run: (providers: MusicGenerationProvider[]) => T | Promise<T>,
+): Promise<T> {
+  return withAcquiredPluginCapabilityProviders({ key: "musicGenerationProviders", cfg }, run);
+}

--- a/src/music-generation/runtime.resources.test.ts
+++ b/src/music-generation/runtime.resources.test.ts
@@ -1,0 +1,391 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { captureAsyncWorkTracker, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { generateMusic } from "./runtime.js";
+
+function createNativeMusicFixture(
+  rejectGeneration = false,
+  id = "native-music-owner",
+  disposalContext: "operation" | "registration" | "node-bound" = "operation",
+) {
+  const dir = makePluginLoaderTempDir();
+  const alias = id === "native-music-owner" ? "native-music-alias" : `${id}-alias`;
+  const key = `__openclaw_music_resources_${path.basename(dir)}`;
+  const started = createDeferredCore();
+  const resume = createDeferredCore();
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    reads: number[];
+  }> = [];
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: { connections, started, resume, captureAsyncWorkTracker },
+  });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, reads: [] };
+    state.connections.push(connection);
+    let trackCleanup = state.captureAsyncWorkTracker();
+    const disposeNative = async () => {
+      await Promise.resolve();
+      connection.reads.push(database.prepare("SELECT 42 AS value").get().value);
+      connection.disposals++;
+      database.close();
+    };
+    let runDispose = () => trackCleanup(disposeNative);
+    api.registerRuntimeLifecycle({
+      id: "native-music-resource",
+      dispose: () => runDispose(),
+    });
+    api.registerMusicGenerationProvider({
+      id: ${JSON.stringify(id)},
+      aliases: [${JSON.stringify(alias)}],
+      label: "Native music fixture",
+      defaultModel: "fixture-model",
+      capabilities: {},
+      async generateMusic() {
+        if (${JSON.stringify(disposalContext)} === "operation") {
+          trackCleanup = state.captureAsyncWorkTracker();
+        } else if (${JSON.stringify(disposalContext)} === "node-bound") {
+          runDispose = require("node:async_hooks").AsyncLocalStorage.bind(disposeNative);
+        }
+        connection.reads.push(database.prepare("SELECT 42 AS value").get().value);
+        state.started.resolve();
+        await state.resume.promise;
+        connection.reads.push(database.prepare("SELECT 42 AS value").get().value);
+        if (${rejectGeneration}) throw new Error("native music generation failed");
+        return { tracks: [{ buffer: Buffer.from("native music 42"), mimeType: "audio/mpeg" }] };
+      },
+    });
+  },
+};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { musicGenerationProviders: [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const config: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const run = () =>
+    generateMusic({
+      cfg: config,
+      prompt: "synthetic native resource proof",
+      modelOverride: `${alias}/fixture-model`,
+      autoProviderFallback: false,
+    });
+  return {
+    config,
+    plugin,
+    connections,
+    started,
+    resume,
+    run,
+    withEnvironment: (operation: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        operation,
+      ),
+    cleanup() {
+      resume.resolve();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+async function waitForProviderStart(
+  started: Promise<void>,
+  operation: Promise<unknown>,
+): Promise<void> {
+  await Promise.race([
+    started,
+    operation.then(() => {
+      throw new Error("Music operation settled before invoking the native provider");
+    }),
+  ]);
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("music generation registration resources", () => {
+  it.each([false, true])(
+    "releases a cold native registration after generation settles (reject=%s)",
+    async (rejectGeneration) => {
+      const fixture = createNativeMusicFixture(rejectGeneration);
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const result = fixture.run();
+          const settled = result.then(
+            (value) => ({ value, error: undefined }),
+            (error: unknown) => ({ value: undefined, error }),
+          );
+          try {
+            await waitForProviderStart(fixture.started.promise, settled);
+            expect(fixture.connections).toHaveLength(1);
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            expect(fixture.connections[0]!.disposals).toBe(0);
+            fixture.resume.resolve();
+            const outcome = await settled;
+            if (rejectGeneration) {
+              expect(outcome.error).toBeInstanceOf(Error);
+              expect(String(outcome.error)).toContain("native music generation failed");
+            } else {
+              expect(outcome.error).toBeUndefined();
+              expect(outcome.value?.tracks[0]?.buffer.toString()).toBe("native music 42");
+              expect(outcome.value?.provider).toBe("native-music-alias");
+            }
+            expect(fixture.connections[0]!.database.isOpen).toBe(false);
+            expect(fixture.connections[0]!.disposals).toBe(1);
+            expect(fixture.connections[0]!.reads).toEqual([42, 42, 42]);
+          } finally {
+            fixture.resume.resolve();
+            await settled;
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("selects an override alias from a different eligible plugin than the configured model", async () => {
+    const configured = createNativeMusicFixture(false, "configured-music-owner");
+    const override = createNativeMusicFixture();
+    configured.resume.resolve();
+    try {
+      await override.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const result = generateMusic({
+          cfg: {
+            agents: {
+              defaults: {
+                mediaModels: { music: { primary: "configured-music-owner/fixture-model" } },
+              },
+            },
+            plugins: {
+              allow: [configured.plugin.id, override.plugin.id],
+              load: { paths: [configured.plugin.file, override.plugin.file] },
+              slots: { memory: "none" },
+            },
+          },
+          prompt: "synthetic override selection proof",
+          modelOverride: "native-music-alias/fixture-model",
+        });
+        const settled = result.then(
+          (value) => ({ value, error: undefined }),
+          (error: unknown) => ({ value: undefined, error }),
+        );
+        try {
+          await waitForProviderStart(override.started.promise, settled);
+          expect(configured.connections).toHaveLength(1);
+          expect(override.connections).toHaveLength(1);
+          expect(configured.connections[0]!.reads).toEqual([]);
+          expect(override.connections[0]!.database.isOpen).toBe(true);
+          override.resume.resolve();
+          const outcome = await settled;
+          expect(outcome.error).toBeUndefined();
+          expect(outcome.value?.provider).toBe("native-music-alias");
+          expect(outcome.value?.tracks[0]?.buffer.toString()).toBe("native music 42");
+          for (const { database, disposals } of [
+            ...configured.connections,
+            ...override.connections,
+          ]) {
+            expect(database.isOpen).toBe(false);
+            expect(disposals).toBe(1);
+          }
+        } finally {
+          override.resume.resolve();
+          await settled;
+        }
+      });
+    } finally {
+      configured.cleanup();
+      override.cleanup();
+    }
+  });
+
+  it.each(["registration", "node-bound"] as const)(
+    "supports later managed-host disposal with %s cleanup context",
+    async (disposalContext) => {
+      const fixture = createNativeMusicFixture(false, "native-music-owner", disposalContext);
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const inspection = await acquirePluginRegistryForInspection({ config: fixture.config });
+          try {
+            fixture.resume.resolve();
+            const result = await withPluginRuntimeRegistryScope(inspection.registry, fixture.run);
+            expect(result.tracks[0]?.buffer.toString()).toBe("native music 42");
+            expect(fixture.connections).toHaveLength(1);
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            expect(fixture.connections[0]!.disposals).toBe(0);
+            await inspection.release();
+            expect(fixture.connections[0]!.database.isOpen).toBe(false);
+            expect(fixture.connections[0]!.reads).toEqual([42, 42, 42]);
+            expect(fixture.connections[0]!.disposals).toBe(1);
+          } finally {
+            fixture.resume.resolve();
+            await inspection.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("joins admitted getter work before releasing the last claim on projection failure", async () => {
+    const fixture = createNativeMusicFixture();
+    const readGate = createDeferredCore();
+    const entered = createDeferredCore();
+    const projectionError = new Error("native music projection failed");
+    let projectionWork: Promise<void> | undefined;
+    let parentRelease: Promise<void> | undefined;
+    let read: unknown;
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.config });
+        const connection = fixture.connections[0]!;
+        const provider = inspection.registry.musicGenerationProviders[0]!.provider;
+        Object.defineProperty(provider, "id", {
+          get() {
+            projectionWork ??= trackAsyncWork(async () => {
+              await readGate.promise;
+              read = connection.database.prepare("SELECT 42 AS value").get();
+            });
+            void projectionWork.catch(() => undefined);
+            parentRelease ??= inspection.release();
+            entered.resolve();
+            throw projectionError;
+          },
+        });
+        const settled = withPluginRuntimeRegistryScope(inspection.registry, fixture.run).then(
+          (value) => ({ value, error: undefined }),
+          (error: unknown) => ({ value: undefined, error }),
+        );
+        try {
+          await waitForProviderStart(entered.promise, settled);
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(connection.database.isOpen).toBe(true);
+          expect(connection.disposals).toBe(0);
+          readGate.resolve();
+          const outcome = await settled;
+          expect(outcome.error).toBe(projectionError);
+          await projectionWork;
+          expect(read).toEqual({ value: 42 });
+          expect(connection.database.isOpen).toBe(false);
+          expect(connection.disposals).toBe(1);
+        } finally {
+          readGate.resolve();
+          fixture.resume.resolve();
+          await Promise.allSettled([settled, projectionWork, parentRelease]);
+          await inspection.release();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each(["managed", "managed-getter", "raw"] as const)(
+    "preserves the existing %s registration owner during generation",
+    async (ownership) => {
+      const fixture = createNativeMusicFixture();
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const inspection =
+            ownership !== "raw"
+              ? await acquirePluginRegistryForInspection({ config: fixture.config })
+              : undefined;
+          const registry =
+            inspection?.registry ?? loadPluginRegistryHandle({ config: fixture.config });
+          let projectionRelease: Promise<void> | undefined;
+          if (ownership === "managed-getter") {
+            expect(inspection).toBeDefined();
+            const managed = inspection!;
+            const provider = managed.registry.musicGenerationProviders[0]!.provider;
+            const id = provider.id;
+            Object.defineProperty(provider, "id", {
+              get() {
+                projectionRelease ??= managed.release();
+                return id;
+              },
+            });
+          }
+          const result = withPluginRuntimeRegistryScope(registry, fixture.run);
+          const settled = result.then(
+            (value) => ({ value, error: undefined }),
+            (error: unknown) => ({ value: undefined, error }),
+          );
+          try {
+            await waitForProviderStart(fixture.started.promise, settled);
+            expect(fixture.connections).toHaveLength(1);
+            if (ownership === "managed-getter") {
+              expect(projectionRelease).toBeDefined();
+              await projectionRelease;
+            }
+            await inspection?.release();
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            fixture.resume.resolve();
+            const outcome = await settled;
+            expect(outcome.error).toBeUndefined();
+            expect(outcome.value?.tracks[0]?.buffer.toString()).toBe("native music 42");
+            expect(fixture.connections[0]!.database.isOpen).toBe(ownership === "raw");
+            expect(fixture.connections[0]!.disposals).toBe(ownership === "raw" ? 0 : 1);
+          } finally {
+            fixture.resume.resolve();
+            await settled;
+            await inspection?.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+});

--- a/src/music-generation/runtime.ts
+++ b/src/music-generation/runtime.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseMusicGenerationModelRef } from "../media-generation/model-ref.js";
 import {
+  withMusicGenerationProviders,
   getMusicGenerationProvider,
   listMusicGenerationProviders,
 } from "../media-generation/registry.js";
@@ -14,6 +15,10 @@ import {
   resolveReferenceImageCapabilityError,
   runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
+import {
+  buildCapabilityProviderIndex,
+  normalizeCapabilityProviderId,
+} from "../plugins/provider-registry-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveMusicGenerationOverrides } from "./normalization.js";
 import type { GenerateMusicParams, GenerateMusicRuntimeResult } from "./runtime-types.js";
@@ -48,6 +53,29 @@ export function listRuntimeMusicGenerationProviders(
 export async function generateMusic(
   params: GenerateMusicParams,
   deps: MusicGenerationRuntimeDeps = {},
+): Promise<GenerateMusicRuntimeResult> {
+  if (deps.getProvider && deps.listProviders) {
+    return runMusicGeneration(params, deps);
+  }
+  return withMusicGenerationProviders(params.cfg, (providers) => {
+    const canonical = buildCapabilityProviderIndex(providers, "canonical");
+    const aliases = buildCapabilityProviderIndex(providers, "aliases");
+    return runMusicGeneration(params, {
+      ...deps,
+      getProvider:
+        deps.getProvider ??
+        ((id) => {
+          const normalized = normalizeCapabilityProviderId(id);
+          return normalized ? aliases.get(normalized) : undefined;
+        }),
+      listProviders: deps.listProviders ?? (() => [...canonical.values()]),
+    });
+  });
+}
+
+async function runMusicGeneration(
+  params: GenerateMusicParams,
+  deps: MusicGenerationRuntimeDeps,
 ): Promise<GenerateMusicRuntimeResult> {
   const getProvider = deps.getProvider ?? getMusicGenerationProvider;
   const listProviders = deps.listProviders ?? listMusicGenerationProviders;

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -3,7 +3,10 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { getGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
-import { loadOpenClawPluginsWithInternalOverrides } from "./loader-runtime-load.js";
+import {
+  acquirePluginRegistryWithInternalOverrides,
+  loadOpenClawPluginsWithInternalOverrides,
+} from "./loader-runtime-load.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -26,23 +29,36 @@ function createCapabilityRegistrationRuntime(
   };
 }
 
-export function loadBundledCapabilityRuntimeRegistry(
-  params: Pick<
-    PluginLoadOptions,
-    | "env"
-    | "config"
-    | "workspaceDir"
-    | "installRecords"
-    | "manifestRegistry"
-    | "activationSourceConfig"
-    | "autoEnabledReasons"
-    | "preferBuiltPluginArtifacts"
-    | "pluginSdkResolution"
-  > & {
-    pluginIds: readonly string[];
-    discovery?: PluginDiscoveryResult;
-  },
-) {
+type BundledCapabilityRuntimeParams = Pick<
+  PluginLoadOptions,
+  | "env"
+  | "config"
+  | "workspaceDir"
+  | "installRecords"
+  | "manifestRegistry"
+  | "activationSourceConfig"
+  | "autoEnabledReasons"
+  | "preferBuiltPluginArtifacts"
+  | "pluginSdkResolution"
+> & {
+  pluginIds: readonly string[];
+  discovery?: PluginDiscoveryResult;
+};
+
+export function loadBundledCapabilityRuntimeRegistry(params: BundledCapabilityRuntimeParams) {
+  const { options, overrides } = prepareBundledCapabilityRuntime(params);
+  return loadOpenClawPluginsWithInternalOverrides(options, overrides);
+}
+
+export function acquireBundledCapabilityRuntimeRegistry(params: BundledCapabilityRuntimeParams) {
+  const { options, overrides } = prepareBundledCapabilityRuntime(params);
+  return acquirePluginRegistryWithInternalOverrides(options, overrides);
+}
+
+function prepareBundledCapabilityRuntime(params: BundledCapabilityRuntimeParams): {
+  options: PluginLoadOptions & { cache: false; activate: false };
+  overrides: Parameters<typeof loadOpenClawPluginsWithInternalOverrides>[1];
+} {
   const { pluginIds: requestedPluginIds, ...loadOptions } = params;
   const env = params.env ?? process.env;
   // Only the speech owner may opt into legacy global-disable compatibility before capture.
@@ -84,8 +100,8 @@ export function loadBundledCapabilityRuntimeRegistry(
     ),
     diagnostics: manifestRegistry.diagnostics,
   };
-  return loadOpenClawPluginsWithInternalOverrides(
-    {
+  return {
+    options: {
       ...loadOptions,
       config,
       env,
@@ -102,7 +118,7 @@ export function loadBundledCapabilityRuntimeRegistry(
         debug: (message) => log.debug(message),
       },
     },
-    {
+    overrides: {
       // Discovery needs the current config, but not the full host runtime graph. The registry
       // still supplies its scoped lazy methods around this narrow base runtime.
       runtime: createCapabilityRegistrationRuntime(config),
@@ -111,5 +127,5 @@ export function loadBundledCapabilityRuntimeRegistry(
         loaderFilename: import.meta.url,
       },
     },
-  );
+  };
 }

--- a/src/plugins/capability-provider-acquisition.ts
+++ b/src/plugins/capability-provider-acquisition.ts
@@ -1,0 +1,97 @@
+import type { Result } from "@openclaw/normalization-core/result";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { acquireBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
+import {
+  preparePluginCapabilityProviderResolution,
+  type CapabilityProviderFor,
+} from "./capability-provider-runtime.js";
+import { acquirePluginRegistryForInspection, isPluginRegistryLoadInFlight } from "./loader.js";
+import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
+import type { PluginRegistry } from "./registry-types.js";
+
+/** Acquires only fresh registrations; existing raw hosts keep their own custody. */
+export async function withAcquiredPluginCapabilityProviders<
+  K extends Parameters<typeof preparePluginCapabilityProviderResolution>[0]["key"],
+  T,
+>(
+  params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0],
+  run: (providers: CapabilityProviderFor<K>[]) => T | Promise<T>,
+): Promise<T> {
+  const work = new AsyncWorkScope();
+  const releases: Array<() => Promise<void>> = [];
+  const retained = new Set<PluginRegistry>();
+  const release = () =>
+    Promise.allSettled(releases.map(async (dispose) => await dispose())).then((results) => {
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "Capability registration cleanup failed");
+      }
+    });
+  const retain = (registry: PluginRegistry | undefined) => {
+    if (!registry || retained.has(registry)) {
+      return;
+    }
+    retained.add(registry);
+    const resources = getPluginRegistryInspectionResources(registry);
+    if (resources) {
+      releases.push(resources.retain().release);
+    }
+  };
+  let outcome: Result<T, unknown>;
+  try {
+    const value = await work.track(async () => {
+      const resolution = preparePluginCapabilityProviderResolution(params, retain);
+      let entries: PluginRegistry[K] = [];
+      if (resolution.load) {
+        const load = resolution.prepareLoad();
+        let registry = load.loadedRegistry;
+        if (!registry) {
+          const loadOptions = load.resolveLoadOptions();
+          if (!isPluginRegistryLoadInFlight(loadOptions)) {
+            const acquired = await acquirePluginRegistryForInspection(loadOptions);
+            releases.push(acquired.release);
+            registry = acquired.registry;
+          }
+        }
+        const fallback = load.fallback(registry);
+        entries = fallback.entries;
+        if (fallback.pluginIds.length > 0) {
+          const captured = await acquireBundledCapabilityRuntimeRegistry({
+            ...resolution.load.loadOptions,
+            pluginIds: fallback.pluginIds,
+          });
+          releases.push(captured.release);
+          entries = load.merge(entries, captured.registry);
+        }
+      }
+      return await run(resolution.resolve(entries));
+    });
+    outcome = { ok: true, value };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+  try {
+    work.beginClose();
+    // Acquisition getters and provider callbacks share the same admitted work owner.
+    await work.runWhenIdle(release);
+  } catch (cleanupError) {
+    outcome = {
+      ok: false,
+      error: outcome.ok
+        ? cleanupError
+        : new AggregateError(
+            [outcome.error, cleanupError],
+            "Capability operation and registration cleanup failed",
+            { cause: outcome.error },
+          ),
+    };
+  } finally {
+    await work.drain();
+  }
+  if (!outcome.ok) {
+    throw outcome.error;
+  }
+  return outcome.value;
+}

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -391,12 +391,15 @@ function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegi
   }) as PluginRegistry[K];
 }
 
-function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(params: {
-  key: K;
-  bundledCompatPluginIds: string[];
-  loadOptions: PluginLoadOptions;
-  requested?: Set<string>;
-}): PluginRegistry[K] {
+function prepareCapabilityProviderLoad<K extends CapabilityProviderRegistryKey>(
+  params: {
+    key: K;
+    bundledCompatPluginIds: string[];
+    loadOptions: PluginLoadOptions;
+    requested?: Set<string>;
+  },
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
+) {
   const allowedPluginIds = new Set(params.loadOptions.onlyPluginIds);
   const filterAllowedEntries = (registry: PluginRegistry | undefined): PluginRegistry[K] =>
     (registry?.[params.key] ?? []).filter((entry) =>
@@ -413,12 +416,13 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
         workspaceDir: params.loadOptions.workspaceDir,
         requiredPluginIds: params.loadOptions.onlyPluginIds,
       });
+  onSelectedRegistry?.(loadedRegistry);
   const catalogFamily = shouldScopeCapabilityLoadToRequestedProviders(params.key)
     ? params.key
     : undefined;
-  const registry =
-    loadedRegistry ??
-    resolveRuntimePluginRegistry({
+  return {
+    loadedRegistry,
+    resolveLoadOptions: () => ({
       ...params.loadOptions,
       ...(catalogFamily
         ? {
@@ -428,32 +432,48 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
             },
           }
         : {}),
-    });
-  const entries = filterAllowedEntries(registry);
-  const missingRequested =
-    params.requested && params.requested.size > 0 ? new Set(params.requested) : undefined;
-  if (missingRequested) {
-    removeActiveProviderIds(missingRequested, entries);
-  }
-  if (entries.length > 0 && (!missingRequested || missingRequested.size === 0)) {
+    }),
+    merge(entries: PluginRegistry[K], registry: PluginRegistry) {
+      return mergeCapabilityProviderEntries(entries, filterAllowedEntries(registry));
+    },
+    filterAllowedEntries,
+    fallback(registry: PluginRegistry | undefined) {
+      const entries = filterAllowedEntries(registry);
+      const missingRequested =
+        params.requested && params.requested.size > 0 ? new Set(params.requested) : undefined;
+      if (missingRequested) {
+        removeActiveProviderIds(missingRequested, entries);
+      }
+      if (entries.length > 0 && (!missingRequested || missingRequested.size === 0)) {
+        return { entries, pluginIds: [] };
+      }
+      const bundledCompatPluginIds = params.bundledCompatPluginIds.filter(
+        (pluginId) =>
+          !registry?.plugins.some(
+            (plugin) =>
+              plugin.id === pluginId &&
+              catalogFamily &&
+              plugin.capabilityCatalog?.includes(catalogFamily),
+          ),
+      );
+      return { entries, pluginIds: bundledCompatPluginIds };
+    },
+  };
+}
+
+function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
+  params: Parameters<typeof prepareCapabilityProviderLoad<K>>[0],
+): PluginRegistry[K] {
+  const load = prepareCapabilityProviderLoad(params);
+  const registry = load.loadedRegistry ?? resolveRuntimePluginRegistry(load.resolveLoadOptions());
+  const { entries, pluginIds } = load.fallback(registry);
+  if (pluginIds.length === 0) {
     return entries;
   }
-  const bundledCompatPluginIds = params.bundledCompatPluginIds.filter(
-    (pluginId) =>
-      !registry?.plugins.some(
-        (plugin) =>
-          plugin.id === pluginId &&
-          catalogFamily &&
-          plugin.capabilityCatalog?.includes(catalogFamily),
-      ),
-  );
-  if (bundledCompatPluginIds.length === 0) {
-    return entries;
-  }
-  const captured = filterAllowedEntries(
+  const captured = load.filterAllowedEntries(
     loadBundledCapabilityRuntimeRegistry({
       ...params.loadOptions,
-      pluginIds: bundledCompatPluginIds,
+      pluginIds,
     }),
   );
   return entries.length > 0 ? mergeCapabilityProviderEntries(entries, captured) : captured;
@@ -520,17 +540,24 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   return findProviderById(loadedProviders, params.providerId);
 }
 
-export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
-  key: K;
-  cfg?: OpenClawConfig;
-  additionalProviderIds?: readonly string[];
-}): CapabilityProviderFor<K>[] {
+export function preparePluginCapabilityProviderResolution<K extends CapabilityProviderRegistryKey>(
+  params: {
+    key: K;
+    cfg?: OpenClawConfig;
+    additionalProviderIds?: readonly string[];
+  },
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
+) {
   if (shouldSkipCapabilityResolution(params)) {
-    return [];
+    return {
+      load: undefined,
+      resolve: (_entries: PluginRegistry[K]): CapabilityProviderFor<K>[] => [],
+    };
   }
 
   const activeRegistry =
     getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getLoadedRuntimePluginRegistry();
+  onSelectedRegistry?.(activeRegistry);
   const activeProviders = filterPolicyAllowedCapabilityProviders({
     entries: activeRegistry?.[params.key] ?? [],
     registry: activeRegistry,
@@ -554,7 +581,11 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   removeActiveProviderIds(requested, activeProviders);
   const requestedProviders = requested.size > 0 ? requested : undefined;
   if (activeProviders.length > 0 && !requestedProviders && !mergeManifestProviders) {
-    return activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[];
+    return {
+      load: undefined,
+      resolve: (_entries: PluginRegistry[K]) =>
+        activeProviders.map((entry) => entry.provider) as CapabilityProviderFor<K>[],
+    };
   }
   const requestedProviderLoadScope =
     requestedProviders && shouldScopeCapabilityLoadToRequestedProviders(params.key)
@@ -591,24 +622,39 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     resolution: pluginIds,
     loadContext,
   });
-  const loadedProviders = loadCapabilityProviderEntries({
+  const load = {
     key: params.key,
     bundledCompatPluginIds: pluginIds.bundledCompatPluginIds,
     loadOptions,
     requested: requestedProviderFilter,
-  });
-  const loadedProviderFilter =
-    activeProviders.length > 0 ? requestedProviders : requestedProviderFilter;
-  const requestedLoadedProviders = loadedProviderFilter
-    ? filterLoadedProvidersForRequestedConfig({
-        key: params.key,
-        requested: loadedProviderFilter,
-        entries: loadedProviders,
-      })
-    : loadedProviders;
-  return mergeCapabilityProviderEntries(activeProviders, requestedLoadedProviders).map(
-    (entry) => entry.provider as CapabilityProviderFor<K>,
-  );
+  };
+  return {
+    load,
+    prepareLoad: () => prepareCapabilityProviderLoad(load, onSelectedRegistry),
+    resolve: (loadedProviders: PluginRegistry[K]): CapabilityProviderFor<K>[] => {
+      const loadedProviderFilter =
+        activeProviders.length > 0 ? requestedProviders : requestedProviderFilter;
+      const requestedLoadedProviders = loadedProviderFilter
+        ? filterLoadedProvidersForRequestedConfig({
+            key: params.key,
+            requested: loadedProviderFilter,
+            entries: loadedProviders,
+          })
+        : loadedProviders;
+      return mergeCapabilityProviderEntries(activeProviders, requestedLoadedProviders).map(
+        (entry) => entry.provider as CapabilityProviderFor<K>,
+      );
+    },
+  };
+}
+
+export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
+  key: K;
+  cfg?: OpenClawConfig;
+  additionalProviderIds?: readonly string[];
+}): CapabilityProviderFor<K>[] {
+  const resolution = preparePluginCapabilityProviderResolution(params);
+  return resolution.resolve(resolution.load ? loadCapabilityProviderEntries(resolution.load) : []);
 }
 
 export function prepareMediaCapabilityProviders(params: {

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -92,14 +92,22 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 export async function acquirePluginRegistryForInspection(
   options: Omit<PluginLoadOptions, "activate" | "cache"> = {},
 ): Promise<{ registry: PluginRegistry; release: () => Promise<void> }> {
-  const resources = new PluginRegistryInspectionResources();
-  try {
-    const registry = loadOpenClawPluginsCore(
+  return acquireRegistryResources((resources) =>
+    loadOpenClawPluginsCore(
       { ...options, activate: false, cache: false },
       loaderBindings,
       undefined,
       resources,
-    );
+    ),
+  );
+}
+
+async function acquireRegistryResources(
+  load: (resources: PluginRegistryInspectionResources) => PluginRegistry,
+): Promise<{ registry: PluginRegistry; release: () => Promise<void> }> {
+  const resources = new PluginRegistryInspectionResources();
+  try {
+    const registry = load(resources);
     return { registry, release: () => resources.release() };
   } catch (error) {
     try {
@@ -115,12 +123,32 @@ export async function acquirePluginRegistryForInspection(
   }
 }
 
+type ScopedRuntimeOverrides = Omit<InternalPluginLoadOverrides, "runtime"> & {
+  runtime: Pick<PluginRuntime, "config"> &
+    Partial<Pick<PluginRuntime, "modelAuth" | "modelConfig">>;
+};
+
 export function loadOpenClawPluginsWithInternalOverrides(
   options: PluginLoadOptions & { cache: false },
-  overrides: Omit<InternalPluginLoadOverrides, "runtime"> & {
-    runtime: Pick<PluginRuntime, "config"> &
-      Partial<Pick<PluginRuntime, "modelAuth" | "modelConfig">>;
-  },
+  overrides: ScopedRuntimeOverrides,
+): PluginRegistry {
+  return loadRegistryWithInternalOverrides(options, overrides);
+}
+
+/** Owns the same narrow capability runtime without publishing or caching its registrations. */
+export function acquirePluginRegistryWithInternalOverrides(
+  options: PluginLoadOptions & { cache: false; activate: false },
+  overrides: ScopedRuntimeOverrides,
+): Promise<{ registry: PluginRegistry; release: () => Promise<void> }> {
+  return acquireRegistryResources((resources) =>
+    loadRegistryWithInternalOverrides(options, overrides, resources),
+  );
+}
+
+function loadRegistryWithInternalOverrides(
+  options: PluginLoadOptions & { cache: false },
+  overrides: ScopedRuntimeOverrides,
+  resources?: PluginRegistryInspectionResources,
 ): PluginRegistry {
   const runtimeModelAuth = overrides.runtime.modelAuth ??
     options.runtimeOptions?.modelAuth ?? { ...loaderBindings.modelAuth };
@@ -141,7 +169,7 @@ export function loadOpenClawPluginsWithInternalOverrides(
   delete runtimeDescriptors.modelAuth;
   delete runtimeDescriptors.modelConfig;
   Object.defineProperties(runtime, runtimeDescriptors);
-  return loadOpenClawPluginsCore(options, loaderBindings, { ...overrides, runtime });
+  return loadOpenClawPluginsCore(options, loaderBindings, { ...overrides, runtime }, resources);
 }
 
 export function resolveNativePluginModelAuth(): PluginRuntime["modelAuth"] {


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Music generation could leave a cold plugin's database open after the operation, or lose a managed registration while an accepted callback still used it. Provider projection could also throw after starting work, releasing the registration before that work finished.

## Why This Change Was Made

Capability acquisition and the actual music operation now share one resource owner. It retains managed registrations before reading provider properties, joins admitted work on success or error, then releases the registration. Fresh fallback registrations are owned by that finite operation. Providers supplied by the caller and unmanaged host registrations retain their existing ownership.

The shared selection policy and raw resolver signatures remain unchanged. The acquisition helper is internal; this adds no public SDK export, configuration, schema, dependency, or version change.

## User Impact

The public music runtime closes operation-owned plugin resources after completion, including failed operations. Returned audio remains usable after cleanup. Existing provider selection, aliases, fallback, and caller-owned provider behavior remain intact.

## Evidence

Three initial native SQLite ownership regressions failed before the repair while the raw-owner control passed. Independent review found an additional throwing-provider-getter race; its native regression failed before the callback-owned repair. Nine native cases and 149 existing sibling tests now pass, including registration-stable and Node-bound delayed cleanup controls. Fresh independent Codex review is clean. The canonical changed gate passed in 335.1 seconds and the ordinary build in 210.2 seconds.

Actual compiled public music-generation calls ran success → rejection → success with synthetic plugins and native SQLite. Cold calls registered/disposed three times; managed calls shared one registration until host release; raw calls performed no automatic disposal and closed through explicit caller cleanup. Returned buffers were saved and read back, database disposal markers were checked, and read-only reopen verified the final state. Every owned process joined and source/build seals stayed stable.

Observed call timings were 23.03 / 5.29 / 3.18 ms cold, 13.56 / 2.13 / 0.78 ms managed, and 7.05 / 2.05 / 0.61 ms raw. These are single-fixture measurements, not a before/after performance claim. Initial managed/raw proof fixtures lacked the production host registry scope; the corrected probes use that existing scope and preserve the original failures. No external model calls or vendor credentials were used.
