### PR TITLE
improve(test): avoid repeated worker transform builds

### DIFF
--- a/test/scripts/vitest-worker-artifacts.transforms.test.ts
+++ b/test/scripts/vitest-worker-artifacts.transforms.test.ts
@@ -10,15 +10,9 @@ const it = createWorkerArtifactTest();
 const concurrent = process.platform !== "win32";
 
 describe("fresh compiled subprocess invocation", { concurrent }, () => {
-  it.for(
-    (["single", "projects"] as const).flatMap((layout) =>
-      (["fresh generations", "source mode", "source and config edits"] as const).map(
-        (invariant) => ({ layout, invariant }),
-      ),
-    ),
-  )(
-    "preserves filesystem transforms for $invariant ($layout)",
-    ({ layout, invariant }, { workerArtifacts }) =>
+  it.for((["single", "projects"] as const).map((layout) => ({ layout })))(
+    "preserves filesystem transforms across fresh generations, source mode, and edits ($layout)",
+    ({ layout }, { workerArtifacts }) =>
       workerArtifacts.fixtureLifetime.run(async () => {
         const { node } = workerArtifacts.createFixtureCommands();
         const directory = workerArtifacts.fixtureDirectory();
@@ -100,30 +94,26 @@ describe("fresh compiled subprocess invocation", { concurrent }, () => {
         expect(
           JSON.parse(fs.readFileSync(path.join(cacheDirectory, "_metadata.json"), "utf8")),
         ).toEqual({ lockfileHash: expect.stringMatching(/^[a-f\d]{8}$/u) });
-        if (invariant === "fresh generations") {
-          await launch("compiled");
-          expect(counts(), "unchanged parents must reuse filesystem transforms").toEqual([1, 1]);
-        } else if (invariant === "source mode") {
-          await launch("source");
-          expect(counts()).toEqual([2, 2]);
-          await launch("compiled");
-          expect(counts()).toEqual([2, 2]);
-        } else {
-          fs.writeFileSync(value, 'export const value: string = "second";');
-          await launch("compiled", "second");
-          expect(counts()).toEqual([2, 1]);
-          fs.writeFileSync(
-            config,
-            fs
-              .readFileSync(config, "utf8")
-              .replace(
-                `replacement:${JSON.stringify(value)}`,
-                `replacement:${JSON.stringify(configuredValue)}`,
-              ),
-          );
-          await launch("compiled", "configured");
-          expect(counts()).toEqual([3, 2]);
-        }
+        await launch("compiled");
+        expect(counts(), "unchanged parents must reuse filesystem transforms").toEqual([1, 1]);
+        await launch("source");
+        expect(counts()).toEqual([2, 2]);
+        await launch("compiled");
+        expect(counts()).toEqual([2, 2]);
+        fs.writeFileSync(value, 'export const value: string = "second";');
+        await launch("compiled", "second");
+        expect(counts()).toEqual([3, 2]);
+        fs.writeFileSync(
+          config,
+          fs
+            .readFileSync(config, "utf8")
+            .replace(
+              `replacement:${JSON.stringify(value)}`,
+              `replacement:${JSON.stringify(configuredValue)}`,
+            ),
+        );
+        await launch("compiled", "configured");
+        expect(counts()).toEqual([4, 3]);
       }),
   );
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The worker-transform proof repeatedly rebuilds the complete worker set while testing overlapping cache transitions. This maintainer-requested optimization removes duplicate setup from that tooling test.

## Why This Change Was Made

Combine the three invariant cases into one sequence for each of the existing `single` and `projects` layouts. Each layout retains six fresh subprocess launches: five compiled and one source.

The sequence still checks cold metadata, warm reuse, source mode, return to compiled mode, source edits and alias edits. The launch assertions are unchanged, and all five compiled generations must be unique and disposed. This removes four compiler preparations overall without changing the compiler, harness, dependencies, concurrency or 120-second case timeout.

## User Impact

No product behavior changes. Developers run the same worker and cache contracts with less duplicated compilation. The measurements below are local Linux observations, not Windows or whole-CI speedup claims.

## Evidence

Matched full-file Linux runs on Node 24.19.0, based on `89168d55ee1`, with the same physical dependencies and unchanged concurrent-layout path:

| Pair | Invocation Before / After | File Before / After |
| --- | --- | --- |
| Initial | 101.982s / 69.753s | 98.270s / 67.375s |
| Warmed | 104.469s / 82.130s | 101.976s / 79.803s |

This is a shared host; the two observed file reductions were 31.44% and 21.74%, not a statistical estimate. Final whole-case times were 78.622s (`single`) and 79.803s (`projects`). Baselines passed all six cases; both candidate runs passed both complete sequences.

```sh
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.tooling.config.ts \
  test/scripts/vitest-worker-artifacts.transforms.test.ts
```

- Both layouts retained `C [1,1] -> C [1,1] -> S [2,2] -> C [2,2] -> C "second" [3,2] -> C "configured" [4,3]`, with `configValue` remaining `"first"`.
- Temporary fixture fault injections for lost warm reuse, stale source and stale alias each failed at the intended assertion in both layouts. The real edits and assertions stayed intact. All controls were removed before the final full-file pass.
- Every local Linux baseline, candidate and negative-control invocation left no fixture or generation directories behind.
- Scoped changed checks passed (exit 0), including root-test typing and lint. Fresh independent P2 review is scoped-clean with no actionable findings.
- Normal Blacksmith Windows CI for head `5446cbbd9be2e6724173a2cab6ce3cf3b88fdf10` passed both complete cases: `single` 101.467s and `projects` 91.329s, leaving 18.533s and 28.671s below the unchanged 120-second limit. This is attempt-1 evidence from September 9, 2026, 07:02:49-07:16:48 UTC, reused with its original execution timestamps in attempt 2; Windows was not rerun. Job: https://github.com/openclaw/openclaw/actions/runs/34321793844/job/102370052191
- All twelve Windows launch observations, all ten compiled-generation disposal assertions and fixture teardown passed. The unchanged Windows launcher separately retained its outer temporary namespace because descendant completion is unverified on a non-group launch. Runner-wide process/filesystem cleanup is not claimed. These are single-run Windows observations, not a matched-host Windows speedup comparison.

## CI Recovery And Reliability Follow-Up

- Attempt 1 failed a separate announcement assertion at `src/agents/subagents/announce/subagent-announce.test.ts:556`: received `retryable`, expected `delivered`, after the credential guard rejected a gateway history request. The failed test and owner match task base, head, CI base and tested merge; the worker test is absent from that job. The original failure remains valid evidence: https://github.com/openclaw/openclaw/actions/runs/34321793844/job/102370053206
- Independent unchanged local probes passed the single case, all 16 announcement-file tests, and all 85 output-then-announcement tests in one observed worker. A separate CI run also passed the case in 13ms with matching key source blobs: https://github.com/openclaw/openclaw/actions/runs/34323392493/job/102375133567
- One reviewed, job-specific retry passed on the unchanged head and original tested merge. The case passed in 16ms; all 71 files in its shard passed. The retry completed at 08:01:25 UTC on September 9 and the required aggregate gate passed at 08:01:31 UTC. Retry: https://github.com/openclaw/openclaw/actions/runs/34321793844/job/102382121138
- The existing workflow routed this retry to GitHub-hosted `ubuntu-24.04` (four detected cores, Node 24.20.0), versus attempt 1's Blacksmith runner and Node 24.19.0. Its full test step took 12m55s. This is not a matched-hardware timing comparison; no backend, timeout, test source or concurrency setting was changed for recovery.
- Reliability follow-up remains: establish the exact import/mock-cache escape and a deterministic reproduction before changing the announcement test's output dependency binding. The auth guard correctly rejected the unbound request. Passing recovery does not establish a fix or resolve the cause. No repair patch or second retry was made.
