### PR TITLE
fix(auto-reply): resolve the CLI execution auth identity at dispatch

### DIFF
--- a/src/auto-reply/reply/agent-runner-auth-profile.ts
+++ b/src/auto-reply/reply/agent-runner-auth-profile.ts
@@ -1,11 +1,9 @@
 // Resolves auth profile settings that agent runner forwards to providers.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import {
   resolveProviderIdForAuth,
   type ProviderAuthAliasLookupParams,
 } from "../../agents/provider-auth-aliases.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { FollowupRun } from "./queue.js";
 
 /** Keeps an auth profile only when the current provider shares the primary auth scope. */
@@ -44,29 +42,6 @@ export function resolveRunAuthProfile(
     authProfileIdSource: run.authProfileIdSource,
     config: params?.config ?? run.config,
     workspaceDir: run.workspaceDir,
-  });
-}
-
-/**
- * Converts the session-layer profile selection into the CLI execution identity
- * at the dispatch boundary. A session pin resolved for the model provider (for
- * example "anthropic:default") must not reach a claude-cli child as a forwarded
- * API key when auth.order names the backend's native login; the gateway command
- * path applies the same filter before preparing its runs.
- */
-export function resolveCliExecutionForwardedAuthProfileId(params: {
-  cliExecutionProvider: string;
-  authProfileProvider: string;
-  config: OpenClawConfig;
-  agentDir: string;
-  selected: { authProfileId?: string; authProfileIdSource?: "auto" | "user" };
-}): string | undefined {
-  return resolveCliExecutionAuthProfileId({
-    cliExecutionProvider: params.cliExecutionProvider,
-    authProfileProvider: params.authProfileProvider,
-    config: params.config,
-    agentDir: params.agentDir,
-    selected: params.selected,
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-auth-profile.ts
+++ b/src/auto-reply/reply/agent-runner-auth-profile.ts
@@ -1,9 +1,11 @@
 // Resolves auth profile settings that agent runner forwards to providers.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import {
   resolveProviderIdForAuth,
   type ProviderAuthAliasLookupParams,
 } from "../../agents/provider-auth-aliases.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { FollowupRun } from "./queue.js";
 
 /** Keeps an auth profile only when the current provider shares the primary auth scope. */
@@ -42,6 +44,33 @@ export function resolveRunAuthProfile(
     authProfileIdSource: run.authProfileIdSource,
     config: params?.config ?? run.config,
     workspaceDir: run.workspaceDir,
+  });
+}
+
+/**
+ * Converts a candidate run's session-layer auth selection into the CLI execution
+ * identity forwarded to a backend child. The session layer pins by model provider
+ * (for example "anthropic:default"), while auth.order can name the backend's
+ * native login; forwarding the model-provider pin would silently bill the stored
+ * API key instead of the CLI's own login. The gateway command path applies the
+ * same conversion before preparing its runs.
+ */
+export function resolveCliForwardedAuthProfileId(params: {
+  candidateRun: FollowupRun["run"];
+  cliExecutionProvider: string;
+  authProfileProvider: string;
+  config: OpenClawConfig;
+  agentDir: string;
+}): string | undefined {
+  const selected = resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
+    config: params.config,
+  });
+  return resolveCliExecutionAuthProfileId({
+    cliExecutionProvider: params.cliExecutionProvider,
+    authProfileProvider: params.authProfileProvider,
+    config: params.config,
+    agentDir: params.agentDir,
+    selected,
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-auth-profile.ts
+++ b/src/auto-reply/reply/agent-runner-auth-profile.ts
@@ -1,9 +1,11 @@
 // Resolves auth profile settings that agent runner forwards to providers.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import {
   resolveProviderIdForAuth,
   type ProviderAuthAliasLookupParams,
 } from "../../agents/provider-auth-aliases.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { FollowupRun } from "./queue.js";
 
 /** Keeps an auth profile only when the current provider shares the primary auth scope. */
@@ -42,6 +44,29 @@ export function resolveRunAuthProfile(
     authProfileIdSource: run.authProfileIdSource,
     config: params?.config ?? run.config,
     workspaceDir: run.workspaceDir,
+  });
+}
+
+/**
+ * Converts the session-layer profile selection into the CLI execution identity
+ * at the dispatch boundary. A session pin resolved for the model provider (for
+ * example "anthropic:default") must not reach a claude-cli child as a forwarded
+ * API key when auth.order names the backend's native login; the gateway command
+ * path applies the same filter before preparing its runs.
+ */
+export function resolveCliExecutionForwardedAuthProfileId(params: {
+  cliExecutionProvider: string;
+  authProfileProvider: string;
+  config: OpenClawConfig;
+  agentDir: string;
+  selected: { authProfileId?: string; authProfileIdSource?: "auto" | "user" };
+}): string | undefined {
+  return resolveCliExecutionAuthProfileId({
+    cliExecutionProvider: params.cliExecutionProvider,
+    authProfileProvider: params.authProfileProvider,
+    config: params.config,
+    agentDir: params.agentDir,
+    selected: params.selected,
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
@@ -4,6 +4,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
+import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import type { FollowupRun } from "./queue.js";
 
 const mocks = vi.hoisted(() => ({
@@ -18,11 +20,6 @@ vi.mock("../../agents/auth-profiles/store-runtime.js", () => ({
 vi.mock("../../agents/auth-profiles/order.js", () => ({
   resolveAuthProfileOrder: () => mocks.order,
 }));
-
-import {
-  resolveCliExecutionForwardedAuthProfileId,
-  resolveRunAuthProfile,
-} from "./agent-runner-auth-profile.js";
 
 const sessionPinRun = {
   provider: "anthropic",
@@ -71,7 +68,7 @@ describe("reply CLI dispatch auth identity", () => {
     });
 
     expect(
-      resolveCliExecutionForwardedAuthProfileId({
+      resolveCliExecutionAuthProfileId({
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},
@@ -90,7 +87,7 @@ describe("reply CLI dispatch auth identity", () => {
     };
 
     expect(
-      resolveCliExecutionForwardedAuthProfileId({
+      resolveCliExecutionAuthProfileId({
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},
@@ -100,7 +97,7 @@ describe("reply CLI dispatch auth identity", () => {
     ).toBe("claude-cli:work");
 
     expect(
-      resolveCliExecutionForwardedAuthProfileId({
+      resolveCliExecutionAuthProfileId({
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},

--- a/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
@@ -1,25 +1,42 @@
 // Tests the CLI dispatch boundary's auth identity conversion: a session pin
 // resolved for the model provider must not leak into a claude-cli child as a
-// forwarded API key when auth.order names the backend's native login.
+// forwarded API key when auth.order names the backend's native login. The
+// helper-level cases pin the conversion contract; the executeAgentTurn cases
+// observe the credential that actually reaches the CLI runner through the
+// reply dispatch, so restoring the raw session pin at the dispatch site fails.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import {
   resolveCliForwardedAuthProfileId,
   resolveRunAuthProfile,
 } from "./agent-runner-auth-profile.js";
+import {
+  setupAgentRunnerExecutionTestState,
+  getExecuteAgentTurnForTest,
+  createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  initialFallbackAttemptOptions,
+  requireMockCall,
+} from "./agent-runner-execution.test-support.js";
+import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 import type { FollowupRun } from "./queue.js";
+
+const state = await setupAgentRunnerExecutionTestState();
 
 const mocks = vi.hoisted(() => ({
   order: [] as string[],
   profiles: {} as Record<string, AuthProfileCredential>,
 }));
 
-vi.mock("../../agents/auth-profiles/store-runtime.js", () => ({
+vi.mock("../../agents/auth-profiles/store-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/auth-profiles/store-runtime.js")>()),
   loadAuthProfileStoreForRuntime: () => ({ version: 1, profiles: mocks.profiles }),
 }));
 
-vi.mock("../../agents/auth-profiles/order.js", () => ({
+vi.mock("../../agents/auth-profiles/order.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/auth-profiles/order.js")>()),
   resolveAuthProfileOrder: () => mocks.order,
 }));
 
@@ -116,5 +133,75 @@ describe("reply CLI dispatch auth identity", () => {
         agentDir: "/tmp/unused-agent",
       }),
     ).toBeUndefined();
+  });
+
+  it("forwards no auth profile through the reply dispatch when the session auto-pins a model-provider key", async () => {
+    mocks.profiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run(
+        "claude-cli",
+        "claude-sonnet-4-6",
+        initialFallbackAttemptOptions(params),
+      ),
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({ payloads: [{ text: "done" }], meta: {} });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.authProfileId = "anthropic:default";
+    followupRun.run.authProfileIdSource = "auto";
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    const forwarded = requireMockCall(
+      state.runCliAgentMock,
+      0,
+      "CLI run params",
+    )[0] as RunCliAgentParams;
+    expect(forwarded.authProfileId).toBeUndefined();
+  });
+
+  it("forwards a backend-owned profile through the reply dispatch", async () => {
+    mocks.profiles["claude-cli:work"] = {
+      type: "api_key",
+      provider: "claude-cli",
+      key: "test-claude-key",
+    };
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run(
+        "claude-cli",
+        "claude-sonnet-4-6",
+        initialFallbackAttemptOptions(params),
+      ),
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({ payloads: [{ text: "done" }], meta: {} });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.authProfileId = "claude-cli:work";
+    followupRun.run.authProfileIdSource = "auto";
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    const forwarded = requireMockCall(
+      state.runCliAgentMock,
+      0,
+      "CLI run params",
+    )[0] as RunCliAgentParams;
+    expect(forwarded.authProfileId).toBe("claude-cli:work");
   });
 });

--- a/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
@@ -1,0 +1,112 @@
+// Tests the CLI dispatch boundary's auth identity conversion: a session pin
+// resolved for the model provider must not leak into a claude-cli child as a
+// forwarded API key when auth.order names the backend's native login.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { FollowupRun } from "./queue.js";
+
+const mocks = vi.hoisted(() => ({
+  order: [] as string[],
+  profiles: {} as Record<string, AuthProfileCredential>,
+}));
+
+vi.mock("../../agents/auth-profiles/store-runtime.js", () => ({
+  loadAuthProfileStoreForRuntime: () => ({ version: 1, profiles: mocks.profiles }),
+}));
+
+vi.mock("../../agents/auth-profiles/order.js", () => ({
+  resolveAuthProfileOrder: () => mocks.order,
+}));
+
+import {
+  resolveCliExecutionForwardedAuthProfileId,
+  resolveRunAuthProfile,
+} from "./agent-runner-auth-profile.js";
+
+const sessionPinRun = {
+  provider: "anthropic",
+  authProfileId: "anthropic:default",
+  authProfileIdSource: "auto",
+} as FollowupRun["run"];
+
+describe("reply CLI dispatch auth identity", () => {
+  beforeEach(() => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+      resolvePluginSetupCliBackend: () => undefined,
+    });
+    mocks.order.length = 0;
+    for (const profileId of Object.keys(mocks.profiles)) {
+      delete mocks.profiles[profileId];
+    }
+  });
+
+  afterEach(() => {
+    cliBackendsTesting.resetDepsForTest();
+  });
+
+  it("drops a model-provider auto pin at the CLI dispatch boundary", () => {
+    // Issue repro: auth.order.claude-cli names the backend's native login, the
+    // store only holds an api_key profile for the model provider, and the
+    // session layer auto-pins it for the turn. The dispatch boundary must drop
+    // that pin so the CLI child keeps its own login instead of silently
+    // billing the stored key.
+    mocks.profiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    const selected = resolveRunAuthProfile(sessionPinRun, "claude-cli", { config: {} });
+    expect(selected).toEqual({
+      authProfileId: "anthropic:default",
+      authProfileIdSource: "auto",
+    });
+
+    expect(
+      resolveCliExecutionForwardedAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps a profile the CLI backend owns and forwards a native login as none", () => {
+    mocks.order.push("claude-cli:work");
+    mocks.profiles["claude-cli:work"] = {
+      type: "api_key",
+      provider: "claude-cli",
+      key: "test-claude-key",
+    };
+
+    expect(
+      resolveCliExecutionForwardedAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: { authProfileId: "claude-cli:work", authProfileIdSource: "user" },
+      }),
+    ).toBe("claude-cli:work");
+
+    expect(
+      resolveCliExecutionForwardedAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: { authProfileId: "anthropic:claude-cli", authProfileIdSource: "user" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts
@@ -4,8 +4,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
-import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
-import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
+import {
+  resolveCliForwardedAuthProfileId,
+  resolveRunAuthProfile,
+} from "./agent-runner-auth-profile.js";
 import type { FollowupRun } from "./queue.js";
 
 const mocks = vi.hoisted(() => ({
@@ -53,27 +55,28 @@ describe("reply CLI dispatch auth identity", () => {
   it("drops a model-provider auto pin at the CLI dispatch boundary", () => {
     // Issue repro: auth.order.claude-cli names the backend's native login, the
     // store only holds an api_key profile for the model provider, and the
-    // session layer auto-pins it for the turn. The dispatch boundary must drop
-    // that pin so the CLI child keeps its own login instead of silently
-    // billing the stored key.
+    // session layer auto-pins it for the turn. The boundary must drop that pin
+    // so the CLI child keeps its own login instead of silently billing the
+    // stored key.
     mocks.profiles["anthropic:default"] = {
       type: "api_key",
       provider: "anthropic",
       key: "test-anthropic-key",
     };
-    const selected = resolveRunAuthProfile(sessionPinRun, "claude-cli", { config: {} });
-    expect(selected).toEqual({
+    // The session layer alone forwards the model-provider pin to the run; the
+    // dispatch boundary must convert it to the CLI execution identity.
+    expect(resolveRunAuthProfile(sessionPinRun, "claude-cli", { config: {} })).toEqual({
       authProfileId: "anthropic:default",
       authProfileIdSource: "auto",
     });
 
     expect(
-      resolveCliExecutionAuthProfileId({
+      resolveCliForwardedAuthProfileId({
+        candidateRun: sessionPinRun,
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},
         agentDir: "/tmp/unused-agent",
-        selected,
       }),
     ).toBeUndefined();
   });
@@ -87,22 +90,30 @@ describe("reply CLI dispatch auth identity", () => {
     };
 
     expect(
-      resolveCliExecutionAuthProfileId({
+      resolveCliForwardedAuthProfileId({
+        candidateRun: {
+          provider: "anthropic",
+          authProfileId: "claude-cli:work",
+          authProfileIdSource: "user",
+        } as FollowupRun["run"],
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},
         agentDir: "/tmp/unused-agent",
-        selected: { authProfileId: "claude-cli:work", authProfileIdSource: "user" },
       }),
     ).toBe("claude-cli:work");
 
     expect(
-      resolveCliExecutionAuthProfileId({
+      resolveCliForwardedAuthProfileId({
+        candidateRun: {
+          provider: "anthropic",
+          authProfileId: "anthropic:claude-cli",
+          authProfileIdSource: "user",
+        } as FollowupRun["run"],
         cliExecutionProvider: "claude-cli",
         authProfileProvider: "anthropic",
         config: {},
         agentDir: "/tmp/unused-agent",
-        selected: { authProfileId: "anthropic:claude-cli", authProfileIdSource: "user" },
       }),
     ).toBeUndefined();
   });

--- a/src/auto-reply/reply/agent-runner-cli-candidate.cli-child-auth.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.cli-child-auth.test.ts
@@ -1,0 +1,261 @@
+// Proves the CLI child credential handoff end to end: the reply dispatch
+// converts a session-layer auth pin before the run, and the spawned claude
+// child must observe the converted identity. A model-provider auto pin must
+// reach the child as no forwarded credential so the CLI keeps its own native
+// login, while a profile the backend owns is forwarded and materialized by the
+// backend's own execution preparation. The stub child records only credential
+// env key names, never values.
+import { mkdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import nodePath from "node:path";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveAgentDir } from "../../agents/agent-scope-config.js";
+import { clearAuthProfileMigrationDiagnostics } from "../../agents/auth-profiles/legacy-source-diagnostic.js";
+import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store-runtime.js";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { TemplateContext } from "../templating.js";
+import {
+  setupAgentRunnerExecutionTestState,
+  getExecuteAgentTurnForTest,
+  createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  initialFallbackAttemptOptions,
+  requireMockCall,
+  loadActualRunCliAgentForTest,
+} from "./agent-runner-execution.test-support.js";
+import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
+
+const state = await setupAgentRunnerExecutionTestState();
+
+const scriptedCliProgram = String.raw`
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  if (!input.trim()) process.exit(2);
+  const fs = require("node:fs");
+  const dumpPath = process.argv[1] || process.env.OPENCLAW_TEST_CHILD_DUMP;
+  if (!dumpPath) process.exit(3);
+  const credentialEnvKeys = Object.keys(process.env)
+    .filter((name) => name === "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR")
+    .sort();
+  fs.appendFileSync(
+    dumpPath,
+    JSON.stringify({
+      credentialEnvKeys,
+      forwardsApiKeyDescriptor: Boolean(process.env.CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR),
+    }) + "\n",
+  );
+  const events = [
+    { type: "init", session_id: "scripted-auth-handoff" },
+    {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Scripted final answer." },
+      },
+    },
+    { type: "stream_event", event: { type: "message_stop" } },
+    { type: "result", session_id: "scripted-auth-handoff", result: "Scripted final answer." },
+  ];
+  process.stdout.write(events.map((event) => JSON.stringify(event)).join("\n") + "\n");
+});
+`;
+
+type ChildCredentialDump = {
+  credentialEnvKeys: string[];
+  forwardsApiKeyDescriptor: boolean;
+};
+
+const claudeCliModel = "claude-opus-4-6";
+
+describe("executeAgentTurn: CLI child credential handoff", () => {
+  let stateDir: string;
+  let agentDir: string;
+  let dumpPath: string;
+
+  beforeEach(() => {
+    stateDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-cli-child-auth-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    agentDir = resolveAgentDir({}, "agent");
+    mkdirSync(agentDir, { recursive: true });
+    dumpPath = nodePath.join(stateDir, "child-credential-dumps.jsonl");
+    vi.stubEnv("OPENCLAW_TEST_CHILD_DUMP", dumpPath);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    clearAuthProfileMigrationDiagnostics();
+    cliBackendsTesting.resetDepsForTest();
+  });
+
+  async function seedAuthProfile(profileId: string, credential: AuthProfileCredential) {
+    await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (store) => {
+        store.profiles[profileId] = credential;
+        return true;
+      },
+    });
+  }
+
+  function registerScriptedClaudeCliBackend() {
+    // The stub backend keeps the core one-shot JSONL transport; the plugin's
+    // own credential materialization seam is covered by the plugin's tests, so
+    // this child run observes the credential env the runner forwards itself.
+    const backend = {
+      id: "claude-cli",
+      modelProvider: "anthropic",
+      pluginId: "anthropic",
+      bundleMcp: false,
+      config: {
+        command: process.execPath,
+        args: ["-e", scriptedCliProgram, dumpPath],
+        input: "stdin" as const,
+        output: "jsonl" as const,
+        jsonlDialect: "claude-stream-json" as const,
+        sessionMode: "none" as const,
+        systemPromptWhen: "never" as const,
+      },
+    };
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: ({ backend: id }) =>
+        id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
+      resolveRuntimeCliBackends: () => [backend],
+    });
+  }
+
+  function runRealCliRunnerForOnce() {
+    state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
+      return await (
+        await loadActualRunCliAgentForTest()
+      )(params);
+    });
+  }
+
+  function useClaudeCliFallback() {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", claudeCliModel, initialFallbackAttemptOptions(params)),
+      provider: "claude-cli",
+      model: claudeCliModel,
+      attempts: [],
+    }));
+  }
+
+  function createClaudeCliFollowupRun() {
+    const followupRun = createFollowupRun();
+    followupRun.run.agentId = "agent";
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = claudeCliModel;
+    followupRun.run.skillsSnapshot = { prompt: "", skills: [], version: 0 };
+    followupRun.run.timeoutMs = 10_000;
+    return followupRun;
+  }
+
+  async function readChildDump(): Promise<ChildCredentialDump> {
+    const raw = await readFile(dumpPath, "utf8");
+    const lines = raw.split("\n").filter((line) => line.trim());
+    expect(lines).toHaveLength(1);
+    return JSON.parse(lines[0] ?? "") as ChildCredentialDump;
+  }
+
+  it("spawns the claude child with no forwarded credential for a model-provider auto pin", async () => {
+    registerScriptedClaudeCliBackend();
+    runRealCliRunnerForOnce();
+    await seedAuthProfile("anthropic:default", {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    });
+    useClaudeCliFallback();
+
+    const followupRun = createClaudeCliFollowupRun();
+    followupRun.run.authProfileId = "anthropic:default";
+    followupRun.run.authProfileIdSource = "auto";
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "Scripted final answer." }]);
+    }
+    // The dispatch boundary dropped the model-provider pin, so the claude child
+    // keeps its own native login instead of silently billing the stored key.
+    const dump = await readChildDump();
+    expect(dump.forwardsApiKeyDescriptor).toBe(false);
+    expect(dump.credentialEnvKeys).toEqual([]);
+  }, 60_000);
+
+  it("drops a model-provider auto pin at the reply dispatch before the child runs", async () => {
+    registerScriptedClaudeCliBackend();
+    state.runCliAgentMock.mockResolvedValueOnce({ payloads: [{ text: "done" }], meta: {} });
+    await seedAuthProfile("anthropic:default", {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    });
+    useClaudeCliFallback();
+
+    const followupRun = createClaudeCliFollowupRun();
+    followupRun.run.authProfileId = "anthropic:default";
+    followupRun.run.authProfileIdSource = "auto";
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    const forwarded = requireMockCall(
+      state.runCliAgentMock,
+      0,
+      "CLI run params",
+    )[0] as RunCliAgentParams;
+    expect(forwarded.authProfileId).toBeUndefined();
+  }, 60_000);
+
+  it("forwards a backend-owned profile through the reply dispatch for the child handoff", async () => {
+    registerScriptedClaudeCliBackend();
+    state.runCliAgentMock.mockResolvedValueOnce({ payloads: [{ text: "done" }], meta: {} });
+    await seedAuthProfile("claude-cli:work", {
+      type: "api_key",
+      provider: "claude-cli",
+      key: "test-claude-key",
+    });
+    useClaudeCliFallback();
+
+    const followupRun = createClaudeCliFollowupRun();
+    followupRun.run.authProfileId = "claude-cli:work";
+    followupRun.run.authProfileIdSource = "auto";
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    const forwarded = requireMockCall(
+      state.runCliAgentMock,
+      0,
+      "CLI run params",
+    )[0] as RunCliAgentParams;
+    expect(forwarded.authProfileId).toBe("claude-cli:work");
+  }, 60_000);
+});

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,3 +1,4 @@
+import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { buildCliMcpDelegationCapabilityBinding } from "../../agents/cli-runner/mcp-grant-context.js";
 import {
@@ -23,7 +24,10 @@ import {
   hasNewGeneratedMediaTaskForSessionKey,
 } from "../../tasks/task-status-access.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
-import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
+import {
+  resolveCliExecutionForwardedAuthProfileId,
+  resolveRunAuthProfile,
+} from "./agent-runner-auth-profile.js";
 import {
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
@@ -82,6 +86,13 @@ export async function runCliFallbackCandidate(
   params.onLifecycleBackstop(lifecycleBackstop);
   const authProfile = resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
     config: params.runtimeConfig,
+  });
+  const cliAuthProfileId = resolveCliExecutionForwardedAuthProfileId({
+    cliExecutionProvider: params.cliExecutionProvider,
+    authProfileProvider: params.provider,
+    config: params.runtimeConfig,
+    agentDir: resolveAgentDir(params.runtimeConfig, turn.followupRun.run.agentId),
+    selected: authProfile,
   });
   const hookMessageProvider = resolveOriginMessageProvider({
     originatingChannel: turn.followupRun.originatingChannel,
@@ -388,7 +399,7 @@ export async function runCliFallbackCandidate(
             ownerNumbers: turn.followupRun.run.ownerNumbers,
             cliSessionId: cliSessionBinding?.sessionId,
             cliSessionBinding,
-            authProfileId: authProfile.authProfileId,
+            authProfileId: cliAuthProfileId,
             bootstrapContextMode: turn.opts?.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
             bootstrapPromptWarningSignaturesSeen: params.bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,6 +1,5 @@
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import { buildCliMcpDelegationCapabilityBinding } from "../../agents/cli-runner/mcp-grant-context.js";
 import {
   clearCliSessionInStore,
@@ -25,7 +24,7 @@ import {
   hasNewGeneratedMediaTaskForSessionKey,
 } from "../../tasks/task-status-access.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
-import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
+import { resolveCliForwardedAuthProfileId } from "./agent-runner-auth-profile.js";
 import {
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
@@ -82,15 +81,12 @@ export async function runCliFallbackCandidate(
       resolveReplyOperationTerminationFields(error, params.runAbortSignal, turn.replyOperation),
   });
   params.onLifecycleBackstop(lifecycleBackstop);
-  const authProfile = resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
-    config: params.runtimeConfig,
-  });
-  const cliAuthProfileId = resolveCliExecutionAuthProfileId({
+  const cliAuthProfileId = resolveCliForwardedAuthProfileId({
+    candidateRun: params.candidateRun,
     cliExecutionProvider: params.cliExecutionProvider,
     authProfileProvider: params.provider,
     config: params.runtimeConfig,
     agentDir: resolveAgentDir(params.runtimeConfig, turn.followupRun.run.agentId),
-    selected: authProfile,
   });
   const hookMessageProvider = resolveOriginMessageProvider({
     originatingChannel: turn.followupRun.originatingChannel,

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,5 +1,6 @@
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import { buildCliMcpDelegationCapabilityBinding } from "../../agents/cli-runner/mcp-grant-context.js";
 import {
   clearCliSessionInStore,
@@ -24,10 +25,7 @@ import {
   hasNewGeneratedMediaTaskForSessionKey,
 } from "../../tasks/task-status-access.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
-import {
-  resolveCliExecutionForwardedAuthProfileId,
-  resolveRunAuthProfile,
-} from "./agent-runner-auth-profile.js";
+import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
@@ -87,7 +85,7 @@ export async function runCliFallbackCandidate(
   const authProfile = resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
     config: params.runtimeConfig,
   });
-  const cliAuthProfileId = resolveCliExecutionForwardedAuthProfileId({
+  const cliAuthProfileId = resolveCliExecutionAuthProfileId({
     cliExecutionProvider: params.cliExecutionProvider,
     authProfileProvider: params.provider,
     config: params.runtimeConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes #142820.

A Telegram-inbound turn on the `claude-cli` backend spawned the `claude` child with the stored `anthropic:default` api_key forwarded as `CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR` — silently billing the API-key credential. An `openclaw agent` turn on the same agent and session key 28 seconds later spawned the child with no credential and correctly fell through to the CLI's own subscription login. No `authProfileOverride` session pin existed during either run.

## Root Cause

The two run paths resolve auth differently:

- **Gateway command path** (`src/agents/command/attempt-execution.ts:884-895`): for CLI backends it converts the session selection through `resolveCliExecutionAuthProfileId` (`src/agents/cli-execution-auth.ts`), which resolves the order under the *backend id* (`claude-cli`). With `auth.order.claude-cli = ["anthropic:claude-cli"]`, the explicit order names a native-login id that the store does not hold, so the resolver returns `undefined` and the run falls through to the CLI's native login.
- **Reply dispatch path** (`src/auto-reply/reply/agent-runner-cli-candidate.ts`): the session layer (`resolveSessionAuthSelection` → `resolveSessionAuthProfileOverride` in `src/agents/auth-profiles/session-override.ts`) resolves the order under the *model provider* (`anthropic`), misses the backend-keyed order, auto-pins the only compatible store profile (`anthropic:default`, api_key), and the dispatch boundary forwarded that id verbatim into the run. `prepare.ts`'s explicit-profile branch then materialized the key and the CLI child inherited it.

The reply path skipped the CLI execution auth owner entirely.

## Solution

Convert the session-layer selection through the same CLI execution owner at the reply dispatch boundary:

- New `resolveCliForwardedAuthProfileId` in `src/auto-reply/reply/agent-runner-auth-profile.ts` composes the two steps the boundary needs: it resolves the candidate run's session-layer pin (`resolveRunAuthProfile`) and converts it through `resolveCliExecutionAuthProfileId` with the backend's agent dir.
- `agent-runner-cli-candidate.ts` (the shared dispatch for the primary and every fallback CLI candidate) consumes that single unit for the forwarded `authProfileId`.

Behavior preserved: profiles owned by the CLI backend are still forwarded, native-login ids forward as none, and a user-locked profile owned by another provider still fails closed (`CliExecutionAuthProfileError`) instead of running as another identity.

## Evidence

- Dispatch-level regression `src/auto-reply/reply/agent-runner-cli-candidate.auth-profile.test.ts` drives `executeAgentTurn` through the real CLI fallback candidate dispatch (`runCliFallbackCandidate` → `runCliAgentWithLifecycle`) and asserts the `authProfileId` that actually reaches the CLI runner (`runCliAgent` params): a model-provider auto pin (`anthropic:default`, api_key) forwards as `undefined`, and a backend-owned profile (`claude-cli:work`) still forwards. Pre-fix red: with the dispatch site restored to `main`'s raw `resolveRunAuthProfile(...).authProfileId` forwarding, the dispatch assertion fails with `expected 'anthropic:default' to be undefined` — the reported silent-billing defect observed at the exact forwarded boundary — and passes with the fix. Helper-level cases pin the conversion contract (native-login id forwards as none, cross-provider user lock fails closed).
- Child-level regression `src/auto-reply/reply/agent-runner-cli-candidate.cli-child-auth.test.ts` spawns a real claude stub child (JSONL on stdout, credential env key names only — never values) through `executeAgentTurn` → the real CLI runner, with a real SQLite auth store seeded under an isolated `OPENCLAW_STATE_DIR`. A model-provider auto pin (`anthropic:default`) completes the turn with the child observing **no** `CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR` (its native login stays intact), and the same real-store dispatch forwards a backend-owned profile (`claude-cli:work`) for the backend's own materialization. Pre-fix red: restoring `main`'s dispatch forwarding fails the real-store drop assertion with `expected 'anthropic:default' to be undefined`. (The plugin-owned last mile — credential → private descriptor env — stays covered by the plugin's own `prepareExecution` suites; this suite observes the credential env the runner forwards.)
- Sibling suites green: `agent-runner-utils`, `agent-runner-execution-probes`, `agent-runner-cli-candidate`, `cli-execution-auth` (42 tests total).
- `tsgo` core and the auto-reply test shard pass on fresh `tsbuildinfo` caches; `oxlint --type-aware` and `oxfmt` clean on the touched files.
### Installed-backend real-behavior proof (after-fix, 2026-09-09)

Covers the three review asks through the installed Anthropic CLI backend. Setup: `dist` built from this head (banner `2026.9.3 (84c3b42)`), the bundled Anthropic plugin's `claude-cli` backend with its direct stdio transport to the installed Claude Code 2.1.266, an isolated `OPENCLAW_STATE_DIR` and workspace, real agent turns (`openclaw agent --local --model claude-cli/sonnet`). The claude child process was observed through `/proc/<pid>/environ` and `/proc/<pid>/fd` while the turn was live — credential env **key names only**, never values; endpoint and credential values never printed.

1. **Explicit managed credential materializes through the real plugin seam.** Config `auth.order.claude-cli = ["claude-cli:work"]` with a seeded store profile (`claude-cli:work`, token type). The run selected that profile (the auth-failure ledger keyed the first turn's model-region 403 to `profile=sha256:ac5dc42b7f3c provider=claude-cli`, not to a fallback), and the live claude child's environment had `CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR` **present** with every host `ANTHROPIC_*` var cleared (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` all absent — the backend's clearEnv list). The turn completed (`MANAGED-OK`).
2. **Existing-session transition across the credential boundary is explicit, not silent.** Same session key, then the store profile was removed so the session's selection dangles. The next turn's claude child environment had **no** descriptor key at all (native CLI login), and OpenClaw refused to carry the CLI-side history across the boundary (`cli session history refused across auth boundary: reason=auth-unknown`, `historyPrompt=none`) while continuing with a fresh CLI session id. The turn completed (`NATIVE-STILL-OK`). This is the P1 merge-risk scenario end to end: the credential identity changes and the run neither silently reuses the previous identity's CLI history nor fails.
3. **Native login on a fresh session.** No profiles configured. The claude child environment again had no descriptor key and no inherited `ANTHROPIC_*` values; the CLI authenticated from its own config (`--setting-sources user`). The turn completed (`NATIVE-FRESH-OK`) and the CLI session id stayed stable across a follow-up turn (`useResume=true`, same resume id).

These observations close the gap between the dispatch-level regression (the forwarded `authProfileId` the runner receives) and the plugin's own `prepareExecution` suites (credential → descriptor): on the installed backend, the forwarded identity is what actually materializes in the child — descriptor present only for an explicit managed selection, never for the auto-pin drop path — and the transition from a managed credential to native CLI login is a deliberate, logged boundary event with a fresh CLI session id.
### Installed-backend channel-reply proof (after-fix, 2026-09-10)

Covers the remaining ask directly: an **inbound channel turn** through the installed backend with the report's store state, observed at the live claude child. Setup: `dist` built from this head (banner `2026.9.3 (4af9225)`), a real gateway process with a real channel plugin — `qa-channel`, the repo's synthetic Slack-class transport, which enters through the same `channelRuntime.inbound.dispatch` → reply-dispatch boundary a Telegram adapter uses (no substitute backend; the bundled Anthropic plugin's `claude-cli` backend spawns the installed Claude Code 2.1.266 child). Isolated `OPENCLAW_STATE_DIR`, `agents.defaults.model = "claude-cli/sonnet"`, and the report's exact store state: exactly one profile `anthropic:default` (api_key) with `auth.order.claude-cli = ["anthropic:claude-cli"]`, no session pin. While each turn was live an observer polled `/proc` under the gateway's task tree for the claude child and recorded credential env **key names** and descriptor-fd presence only — never values.

1. **Reported scenario, after fix — the inbound reply run forwards no credential.** An inbound DM injected through the channel's local bus entered the reply dispatch (`trigger=user`). The spawned claude child's environment had **zero** credential keys (`CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR`, `CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` all absent), the turn completed through the CLI's own login, and the channel delivered the reply back to the bus transcript (`REPLY_OK`):

   ```shell
   [agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
   [agent/cli-backend] cli exec: provider=claude-cli model=sonnet promptChars=287 trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
   [agent/cli-backend] cli turn: provider=claude-cli model=sonnet durationMs=12221 outBytes=8 outHash=7dbe04c44128
   ```

2. **Same reply path forwards a managed credential when the policy selects one.** With `auth.order.claude-cli = ["claude-cli:work"]` and that backend-owned profile in the store (everything else identical, fresh gateway + fresh session), the same inbound-reply dispatch spawned the claude child with `CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR` **present**, and the turn completed with `MANAGED_OK` delivered back through the channel. The zero-credential observation above is therefore the automatic-selection conversion at the changed dispatch boundary — not a pipeline that never forwards.

Together with the command-path observations above, the credential the channel-originated turn finally uses is now established end to end on the installed backend: the automatic model-provider api_key selection reaches the claude child as no credential (native CLI login), an explicit managed selection still materializes its descriptor, and the transition between identities stays a logged boundary event.



## Impact

Subscription users reaching a `claude-cli` agent through any channel (Telegram observed) stop silently switching from their CLI subscription login to the stored API key; the channel path now matches the documented CLI-backend behavior of the command path.




