### PR TITLE
improve(test): reduce startup work for focused fast tests

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -156,11 +156,20 @@ describe("unit-fast vitest lane", () => {
       try {
         const includeFile = path.join(directory, "include.json");
         fs.writeFileSync(includeFile, JSON.stringify(selectedTests));
-        process.env.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
-        const selections = [];
-        for (const name of ["unit-fast", "unit-fast-isolated", "unit-fast-fake-timers"]) {
-          const { default: config } = await import("./test/vitest/vitest." + name + ".config.ts?io-probe=" + Date.now());
-          selections.push(config.test.include);
+        const selections = {};
+        for (const mode of ["cli", "env"]) {
+          if (mode === "cli") {
+            delete process.env.OPENCLAW_VITEST_INCLUDE_FILE;
+            process.argv = ["node", "vitest", "run", ...selectedTests];
+          } else {
+            process.env.OPENCLAW_VITEST_INCLUDE_FILE = includeFile;
+            process.argv = ["node", "vitest", "run"];
+          }
+          selections[mode] = [];
+          for (const name of ["unit-fast", "unit-fast-isolated", "unit-fast-fake-timers"]) {
+            const { default: config } = await import("./test/vitest/vitest." + name + ".config.ts?io-probe=" + mode);
+            selections[mode].push(config.test.include);
+          }
         }
         console.log("UNIT_FAST_SELECTION_PROBE", JSON.stringify(selections));
         const { default: unitConfig, createUnitVitestConfigWithOptions } = await import("./test/vitest/vitest.unit.config.ts?io-probe=" + Date.now());
@@ -229,11 +238,15 @@ describe("unit-fast vitest lane", () => {
     expect(Number(probeMatch?.[5])).toBe(0);
     const selection = configProbeResult.stdout.match(/UNIT_FAST_SELECTION_PROBE (.+)/u);
     expect(selection, configProbeResult.stdout).not.toBeNull();
-    expect(JSON.parse(selection?.[1] ?? "null")).toEqual([
+    const selectedFastIncludes = [
       ["src/agents/agent-tools.deferred-followup-guidance.test.ts"],
       ["src/test-utils/openclaw-test-state.test.ts"],
       ["src/utils.test.ts"],
-    ]);
+    ];
+    expect(JSON.parse(selection?.[1] ?? "null")).toEqual({
+      cli: selectedFastIncludes,
+      env: selectedFastIncludes,
+    });
     const unitSelection = configProbeResult.stdout.match(/UNIT_SELECTION_PROBE (.+)/u);
     expect(unitSelection, configProbeResult.stdout).not.toBeNull();
     const excluded = [

--- a/test/vitest/vitest.unit-fast-fake-timers.config.ts
+++ b/test/vitest/vitest.unit-fast-fake-timers.config.ts
@@ -11,6 +11,7 @@ import {
   sharedVitestConfig,
 } from "./vitest.shared.config.ts";
 import { getUnitFastTimerTestFiles } from "./vitest.unit-fast-paths.mjs";
+import { unitTestIncludePatterns } from "./vitest.unit-paths.mjs";
 
 export function createUnitFastFakeTimersVitestConfig(
   env: Record<string, string | undefined> = process.env,
@@ -19,7 +20,9 @@ export function createUnitFastFakeTimersVitestConfig(
   const sharedTest = sharedVitestConfig.test ?? {};
   const sharedSequence = (sharedTest as { sequence?: { groupOrder?: number } }).sequence;
   const selectedPatterns = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-  const unitFastTimerTestFiles = getUnitFastTimerTestFiles(selectedPatterns);
+  const discoveryPatterns =
+    selectedPatterns ?? narrowIncludePatternsForCli(unitTestIncludePatterns, options.argv);
+  const unitFastTimerTestFiles = getUnitFastTimerTestFiles(discoveryPatterns);
   const includeFromEnv = intersectIncludePatterns(unitFastTimerTestFiles, selectedPatterns);
   const cliInclude = narrowIncludePatternsForCli(unitFastTimerTestFiles, options.argv);
 

--- a/test/vitest/vitest.unit-fast-isolated.config.ts
+++ b/test/vitest/vitest.unit-fast-isolated.config.ts
@@ -7,6 +7,7 @@ import {
 } from "./vitest.pattern-file.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { getUnitFastIsolatedTestFiles } from "./vitest.unit-fast-paths.mjs";
+import { unitTestIncludePatterns } from "./vitest.unit-paths.mjs";
 
 export function createUnitFastIsolatedVitestConfig(
   env: Record<string, string | undefined> = process.env,
@@ -14,7 +15,9 @@ export function createUnitFastIsolatedVitestConfig(
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
   const selectedPatterns = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-  const isolatedTestFiles = getUnitFastIsolatedTestFiles(selectedPatterns);
+  const discoveryPatterns =
+    selectedPatterns ?? narrowIncludePatternsForCli(unitTestIncludePatterns, options.argv);
+  const isolatedTestFiles = getUnitFastIsolatedTestFiles(discoveryPatterns);
   const includeFromEnv = intersectIncludePatterns(isolatedTestFiles, selectedPatterns);
   const cliInclude = narrowIncludePatternsForCli(isolatedTestFiles, options.argv);
 

--- a/test/vitest/vitest.unit-fast.config.ts
+++ b/test/vitest/vitest.unit-fast.config.ts
@@ -11,6 +11,7 @@ import {
   getUnitFastTestFiles,
   getUnitFastTimerTestFiles,
 } from "./vitest.unit-fast-paths.mjs";
+import { unitTestIncludePatterns } from "./vitest.unit-paths.mjs";
 
 export function createUnitFastVitestConfig(
   env: Record<string, string | undefined> = process.env,
@@ -18,9 +19,11 @@ export function createUnitFastVitestConfig(
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
   const selectedPatterns = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-  const timerTestFiles = new Set(getUnitFastTimerTestFiles(selectedPatterns));
-  const isolatedTestFiles = new Set(getUnitFastIsolatedTestFiles(selectedPatterns));
-  const unitFastTestFiles = getUnitFastTestFiles(selectedPatterns).filter(
+  const discoveryPatterns =
+    selectedPatterns ?? narrowIncludePatternsForCli(unitTestIncludePatterns, options.argv);
+  const timerTestFiles = new Set(getUnitFastTimerTestFiles(discoveryPatterns));
+  const isolatedTestFiles = new Set(getUnitFastIsolatedTestFiles(discoveryPatterns));
+  const unitFastTestFiles = getUnitFastTestFiles(discoveryPatterns).filter(
     (file) => !timerTestFiles.has(file) && !isolatedTestFiles.has(file),
   );
   const includeFromEnv = intersectIncludePatterns(unitFastTestFiles, selectedPatterns);


### PR DESCRIPTION
## What Problem This Solves

Focused runs through an explicit fast Vitest configuration classify unrelated test source files before applying the command-line selection, adding startup work even for a single test file.

## Why This Change Was Made

The ordinary, isolated, and fake-timer fast configurations now pass the existing CLI selection into source discovery. The existing owners still decide final test membership, ENV precedence, isolation, timer ordering, and full-inventory caching.

Related: #134038, which introduced the selected-analysis APIs reused here.

## User Impact

Developers running focused fast tests avoid unnecessary source reads. Full runs and the selected tests' execution settings retain their behavior.

## Evidence

The identical regression fails before the change with 123 unrelated source reads and passes afterward with zero. All 173 owner, sibling, and pattern-selection cases pass, including later full-inventory behavior. Fresh independent review found no actionable findings.

Four fresh-process config-only measurements on macOS with Node 26.8.1, ordered before/after/after/before, retained identical selection and one Git inventory call per process. Unrelated test-body reads fell from 5,735 to zero; measured config import times were 1.11–1.87 seconds before and 0.34–0.35 seconds after. These are descriptive config-import measurements, not end-to-end test timings or a universal speed guarantee.

All 15 canonical changed-file checks passed after a clean full-workspace frozen install on Linux with Node 24.19.0. The initial local typecheck failed because the borrowed dependency layout lacked plugin-local packages; that failure is retained, and the clean-install run passed the full type graph without source changes. Required [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34322160501) passed on this exact commit.
