### PR TITLE
improve(test): reuse service-worker E2E production builds

### DIFF
--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -47,6 +47,21 @@ type InstallGate = {
 let browser: Browser;
 let outDir: string;
 let server: ControlUiE2eServer;
+let buildBPromise: Promise<void> | undefined;
+
+async function stageBuildB(destination: string): Promise<void> {
+  const pristineDir = `${outDir}-build-b`;
+  buildBPromise ??= buildProductionControlUiE2e(pristineDir, buildB);
+  await buildBPromise;
+  await rm(destination, { force: true, recursive: true });
+  try {
+    // Each deployment owns its bytes; the terminal case modifies its worker.
+    await cp(pristineDir, destination, { recursive: true, dereference: true });
+  } catch (error) {
+    await rm(destination, { force: true, recursive: true });
+    throw error;
+  }
+}
 
 async function findBuildAsset(buildId: string, buildDir = outDir): Promise<BuildAsset> {
   const assetsDir = path.join(buildDir, "assets");
@@ -270,14 +285,20 @@ describe("Control UI service-worker production update E2E", () => {
   }, 120_000);
 
   afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-    if (outDir) {
-      await Promise.all(
-        [outDir, `${outDir}-next`, `${outDir}-previous`].map((dir) =>
-          rm(dir, { force: true, recursive: true }),
-        ),
-      );
+    try {
+      await browser?.close();
+    } finally {
+      try {
+        await server?.close();
+      } finally {
+        if (outDir) {
+          await Promise.all(
+            ["", "-build-b", "-next", "-previous", "-foreground", "-sleeping"].map((suffix) =>
+              rm(`${outDir}${suffix}`, { force: true, recursive: true }),
+            ),
+          );
+        }
+      }
     }
   });
 
@@ -357,7 +378,7 @@ describe("Control UI service-worker production update E2E", () => {
         const draft =
           mode === "chat" ? "keep my draft through the missed update" : '{ "count": 2 }';
         await editor.fill(draft);
-        await buildProductionControlUiE2e(nextDir, buildB);
+        await stageBuildB(nextDir);
         await page.evaluate(() => sessionStorage.setItem("test-missed-activation", "1"));
         await rename(outDir, previousDir);
         await rename(nextDir, outDir);
@@ -507,7 +528,7 @@ describe("Control UI service-worker production update E2E", () => {
       const nextOutDir = `${outDir}-next`;
       const previousOutDir = `${outDir}-previous`;
       installGate = await createInstallGate();
-      await buildProductionControlUiE2e(nextOutDir, buildB);
+      await stageBuildB(nextOutDir);
       await holdReplacementWorkerInstalling(nextOutDir, installGate.url);
       const assetB = await findBuildAsset(buildB, nextOutDir);
       expect(assetB.path).not.toBe(assetA.path);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The service-worker production-update E2E file rebuilds the identical replacement UI three times. Those repeated fixture compilations add overhead without testing different build inputs.

## Why This Change Was Made

Build replacement B lazily once per file and give every deployment an independent recursive copy. The terminal install-gate case mutates only its copied worker. A rejected build stays rejected; failed copies remove their partial destination. Teardown closes the browser, then the server, then all owned directories.

Only `ui/src/e2e/service-worker-update.e2e.test.ts` changes. All four cases, assertions, browser contexts, execution order, both 300 ms negative guards, the update fence, real Vite builds, real browser, and real server remain intact. No production, shared-helper, configuration, dependency, coverage, or timeout changes.

## User Impact

No product behavior changes. Developers run the same full-file coverage with two actual production builds instead of four. Selecting only the deep-link case still builds A alone.

## Evidence

Matched Linux full-file invocations against base `b04a3f83adad8bd6a2ca8408e7940fc6bcbde212`, with the same physical dependencies and runtime, fresh module caches, and fresh task-owned temporary directories:

| Pair | Before | After | Production builds | Passing cases |
| --- | ---: | ---: | --- | --- |
| 1 | 74.994 s | 47.726 s | 4 -> 2 | 4/4 -> 4/4 |
| 2 | 74.719 s | 47.848 s | 4 -> 2 | 4/4 -> 4/4 |

About 27 seconds (36%) less local invocation time. Recorded Vite build totals fall from 55.54 to 28.01 seconds and 55.45 to 28.13 seconds; non-build residuals stay around 19-20 seconds. These are shared-host observations, not an uncontended benchmark or CI timing forecast. A separate 77.450-second baseline overlapping another scan is retained for correctness but excluded from these pairs. The deterministic result is four builds reduced to two.

Command used unchanged for each full-file timing:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/service-worker-update.e2e.test.ts --reporter=verbose
```

Additional untimed proofs used external observation/fault injection, with no repository helper or export changes:

- Full-file run passes all four cases with two builds. All three stages contain 1,983 files with matching full-tree content hashes, independent inodes, and no symlinks. Terminal worker mutation leaves pristine B unchanged, including immediately before cleanup.
- Deep-link-only selection passes with exactly one A build; the other three cases are skipped only in this supplemental laziness probe.
- A single config-draft case with an injected partial-copy failure exits 1 as expected. Its partial stage is removed, published A and pristine B stay unchanged, and no partial publication or task-temp leak occurs.
- The same single case with a separate write fault inside the real B builder exits 1 as expected after emitting 1,142 partial files. Cleanup removes partial B; exactly one B attempt occurs, with no copy, retry, fallback, or publication. Published A stays unchanged and no task-temp entries remain.
- Changed checks pass, including UI E2E typechecking, all three Knip scans, scoped type-aware lint, formatting, and `git diff --check`. Independent review through P2 is scoped-clean.

Candidate file SHA-256: `bc906bda534fc9182a4f8e9dfe47955ac74a5aff63812fc4e6e628c1a302980a`.

Observed pristine B tree SHA-256: `5969e62201d62474133f7d1bdb140aef15a9b972cbf9dcdb77676c82e3aced3d`.

Proof is local Linux/Chromium; no new CI timing or other-platform result is claimed.
