### PR TITLE
fix(ci): validate frozen bundles with their shipped client layout

### DIFF
--- a/scripts/e2e/agent-bundle-mcp-tools-docker.sh
+++ b/scripts/e2e/agent-bundle-mcp-tools-docker.sh
@@ -11,7 +11,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
-openclaw_resolve_frozen_core_harness_capabilities "$SOURCE_ROOT"
+openclaw_resolve_frozen_agent_bundle_mcp_contract "$SOURCE_ROOT" || exit $?
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-agent-bundle-mcp-tools-e2e" OPENCLAW_IMAGE)"
 CONTAINER_NAME="openclaw-agent-bundle-mcp-tools-e2e-$$"
 RUN_LOG="$(mktemp -t openclaw-agent-bundle-mcp-tools-log.XXXXXX)"
@@ -24,23 +24,33 @@ cleanup() {
 }
 trap cleanup EXIT
 
-docker_e2e_build_or_reuse "$IMAGE_NAME" agent-bundle-mcp-tools
-OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 agent-bundle-mcp-tools empty)"
-CLIENT_PATH="test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
+CLIENT_PATH="$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH"
 CLIENT_MOUNT_ARGS=()
 if [ "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" = "legacy" ]; then
-  # The selected release's client imports a trusted E2E helper and ../../dist.
-  # Materialize its committed source tree outside the trusted read-only harness.
+  # Keep the selected client's import depth and helper without executing either.
   LEGACY_CLIENT_SOURCE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-frozen-agent-bundle-mcp-tools.XXXXXX")"
   # Preserve its root package.json so tsx retains the selected release's ESM scope,
   # then link the package-owned dependencies.
-  git -C "$SOURCE_ROOT" archive "$OPENCLAW_SELECTED_SHA" -- \
+  GIT_NO_LAZY_FETCH=1 GIT_NO_REPLACE_OBJECTS=1 git -C "$SOURCE_ROOT" archive "$OPENCLAW_SELECTED_SHA" -- \
     package.json \
     scripts/e2e/lib/temp-state-dir.ts \
-    scripts/e2e/agent-bundle-mcp-tools-docker-client.ts |
+    "$CLIENT_PATH" |
     tar -x -C "$LEGACY_CLIENT_SOURCE_ROOT"
+  for required_path in package.json scripts/e2e/lib/temp-state-dir.ts "$CLIENT_PATH"; do
+    if [ ! -f "$LEGACY_CLIENT_SOURCE_ROOT/$required_path" ] || [ -L "$LEGACY_CLIENT_SOURCE_ROOT/$required_path" ]; then
+      echo "missing regular staged bundle input: $required_path" >&2
+      exit 2
+    fi
+    # Archive attributes must not silently rewrite the selected source bytes.
+    if ! GIT_NO_LAZY_FETCH=1 GIT_NO_REPLACE_OBJECTS=1 git -C "$SOURCE_ROOT" \
+      cat-file blob "$OPENCLAW_SELECTED_SHA:$required_path" |
+      cmp -s - "$LEGACY_CLIENT_SOURCE_ROOT/$required_path"; then
+      echo "staged bundle input differs from selected source: $required_path" >&2
+      exit 2
+    fi
+  done
   LEGACY_CLIENT_ROOT="/tmp/openclaw-frozen-agent-bundle-mcp-tools"
-  CLIENT_PATH="$LEGACY_CLIENT_ROOT/scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"
+  CLIENT_PATH="$LEGACY_CLIENT_ROOT/$CLIENT_PATH"
   ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"
   ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"
   # The functional image runs as UID 1001 and must traverse this host-owned staging root.
@@ -49,6 +59,9 @@ if [ "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" = "legacy" ]; then
     -v "$LEGACY_CLIENT_SOURCE_ROOT:$LEGACY_CLIENT_ROOT:ro"
   )
 fi
+
+docker_e2e_build_or_reuse "$IMAGE_NAME" agent-bundle-mcp-tools
+OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 agent-bundle-mcp-tools empty)"
 
 echo "Running in-container OpenClaw bundle MCP tool availability smoke..."
 # Harness files are mounted read-only; the app under test comes from /app/dist.

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -163,12 +163,165 @@ openclaw_append_frozen_plugin_harness_docker_env() {
   fi
 }
 
+openclaw_resolve_frozen_agent_bundle_mcp_contract() {
+  local source_root="${1:?missing selected source root}" authorization_status=0 resolved trusted_helper
+
+  export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="" \
+    OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH=""
+  openclaw_frozen_target_omissions_authorized || authorization_status=$?
+  if [ "$authorization_status" -eq 1 ]; then
+    export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="current" \
+      OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH="test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts"
+    return 0
+  fi
+  [ "$authorization_status" -eq 0 ] || return "$authorization_status"
+  trusted_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/frozen-target-compat.sh" || return 2
+
+  # Walk committed trees so only a successfully read tree can prove absence.
+  # This reader is deliberately local to the bundle contract, not the other dialects.
+  resolved="$(node --input-type=module -e '
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+const [root, sha, trustedHelper] = process.argv.slice(1);
+const fail = (message) => { throw new Error(message); };
+const git = (...args) => {
+  try {
+    return execFileSync("git", ["-C", root, ...args], {
+      encoding: "utf8",
+      env: { ...process.env, GIT_NO_LAZY_FETCH: "1", GIT_NO_REPLACE_OBJECTS: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch {
+    fail(`unable to read selected bundle source (${args[0]})`);
+  }
+};
+try {
+  const version = /^git version (\d+)\.(\d+)/.exec(git("--version"));
+  if (!version || Number(version[1]) < 2 ||
+      (Number(version[1]) === 2 && Number(version[2]) < 45)) {
+    fail("frozen bundle source reads require Git 2.45 or newer (no lazy fetch)");
+  }
+  if (git("rev-parse", "HEAD").trim() !== sha) {
+    fail("selected source checkout does not match OPENCLAW_SELECTED_SHA");
+  }
+  if (git("cat-file", "-t", sha).trim() !== "commit") {
+    fail("selected bundle source must be a commit");
+  }
+  const rootTree = git("rev-parse", `${sha}^{tree}`).trim();
+  const read = (relativePath) => {
+    let tree = rootTree;
+    const parts = relativePath.split("/");
+    for (let i = 0; i < parts.length; i++) {
+      const entries = git("ls-tree", "-z", tree).split("\0").filter(Boolean).map((line) => {
+        const match = /^([0-7]{6}) (blob|tree|commit) ([0-9a-f]{40})\t([\s\S]+)$/.exec(line);
+        if (!match) fail("invalid selected bundle tree entry");
+        return { mode: match[1], type: match[2], oid: match[3], name: match[4] };
+      });
+      const entry = entries.find((candidate) => candidate.name === parts[i]);
+      if (!entry) return null;
+      if (i < parts.length - 1) {
+        if (entry.mode !== "040000" || entry.type !== "tree") {
+          fail(`expected committed directory for ${relativePath}`);
+        }
+        tree = entry.oid;
+      } else {
+        if (!["100644", "100755"].includes(entry.mode) || entry.type !== "blob") {
+          fail(`expected regular committed file for ${relativePath}`);
+        }
+        return git("cat-file", "blob", entry.oid);
+      }
+    }
+  };
+  const required = (relativePath) => {
+    const source = read(relativePath);
+    if (source === null) fail(`missing required bundle source: ${relativePath}`);
+    return source;
+  };
+  let ts;
+  try { ts = createRequire(trustedHelper)("typescript"); } catch {
+    fail("unable to load trusted TypeScript parser for bundle contract");
+  }
+  // Parse source text only: no target imports, config, plugins or type resolution.
+  const parse = (relativePath, source) => {
+    const file = ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+    if (file.parseDiagnostics.length) fail(`invalid selected bundle syntax contract: ${relativePath}`);
+    return file;
+  };
+  const hasExport = (file, name) => file.statements.some((node) =>
+    ts.isFunctionDeclaration(node) && node.name?.text === name && node.body &&
+    node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) &&
+    node.modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) &&
+    !node.modifiers.some((modifier) =>
+      [ts.SyntaxKind.DefaultKeyword, ts.SyntaxKind.DeclareKeyword].includes(modifier.kind)));
+  const imports = (file) => file.statements.filter((node) =>
+    ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier));
+  const hasImport = (file, module, names) => imports(file).some((node) => {
+    const clause = node.importClause;
+    return node.moduleSpecifier.text === module && clause && !clause.isTypeOnly &&
+      clause.namedBindings && ts.isNamedImports(clause.namedBindings) &&
+      names.every((name) => clause.namedBindings.elements.some((element) =>
+        !element.isTypeOnly && element.name.text === name &&
+        (element.propertyName?.text ?? element.name.text) === name));
+  });
+  const importsOwner = (file, owner) => imports(file).some((node) =>
+    node.moduleSpecifier.text.endsWith(`/agent-bundle-mcp-${owner}.js`));
+  const layouts = [
+    {
+      path: "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts",
+      dist: "../../dist",
+      helper: "./lib/temp-state-dir.ts",
+    },
+    {
+      path: "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts",
+      dist: "../../../../dist",
+      helper: "../../../../scripts/e2e/lib/temp-state-dir.ts",
+    },
+  ];
+  const clients = layouts.map((layout) => ({ ...layout, source: read(layout.path) }))
+    .filter((layout) => layout.source !== null);
+  if (clients.length !== 1) fail("expected exactly one committed bundle client layout");
+  const client = clients[0];
+  const clientModule = parse(client.path, client.source);
+  let manifest;
+  try { manifest = JSON.parse(required("package.json")); } catch {
+    fail("unable to read selected bundle package.json");
+  }
+  if (manifest?.type !== "module") fail("selected bundle package.json must retain ESM scope");
+  const helper = parse("scripts/e2e/lib/temp-state-dir.ts", required("scripts/e2e/lib/temp-state-dir.ts"));
+  if (!hasExport(helper, "createE2eStateDir") ||
+      !hasImport(clientModule, client.helper, ["createE2eStateDir"])) {
+    fail("unrecognized selected bundle helper contract");
+  }
+  const manager = read("src/agents/agent-bundle-mcp-manager-api.ts");
+  const ownerName = manager === null ? "runtime" : "manager-api";
+  const acquire = manager === null ? "getOrCreateSessionMcpRuntime" : "acquireSessionMcpRuntime";
+  const owner = parse(`src/agents/agent-bundle-mcp-${ownerName}.ts`,
+    manager ?? required("src/agents/agent-bundle-mcp-runtime.ts"));
+  if (!hasExport(owner, acquire) || !hasExport(owner, "disposeAllSessionMcpRuntimes") ||
+      !hasImport(clientModule, `${client.dist}/agents/agent-bundle-mcp-${ownerName}.js`,
+        [acquire, "disposeAllSessionMcpRuntimes"]) ||
+      (manager !== null && client.path !== layouts[1].path) ||
+      importsOwner(clientModule, manager === null ? "manager-api" : "runtime")) {
+    fail("unrecognized selected bundle client/API contract");
+  }
+  process.stdout.write(`${manager === null ? "legacy" : "current"}:${client.path}`);
+} catch (error) {
+  console.error(`frozen bundle contract: ${error.message}`);
+  process.exitCode = 2;
+}
+' "$source_root" "$OPENCLAW_SELECTED_SHA" "$trusted_helper")" || return 2
+
+  export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="${resolved%%:*}" \
+    OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH="${resolved#*:}"
+}
+
 openclaw_resolve_frozen_core_harness_capabilities() {
   local source_root="${1:?missing selected source root}" authorization_status=0
 
   export OPENCLAW_FROZEN_TARGET_ONBOARD_CASES="" \
     OPENCLAW_FROZEN_TARGET_ONBOARD_SESSION_MEMORY_HOOK_MODE="required" \
-    OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="current" \
     OPENCLAW_FROZEN_TARGET_MCP_MEMORY_CONFIG_MODE="current" \
     OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE="current" \
     OPENCLAW_FROZEN_TARGET_RUNTIME_CONTEXT_INPUT_MODE="producer-fragments" \
@@ -229,14 +382,5 @@ openclaw_resolve_frozen_core_harness_capabilities() {
   if openclaw_frozen_target_source_contains "$source_root" src/agents/code-mode-namespaces.ts '"ALL_TOOLS"' &&
     ! openclaw_frozen_target_source_contains "$source_root" src/agents/code-mode-namespaces.ts '"catalog"'; then
     export OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE="legacy"
-  fi
-
-  # The manager API and MCP App assertions were added after the selected
-  # release. Run its still-packaged bundle-MCP contract instead of importing a
-  # new dist entry the release cannot contain.
-  if ! git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-manager-api.ts" 2>/dev/null &&
-    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/agents/agent-bundle-mcp-runtime.ts" 2>/dev/null &&
-    git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:scripts/e2e/agent-bundle-mcp-tools-docker-client.ts" 2>/dev/null; then
-    export OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE="legacy"
   fi
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6558,19 +6558,215 @@ process.exit(73);
     expect(pluginBinding).not.toContain('readFileSync(logPath, "utf8")');
   });
 
-  it("materializes legacy bundle-MCP client links before its read-only Docker mount", () => {
-    const runner = readFileSync(AGENT_BUNDLE_MCP_TOOLS_DOCKER_E2E_PATH, "utf8");
-
-    expectTextToIncludeAll(runner, [
-      "scripts/e2e/lib/temp-state-dir.ts \\",
-      "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts |",
-      'CLIENT_PATH="$LEGACY_CLIENT_ROOT/scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"',
-      'ln -s /app/dist "$LEGACY_CLIENT_SOURCE_ROOT/dist"',
-      'ln -s /app/node_modules "$LEGACY_CLIENT_SOURCE_ROOT/node_modules"',
-      '-v "$LEGACY_CLIENT_SOURCE_ROOT:$LEGACY_CLIENT_ROOT:ro"',
-    ]);
-    expect(runner).not.toContain("CLIENT_PRELUDE");
-  });
+  it.each(
+    [
+      {
+        layout: "June",
+        clientPath: "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts",
+        distPrefix: "../../dist",
+        helperImport: "./lib/temp-state-dir.ts",
+      },
+      {
+        layout: "July",
+        clientPath: "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts",
+        distPrefix: "../../../../dist",
+        helperImport: "../../../../scripts/e2e/lib/temp-state-dir.ts",
+      },
+    ].flatMap((layout) =>
+      [
+        "success",
+        "missing helper",
+        "archive failure",
+        "empty extraction",
+        "altered extraction",
+      ].map((scenario) => ({
+        layout: layout.layout,
+        clientPath: layout.clientPath,
+        distPrefix: layout.distPrefix,
+        helperImport: layout.helperImport,
+        scenario,
+      })),
+    ),
+  )(
+    "stages the committed $layout bundle-MCP client through the real runner: $scenario",
+    (layout) => {
+      const root = tempDirs.make("openclaw-bundle-client-");
+      const source = join(root, "source");
+      const bin = join(root, "bin");
+      mkdirSync(source);
+      mkdirSync(bin);
+      const helperPath = "scripts/e2e/lib/temp-state-dir.ts";
+      const client = [
+        `import { disposeAllSessionMcpRuntimes, getOrCreateSessionMcpRuntime } from "${layout.distPrefix}/agents/agent-bundle-mcp-runtime.js";`,
+        `import { createE2eStateDir } from "${layout.helperImport}";`,
+        'throw new Error("target client must not execute in the staging fixture");',
+        "",
+      ].join("\n");
+      const helper =
+        'export async function createE2eStateDir() { throw new Error("not executed"); }\n';
+      const manifest = `${JSON.stringify({ name: "openclaw", type: "module", version: "2026.7.33" })}\n`;
+      for (const [relative, content] of Object.entries({
+        "package.json": manifest,
+        [layout.clientPath]: client,
+        [helperPath]: helper,
+        "src/agents/agent-bundle-mcp-runtime.ts":
+          "export async function getOrCreateSessionMcpRuntime() {}\nexport async function disposeAllSessionMcpRuntimes() {}\n",
+        "src/agents/embedded-agent-runner/run/runtime-context-prompt.ts":
+          "type Params = { modelPrompt?: string; };\nextractInternalRuntimeContext();\n",
+      })) {
+        if (layout.scenario === "missing helper" && relative === helperPath) {
+          continue;
+        }
+        mkdirSync(dirname(join(source, relative)), { recursive: true });
+        writeFileSync(join(source, relative), content);
+      }
+      const git = (...args: string[]) =>
+        execFileSync(
+          "git",
+          ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", ...args],
+          { cwd: source, encoding: "utf8" },
+        ).trim();
+      git("init", "-q");
+      git("config", "user.email", "test@example.invalid");
+      git("config", "user.name", "Test");
+      git("add", ".");
+      git("commit", "-qm", "fixture");
+      const selectedSha = git("rev-parse", "HEAD");
+      writeFileSync(join(source, layout.clientPath), "dirty client decoy\n");
+      mkdirSync(dirname(join(source, helperPath)), { recursive: true });
+      writeFileSync(join(source, helperPath), "dirty helper decoy\n");
+      writeFileSync(join(source, "package.json"), '{"type":"commonjs"}\n');
+      const capture = join(root, "docker.jsonl");
+      if (layout.scenario === "archive failure") {
+        const realGit = execFileSync("bash", ["-c", "command -v git"], { encoding: "utf8" }).trim();
+        writeExecutables(bin, {
+          git: `#!${process.execPath}
+const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2);
+if (args.includes("archive")) process.exit(2);
+const result = spawnSync(${JSON.stringify(realGit)}, args, { stdio: "inherit" });
+process.exit(result.status ?? 1);
+`,
+        });
+      }
+      if (layout.scenario === "empty extraction" || layout.scenario === "altered extraction") {
+        const realTar = execFileSync("bash", ["-c", "command -v tar"], { encoding: "utf8" }).trim();
+        writeExecutables(bin, {
+          tar: `#!${process.execPath}
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (${JSON.stringify(layout.scenario)} === "empty extraction") {
+  process.stdin.resume();
+} else {
+  const result = spawnSync(${JSON.stringify(realTar)}, args, { stdio: "inherit" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+  fs.appendFileSync(path.join(args[args.indexOf("-C") + 1], ${JSON.stringify(layout.clientPath)}), "altered bytes\\n");
+}
+`,
+        });
+      }
+      writeExecutables(bin, {
+        docker: `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+let staged = null;
+const mount = args.find(arg => arg.endsWith(":/tmp/openclaw-frozen-agent-bundle-mcp-tools:ro"));
+if (args[0] === "run" && mount) {
+  const root = mount.slice(0, mount.indexOf(":"));
+  const client = path.join(root, process.env.FIXTURE_CLIENT_PATH);
+  staged = {
+    root,
+    client: fs.readFileSync(client, "utf8"),
+    helper: fs.readFileSync(path.resolve(path.dirname(client), process.env.FIXTURE_HELPER_IMPORT), "utf8"),
+    manifest: fs.readFileSync(path.join(root, "package.json"), "utf8"),
+    dist: fs.readlinkSync(path.join(root, "dist")),
+    modules: fs.readlinkSync(path.join(root, "node_modules")),
+    mode: fs.statSync(root).mode & 0o777,
+    entries: fs.readdirSync(root, { recursive: true }).sort()
+  };
+}
+fs.appendFileSync(process.env.FIXTURE_DOCKER_CAPTURE, JSON.stringify({ args, staged }) + "\\n");
+`,
+      });
+      const result = spawnSync("bash", [AGENT_BUNDLE_MCP_TOOLS_DOCKER_E2E_PATH], {
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          PATH: `${bin}:${process.env.PATH}`,
+          HOME: root,
+          TMPDIR: root,
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: source,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+          OPENCLAW_SELECTED_SHA: selectedSha,
+          OPENCLAW_TOOLING_SHA: "b".repeat(40),
+          OPENCLAW_SKIP_DOCKER_BUILD: "1",
+          OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1",
+          FIXTURE_DOCKER_CAPTURE: capture,
+          FIXTURE_CLIENT_PATH: layout.clientPath,
+          FIXTURE_HELPER_IMPORT: layout.helperImport,
+        },
+      });
+      const calls: Array<{
+        args: string[];
+        staged: {
+          root: string;
+          client: string;
+          helper: string;
+          manifest: string;
+          dist: string;
+          modules: string;
+          mode: number;
+          entries: string[];
+        } | null;
+      }> = existsSync(capture)
+        ? readFileSync(capture, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line))
+        : [];
+      if (layout.scenario !== "success") {
+        expect(result.status, result.stderr + result.stdout).not.toBe(0);
+        expect(calls.every((call) => call.args[0] === "rm")).toBe(true);
+        expect(
+          readdirSync(root).filter((entry) =>
+            entry.startsWith("openclaw-frozen-agent-bundle-mcp-tools."),
+          ),
+        ).toEqual([]);
+        if (layout.scenario === "missing helper") {
+          expect(result.stderr).toContain("missing required");
+        }
+        if (layout.scenario === "empty extraction") {
+          expect(result.stderr).toContain("missing regular staged");
+        }
+        if (layout.scenario === "altered extraction") {
+          expect(result.stderr).toContain("differs from selected source");
+        }
+        return;
+      }
+      expect(result.status, result.stderr + result.stdout).toBe(0);
+      const run = calls.find((call) => call.args[0] === "run");
+      if (!run?.staged) {
+        throw new Error("runner did not mount the selected client");
+      }
+      expect(run.staged).toMatchObject({
+        client,
+        helper,
+        manifest,
+        dist: "/app/dist",
+        modules: "/app/node_modules",
+        mode: 0o755,
+      });
+      expect(run.args.at(-1)).toContain(
+        `tsx /tmp/openclaw-frozen-agent-bundle-mcp-tools/${layout.clientPath}`,
+      );
+      expect(run.staged.entries).not.toContain("src");
+      expect(existsSync(run.staged.root)).toBe(false);
+      expect(calls.filter((call) => call.args[0] === "run")).toHaveLength(1);
+    },
+  );
 
   it("keeps Open WebUI Docker E2E resource-guarded", () => {
     const runner = readFileSync(OPENWEBUI_DOCKER_E2E_PATH, "utf8");

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -1,6 +1,14 @@
 // Live Docker Stage tests cover live docker stage script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +18,317 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const stageScriptPath = path.join(repoRoot, "scripts/lib/live-docker-stage.sh");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("frozen bundle committed contract", () => {
+  const juneClient = "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts";
+  const julyClient = "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts";
+  const helperPath = "scripts/e2e/lib/temp-state-dir.ts";
+  const runtimePath = "src/agents/agent-bundle-mcp-runtime.ts";
+  const managerPath = "src/agents/agent-bundle-mcp-manager-api.ts";
+  const runtimeSource =
+    "export async function getOrCreateSessionMcpRuntime() {}\nexport async function disposeAllSessionMcpRuntimes() {}\n";
+  const managerSource =
+    "export async function acquireSessionMcpRuntime() {}\nexport async function disposeAllSessionMcpRuntimes() {}\n";
+
+  function fixture(
+    layout: "June" | "July" | "current" = "July",
+    overrides: Record<string, string | null> = {},
+  ) {
+    const root = tempDirs.make("openclaw-frozen-bundle-contract-");
+    const clientPath = layout === "June" ? juneClient : julyClient;
+    const prefix = layout === "June" ? "../.." : "../../../..";
+    const owner = layout === "current" ? "manager-api" : "runtime";
+    const acquire =
+      layout === "current" ? "acquireSessionMcpRuntime" : "getOrCreateSessionMcpRuntime";
+    const files: Record<string, string | null> = {
+      "package.json": '{"type":"module","version":"2026.1.0"}\n',
+      [clientPath]: [
+        `import { ${acquire}, disposeAllSessionMcpRuntimes } from "${prefix}/dist/agents/agent-bundle-mcp-${owner}.js";`,
+        `import { createE2eStateDir } from "${layout === "June" ? "./lib" : `${prefix}/scripts/e2e/lib`}/temp-state-dir.ts";`,
+        'throw new Error("selected client must not execute during resolution");',
+        "",
+      ].join("\n"),
+      [helperPath]: "export async function createE2eStateDir() {}\n",
+      [runtimePath]: runtimeSource,
+      ...(layout === "current" ? { [managerPath]: managerSource } : {}),
+      ...overrides,
+    };
+    for (const [relative, content] of Object.entries(files)) {
+      if (content === null) {
+        continue;
+      }
+      mkdirSync(path.dirname(path.join(root, relative)), { recursive: true });
+      writeFileSync(path.join(root, relative), content);
+    }
+    const git = (...args: string[]) =>
+      execFileSync(
+        "git",
+        ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", ...args],
+        { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ).trim();
+    git("init", "-q");
+    git("config", "user.email", "test@example.invalid");
+    git("config", "user.name", "Test");
+    const commit = () => {
+      git("add", ".");
+      git("commit", "-qm", "fixture");
+      return git("rev-parse", "HEAD");
+    };
+    return { root, git, commit, sha: commit(), clientPath, files };
+  }
+
+  function resolve(
+    source: { root: string; sha: string },
+    env: Record<string, string> = {},
+    cwd = repoRoot,
+  ) {
+    return spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; source "$1"; status=0; openclaw_resolve_frozen_agent_bundle_mcp_contract "$2" || status=$?; printf "%s:%s\\n" "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE" "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH"; exit "$status"',
+        "test",
+        stageScriptPath,
+        source.root,
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+          OPENCLAW_SELECTED_SHA: source.sha,
+          OPENCLAW_TOOLING_SHA: "b".repeat(40),
+          OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE: "stale",
+          OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_CLIENT_PATH: "stale",
+          ...env,
+        },
+      },
+    );
+  }
+
+  function expectRejected(result: ReturnType<typeof resolve>, message: string) {
+    expect(result.status, result.stderr).toBe(2);
+    expect(result.stderr).toContain(message);
+    expect(result.stdout).toBe(":\n");
+  }
+
+  it.each(["June", "July", "current"] as const)(
+    "selects the committed %s contract regardless of package version and dirty decoys",
+    (layout) => {
+      const source = fixture(layout);
+      writeFileSync(path.join(source.root, source.clientPath), "dirty client\n");
+      writeFileSync(path.join(source.root, helperPath), "dirty helper\n");
+      writeFileSync(path.join(source.root, "package.json"), '{"type":"commonjs"}');
+      if (layout !== "current") {
+        writeFileSync(path.join(source.root, managerPath), managerSource);
+      }
+      const result = resolve(source);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe(
+        `${layout === "current" ? "current" : "legacy"}:${source.clientPath}\n`,
+      );
+    },
+  );
+
+  it("keeps authorization off on the current harness without reading selected source", () => {
+    const result = resolve(
+      { root: "/nonexistent-bundle-source", sha: "malformed" },
+      { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "0" },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`current:${julyClient}\n`);
+  });
+
+  it("loads the parser from trusted tooling even when invoked inside selected source", () => {
+    const source = fixture();
+    const targetParser = path.join(source.root, "node_modules/typescript");
+    mkdirSync(targetParser, { recursive: true });
+    writeFileSync(path.join(targetParser, "package.json"), '{"main":"index.js"}');
+    writeFileSync(
+      path.join(targetParser, "index.js"),
+      'throw new Error("target parser executed");',
+    );
+    const result = resolve(source, {}, source.root);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`legacy:${julyClient}\n`);
+  });
+
+  it.each<{ env: Record<string, string>; error: string }>([
+    { env: { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "yes" }, error: "expected 0 or 1" },
+    { env: { OPENCLAW_SELECTED_SHA: "short" }, error: "full lowercase commit SHA" },
+    { env: { OPENCLAW_TOOLING_SHA: "SHORT" }, error: "full lowercase commit SHA" },
+    { env: { OPENCLAW_SELECTED_SHA: "c".repeat(40) }, error: "checkout does not match" },
+  ])("rejects malformed frozen identity $env", ({ env, error }) => {
+    expectRejected(resolve(fixture(), env), error);
+  });
+
+  it("rejects identical selected and tooling identities", () => {
+    const source = fixture();
+    expectRejected(resolve(source, { OPENCLAW_TOOLING_SHA: source.sha }), "require distinct");
+  });
+
+  it.each<{ name: string; files: Record<string, string | null>; error: string }>([
+    { name: "both layouts", files: { [juneClient]: "export {};\n" }, error: "exactly one" },
+    { name: "no layout", files: { [julyClient]: null }, error: "exactly one" },
+    { name: "missing runtime", files: { [runtimePath]: null }, error: "missing required" },
+    {
+      name: "unknown runtime",
+      files: { [runtimePath]: "export {};\n" },
+      error: "client/API contract",
+    },
+    {
+      name: "unknown manager",
+      files: { [managerPath]: "export {};\n" },
+      error: "client/API contract",
+    },
+    {
+      name: "mixed manager/client",
+      files: { [managerPath]: managerSource },
+      error: "client/API contract",
+    },
+    { name: "unknown client", files: { [julyClient]: "export {};\n" }, error: "helper contract" },
+    { name: "missing helper", files: { [helperPath]: null }, error: "missing required" },
+    { name: "unknown helper", files: { [helperPath]: "export {};\n" }, error: "helper contract" },
+    { name: "missing manifest", files: { "package.json": null }, error: "package.json" },
+    { name: "invalid manifest", files: { "package.json": "invalid" }, error: "package.json" },
+    {
+      name: "non-ESM manifest",
+      files: { "package.json": '{"type":"commonjs"}' },
+      error: "ESM scope",
+    },
+  ])("rejects $name without publishing stale selection", ({ files, error }) => {
+    expectRejected(resolve(fixture("July", files)), error);
+  });
+
+  it("rejects a manager client whose required API export is missing", () => {
+    expectRejected(
+      resolve(
+        fixture("current", {
+          [managerPath]: "export async function acquireSessionMcpRuntime() {}\n",
+        }),
+      ),
+      "client/API contract",
+    );
+  });
+
+  it.each(
+    [runtimePath, helperPath, julyClient].flatMap((relative) =>
+      ["comment", "template", "invalid syntax"].map((form) => ({ relative, form })),
+    ),
+  )("rejects $relative contract markers in $form", ({ relative, form }) => {
+    const source = fixture();
+    const original = source.files[relative];
+    const content =
+      form === "comment"
+        ? `/*\n${original}*/\n`
+        : form === "template"
+          ? `const inert = \`\n${original}\`;\n`
+          : `${original}\nfunction (`;
+    writeFileSync(path.join(source.root, relative), content);
+    source.sha = source.commit();
+    expectRejected(resolve(source), "contract");
+  });
+
+  it.each([julyClient, helperPath, "package.json", runtimePath, managerPath, "test/e2e"])(
+    "rejects committed symlinks at %s",
+    (relative) => {
+      const source = fixture();
+      rmSync(path.join(source.root, relative), { recursive: true, force: true });
+      symlinkSync("nonexistent-target", path.join(source.root, relative));
+      source.sha = source.commit();
+      const result = resolve(source);
+      expectRejected(result, relative === "package.json" ? "package.json" : "expected");
+    },
+  );
+
+  it("rejects a directory in place of a client blob", () => {
+    const source = fixture();
+    rmSync(path.join(source.root, julyClient));
+    mkdirSync(path.join(source.root, julyClient));
+    writeFileSync(path.join(source.root, julyClient, "nested.ts"), "export {};\n");
+    source.sha = source.commit();
+    expectRejected(resolve(source), "expected regular committed file");
+  });
+
+  it.each([
+    "commit",
+    "root tree",
+    "intermediate tree",
+    "client blob",
+    "manager blob",
+    "helper blob",
+  ])("rejects a missing %s without lazy hydration", (missing) => {
+    const source = fixture("current");
+    const object = source.git(
+      "rev-parse",
+      missing === "commit"
+        ? source.sha
+        : missing === "root tree"
+          ? `${source.sha}^{tree}`
+          : `${source.sha}:${
+              missing === "intermediate tree"
+                ? "src/agents"
+                : missing === "client blob"
+                  ? julyClient
+                  : missing === "manager blob"
+                    ? managerPath
+                    : helperPath
+            }`,
+    );
+    const bin = path.join(source.root, "transport-bin");
+    const transportLog = path.join(source.root, "transport.log");
+    mkdirSync(bin);
+    writeFileSync(
+      path.join(bin, "git-remote-fixture"),
+      '#!/bin/sh\nprintf "unexpected hydration\\n" >> "$BUNDLE_TRANSPORT_LOG"\nexit 1\n',
+      { mode: 0o755 },
+    );
+    source.git("config", "remote.origin.url", "fixture::unavailable");
+    source.git("config", "remote.origin.promisor", "true");
+    source.git("config", "extensions.partialClone", "origin");
+    source.git("config", "protocol.fixture.allow", "always");
+    rmSync(path.join(source.root, ".git/objects", object.slice(0, 2), object.slice(2)));
+    const result = resolve(source, {
+      PATH: `${bin}:${process.env.PATH}`,
+      BUNDLE_TRANSPORT_LOG: transportLog,
+    });
+    expectRejected(result, "unable to read selected bundle source");
+    expect(existsSync(transportLog)).toBe(false);
+  });
+
+  it("rejects a corrupt referenced blob instead of treating its owner as absent", () => {
+    const source = fixture("current");
+    const object = source.git("rev-parse", `${source.sha}:${managerPath}`);
+    const objectPath = path.join(source.root, ".git/objects", object.slice(0, 2), object.slice(2));
+    rmSync(objectPath);
+    writeFileSync(objectPath, "corrupt fixture object\n");
+    expectRejected(resolve(source), "unable to read selected bundle source");
+  });
+
+  it("does not read an unrelated missing runtime-context blob", () => {
+    const unrelated = "src/agents/embedded-agent-runner/run/runtime-context-prompt.ts";
+    const source = fixture("July", { [unrelated]: "unknown runtime-context contract\n" });
+    const object = source.git("rev-parse", `${source.sha}:${unrelated}`);
+    rmSync(path.join(source.root, ".git/objects", object.slice(0, 2), object.slice(2)));
+    const result = resolve(source);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`legacy:${julyClient}\n`);
+  });
+
+  it("rejects older Git before attempting object reads", () => {
+    const source = fixture();
+    const bin = path.join(source.root, "old-git-bin");
+    mkdirSync(bin);
+    writeFileSync(
+      path.join(bin, "git"),
+      '#!/bin/sh\ncase "$*" in *--version) printf "git version 2.44.0\\n";; *) exit 99;; esac\n',
+      { mode: 0o755 },
+    );
+    expectRejected(resolve(source, { PATH: `${bin}:${process.env.PATH}` }), "Git 2.45 or newer");
+  });
+});
 
 describe("live Docker state staging", () => {
   function linkFixtureNodeModules(root: string) {
@@ -500,15 +819,9 @@ export function parseRegistryNpmSpec(spec: string) {
     mkdirSync(path.join(root, "src/commands"), { recursive: true });
     mkdirSync(path.join(root, "scripts"), { recursive: true });
     mkdirSync(path.join(root, "src/config"), { recursive: true });
-    mkdirSync(path.join(root, "scripts/e2e"), { recursive: true });
     writeFileSync(
       path.join(root, "src/agents/code-mode-namespaces.ts"),
       'export const globals = ["ALL_TOOLS"];\n',
-    );
-    writeFileSync(path.join(root, "src/agents/agent-bundle-mcp-runtime.ts"), "export {};\n");
-    writeFileSync(
-      path.join(root, "scripts/e2e/agent-bundle-mcp-tools-docker-client.ts"),
-      "export {};\n",
     );
     writeFileSync(
       path.join(root, "src/config/zod-schema.ts"),
@@ -537,7 +850,7 @@ export function parseRegistryNpmSpec(spec: string) {
     }).trim();
     const resolveCoreDialects = [
       "-c",
-      'set -euo pipefail; source "$1"; openclaw_resolve_frozen_core_harness_capabilities "$2"; openclaw_resolve_frozen_live_cli_backend_package_mode "$2"; printf "%s|%s|%s|%s|%s|%s\\n" "$OPENCLAW_FROZEN_TARGET_SESSION_REPAIR_MODE" "$OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE" "$OPENCLAW_FROZEN_TARGET_LIVE_CLI_BACKEND_PACKAGE_MODE" "$OPENCLAW_FROZEN_TARGET_RUNTIME_CONTEXT_INPUT_MODE" "$OPENCLAW_FROZEN_TARGET_ONBOARD_CASES" "$OPENCLAW_FROZEN_TARGET_AGENT_BUNDLE_MCP_MODE"',
+      'set -euo pipefail; source "$1"; openclaw_resolve_frozen_core_harness_capabilities "$2"; openclaw_resolve_frozen_live_cli_backend_package_mode "$2"; printf "%s|%s|%s|%s|%s\\n" "$OPENCLAW_FROZEN_TARGET_SESSION_REPAIR_MODE" "$OPENCLAW_FROZEN_TARGET_MCP_CODE_MODE_CATALOG_MODE" "$OPENCLAW_FROZEN_TARGET_LIVE_CLI_BACKEND_PACKAGE_MODE" "$OPENCLAW_FROZEN_TARGET_RUNTIME_CONTEXT_INPUT_MODE" "$OPENCLAW_FROZEN_TARGET_ONBOARD_CASES"',
       "test",
       stageScriptPath,
       root,
@@ -552,7 +865,7 @@ export function parseRegistryNpmSpec(spec: string) {
     });
 
     expect(strictResult.status, strictResult.stderr).toBe(0);
-    expect(strictResult.stdout.trim()).toBe("sqlite|current|current|producer-fragments||current");
+    expect(strictResult.stdout.trim()).toBe("sqlite|current|current|producer-fragments|");
 
     const result = spawnSync("bash", resolveCoreDialects, {
       encoding: "utf8",
@@ -566,7 +879,7 @@ export function parseRegistryNpmSpec(spec: string) {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe(
-      "jsonl|legacy|legacy|legacy-marked-prompt|local-basic,remote-non-interactive,reset,channels,skills|legacy",
+      "jsonl|legacy|legacy|legacy-marked-prompt|local-basic,remote-non-interactive,reset,channels,skills",
     );
   });
 


### PR DESCRIPTION
Fixes #142921

## What Problem This Solves

Fixes an issue where maintainers validating frozen July releases would run the
current bundle-MCP client instead of the client shipped with the selected
source. That can require manager APIs the selected release does not provide.
June and July ship different client paths and import depths.

## Why This Change Was Made

Resolve the bundle contract independently from unrelated harness capabilities,
using committed source and the trusted TypeScript parser. Select exactly one
supported client/API/helper contract, distinguish proven absence from Git
errors, and reject unknown or ambiguous contracts before Docker work.

For legacy releases, preserve the selected client, helper and package module
scope byte-for-byte, with the existing read-only mount and installed-package
links. This does not change broader release admission, workflow selection,
publication, or release retry behavior.

## User Impact

Frozen bundle validation uses the selected release's shipped client layout.
Unreadable or unsupported source fails explicitly rather than silently falling
back to the current client. Validation without frozen authorization retains
the current trusted harness.

## Evidence

- Real-wrapper regression: June passed before the fix; July failed because
  selected-client staging was absent. Both layouts now pass.
- All 10 recording-Docker staging cases and all 75 resolver/sibling cases
  pass. Coverage includes dirty decoys, missing/corrupt Git objects, zero
  promisor fetches, ambiguous layouts, inert syntax markers, parser ownership,
  staging failures, exact bytes, imports, links, permissions and cleanup.
- The final resolver passed source-only checks against actual commits
  `75d9ce233a4ef85d4e4ffd2c7c0eea99c81d40ff` (June),
  `40c645cc96854bf6814928ceaf69964d20d09586` (July), and
  `84807aa2c2df61273cd8e58fdd699e82ae3993d4` (current).
- Selected changed gates, root-test typecheck, lint, formatting and shell
  syntax checks pass.
- The trusted workflow setup already installs pinned TypeScript 6.0.3 in the
  separate release harness with lifecycle scripts disabled. No dependency or
  lockfile change is required.

Limitations: the full Docker-helper suite encountered one unchanged published
auth-probe sibling failure because another host service was listening on fixed
port 18789. The focused rerun reproduced that failure; the other listener and
unrelated test were not changed. A completely green full Docker-helper run is
not claimed.

Recording-Docker tests inspect staging but do not execute target clients.
No real Docker lane, FRV workflow, release, or publication was run for this
change.
