### PR TITLE
fix(image): close registration resources after generation

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -45,9 +45,10 @@ still does not invoke a discovery-only engine factory. `dispose()` must not dele
 durable state or disable another registration. Existing raw loader and Gateway
 lifetimes do not gain automatic disposal: keep their `cleanup(ctx)` behavior.
 
-Music generation also owns fresh registrations acquired by
-`api.runtime.musicGeneration.generate(...)`. It waits for the provider's complete
-audio buffers and tracked operation cleanup, then awaits registration disposal
+Image and music generation also own fresh registrations acquired by
+`api.runtime.imageGeneration.generate(...)` and
+`api.runtime.musicGeneration.generate(...)`. They wait for the provider's complete
+image or audio buffers and tracked operation cleanup, then await registration disposal
 before resolving or rejecting. Existing managed registrations are retained for
 the operation; raw host registrations and caller-supplied providers retain their
 existing owner. Provider listing still returns caller-owned callbacks and does

--- a/src/image-generation/runtime.resources.test.ts
+++ b/src/image-generation/runtime.resources.test.ts
@@ -1,0 +1,300 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { generateImage, type GenerateImageParams } from "./runtime.js";
+import type { ImageGenerationRequest } from "./types.js";
+
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMQVDL+DwACFAFmBODefwAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+function createNativeImageFixture(id = "native-image-owner", rejectGeneration = false) {
+  const dir = makePluginLoaderTempDir();
+  const key = `__openclaw_image_resources_${path.basename(dir)}`;
+  const started = createDeferredCore();
+  const resume = createDeferredCore();
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    reads: number[];
+    requests: ImageGenerationRequest[];
+  }> = [];
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: { connections, started, resume, png },
+  });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, reads: [], requests: [] };
+    state.connections.push(connection);
+    const read = () => {
+      const value = database.prepare("SELECT 42 AS value").get().value;
+      connection.reads.push(value);
+      return value;
+    };
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "native-image-resource",
+      dispose() {
+        read();
+        connection.disposals++;
+        database.close();
+      },
+    });
+    api.registerImageGenerationProvider({
+      id: ${JSON.stringify(id)},
+      aliases: [${JSON.stringify(`${id}-alias`)}],
+      defaultModel: "fixture-model",
+      capabilities: { generate: {}, edit: { enabled: true, maxInputImages: 1 } },
+      async generateImage(request) {
+        connection.requests.push(request);
+        read();
+        state.started.resolve();
+        await state.resume.promise;
+        read();
+        if (${rejectGeneration}) throw new Error("native image generation failed");
+        return {
+          images: [{ buffer: state.png, mimeType: "image/png", fileName: "native.png" }],
+          metadata: { get nativeValue() { return read(); } },
+        };
+      },
+    });
+  },
+};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { imageGenerationProviders: [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const config: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const params: GenerateImageParams = {
+    cfg: config,
+    prompt: "synthetic native image resource proof",
+    modelOverride: `${id}-alias/fixture-model`,
+    autoProviderFallback: false,
+    inputImages: [{ buffer: png, mimeType: "image/png" }],
+    timeoutMs: 12_345,
+    providerOptions: { fixture: "kept" },
+    ssrfPolicy: { allowRfc2544BenchmarkRange: true },
+  };
+  return {
+    plugin,
+    connections,
+    started,
+    resume,
+    config,
+    params,
+    run: () => generateImage(params),
+    withEnvironment: (run: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        run,
+      ),
+    cleanup() {
+      resume.resolve();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+function settle<T>(operation: Promise<T>) {
+  return operation.then(
+    (value) => ({ value, error: undefined }),
+    (error: unknown) => ({ value: undefined, error }),
+  );
+}
+
+async function waitForProviderStart(started: Promise<void>, operation: Promise<unknown>) {
+  await Promise.race([
+    started,
+    operation.then(() => {
+      throw new Error("Image operation settled before invoking the native provider");
+    }),
+  ]);
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("image generation registration resources", () => {
+  it.each([false, true])(
+    "releases cold image resources after settlement (reject=%s)",
+    async (reject) => {
+      const fixture = createNativeImageFixture("native-image-owner", reject);
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const outcome = settle(fixture.run());
+          try {
+            await waitForProviderStart(fixture.started.promise, outcome);
+            expect(fixture.connections).toHaveLength(1);
+            const connection = fixture.connections[0]!;
+            expect(connection.database.isOpen).toBe(true);
+            expect(connection.disposals).toBe(0);
+            fixture.resume.resolve();
+            const result = await outcome;
+            if (reject) {
+              expect(String(result.error)).toContain("native image generation failed");
+            } else {
+              expect(result.error).toBeUndefined();
+              expect(result.value?.images[0]?.buffer).toEqual(png);
+              expect(result.value?.metadata).toEqual({ nativeValue: 42 });
+            }
+            expect(connection.requests[0]).toMatchObject({
+              provider: "native-image-owner-alias",
+              timeoutMs: 12_345,
+              inputImages: fixture.params.inputImages,
+              providerOptions: fixture.params.providerOptions,
+              ssrfPolicy: fixture.params.ssrfPolicy,
+            });
+            expect(connection.database.isOpen).toBe(false);
+            expect(connection.disposals).toBe(1);
+            expect(connection.reads).toEqual(reject ? [42, 42, 42] : [42, 42, 42, 42]);
+          } finally {
+            fixture.resume.resolve();
+            await outcome;
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["managed", "raw"] as const)(
+    "preserves the %s host owner through image generation",
+    async (owner) => {
+      const fixture = createNativeImageFixture();
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const inspection =
+            owner === "managed"
+              ? await acquirePluginRegistryForInspection({ config: fixture.config })
+              : undefined;
+          const registry =
+            inspection?.registry ?? loadPluginRegistryHandle({ config: fixture.config });
+          const outcome = settle(withPluginRuntimeRegistryScope(registry, fixture.run));
+          try {
+            await waitForProviderStart(fixture.started.promise, outcome);
+            expect(fixture.connections).toHaveLength(1);
+            await inspection?.release();
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            fixture.resume.resolve();
+            const result = await outcome;
+            expect(result.error).toBeUndefined();
+            expect(result.value?.images[0]?.buffer).toEqual(png);
+            expect(result.value?.metadata).toEqual({ nativeValue: 42 });
+            expect(fixture.connections[0]!.database.isOpen).toBe(owner === "raw");
+            expect(fixture.connections[0]!.disposals).toBe(owner === "raw" ? 0 : 1);
+          } finally {
+            fixture.resume.resolve();
+            await outcome;
+            await inspection?.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["override", "fallback"] as const)(
+    "retains both eligible registrations for %s selection",
+    async (selection) => {
+      const first = createNativeImageFixture("first-image-owner", true);
+      const second = createNativeImageFixture("second-image-owner");
+      first.resume.resolve();
+      try {
+        await second.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const outcome = settle(
+            generateImage({
+              ...second.params,
+              cfg: {
+                agents: {
+                  defaults: {
+                    mediaModels: {
+                      image: {
+                        primary: "first-image-owner/fixture-model",
+                        fallbacks: ["second-image-owner-alias/fixture-model"],
+                      },
+                    },
+                  },
+                },
+                plugins: {
+                  allow: [first.plugin.id, second.plugin.id],
+                  load: { paths: [first.plugin.file, second.plugin.file] },
+                  slots: { memory: "none" },
+                },
+              },
+              modelOverride: selection === "override" ? second.params.modelOverride : undefined,
+            }),
+          );
+          try {
+            await waitForProviderStart(second.started.promise, outcome);
+            expect(first.connections).toHaveLength(1);
+            expect(second.connections).toHaveLength(1);
+            expect(first.connections[0]!.requests).toHaveLength(selection === "override" ? 0 : 1);
+            expect(first.connections[0]!.database.isOpen).toBe(true);
+            second.resume.resolve();
+            const result = await outcome;
+            expect(result.error).toBeUndefined();
+            expect(result.value?.provider).toBe("second-image-owner-alias");
+            expect(result.value?.images[0]?.buffer).toEqual(png);
+            expect(result.value?.attempts).toHaveLength(selection === "override" ? 0 : 1);
+            for (const connection of [...first.connections, ...second.connections]) {
+              expect(connection.database.isOpen).toBe(false);
+              expect(connection.disposals).toBe(1);
+            }
+          } finally {
+            second.resume.resolve();
+            await outcome;
+          }
+        });
+      } finally {
+        first.cleanup();
+        second.cleanup();
+      }
+    },
+  );
+});

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -6,6 +6,7 @@ import { parseImageGenerationModelRef } from "../media-generation/model-ref.js";
 import {
   getImageGenerationProvider,
   listImageGenerationProviders,
+  withImageGenerationProviders,
 } from "../media-generation/registry.js";
 import {
   buildMediaGenerationNormalizationMetadata,
@@ -15,6 +16,10 @@ import {
   resolveReferenceImageCapabilityError,
   runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
+import {
+  buildCapabilityProviderIndex,
+  normalizeCapabilityProviderId,
+} from "../plugins/provider-registry-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveImageGenerationMaxInputImages } from "./capabilities.js";
 import { resolveImageGenerationOverrides } from "./normalization.js";
@@ -59,6 +64,29 @@ export function listRuntimeImageGenerationProviders(
 export async function generateImage(
   params: GenerateImageParams,
   deps: ImageGenerationRuntimeDeps = {},
+): Promise<GenerateImageRuntimeResult> {
+  if (deps.getProvider && deps.listProviders) {
+    return runImageGeneration(params, deps);
+  }
+  return withImageGenerationProviders(params.cfg, (providers) => {
+    const canonical = buildCapabilityProviderIndex(providers, "canonical");
+    const aliases = buildCapabilityProviderIndex(providers, "aliases");
+    return runImageGeneration(params, {
+      ...deps,
+      getProvider:
+        deps.getProvider ??
+        ((id) => {
+          const normalized = normalizeCapabilityProviderId(id);
+          return normalized ? aliases.get(normalized) : undefined;
+        }),
+      listProviders: deps.listProviders ?? (() => [...canonical.values()]),
+    });
+  });
+}
+
+async function runImageGeneration(
+  params: GenerateImageParams,
+  deps: ImageGenerationRuntimeDeps,
 ): Promise<GenerateImageRuntimeResult> {
   const getProvider = deps.getProvider ?? getImageGenerationProvider;
   const listProviders = deps.listProviders ?? listImageGenerationProviders;

--- a/src/media-generation/registry.ts
+++ b/src/media-generation/registry.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ImageGenerationProvider } from "../image-generation/types.js";
 import type { MusicGenerationProvider } from "../music-generation/types.js";
 import { withAcquiredPluginCapabilityProviders } from "../plugins/capability-provider-acquisition.js";
 import { createMediaProviderRegistry } from "./provider-registry.js";
@@ -20,6 +21,14 @@ export const {
   listProviders: listVideoGenerationProviders,
   getProvider: getVideoGenerationProvider,
 } = createMediaProviderRegistry("videoGenerationProviders");
+
+/** Owns providers loaded for one buffered image-generation operation. */
+export function withImageGenerationProviders<T>(
+  cfg: OpenClawConfig,
+  run: (providers: ImageGenerationProvider[]) => T | Promise<T>,
+): Promise<T> {
+  return withAcquiredPluginCapabilityProviders({ key: "imageGenerationProviders", cfg }, run);
+}
 
 /** Owns providers loaded for one buffered music-generation operation. */
 export function withMusicGenerationProviders<T>(


### PR DESCRIPTION
Related: #140674, #142834

## What Problem This Solves

Default image generation could leave a cold plugin registration's database open after completion, or close a managed registration while an accepted image operation still used it.

## Why This Change Was Made

The image runtime now uses the shared capability operation owner from #142834. It retains managed sources or owns fresh registrations through selection, fallback, generation, result validation, metadata projection, and tracked cleanup. The existing generation body and provider-selection policy remain unchanged. Caller-supplied resolvers and unmanaged host registrations keep their existing custody.

## User Impact

The public image runtime closes the registrations it owns after completed image operations, including failures. Returned image buffers remain usable after cleanup. Provider aliases, overrides, fallback ordering, input images, timeout, provider options, and SSRF policy retain their behavior. No public API, configuration, schema, dependency, or version changes.

## Evidence

The unchanged production baseline failed five native SQLite ownership cases while its raw-host control passed. All six now pass, along with 77 image/shared/music sibling cases. The four-file independent Codex review is clean. The canonical changed gate passed in 351.9 seconds and the ordinary build in 226.3 seconds. A test-only PNG fixture checksum correction was independently decoded and revalidated after the initial review/gate; production bytes were unchanged.

Actual compiled public image-generation calls ran success → rejection → success in cold, managed, and raw modes. Cold operations registered/disposed three times; managed operations reused one registration until host release; raw operations received no automatic disposal and closed through caller cleanup. Saved output decoded to the expected pixel, all request options were checked, and native close markers plus read-only SQLite reopening verified completion. Source and all 11,384 build artifacts stayed unchanged; every owned process group joined.

Illustrative call times were 44.40 / 18.82 / 4.10 ms cold, 7.44 / 12.24 / 1.24 ms managed, and 6.92 / 12.01 / 1.08 ms raw. These are synthetic per-mode observations, not a statistical before/after performance claim. No vendor calls or real user state were used.

This slice covers default runtime acquisition. The agent tool's prepared provider arrays and detached background jobs require their own owner transfer and remain separate work. It does not claim to drain untracked vendor sibling requests.
