### PR TITLE
fix(ci): reuse authenticated Bun image archives

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -328,21 +328,6 @@ runs:
         echo "NODE_COMPILE_CACHE_PORTABLE=1" >> "$GITHUB_ENV"
         echo "OPENCLAW_NODE_COMPILE_CACHE_WRITER=0" >> "$GITHUB_ENV"
 
-    - name: Setup Bun
-      if: inputs.install-bun == 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-        npm install -g bun@1.4.0
-
-    - name: Runtime versions
-      shell: bash
-      run: |
-        node -v
-        npm -v
-        pnpm -v
-        if command -v bun &>/dev/null; then bun -v; fi
-
     - name: Capture node path
       shell: bash
       run: |
@@ -353,6 +338,27 @@ runs:
         # zizmor: ignore[github-env] node_bin comes from trusted actions/setup-node output in this composite action.
         echo "NODE_BIN=$node_bin" >> "$GITHUB_ENV"
         echo "$node_bin" >> "$GITHUB_PATH"
+
+    - name: Setup Bun
+      if: inputs.install-bun == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        bun_bin="$(node "$GITHUB_ACTION_PATH/seed-bun-from-image.mjs")"
+        if [[ -n "$bun_bin" ]]; then
+          export PATH="$bun_bin:$PATH"
+          echo "$bun_bin" >> "$GITHUB_PATH"
+        else
+          npm install -g bun@1.4.0
+        fi
+
+    - name: Runtime versions
+      shell: bash
+      run: |
+        node -v
+        npm -v
+        pnpm -v
+        if command -v bun &>/dev/null; then bun -v; fi
 
     - name: Install dependencies
       if: inputs.install-deps == 'true'

--- a/.github/actions/setup-node-env/seed-bun-from-image.mjs
+++ b/.github/actions/setup-node-env/seed-bun-from-image.mjs
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, mkdir, mkdtemp, open, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const version = "1.4.0";
+const archives = {
+  "linux-x64": "2d03fb5fb83ac8b567aca0a281b2ce1a1a19d488f56c2968d88c3f25e92fe452",
+  "linux-x64-baseline": "184fb4595f0d401a217cf7c78c1bc430ba83314dab7a8b94805babbf7fa7097f",
+};
+
+async function optimizedSupported() {
+  let cpuinfo;
+  try {
+    cpuinfo = await readFile("/proc/cpuinfo", "utf8");
+  } catch {
+    return false;
+  }
+  let cpu = false;
+  let flags;
+  let seen = false;
+  let missing = false;
+  function finishCpu() {
+    if (cpu) {
+      seen = true;
+      if (!flags?.includes("avx") || !flags.includes("avx2")) {
+        missing = true;
+      }
+    }
+    cpu = false;
+    flags = undefined;
+  }
+  // A later processor record without flags must not inherit an earlier CPU's evidence.
+  for (const line of cpuinfo.split("\n")) {
+    const colon = line.indexOf(":");
+    const key = line.slice(0, colon).trim();
+    if (!line.trim() || key === "processor") {
+      finishCpu();
+      cpu = key === "processor";
+    } else if (key === "flags") {
+      if (!cpu || flags) {
+        missing = true;
+      }
+      flags = line
+        .slice(colon + 1)
+        .trim()
+        .split(/\s+/u);
+    }
+  }
+  finishCpu();
+  return seen && !missing;
+}
+
+async function seed() {
+  if (
+    process.platform !== "linux" ||
+    process.arch !== "x64" ||
+    !process.report.getReport().header.glibcVersionRuntime
+  ) {
+    return;
+  }
+  const variant = (await optimizedSupported()) ? "linux-x64" : "linux-x64-baseline";
+  const name = `bun-v${version}-${variant}.zip`;
+  let source;
+  try {
+    source = await open(
+      join("/opt/crabbox/toolchain-archives", name),
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  let destination;
+  let ready = false;
+  try {
+    if (!(await source.stat()).isFile()) {
+      throw new Error(`${name} is not a regular archive`);
+    }
+    destination = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), "openclaw-bun-"));
+    const archive = join(destination, name);
+    await writeFile(archive, await source.readFile(), { mode: 0o600, flag: "wx" });
+    if (
+      createHash("sha256")
+        .update(await readFile(archive))
+        .digest("hex") !== archives[variant]
+    ) {
+      throw new Error(`${name} failed SHA256 verification`);
+    }
+    const member = `bun-${variant}/bun`;
+    const entries = execFileSync("unzip", ["-Z1", archive], { encoding: "utf8" })
+      .trim()
+      .split("\n");
+    if (
+      entries.filter((entry) => entry === member).length !== 1 ||
+      entries.some((entry) => entry !== member && entry !== `bun-${variant}/`)
+    ) {
+      throw new Error(`${name} has an unexpected archive layout`);
+    }
+    const bin = join(destination, "bin");
+    await mkdir(bin, { mode: 0o700 });
+    const executable = join(bin, "bun");
+    const output = await open(executable, "wx", 0o600);
+    try {
+      // Stream only the authenticated member into a new regular file, never archive paths.
+      execFileSync("unzip", ["-p", archive, member], { stdio: ["ignore", output.fd, "pipe"] });
+    } finally {
+      await output.close();
+    }
+    await chmod(executable, 0o755);
+    const actual = execFileSync(executable, ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+    }).trim();
+    if (actual !== version) {
+      throw new Error(`Expected Bun ${version}, got ${actual}`);
+    }
+    await symlink("bun", join(bin, "bunx"));
+    await rm(archive);
+    ready = true;
+    process.stdout.write(`${bin}\n`);
+  } finally {
+    await source.close();
+    if (destination && !ready) {
+      await rm(destination, { recursive: true, force: true });
+    }
+  }
+}
+
+try {
+  await seed();
+} catch (error) {
+  console.error(`Bun image cache: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -22,6 +22,7 @@ const repositoryScriptEntries = [
   ".github/actions/mobile-release-authority/authority.mjs!",
   // setup-node-env invokes this helper from composite-action YAML.
   ".github/actions/setup-node-env/dependency-fingerprint.mjs!",
+  ".github/actions/setup-node-env/seed-bun-from-image.mjs!",
   // setup-pnpm-store-cache invokes this helper from composite-action YAML.
   ".github/actions/setup-pnpm-store-cache/seed-pnpm-from-image.mjs!",
   "apps/android/scripts/build-release-artifacts.ts!",

--- a/docs/ci/local-proof.md
+++ b/docs/ci/local-proof.md
@@ -163,6 +163,18 @@ seed a job-private Corepack home from the same authenticated pnpm archives.
 These runtime archives do not replace the frozen-lockfile dependency install
 or change the dependency-store cache keys.
 
+With `install-bun: "true"`, `setup-node-env` can also reuse the original pinned
+Bun 1.4.0 ZIPs from `/opt/crabbox/toolchain-archives` on Linux glibc x64.
+It authenticates a private copy before extracting a fresh job-private `bun`
+and `bunx`, then publishes their directory after the Node PATH entry.
+The baseline archive is the default; the optimized x64 archive requires AVX
+and AVX2 evidence for every visible guest CPU. Missing CPU evidence uses baseline.
+A missing matching archive or an unsupported platform keeps the pinned npm
+installation path. A present corrupt or malformed archive fails setup instead
+of falling back to an existing Bun. `install-bun: "false"` skips both paths;
+it does not remove Bun already supplied by the runner. This reuse does not
+cover ARM, musl, or the untrusted bootstrap.
+
 Unset all `CRABBOX_TAILSCALE*` overrides, force `--network public
 --tailscale=false`, clear exit-node/LAN flags, and require `crabbox inspect` to
 report public networking with no Tailscale state before uploading any script.

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2234,9 +2234,10 @@ const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
   [".github/workflows/update-migration.yml", [packageAcceptance, workflowGuards]],
   [
     ".github/actions/setup-node-env/action.yml",
-    ["install-trufflehog", packageAcceptance, workflowGuards],
+    ["install-trufflehog", "setup-node-env-bun", packageAcceptance, workflowGuards],
   ],
   [".github/actions/setup-node-env/dependency-fingerprint.mjs", [workflowGuards]],
+  [".github/actions/setup-node-env/seed-bun-from-image.mjs", ["setup-node-env-bun"]],
   [".github/actions/setup-pnpm-store-cache/action.yml", [packageAcceptance, workflowGuards]],
   [".github/actions/setup-pnpm-store-cache/ensure-node.sh", ["setup-pnpm-store-cache-ensure-node"]],
   ["test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts", [dockerE2e, pluginPrerelease]],

--- a/test/scripts/setup-node-env-bun.test.ts
+++ b/test/scripts/setup-node-env-bun.test.ts
@@ -1,0 +1,370 @@
+import { execFileSync, spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const helperPath = ".github/actions/setup-node-env/seed-bun-from-image.mjs";
+const pins = {
+  "linux-x64": "2d03fb5fb83ac8b567aca0a281b2ce1a1a19d488f56c2968d88c3f25e92fe452",
+  "linux-x64-baseline": "184fb4595f0d401a217cf7c78c1bc430ba83314dab7a8b94805babbf7fa7097f",
+};
+type Variant = keyof typeof pins;
+type Step = { name: string; run?: string; if?: string };
+const action = parse(readFileSync(".github/actions/setup-node-env/action.yml", "utf8")) as {
+  runs: { steps: Step[] };
+};
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function fixture(options: { platform?: string; arch?: string; glibc?: boolean } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "bun-image-"));
+  roots.push(root);
+  const image = join(root, "image");
+  const runnerTemp = join(root, "runner");
+  const actionPath = join(root, "action");
+  const nodeBin = join(root, "node-bin");
+  const cpu = join(root, "cpuinfo");
+  const npmLog = join(root, "npm.log");
+  const helperLog = join(root, "helper.log");
+  const bunLog = join(root, "bun.log");
+  for (const directory of [image, runnerTemp, actionPath, nodeBin]) {
+    mkdirSync(directory);
+  }
+  writeFileSync(cpu, "");
+  const shell = (path: string, body: string) =>
+    writeFileSync(path, `#!/bin/bash\nset -euo pipefail\n${body}\n`, { mode: 0o755 });
+  shell(
+    join(nodeBin, "node"),
+    `if [[ "$*" == "-p process.execPath" ]]; then
+  printf '%s/node\\n' "$FIXTURE_NODE_BIN"
+else
+  if [[ "\${1:-}" == *seed-bun-from-image.mjs ]]; then
+    echo helper >> "$FIXTURE_HELPER_LOG"
+  fi
+  exec "$FIXTURE_REAL_NODE" "$@"
+fi`,
+  );
+  shell(
+    join(nodeBin, "npm"),
+    `if [[ "$*" == "-v" ]]; then
+  echo fixture-npm
+else
+  printf '%s\\n' "$*" >> "$FIXTURE_NPM_LOG"
+  [[ "$*" == "install -g bun@1.4.0" ]]
+  cp "$FIXTURE_FALLBACK" "$FIXTURE_NODE_BIN/bun"
+fi`,
+  );
+  shell(join(nodeBin, "pnpm"), "echo fixture-pnpm");
+  shell(join(nodeBin, "bun"), "echo stale-node-bun");
+  symlinkSync("bun", join(nodeBin, "bunx"));
+  shell(join(root, "fallback-bun"), "echo npm-fallback-bun");
+  const hashes = new Map<Variant, string>();
+  function archive(variant: Variant, version = "1.4.0", member = `bun-${variant}/bun`) {
+    const stage = join(root, `stage-${variant}`);
+    rmSync(stage, { recursive: true, force: true });
+    mkdirSync(join(stage, member, ".."), { recursive: true });
+    shell(
+      join(stage, member),
+      `echo ${variant} >> "$FIXTURE_BUN_LOG"
+if [[ "\${1:-}" == "--version" || "\${1:-}" == "-v" ]]; then
+  echo ${version}
+else
+  echo ${variant}
+fi`,
+    );
+    const path = join(image, `bun-v1.4.0-${variant}.zip`);
+    rmSync(path, { force: true });
+    execFileSync("zip", ["-q", path, member], { cwd: stage });
+    hashes.set(variant, createHash("sha256").update(readFileSync(path)).digest("hex"));
+    return path;
+  }
+  for (const variant of Object.keys(pins) as Variant[]) {
+    archive(variant);
+  }
+  const scriptPath = join(actionPath, "seed-bun-from-image.mjs");
+  function prepareHelper() {
+    if (!existsSync(helperPath)) {
+      return;
+    }
+    // Only the trusted fixture substitutes host facts and source-owned digest anchors.
+    let source = readFileSync(helperPath, "utf8")
+      .replaceAll("/opt/crabbox/toolchain-archives", image)
+      .replaceAll("/proc/cpuinfo", cpu)
+      .replaceAll("process.platform", JSON.stringify(options.platform ?? "linux"))
+      .replaceAll("process.arch", JSON.stringify(options.arch ?? "x64"))
+      .replaceAll(
+        "process.report.getReport().header.glibcVersionRuntime",
+        options.glibc === false ? "undefined" : '"2.39"',
+      );
+    for (const variant of Object.keys(pins) as Variant[]) {
+      const hash = hashes.get(variant);
+      if (!hash || !source.includes(pins[variant])) {
+        throw new Error(`Missing fixture digest anchor for ${variant}`);
+      }
+      source = source.replace(pins[variant], hash);
+    }
+    writeFileSync(scriptPath, source);
+  }
+  const env = {
+    HOME: root,
+    PATH: `${nodeBin}:/usr/bin:/bin`,
+    RUNNER_TEMP: runnerTemp,
+    GITHUB_ACTION_PATH: actionPath,
+    FIXTURE_REAL_NODE: process.execPath,
+    FIXTURE_NODE_BIN: nodeBin,
+    FIXTURE_NPM_LOG: npmLog,
+    FIXTURE_HELPER_LOG: helperLog,
+    FIXTURE_BUN_LOG: bunLog,
+    FIXTURE_FALLBACK: join(root, "fallback-bun"),
+  };
+  const log = (path: string) => (existsSync(path) ? readFileSync(path, "utf8").trim() : "");
+  function runAction(installBun = true) {
+    prepareHelper();
+    const additions: string[] = [];
+    const jobEnv: Record<string, string> = { ...env };
+    const runs = new Map<string, SpawnSyncReturns<string>>();
+    function step(name: string, body: string) {
+      const githubPath = join(root, "github-path");
+      const githubEnv = join(root, "github-env");
+      writeFileSync(githubPath, "");
+      writeFileSync(githubEnv, "");
+      const result = spawnSync(
+        "/bin/bash",
+        ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", body],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: {
+            ...jobEnv,
+            PATH: [...additions.toReversed(), env.PATH].join(":"),
+            GITHUB_PATH: githubPath,
+            GITHUB_ENV: githubEnv,
+          },
+        },
+      );
+      runs.set(name, result);
+      for (const line of readFileSync(githubPath, "utf8").split("\n").filter(Boolean)) {
+        const old = additions.indexOf(line);
+        if (old !== -1) {
+          additions.splice(old, 1);
+        }
+        additions.push(line);
+      }
+      for (const line of readFileSync(githubEnv, "utf8").split("\n").filter(Boolean)) {
+        const equals = line.indexOf("=");
+        jobEnv[line.slice(0, equals)] = line.slice(equals + 1);
+      }
+      return result;
+    }
+    for (const entry of action.runs.steps) {
+      if (!["Capture node path", "Setup Bun", "Runtime versions"].includes(entry.name)) {
+        continue;
+      }
+      if (entry.if) {
+        expect(entry.if).toBe("inputs.install-bun == 'true'");
+        if (!installBun) {
+          continue;
+        }
+      }
+      if (!entry.run) {
+        throw new Error(`Missing executable block for ${entry.name}`);
+      }
+      const result = step(
+        entry.name,
+        entry.name === "Setup Bun"
+          ? `${entry.run}\ncommand -v bun\ncommand -v bunx\nbun --fixture\nbunx --fixture`
+          : entry.run,
+      );
+      if (result.status !== 0) {
+        return { result, runs };
+      }
+    }
+    return {
+      result: step(
+        "next",
+        'command -v bun\ncommand -v bunx\nbun --fixture\nbunx --fixture\nprintf "%s\\n" "$NODE_BIN"',
+      ),
+      runs,
+    };
+  }
+  return {
+    root,
+    image,
+    runnerTemp,
+    nodeBin,
+    cpu,
+    npmLog,
+    helperLog,
+    bunLog,
+    log,
+    archive,
+    hashes,
+    runAction,
+    run() {
+      prepareHelper();
+      return spawnSync(process.execPath, [scriptPath], { encoding: "utf8", env });
+    },
+  };
+}
+
+describe("Bun image archive consumer", () => {
+  it("uses fresh private Bun before stale Node-bin Bun in the setup step and later shells", () => {
+    const f = fixture();
+    const { result, runs } = f.runAction();
+    expect(result.status, result.stderr).toBe(0);
+    expect(f.log(f.npmLog)).toBe("");
+    for (const output of [runs.get("Setup Bun")?.stdout, result.stdout]) {
+      expect(output).toContain(`${f.runnerTemp}/`);
+      expect(output).toContain("linux-x64-baseline\nlinux-x64-baseline");
+      expect(output).not.toContain("stale-node-bun");
+    }
+    expect(result.stdout).toContain(f.nodeBin);
+  });
+
+  it("creates independent private destinations and never reuses a modified extracted Bun", () => {
+    const f = fixture();
+    const bins: string[] = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = f.run();
+      expect(result.status, result.stderr).toBe(0);
+      const bin = result.stdout.trim();
+      bins.push(bin);
+      expect(statSync(join(bin, "..")).mode & 0o777).toBe(0o700);
+      expect(readdirSync(join(bin, ".."))).toEqual(["bin"]);
+      expect(readFileSync(join(bin, "bunx"))).toEqual(readFileSync(join(bin, "bun")));
+      writeFileSync(join(bin, "bun"), "modified extracted executable");
+    }
+    expect(bins[0]).not.toBe(bins[1]);
+    expect(f.log(f.bunLog).split("\n")).toEqual(["linux-x64-baseline", "linux-x64-baseline"]);
+    expect(readdirSync(f.runnerTemp)).toHaveLength(2);
+  });
+
+  it.each([
+    ["all flags", "processor\t: 0\nflags\t\t: sse4_2 avx avx2\n", true],
+    ["only AVX2", "processor : 0\nflags : avx2\n", false],
+    ["only AVX", "processor : 0\nflags : avx\n", false],
+    ["mixed CPUs", "processor : 0\nflags : avx avx2\n\nprocessor : 1\nflags : avx\n", false],
+    ["both CPUs", "processor : 0\nflags : avx avx2\n\nprocessor : 1\nflags : avx2 avx\n\n", true],
+    [
+      "later flags missing",
+      "processor : 0\nflags : avx avx2\n\nprocessor : 1\nmodel name : incomplete fixture\n",
+      false,
+    ],
+    [
+      "earlier flags missing",
+      "processor : 0\nmodel name : incomplete fixture\n\nprocessor : 1\nflags : avx avx2",
+      false,
+    ],
+    ["sole flags missing", "processor : 0\nmodel name : incomplete fixture\n", false],
+    ["unowned flags", "flags : avx avx2\n", false],
+    ["empty evidence", "", false],
+    ["unreadable evidence", undefined, false],
+  ] as const)("selects the safe archive with %s", (_name, cpuinfo, optimized) => {
+    const f = fixture();
+    if (cpuinfo === undefined) {
+      rmSync(f.cpu);
+    } else {
+      writeFileSync(f.cpu, cpuinfo);
+    }
+    const result = f.run();
+    expect(result.status, result.stderr).toBe(0);
+    expect(f.log(f.bunLog)).toBe(optimized ? "linux-x64" : "linux-x64-baseline");
+  });
+
+  it.each([
+    "tampered",
+    "wrong-variant",
+    "directory",
+    "symlink",
+    "malformed",
+    "layout",
+    "version",
+  ] as const)(
+    "fails setup on a present %s archive despite an old Bun, without npm fallback",
+    (kind) => {
+      const f = fixture();
+      const baseline: Variant = "linux-x64-baseline";
+      const archive = join(f.image, `bun-v1.4.0-${baseline}.zip`);
+      if (kind === "version") {
+        f.archive(baseline, "1.3.0");
+      } else if (kind === "layout") {
+        f.archive(baseline, "1.4.0", "unexpected/bun");
+      } else if (kind === "directory" || kind === "symlink") {
+        rmSync(archive);
+        if (kind === "directory") {
+          mkdirSync(archive);
+        } else {
+          symlinkSync(join(f.image, "bun-v1.4.0-linux-x64.zip"), archive);
+        }
+      } else {
+        writeFileSync(
+          archive,
+          kind === "wrong-variant"
+            ? readFileSync(join(f.image, "bun-v1.4.0-linux-x64.zip"))
+            : "not an original Bun archive",
+        );
+        if (kind === "malformed") {
+          f.hashes.set(baseline, createHash("sha256").update(readFileSync(archive)).digest("hex"));
+        }
+      }
+      const { result, runs } = f.runAction();
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Bun image cache:");
+      expect(f.log(f.npmLog)).toBe("");
+      expect(runs.has("Runtime versions")).toBe(false);
+      expect(readdirSync(f.runnerTemp)).toEqual([]);
+      expect(f.log(f.bunLog)).toBe(kind === "version" ? baseline : "");
+    },
+  );
+
+  it("uses the unchanged pinned npm fallback only when the matching archive is missing", () => {
+    const f = fixture();
+    rmSync(join(f.image, "bun-v1.4.0-linux-x64-baseline.zip"));
+    const { result } = f.runAction();
+    expect(result.status, result.stderr).toBe(0);
+    expect(f.log(f.npmLog)).toBe("install -g bun@1.4.0");
+    expect(result.stdout).toContain("npm-fallback-bun");
+    expect(readdirSync(f.runnerTemp)).toEqual([]);
+  });
+
+  it.each([{ platform: "darwin" }, { platform: "win32" }, { arch: "arm64" }, { glibc: false }])(
+    "preserves npm installation on unsupported $platform/$arch/$glibc routes",
+    (options) => {
+      const f = fixture(options);
+      writeFileSync(join(f.image, "bun-v1.4.0-linux-x64-baseline.zip"), "corrupt but ineligible");
+      const { result } = f.runAction();
+      expect(result.status, result.stderr).toBe(0);
+      expect(f.log(f.npmLog)).toBe("install -g bun@1.4.0");
+      expect(readdirSync(f.runnerTemp)).toEqual([]);
+      expect(f.log(f.bunLog)).toBe("");
+    },
+  );
+
+  it("skips both the helper and npm when disabled without requiring existing Bun to disappear", () => {
+    const f = fixture();
+    writeFileSync(join(f.image, "bun-v1.4.0-linux-x64-baseline.zip"), "corrupt but disabled");
+    const { result } = f.runAction(false);
+    expect(result.status, result.stderr).toBe(0);
+    expect(f.log(f.npmLog)).toBe("");
+    expect(f.log(f.helperLog)).toBe("");
+    expect(result.stdout).toContain("stale-node-bun");
+    expect(readdirSync(f.runnerTemp)).toEqual([]);
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1103,7 +1103,10 @@ describe("scripts/test-projects changed-target routing", () => {
     },
     {
       changedPath: ".github/actions/setup-node-env/action.yml",
-      exactTargets: ["test/scripts/install-trufflehog.test.ts"],
+      exactTargets: [
+        "test/scripts/install-trufflehog.test.ts",
+        "test/scripts/setup-node-env-bun.test.ts",
+      ],
     },
   ])("unions exact owners and references for $changedPath", ({ changedPath, exactTargets }) => {
     withTinyGitRepo(
@@ -1120,6 +1123,13 @@ describe("scripts/test-projects changed-target routing", () => {
         expect(targets).toContain("test/scripts/direct-workflow-reference.test.ts");
         expect(targets).toContain("test/scripts/ci-workflow-guards.test.ts");
       },
+    );
+  });
+
+  it("routes the Bun image consumer to its executable action regression", () => {
+    expectChangedTargets(
+      [".github/actions/setup-node-env/seed-bun-from-image.mjs"],
+      ["test/scripts/setup-node-env-bun.test.ts"],
     );
   });
 


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/2009
Related: https://github.com/openclaw/openclaw/pull/140680

## What Problem This Solves

Fixes an issue where CI jobs install Bun from npm even when the Linux runner image already contains the pinned original archives. A runner's existing Node-bin Bun can also take precedence over a freshly prepared private Bun.

## Why This Change Was Made

The setup action verifies a private copy of the original Bun 1.4.0 archive, extracts a fresh job-private executable, and publishes its path after capturing Node's path. Baseline x64 is the default; the optimized archive requires AVX and AVX2 evidence for every visible CPU.

Missing archives and unsupported platforms retain the pinned npm installation path. A present invalid archive fails setup without fallback. Disabling Bun installation still skips both paths. Planner production code and existing planner tests are unchanged.

## User Impact

Trusted Linux glibc x64 jobs can reuse authenticated image archives without another Bun installation download. This does not extend image reuse to ARM, musl, or the untrusted bootstrap.

## Evidence

- 30 distinct local tests passed: 26 executable Bun fixtures, two routing cases, and two existing planner coverage/growth cases. One routing case was initially filtered by its shortened test name and then executed separately; no passing test was rerun.
- Twelve changed-check stages passed, including formatting and script erasability. Targeted tooling/test lint, coercion checks, helper syntax, action ShellCheck/interpolation, and docs MDX validation passed.
- The changed-check gate then failed during setup at the declaration-isolation guard because the approved shared compiler installation resolves outside the worktree. The guard was not bypassed or retried; no dependencies were installed or relinked. Scripts and root-test typechecks were not executed locally.
- Exact-head CI https://github.com/openclaw/openclaw/actions/runs/34314262192 completed successfully on attempt 1. The successful `check-test-types` job's complete log records actual `tsgo:scripts` and `tsgo:test:root` compiler commands on the PR merge target `e86dcfb19d89793fa3b338be84fa4cd358f4a4cf`, combining head `ca5b219fdd26efaf33ce8816cb03f1d9a3087f38` with base `ec7464766fabd864d91e111871b62b68dcc38e99`; this is not a bare-head checkout. The native exact-head watch finished GREEN. One metadata TLS retry was retained; no CI rerun was requested.
- One fresh default P0 review of the exact seven-file candidate completed scoped-clean with no findings.

## Maintainer Review Disposition

The current exact-head review found no actionable correctness or security defect. Present-corruption rejection is the intentional, documented integrity/availability tradeoff; no fallback repair is added. Native Linux execution of this exact candidate and AMI qualification remain unproved: qualify before broad image rollout, rather than treating earlier component proof as this candidate's qualification. The generic database-migration checkbox does not apply: existing ZIP inputs and fresh private extraction introduce no user-state or schema migration.

Local results are macOS/Node 26 fixture and integration results, not a new native Bun proof. Earlier campaign/native baseline evidence is inherited context, not qualification of this candidate or a whole AMI. No benchmark or image-publication result is claimed.

<!-- Punchcard-Session: calm-lantern-orchard-dn -->
