### PR TITLE
refactor(gateway): render HTTP conversation history directly

### DIFF
--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -1,7 +1,7 @@
 // Gateway agent prompt builder.
 // Converts conversation entries into the latest-message-plus-history prompt.
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
-import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
+import { buildHistoryContext, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 
 export type ConversationEntry = {
@@ -22,28 +22,15 @@ export function renderConversationToolCall(call: ConversationToolCall): string {
 // for the active user turn. Keep it shared so the two endpoints stay in sync.
 export const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 
-/**
- * Coerce body to string. Handles cases where body is a content array
- * (e.g. [{type:"text", text:"hello"}]) that would serialize as
- * [object Object] if used directly in a template literal.
- */
-function safeBody(body: unknown): string {
-  return typeof body === "string" ? body : (extractTextFromChatContent(body) ?? "");
-}
-
-function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
-  const body = safeBody(entry.entry.body);
-  if (
-    entry.role === "assistant" &&
+/** Normalize content-array bodies and omit provenance-marked stream-error placeholders. */
+function toPromptBody(entry: ConversationEntry): string | null {
+  const raw = entry.entry.body;
+  const body = typeof raw === "string" ? raw : (extractTextFromChatContent(raw) ?? "");
+  return entry.role === "assistant" &&
     entry.internalStreamError === true &&
     body.trim() === STREAM_ERROR_FALLBACK_TEXT
-  ) {
-    return null;
-  }
-  return {
-    ...entry.entry,
-    body,
-  };
+    ? null
+    : body;
 }
 
 /** Build the prompt text sent to an agent from ordered conversation entries. */
@@ -72,27 +59,26 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
     return "";
   }
 
-  const historyEntries: HistoryEntry[] = [];
-  entries.slice(0, currentIndex).forEach((entry) => {
-    const promptEntry = toPromptEntry(entry);
-    if (promptEntry) {
-      historyEntries.push(promptEntry);
+  const historyLines: string[] = [];
+  // Both HTTP adapters construct dense entries before selecting the current turn.
+  for (let index = 0; index < currentIndex; index += 1) {
+    const entry = entries[index]!;
+    const body = toPromptBody(entry);
+    if (body !== null) {
+      historyLines.push(`${entry.entry.sender}: ${body}`);
     }
-  });
-  const currentPromptEntry = toPromptEntry(currentConversationEntry);
-  if (!currentPromptEntry) {
+  }
+  const currentBody = toPromptBody(currentConversationEntry);
+  if (currentBody === null) {
     return "";
   }
   // A completed tool call still needs its identity when its output is empty.
-  if (historyEntries.length === 0 && currentConversationEntry.role !== "tool") {
-    return currentPromptEntry.body;
+  if (historyLines.length === 0 && currentConversationEntry.role !== "tool") {
+    return currentBody;
   }
 
-  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${entry.body}`;
-  return buildHistoryContextFromEntries({
-    entries: historyEntries,
-    currentMessage: formatEntry(currentPromptEntry),
-    formatEntry,
-    excludeLast: false,
+  return buildHistoryContext({
+    historyText: historyLines.join("\n"),
+    currentMessage: `${currentEntry.sender}: ${currentBody}`,
   });
 }


### PR DESCRIPTION
Related: #142309

Merged into `main` as [b795af8a](https://github.com/openclaw/openclaw/commit/b795af8a992e75dafb0feb431a7097363428d1eb) on 2026-09-09. The merged `src/gateway/agent-prompt.ts` was verified against the reviewed candidate source.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Clients replaying conversation history through `/v1/chat/completions` or `/v1/responses` rebuild an agent prompt for each request. This maintainer-requested cleanup targets avoidable work in that request-local component while preserving the conversation sent to the agent.

## Why This Change Was Made

Render normalized history text directly through the existing framing helper, removing the history slice, temporary entry clones, and later formatting pass: **14 fewer production lines, with no test changes**. The original reverse current-turn search, body coercion, empty tool-result identity, provenance-based error filtering, and framing remain unchanged under both HTTP adapters' owned dense/plain-entry contract.

## User Impact

No intended user-visible behavior change: prompt bytes, history order, current-turn selection, and attachment-only placeholders are preserved. Seven of eight paired warm medians decreased, but meaningful order-dependent regressions remain; these observations do not establish a whole-Gateway latency improvement or memory savings.

## Evidence

- Both existing whole files passed on baseline and candidate: `src/gateway/agent-prompt.test.ts` and `src/gateway/openresponses-parity.test.ts` (**23 tests before, 23 after**). Fixed suite wall times were 2.174 seconds before and 3.023 seconds after; these are test-run timings, not production performance evidence.
- Seven fresh individual guards passed: changelog attribution, both extension wildcard checks, dependency pins, plugin compatibility boundary report, media-download helpers, and runtime-sidecar loaders. The compatibility report ran on the base containing #142708; no historical calendar failure or date override was carried forward.
- Fresh independent Codex P2 review returned `scoped-clean`, no findings, confidence **0.98**.
- **All 21 ordinary-CI obligations have successful exact-head coverage for `0b955ef51cd12582d4d8bbfa07e26d37764a3ea6`.** [CI run 34315737210](https://github.com/openclaw/openclaw/actions/runs/34315737210) completed successfully. An independent audit verified the selected owner jobs on GitHub merge snapshot `7dc5439787649246ea8138963d2cae84a8a44e89` (base `1ab71b84dc2996685c3e20aadc469ffbd4231483`, containing that PR head). Combined with the seven separately executed candidate guard passes above, all 28 planned obligations have passing coverage; the seven supplements are not represented as executions inside CI.

The fixed macOS arm64 / Node v26.8.1 experiment called the real exported Responses prompt builder **176 times** in B0/C0/C1/B1 order: four cases, one initial call, two warmups, and eight warm calls per case and process. Every complete result and original/after-call input matched independent literal fixtures; own-undefined metadata and the active-message reference check were retained. An independent saved-data audit reproduced all full-value checks and arithmetic without additional product execution. The measurement source was frozen at baseline `894b8032de5103b7c4fe131c93d27fecfdef0f7e` plus this one-file candidate; it was not retimed on moving main.

Exact warm medians below are **nanoseconds**, with eight samples per variant/order. Forward compares B0→C0; reverse compares B1→C1, although the latter candidate ran before its baseline.

| Case | Forward baseline → candidate | Change | Reverse baseline → candidate | Change |
|---|---:|---:|---:|---:|
| Single user | 3583.0 → 2958.5 | −17.43% | 3229.5 → 3020.5 | −6.47% |
| 20 history messages | 6833.0 → 4479.0 | −34.45% | 6771.0 → 4750.0 | −29.85% |
| 200 history messages | 36583.0 → 25520.5 | −30.24% | 21708.5 → 29208.5 | **+34.55%** |
| 40 tool-call/result pairs | 17271.5 → 10187.5 | −41.02% | 11625.0 → 10166.5 | −12.55% |

Seven of eight medians decreased, but the reverse 200-message case also regressed **+27.15% in warm wall mean and +66.18% in maximum**. Its warm CPU mean rose **107.83%**, with a maximum of **50→274 µs (+448%)**. The forward single-user CPU mean rose **107.55%**, with a maximum of **16→78 µs (+387.50%)**, despite a tied CPU median and improved wall median. All observations are retained, including nine adverse wall and fourteen adverse total-CPU comparisons among the 88 ordinal initial/warmup/warm pairs. Eight warm samples are descriptive, not a tail-latency or statistical-significance estimate; process-wide CPU intervals also include timer/sampling overhead and can reflect GC or background work.

Native kernel peak RSS increased **109,101,056→110,215,168 bytes (+1.02%)** forward and **108,658,688→110,280,704 bytes (+1.49%)** reverse. Sampled tree RSS was only approximately 0.6–0.7 MB while kernel peaks exceeded 108 MB, showing that these short-child samples missed the representative footprint. Those sampled decreases are not memory-improvement evidence. No allocation or memory-saving claim is made.

Artifact qualification: an unused preparation `SCHEDULE.json` retained stale **600-second** child-limit metadata. The admitted `SPEC.json` and all four actual admissions enforced **55 seconds per child**, with a 360-second aggregate limit and 16 GiB RSS cap; no 600-second bound was used. Original artifacts, all nine complete tool-call envelopes including source-placement stdin bodies, every return/input, and all initial/warmup/warm/resource observations were preserved. This is a prompt-building component measurement, not an HTTP request, provider turn, or full Gateway benchmark.
