### PR TITLE
fix(qa): run packaged scenario CLI commands with the selected candidate

### DIFF
--- a/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
+++ b/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
@@ -9,6 +9,7 @@ import { runQaGatewayCliCommand } from "./gateway-child-command.js";
 import { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
 import { createQaGatewayChild } from "./gateway-child.js";
 import { isQaPosixProcessGroupAlive } from "./posix-process-group.js";
+import { runQaCli } from "./qa-cli-process.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 // RPC is outside these process-lifetime tests. HTTP readiness and all processes stay real.
@@ -30,6 +31,7 @@ type FixtureRecord = {
 const fixtureSource = String.raw`
 import fs from "node:fs";
 import http from "node:http";
+import path from "node:path";
 import { spawn, execFileSync } from "node:child_process";
 import { once } from "node:events";
 const [record, phase, mode, command, ...args] = process.argv.slice(2);
@@ -70,8 +72,18 @@ if (command === "descendant") {
       process.exit(mode === "failure" ? 17 : 0);
     }
   } else if (current === "gateway") {
+    fs.writeFileSync(path.join(process.env.OPENCLAW_STATE_DIR, "candidate-owner"), String(process.pid));
     http.createServer((_request, response) => response.end("ok"))
       .listen(Number(args[args.indexOf("--port") + 1]), "127.0.0.1");
+  } else if (current === "message") {
+    const ownerPid = Number(fs.readFileSync(path.join(process.env.OPENCLAW_STATE_DIR, "candidate-owner"), "utf8"));
+    process.kill(ownerPid, 0);
+    if (args.includes("--gateway-only")) throw new Error("Gateway-only argument reached scenario CLI");
+    if (args.includes("--unsupported")) {
+      console.error("candidate does not support this action");
+      process.exit(2);
+    }
+    console.log(JSON.stringify({ ownerPid, args, cwd: process.cwd(), marker: process.env.QA_CLI_MARKER }));
   } else {
     if (current === "help") process.stdout.write("--accept-capabilities");
     process.exit(0);
@@ -224,6 +236,55 @@ async function fixture(phase: string, mode: string) {
 }
 
 describe.skipIf(process.platform === "win32")("packaged QA bootstrap lifetime", () => {
+  it("uses the direct candidate CLI while its Gateway owns the state", async () => {
+    const f = await fixture("hang", "running");
+    const repoRoot = path.join(f.root, "harness");
+    await fs.mkdir(path.join(repoRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "dist", "index.js"),
+      'throw new Error("harness CLI must not touch candidate-owned state");\n',
+    );
+    const gateway = await f.owner.start({
+      repoRoot,
+      command: { ...f.command, cwd: f.root, argsSuffix: ["--gateway-only"] },
+      providerMode: "mock-openai",
+      controlUiEnabled: false,
+      transportBaseUrl: "http://127.0.0.1:1",
+      runtimeEnvPatch: { QA_CLI_MARKER: "gateway" },
+    });
+    const env = {
+      gateway,
+      repoRoot,
+      providerMode: "mock-openai" as const,
+      primaryModel: "openai/gpt-5",
+      alternateModel: "openai/gpt-5",
+    };
+    await expect(
+      runQaCli(env, ["message", "edit", "--json"], {
+        json: true,
+        env: { QA_CLI_MARKER: "scenario" },
+      }),
+    ).resolves.toEqual({
+      ownerPid: gateway.pid,
+      args: ["edit", "--json"],
+      cwd: f.root,
+      marker: "scenario",
+    });
+    await expect(runQaCli(env, ["message", "edit", "--unsupported"])).rejects.toThrow(
+      "qa cli failed (2): candidate does not support this action",
+    );
+    expect(f.records().map((entry) => entry.kind)).toEqual([
+      "openai",
+      "anthropic",
+      "help",
+      "repair",
+      "gateway",
+      "message",
+      "message",
+    ]);
+    expect(isQaPosixProcessGroupAlive(gateway.pid!)).toBe(true);
+  });
+
   it.each([
     { phase: "openai", mode: "running" },
     { phase: "anthropic", mode: "running" },

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -530,6 +530,7 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
       },
     });
     const gateway = await owner.start();
+    expect(gateway.cliCommand).toBeUndefined();
     pids();
     const denied = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
       if (target === gateway.tempRoot) {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -248,6 +248,11 @@ async function startOwnedGatewayChild(
     tempRoot,
     configPath,
     runtimeEnv: runningEnv,
+    // Verified launchers implement a Gateway-only process boundary, not a direct CLI.
+    cliCommand:
+      params.command && !params.command.processBoundary
+        ? { executablePath: nodeExecPath, argsPrefix: [...cliArgsPrefix], cwd: gatewayCwd }
+        : undefined,
     logs,
     ...createQaGatewayChildLogAccess(output),
     runCli(args: readonly string[]) {

--- a/extensions/qa-lab/src/qa-cli-process.ts
+++ b/extensions/qa-lab/src/qa-cli-process.ts
@@ -198,11 +198,14 @@ async function runQaCli(
   const stdout = createQaChildOutputCapture();
   const stdoutTail = createQaChildOutputTail();
   const stderr = createQaChildOutputTail();
-  const distEntryPath = path.join(env.repoRoot, "dist", "index.js");
-  const nodeExecPath = await resolveQaNodeExecPath();
+  const command = env.gateway.cliCommand ?? {
+    executablePath: await resolveQaNodeExecPath(),
+    argsPrefix: [path.join(env.repoRoot, "dist", "index.js")],
+    cwd: env.gateway.tempRoot,
+  };
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(nodeExecPath, [distEntryPath, ...args], {
-      cwd: env.gateway.tempRoot,
+    const child = spawn(command.executablePath, [...command.argsPrefix, ...args], {
+      cwd: command.cwd,
       env: {
         ...env.gateway.runtimeEnv,
         ...opts?.env,

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -152,21 +152,38 @@ describe("qa suite runtime agent process helpers", () => {
     readSessionTranscriptSummaryMock.mockReset();
   });
 
-  it("runs the qa cli through the resolved node executable", async () => {
-    const { child, pending } = startMockQaCli({ args: ["qa", "suite"] });
+  it.each([
+    { name: "repository", cliCommand: undefined },
+    {
+      name: "candidate",
+      cliCommand: {
+        executablePath: "/candidate/bin/openclaw",
+        argsPrefix: ["--profile", "qa"],
+        cwd: "/candidate",
+      },
+    },
+  ])("runs the qa cli through the $name command", async ({ cliCommand }) => {
+    const { child, pending } = startMockQaCli({
+      args: ["qa", "suite"],
+      env: { ...QA_CLI_ENV, gateway: { ...QA_CLI_ENV.gateway, cliCommand } },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit("data", Buffer.from("ok\n"));
     child.emit("close", 0);
 
     await expect(pending).resolves.toBe("ok");
-    const spawnCall = firstSpawnCall();
-    expect(spawnCall?.[0]).toBe("/usr/bin/node");
-    expect(spawnCall?.[1]).toEqual([path.join("/repo", "dist", "index.js"), "qa", "suite"]);
-    expect((spawnCall?.[2] as { cwd?: string; env?: unknown } | undefined)?.cwd).toBe(
-      "/tmp/runtime",
-    );
-    expect((spawnCall?.[2] as { env?: unknown } | undefined)?.env).toEqual({ PATH: "/usr/bin" });
+    expect(firstSpawnCall()).toEqual([
+      cliCommand?.executablePath ?? "/usr/bin/node",
+      [...(cliCommand?.argsPrefix ?? [path.join("/repo", "dist", "index.js")]), "qa", "suite"],
+      {
+        cwd: cliCommand?.cwd ?? "/tmp/runtime",
+        env: { PATH: "/usr/bin" },
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    ]);
+    expect(resolveQaNodeExecPathMock).toHaveBeenCalledTimes(cliCommand ? 0 : 1);
   });
 
   it("caps oversized qa cli timeout timers", async () => {

--- a/extensions/qa-lab/src/suite-runtime-types.ts
+++ b/extensions/qa-lab/src/suite-runtime-types.ts
@@ -8,6 +8,11 @@ type QaRuntimeGatewayClient = {
   tempRoot: string;
   workspaceDir: string;
   runtimeEnv: NodeJS.ProcessEnv;
+  cliCommand?: {
+    executablePath: string;
+    argsPrefix: readonly string[];
+    cwd: string;
+  };
   getProcessCpuMs?: () => number | null;
   getProcessRssBytes?: () => number | null;
   logs?: () => string;


### PR DESCRIPTION
Fixes #142923

## What Problem This Solves

Fixes an issue where maintainers running packaged-candidate QA scenarios would
execute scenario CLI commands from the repository harness while the selected
candidate's Gateway owned the test state. This mixes builds instead of testing
the selected candidate consistently.

## Why This Change Was Made

Carry the already prepared direct-candidate executable, argument prefix, and
working directory through the QA Gateway handle and use them in the existing
scenario CLI executor. Keep repository-only fallback behavior and exclude
verified Gateway-only launchers and Gateway-only suffix arguments.

Execution budgets, output parsing, environment overrides, failure propagation,
and process cleanup are unchanged. No production schema, workflow, retry, or
release behavior changes.

## User Impact

Packaged-candidate QA commands now exercise the intended candidate alongside
its Gateway. Unsupported candidate commands still fail rather than silently
falling back to the harness.

## Evidence

- Two candidate-binding regressions fail on the original implementation; the
  repository fallback control passes.
- 174 owner tests pass, including real-process lifecycle and fallback coverage.
  The bootstrap regression is a synthetic candidate fixture, not installed
  OpenClaw capability proof.
- Changed gates pass, including extension production/test typechecks and
  targeted lint. A compiler input snapshot stopped the first lint prerequisite
  during dependency metadata activity; the exact lint retry and all remaining
  guards exited 0. No check was weakened or skipped to hide that failure.
- Independent scoped review found no actionable issues.
- Separate installed-product proof uses npm `openclaw@2026.9.3`, embedded source
  `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7`: the patched executor successfully
  runs `message send` and `message edit` against a loopback Telegram mock while
  the actual candidate Gateway owns its isolated SQLite state. The mock
  receives the expected edit target, message ID, and replacement content.
  Initial authenticated send adds eight lazy profile tables/indexes; edit
  leaves the schema unchanged, and migration metadata is unchanged throughout.
  The added definitions match the pinned candidate's lazy profile schema.
  Attribution to first-connection initialization is a source-supported
  inference, not per-process SQL writer tracing.

The installed probe exercises the real executor/candidate capability; the
separate synthetic real-process regression covers Gateway-handle propagation.
The tested public npm artifact is not claimed to be byte-identical to the
historical sealed FRV artifact. The Gateway fetched its public model catalog,
so this was not airgapped. No full QA suite, live Telegram, rich-format rendering,
full package acceptance, or full release-validation recovery is claimed. Raw
runtime logs and state remain private.
