### PR TITLE
refactor(tests): reuse response cancellation fixtures

### DIFF
--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -3,32 +3,11 @@ import { createServer, type Server } from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { DiscordApiError, fetchDiscord, requestDiscord } from "./api.js";
 import { jsonResponse } from "./test-http-helpers.js";
 
 const DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024;
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 async function listenLoopbackServer(server: Server): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -119,7 +98,7 @@ describe("fetchDiscord", () => {
   });
 
   it("bounds Discord API error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"discord api unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"discord api unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/discord/src/pluralkit.test.ts
+++ b/extensions/discord/src/pluralkit.test.ts
@@ -1,5 +1,6 @@
 // Discord tests cover pluralkit plugin behavior.
 import { describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { fetchPluralKitMessageInfo } from "./pluralkit.js";
 
 type MockResponse = {
@@ -24,28 +25,6 @@ const buildResponse = (params: { status: number; body?: unknown }): MockResponse
   };
 };
 
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
-
 describe("fetchPluralKitMessageInfo", () => {
   it("returns null when disabled", async () => {
     const fetcher = vi.fn();
@@ -59,7 +38,7 @@ describe("fetchPluralKitMessageInfo", () => {
   });
 
   it("returns null on 404", async () => {
-    const tracked = cancelTrackedResponse("missing", { status: 404 });
+    const tracked = cancelTrackedTextResponse("missing", { status: 404 });
     const fetcher = vi.fn(async () => tracked.response);
     const result = await fetchPluralKitMessageInfo({
       messageId: "missing",
@@ -181,7 +160,7 @@ describe("fetchPluralKitMessageInfo", () => {
   });
 
   it("bounds PluralKit API error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"plural failure ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"plural failure ".repeat(1024)}tail`, {
       status: 500,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover send.webhook.proxy plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { DiscordError, RateLimitError } from "./internal/rest-errors.js";
 import { sendWebhookMessageDiscord } from "./send.webhook.js";
 
@@ -14,28 +15,6 @@ vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
     makeProxyFetch: makeProxyFetchMock,
   };
 });
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 describe("sendWebhookMessageDiscord proxy support", () => {
   beforeEach(() => {
@@ -203,7 +182,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
   });
 
   it("keeps a successful send when the webhook response body exceeds the limit", async () => {
-    const tracked = cancelTrackedResponse(`{"id":"${"x".repeat(16 * 1024 * 1024)}"}`, {
+    const tracked = cancelTrackedTextResponse(`{"id":"${"x".repeat(16 * 1024 * 1024)}"}`, {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -412,7 +391,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
   });
 
   it("bounds webhook error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"upstream unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"upstream unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { DiscordError, type RequestClient } from "./internal/discord.js";
 import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
 import { hasDiscordMessageCreateAmbiguity, type DiscordRetryRunner } from "./retry.js";
@@ -68,28 +69,6 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
 
 let ensureOggOpus: typeof import("./voice-message.js").ensureOggOpus;
 let sendDiscordVoiceMessage: typeof import("./voice-message.js").sendDiscordVoiceMessage;
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 describe("ensureOggOpus", () => {
   beforeAll(async () => {
@@ -300,7 +279,7 @@ describe("sendDiscordVoiceMessage", () => {
     const post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }));
     const rest = createRest(post);
     let uploadUrlRequests = 0;
-    const successfulUpload = cancelTrackedResponse("uploaded", { status: 200 });
+    const successfulUpload = cancelTrackedTextResponse("uploaded", { status: 200 });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = input instanceof Request ? input.url : String(input);
       const method = input instanceof Request ? input.method : (init?.method ?? "GET");
@@ -632,7 +611,7 @@ describe("sendDiscordVoiceMessage", () => {
 
   it("bounds voice upload error bodies without using response.text()", async () => {
     const rest = createRest();
-    const tracked = cancelTrackedResponse(`${"cdn unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"cdn unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -24,6 +24,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 
 afterAll(() => {
@@ -46,28 +47,6 @@ function shouldContinueAutoSelection(error: Error): boolean {
 
 function buildModelsResponse(models: Array<{ id: string; supported_endpoints?: unknown }>) {
   return { data: models };
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 function mockDiscoveryResponse(spec: {
@@ -302,7 +281,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   });
 
   it("bounds model discovery error bodies", async () => {
-    const tracked = cancelTrackedResponse(`${"discovery denied ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"discovery denied ".repeat(1024)}tail`, {
       status: 503,
       headers: { "content-type": "text/plain" },
     });
@@ -335,7 +314,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
         { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
       ]),
     });
-    const tracked = cancelTrackedResponse(`${"embedding denied ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"embedding denied ".repeat(1024)}tail`, {
       status: 429,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/google-meet/src/google-api-errors.test.ts
+++ b/extensions/google-meet/src/google-api-errors.test.ts
@@ -1,32 +1,11 @@
 // Google Meet tests cover bounded Google API error handling.
 import { describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { googleApiError } from "./google-api-errors.js";
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 describe("googleApiError", () => {
   it("bounds Google API error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"access denied ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"access denied ".repeat(1024)}tail`, {
       status: 403,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/lmstudio/src/models.fetch.test.ts
+++ b/extensions/lmstudio/src/models.fetch.test.ts
@@ -1,6 +1,7 @@
 import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterAll, afterEach, assert, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import plugin from "../index.js";
 import { fetchLmstudioModels } from "./models.fetch.js";
 import { discoverLmstudioProvider } from "./setup.js";
@@ -130,32 +131,10 @@ describe("LM Studio catalog acquisition", () => {
 });
 
 describe("LM Studio model response release", () => {
-  const cancelTrackedResponse = (
-    text: string,
-    init: ResponseInit,
-  ): {
-    response: Response;
-    wasCanceled: () => boolean;
-  } => {
-    let canceled = false;
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(text));
-      },
-      cancel() {
-        canceled = true;
-      },
-    });
-    return {
-      response: new Response(stream, init),
-      wasCanceled: () => canceled,
-    };
-  };
-
   it.each([false, true])(
     "releases guarded non-ok discovery without waiting for capture (retained clone: %s)",
     async (retainCaptureClone) => {
-      const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+      const tracked = cancelTrackedTextResponse("unavailable", { status: 503 });
       const captureClone = retainCaptureClone ? tracked.response.clone() : undefined;
       const release = vi.fn(async () => undefined);
       fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -5,6 +5,7 @@ import {
   SELF_HOSTED_DEFAULT_MAX_TOKENS,
 } from "openclaw/plugin-sdk/provider-setup";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH } from "./defaults.js";
 import {
   discoverLmstudioModels,
@@ -59,27 +60,6 @@ describe("lmstudio-models", () => {
       throw new Error("Expected request body to be a JSON string");
     }
     return JSON.parse(init.body) as unknown;
-  };
-  const cancelTrackedResponse = (
-    text: string,
-    init: ResponseInit,
-  ): {
-    response: Response;
-    wasCanceled: () => boolean;
-  } => {
-    let canceled = false;
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(text));
-      },
-      cancel() {
-        canceled = true;
-      },
-    });
-    return {
-      response: new Response(stream, init),
-      wasCanceled: () => canceled,
-    };
   };
   const createModelLoadFetchMock = (params?: {
     key?: string;
@@ -596,7 +576,7 @@ describe("lmstudio-models", () => {
   });
 
   it("cancels the response body after a non-ok model discovery response", async () => {
-    const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+    const tracked = cancelTrackedTextResponse("unavailable", { status: 503 });
     const fetchMock = vi.fn(async () => tracked.response);
 
     const result = await fetchLmstudioModels({
@@ -905,7 +885,7 @@ describe("lmstudio-models", () => {
   it("suppresses truncated model load error bodies", async () => {
     const credential = "split-credential-xyz";
     const body = `${"x".repeat(8 * 1024 - 2)}${credential}${"y".repeat(1000)}`;
-    const tracked = cancelTrackedResponse(body, { status: 503 });
+    const tracked = cancelTrackedTextResponse(body, { status: 503 });
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     const fetchMock = vi.fn(async (url: string | URL) => {
       if (String(url).endsWith("/api/v1/models")) {

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -13,6 +13,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   };
 });
 
+import { cancelTrackedTextResponse } from "../../../test-support/streaming-error-response.js";
 import {
   createMattermostClient,
   createMattermostDirectChannelWithRetry,
@@ -97,28 +98,6 @@ function streamingMattermostResponse(body: unknown): {
       arrayBuffer,
     } as unknown as Response,
     arrayBuffer,
-  };
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
   };
 }
 
@@ -243,7 +222,7 @@ describe("createMattermostClient", () => {
 
   it("bounds and cancels guarded Mattermost error bodies", async () => {
     const release = vi.fn(async () => {});
-    const tracked = cancelTrackedResponse(`${"upstream unavailable ".repeat(512)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"upstream unavailable ".repeat(512)}tail`, {
       status: 503,
       statusText: "Service Unavailable",
       headers: { "content-type": "text/plain" },
@@ -314,7 +293,7 @@ describe("createMattermostClient", () => {
 
   it("rejects oversized guarded Mattermost success text bodies instead of truncating", async () => {
     const release = vi.fn(async () => {});
-    const tracked = cancelTrackedResponse(`${"plain success ".repeat(7000)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"plain success ".repeat(7000)}tail`, {
       status: 200,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/microsoft-foundry/onboard.connection.test.ts
+++ b/extensions/microsoft-foundry/onboard.connection.test.ts
@@ -1,5 +1,6 @@
 // Microsoft Foundry tests cover bounded connection-test error reads.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
 import * as cli from "./cli.js";
 import { promptTenantId, testFoundryConnection } from "./onboard.js";
 import {
@@ -70,28 +71,6 @@ const foundryConnectionRequestCases: FoundryConnectionRequestCase[] = [
   },
 ];
 
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
-
 describe("testFoundryConnection", () => {
   beforeEach(() => {
     vi.spyOn(cli, "getAccessTokenResult").mockReturnValue({ accessToken: "token" });
@@ -137,7 +116,7 @@ describe("testFoundryConnection", () => {
 
   it("bounds connection-test error bodies without using response.text()", async () => {
     const note = vi.fn();
-    const tracked = cancelTrackedResponse(`${"foundry failure ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"foundry failure ".repeat(1024)}tail`, {
       status: 503,
       headers: { "content-type": "text/plain" },
     });

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -4,31 +4,10 @@ import type { Socket } from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
 import { loginMiniMaxPortalOAuth } from "./oauth.js";
 
 const MINIMAX_OAUTH_FETCH_TIMEOUT_MS = 30_000;
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
   return new Promise((resolve) => {
@@ -361,7 +340,7 @@ describe("loginMiniMaxPortalOAuth", () => {
   );
 
   it("bounds authorization error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(
+    const tracked = cancelTrackedTextResponse(
       `${"minimax authorization unavailable ".repeat(1024)}tail`,
       {
         status: 503,
@@ -383,7 +362,7 @@ describe("loginMiniMaxPortalOAuth", () => {
   });
 
   it("bounds token error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"minimax token unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"minimax token unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "Content-Type": "text/plain" },
     });
@@ -400,7 +379,7 @@ describe("loginMiniMaxPortalOAuth", () => {
   });
 
   it("bounds HTTP 200 token bodies before app-level parsing", async () => {
-    const tracked = cancelTrackedResponse(`${'{"status":"error","detail":"'.repeat(512)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${'{"status":"error","detail":"'.repeat(512)}tail`, {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });

--- a/extensions/msteams/src/attachments.graph.test.ts
+++ b/extensions/msteams/src/attachments.graph.test.ts
@@ -1,6 +1,7 @@
 // Msteams tests cover attachments.graph plugin behavior.
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import type { PluginRuntime } from "../runtime-api.js";
 import { readRemoteMediaResponse } from "./attachments.test-helpers.js";
 import { downloadMSTeamsGraphMedia } from "./attachments/graph.js";
@@ -148,27 +149,6 @@ const createJsonResponse = (payload: unknown, status = 200) =>
   new Response(JSON.stringify(payload), { status });
 const createGraphCollectionResponse = (value: unknown[]) => createJsonResponse({ value });
 const createNotFoundResponse = () => new Response("not found", { status: 404 });
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 const createRedirectResponse = (location: string, status = 302) =>
   new Response(null, { status, headers: { location } });
 const asFetchFn = (fetchFn: unknown): FetchFn => fetchFn as FetchFn;
@@ -346,7 +326,7 @@ describe("msteams graph attachments", () => {
   it.each<GraphMediaSuccessCase>(GRAPH_MEDIA_SUCCESS_CASES)("$label", runGraphMediaSuccessCase);
 
   it("cancels non-OK Graph collection bodies before returning empty hosted content", async () => {
-    const tracked = cancelTrackedResponse("missing hosted contents", { status: 404 });
+    const tracked = cancelTrackedTextResponse("missing hosted contents", { status: 404 });
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = resolveRequestUrl(input);
       if (url === DEFAULT_MESSAGE_URL) {

--- a/extensions/nextcloud-talk/src/bot-preflight.test.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.test.ts
@@ -1,5 +1,6 @@
 // Nextcloud Talk tests cover bot preflight plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -34,28 +35,6 @@ function account(
       webhookPublicUrl: "https://bot.example.com/nextcloud-talk-webhook",
     },
     ...overrides,
-  };
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
   };
 }
 
@@ -155,10 +134,13 @@ describe("probeNextcloudTalkBotResponseFeature", () => {
   });
 
   it("bounds bot admin error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"nextcloud bot admin failure ".repeat(1024)}tail`, {
-      status: 503,
-      headers: { "content-type": "text/plain" },
-    });
+    const tracked = cancelTrackedTextResponse(
+      `${"nextcloud bot admin failure ".repeat(1024)}tail`,
+      {
+        status: 503,
+        headers: { "content-type": "text/plain" },
+      },
+    );
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
       response: tracked.response,

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -6,6 +6,7 @@ import type { Socket } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
 import { jsonResponse, requestBodyText, requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { OLLAMA_DEFAULT_CONTEXT_WINDOW } from "./defaults.js";
 import {
   buildOllamaProvider,
@@ -21,28 +22,6 @@ import {
   resolveOllamaApiBase,
   type OllamaTagModel,
 } from "./provider-models.js";
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 describe("ollama provider models", () => {
   afterEach(() => {
@@ -805,7 +784,7 @@ describe("ollama provider models", () => {
   });
 
   it("cancels non-OK discovery response bodies before fallback results", async () => {
-    const tagsResponse = cancelTrackedResponse("ollama unavailable", { status: 503 });
+    const tagsResponse = cancelTrackedTextResponse("ollama unavailable", { status: 503 });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => tagsResponse.response),
@@ -817,7 +796,7 @@ describe("ollama provider models", () => {
     });
     expect(tagsResponse.wasCanceled()).toBe(true);
 
-    const psResponse = cancelTrackedResponse("process listing unavailable", { status: 503 });
+    const psResponse = cancelTrackedTextResponse("process listing unavailable", { status: 503 });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => psResponse.response),
@@ -829,7 +808,7 @@ describe("ollama provider models", () => {
     });
     expect(psResponse.wasCanceled()).toBe(true);
 
-    const showResponse = cancelTrackedResponse("model unavailable", { status: 503 });
+    const showResponse = cancelTrackedTextResponse("model unavailable", { status: 503 });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => showResponse.response),
@@ -842,7 +821,7 @@ describe("ollama provider models", () => {
   });
 
   it("reports failed strict model inspections while releasing their response bodies", async () => {
-    const showResponse = cancelTrackedResponse("model unavailable", { status: 503 });
+    const showResponse = cancelTrackedTextResponse("model unavailable", { status: 503 });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => showResponse.response),

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -21,6 +21,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
   };
 });
 
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { OLLAMA_INCOMPLETE_STREAM_ERROR } from "./stream-contract.js";
 import {
   buildOllamaChatRequest,
@@ -1691,28 +1692,6 @@ function getGuardedFetchJsonBody(
     throw new Error("Expected string request body");
   }
   return requireRecord(JSON.parse(body), "Ollama request body");
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 async function createOllamaTestStream(params: {
@@ -3512,7 +3491,7 @@ describe("createOllamaStreamFn", () => {
   });
 
   it("surfaces bounded non-2xx HTTP response text as a status-prefixed error", async () => {
-    const tracked = cancelTrackedResponse(`${"Service Unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"Service Unavailable ".repeat(1024)}tail`, {
       status: 503,
       statusText: "Service Unavailable",
     });
@@ -3547,7 +3526,7 @@ describe("createOllamaStreamFn", () => {
     const configuredSecret = "stream-boundary-credential-secret";
     const retainedPrefix = configuredSecret.slice(0, -5);
     const safeMarker = "bounded stream diagnostic: ";
-    const tracked = cancelTrackedResponse(
+    const tracked = cancelTrackedTextResponse(
       `${safeMarker}${"x".repeat(8 * 1024 - safeMarker.length - retainedPrefix.length)}${configuredSecret} trailing text`,
       { status: 503, statusText: "Service Unavailable" },
     );

--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -1,6 +1,7 @@
 // Openai tests cover embedding batch plugin behavior.
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
 import { runOpenAiEmbeddingBatches } from "./embedding-batch.js";
 import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
 
@@ -15,28 +16,6 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 function jsonlBytes(value: string): number {
   return jsonlEncoder.encode(value).byteLength;
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 function fetchInputUrl(input: RequestInfo | URL): string {
@@ -941,7 +920,7 @@ describe("OpenAI embedding batch output", () => {
   });
 
   it("bounds batch resource error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"batch status unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"batch status unavailable ".repeat(1024)}tail`, {
       status: 400,
       headers: { "Content-Type": "text/plain" },
     });

--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -2,6 +2,7 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resolveOpenAICodexAccessTokenExpiry } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../test-support/streaming-error-response.js";
 import { loginOpenAICodexDeviceCode } from "./openai-chatgpt-device-code.js";
 
 function createJwt(payload: Record<string, unknown>): string {
@@ -17,28 +18,6 @@ function createJsonResponse(body: unknown, init?: { status?: number }) {
       "Content-Type": "application/json",
     },
   });
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: number) {
@@ -666,7 +645,7 @@ describe("loginOpenAICodexDeviceCode", () => {
   });
 
   it("bounds user-code error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"device code unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"device code unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "Content-Type": "text/plain" },
     });

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
+import {
+  cancelTrackedTextResponse,
+  createStreamingResponse,
+} from "../../test-support/streaming-error-response.js";
 type EndpointCall = {
   url: string;
   timeoutSeconds: number;
@@ -97,21 +100,6 @@ function pushMcpHandshake(
       result: { content: [{ type: "text", text: JSON.stringify(toolPayload) }] },
     }),
   );
-}
-function cancelTrackedResponse(text: string, init: ResponseInit) {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 beforeEach(() => {
   endpointMockState.calls = [];
@@ -421,10 +409,13 @@ describe("parallel web search provider", () => {
     expect(body.advanced_settings?.max_results).toBe(5);
   });
   it("bounds Parallel API error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"parallel upstream unavailable ".repeat(1024)}tail`, {
-      status: 503,
-      headers: { "Content-Type": "text/plain" },
-    });
+    const tracked = cancelTrackedTextResponse(
+      `${"parallel upstream unavailable ".repeat(1024)}tail`,
+      {
+        status: 503,
+        headers: { "Content-Type": "text/plain" },
+      },
+    );
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     endpointMockState.responses.push(tracked.response);
     const error = await paidTool()
@@ -720,7 +711,7 @@ describe("runParallelMcpSearch", () => {
     expect(headerOf(endpointCall(1), "MCP-Protocol-Version")).toBe("2025-06-18");
   });
   it("bounds initialize error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"parallel mcp unavailable ".repeat(1024)}tail`, {
+    const tracked = cancelTrackedTextResponse(`${"parallel mcp unavailable ".repeat(1024)}tail`, {
       status: 503,
       headers: { "Content-Type": "text/plain" },
     });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Eighteen plugin test files duplicate the same open-response fixture used to observe body cancellation, even though a shared implementation already exists.

## Why This Change Was Made

Reuse the existing `cancelTrackedTextResponse` helper and remove the local copies. All 31 call sites retain their exact text and response options. Each invocation still creates fresh stream, response and cancellation state; every bounded-read, error, redaction, release and cancellation assertion remains unchanged.

## User Impact

No user-visible behavior change. This removes 361 net test lines without changing production code, the shared helper, or scenario coverage.

## Evidence

- All 18 complete affected suites plus an unchanged existing-helper user passed before and after: 593 cases across 19 files, with identical per-file ordered case names.
- Structural checks confirm identical helper bodies, all 31 argument lists, and all code outside the scoped declaration/import/call changes.
- A direct shared-fixture check confirms fresh responses/streams, the UTF-8 first chunk, open-body cancellation and independent cancellation flags.
- Full mapped changed checks, diff-scoped cleanup and fresh independent P2 review passed with no findings.

No runtime improvement is claimed from warm-cache timings.
