### PR TITLE
fix(linux): honor SSH alias ports

### DIFF
--- a/apps/linux/src-tauri/src/remote_gateway.rs
+++ b/apps/linux/src-tauri/src/remote_gateway.rs
@@ -92,7 +92,7 @@ fn is_private_host(host: &str) -> bool {
     }
 }
 
-pub(crate) fn validate_ssh_target(raw: &str) -> Result<(String, u16), String> {
+pub(crate) fn validate_ssh_target(raw: &str) -> Result<(String, Option<u16>), String> {
     let value = raw.trim();
     let invalid = || {
         "Enter a valid SSH target such as operator@gateway.example.com or operator@host:2222."
@@ -124,9 +124,9 @@ pub(crate) fn validate_ssh_target(raw: &str) -> Result<(String, u16), String> {
         if port == 0 {
             return Err(invalid());
         }
-        (host, port)
+        (host, Some(port))
     } else {
-        (host_port, 22)
+        (host_port, None)
     };
     if host.starts_with('-') || host.starts_with(':') || host.ends_with(':') || host.contains('@') {
         return Err(invalid());
@@ -667,13 +667,17 @@ pub(crate) fn start_tunnel(
             "OpenSSH is not installed. Install your system's OpenSSH client.".to_string()
         })?;
 
-    let mut child = Command::new(executable)
+    let mut command = Command::new(executable);
+    command.args([
+        "-N",
+        "-L",
+        &format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"),
+    ]);
+    if let Some(ssh_port) = ssh_port {
+        command.args(["-p", &ssh_port.to_string()]);
+    }
+    let mut child = command
         .args([
-            "-N",
-            "-L",
-            &format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"),
-            "-p",
-            &ssh_port.to_string(),
             "-o",
             "BatchMode=yes",
             "-o",
@@ -820,11 +824,11 @@ mod tests {
     fn ssh_target_accepts_optional_port_and_rejects_argument_injection() {
         assert_eq!(
             validate_ssh_target("operator@studio.example:2222").expect("target"),
-            ("operator@studio.example".to_string(), 2222)
+            ("operator@studio.example".to_string(), Some(2222))
         );
         assert_eq!(
             validate_ssh_target("studio.local").expect("target"),
-            ("studio.local".to_string(), 22)
+            ("studio.local".to_string(), None)
         );
         for target in [
             "",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux companion users connecting through an OpenSSH Host alias with a nondefault configured port would connect to port 22 instead. This affected SSH tunnel setup when the entered target omitted an explicit port, despite the companion supporting existing OpenSSH configuration.

## Why This Change Was Made

Preserve the distinction between an omitted SSH port and an explicit port: `validate_ssh_target` returns an optional port, and `start_tunnel` emits `-p` only when one was supplied. Existing Rust parser regressions are updated without adding a production helper or export for testing.

Argument-injection rejection, strict host-key checking, batch mode, loopback forwarding, and child-process ownership remain unchanged. IPv6 parsing and dead-tunnel/false-connected behavior are outside this repair.

## User Impact

SSH aliases now retain their configured port when the target omits one. Explicit ports, including `:22`, still override OpenSSH configuration. Hosts without a configured or explicit port continue to use OpenSSH's default.

## Evidence

Remote proof: Blacksmith run https://github.com/openclaw/openclaw/actions/runs/34319349370, with original source at baseline `7757d0a88d5` (`7757d0a88d571e4be4032a7337105d6faced0da9`).

- Before: compiled production command arguments failed the isolated alias regression with expected port `2222`, actual port `22`.
- After: compiled production command arguments passed alias inheritance, explicit-port overrides, argument-injection rejection, and security-option checks against real `ssh -G -F` output.
- `cargo +stable fmt --check`: passed.
- `cargo +stable test --locked --all-targets`: 135 + 10 tests passed; one logind integration test was ignored.
- Local `check:changed` and `git diff --check`: passed.
- Fresh autoreview: no actionable P0-P2 findings.
- TruffleHog scan: passed.
- Exact-head Linux build and macOS companion tests: passed, https://github.com/openclaw/openclaw/actions/runs/34320496723.
- Ready-event `openclaw/ci-gate`: passed, https://github.com/openclaw/openclaw/actions/runs/34320572389/job/102368682176.

The one-off source-extraction probe is retained outside the product as a campaign artifact, not as a permanent implementation-layout-coupled test. Rust parser regressions remain in the product.

### Native SSH Proof

Run: https://github.com/openclaw/openclaw/actions/runs/34321151352. The actual unbundled GTK/WebKit app ran in private loopback network, PID, and mount namespaces with a disposable account home. Alias port `37717` existed only in OpenSSH configuration; host-key verification was pinned.

**Before (`7757d0a88d5`):** the app forced port `22` and failed, with no fixture request, authentication POST, or forward.

![Before: native SSH connection fails on forced port 22](https://github.com/user-attachments/assets/bc6ef601-e91a-45ea-aa4a-622abb43f2b2)

**Fixed (`89e81d5079f`):** all seven checks passed: fresh native bootstrap, fixture challenge, forwarded origin, app-owned real `ssh -L` process, SSH-owned listener, accepted task public-key authentication, and a saved alias without an explicit port.

![Fixed: native SSH alias tunnel passes all seven checks](https://github.com/user-attachments/assets/9871dad4-2e1d-4d96-88f1-2c9aaa9508ce)

**Fresh-start negative control:** with the SSH daemon absent but the same HTTP fixture alive, the fixed app failed on port `37717`. No fixture request, authentication POST, or forward occurred.

![Negative control: native connection fails when the SSH daemon is absent](https://github.com/user-attachments/assets/c3c3960c-368d-4bb3-b0c9-8a2eec69959f)

Proof boundary: native saved-SSH reconnect and real OpenSSH transport to a synthetic HTTP auth-bootstrap fixture. This does not claim a real Gateway WebSocket handshake, full Control UI session, or external-network or packaged-app proof. The three captures were visually inspected and sanitized; the dedicated proof lease is stopped.
