### PR TITLE
fix(ui): explain paused weekly skill reviews

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3593,6 +3593,7 @@ export const en: TranslationMap & {
     header: {
       selfLearning: "Self-learning",
       selfLearningAria: "Toggle autonomous self-learning",
+      weeklyReviewsPaused: "Weekly reviews paused. Enable cron in Automation settings.",
       selfLearningTooltip:
         "Capture corrections and review completed work as reusable skills. Automatic mode applies scanner-approved captures to Skills.",
     },

--- a/ui/src/pages/skill-workshop/header-controls.test.ts
+++ b/ui/src/pages/skill-workshop/header-controls.test.ts
@@ -4,6 +4,8 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { renderSkillWorkshopHeaderControls } from "./header-controls.ts";
 import { createSkillWorkshopState } from "./proposals.ts";
+import { resolveSelfLearning } from "./self-learning.ts";
+import { createContext, createRuntimeConfigStub } from "./skill-workshop-page.test-support.ts";
 
 describe("skill workshop header tabs", () => {
   it("renders Skills by default and reports the requested section", () => {
@@ -13,6 +15,7 @@ describe("skill workshop header tabs", () => {
     render(
       renderSkillWorkshopHeaderControls(state, {
         selfLearning: null,
+        automationHref: "/settings/automation?section=cron",
         onSelfLearningToggle: () => undefined,
         onModeChange,
       }),
@@ -27,5 +30,50 @@ describe("skill workshop header tabs", () => {
       ?.dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
 
     expect(onModeChange).toHaveBeenCalledWith("suggestions");
+  });
+
+  it.each([
+    ["cron disabled", { cron: { enabled: false } }, false, true],
+    ["refreshing a disabled-cron snapshot", { cron: { enabled: false } }, true, false],
+    ["cron enabled", { cron: { enabled: true } }, false, false],
+    ["default cron", {}, false, false],
+    [
+      "self-learning off",
+      { cron: { enabled: false }, skills: { workshop: { autonomous: { mode: "off" } } } },
+      false,
+      false,
+    ],
+    ["config not loaded", null, false, false],
+  ] as const)("explains weekly review availability with %s", (_name, config, loading, paused) => {
+    const container = document.createElement("div");
+    const onSelfLearningToggle = vi.fn();
+    const automationHref = "/control/settings/automation?section=cron";
+    const runtimeConfig = createRuntimeConfigStub({ sourceConfig: config ?? undefined });
+    runtimeConfig.state.configLoading = loading;
+    const context = createContext(vi.fn(), { runtimeConfig });
+    render(
+      renderSkillWorkshopHeaderControls(createSkillWorkshopState(), {
+        selfLearning: resolveSelfLearning(context.runtimeConfig, false, null, true),
+        automationHref,
+        onSelfLearningToggle,
+        onModeChange: () => undefined,
+      }),
+      container,
+    );
+    const warning = container.querySelector(".sw-self-learning-warning");
+    expect(warning !== null).toBe(paused);
+    if (paused) {
+      expect(warning?.textContent).toContain(
+        "Weekly reviews paused. Enable cron in Automation settings.",
+      );
+      const link = warning?.querySelector("a");
+      expect(link?.getAttribute("href")).toBe(automationHref);
+      link?.addEventListener("click", (event) => event.preventDefault());
+      link?.click();
+      expect(onSelfLearningToggle).not.toHaveBeenCalled();
+      const toggle = container.querySelector<HTMLInputElement>("input[type='checkbox']");
+      expect(toggle?.checked).toBe(true);
+      expect(toggle?.disabled).toBe(false);
+    }
   });
 });

--- a/ui/src/pages/skill-workshop/header-controls.test.ts
+++ b/ui/src/pages/skill-workshop/header-controls.test.ts
@@ -38,6 +38,18 @@ describe("skill workshop header tabs", () => {
     ["cron enabled", { cron: { enabled: true } }, false, false],
     ["default cron", {}, false, false],
     [
+      "propose mode with cron disabled",
+      { cron: { enabled: false }, skills: { workshop: { autonomous: { mode: "propose" } } } },
+      false,
+      false,
+    ],
+    [
+      "propose mode with cron enabled",
+      { cron: { enabled: true }, skills: { workshop: { autonomous: { mode: "propose" } } } },
+      false,
+      false,
+    ],
+    [
       "self-learning off",
       { cron: { enabled: false }, skills: { workshop: { autonomous: { mode: "off" } } } },
       false,

--- a/ui/src/pages/skill-workshop/header-controls.ts
+++ b/ui/src/pages/skill-workshop/header-controls.ts
@@ -9,6 +9,7 @@ import { saveSkillWorkshopMode } from "./storage.ts";
 
 type SkillWorkshopHeaderProps = {
   selfLearning: SkillWorkshopSelfLearning | null;
+  automationHref: string;
   onSelfLearningToggle: (enabled: boolean) => void;
   // The page owns what a section change resets, so the strip only reports it.
   onModeChange: (mode: SkillWorkshopMode) => void;
@@ -33,7 +34,7 @@ function sectionIcon(icon: TemplateResult) {
 
 export function renderSkillWorkshopHeaderControls(
   state: SkillWorkshopState,
-  { selfLearning, onSelfLearningToggle, onModeChange }: SkillWorkshopHeaderProps,
+  { selfLearning, automationHref, onSelfLearningToggle, onModeChange }: SkillWorkshopHeaderProps,
 ) {
   // A failed or unfinished list read would otherwise publish a stale or
   // zero count as if it were the current inventory.
@@ -72,7 +73,7 @@ export function renderSkillWorkshopHeaderControls(
         variant: "sub",
         onSelect: onModeChange,
       })}
-      ${renderSelfLearningToggle(selfLearning, onSelfLearningToggle)}
+      ${renderSelfLearningToggle(selfLearning, onSelfLearningToggle, automationHref)}
     </div>
   `;
 }

--- a/ui/src/pages/skill-workshop/page-view.ts
+++ b/ui/src/pages/skill-workshop/page-view.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { pathForRoute } from "../../app-route-paths.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import {
   filterSkillWorkshopProposals,
@@ -75,7 +76,11 @@ export function renderSkillWorkshopPage(
             selectedId: state.skillWorkshopAgentId,
             allowAll: false,
           })}
-          ${renderSkillWorkshopHeaderControls(state, { ...renderContext, onModeChange: selectMode })}
+          ${renderSkillWorkshopHeaderControls(state, {
+            ...renderContext,
+            automationHref: `${pathForRoute("automation", context.basePath)}?section=cron`,
+            onModeChange: selectMode,
+          })}
         </div>
         ${(() => {
           const visibleProposals = filterSkillWorkshopProposals(

--- a/ui/src/pages/skill-workshop/self-learning.ts
+++ b/ui/src/pages/skill-workshop/self-learning.ts
@@ -27,11 +27,11 @@ export function resolveSelfLearning(
   }
   const workshop = asRecord(asRecord(config.skills)?.workshop);
   // The Gateway defaults an absent autonomous mode to automatic self-learning.
-  const enabled = asRecord(workshop?.autonomous)?.mode !== "off";
+  const mode = asRecord(workshop?.autonomous)?.mode ?? "auto";
   return {
-    enabled,
+    enabled: mode !== "off",
     weeklyReviewsPaused:
-      enabled &&
+      mode === "auto" &&
       runtimeConfig?.state.configLoading === false &&
       asRecord(config.cron)?.enabled === false,
     busy,

--- a/ui/src/pages/skill-workshop/self-learning.ts
+++ b/ui/src/pages/skill-workshop/self-learning.ts
@@ -1,27 +1,19 @@
-// Self-learning (skills.workshop.autonomous.mode) surface for the Workshop
-// tab: config read/patch plumbing plus the toggle, pitch, and error renderers.
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
+import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
 import type { RuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
 
 export type SkillWorkshopSelfLearning = {
   enabled: boolean;
+  weeklyReviewsPaused: boolean;
   busy: boolean;
   canUpdate: boolean;
   error: string | null;
 };
 
 const CONFIG_CHANGED_SINCE_LOAD = "config changed since last load";
-
-// Mirrors the gateway default for skills.workshop.autonomous.mode: absent
-// config means automatic self-learning. Snapshot sourceConfig/resolved are both
-// $include-resolved (src/config/io.ts), so the editable read is display-safe.
-function isSelfLearningEnabled(config: Record<string, unknown>): boolean {
-  const workshop = asRecord(asRecord(config.skills)?.workshop);
-  return asRecord(workshop?.autonomous)?.mode !== "off";
-}
 
 export function resolveSelfLearning(
   runtimeConfig: RuntimeConfigCapability | undefined,
@@ -30,7 +22,22 @@ export function resolveSelfLearning(
   canUpdate: boolean,
 ): SkillWorkshopSelfLearning | null {
   const config = resolveEditableSnapshotConfig(runtimeConfig?.state.configSnapshot);
-  return config ? { enabled: isSelfLearningEnabled(config), busy, canUpdate, error } : null;
+  if (!config) {
+    return null;
+  }
+  const workshop = asRecord(asRecord(config.skills)?.workshop);
+  // The Gateway defaults an absent autonomous mode to automatic self-learning.
+  const enabled = asRecord(workshop?.autonomous)?.mode !== "off";
+  return {
+    enabled,
+    weeklyReviewsPaused:
+      enabled &&
+      runtimeConfig?.state.configLoading === false &&
+      asRecord(config.cron)?.enabled === false,
+    busy,
+    canUpdate,
+    error,
+  };
 }
 
 /** Patch the canonical config key; returns an error message or null on success. */
@@ -76,6 +83,7 @@ export async function setSelfLearningEnabled(
 export function renderSelfLearningToggle(
   selfLearning: SkillWorkshopSelfLearning | null,
   onToggle: (enabled: boolean) => void,
+  automationHref: string,
 ) {
   if (!selfLearning) {
     return nothing;
@@ -92,6 +100,14 @@ export function renderSelfLearningToggle(
       <span class="sw-self-learning-toggle__track" aria-hidden="true"></span>
       <span class="sw-self-learning-toggle__label">${t("skillWorkshop.header.selfLearning")}</span>
     </label>
+    ${
+      selfLearning.weeklyReviewsPaused
+        ? html`<span class="sw-self-learning-warning" role="status">
+            <span aria-hidden="true">${icons.alertTriangle}</span>
+            <a href=${automationHref}>${t("skillWorkshop.header.weeklyReviewsPaused")}</a>
+          </span>`
+        : nothing
+    }
   `;
 }
 

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1328,6 +1328,23 @@
   pointer-events: none;
 }
 
+.sw-self-learning-warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--warn-strong);
+  font-size: 12.5px;
+}
+
+.sw-self-learning-warning svg {
+  width: 14px;
+  height: 14px;
+}
+
+.sw-self-learning-warning a {
+  color: inherit;
+}
+
 .sw-self-learning-toggle__track {
   position: relative;
   width: 32px;


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop showed Self-learning enabled without explaining that weekly reviews were paused when global scheduling was disabled.

## Why This Change Was Made

Show a compact warning from the current saved config in automatic mode, with a direct link to scheduling controls. Hide it in proposal-only/off modes and while config is unavailable or loading. Existing subscriptions and navigation own updates.

## User Impact

Users can see why weekly reviews are paused and resume them from the linked setting. The warning clears after enabling scheduling without turning Self-learning off.

## Evidence

A real Gateway/browser reproduced the missing explanation. Fourteen focused tests passed, including stale-config and proposal-only regressions. Browser checks covered visibility, keyboard navigation, settings return, and a 375-pixel layout. Formatting, styles, and translation checks passed. The isolated type-aware lint attempt exceeded its memory limit; no pass was claimed.
