### PR TITLE
improve(e2e): reduce upgrade survivor config setup launches

### DIFF
--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -35,10 +35,15 @@ describe("discord config schema", () => {
     [null, false],
   ] as const)("preserves supported Discord DM input for baseline %s", (version, legacy) => {
     const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
-      (entry) => entry.id === "channels-discord",
+      (entry) => entry.argv[2] === "channels.discord" || entry.argv[2] === "--batch-json",
     );
     expect(step).toBeDefined();
-    const discord = JSON.parse(step?.argv[3] ?? "{}");
+    const payload = JSON.parse(step?.argv[3] ?? "");
+    const discord =
+      step?.argv[2] === "--batch-json"
+        ? payload.find((entry: { path: string }) => entry.path === "channels.discord")?.value
+        : payload;
+    expect(discord).toBeDefined();
     if (legacy) {
       expect(discord.dm).toEqual({ policy: "allowlist", allowFrom: ["111111111111111111"] });
       expect(discord.dmPolicy).toBeUndefined();

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -4,7 +4,11 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { compareReleaseVersions, parseReleaseVersion } from "../../../lib/release-version.mjs";
+import {
+  compareReleaseVersions,
+  parsePinnedReleaseVersion,
+  parseReleaseVersion,
+} from "../../../lib/release-version.mjs";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "../../../windows-cmd-helpers.mjs";
 
 const args = process.argv.slice(2);
@@ -15,6 +19,7 @@ export const CONFIG_COMMAND_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
 type ConfigStep = {
   id: string;
   intent: string;
+  intents?: string[];
   argv: string[];
   prepublishPluginPackages?: string[];
 };
@@ -395,14 +400,68 @@ function adaptStepForBaseline(
   return step;
 }
 
+function* adaptRecipeForBaseline(
+  steps: ConfigStep[],
+  baselineVersion: string | null,
+  summary: BaselineAdaptationSummary,
+): Generator<ConfigStep> {
+  // Older and suffixed releases retain their existing command and receipt contract.
+  const pinnedVersion = parsePinnedReleaseVersion(baselineVersion ?? "");
+  const comparison = pinnedVersion ? compareReleaseVersions(pinnedVersion, "2026.6.34") : null;
+  const batchChannels = comparison !== null && comparison >= 0;
+  let batchedThrough = -1;
+  // Adapt only reached steps so an earlier failure cannot report future skipped intents.
+  for (const [index, step] of steps.entries()) {
+    if (index <= batchedThrough) {
+      continue;
+    }
+    if (
+      batchChannels &&
+      step.id === "channels-discord" &&
+      steps[index + 1]?.id === "channels-telegram" &&
+      steps[index + 2]?.id === "channels-whatsapp"
+    ) {
+      const channels = steps.slice(index, index + 3).map((channel) => {
+        const adapted = adaptStepForBaseline(channel, baselineVersion, summary);
+        if (!adapted || adapted.argv[3] === undefined) {
+          throw new Error(`config recipe step ${channel.id} is missing its JSON value`);
+        }
+        return {
+          intent: adapted.intent,
+          path: adapted.argv[2],
+          value: JSON.parse(adapted.argv[3]),
+        };
+      });
+      yield {
+        id: "channels",
+        intent: "channels",
+        intents: channels.map((channel) => channel.intent),
+        argv: [
+          "config",
+          "set",
+          "--batch-json",
+          JSON.stringify(channels.map((channel) => ({ path: channel.path, value: channel.value }))),
+        ],
+      };
+      batchedThrough = index + 2;
+      continue;
+    }
+    const adapted = adaptStepForBaseline(step, baselineVersion, summary);
+    if (adapted) {
+      yield adapted;
+    }
+  }
+}
+
 export function resolveUpgradeSurvivorConfigStepsForBaseline(
   scenario = "base",
   baselineVersion: string | null = null,
 ): ConfigStep[] {
-  const summary: BaselineAdaptationSummary = { skippedIntents: [] };
-  return resolveUpgradeSurvivorConfigSteps(scenario)
-    .map((step) => adaptStepForBaseline(step, baselineVersion, summary))
-    .filter((step): step is ConfigStep => step !== null);
+  return [
+    ...adaptRecipeForBaseline(resolveUpgradeSurvivorConfigSteps(scenario), baselineVersion, {
+      skippedIntents: [],
+    }),
+  ];
 }
 
 export function resolveUpgradeSurvivorOpenClawCommand(
@@ -450,6 +509,7 @@ export function runUpgradeSurvivorOpenClawStep(step: ConfigStep, params: ConfigC
   return {
     id: step.id,
     intent: step.intent,
+    intents: step.intents,
     command: invocation.commandLabel,
     status: result.status,
     signal: result.signal,
@@ -484,15 +544,15 @@ function applyRecipe() {
     steps: [],
   };
 
-  for (const step of recipeSteps) {
-    const adaptedStep = adaptStepForBaseline(step, baselineVersion, summary);
-    if (!adaptedStep) {
-      continue;
-    }
-    const outcome = runUpgradeSurvivorOpenClawStep(adaptedStep);
+  for (const step of adaptRecipeForBaseline(recipeSteps, baselineVersion, summary)) {
+    const outcome = runUpgradeSurvivorOpenClawStep(step);
     summary.steps.push(outcome);
-    if (outcome.ok && !summary.acceptedIntents.includes(adaptedStep.intent)) {
-      summary.acceptedIntents.push(adaptedStep.intent);
+    if (outcome.ok) {
+      for (const intent of step.intents ?? [step.intent]) {
+        if (!summary.acceptedIntents.includes(intent)) {
+          summary.acceptedIntents.push(intent);
+        }
+      }
     }
     writeJson(summaryPath, summary);
     if (!outcome.ok) {

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -645,9 +645,15 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes: DockerE2eLan
       if (step.argv[0] !== "config" || step.argv[1] !== "set") {
         continue;
       }
-      const channelId = /^channels\.([a-z0-9][a-z0-9-]*)$/u.exec(step.argv[2] ?? "")?.[1];
-      if (channelId) {
-        configuredChannelIds.add(channelId);
+      const configPaths: string[] =
+        step.argv[2] === "--batch-json"
+          ? JSON.parse(step.argv[3] ?? "").map((entry: { path: string }) => entry.path)
+          : [step.argv[2] ?? ""];
+      for (const configPath of configPaths) {
+        const channelId = /^channels\.([a-z0-9][a-z0-9-]*)$/u.exec(configPath)?.[1];
+        if (channelId) {
+          configuredChannelIds.add(channelId);
+        }
       }
     }
   }

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -1,8 +1,9 @@
 // Upgrade Survivor Config Recipe tests cover upgrade survivor config recipe script behavior.
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -28,6 +29,133 @@ import { AgentsSchema } from "../../src/config/zod-schema.agents.js";
 const RECIPE_PATH = "scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
 const RUN_PATH = "scripts/e2e/lib/upgrade-survivor/run.sh";
 const DOCKER_RUNNER_PATH = "scripts/e2e/upgrade-survivor-docker.sh";
+
+function configLeafWrites(steps: ReturnType<typeof resolveUpgradeSurvivorConfigSteps>) {
+  return steps.flatMap((step): { path: string; value: unknown }[] => {
+    if (step.argv[0] !== "config" || step.argv[1] !== "set") {
+      return [];
+    }
+    if (step.argv[2] === "--batch-json") {
+      return JSON.parse(step.argv[3] ?? "[]");
+    }
+    return step.argv[4] === "--strict-json"
+      ? [{ path: step.argv[2] ?? "", value: JSON.parse(step.argv[3] ?? "null") }]
+      : [];
+  });
+}
+
+function runRecipeFixture(params: {
+  version: string | null;
+  scenario: string;
+  entrypoint?: string;
+  failPath?: string;
+}) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-recipe-"));
+  try {
+    const binDir = join(root, "bin");
+    const logPath = join(root, "openclaw-argv.jsonl");
+    const summaryPath = join(root, "summary.json");
+    const legacyMarker = join(root, "legacy-seeded");
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, "openclaw-log.js"),
+      `
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(args) + "\\n");
+const failPath = process.env.RECIPE_FAIL_PATH;
+const failed = failPath && args[0] === "config" && args[1] === "set" &&
+  (args[2] === failPath || (args[2] === "--batch-json" &&
+    JSON.parse(args[3]).some((entry) => entry.path === failPath)));
+process.exit(failed ? 17 : 0);
+`,
+    );
+    writeFileSync(join(binDir, "openclaw"), `#!/usr/bin/env node\nrequire("./openclaw-log.js");\n`);
+    chmodSync(join(binDir, "openclaw"), 0o755);
+    writeFileSync(
+      join(binDir, "openclaw.cmd"),
+      `@echo off\r\n"${process.execPath}" "%~dp0openclaw-log.js" %*\r\n`,
+    );
+    let command = process.execPath;
+    let cwd = process.cwd();
+    let args = [
+      "--import",
+      "tsx",
+      RECIPE_PATH,
+      "apply",
+      "--summary",
+      summaryPath,
+      ...(params.version === null ? [] : ["--baseline-version", params.version]),
+    ];
+    if (params.entrypoint === "survivor shell") {
+      // Source mounts contain the recipe closure, but no host dependency tree.
+      for (const file of [
+        RECIPE_PATH,
+        "scripts/e2e/lib/upgrade-survivor/config-recipe",
+        "scripts/lib/release-version.mjs",
+        "scripts/windows-cmd-helpers.mjs",
+      ]) {
+        mkdirSync(dirname(join(root, file)), { recursive: true });
+        cpSync(file, join(root, file), { recursive: true });
+      }
+      const launcher = readFileSync(RUN_PATH, "utf8").match(
+        /^apply_baseline_config_recipe\(\) \{[\s\S]*?^\}/mu,
+      )?.[0];
+      expect(launcher).toBeTruthy();
+      const legacyStub =
+        params.scenario === "legacy-operator-state"
+          ? `
+node() {
+  test "$1" = scripts/e2e/lib/upgrade-survivor/assertions.mjs
+  test "$2" = seed-legacy-operator
+  printf seeded > "$RECIPE_LEGACY_MARKER"
+}
+`
+          : "";
+      command = "bash";
+      cwd = root;
+      args = [
+        "-c",
+        `set -euo pipefail\nsource "$1"\n${legacyStub}\n${launcher}\nSCENARIO="$OPENCLAW_UPGRADE_SURVIVOR_SCENARIO"\nCONFIG_COVERAGE_JSON="$2"\nbaseline_version="$3"\napply_baseline_config_recipe`,
+        "survivor-recipe",
+        join(process.cwd(), "scripts/lib/openclaw-e2e-instance.sh"),
+        summaryPath,
+        params.version ?? "",
+      ];
+    }
+    const result = spawnSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: root,
+        OPENCLAW_STATE_DIR: join(root, "state"),
+        OPENCLAW_CONFIG_PATH: join(root, "config.json"),
+        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: params.scenario,
+        OPENCLAW_UPGRADE_SURVIVOR_UPDATE_CHANNEL: "",
+        RECIPE_FAIL_PATH: params.failPath ?? "",
+        RECIPE_LEGACY_MARKER: legacyMarker,
+        PATH: [binDir, join(process.cwd(), "node_modules/.bin"), process.env.PATH ?? ""].join(
+          delimiter,
+        ),
+      },
+    });
+    const loggedArgs: string[][] = existsSync(logPath)
+      ? readFileSync(logPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line))
+      : [];
+    return {
+      result,
+      loggedArgs,
+      summary: existsSync(summaryPath) ? JSON.parse(readFileSync(summaryPath, "utf8")) : null,
+      legacySeeded: existsSync(legacyMarker),
+    };
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
 
 describe("upgrade survivor config recipe command resolution", () => {
   it("selects the prerelease update channel for the plugin registry", () => {
@@ -200,7 +328,7 @@ esac
   });
 
   it("keeps the watch direct-node recipe isolated from unrelated plugin fixtures", () => {
-    const steps = resolveUpgradeSurvivorConfigSteps("watchos-direct-node");
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline("watchos-direct-node", "2026.6.34");
     const intents = steps.map((step) => step.intent);
 
     expect(intents).toEqual(["update", "gateway", "validate"]);
@@ -208,7 +336,10 @@ esac
   });
 
   it("uses password auth for mobile pairing reconnect coverage", () => {
-    const steps = resolveUpgradeSurvivorConfigSteps("mobile-pairing-reconnect");
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline(
+      "mobile-pairing-reconnect",
+      "2026.6.34",
+    );
     const gateway = JSON.parse(steps.find((step) => step.id === "gateway")?.argv[3] ?? "{}");
 
     expect(steps.map((step) => step.intent)).toEqual(["update", "gateway", "validate"]);
@@ -272,7 +403,15 @@ esac
         ? baseAgents.list.map((agent: { id: string }) => agent.id)
         : Object.keys(baseAgents.entries),
     ).toEqual(["main", "ops"]);
-    expect(steps.find((step) => step.id === "channels-whatsapp")).toBeDefined();
+    expect(configLeafWrites(steps)).toContainEqual({
+      path: "channels.whatsapp",
+      value: JSON.parse(
+        readFileSync(
+          "scripts/e2e/lib/upgrade-survivor/config-recipe/channels-whatsapp.json",
+          "utf8",
+        ),
+      ),
+    });
     expect(steps.at(-1)?.id).toBe("validate");
   });
 
@@ -314,6 +453,66 @@ esac
       expect(agents.list[1].fastModeDefault).toBe(version === "2026.3.13" ? undefined : true);
     },
   );
+
+  it.each([
+    { version: null, batched: false },
+    { version: "unknown", batched: false },
+    { version: "2026.3.22", batched: false },
+    { version: "2026.6.33", batched: false },
+    { version: "2026.6.34-beta.1", batched: false },
+    { version: "2026.7.1-beta.1", batched: false },
+    { version: "2026.7.1-alpha.1", batched: false },
+    { version: "2026.6.34-1", batched: false },
+    { version: "2026.6.34junk", batched: false },
+    { version: "2026.13.1", batched: false },
+    { version: "2026.6.9007199254740993", batched: false },
+    { version: "2026.6.34", batched: true },
+    { version: "2026.7.2", batched: true },
+  ])("batches only supported final baselines: $version", ({ version, batched }) => {
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline("base", version);
+    expect(steps).toHaveLength(batched ? 8 : 10);
+    expect(steps.filter((step) => step.argv[2] === "--batch-json")).toHaveLength(batched ? 1 : 0);
+    expect(configLeafWrites(steps).filter((entry) => entry.path.startsWith("channels."))).toEqual([
+      expect.objectContaining({ path: "channels.discord" }),
+      expect.objectContaining({ path: "channels.telegram" }),
+      expect.objectContaining({ path: "channels.whatsapp" }),
+    ]);
+    expect(steps.flatMap((step) => step.intents ?? [step.intent])).toEqual([
+      "update",
+      "gateway",
+      "models",
+      "agents",
+      "skills",
+      "plugins",
+      "discord-channel",
+      "telegram-channel",
+      "whatsapp-channel",
+      "validate",
+    ]);
+  });
+
+  it.each([
+    { version: "2026.6.34", legacyDm: true },
+    { version: "2026.7.2", legacyDm: false },
+  ])("batches the adapted channel fixtures for $version", ({ version, legacyDm }) => {
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline("base", version);
+    const expected = ["discord", "telegram", "whatsapp"].map((channel) => ({
+      path: `channels.${channel}`,
+      value: JSON.parse(
+        readFileSync(
+          `scripts/e2e/lib/upgrade-survivor/config-recipe/channels-${channel}.json`,
+          "utf8",
+        ),
+      ),
+    }));
+    if (legacyDm) {
+      const { dmPolicy, allowFrom, ...discord } = expected[0]!.value;
+      expected[0]!.value = { ...discord, dm: { policy: dmPolicy, allowFrom } };
+    }
+    const batch = steps.find((step) => step.id === "channels");
+    expect(batch?.argv.slice(0, 3)).toEqual(["config", "set", "--batch-json"]);
+    expect(JSON.parse(batch?.argv[3] ?? "[]")).toEqual(expected);
+  });
 
   it("bounds baseline config commands and reports spawn errors", () => {
     const calls: unknown[] = [];
@@ -366,98 +565,161 @@ esac
   it.each(process.platform === "win32" ? ["recipe CLI"] : ["recipe CLI", "survivor shell"])(
     "skips unsupported ACPX bridge config through the %s",
     (entrypoint) => {
-      const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-recipe-acpx-"));
-      try {
-        const binDir = join(root, "bin");
-        const logPath = join(root, "openclaw-argv.jsonl");
-        const summaryPath = join(root, "summary.json");
-        mkdirSync(binDir, { recursive: true });
-        const openclawLogPath = join(binDir, "openclaw-log.js");
-        const openclawPath = join(binDir, "openclaw");
-        const openclawCmdPath = join(binDir, "openclaw.cmd");
-        writeFileSync(
-          openclawLogPath,
-          `
-const fs = require("node:fs");
-fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)) + "\\n");
-process.exit(0);
-`,
-        );
-        writeFileSync(openclawPath, `#!/usr/bin/env node\nrequire("./openclaw-log.js");\n`);
-        chmodSync(openclawPath, 0o755);
-        writeFileSync(
-          openclawCmdPath,
-          `@echo off\r\n"${process.execPath}" "%~dp0openclaw-log.js" %*\r\n`,
-        );
-
-        let command = process.execPath;
-        let cwd = process.cwd();
-        let args = [
-          "--import",
-          "tsx",
-          RECIPE_PATH,
-          "apply",
-          "--summary",
-          summaryPath,
-          "--baseline-version",
-          "2026.4.21",
-        ];
-        if (entrypoint === "survivor shell") {
-          // Source mounts contain the recipe closure, but no host dependency tree.
-          for (const file of [
-            RECIPE_PATH,
-            "scripts/e2e/lib/upgrade-survivor/config-recipe",
-            "scripts/lib/release-version.mjs",
-            "scripts/windows-cmd-helpers.mjs",
-          ]) {
-            mkdirSync(dirname(join(root, file)), { recursive: true });
-            cpSync(file, join(root, file), { recursive: true });
-          }
-          const launcher = readFileSync(RUN_PATH, "utf8").match(
-            /^apply_baseline_config_recipe\(\) \{[\s\S]*?^\}/mu,
-          )?.[0];
-          expect(launcher).toBeTruthy();
-          command = "bash";
-          cwd = root;
-          args = [
-            "-c",
-            `set -euo pipefail\nsource "$1"\n${launcher}\nSCENARIO="$OPENCLAW_UPGRADE_SURVIVOR_SCENARIO"\nCONFIG_COVERAGE_JSON="$2"\nbaseline_version=2026.4.21\napply_baseline_config_recipe`,
-            "survivor-recipe",
-            join(process.cwd(), "scripts/lib/openclaw-e2e-instance.sh"),
-            summaryPath,
-          ];
-        }
-        execFileSync(command, args, {
-          cwd,
-          env: {
-            ...process.env,
-            OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "acpx-openclaw-tools-bridge",
-            PATH: [binDir, join(process.cwd(), "node_modules/.bin"), process.env.PATH ?? ""].join(
-              delimiter,
-            ),
-          },
-          stdio: "pipe",
-        });
-
-        const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
-        const loggedArgs = readFileSync(logPath, "utf8")
-          .trim()
-          .split("\n")
-          .map((line) => JSON.parse(line));
-        expect(summary.skippedIntents).toContain("acpx-openclaw-tools-bridge");
-        expect(summary.acceptedIntents).not.toContain("acpx-openclaw-tools-bridge");
-        expect(summary.baselineVersion).toBe("2026.4.21");
-        expect(loggedArgs.at(-1)).toEqual(["config", "validate"]);
-        expect(loggedArgs).not.toContainEqual(
-          expect.arrayContaining([
-            "set",
-            "plugins",
-            expect.stringContaining("openClawToolsMcpBridge"),
-          ]),
-        );
-      } finally {
-        rmSync(root, { force: true, recursive: true });
-      }
+      const { result, summary, loggedArgs } = runRecipeFixture({
+        entrypoint,
+        scenario: "acpx-openclaw-tools-bridge",
+        version: "2026.4.21",
+      });
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(summary.skippedIntents).toContain("acpx-openclaw-tools-bridge");
+      expect(summary.acceptedIntents).not.toContain("acpx-openclaw-tools-bridge");
+      expect(summary.baselineVersion).toBe("2026.4.21");
+      expect(loggedArgs.at(-1)).toEqual(["config", "validate"]);
+      expect(loggedArgs).not.toContainEqual(
+        expect.arrayContaining([
+          "set",
+          "plugins",
+          expect.stringContaining("openClawToolsMcpBridge"),
+        ]),
+      );
     },
   );
+
+  it("records one successful batch before overrides and final validation", () => {
+    const scenario = "configured-plugin-installs";
+    const version = "2026.6.34";
+    const { result, summary, loggedArgs } = runRecipeFixture({ scenario, version });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline(scenario, version);
+    expect(loggedArgs).toEqual(steps.map((step) => step.argv));
+    expect(summary.steps.map((step: { id: string }) => step.id)).toEqual([
+      "update-channel",
+      "gateway",
+      "models-openai",
+      "agents",
+      "skills",
+      "plugins",
+      "channels",
+      "plugins-configured-installs",
+      "channels-whatsapp-unset",
+      "channels-matrix",
+      "validate",
+    ]);
+    expect(summary.steps[6]).toMatchObject({
+      id: "channels",
+      ok: true,
+      status: 0,
+      intents: ["discord-channel", "telegram-channel", "whatsapp-channel"],
+    });
+    expect(summary.acceptedIntents).toEqual([
+      "update",
+      "gateway",
+      "models",
+      "agents",
+      "skills",
+      "plugins",
+      "discord-channel",
+      "telegram-channel",
+      "whatsapp-channel",
+      "configured-plugin-installs",
+      "validate",
+    ]);
+    expect(summary.skippedIntents).toEqual([]);
+  });
+
+  it.each([
+    { version: "2026.6.34", batched: true },
+    { version: "2026.3.22", batched: false },
+  ])(
+    "preserves failure receipts and aborts without fallback for $version",
+    ({ version, batched }) => {
+      const { result, summary, loggedArgs } = runRecipeFixture({
+        scenario: "configured-plugin-installs",
+        version,
+        failPath: "channels.telegram",
+      });
+      expect(result.status).toBe(1);
+      const previousIds = [
+        "update-channel",
+        "gateway",
+        "models-openai",
+        "agents",
+        "skills",
+        "plugins",
+      ];
+      expect(summary.steps.map((step: { id: string }) => step.id)).toEqual([
+        ...previousIds,
+        ...(batched ? ["channels"] : ["channels-discord", "channels-telegram"]),
+      ]);
+      expect(summary.steps.slice(0, -1).every((step: { ok: boolean }) => step.ok)).toBe(true);
+      expect(summary.steps.at(-1)).toMatchObject({
+        id: batched ? "channels" : "channels-telegram",
+        ok: false,
+        status: 17,
+      });
+      expect(summary.acceptedIntents).toEqual([
+        "update",
+        "gateway",
+        "models",
+        "agents",
+        "skills",
+        "plugins",
+        ...(batched ? [] : ["discord-channel"]),
+      ]);
+      expect(summary.skippedIntents).toEqual(
+        version === "2026.3.22" ? ["agent-modern-preferences", "memory-plugin-allow"] : [],
+      );
+      const steps = resolveUpgradeSurvivorConfigStepsForBaseline(
+        "configured-plugin-installs",
+        version,
+      );
+      expect(loggedArgs).toEqual(steps.slice(0, batched ? 7 : 8).map((step) => step.argv));
+      expect(result.stderr).toContain(
+        `baseline config recipe failed at ${batched ? "channels" : "channels-telegram"}: 17`,
+      );
+    },
+  );
+
+  it.each([
+    {
+      failPath: "models.providers.openai",
+      failedStep: "models-openai",
+      launches: 3,
+      accepted: ["update", "gateway"],
+      skipped: [],
+    },
+    {
+      failPath: "plugins",
+      failedStep: "plugins",
+      launches: 6,
+      accepted: ["update", "gateway", "models", "agents", "skills"],
+      skipped: ["agent-modern-preferences", "memory-plugin-allow"],
+    },
+  ])(
+    "preserves March failure at $failPath without future receipts",
+    ({ failPath, failedStep, launches, accepted, skipped }) => {
+      const { result, summary, loggedArgs } = runRecipeFixture({
+        scenario: "acpx-openclaw-tools-bridge",
+        version: "2026.3.22",
+        failPath,
+      });
+      expect(result.status).toBe(1);
+      expect(loggedArgs).toHaveLength(launches);
+      expect(summary.steps.at(-1)).toMatchObject({ id: failedStep, ok: false, status: 17 });
+      expect(summary.acceptedIntents).toEqual(accepted);
+      expect(summary.skippedIntents).toEqual(skipped);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("preserves the operator-state recipe bypass", () => {
+    const { result, summary, loggedArgs, legacySeeded } = runRecipeFixture({
+      entrypoint: "survivor shell",
+      scenario: "legacy-operator-state",
+      version: "2026.6.34",
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(legacySeeded).toBe(true);
+    expect(summary).toBeNull();
+    expect(loggedArgs).toEqual([]);
+  });
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Upgrade-survivor release validation launches the baseline CLI separately for three consecutive, independent channel fixture writes. Those repeated CLI startups add avoidable setup time.

## Why This Change Was Made

Batch only the Discord, Telegram, and WhatsApp leaves through the existing `config set --batch-json` interface, after their existing baseline adaptations. Require an unsuffixed final release accepted by `parsePinnedReleaseVersion` at or above the verified working `2026.6.34` baseline. Older, suffixed, unknown, and malformed versions retain individual commands.

The batch produces one actual command receipt and accepts all three channel intents only on success. Failure preserves earlier receipts, records the failed command, and aborts without overrides, final validation, retries, or fallback. Intermediate validation/write/backup checkpoints are intentionally consolidated only for these three leaves; there is no intervening consumer or repair.

Keep both direct resolver consumers aligned with the actual command representation:
the Docker E2E planner reads batch-entry paths through its existing channel catalog,
and the Discord schema test reads the actual Discord leaf from either representation.
The planner's companion-package assertions and every Discord version/schema assertion
remain intact. This is a four-file change: the recipe and its test, the planner, and
the Discord schema test.

No production runtime, dependency, workflow, or fixture JSON changes.

## User Impact

Tooling only: two fewer CLI launches for supported recipe baselines, with the same final configuration, intent coverage, scenario ordering, and bypasses. No sharding, worker changes, or coverage weakening.

## Evidence

One matched local pair using the real published `openclaw@2026.6.34`, isolated HOME/config/state/cache/tmp, and synthetic credentials:

| Whole recipe | CLI launches | Recipe-only time |
| --- | ---: | ---: |
| Unchanged | 10 | 40.175s |
| Batched | 8 | 31.019s |

- Both recipes accepted the same ten intents, skipped none, preserved unrelated channel data, and passed final `config validate`. Full final JSON differs only in `meta.lastTouchedAt`. All original backups and state were archived before reseeding. Installation and package preparation are excluded from timing; this is not a CI-wide timing claim.
- Real invalid-middle batch: first Discord value deliberately differs from active config, Telegram has an invalid boolean, and the later WhatsApp leaf remains valid. The CLI exits nonzero with the Telegram validation error; active config is byte-identical before and after.
- Complete existing files pass: 103 planner tests, 58 Discord schema tests, and all 50 recipe tests. These retain batch all-or-none receipts/abort/no fallback, the distinct legacy receipt contract, final-version guards, Discord adaptation, override ordering, and bypasses. Redundant legacy subprocess rows were removed while retaining the full cheap version table.
- Before the consumer repair, the unchanged planner assertion failed in CI because the companion list omitted Discord and WhatsApp; the existing Discord `2026.8.1` row was also reproduced failing locally at its step-presence assertion. Both now pass without assertion or fixture weakening. Recipe execution and generated arguments are unchanged from the real published-CLI proof.
- Validation: the planner and recipe files ran together with `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/docker-e2e-plan.test.ts test/scripts/upgrade-survivor-config-recipe.test.ts`; the complete Discord file ran with `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/config-schema.test.ts`.
- Fresh four-file `check:changed` exited 0, including extension/script/root-test typechecks, all three dead-export scans, targeted lint, formatting, and applicable owner guards. `git diff --check` passes.
- Fresh independent P2 review of the complete four-file candidate: scoped-clean, no actionable findings.

The unchanged published `2026.3.22` recipe was also attempted. Its package lacks the required WhatsApp plugin and fails before channel writes; that preexisting package/recipe gap remains unchanged. This is why the optimization uses the conservative verified `2026.6.34` floor. No full Docker upgrade or FRV was run for this bounded recipe-only change.
