### PR TITLE
fix(video): retain registration resources through generation

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -55,6 +55,12 @@ existing owner. Provider listing still returns caller-owned callbacks and does
 not acquire a generation lifetime. Return asynchronous provider work and have
 `dispose()` stop and join any additional background work it owns.
 
+Video generation uses the same ownership for
+`api.runtime.videoGeneration.generate(...)`, from model-capability lookup through
+completed video assets and result metadata. Video assets may contain buffers or
+provider-hosted URLs. Downloads after the call returns belong to the caller;
+registration disposal must not invalidate those completed artifacts.
+
 Executable CLI command registration also uses an owned, uncached registry. Its
 resources remain available through asynchronous registration, command actions,
 and their tracked cleanup, then `dispose()` runs. Closing command preparation

--- a/src/media-generation/registry.ts
+++ b/src/media-generation/registry.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ImageGenerationProvider } from "../image-generation/types.js";
 import type { MusicGenerationProvider } from "../music-generation/types.js";
 import { withAcquiredPluginCapabilityProviders } from "../plugins/capability-provider-acquisition.js";
+import type { VideoGenerationProvider } from "../video-generation/types.js";
 import { createMediaProviderRegistry } from "./provider-registry.js";
 
 /** Registry for image-generation providers contributed by plugin capabilities. */
@@ -28,6 +29,14 @@ export function withImageGenerationProviders<T>(
   run: (providers: ImageGenerationProvider[]) => T | Promise<T>,
 ): Promise<T> {
   return withAcquiredPluginCapabilityProviders({ key: "imageGenerationProviders", cfg }, run);
+}
+
+/** Owns providers through generation of completed video assets. */
+export function withVideoGenerationProviders<T>(
+  cfg: OpenClawConfig,
+  run: (providers: VideoGenerationProvider[]) => T | Promise<T>,
+): Promise<T> {
+  return withAcquiredPluginCapabilityProviders({ key: "videoGenerationProviders", cfg }, run);
 }
 
 /** Owns providers loaded for one buffered music-generation operation. */

--- a/src/video-generation/runtime.resources.test.ts
+++ b/src/video-generation/runtime.resources.test.ts
@@ -1,0 +1,353 @@
+import { once } from "node:events";
+import fs from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { generateVideo, type GenerateVideoParams } from "./runtime.js";
+import type { VideoGenerationRequest } from "./types.js";
+
+const videoBytes = Buffer.from("synthetic video bytes 42");
+
+function createNativeVideoFixture(
+  id = "native-video-owner",
+  outcome: "buffer" | "url" | "reject" = "buffer",
+  holdLookup = false,
+  deliveryUrl?: string,
+) {
+  const dir = makePluginLoaderTempDir();
+  const key = `__openclaw_video_resources_${path.basename(dir)}`;
+  const lookupStarted = createDeferredCore();
+  const lookupResume = createDeferredCore();
+  if (!holdLookup) {
+    lookupResume.resolve();
+  }
+  const started = createDeferredCore();
+  const resume = createDeferredCore();
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    requests: VideoGenerationRequest[];
+  }> = [];
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: { connections, lookupStarted, lookupResume, started, resume, videoBytes, deliveryUrl },
+  });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, requests: [] };
+    state.connections.push(connection);
+    const read = () => database.prepare("SELECT 42 AS value").get().value;
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "native-video-resource",
+      dispose() {
+        read();
+        connection.disposals++;
+        database.close();
+      },
+    });
+    api.registerVideoGenerationProvider({
+      id: ${JSON.stringify(id)},
+      aliases: [${JSON.stringify(`${id}-alias`)}],
+      defaultModel: "fixture-model",
+      capabilities: {},
+      async resolveModelCapabilities() {
+        read();
+        state.lookupStarted.resolve();
+        await state.lookupResume.promise;
+        read();
+        return {};
+      },
+      async generateVideo(request) {
+        connection.requests.push(request);
+        read();
+        state.started.resolve();
+        await state.resume.promise;
+        read();
+        if (${JSON.stringify(outcome)} === "reject") throw new Error("native video generation failed");
+        return {
+          videos: [{
+            ...(${JSON.stringify(outcome)} === "url" ? { url: state.deliveryUrl } : { buffer: state.videoBytes }),
+            mimeType: "video/mp4", fileName: "native.mp4",
+          }],
+          metadata: { get nativeValue() { return read(); } },
+        };
+      },
+    });
+  },
+};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { videoGenerationProviders: [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const config: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const params: GenerateVideoParams = {
+    cfg: config,
+    prompt: "synthetic native video resource proof",
+    modelOverride: `${id}-alias/fixture-model`,
+    autoProviderFallback: false,
+    timeoutMs: 12_345,
+    providerOptions: { seed: 42 },
+  };
+  return {
+    plugin,
+    connections,
+    lookupStarted,
+    lookupResume,
+    started,
+    resume,
+    config,
+    params,
+    run: () => generateVideo(params),
+    withEnvironment: (run: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        run,
+      ),
+    cleanup() {
+      lookupResume.resolve();
+      resume.resolve();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+function settle<T>(operation: Promise<T>) {
+  return operation.then(
+    (value) => ({ value, error: undefined }),
+    (error: unknown) => ({ value: undefined, error }),
+  );
+}
+
+async function waitForProviderStart(started: Promise<void>, operation: Promise<unknown>) {
+  await Promise.race([
+    started,
+    operation.then(() => {
+      throw new Error("Video operation settled before invoking the native provider");
+    }),
+  ]);
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("video generation registration resources", () => {
+  it.each(["buffer", "url", "reject"] as const)(
+    "releases cold video resources after %s settlement",
+    async (mode) => {
+      const server =
+        mode === "url"
+          ? createServer((_request, response) => {
+              response.writeHead(200, { "content-type": "video/mp4" });
+              response.end(videoBytes);
+            })
+          : undefined;
+      let deliveryUrl: string | undefined;
+      if (server) {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Expected fixture TCP address");
+        }
+        deliveryUrl = `http://127.0.0.1:${address.port}/generated.mp4`;
+      }
+      const fixture = createNativeVideoFixture("native-video-owner", mode, false, deliveryUrl);
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const outcome = settle(fixture.run());
+          try {
+            await waitForProviderStart(fixture.started.promise, outcome);
+            expect(fixture.connections).toHaveLength(1);
+            const connection = fixture.connections[0]!;
+            expect(connection.database.isOpen).toBe(true);
+            expect(connection.disposals).toBe(0);
+            fixture.resume.resolve();
+            const result = await outcome;
+            if (mode === "reject") {
+              expect(String(result.error)).toContain("native video generation failed");
+            } else {
+              expect(result.error).toBeUndefined();
+              if (mode === "url") {
+                expect(result.value?.videos[0]?.url).toBe(deliveryUrl);
+                expect(result.value?.videos[0]?.buffer).toBeUndefined();
+              } else {
+                expect(result.value?.videos[0]?.buffer).toEqual(videoBytes);
+              }
+              expect(result.value?.metadata).toEqual({ nativeValue: 42 });
+            }
+            expect(connection.requests[0]).toMatchObject({
+              provider: "native-video-owner-alias",
+              timeoutMs: 12_345,
+              providerOptions: fixture.params.providerOptions,
+            });
+            expect(connection.database.isOpen).toBe(false);
+            expect(connection.disposals).toBe(1);
+            if (mode === "url") {
+              const response = await fetch(deliveryUrl!);
+              expect(response.status).toBe(200);
+              expect(Buffer.from(await response.arrayBuffer())).toEqual(videoBytes);
+            }
+          } finally {
+            fixture.lookupResume.resolve();
+            fixture.resume.resolve();
+            await outcome;
+          }
+        });
+      } finally {
+        fixture.cleanup();
+        if (server) {
+          const closed = once(server, "close");
+          server.close();
+          server.closeAllConnections();
+          await closed;
+        }
+      }
+    },
+  );
+
+  it.each(["managed", "raw"] as const)(
+    "preserves the %s host owner through video generation",
+    async (owner) => {
+      const fixture = createNativeVideoFixture("native-video-owner", "buffer", owner === "managed");
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const inspection =
+            owner === "managed"
+              ? await acquirePluginRegistryForInspection({ config: fixture.config })
+              : undefined;
+          const registry =
+            inspection?.registry ?? loadPluginRegistryHandle({ config: fixture.config });
+          const outcome = settle(withPluginRuntimeRegistryScope(registry, fixture.run));
+          try {
+            await waitForProviderStart(
+              owner === "managed" ? fixture.lookupStarted.promise : fixture.started.promise,
+              outcome,
+            );
+            expect(fixture.connections).toHaveLength(1);
+            await inspection?.release();
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            fixture.lookupResume.resolve();
+            await waitForProviderStart(fixture.started.promise, outcome);
+            expect(fixture.connections[0]!.database.isOpen).toBe(true);
+            fixture.resume.resolve();
+            const result = await outcome;
+            expect(result.error).toBeUndefined();
+            expect(result.value?.videos[0]?.buffer).toEqual(videoBytes);
+            expect(result.value?.metadata).toEqual({ nativeValue: 42 });
+            expect(fixture.connections[0]!.database.isOpen).toBe(owner === "raw");
+            expect(fixture.connections[0]!.disposals).toBe(owner === "raw" ? 0 : 1);
+          } finally {
+            fixture.lookupResume.resolve();
+            fixture.resume.resolve();
+            await outcome;
+            await inspection?.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["override", "fallback"] as const)(
+    "retains both eligible registrations for %s selection",
+    async (selection) => {
+      const first = createNativeVideoFixture("first-video-owner", "reject");
+      const second = createNativeVideoFixture("second-video-owner");
+      first.resume.resolve();
+      try {
+        await second.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const outcome = settle(
+            generateVideo({
+              ...second.params,
+              cfg: {
+                agents: {
+                  defaults: {
+                    mediaModels: {
+                      video: {
+                        primary: "first-video-owner/fixture-model",
+                        fallbacks: ["second-video-owner-alias/fixture-model"],
+                      },
+                    },
+                  },
+                },
+                plugins: {
+                  allow: [first.plugin.id, second.plugin.id],
+                  load: { paths: [first.plugin.file, second.plugin.file] },
+                  slots: { memory: "none" },
+                },
+              },
+              modelOverride: selection === "override" ? second.params.modelOverride : undefined,
+            }),
+          );
+          try {
+            await waitForProviderStart(second.started.promise, outcome);
+            expect(first.connections).toHaveLength(1);
+            expect(second.connections).toHaveLength(1);
+            expect(first.connections[0]!.requests).toHaveLength(selection === "override" ? 0 : 1);
+            expect(first.connections[0]!.database.isOpen).toBe(true);
+            second.resume.resolve();
+            const result = await outcome;
+            expect(result.error).toBeUndefined();
+            expect(result.value?.provider).toBe("second-video-owner-alias");
+            expect(result.value?.videos[0]?.buffer).toEqual(videoBytes);
+            expect(result.value?.attempts).toHaveLength(selection === "override" ? 0 : 1);
+            for (const connection of [...first.connections, ...second.connections]) {
+              expect(connection.database.isOpen).toBe(false);
+              expect(connection.disposals).toBe(1);
+            }
+          } finally {
+            second.resume.resolve();
+            await outcome;
+          }
+        });
+      } finally {
+        first.cleanup();
+        second.cleanup();
+      }
+    },
+  );
+});

--- a/src/video-generation/runtime.ts
+++ b/src/video-generation/runtime.ts
@@ -6,6 +6,7 @@ import { parseVideoGenerationModelRef } from "../media-generation/model-ref.js";
 import {
   getVideoGenerationProvider,
   listVideoGenerationProviders,
+  withVideoGenerationProviders,
 } from "../media-generation/registry.js";
 import {
   buildMediaGenerationNormalizationMetadata,
@@ -14,6 +15,10 @@ import {
   resolveMediaProviderRequestTimeoutMs,
   runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
+import {
+  buildCapabilityProviderIndex,
+  normalizeCapabilityProviderId,
+} from "../plugins/provider-registry-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveVideoGenerationModeCapabilities } from "./capabilities.js";
 import {
@@ -116,6 +121,29 @@ export function listRuntimeVideoGenerationProviders(
 export async function generateVideo(
   params: GenerateVideoParams,
   deps: VideoGenerationRuntimeDeps = {},
+): Promise<GenerateVideoRuntimeResult> {
+  if (deps.getProvider && deps.listProviders) {
+    return runVideoGeneration(params, deps);
+  }
+  return withVideoGenerationProviders(params.cfg, (providers) => {
+    const canonical = buildCapabilityProviderIndex(providers, "canonical");
+    const aliases = buildCapabilityProviderIndex(providers, "aliases");
+    return runVideoGeneration(params, {
+      ...deps,
+      getProvider:
+        deps.getProvider ??
+        ((id) => {
+          const normalized = normalizeCapabilityProviderId(id);
+          return normalized ? aliases.get(normalized) : undefined;
+        }),
+      listProviders: deps.listProviders ?? (() => [...canonical.values()]),
+    });
+  });
+}
+
+async function runVideoGeneration(
+  params: GenerateVideoParams,
+  deps: VideoGenerationRuntimeDeps,
 ): Promise<GenerateVideoRuntimeResult> {
   const getProvider = deps.getProvider ?? getVideoGenerationProvider;
   const listProviders = deps.listProviders ?? listVideoGenerationProviders;


### PR DESCRIPTION
Related: #140674, #142834

## What Problem This Solves

Default video generation could leak cold plugin registrations or close managed resources during asynchronous model-capability lookup and generation.

## Why This Change Was Made

The video runtime now uses the shared capability owner from #142834. Its lifetime covers capability lookup, provider selection and fallback, actual generation, result validation, metadata projection, and tracked cleanup. The original operation body remains unchanged. Raw registrations and caller-supplied resolvers retain their existing custody.

## User Impact

Operation-owned registrations close after completed video generation, including failures. The supported result contract still permits buffers and provider-hosted URLs; callers retain ownership of later URL downloads, and cleanup must preserve completed artifacts. Polling, timeout hints, aliases, model overrides, mode/capability checks, options, and duration normalization remain unchanged. No public API, configuration, schema, dependency, or version changes.

## Evidence

The unchanged production baseline failed six native SQLite ownership cases while the raw-host control passed. All seven final cases and 137 existing video/shared/music sibling tests pass. The full independent Codex review is clean. The canonical changed gate passed in 363.1 seconds and the ordinary build in 215.0 seconds.

Actual compiled public video-generation calls ran buffer → URL → rejection → buffer in cold, managed, and raw modes. Cold operations registered/disposed four times; managed operations reused one registration until host release; raw operations received no automatic disposal and closed through caller cleanup. A separately owned fixture HTTP server served the returned URL after provider disposal. Saved and downloaded MP4 output independently decoded to the expected H.264 frame. Native close markers and read-only SQLite reopening verified completion. Source and all 11,389 artifacts stayed unchanged; every owned process group joined.

Illustrative call times were 25.52 / 4.84 / 6.20 / 3.21 ms cold, 8.90 / 1.93 / 4.01 / 4.82 ms managed, and 8.22 / 1.51 / 2.95 / 1.81 ms raw. These are synthetic observations, not a statistical before/after performance claim. No vendor credentials or real user state were used.

This default-runtime slice does not claim to cancel remote backend jobs, drain untracked vendor download siblings, or own the agent tool's prepared callbacks and detached jobs. Those require their actual producer owners.
