### PR TITLE
fix(workspace): treat Windows EPERM as an existing bootstrap target (#135230)

### DIFF
--- a/src/agents/workspace-bootstrap-publish.test.ts
+++ b/src/agents/workspace-bootstrap-publish.test.ts
@@ -163,6 +163,55 @@ describe("bootstrap publication atomicity", () => {
     expect(await listTempSiblings(tempDir)).toEqual([]);
   });
 
+  it.each(["EPERM", "EACCES"])(
+    "treats a Windows %s from the exclusive publish as an existing winner",
+    async (code) => {
+      // Windows NTFS can report EPERM/EACCES instead of EEXIST when the
+      // exclusive link collides with a target that already exists (pending
+      // delete, AV hold, or a workspace behind a directory junction). The
+      // writer must confirm the target exists and accept the collision
+      // instead of failing the workspace turn.
+      const tempDir = await makeTempWorkspace("openclaw-workspace-");
+      const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const linkSpy = vi.spyOn(syncFs, "linkSync").mockImplementation((_source, target) => {
+        // A concurrent writer won the target; Windows reports a
+        // permission-shaped error for the loser instead of EEXIST.
+        syncFs.writeFileSync(target, "CONCURRENT-WINNER\n");
+        throw Object.assign(new Error(`${code}: operation not permitted, link`), { code });
+      });
+
+      try {
+        await expect(workspace.publishBootstrapFile(agentsPath, "OURS\n")).resolves.toBe(false);
+        expect(await fs.readFile(agentsPath, "utf8")).toBe("CONCURRENT-WINNER\n");
+        expect(await listTempSiblings(tempDir)).toEqual([]);
+      } finally {
+        linkSpy.mockRestore();
+        platformSpy.mockRestore();
+      }
+    },
+  );
+
+  it("keeps a Windows EPERM failure when the bootstrap target is still absent", async () => {
+    // The Windows collision acceptance must not swallow a genuine permission
+    // failure: without an existing target the error still propagates.
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const linkSpy = vi.spyOn(syncFs, "linkSync").mockImplementation(() => {
+      throw Object.assign(new Error("EPERM: operation not permitted, link"), { code: "EPERM" });
+    });
+
+    try {
+      await expect(workspace.publishBootstrapFile(agentsPath, "OURS\n")).rejects.toThrow();
+      await expectPathMissing(agentsPath);
+      expect(await listTempSiblings(tempDir)).toEqual([]);
+    } finally {
+      linkSpy.mockRestore();
+      platformSpy.mockRestore();
+    }
+  });
+
   it("keeps a safe reader on the complete single-link file", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -298,6 +298,28 @@ export function isExpectedAbsentBootstrapFile(name: string): boolean {
   return OPTIONAL_BOOTSTRAP_FILENAMES.has(name) || name === DEFAULT_MEMORY_FILENAME;
 }
 
+/**
+ * Windows NTFS can report a permission-shaped error (EPERM/EACCES) instead of
+ * EEXIST when an exclusive create or hard link collides with a target that
+ * already exists (pending delete, antivirus hold, directory junction). Accept
+ * that mapping only after a post-error check confirms the bootstrap target
+ * exists; a genuine access or path failure still propagates.
+ */
+function isWindowsExistingTargetCollision(error: unknown, targetPath: string): boolean {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  if (!hasErrnoCode(error, "EPERM") && !hasErrnoCode(error, "EACCES")) {
+    return false;
+  }
+  try {
+    syncFs.lstatSync(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function publishBootstrapFile(
   filePath: string,
   content: string | Buffer,
@@ -339,7 +361,10 @@ export async function publishBootstrapFile(
       syncFs.unlinkSync(staging.path);
       outcome = { kind: "created" };
     } catch (error) {
-      if (!linked && hasErrnoCode(error, "EEXIST")) {
+      if (
+        !linked &&
+        (hasErrnoCode(error, "EEXIST") || isWindowsExistingTargetCollision(error, targetPath))
+      ) {
         outcome = { kind: "exists" };
       } else if (!linked && isHardlinkFallbackError(error)) {
         outcome = {


### PR DESCRIPTION
## What Problem This Solves

On Windows NTFS, an exclusive bootstrap publish can fail with `EPERM`/`EACCES` instead of `EEXIST` when the target name already exists (delete-pending, antivirus hold, workspace behind a directory junction). `publishBootstrapFile` only accepted `EEXIST` before falling through to the hard-link fallback classification — and `EPERM` is in that fallback set — so the failure surfaced as the misleading `Workspace filesystem does not support atomic bootstrap publication...` (or a raw `EACCES`), aborting `ensureAgentWorkspace` and blocking the chat turn (#135230).

The fix accepts a Windows-only permission-shaped publish failure **only after a post-error check establishes that the bootstrap target already exists**, preserving true permission and path failures:

- `isWindowsExistingTargetCollision(error, targetPath)` is gated on `process.platform === "win32"`, accepts only `EPERM`/`EACCES`, and requires `syncFs.lstatSync(targetPath)` to succeed (same existence notion as the pre-write `lstat`).
- It is checked before `isHardlinkFallbackError`, because `EPERM` is in that fallback set and would otherwise keep masking the collision as a hard-link failure.
- Non-Windows behavior is unchanged; a genuine permission or path failure with no existing target still throws.

> The mechanism in the opening paragraph is the reported one. The **real-Windows errno matrix under Evidence** shows which shapes actually reproduce on NTFS today and flags the open question about this branch; read the two together.

## Evidence

Environment: Windows 11 (10.0.26200, NTFS on every volume), **Node v26.4.0 (libuv 1.52.1)** — a supported runtime per `engines` (`>=24.16.0 <25 || >=26.1.0`), head `bfb112d49c01`. All output below is real terminal output on a real NTFS volume; the only redaction is the temp-directory prefix (`<TEMP>`).

Command (region shard config, single worker, no file parallelism):

```
node node_modules/vitest/vitest.mjs run src/agents/workspace-bootstrap-publish.test.ts --config test/vitest/vitest.agents-core.config.ts --maxWorkers=1 --no-file-parallelism
```

### RED — parent commit `7069a4772ff` (`git checkout HEAD~1 -- src/agents/workspace.ts`)

```
 Test Files  2 failed (2)
      Tests  3 failed | 11 passed | 3 skipped (17)
FAIL  ... > treats a Windows EPERM from the exclusive publish as an existing winner
FAIL  ... > treats a Windows EACCES from the exclusive publish as an existing winner
FAIL  ... > permission-shaped link failure while the bootstrap target exists
AssertionError: expected 'threw: Workspace filesystem does not …' to be 'resolved'
Received: "threw: Workspace filesystem does not support atomic bootstrap publication. Use a workspace on a filesystem with hard-link support."
Caused by: Error: EPERM: operation not permitted, link      (serialized code: EPERM)
Caused by: Error: EACCES: operation not permitted, link     (serialized code: EACCES)
```

(`src/agents/workspace-bootstrap-publish.test.ts` alone before the fix: `2 failed | 8 passed | 3 skipped (13)`.)

### GREEN — head `bfb112d49c01`

```
 Test Files  2 passed (2)
      Tests  14 passed | 3 skipped (17)
```

(`src/agents/workspace-bootstrap-publish.test.ts` alone after the fix: `10 passed | 3 skipped (13)`. The 3 skipped cases are the pre-existing read-only/symlink scenarios, unchanged.)

### Real-filesystem behavior proof (no module mocks)

The reviewer's P1 item is that the hard-link mapping was only supported by mocked `link` errors. The harness below therefore runs the **real `publishBootstrapFile` import** against a real NTFS workspace, with a real second writer claiming the name inside the publish window (through the real `beforePersistentApply` hook + real `fs.writeFileSync`). Nothing intercepts `fs`; every errno is produced by the OS.

Post-fix run:

```
[evidence] RACE :: hookCalls=3 returned=false targetContent="CONCURRENT-WINNER\n" nativeLinkErrno=EEXIST errno=-4075 syscall=link stagingLeftovers=[]
[evidence] PERMISSION :: nameCollisionErrno=EEXIST errno=-4075 syscall=link permissionErrno=EPERM errno=-4048 syscall=link outcome=resolved returned=false targetContent="CONCURRENT-WINNER\n" stagingLeftovers=[]
[evidence] NEGATIVE-CONTROL :: permissionErrno=EPERM errno=-4048 syscall=link threw=Workspace filesystem does not support atomic bootstrap publication. Use a workspace on a filesystem with hard-link support. targetExists=false stagingLeftovers=[]
[evidence] HIDDEN-TARGET :: lstat=exists writeOpenErrno=EPERM errno=-4048 syscall=open exclusiveCreateErrno=EEXIST errno=-4075 syscall=open
 ✓ race: real concurrent winner during the real publish window
 ✓ permission-shaped link failure while the bootstrap target exists
 ✓ negative control: same real permission failure with no target still propagates
 ✓ exclusive-create collision on a real hidden existing target (retired path form)
```

What each scenario is, and what it shows:

- **RACE** — the target name really is absent at the initial `lstat` and really exists when the publish links; the OS reports `EEXIST errno=-4075 syscall=link` for that pair. Pre-fix and post-fix both return `false` and keep the winner bytes, i.e. the plain name collision was already handled by the pre-existing `EEXIST` branch (`stagingLeftovers=[]`, no partial file).
- **PERMISSION** — same real race, plus a real OS state change that makes the staging entry un-linkable, so the real link call fails with a **permission-shaped errno while the bootstrap target really exists** (`EPERM errno=-4048 syscall=link`). Pre-fix: rejected with the misleading `Workspace filesystem does not support atomic bootstrap publication…` (EPERM is a member of `HARDLINK_FALLBACK_CODES`). Post-fix: resolves `false`, winner bytes preserved, staging cleaned up.
- **NEGATIVE-CONTROL** — the identical real `EPERM` with **no** existing target still throws. The `lstat` gate does not swallow genuine access failures.
- **HIDDEN-TARGET** — the retired exclusive-create form from #135230, reproduced natively: a real *hidden* existing `AGENTS.md` opened with `'w'` reports `EPERM errno=-4048 syscall=open` (byte-identical to the issue's `EPERM: operation not permitted, open …AGENTS.md`) even though `lstat` resolves it, while the exclusive `'wx'` open reports `EEXIST`.

### Native Windows errno matrix (real syscalls, redacted)

```
# native errno matrix -- Windows 10.0.26200, node 26.4.0, libuv 1.52.1
# both volumes NTFS: C: yes D: yes
EEXIST errno=-4075 | target = existing regular file            [link]
EEXIST errno=-4075 | target = existing directory               [link]
EEXIST errno=-4075 | target = existing non-empty directory     [link]
EEXIST errno=-4075 | target = existing directory junction      [link]
EEXIST errno=-4075 | target = existing file symlink            [link]
EEXIST errno=-4075 | target = existing hidden file (attrib +H) [link]
EEXIST errno=-4075 | target = existing hidden dir  (attrib +H) [link]
EEXIST errno=-4075 | target = existing, held with FileShare.Read (AV-style hold) [link]
EEXIST errno=-4075 | target = case-insensitive variant of existing name [link]
EEXIST errno=-4075 | target name = the source itself           [link]
EEXIST errno=-4075 | target behind junction on another volume  [link]
OK         | target = delete-pending (unlinked while open) [link]
EPERM errno=-4048  | target = existing hidden file, write-open 'w'  [open]
EEXIST errno=-4075 | target = existing hidden file, exclusive 'wx'  [open]
EEXIST errno=-4075 | target = existing plain file,  exclusive 'wx'  [open]
EPERM errno=-4048  | SOURCE is a directory, target existing    [link]
EPERM errno=-4048  | SOURCE is a directory, target absent      [link]
ENOENT errno=-4058 | SOURCE missing, target existing           [link]
EEXIST errno=-4075 | SOURCE hidden, target existing            [link]
# lstat on the hidden existing target still resolves: yes
```

### How this differs from the existing-file failure already avoided by v2026.9.3

- The failure v2026.9.3 already avoids is the **exclusive-create collision**: an existing target opened for creation/writing. On real Windows an existing *hidden* target reports `EPERM … syscall=open` (row `write-open 'w'`), while a plain existing target reports `EEXIST` (rows `exclusive 'wx'`). This is the errno and syscall in #135230 and it is gone on current main.
- The mapping added here covers the **hard-link** call, a different syscall (`link`, not `open`). On this OS `fs.linkSync` is `CreateHardLinkW(target, source)` followed by `GetLastError()`, and every target-name collision I could build on NTFS reports `EEXIST`, never `EPERM`/`EACCES`. The only real native `EPERM` from `fs.linkSync` on this runtime comes from a non-linkable *source* (rows `SOURCE is a directory`), independent of whether the target exists.

### Remaining risk (honest scope)

- The claim "NTFS reports `EPERM`/`EACCES` instead of `EEXIST` when the hard-link target already exists" **did not reproduce on this machine** in any of the 11 collision shapes above, all of which report `EEXIST` — and `EEXIST` was already handled before this patch (see RACE). So the accepted mapping is a defensive superset, not the fix for the plain collision race. Maintainer call: keep it as defense-in-depth, or drop the branch and rely on the existing `EEXIST` path.
- What **is** proven above on real Windows, with no mocks: a real permission-shaped `link` failure (`EPERM errno=-4048`) alongside a real existing target now resolves to "existing winner" and preserves the file, while the same failure with no existing target still throws (PERMISSION vs NEGATIVE-CONTROL).
- Not exercised here: deny-ACL directories (the elevated token bypasses deny ACEs: `writeFileSync` into a `DENY(W,D)` directory still succeeds), and non-NTFS volumes (only NTFS `C:`/`D:` exist on this machine, so a FAT/exFAT workspace could not be tested).

Closes #135230
