### PR TITLE
fix(agents): retain model context through tool inventory projection

### DIFF
--- a/src/agents/tools-effective-inventory.cold-provider.test.ts
+++ b/src/agents/tools-effective-inventory.cold-provider.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { setRuntimeConfigSnapshot } from "../config/config.js";
 import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.js";
@@ -9,6 +10,7 @@ import {
   createToolsEffectiveHandlers,
   testing,
 } from "../gateway/server-methods/tools-effective.js";
+import { toolsEffectiveTestDependencies } from "../gateway/server-methods/tools-effective.test-support.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
 import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
 import {
@@ -30,10 +32,15 @@ import {
   withOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import { buildBundleMcpToolsFromCatalog } from "./agent-bundle-mcp-tools.js";
+import type { McpToolCatalog } from "./agent-bundle-mcp-types.js";
 import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { acquireReadOnlyPreparedModelRuntime } from "./prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
-import { resolveEffectiveToolInventoryRuntimeModelContextAsync } from "./tools-effective-inventory.js";
+import {
+  acquireEffectiveToolInventoryRuntimeModelContext,
+  resolveEffectiveToolInventory,
+} from "./tools-effective-inventory.js";
 import type { EffectiveToolInventoryResult } from "./tools-effective-inventory.types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -118,6 +125,8 @@ function createFixture(state: OpenClawTestState) {
   const selectedRoot = path.join(root, "selected");
   const unrelatedRoot = path.join(root, "unrelated");
   const emptyBundledRoot = path.join(root, "empty-bundled");
+  const normalizationTrace = path.join(root, "normalization-trace.jsonl");
+  const normalizationFailure = path.join(root, "fail-normalization");
   const agentDir = state.agentDir();
   const workspaceDir = state.workspaceDir;
   for (const dir of [selectedRoot, unrelatedRoot, emptyBundledRoot, agentDir, workspaceDir]) {
@@ -170,6 +179,14 @@ module.exports = {
       },
       normalizeToolSchemas(ctx) {
         if (ctx.model?.api !== "openai-completions") return ctx.tools;
+        const owners = globalThis[Symbol.for("openclaw.preparedModelRuntimeTestApi")]
+          .getPreparedModelRuntimeOwnerCountForTest();
+        fs.appendFileSync(${JSON.stringify(normalizationTrace)}, JSON.stringify({
+          owners, workspaceDir: ctx.workspaceDir, tools: ctx.tools.map(tool => tool.name),
+        }) + "\\n");
+        if (fs.existsSync(${JSON.stringify(normalizationFailure)})) {
+          throw new Error("Synthetic inventory normalization failed");
+        }
         return ctx.tools.map(tool => tool.parameters === undefined
           ? { ...tool, parameters: { type: "object", properties: {}, additionalProperties: false } }
           : tool);
@@ -199,7 +216,22 @@ module.exports = {
     modelProvider: provider,
     modelId: pinnedId,
   };
-  return { state, selected, unrelated, emptyBundledRoot, config, input, inventoryParams };
+  return {
+    state,
+    selected,
+    unrelated,
+    emptyBundledRoot,
+    config,
+    input,
+    inventoryParams,
+    failNormalization: () => fs.writeFileSync(normalizationFailure, "fail", "utf8"),
+    readNormalizations: () =>
+      fs
+        .readFileSync(normalizationTrace, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+  };
 }
 
 function pickerIds(fixture: ReturnType<typeof createFixture>) {
@@ -214,43 +246,53 @@ function pickerIds(fixture: ReturnType<typeof createFixture>) {
   }).entries.flatMap((entry) => entry.rows.map((row) => row.id));
 }
 
+async function createInventoryInvocation(
+  fixture: ReturnType<typeof createFixture>,
+  dependencies?: Parameters<typeof createToolsEffectiveHandlers>[0],
+) {
+  setRuntimeConfigSnapshot(fixture.config);
+  const sessionKey = "agent:main:cold-inventory";
+  await applySessionEntryLifecycleMutation({
+    agentId: "main",
+    storePath: path.join(fixture.state.sessionsDir(), "sessions.json"),
+    upserts: [
+      {
+        sessionKey,
+        entry: {
+          sessionId: "cold-inventory-session",
+          updatedAt: 1,
+          providerOverride: provider,
+          modelOverride: pinnedId,
+          modelOverrideSource: "user",
+        },
+      },
+    ],
+    skipMaintenance: true,
+  });
+  const respond = vi.fn<RespondFn>();
+  const handler = expectDefined(
+    createToolsEffectiveHandlers(dependencies)["tools.effective"],
+    "default tools.effective handler",
+  );
+  const invoke = () =>
+    handler({
+      params: { sessionKey },
+      respond,
+      context: { getRuntimeConfig: () => fixture.config } as GatewayRequestContext,
+      client: null,
+      req: { type: "req", id: "cold-inventory", method: "tools.effective" },
+      isWebchatConnect: () => false,
+    });
+  return { respond, invoke };
+}
+
 describe("cold dynamic-model effective inventory", () => {
   it("includes provider-supported tools through the default Gateway inventory path", async () => {
     await withColdFixture(async (fixture) => {
       expect(pickerIds(fixture)).toEqual([curatedId]);
       expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(false);
-      setRuntimeConfigSnapshot(fixture.config);
-      const sessionKey = "agent:main:cold-inventory";
-      await applySessionEntryLifecycleMutation({
-        agentId: "main",
-        storePath: path.join(fixture.state.sessionsDir(), "sessions.json"),
-        upserts: [
-          {
-            sessionKey,
-            entry: {
-              sessionId: "cold-inventory-session",
-              updatedAt: 1,
-              providerOverride: provider,
-              modelOverride: pinnedId,
-              modelOverrideSource: "user",
-            },
-          },
-        ],
-        skipMaintenance: true,
-      });
-      const respond = vi.fn<RespondFn>();
-      const handler = expectDefined(
-        createToolsEffectiveHandlers()["tools.effective"],
-        "default tools.effective handler",
-      );
-      await handler({
-        params: { sessionKey },
-        respond,
-        context: { getRuntimeConfig: () => fixture.config } as GatewayRequestContext,
-        client: null,
-        req: { type: "req", id: "cold-inventory", method: "tools.effective" },
-        isWebchatConnect: () => false,
-      });
+      const { respond, invoke } = await createInventoryInvocation(fixture);
+      await invoke();
       expect(respond).toHaveBeenCalledExactlyOnceWith(true, expect.any(Object), undefined);
       const inventory = respond.mock.calls[0]?.[1] as EffectiveToolInventoryResult;
       expect({
@@ -265,6 +307,102 @@ describe("cold dynamic-model effective inventory", () => {
         primary: `${provider}/${pinnedId}`,
       });
       expect(pickerIds(fixture)).toEqual([curatedId]);
+      expect(fixture.readNormalizations()).toEqual([
+        {
+          owners: 1,
+          workspaceDir: fixture.input.workspaceDir,
+          tools: ["healthy_tool", "parameterless_tool"],
+        },
+      ]);
+    });
+  });
+
+  it.each([false, true])(
+    "owns base and warm MCP normalization without retaining cached models (sandbox: %s)",
+    async (sandbox) => {
+      await withColdFixture(async (fixture) => {
+        const workspaceDir = sandbox
+          ? path.join(fixture.state.root, "sandbox")
+          : fixture.input.workspaceDir;
+        fs.mkdirSync(workspaceDir, { recursive: true });
+        const catalog: McpToolCatalog = {
+          version: 1,
+          generatedAt: 1,
+          servers: {},
+          tools: [
+            {
+              serverName: "inventory",
+              safeServerName: "inventory",
+              toolName: "probe",
+              inputSchema: Type.Object({}),
+              fallbackDescription: "Synthetic inventory probe",
+            },
+          ],
+        };
+        const { invoke, respond } = await createInventoryInvocation(fixture, {
+          ...toolsEffectiveTestDependencies,
+          acquireEffectiveToolInventoryRuntimeModelContext,
+          resolveEffectiveToolInventory,
+          buildBundleMcpToolsFromCatalog,
+          resolveSessionMcpConfigSummary: () => ({
+            fingerprint: "inventory",
+            serverNames: ["inventory"],
+          }),
+          peekSessionMcpRuntime: () => ({
+            configFingerprint: "inventory",
+            workspaceDir,
+            peekCatalog: () => catalog,
+          }),
+        });
+        const ambient = createEmptyPluginRegistry();
+        const normalizeAmbient = vi.fn(() => {
+          throw new Error("Ambient generation must not normalize prepared inventory");
+        });
+        ambient.providers.push({
+          pluginId: "ambient-provider",
+          source: "test",
+          provider: {
+            id: provider,
+            label: "Ambient provider",
+            auth: [],
+            normalizeToolSchemas: normalizeAmbient,
+          },
+        });
+        for (let request = 0; request < 2; request++) {
+          await withPluginRuntimeRegistryScope(ambient, invoke);
+          expect(respond.mock.calls.at(-1)?.[0]).toBe(true);
+          expect(ownerCount()).toBe(0);
+        }
+        expect(fixture.readNormalizations()).toMatchObject([
+          { owners: 1, workspaceDir: fixture.input.workspaceDir },
+          { owners: 1, workspaceDir },
+          { owners: 1, workspaceDir },
+        ]);
+        const first = respond.mock.calls[0]?.[1];
+        expect(first).toMatchObject({
+          groups: expect.arrayContaining([expect.objectContaining({ id: "mcp" })]),
+        });
+        expect(respond.mock.calls[1]?.[1]).toEqual(first);
+        fixture.failNormalization();
+        await withPluginRuntimeRegistryScope(ambient, invoke);
+        expect(respond.mock.calls.at(-1)?.[0]).toBe(false);
+        expect(ownerCount()).toBe(0);
+        expect(fixture.readNormalizations().at(-1)).toMatchObject({ owners: 1, workspaceDir });
+        expect(normalizeAmbient).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("releases the dynamic owner after base inventory normalization fails", async () => {
+    await withColdFixture(async (fixture) => {
+      fixture.failNormalization();
+      const { invoke, respond } = await createInventoryInvocation(fixture);
+      await invoke();
+      expect(respond.mock.calls.at(-1)?.[0]).toBe(false);
+      expect(ownerCount()).toBe(0);
+      expect(fixture.readNormalizations()).toMatchObject([
+        { owners: 1, workspaceDir: fixture.input.workspaceDir },
+      ]);
     });
   });
 
@@ -337,12 +475,12 @@ describe("cold dynamic-model effective inventory", () => {
       });
       await withPluginRuntimeRegistryScope(registry, async () => {
         expect(resolveProviderRuntimePlugin({ provider, config })).toBeUndefined();
-        await expect(
-          resolveEffectiveToolInventoryRuntimeModelContextAsync({
-            ...fixture.inventoryParams,
-            cfg: config,
-          }),
-        ).resolves.toEqual({});
+        const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+          ...fixture.inventoryParams,
+          cfg: config,
+        });
+        expect(acquired.run((context) => context)).toEqual({});
+        acquired.release();
       });
       expect(ambientHook).not.toHaveBeenCalled();
       expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(false);
@@ -354,14 +492,16 @@ describe("cold dynamic-model effective inventory", () => {
     { modelId: throwingId, throws: true },
   ])("releases the selected owner when resolving $modelId", async ({ modelId, throws }) => {
     await withColdFixture(async (fixture) => {
-      const resolution = resolveEffectiveToolInventoryRuntimeModelContextAsync({
+      const resolution = acquireEffectiveToolInventoryRuntimeModelContext({
         ...fixture.inventoryParams,
         modelId,
       });
       if (throws) {
         await expect(resolution).rejects.toThrow("Provider preparation failed");
       } else {
-        await expect(resolution).resolves.toEqual({});
+        const acquired = await resolution;
+        expect(acquired.run((context) => context)).toEqual({});
+        acquired.release();
       }
       expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(true);
     });

--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -33,6 +33,10 @@ const runtimeMocks = vi.hoisted(() => {
   };
 });
 
+vi.mock("../plugins/runtime/generation-scope.js", () => ({
+  withPluginRuntimeGenerationScope: (_generation: unknown, run: () => unknown) => run(),
+}));
+
 vi.mock("./prepared-model-runtime.js", () => ({
   acquireReadOnlyPreparedModelRuntime: runtimeMocks.acquire,
 }));
@@ -56,7 +60,7 @@ vi.mock("./agent-scope.js", () => ({
   resolveSessionAgentId: () => "main",
 }));
 
-describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
+describe("acquireEffectiveToolInventoryRuntimeModelContext", () => {
   beforeEach(() => {
     runtimeMocks.acquire.mockReset().mockResolvedValue(runtimeMocks.requestLease);
     runtimeMocks.requestLease.snapshot.createStores.mockClear();
@@ -72,22 +76,21 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
     { owner: "published", agentId: "research", lease: runtimeMocks.publishedLease },
   ])("prepares dynamic model context with a $owner runtime lease", async ({ lease, agentId }) => {
     runtimeMocks.acquire.mockResolvedValueOnce(lease);
-    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+    const { acquireEffectiveToolInventoryRuntimeModelContext } =
       await import("./tools-effective-inventory.js");
     const cfg = makeOpenClawConfigFixture();
     const agentDir = `/tmp/agents/${agentId}/agent`;
     const workspaceDir = `/tmp/workspace-${agentId}`;
 
-    await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
-        cfg,
-        agentId,
-        agentDir,
-        workspaceDir,
-        modelProvider: " OpenAI ",
-        modelId: " chat-latest ",
-      }),
-    ).resolves.toMatchObject({
+    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+      cfg,
+      agentId,
+      agentDir,
+      workspaceDir,
+      modelProvider: " OpenAI ",
+      modelId: " chat-latest ",
+    });
+    expect(acquired.run((context) => context)).toMatchObject({
       modelApi: "openai-responses",
       runtimeModel: { id: "chat-latest", provider: "openai" },
     });
@@ -112,29 +115,33 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
       loadRuntimePlugins: true,
       runtimePluginSelections: [{ provider: "openai", modelId: "chat-latest", agentId }],
     });
+    expect(lease.release).not.toHaveBeenCalled();
+    acquired.release();
+    acquired.release();
     expect(lease.release).toHaveBeenCalledTimes(1);
+    expect(() => acquired.run(() => undefined)).toThrow("has been released");
   });
 
   it.each([
     { modelProvider: "", modelId: "chat-latest" },
     { modelProvider: "openai", modelId: " " },
   ])("skips runtime preparation for invalid model input", async (input) => {
-    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+    const { acquireEffectiveToolInventoryRuntimeModelContext } =
       await import("./tools-effective-inventory.js");
 
-    await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
-        cfg: {},
-        ...input,
-      }),
-    ).resolves.toEqual({});
+    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+      cfg: {},
+      ...input,
+    });
+    expect(acquired.run((context) => context)).toEqual({});
+    acquired.release();
     expect(runtimeMocks.acquire).not.toHaveBeenCalled();
     expect(runtimeMocks.resolveModelAsync).not.toHaveBeenCalled();
     expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
   });
 
   it("uses configured model context without acquiring a runtime lease", async () => {
-    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+    const { acquireEffectiveToolInventoryRuntimeModelContext } =
       await import("./tools-effective-inventory.js");
     const cfg = makeOpenClawConfigFixture({
       models: {
@@ -157,16 +164,16 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
       },
     });
 
-    await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
-        cfg,
-        modelProvider: "custom",
-        modelId: "configured",
-      }),
-    ).resolves.toMatchObject({
+    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+      cfg,
+      modelProvider: "custom",
+      modelId: "configured",
+    });
+    expect(acquired.run((context) => context)).toMatchObject({
       modelApi: "anthropic-messages",
       runtimeModel: { id: "configured", provider: "custom" },
     });
+    acquired.release();
     expect(runtimeMocks.acquire).not.toHaveBeenCalled();
     expect(runtimeMocks.resolveModelAsync).not.toHaveBeenCalled();
     expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
@@ -180,19 +187,19 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
     });
-    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+    const { acquireEffectiveToolInventoryRuntimeModelContext } =
       await import("./tools-effective-inventory.js");
 
-    await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
-        cfg: {},
-        modelProvider: "openai",
-        modelId: "bundled",
-      }),
-    ).resolves.toMatchObject({
+    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+      cfg: {},
+      modelProvider: "openai",
+      modelId: "bundled",
+    });
+    expect(acquired.run((context) => context)).toMatchObject({
       modelApi: "openai-responses",
       runtimeModel: { id: "bundled", provider: "openai" },
     });
+    acquired.release();
     expect(runtimeMocks.acquire).not.toHaveBeenCalled();
     expect(runtimeMocks.resolveModelAsync).not.toHaveBeenCalled();
     expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
@@ -201,11 +208,11 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
   it("releases the runtime lease when dynamic model resolution fails", async () => {
     const failure = new Error("dynamic model failed");
     runtimeMocks.resolveModelAsync.mockRejectedValueOnce(failure);
-    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+    const { acquireEffectiveToolInventoryRuntimeModelContext } =
       await import("./tools-effective-inventory.js");
 
     await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
+      acquireEffectiveToolInventoryRuntimeModelContext({
         cfg: {},
         modelProvider: "openai",
         modelId: "chat-latest",

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { extractModelCompat } from "../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtime.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
@@ -235,19 +236,26 @@ function resolveStaticToolInventoryRuntimeModelContext(params: {
   };
 }
 
-/** Resolves dynamic model metadata after publishing a request-owned read snapshot when needed. */
-export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
+type ToolInventoryRuntimeModelContext = ReturnType<
+  typeof resolveStaticToolInventoryRuntimeModelContext
+>;
+
+/** Keeps dynamic model hooks owned and scoped until inventory projection finishes. */
+export async function acquireEffectiveToolInventoryRuntimeModelContext(
   params: Parameters<typeof resolveStaticToolInventoryRuntimeModelContext>[0],
-): Promise<ReturnType<typeof resolveStaticToolInventoryRuntimeModelContext>> {
+): Promise<{
+  run: <T>(project: (context: ToolInventoryRuntimeModelContext) => T) => T;
+  release: () => void;
+}> {
   const staticContext = resolveStaticToolInventoryRuntimeModelContext(params);
   if (staticContext.runtimeModel) {
-    return staticContext;
+    return { run: (project) => project(staticContext), release: () => {} };
   }
 
   const provider = normalizeProviderId(params.modelProvider ?? "");
   const modelId = params.modelId?.trim() ?? "";
   if (!provider || !modelId) {
-    return {};
+    return { run: (project) => project({}), release: () => {} };
   }
   const agentId = params.agentId?.trim() || resolveSessionAgentId({ config: params.cfg });
   const agentDir = params.agentDir ?? resolveAgentDir(params.cfg, agentId);
@@ -261,6 +269,7 @@ export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
     loadRuntimePlugins: true,
     runtimePluginSelections: [{ provider, modelId, agentId }],
   });
+  let transferred = false;
   try {
     const stores = lease.snapshot.createStores();
     const resolved = await resolveModelAsync(provider, modelId, agentDir, params.cfg, {
@@ -271,9 +280,31 @@ export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
       preparedModelRuntime: lease.snapshot,
     });
     const runtimeModel = resolved.model as ProviderRuntimeModel | undefined;
-    return runtimeModel ? { modelApi: runtimeModel.api, runtimeModel } : {};
+    if (!runtimeModel) {
+      return { run: (project) => project({}), release: () => {} };
+    }
+    const context = { modelApi: runtimeModel.api, runtimeModel };
+    let released = false;
+    const acquired = {
+      run: <T>(project: (context: ToolInventoryRuntimeModelContext) => T): T => {
+        if (released) {
+          throw new Error("Tool inventory model context has been released");
+        }
+        return withPluginRuntimeGenerationScope(lease.snapshot, () => project(context));
+      },
+      release: () => {
+        if (!released) {
+          released = true;
+          lease.release();
+        }
+      },
+    };
+    transferred = true;
+    return acquired;
   } finally {
-    lease.release();
+    if (!transferred) {
+      lease.release();
+    }
   }
 }
 

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -573,6 +573,7 @@ const toolsTestState = vi.hoisted(() => {
   const defaultResolveTools = (): EffectiveToolInventoryResult => makeDefaultInventory();
 
   return {
+    releaseRuntimeModel: vi.fn(),
     resolveToolsImpl: defaultResolveTools,
     resolveToolsMock: vi.fn((..._args: unknown[]) => defaultResolveTools()),
     resolveRuntimeModelContextMock: vi.fn(async (_params: unknown) => ({})),
@@ -586,8 +587,13 @@ const toolsTestState = vi.hoisted(() => {
 
 vi.mock("../../agents/tools-effective-inventory.js", () => ({
   resolveEffectiveToolInventory: (...args: unknown[]) => toolsTestState.resolveToolsMock(...args),
-  resolveEffectiveToolInventoryRuntimeModelContextAsync: (params: unknown) =>
-    toolsTestState.resolveRuntimeModelContextMock(params),
+  acquireEffectiveToolInventoryRuntimeModelContext: async (params: unknown) => {
+    const context = await toolsTestState.resolveRuntimeModelContextMock(params);
+    return {
+      run: <T>(project: (value: typeof context) => T): T => project(context),
+      release: toolsTestState.releaseRuntimeModel,
+    };
+  },
 }));
 
 vi.mock("./agent-runner-utils.js", () => ({
@@ -637,6 +643,7 @@ describe("handleToolsCommand", () => {
   });
 
   beforeEach(() => {
+    toolsTestState.releaseRuntimeModel.mockClear();
     toolsTestState.resolveToolsMock.mockReset();
     toolsTestState.resolveToolsImpl = () => makeDefaultInventory();
     toolsTestState.resolveRuntimeModelContextMock.mockReset();
@@ -827,6 +834,22 @@ describe("handleToolsCommand", () => {
       modelApi: "openai-responses",
       runtimeModel,
     });
+    expect(toolsTestState.releaseRuntimeModel).toHaveBeenCalledOnce();
+  });
+
+  it("releases the model context when tools projection fails", async () => {
+    const { buildCommandTestParamsLocal, handleToolsCommandLocal } = await loadToolsHarness({
+      resolveTools: () => {
+        expect(toolsTestState.releaseRuntimeModel).not.toHaveBeenCalled();
+        throw new Error("inventory projection failed");
+      },
+    });
+    const result = await handleToolsCommandLocal(
+      buildCommandTestParamsLocal("/tools", buildConfig(), undefined, { workspaceDir: "/tmp" }),
+      true,
+    );
+    expect(result?.reply?.text).toContain("Couldn't load available tools");
+    expect(toolsTestState.releaseRuntimeModel).toHaveBeenCalledOnce();
   });
 
   it("ignores unauthorized senders", async () => {

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -1,7 +1,7 @@
 /** Handles informational commands such as /help, /commands, /tools, and exports. */
 import {
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext,
 } from "../../agents/tools-effective-inventory.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import {
@@ -163,7 +163,7 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
       config: params.cfg,
       hasRepliedRef: undefined,
     });
-    const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
+    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
       cfg: params.cfg,
       agentId: params.agentId,
       agentDir: sessionBound ? undefined : params.agentDir,
@@ -171,41 +171,47 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
       modelProvider: params.provider,
       modelId: params.model,
     });
-    const result = resolveEffectiveToolInventory({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      workspaceDir: params.workspaceDir,
-      agentDir: sessionBound ? undefined : params.agentDir,
-      modelProvider: params.provider,
-      modelId: params.model,
-      modelApi: runtimeModelContext.modelApi,
-      runtimeModel: runtimeModelContext.runtimeModel,
-      messageProvider: params.command.channel,
-      senderId: params.command.senderId,
-      senderName: params.ctx.SenderName,
-      senderUsername: params.ctx.SenderUsername,
-      senderE164: params.ctx.SenderE164,
-      accountId: effectiveAccountId,
-      currentChannelId: threadingContext.currentChannelId,
-      currentThreadTs:
-        typeof params.ctx.MessageThreadId === "string" ||
-        typeof params.ctx.MessageThreadId === "number"
-          ? String(params.ctx.MessageThreadId)
-          : undefined,
-      currentMessageId: threadingContext.currentMessageId,
-      groupId: targetSessionEntry?.groupId ?? extractExplicitGroupId(params.ctx.From),
-      groupChannel:
-        targetSessionEntry?.groupChannel ?? params.ctx.GroupChannel ?? params.ctx.GroupSubject,
-      groupSpace: targetSessionEntry?.space ?? params.ctx.GroupSpace,
-      replyToMode: resolveReplyToMode(
-        params.cfg,
-        params.ctx.OriginatingChannel ?? params.ctx.Provider,
-        effectiveAccountId,
-        params.ctx.ChatType,
-      ),
-    });
-    return commandReply(buildToolsMessage(result, { verbose }));
+    try {
+      return acquired.run((runtimeModelContext) => {
+        const result = resolveEffectiveToolInventory({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.workspaceDir,
+          agentDir: sessionBound ? undefined : params.agentDir,
+          modelProvider: params.provider,
+          modelId: params.model,
+          modelApi: runtimeModelContext.modelApi,
+          runtimeModel: runtimeModelContext.runtimeModel,
+          messageProvider: params.command.channel,
+          senderId: params.command.senderId,
+          senderName: params.ctx.SenderName,
+          senderUsername: params.ctx.SenderUsername,
+          senderE164: params.ctx.SenderE164,
+          accountId: effectiveAccountId,
+          currentChannelId: threadingContext.currentChannelId,
+          currentThreadTs:
+            typeof params.ctx.MessageThreadId === "string" ||
+            typeof params.ctx.MessageThreadId === "number"
+              ? String(params.ctx.MessageThreadId)
+              : undefined,
+          currentMessageId: threadingContext.currentMessageId,
+          groupId: targetSessionEntry?.groupId ?? extractExplicitGroupId(params.ctx.From),
+          groupChannel:
+            targetSessionEntry?.groupChannel ?? params.ctx.GroupChannel ?? params.ctx.GroupSubject,
+          groupSpace: targetSessionEntry?.space ?? params.ctx.GroupSpace,
+          replyToMode: resolveReplyToMode(
+            params.cfg,
+            params.ctx.OriginatingChannel ?? params.ctx.Provider,
+            effectiveAccountId,
+            params.ctx.ChatType,
+          ),
+        });
+        return commandReply(buildToolsMessage(result, { verbose }));
+      });
+    } finally {
+      acquired.release();
+    }
   } catch {
     // Inventory resolves in-process after sender authorization; this path cannot receive
     // gateway RPC scope errors, so failures here are local discovery failures.

--- a/src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts
@@ -11,7 +11,8 @@ const inventoryMocks = vi.hoisted(() => {
   };
   return {
     runtimeModel,
-    resolveRuntimeModelContext: vi.fn(async () => ({
+    release: vi.fn(),
+    resolveRuntimeModelContext: vi.fn(async (_params: unknown) => ({
       modelApi: runtimeModel.api,
       runtimeModel,
     })),
@@ -45,11 +46,18 @@ const inventoryMocks = vi.hoisted(() => {
 
 vi.mock("../../agents/tools-effective-inventory.js", () => ({
   resolveEffectiveToolInventory: inventoryMocks.resolveInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync: inventoryMocks.resolveRuntimeModelContext,
+  acquireEffectiveToolInventoryRuntimeModelContext: async (params: unknown) => {
+    const context = await inventoryMocks.resolveRuntimeModelContext(params);
+    return {
+      run: <T>(project: (value: typeof context) => T): T => project(context),
+      release: inventoryMocks.release,
+    };
+  },
 }));
 
 describe("resolveBareResetBootstrapFileAccess runtime model ownership", () => {
   beforeEach(() => {
+    inventoryMocks.release.mockClear();
     inventoryMocks.resolveInventory.mockClear();
     inventoryMocks.resolveRuntimeModelContext.mockClear();
   });
@@ -85,5 +93,17 @@ describe("resolveBareResetBootstrapFileAccess runtime model ownership", () => {
     });
     expect(Object.hasOwn(inventoryParams ?? {}, "modelApi")).toBe(true);
     expect(Object.hasOwn(inventoryParams ?? {}, "runtimeModel")).toBe(true);
+    expect(inventoryMocks.release).toHaveBeenCalledOnce();
+  });
+
+  it("releases the model context when bootstrap inventory projection fails", async () => {
+    const { resolveBareResetBootstrapFileAccess } = await import("./session-reset-prompt.js");
+    const failure = new Error("inventory projection failed");
+    inventoryMocks.resolveInventory.mockImplementationOnce(() => {
+      expect(inventoryMocks.release).not.toHaveBeenCalled();
+      throw failure;
+    });
+    await expect(resolveBareResetBootstrapFileAccess({ cfg: {} })).rejects.toBe(failure);
+    expect(inventoryMocks.release).toHaveBeenCalledOnce();
   });
 });

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -7,7 +7,7 @@ import {
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import {
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext,
 } from "../../agents/tools-effective-inventory.js";
 import { isWorkspaceBootstrapPending } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -47,27 +47,34 @@ export async function resolveBareResetBootstrapFileAccess(params: {
   modelProvider?: string;
   modelId?: string;
 }): Promise<boolean> {
-  if (!params.cfg) {
+  const cfg = params.cfg;
+  if (!cfg) {
     return false;
   }
-  const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
-    cfg: params.cfg,
+  const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+    cfg,
     agentId: params.agentId,
     workspaceDir: params.workspaceDir,
     modelProvider: params.modelProvider,
     modelId: params.modelId,
   });
-  const inventory = resolveEffectiveToolInventory({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-    workspaceDir: params.workspaceDir,
-    modelProvider: params.modelProvider,
-    modelId: params.modelId,
-    modelApi: runtimeModelContext.modelApi,
-    runtimeModel: runtimeModelContext.runtimeModel,
-  });
-  return inventory.groups.some((group) => group.tools.some((tool) => tool.id === "read"));
+  try {
+    return acquired.run((runtimeModelContext) => {
+      const inventory = resolveEffectiveToolInventory({
+        cfg,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        workspaceDir: params.workspaceDir,
+        modelProvider: params.modelProvider,
+        modelId: params.modelId,
+        modelApi: runtimeModelContext.modelApi,
+        runtimeModel: runtimeModelContext.runtimeModel,
+      });
+      return inventory.groups.some((group) => group.tools.some((tool) => tool.id === "read"));
+    });
+  } finally {
+    acquired.release();
+  }
 }
 
 export async function resolveBareSessionResetPromptState(params: {

--- a/src/gateway/server-methods/tools-effective.test-support.ts
+++ b/src/gateway/server-methods/tools-effective.test-support.ts
@@ -40,9 +40,10 @@ const resolveEffectiveToolInventory = vi.fn<
   modelId: params.modelId,
 }));
 
-type RuntimeModelContext = Awaited<
-  ReturnType<ToolsEffectiveDependencies["resolveEffectiveToolInventoryRuntimeModelContextAsync"]>
+type AcquiredRuntimeModelContext = Awaited<
+  ReturnType<ToolsEffectiveDependencies["acquireEffectiveToolInventoryRuntimeModelContext"]>
 >;
+type RuntimeModelContext = Parameters<Parameters<AcquiredRuntimeModelContext["run"]>[0]>[0];
 
 const resolveEffectiveToolInventoryRuntimeModelContext = vi.fn(
   (_params?: unknown): RuntimeModelContext => ({
@@ -55,11 +56,13 @@ export const toolsEffectiveInventoryMocks = {
   resolveEffectiveToolInventoryRuntimeModelContext,
 };
 
-const resolveEffectiveToolInventoryRuntimeModelContextAsync = vi.fn<
-  ToolsEffectiveDependencies["resolveEffectiveToolInventoryRuntimeModelContextAsync"]
->(async (params) =>
-  toolsEffectiveInventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext(params),
-);
+const acquireEffectiveToolInventoryRuntimeModelContext = vi.fn<
+  ToolsEffectiveDependencies["acquireEffectiveToolInventoryRuntimeModelContext"]
+>(async (params) => {
+  const context =
+    toolsEffectiveInventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext(params);
+  return { run: (project) => project(context), release: () => {} };
+});
 
 export const toolsEffectiveTestDependencies: ToolsEffectiveDependencies = {
   applyFinalEffectiveToolPolicy: vi.fn<ToolsEffectiveDependencies["applyFinalEffectiveToolPolicy"]>(
@@ -79,7 +82,7 @@ export const toolsEffectiveTestDependencies: ToolsEffectiveDependencies = {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveEffectiveToolInventory: toolsEffectiveInventoryMocks.resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext,
   resolveReplyToMode,
   resolveRuntimeConfigCacheKey,
   resolveSessionAgentId,

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -9,9 +9,16 @@ import { setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { createToolsEffectiveHandlers, testing } from "./tools-effective.js";
 
 type ToolsEffectiveDependencies = NonNullable<Parameters<typeof createToolsEffectiveHandlers>[0]>;
-type RuntimeModelContext = Awaited<
-  ReturnType<ToolsEffectiveDependencies["resolveEffectiveToolInventoryRuntimeModelContextAsync"]>
+type AcquiredRuntimeModelContext = Awaited<
+  ReturnType<ToolsEffectiveDependencies["acquireEffectiveToolInventoryRuntimeModelContext"]>
 >;
+type RuntimeModelContext = Parameters<Parameters<AcquiredRuntimeModelContext["run"]>[0]>[0];
+
+function createAcquiredRuntimeModelContext(
+  context: RuntimeModelContext,
+): AcquiredRuntimeModelContext {
+  return { run: (project) => project(context), release: vi.fn() };
+}
 
 const resolveEffectiveToolInventoryRuntimeModelContextMock = vi.hoisted(() =>
   vi.fn((_params?: unknown): RuntimeModelContext => ({
@@ -90,9 +97,11 @@ const runtimeMocks = vi.hoisted(() => ({
   resolveSessionModelRef: vi.fn(() => ({ provider: "openai", model: "gpt-4.1" })),
   resolveEffectiveToolInventoryRuntimeModelContext:
     resolveEffectiveToolInventoryRuntimeModelContextMock,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync: vi.fn<
-    ToolsEffectiveDependencies["resolveEffectiveToolInventoryRuntimeModelContextAsync"]
-  >(async (params) => resolveEffectiveToolInventoryRuntimeModelContextMock(params)),
+  acquireEffectiveToolInventoryRuntimeModelContext: vi.fn<
+    ToolsEffectiveDependencies["acquireEffectiveToolInventoryRuntimeModelContext"]
+  >(async (params) =>
+    createAcquiredRuntimeModelContext(resolveEffectiveToolInventoryRuntimeModelContextMock(params)),
+  ),
 }));
 
 const nodePluginToolSnapshotMocks = vi.hoisted(() => ({
@@ -115,8 +124,8 @@ const toolsEffectiveDependencies: ToolsEffectiveDependencies = {
   resolveAgentDir: runtimeMocks.resolveAgentDir,
   resolveAgentWorkspaceDir: runtimeMocks.resolveAgentWorkspaceDir,
   resolveEffectiveToolInventory: runtimeMocks.resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync:
-    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext:
+    runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext,
   resolveReplyToMode: runtimeMocks.resolveReplyToMode,
   resolveRuntimeConfigCacheKey: runtimeMocks.resolveRuntimeConfigCacheKey,
   resolveSessionAgentId: runtimeMocks.resolveSessionAgentId,
@@ -320,6 +329,13 @@ describe("tools.effective handler", () => {
         maxTokens: 8_192,
       },
     });
+    runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext
+      .mockReset()
+      .mockImplementation(async (params) =>
+        createAcquiredRuntimeModelContext(
+          resolveEffectiveToolInventoryRuntimeModelContextMock(params),
+        ),
+      );
     runtimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
       fingerprint: "mcp:1:test",
       serverNames: [] as string[],
@@ -583,29 +599,29 @@ describe("tools.effective handler", () => {
     runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext.mockImplementation(() => {
       throw new Error("synchronous model context should not be used");
     });
-    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue({
-      modelApi: "openai-responses",
-      runtimeModel: {
-        id: "gpt-4.1",
-        name: "GPT 4.1",
-        provider: "openai",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 128_000,
-        maxTokens: 8_192,
-      },
-    });
+    runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext.mockResolvedValue(
+      createAcquiredRuntimeModelContext({
+        modelApi: "openai-responses",
+        runtimeModel: {
+          id: "gpt-4.1",
+          name: "GPT 4.1",
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 8_192,
+        },
+      }),
+    );
 
     const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
     await invoke();
 
     expect(firstRespondCall(respond)?.[0]).toBe(true);
-    expect(
-      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    ).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext).toHaveBeenCalledTimes(2);
     expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
   });
 
@@ -613,17 +629,15 @@ describe("tools.effective handler", () => {
     runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext.mockImplementation(() => {
       throw new Error("synchronous model context should not be used");
     });
-    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue(
-      {} as never,
+    runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext.mockResolvedValue(
+      createAcquiredRuntimeModelContext({}),
     );
 
     const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
     await invoke();
 
     expect(firstRespondCall(respond)?.[0]).toBe(true);
-    expect(
-      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    ).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext).toHaveBeenCalledTimes(1);
     expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
   });
 
@@ -776,12 +790,8 @@ describe("tools.effective handler", () => {
       workspaceDir: "/tmp/sandbox-copy",
       cfg: {},
     });
-    expect(
-      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    ).toHaveBeenLastCalledWith(
+    expect(runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext).toHaveBeenCalledTimes(2);
+    expect(runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext).toHaveBeenLastCalledWith(
       expect.objectContaining({
         workspaceDir: "/tmp/sandbox-copy",
         modelProvider: "openai",
@@ -790,15 +800,28 @@ describe("tools.effective handler", () => {
     );
   });
 
-  it("does not project warm MCP tools filtered out by final policy", async () => {
-    mockWarmMcpTool();
-    runtimeMocks.applyFinalEffectiveToolPolicy.mockReturnValueOnce([]);
-
-    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
-    await invoke();
-
-    expectPayloadGroupIds(respond, ["core"]);
-  });
+  it.each(["empty", "filtered"])(
+    "preserves base output without another model acquisition for %s MCP tools",
+    async (kind) => {
+      const base = {
+        ...makeCoreInventory(),
+        notices: [{ id: "base-notice", severity: "info", message: "Keep the base notice" }],
+      };
+      runtimeMocks.resolveEffectiveToolInventory.mockReturnValueOnce(base);
+      mockMcpConfigSummary();
+      mockWarmMcpRuntime(makeMcpCatalog());
+      runtimeMocks.buildBundleMcpToolsFromCatalog.mockReturnValueOnce(
+        kind === "empty" ? [] : [makeMcpTool()],
+      );
+      if (kind === "filtered") {
+        runtimeMocks.applyFinalEffectiveToolPolicy.mockReturnValueOnce([]);
+      }
+      const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+      await invoke();
+      expect(firstRespondCall(respond)?.[1]).toEqual(base);
+      expect(runtimeMocks.acquireEffectiveToolInventoryRuntimeModelContext).toHaveBeenCalledOnce();
+    },
+  );
 
   it("quarantines warm MCP tools with schemas the runtime cannot project", async () => {
     mockWarmMcpTool({ type: "array", items: { type: "string" } });

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -23,7 +23,7 @@ import { getRegisteredAgentHarness } from "../../agents/harness/registry.js";
 import { buildEffectiveToolInventoryGroups } from "../../agents/tools-effective-inventory-groups.js";
 import {
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext,
 } from "../../agents/tools-effective-inventory.js";
 import type {
   EffectiveToolInventoryNotice,
@@ -66,7 +66,7 @@ const defaultToolsEffectiveDependencies = {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+  acquireEffectiveToolInventoryRuntimeModelContext,
   resolveReplyToMode,
   resolveRuntimeConfigCacheKey,
   resolveSessionAgentId,
@@ -121,23 +121,14 @@ type TrustedToolsEffectiveContext = {
 };
 
 type ToolsEffectiveCacheEntry = {
-  value: BaseToolsEffectiveResolution;
+  value: EffectiveToolInventoryResult;
   createdAtMs: number;
-};
-
-type RuntimeModelContext = Awaited<
-  ReturnType<typeof resolveEffectiveToolInventoryRuntimeModelContextAsync>
->;
-
-type BaseToolsEffectiveResolution = {
-  inventory: EffectiveToolInventoryResult;
-  runtimeModelContext: RuntimeModelContext;
 };
 
 type SessionMcpConfigSummary = ReturnType<typeof resolveSessionMcpConfigSummary>;
 
 const toolsEffectiveCache = new Map<string, ToolsEffectiveCacheEntry>();
-const toolsEffectiveInflight = new Map<string, Promise<BaseToolsEffectiveResolution>>();
+const toolsEffectiveInflight = new Map<string, Promise<EffectiveToolInventoryResult>>();
 const mcpConfigSummaryCache = new Map<string, SessionMcpConfigSummary>();
 
 function optionalCacheString(value: string | undefined | null): string {
@@ -207,7 +198,7 @@ function resolveCachedSessionMcpConfigSummary(params: {
   return summary;
 }
 
-function cacheToolsEffectiveResult(key: string, value: BaseToolsEffectiveResolution): void {
+function cacheToolsEffectiveResult(key: string, value: EffectiveToolInventoryResult): void {
   toolsEffectiveCache.delete(key);
   toolsEffectiveCache.set(key, { value, createdAtMs: nowForToolsEffectiveCache() });
   pruneMapToMaxSize(toolsEffectiveCache, TOOLS_EFFECTIVE_CACHE_LIMIT);
@@ -220,13 +211,13 @@ function scheduleBaseToolsEffectiveRefresh(
   key: string,
   context: TrustedToolsEffectiveContext,
   dependencies: ToolsEffectiveDependencies,
-): Promise<BaseToolsEffectiveResolution> {
+): Promise<EffectiveToolInventoryResult> {
   const existing = toolsEffectiveInflight.get(key);
   if (existing) {
     return existing;
   }
   const startedAt = nowForToolsEffectiveCache();
-  const task = new Promise<BaseToolsEffectiveResolution>((resolve, reject) => {
+  const task = new Promise<EffectiveToolInventoryResult>((resolve, reject) => {
     setImmediate(() => {
       void resolveBaseToolsEffectiveInventory(context, dependencies)
         .then((value) => {
@@ -234,7 +225,7 @@ function scheduleBaseToolsEffectiveRefresh(
           const durationMs = nowForToolsEffectiveCache() - startedAt;
           if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
             logDebug(
-              `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.inventory.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
+              `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
             );
           }
           resolve(value);
@@ -261,7 +252,7 @@ async function resolveCachedBaseToolsEffective(params: {
   sessionKey: string;
   context: TrustedToolsEffectiveContext;
   dependencies: ToolsEffectiveDependencies;
-}): Promise<BaseToolsEffectiveResolution> {
+}): Promise<EffectiveToolInventoryResult> {
   const key = buildToolsEffectiveCacheKey(params);
   const now = nowForToolsEffectiveCache();
   const cached = toolsEffectiveCache.get(key);
@@ -391,39 +382,41 @@ function maybeAppendMcpNotice(
 async function resolveBaseToolsEffectiveInventory(
   context: TrustedToolsEffectiveContext,
   dependencies: ToolsEffectiveDependencies,
-): Promise<BaseToolsEffectiveResolution> {
+): Promise<EffectiveToolInventoryResult> {
   const agentDir = dependencies.resolveAgentDir(context.cfg, context.agentId);
-  const runtimeModelContext =
-    await dependencies.resolveEffectiveToolInventoryRuntimeModelContextAsync({
-      cfg: context.cfg,
-      agentId: context.agentId,
-      agentDir,
-      workspaceDir: context.workspaceDir,
-      modelProvider: context.modelProvider,
-      modelId: context.modelId,
-    });
-  return {
-    runtimeModelContext,
-    inventory: dependencies.resolveEffectiveToolInventory({
-      cfg: context.cfg,
-      agentId: context.agentId,
-      agentDir,
-      sessionKey: context.sessionKey,
-      workspaceDir: context.workspaceDir,
-      messageProvider: context.messageProvider,
-      modelProvider: context.modelProvider,
-      modelId: context.modelId,
-      modelApi: runtimeModelContext.modelApi,
-      runtimeModel: runtimeModelContext.runtimeModel,
-      currentChannelId: context.currentChannelId,
-      currentThreadTs: context.currentThreadTs,
-      accountId: context.accountId,
-      groupId: context.groupId,
-      groupChannel: context.groupChannel,
-      groupSpace: context.groupSpace,
-      replyToMode: context.replyToMode,
-    }),
-  };
+  const acquired = await dependencies.acquireEffectiveToolInventoryRuntimeModelContext({
+    cfg: context.cfg,
+    agentId: context.agentId,
+    agentDir,
+    workspaceDir: context.workspaceDir,
+    modelProvider: context.modelProvider,
+    modelId: context.modelId,
+  });
+  try {
+    return acquired.run((runtimeModelContext) =>
+      dependencies.resolveEffectiveToolInventory({
+        cfg: context.cfg,
+        agentId: context.agentId,
+        agentDir,
+        sessionKey: context.sessionKey,
+        workspaceDir: context.workspaceDir,
+        messageProvider: context.messageProvider,
+        modelProvider: context.modelProvider,
+        modelId: context.modelId,
+        modelApi: runtimeModelContext.modelApi,
+        runtimeModel: runtimeModelContext.runtimeModel,
+        currentChannelId: context.currentChannelId,
+        currentThreadTs: context.currentThreadTs,
+        accountId: context.accountId,
+        groupId: context.groupId,
+        groupChannel: context.groupChannel,
+        groupSpace: context.groupSpace,
+        replyToMode: context.replyToMode,
+      }),
+    );
+  } finally {
+    acquired.release();
+  }
 }
 
 function filterMcpTools(params: {
@@ -455,12 +448,11 @@ async function resolveReadOnlyToolsEffectiveInventory(
   context: TrustedToolsEffectiveContext,
   dependencies: ToolsEffectiveDependencies,
 ): Promise<EffectiveToolInventoryResult> {
-  const baseResolution = await resolveCachedBaseToolsEffective({
+  const base = await resolveCachedBaseToolsEffective({
     sessionKey: context.sessionKey,
     context,
     dependencies,
   });
-  const base = baseResolution.inventory;
   const harness = context.agentHarnessId
     ? dependencies.getRegisteredAgentHarness(context.agentHarnessId)?.harness
     : undefined;
@@ -488,7 +480,6 @@ async function resolveReadOnlyToolsEffectiveInventory(
           base,
           catalog,
           context,
-          runtimeModelContext: baseResolution.runtimeModelContext,
           workspaceDir: context.workspaceDir,
           dependencies,
         });
@@ -532,22 +523,10 @@ async function resolveReadOnlyToolsEffectiveInventory(
   if (!catalog) {
     return maybeAppendMcpNotice(base, mcpConfig.serverNames, "not-listed");
   }
-  const runtimeModelContext =
-    runtime.workspaceDir === context.workspaceDir
-      ? baseResolution.runtimeModelContext
-      : await dependencies.resolveEffectiveToolInventoryRuntimeModelContextAsync({
-          cfg: context.cfg,
-          agentId: context.agentId,
-          agentDir: dependencies.resolveAgentDir(context.cfg, context.agentId),
-          workspaceDir: runtime.workspaceDir,
-          modelProvider: context.modelProvider,
-          modelId: context.modelId,
-        });
   return await projectMcpCatalog({
     base,
     catalog,
     context,
-    runtimeModelContext,
     workspaceDir: runtime.workspaceDir,
     dependencies,
   });
@@ -557,7 +536,6 @@ async function projectMcpCatalog(params: {
   base: EffectiveToolInventoryResult;
   catalog: Parameters<typeof buildBundleMcpToolsFromCatalog>[0]["catalog"];
   context: TrustedToolsEffectiveContext;
-  runtimeModelContext: RuntimeModelContext;
   workspaceDir: string;
   dependencies: ToolsEffectiveDependencies;
 }): Promise<EffectiveToolInventoryResult> {
@@ -571,16 +549,33 @@ async function projectMcpCatalog(params: {
     mcpTools: projectedMcpTools,
     dependencies: params.dependencies,
   });
-  const mcpInventory = buildRuntimeCompatibleMcpToolInventory({
-    tools: filteredMcpTools,
+  if (filteredMcpTools.length === 0) {
+    return params.base;
+  }
+  const acquired = await params.dependencies.acquireEffectiveToolInventoryRuntimeModelContext({
     cfg: params.context.cfg,
+    agentId: params.context.agentId,
+    agentDir: params.dependencies.resolveAgentDir(params.context.cfg, params.context.agentId),
     workspaceDir: params.workspaceDir,
     modelProvider: params.context.modelProvider,
     modelId: params.context.modelId,
-    modelApi: params.runtimeModelContext.modelApi,
-    runtimeModel: params.runtimeModelContext.runtimeModel,
   });
-  return appendMcpInventoryGroups({ base: params.base, mcpInventory });
+  try {
+    return acquired.run((runtimeModelContext) => {
+      const mcpInventory = buildRuntimeCompatibleMcpToolInventory({
+        tools: filteredMcpTools,
+        cfg: params.context.cfg,
+        workspaceDir: params.workspaceDir,
+        modelProvider: params.context.modelProvider,
+        modelId: params.context.modelId,
+        modelApi: runtimeModelContext.modelApi,
+        runtimeModel: runtimeModelContext.runtimeModel,
+      });
+      return appendMcpInventoryGroups({ base: params.base, mcpInventory });
+    });
+  } finally {
+    acquired.release();
+  }
 }
 
 function resolveTrustedToolsEffectiveContext(params: {


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Dynamic tool inventory released its prepared model lease before provider callbacks projected the tool schemas. The Gateway then cached that executable model after release. MCP projection could also miss the selected provider's normalizer because it ran outside that prepared generation.

## Why This Change Was Made

An internal acquisition now keeps the original model lease and runs projection inside its exact generation. The informational command, session-reset check, and Gateway consumers release it after projection. The Gateway cache stores inventory data; a nonempty MCP projection acquires its workspace-specific model context when needed.

Static resolution, stale/background refresh, coalescing, and read-only MCP behavior remain unchanged. The handle rejects use after its own release without introducing a new snapshot-publication freshness policy. No public SDK, configuration, schema, dependency, or version changes.

## User Impact

Tool inventories use the intended provider's schema normalization while its resources are owned, including sandbox MCP workspaces. Unrelated ambient providers cannot substitute for the selected generation. Empty or filtered MCP catalogs preserve the base inventory without additional acquisition.

## Evidence

A native failing-before test observed zero prepared owners inside the actual provider normalization hook. The repaired path observes one, then releases it after projection. All 87 focused tests pass, covering native same/sandbox MCP scopes, competing ambient providers, errors, cache behavior, and command/reset callers. The canonical changed gate, 207.2-second ordinary build, and fresh full-scope independent Codex review pass. A callback config-narrowing error found by the first gate was repaired by capturing the existing config value, and the final reset cases were rerun.

A real built Gateway and two built CLI tools.effective calls returned identical inventories containing the synthetic plugin tool; the dynamic provider normalizer ran. Readiness took 4.56 seconds and the CLI calls 0.80 / 0.61 seconds, including process startup and connection. The owned Gateway drained and exited zero. The initial fixture was missing its required tools manifest contract; only that synthetic fixture was corrected.

Paired in-process handler measurements on the same base used 25 alternating samples after five warmups. With Node 24.20, uncached base+MCP took 6.35 → 6.62 ms, warm inventory without MCP 0.118 → 0.118 ms, and warm MCP 0.25 → 1.44 ms. The latter pays for one real acquisition and the previously missed selected normalizer. Node 26 showed a similar approximately 1.3 ms warm-MCP cost. These are bounded synthetic measurements, not a general speedup claim.

All runtime proof used isolated synthetic state and no external provider requests. General prepared/cache physical disposal remains separate work.
