### PR TITLE
fix(ci): complete Android cold-boot observation

### DIFF
--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -142,6 +142,8 @@ jobs:
           emulator_pid=""
           adb_started=0
           readiness_failure_latched=0
+          final_cold_boot_observation_seconds=900
+          emulator_observation_deadline=0
 
           capture_accel_check() {
             local accel_raw="$DIAGNOSTIC_DIR/emulator-accel-check.raw"
@@ -198,22 +200,28 @@ jobs:
             local output_file="$1"
             local deadline="$2"
             shift 2
+            local probe_deadline
             local probe_pid
-            local probe_poll_seconds=1
+            local probe_poll_seconds=0.1
+            local probe_timeout_seconds=5
 
             probe_status=0
             probe_timed_out=false
+            : >"$output_file"
             if (( SECONDS >= deadline )); then
-              : >"$output_file"
               probe_status=124
               probe_timed_out=true
               return 0
             fi
 
+            probe_deadline=$((SECONDS + probe_timeout_seconds))
+            if (( probe_deadline > deadline )); then
+              probe_deadline=$deadline
+            fi
             "$@" >"$output_file" 2>&1 &
             probe_pid=$!
             while kill -0 "$probe_pid" 2>/dev/null; do
-              if (( SECONDS >= deadline )); then
+              if (( SECONDS >= probe_deadline )); then
                 probe_timed_out=true
                 if kill "$probe_pid" 2>/dev/null; then
                   :
@@ -225,12 +233,12 @@ jobs:
               fi
               sleep "$probe_poll_seconds"
             done
-            if wait "$probe_pid"; then
+            if wait "$probe_pid" 2>/dev/null; then
               probe_status=0
             else
               probe_status=$?
             fi
-            if (( SECONDS >= deadline )); then
+            if (( SECONDS >= probe_deadline )); then
               probe_timed_out=true
             fi
             if [[ "$probe_timed_out" == "true" ]]; then
@@ -238,14 +246,78 @@ jobs:
             fi
           }
 
+          retain_probe_output() {
+            local source_file="$1"
+            local destination_file="$2"
+            local max_bytes="$3"
+            local exit_status="$4"
+            local timed_out="$5"
+            local output_bytes
+            local output_truncated=false
+            local retained_bytes
+
+            output_bytes="$(wc -c <"$source_file" | tr -d ' ')"
+            retained_bytes="$output_bytes"
+            if (( output_bytes > max_bytes )); then
+              head -c "$max_bytes" "$source_file" >"$destination_file"
+              retained_bytes="$max_bytes"
+              output_truncated=true
+            else
+              cp "$source_file" "$destination_file"
+            fi
+            rm -f "$source_file"
+            {
+              printf '\nprobe_exit_status=%s\n' "$exit_status"
+              printf 'probe_timed_out=%s\n' "$timed_out"
+              printf 'output_bytes=%s\n' "$output_bytes"
+              printf 'retained_bytes=%s\n' "$retained_bytes"
+              printf 'output_truncated=%s\n' "$output_truncated"
+            } >>"$destination_file"
+          }
+
+          capture_cold_boot_snapshot() {
+            local snapshot_name="$1"
+            local serial="$2"
+            local observation_deadline="$3"
+            local snapshot_properties_max_bytes=65536
+            local snapshot_logcat_max_bytes=262144
+            local snapshot_dir="$DIAGNOSTIC_DIR/cold-boot-snapshots/$snapshot_name"
+            local probe_output="$DIAGNOSTIC_DIR/cold-boot-snapshot.raw"
+            local remaining_seconds=$((observation_deadline - SECONDS))
+
+            if (( remaining_seconds < 0 )); then
+              remaining_seconds=0
+            fi
+            mkdir -p "$snapshot_dir"
+            {
+              printf 'snapshot=%s\n' "$snapshot_name"
+              printf 'captured_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              printf 'serial=%s\n' "$serial"
+              printf 'avd_name=%s\n' "$AVD_NAME"
+              printf 'remaining_seconds_at_start=%s\n' "$remaining_seconds"
+            } >"$snapshot_dir/metadata.txt"
+
+            run_bounded_probe "$probe_output" "$observation_deadline" \
+              adb -s "$serial" shell getprop
+            retain_probe_output "$probe_output" "$snapshot_dir/boot-properties.txt" \
+              "$snapshot_properties_max_bytes" "$probe_status" "$probe_timed_out"
+
+            run_bounded_probe "$probe_output" "$observation_deadline" \
+              adb -s "$serial" logcat -b system -b crash -d -v threadtime -t 2000
+            retain_probe_output "$probe_output" "$snapshot_dir/system-crash-logcat.txt" \
+              "$snapshot_logcat_max_bytes" "$probe_status" "$probe_timed_out"
+          }
+
           observe_after_readiness_timeout() {
             local serial="${1:-}"
-            local post_deadline_observation_seconds=300
-            local post_deadline_poll_seconds=2
-            local observation_deadline=$((SECONDS + post_deadline_observation_seconds))
+            local observation_deadline="$2"
+            local observation_poll_seconds=2
+            local final_snapshot_lead_seconds=15
             local observation_log="$DIAGNOSTIC_DIR/post-deadline-observations.log"
             local observation_stop="observation-cap-reached"
             local late_adb_recorded=false
+            local first_snapshot_recorded=false
+            local final_snapshot_recorded=false
             local observed_at
             local probe_output="$DIAGNOSTIC_DIR/post-deadline-probe.raw"
             local adb_output
@@ -257,7 +329,7 @@ jobs:
 
             {
               printf 'original_deadline_reached_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-              printf 'observation_cap_seconds=%s\n' "$post_deadline_observation_seconds"
+              printf 'observation_cap_seconds=%s\n' "$final_cold_boot_observation_seconds"
               printf 'owned_emulator_pid=%s\n' "$emulator_pid"
             } >>"$observation_log"
 
@@ -276,81 +348,88 @@ jobs:
                   "$observed_at" "$probe_status" "$probe_timed_out"
                 printf '%s\n' "$adb_output"
               } >>"$observation_log"
-              if [[ "$probe_timed_out" == "true" ]]; then
-                observation_stop="adb-devices-timeout"
-                break
-              fi
-              if [[ "$probe_status" -ne 0 ]]; then
-                observation_stop="adb-devices-failed"
-                break
+              if [[ "$probe_timed_out" == "false" && "$probe_status" == "0" ]]; then
+                serials="$(printf '%s\n' "$adb_output" | awk 'NR > 1 && $2 == "device" { print $1 }')"
+                count="$(printf '%s\n' "$serials" | sed '/^$/d' | wc -l | tr -d ' ')"
+                if [[ "$count" -gt 1 ]]; then
+                  observation_stop="unexpected-multiple-devices"
+                  break
+                fi
+                if [[ "$count" == "1" ]]; then
+                  if [[ -n "$serial" && "$serial" != "$serials" ]]; then
+                    observation_stop="unexpected-device-change"
+                    break
+                  fi
+                  if [[ -z "$serial" ]]; then
+                    serial="$serials"
+                  fi
+                  run_bounded_probe "$probe_output" "$observation_deadline" \
+                    adb -s "$serial" emu avd name
+                  avd_name="$(head -c 4096 "$probe_output" | tr -d '\r' | sed -n '1p')"
+                  printf '[%s] serial=%s avd_status=%s avd_timed_out=%s avd_name=%s\n' \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$serial" "$probe_status" \
+                    "$probe_timed_out" "${avd_name:-unset}" >>"$observation_log"
+                  if [[ "$probe_timed_out" == "false" && "$probe_status" == "0" ]]; then
+                    if [[ "$avd_name" != "$AVD_NAME" ]]; then
+                      observation_stop="unexpected-avd"
+                      break
+                    fi
+                    if [[ "$late_adb_recorded" == "false" ]]; then
+                      printf 'late_adb_online_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                        >>"$observation_log"
+                      late_adb_recorded=true
+                    fi
+                    if [[ "$first_snapshot_recorded" == "false" ]]; then
+                      capture_cold_boot_snapshot "first-online" "$serial" "$observation_deadline"
+                      first_snapshot_recorded=true
+                    fi
+
+                    if (( SECONDS < observation_deadline )); then
+                      run_bounded_probe "$probe_output" "$observation_deadline" \
+                        adb -s "$serial" shell getprop sys.boot_completed
+                      boot_completed="$(tr -d '\r' <"$probe_output")"
+                      printf '[%s] serial=%s boot_status=%s boot_timed_out=%s boot_completed=%s\n' \
+                        "$observed_at" "$serial" "$probe_status" "$probe_timed_out" \
+                        "${boot_completed:-unset}" >>"$observation_log"
+                      if [[ "$probe_timed_out" == "false" && "$probe_status" == "0" &&
+                        "$boot_completed" == "1" ]]; then
+                        printf 'late_boot_completed_at=%s\n' \
+                          "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$observation_log"
+                        observation_stop="late-boot-completed"
+                        break
+                      fi
+                      remaining_seconds=$((observation_deadline - SECONDS))
+                      if [[ "$final_snapshot_recorded" == "false" ]] &&
+                        (( remaining_seconds <= final_snapshot_lead_seconds )); then
+                        capture_cold_boot_snapshot \
+                          "near-ceiling" "$serial" "$observation_deadline"
+                        final_snapshot_recorded=true
+                      fi
+                    fi
+                  fi
+                fi
               fi
 
-              serials="$(printf '%s\n' "$adb_output" | awk 'NR > 1 && $2 == "device" { print $1 }')"
-              count="$(printf '%s\n' "$serials" | sed '/^$/d' | wc -l | tr -d ' ')"
-              if [[ "$count" -gt 1 ]]; then
-                observation_stop="unexpected-multiple-devices"
+              if (( SECONDS >= observation_deadline )); then
                 break
               fi
-              if [[ "$count" == "1" ]]; then
-                if [[ -n "$serial" && "$serial" != "$serials" ]]; then
-                  observation_stop="unexpected-device-change"
-                  break
-                fi
-                if [[ -z "$serial" ]]; then
-                  serial="$serials"
-                fi
-                run_bounded_probe "$probe_output" "$observation_deadline" \
-                  adb -s "$serial" emu avd name
-                avd_name="$(head -c 4096 "$probe_output" | tr -d '\r' | sed -n '1p')"
-                printf '[%s] serial=%s avd_status=%s avd_name=%s\n' \
-                  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$serial" "$probe_status" \
-                  "${avd_name:-unset}" >>"$observation_log"
-                if [[ "$probe_timed_out" == "true" ]]; then
-                  observation_stop="avd-identity-timeout"
-                  break
-                fi
-                if [[ "$probe_status" -ne 0 || "$avd_name" != "$AVD_NAME" ]]; then
-                  observation_stop="unexpected-avd"
-                  break
-                fi
-                if [[ "$late_adb_recorded" == "false" ]]; then
-                  printf 'late_adb_online_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                    >>"$observation_log"
-                  late_adb_recorded=true
-                fi
-
-                run_bounded_probe "$probe_output" "$observation_deadline" \
-                  adb -s "$serial" shell getprop sys.boot_completed
-                boot_completed="$(tr -d '\r' <"$probe_output")"
-                printf '[%s] serial=%s boot_status=%s boot_completed=%s\n' \
-                  "$observed_at" "$serial" "$probe_status" "${boot_completed:-unset}" \
-                  >>"$observation_log"
-                if [[ "$probe_timed_out" == "true" ]]; then
-                  observation_stop="boot-query-timeout"
-                  break
-                fi
-                if [[ "$probe_status" == "0" && "$boot_completed" == "1" ]]; then
-                  printf 'late_boot_completed_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                    >>"$observation_log"
-                  observation_stop="late-boot-completed"
-                  break
-                fi
-              fi
-
               sample_owned_qemu
               remaining_seconds=$((observation_deadline - SECONDS))
               if (( remaining_seconds <= 0 )); then
                 break
               fi
-              if (( remaining_seconds < post_deadline_poll_seconds )); then
+              if (( remaining_seconds < observation_poll_seconds )); then
                 sleep "$remaining_seconds"
               else
-                sleep "$post_deadline_poll_seconds"
+                sleep "$observation_poll_seconds"
               fi
             done
 
+            rm -f "$probe_output"
             printf 'observation_finished_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               >>"$observation_log"
+            printf 'first_snapshot_recorded=%s\n' "$first_snapshot_recorded" >>"$observation_log"
+            printf 'final_snapshot_recorded=%s\n' "$final_snapshot_recorded" >>"$observation_log"
             printf 'observation_stop=%s\n' "$observation_stop" >>"$observation_log"
           }
 
@@ -359,7 +438,7 @@ jobs:
             local serial="${2:-}"
 
             readiness_failure_latched=1
-            observe_after_readiness_timeout "$serial"
+            observe_after_readiness_timeout "$serial" "$emulator_observation_deadline"
             printf '::error::%s\n' "$failure_message" >&2
             return 1
           }
@@ -422,6 +501,8 @@ jobs:
           emulator_args=(-avd "$AVD_NAME" -no-window -no-audio -no-boot-anim -verbose -show-kernel)
           printf '%q ' "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator-args.txt"
           printf '\n' >>"$DIAGNOSTIC_DIR/emulator-args.txt"
+          emulator_launch_seconds=$SECONDS
+          emulator_observation_deadline=$((emulator_launch_seconds + final_cold_boot_observation_seconds))
           emulator "${emulator_args[@]}" >"$DIAGNOSTIC_DIR/emulator.log" 2>&1 &
           emulator_pid=$!
           printf 'emulator_pid=%s\n' "$emulator_pid" >"$DIAGNOSTIC_DIR/process-status.log"

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -2031,7 +2031,7 @@ describe("mobile release authority", () => {
     expect(accelFunctionEnd).toBeGreaterThan(accelFunctionStart);
     const accelFunction = diagnostic
       .slice(accelFunctionStart, accelFunctionEnd)
-      .replace("accel_check_timeout_seconds=10", "accel_check_timeout_seconds=1");
+      .replace("accel_check_timeout_seconds=10", "accel_check_timeout_seconds=3");
     const runAccelCheck = (emulatorSource: string) => {
       const root = tempRoots.make("openclaw-android-emulator-accel-check-");
       const bin = path.join(root, "bin");
@@ -2049,7 +2049,7 @@ describe("mobile release authority", () => {
             DIAGNOSTIC_DIR: diagnosticDir,
             PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
           },
-          timeout: 5_000,
+          timeout: 7_000,
         },
       );
       return {
@@ -2070,7 +2070,16 @@ describe("mobile release authority", () => {
     expect(timedOutAccel.output).toContain("timed_out=true");
 
     expect(diagnostic).toContain("observe_after_readiness_timeout() {");
-    expect(diagnostic).toContain("post_deadline_observation_seconds=300");
+    expect(diagnostic).toContain("final_cold_boot_observation_seconds=900");
+    expect(diagnostic).toContain("probe_timeout_seconds=5");
+    expect(diagnostic).toContain("final_snapshot_lead_seconds=15");
+    expect(diagnostic).toContain("snapshot_properties_max_bytes=65536");
+    expect(diagnostic).toContain("snapshot_logcat_max_bytes=262144");
+    expect(diagnostic).toContain("capture_cold_boot_snapshot() {");
+    expect(diagnostic).toContain(
+      "emulator_observation_deadline=$((emulator_launch_seconds + final_cold_boot_observation_seconds))",
+    );
+    expect(diagnostic).not.toContain("post_deadline_observation_seconds");
     expect(diagnostic).toContain("fail_after_readiness_timeout() {");
     const observationFunctionStart = diagnostic.indexOf("run_bounded_probe() {");
     const observationFunctionEnd = diagnostic.indexOf(
@@ -2083,16 +2092,29 @@ describe("mobile release authority", () => {
     expect(failureFunctionEnd).toBeGreaterThan(observationFunctionEnd);
     const observationFunctions = diagnostic
       .slice(observationFunctionStart, failureFunctionEnd)
-      .replace("probe_poll_seconds=1", "probe_poll_seconds=0.05")
-      .replace("post_deadline_observation_seconds=300", "post_deadline_observation_seconds=3")
-      .replace("post_deadline_poll_seconds=2", "post_deadline_poll_seconds=1");
-    const runPostDeadlineObservation = (adbSource: string, functions = observationFunctions) => {
+      .replace("observation_poll_seconds=2", "observation_poll_seconds=1")
+      .replace("final_snapshot_lead_seconds=15", "final_snapshot_lead_seconds=4")
+      .replace("snapshot_properties_max_bytes=65536", "snapshot_properties_max_bytes=64")
+      .replace("snapshot_logcat_max_bytes=262144", "snapshot_logcat_max_bytes=128");
+    const runPostDeadlineObservation = (
+      adbSource: string,
+      options: {
+        deadlineSeconds?: number;
+        functions?: string;
+        initialSerial?: string;
+        preObservationDelaySeconds?: number;
+      } = {},
+    ) => {
       const root = tempRoots.make("openclaw-android-emulator-post-deadline-");
       const bin = path.join(root, "bin");
       const diagnosticDir = path.join(root, "diagnostic");
+      const deadlineSeconds = options.deadlineSeconds ?? 12;
+      const functions = options.functions ?? observationFunctions;
+      const preObservationDelaySeconds = options.preObservationDelaySeconds ?? 0;
       fs.mkdirSync(bin);
       fs.mkdirSync(diagnosticDir);
       fs.writeFileSync(path.join(bin, "adb"), adbSource, { mode: 0o755 });
+      const startedAt = Date.now();
       const result = spawnSync(
         "/bin/bash",
         [
@@ -2103,8 +2125,11 @@ describe("mobile release authority", () => {
             functions,
             "readiness_failure_latched=0",
             "emulator_pid=$$",
+            "final_cold_boot_observation_seconds=900",
+            `emulator_observation_deadline=$((SECONDS + ${deadlineSeconds}))`,
             'export AVD_NAME="OpenClaw_Screenshots_API36"',
-            'fail_after_readiness_timeout "latched readiness failure" ""',
+            `sleep ${preObservationDelaySeconds}`,
+            'fail_after_readiness_timeout "latched readiness failure" "${INITIAL_SERIAL:-}"',
           ].join("\n"),
         ],
         {
@@ -2112,17 +2137,22 @@ describe("mobile release authority", () => {
           env: {
             ...process.env,
             DIAGNOSTIC_DIR: diagnosticDir,
+            INITIAL_SERIAL: options.initialSerial ?? "",
             PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
           },
-          timeout: 5_000,
+          timeout: 20_000,
         },
       );
+      const snapshotsRoot = path.join(diagnosticDir, "cold-boot-snapshots");
       return {
+        durationMs: Date.now() - startedAt,
         observations: fs.readFileSync(
           path.join(diagnosticDir, "post-deadline-observations.log"),
           "utf8",
         ),
         result,
+        snapshots: fs.existsSync(snapshotsRoot) ? fs.readdirSync(snapshotsRoot).toSorted() : [],
+        snapshotsRoot,
       };
     };
 
@@ -2141,6 +2171,56 @@ fi
     expect(lateReady.observations).toContain("late_adb_online_at=");
     expect(lateReady.observations).toContain("late_boot_completed_at=");
     expect(lateReady.observations).toContain("observation_stop=late-boot-completed");
+    expect(lateReady.snapshots).toEqual(["first-online"]);
+    expect(
+      fs.readFileSync(
+        path.join(lateReady.snapshotsRoot, "first-online", "boot-properties.txt"),
+        "utf8",
+      ),
+    ).toContain("probe_exit_status=0");
+
+    const lateReadyNearCeilingFunctions = observationFunctions.replace(
+      "final_snapshot_lead_seconds=4",
+      "final_snapshot_lead_seconds=60",
+    );
+    const lateReadyNearCeiling = runPostDeadlineObservation(
+      `#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5554\\tdevice product:sdk model:sdk\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" ]]; then
+  printf '1\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "emu" ]]; then
+  printf '%s\\nOK\\n' "\${AVD_NAME:?}"
+fi
+`,
+      { functions: lateReadyNearCeilingFunctions },
+    );
+    expect(lateReadyNearCeiling.result.status).toBe(1);
+    expect(lateReadyNearCeiling.observations).toContain("late_boot_completed_at=");
+    expect(lateReadyNearCeiling.observations).toContain("observation_stop=late-boot-completed");
+    expect(lateReadyNearCeiling.snapshots).toEqual(["first-online"]);
+
+    const failedBootProbeNearCeiling = runPostDeadlineObservation(
+      `#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5554\\tdevice product:sdk model:sdk\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "emu" ]]; then
+  printf '%s\\nOK\\n' "\${AVD_NAME:?}"
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" && "\${5:-}" == "sys.boot_completed" ]]; then
+  exit 7
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" ]]; then
+  printf '[init.svc.example]: [running]\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "logcat" ]]; then
+  printf 'system crash evidence line\\n'
+fi
+`,
+      { functions: lateReadyNearCeilingFunctions },
+    );
+    expect(failedBootProbeNearCeiling.result.status).toBe(1);
+    expect(failedBootProbeNearCeiling.observations).toContain("boot_status=7");
+    expect(failedBootProbeNearCeiling.snapshots).toEqual(["first-online", "near-ceiling"]);
 
     const unrelatedDevice = runPostDeadlineObservation(`#!/bin/bash
 set -euo pipefail
@@ -2156,11 +2236,21 @@ fi
     expect(unrelatedDevice.observations).toContain("observation_stop=unexpected-avd");
     expect(unrelatedDevice.observations).not.toContain("late_adb_online_at=");
     expect(unrelatedDevice.observations).not.toContain("late_boot_completed_at=");
+    expect(unrelatedDevice.snapshots).toEqual([]);
 
-    const cappedObservationFunctions = observationFunctions.replace(
-      "post_deadline_observation_seconds=3",
-      "post_deadline_observation_seconds=1",
+    const changedDevice = runPostDeadlineObservation(
+      `#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5556\\tdevice product:sdk model:sdk\\n'
+fi
+`,
+      { initialSerial: "emulator-5554" },
     );
+    expect(changedDevice.result.status).toBe(1);
+    expect(changedDevice.observations).toContain("observation_stop=unexpected-device-change");
+    expect(changedDevice.snapshots).toEqual([]);
+
     const capped = runPostDeadlineObservation(
       `#!/bin/bash
 set -euo pipefail
@@ -2168,31 +2258,70 @@ if [[ "\${1:-}" == "devices" ]]; then
   printf 'List of devices attached\\n\\n'
 fi
 `,
-      cappedObservationFunctions,
+      { deadlineSeconds: 2 },
     );
     expect(capped.result.status).toBe(1);
     expect(capped.result.stderr).toContain("::error::latched readiness failure");
-    expect(capped.observations).toContain("observation_cap_seconds=1");
+    expect(capped.observations).toContain("observation_cap_seconds=900");
     expect(capped.observations).toContain("observation_stop=observation-cap-reached");
+
+    const absoluteCap = runPostDeadlineObservation(
+      `#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\n\\n'
+fi
+`,
+      { deadlineSeconds: 3, preObservationDelaySeconds: 2 },
+    );
+    expect(absoluteCap.result.status).toBe(1);
+    expect(absoluteCap.durationMs).toBeLessThan(5_000);
+    expect(absoluteCap.observations).toContain("observation_stop=observation-cap-reached");
+
+    const boundedSnapshots = runPostDeadlineObservation(`#!/bin/bash
+set -euo pipefail
+if [[ "\${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\\nemulator-5554\\tdevice product:sdk model:sdk\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "emu" ]]; then
+  printf '%s\\nOK\\n' "\${AVD_NAME:?}"
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" && "\${5:-}" == "sys.boot_completed" ]]; then
+  printf '\\n'
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "shell" ]]; then
+  for _ in {1..40}; do printf '[init.svc.example]: [running]\\n'; done
+elif [[ "\${1:-}" == "-s" && "\${3:-}" == "logcat" ]]; then
+  for _ in {1..40}; do printf 'system crash evidence line\\n'; done
+fi
+`);
+    expect(boundedSnapshots.result.status).toBe(1);
+    expect(boundedSnapshots.observations).toContain("observation_stop=observation-cap-reached");
+    expect(boundedSnapshots.snapshots).toEqual(["first-online", "near-ceiling"]);
+    for (const snapshot of boundedSnapshots.snapshots) {
+      const properties = fs.readFileSync(
+        path.join(boundedSnapshots.snapshotsRoot, snapshot, "boot-properties.txt"),
+        "utf8",
+      );
+      const logcat = fs.readFileSync(
+        path.join(boundedSnapshots.snapshotsRoot, snapshot, "system-crash-logcat.txt"),
+        "utf8",
+      );
+      expect(properties).toContain("output_truncated=true");
+      expect(properties).toContain("retained_bytes=64");
+      expect(logcat).toContain("output_truncated=true");
+      expect(logcat).toContain("retained_bytes=128");
+    }
 
     const probeFunctionEnd = observationFunctions.indexOf("\n\nobserve_after_readiness_timeout()");
     expect(probeFunctionEnd).toBeGreaterThan(0);
     const probeFunction = observationFunctions.slice(0, probeFunctionEnd);
-    const completionRace = spawnSync(
+    const fastProbeStartedAt = Date.now();
+    const fastProbe = spawnSync(
       "/bin/bash",
       [
         "-c",
         [
           "set -euo pipefail",
-          "kill() {",
-          '  if [[ "${1:-}" == "-0" ]]; then',
-          "    sleep 1",
-          "    return 1",
-          "  fi",
-          '  command kill "$@"',
-          "}",
           probeFunction,
-          'run_bounded_probe "$PROBE_OUTPUT" "$((SECONDS + 1))" /usr/bin/true',
+          'run_bounded_probe "$PROBE_OUTPUT" "$((SECONDS + 10))" /usr/bin/true',
           'printf "status=%s timed_out=%s\\n" "$probe_status" "$probe_timed_out"',
         ].join("\n"),
       ],
@@ -2200,13 +2329,43 @@ fi
         encoding: "utf8",
         env: {
           ...process.env,
-          PROBE_OUTPUT: path.join(tempRoots.make("openclaw-android-probe-race-"), "probe.txt"),
+          PROBE_OUTPUT: path.join(tempRoots.make("openclaw-android-probe-fast-"), "probe.txt"),
+        },
+        timeout: 2_000,
+      },
+    );
+    expect(fastProbe.status, fastProbe.stderr).toBe(0);
+    expect(fastProbe.stdout).toBe("status=0 timed_out=false\n");
+    expect(Date.now() - fastProbeStartedAt).toBeLessThan(2_000);
+
+    const probeTimeoutRoot = tempRoots.make("openclaw-android-probe-timeout-");
+    const probePidFile = path.join(probeTimeoutRoot, "probe.pid");
+    const probeTimeout = spawnSync(
+      "/bin/bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          probeFunction,
+          'run_bounded_probe "$PROBE_OUTPUT" "$((SECONDS + 1))" /bin/bash -c ' +
+            '\'trap "" TERM; printf "%s\\n" "$$" >"$PROBE_PID_FILE"; exec sleep 30\'',
+          'printf "status=%s timed_out=%s\\n" "$probe_status" "$probe_timed_out"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PROBE_OUTPUT: path.join(probeTimeoutRoot, "probe.txt"),
+          PROBE_PID_FILE: probePidFile,
         },
         timeout: 5_000,
       },
     );
-    expect(completionRace.status, completionRace.stderr).toBe(0);
-    expect(completionRace.stdout).toBe("status=124 timed_out=true\n");
+    expect(probeTimeout.status, probeTimeout.stderr).toBe(0);
+    expect(probeTimeout.stdout).toBe("status=124 timed_out=true\n");
+    const probePid = Number.parseInt(fs.readFileSync(probePidFile, "utf8").trim(), 10);
+    expect(() => process.kill(probePid, 0)).toThrow();
 
     const cleanupFunctionStart = diagnostic.indexOf("cleanup() {");
     const cleanupFunctionEnd = diagnostic.indexOf("\ntrap cleanup EXIT", cleanupFunctionStart);
@@ -2231,10 +2390,6 @@ fi
       { mode: 0o755 },
     );
     fs.writeFileSync(path.join(hangingBin, "ps"), "#!/bin/bash\nexit 0\n", { mode: 0o755 });
-    const hangingObservationFunctions = observationFunctions.replace(
-      "post_deadline_observation_seconds=3",
-      "post_deadline_observation_seconds=2",
-    );
     const hangingResult = spawnSync(
       "/bin/bash",
       [
@@ -2242,10 +2397,12 @@ fi
         [
           "set -euo pipefail",
           "sample_owned_qemu() { :; }",
-          hangingObservationFunctions,
+          observationFunctions,
           cleanupFunction,
           "readiness_failure_latched=0",
           "adb_started=1",
+          "final_cold_boot_observation_seconds=900",
+          "emulator_observation_deadline=$((SECONDS + 3))",
           'export AVD_NAME="OpenClaw_Screenshots_API36"',
           "sleep 30 &",
           "emulator_pid=$!",
@@ -2264,7 +2421,7 @@ fi
           EMULATOR_PID_FILE: emulatorPidFile,
           PATH: `${hangingBin}${path.delimiter}${process.env.PATH ?? ""}`,
         },
-        timeout: 5_000,
+        timeout: 10_000,
       },
     );
     expect(hangingResult.status, hangingResult.stderr).toBe(1);
@@ -2273,7 +2430,7 @@ fi
       "utf8",
     );
     expect(hangingObservations).toContain("adb_timed_out=true");
-    expect(hangingObservations).toContain("observation_stop=adb-devices-timeout");
+    expect(hangingObservations).toContain("observation_stop=observation-cap-reached");
     expect(fs.readFileSync(path.join(hangingRoot, "cleanup.trace"), "utf8")).toBe("cleanup\n");
     expect(fs.readFileSync(path.join(hangingDiagnosticDir, "cleanup.log"), "utf8")).toContain(
       "adb_kill_server_skipped_after_latched_timeout=true",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the secretless Android emulator diagnostic permanently stopped at the original 180-second readiness deadline, so a slow cold boot could not produce bounded late-start evidence for release qualification.

## Why This Change Was Made

The diagnostic still fails permanently at 180 seconds, then observes the same owned emulator for a bounded additional window. It records late ADB and boot-completion timing without turning the run green, extends no release timeout, and preserves the trusted-tooling/candidate isolation boundary.

## User Impact

Release operators get enough retained evidence to distinguish a permanently failed boot from a device that became available shortly after the release deadline. This is diagnostic-only: it does not change Android release authority, credentials, destinations, candidate code, or store behavior.

## Evidence

- Focused executable regression: pass in 42.80 seconds.
- Existing owner suite: 62/62 passed.
- Static workflow and formatting checks passed.
- Final independent review: no findings.
- Exact-head hosted test types and required CI remain mandatory before landing.
- Scope: `.github/workflows/android-emulator-diagnostic.yml` and `test/scripts/mobile-release-authority.test.ts` only.
- Commit: `be955596a081bfc3dfb03b1d614667bbbc038eb1`, signed and based on `0367f4d4b24cf8a7c4aabe6be2b9075c0be5c4e3`.

Punchcard-Session: calm-meadow-summit-7q
