### PR TITLE
fix(linux): restrict sleep control to owned gateways

### DIFF
--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -1,5 +1,5 @@
 use crate::cli::OpenClawCli;
-use crate::gateway_ws::GatewayWsConfig;
+use crate::gateway_ws::{GatewayOwnership, GatewayWsConfig};
 use serde::{Deserialize, Serialize};
 use std::thread;
 use std::time::Duration;
@@ -252,6 +252,7 @@ pub fn dashboard(cli: &OpenClawCli, snapshot: GatewaySnapshot) -> Result<ReadyGa
                 token,
                 response.gateway_password,
                 response.tls_fingerprint,
+                GatewayOwnership::Local,
             ),
         });
     }

--- a/apps/linux/src-tauri/src/gateway_sleep.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep.rs
@@ -17,9 +17,15 @@ pub(crate) enum SleepPrepareOutcome {
     Busy,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GatewaySleepRoute {
+    pub(crate) ws_url: String,
+    pub(crate) generation: u64,
+}
+
 struct HeldSuspension {
     id: String,
-    route: String,
+    route: GatewaySleepRoute,
 }
 
 #[derive(Default)]
@@ -30,9 +36,9 @@ struct CycleState {
 
 pub(crate) struct GatewaySleepCycleController {
     request_id: String,
-    current_route: Arc<dyn Fn() -> Option<String> + Send + Sync>,
-    prepare: Arc<dyn Fn(String) -> PrepareFuture + Send + Sync>,
-    resume: Arc<dyn Fn(String) -> ResumeFuture + Send + Sync>,
+    current_route: Arc<dyn Fn() -> Option<GatewaySleepRoute> + Send + Sync>,
+    prepare: Arc<dyn Fn(String, GatewaySleepRoute) -> PrepareFuture + Send + Sync>,
+    resume: Arc<dyn Fn(String, GatewaySleepRoute) -> ResumeFuture + Send + Sync>,
     refresh: Arc<dyn Fn() -> RefreshFuture + Send + Sync>,
     retry_delay: Arc<dyn Fn(Duration) -> DelayFuture + Send + Sync>,
     log: Arc<dyn Fn(String) + Send + Sync>,
@@ -50,13 +56,13 @@ impl GatewaySleepCycleController {
         log: L,
     ) -> Self
     where
-        P: Fn(String) -> PF + Send + Sync + 'static,
+        P: Fn(String, GatewaySleepRoute) -> PF + Send + Sync + 'static,
         PF: Future<Output = Result<SleepPrepareOutcome, String>> + Send + 'static,
-        R: Fn(String) -> RF + Send + Sync + 'static,
+        R: Fn(String, GatewaySleepRoute) -> RF + Send + Sync + 'static,
         RF: Future<Output = Result<(), String>> + Send + 'static,
         F: Fn() -> FF + Send + Sync + 'static,
         FF: Future<Output = ()> + Send + 'static,
-        C: Fn() -> Option<String> + Send + Sync + 'static,
+        C: Fn() -> Option<GatewaySleepRoute> + Send + Sync + 'static,
         D: Fn(Duration) -> DF + Send + Sync + 'static,
         DF: Future<Output = ()> + Send + 'static,
         L: Fn(String) + Send + Sync + 'static,
@@ -64,8 +70,8 @@ impl GatewaySleepCycleController {
         Self {
             request_id,
             current_route: Arc::new(current_route),
-            prepare: Arc::new(move |request_id| Box::pin(prepare(request_id))),
-            resume: Arc::new(move |suspension_id| Box::pin(resume(suspension_id))),
+            prepare: Arc::new(move |request_id, route| Box::pin(prepare(request_id, route))),
+            resume: Arc::new(move |suspension_id, route| Box::pin(resume(suspension_id, route))),
             refresh: Arc::new(move || Box::pin(refresh())),
             retry_delay: Arc::new(move |delay| Box::pin(retry_delay(delay))),
             log: Arc::new(log),
@@ -74,7 +80,7 @@ impl GatewaySleepCycleController {
     }
 
     pub(crate) async fn will_sleep(&self) {
-        // The production route closure exposes only configured loopback gateways.
+        // The production route closure exposes only locally owned loopback gateways.
         let Some(route) = (self.current_route)() else {
             return;
         };
@@ -86,8 +92,12 @@ impl GatewaySleepCycleController {
             state.generation = state.generation.wrapping_add(1);
             state.generation
         };
-        match (self.prepare)(self.request_id.clone()).await {
+        match (self.prepare)(self.request_id.clone(), route.clone()).await {
             Ok(SleepPrepareOutcome::Ready { suspension_id }) => {
+                if (self.current_route)().as_ref() != Some(&route) {
+                    self.log_route_changed();
+                    return;
+                }
                 let late = {
                     let mut state = self
                         .state
@@ -96,7 +106,7 @@ impl GatewaySleepCycleController {
                     if generation == state.generation {
                         state.suspension = Some(HeldSuspension {
                             id: suspension_id.clone(),
-                            route,
+                            route: route.clone(),
                         });
                         false
                     } else {
@@ -105,7 +115,7 @@ impl GatewaySleepCycleController {
                 };
                 if late {
                     // Wake or a newer cycle won the race; do not leave the late lease active.
-                    if let Err(error) = (self.resume)(suspension_id).await {
+                    if let Err(error) = (self.resume)(suspension_id, route).await {
                         (self.log)(format!("gateway sleep preparation failed: {error}"));
                     }
                 }
@@ -132,10 +142,7 @@ impl GatewaySleepCycleController {
         };
         if (self.current_route)().is_none() {
             if suspension.is_some() {
-                (self.log)(
-                    "dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire"
-                        .into(),
-                );
+                self.log_route_changed();
             }
             return;
         }
@@ -144,17 +151,21 @@ impl GatewaySleepCycleController {
         (self.refresh)().await;
         if let Some(suspension) = suspension {
             if (self.current_route)().as_ref() == Some(&suspension.route) {
-                self.resume_with_retries(suspension.id, generation).await;
+                self.resume_with_retries(suspension, generation).await;
             } else {
-                (self.log)(
-                    "dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire"
-                        .into(),
-                );
+                self.log_route_changed();
             }
         }
     }
 
-    async fn resume_with_retries(&self, suspension_id: String, generation: u64) {
+    fn log_route_changed(&self) {
+        (self.log)(
+            "dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire"
+                .into(),
+        );
+    }
+
+    async fn resume_with_retries(&self, suspension: HeldSuspension, generation: u64) {
         for attempt in 1..=RESUME_ATTEMPTS {
             // A new sleep cycle owns the connection; abandoned leases self-expire.
             if generation
@@ -166,7 +177,11 @@ impl GatewaySleepCycleController {
             {
                 return;
             }
-            match (self.resume)(suspension_id.clone()).await {
+            if (self.current_route)().as_ref() != Some(&suspension.route) {
+                self.log_route_changed();
+                return;
+            }
+            match (self.resume)(suspension.id.clone(), suspension.route.clone()).await {
                 Ok(()) => return,
                 Err(error) => {
                     (self.log)(format!(
@@ -188,13 +203,20 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::oneshot;
 
-    fn route_state(value: Option<&str>) -> Arc<Mutex<Option<String>>> {
-        Arc::new(Mutex::new(value.map(str::to_string)))
+    fn local_route(url: &str, generation: u64) -> GatewaySleepRoute {
+        GatewaySleepRoute {
+            ws_url: url.to_string(),
+            generation,
+        }
+    }
+
+    fn route_state(value: Option<&str>) -> Arc<Mutex<Option<GatewaySleepRoute>>> {
+        Arc::new(Mutex::new(value.map(|url| local_route(url, 1))))
     }
 
     fn current_route(
-        route: &Arc<Mutex<Option<String>>>,
-    ) -> impl Fn() -> Option<String> + Send + Sync + 'static {
+        route: &Arc<Mutex<Option<GatewaySleepRoute>>>,
+    ) -> impl Fn() -> Option<GatewaySleepRoute> + Send + Sync + 'static {
         let route = Arc::clone(route);
         move || route.lock().expect("route mutex poisoned").clone()
     }
@@ -215,7 +237,7 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            move |request_id| {
+            move |request_id, _| {
                 prepared_ids.lock().unwrap().push(request_id);
                 prepare_events.lock().unwrap().push("prepare");
                 async {
@@ -224,7 +246,7 @@ mod tests {
                     })
                 }
             },
-            move |_| {
+            move |_, _| {
                 resume_events.lock().unwrap().push("resume");
                 async { Ok(()) }
             },
@@ -259,8 +281,8 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async { Ok(SleepPrepareOutcome::Busy) },
-            move |_| {
+            |_, _| async { Ok(SleepPrepareOutcome::Busy) },
+            move |_, _| {
                 resumed.fetch_add(1, Ordering::SeqCst);
                 async { Ok(()) }
             },
@@ -295,8 +317,8 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async { Err("prepare failed".into()) },
-            move |_| {
+            |_, _| async { Err("prepare failed".into()) },
+            move |_, _| {
                 resumed.fetch_add(1, Ordering::SeqCst);
                 async { Ok(()) }
             },
@@ -331,12 +353,12 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async {
+            |_, _| async {
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "suspension-1".into(),
                 })
             },
-            move |_| {
+            move |_, _| {
                 resumed.fetch_add(1, Ordering::SeqCst);
                 async { Ok(()) }
             },
@@ -349,7 +371,7 @@ mod tests {
         );
 
         controller.will_sleep().await;
-        *route.lock().unwrap() = Some("ws://127.0.0.1:19001".into());
+        *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:19001", 2));
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -372,12 +394,12 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async {
+            |_, _| async {
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "suspension-1".into(),
                 })
             },
-            move |_| {
+            move |_, _| {
                 resumed.fetch_add(1, Ordering::SeqCst);
                 async { Ok(()) }
             },
@@ -392,7 +414,7 @@ mod tests {
         controller.will_sleep().await;
         *route.lock().unwrap() = None;
         controller.did_wake().await;
-        *route.lock().unwrap() = Some("ws://127.0.0.1:18789".into());
+        *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:18789", 3));
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -401,95 +423,120 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn late_prepare_response_resumes_immediately() {
-        let route = route_state(Some("ws://127.0.0.1:18789"));
-        let (release, receiver) = oneshot::channel();
-        let (started, prepare_started) = oneshot::channel();
-        let receiver = Arc::new(Mutex::new(Some(receiver)));
-        let prepare_receiver = Arc::clone(&receiver);
-        let started = Arc::new(Mutex::new(Some(started)));
-        let prepare_started_sender = Arc::clone(&started);
-        let resumed_ids = Arc::new(Mutex::new(Vec::new()));
-        let resumed = Arc::clone(&resumed_ids);
-        let controller = Arc::new(GatewaySleepCycleController::new(
-            "linux-sleep-test-run".into(),
-            current_route(&route),
-            move |_| {
-                let receiver = prepare_receiver.lock().unwrap().take().unwrap();
-                prepare_started_sender
-                    .lock()
-                    .unwrap()
-                    .take()
-                    .unwrap()
-                    .send(())
-                    .unwrap();
-                async move {
-                    let _ = receiver.await;
-                    Ok(SleepPrepareOutcome::Ready {
-                        suspension_id: "late-suspension".into(),
-                    })
-                }
-            },
-            move |id| {
-                resumed.lock().unwrap().push(id);
-                async { Ok(()) }
-            },
-            || async {},
-            no_delay,
-            |_| {},
-        ));
+    async fn late_prepare_response_resumes_only_on_its_original_route() {
+        for (replacement, unchanged) in [
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true),
+            (Some(local_route("ws://127.0.0.1:19001", 2)), false),
+            (None, false),
+            (Some(local_route("ws://127.0.0.1:18789", 3)), false),
+        ] {
+            let route = route_state(Some("ws://127.0.0.1:18789"));
+            let (release, receiver) = oneshot::channel();
+            let (started, prepare_started) = oneshot::channel();
+            let receiver = Arc::new(Mutex::new(Some(receiver)));
+            let prepare_receiver = Arc::clone(&receiver);
+            let started = Arc::new(Mutex::new(Some(started)));
+            let prepare_started_sender = Arc::clone(&started);
+            let resumed_ids = Arc::new(Mutex::new(Vec::new()));
+            let resumed = Arc::clone(&resumed_ids);
+            let controller = Arc::new(GatewaySleepCycleController::new(
+                "linux-sleep-test-run".into(),
+                current_route(&route),
+                move |_, _| {
+                    let receiver = prepare_receiver.lock().unwrap().take().unwrap();
+                    prepare_started_sender
+                        .lock()
+                        .unwrap()
+                        .take()
+                        .unwrap()
+                        .send(())
+                        .unwrap();
+                    async move {
+                        let _ = receiver.await;
+                        Ok(SleepPrepareOutcome::Ready {
+                            suspension_id: "late-suspension".into(),
+                        })
+                    }
+                },
+                move |id, _| {
+                    resumed.lock().unwrap().push(id);
+                    async { Ok(()) }
+                },
+                || async {},
+                no_delay,
+                |_| {},
+            ));
 
-        let sleeping = {
-            let controller = Arc::clone(&controller);
-            tokio::spawn(async move { controller.will_sleep().await })
-        };
-        prepare_started.await.unwrap();
-        controller.did_wake().await;
-        release.send(()).unwrap();
-        sleeping.await.unwrap();
-        controller.did_wake().await;
+            let sleeping = {
+                let controller = Arc::clone(&controller);
+                tokio::spawn(async move { controller.will_sleep().await })
+            };
+            prepare_started.await.unwrap();
+            controller.did_wake().await;
+            *route.lock().unwrap() = replacement.clone();
+            release.send(()).unwrap();
+            sleeping.await.unwrap();
+            controller.did_wake().await;
 
-        assert_eq!(*resumed_ids.lock().unwrap(), ["late-suspension"]);
+            let expected = if unchanged {
+                vec!["late-suspension"]
+            } else {
+                vec![]
+            };
+            assert_eq!(*resumed_ids.lock().unwrap(), expected, "{replacement:?}");
+        }
     }
 
     #[tokio::test]
-    async fn resume_retries_then_succeeds() {
-        let route = route_state(Some("ws://127.0.0.1:18789"));
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let attempted = Arc::clone(&attempts);
-        let delays = Arc::new(AtomicUsize::new(0));
-        let delayed = Arc::clone(&delays);
-        let controller = GatewaySleepCycleController::new(
-            "linux-sleep-test-run".into(),
-            current_route(&route),
-            |_| async {
-                Ok(SleepPrepareOutcome::Ready {
-                    suspension_id: "suspension-retry".into(),
-                })
-            },
-            move |_| {
-                let attempt = attempted.fetch_add(1, Ordering::SeqCst);
-                async move {
-                    if attempt == 0 {
-                        Err("transport failed".into())
-                    } else {
-                        Ok(())
+    async fn resume_retries_only_on_its_original_route() {
+        for (replacement, unchanged) in [
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true),
+            (Some(local_route("ws://127.0.0.1:19001", 2)), false),
+            (None, false),
+            (Some(local_route("ws://127.0.0.1:18789", 3)), false),
+        ] {
+            let route = route_state(Some("ws://127.0.0.1:18789"));
+            let delay_route = route.clone();
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let attempted = Arc::clone(&attempts);
+            let delays = Arc::new(AtomicUsize::new(0));
+            let delayed = Arc::clone(&delays);
+            let controller = GatewaySleepCycleController::new(
+                "linux-sleep-test-run".into(),
+                current_route(&route),
+                |_, _| async {
+                    Ok(SleepPrepareOutcome::Ready {
+                        suspension_id: "suspension-retry".into(),
+                    })
+                },
+                move |_, _| {
+                    let attempt = attempted.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if attempt == 0 {
+                            Err("transport failed".into())
+                        } else {
+                            Ok(())
+                        }
                     }
-                }
-            },
-            || async {},
-            move |_| {
-                delayed.fetch_add(1, Ordering::SeqCst);
-                async {}
-            },
-            |_| {},
-        );
+                },
+                || async {},
+                move |_| {
+                    delayed.fetch_add(1, Ordering::SeqCst);
+                    *delay_route.lock().unwrap() = replacement.clone();
+                    async {}
+                },
+                |_| {},
+            );
 
-        controller.will_sleep().await;
-        controller.did_wake().await;
+            controller.will_sleep().await;
+            controller.did_wake().await;
 
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        assert_eq!(delays.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                attempts.load(Ordering::SeqCst),
+                if unchanged { 2 } else { 1 }
+            );
+            assert_eq!(delays.load(Ordering::SeqCst), 1);
+        }
     }
 
     #[tokio::test]
@@ -502,12 +549,12 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async {
+            |_, _| async {
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "suspension-exhaust".into(),
                 })
             },
-            move |_| {
+            move |_, _| {
                 attempted.fetch_add(1, Ordering::SeqCst);
                 async { Err("transport failed".into()) }
             },
@@ -537,12 +584,12 @@ mod tests {
         let controller = Arc::new(GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async {
+            |_, _| async {
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "suspension-abort".into(),
                 })
             },
-            move |_| {
+            move |_, _| {
                 attempted.fetch_add(1, Ordering::SeqCst);
                 async { Err("transport failed".into()) }
             },
@@ -569,12 +616,12 @@ mod tests {
         let controller = GatewaySleepCycleController::new(
             "linux-sleep-test-run".into(),
             current_route(&route),
-            |_| async {
+            |_, _| async {
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "suspension-failure".into(),
                 })
             },
-            move |_| {
+            move |_, _| {
                 attempted.fetch_add(1, Ordering::SeqCst);
                 async { Err("transport failed".into()) }
             },

--- a/apps/linux/src-tauri/src/gateway_sleep_logind.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep_logind.rs
@@ -23,15 +23,15 @@ impl SleepBridge {
         let end_gateway = gateway;
         let controller = Arc::new(GatewaySleepCycleController::new(
             format!("linux-sleep-{}", Uuid::new_v4()),
-            move || route_gateway.loopback_route_token(),
-            move |request_id| {
+            move || route_gateway.sleep_route(),
+            move |request_id, route| {
                 let gateway = prepare_gateway.clone();
-                async move { gateway.suspend_prepare(request_id).await }
+                async move { gateway.suspend_prepare(request_id, route).await }
             },
-            move |suspension_id| {
+            move |suspension_id, route| {
                 let gateway = resume_gateway.clone();
                 async move {
-                    gateway.suspend_resume(suspension_id).await?;
+                    gateway.suspend_resume(suspension_id, route).await?;
                     Ok(())
                 }
             },
@@ -44,7 +44,7 @@ impl SleepBridge {
         ));
         let begin_sleep_cycle: BeginSleepCycleHook = Arc::new(move || {
             // A remote or unconfigured route must not activate the driver.
-            if begin_gateway.loopback_route_token().is_none() {
+            if begin_gateway.sleep_route().is_none() {
                 return false;
             }
             begin_gateway.begin_sleep_cycle();

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -2,10 +2,12 @@ use crate::gateway_device_identity::{
     GatewayAuth, GatewayDeviceIdentity, GatewayDeviceIdentityStore, CLIENT_DEVICE_FAMILY,
     CLIENT_ID, CLIENT_MODE, CLIENT_PLATFORM, CLIENT_ROLE, CLIENT_SCOPES,
 };
+#[cfg(target_os = "linux")]
+use crate::gateway_sleep::GatewaySleepRoute;
 #[cfg(any(target_os = "linux", test))]
 use crate::gateway_sleep::SleepPrepareOutcome;
 use crate::quickchat::QUICKCHAT_LABEL;
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{Sink, SinkExt, StreamExt};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
@@ -18,6 +20,7 @@ use std::fmt;
 use std::io::ErrorKind;
 #[cfg(any(target_os = "linux", test))]
 use std::net::IpAddr;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -56,12 +59,19 @@ const MIN_PROTOCOL_VERSION: u32 = 4;
 const MAX_PROTOCOL_VERSION: u32 = 4;
 const INLINE_WIDGETS_CLIENT_CAPABILITY: &str = "inline-widgets";
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum GatewayOwnership {
+    Local,
+    Remote,
+}
+
 #[derive(Clone)]
 pub struct GatewayWsConfig {
     ws_url: String,
     token: Option<String>,
     password: Option<String>,
     tls_fingerprint: Option<String>,
+    ownership: GatewayOwnership,
 }
 
 impl GatewayWsConfig {
@@ -70,12 +80,14 @@ impl GatewayWsConfig {
         token: Option<String>,
         password: Option<String>,
         tls_fingerprint: Option<String>,
+        ownership: GatewayOwnership,
     ) -> Self {
         Self {
             ws_url,
             token,
             password,
             tls_fingerprint,
+            ownership,
         }
     }
 }
@@ -291,10 +303,12 @@ enum GatewayRequest {
     #[cfg(target_os = "linux")]
     SuspendPrepare {
         request_id: String,
+        route: GatewaySleepRoute,
     },
     #[cfg(target_os = "linux")]
     SuspendResume {
         suspension_id: String,
+        route: GatewaySleepRoute,
     },
 }
 
@@ -458,21 +472,27 @@ impl GatewayClient {
     }
 
     fn set_configuration(&self, app: &AppHandle, config: Option<GatewayWsConfig>) {
-        *self
-            .inner
-            .config
-            .lock()
-            .expect("gateway config mutex poisoned") = config;
+        let generation = self.replace_configuration(config);
         *self
             .inner
             .agents_cache
             .lock()
             .expect("gateway agents cache mutex poisoned") = None;
-        let generation = self.inner.config_generation.fetch_add(1, Ordering::SeqCst) + 1;
         self.set_canvas_surface_url(generation, None);
         self.inner.reconnect_paused.store(false, Ordering::SeqCst);
         self.set_connection_state(app, GatewayConnectionState::Down, None);
         self.resume_reconnect();
+    }
+
+    fn replace_configuration(&self, config: Option<GatewayWsConfig>) -> u64 {
+        // Publish the route and its generation together, including same-URL mode changes.
+        let mut current = self
+            .inner
+            .config
+            .lock()
+            .expect("gateway config mutex poisoned");
+        *current = config;
+        self.inner.config_generation.fetch_add(1, Ordering::SeqCst) + 1
     }
 
     pub fn activate(&self, app: AppHandle) {
@@ -599,11 +619,15 @@ impl GatewayClient {
     }
 
     #[cfg(target_os = "linux")]
-    pub async fn suspend_prepare(&self, request_id: String) -> Result<SleepPrepareOutcome, String> {
+    pub async fn suspend_prepare(
+        &self,
+        request_id: String,
+        route: GatewaySleepRoute,
+    ) -> Result<SleepPrepareOutcome, String> {
         let response = tokio::time::timeout(SUSPEND_REQUEST_TIMEOUT, async {
-            self.wait_for_sleep_connection().await;
+            self.wait_for_sleep_connection(&route).await?;
             self.request_with_budget(
-                GatewayRequest::SuspendPrepare { request_id },
+                GatewayRequest::SuspendPrepare { request_id, route },
                 Some(SUSPEND_REQUEST_TIMEOUT),
             )
             .await
@@ -619,11 +643,18 @@ impl GatewayClient {
     }
 
     #[cfg(target_os = "linux")]
-    pub async fn suspend_resume(&self, suspension_id: String) -> Result<bool, String> {
+    pub async fn suspend_resume(
+        &self,
+        suspension_id: String,
+        route: GatewaySleepRoute,
+    ) -> Result<bool, String> {
         let response = tokio::time::timeout(SUSPEND_REQUEST_TIMEOUT, async {
-            self.wait_for_sleep_connection().await;
+            self.wait_for_sleep_connection(&route).await?;
             self.request_with_budget(
-                GatewayRequest::SuspendResume { suspension_id },
+                GatewayRequest::SuspendResume {
+                    suspension_id,
+                    route,
+                },
                 Some(SUSPEND_REQUEST_TIMEOUT),
             )
             .await
@@ -639,14 +670,21 @@ impl GatewayClient {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn loopback_route_token(&self) -> Option<String> {
-        self.inner
+    pub fn sleep_route(&self) -> Option<GatewaySleepRoute> {
+        let current = self
+            .inner
             .config
             .lock()
-            .expect("gateway config mutex poisoned")
+            .expect("gateway config mutex poisoned");
+        current
             .as_ref()
-            .map(|config| config.ws_url.clone())
-            .filter(|route| is_loopback_ws_url(route))
+            .filter(|config| {
+                config.ownership == GatewayOwnership::Local && is_loopback_ws_url(&config.ws_url)
+            })
+            .map(|config| GatewaySleepRoute {
+                ws_url: config.ws_url.clone(),
+                generation: self.inner.config_generation.load(Ordering::SeqCst),
+            })
     }
 
     pub fn resume_reconnect(&self) {
@@ -686,8 +724,14 @@ impl GatewayClient {
     }
 
     #[cfg(target_os = "linux")]
-    async fn wait_for_sleep_connection(&self) {
-        while !self.is_connected() {
+    async fn wait_for_sleep_connection(&self, route: &GatewaySleepRoute) -> Result<(), String> {
+        loop {
+            if self.sleep_route().as_ref() != Some(route) {
+                return Err("Gateway sleep route changed; lease will self-expire.".to_string());
+            }
+            if self.is_connected() {
+                return Ok(());
+            }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
     }
@@ -739,12 +783,17 @@ impl GatewayClient {
                 reconnect_attempt = 0;
                 continue;
             }
-            let config = self
-                .inner
-                .config
-                .lock()
-                .expect("gateway config mutex poisoned")
-                .clone();
+            let (config, generation) = {
+                let current = self
+                    .inner
+                    .config
+                    .lock()
+                    .expect("gateway config mutex poisoned");
+                (
+                    current.clone(),
+                    self.inner.config_generation.load(Ordering::SeqCst),
+                )
+            };
             let Some(config) = config else {
                 self.inner.reconnect_paused.store(false, Ordering::SeqCst);
                 self.set_connection_state(&app, GatewayConnectionState::Down, None);
@@ -754,7 +803,6 @@ impl GatewayClient {
             while let Ok(command) = receiver.try_recv() {
                 reject_disconnected_command(command);
             }
-            let generation = self.inner.config_generation.load(Ordering::SeqCst);
             let connection_result = self
                 .connect_and_serve(&app, &config, generation, &mut receiver)
                 .await;
@@ -859,19 +907,26 @@ impl GatewayClient {
                 config_changed.store(true, Ordering::SeqCst);
             }
         };
-        let hello =
-            match request_on_socket(&mut socket, "connect", params, REQUEST_TIMEOUT, &dispatch)
-                .await
-            {
-                Ok(hello) => hello,
-                Err(failure) => {
-                    let failure = failure.classify_connect(&auth);
-                    if should_clear_stored_device_token(&failure, &auth) {
-                        self.clear_device_token(&config.ws_url)?;
-                    }
-                    return Err(failure);
+        let hello = match request_on_socket(
+            &mut socket,
+            "connect",
+            params,
+            REQUEST_TIMEOUT,
+            &dispatch,
+            #[cfg(target_os = "linux")]
+            None,
+        )
+        .await
+        {
+            Ok(hello) => hello,
+            Err(failure) => {
+                let failure = failure.classify_connect(&auth);
+                if should_clear_stored_device_token(&failure, &auth) {
+                    self.clear_device_token(&config.ws_url)?;
                 }
-            };
+                return Err(failure);
+            }
+        };
         drop(auth);
         let hello = validate_hello(hello).map_err(RequestFailure::transport)?;
         if let Some(device_token) = hello.device_token.as_deref() {
@@ -919,7 +974,7 @@ impl GatewayClient {
                     match command {
                         DriverCommand::Reconfigure => return Ok(()),
                         DriverCommand::Request { request, budget, reply } => {
-                            let result = perform_request(&mut socket, request, budget, &dispatch).await;
+                            let result = perform_request(self, generation, &mut socket, request, budget, &dispatch).await;
                             last_gateway_activity = Instant::now();
                             match result {
                                 Ok(response) => {
@@ -1352,12 +1407,20 @@ async fn wait_for_connect_challenge(
     .map_err(|_| RequestFailure::transport("Gateway connect challenge timed out."))?
 }
 
+#[cfg(target_os = "linux")]
+struct SleepDispatch<'a> {
+    client: &'a GatewayClient,
+    route: &'a GatewaySleepRoute,
+    connection_generation: u64,
+}
+
 async fn request_on_socket<T, F>(
     socket: &mut GatewaySocket,
     method: &str,
     params: Value,
     budget: Duration,
     dispatch: &F,
+    #[cfg(target_os = "linux")] sleep: Option<SleepDispatch<'_>>,
 ) -> Result<T, RequestFailure>
 where
     T: DeserializeOwned,
@@ -1367,8 +1430,50 @@ where
     let encoded = serde_json::to_string(&request_frame(&id, method, params)).map_err(|error| {
         RequestFailure::transport(format!("Could not encode {method}: {error}"))
     })?;
+    futures_util::future::poll_fn(|cx| Pin::new(&mut *socket).poll_ready(cx))
+        .await
+        .map_err(|error| RequestFailure::transport(format!("Could not send {method}: {error}")))?;
+    {
+        // Read current authority after transport readiness, and hold it through enqueue.
+        // The socket generation also fences commands queued for a replaced connection.
+        #[cfg(target_os = "linux")]
+        let current = sleep.as_ref().map(|sleep| {
+            sleep
+                .client
+                .inner
+                .config
+                .lock()
+                .expect("gateway config mutex poisoned")
+        });
+        #[cfg(target_os = "linux")]
+        if let Some(sleep) = sleep.as_ref() {
+            let owned = current
+                .as_ref()
+                .and_then(|current| current.as_ref())
+                .is_some_and(|config| {
+                    config.ownership == GatewayOwnership::Local
+                        && config.ws_url == sleep.route.ws_url
+                        && is_loopback_ws_url(&config.ws_url)
+                });
+            if !owned
+                || sleep.route.generation != sleep.connection_generation
+                || sleep.client.inner.config_generation.load(Ordering::SeqCst)
+                    != sleep.route.generation
+            {
+                return Err(RequestFailure::method_with_details(
+                    "Gateway sleep route changed; lease will self-expire.",
+                    None,
+                ));
+            }
+        }
+        Pin::new(&mut *socket)
+            .start_send(Message::Text(encoded.into()))
+            .map_err(|error| {
+                RequestFailure::transport(format!("Could not send {method}: {error}"))
+            })?;
+    }
     socket
-        .send(Message::Text(encoded.into()))
+        .flush()
         .await
         .map_err(|error| RequestFailure::transport(format!("Could not send {method}: {error}")))?;
 
@@ -1405,6 +1510,8 @@ where
 }
 
 async fn perform_request<F>(
+    client: &GatewayClient,
+    connection_generation: u64,
     socket: &mut GatewaySocket,
     request: GatewayRequest,
     budget: Option<Duration>,
@@ -1413,6 +1520,8 @@ async fn perform_request<F>(
 where
     F: Fn(&Value),
 {
+    #[cfg(not(target_os = "linux"))]
+    let _ = (client, connection_generation);
     let budget = budget.unwrap_or(REQUEST_TIMEOUT);
     match request {
         GatewayRequest::AgentsList => request_agents_list(socket, budget, dispatch)
@@ -1422,18 +1531,33 @@ where
             let params = serde_json::to_value(params).map_err(|error| {
                 RequestFailure::transport(format!("Could not encode chat.send: {error}"))
             })?;
-            request_on_socket(socket, "chat.send", params, budget, dispatch)
-                .await
-                .map(GatewayResponse::ChatSend)
+            request_on_socket(
+                socket,
+                "chat.send",
+                params,
+                budget,
+                dispatch,
+                #[cfg(target_os = "linux")]
+                None,
+            )
+            .await
+            .map(GatewayResponse::ChatSend)
         }
         GatewayRequest::RefreshCanvasSurface { observed_url } => {
             let mut params = json!({ "surface": "canvas" });
             if let Some(observed_url) = observed_url {
                 params["observedUrl"] = Value::String(observed_url);
             }
-            let response: PluginSurfaceRefreshResponse =
-                request_on_socket(socket, "plugin.surface.refresh", params, budget, dispatch)
-                    .await?;
+            let response: PluginSurfaceRefreshResponse = request_on_socket(
+                socket,
+                "plugin.surface.refresh",
+                params,
+                budget,
+                dispatch,
+                #[cfg(target_os = "linux")]
+                None,
+            )
+            .await?;
             let canvas = response
                 .plugin_surface_urls
                 .and_then(|urls| urls.get("canvas").cloned())
@@ -1442,22 +1566,35 @@ where
             Ok(GatewayResponse::CanvasSurface(canvas))
         }
         #[cfg(target_os = "linux")]
-        GatewayRequest::SuspendPrepare { request_id } => request_on_socket(
+        GatewayRequest::SuspendPrepare { request_id, route } => request_on_socket(
             socket,
             "gateway.suspend.prepare",
             json!({ "requestId": request_id }),
             budget,
             dispatch,
+            Some(SleepDispatch {
+                client,
+                route: &route,
+                connection_generation,
+            }),
         )
         .await
         .map(GatewayResponse::SuspendPrepare),
         #[cfg(target_os = "linux")]
-        GatewayRequest::SuspendResume { suspension_id } => request_on_socket(
+        GatewayRequest::SuspendResume {
+            suspension_id,
+            route,
+        } => request_on_socket(
             socket,
             "gateway.suspend.resume",
             json!({ "suspensionId": suspension_id }),
             budget,
             dispatch,
+            Some(SleepDispatch {
+                client,
+                route: &route,
+                connection_generation,
+            }),
         )
         .await
         .map(GatewayResponse::SuspendResume),
@@ -1489,7 +1626,16 @@ async fn request_agents_list<F>(
 where
     F: Fn(&Value),
 {
-    request_on_socket(socket, "agents.list", json!({}), budget, dispatch).await
+    request_on_socket(
+        socket,
+        "agents.list",
+        json!({}),
+        budget,
+        dispatch,
+        #[cfg(target_os = "linux")]
+        None,
+    )
+    .await
 }
 
 async fn request_gateway_accent<F>(
@@ -1499,8 +1645,16 @@ async fn request_gateway_accent<F>(
 where
     F: Fn(&Value),
 {
-    let config =
-        request_on_socket(socket, "config.get", json!({}), REQUEST_TIMEOUT, dispatch).await?;
+    let config = request_on_socket(
+        socket,
+        "config.get",
+        json!({}),
+        REQUEST_TIMEOUT,
+        dispatch,
+        #[cfg(target_os = "linux")]
+        None,
+    )
+    .await?;
     Ok(gateway_user_accent(&config))
 }
 
@@ -1805,6 +1959,19 @@ esac
             }
         }
 
+        #[cfg(target_os = "linux")]
+        pub(super) fn local_ws_config(ws_url: &str) -> GatewayWsConfig {
+            CliFixture::new()
+                .ready(json!({
+                    "ok": true,
+                    "url": "http://127.0.0.1:18789/#token=fixture-token",
+                    "browserUrl": "http://127.0.0.1:18789/#bootstrapToken=fixture-grant",
+                    "wsUrl": ws_url,
+                }))
+                .expect("local Gateway handoff")
+                .gateway_ws
+        }
+
         #[test]
         fn gateway_actions_supply_stop_consent_without_forcing_restart() {
             let _fixture = CliFixture::new();
@@ -1929,6 +2096,15 @@ esac
 
     #[tokio::test]
     async fn malformed_success_payloads_require_reconnection() {
+        let client = GatewayClient::new();
+        #[cfg(target_os = "linux")]
+        let route = {
+            client.replace_configuration(Some(dashboard_handoff::local_ws_config(
+                "ws://127.0.0.1:18789",
+            )));
+            client.sleep_route().expect("local sleep route")
+        };
+        let generation = client.inner.config_generation.load(Ordering::SeqCst);
         let requests = [
             ("agents.list", GatewayRequest::AgentsList),
             (
@@ -1949,6 +2125,7 @@ esac
                 "gateway.suspend.prepare",
                 GatewayRequest::SuspendPrepare {
                     request_id: "fixture-sleep".into(),
+                    route: route.clone(),
                 },
             ),
             #[cfg(target_os = "linux")]
@@ -1956,6 +2133,7 @@ esac
                 "gateway.suspend.resume",
                 GatewayRequest::SuspendResume {
                     suspension_id: "fixture-sleep".into(),
+                    route: route.clone(),
                 },
             ),
         ];
@@ -1986,7 +2164,7 @@ esac
             let (mut socket, _) = connect_async(format!("ws://{address}"))
                 .await
                 .expect("connect fixture");
-            let failure = perform_request(&mut socket, request, None, &|_| {})
+            let failure = perform_request(&client, generation, &mut socket, request, None, &|_| {})
                 .await
                 .err()
                 .expect("typed response must reject a number");
@@ -2040,7 +2218,16 @@ esac
         else {
             panic!("expected request command");
         };
-        let failure = match perform_request(&mut socket, request, budget, &|_| {}).await {
+        let failure = match perform_request(
+            &GatewayClient::new(),
+            0,
+            &mut socket,
+            request,
+            budget,
+            &|_| {},
+        )
+        .await
+        {
             Ok(_) => panic!("hung request should time out"),
             Err(failure) => failure,
         };
@@ -2065,6 +2252,384 @@ esac
             Err(error) => assert!(error.contains("agents.list request timed out")),
         }
         server.abort();
+    }
+
+    #[cfg(target_os = "linux")]
+    mod sleep_route_ownership {
+        use super::*;
+        use crate::gateway_sleep::GatewaySleepCycleController;
+
+        fn remote_config(transport: &str, url: &str) -> GatewayWsConfig {
+            let request = crate::remote_gateway::RemoteGatewayRequest {
+                transport: transport.into(),
+                url: Some(url.into()),
+                ssh_target: (transport == "ssh").then(|| "operator@gateway.example".into()),
+                token: None,
+                password: None,
+                remote_port: None,
+                tls_fingerprint: None,
+            };
+            crate::remote_ws_config(&request, &Url::parse(url).expect("Gateway URL"))
+        }
+
+        struct SleepSocketFixture {
+            client: GatewayClient,
+            generation: u64,
+            socket: GatewaySocket,
+            receiver: mpsc::Receiver<DriverCommand>,
+            server: tokio::task::JoinHandle<Vec<Value>>,
+            fail_resume: Arc<AtomicBool>,
+        }
+
+        impl SleepSocketFixture {
+            async fn new(config: impl FnOnce(&str) -> GatewayWsConfig) -> Self {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                    .await
+                    .expect("bind sleep socket");
+                let url = format!("ws://{}", listener.local_addr().unwrap());
+                let client = GatewayClient::new();
+                let generation = client.replace_configuration(Some(config(&url)));
+                let (commands, receiver) = mpsc::channel(16);
+                *client.inner.commands.lock().unwrap() = Some(commands);
+                client
+                    .inner
+                    .connection_state
+                    .store(GatewayConnectionState::Up as u64, Ordering::SeqCst);
+                let fail_resume = Arc::new(AtomicBool::new(false));
+                let server_fail_resume = fail_resume.clone();
+                let server = tokio::spawn(async move {
+                    let (stream, _) = listener.accept().await.unwrap();
+                    let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+                    let mut frames = Vec::new();
+                    while let Some(Ok(Message::Text(text))) = socket.next().await {
+                        let frame: Value = serde_json::from_str(&text).unwrap();
+                        let payload = match frame["method"].as_str().unwrap() {
+                            "gateway.suspend.prepare" => json!({
+                                "status": "ready", "suspensionId": "fixture-suspension",
+                            }),
+                            "gateway.suspend.resume" => json!({ "resumed": true }),
+                            method => panic!("unexpected sleep RPC: {method}"),
+                        };
+                        let response = if frame["method"] == "gateway.suspend.resume"
+                            && server_fail_resume.swap(false, Ordering::SeqCst)
+                        {
+                            json!({
+                                "type": "res", "id": frame["id"], "ok": false,
+                                "error": { "message": "fixture resume failure" },
+                            })
+                        } else {
+                            json!({
+                                "type": "res", "id": frame["id"], "ok": true, "payload": payload,
+                            })
+                        };
+                        socket
+                            .send(Message::Text(response.to_string().into()))
+                            .await
+                            .unwrap();
+                        frames.push(frame);
+                    }
+                    frames
+                });
+                let (socket, _) = connect_async(url).await.expect("connect sleep socket");
+                Self {
+                    client,
+                    generation,
+                    socket,
+                    receiver,
+                    server,
+                    fail_resume,
+                }
+            }
+
+            async fn dispatch(&mut self, command: DriverCommand) {
+                let DriverCommand::Request {
+                    request,
+                    budget,
+                    reply,
+                } = command
+                else {
+                    panic!("expected sleep request");
+                };
+                let result = perform_request(
+                    &self.client,
+                    self.generation,
+                    &mut self.socket,
+                    request,
+                    budget,
+                    &|_| {},
+                )
+                .await
+                .map_err(|failure| failure.message);
+                let _ = reply.send(result);
+            }
+
+            async fn next_request(&mut self) -> DriverCommand {
+                tokio::time::timeout(Duration::from_secs(1), self.receiver.recv())
+                    .await
+                    .expect("queued sleep request")
+                    .expect("open driver queue")
+            }
+
+            async fn drive<T>(&mut self, future: impl std::future::Future<Output = T>) -> T {
+                tokio::pin!(future);
+                loop {
+                    tokio::select! {
+                        result = &mut future => return result,
+                        command = self.receiver.recv() => {
+                            self.dispatch(command.expect("driver command")).await;
+                        }
+                    }
+                }
+            }
+
+            fn switch_route(client: &GatewayClient, replacement: &str) {
+                let url = client
+                    .inner
+                    .config
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .unwrap()
+                    .ws_url
+                    .clone();
+                match replacement {
+                    "remote" => {
+                        client.replace_configuration(Some(remote_config("ssh", &url)));
+                    }
+                    "local" => {
+                        client.replace_configuration(Some(dashboard_handoff::local_ws_config(
+                            &format!("{url}/replacement"),
+                        )));
+                    }
+                    "roundtrip" => {
+                        client.replace_configuration(Some(remote_config("direct", &url)));
+                        client
+                            .replace_configuration(Some(dashboard_handoff::local_ws_config(&url)));
+                    }
+                    _ => panic!("unknown replacement"),
+                }
+            }
+
+            async fn finish(self) -> Vec<Value> {
+                drop(self.socket);
+                tokio::time::timeout(Duration::from_secs(1), self.server)
+                    .await
+                    .expect("socket fixture stopped")
+                    .expect("socket fixture")
+            }
+        }
+
+        fn controller(
+            client: &GatewayClient,
+            retry_delay: impl Fn(Duration) -> std::future::Ready<()> + Send + Sync + 'static,
+        ) -> GatewaySleepCycleController {
+            let current = client.clone();
+            let prepare = client.clone();
+            let resume = client.clone();
+            GatewaySleepCycleController::new(
+                "fixture-sleep".into(),
+                move || current.sleep_route(),
+                move |id, route| {
+                    let client = prepare.clone();
+                    async move { client.suspend_prepare(id, route).await }
+                },
+                move |id, route| {
+                    let client = resume.clone();
+                    async move { client.suspend_resume(id, route).await.map(|_| ()) }
+                },
+                || async {},
+                retry_delay,
+                |_| {},
+            )
+        }
+
+        async fn sleep_request(
+            client: &GatewayClient,
+            route: GatewaySleepRoute,
+            resume: bool,
+        ) -> Result<(), String> {
+            if resume {
+                client
+                    .suspend_resume("fixture-suspension".into(), route)
+                    .await
+                    .map(|_| ())
+            } else {
+                client
+                    .suspend_prepare("fixture-sleep".into(), route)
+                    .await
+                    .map(|_| ())
+            }
+        }
+
+        #[tokio::test]
+        async fn producer_ownership_controls_observable_sleep_rpcs() {
+            for mode in [
+                "local",
+                "direct-remote",
+                "direct-loopback",
+                "ssh-loopback",
+                "local-nonloopback",
+            ] {
+                let mut fixture = SleepSocketFixture::new(|url| match mode {
+                    "local" => dashboard_handoff::local_ws_config(url),
+                    "direct-remote" => remote_config("direct", "wss://gateway.example"),
+                    "direct-loopback" => remote_config("direct", url),
+                    "ssh-loopback" => remote_config("ssh", url),
+                    "local-nonloopback" => {
+                        dashboard_handoff::local_ws_config("wss://gateway.example")
+                    }
+                    _ => unreachable!(),
+                })
+                .await;
+                let controller = controller(&fixture.client, |_| std::future::ready(()));
+                let cycle = async {
+                    controller.will_sleep().await;
+                    controller.did_wake().await;
+                };
+                fixture.drive(cycle).await;
+                let frames = fixture.finish().await;
+                let methods: Vec<_> = frames
+                    .iter()
+                    .map(|frame| frame["method"].as_str().unwrap())
+                    .collect();
+                if mode == "local" {
+                    assert_eq!(
+                        methods,
+                        ["gateway.suspend.prepare", "gateway.suspend.resume"]
+                    );
+                    assert_eq!(frames[0]["params"], json!({ "requestId": "fixture-sleep" }));
+                    assert_eq!(
+                        frames[1]["params"],
+                        json!({ "suspensionId": "fixture-suspension" })
+                    );
+                } else {
+                    assert!(frames.is_empty(), "{mode} sent {frames:?}");
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn route_switch_while_waiting_never_sends_sleep_rpcs() {
+            for resume in [false, true] {
+                for replacement in ["remote", "local", "roundtrip"] {
+                    let mut fixture =
+                        SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
+                    let client = fixture.client.clone();
+                    let route = client.sleep_route().unwrap();
+                    client
+                        .inner
+                        .connection_state
+                        .store(GatewayConnectionState::Down as u64, Ordering::SeqCst);
+                    let mut request = Box::pin(sleep_request(&client, route, resume));
+                    assert!(futures_util::poll!(&mut request).is_pending());
+                    SleepSocketFixture::switch_route(&client, replacement);
+                    client
+                        .inner
+                        .connection_state
+                        .store(GatewayConnectionState::Up as u64, Ordering::SeqCst);
+                    let result = fixture.drive(request).await;
+                    let frames = fixture.finish().await;
+                    assert!(
+                        frames.is_empty(),
+                        "{replacement}, resume={resume}: {frames:?}"
+                    );
+                    assert!(result.unwrap_err().contains("route changed"));
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn queued_sleep_commands_revalidate_current_route() {
+            for resume in [false, true] {
+                for replacement in ["remote", "local", "roundtrip"] {
+                    let mut fixture =
+                        SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
+                    let client = fixture.client.clone();
+                    let route = client.sleep_route().unwrap();
+                    let mut request = Box::pin(sleep_request(&client, route, resume));
+                    assert!(futures_util::poll!(&mut request).is_pending());
+                    let command = fixture.next_request().await;
+                    SleepSocketFixture::switch_route(&client, replacement);
+                    fixture.dispatch(command).await;
+                    assert!(request.await.unwrap_err().contains("route changed"));
+                    assert!(
+                        fixture.finish().await.is_empty(),
+                        "{replacement}, resume={resume}"
+                    );
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn sleep_commands_cannot_use_previous_route_socket() {
+            for resume in [false, true] {
+                let mut fixture = SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
+                SleepSocketFixture::switch_route(&fixture.client, "roundtrip");
+                let client = fixture.client.clone();
+                let route = client.sleep_route().unwrap();
+                let mut request = Box::pin(sleep_request(&client, route, resume));
+                assert!(futures_util::poll!(&mut request).is_pending());
+                let command = fixture.next_request().await;
+                fixture.dispatch(command).await;
+                assert!(request.await.unwrap_err().contains("route changed"));
+                assert!(fixture.finish().await.is_empty());
+            }
+        }
+
+        #[tokio::test]
+        async fn prepared_lease_never_resumes_on_a_replacement_route() {
+            for replacement in ["remote", "local", "roundtrip"] {
+                for late in [false, true] {
+                    let mut fixture =
+                        SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
+                    let controller = controller(&fixture.client, |_| std::future::ready(()));
+                    let mut sleeping = Box::pin(controller.will_sleep());
+                    assert!(futures_util::poll!(&mut sleeping).is_pending());
+                    let command = fixture.next_request().await;
+                    fixture.dispatch(command).await;
+                    if late {
+                        controller.did_wake().await;
+                        SleepSocketFixture::switch_route(&fixture.client, replacement);
+                        fixture.drive(sleeping).await;
+                    } else {
+                        sleeping.await;
+                        SleepSocketFixture::switch_route(&fixture.client, replacement);
+                    }
+                    fixture.drive(controller.did_wake()).await;
+                    let frames = fixture.finish().await;
+                    assert_eq!(frames.len(), 1, "{replacement}, late={late}: {frames:?}");
+                    assert_eq!(frames[0]["method"], "gateway.suspend.prepare");
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn resume_retry_never_crosses_route_ownership() {
+            for replacement in ["unchanged", "remote", "local", "roundtrip"] {
+                let mut fixture = SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
+                let client = fixture.client.clone();
+                let controller = controller(&fixture.client, move |_| {
+                    if replacement != "unchanged" {
+                        SleepSocketFixture::switch_route(&client, replacement);
+                    }
+                    std::future::ready(())
+                });
+                fixture.drive(controller.will_sleep()).await;
+                fixture.fail_resume.store(true, Ordering::SeqCst);
+                fixture.drive(controller.did_wake()).await;
+                let frames = fixture.finish().await;
+                let expected = if replacement == "unchanged" { 3 } else { 2 };
+                assert_eq!(frames.len(), expected, "{replacement}: {frames:?}");
+                assert_eq!(frames[0]["method"], "gateway.suspend.prepare");
+                for frame in &frames[1..] {
+                    assert_eq!(frame["method"], "gateway.suspend.resume");
+                    assert_eq!(
+                        frame["params"],
+                        json!({ "suspensionId": "fixture-suspension" })
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -3,7 +3,7 @@ mod discovery;
 mod gateway;
 mod gateway_device_identity;
 mod gateway_operation_queue;
-#[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
+#[cfg(any(target_os = "linux", test))]
 mod gateway_sleep;
 #[cfg(target_os = "linux")]
 mod gateway_sleep_logind;
@@ -84,6 +84,23 @@ fn native_auth_initialization_script(
   }} catch {{}}
 }})();"#
     ))
+}
+
+fn remote_ws_config(
+    request: &RemoteGatewayRequest,
+    gateway_url: &Url,
+) -> gateway_ws::GatewayWsConfig {
+    gateway_ws::GatewayWsConfig::new(
+        gateway_url.to_string(),
+        request.token.clone(),
+        request.password.clone(),
+        if gateway_url.scheme() == "wss" {
+            request.tls_fingerprint.clone()
+        } else {
+            None
+        },
+        gateway_ws::GatewayOwnership::Remote,
+    )
 }
 
 fn open_external_browser(app: &AppHandle, url: &Url) {
@@ -625,19 +642,8 @@ impl DesktopState {
         *active_tunnel = tunnel;
         drop(active_tunnel);
 
-        app.state::<gateway_ws::GatewayClient>().configure(
-            app,
-            gateway_ws::GatewayWsConfig::new(
-                gateway_url.to_string(),
-                request.token.clone(),
-                request.password.clone(),
-                if gateway_url.scheme() == "wss" {
-                    request.tls_fingerprint.clone()
-                } else {
-                    None
-                },
-            ),
-        );
+        app.state::<gateway_ws::GatewayClient>()
+            .configure(app, remote_ws_config(&request, &gateway_url));
         self.navigate_authenticated_remote(app, target, script)?;
         let snapshot = GatewaySnapshot {
             phase: "connected",

--- a/apps/linux/src-tauri/tests/logind_sleep.rs
+++ b/apps/linux/src-tauri/tests/logind_sleep.rs
@@ -5,7 +5,7 @@ mod gateway_sleep;
 #[path = "../src/gateway_sleep_logind_listener.rs"]
 mod gateway_sleep_logind_listener;
 
-use gateway_sleep::{GatewaySleepCycleController, SleepPrepareOutcome};
+use gateway_sleep::{GatewaySleepCycleController, GatewaySleepRoute, SleepPrepareOutcome};
 use gateway_sleep_logind_listener::{run_listener, BeginSleepCycleHook, EndSleepCycleHook};
 use std::io::{BufRead, BufReader, Read};
 use std::os::fd::OwnedFd as StdOwnedFd;
@@ -192,8 +192,13 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     let resume_events = event_tx.clone();
     let controller = Arc::new(GatewaySleepCycleController::new(
         "logind-proof".into(),
-        || Some("ws://127.0.0.1:18789".into()),
-        move |_| {
+        || {
+            Some(GatewaySleepRoute {
+                ws_url: "ws://127.0.0.1:18789".into(),
+                generation: 1,
+            })
+        },
+        move |_, _| {
             let events = prepare_events.clone();
             async move {
                 let _ = events.send(MockEvent::Prepare);
@@ -202,7 +207,7 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
                 })
             }
         },
-        move |_| {
+        move |_, _| {
             let events = resume_events.clone();
             async move {
                 let _ = events.send(MockEvent::Resume);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users connected to a remote Gateway through a loopback URL, including an SSH tunnel, could suspend that remote Gateway when their Linux desktop went to sleep. Switching Gateway routes during sleep preparation or wake recovery could also send a suspension cleanup or retry to the replacement route.

## Why This Change Was Made

Local and remote connection producers now carry explicit ownership, and sleep coordination requires both local ownership and a loopback endpoint. The originating route and configuration generation remain attached through connection waits, queued requests, cleanup, and retries; socket dispatch revalidates current ownership and the active connection before sending.

Linux sleep-specific types and arguments remain platform-gated. The existing logind inhibitor lifecycle is preserved.

## User Impact

Sleeping or waking the Linux companion no longer initiates suspend/resume RPCs against remote Gateways. Locally managed loopback Gateways retain sleep coordination, while switching routes invalidates outstanding sleep work instead of applying it to the new route.

## Evidence

- The tested six-file candidate was committed unchanged as `31dcf691918db1f4c05c6565bfba2613dd722049`.
- Exact-head Linux and macOS CI passed for `31dcf691918db1f4c05c6565bfba2613dd722049`: [Linux App run 34321901565](https://github.com/openclaw/openclaw/actions/runs/34321901565).
- Blacksmith proof host: [workflow run 34319349370](https://github.com/openclaw/openclaw/actions/runs/34319349370). The existing runner hosted the isolated baseline and final-candidate commands described below; this provisioning workflow is not a claim that branch CI has passed.
- Before-fix regressions against production from `7757d0a88d571e4be4032a7337105d6faced0da9`: all 6 socket regressions and 2 controller regressions failed for the intended behavior; 8 other controller cases passed. Observable RPC assertions were unchanged.
- Final Linux candidate, Rust 1.98.1: `cargo fmt --check`, the 6 socket and 10 controller tests, and `cargo build --locked` passed.
- `cargo test --locked --all-targets`: 141 binary tests and 10 integration-module tests passed. The explicitly invoked, normally ignored private logind full sleep cycle also passed: **152 passing tests across targets**.
- Socket fixtures use producer-created configurations and cover owned-local success, direct remote/direct-loopback/SSH-loopback rejection, queued and connection-wait route changes, stale sockets, late preparation cleanup, retries, and same-URL local-to-remote-to-local transitions.
- Fresh independent review through P2: no findings.
- [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/142913#issuecomment-5597725480) found no actionable correctness or security issues and marked the PR ready for maintainer review.
- Required `openclaw/ci-gate`: **SUCCESS** for `31dcf691918db1f4c05c6565bfba2613dd722049` ([CI gate job](https://github.com/openclaw/openclaw/actions/runs/34322028393/job/102372562431)). Required checks report 1 successful and 0 pending.
- Repository-native prepare/merge checks remain pending.

### Native Before/After

The actual original baseline binary and final candidate ran in native GTK/WebKit with a saved remote direct-loopback configuration, a synthetic HTTP dashboard/Gateway fixture, and private D-Bus logind. No real Gateway or physical host sleep was used.

The original binary first opened its native Gateway WebSocket when sleep was signaled, sent `gateway.suspend.prepare`, then sent `gateway.suspend.resume` on wake. The proof exited **1: `REMOTE_SLEEP_RPC`**.

The fixed binary loaded the remote HTTP dashboard but made **zero native WebSocket connections or handshakes**, with no sleep RPCs; the proof exited **0: `PASS`**. This demonstrates prevention of unauthorized RPC initiation, not a successful fixed-binary real-Gateway WebSocket handshake. The Rust socket tests cover already-connected and route-race behavior.

Both binaries released the delay inhibitor after the sleep signal and reacquired it on wake, proving the private signals were consumed. The same assertions ran against both binaries, including a 15-second wake observation. Screenshots were inspected; OCR used grayscale input to recognize colored status text while retaining the original color captures.

**Before: remote suspend RPC observed**

![Original native companion suspends the synthetic remote Gateway](https://github.com/user-attachments/assets/7210fc5a-545c-4bc8-a9da-7344374baa2c)

**After: remote Gateway remains active; no sleep RPC**

![Fixed native companion leaves the synthetic remote Gateway active](https://github.com/user-attachments/assets/b00d1d2e-f47c-483c-aba3-0e91d5f27349)

Windows build/runtime compatibility and physical suspend/resume remain unverified in this campaign. The one-off proof helpers and pre-fix overlay are not included in the change.
