### PR TITLE
refactor(tests): share independent no-queued-reply expectations

### DIFF
--- a/src/auto-reply/dispatch.delivery-order.test.ts
+++ b/src/auto-reply/dispatch.delivery-order.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { expectedNoQueuedReplyResult } from "./reply/dispatch-result-expectations.test-support.js";
 import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatchBeforeDeliverOptions } from "./reply/reply-dispatcher.types.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
@@ -340,10 +341,7 @@ describe("foreground reply delivery order", () => {
 
     await expect(olderDispatch).resolves.toEqual(settledFinalResult());
     const newerResult = await newerDispatch;
-    expect(newerResult).toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    expect(newerResult).toMatchObject(expectedNoQueuedReplyResult());
     expect(newerResult.settledReceipt?.anyVisibleDelivered).toBe(false);
     expect(deliveries).toEqual([{ kind: "final", text: "old final" }]);
   });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -50,6 +50,7 @@ import {
 } from "./agent-turn-attachments.js";
 import { tryDispatchAcpReplyCore } from "./dispatch-acp.js";
 import { createAbortAwareDispatcher } from "./dispatch-from-config.abort.js";
+import { expectedNoQueuedReplyResult } from "./dispatch-result-expectations.test-support.js";
 import {
   appendRecentHistoryImageContext,
   resolveRecentInboundHistoryImages,
@@ -1067,10 +1068,7 @@ describe("tryDispatchAcpReplyCore", () => {
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
 
-    expect(result).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    expect(result).toEqual(expectedNoQueuedReplyResult());
     expect(transport).not.toHaveBeenCalled();
     expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
     expect(recordProcessed).toHaveBeenCalledWith("completed", {

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -31,6 +31,7 @@ import {
   sessionStoreMocks,
   setDiscordTestRegistry,
 } from "./dispatch-from-config.shared.test-harness.js";
+import { expectedNoQueuedReplyResult } from "./dispatch-result-expectations.test-support.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
@@ -452,10 +453,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(tailAbortSignal).toBeDefined();
       expect(replyRunRegistry.abort("agent:tail-abort")).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get("agent:tail-abort")).toBe(operation);
       expect(operation?.abortSignal.aborted).toBe(true);
       expect(tailAbortSignal?.aborted).toBe(true);
@@ -528,10 +526,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(operation?.ownerSettlement).toBeDefined();
       expect(replyRunRegistry.abort("agent:reply-dispatch-abort")).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get("agent:reply-dispatch-abort")).toBe(operation);
       expect(operation?.abortSignal.aborted).toBe(true);
       expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
@@ -665,10 +660,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(replyRunRegistry.abort(boundAcpSessionKey)).toBe(false);
       expect(replyRunRegistry.abort(sourceSessionKey)).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get(sourceSessionKey)).toBe(operation);
       expect(replyRunRegistry.get(boundAcpSessionKey)).toBeUndefined();
       expect(operation?.abortSignal.aborted).toBe(true);
@@ -724,10 +716,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(operation?.ownerSettlement).toBeDefined();
       expect(replyRunRegistry.abort("agent:pre-dispatch-abort")).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get("agent:pre-dispatch-abort")).toBe(operation);
       expect(operation?.abortSignal.aborted).toBe(true);
       expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
@@ -787,10 +776,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(operation?.ownerSettlement).toBeDefined();
       expect(replyRunRegistry.abort("agent:diagnostics-disabled-abort")).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get("agent:diagnostics-disabled-abort")).toBe(operation);
       expect(operation?.abortSignal.aborted).toBe(true);
       expect(diagnosticMocks.logMessageProcessed).not.toHaveBeenCalled();
@@ -904,10 +890,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       replyResolver: vi.fn(),
     });
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(mocks.routeReply).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(existingOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
@@ -995,10 +978,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     expect(existingOperation.abortSignal.aborted).toBe(true);
     expect(hookAbortSignal?.aborted).toBe(true);
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(existingOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
 
     releaseHook();
@@ -1040,10 +1020,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
 
     expect(replyRunRegistry.abort("agent:already-active-resolver")).toBe(true);
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(existingOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
     expect(replyResolver).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
@@ -1081,10 +1058,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
 
     callerAbort.abort();
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(existingOperation.result).toBeNull();
     expect(replyResolver).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
@@ -1130,10 +1104,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     await resolverStartedPromise;
     expect(replyRunRegistry.abort("agent:resolver-abort")).toBe(true);
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
 
     releaseResolver();
@@ -1186,10 +1157,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     await resolverStartedPromise;
     expect(replyRunRegistry.abort("agent:resolver-abort-error")).toBe(true);
 
-    await expect(dispatchPromise).resolves.toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
     expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
       expect.objectContaining({
         outcome: "skipped",
@@ -1257,10 +1225,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       expect(replyRunRegistry.abort(targetSessionKey)).toBe(false);
       expect(replyRunRegistry.abort(sourceSessionKey)).toBe(true);
 
-      await expect(dispatchPromise).resolves.toMatchObject({
-        queuedFinal: false,
-        counts: { tool: 0, block: 0, final: 0 },
-      });
+      await expect(dispatchPromise).resolves.toMatchObject(expectedNoQueuedReplyResult());
       expect(replyRunRegistry.get(sourceSessionKey)).toBe(operation);
       expect(replyRunRegistry.get(targetSessionKey)).toBeUndefined();
       expect(operation?.abortSignal.aborted).toBe(true);

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./dispatch-from-config.shared.test-harness.js";
 import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { withDispatchProcessedOutcomeSink } from "./dispatch-processed-outcome.js";
+import { expectedNoQueuedReplyResult } from "./dispatch-result-expectations.test-support.js";
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 
@@ -205,10 +206,7 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
       code: "run_failed",
       cause: resolverError,
     });
-    expect(result).toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
+    expect(result).toMatchObject(expectedNoQueuedReplyResult());
     expect(readAgentRunTerminalOutcome(result)).toBe("failed");
     expect(dispatchParams.dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/dispatch-result-expectations.test-support.ts
+++ b/src/auto-reply/reply/dispatch-result-expectations.test-support.ts
@@ -1,0 +1,6 @@
+export function expectedNoQueuedReplyResult() {
+  return {
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  };
+}


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Fifteen dispatch assertions repeat the same no-queued-reply result shape across related delivery, cancellation and terminal-failure suites.

## Why This Change Was Made

Share a pure expected-result constructor that returns fresh literal objects, independently of production and mock inputs. Preserve every existing matcher and companion no-send, terminal-outcome, receipt and operation-ownership assertion. Queue counts alone are not treated as delivery proof.

## User Impact

No user-visible behavior change. The five-file cleanup removes 35 net test/support lines without deleting scenarios or changing runtime behavior.

## Evidence

- All four complete suites passed before and after: 256 cases, with identical per-file ordered case names and statuses.
- Full AST expansion reconstructs the original consumers; all fifteen constructor calls remain expected-only, with exact values/key order and two fresh objects per call.
- Full mapped changed checks, diff-scoped cleanup and fresh independent P2 review passed with no findings.

No runtime improvement is claimed.
