### PR TITLE
fix(ui): distinguish child-batch completion from parent-turn completion in Swarm cards

### DIFF
--- a/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
@@ -72,6 +72,8 @@ suite.define(() => {
         // The collector summary owns completion even while child rows are stale.
         const completedParent = {
           ...parent,
+          status: "running",
+          hasActiveRun: true,
           updatedAt: 2,
           swarm: {
             groups: [
@@ -114,14 +116,44 @@ suite.define(() => {
         );
         await summary.focus();
         await page.keyboard.press("Enter");
-        await expect.poll(() => widget.locator(".chat-swarm__tasks").isVisible()).toBe(true);
-        expect(
-          await widget
-            .getByText("Child runs finished. Check the conversation for the final response.")
-            .isVisible(),
-        ).toBe(true);
+        await expect
+          .poll(() =>
+            widget
+              .getByText("Child runs finished. The parent is processing their results.")
+              .isVisible(),
+          )
+          .toBe(true);
         await page.screenshot({
           path: path.join(proofDir, "completed-details.png"),
+          animations: "disabled",
+        });
+
+        // When the parent turn also settles, the card directs to the final response.
+        const settledParent = {
+          ...completedParent,
+          status: "done",
+          hasActiveRun: false,
+          updatedAt: 3,
+        };
+        await gateway.setMethodResponse("sessions.describe", { session: settledParent });
+        await gateway.setMethodResponse(
+          "sessions.list",
+          chatSessionListResponse([settledParent, ...children]),
+        );
+        await gateway.emitGatewayEvent("sessions.changed", {
+          sessionKey,
+          agentId: "main",
+          reason: "swarm",
+        });
+        await expect
+          .poll(() =>
+            widget
+              .getByText("Child runs finished. Check the conversation for the final response.")
+              .isVisible(),
+          )
+          .toBe(true);
+        await page.screenshot({
+          path: path.join(proofDir, "settled-details.png"),
           animations: "disabled",
         });
         await page.keyboard.press("Space");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3216,6 +3216,7 @@ export const en: TranslationMap & {
       finished: "{done} completed · {failed} failed",
       completed: "{done} completed",
       childOutcome: "Child runs finished. Check the conversation for the final response.",
+      childOutcomeProcessing: "Child runs finished. The parent is processing their results.",
       details: "Child details",
       detailsUnavailable: "Child details are unavailable. Counts include all accepted workers.",
       otherGroups: "{count} more active groups",

--- a/ui/src/pages/chat/components/chat-swarm-progress.test.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.test.ts
@@ -275,6 +275,46 @@ describe("chat Swarm progress", () => {
     expect(container.textContent).toContain("Check the conversation for the final response");
   });
 
+  it("says the parent is processing while child runs are finished but the parent is still active", () => {
+    const completed = session({ key: "completed", status: "done", hasActiveRun: true });
+    const parentActive: (typeof completed)[] = [];
+    for (const row of withSummary([completed])) {
+      parentActive.push(
+        row.key === parentSessionKey
+          ? { ...row, status: "running" as const, hasActiveRun: true }
+          : row,
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions: parentActive }),
+      container,
+    );
+    expect(container.textContent).toContain("The parent is processing their results");
+    expect(container.textContent).not.toContain("Check the conversation for the final response");
+  });
+
+  it("directs to the final response when child runs are finished and the parent is not active", () => {
+    const completed = session({ key: "completed", status: "done", hasActiveRun: false });
+    const parentDone: (typeof completed)[] = [];
+    for (const row of withSummary([completed])) {
+      parentDone.push(
+        row.key === parentSessionKey
+          ? { ...row, status: "done" as const, hasActiveRun: false }
+          : row,
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions: parentDone }),
+      container,
+    );
+    expect(container.textContent).toContain("Check the conversation for the final response");
+    expect(container.textContent).not.toContain("The parent is processing their results");
+  });
+
   it("keeps tasks from every phase in the compact detail", () => {
     const container = renderProgress([
       session({ key: "unphased", label: "Older child", status: "running" }),

--- a/ui/src/pages/chat/components/chat-swarm-progress.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.ts
@@ -5,6 +5,7 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatDurationCompact } from "../../../lib/format.ts";
 import { resolveSessionDisplayName } from "../../../lib/session-display.ts";
+import { isSessionRunActive } from "../../../lib/session-run-state.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 
 type SwarmDotStatus = "queued" | "running" | "done" | "failed";
@@ -78,15 +79,17 @@ export function renderChatSwarmProgress({
   sessionKey: string;
   agentId?: string;
 }): TemplateResult | typeof nothing {
-  const summary = sessions.find(
+  const parentRow = sessions.find(
     (row) =>
       areUiSessionKeysEquivalent(row.key, sessionKey) &&
       ((sessionKey !== "global" && sessionKey !== "unknown") ||
         Boolean(agentId && row.agentId === agentId)),
-  )?.swarm;
+  );
+  const summary = parentRow?.swarm;
   if (!summary?.groups.length) {
     return nothing;
   }
+  const parentActive = parentRow ? isSessionRunActive(parentRow) : false;
   const details = collectSwarmTasks(sessions, summary.groups);
   return html` <aside
     class="chat-swarm"
@@ -149,14 +152,14 @@ export function renderChatSwarmProgress({
                       ${total > markers.length ? html`<span>+${total - markers.length}</span>` : nothing}
                     </div>
                     <div class="chat-swarm__counts">${counts}</div>
-                    ${terminal ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.childOutcome")}</div>` : nothing}
+                    ${terminal ? html`<div class="chat-swarm__outcome">${t(parentActive ? "labsPage.swarm.childOutcomeProcessing" : "labsPage.swarm.childOutcome")}</div>` : nothing}
                     <span class="chat-swarm__disclosure"
                       >${t("labsPage.swarm.details")} ${icons.chevronDown}</span
                     >
                   `
             }
           </summary>
-          ${successful ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.childOutcome")}</div>` : nothing}
+          ${successful ? html`<div class="chat-swarm__outcome">${t(parentActive ? "labsPage.swarm.childOutcomeProcessing" : "labsPage.swarm.childOutcome")}</div>` : nothing}
           <div class="chat-swarm__tasks" role="list">
             ${tasks.length === 0 ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.detailsUnavailable")}</div>` : nothing}
             ${tasks.map(


### PR DESCRIPTION
## What Problem This Solves

Swarm told users to check for a final response as soon as children finished, even while the parent was still processing.

## User Impact

Completed child work now shows truthful parent-processing guidance until the parent settles.

## Why This Change Was Made

When all collected child runs finish while the parent turn is still active, show that the parent is processing their results. Show the final-response reminder only after the parent settles. Both compact and expanded Swarm guidance use the canonical parent run-state helper; collector counts keep their existing owner.

Fixes #142189.

## Evidence

Exact-head hosted CI passed on `3ad1066` (run34319955522, attempt3). An unrelated terminal reconnect assertion failed once at its one-second deadline; both full local terminal suites passed (37 tests), then the unchanged hosted retry passed all5,597 UI tests. No test deadline or production code was changed.

- 51 renderer, run-state, and roster tests pass. Restoring the exact base renderer makes the active-parent regression fail.
- Six Chromium scenarios pass, covering desktop/mobile, many children, stale child rows, active-to-settled parent transitions, disclosure controls, and failure/reload/cross-agent behavior.
- Fresh P3 autoreview is scoped-clean. Full `check:changed --base origin/main` passed on `3ad1066f6bf72bc71ff4f9fbc98945bb6b927f9c`.
- Real isolated Gateway and Anthropic Sonnet 4.6: two collector children finish, the parent waits 25 seconds, then produces its final response. The observed parent status is `running` with two completed children, then `done`. The baseline and candidate use the same runtime, configuration, and provider; only the renderer is replaced with exact base `8d7e1e9` for the baseline. Source and served candidate bundle were restored and verified byte-for-byte afterward.

Production +8/-4 (net +4); tests +78/-6 (net +72). The small production addition expresses the independently owned parent lifecycle using the existing shared helper. No config, schema, protocol, or provider contract changes.

## Before / after proof

All three embedded assets were also verified rendering on this GitHub PR page at their original resolution.

Both frames show the same lifecycle phase: two completed children and an active parent. Captures were inspected and also attached in the originating task. Unrelated profile/model labels are masked.

| Before | After |
|---|---|
| ![Before: premature final-response reminder while parent is active](https://github.com/user-attachments/assets/020ac9d6-3822-443e-b202-022a0eaad1d6) | ![After: parent is processing completed child results](https://github.com/user-attachments/assets/0fc30f0a-be44-44ad-bee0-c46dc93d9174) |

![After: settled parent and actual final response](https://github.com/user-attachments/assets/17a0ed17-d989-406d-91c8-2badbdc75e45)

The refreshed September 15 ClawSweeper revision 15 (18:05 UTC) rates readiness/patch Platinum Hermit and proof Diamond Lobster, with no findings or before-merge actions. Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34319955522) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/34319955732) passed before native landing as `0765ee29203324c161a7a785cb8af962739767c8`.

## Separate follow-up observed

Collector children can emit an extra “no message came through—just internal runtime context” completion notice after returning a successful structured result. This was observed during the real run and remains a separate collector-notice issue; it does not change the completed child facts or the parent-state guidance repaired here.
