### PR TITLE
fix: update confirmation shows stale commit counts after refresh

### DIFF
--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -140,21 +140,62 @@ it("shows the git target when no package version is available", async () => {
   await settled;
 });
 
-it("states a git distance once instead of labelling it as an available version", async () => {
-  const { settled } = startUpdate({
-    updateAvailable: { channel: "dev", currentVersion: "2026.8.1", latestVersion: "2026.8.1" },
-    updateSchedule: {
-      target: { commitsBehind: 246, kind: "git" },
-    } as unknown as UpdateScheduleState,
-  });
-  const { modal } = await getRenderedModalDialog(document.body);
+it.each([
+  { cachedBehind: 246, git: undefined, expectedDistance: "246 commits behind" },
+  {
+    cachedBehind: 1,
+    git: { status: "behind", commitsBehind: 50 },
+    expectedDistance: "50 commits behind",
+  },
+  {
+    cachedBehind: 246,
+    git: { status: "behind", commitsBehind: 1 },
+    expectedDistance: "1 commit behind",
+  },
+  {
+    cachedBehind: 1,
+    git: { status: "diverged", commitsAhead: 2, commitsBehind: 50 },
+    expectedDistance: "50 commits behind",
+  },
+  {
+    cachedBehind: undefined,
+    git: { status: "behind", commitsBehind: 50 },
+    expectedDistance: "50 commits behind",
+  },
+] as const)(
+  "states $expectedDistance using the checkout comparison when present ($git)",
+  async ({ cachedBehind, git, expectedDistance }) => {
+    const { settled } = startUpdate({
+      updateAvailable: {
+        channel: "dev",
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.1",
+        commitsBehind: cachedBehind,
+      },
+      updateSchedule: {
+        channel: "dev",
+        autoEnabled: false,
+        install: { kind: "git", git },
+        target:
+          cachedBehind === undefined
+            ? undefined
+            : {
+                commitsBehind: cachedBehind,
+                kind: "git",
+                upstreamRef: "origin/main",
+                upstreamSha: "abc1234",
+              },
+      },
+    });
+    const { modal } = await getRenderedModalDialog(document.body);
 
-  expect(modal.textContent).toContain("Installed v2026.8.1 · 246 commits behind");
-  expect(modal.textContent).not.toContain("Available 246");
+    expect(modal.textContent).toContain(`Installed v2026.8.1 · ${expectedDistance}`);
+    expect(modal.textContent).not.toContain(`Available ${expectedDistance}`);
 
-  findButton("Cancel").click();
-  await settled;
-});
+    findButton("Cancel").click();
+    await settled;
+  },
+);
 
 it("keeps a repeated request from stacking a second confirmation or update", async () => {
   const first = startUpdate();

--- a/ui/src/app/update-confirmation.runtime.ts
+++ b/ui/src/app/update-confirmation.runtime.ts
@@ -44,8 +44,12 @@ function formatInstalledAndAvailable(
   if (installed && available) {
     // A commit count already reads as a distance, so "Available 246 commits
     // behind" would double the framing; only a version needs the label.
+    const git = updateSchedule?.install?.git;
     const behind =
-      updateSchedule?.target?.kind === "git" || updateAvailable?.commitsBehind !== undefined;
+      git?.status === "behind" ||
+      git?.status === "diverged" ||
+      updateSchedule?.target?.kind === "git" ||
+      updateAvailable?.commitsBehind !== undefined;
     return t(behind ? "updates.confirm.versionsBehind" : "updates.confirm.versions", {
       available,
       installed,

--- a/ui/src/app/update-schedule-projection.ts
+++ b/ui/src/app/update-schedule-projection.ts
@@ -108,13 +108,19 @@ export function formatUpdateCampaignLabel(
   });
 }
 
+/** Formats update availability using the refreshed checkout distance when present. */
 export function formatUpdateTargetLabel(
   schedule: UpdateScheduleState | null | undefined,
   updateAvailable: UpdateAvailable | null | undefined,
 ): string | null {
   const target = schedule?.target;
+  const git = schedule?.install?.git;
+  // Checkout refreshes update install status without replacing the announced target.
+  const comparedBehind =
+    git?.status === "behind" || git?.status === "diverged" ? git.commitsBehind : undefined;
   const commitsBehind =
-    target?.kind === "git" ? target.commitsBehind : updateAvailable?.commitsBehind;
+    comparedBehind ??
+    (target?.kind === "git" ? target.commitsBehind : updateAvailable?.commitsBehind);
   if (commitsBehind !== undefined) {
     return t(commitsBehind === 1 ? "updates.target.commitBehind" : "updates.target.commitsBehind", {
       count: String(commitsBehind),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Control UI update confirmation after refreshing update status see a different number of commits behind than Settings. For example, Settings shows 50 commits behind while the confirmation still shows 1.

## Why This Change Was Made

Shared update labels prefer the refreshed checkout comparison when it supplies a commit count, then fall back to the announced target or cached availability. The confirmation also treats a checkout-only count as a distance, preserving its wording before target metadata arrives. Update targets, campaign state, and update execution are unchanged.

## User Impact

The update confirmation and sidebar use the refreshed commit count shown in Settings. If no refreshed count exists, they retain the existing fallback.

## Evidence

- Rendered confirmation regressions fail before the fix for increasing and decreasing counts and diverged checkouts. A separate regression catches checkout-only metadata producing redundant wording.
- After the fix, 62 tests pass across the confirmation, Settings, and sidebar suites:

  ```sh
  node scripts/run-vitest.mjs ui/src/app/update-confirmation.runtime.test.ts ui/src/components/sidebar-update-card.test.ts ui/src/pages/config/updates.test.ts
  ```

- Proof uses isolated synthetic UI data. No live Gateway was updated or restarted.
- Changed-scope checks pass, including core-test and UI typechecking, lint, formatting, i18n verification, and repository guards:

  ```sh
  node scripts/check-changed.mjs -- ui/src/app/update-schedule-projection.ts ui/src/app/update-confirmation.runtime.ts ui/src/app/update-confirmation.runtime.test.ts
  ```

- Independent autoreview reports no actionable P0–P2 findings. `git diff --check` passes.
