### PR TITLE
refactor(tests): consolidate duplicate setup inference cases

### DIFF
--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -137,16 +137,7 @@ describe("isolated setup inference detection", () => {
     expect(JSON.parse(response.body)).toEqual({ ok: true, status: "live" });
     expect(elapsedMs).toBeLessThan(500);
     const detection = await pending;
-    expect(detection).toMatchObject({
-      candidates: fallback.candidates,
-      unavailableCandidates: fallback.unavailableCandidates,
-      manualProviders: fallback.manualProviders,
-      authOptions: fallback.authOptions,
-      recommendedInstalls: fallback.recommendedInstalls,
-      workspace: fallback.workspace,
-      setupComplete: fallback.setupComplete,
-    });
-    expect(detection.prepareOptions ?? []).toEqual([]);
+    expect(detection).toEqual(fallback);
     expect(performance.now() - pendingStartedAt).toBeLessThan(10_000);
   });
 
@@ -165,26 +156,6 @@ describe("isolated setup inference detection", () => {
         "AI access detection did not finish after 0.05s. " +
         "This Gateway may still be checking — try again.",
     });
-  });
-
-  it("returns partial candidates when detection times out", async () => {
-    const { detectSetupInferenceIsolated } = await loadDetectionModule();
-    const partial = detectedCodex();
-
-    const detection = await detectSetupInferenceIsolated({
-      workerUrl: blockingWorkerUrl,
-      workerData: {
-        blockMs: 30_000,
-        detection: emptyDetection(),
-        partialDetection: partial,
-      },
-      // Generous timeout: the partial must beat the deadline on loaded CI
-      // runners, or the empty-timeout rejection makes this flake.
-      timeoutMs: 3_000,
-      fallbackEnv: {},
-    });
-
-    expect(detection).toEqual(partial);
   });
 
   it("returns ambient API keys when detection times out", async () => {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2645,33 +2645,6 @@ describe("activateSetupInference", () => {
     });
   });
 
-  it("returns an auth failure when the verified owner drifts during persistence", async () => {
-    const configHarness = createPreRosterConfigTransformHarness();
-    const result = await activateSetupInference({
-      kind: "openai-api-key",
-      deps: {
-        runEmbeddedAgent: vi.fn(successfulRunner("openai", "gpt-5.6-sol")) as never,
-        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
-        // The real revalidation throws when the current route owner no longer
-        // matches the probe credential (e.g. a Codex-imported OAuth profile
-        // outranking the probed env key). The ladder needs a failure result.
-        createSystemAgentVerifiedInferenceBinding: vi.fn(async () => {
-          throw new Error(
-            "The successful inference credential is no longer the active route owner.",
-          );
-        }) as never,
-      },
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      status: "auth",
-      error: expect.stringContaining("verified inference owner changed"),
-    });
-    expect(result).not.toHaveProperty("disposition");
-    expect(configHarness.current()).toEqual({});
-  });
-
   it("revalidates a stable CLI runtime owner at the config commit boundary", async () => {
     const configHarness = createPreRosterConfigTransformHarness();
     const resolveCliRuntimeOwnerFingerprint = vi.fn(async () => "test-runtime-owner");
@@ -2757,6 +2730,10 @@ describe("activateSetupInference", () => {
       ok: false,
       status: "auth",
       error: expect.stringContaining("active route owner"),
+    });
+    expect(result).not.toHaveProperty("disposition");
+    expect(result).toMatchObject({
+      error: expect.stringContaining("verified inference owner changed"),
     });
     expect(configHarness.transform).toHaveBeenCalledOnce();
     expect(configHarness.current()).toEqual({});


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Setup inference tests repeat a populated-partial timeout worker run and an injected owner-error scenario already covered through real credential drift.

## Why This Change Was Made

Move the complete partial-result equality assertion into the existing HTTP-responsiveness case, then remove the identical partial-timeout case. Move disposition-absence and generic owner-error assertions into the real credential-drift case before removing its injected-error duplicate. Preserve all other scenarios, worker deadlines, runtime calls and production behavior.

## User Impact

No user-visible behavior change. Two redundant cases and 52 net test lines are removed while their meaningful observations remain in stronger existing cases.

## Evidence

- Both complete owner suites passed before and after: 174 cases before, 172 after, with exactly the two named cases removed and every retained case in the same per-file order.
- Three focused temporary owner mutations failed at the intended retained assertions: missing partial-result field, unexpected disposition property, and missing generic owner-error context. All production bytes were restored exactly.
- Full mapped changed checks, diff-scoped cleanup and fresh independent P2 review passed with no findings.

The removed timeout case used a separate three-second worker deadline. No measured runtime improvement is claimed from the before/after runs because cache state differed.
