### PR TITLE
fix(codex): surface OAuth reauthentication recovery

### DIFF
--- a/extensions/codex/src/app-server/auth-refresh-error.ts
+++ b/extensions/codex/src/app-server/auth-refresh-error.ts
@@ -1,0 +1,43 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_ERROR_CODE = -32_090;
+export const CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_RESPONSE_MESSAGE =
+  "OAuth reauthentication required";
+
+// Codex drops callback messages because they may contain tokens, but preserves
+// this numeric code in its sanitized terminal error.
+const CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_MESSAGE = `auth refresh request failed: code=${CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_ERROR_CODE}`;
+const OPENAI_REAUTH_REQUIRED_RAW_ERROR = "OAuth token refresh failed for openai: sign_in_again";
+
+const PERMANENT_OPENAI_OAUTH_REASONS = new Set([
+  "expired",
+  "invalid_grant",
+  "invalid_refresh_token",
+  "refresh_token_reused",
+  "revoked",
+  "token_invalidated",
+]);
+
+export function isPermanentOpenAIOAuthRefreshFailure(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name !== "OAuthRefreshFailureError") {
+    return false;
+  }
+  const failure = asOptionalRecord(error);
+  const reason = failure?.reason;
+  return (
+    failure?.provider === "openai" &&
+    typeof reason === "string" &&
+    PERMANENT_OPENAI_OAUTH_REASONS.has(reason)
+  );
+}
+
+export function readCodexExternalAuthReauthFailure(
+  message: string | null | undefined,
+): Error | undefined {
+  if (message !== CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_MESSAGE) {
+    return undefined;
+  }
+  return Object.assign(new Error(CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_RESPONSE_MESSAGE), {
+    rawError: OPENAI_REAUTH_REQUIRED_RAW_ERROR,
+  });
+}

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -158,7 +158,7 @@ describe("Codex app-server client runtime", () => {
 
     expect(JSON.parse(harness.writes.at(-1) ?? "{}")).toMatchObject({
       id: "refresh-timed-out",
-      error: { message: expect.stringContaining("token refresh timed out") },
+      error: { code: -32603, message: expect.stringContaining("token refresh timed out") },
     });
   });
 

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -13,6 +13,14 @@ import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from
 
 const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 660_000;
 
+function createStructuredOAuthRefreshFailure(provider: string, reason: string): Error {
+  return Object.assign(new Error("sanitized OAuth refresh failure"), {
+    name: "OAuthRefreshFailureError",
+    provider,
+    reason,
+  });
+}
+
 describe("CodexAppServerClient", () => {
   const clients: CodexAppServerClient[] = [];
   const newerMinorVersion = new SemVer(CODEX_APP_SERVER_VERSION).inc("minor").version;
@@ -780,13 +788,13 @@ describe("CodexAppServerClient", () => {
     });
   });
 
-  it("returns JSON-RPC internal errors when server request handlers throw", async () => {
+  it("returns a private JSON-RPC code for permanent OAuth refresh failures", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const harness = createClientHarness();
     clients.push(harness.client);
     harness.client.addRequestHandler((request) => {
       if (request.method === "account/chatgptAuthTokens/refresh") {
-        throw new Error("refresh_token_invalidated: reauthentication required");
+        throw createStructuredOAuthRefreshFailure("openai", "token_invalidated");
       }
       return undefined;
     });
@@ -801,8 +809,8 @@ describe("CodexAppServerClient", () => {
     expect(JSON.parse(harness.writes[0] ?? "{}")).toEqual({
       id: "srv-refresh",
       error: {
-        code: -32603,
-        message: "refresh_token_invalidated: reauthentication required",
+        code: -32090,
+        message: "OAuth reauthentication required",
       },
     });
     expect(warn).toHaveBeenCalledWith("codex app-server server request handler failed", {
@@ -810,6 +818,55 @@ describe("CodexAppServerClient", () => {
       method: "account/chatgptAuthTokens/refresh",
       error: expect.any(Error),
     });
+  });
+
+  it.each([
+    {
+      label: "transient failures",
+      error: new Error("temporary auth service failure"),
+    },
+    {
+      label: "other providers",
+      error: createStructuredOAuthRefreshFailure("anthropic", "token_invalidated"),
+    },
+    {
+      label: "unverified login hints",
+      error: createStructuredOAuthRefreshFailure("openai", "sign_in_again"),
+    },
+    {
+      label: "wrapped permanent failures",
+      error: new Error("wrapper", {
+        cause: createStructuredOAuthRefreshFailure("openai", "token_invalidated"),
+      }),
+    },
+    {
+      label: "non-Error lookalikes",
+      error: {
+        name: "OAuthRefreshFailureError",
+        provider: "openai",
+        reason: "token_invalidated",
+      },
+    },
+  ])("keeps $label on the JSON-RPC internal error code", async ({ error }) => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    harness.client.addRequestHandler(() => {
+      throw error;
+    });
+
+    harness.send({
+      id: "srv-generic",
+      method: "account/chatgptAuthTokens/refresh",
+      params: { accountId: "acct-1" },
+    });
+    await vi.waitFor(() => expect(harness.writes.length).toBe(1));
+
+    expect(JSON.parse(harness.writes[0] ?? "{}")).toMatchObject({
+      id: "srv-generic",
+      error: { code: -32603 },
+    });
+    expect(warn).toHaveBeenCalledOnce();
   });
 
   it("fails closed when a dynamic tool server request handler hangs", async () => {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -9,6 +9,11 @@ import { coerceErrorMessage, toStringifiedError } from "openclaw/plugin-sdk/erro
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { parse as parseSemver } from "semver";
+import {
+  CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_ERROR_CODE,
+  CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_RESPONSE_MESSAGE,
+  isPermanentOpenAIOAuthRefreshFailure,
+} from "./auth-refresh-error.js";
 import type { CodexAppServerStartOptions } from "./config-contracts.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config-runtime.js";
 import { resolveDynamicToolServerRequestTimeoutMs } from "./dynamic-tool-execution.js";
@@ -974,11 +979,16 @@ export class CodexAppServerClient {
         method: request.method,
         error,
       });
+      const permanentOAuthFailure =
+        request.method === "account/chatgptAuthTokens/refresh" &&
+        isPermanentOpenAIOAuthRefreshFailure(error);
       this.writeMessage({
         id: request.id,
         error: {
-          code: -32603,
-          message,
+          code: permanentOAuthFailure ? CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_ERROR_CODE : -32603,
+          message: permanentOAuthFailure
+            ? CODEX_EXTERNAL_AUTH_REAUTH_REQUIRED_RESPONSE_MESSAGE
+            : message,
         },
       });
     }

--- a/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
+++ b/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
@@ -58,6 +58,32 @@ describe("CodexAppServerEventProjector terminal errors", () => {
     },
   );
 
+  it.each(["error", "turn/completed"] as const)(
+    "reconstructs permanent OpenAI OAuth evidence from Codex %s failures",
+    async (method) => {
+      const projector = await createProjector();
+      const error = {
+        message: "auth refresh request failed: code=-32090",
+        codexErrorInfo: "other",
+      };
+      await projector.handleNotification(
+        forCurrentTurn(
+          method,
+          method === "error"
+            ? { error, willRetry: false }
+            : { turn: { id: TURN_ID, status: "failed", items: [], error } },
+        ),
+      );
+
+      const terminal = readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry()));
+      expect(terminal.promptError).toMatchObject({
+        name: "Error",
+        message: "OAuth reauthentication required",
+        rawError: "OAuth token refresh failed for openai: sign_in_again",
+      });
+    },
+  );
+
   it("does not treat app-server interrupted status as a user cancellation by itself", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/usage-limit-error.ts
+++ b/extensions/codex/src/app-server/usage-limit-error.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { markAuthProfileBlockedUntil } from "openclaw/plugin-sdk/agent-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readCodexExternalAuthReauthFailure } from "./auth-refresh-error.js";
 import { CODEX_CONTROL_METHODS } from "./capabilities.js";
 import type { CodexAppServerClient } from "./client.js";
 import { isJsonObject, type CodexServerNotification, type JsonValue } from "./protocol.js";
@@ -45,6 +46,10 @@ export class CodexUsageLimitPromptError extends Error {
 export function resolveCodexPromptError(
   source: Pick<CodexUsageLimitErrorSource, "message" | "codexErrorInfo" | "rateLimits">,
 ): string | Error | undefined {
+  const authRefreshFailure = readCodexExternalAuthReauthFailure(source.message);
+  if (authRefreshFailure) {
+    return authRefreshFailure;
+  }
   const usageLimitMessage = formatCodexUsageLimitErrorMessage(source);
   if (usageLimitMessage) {
     return new CodexUsageLimitPromptError(usageLimitMessage);


### PR DESCRIPTION
Fixes #89278

## What Problem This Solves

Fixes an issue where users with a revoked or invalidated Codex OAuth session would receive a generic 10-second refresh timeout instead of actionable sign-in recovery.

## Why This Change Was Made

Codex intentionally removes callback error messages because they may contain credentials, but retains the JSON-RPC numeric code. OpenClaw now uses a private, non-colliding code only for directly structured permanent OpenAI OAuth failures, then reconstructs bounded safe evidence when Codex returns its sanitized terminal error.

Transient failures, timeouts, other providers, wrappers, and unverified login hints remain on the generic path. This does not change Codex's upstream fixed 10-second callback deadline; the late-rotation reuse landed separately in #142628.

## User Impact

Revoked or invalidated Codex OAuth sessions can surface the existing inline `/login codex` recovery in interactive replies and scheduled failure alerts instead of ending as a generic timeout.

## Evidence

- Direct dependency inspection: Codex `external_auth.rs` discards the callback message and emits only `auth refresh request failed: code=<n>`.
- Private code `-32090` does not collide with Codex's existing `-32001` overload code.
- `125/125` focused Codex client, runtime, and terminal projection tests pass.
- `118/118` OAuth classifier, interactive reply, cron alert, and payload recovery tests pass.
- Plugin SDK surface remains pinned at `4,447` public exports.
- Independent autoreview: scoped clean through P2, overall patch correctness `0.94`.

Landing still requires exact-head CI and auth-owner review. A pre-existing artifact lock prevented the local aggregate typecheck; no lock or process owned by another session was modified.
