### PR TITLE
fix(skills): scope the Skill Workshop guardrail to Workshop-owned targets

### DIFF
--- a/src/agents/skill-workshop-prompt.test.ts
+++ b/src/agents/skill-workshop-prompt.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression coverage for #140246: the shared Skill Workshop prompt must scope
+ * its direct-write prohibition to Workshop-owned targets while leaving
+ * user-requested edits to repository-owned skill source on the normal
+ * repository file-tool route.
+ */
+import { describe, expect, it } from "vitest";
+import { buildSkillWorkshopPromptSection } from "./skill-workshop-prompt.js";
+
+const section = () => buildSkillWorkshopPromptSection().join("\n");
+
+describe("buildSkillWorkshopPromptSection", () => {
+  it("allows user-requested edits to repository-owned skill source", () => {
+    const prompt = section();
+    expect(prompt).toContain("repository-owned");
+    expect(prompt).toContain("ordinary repository checkout");
+    expect(prompt).toContain("do not route them through Workshop");
+    expect(prompt).toContain("normal repository file tools");
+  });
+
+  it("does not infer Workshop ownership from a SKILL.md filename, skill-like directory, or installed-name collision", () => {
+    const prompt = section();
+    expect(prompt).toContain("`SKILL.md` filename");
+    expect(prompt).toContain("skill-like directory");
+    expect(prompt).toContain("name collision with an installed skill");
+  });
+
+  it("still blocks direct writes to Workshop proposal and skill files", () => {
+    const prompt = section();
+    expect(prompt).toContain(
+      "never write Workshop proposal or Workshop-owned skill files directly",
+    );
+  });
+
+  it("still gates publication, apply, and unsolicited repairs", () => {
+    const prompt = section();
+    expect(prompt).toContain("Draft-only reviews continue to stage proposals");
+    expect(prompt).toContain("Publication-only create/update requires an explicit user request");
+    expect(prompt).toContain("Apply/reject/quarantine only explicit user ask");
+    expect(prompt).toContain("unsolicited improvements stay pending proposals");
+  });
+});

--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -8,7 +8,8 @@ export const SKILL_WORKSHOP_TOOL_NAME = "skill_workshop";
 export function buildSkillWorkshopPromptSection(): string[] {
   return [
     "## Skill Workshop",
-    "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.",
+    "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write Workshop proposal or Workshop-owned skill files directly.",
+    "Exception: user-requested edits to repository-owned skill source in an ordinary repository checkout are normal repository work—apply them with normal repository file tools, do not route them through Workshop, and never infer Workshop ownership from a `SKILL.md` filename, skill-like directory, or name collision with an installed skill.",
     "Exception: background Workshop maintenance may use normal file tools inside its provided Workshop directory when the run authorizes direct edits. Draft-only reviews continue to stage proposals.",
     "Used skill proved wrong or incomplete: read it and follow the available tool's publication and autonomous policy. Where supported, autonomous mode may disable repair, stage a proposal, or apply it. Without an applicable autonomous policy, unsolicited improvements stay pending proposals when supported; otherwise describe the suggestion without publishing. Capture only durable, evidenced procedure changes—never task artifacts, transient failures, or unresolved guesses.",
     "Publication-only create/update requires an explicit user request; never present it as a pending draft. Apply/reject/quarantine only explicit user ask.",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1466,6 +1466,7 @@ describe("buildAgentSystemPrompt", () => {
     });
     expect(withoutTool).not.toContain("## Skill Workshop");
     expect(withoutTool).not.toContain("Durable reusable skill/playbook/workflow work");
+    expect(withoutTool).not.toContain("repository-owned skill source");
 
     const withTool = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -1474,6 +1475,11 @@ describe("buildAgentSystemPrompt", () => {
     expect(withTool).toContain("- skill_workshop: Author reusable skills");
     expect(withTool).toContain("## Skill Workshop");
     expect(withTool).toContain("Durable reusable skill/playbook/workflow work");
+    expect(withTool).toContain(
+      "never write Workshop proposal or Workshop-owned skill files directly",
+    );
+    expect(withTool).toContain("repository-owned skill source");
+    expect(withTool).toContain("never infer Workshop ownership");
     expect(withTool).toContain("Used skill proved wrong or incomplete");
     expect(withTool).toContain(
       "Where supported, autonomous mode may disable repair, stage a proposal, or apply it",


### PR DESCRIPTION
## What Problem This Solves

The shared Skill Workshop instruction says "never write proposal/skill files directly," although the documented contract assigns repository-owned skill source to ordinary file tools. That unqualified instruction can conflict with an explicitly authorized repository edit.

This scopes the prohibition to Workshop proposals and Workshop-owned skills. It explicitly permits requested repository-source edits and says that filenames, skill-like directories, and installed-name collisions do not establish Workshop ownership. Existing publication, approval, containment, and background-maintenance rules stay intact.

## Evidence

- Captured complete provider requests through an isolated built Gateway and real agent turns. Main sends the broad prohibition; the candidate sends the ownership-scoped instruction.
- A real model edited only the requested repository line through ordinary file tools while a same-named Workshop skill remained unchanged.
- For the Workshop-owned copy, the model staged a pending update through `skill_workshop`. Operator denial kept it pending; a separately authorized approval applied it. The repository copy stayed unchanged.
- Workshop rejected an update targeting the external repository file. The agent's actual `read` call outside its configured workspace was rejected without fallback or extra writes.
- 168 system-prompt tests, 14 Workshop ownership tests, and 4 focused prompt tests passed. The old prompt fails 3 of the 4 focused checks. Formatting, lint, and the existing source ratchets passed.
- The baseline model also completed the repository edit. These runs prove the request-level instruction correction and the recorded routing/approval controls; they do not establish a lower refusal rate or universal model compliance. Earlier PR #140285 remains contrary refusal-reproduction evidence. Prompt wording is not a security boundary.

Fixes #140246.
