### PR TITLE
fix(ci): identify incompatible FRV collector evidence

### DIFF
--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -2002,7 +2002,13 @@ function verifyStateTransition(decision, drain, executionPlan) {
     (decision.state === "passed" && drain.state === "blocked_complete") ||
     (decision.state.startsWith("blocked_") && drain.state === "passed" && !reuseRecovery)
   ) {
-    throw new Error("release decision and diagnostic drain transition is invalid");
+    throw new Error(
+      "release decision and diagnostic drain transition is invalid: " +
+        `decision(parentRunAttempt=${decision.parentRunAttempt}, state=${decision.state}), ` +
+        `drain(parentRunAttempt=${drain.parentRunAttempt}, state=${drain.state}); ` +
+        `executionPlan(originalParentRunAttempt=${executionPlan.parentRunAttempt}, sha256=${executionPlan.sha256}); ` +
+        "compatible collector evidence for the same execution plan is required",
+    );
   }
   if (
     decision.state.startsWith("blocked_") &&

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -2213,19 +2213,44 @@ describe("release state artifacts", () => {
     ).toThrow(/invalid|gapped|malformed/u);
   });
 
-  it("selects the newest decision and drain independently across asymmetric retries", () => {
-    const sealedPlan = executionPlan({ rerunGroup: "ci" });
-    const selected = selectReleaseStateArtifacts(
-      sealedPlan,
-      [
-        { name: "full-release-decision-77-1", payload: artifact("decision", 1, sealedPlan) },
-        { name: "full-release-decision-77-2", payload: artifact("decision", 2, sealedPlan) },
-      ],
-      [{ name: "full-release-diagnostics-77-1", payload: artifact("drain", 1, sealedPlan) }],
-      stateExpected(3),
-    );
-    expect(selected.sourceAttempts).toEqual({ decision: 2, drain: 1, executionPlan: 1 });
-  });
+  it.each(["passed", "blocked_complete"])(
+    "validates the newest decision and drain across asymmetric retries from %s",
+    (initialState) => {
+      const sealedPlan = executionPlan({ rerunGroup: "ci" });
+      const initialChild =
+        initialState === "blocked_complete" ? { conclusion: "failure", jobs: [FAILED_JOB] } : {};
+      const select = () =>
+        selectReleaseStateArtifacts(
+          sealedPlan,
+          [
+            {
+              name: "full-release-decision-77-1",
+              payload: artifact("decision", 1, sealedPlan, initialChild),
+            },
+            { name: "full-release-decision-77-2", payload: artifact("decision", 2, sealedPlan) },
+          ],
+          [
+            {
+              name: "full-release-diagnostics-77-1",
+              payload: artifact("drain", 1, sealedPlan, initialChild),
+            },
+          ],
+          stateExpected(3),
+        );
+      if (initialState === "blocked_complete") {
+        expect(select).toThrow("release decision and diagnostic drain transition is invalid");
+        expect(select).toThrow(
+          "release decision and diagnostic drain transition is invalid: " +
+            "decision(parentRunAttempt=2, state=passed), " +
+            "drain(parentRunAttempt=1, state=blocked_complete); " +
+            `executionPlan(originalParentRunAttempt=1, sha256=${String(sealedPlan.sha256)}); ` +
+            "compatible collector evidence for the same execution plan is required",
+        );
+      } else {
+        expect(select().sourceAttempts).toEqual({ decision: 2, drain: 1, executionPlan: 1 });
+      }
+    },
+  );
 
   it("selects a blocked decision with its completed diagnostic drain", () => {
     const { decision, sealedPlan } = blockedArtifacts();


### PR DESCRIPTION
Fixes #142905

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators verifying incompatible Full Release Validation collector evidence receive a transition error without the selected collector attempts, states, or common execution-plan identity.

The selector already rejects the invalid pair correctly. This is a diagnostic improvement, not a selector-policy repair.

## Why This Change Was Made

Keep the generic error prefix and add each selected collector's actual parent attempt and state, the validated execution plan's original attempt and SHA256, and the requirement for compatible collector evidence.

Extend the existing asymmetric fixture with blocked Decision-1/Drain-1 followed by passed Decision-2, while retaining the valid passed asymmetric case. Selection, provenance checks, exit behavior, controller/retry behavior, workflows, and release bytes are unchanged.

## User Impact

Operators can identify the incompatible evidence directly from the rejection message. No artifact pair becomes newly acceptable, and the diagnostic does not recommend a potentially unsupported retry.

## Evidence

- Regression-first: the base rejects the invalid pair but fails the new diagnostic assertion; the valid asymmetric case passes.
- Final focused owner suite: all 289 tests in `test/scripts/full-release-validation-state.test.ts` pass.
- Scoped production/test lint, formatting, and `git diff --check` pass.
- All selected changed-file checks pass, including the root-test typecheck after provisioning checkout-owned dependencies and materializing the pinned checkout. Source and lockfile bytes are unchanged by that prerequisite repair.
- Independent autoreview reports no actionable findings through P2.
- No real Full Release Validation run, retry, dispatch, or release action was performed. Historical raw failure logs remain private.
