### PR TITLE
fix(auth): preserve device-code verification link boundaries

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { runGitHubCopilotDeviceFlow } from "./login.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -1450,7 +1451,7 @@ describe("github-copilot plugin", () => {
     const prompter = {
       confirm: vi.fn(async () => false),
       text: vi.fn(async () => ""),
-      note: vi.fn(),
+      note: vi.fn(async (_message: string, _title?: string) => {}),
     };
 
     const result = await runDeviceAuthWithTty(
@@ -1479,7 +1480,15 @@ describe("github-copilot plugin", () => {
 
     // Domain switch must not offer to reuse the tenant-scoped token.
     expect(prompter.confirm).not.toHaveBeenCalled();
-    expect(prompter.note).toHaveBeenCalled();
+    const deviceNote = prompter.note.mock.calls.find(
+      ([, title]) => title === "Authorize GitHub Copilot",
+    );
+    expect(deviceNote).toBeDefined();
+    const [message] = expectDefined(deviceNote, "device-code note");
+    expect(markdownToIR(message, { linkify: false }).links.map((link) => link.href)).toEqual([
+      "https://github.com/login/device",
+    ]);
+    expect(message).toContain("\nCode: ABCD-1234\n");
     expect(result.profiles[0]?.credential).toEqual({
       type: "token",
       provider: "github-copilot",

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -544,7 +544,7 @@ export default definePluginEntry({
             await ctx.prompter.note(
               [
                 "Open this URL in your browser and enter the code below.",
-                `URL: ${verificationUrl}`,
+                `URL: <${verificationUrl}>`,
                 `Code: ${userCode}`,
                 `Code expires in ${expiresInMinutes} minutes. Never share it.`,
                 "",

--- a/extensions/openai/openai-chatgpt-provider.test.ts
+++ b/extensions/openai/openai-chatgpt-provider.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover openai chatgpt provider plugin behavior.
+import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const refreshOpenAICodexTokenMock = vi.hoisted(() => vi.fn());
@@ -85,57 +86,70 @@ describe("OpenAI provider Codex transport hooks", () => {
     });
   });
 
-  it("presents the OpenAI user code through structured device-code UI", async () => {
-    const provider = buildOpenAIProvider();
-    const deviceCodeMethod = provider.auth?.find((method) => method.id === "device-code");
-    const deviceCode = vi.fn(async () => {});
-    const note = vi.fn(async () => {});
-    const openUrl = vi.fn(async () => {});
-    loginOpenAICodexDeviceCodeMock.mockImplementationOnce(
-      async (params: {
-        onVerification: (prompt: {
-          verificationUrl: string;
-          userCode: string;
-          expiresInMs: number;
-        }) => Promise<void>;
-      }) => {
-        await params.onVerification({
-          verificationUrl: "https://auth.openai.com/codex/device",
-          userCode: "ABCD-EFGH",
-          expiresInMs: 15 * 60_000,
-        });
-        return {
-          access: "access-token",
-          refresh: "refresh-token",
-          expires: 1_700_000_000_000,
-        };
-      },
-    );
+  it.each(["structured", "note"])(
+    "presents a bounded device-code link through %s UI",
+    async (surface) => {
+      const provider = buildOpenAIProvider();
+      const deviceCodeMethod = provider.auth?.find((method) => method.id === "device-code");
+      const deviceCode = vi.fn(async () => {});
+      const note = vi.fn(async (_message: string, _title?: string) => {});
+      const openUrl = vi.fn(async () => {});
+      loginOpenAICodexDeviceCodeMock.mockImplementationOnce(
+        async (params: {
+          onVerification: (prompt: {
+            verificationUrl: string;
+            userCode: string;
+            expiresInMs: number;
+          }) => Promise<void>;
+        }) => {
+          await params.onVerification({
+            verificationUrl: "https://auth.openai.com/codex/device",
+            userCode: "ABCD-EFGH",
+            expiresInMs: 15 * 60_000,
+          });
+          return {
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: 1_700_000_000_000,
+          };
+        },
+      );
 
-    await deviceCodeMethod?.run({
-      isRemote: true,
-      openUrl,
-      prompter: {
-        deviceCode,
-        note,
-        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-      },
-      runtime: { log: vi.fn(), error: vi.fn() },
-      config: {},
-      oauth: {},
-    } as never);
+      await deviceCodeMethod?.run({
+        isRemote: true,
+        openUrl,
+        prompter: {
+          ...(surface === "structured" ? { deviceCode } : {}),
+          note,
+          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        },
+        runtime: { log: vi.fn(), error: vi.fn() },
+        config: {},
+        oauth: {},
+      } as never);
 
-    expect(deviceCode).toHaveBeenCalledWith({
-      title: "OpenAI Codex device code",
-      code: "ABCD-EFGH",
-      expiresInMinutes: 15,
-      message: [
-        "Open this URL in your LOCAL browser and enter the code below.",
-        "URL: https://auth.openai.com/codex/device",
-      ].join("\n"),
-    });
-    expect(note).not.toHaveBeenCalled();
-  });
+      if (surface === "note") {
+        expect(note).toHaveBeenCalledOnce();
+        const [message] = note.mock.calls[0]!;
+        expect(markdownToIR(message, { linkify: false }).links.map((link) => link.href)).toEqual([
+          "https://auth.openai.com/codex/device",
+        ]);
+        expect(message).toContain("\nCode: ABCD-EFGH\n");
+        expect(openUrl).toHaveBeenCalledWith("https://auth.openai.com/codex/device");
+        return;
+      }
+      expect(deviceCode).toHaveBeenCalledWith({
+        title: "OpenAI Codex device code",
+        code: "ABCD-EFGH",
+        expiresInMinutes: 15,
+        message: [
+          "Open this URL in your LOCAL browser and enter the code below.",
+          "URL: <https://auth.openai.com/codex/device>",
+        ].join("\n"),
+      });
+      expect(note).not.toHaveBeenCalled();
+    },
+  );
 
   it("routes Codex-backed OpenAI models through the Codex Responses transport", () => {
     const provider = buildOpenAIProvider();

--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -557,7 +557,7 @@ async function runOpenAICodexDeviceCode(ctx: ProviderAuthContext) {
           ctx.isRemote
             ? "Open this URL in your LOCAL browser and enter the code below."
             : "Open this URL in your browser and enter the code below.",
-          `URL: ${verificationUrl}`,
+          `URL: <${verificationUrl}>`,
         ].join("\n");
         if (ctx.isRemote) {
           await ctx.openUrl(verificationUrl);

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -8,6 +8,7 @@ import {
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { withProxyFixture } from "openclaw/plugin-sdk/test-env";
+import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { fetch as undiciFetch, MockAgent, type Dispatcher } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyXaiConfig } from "./onboard.js";
@@ -781,7 +782,13 @@ describe("xAI OAuth", () => {
     },
   );
 
-  it("falls back for unsafe xAI device-code lifetime fields", async () => {
+  it.each([
+    { completeUri: undefined, expectedUrl: "https://accounts.x.ai/oauth2/device" },
+    {
+      completeUri: "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234&source=cli",
+      expectedUrl: "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234&source=cli",
+    },
+  ])("preserves the device-code note link $expectedUrl", async ({ completeUri, expectedUrl }) => {
     const progress = {
       update: vi.fn(),
       stop: vi.fn(),
@@ -800,6 +807,7 @@ describe("xAI OAuth", () => {
           device_code: "device-code-1",
           user_code: "ABCD-1234",
           verification_uri: "https://accounts.x.ai/oauth2/device",
+          verification_uri_complete: completeUri,
           expires_in: Number.MAX_SAFE_INTEGER,
           interval: Number.MAX_SAFE_INTEGER,
         }),
@@ -842,6 +850,12 @@ describe("xAI OAuth", () => {
       expect.stringContaining("Code expires in 5 minutes."),
       "xAI OAuth",
     );
+    const [message] = note.mock.calls[0]!;
+    expect(markdownToIR(message, { linkify: false }).links.map((link) => link.href)).toEqual([
+      expectedUrl,
+    ]);
+    expect(message).toContain("\nCode: ABCD-1234\n");
+    expect(ctx.openUrl).toHaveBeenCalledWith(expectedUrl);
     expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
   });
 });

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -590,7 +590,7 @@ async function noteXaiDeviceCode(
       ctx.isRemote
         ? "Open this URL in your LOCAL browser and enter the code below."
         : "Open this URL in your browser and enter the code below.",
-      `URL: ${deviceCode.verificationUriComplete ?? deviceCode.verificationUri}`,
+      `URL: <${deviceCode.verificationUriComplete ?? deviceCode.verificationUri}>`,
       `Code: ${deviceCode.userCode}`,
       `Code expires in ${expiresInMinutes} minutes. Never share it.`,
     ].join("\n"),


### PR DESCRIPTION
## What Problem This Solves

Device-code sign-in messages could produce a broken clickable link when the channel renderer included the next line’s Code label in the URL.

## Why This Change Was Made

The three device-code prompt producers now emit standard autolinks around the complete verification URL. Browser callbacks still receive the raw URL; authentication behavior is unchanged.

## User Impact

Users can open the sign-in URL independently of the code label. This fixes authored login prompts rather than the channel’s general bare-link parser.

## Evidence

Signed channel-event replay through a real Gateway and live delivery reproduced the malformed stored link before the fix and the exact destination afterward. A streamed link with query parameters also retained its destination. All five regressions failed when the production edits were removed; all 101 affected tests passed with the fix. Sign-in completion was not performed.
