### PR TITLE
fix(ci): isolate iOS release signing keychain

### DIFF
--- a/.github/actions/ios-signing-keychain/action.yml
+++ b/.github/actions/ios-signing-keychain/action.yml
@@ -1,0 +1,8 @@
+name: iOS signing keychain
+description: Create and clean up the job-owned keychain used for readonly iOS release signing.
+
+runs:
+  using: node24
+  main: keychain.mjs
+  post: post.mjs
+  post-if: always()

--- a/.github/actions/ios-signing-keychain/keychain.mjs
+++ b/.github/actions/ios-signing-keychain/keychain.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const KEYCHAIN_ROOT_PREFIX = "openclaw-ios-signing-keychain-";
+const KEYCHAIN_NAME = "signing.keychain";
+const PROBE_ROOT_PREFIX = "openclaw-ios-codesign-probe-";
+const KEYCHAIN_LIFETIME_SECONDS = 10_800;
+const FASTLANE_TIMEOUT_MS = 60_000;
+const IDENTITY_TIMEOUT_MS = 15_000;
+const CODESIGN_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+
+function requiredEnvironment(env, name) {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function assertSingleLine(name, value) {
+  if (/[\r\n]/u.test(value)) {
+    throw new Error(`${name} must be a single line`);
+  }
+}
+
+function isStrictDescendant(parent, candidate) {
+  const relative = path.relative(parent, candidate);
+  return relative !== "" && !relative.startsWith(`..${path.sep}`) && relative !== "..";
+}
+
+function assertStrictDescendant(parent, candidate, label) {
+  if (!isStrictDescendant(parent, candidate)) {
+    throw new Error(`${label} must stay inside ${parent}`);
+  }
+}
+
+function appendCommandValue(file, name, value, appendFile = fs.appendFileSync) {
+  assertSingleLine(name, value);
+  appendFile(file, `${name}=${value}\n`, "utf8");
+}
+
+function maskSecret(secret, output = process.stdout) {
+  const escaped = secret.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+  output.write(`::add-mask::${escaped}\n`);
+}
+
+function existingOwnedKeychain(root, candidate) {
+  if (!fs.existsSync(candidate)) {
+    return undefined;
+  }
+  const stat = fs.lstatSync(candidate);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`Owned keychain path is not a regular file: ${candidate}`);
+  }
+  const resolved = fs.realpathSync(candidate);
+  assertStrictDescendant(root, resolved, "Owned keychain");
+  return resolved;
+}
+
+function validateOwnedRoot(runnerTemp, ownedRoot, requireExisting) {
+  const resolvedRunnerTemp = fs.realpathSync(runnerTemp);
+  const absoluteRoot = path.resolve(ownedRoot);
+  assertStrictDescendant(resolvedRunnerTemp, absoluteRoot, "Owned keychain root");
+  if (!path.basename(absoluteRoot).startsWith(KEYCHAIN_ROOT_PREFIX)) {
+    throw new Error(`Unexpected owned keychain root: ${absoluteRoot}`);
+  }
+  if (!fs.existsSync(absoluteRoot)) {
+    if (requireExisting) {
+      throw new Error(`Owned keychain root is missing: ${absoluteRoot}`);
+    }
+    return absoluteRoot;
+  }
+  const stat = fs.lstatSync(absoluteRoot);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Owned keychain root is not a directory: ${absoluteRoot}`);
+  }
+  const resolvedRoot = fs.realpathSync(absoluteRoot);
+  assertStrictDescendant(resolvedRunnerTemp, resolvedRoot, "Owned keychain root");
+  if (resolvedRoot !== absoluteRoot) {
+    throw new Error(`Owned keychain root changed identity: ${absoluteRoot}`);
+  }
+  return resolvedRoot;
+}
+
+function validateOwnedKeychain(root, requestedPath, candidate, requireExisting) {
+  const expectedPaths = new Set([requestedPath, `${requestedPath}-db`]);
+  const absoluteCandidate = path.resolve(candidate);
+  if (!expectedPaths.has(absoluteCandidate)) {
+    throw new Error(`Unexpected owned keychain path: ${absoluteCandidate}`);
+  }
+  assertStrictDescendant(root, absoluteCandidate, "Owned keychain");
+  const resolved = existingOwnedKeychain(root, absoluteCandidate);
+  if (requireExisting && !resolved) {
+    throw new Error(`Owned keychain is missing: ${absoluteCandidate}`);
+  }
+  return resolved ?? absoluteCandidate;
+}
+
+function fastlaneCommand(action, parameters) {
+  return [
+    "_2.6.9_",
+    "exec",
+    "fastlane",
+    "run",
+    action,
+    ...Object.entries(parameters).map(([name, value]) => `${name}:${value}`),
+  ];
+}
+
+export async function runBounded(command, args, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const terminateGraceMs = options.terminateGraceMs ?? 2_000;
+  const maxOutputBytes = options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
+  const ownsProcessGroup = process.platform !== "win32";
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    detached: ownsProcessGroup,
+    env: options.env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = [];
+  const stderr = [];
+  let outputBytes = 0;
+  let terminationReason;
+  let terminationStartedAt;
+  let terminationError;
+  let closed = false;
+  let forceKillTimer;
+
+  const signalOwnedProcess = (signal) => {
+    try {
+      if (ownsProcessGroup && child.pid) {
+        process.kill(-child.pid, signal);
+      } else {
+        child.kill(signal);
+      }
+      return true;
+    } catch (error) {
+      if (error?.code === "ESRCH") {
+        return false;
+      }
+      terminationError ??= error;
+      return false;
+    }
+  };
+  const ownedProcessGroupExists = () => {
+    if (!ownsProcessGroup || !child.pid) {
+      return false;
+    }
+    try {
+      process.kill(-child.pid, 0);
+      return true;
+    } catch (error) {
+      if (error?.code === "ESRCH") {
+        return false;
+      }
+      throw error;
+    }
+  };
+  const terminate = (reason) => {
+    if (closed || terminationReason) {
+      return;
+    }
+    terminationReason = reason;
+    terminationStartedAt = Date.now();
+    signalOwnedProcess("SIGTERM");
+    forceKillTimer = setTimeout(() => {
+      if (!closed || ownedProcessGroupExists()) {
+        signalOwnedProcess("SIGKILL");
+      }
+    }, terminateGraceMs);
+    forceKillTimer.unref();
+  };
+  const capture = (target, chunk) => {
+    outputBytes += chunk.length;
+    if (outputBytes > maxOutputBytes) {
+      terminate(`exceeded the ${maxOutputBytes}-byte output limit`);
+      return;
+    }
+    target.push(chunk);
+  };
+
+  child.stdout.on("data", (chunk) => capture(stdout, chunk));
+  child.stderr.on("data", (chunk) => capture(stderr, chunk));
+  const timeout = setTimeout(() => terminate(`timed out after ${timeoutMs}ms`), timeoutMs);
+  timeout.unref();
+
+  try {
+    const result = await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => {
+        closed = true;
+        resolve({ code, signal });
+      });
+    });
+    const stdoutText = Buffer.concat(stdout).toString("utf8");
+    const stderrText = Buffer.concat(stderr).toString("utf8");
+    if (terminationReason && ownsProcessGroup && child.pid) {
+      const graceRemaining = Math.max(
+        0,
+        (terminationStartedAt ?? Date.now()) + terminateGraceMs - Date.now(),
+      );
+      if (graceRemaining > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, graceRemaining);
+        });
+      }
+      if (ownedProcessGroupExists()) {
+        signalOwnedProcess("SIGKILL");
+        const joinDeadline = Date.now() + 2_000;
+        while (ownedProcessGroupExists() && Date.now() < joinDeadline) {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+          });
+        }
+        if (ownedProcessGroupExists()) {
+          throw new Error(`${command} owned process group did not terminate`);
+        }
+      }
+    }
+    if (terminationError) {
+      throw terminationError;
+    }
+    if (terminationReason) {
+      throw new Error(`${command} ${terminationReason}`);
+    }
+    if (result.code !== 0) {
+      const detail =
+        stderrText.trim() || stdoutText.trim() || `signal ${result.signal ?? "unknown"}`;
+      throw new Error(`${command} exited with ${result.code}: ${detail}`);
+    }
+    return { stderr: stderrText, stdout: stdoutText };
+  } finally {
+    clearTimeout(timeout);
+    if (forceKillTimer) {
+      clearTimeout(forceKillTimer);
+    }
+  }
+}
+
+export async function createOwnedKeychain(options = {}) {
+  const env = options.env ?? process.env;
+  const runCommand = options.runCommand ?? runBounded;
+  const appendFile = options.appendFile ?? fs.appendFileSync;
+  const output = options.output ?? process.stdout;
+  const runnerTemp = fs.realpathSync(requiredEnvironment(env, "RUNNER_TEMP"));
+  const workspace = fs.realpathSync(requiredEnvironment(env, "GITHUB_WORKSPACE"));
+  const stateFile = requiredEnvironment(env, "GITHUB_STATE");
+  const environmentFile = requiredEnvironment(env, "GITHUB_ENV");
+  const ownedRoot = fs.mkdtempSync(path.join(runnerTemp, KEYCHAIN_ROOT_PREFIX));
+  fs.chmodSync(ownedRoot, 0o700);
+  const requestedPath = path.join(ownedRoot, KEYCHAIN_NAME);
+
+  // State is registered before creation so the post action owns partial failures too.
+  appendCommandValue(stateFile, "owned_root", ownedRoot, appendFile);
+  appendCommandValue(stateFile, "requested_path", requestedPath, appendFile);
+
+  const password = crypto.randomBytes(32).toString("hex");
+  maskSecret(password, output);
+  await runCommand(
+    "bundle",
+    fastlaneCommand("create_keychain", {
+      add_to_search_list: true,
+      default_keychain: false,
+      lock_after_timeout: true,
+      lock_when_sleeps: false,
+      path: requestedPath,
+      require_create: true,
+      timeout: KEYCHAIN_LIFETIME_SECONDS,
+      unlock: true,
+    }),
+    {
+      cwd: path.join(workspace, "apps/ios"),
+      env: { ...env, KEYCHAIN_PASSWORD: password },
+      timeoutMs: FASTLANE_TIMEOUT_MS,
+    },
+  );
+
+  const created = [requestedPath, `${requestedPath}-db`]
+    .map((candidate) => existingOwnedKeychain(ownedRoot, candidate))
+    .filter(Boolean);
+  if (created.length !== 1) {
+    throw new Error(`Expected one job-owned keychain, found ${created.length}`);
+  }
+  const resolvedPath = created[0];
+  if (!resolvedPath.endsWith("-db")) {
+    throw new Error(`Expected the resolved macOS keychain path to end in -db: ${resolvedPath}`);
+  }
+
+  appendCommandValue(stateFile, "resolved_path", resolvedPath, appendFile);
+  appendCommandValue(environmentFile, "MATCH_KEYCHAIN_NAME", resolvedPath, appendFile);
+  appendCommandValue(environmentFile, "MATCH_KEYCHAIN_PASSWORD", password, appendFile);
+  return { ownedRoot, password, requestedPath, resolvedPath };
+}
+
+export async function cleanupOwnedKeychain(options = {}) {
+  const env = options.env ?? process.env;
+  const runCommand = options.runCommand ?? runBounded;
+  const ownedRoot = env.STATE_owned_root?.trim();
+  if (!ownedRoot) {
+    return { removed: false };
+  }
+  const runnerTemp = requiredEnvironment(env, "RUNNER_TEMP");
+  const workspace = fs.realpathSync(requiredEnvironment(env, "GITHUB_WORKSPACE"));
+  const root = validateOwnedRoot(runnerTemp, ownedRoot, false);
+  if (!fs.existsSync(root)) {
+    return { removed: false };
+  }
+  const expectedRequestedPath = path.join(root, KEYCHAIN_NAME);
+  const requestedPath = path.resolve(requiredEnvironment(env, "STATE_requested_path"));
+  if (requestedPath !== expectedRequestedPath) {
+    throw new Error(`Unexpected requested keychain path: ${requestedPath}`);
+  }
+
+  const candidates = env.STATE_resolved_path?.trim()
+    ? [validateOwnedKeychain(root, requestedPath, env.STATE_resolved_path, false)]
+    : [requestedPath, `${requestedPath}-db`];
+  const existing = candidates
+    .map((candidate) => existingOwnedKeychain(root, candidate))
+    .filter(Boolean);
+  if (existing.length > 1) {
+    throw new Error(`Refusing ambiguous job-owned keychain cleanup in ${root}`);
+  }
+  if (existing.length === 1) {
+    const keychainPath = existing[0];
+    await runCommand(
+      "bundle",
+      fastlaneCommand("delete_keychain", { keychain_path: keychainPath }),
+      {
+        cwd: path.join(workspace, "apps/ios"),
+        env,
+        timeoutMs: FASTLANE_TIMEOUT_MS,
+      },
+    );
+    if (fs.existsSync(keychainPath)) {
+      throw new Error(`Job-owned keychain still exists after cleanup: ${keychainPath}`);
+    }
+  }
+  fs.rmdirSync(root);
+  return { removed: existing.length === 1 };
+}
+
+function expectedTeamId(workspace) {
+  const signingConfig = JSON.parse(
+    fs.readFileSync(path.join(workspace, "apps/ios/Config/AppStoreSigning.json"), "utf8"),
+  );
+  const teamId = signingConfig.teamId;
+  if (typeof teamId !== "string" || !/^[A-Z0-9]{10}$/u.test(teamId)) {
+    throw new Error("AppStoreSigning.json has an invalid teamId");
+  }
+  return teamId;
+}
+
+function selectDistributionIdentity(source, teamId) {
+  const identities = source
+    .split(/\r?\n/u)
+    .map((line) => line.match(/^\s*\d+\)\s+([0-9A-Fa-f]{40})\s+"([^"]+)"\s*$/u))
+    .filter(Boolean)
+    .map((match) => ({ hash: match[1], name: match[2] }))
+    .filter(
+      (identity) =>
+        identity.name.startsWith("Apple Distribution:") && identity.name.endsWith(`(${teamId})`),
+    );
+  if (identities.length !== 1) {
+    throw new Error(
+      `Expected one Apple Distribution identity for team ${teamId}, found ${identities.length}`,
+    );
+  }
+  return identities[0];
+}
+
+export async function probeOwnedKeychain(options = {}) {
+  const env = options.env ?? process.env;
+  const runCommand = options.runCommand ?? runBounded;
+  const runnerTemp = fs.realpathSync(requiredEnvironment(env, "RUNNER_TEMP"));
+  const workspace = fs.realpathSync(requiredEnvironment(env, "GITHUB_WORKSPACE"));
+  const keychainPath = path.resolve(requiredEnvironment(env, "MATCH_KEYCHAIN_NAME"));
+  const ownedRoot = validateOwnedRoot(runnerTemp, path.dirname(keychainPath), true);
+  const requestedPath = path.join(ownedRoot, KEYCHAIN_NAME);
+  const resolvedKeychain = validateOwnedKeychain(ownedRoot, requestedPath, keychainPath, true);
+  if (!resolvedKeychain.endsWith("-db")) {
+    throw new Error(`Expected the resolved macOS keychain path to end in -db: ${resolvedKeychain}`);
+  }
+
+  const teamId = expectedTeamId(workspace);
+  const identityResult = await runCommand(
+    "/usr/bin/security",
+    ["find-identity", "-v", "-p", "codesigning", resolvedKeychain],
+    { env, timeoutMs: IDENTITY_TIMEOUT_MS },
+  );
+  const identity = selectDistributionIdentity(
+    `${identityResult.stdout}\n${identityResult.stderr}`,
+    teamId,
+  );
+  const probeRoot = fs.mkdtempSync(path.join(runnerTemp, PROBE_ROOT_PREFIX));
+  fs.chmodSync(probeRoot, 0o700);
+  const probePath = path.join(probeRoot, "true");
+
+  try {
+    fs.copyFileSync("/usr/bin/true", probePath, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(probePath, 0o700);
+    await runCommand(
+      "/usr/bin/codesign",
+      [
+        "--force",
+        "--sign",
+        identity.hash,
+        "--timestamp=none",
+        "--keychain",
+        resolvedKeychain,
+        probePath,
+      ],
+      { env, timeoutMs: CODESIGN_TIMEOUT_MS },
+    );
+    await runCommand("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", probePath], {
+      env,
+      timeoutMs: CODESIGN_TIMEOUT_MS,
+    });
+    const details = await runCommand("/usr/bin/codesign", ["--display", "--verbose=4", probePath], {
+      env,
+      timeoutMs: IDENTITY_TIMEOUT_MS,
+    });
+    if (
+      !`${details.stdout}\n${details.stderr}`.split(/\r?\n/u).includes(`TeamIdentifier=${teamId}`)
+    ) {
+      throw new Error(`Signed probe does not belong to expected team ${teamId}`);
+    }
+    return { identity: identity.name, teamId };
+  } finally {
+    fs.rmSync(probeRoot, { force: true, recursive: true });
+  }
+}
+
+async function main() {
+  if (process.argv[2] === "probe") {
+    await probeOwnedKeychain();
+    return;
+  }
+  if (process.argv.length > 2) {
+    throw new Error(`Unknown iOS signing keychain operation: ${process.argv[2]}`);
+  }
+  await createOwnedKeychain();
+}
+
+const isDirectRun =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.github/actions/ios-signing-keychain/post.mjs
+++ b/.github/actions/ios-signing-keychain/post.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { cleanupOwnedKeychain } from "./keychain.mjs";
+
+cleanupOwnedKeychain().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.github/workflows/ios-beta-release.yml
+++ b/.github/workflows/ios-beta-release.yml
@@ -122,6 +122,7 @@ jobs:
           fetch-depth: 0
           sparse-checkout: |
             .github/actions/mobile-release-authority
+            .github/actions/ios-signing-keychain
             scripts
             apps/mobile/version.json
             apps/android/version.json
@@ -239,6 +240,9 @@ jobs:
           test -n "$watch_toolchain"
           rustup toolchain install "$watch_toolchain" --profile minimal --component rust-src
 
+      - name: Create job-owned iOS signing keychain
+        uses: ./apps/ios/build/mobile-release-ci/authority/.github/actions/ios-signing-keychain
+
       - name: Refresh trusted authority before store access
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -254,6 +258,26 @@ jobs:
             apps/android/Config/Version.properties
             apps/android/fastlane/metadata/android/en-US/release_notes.txt
             apps/ios/CHANGELOG.md
+
+      - name: Revalidate release authority immediately before signing proof
+        uses: ./apps/ios/build/mobile-release-ci/sink/.github/actions/mobile-release-authority
+        with:
+          operation: revalidate
+          platform: ios
+          workflow-path: .github/workflows/ios-beta-release.yml
+          workflow-full-ref: ${{ github.workflow_ref }}
+          workflow-sha: ${{ github.workflow_sha }}
+          target-ref: ${{ needs.authorize.outputs.target_ref }}
+          target-sha: ${{ env.RELEASE_TARGET_SHA }}
+          authority-run-id: ${{ needs.authorize.outputs.run_id }}
+
+      - name: Validate readonly iOS signing key access
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: |
+          set -euo pipefail
+          pnpm ios:release:signing:check
+          node apps/ios/build/mobile-release-ci/authority/.github/actions/ios-signing-keychain/keychain.mjs probe
 
       - name: Revalidate release authority immediately before upload
         uses: ./apps/ios/build/mobile-release-ci/sink/.github/actions/mobile-release-authority

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -2658,7 +2658,15 @@ describe("mobile release authority", () => {
           .split("\n")
           .map((value) => Number.parseInt(value, 10));
         expect(processIds).toHaveLength(2);
-        expect(() => process.kill(-processIds[0], 0)).toThrow();
+        const processGroupId = processIds[0];
+        if (
+          typeof processGroupId !== "number" ||
+          !Number.isSafeInteger(processGroupId) ||
+          processGroupId <= 0
+        ) {
+          throw new Error(`Invalid owned process-group ID: ${processGroupId}`);
+        }
+        expect(() => process.kill(-processGroupId, 0)).toThrow();
       };
 
       await exerciseOwnedProcessTree({

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -3,6 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import {
+  cleanupOwnedKeychain,
+  createOwnedKeychain,
+  probeOwnedKeychain,
+  runBounded,
+} from "../../.github/actions/ios-signing-keychain/keychain.mjs";
 import { verifyAndroidReleaseSource } from "../../apps/android/scripts/build-release-artifacts.ts";
 import {
   mobileReleasePlanDigest,
@@ -2017,6 +2023,11 @@ describe("mobile release authority", () => {
               {
                 jobName: "release",
                 secret: "MATCH_PASSWORD",
+                stepName: "Validate readonly iOS signing key access",
+              },
+              {
+                jobName: "release",
+                secret: "MATCH_PASSWORD",
                 stepName: "Upload and distribute iOS beta",
               },
               {
@@ -2240,6 +2251,431 @@ describe("mobile release authority", () => {
         value: project.options?.deploymentTarget?.iOS,
       },
     ]);
+  });
+
+  it("owns the iOS signing keychain through trusted authority code", () => {
+    const source = fs.readFileSync(".github/workflows/ios-beta-release.yml", "utf8");
+    const workflow = parse(source) as {
+      jobs: {
+        release: {
+          steps: Array<{
+            env?: Record<string, string>;
+            name: string;
+            run?: string;
+            uses?: string;
+            with?: Record<string, unknown>;
+          }>;
+        };
+      };
+    };
+    const releaseSteps = workflow.jobs.release.steps;
+    const createIndex = releaseSteps.findIndex(
+      (step) => step.name === "Create job-owned iOS signing keychain",
+    );
+    const sinkCheckoutIndex = releaseSteps.findIndex(
+      (step) => step.name === "Refresh trusted authority before store access",
+    );
+    const signingRevalidateIndex = releaseSteps.findIndex(
+      (step) => step.name === "Revalidate release authority immediately before signing proof",
+    );
+    const signingProofIndex = releaseSteps.findIndex(
+      (step) => step.name === "Validate readonly iOS signing key access",
+    );
+    const uploadRevalidateIndex = releaseSteps.findIndex(
+      (step) => step.name === "Revalidate release authority immediately before upload",
+    );
+    const uploadIndex = releaseSteps.findIndex(
+      (step) => step.name === "Upload and distribute iOS beta",
+    );
+
+    expect(createIndex).toBeGreaterThan(-1);
+    expect(releaseSteps[createIndex]?.uses).toBe(
+      "./apps/ios/build/mobile-release-ci/authority/.github/actions/ios-signing-keychain",
+    );
+    expect(sinkCheckoutIndex).toBeGreaterThan(createIndex);
+    expect(signingRevalidateIndex).toBe(sinkCheckoutIndex + 1);
+    expect(signingProofIndex).toBe(signingRevalidateIndex + 1);
+    expect(uploadRevalidateIndex).toBe(signingProofIndex + 1);
+    expect(uploadIndex).toBe(uploadRevalidateIndex + 1);
+    expect(releaseSteps[signingProofIndex]?.env).toEqual({
+      MATCH_PASSWORD: "${{ secrets.MATCH_PASSWORD }}",
+    });
+    expect(releaseSteps[signingProofIndex]?.run).toContain("pnpm ios:release:signing:check");
+    expect(releaseSteps[signingProofIndex]?.run).toContain(
+      "authority/.github/actions/ios-signing-keychain/keychain.mjs probe",
+    );
+    const authorityCheckout = releaseSteps.find(
+      (step) => step.name === "Checkout trusted mobile release authority",
+    );
+    expect(authorityCheckout?.with?.["sparse-checkout"]).toContain(
+      ".github/actions/ios-signing-keychain",
+    );
+    const action = parse(
+      fs.readFileSync(".github/actions/ios-signing-keychain/action.yml", "utf8"),
+    ) as {
+      runs: {
+        main: string;
+        post: string;
+        "post-if": string;
+        using: string;
+      };
+    };
+    expect(action.runs).toEqual({
+      using: "node24",
+      main: "keychain.mjs",
+      post: "post.mjs",
+      "post-if": "always()",
+    });
+  });
+
+  it("keeps an absent-state iOS keychain post cleanup side-effect free", () => {
+    const runnerTemp = tempRoots.make("openclaw-ios-keychain-post-runner-");
+    const workspace = tempRoots.make("openclaw-ios-keychain-post-workspace-");
+    fs.mkdirSync(path.join(workspace, "apps/ios"), { recursive: true });
+    const fakeBin = path.join(runnerTemp, "bin");
+    const bundleMarker = path.join(runnerTemp, "bundle-called");
+    const environmentFile = path.join(runnerTemp, "environment");
+    const stateFile = path.join(runnerTemp, "state");
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(path.join(fakeBin, "bundle"), '#!/bin/sh\n: > "$BUNDLE_MARKER"\nexit 99\n', {
+      mode: 0o700,
+    });
+
+    const result = spawnSync(process.execPath, [".github/actions/ios-signing-keychain/post.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        BUNDLE_MARKER: bundleMarker,
+        GITHUB_ENV: environmentFile,
+        GITHUB_STATE: stateFile,
+        GITHUB_WORKSPACE: workspace,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        RUNNER_TEMP: runnerTemp,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.existsSync(bundleMarker)).toBe(false);
+    expect(fs.existsSync(environmentFile)).toBe(false);
+    expect(fs.existsSync(stateFile)).toBe(false);
+    expect(
+      fs
+        .readdirSync(runnerTemp)
+        .some((entry) => entry.startsWith("openclaw-ios-signing-keychain-")),
+    ).toBe(false);
+    const postSource = fs.readFileSync(".github/actions/ios-signing-keychain/post.mjs", "utf8");
+    expect(postSource).toContain('import { cleanupOwnedKeychain } from "./keychain.mjs";');
+    expect(postSource).not.toContain("createOwnedKeychain");
+  });
+
+  it("masks and owns the exact resolved iOS keychain through post cleanup", async () => {
+    const runnerTemp = tempRoots.make("openclaw-ios-keychain-runner-");
+    const workspace = tempRoots.make("openclaw-ios-keychain-workspace-");
+    fs.mkdirSync(path.join(workspace, "apps/ios"), { recursive: true });
+    const environmentFile = path.join(runnerTemp, "environment");
+    const stateFile = path.join(runnerTemp, "state");
+    const env = {
+      ...process.env,
+      GITHUB_ENV: environmentFile,
+      GITHUB_STATE: stateFile,
+      GITHUB_WORKSPACE: workspace,
+      RUNNER_TEMP: runnerTemp,
+    };
+    let actionOutput = "";
+    const output = {
+      write(value: string) {
+        actionOutput += value;
+        return true;
+      },
+    };
+    const commands: Array<{ args: string[]; executable: string }> = [];
+    const runCommand = async (
+      executable: string,
+      args: string[],
+      options: { env?: NodeJS.ProcessEnv },
+    ) => {
+      commands.push({ args, executable });
+      expect(executable).toBe("bundle");
+      if (args.includes("create_keychain")) {
+        const requestedPath = args.find((argument) => argument.startsWith("path:"))?.slice(5);
+        if (!requestedPath) {
+          throw new Error("Missing create_keychain path");
+        }
+        expect(fs.readFileSync(stateFile, "utf8")).toContain(`requested_path=${requestedPath}\n`);
+        const password = options.env?.KEYCHAIN_PASSWORD;
+        expect(password).toMatch(/^[a-f0-9]{64}$/u);
+        expect(args.join("\n")).not.toContain(password);
+        fs.writeFileSync(`${requestedPath}-db`, "owned keychain\n");
+      } else if (args.includes("delete_keychain")) {
+        const keychainPath = args
+          .find((argument) => argument.startsWith("keychain_path:"))
+          ?.slice("keychain_path:".length);
+        if (!keychainPath) {
+          throw new Error("Missing delete_keychain path");
+        }
+        fs.unlinkSync(keychainPath);
+      } else {
+        throw new Error(`Unexpected Fastlane action: ${args.join(" ")}`);
+      }
+      return { stderr: "", stdout: "" };
+    };
+
+    const created = await createOwnedKeychain({ env, output, runCommand });
+    expect(created.resolvedPath).toBe(`${created.requestedPath}-db`);
+    expect(fs.statSync(created.ownedRoot).mode & 0o777).toBe(0o700);
+    expect(actionOutput).toBe(`::add-mask::${created.password}\n`);
+    expect(fs.readFileSync(environmentFile, "utf8")).toBe(
+      `MATCH_KEYCHAIN_NAME=${created.resolvedPath}\n` +
+        `MATCH_KEYCHAIN_PASSWORD=${created.password}\n`,
+    );
+    const state = Object.fromEntries(
+      fs
+        .readFileSync(stateFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split(/[=](.*)/su).slice(0, 2)),
+    );
+    await cleanupOwnedKeychain({
+      env: {
+        ...env,
+        STATE_owned_root: state.owned_root,
+        STATE_requested_path: state.requested_path,
+        STATE_resolved_path: state.resolved_path,
+      },
+      runCommand,
+    });
+    expect(fs.existsSync(created.ownedRoot)).toBe(false);
+    expect(commands.map(({ args }) => args[4])).toEqual(["create_keychain", "delete_keychain"]);
+
+    const source = fs.readFileSync(".github/actions/ios-signing-keychain/keychain.mjs", "utf8");
+    expect(source.indexOf("maskSecret(password, output)")).toBeLessThan(
+      source.indexOf(
+        'appendCommandValue(environmentFile, "MATCH_KEYCHAIN_PASSWORD", password, appendFile)',
+      ),
+    );
+    expect(source).toContain("default_keychain: false");
+    expect(source).toContain("lock_after_timeout: true");
+    expect(source).toContain("timeout: KEYCHAIN_LIFETIME_SECONDS");
+    expect(source).not.toContain("skip_set_partition_list");
+  });
+
+  it("cleans a partial iOS keychain create and refuses paths outside its ownership", async () => {
+    const runnerTemp = tempRoots.make("openclaw-ios-keychain-partial-runner-");
+    const workspace = tempRoots.make("openclaw-ios-keychain-partial-workspace-");
+    fs.mkdirSync(path.join(workspace, "apps/ios"), { recursive: true });
+    const environmentFile = path.join(runnerTemp, "environment");
+    const stateFile = path.join(runnerTemp, "state");
+    const env = {
+      ...process.env,
+      GITHUB_ENV: environmentFile,
+      GITHUB_STATE: stateFile,
+      GITHUB_WORKSPACE: workspace,
+      RUNNER_TEMP: runnerTemp,
+    };
+    const createCommand = async (_command: string, args: string[]) => {
+      const requestedPath = args.find((argument) => argument.startsWith("path:"))?.slice(5);
+      if (!requestedPath) {
+        throw new Error("Missing partial create path");
+      }
+      fs.writeFileSync(`${requestedPath}-db`, "partial keychain\n");
+      throw new Error("partial create");
+    };
+
+    await expect(
+      createOwnedKeychain({
+        env,
+        output: { write: () => true },
+        runCommand: createCommand,
+      }),
+    ).rejects.toThrow("partial create");
+    expect(fs.existsSync(environmentFile)).toBe(false);
+    const state = Object.fromEntries(
+      fs
+        .readFileSync(stateFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split(/[=](.*)/su).slice(0, 2)),
+    );
+    const partialPath = `${state.requested_path}-db`;
+    expect(fs.existsSync(partialPath)).toBe(true);
+    await cleanupOwnedKeychain({
+      env: {
+        ...env,
+        STATE_owned_root: state.owned_root,
+        STATE_requested_path: state.requested_path,
+      },
+      runCommand: async (_command: string, args: string[]) => {
+        const keychainPath = args
+          .find((argument) => argument.startsWith("keychain_path:"))
+          ?.slice("keychain_path:".length);
+        expect(keychainPath).toBe(partialPath);
+        fs.unlinkSync(partialPath);
+        return { stderr: "", stdout: "" };
+      },
+    });
+    expect(fs.existsSync(state.owned_root)).toBe(false);
+
+    const outsidePath = path.join(runnerTemp, "outside.keychain-db");
+    fs.writeFileSync(outsidePath, "not owned\n");
+    const ownedRoot = fs.mkdtempSync(path.join(runnerTemp, "openclaw-ios-signing-keychain-"));
+    const requestedPath = path.join(ownedRoot, "signing.keychain");
+    let cleanupCalled = false;
+    await expect(
+      cleanupOwnedKeychain({
+        env: {
+          ...env,
+          STATE_owned_root: ownedRoot,
+          STATE_requested_path: requestedPath,
+          STATE_resolved_path: outsidePath,
+        },
+        runCommand: async () => {
+          cleanupCalled = true;
+          return { stderr: "", stdout: "" };
+        },
+      }),
+    ).rejects.toThrow("Unexpected owned keychain path");
+    expect(cleanupCalled).toBe(false);
+    expect(fs.existsSync(outsidePath)).toBe(true);
+  });
+
+  it("binds the signing probe to the configured team and bounds owned child processes", async () => {
+    const runnerTemp = tempRoots.make("openclaw-ios-keychain-probe-runner-");
+    const workspace = tempRoots.make("openclaw-ios-keychain-probe-workspace-");
+    writeFile(
+      workspace,
+      "apps/ios/Config/AppStoreSigning.json",
+      `${JSON.stringify({ teamId: "FWJYW4S8P8" }, null, 2)}\n`,
+    );
+    const ownedRoot = fs.mkdtempSync(path.join(runnerTemp, "openclaw-ios-signing-keychain-"));
+    const keychainPath = path.join(ownedRoot, "signing.keychain-db");
+    fs.writeFileSync(keychainPath, "owned keychain\n");
+    const calls: Array<{ args: string[]; executable: string; timeoutMs?: number }> = [];
+    const identityHash = "A".repeat(40);
+    const runCommand = async (
+      executable: string,
+      args: string[],
+      options: { timeoutMs?: number },
+    ) => {
+      calls.push({ args, executable, timeoutMs: options.timeoutMs });
+      if (executable === "/usr/bin/security") {
+        return {
+          stderr: "",
+          stdout: `  1) ${identityHash} "Apple Distribution: OpenClaw Foundation (FWJYW4S8P8)"\n`,
+        };
+      }
+      const probePath = args.at(-1);
+      expect(executable).toBe("/usr/bin/codesign");
+      expect(probePath).toBeTruthy();
+      expect(fs.readFileSync(probePath as string)).toEqual(fs.readFileSync("/usr/bin/true"));
+      if (args.includes("--display")) {
+        return { stderr: "TeamIdentifier=FWJYW4S8P8\n", stdout: "" };
+      }
+      return { stderr: "", stdout: "" };
+    };
+
+    await expect(
+      probeOwnedKeychain({
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: workspace,
+          MATCH_KEYCHAIN_NAME: keychainPath,
+          RUNNER_TEMP: runnerTemp,
+        },
+        runCommand,
+      }),
+    ).resolves.toEqual({
+      identity: "Apple Distribution: OpenClaw Foundation (FWJYW4S8P8)",
+      teamId: "FWJYW4S8P8",
+    });
+    expect(calls.map(({ executable }) => executable)).toEqual([
+      "/usr/bin/security",
+      "/usr/bin/codesign",
+      "/usr/bin/codesign",
+      "/usr/bin/codesign",
+    ]);
+    expect(calls.every(({ timeoutMs }) => timeoutMs !== undefined && timeoutMs <= 30_000)).toBe(
+      true,
+    );
+    expect(calls.some(({ executable, args }) => executable === args.at(-1))).toBe(false);
+    expect(
+      fs.readdirSync(runnerTemp).some((entry) => entry.startsWith("openclaw-ios-codesign-probe-")),
+    ).toBe(false);
+
+    await expect(
+      probeOwnedKeychain({
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: workspace,
+          MATCH_KEYCHAIN_NAME: keychainPath,
+          RUNNER_TEMP: runnerTemp,
+        },
+        runCommand: async () => ({
+          stderr: "",
+          stdout: `  1) ${identityHash} "Apple Distribution: Other Team (AAAAAAAAAA)"\n`,
+        }),
+      }),
+    ).rejects.toThrow("Expected one Apple Distribution identity for team FWJYW4S8P8, found 0");
+
+    if (process.platform !== "win32") {
+      const exerciseOwnedProcessTree = async ({
+        expectedError,
+        grandchildSource,
+        maxOutputBytes,
+        name,
+        timeoutMs,
+      }: {
+        expectedError: string;
+        grandchildSource: string;
+        maxOutputBytes?: number;
+        name: string;
+        timeoutMs: number;
+      }) => {
+        const pidFile = path.join(runnerTemp, `${name}.pid`);
+        const parentSource = [
+          'const { spawn } = require("node:child_process");',
+          'const fs = require("node:fs");',
+          `const child = spawn(process.execPath, ["-e", ${JSON.stringify(grandchildSource)}], {`,
+          '  stdio: ["ignore", process.stdout, process.stderr],',
+          "});",
+          "fs.writeFileSync(process.env.PID_FILE, `${process.pid}\\n${child.pid}\\n`);",
+          'process.on("SIGTERM", () => {});',
+          "setInterval(() => {}, 1000);",
+        ].join("\n");
+        const startedAt = Date.now();
+        await expect(
+          runBounded(process.execPath, ["-e", parentSource], {
+            env: { ...process.env, PID_FILE: pidFile },
+            maxOutputBytes,
+            terminateGraceMs: 200,
+            timeoutMs,
+          }),
+        ).rejects.toThrow(expectedError);
+        expect(Date.now() - startedAt).toBeLessThan(3_000);
+        const processIds = fs
+          .readFileSync(pidFile, "utf8")
+          .trim()
+          .split("\n")
+          .map((value) => Number.parseInt(value, 10));
+        expect(processIds).toHaveLength(2);
+        expect(() => process.kill(-processIds[0], 0)).toThrow();
+      };
+
+      await exerciseOwnedProcessTree({
+        expectedError: "timed out after 1000ms",
+        grandchildSource: 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 5000);',
+        name: "timeout-tree",
+        timeoutMs: 1_000,
+      });
+      await exerciseOwnedProcessTree({
+        expectedError: "exceeded the 4096-byte output limit",
+        grandchildSource:
+          'process.on("SIGTERM", () => {}); setInterval(() => process.stdout.write("x".repeat(2048)), 1);',
+        maxOutputBytes: 4096,
+        name: "output-cap-tree",
+        timeoutMs: 5_000,
+      });
+    }
   });
 
   it("installs the pinned Watch Rust toolchain before iOS store access", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes the release incident where Fastlane hit login-keychain password and partition-list errors, then the device archive remained incomplete until the job timed out before repository upload.

## Why This Change Was Made

The workflow now creates a unique job-owned keychain under `RUNNER_TEMP`, proves key use and the expected distribution identity against the configured team before archive/upload work, and removes only that owned keychain through a dedicated post action configured with `post-if: always()`. Hard runner loss cannot guarantee cleanup. Child signing probes are time-bounded and terminate their owned process group, including inherited descendants, before the workflow continues.

The release authority, candidate admission, TestFlight destination, credentials, and frozen release candidate are unchanged.

## User Impact

Mobile release operators get deterministic, isolated iOS signing state with fail-closed identity checks and bounded cleanup. This change does not submit App Review, distribute externally, or perform a release.

## Evidence

- Owner action tests: 65/65 passed.
- Dedicated post/process regressions: 3/3 passed.
- iOS release workflow gates: 36/36 passed.
- Static proof: actionlint, embedded Bash syntax, Node syntax, exact-file formatting/lint, and `git diff --check` passed.
- Fresh canonical autoreview: no P0-P2 findings.
- Exact-head ClawSweeper review: no findings and no before-merge actions. Its optional live macOS import/probe/post-cleanup proof is deferred because this repair handoff authorizes no signing credentials or new iOS release budget; a separately authorized release run must supply that evidence.
- Red-to-green coverage includes partial keychain creation, absent-state post cleanup, owned-path containment, masking, team-bound identity proof, direct-child timeout, and inherited-descendant termination/join.
- Ready-run CI `34313904855` exposed a related `noUncheckedIndexedAccess` error in the new process-group regression. Follow-up `5bfea39315b71570fb4377847ed4458ec4614ea6` adds an explicit positive safe-integer guard; the focused test passed 1/1, format/lint/diff checks passed, and the target file has no direct compiler diagnostic.
- Local `check:workflows` was not completed because the configured pre-commit 4.6.2 prerequisite could not resolve in that environment; exact-head hosted workflow validation remains required.
- No live credentials, signing, TestFlight upload, candidate mutation, or store action was used for this repair.

Punchcard-Session: calm-meadow-summit-7q
