### PR TITLE
improve(packaging): streamline package import scanning

### DIFF
--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -30,8 +30,7 @@ function resolveDistImportPath(importerPath, specifier) {
   return path.posix.normalize(path.posix.join(path.posix.dirname(importerPath), stripped));
 }
 
-function collectImportSpecifiers(source, importerPath) {
-  const specifiers = [];
+function appendImportEdges(source, importerPath, imports) {
   const sourceFile = ts.createSourceFile(
     importerPath,
     source,
@@ -44,17 +43,18 @@ function collectImportSpecifiers(source, importerPath) {
     sourceFile,
     ({ kind, specifier }) => {
       if (
-        specifier.startsWith(".") &&
-        (kind !== "import-meta-url" ||
-          (hasJavaScriptFileExtension(specifier) &&
-            resolveDistImportPath(importerPath, specifier)?.startsWith("dist/")))
+        !specifier.startsWith(".") ||
+        (kind === "import-meta-url" && !hasJavaScriptFileExtension(specifier))
       ) {
-        specifiers.push(specifier);
+        return;
+      }
+      const importedPath = resolveDistImportPath(importerPath, specifier);
+      if (importedPath && (kind !== "import-meta-url" || importedPath.startsWith("dist/"))) {
+        imports.push({ importerPath, importedPath });
       }
     },
     { includeCommonJs: true, includeImportMetaUrl: true },
   );
-  return specifiers;
 }
 
 /** Collect missing-file errors for relative imports inside package dist files. */
@@ -75,21 +75,20 @@ export function collectPackageDistImportErrors(params) {
 
 /** Collect relative dist import edges from package JavaScript files. */
 export function collectPackageDistImports(params) {
-  const files = [...new Set(params.files.map(normalizePackagePath))];
+  const files =
+    params.files.length === 1
+      ? [normalizePackagePath(params.files[0])]
+      : [...new Set(params.files.map(normalizePackagePath))].toSorted((left, right) =>
+          left.localeCompare(right),
+        );
   const imports = [];
 
-  for (const importerPath of files.toSorted((left, right) => left.localeCompare(right))) {
+  for (const importerPath of files) {
     if (!JS_DIST_FILE_RE.test(importerPath) || importerPath.includes("/node_modules/")) {
       continue;
     }
     const source = params.readText(importerPath);
-    for (const specifier of collectImportSpecifiers(source, importerPath)) {
-      const importedPath = resolveDistImportPath(importerPath, specifier);
-      if (!importedPath) {
-        continue;
-      }
-      imports.push({ importerPath, importedPath });
-    }
+    appendImportEdges(source, importerPath, imports);
   }
 
   return imports;

--- a/test/scripts/check-package-dist-imports.test.ts
+++ b/test/scripts/check-package-dist-imports.test.ts
@@ -1,7 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  collectPackageDistImportErrors,
+  collectPackageDistImports,
+} from "../../scripts/lib/package-dist-imports.mjs";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const CHECK_SCRIPT = "scripts/check-package-dist-imports.mjs";
@@ -9,6 +13,133 @@ const tempDirs: string[] = [];
 
 afterEach(() => {
   cleanupTempDirs(tempDirs);
+});
+
+describe("collectPackageDistImports", () => {
+  it("preserves ordered duplicate edges and the narrower import.meta.url filter", () => {
+    const imports = collectPackageDistImports({
+      files: ["dist/index.js"],
+      readText: () =>
+        [
+          'import "./chunk.js?first";',
+          'export * from "./chunk.js#second";',
+          'import("./data.json");',
+          'require("../outside.cjs");',
+          'new URL("./chunk.js?third", import.meta.url);',
+          'new URL("./asset.png", import.meta.url);',
+          'new URL("../outside.cjs", import.meta.url);',
+          'require("./chunk.js");',
+          'import "node:fs";',
+          'import "/absolute.js";',
+        ].join("\n"),
+    });
+
+    expect(imports).toEqual(
+      [
+        "dist/chunk.js",
+        "dist/chunk.js",
+        "dist/data.json",
+        "outside.cjs",
+        "dist/chunk.js",
+        "dist/chunk.js",
+      ].map((importedPath) => ({ importerPath: "dist/index.js", importedPath })),
+    );
+    expect(
+      collectPackageDistImportErrors({
+        files: ["dist/index.js"],
+        imports,
+        readText: () => {
+          throw new Error("provided edges must not reread the source");
+        },
+      }),
+    ).toEqual(imports.map(({ importedPath }) => `dist/index.js imports missing ${importedPath}`));
+  });
+
+  it("normalizes a single file and reuses its only source buffer", () => {
+    const readText = vi.fn((relativePath: string): string => {
+      expect(relativePath).toBe("dist/index.mjs");
+      if (readText.mock.calls.length > 1) {
+        throw new Error("source buffer must be read only once");
+      }
+      return 'import "./chunk.mjs";';
+    });
+    const imports = collectPackageDistImports({
+      files: ["package\\dist\\index.mjs"],
+      readText,
+    });
+
+    expect(readText).toHaveBeenCalledTimes(1);
+    expect(imports).toEqual([{ importerPath: "dist/index.mjs", importedPath: "dist/chunk.mjs" }]);
+  });
+
+  it.each([
+    { files: [] },
+    { files: ["README.md"] },
+    { files: ["package/dist/node_modules/dependency/index.js"] },
+  ])("does not read skipped input $files", ({ files }) => {
+    const readText = vi.fn(() => {
+      throw new Error("skipped files must not be read");
+    });
+    expect(collectPackageDistImports({ files, readText })).toEqual([]);
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  it("normalizes, deduplicates and orders multiple files without reordering their edges", () => {
+    const readText = vi.fn(() => 'require("./second.cjs"); import("./first.js");');
+    const imports = collectPackageDistImports({
+      files: [
+        "dist/z.cjs",
+        "package\\dist\\a.js",
+        "dist/a.js",
+        "package/dist/z.cjs",
+        "dist/node_modules/dependency/index.js",
+        "README.md",
+      ],
+      readText,
+    });
+
+    expect(readText.mock.calls).toEqual([["dist/a.js"], ["dist/z.cjs"]]);
+    expect(imports).toEqual(
+      ["dist/a.js", "dist/z.cjs"].flatMap((importerPath) =>
+        ["dist/second.cjs", "dist/first.js"].map((importedPath) => ({
+          importerPath,
+          importedPath,
+        })),
+      ),
+    );
+  });
+
+  it.each([
+    {
+      name: "nested import",
+      source: 'function f() { import "./a.mjs"; }',
+      paths: ["dist/a.mjs"],
+    },
+    {
+      name: "TypeScript import equals",
+      source: 'import x = require("./a.cjs");',
+      paths: ["dist/a.cjs"],
+    },
+    {
+      name: "syntax error between imports",
+      source: 'import "./before.mjs"; const = ; import "./after.mjs";',
+      paths: ["dist/before.mjs", "dist/after.mjs"],
+    },
+    {
+      name: "unterminated string after require",
+      source: 'require("./before.cjs"); const s = "unterminated',
+      paths: ["dist/before.cjs"],
+    },
+    {
+      name: "syntax error before require",
+      source: 'const = ; require("./after.cjs");',
+      paths: ["dist/after.cjs"],
+    },
+  ])("preserves TypeScript recovery for $name", ({ source, paths }) => {
+    expect(collectPackageDistImports({ files: ["dist/index.js"], readText: () => source })).toEqual(
+      paths.map((importedPath) => ({ importerPath: "dist/index.js", importedPath })),
+    );
+  });
 });
 
 describe("check-package-dist-imports", () => {

--- a/test/scripts/check-package-dist-imports.test.ts
+++ b/test/scripts/check-package-dist-imports.test.ts
@@ -1,11 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  collectPackageDistImportErrors,
-  collectPackageDistImports,
-} from "../../scripts/lib/package-dist-imports.mjs";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectPackageDistImports } from "../../scripts/lib/package-dist-imports.mjs";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const CHECK_SCRIPT = "scripts/check-package-dist-imports.mjs";
@@ -16,128 +13,23 @@ afterEach(() => {
 });
 
 describe("collectPackageDistImports", () => {
-  it("preserves ordered duplicate edges and the narrower import.meta.url filter", () => {
-    const imports = collectPackageDistImports({
-      files: ["dist/index.js"],
-      readText: () =>
-        [
-          'import "./chunk.js?first";',
-          'export * from "./chunk.js#second";',
-          'import("./data.json");',
-          'require("../outside.cjs");',
-          'new URL("./chunk.js?third", import.meta.url);',
-          'new URL("./asset.png", import.meta.url);',
-          'new URL("../outside.cjs", import.meta.url);',
-          'require("./chunk.js");',
-          'import "node:fs";',
-          'import "/absolute.js";',
-        ].join("\n"),
-    });
-
-    expect(imports).toEqual(
-      [
-        "dist/chunk.js",
-        "dist/chunk.js",
-        "dist/data.json",
-        "outside.cjs",
-        "dist/chunk.js",
-        "dist/chunk.js",
-      ].map((importedPath) => ({ importerPath: "dist/index.js", importedPath })),
-    );
-    expect(
-      collectPackageDistImportErrors({
-        files: ["dist/index.js"],
-        imports,
-        readText: () => {
-          throw new Error("provided edges must not reread the source");
-        },
-      }),
-    ).toEqual(imports.map(({ importedPath }) => `dist/index.js imports missing ${importedPath}`));
-  });
-
-  it("normalizes a single file and reuses its only source buffer", () => {
-    const readText = vi.fn((relativePath: string): string => {
-      expect(relativePath).toBe("dist/index.mjs");
-      if (readText.mock.calls.length > 1) {
-        throw new Error("source buffer must be read only once");
-      }
-      return 'import "./chunk.mjs";';
-    });
+  it("limits URL dependencies without filtering ordinary relative imports", () => {
     const imports = collectPackageDistImports({
       files: ["package\\dist\\index.mjs"],
-      readText,
+      readText: () =>
+        [
+          'import("./data.json");',
+          'require("../outside.cjs");',
+          'new URL("./worker.mjs?rev=1", import.meta.url);',
+          'new URL("./asset.png", import.meta.url);',
+          'new URL("../outside.cjs", import.meta.url);',
+        ].join("\n"),
     });
-
-    expect(readText).toHaveBeenCalledTimes(1);
-    expect(imports).toEqual([{ importerPath: "dist/index.mjs", importedPath: "dist/chunk.mjs" }]);
-  });
-
-  it.each([
-    { files: [] },
-    { files: ["README.md"] },
-    { files: ["package/dist/node_modules/dependency/index.js"] },
-  ])("does not read skipped input $files", ({ files }) => {
-    const readText = vi.fn(() => {
-      throw new Error("skipped files must not be read");
-    });
-    expect(collectPackageDistImports({ files, readText })).toEqual([]);
-    expect(readText).not.toHaveBeenCalled();
-  });
-
-  it("normalizes, deduplicates and orders multiple files without reordering their edges", () => {
-    const readText = vi.fn(() => 'require("./second.cjs"); import("./first.js");');
-    const imports = collectPackageDistImports({
-      files: [
-        "dist/z.cjs",
-        "package\\dist\\a.js",
-        "dist/a.js",
-        "package/dist/z.cjs",
-        "dist/node_modules/dependency/index.js",
-        "README.md",
-      ],
-      readText,
-    });
-
-    expect(readText.mock.calls).toEqual([["dist/a.js"], ["dist/z.cjs"]]);
     expect(imports).toEqual(
-      ["dist/a.js", "dist/z.cjs"].flatMap((importerPath) =>
-        ["dist/second.cjs", "dist/first.js"].map((importedPath) => ({
-          importerPath,
-          importedPath,
-        })),
-      ),
-    );
-  });
-
-  it.each([
-    {
-      name: "nested import",
-      source: 'function f() { import "./a.mjs"; }',
-      paths: ["dist/a.mjs"],
-    },
-    {
-      name: "TypeScript import equals",
-      source: 'import x = require("./a.cjs");',
-      paths: ["dist/a.cjs"],
-    },
-    {
-      name: "syntax error between imports",
-      source: 'import "./before.mjs"; const = ; import "./after.mjs";',
-      paths: ["dist/before.mjs", "dist/after.mjs"],
-    },
-    {
-      name: "unterminated string after require",
-      source: 'require("./before.cjs"); const s = "unterminated',
-      paths: ["dist/before.cjs"],
-    },
-    {
-      name: "syntax error before require",
-      source: 'const = ; require("./after.cjs");',
-      paths: ["dist/after.cjs"],
-    },
-  ])("preserves TypeScript recovery for $name", ({ source, paths }) => {
-    expect(collectPackageDistImports({ files: ["dist/index.js"], readText: () => source })).toEqual(
-      paths.map((importedPath) => ({ importerPath: "dist/index.js", importedPath })),
+      ["dist/data.json", "outside.cjs", "dist/worker.mjs"].map((importedPath) => ({
+        importerPath: "dist/index.mjs",
+        importedPath,
+      })),
     );
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Package import validation creates an intermediate specifier array for every
JavaScript file. The node bootstrap artifact builder also invokes this scanner
one already-read file at a time, repeatedly paying for collection normalization,
deduplication, and sorting that a singleton does not need.

## Why This Change Was Made

Append resolved import edges during the existing AST traversal and normalize
single-file inputs directly. Keep the TypeScript parser, parse options, visitor,
multi-file normalization and ordering, and existing import filters.

The final PR has 16 additions and 17 deletions in the scanner, plus one focused
23-line test for normalized singleton paths and the distinction between ordinary
relative imports and `import.meta.url` dependencies. The earlier 131-line helper
test inventory has been removed; existing CLI, tarball, and artifact tests remain.

This addresses the closure feedback without introducing a parser replacement,
cache, dependency, benchmark-only production API, or package-policy change.
The original PR ancestry is preserved.

## User Impact

Package closure checks and node bootstrap artifacts retain the same behavior
with fewer temporary collections. This is a small simplification, not evidence
of a material improvement in startup, packaging time, package size, or process
memory.

## Evidence

Repaired head: `0144fc26518181100e6e9434fbe5a1b1e50898a0`.
Comparison base: `62d1ef6a71d3fbbca61cb1af3c26f6e83cb949fa`.

- All **116 tests across three files** passed through `scripts/run-vitest.mjs`:
  `check-package-dist-imports.test.ts`, `check-openclaw-package-tarball.test.ts`,
  and `node-bootstrap-artifact.test.ts`.
- The existing artifact tests build, extract, and run packages with their
  plugins and private JavaScript dependency. They also reject incomplete import
  closure and verify artifact integrity and cleanup.
- Fresh independent final-diff review through P2 found no actionable issues.
- Formatting, `git diff --check`, and the first 11 `check:changed` guards passed.
- Six alternating fresh-process pairs exercised the actual
  `createNodeBootstrapArtifactProvider().prepare()` path, including file reads,
  scanning, tar creation, hashing, and archive validation. Only the scanner
  source changed between arms.
- Every pair produced the same 10,010-byte archive with SHA-256
  `20826e862d9b14aa15efd46b8d5e3e2e7604c622fe1488f2e0c2f16f8085c518`.
  Each provider's cached result identity and owned-archive cleanup also passed.

The timing fixture is synthetic: 512 generated modules, a bundled plugin, and
one private JavaScript dependency, totaling 525 input files. On a shared Darwin
ARM64 host with Node 26.7.0:

| Complete artifact preparation | Baseline median | Candidate median |
| --- | ---: | ---: |
| Wall time | 147.149 ms | 144.682 ms |
| Process CPU time | 339.012 ms | 338.509 ms |

The median paired wall-time saving was 2.107 ms (1.42%), but only three of six
pairs favored the candidate. The first baseline sample was much slower than
the rest; it was retained. These measurements do not demonstrate a reproducible
material speed gain. No allocated-byte, retained-heap, RSS, or real-distribution
performance claim is made.

**Local proof limits:** the root-test typecheck refused the borrowed dependency
installation at the repository's declaration-containment boundary. The guard
was not bypassed or reconfigured, and subsequent changed checks and a full local
build remain unrun. Clean exact-head hosted checks are required before landing.
