### PR TITLE
refactor: simplify Gateway cron lifecycle test gates

### DIFF
--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -1,6 +1,7 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { CronJob } from "../cron/types.js";
 import { resolveExitWatchShell } from "./cron-exit-watch-shell.js";
 import { createCronExitWatchers, type CronExitResult } from "./cron-exit-watchers.js";
@@ -148,10 +149,7 @@ describe("createCronExitWatchers", () => {
 
   it("rebinds live watchers but drains callbacks already owned by the previous scheduler", async () => {
     const { supervisor, runs } = makeFakeSupervisor();
-    let releasePersistence = () => {};
-    const persistenceGate = new Promise<void>((resolve) => {
-      releasePersistence = resolve;
-    });
+    const { promise: persistenceGate, resolve: releasePersistence } = createDeferred();
     const releaseCompletion = vi.fn();
     const oldPersistCompletion = vi.fn(async () => {
       await persistenceGate;

--- a/src/gateway/cron-stream-output.interleavings.test.ts
+++ b/src/gateway/cron-stream-output.interleavings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { CronJob } from "../cron/types.js";
 import {
   createWatchers,
@@ -280,14 +281,8 @@ describe("cron stream output", () => {
     it("drains output accepted behind a slow owner write before entering backoff", async () => {
       vi.useFakeTimers();
       const fake = fakeSupervisor();
-      let releasePayload!: () => void;
-      const payload = new Promise<void>((resolve) => {
-        releasePayload = resolve;
-      });
-      let releaseCounter!: () => void;
-      const counter = new Promise<void>((resolve) => {
-        releaseCounter = resolve;
-      });
+      const { promise: payload, resolve: releasePayload } = createDeferred();
+      const { promise: counter, resolve: releaseCounter } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
         if (patch.streamCoalescedBatches === 1) {
           await counter;
@@ -343,18 +338,9 @@ describe("cron stream output", () => {
     it("lets a stop requested during exit draining own teardown without counting failure", async () => {
       vi.useFakeTimers();
       const fake = fakeSupervisor();
-      let releasePayload!: () => void;
-      const payload = new Promise<void>((resolve) => {
-        releasePayload = resolve;
-      });
-      let markDrainEntered!: () => void;
-      const drainEntered = new Promise<void>((resolve) => {
-        markDrainEntered = resolve;
-      });
-      let releaseDrain!: () => void;
-      const drain = new Promise<void>((resolve) => {
-        releaseDrain = resolve;
-      });
+      const { promise: payload, resolve: releasePayload } = createDeferred();
+      const { promise: drainEntered, resolve: markDrainEntered } = createDeferred();
+      const { promise: drain, resolve: releaseDrain } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
         if (patch.streamCoalescedBatches === 2) {
           markDrainEntered();
@@ -430,14 +416,8 @@ describe("cron stream output", () => {
     it("bounds raw output while a serialized counter write is slow", async () => {
       vi.useFakeTimers();
       const fake = fakeSupervisor();
-      let releasePayload!: () => void;
-      const payload = new Promise<void>((resolve) => {
-        releasePayload = resolve;
-      });
-      let releaseCounter!: () => void;
-      const counter = new Promise<void>((resolve) => {
-        releaseCounter = resolve;
-      });
+      const { promise: payload, resolve: releasePayload } = createDeferred();
+      const { promise: counter, resolve: releaseCounter } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, patch: Partial<CronJob["state"]>) => {
         if (patch.streamCoalescedBatches === 1) {
           await counter;
@@ -497,10 +477,7 @@ describe("cron stream output", () => {
     it("bounds stop while a payload remains in flight and freezes its counter", async () => {
       vi.useFakeTimers();
       const fake = fakeSupervisor();
-      let releasePayload!: () => void;
-      const payload = new Promise<void>((resolve) => {
-        releasePayload = resolve;
-      });
+      const { promise: payload, resolve: releasePayload } = createDeferred();
       const updateState = vi.fn(async (_jobId: string, _patch: Partial<CronJob["state"]>) => {});
       const watchers = createWatchers({
         getProcessSupervisor: () => fake.supervisor,

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -2,6 +2,7 @@
  * Tests lazy cron startup behavior in the gateway server.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../test/helpers/promise.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayCronServiceContract } from "./server-cron-contract.js";
@@ -22,14 +23,6 @@ vi.mock("./server-cron.js", () => ({
 }));
 
 const { createLazyGatewayCronState } = await import("./server-cron-lazy.js");
-
-function deferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 describe("createLazyGatewayCronState", () => {
   beforeEach(() => {

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -2,6 +2,7 @@
 // including URL redaction for invalid webhook destinations.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as createVoidDeferred } from "../../test/helpers/promise.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
 import {
@@ -71,14 +72,6 @@ function webhookRequestBody() {
     throw new Error("expected webhook request body");
   }
   return JSON.parse(init.body);
-}
-
-function createVoidDeferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function createWebhookJob(delivery: NonNullable<CronJob["delivery"]>): CronJob {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1513,10 +1513,7 @@ describe("buildGatewayCronService", () => {
       // stale snapshot. The revision fence must re-list instead of stopping the
       // freshly started owner as "removed".
       const originalList = state.cron.list.bind(state.cron);
-      let releaseStaleList!: () => void;
-      const staleListGate = new Promise<void>((resolve) => {
-        releaseStaleList = resolve;
-      });
+      const { promise: staleListGate, resolve: releaseStaleList } = createDeferred();
       let armed = true;
       state.cron.list = async (opts?: Parameters<typeof originalList>[0]) => {
         if (!armed) {
@@ -1552,10 +1549,7 @@ describe("buildGatewayCronService", () => {
 
   it("drains stream teardown once when stop and stopAndDrain overlap", async () => {
     const cancel = vi.fn();
-    let resolveWait!: () => void;
-    const wait = new Promise<void>((resolve) => {
-      resolveWait = resolve;
-    });
+    const { promise: wait, resolve: resolveWait } = createDeferred();
     const spawn = vi.fn(async () => ({
       runId: "run-single-drain-stream",
       startedAtMs: Date.now(),
@@ -1592,10 +1586,7 @@ describe("buildGatewayCronService", () => {
 
   it("retries stream teardown after a prior drain failure", async () => {
     vi.useFakeTimers();
-    let resolveWait!: () => void;
-    const wait = new Promise<void>((resolve) => {
-      resolveWait = resolve;
-    });
+    const { promise: wait, resolve: resolveWait } = createDeferred();
     let cancelAttempts = 0;
     const cancel = vi.fn(() => {
       cancelAttempts += 1;
@@ -1640,10 +1631,7 @@ describe("buildGatewayCronService", () => {
 
   it("reports a committed stream update as successful when source teardown fails", async () => {
     vi.useFakeTimers();
-    let resolveWait!: () => void;
-    const wait = new Promise<void>((resolve) => {
-      resolveWait = resolve;
-    });
+    const { promise: wait, resolve: resolveWait } = createDeferred();
     let cancelAttempts = 0;
     const cancel = vi.fn(() => {
       cancelAttempts += 1;
@@ -1689,10 +1677,7 @@ describe("buildGatewayCronService", () => {
 
   it("keeps a failed stream removal in an explicit terminal error state", async () => {
     vi.useFakeTimers();
-    let resolveWait!: () => void;
-    const wait = new Promise<void>((resolve) => {
-      resolveWait = resolve;
-    });
+    const { promise: wait, resolve: resolveWait } = createDeferred();
     let cancelAttempts = 0;
     const cancel = vi.fn(() => {
       cancelAttempts += 1;


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Gateway cron lifecycle tests duplicate Promise resolver capture and two local deferred constructors across stream, exit-watcher, notification and lazy-start fixtures.

## Why This Change Was Made

Reuse the existing deferred helper for fourteen eager capture pairs and replace the two local helper definitions with imports under their existing names. Preserve allocation points, resolver calls, assertions, deadlines and cleanup. Conditional, lazy and non-void captures remain unchanged. The five-file change removes 54 net test lines without removing cases or changing production code.

## User Impact

No product behavior changes. Maintainers retain the same independent lifecycle and delivery coverage with less fixture boilerplate.

## Evidence

All five changed suites plus the reconciliation sibling passed all 226 cases before and after, with no skips and identical ordered cases within each file. Source-marker and symbol checks preserve outside-edit tokens, resolver uses and all ten local-helper consumers; none observes helper object shape or the additional native rejection capability.

The mapped changed gate passed. Fresh P2 review found no actionable issues. No runtime speedup is claimed.
