### PR TITLE
improve(test): avoid real-time waits in Mermaid timeout coverage

### DIFF
--- a/ui/src/components/markdown-mermaid-native.browser.test.ts
+++ b/ui/src/components/markdown-mermaid-native.browser.test.ts
@@ -1,5 +1,6 @@
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.ts";
 import "../../../packages/mermaid-renderer/src/native.ts";
 
 type NativeReply = {
@@ -38,6 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
   window.dispatchEvent(new PageTransitionEvent("pagehide"));
   delete window.ChatMermaidBridge;
   diagram.remove();
@@ -99,11 +101,15 @@ describe("native Mermaid document", () => {
     "reports %s timeouts as retryable and recovers on the next request",
     async (boundary) => {
       const source = "flowchart LR\nA[Waiting] --> B[Ready]";
+      const deadline = boundary === "image decode" ? 5_000 : 15_000;
+      const stalled = createDeferred();
+      const decoding = createDeferred();
       if (boundary === "engine load") {
         const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, "srcdoc")!;
         vi.spyOn(HTMLIFrameElement.prototype, "srcdoc", "set").mockImplementation(
           function (this: HTMLIFrameElement) {
             descriptor.set!.call(this, "<!doctype html><html></html>");
+            stalled.resolve();
           },
         );
       } else if (boundary === "engine render") {
@@ -113,20 +119,56 @@ describe("native Mermaid document", () => {
           this: MessagePort,
           ...args
         ) {
-          if (asRecord(args[0]).source !== source) {
+          if (asRecord(args[0]).source === source) {
+            stalled.resolve();
+          } else {
             Reflect.apply(postMessage, this, args);
           }
         });
       } else {
-        vi.spyOn(HTMLImageElement.prototype, "decode").mockImplementationOnce(
-          () => new Promise(() => {}),
-        );
+        vi.spyOn(HTMLImageElement.prototype, "decode").mockImplementationOnce(() => {
+          stalled.resolve();
+          return decoding.promise;
+        });
       }
 
-      await window.renderMermaid({ id: "timeout", source, widthCssPx: 320, theme });
-      expect(replies[0]).toMatchObject({ id: "timeout", success: false, retryable: true });
-      expect(diagram.querySelector("img")).toBeNull();
-      vi.restoreAllMocks();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const schedule = vi.spyOn(window, "setTimeout");
+      let pending: Promise<void> | undefined;
+      let settled = false;
+      try {
+        pending = window
+          .renderMermaid({ id: "timeout", source, widthCssPx: 320, theme })
+          .finally(() => {
+            settled = true;
+          });
+        // Load/decode arm their watchdog after the intercepted call returns.
+        // Awaiting the stall lets that synchronous registration finish.
+        await stalled.promise;
+        expect(schedule).toHaveBeenLastCalledWith(expect.any(Function), deadline);
+        expect(vi.getTimerCount()).toBe(1);
+        await vi.advanceTimersByTimeAsync(deadline - 1);
+        expect(settled).toBe(false);
+        expect(replies).toEqual([]);
+        expect(diagram.querySelector("img")).toBeNull();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(settled).toBe(true);
+        await pending;
+        expect(replies[0]).toMatchObject({ id: "timeout", success: false, retryable: true });
+        expect(diagram.querySelector("img")).toBeNull();
+      } finally {
+        try {
+          // A failed assertion must not strand the serialized native decode queue.
+          decoding.resolve();
+          if (pending && !settled) {
+            window.dispatchEvent(new PageTransitionEvent("pagehide"));
+            await pending;
+          }
+        } finally {
+          vi.restoreAllMocks();
+          vi.useRealTimers();
+        }
+      }
       await window.renderMermaid({ id: "recovered", source, widthCssPx: 320, theme });
       expect(replies[1]).toMatchObject({ id: "recovered", success: true });
       expect(diagram.querySelector("img")?.complete).toBe(true);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

The native Mermaid browser tests spend 35 seconds waiting for intentionally
stalled engine-load, render, and image-decode watchdogs on every invocation.

## Why This Change Was Made

Scope fake `setTimeout`/`clearTimeout` to those three existing timeout cases.
Wait for the deliberate stall, assert the unchanged 15,000/5,000 ms deadline,
prove the request is still pending one millisecond before it, and verify the
original retryable failure at the deadline. Restore real timers before recovery.

Real iframe isolation, messaging, rendering, decoding, and recovery remain.
Failure cleanup releases the stalled decode promise and disposes pending work
so the serialized native queue cannot strand later cases. Only the native test
file changes; production code, test configuration, case coverage, and sharding
are unchanged.

## User Impact

No product behavior changes. The selected native browser file's median case
runtime fell from 43.379 s to 8.381 s, saving 34.998 s (80.68%) locally.
This is not an end-to-end CI improvement claim or the target of the related
issue's independent campaign.

## Evidence

Paired on one Linux host with the same owned frozen dependency install, Chromium,
cache, worker geometry, and complete native + runtime sibling selection.
Alternating baseline/candidate runs followed excluded warmups. Every measured
run passed the same 16 cases. Baseline: `f8bec277cbe1a28cb8aae2cfc7b01b0bb57a31d3`.

| Pair | Baseline native cases | Candidate native cases | Baseline invocation | Candidate invocation |
| --- | ---: | ---: | ---: | ---: |
| 1 | 43.207 s | 8.834 s | 51.046 s | 16.667 s |
| 2 | 44.214 s | 8.381 s | 52.978 s | 16.336 s |
| 3 | 43.379 s | 7.993 s | 57.499 s | 15.333 s |
| Median | 43.379 s | 8.381 s | 52.978 s | 16.336 s |

Case durations include real rendering/recovery and applicable hooks, not module
loading. Invocation durations include both selected files and process overhead;
their 69.16% median reduction is limited to this selection. The three timeout
cases alone fell from median 38.531 s to 3.496 s. Sibling variance is not claimed
as an optimization.

- Node 24.19.0, pnpm 12.3.4, Vitest 5.0.0, Playwright 1.62.1,
  Chromium 151.0.7922.34; serial paired runs on an 8-logical-CPU Linux host.
- Default UI project geometry also passed all 16 owner + sibling cases.
- Mutation control: disabling the three watchdog callbacks failed exactly the
  three deadline-completion assertions; the other 13 cases passed.
- Mutation control: shortening deadlines by one millisecond failed exactly the
  three scheduled-delay assertions; the other 13 cases passed.
- All temporary production mutations were restored and source hashes verified.
- Local changed checks passed, including the resumed graph boundary, UI i18n,
  narrow `ui-other` typecheck, coercion guard, dead-export scans, and targeted
  lint. Formatting and `git diff --check` passed. Independent P2 review completed
  scoped-clean with no actionable findings.

No full UI lane, release validation, or live Gateway run was needed for this
test-only boundary. Raw local samples and case identities are retained outside
the repository; private host paths and generated browser caches are not included.
