### PR TITLE
fix(ci): retain Android emulator post-timeout evidence

### DIFF
--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -141,6 +141,7 @@ jobs:
           set -euo pipefail
           emulator_pid=""
           adb_started=0
+          readiness_failure_latched=0
 
           capture_accel_check() {
             local accel_raw="$DIAGNOSTIC_DIR/emulator-accel-check.raw"
@@ -193,6 +194,176 @@ jobs:
             return 0
           }
 
+          run_bounded_probe() {
+            local output_file="$1"
+            local deadline="$2"
+            shift 2
+            local probe_pid
+            local probe_poll_seconds=1
+
+            probe_status=0
+            probe_timed_out=false
+            if (( SECONDS >= deadline )); then
+              : >"$output_file"
+              probe_status=124
+              probe_timed_out=true
+              return 0
+            fi
+
+            "$@" >"$output_file" 2>&1 &
+            probe_pid=$!
+            while kill -0 "$probe_pid" 2>/dev/null; do
+              if (( SECONDS >= deadline )); then
+                probe_timed_out=true
+                if kill "$probe_pid" 2>/dev/null; then
+                  :
+                fi
+                if kill -0 "$probe_pid" 2>/dev/null && kill -9 "$probe_pid" 2>/dev/null; then
+                  :
+                fi
+                break
+              fi
+              sleep "$probe_poll_seconds"
+            done
+            if wait "$probe_pid"; then
+              probe_status=0
+            else
+              probe_status=$?
+            fi
+            if (( SECONDS >= deadline )); then
+              probe_timed_out=true
+            fi
+            if [[ "$probe_timed_out" == "true" ]]; then
+              probe_status=124
+            fi
+          }
+
+          observe_after_readiness_timeout() {
+            local serial="${1:-}"
+            local post_deadline_observation_seconds=300
+            local post_deadline_poll_seconds=2
+            local observation_deadline=$((SECONDS + post_deadline_observation_seconds))
+            local observation_log="$DIAGNOSTIC_DIR/post-deadline-observations.log"
+            local observation_stop="observation-cap-reached"
+            local late_adb_recorded=false
+            local observed_at
+            local probe_output="$DIAGNOSTIC_DIR/post-deadline-probe.raw"
+            local adb_output
+            local serials
+            local count
+            local avd_name
+            local boot_completed
+            local remaining_seconds
+
+            {
+              printf 'original_deadline_reached_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              printf 'observation_cap_seconds=%s\n' "$post_deadline_observation_seconds"
+              printf 'owned_emulator_pid=%s\n' "$emulator_pid"
+            } >>"$observation_log"
+
+            while (( SECONDS < observation_deadline )); do
+              observed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              if ! kill -0 "$emulator_pid" 2>/dev/null; then
+                observation_stop="owned-emulator-exited"
+                printf '[%s] owned_emulator_exited=true\n' "$observed_at" >>"$observation_log"
+                break
+              fi
+
+              run_bounded_probe "$probe_output" "$observation_deadline" adb devices -l
+              adb_output="$(head -c 16384 "$probe_output")"
+              {
+                printf '\n[%s] post-deadline adb_status=%s adb_timed_out=%s\n' \
+                  "$observed_at" "$probe_status" "$probe_timed_out"
+                printf '%s\n' "$adb_output"
+              } >>"$observation_log"
+              if [[ "$probe_timed_out" == "true" ]]; then
+                observation_stop="adb-devices-timeout"
+                break
+              fi
+              if [[ "$probe_status" -ne 0 ]]; then
+                observation_stop="adb-devices-failed"
+                break
+              fi
+
+              serials="$(printf '%s\n' "$adb_output" | awk 'NR > 1 && $2 == "device" { print $1 }')"
+              count="$(printf '%s\n' "$serials" | sed '/^$/d' | wc -l | tr -d ' ')"
+              if [[ "$count" -gt 1 ]]; then
+                observation_stop="unexpected-multiple-devices"
+                break
+              fi
+              if [[ "$count" == "1" ]]; then
+                if [[ -n "$serial" && "$serial" != "$serials" ]]; then
+                  observation_stop="unexpected-device-change"
+                  break
+                fi
+                if [[ -z "$serial" ]]; then
+                  serial="$serials"
+                fi
+                run_bounded_probe "$probe_output" "$observation_deadline" \
+                  adb -s "$serial" emu avd name
+                avd_name="$(head -c 4096 "$probe_output" | tr -d '\r' | sed -n '1p')"
+                printf '[%s] serial=%s avd_status=%s avd_name=%s\n' \
+                  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$serial" "$probe_status" \
+                  "${avd_name:-unset}" >>"$observation_log"
+                if [[ "$probe_timed_out" == "true" ]]; then
+                  observation_stop="avd-identity-timeout"
+                  break
+                fi
+                if [[ "$probe_status" -ne 0 || "$avd_name" != "$AVD_NAME" ]]; then
+                  observation_stop="unexpected-avd"
+                  break
+                fi
+                if [[ "$late_adb_recorded" == "false" ]]; then
+                  printf 'late_adb_online_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    >>"$observation_log"
+                  late_adb_recorded=true
+                fi
+
+                run_bounded_probe "$probe_output" "$observation_deadline" \
+                  adb -s "$serial" shell getprop sys.boot_completed
+                boot_completed="$(tr -d '\r' <"$probe_output")"
+                printf '[%s] serial=%s boot_status=%s boot_completed=%s\n' \
+                  "$observed_at" "$serial" "$probe_status" "${boot_completed:-unset}" \
+                  >>"$observation_log"
+                if [[ "$probe_timed_out" == "true" ]]; then
+                  observation_stop="boot-query-timeout"
+                  break
+                fi
+                if [[ "$probe_status" == "0" && "$boot_completed" == "1" ]]; then
+                  printf 'late_boot_completed_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    >>"$observation_log"
+                  observation_stop="late-boot-completed"
+                  break
+                fi
+              fi
+
+              sample_owned_qemu
+              remaining_seconds=$((observation_deadline - SECONDS))
+              if (( remaining_seconds <= 0 )); then
+                break
+              fi
+              if (( remaining_seconds < post_deadline_poll_seconds )); then
+                sleep "$remaining_seconds"
+              else
+                sleep "$post_deadline_poll_seconds"
+              fi
+            done
+
+            printf 'observation_finished_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              >>"$observation_log"
+            printf 'observation_stop=%s\n' "$observation_stop" >>"$observation_log"
+          }
+
+          fail_after_readiness_timeout() {
+            local failure_message="$1"
+            local serial="${2:-}"
+
+            readiness_failure_latched=1
+            observe_after_readiness_timeout "$serial"
+            printf '::error::%s\n' "$failure_message" >&2
+            return 1
+          }
+
           cleanup() {
             status=$?
             set +e
@@ -202,7 +373,11 @@ jobs:
               if [[ -n "$emulator_pid" ]]; then
                 ps -p "$emulator_pid" -o pid=,ppid=,stat=,etime=,command=
               fi
-              adb devices -l
+              if [[ "$readiness_failure_latched" == "1" ]]; then
+                printf 'adb_devices_skipped_after_latched_timeout=true\n'
+              else
+                adb devices -l
+              fi
             } >>"$DIAGNOSTIC_DIR/process-status.log" 2>&1
             if [[ -n "$emulator_pid" ]] && kill -0 "$emulator_pid" 2>/dev/null; then
               kill "$emulator_pid"
@@ -215,8 +390,11 @@ jobs:
               fi
               wait "$emulator_pid" 2>/dev/null
             fi
-            if [[ "$adb_started" == "1" ]]; then
+            if [[ "$adb_started" == "1" && "$readiness_failure_latched" != "1" ]]; then
               adb kill-server
+            elif [[ "$adb_started" == "1" ]]; then
+              printf 'adb_kill_server_skipped_after_latched_timeout=true\n' \
+                >>"$DIAGNOSTIC_DIR/cleanup.log"
             fi
             avdmanager delete avd --name "$AVD_NAME" \
               >>"$DIAGNOSTIC_DIR/cleanup.log" 2>&1
@@ -273,8 +451,8 @@ jobs:
             sleep 2
           done
           if [[ -z "$serial" ]]; then
-            echo "::error::Timed out waiting for exactly one Android emulator device"
-            exit 1
+            fail_after_readiness_timeout \
+              "Timed out waiting for exactly one Android emulator device" ""
           fi
 
           adb -s "$serial" wait-for-device
@@ -301,8 +479,8 @@ jobs:
             sleep 2
           done
 
-          echo "::error::Timed out waiting for Android emulator boot completion"
-          exit 1
+          fail_after_readiness_timeout \
+            "Timed out waiting for Android emulator boot completion" "$serial"
 
       - name: Upload Android emulator diagnostic
         if: always()

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -2023,7 +2023,7 @@ describe("mobile release authority", () => {
       'ps -p "$emulator_pid" -o pid=,ppid=,%cpu=,rss=,stat=,etime=,command=',
     );
     expect(diagnostic).toContain('>>"$DIAGNOSTIC_DIR/owned-qemu-samples.log" 2>&1');
-    expect(diagnostic.match(/\bsample_owned_qemu\b/gu)).toHaveLength(4);
+    expect(diagnostic.match(/\bsample_owned_qemu\b/gu)).toHaveLength(5);
 
     const accelFunctionStart = diagnostic.indexOf("capture_accel_check() {");
     const accelFunctionEnd = diagnostic.indexOf("\n\nsample_owned_qemu()", accelFunctionStart);
@@ -2068,6 +2068,220 @@ describe("mobile release authority", () => {
     expect(timedOutAccel.result.status, timedOutAccel.result.stderr).toBe(0);
     expect(timedOutAccel.output).toContain("exit_status=124");
     expect(timedOutAccel.output).toContain("timed_out=true");
+
+    expect(diagnostic).toContain("observe_after_readiness_timeout() {");
+    expect(diagnostic).toContain("post_deadline_observation_seconds=300");
+    expect(diagnostic).toContain("fail_after_readiness_timeout() {");
+    const observationFunctionStart = diagnostic.indexOf("run_bounded_probe() {");
+    const observationFunctionEnd = diagnostic.indexOf(
+      "\n\nfail_after_readiness_timeout()",
+      observationFunctionStart,
+    );
+    const failureFunctionEnd = diagnostic.indexOf("\n\ncleanup()", observationFunctionEnd);
+    expect(observationFunctionStart).toBeGreaterThanOrEqual(0);
+    expect(observationFunctionEnd).toBeGreaterThan(observationFunctionStart);
+    expect(failureFunctionEnd).toBeGreaterThan(observationFunctionEnd);
+    const observationFunctions = diagnostic
+      .slice(observationFunctionStart, failureFunctionEnd)
+      .replace("probe_poll_seconds=1", "probe_poll_seconds=0.05")
+      .replace("post_deadline_observation_seconds=300", "post_deadline_observation_seconds=3")
+      .replace("post_deadline_poll_seconds=2", "post_deadline_poll_seconds=1");
+    const runPostDeadlineObservation = (adbSource: string, functions = observationFunctions) => {
+      const root = tempRoots.make("openclaw-android-emulator-post-deadline-");
+      const bin = path.join(root, "bin");
+      const diagnosticDir = path.join(root, "diagnostic");
+      fs.mkdirSync(bin);
+      fs.mkdirSync(diagnosticDir);
+      fs.writeFileSync(path.join(bin, "adb"), adbSource, { mode: 0o755 });
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            "sample_owned_qemu() { :; }",
+            functions,
+            "readiness_failure_latched=0",
+            "emulator_pid=$$",
+            'export AVD_NAME="OpenClaw_Screenshots_API36"',
+            'fail_after_readiness_timeout "latched readiness failure" ""',
+          ].join("\n"),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DIAGNOSTIC_DIR: diagnosticDir,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+          timeout: 5_000,
+        },
+      );
+      return {
+        observations: fs.readFileSync(
+          path.join(diagnosticDir, "post-deadline-observations.log"),
+          "utf8",
+        ),
+        result,
+      };
+    };
+
+    const lateReady = runPostDeadlineObservation(`#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5554\\tdevice product:sdk model:sdk\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" ]]; then
+  printf '1\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "emu" ]]; then
+  printf '%s\\nOK\\n' "\${AVD_NAME:?}"
+fi
+`);
+    expect(lateReady.result.status).toBe(1);
+    expect(lateReady.result.stderr).toContain("::error::latched readiness failure");
+    expect(lateReady.observations).toContain("late_adb_online_at=");
+    expect(lateReady.observations).toContain("late_boot_completed_at=");
+    expect(lateReady.observations).toContain("observation_stop=late-boot-completed");
+
+    const unrelatedDevice = runPostDeadlineObservation(`#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5554\\tdevice product:sdk model:sdk\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "emu" ]]; then
+  printf 'Another_AVD\\nOK\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" ]]; then
+  printf '1\\n'
+fi
+`);
+    expect(unrelatedDevice.result.status).toBe(1);
+    expect(unrelatedDevice.observations).toContain("observation_stop=unexpected-avd");
+    expect(unrelatedDevice.observations).not.toContain("late_adb_online_at=");
+    expect(unrelatedDevice.observations).not.toContain("late_boot_completed_at=");
+
+    const cappedObservationFunctions = observationFunctions.replace(
+      "post_deadline_observation_seconds=3",
+      "post_deadline_observation_seconds=1",
+    );
+    const capped = runPostDeadlineObservation(
+      `#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\n\\n'
+fi
+`,
+      cappedObservationFunctions,
+    );
+    expect(capped.result.status).toBe(1);
+    expect(capped.result.stderr).toContain("::error::latched readiness failure");
+    expect(capped.observations).toContain("observation_cap_seconds=1");
+    expect(capped.observations).toContain("observation_stop=observation-cap-reached");
+
+    const probeFunctionEnd = observationFunctions.indexOf("\n\nobserve_after_readiness_timeout()");
+    expect(probeFunctionEnd).toBeGreaterThan(0);
+    const probeFunction = observationFunctions.slice(0, probeFunctionEnd);
+    const completionRace = spawnSync(
+      "/bin/bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          "kill() {",
+          '  if [[ "${1:-}" == "-0" ]]; then',
+          "    sleep 1",
+          "    return 1",
+          "  fi",
+          '  command kill "$@"',
+          "}",
+          probeFunction,
+          'run_bounded_probe "$PROBE_OUTPUT" "$((SECONDS + 1))" /usr/bin/true',
+          'printf "status=%s timed_out=%s\\n" "$probe_status" "$probe_timed_out"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PROBE_OUTPUT: path.join(tempRoots.make("openclaw-android-probe-race-"), "probe.txt"),
+        },
+        timeout: 5_000,
+      },
+    );
+    expect(completionRace.status, completionRace.stderr).toBe(0);
+    expect(completionRace.stdout).toBe("status=124 timed_out=true\n");
+
+    const cleanupFunctionStart = diagnostic.indexOf("cleanup() {");
+    const cleanupFunctionEnd = diagnostic.indexOf("\ntrap cleanup EXIT", cleanupFunctionStart);
+    expect(cleanupFunctionStart).toBeGreaterThan(failureFunctionEnd);
+    expect(cleanupFunctionEnd).toBeGreaterThan(cleanupFunctionStart);
+    const cleanupFunction = diagnostic.slice(cleanupFunctionStart, cleanupFunctionEnd);
+    const hangingRoot = tempRoots.make("openclaw-android-emulator-hanging-adb-");
+    const hangingBin = path.join(hangingRoot, "bin");
+    const hangingDiagnosticDir = path.join(hangingRoot, "diagnostic");
+    const adbPidFile = path.join(hangingRoot, "adb.pid");
+    const emulatorPidFile = path.join(hangingRoot, "emulator.pid");
+    fs.mkdirSync(hangingBin);
+    fs.mkdirSync(hangingDiagnosticDir);
+    fs.writeFileSync(
+      path.join(hangingBin, "adb"),
+      '#!/bin/bash\nset -euo pipefail\nprintf \'%s\\n\' "$$" >"$ADB_PID_FILE"\nexec sleep 30\n',
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(hangingBin, "avdmanager"),
+      "#!/bin/bash\nset -euo pipefail\nprintf 'cleanup\\n' >>\"$CLEANUP_TRACE\"\n",
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(hangingBin, "ps"), "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+    const hangingObservationFunctions = observationFunctions.replace(
+      "post_deadline_observation_seconds=3",
+      "post_deadline_observation_seconds=2",
+    );
+    const hangingResult = spawnSync(
+      "/bin/bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          "sample_owned_qemu() { :; }",
+          hangingObservationFunctions,
+          cleanupFunction,
+          "readiness_failure_latched=0",
+          "adb_started=1",
+          'export AVD_NAME="OpenClaw_Screenshots_API36"',
+          "sleep 30 &",
+          "emulator_pid=$!",
+          'printf "%s\\n" "$emulator_pid" >"$EMULATOR_PID_FILE"',
+          "trap cleanup EXIT",
+          'fail_after_readiness_timeout "latched readiness failure" ""',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ADB_PID_FILE: adbPidFile,
+          CLEANUP_TRACE: path.join(hangingRoot, "cleanup.trace"),
+          DIAGNOSTIC_DIR: hangingDiagnosticDir,
+          EMULATOR_PID_FILE: emulatorPidFile,
+          PATH: `${hangingBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+        timeout: 5_000,
+      },
+    );
+    expect(hangingResult.status, hangingResult.stderr).toBe(1);
+    const hangingObservations = fs.readFileSync(
+      path.join(hangingDiagnosticDir, "post-deadline-observations.log"),
+      "utf8",
+    );
+    expect(hangingObservations).toContain("adb_timed_out=true");
+    expect(hangingObservations).toContain("observation_stop=adb-devices-timeout");
+    expect(fs.readFileSync(path.join(hangingRoot, "cleanup.trace"), "utf8")).toBe("cleanup\n");
+    expect(fs.readFileSync(path.join(hangingDiagnosticDir, "cleanup.log"), "utf8")).toContain(
+      "adb_kill_server_skipped_after_latched_timeout=true",
+    );
+    for (const pidFile of [adbPidFile, emulatorPidFile]) {
+      const pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+      expect(() => process.kill(pid, 0)).toThrow();
+    }
     expect(diagnostic).toContain(
       "device_deadline=$((SECONDS + ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS))",
     );
@@ -2080,6 +2294,13 @@ describe("mobile release authority", () => {
     expect(diagnostic).toContain('ps -p "$emulator_pid"');
     expect(diagnostic).toContain('kill "$emulator_pid"');
     expect(diagnostic).toContain("adb kill-server");
+    expect(diagnostic).toContain("trap cleanup EXIT");
+    expect(diagnostic).toMatch(
+      /fail_after_readiness_timeout \\\n\s+"Timed out waiting for exactly one Android emulator device" ""/u,
+    );
+    expect(diagnostic).toMatch(
+      /fail_after_readiness_timeout \\\n\s+"Timed out waiting for Android emulator boot completion" "\$serial"/u,
+    );
     expect(steps[artifactIndex]).toMatchObject({
       if: "always()",
       uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",


### PR DESCRIPTION
## What Problem This Solves

Resolves a diagnostic gap where the Android emulator workflow stopped at its 180-second readiness deadline without showing whether the same launched emulator became available shortly afterward.

## Why This Change Was Made

The workflow now permanently latches the original timeout as failure, then observes only the owned emulator for at most 300 additional seconds. Every ADB probe shares that absolute deadline, validates the exact AVD identity, records fresh late-online and boot timestamps, and terminates only its own probe child. Latched cleanup skips potentially blocking ADB calls while still terminating the owned emulator and preserving the unconditional diagnostic artifact.

This does not increase the release readiness timeout, retry a failed run, alter release authority, change the frozen candidate, or claim that observed progress proves eventual boot success or CPU causality.

## User Impact

Release operators get bounded post-timeout evidence that distinguishes a hard startup failure from an emulator that becomes ready shortly after the qualification deadline. The diagnostic remains failed in both cases, so release qualification cannot be weakened by late readiness.

## Evidence

- Red proof on the landed baseline: owner suite 61/62; the new post-deadline boundary was absent.
- Focused executable proof: late readiness remains exit 1; unrelated AVD identity is rejected; the 300-second cap is modeled; a hanging ADB probe is terminated and joined; owned-emulator cleanup still runs.
- Final owner suite before review: 62/62 passed.
- Final affected regression after review repairs: 1/1 passed.
- Static proof: `actionlint`, embedded Bash `bash -n`, repository formatter, scoped oxlint, `git diff --check`, and privacy scan passed.
- P1 autoreview: initial AVD-identity and deadline-completion race findings fixed; final exact-byte review clean at 0.97 confidence.
- LOC: workflow/tooling +184/-6; tests +222/-1. Production growth owns the bounded probe lifecycle, irreversible failure latch, same-AVD validation, and nonblocking cleanup contract.

Hosted execution remains required to capture real post-deadline emulator behavior. No Android release, Play upload, App Review, production promotion, or candidate mutation is part of this PR.

Punchcard-Session: calm-meadow-summit-7q
