### PR TITLE
fix(ui): open agent settings on Overview by default

### DIFF
--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -460,7 +460,7 @@ describe("Agent panel route paths", () => {
     expect(pathname).toBe("/ui/settings/agents/research");
     expect(agentRouteFromPath(pathname, "/ui")).toEqual({
       agentId: "research",
-      panel: "files",
+      panel: "overview",
       panelSegment: null,
       invalidPanel: false,
     });
@@ -470,7 +470,7 @@ describe("Agent panel route paths", () => {
   it("falls back unknown panel segments to the default panel", () => {
     expect(agentRouteFromPath("/settings/agents/research/unknown")).toEqual({
       agentId: "research",
-      panel: "files",
+      panel: "overview",
       panelSegment: null,
       invalidPanel: true,
     });

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -184,8 +184,8 @@ suite.define(() => {
             .toBe("reviewer");
           await waitForRequest(
             gateway,
-            "agents.files.list",
-            (params) => params.agentId === "reviewer",
+            "models.list",
+            (params) => params.agentId === "reviewer" && params.view === "configured",
           );
           await screenshot(page, "10-reloaded-reviewer.png");
           await page.goBack();

--- a/ui/src/lib/agents/panels.ts
+++ b/ui/src/lib/agents/panels.ts
@@ -10,7 +10,7 @@ const AGENT_PANEL_IDS = [
 
 export type AgentsPanel = (typeof AGENT_PANEL_IDS)[number];
 
-export const DEFAULT_AGENT_PANEL: AgentsPanel = "files";
+export const DEFAULT_AGENT_PANEL: AgentsPanel = "overview";
 
 export function isAgentsPanel(value: string): value is AgentsPanel {
   return AGENT_PANEL_IDS.some((panel) => panel === value);

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -903,6 +903,7 @@ describe("AgentsPage gateway lifecycle", () => {
       agents: [{ id: "main", name: "Main" }],
     };
     page.agentsSelectedId = "main";
+    page.routeData = { panel: "files" } as AgentsRouteData;
     page.agentFileContents = { "cached.md": "keep" };
     page.routeDataInitialized = true;
     page.context = {
@@ -1030,6 +1031,7 @@ describe("AgentsPage gateway lifecycle", () => {
     } as unknown as ApplicationContext["sessions"];
     const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
     const context = pageContext(currentGateway, agents, { sessions: oldSessions });
+    page.routeData = agentsRouteData(currentGateway);
     page.context = context;
     setPageGateway(page, client);
     page.subscriptions.hostConnected();

--- a/ui/src/pages/agents/route-location.test.ts
+++ b/ui/src/pages/agents/route-location.test.ts
@@ -10,8 +10,8 @@ function location(url: string): RouteLocation {
 
 describe("Agents route location", () => {
   it.each([
-    ["/settings/agents", null, "files"],
-    ["/settings/agents/research", "research", "files"],
+    ["/settings/agents", null, "overview"],
+    ["/settings/agents/research", "research", "overview"],
     ["/settings/agents/research/overview", "research", "overview"],
     ["/settings/agents/research/files", "research", "files"],
     ["/settings/agents/research/tools", "research", "tools"],
@@ -34,7 +34,7 @@ describe("Agents route location", () => {
     ).toEqual({
       location: location("/settings/agents?agent=team.writer&probe=1#catalog"),
       requestedAgentId: "team.writer",
-      panel: "files",
+      panel: "overview",
       canonicalLocation: location("/settings/agents/team%2Ewriter?probe=1#catalog"),
     });
   });
@@ -59,7 +59,7 @@ describe("Agents route location", () => {
     ).toEqual({
       location: location("/ui/settings/agents/research/unknown?probe=1#files"),
       requestedAgentId: "research",
-      panel: "files",
+      panel: "overview",
       canonicalLocation: location("/ui/settings/agents/research?probe=1#files"),
     });
   });
@@ -68,7 +68,7 @@ describe("Agents route location", () => {
     expect(resolveAgentsRouteLocation(location("/settings/agents?agent=team%2Fwriter"))).toEqual({
       location: location("/settings/agents?agent=team%2Fwriter"),
       requestedAgentId: null,
-      panel: "files",
+      panel: "overview",
       canonicalLocation: location("/settings/agents"),
     });
   });
@@ -79,7 +79,7 @@ describe("Agents route location", () => {
     ).toEqual({
       location: location(`/settings/agents?agent=${encodeURIComponent(agentId)}`),
       requestedAgentId: null,
-      panel: "files",
+      panel: "overview",
       canonicalLocation: location("/settings/agents"),
     });
   });

--- a/ui/src/pages/agents/route-navigation.test.ts
+++ b/ui/src/pages/agents/route-navigation.test.ts
@@ -15,12 +15,12 @@ function context() {
 }
 
 describe("Agents route navigation", () => {
-  it("pushes agent and panel selections without mutating route state", () => {
+  it.each(["files", "tools"] as const)("preserves the %s panel when switching agents", (panel) => {
     const navigation = context();
 
-    navigateToAgent(navigation, "research", "main", "tools");
+    navigateToAgent(navigation, "research", "main", panel);
     expect(navigation.navigate).toHaveBeenCalledWith("agents", {
-      pathname: "/ui/settings/agents/research/tools",
+      pathname: `/ui/settings/agents/research/${panel}`,
     });
 
     navigateToAgentPanel(navigation, "main", "tools", "memory");
@@ -32,12 +32,12 @@ describe("Agents route navigation", () => {
   it("uses the concise agent path for the default panel and ignores no-op selections", () => {
     const navigation = context();
 
-    navigateToAgent(navigation, "research", "main", "files");
+    navigateToAgent(navigation, "research", "main", "overview");
     expect(navigation.navigate).toHaveBeenCalledWith("agents", {
       pathname: "/ui/settings/agents/research",
     });
-    navigateToAgent(navigation, "main", "main", "files");
-    navigateToAgentPanel(navigation, "main", "files", "files");
+    navigateToAgent(navigation, "main", "main", "overview");
+    navigateToAgentPanel(navigation, "main", "overview", "overview");
     expect(navigation.navigate).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/pages/agents/route.test.ts
+++ b/ui/src/pages/agents/route.test.ts
@@ -60,7 +60,7 @@ describe("agents route", () => {
     const result = await loadRoute("/settings/agents");
 
     expect(result.requestedAgentId).toBeNull();
-    expect(result.panel).toBe("files");
+    expect(result.panel).toBe("overview");
     expect(result.canonicalLocation).toBeUndefined();
   });
 
@@ -75,7 +75,7 @@ describe("agents route", () => {
   it("returns the canonical replacement for a legacy agent query", async () => {
     const result = await loadRoute("/settings/agents?agent=research&probe=1#files");
 
-    expect(result.panel).toBe("files");
+    expect(result.panel).toBe("overview");
     expect(result.canonicalLocation).toEqual({
       pathname: "/settings/agents/research",
       search: "?probe=1",


### PR DESCRIPTION
Closes #142883 — Agents settings opens Files instead of Overview.

## What Problem This Solves

Fixes an issue where users opening **Settings → Agents** would land on Files instead of Overview when the URL did not specify a panel.

## Why This Change Was Made

Set the existing shared agent-panel default to Overview. The route parser, route loader, page fallback, and agent-switch navigation already consume that single default; no additional routing path or configuration is needed. Explicit Files and other panel links remain unchanged.

Production delta: +1/−1 (net 0). Tests: +18/−16 (net +2). Existing route expectations are updated, Files/Tools switching coverage is table-driven, and two lifecycle fixtures now explicitly select their intended Files panel.

## User Impact

Opening `/settings/agents` or `/settings/agents/<agentId>` selects Overview. Selecting Files still produces an explicit `/files` URL that survives reload and agent switching. Unknown panel segments continue normalizing to the default panel.

## Evidence

- Regression first: the updated route tests failed on the original source with 12 cases receiving Files instead of Overview; 57 cases passed.
- After repair: **103 tests passed across five files**:
  ```sh
  node scripts/run-vitest.mjs ui/src/pages/agents/route-location.test.ts ui/src/pages/agents/route-navigation.test.ts ui/src/pages/agents/route.test.ts ui/src/app-route-paths.test.ts ui/src/pages/agents/agents-page.test.ts
  ```
- `pnpm ui:build` passed before and after the change.
- Real Chromium against a separate loopback-only Gateway with an isolated temporary state directory: initial Agents route changed from Files to Overview; Files selection and reload passed; the agent-specific bare route selected Overview. No mock Gateway or operator-instance changes. Candidate UI was served through the existing local Gateway build (2026.9.3); this is a UI-only change.
- Confirmed the served entry asset changed from `index-mIUdTz76.js` to `index-obMAelfW.js`.
- Fresh autoreview at P2: scoped-clean, no actionable findings.
- `node scripts/check-changed.mjs` passed, including all 17 core-test typecheck shards, UI typecheck, i18n verification, dead-export scans, and lint/guards.
- The two-line lifecycle-fixture adjustment was additionally checked with `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/agents/agents-page.test.ts` and `node_modules/.bin/oxfmt --check ui/src/pages/agents/agents-page.test.ts`.
- `git diff --check` passed.

### Before

![Agents opens Files](https://github.com/user-attachments/assets/82b97477-1f5c-404e-a564-3243633e016b)

### After

![Agents opens Overview](https://github.com/user-attachments/assets/2fe2b00e-43d1-4157-bd67-91d42519100c)

Screenshots are inspected crops of the real running UI, excluding unrelated model details.
