### PR TITLE
improve(test): remove real deadline wait from Swift polling regression

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
@@ -13,10 +13,11 @@ func waitUntil(
     // only matters under full-suite parallel load, where 3s flaked on CI.
     timeoutSeconds: Double = 15.0,
     pollMs: UInt64 = 10,
+    now: @Sendable () -> Date = { Date() },
     _ condition: @escaping @Sendable () async -> Bool) async throws
 {
-    let deadline = Date().addingTimeInterval(timeoutSeconds)
-    while Date() < deadline {
+    let deadline = now().addingTimeInterval(timeoutSeconds)
+    while now() < deadline {
         if await condition() { return }
         try await Task.sleep(nanoseconds: pollMs * 1_000_000)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpersTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpersTests.swift
@@ -1,23 +1,18 @@
 import Foundation
+import Synchronization
 import Testing
 
 private actor CompletingAsyncCondition {
+    nonisolated let clock = Mutex(Date(timeIntervalSince1970: 0))
     private(set) var completed = false
 
     func snapshot() async -> Bool {
         let snapshot = self.completed
         if snapshot { return snapshot }
 
-        // Predicate entry follows the helper's deadline construction, so this
-        // stale observation returns after that unchanged 15-second deadline.
-        let deadline = Date().addingTimeInterval(15)
-        do {
-            while Date() < deadline {
-                try await Task.sleep(nanoseconds: 10_000_000)
-            }
-        } catch {
-            return snapshot
-        }
+        // Keep time frozen until predicate entry so preemption cannot skip the first poll.
+        await Task.yield()
+        self.clock.withLock { $0.addTimeInterval(16) }
         self.completed = true
         return snapshot
     }
@@ -27,7 +22,9 @@ struct TestAsyncHelpersTests {
     @Test func `rechecks completion after an async predicate outlasts the deadline`() async throws {
         let condition = CompletingAsyncCondition()
 
-        try await waitUntil("completed async snapshot") { await condition.snapshot() }
+        try await waitUntil(
+            "completed async snapshot",
+            now: { condition.clock.withLock { $0 } }) { await condition.snapshot() }
 
         #expect(await condition.completed)
     }


### PR DESCRIPTION
Related: #139428 (https://github.com/openclaw/openclaw/issues/139428)

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through the same-repository branch.

</details>

## What Problem This Solves

The OpenClawKit polling regression spends a real 15 seconds proving completion
that arrives after a deadline. That delay is paid on every execution even though
the regression only needs to exercise the final completion recheck.

## Why This Change Was Made

Inject a clock into test support, defaulting to `Date()`. The regression's
mutex-protected clock stays frozen until predicate entry, then advances beyond
the deadline after an asynchronous yield while returning a stale false result.
Only the final recheck can observe completion.

The 15-second default, real 10ms poll sleep, cancellation propagation, timeout
label, and final recheck are unchanged. This preserves the regression from
https://github.com/openclaw/openclaw/pull/140119 without using a shorter,
scheduler-sensitive real deadline. Only two test/support files change; no
production, dependency, workflow, or configuration changes.

## User Impact

No runtime behavior changes. Developers retain all three polling-helper cases
while eliminating the regression's real 15-second wait.

## Evidence

Matched isolated Linux SwiftPM proof used Swift 6.3, exactly these two source
files, the repository's StrictConcurrency and SwiftTesting flags, one build job,
and non-parallel test execution:

| Case | Baseline | Candidate |
| --- | ---: | ---: |
| Completion after deadline | 15.018s | 0.011s |
| Timeout label | 0.002s | 0.001s |
| Cancellation | 0.001s | 0.001s |
| All three passing cases | 15.023s | 0.013s |

Build time is separate: 9.62s baseline and 10.00s candidate. The measured test
saving is 15.010s, not a build, cache, download, or scheduling improvement.

- Negative control: removing only the final recheck in an external fixture
  fails the completion regression with
  `Timeout waiting for: completed async snapshot`; the other two cases pass.
- Fresh P2 autoreview: scoped-clean, no findings.
- Linux-selected changed checks completed across interruption recovery, without
  repeating completed cases. Two fixture-write failures caused by a host
  `/tmp` quota passed when retried after the environment recovered. The
  original interrupted gate is not claimed as an uninterrupted green run.
- `git diff --check` passes. Existing non-Linux cases remain platform-skipped;
  no skip or assertion changes were made.
- Exact-head CI passed:
  https://github.com/openclaw/openclaw/actions/runs/34319058009
- Native job 102361580504 used Apple Swift 6.3.3 and passed 1,667 OpenClawKit
  tests. Its log explicitly records all three helper cases passing: completion
  5.818s, timeout label 5.214s, cancellation 5.509s; helper suite 6.067s.
  These full-suite timings are not the matched isolated performance comparison.
- The native `Swift lint` step executed successfully with zero violations in
  355 macOS and 22 Swabble files. Existing lint configuration does not target
  shared kit test files; the native OpenClawKit run provides their compile/test
  proof.
