### PR TITLE
fix(sessions): decode saved entries once per patch

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-equality.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-equality.ts
@@ -1,6 +1,17 @@
 import type { SessionEntry } from "./types.js";
 
-export type SqliteLifecycleTargetSnapshot = Array<{ entry: SessionEntry; sessionKey: string }>;
+export type SqliteLifecycleTargetSnapshot = Array<{
+  entry: SessionEntry;
+  sessionKey: string;
+  /**
+   * Raw persisted rows the preparation scanned, kept so the commit edge can prove the row is
+   * unchanged without decoding it again. Absent = the caller must re-read hydrated rows.
+   */
+  persistedRows?: {
+    lookupKeys: readonly string[];
+    rows: readonly Readonly<Record<string, unknown>>[];
+  };
+}>;
 
 class SqliteSessionMutationConflictError extends Error {
   constructor(operationLabel: string) {

--- a/src/config/sessions/session-accessor.sqlite-entry-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-read.ts
@@ -69,14 +69,25 @@ export function readSessionEntryRow(
   database: OpenClawAgentDatabaseReader,
   sessionKey: string,
 ): ResolvedSessionEntryRow | undefined {
-  assertCanonicalSqliteSessionKeysCurrent(database);
-  return readSessionEntryRowUnchecked(database, sessionKey);
+  return readSessionEntryRowScan(database, sessionKey)?.selected;
 }
 
-function readSessionEntryRowUnchecked(
+/**
+ * Reads the selected row plus every raw row the lookup scanned. A write transaction that must
+ * prove this logical row is unchanged can re-read and compare the raw rows instead of decoding
+ * the entry JSON again.
+ */
+export function readSessionEntryRowScan(
   database: OpenClawAgentDatabaseReader,
   sessionKey: string,
-): ResolvedSessionEntryRow | undefined {
+):
+  | {
+      lookupKeys: string[];
+      rows: SessionEntryRow[];
+      selected: ResolvedSessionEntryRow | undefined;
+    }
+  | undefined {
+  assertCanonicalSqliteSessionKeysCurrent(database);
   const db = getSessionKysely(database.db);
   const lookupKeys = collectSessionEntryLookupKeys(database, sessionKey);
   if (lookupKeys.length === 0) {
@@ -98,7 +109,7 @@ function readSessionEntryRowUnchecked(
     }
     selected = { entry, row };
   }
-  return selected;
+  return { lookupKeys, rows, selected };
 }
 
 export function readExactSessionEntryRow(

--- a/src/config/sessions/session-accessor.sqlite-entry-revalidation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-revalidation.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { onSessionIdentityMutation } from "./session-accessor.js";
+import {
+  loadExactSessionEntry,
+  patchSessionEntryCore,
+  patchSessionEntryTarget,
+  upsertSessionEntryCore,
+} from "./session-accessor.sqlite-entry.js";
+
+const tempDirs = createTempDirTracker();
+const sessionKey = "agent:main:entry-revalidation";
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+describe("SQLite session entry patch commit revalidation", () => {
+  let env: NodeJS.ProcessEnv;
+  let scope: { agentId: string; env: NodeJS.ProcessEnv; sessionKey: string };
+  let database: ReturnType<typeof openOpenClawAgentDatabase>;
+
+  beforeEach(async () => {
+    env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-entry-revalidation-")),
+    };
+    scope = { agentId: "main", env, sessionKey };
+    await upsertSessionEntryCore(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    database = openOpenClawAgentDatabase({ agentId: "main", env });
+  });
+
+  /** Simulate another writer landing between patch preparation and its commit. */
+  function mutateRowOutOfBand(patch: Record<string, string>): void {
+    const other = new DatabaseSync(database.path);
+    try {
+      const entries = Object.entries(patch);
+      const setters = entries.map(([key]) => `'$.${key}', ?`).join(", ");
+      other
+        .prepare(
+          `UPDATE session_nodes SET entry_json = json_set(entry_json, ${setters}) WHERE session_key = ?`,
+        )
+        .run(...entries.map(([, value]) => value), sessionKey);
+    } finally {
+      other.close();
+    }
+  }
+
+  it("commits the patch when the persisted row is unchanged since preparation", async () => {
+    const persisted = await patchSessionEntryCore(scope, () => ({ model: "gpt-5.6" }));
+    expect(persisted).toMatchObject({ model: "gpt-5.6", sessionId: "session-1" });
+    expect(loadExactSessionEntry(scope)?.entry).toMatchObject({
+      model: "gpt-5.6",
+      sessionId: "session-1",
+    });
+  });
+
+  it("rejects the commit when the row changed while the update callback ran", async () => {
+    await expect(
+      patchSessionEntryCore(scope, () => {
+        mutateRowOutOfBand({ model: "gpt-5.7" });
+        return { label: "renamed" };
+      }),
+    ).rejects.toMatchObject({ name: "SqliteSessionMutationConflictError" });
+    expect(loadExactSessionEntry(scope)?.entry).toMatchObject({ model: "gpt-5.7" });
+    expect(loadExactSessionEntry(scope)?.entry.label).toBeUndefined();
+  });
+
+  it("rejects a lifecycle-target patch when the row changed while the update callback ran", async () => {
+    await expect(
+      patchSessionEntryTarget(
+        {
+          agentId: scope.agentId,
+          storePath: database.path,
+          target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        },
+        () => {
+          mutateRowOutOfBand({ model: "gpt-5.8" });
+          return { label: "renamed" };
+        },
+      ),
+    ).rejects.toMatchObject({ name: "SqliteSessionMutationConflictError" });
+    expect(loadExactSessionEntry(scope)?.entry).toMatchObject({ model: "gpt-5.8" });
+  });
+
+  it("still publishes an identity replacement when a patch rotates the session id", async () => {
+    const mutations: unknown[] = [];
+    const unsubscribe = onSessionIdentityMutation((mutation) => mutations.push(mutation));
+    try {
+      await patchSessionEntryCore(scope, () => ({ sessionId: "session-2" }));
+    } finally {
+      unsubscribe();
+    }
+    expect(mutations).toContainEqual(
+      expect.objectContaining({
+        kind: "replace",
+        previous: expect.objectContaining({ sessionId: "session-1", sessionKeys: [sessionKey] }),
+        current: expect.objectContaining({ sessionId: "session-2", sessionKeys: [sessionKey] }),
+      }),
+    );
+  });
+
+  it("does not publish an identity mutation when a patch keeps the session id", async () => {
+    const mutations: unknown[] = [];
+    const unsubscribe = onSessionIdentityMutation((mutation) => mutations.push(mutation));
+    try {
+      await patchSessionEntryCore(scope, () => ({ updatedAt: 20 }));
+    } finally {
+      unsubscribe();
+    }
+    expect(mutations).toEqual([]);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -3,6 +3,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
+  sqliteStringSet,
 } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -23,7 +24,7 @@ import {
 } from "./session-accessor.sqlite-entry-equality.js";
 import {
   readExactSessionEntryRow,
-  readSessionEntryRow,
+  readSessionEntryRowScan,
 } from "./session-accessor.sqlite-entry-read.js";
 import {
   clearSessionCollaborationForKey,
@@ -93,10 +94,77 @@ export function readSessionEntrySelectionSnapshot(
   sessionKey: string,
   exact: boolean,
 ): SqliteLifecycleTargetSnapshot {
-  const selected = exact
-    ? readExactSessionEntryRow(database, sessionKey)
-    : readSessionEntryRow(database, sessionKey);
-  return selected ? [{ entry: selected.entry, sessionKey: selected.row.session_key }] : [];
+  if (exact) {
+    const selected = readExactSessionEntryRow(database, sessionKey);
+    return selected
+      ? [
+          {
+            entry: selected.entry,
+            sessionKey: selected.row.session_key,
+            persistedRows: {
+              lookupKeys: [sessionKey.trim()],
+              // SAFETY: session_nodes rows are plain column-value objects; the cast only widens to a generic record for raw comparison.
+              rows: [selected.row as Readonly<Record<string, unknown>>],
+            },
+          },
+        ]
+      : [];
+  }
+  const scanned = readSessionEntryRowScan(database, sessionKey);
+  return scanned?.selected
+    ? [
+        {
+          entry: scanned.selected.entry,
+          sessionKey: scanned.selected.row.session_key,
+          persistedRows: { lookupKeys: scanned.lookupKeys, rows: scanned.rows },
+        },
+      ]
+    : [];
+}
+
+/**
+ * Commit-edge compare-and-swap without rehydrating the row. The prepared snapshot carries the
+ * exact raw rows its entries were decoded from, so an identical raw read proves the prepared
+ * entries are still authoritative. Any difference (or a snapshot without raw rows) returns
+ * undefined and the caller falls back to the hydrated re-read and deep comparison.
+ */
+export function readUnchangedLifecycleTargetSnapshot(
+  database: OpenClawAgentDatabase,
+  prepared: SqliteLifecycleTargetSnapshot,
+): SqliteLifecycleTargetSnapshot | undefined {
+  const persisted = prepared[0]?.persistedRows;
+  if (!persisted || persisted.lookupKeys.length === 0) {
+    return undefined;
+  }
+  const rows = executeSqliteQuerySync(
+    database.db,
+    getSessionKysely(database.db)
+      .selectFrom("session_nodes")
+      .selectAll()
+      .where("session_key", "in", sqliteStringSet(persisted.lookupKeys))
+      .orderBy("session_key", "asc"),
+  ).rows;
+  if (rows.length !== persisted.rows.length) {
+    return undefined;
+  }
+  const unchanged = rows.every((row, index) =>
+    rawSessionEntryRowsEqual(row, persisted.rows[index]!),
+  );
+  return unchanged ? prepared : undefined;
+}
+
+/** Union of keys: an exact row and its selected projection compare on the columns both own. */
+function rawSessionEntryRowsEqual(
+  left: Readonly<Record<string, unknown>>,
+  right: Readonly<Record<string, unknown>>,
+): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!isDeepStrictEqual(left[key], right[key])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function resolveLifecyclePrimaryEntry(
@@ -107,7 +175,7 @@ export function resolveLifecyclePrimaryEntry(
   const rows = target.storeKeys.flatMap((key) => {
     const sessionKey = key.trim();
     const row = readExactSessionEntryRow(database, sessionKey);
-    return row ? [{ sessionKey, entry: row.entry }] : [];
+    return row ? [{ sessionKey, entry: row.entry, rawRow: row.row }] : [];
   });
   if (rows.length > 1) {
     throw canonicalSessionKeyMigrationRequiredError(
@@ -120,7 +188,17 @@ export function resolveLifecyclePrimaryEntry(
       `non-canonical persisted row resolves to session key ${target.canonicalKey}`,
     );
   }
-  return row;
+  return row
+    ? {
+        entry: row.entry,
+        sessionKey: row.sessionKey,
+        persistedRows: {
+          lookupKeys: target.storeKeys.map((key) => key.trim()),
+          // SAFETY: session_nodes rows are plain column-value objects; the cast only widens to a generic record for raw comparison.
+          rows: [row.rawRow as Readonly<Record<string, unknown>>],
+        },
+      }
+    : undefined;
 }
 
 export function readLifecycleTargetSnapshot(
@@ -386,6 +464,8 @@ export function writeSessionEntry(
   entry: SessionEntry,
   options: {
     allowStoredAliases?: boolean;
+    /** Persisted canonical row the caller already decoded; null proves the row is absent. */
+    canonicalPreviousEntry?: SessionEntry | null;
     consumePendingReset?: boolean;
     preserveNodeSuggestions?: boolean;
     previousEntry?: SessionEntry | null;
@@ -408,10 +488,13 @@ export function writeSessionEntry(
   }
   // Doctor validated the raw rejected row before entering the transaction and passes its
   // hydrated snapshot explicitly; re-reading it through the runtime parser must stay fail-closed.
+  // Callers that already decoded this canonical row pass canonicalPreviousEntry to skip the read.
   const canonicalPreviousEntry =
-    options.allowStoredAliases && options.previousEntry !== undefined
-      ? (options.previousEntry ?? undefined)
-      : readExactSessionEntryRow(database, sessionKey)?.entry;
+    options.canonicalPreviousEntry !== undefined
+      ? (options.canonicalPreviousEntry ?? undefined)
+      : options.allowStoredAliases && options.previousEntry !== undefined
+        ? (options.previousEntry ?? undefined)
+        : readExactSessionEntryRow(database, sessionKey)?.entry;
   if (canonicalPreviousEntry?.sandbox === "required") {
     if (
       normalizedEntry.sandbox !== "required" ||

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -52,6 +52,7 @@ import {
   readLifecycleTargetSnapshot,
   readSessionEntrySelectionSnapshot,
   readSessionIdentitySnapshot,
+  readUnchangedLifecycleTargetSnapshot,
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { listTranscriptInstancesFromDatabase } from "./session-accessor.sqlite-history.js";
@@ -562,8 +563,13 @@ async function patchSqliteSessionEntrySnapshot(
             if (options.shouldCommit?.() === false) {
               return undefined;
             }
-            const fresh = params.readSnapshot(writeDatabase);
-            assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
+            // Unchanged raw rows decode identically; only a changed row pays the hydrated
+            // re-read and deep comparison that owns the conflict error.
+            let fresh = readUnchangedLifecycleTargetSnapshot(writeDatabase, prepared);
+            if (!fresh) {
+              fresh = params.readSnapshot(writeDatabase);
+              assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
+            }
             options.assertCommitAllowed?.();
             if (!next) {
               result = cloneSessionEntry(writeBase);
@@ -575,6 +581,10 @@ async function patchSqliteSessionEntrySnapshot(
             const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
               ...(options.consumePendingReset ? { consumePendingReset: true } : {}),
               previousEntry: selectedPreviousEntry,
+              // The validated snapshot already owns this canonical row's decode.
+              ...(fresh[0]?.sessionKey === sessionKey
+                ? { canonicalPreviousEntry: fresh[0].entry }
+                : {}),
             });
             wrote = true;
             // Identity observers only consume sessionId, already owned by this canonical write.

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -86,7 +86,9 @@ describe("SQLite session row persistence", () => {
         const decodes = parse.mock.calls.filter(([text]) =>
           text.includes("identity-decode-payload:"),
         ).length;
-        expect(decodes).toBeLessThanOrEqual(iterations * 3);
+        // One decode per patch: preparation owns the only hydration of the row; the commit
+        // revalidates the persisted row without decoding and the writer reuses that row.
+        expect(decodes).toBeLessThanOrEqual(iterations);
       } finally {
         parse.mockRestore();
         unsubscribe();


### PR DESCRIPTION
Closes #136338. Related: #119720 (separate broader work).

## What Problem This Solves

Resolves a problem where updating session metadata performs avoidable Gateway work, especially for sessions with large saved prompts.

## Why This Change Was Made

A successful patch decoded the same saved entry during preparation, commit revalidation, and the canonical write. Carry complete persisted rows through preparation, compare every column inside the existing write transaction, and reuse the decoded canonical entry only for its validated matching key. Changed rows keep the existing hydrated conflict check.

Restore canonical-store validation for the current connection before reuse, including no-op patches. Preserve the exact-replacement reader exception and the lifecycle reader's stricter policy. This builds on @Finn763's contribution and preserves its ancestry.

## User Impact

Visible session behavior and conflict protections stay the same. The exercised unchanged-row update path decodes the saved payload once instead of three times. The small timing samples do not establish a user-visible latency or throughput improvement.

## Evidence

Built and tested on an isolated native runtime using the real authenticated `session.visibility.set` Gateway route and a valid SDK-seeded saved prompt of 17,431 bytes. Requests alternate the existing `shared` and `read-only` values.

| Actual runtime observation | Baseline `341b759ae6bd` | Candidate `73ad53808bf6` |
| --- | --- | --- |
| Full saved-entry decodes per successful patch, four requests | 3, 3, 3, 3 | 1, 1, 1, 1 |
| Equal-visibility request | Success, zero decodes | Success, zero decodes |
| Prepared request → separate normal committed SDK writer → resume | Not rerun; historical `7115c4b6` proof retained | Conflict rejected; writer data retained |
| Public response and sharing event | Requested visibility | Requested visibility |

A fresh independent runtime validation exercised six more candidate updates; each decoded once. It independently reproduced the ordered conflict, checked the returned error and absence of a sharing success event, and reopened the resulting data.

Same-store compatibility: the candidate updated the existing baseline database without reseeding. The saved baseline runtime then read the same store and returned the identical complete canonical/raw snapshot as the candidate reader. The agent-store schema and user version 19 stayed unchanged. The inherited shared-store schema is version 17 in both current builds; this is not a claim of downgrade support to the historical version 16. Identity, creation provenance, terminal status, and the complete saved payload were preserved. Public fixtures had empty owner/participant projections; separate native owner tests cover nonempty owner and participant data.

Native checks: 65 focused tests passed, plus targeted formatting, lint, assertion/line-budget checks, and the repository commit hook. The six canonical-validation regressions previously failed on the original incoming implementation because invalidated stores incorrectly returned success. The contributor rebase retained that omission; all six pass on this repaired integration. Coverage includes exact replacement, reopened handles, raw-column differences, missing snapshots, key provenance, participant ownership, creation policy, and commit/publication guards.

Twelve matched samples with parse observation disabled recorded median RPC times of 5.700 ms and 4.647 ms, and median Gateway CPU of 8.013 ms and 6.451 ms. These samples overlap and establish no general latency or throughput improvement. The measured claim is the deterministic reduction from three saved-entry hydrations to one on the exercised unchanged-row path. Cold canonical validation remains required.

Complete private traces, fixture sources, failed attempts, build identities, and independent reviews are retained for the final review. Public evidence omits session contents, credentials, private paths, hosts, and execution metadata.

The current candidate preserves the contributor rebase as an ancestor. Earlier proof remains attached to its original build; the current Gateway, admission, conflict and same-store observations were repeated because relevant inherited owners changed.
