### PR TITLE
fix(discord): preserve ambient voice note transcripts

### DIFF
--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -278,6 +278,150 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.queuedBody).not.toContain("[Chat history]");
   });
 
+  it("keeps completed audio transcripts in room-event bodies", () => {
+    const transcript = "turn left at the next light";
+    const agentText = `[Audio]\nTranscript:\n${transcript}`;
+    const transportEnvelope = "[Discord channel #ambient]\n[media attached: voice-message.ogg]";
+    const ctx = finalizeInboundContext({
+      Body: transportEnvelope,
+      BodyForAgent: agentText,
+      RawBody: transportEnvelope,
+      CommandBody: transportEnvelope,
+      Transcript: transcript,
+      MediaUnderstanding: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: transcript,
+          provider: "groq",
+        },
+      ],
+      Provider: "discord",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+      MessageSid: "2003",
+      SenderName: "Alice",
+    });
+    const sessionCtx = finalizeInboundContext({ ...ctx });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx,
+      sessionCtx,
+      baseBody: sessionCtx.agentText,
+      hasUserBody: true,
+      inboundUserContext: "Conversation info:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.queuedBody).toBe(`#2003 Alice: ${agentText}`);
+    expect(envelope.transcriptCommandBody).toBe(envelope.queuedBody);
+    expect(envelope.queuedBody).not.toContain(transportEnvelope);
+  });
+
+  it("does not infer room-event transcript ownership from matching text", () => {
+    const ctx = finalizeInboundContext({
+      Body: "typed message",
+      BodyForAgent: "look at the book",
+      CommandBody: "typed message",
+      Transcript: "ok",
+      Provider: "discord",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+      MessageSid: "2004",
+      SenderName: "Alice",
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx,
+      sessionCtx: finalizeInboundContext({ ...ctx }),
+      baseBody: ctx.agentText,
+      hasUserBody: true,
+      inboundUserContext: "Conversation info:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.queuedBody).toBe("#2004 Alice: typed message");
+  });
+
+  it("does not borrow audio provenance from a different room-event projection", () => {
+    const ctx = finalizeInboundContext({
+      Body: "current typed message",
+      BodyForAgent: "current agent text",
+      CommandBody: "current typed message",
+      MediaUnderstanding: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: "previous transcript",
+          provider: "groq",
+        },
+      ],
+      Provider: "discord",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+      MessageSid: "2005",
+      SenderName: "Alice",
+    });
+    const sessionCtx = finalizeInboundContext({
+      ...ctx,
+      BodyForAgent: "unrelated session projection",
+      agentText: "unrelated session projection",
+      MediaUnderstanding: undefined,
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx,
+      sessionCtx,
+      baseBody: sessionCtx.agentText,
+      hasUserBody: true,
+      inboundUserContext: "Conversation info:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.queuedBody).toBe("#2005 Alice: current typed message");
+  });
+
+  it("requires an exact canonical audio body match", () => {
+    const agentText = "[Audio]\nTranscript:\nok";
+    const ctx = finalizeInboundContext({
+      Body: "typed message",
+      BodyForAgent: agentText,
+      CommandBody: "typed message",
+      MediaUnderstanding: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: "ok",
+          provider: "groq",
+        },
+      ],
+      Provider: "discord",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+      MessageSid: "2006",
+      SenderName: "Alice",
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx,
+      sessionCtx: finalizeInboundContext({ ...ctx }),
+      baseBody: ` ${agentText}`,
+      hasUserBody: true,
+      inboundUserContext: "Conversation info:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.queuedBody).toBe("#2006 Alice: typed message");
+  });
+
   it("keeps media-only notes in ordinary user request transcripts", () => {
     const sessionCtx = finalizeInboundContext({
       Body: "",

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -119,7 +119,19 @@ function formatRoomEventLine(ctx: TemplateContext, body: string): string {
 }
 
 function resolveRoomEventBody(params: ReplyPromptEnvelopeBaseParams): string {
+  const hasBaseBody = Boolean(normalizeOptionalString(params.baseBody));
+  const hasCompletedAudioBody =
+    hasBaseBody &&
+    [params.ctx, params.sessionCtx].some(
+      (ctx) =>
+        ctx.MediaUnderstanding?.some((output) => output.kind === "audio.transcription") &&
+        params.baseBody === ctx.agentText,
+    );
+  // Command text intentionally excludes machine transcripts. Prefer the
+  // enriched body only when this event owns an audio output and the body is
+  // still one of its canonical agent-text projections.
   return (
+    (hasCompletedAudioBody ? params.baseBody : undefined) ??
     normalizeOptionalString(params.ctx.commandText) ??
     normalizeOptionalString(params.sessionCtx.commandText) ??
     (params.hasUserBody ? params.baseBody.trim() : undefined) ??


### PR DESCRIPTION
Closes #142832

## What Problem This Solves

Fixes an issue where Discord users sending voice notes in ambient channels would have the spoken words omitted from the agent input. The agent received Discord's transport envelope instead of the completed audio transcript.

## Why This Change Was Made

Room-event prompt assembly now prefers completed audio content only when the same inbound context owns an `audio.transcription` result and the candidate body is byte-identical to that context's canonical agent text. This keeps the transcript in the model-facing and persisted room-event body without allowing machine-generated speech to enter command parsing or borrowing provenance from another projection.

## User Impact

Authorized Discord voice notes in ambient channels reach the agent with their transcribed words. Existing ambient reply policy remains unchanged, so transcription alone does not require a visible response.

## Evidence

### Real Discord behavior (after fix)

Executed on exact head `1148050aca72ba3d64a5fbd44b1c0b2d38f81a51` on September 9, 2026.

A real, captionless Discord voice note was sent in a private test guild without mentioning the bot. The test channel had `requireMention=false`, `messages.groupChat.unmentionedInbound="room_event"`, and `messages.groupChat.visibleReplies="message_tool"`.

The live channel probe reported:

```text
Discord: enabled, configured, running, connected
Bot probe: works
Security audit: ok
```

The Gateway trace recorded the production route (identifiers redacted):

```text
mention=no type=guild content=yes
shouldRequireMention=false ... wasMentioned=false
preview="[identity redacted]: OpenClaw proof one four two eight three two, turn left at the next light."
Delivery suppressed by sourceReplyDeliveryMode: message_tool_only — agent will still process the message
session state: processing -> idle reason="run_completed"
message processed: channel=discord outcome=completed
```

A read-only query of the persisted session event verified both the model-input projection and retained history:

```text
seq  event_type  role  model_input                   retained_text
---  ----------  ----  ----------------------------  -------------------------------------------------------------------------
1    message     user  room_event with spoken words  OpenClaw proof one four two eight three two, turn left at the next light.
```

For `model_input`, the query required the stored `message.__openclaw.upstreamUserText` to contain both `inbound_event_kind: room_event` and the spoken sentence. `retained_text` was read from the same persisted `transcript_events` row. The row contained the spoken words rather than `<media:audio>` or a Discord transport envelope. No visible reply was expected or emitted because the ambient channel used message-tool-only delivery. Server, channel, message, session, and user identifiers were redacted; no credentials are included.

### Regression and focused validation

- Pre-fix regression on `68be5fdcd14bd9db8572385072c1b8ec11eacaf8`: `node scripts/run-vitest.mjs src/auto-reply/reply/prompt-prelude.test.ts` failed because the queued room-event body contained the Discord transport envelope instead of the transcript.
- Post-fix exact-head proof on `1148050aca72ba3d64a5fbd44b1c0b2d38f81a51`: 133 focused assertions passed across media understanding, prompt assembly, Discord session routing, and Discord room events.
- `node scripts/check-changed.mjs --base upstream/main -- src/auto-reply/reply/prompt-prelude.ts src/auto-reply/reply/prompt-prelude.test.ts`
- Independent local review found no actionable P0-P2 findings after provenance hardening.
