### PR TITLE
fix(agents): retain Traditional Chinese policy digest markers

### DIFF
--- a/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
@@ -311,10 +311,10 @@ describe("buildBootstrapContextFiles", () => {
     expect(result?.content).toContain("[...1 more policy lines omitted...]");
     expect(result?.content.length).toBeLessThanOrEqual(600);
   });
-  it("prioritizes non-Latin mandatory policy markers", () => {
+  it("prioritizes Traditional Chinese mandatory bullets", () => {
     const earlyShort = "- Early normal ".padEnd(20, "a");
     const earlyLong = "- Normal payload ".padEnd(70, "b");
-    const urgent = "🔴 禁止共享账号 ".padEnd(140, "字");
+    const urgent = "- 嚴禁共用登入帳號 ".padEnd(140, "字");
     const lateShort = "- Late normal ".padEnd(20, "d");
     const [result] = buildBootstrapContextFiles(
       [makeMiddleBootstrapFile([earlyShort, "", earlyLong, "", urgent, "", lateShort])],

--- a/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
@@ -173,6 +173,28 @@ describe("buildBootstrapContextFiles", () => {
     expect(result?.content).toContain(requiredScopedInstruction);
     expect(result?.content).toContain("[...truncated, read AGENTS.md for full content...]");
   });
+  it("keeps non-Latin mandatory policy lines from oversized AGENTS.md middle content", () => {
+    const mandatory = "禁止在此子树使用共享账号";
+    const ordinary = "请保持本段内容简洁";
+    const content = [
+      "# Root policy",
+      "A".repeat(900),
+      "",
+      mandatory,
+      "",
+      ordinary,
+      "B".repeat(700),
+      "tail marker",
+    ].join("\n");
+    const [result] = buildBootstrapContextFiles([makeFile({ content })], {
+      maxChars: 600,
+    });
+
+    expect(result?.content).toContain("[Policy digest from AGENTS.md]");
+    expect(result?.content).toContain(mandatory);
+    expect(result?.content).not.toContain(ordinary);
+    expect(result?.content.length).toBeLessThanOrEqual(600);
+  });
   it("keeps the quoted heartbeat example with its framing", () => {
     const frame = "Example heartbeat prompt:";
     const [result] = buildBootstrapContextFiles(
@@ -278,6 +300,21 @@ describe("buildBootstrapContextFiles", () => {
     const earlyShort = "- Early normal ".padEnd(20, "a");
     const earlyLong = "- Normal payload ".padEnd(70, "b");
     const urgent = "Never ".padEnd(140, "c");
+    const lateShort = "- Late normal ".padEnd(20, "d");
+    const [result] = buildBootstrapContextFiles(
+      [makeMiddleBootstrapFile([earlyShort, "", earlyLong, "", urgent, "", lateShort])],
+      { maxChars: 600 },
+    );
+
+    expect(result?.content).toContain([earlyShort, urgent, lateShort].join("\n"));
+    expect(result?.content).not.toContain(earlyLong);
+    expect(result?.content).toContain("[...1 more policy lines omitted...]");
+    expect(result?.content.length).toBeLessThanOrEqual(600);
+  });
+  it("prioritizes non-Latin mandatory policy markers", () => {
+    const earlyShort = "- Early normal ".padEnd(20, "a");
+    const earlyLong = "- Normal payload ".padEnd(70, "b");
+    const urgent = "🔴 禁止共享账号 ".padEnd(140, "字");
     const lateShort = "- Late normal ".padEnd(20, "d");
     const [result] = buildBootstrapContextFiles(
       [makeMiddleBootstrapFile([earlyShort, "", earlyLong, "", urgent, "", lateShort])],

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -105,6 +105,10 @@ const AGENTS_POLICY_DIGEST_RATIO = 0.35;
 const AGENTS_POLICY_HEAD_RATIO = 0.45;
 const AGENTS_POLICY_TAIL_RATIO = 0.15;
 const AGENTS_POLICY_DIGEST_MAX_LINE_CHARS = 240;
+const AGENTS_POLICY_DIGEST_CANDIDATE_PATTERN =
+  /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|owner|security|secret|credential|test|validation|command|commit|push|github|pr)\b|(?:🔴|禁止|嚴禁|不得|絕不|絕對不|切勿|必須|務必|一律|紅線)/iu;
+const AGENTS_POLICY_DIGEST_HIGH_PRIORITY_PATTERN =
+  /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b|(?:🔴|禁止|嚴禁|不得|絕不|絕對不|切勿)/iu;
 
 type TrimBootstrapResult = {
   content: string;
@@ -159,9 +163,7 @@ function isPolicyDigestCandidate(line: string): boolean {
   if (/^(?:#{1,6}|\s*[-*+]|\s*\d+[.)])\s+\S/u.test(line)) {
     return true;
   }
-  return /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|owner|security|secret|credential|test|validation|command|commit|push|github|pr)\b/iu.test(
-    line,
-  );
+  return AGENTS_POLICY_DIGEST_CANDIDATE_PATTERN.test(line);
 }
 
 function normalizePolicyDigestLine(line: string): string {
@@ -218,8 +220,6 @@ function trimAgentsBootstrapContent(trimmed: string, maxChars: number): TrimBoot
   // Budget refinement reselects these distinct source-ordered lines without reparsing them.
   const candidates: PolicyDigestCandidate[] = [];
   if (!(digestBudget <= 0)) {
-    const highPriorityPattern =
-      /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b/iu;
     let lastProseLine: string | null = null;
     for (const sourceLine of trimmed.split(/\r?\n/u)) {
       const line = normalizePolicyDigestLine(sourceLine);
@@ -234,7 +234,7 @@ function trimAgentsBootstrapContent(trimmed: string, maxChars: number): TrimBoot
         candidates.push({
           // Select framing and its candidate as one indivisible text unit.
           text: lastProseLine === null ? line : `${lastProseLine}\n${line}`,
-          highPriority: highPriorityPattern.test(line),
+          highPriority: AGENTS_POLICY_DIGEST_HIGH_PRIORITY_PATTERN.test(line),
         });
         lastProseLine = null;
       } else {


### PR DESCRIPTION
Fixes #142848

## What Problem This Solves

Oversized `AGENTS.md` files can lose standalone Traditional Chinese mandatory lines from the middle of the context sent to the model. Chinese bullets enter the existing policy digest but lack mandatory-marker priority.

## Why This Change Was Made

Extend the existing candidate and priority patterns with the demonstrated Traditional Chinese markers, without Latin word boundaries around those alternatives. Keep the high-priority vocabulary narrower than the candidate vocabulary. English matching, source ordering, framing, and configured context limits retain their existing rules.

The priority regression uses a Chinese bullet without a red-circle marker, so it detects lost Chinese priority independently of structural admission.

## User Impact

The bounded policy digest can retain the demonstrated mandatory markers in Traditional Chinese workspace instructions. This does not promise complete Chinese, Japanese, Korean, or universal non-Latin coverage, or retention of every line under an exhausted budget.

## Evidence

The public packaged `agent --local` command read an oversized synthetic workspace and sent its complete request to a local capture endpoint. Both builds used the same authored files, explicit bootstrap budgets, ordinary turn, and fixed endpoint response. The proof checks submitted context, not model compliance.

| Scenario | Baseline `9d89877dd6d9` | Candidate |
| --- | --- | --- |
| Standalone Traditional Chinese prohibition | Omitted from submitted context | Retained once |
| Ordinary Chinese middle prose | Omitted | Omitted |
| English prohibition | Retained | Retained |

- Independent acceptance passed 14 paired scenarios (28 public turns). Each completed one full captured request without retries or fallback.
- A Chinese structural bullet without a red circle gained priority over earlier ordinary bullets. The tested obligation/prohibition pair preserved the narrower high-priority vocabulary.
- English rules, source order, quoted framing, backtick/tilde frame resets, omission notices, repeated frames, UTF-16 boundaries, total budgets, and short-file content passed. The tight shared-budget case stayed at 649 of 650 UTF-16 units on both builds.
- 113 focused cases passed across the context builder, budget, and bootstrap loader suites. The 37-case builder suite was rerun after the test correction. The corrected priority case fails on the baseline because the already-admitted Chinese bullet loses priority. Formatting, syntax lint, and the native commit hook passed.
- Public proof used baseline `9d89877dd6d9` and candidate `540241a808e7`. Final head `0fe758a9ca26` only strengthens the test fixture; production code is unchanged. [Hosted checks](https://github.com/openclaw/openclaw/pull/142915/checks) validate that final head.

Limits: the capture endpoint returns a fixed response, so this proves submitted context and transport rather than model compliance. Fences preserve the existing frame-reset behavior; they do not universally exclude interior policy-like lines. Short files retain existing `trimEnd` behavior. Bootstrap limits apply to injected file content, not the entire request with tool definitions and other prompt text.
