### PR TITLE
perf: reduce generated media reference formatting overhead

### DIFF
--- a/src/agents/internal-events.test.ts
+++ b/src/agents/internal-events.test.ts
@@ -83,6 +83,25 @@ describe("agent internal events", () => {
     expect(media).toEqual(["https://example.test/report.png"]);
   });
 
+  it("normalizes media references while preserving Unicode and delimiter modes", () => {
+    const unicode = "雪😀\ud800x\udc00\u0085\u200b\u2028Z";
+    const reference = ` /tmp/a\r\nb\rc\nd\te\u0000f\u001fg\u007fh/${unicode}/${INTERNAL_RUNTIME_CONTEXT_BEGIN}/${INTERNAL_RUNTIME_CONTEXT_END}.png `;
+    const normalized = `/tmp/a b c d e f g h/${unicode}/${INTERNAL_RUNTIME_CONTEXT_BEGIN}/${INTERNAL_RUNTIME_CONTEXT_END}.png`;
+    const protectedReference = `/tmp/a b c d e f g h/${unicode}/[[OPENCLAW_INTERNAL_CONTEXT_BEGIN]]/[[OPENCLAW_INTERNAL_CONTEXT_END]].png`;
+    const mediaUrls = [reference, normalized];
+    const raw = buildGeneratedMediaDeliveryContext(mediaUrls, false);
+    const protectedPrompt = formatAgentInternalEventsForPrompt([
+      { ...taskCompletionEvent("result"), mediaUrls },
+    ]);
+
+    expect(raw.find((fragment) => fragment.kind === "conversation-data")?.text).toBe(
+      `Generated media:\nMEDIA:${normalized}`,
+    );
+    expect(protectedPrompt).toContain(`\nGenerated media:\nMEDIA:${protectedReference}\n`);
+    expect(protectedPrompt.split("\nMEDIA:")).toHaveLength(2);
+    expect(mediaUrls).toEqual([reference, normalized]);
+  });
+
   it("bounds protected and plain child-result projections after escaping", () => {
     const fullResult = `${"<".repeat(MAX_CHILD_RESULT_CHARS)}-unbounded-tail`;
     const event = taskCompletionEvent(fullResult);

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -57,6 +57,8 @@ const TASK_COMPLETION_RESULT_TRUNCATION_NOTICE = "\n[child result truncated]";
 const MAX_TASK_COMPLETION_STATUS_LABEL_CHARS = 500;
 const TASK_COMPLETION_STATUS_LABEL_TRUNCATION_MARKER = "…[truncated]";
 
+const MEDIA_DIRECTIVE_CONTROL_CHARS = new RegExp(String.raw`[\u0000-\u001f\u007f]`, "g");
+
 /** Internal event variants that can be rendered into agent prompt context. */
 export type AgentInternalEvent = AgentTaskCompletionInternalEvent;
 
@@ -120,10 +122,7 @@ function sanitizeMultilineField(value: string): string {
 function sanitizeMediaDirectiveValue(value: string, raw = false): string | null {
   const sanitized = (raw ? value : escapeInternalRuntimeContextDelimiters(value))
     .replace(/\r?\n/g, " ")
-    .replace(/./gs, (char) => {
-      const code = char.charCodeAt(0);
-      return code < 32 || code === 127 ? " " : char;
-    })
+    .replace(MEDIA_DIRECTIVE_CONTROL_CHARS, " ")
     .trim();
   return sanitized || null;
 }


### PR DESCRIPTION
## What Problem This Solves

Preparing generated-media references for an agent prompt calls JavaScript once for every character, including ordinary URL and path characters that need no change. This adds unnecessary work to internal-event formatting, especially for longer references.

## Why This Change Was Made

Replace that per-character callback with one regex matching exactly the existing C0 and DEL character set. CRLF handling still runs first; delimiter escaping, Unicode and surrogate units, trimming, reference order, deduplication and transport references keep their existing behavior. This removes one production line overall without adding a cache, configuration or public API.

## User Impact

Generated-media prompt content is unchanged. The fixed local comparison measured lower median preparation time for ordinary and long URLs in both orders. Small controls were mixed; this is an event-formatting result, not a measured end-to-end Gateway or provider improvement.

## Evidence

The added boundary preservation test passes on both the original implementation and this change; it is not a claimed pre-fix regression failure. Focused original-source proof passed 13 tests, candidate proof passed 13, and sibling suites passed 112: **125 candidate tests across three suites**, with 13 original-source tests separately. Frozen install, formatter and diff checks passed. The dry plan selected 29 checks; that is scope evidence, not a claim that all 29 ran locally.

Six supplementary checks passed. **The seventh, plugin-boundary-report, exited 1** because `sdk-untrusted-context-identifier-aliases` was due for removal at the actual execution date. The change does not touch that record or its calendar policy; the original failure remains recorded as failed, not relabeled or waived. The independent numerical audit verified all 400 outputs, the exhaustive Unicode fixture, and every reported comparison. All 22 ordinary CI obligations passed in [exact-head run34312282314](https://github.com/openclaw/openclaw/actions/runs/34312282314), with complete lint/type partitions. Native preparation and merge completed as [ec7464766fa](https://github.com/openclaw/openclaw/commit/ec7464766fabd864d91e111871b62b68dcc38e99); the resulting source was verified on clean main. [Upstream #142708](https://github.com/openclaw/openclaw/pull/142708) separately repairs the compatibility record; that repair was not copied into this author checkout or used to relabel the old failure. Fresh scoped Codex review reported no findings (0.99 confidence).

The fixed B0/C0/C1/B1 cohort ran once, with no calibration or retries. It captured **400 complete returns and 196 protected-entry clocks**. All seven literal fixture profiles, raw sibling outputs and one untimed exhaustive 65,536-code-unit UTF16 fixture per phase passed lossless V8 output/input-preservation and cross-phase equality checks. The protected internal-event formatting entry was timed; raw sibling calls, exhaustive correctness, serialization and assertions were untimed.

Median times below are microseconds per protected-entry call; negative deltas mean less time. Each median uses five fixed steady samples.

| Case | B0 → C0 median (µs) | Delta | B1 → C1 median (µs) | Delta |
| --- | ---: | ---: | ---: | ---: |
| no-media | 12.333 → 10.959 | -11.14% | 10.583 → 16.083 | +51.97% |
| short-path | 6.875 → 8.417 | +22.43% | 9.500 → 6.417 | -32.45% |
| url | 6.542 → 4.166 | -36.32% | 6.959 → 4.041 | -41.93% |
| long-url | 14.833 → 5.250 | -64.61% | 15.583 → 5.125 | -67.11% |
| controls-unicode | 5.459 → 4.834 | -11.45% | 6.916 → 4.834 | -30.10% |
| delimiter-modes | 6.625 → 5.000 | -24.53% | 5.875 → 4.250 | -27.66% |
| dedup-order | 5.125 → 5.209 | +1.64% | 6.250 → 4.292 | -31.33% |

All adverse results are retained: **3/14 medians, 15/56 steady statistics, 20/98 indexed observations, 5/14 first observations, 2/14 warm observations and 2/10 resource comparisons**. These categories overlap. Forward short-path mean rose 10.3834→14.1416 µs (+36.19%) and max 22.875→32.208 µs (+40.80%); controls max rose 5.584→9.792 µs (+75.36%); dedup max rose 6.042→12.542 µs (+107.58%). Reverse no-media mean rose 10.4168→17.6418 µs (+69.36%) and max 11.792→31.042 µs (+163.25%). Forward URL first observation rose 7.292→17.750 µs (+143.42%). The no-media control does not execute the changed sanitizer. First observations are after imports and potentially earlier rows, not cold startup; five-sample p95 equals max, not a population-tail estimate.

| Phase | Whole native process wall (s) | Kernel child max RSS (bytes) | Sampled tree peak RSS (bytes) |
| --- | ---: | ---: | ---: |
| B0 | 0.373373708 | 158,908,416 | 134,578,176 |
| C0 | 0.302213375 | 151,764,992 | 138,887,168 |
| C1 | 0.302639875 | 155,762,688 | 144,310,272 |
| B1 | 0.330003333 | 160,481,280 | 138,067,968 |

Whole-process wall fell 19.06%/8.29% and kernel child max RSS fell 4.50%/2.94%, while sampled tree peak RSS rose 3.20%/4.52%. These resources include imports, untimed work, fixture handling, capture and checks; they do not establish sanitizer heap-allocation savings. The reducer closed in 0.151823958 s. Absolute monotonic cohort timing was 160.875157375 s including orchestration, under the fixed 360-second bound.

Every native monitor and outer tool completed successfully; fresh PID/group/outer-parent absence was recorded after each phase. Candidate source was restored before reduction, the preservation test stayed unchanged, and all admissions were disabled. The original raw records remain unchanged. A supplemental invocation record retains exact later phase calls and closure/placement tool results; original B0 call arguments are unavailable after context compaction, and individual absence observations lack contemporaneous timestamps. START/FINAL are aggregate bounds, not substitutes for those timestamps.

Local evidence retains complete raw returns, every timing sample, all comparisons and resource receipts. No live Gateway, external delivery, provider request, complete-normal-pass or cold-start claim is made.
