### PR TITLE
refactor(tests): advance the captured ngrok startup deadline

### DIFF
--- a/extensions/voice-call/src/tunnel.process.test.ts
+++ b/extensions/voice-call/src/tunnel.process.test.ts
@@ -221,7 +221,6 @@ describe.skipIf(process.platform === "win32")("voice-call tunnel child process",
         .toBe("SIGTERM");
       expect(await waitForProcessExit(childPid, 1_000)).toBe(true);
     } finally {
-      clearTimeout(startupTimer);
       process.env.PATH = previousPath;
       if (previousPidPath === undefined) {
         delete process.env.OPENCLAW_NGROK_PID_FILE;

--- a/extensions/voice-call/src/tunnel.process.test.ts
+++ b/extensions/voice-call/src/tunnel.process.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { startTunnel } from "./tunnel.js";
 
 function isProcessAlive(pid: number): boolean {
@@ -154,6 +154,7 @@ describe.skipIf(process.platform === "win32")("voice-call tunnel child process",
     const previousPidPath = process.env.OPENCLAW_NGROK_PID_FILE;
     const previousSignalPath = process.env.OPENCLAW_NGROK_SIGNAL_FILE;
     let childPid: number | undefined;
+    let startupTimer: ReturnType<typeof setTimeout> | undefined;
 
     await fs.writeFile(
       ngrokPath,
@@ -171,12 +172,38 @@ describe.skipIf(process.platform === "win32")("voice-call tunnel child process",
     process.env.OPENCLAW_NGROK_SIGNAL_FILE = signalPath;
 
     try {
-      const result = startTunnel({
-        provider: "ngrok",
-        port: 3334,
-        path: "/voice/webhook",
-      });
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      let result: ReturnType<typeof startTunnel>;
+      let timeoutCalls: typeof timeoutSpy.mock.calls;
+      let timeoutResults: typeof timeoutSpy.mock.results;
+      try {
+        result = startTunnel({
+          provider: "ngrok",
+          port: 3334,
+          path: "/voice/webhook",
+        });
+        // Keep setup failures from leaving an unobserved startup rejection.
+        void result.catch(() => undefined);
+        timeoutCalls = [...timeoutSpy.mock.calls];
+        timeoutResults = [...timeoutSpy.mock.results];
+        const timer = timeoutResults[0];
+        if (timer?.type === "return") {
+          startupTimer = timer.value;
+        }
+      } finally {
+        timeoutSpy.mockRestore();
+      }
       childPid = await readPid(pidPath);
+
+      expect(timeoutCalls).toEqual([[expect.any(Function), 30_000]]);
+      const callback = timeoutCalls[0]?.[0];
+      expect(timeoutResults).toHaveLength(1);
+      if (typeof callback !== "function" || !startupTimer) {
+        throw new Error("Expected one native ngrok startup deadline");
+      }
+      // Advance only startup readiness; real signal escalation and child closure stay timed.
+      clearTimeout(startupTimer);
+      callback();
 
       await expect(result).rejects.toThrow("ngrok startup timed out (30s)");
 
@@ -194,6 +221,7 @@ describe.skipIf(process.platform === "win32")("voice-call tunnel child process",
         .toBe("SIGTERM");
       expect(await waitForProcessExit(childPid, 1_000)).toBe(true);
     } finally {
+      clearTimeout(startupTimer);
       process.env.PATH = previousPath;
       if (previousPidPath === undefined) {
         delete process.env.OPENCLAW_NGROK_PID_FILE;


### PR DESCRIPTION
## What Problem This Solves

The real ngrok startup-timeout process test spends 30 seconds waiting before it can exercise the child-termination behavior it protects.

## Why This Change Was Made

Capture the actual native startup timer during the synchronous `startTunnel` call and assert its configured 30,000ms budget. Restore the call-through spy immediately, wait for the real signal-resistant child to report readiness, then cancel and invoke that exact startup callback once. The real two-second SIGTERM grace, one-second bounded close wait, process-exit assertions and 40-second test deadline remain unchanged.

## User Impact

No production behavior changes. This test-only change adds 27 lines and avoids the controlled startup wait in one process test.

## Evidence

- Both complete process and unit suites passed before and after: 19 cases, zero pending, identical ordered names and statuses.
- The target process case took 32.014s before and 2.054s after in one local pair. This is a single-case result, not an overall suite-runtime claim. The baseline external PID observer missed Vitest’s nested temporary namespace; its original process assertions passed. The corrected candidate observer recorded the two PID-file fixtures and confirmed they were dead after the run.
- A temporary 30,001ms budget failed the new argument assertion. Disabling forced termination failed the existing process-exit assertion. Both controls’ observed PID fixtures were dead after cleanup, and production source was restored exactly.
- The mapped changed gate, deslop pass and fresh P2 review passed.

The initial revision cancelled the cleanup deadline when PID discovery failed. The follow-up removes that unconditional cancellation: the accelerated success path still cancels its timer, while failed PID discovery retains the original native termination fallback. A real-child control held cleanup for 34 seconds before runner teardown: the initial revision left its child alive and required a safety kill; the repaired revision had already terminated its child through the original deadline, without a safety kill. Both controls retained the intended synthetic failure and left their observed PID fixture dead.
