### PR TITLE
fix(ci): recover full release dispatches after lost responses

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -172,6 +172,7 @@ env:
   GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN: "HTTP 5[0-9][0-9]|Server Error|invalid character .* looking for beginning of value|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i/o timeout|network is unreachable|(^|[^A-Za-z0-9_])EOF([^A-Za-z0-9_]|$)|ETIMEDOUT|ECONNRESET|EAI_AGAIN"
   NODE_VERSION: "24.19.0"
   RELEASE_ISOLATION_TOOLING_CONTRACT: "2"
+  FULL_RELEASE_DISPATCH_WITNESS_CONTRACT: "1"
 
 jobs:
   resolve_target:
@@ -197,6 +198,75 @@ jobs:
       candidate_request_json: ${{ steps.candidate_request.outputs.request_json }}
       candidate_request_sha256: ${{ steps.candidate_request.outputs.request_sha256 }}
     steps:
+      - name: Retain root dispatch inputs
+        id: dispatch_witness
+        env:
+          DISPATCH_SERVER_URL: ${{ github.server_url }}
+          DISPATCH_WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const { createHash } = require("node:crypto");
+          const env = process.env;
+          const descriptor = fs.openSync(env.GITHUB_EVENT_PATH, "r");
+          let event;
+          try {
+            const size = fs.fstatSync(descriptor).size;
+            if (size > 1024 * 1024) throw new Error("Event exceeds its byte limit");
+            const bytes = Buffer.alloc(size + 1);
+            const length = fs.readSync(descriptor, bytes, 0, bytes.length, 0);
+            if (length !== size) throw new Error("Event changed while reading");
+            event = JSON.parse(bytes.subarray(0, length).toString("utf8"));
+          } catch {
+            throw new Error("Invalid or oversized root dispatch event");
+          } finally {
+            fs.closeSync(descriptor);
+          }
+          const inputs = event?.inputs;
+          if (!inputs || typeof inputs !== "object" || Array.isArray(inputs) ||
+              Object.values(inputs).some((value) => !["string", "boolean", "number"].includes(typeof value) ||
+                (typeof value === "number" && !Number.isFinite(value)))) {
+            throw new Error("Invalid root dispatch inputs");
+          }
+          // The immutable workflow binds input types; event booleans use wire strings.
+          const wireInputs = Object.fromEntries(
+            Object.keys(inputs).sort().map((key) => [key, String(inputs[key])]),
+          );
+          const canonicalInputs = JSON.stringify(wireInputs);
+          if (Buffer.byteLength(canonicalInputs) > 128 * 1024) {
+            throw new Error("Root dispatch inputs exceed their byte limit");
+          }
+          const witness = {
+            kind: "openclaw.full-release-dispatch-inputs/v1",
+            serverUrl: env.DISPATCH_SERVER_URL,
+            repository: env.GITHUB_REPOSITORY,
+            workflowRef: env.DISPATCH_WORKFLOW_REF,
+            event: env.GITHUB_EVENT_NAME,
+            ref: env.GITHUB_REF,
+            sha: env.GITHUB_SHA,
+            runId: env.GITHUB_RUN_ID,
+            runAttempt: env.GITHUB_RUN_ATTEMPT,
+            inputsDigest: `sha256:${createHash("sha256").update(canonicalInputs).digest("hex")}`,
+          };
+          const bytes = JSON.stringify(witness) + "\n";
+          if (Buffer.byteLength(bytes) > 128 * 1024) {
+            throw new Error("Root dispatch witness exceeds its byte limit");
+          }
+          const directory = path.join(env.RUNNER_TEMP, "full-release-dispatch-inputs");
+          fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+          fs.writeFileSync(path.join(directory, "dispatch-inputs.json"), bytes, { mode: 0o600 });
+          NODE
+
+      - name: Upload root dispatch inputs
+        if: ${{ steps.dispatch_witness.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: full-release-dispatch-inputs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-dispatch-inputs/dispatch-inputs.json
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Checkout trusted workflow helper
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/reference/full-release-validation/dispatch.md
+++ b/docs/reference/full-release-validation/dispatch.md
@@ -41,6 +41,52 @@ them for later Code-SHA, Release-SHA, and focused reruns. Main lineage
 authorizes the initial Tooling SHA selection; it does not authorize refreshing
 the tooling from moving `main`.
 
+## Retain and reconcile the root request
+
+Before creating remote refs, the helper writes a private operator artifact at
+`.artifacts/full-release-validation/<request-id>.json` and prints its path.
+Use `--request-file <path>` to choose the artifact location. It retains the
+repository, workflow, frozen target/tooling identities, transport refs, complete
+typed/defaulted inputs, effective soak, and the first observed run and attempt.
+The helper records attempted intent before its single workflow dispatch POST.
+
+After a lost response or interruption, reuse that exact artifact:
+
+```bash
+node scripts/full-release-validation-at-sha.mjs \
+  --reconcile-request .artifacts/full-release-validation/<request-id>.json
+```
+
+An existing `--request-file` also enters read-only reconciliation; conflicting
+target, tooling, or input arguments are rejected. Recovery performs no ref
+creation/deletion, dispatch, rerun, cancellation, Git fetch, or request rewrite.
+`dispatch=observed` reports the exact run URL and attempt, not successful
+validation. A newer attempt cannot replace the retained attempt.
+
+Missing or ambiguous runs, incomplete pagination, unavailable or mismatched input
+witnesses, and exhausted discovery remain `dispatch=unknown`. A complete HTTP
+rejection is retained as `dispatch=rejected`; neither state permits redispatch.
+Keep the artifact and printed refs for investigation. There is no automatic
+retention expiry or cleanup for the local artifact; remove it only through
+deliberate operator cleanup. Losing or deleting it never proves non-execution.
+Independent requests and copies on other hosts are not globally deduplicated.
+
+New requests require `FULL_RELEASE_DISPATCH_WITNESS_CONTRACT=1` in the pinned
+workflow. Older frozen tooling fails before remote creation instead of starting
+work whose inputs cannot be proven. The helper never upgrades the Tooling SHA.
+Use `frv status` for already-running frozen validations; choosing different
+tooling for a new validation requires the release owner's explicit decision.
+The workflow's separate input witness is attempt-bound and retained for seven
+days. It reads the event file directly, without interpolating inputs into step
+environment variables or logs. Only safe GitHub context and a SHA-256 digest are
+uploaded: input keys sorted lexicographically, primitive values normalized to
+wire strings, then JSON serialization. The immutable workflow SHA binds the
+input types; the complete typed and wire maps remain in the private local
+artifact. Runner or artifact-service failure can leave the witness unavailable;
+it is never a release receipt or publication authority.
+
+## Select coverage
+
 `provider` also accepts `anthropic` or `minimax` for cross-OS onboarding and the
 end-to-end agent turn. Regular `release/*` targets accept the branch's final
 package version or a matching beta prerelease. For a correction, use

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -5,10 +5,27 @@ import {
   spawnSync,
   type ExecFileSyncOptionsWithStringEncoding,
 } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 import { parse as parseYaml } from "yaml";
 import { isRecord as isJsonRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import {
@@ -18,6 +35,10 @@ import {
   MAX_RELEASE_ARTIFACT_BYTES,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
+import {
+  inspectActionsArtifactZipWithPolicy,
+  readBoundedRegularFile,
+} from "./lib/actions-artifact-archive.mjs";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { execPlainGh } from "./lib/plain-gh.mjs";
 import { parseReleaseContextRef, resolveReleaseContextIdentity } from "./lib/release-context.mjs";
@@ -39,6 +60,13 @@ const FULL_RELEASE_PROGRESS_INTERVAL_MS = 15 * 60_000;
 const FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS = [30_000, 60_000, 120_000];
 const RELEASE_DECISION_FILE = "full-release-decision.json";
 const GH_NO_CACHE_HEADER = "Cache-Control: max-age=0";
+const REQUEST_KIND = "openclaw.full-release-dispatch/v1";
+const WITNESS_KIND = "openclaw.full-release-dispatch-inputs/v1";
+const WITNESS_FILE = "dispatch-inputs.json";
+const MAX_REQUEST_BYTES = 128 * 1024;
+const MAX_WITNESS_ARCHIVE_BYTES = 256 * 1024;
+const RUN_PAGE_SIZE = 20;
+const MAX_RUN_PAGES = 5;
 const GH_READ_OPTIONS = {
   encoding: "utf8",
   killSignal: "SIGKILL",
@@ -93,6 +121,37 @@ type TrustedWorkflowHarness = {
   contract: "1" | "2";
   verifierPath: string;
 };
+type DispatchInputs = Record<string, string | boolean | number>;
+type DispatchRun = { id: number; attempt: number };
+type DispatchRequest = {
+  id: string;
+  host: "github.com";
+  repository: typeof REPOSITORY;
+  workflowId: number;
+  workflowPath: typeof TRUSTED_WORKFLOW_PATH;
+  event: "workflow_dispatch";
+  workflowSha: string;
+  trustedWorkflowRef: string;
+  targetSha: string;
+  targetVersion: string;
+  targetContextRef: string;
+  workflowRef: string;
+  targetRef: string;
+  wireInputs: Record<string, string>;
+  inputs: DispatchInputs;
+  effectiveSoak: boolean;
+};
+type DispatchRecord = {
+  kind: typeof REQUEST_KIND;
+  request: DispatchRequest;
+  phase: "prepared" | "attempted" | "observed" | "rejected";
+  refs: {
+    target: "intended" | "uncertain" | "created";
+    workflow: "intended" | "uncertain" | "created";
+  };
+  error: "none" | "transport" | "unclassified" | "http-rejection";
+  run: DispatchRun | null;
+};
 
 function stringValue(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
@@ -114,7 +173,13 @@ function requiredPositiveInteger(value: unknown, label: string): number {
 }
 
 function usage() {
-  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-tooling-sha>] [--trusted-workflow-ref <main-or-release-publish-tag>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-tooling-sha>] [--trusted-workflow-ref <main-or-release-publish-tag>] [--request-file <path>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+       node scripts/full-release-validation-at-sha.mjs --reconcile-request <path>
+
+Retains a private request artifact before remote mutations. An existing --request-file
+always performs read-only reconciliation. --reconcile-request refuses a missing file.
+Retain the artifact until operator cleanup; its loss never proves non-execution.
+Frozen tooling must declare FULL_RELEASE_DISPATCH_WITNESS_CONTRACT=1 before a new request.
 
 Creates temporary remote branches pinned to the exact Tooling SHA and Validation SHA,
 dispatches Full Release Validation with the full Validation SHA as its ref input
@@ -161,7 +226,11 @@ function runStatus(command: string, args: string[], options: CommandOptions = {}
   });
 }
 
-function runGh(args: string[], options: CommandOptions = {}) {
+function runGh(inputArgs: string[], options: CommandOptions = {}) {
+  const args =
+    inputArgs[0] === "api" && !inputArgs.includes("--hostname")
+      ? [...inputArgs, "--hostname", "github.com"]
+      : inputArgs;
   if (options.dryRun) {
     console.log(["+", "gh", ...args].join(" "));
     return "";
@@ -171,7 +240,7 @@ function runGh(args: string[], options: CommandOptions = {}) {
     stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
     ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
   });
-  return typeof output === "string" ? output.trim() : "";
+  return typeof output === "string" ? (args.includes("--include") ? output : output.trim()) : "";
 }
 
 function runGhStatus(args: string[], options: CommandOptions = {}): CommandStatus {
@@ -211,7 +280,17 @@ function readGhApi(
   options: ExecFileSyncOptionsWithStringEncoding = GH_READ_OPTIONS,
 ) {
   return execPlainGh(
-    ["api", "--method", "GET", endpoint, ...fields, "-H", GH_NO_CACHE_HEADER],
+    [
+      "api",
+      "--method",
+      "GET",
+      endpoint,
+      ...fields,
+      "--hostname",
+      "github.com",
+      "-H",
+      GH_NO_CACHE_HEADER,
+    ],
     options,
   );
 }
@@ -299,6 +378,9 @@ export function parseArgs(argv: string[]) {
     targetRef: "",
     trustedWorkflowRef: "main",
     workflowSha: "",
+    requestFile: "",
+    reconcileRequest: "",
+    specifiedInputs: [] as string[],
     keepBranch: false,
     dryRun: false,
     inputs,
@@ -312,6 +394,15 @@ export function parseArgs(argv: string[]) {
     }
     if (arg === "--sha") {
       args.sha = requireOptionArgument(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg === "--request-file" || arg === "--reconcile-request") {
+      args[arg === "--request-file" ? "requestFile" : "reconcileRequest"] = requireOptionArgument(
+        argv,
+        i,
+        arg,
+      );
       i += 1;
       continue;
     }
@@ -354,6 +445,7 @@ export function parseArgs(argv: string[]) {
           throw new Error(`Unsupported extra argument after --: ${extra}`);
         }
         args.inputs[key] = valueParts.join("=");
+        args.specifiedInputs.push(key);
       }
       break;
     }
@@ -365,6 +457,7 @@ export function parseArgs(argv: string[]) {
         throw new Error(`Invalid -f assignment: ${assignment}`);
       }
       args.inputs[key] = valueParts.join("=");
+      args.specifiedInputs.push(key);
       continue;
     }
     if (arg.startsWith("-f") && arg.includes("=")) {
@@ -374,11 +467,18 @@ export function parseArgs(argv: string[]) {
         throw new Error(`Invalid -f assignment: ${arg}`);
       }
       args.inputs[key] = valueParts.join("=");
+      args.specifiedInputs.push(key);
       continue;
     }
     throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (args.reconcileRequest) {
+    if (argv.length !== 2 || argv[0] !== "--reconcile-request") {
+      throw new Error("--reconcile-request accepts only the retained request path");
+    }
+    return args;
+  }
   if (!["true", "false"].includes(args.inputs.reuse_evidence)) {
     throw new Error("reuse_evidence must be true or false");
   }
@@ -617,27 +717,574 @@ function resolveTrustedWorkflowSha(requestedSha: string, trustedWorkflowRef: str
   return workflowSha;
 }
 
-function collectRunId(dispatchOutput: string) {
-  const match = dispatchOutput.match(/actions\/runs\/(\d+)/);
-  return match?.[1] ?? "";
+function requireDispatch(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
 }
 
-function findLatestRunId(branch: string, sha: string) {
-  const response: unknown = JSON.parse(
+function exactKeys(value: unknown, keys: string[]): value is Record<string, unknown> {
+  return isJsonRecord(value) && isDeepStrictEqual(Object.keys(value).toSorted(), keys.toSorted());
+}
+
+export function dispatchInputsDigest(inputs: DispatchInputs): string {
+  const wireInputs = Object.fromEntries(
+    Object.keys(inputs)
+      .toSorted()
+      .map((key) => [key, String(inputs[key])]),
+  );
+  return `sha256:${createHash("sha256").update(JSON.stringify(wireInputs)).digest("hex")}`;
+}
+
+function validateDispatchRecord(value: unknown): asserts value is DispatchRecord {
+  requireDispatch(
+    exactKeys(value, ["kind", "request", "phase", "refs", "error", "run"]) &&
+      value.kind === REQUEST_KIND &&
+      ["prepared", "attempted", "observed", "rejected"].includes(stringValue(value.phase)) &&
+      ["none", "transport", "unclassified", "http-rejection"].includes(stringValue(value.error)),
+    "Invalid retained dispatch record",
+  );
+  const request = value.request;
+  requireDispatch(
+    exactKeys(request, [
+      "id",
+      "host",
+      "repository",
+      "workflowId",
+      "workflowPath",
+      "event",
+      "workflowSha",
+      "trustedWorkflowRef",
+      "targetSha",
+      "targetVersion",
+      "targetContextRef",
+      "workflowRef",
+      "targetRef",
+      "wireInputs",
+      "inputs",
+      "effectiveSoak",
+    ]) &&
+      typeof request.id === "string" &&
+      /^[a-f0-9-]{36}$/u.test(request.id) &&
+      request.host === "github.com" &&
+      request.repository === REPOSITORY &&
+      request.workflowPath === TRUSTED_WORKFLOW_PATH &&
+      request.event === "workflow_dispatch" &&
+      Number.isSafeInteger(request.workflowId) &&
+      Number(request.workflowId) > 0 &&
+      typeof request.workflowSha === "string" &&
+      SHA_PATTERN.test(request.workflowSha) &&
+      typeof request.targetSha === "string" &&
+      SHA_PATTERN.test(request.targetSha) &&
+      typeof request.targetVersion === "string" &&
+      /^[0-9]{4}\.[0-9]+\.[0-9]+(?:-.+)?$/u.test(request.targetVersion) &&
+      typeof request.targetContextRef === "string" &&
+      typeof request.trustedWorkflowRef === "string" &&
+      (request.trustedWorkflowRef === "main" ||
+        TRUSTED_WORKFLOW_TAG_PATTERN.test(request.trustedWorkflowRef)) &&
+      typeof request.workflowRef === "string" &&
+      new RegExp(`^release-ci/${request.workflowSha.slice(0, 12)}-[0-9]+$`, "u").test(
+        request.workflowRef,
+      ) &&
+      typeof request.targetRef === "string" &&
+      new RegExp(`^validation/target-${request.targetSha.slice(0, 12)}-[0-9]+$`, "u").test(
+        request.targetRef,
+      ) &&
+      isJsonRecord(request.wireInputs) &&
+      isJsonRecord(request.inputs) &&
+      isDeepStrictEqual(
+        Object.keys(request.wireInputs).toSorted(),
+        Object.keys(request.inputs).toSorted(),
+      ),
+    "Invalid retained dispatch request identity",
+  );
+  for (const [key, input] of Object.entries(request.inputs)) {
+    requireDispatch(
+      /^[a-z][a-z0-9_]*$/u.test(key) &&
+        (typeof input === "string" ||
+          typeof input === "boolean" ||
+          (typeof input === "number" && Number.isFinite(input))) &&
+        request.wireInputs[key] === String(input),
+      "Invalid retained dispatch inputs",
+    );
+  }
+  requireDispatch(
+    request.inputs.ref === request.targetSha &&
+      request.inputs.expected_sha === request.targetSha &&
+      (request.targetContextRef === request.targetSha
+        ? !request.inputs.target_context_ref
+        : request.inputs.target_context_ref === request.targetContextRef) &&
+      request.effectiveSoak ===
+        (request.inputs.run_release_soak === true ||
+          request.inputs.release_profile === "stable" ||
+          request.inputs.release_profile === "full"),
+    "Retained dispatch selection does not match its identity",
+  );
+  if (request.inputs.trusted_workflow_json) {
+    requireDispatch(
+      typeof request.inputs.trusted_workflow_json === "string" &&
+        isDeepStrictEqual(JSON.parse(request.inputs.trusted_workflow_json), {
+          fullRef:
+            request.trustedWorkflowRef === "main"
+              ? "refs/heads/main"
+              : `refs/tags/${request.trustedWorkflowRef}`,
+          ref: request.trustedWorkflowRef,
+          sha: request.workflowSha,
+        }),
+      "Retained trusted workflow identity changed",
+    );
+  }
+  requireDispatch(
+    exactKeys(value.refs, ["target", "workflow"]) &&
+      Object.values(value.refs).every((state) =>
+        ["intended", "uncertain", "created"].includes(stringValue(state)),
+      ) &&
+      (value.run === null ||
+        (exactKeys(value.run, ["id", "attempt"]) &&
+          Number.isSafeInteger(value.run.id) &&
+          Number(value.run.id) > 0 &&
+          Number.isSafeInteger(value.run.attempt) &&
+          Number(value.run.attempt) > 0)) &&
+      (value.phase === "observed" ? value.run !== null : value.run === null) &&
+      (value.phase !== "rejected" || value.error === "http-rejection"),
+    "Invalid retained dispatch outcome",
+  );
+}
+
+function assertRequestPath(path: string) {
+  let current = resolve(path);
+  while (true) {
+    try {
+      const info = lstatSync(current);
+      requireDispatch(!info.isSymbolicLink(), "Request path must not contain symlinks");
+      if (current === resolve(path)) {
+        requireDispatch(
+          info.isFile() && (info.mode & 0o077) === 0,
+          "Request must be a private regular file",
+        );
+      } else {
+        requireDispatch(info.isDirectory(), "Request parent must be a directory");
+      }
+    } catch (error) {
+      if (!isJsonRecord(error) || error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+}
+
+function readDispatchRecord(path: string): DispatchRecord {
+  assertRequestPath(path);
+  const bytes = readBoundedRegularFile(path, {
+    maxBytes: MAX_REQUEST_BYTES,
+    label: "Retained dispatch request",
+  });
+  const value: unknown = JSON.parse(bytes.toString("utf8"));
+  requireDispatch(
+    bytes.equals(Buffer.from(`${JSON.stringify(value)}\n`)),
+    "Retained request is not complete canonical JSON",
+  );
+  validateDispatchRecord(value);
+  return value;
+}
+
+function retainDispatchRecord(path: string, record: DispatchRecord, previous?: DispatchRecord) {
+  validateDispatchRecord(record);
+  const bytes = `${JSON.stringify(record)}\n`;
+  requireDispatch(
+    Buffer.byteLength(bytes) <= MAX_REQUEST_BYTES,
+    "Dispatch request exceeds its byte limit",
+  );
+  assertRequestPath(path);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  assertRequestPath(path);
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  const descriptor = openSync(temporary, "wx", 0o600);
+  try {
+    try {
+      writeFileSync(descriptor, bytes);
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+    if (previous) {
+      requireDispatch(
+        isDeepStrictEqual(readDispatchRecord(path), previous),
+        "Retained request changed during dispatch",
+      );
+      renameSync(temporary, path);
+    } else {
+      // A fully written exclusive claim prevents a second caller from issuing the POST.
+      linkSync(temporary, path);
+      unlinkSync(temporary);
+    }
+    const directory = openSync(dirname(path), "r");
+    try {
+      fsyncSync(directory);
+    } finally {
+      closeSync(directory);
+    }
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+function resolveDispatchSelection(workflowSha: string, overrides: Record<string, string>) {
+  const workflow: unknown = parseYaml(
+    run("git", ["show", `${workflowSha}:${TRUSTED_WORKFLOW_PATH}`]),
+  );
+  requireDispatch(
+    isJsonRecord(workflow) &&
+      isJsonRecord(workflow.env) &&
+      workflow.env.FULL_RELEASE_DISPATCH_WITNESS_CONTRACT === "1",
+    `Tooling SHA ${workflowSha} does not support FULL_RELEASE_DISPATCH_WITNESS_CONTRACT=1; no remote refs or run were created. Keep the frozen Tooling SHA. Existing runs use frv status; a new request needs separately approved witness-capable tooling.`,
+  );
+  requireDispatch(
+    isJsonRecord(workflow.on) &&
+      isJsonRecord(workflow.on.workflow_dispatch) &&
+      isJsonRecord(workflow.on.workflow_dispatch.inputs),
+    "Pinned workflow input schema is invalid",
+  );
+  const definitions = workflow.on.workflow_dispatch.inputs;
+  requireDispatch(
+    Object.keys(overrides).every((key) => Object.hasOwn(definitions, key)),
+    "Undeclared workflow input",
+  );
+  const inputs: DispatchInputs = {};
+  const wireInputs: Record<string, string> = {};
+  for (const [key, definition] of Object.entries(definitions)) {
+    requireDispatch(
+      /^[a-z][a-z0-9_]*$/u.test(key) && isJsonRecord(definition),
+      "Invalid workflow input definition",
+    );
+    const raw: unknown =
+      overrides[key] ?? definition.default ?? (definition.type === "boolean" ? false : "");
+    const text = String(raw);
+    let value: string | number | boolean = text;
+    if (definition.type === "boolean") {
+      requireDispatch(["true", "false"].includes(text), `Input ${key} must be true or false`);
+      value = text === "true";
+    } else if (definition.type === "number") {
+      requireDispatch(
+        text.trim() !== "" && Number.isFinite(Number(text)),
+        `Input ${key} must be a number`,
+      );
+      value = Number(text);
+    } else {
+      requireDispatch(
+        ["string", "choice", "environment"].includes(stringValue(definition.type)),
+        `Unsupported input type for ${key}`,
+      );
+      if (definition.type === "choice") {
+        requireDispatch(
+          Array.isArray(definition.options) && definition.options.includes(text),
+          `Invalid choice for ${key}`,
+        );
+      }
+    }
+    inputs[key] = value;
+    wireInputs[key] = String(value);
+  }
+  return {
+    inputs,
+    wireInputs,
+    effectiveSoak:
+      inputs.run_release_soak === true ||
+      inputs.release_profile === "stable" ||
+      inputs.release_profile === "full",
+  };
+}
+
+function parseGhHttpResponse(output: string) {
+  const match = /^HTTP\/[\d.]+ (\d{3})[^\r\n]*\r?\n([\s\S]*?)\r?\n\r?\n([\s\S]*)$/u.exec(output);
+  requireDispatch(match, "GitHub response did not include complete HTTP headers");
+  const headers = new Headers();
+  for (const line of match[2]!.split(/\r?\n/u)) {
+    if (!line) {
+      continue;
+    }
+    const separator = line.indexOf(":");
+    requireDispatch(separator > 0, "GitHub response contains malformed headers");
+    headers.append(line.slice(0, separator), line.slice(separator + 1).trim());
+  }
+  return { status: Number(match[1]), headers, body: match[3]! };
+}
+
+function readDispatchRuns(request: DispatchRequest) {
+  const runs: Record<string, unknown>[] = [];
+  let total: number | undefined;
+  for (let page = 1; page <= MAX_RUN_PAGES; page += 1) {
+    const response = parseGhHttpResponse(
+      readGhApi(`repos/${REPOSITORY}/actions/workflows/${request.workflowId}/runs`, [
+        "--include",
+        "-f",
+        `branch=${request.workflowRef}`,
+        "-f",
+        "event=workflow_dispatch",
+        "-f",
+        `per_page=${RUN_PAGE_SIZE}`,
+        "-f",
+        `page=${page}`,
+      ]),
+    );
+    requireDispatch(
+      response.status === 200,
+      "Dispatch run inventory returned a non-success response",
+    );
+    const value: unknown = JSON.parse(response.body);
+    requireDispatch(
+      isJsonRecord(value) &&
+        Array.isArray(value.workflow_runs) &&
+        Number.isSafeInteger(value.total_count) &&
+        Number(value.total_count) >= 0 &&
+        Number(value.total_count) <= RUN_PAGE_SIZE * MAX_RUN_PAGES,
+      "Dispatch run inventory is incomplete or exceeds its bound",
+    );
+    total ??= Number(value.total_count);
+    requireDispatch(
+      value.total_count === total &&
+        value.workflow_runs.length === Math.min(RUN_PAGE_SIZE, total - runs.length),
+      "Dispatch run pagination changed or is incomplete",
+    );
+    for (const item of value.workflow_runs) {
+      requireDispatch(
+        isJsonRecord(item) &&
+          Number.isSafeInteger(item.id) &&
+          Number(item.id) > 0 &&
+          !runs.some((other) => other.id === item.id),
+        "Dispatch run inventory contains invalid or repeated IDs",
+      );
+      runs.push(item);
+    }
+    const next = response.headers.get("link")?.match(/<([^>]+)>;\s*rel="next"/u)?.[1];
+    if (runs.length === total) {
+      requireDispatch(!next, "Dispatch run pagination is uncertain");
+      return runs;
+    }
+    requireDispatch(next, "Dispatch run inventory omitted its next page");
+    const url = new URL(next);
+    requireDispatch(
+      url.origin === "https://api.github.com" &&
+        url.pathname === `/repos/${REPOSITORY}/actions/workflows/${request.workflowId}/runs` &&
+        url.searchParams.get("page") === String(page + 1) &&
+        url.searchParams.get("branch") === request.workflowRef &&
+        url.searchParams.get("event") === "workflow_dispatch" &&
+        url.searchParams.get("per_page") === String(RUN_PAGE_SIZE),
+      "Dispatch run pagination changed scope",
+    );
+  }
+  throw new Error("Dispatch run inventory exceeded its page bound");
+}
+
+function assertDispatchRun(workflowRun: unknown, request: DispatchRequest, expected: DispatchRun) {
+  requireDispatch(
+    isJsonRecord(workflowRun) &&
+      workflowRun.id === expected.id &&
+      workflowRun.run_attempt === expected.attempt &&
+      workflowRun.workflow_id === request.workflowId &&
+      workflowRun.head_sha === request.workflowSha &&
+      workflowRun.head_branch === request.workflowRef &&
+      workflowRun.event === request.event &&
+      [
+        request.workflowPath,
+        `${request.workflowPath}@${request.workflowRef}`,
+        `${request.workflowPath}@refs/heads/${request.workflowRef}`,
+      ].includes(stringValue(workflowRun.path)) &&
+      isJsonRecord(workflowRun.repository) &&
+      workflowRun.repository.full_name === request.repository &&
+      isJsonRecord(workflowRun.head_repository) &&
+      workflowRun.head_repository.full_name === request.repository &&
+      workflowRun.display_title === "Full Release Validation" &&
+      workflowRun.html_url === `https://github.com/${REPOSITORY}/actions/runs/${expected.id}`,
+    "Dispatch run does not match the exact retained workflow/ref/event/attempt identity",
+  );
+}
+
+async function readDispatchWitness(request: DispatchRequest, observed: DispatchRun) {
+  const name = `full-release-dispatch-inputs-${observed.id}-${observed.attempt}`;
+  const inventory: unknown = JSON.parse(
     readGhApi(
-      `repos/${REPOSITORY}/actions/workflows/${WORKFLOW}/runs`,
-      ["-f", `branch=${branch}`, "-f", "event=workflow_dispatch", "-f", "per_page=20"],
-      GH_READ_OPTIONS,
+      `repos/${REPOSITORY}/actions/runs/${observed.id}/artifacts`,
+      ["-f", `name=${name}`, "-f", "per_page=100"],
+      { ...GH_READ_OPTIONS, maxBuffer: MAX_REQUEST_BYTES },
     ),
   );
-  if (!isJsonRecord(response) || !Array.isArray(response.workflow_runs)) {
-    throw new Error("Full Release Validation run list response was invalid");
-  }
-  const match = response.workflow_runs.find(
-    (runItem: unknown) => isJsonRecord(runItem) && runItem.head_sha === sha,
+  requireDispatch(
+    isJsonRecord(inventory) &&
+      Array.isArray(inventory.artifacts) &&
+      Number.isSafeInteger(inventory.total_count) &&
+      inventory.total_count === inventory.artifacts.length &&
+      inventory.total_count <= 100,
+    "Dispatch witness inventory is incomplete",
   );
-  const databaseId = isJsonRecord(match) ? match.id : undefined;
-  return typeof databaseId === "string" || typeof databaseId === "number" ? String(databaseId) : "";
+  if (inventory.artifacts.length === 0) {
+    return false;
+  }
+  requireDispatch(inventory.artifacts.length === 1, "Dispatch witness is ambiguous");
+  const metadata: unknown = inventory.artifacts[0];
+  requireDispatch(
+    isJsonRecord(metadata) &&
+      typeof metadata.id === "number" &&
+      Number.isSafeInteger(metadata.id) &&
+      metadata.id > 0 &&
+      metadata.name === name &&
+      typeof metadata.size_in_bytes === "number" &&
+      Number.isSafeInteger(metadata.size_in_bytes) &&
+      metadata.size_in_bytes > 0 &&
+      metadata.size_in_bytes <= MAX_WITNESS_ARCHIVE_BYTES &&
+      typeof metadata.digest === "string" &&
+      /^sha256:[a-f0-9]{64}$/u.test(metadata.digest) &&
+      metadata.expired === false &&
+      typeof metadata.expires_at === "string" &&
+      Date.parse(metadata.expires_at) > Date.now() &&
+      isJsonRecord(metadata.workflow_run) &&
+      metadata.workflow_run.id === observed.id &&
+      metadata.workflow_run.head_sha === request.workflowSha,
+    "Dispatch witness metadata does not match its exact run",
+  );
+  const artifactEndpoint = `repos/${REPOSITORY}/actions/artifacts/${metadata.id}`;
+  const exactMetadata: unknown = JSON.parse(
+    readGhApi(artifactEndpoint, [], { ...GH_READ_OPTIONS, maxBuffer: MAX_REQUEST_BYTES }),
+  );
+  requireDispatch(
+    isJsonRecord(exactMetadata) &&
+      exactMetadata.id === metadata.id &&
+      exactMetadata.name === name &&
+      exactMetadata.size_in_bytes === metadata.size_in_bytes &&
+      exactMetadata.digest === metadata.digest &&
+      exactMetadata.expired === false &&
+      exactMetadata.expires_at === metadata.expires_at &&
+      Date.parse(metadata.expires_at) > Date.now() &&
+      isJsonRecord(exactMetadata.workflow_run) &&
+      exactMetadata.workflow_run.id === observed.id &&
+      exactMetadata.workflow_run.head_sha === request.workflowSha,
+    "Dispatch witness metadata changed from its exact artifact tuple",
+  );
+  // Keep credentials and redirects owned by the selected CLI; ZIP bytes must not be decoded.
+  const archiveBytes = execPlainGh(
+    [
+      "api",
+      "--method",
+      "GET",
+      `${artifactEndpoint}/zip`,
+      "--hostname",
+      "github.com",
+      "-H",
+      GH_NO_CACHE_HEADER,
+    ],
+    { ...GH_READ_OPTIONS, encoding: null, maxBuffer: MAX_WITNESS_ARCHIVE_BYTES },
+  );
+  requireDispatch(
+    archiveBytes.byteLength === metadata.size_in_bytes &&
+      `sha256:${createHash("sha256").update(archiveBytes).digest("hex")}` === metadata.digest,
+    "Dispatch witness archive does not match its exact size and digest",
+  );
+  const files = inspectActionsArtifactZipWithPolicy(archiveBytes, {
+    expectedEntries: [WITNESS_FILE],
+    maxArchiveBytes: MAX_WITNESS_ARCHIVE_BYTES,
+    maxCompressedEntryBytes: () => MAX_WITNESS_ARCHIVE_BYTES,
+    maxEntryBytes: () => MAX_REQUEST_BYTES,
+    maxExpandedBytes: MAX_REQUEST_BYTES,
+  });
+  const witness: unknown = JSON.parse(files.get(WITNESS_FILE).toString("utf8"));
+  requireDispatch(
+    isDeepStrictEqual(witness, {
+      kind: WITNESS_KIND,
+      serverUrl: "https://github.com",
+      repository: REPOSITORY,
+      workflowRef: `${REPOSITORY}/${request.workflowPath}@refs/heads/${request.workflowRef}`,
+      event: request.event,
+      ref: `refs/heads/${request.workflowRef}`,
+      sha: request.workflowSha,
+      runId: String(observed.id),
+      runAttempt: String(observed.attempt),
+      inputsDigest: dispatchInputsDigest(request.wireInputs),
+    }),
+    "Dispatch input witness does not match the complete retained request",
+  );
+  return true;
+}
+
+async function reconcileDispatch(record: DispatchRecord): Promise<DispatchRun> {
+  requireDispatch(
+    record.phase !== "prepared",
+    "No attempted workflow POST was retained; dispatch remains unknown",
+  );
+  requireDispatch(
+    record.phase !== "rejected",
+    "dispatch=rejected: GitHub rejected the retained request",
+  );
+  const request = record.request;
+  for (let attempt = 0; attempt <= FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length; attempt += 1) {
+    const runs = readDispatchRuns(request);
+    if (runs.length > 0) {
+      requireDispatch(
+        runs.length === 1,
+        "Multiple dispatch runs exist for the retained transport; adoption is ambiguous",
+      );
+      const observed = record.run ?? { id: Number(runs[0]!.id), attempt: 1 };
+      assertDispatchRun(runs[0], request, observed);
+      assertDispatchRun(
+        JSON.parse(readGhApi(`repos/${REPOSITORY}/actions/runs/${observed.id}`)),
+        request,
+        observed,
+      );
+      if (await readDispatchWitness(request, observed)) {
+        // Recheck both identity and inventory after the archive read, which can span a rerun.
+        assertDispatchRun(
+          JSON.parse(readGhApi(`repos/${REPOSITORY}/actions/runs/${observed.id}`)),
+          request,
+          observed,
+        );
+        const after = readDispatchRuns(request);
+        requireDispatch(after.length === 1, "Dispatch run inventory changed during reconciliation");
+        assertDispatchRun(after[0], request, observed);
+        return observed;
+      }
+    }
+    if (attempt < FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length) {
+      Atomics.wait(
+        new Int32Array(new SharedArrayBuffer(4)),
+        0,
+        0,
+        FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS[attempt],
+      );
+    }
+  }
+  throw new Error("Could not determine Full Release Validation run id: discovery exhausted");
+}
+
+async function reopenDispatch(path: string, args: ReturnType<typeof parseArgs>, argv: string[]) {
+  const record = readDispatchRecord(path);
+  const request = record.request;
+  requireDispatch(
+    (!args.sha || args.sha === request.targetSha) &&
+      (!args.workflowSha || args.workflowSha === request.workflowSha) &&
+      (!args.targetRef || args.targetRef === request.targetContextRef) &&
+      (!argv.includes("--trusted-workflow-ref") ||
+        args.trustedWorkflowRef === request.trustedWorkflowRef) &&
+      args.specifiedInputs.every((key) => args.inputs[key] === request.wireInputs[key]),
+    "Reopen arguments conflict with the retained request",
+  );
+  try {
+    const observed = await reconcileDispatch(record);
+    console.log(
+      `dispatch=observed: https://github.com/${REPOSITORY}/actions/runs/${observed.id} attempt=${observed.attempt}`,
+    );
+  } catch (error) {
+    console.error(
+      `dispatch=${record.phase === "rejected" ? "rejected" : "unknown"} error=${record.error}`,
+    );
+    console.error(
+      `Retained refs: refs/heads/${request.workflowRef} and refs/heads/${request.targetRef}`,
+    );
+    throw error;
+  }
 }
 
 function readWorkflowRun(parentRunId: string, workflowSha: string) {
@@ -811,7 +1458,7 @@ function releaseDecisionAvailable(parentRunId: string, parentRunAttempt: number)
   }
 }
 
-function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
+function waitForWorkflowRun(parentRunId: string, workflowSha: string, record?: DispatchRecord) {
   let lastSummary = "";
   let consecutiveErrors = 0;
   const startedAt = Date.now();
@@ -840,6 +1487,9 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
       lastSummary = summary;
     }
     if (suite) {
+      if (record?.run) {
+        assertDispatchRun(suite, record.request, record.run);
+      }
       const attempt = requiredPositiveInteger(suite.run_attempt, "parent run attempt");
       if (decision?.attempt !== attempt) {
         decision = { attempt, state: "unavailable" };
@@ -1060,8 +1710,17 @@ function verifyReleaseEvidence(
   }
 }
 
-function main() {
-  const args = parseArgs(process.argv.slice(2));
+async function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+  const reopenPath = args.reconcileRequest || args.requestFile;
+  if (reopenPath) {
+    assertRequestPath(reopenPath);
+    if (args.reconcileRequest || existsSync(reopenPath)) {
+      await reopenDispatch(reopenPath, args, argv);
+      return;
+    }
+  }
   const targetSha = resolveTargetSha(args.sha, args.targetRef);
   const targetVersion = targetVersionForTarget(targetSha);
   args.inputs.release_profile ??= releaseProfileForVersion(targetVersion);
@@ -1099,7 +1758,50 @@ function main() {
     ...(targetContextRef !== targetSha ? { target_context_ref: targetContextRef } : {}),
     ...args.inputs,
   };
+  const selection = resolveDispatchSelection(workflowSha, dispatchInputs);
+  const requestId = randomUUID();
+  const requestPath = resolve(
+    args.requestFile || join(".artifacts", "full-release-validation", `${requestId}.json`),
+  );
+  let record: DispatchRecord | undefined;
+  if (!args.dryRun) {
+    const workflow: unknown = JSON.parse(
+      readGhApi(`repos/${REPOSITORY}/actions/workflows/${WORKFLOW}`),
+    );
+    requireDispatch(
+      isJsonRecord(workflow) &&
+        workflow.path === TRUSTED_WORKFLOW_PATH &&
+        Number.isSafeInteger(workflow.id) &&
+        Number(workflow.id) > 0,
+      "Workflow metadata does not match the pinned workflow path",
+    );
+    record = {
+      kind: REQUEST_KIND,
+      request: {
+        id: requestId,
+        host: "github.com",
+        repository: REPOSITORY,
+        workflowId: Number(workflow.id),
+        workflowPath: TRUSTED_WORKFLOW_PATH,
+        event: "workflow_dispatch",
+        workflowSha,
+        trustedWorkflowRef: args.trustedWorkflowRef,
+        targetSha,
+        targetVersion,
+        targetContextRef,
+        workflowRef: branch,
+        targetRef: targetBranch,
+        ...selection,
+      },
+      phase: "prepared",
+      refs: { target: "intended", workflow: "intended" },
+      error: "none",
+      run: null,
+    };
+    retainDispatchRecord(requestPath, record);
+  }
 
+  console.log(`Request artifact: ${requestPath}${args.dryRun ? " (dry run; not written)" : ""}`);
   console.log(`Validation SHA: ${targetSha}`);
   console.log(`Tooling SHA: ${workflowSha}`);
   console.log(`Trusted workflow ref: ${args.trustedWorkflowRef}`);
@@ -1116,48 +1818,84 @@ function main() {
   let workflowRefCreated = false;
   let dispatchAttempted = false;
   let operationError: Error | undefined;
+  const retain = (next: DispatchRecord) => {
+    retainDispatchRecord(requestPath, next, record);
+    record = next;
+  };
   try {
+    if (record) {
+      retain({ ...record, refs: { ...record.refs, target: "uncertain" } });
+    }
     createTemporaryRef(remoteTargetBranchRef, targetSha, args.dryRun);
     targetRefCreated = true;
+    if (record) {
+      retain({ ...record, refs: { ...record.refs, target: "created", workflow: "uncertain" } });
+    }
     createTemporaryRef(remoteBranchRef, workflowSha, args.dryRun);
     workflowRefCreated = true;
-
-    const dispatchArgs = ["workflow", "run", WORKFLOW, "--ref", branch];
-    for (const [key, value] of Object.entries(dispatchInputs)) {
-      dispatchArgs.push("-f", `${key}=${value}`);
+    if (record) {
+      retain({ ...record, phase: "attempted", refs: { target: "created", workflow: "created" } });
+    }
+    const dispatchArgs = [
+      "api",
+      "--include",
+      "--method",
+      "POST",
+      `repos/${REPOSITORY}/actions/workflows/${WORKFLOW}/dispatches`,
+      "--hostname",
+      "github.com",
+      "-f",
+      `ref=${branch}`,
+    ];
+    for (const [key, value] of Object.entries(selection.wireInputs)) {
+      dispatchArgs.push("-f", `inputs[${key}]=${value}`);
     }
 
     // Once dispatch starts, the refs may be needed for GitHub reruns even when
     // the client loses the response. Cleanup resumes only after verified success.
     dispatchAttempted = true;
-    const dispatchOutput = runGh(dispatchArgs, { dryRun: args.dryRun });
-    if (dispatchOutput) {
-      console.log(dispatchOutput);
-    }
-    parentRunId = collectRunId(dispatchOutput);
-    if (!parentRunId && !args.dryRun) {
-      for (let attempt = 0; attempt <= FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length; attempt += 1) {
-        parentRunId = findLatestRunId(branch, workflowSha);
-        if (parentRunId) {
-          break;
-        }
-        if (attempt < FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length) {
-          Atomics.wait(
-            new Int32Array(new SharedArrayBuffer(4)),
-            0,
-            0,
-            FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS[attempt],
-          );
-        }
+    let dispatchOutput = "";
+    let dispatchError: unknown;
+    try {
+      if (args.dryRun) {
+        console.log(
+          `+ gh api --method POST repos/${REPOSITORY}/actions/workflows/${WORKFLOW}/dispatches (input values omitted)`,
+        );
+      } else {
+        dispatchOutput = runGh(dispatchArgs, { stdio: ["ignore", "pipe", "pipe"] });
       }
+    } catch (error) {
+      dispatchError = error;
+      dispatchOutput = error instanceof Error && "stdout" in error ? stringValue(error.stdout) : "";
     }
-    if (!parentRunId) {
-      if (!args.dryRun) {
-        throw new Error("Could not determine Full Release Validation run id.");
+    if (record) {
+      let responseStatus = 0;
+      try {
+        responseStatus = parseGhHttpResponse(dispatchOutput).status;
+      } catch {
+        // A missing or partial response is not evidence that GitHub rejected the POST.
       }
-    } else {
+      if ([400, 401, 403, 404, 422].includes(responseStatus)) {
+        retain({ ...record, phase: "rejected", error: "http-rejection" });
+        throw new Error(`dispatch=rejected: GitHub returned HTTP ${responseStatus}`);
+      }
+      if (dispatchError || responseStatus !== 204) {
+        retain({
+          ...record,
+          error:
+            classifyReleaseGhTransportError(dispatchError) === "transient"
+              ? "transport"
+              : "unclassified",
+        });
+      }
+      const observed = await reconcileDispatch(record);
+      retain({ ...record, phase: "observed", run: observed });
+      parentRunId = String(observed.id);
+      console.log(`dispatch=observed: attempt=${observed.attempt}`);
+    }
+    if (parentRunId) {
       console.log(`Parent run: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`);
-      const completedRun = waitForWorkflowRun(parentRunId, workflowSha);
+      const completedRun = waitForWorkflowRun(parentRunId, workflowSha, record);
       parentConclusion = stringValue(completedRun.conclusion);
       if (parentConclusion !== "success") {
         throw new Error(
@@ -1169,13 +1907,25 @@ function main() {
     }
   } catch (error) {
     operationError = error instanceof Error ? error : new Error(String(error));
+    if (record) {
+      console.error(
+        `dispatch=${record.phase === "rejected" ? "rejected" : record.phase === "observed" ? "observed" : "unknown"} error=${record.error}`,
+      );
+      console.error(`Retained refs: ${remoteBranchRef} and ${remoteTargetBranchRef}`);
+      console.error(
+        `node scripts/full-release-validation-at-sha.mjs --reconcile-request ${JSON.stringify(requestPath)}`,
+      );
+    }
   }
 
   const createdRefs = [
     ...(workflowRefCreated ? [remoteBranchRef] : []),
     ...(targetRefCreated ? [remoteTargetBranchRef] : []),
   ];
-  const cleanupBeforeDispatch = !dispatchAttempted && createdRefs.length > 0;
+  const cleanupBeforeDispatch =
+    !dispatchAttempted &&
+    createdRefs.length > 0 &&
+    !Object.values(record?.refs ?? {}).includes("uncertain");
   const cleanupAfterSuccess = shouldDeleteTemporaryWorkflowRef({
     keepBranch: args.keepBranch,
     dryRun: args.dryRun,
@@ -1218,7 +1968,7 @@ function main() {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    main();
+    await main();
   } catch (error) {
     console.error(
       `[full-release-validation] FAILED: ${error instanceof Error ? error.message : String(error)}`,

--- a/test/scripts/full-release-artifact-contract.test.ts
+++ b/test/scripts/full-release-artifact-contract.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -89,6 +90,169 @@ function fullMatrixDecision(children = fullMatrixChildren()) {
 
 describe("full release artifact contract", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  function runDispatchWitness(event: unknown, rawEvent?: string) {
+    const workflow = parse(readFileSync(".github/workflows/full-release-validation.yml", "utf8"));
+    const steps = workflow.jobs.resolve_target.steps;
+    const writer = steps.find((step: { id?: string }) => step.id === "dispatch_witness");
+    const dir = tempDirs.make("full-release-dispatch-inputs-");
+    const eventPath = join(dir, "event.json");
+    writeFileSync(eventPath, rawEvent ?? JSON.stringify(event));
+    const context = {
+      serverUrl: "https://github.com",
+      repository: "openclaw/openclaw",
+      workflowRef:
+        "openclaw/openclaw/.github/workflows/full-release-validation.yml@refs/heads/release-ci/test",
+      event: "workflow_dispatch",
+      ref: "refs/heads/release-ci/test",
+      sha: SHA,
+      runId: "123",
+      runAttempt: "2",
+    };
+    const result = spawnSync("bash", ["-c", writer.run], {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH,
+        RUNNER_TEMP: dir,
+        GITHUB_EVENT_PATH: eventPath,
+        DISPATCH_SERVER_URL: context.serverUrl,
+        DISPATCH_WORKFLOW_REF: context.workflowRef,
+        GITHUB_REPOSITORY: context.repository,
+        GITHUB_EVENT_NAME: context.event,
+        GITHUB_REF: context.ref,
+        GITHUB_SHA: context.sha,
+        GITHUB_RUN_ID: context.runId,
+        GITHUB_RUN_ATTEMPT: context.runAttempt,
+      },
+    });
+    const artifactPath = join(dir, "full-release-dispatch-inputs/dispatch-inputs.json");
+    const bytes = existsSync(artifactPath) ? readFileSync(artifactPath, "utf8") : "";
+    return { result, bytes, context, dir, workflow, writer, steps };
+  }
+
+  it.each([false, true])("writes only a full-input digest and safe context (soak=%s)", (soak) => {
+    const privateValue = "/private/example/operator/candidate.tgz";
+    const secretValue = "synthetic-private-dispatch-value";
+    const shellValue = 'line one\n$(touch unexpected) "quoted"';
+    const { result, bytes, context, dir, workflow, writer, steps } = runDispatchWitness({
+      inputs: {
+        text: shellValue,
+        secret: secretValue,
+        package: privateValue,
+        run_release_soak: String(soak),
+        count: 3,
+        empty: "",
+      },
+    });
+    const canonical = JSON.stringify({
+      count: "3",
+      empty: "",
+      package: privateValue,
+      run_release_soak: String(soak),
+      secret: secretValue,
+      text: shellValue,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(bytes)).toEqual({
+      kind: "openclaw.full-release-dispatch-inputs/v1",
+      ...context,
+      inputsDigest: `sha256:${createHash("sha256").update(canonical).digest("hex")}`,
+    });
+    for (const value of [privateValue, secretValue, shellValue]) {
+      expect(bytes + result.stdout + result.stderr + JSON.stringify(writer.env)).not.toContain(
+        value,
+      );
+    }
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(JSON.stringify(writer.env)).not.toMatch(/inputs|github\.event/u);
+    expect(writer.run).not.toContain("${{");
+    expect(existsSync(join(dir, "unexpected"))).toBe(false);
+    expect(workflow.env.FULL_RELEASE_DISPATCH_WITNESS_CONTRACT).toBe("1");
+    expect(steps.indexOf(writer)).toBeLessThan(
+      steps.findIndex((step: { id?: string }) => step.id === "tooling_identity"),
+    );
+    expect(
+      steps.find((step: { name?: string }) => step.name === "Upload root dispatch inputs").with,
+    ).toMatchObject({
+      name: "full-release-dispatch-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+      "if-no-files-found": "error",
+      "retention-days": 7,
+    });
+  });
+
+  it("binds every declared input and default independently of event key order", () => {
+    const workflow = parse(readFileSync(".github/workflows/full-release-validation.yml", "utf8"));
+    const definitions = workflow.on.workflow_dispatch.inputs as Record<
+      string,
+      { default?: unknown }
+    >;
+    const inputs = Object.fromEntries(
+      Object.entries(definitions).map(([key, definition]) => {
+        const value = definition.default ?? "";
+        if (typeof value !== "string" && typeof value !== "boolean" && typeof value !== "number") {
+          throw new Error("Workflow input default must be a primitive");
+        }
+        return [key, String(value)];
+      }),
+    );
+    const original = runDispatchWitness({ inputs });
+    expect(original.result.status, original.result.stderr).toBe(0);
+    const reordered = runDispatchWitness({
+      inputs: Object.fromEntries(Object.entries(inputs).toReversed()),
+    });
+    expect(reordered.result.status, reordered.result.stderr).toBe(0);
+    expect(reordered.bytes).toBe(original.bytes);
+    for (const key of Object.keys(inputs)) {
+      const changed = runDispatchWitness({
+        inputs: { ...inputs, [key]: `${inputs[key]}-changed` },
+      });
+      expect(changed.result.status, changed.result.stderr).toBe(0);
+      expect(JSON.parse(changed.bytes).inputsDigest, key).not.toBe(
+        JSON.parse(original.bytes).inputsDigest,
+      );
+    }
+    expect(runDispatchWitness({ inputs: { value: false, count: 3 } }).bytes).toBe(
+      runDispatchWitness({ inputs: { count: "3", value: "false" } }).bytes,
+    );
+    expect(runDispatchWitness({ inputs: { value: "" } }).bytes).not.toBe(
+      runDispatchWitness({ inputs: {} }).bytes,
+    );
+  });
+
+  it.each([
+    {
+      name: "oversized event",
+      event: { inputs: {}, padding: "x".repeat(1024 * 1024) },
+      error: "Invalid or oversized root dispatch event",
+    },
+    {
+      name: "oversized inputs",
+      event: { inputs: { payload: "x".repeat(129 * 1024) } },
+      error: "Root dispatch inputs exceed their byte limit",
+    },
+    {
+      name: "nested inputs",
+      event: { inputs: { payload: { private: "synthetic-private-dispatch-value" } } },
+      error: "Invalid root dispatch inputs",
+    },
+    {
+      name: "malformed event",
+      event: {},
+      rawEvent: '{"inputs":"synthetic-private-dispatch-value',
+      error: "Invalid or oversized root dispatch event",
+    },
+  ])(
+    "refuses $name without a partial artifact or raw values in logs",
+    ({ event, rawEvent, error }) => {
+      const { result, bytes } = runDispatchWitness(event, rawEvent);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(error);
+      expect(result.stderr + result.stdout).not.toContain("synthetic-private-dispatch-value");
+      expect(bytes).toBe("");
+    },
+  );
 
   it.each([false, true])(
     "writes all matrix evidence with reuse=%s without argv size limits",

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -1,11 +1,23 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
   assertTrustedWorkflowHarness,
+  dispatchInputsDigest,
   FULL_RELEASE_GITHUB_POLL_INTERVAL_MS,
   FULL_RELEASE_WAIT_TIMEOUT_MINUTES,
   parseArgs,
@@ -33,7 +45,8 @@ const CONTRACT_ONE_WORKFLOW_SOURCE = CURRENT_WORKFLOW_SOURCE.replace(
 ).replace(
   `      trusted_workflow_json:
         description: Trusted release tooling identity JSON
-        required: true
+        required: false
+        default: ""
         type: string
 `,
   "",
@@ -59,7 +72,30 @@ function createDispatchFixture(
     createRefFailure?: "target" | "workflow";
     deleteRefFailures?: Array<"target" | "workflow">;
     dispatchFailure?: boolean;
+    acceptedDispatchFailure?: boolean;
     dispatchReturnsRunUrl?: boolean;
+    duplicateRuns?: boolean;
+    duplicateOnSecondPage?: boolean;
+    runIdentityOverrides?: Record<string, unknown>;
+    runPathStyle?: "bare" | "short-ref" | "full-ref";
+    witnessOverrides?: Record<string, unknown>;
+    witnessInputs?: Record<string, unknown>;
+    witnessMissing?: boolean;
+    witnessDuplicate?: boolean;
+    ghRoute?: "path" | "explicit";
+    tokenPresent?: boolean;
+    artifactMetadata?: Record<string, unknown>;
+    exactArtifactMetadata?: Record<string, unknown>;
+    artifactReadError?: "metadata" | "archive";
+    oversizedArtifactMetadata?: boolean;
+    archiveFailure?: "oversized" | "truncated" | "corrupt" | "digest";
+    inventoryError?: string;
+    malformedInventory?: boolean;
+    incompletePagination?: boolean;
+    dispatchHttpStatus?: number;
+    failIntentWrite?: boolean;
+    stopBeforeDispatch?: boolean;
+    reopenDuringDispatch?: boolean;
     parentRunStates?: Array<{
       conclusion: string | null;
       status: string;
@@ -87,6 +123,10 @@ function createDispatchFixture(
   const pathGhCallsPath = join(root, "path-gh-calls.jsonl");
   const parentRunIndexPath = join(root, "parent-run-index.txt");
   const runDiscoveryIndexPath = join(root, "run-discovery-index.txt");
+  const acceptedRunPath = join(root, "accepted-run.json");
+  const artifactFixturePath = join(root, "artifact-fixture.cjs");
+  const fetchCallsPath = join(root, "fetch-calls.txt");
+  const artifactTransportPath = join(root, "artifact-transport.jsonl");
   const preloadPath = join(root, "immediate-poll.mjs");
   const waitCallsPath = join(root, "wait-calls.txt");
   const releaseRef = options.releaseRef ?? "release/2026.8.1";
@@ -95,12 +135,41 @@ function createDispatchFixture(
   writeFileSync(gitCallsPath, "");
   writeFileSync(ghCallsPath, "");
   writeFileSync(pathGhCallsPath, "");
-  writeFileSync(parentRunIndexPath, "0");
+  writeFileSync(parentRunIndexPath, "-2");
   writeFileSync(runDiscoveryIndexPath, "0");
   writeFileSync(waitCallsPath, "");
+  writeFileSync(fetchCallsPath, "");
+  writeFileSync(artifactTransportPath, "");
   writeFileSync(
     preloadPath,
     `import { appendFileSync } from "node:fs";
+import fs from "node:fs";
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+const write = fs.writeFileSync;
+fs.writeFileSync = (path, data, ...args) => {
+  if (${JSON.stringify(options.failIntentWrite ?? false)} && String(data).includes('"phase":"attempted"')) {
+    throw new Error("injected intent write failure");
+  }
+  return write(path, data, ...args);
+};
+const execute = childProcess.execFileSync;
+childProcess.execFileSync = (file, args, options) => {
+  if (${JSON.stringify(options.stopBeforeDispatch ?? false)} && args?.some((arg) => arg.endsWith("/dispatches"))) {
+    process.exit(77);
+  }
+  if (args?.some((arg) => /\\/actions\\/artifacts\\/\\d+(?:\\/zip)?$/.test(arg))) {
+    appendFileSync(${JSON.stringify(artifactTransportPath)}, JSON.stringify({
+      args, encoding: options.encoding, timeout: options.timeout, maxBuffer: options.maxBuffer,
+    }) + "\\n");
+  }
+  return execute(file, args, options);
+};
+syncBuiltinESMExports();
+globalThis.fetch = async () => {
+  appendFileSync(${JSON.stringify(fetchCallsPath)}, "forbidden Node fetch\\n");
+  throw new Error("Node fetch must not bypass the selected GitHub CLI");
+};
 const wait = Atomics.wait;
 const now = Date.now;
 let elapsed = 0;
@@ -160,6 +229,48 @@ console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { run
     on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
   };
   const declaredWorkflowInputs = Object.keys(workflow.on?.workflow_dispatch?.inputs ?? {});
+  writeFileSync(
+    artifactFixturePath,
+    `const fs = require("node:fs");
+const { createHash } = require("node:crypto");
+const JSZip = require(${JSON.stringify(createRequire(import.meta.url).resolve("jszip"))});
+module.exports = async () => {
+  const accepted = JSON.parse(fs.readFileSync(${JSON.stringify(acceptedRunPath)}, "utf8"));
+  const inputs = { ...accepted.inputs, ...${JSON.stringify(options.witnessInputs ?? {})} };
+  const canonicalInputs = JSON.stringify(Object.fromEntries(
+    Object.entries(inputs).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
+      .map(([key, value]) => [key, String(value)]),
+  ));
+  const witness = {
+    kind: "openclaw.full-release-dispatch-inputs/v1",
+    serverUrl: "https://github.com",
+    repository: "openclaw/openclaw",
+    workflowRef: "openclaw/openclaw/.github/workflows/full-release-validation.yml@refs/heads/" + accepted.ref,
+    event: "workflow_dispatch",
+    ref: "refs/heads/" + accepted.ref,
+    sha: process.env.MOCK_WORKFLOW_SHA,
+    runId: "123", runAttempt: "1",
+    inputsDigest: "sha256:" + createHash("sha256").update(canonicalInputs).digest("hex"),
+    ...${JSON.stringify(options.witnessOverrides ?? {})},
+  };
+  const zip = new JSZip();
+  zip.file("dispatch-inputs.json", JSON.stringify(witness) + "\\n", { date: new Date("2026-01-01T00:00:00Z") });
+  const bytes = ${JSON.stringify(options.archiveFailure ?? "")} === "corrupt"
+    ? Buffer.from("not a ZIP archive")
+    : await zip.generateAsync({ type: "nodebuffer", compression: "STORE" });
+  return {
+    bytes,
+    metadata: {
+      id: 9001, name: "full-release-dispatch-inputs-123-1", expired: false,
+      expires_at: "2099-01-01T00:00:00Z", size_in_bytes: bytes.length,
+      digest: "sha256:" + createHash("sha256").update(bytes).digest("hex"),
+      workflow_run: { id: 123, head_sha: process.env.MOCK_WORKFLOW_SHA },
+      ...${JSON.stringify(options.artifactMetadata ?? {})},
+    },
+  };
+};
+`,
+  );
   writeFileSync(join(checkout, "package.json"), '{"version":"2026.8.1"}\n');
   runGit(checkout, ["add", ".github/workflows/full-release-validation.yml", "package.json"]);
   runGit(checkout, ["commit", "-m", "test: trusted workflow contract"]);
@@ -220,9 +331,17 @@ const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.MOCK_GH_CALLS, JSON.stringify(args) + "\\n");
+if (process.argv[1] === ${JSON.stringify(ghPath)}) {
+  fs.appendFileSync(process.env.MOCK_PATH_GH_CALLS, JSON.stringify(args) + "\\n");
+}
+if (args[0] === "auth" && args[1] === "token") {
+  console.error("fixture credentials belong to the selected CLI");
+  process.exit(90);
+}
 const parentRunStates = ${JSON.stringify(options.parentRunStates ?? [{ conclusion: "success", status: "completed" }])};
 const parentRunIndexPath = ${JSON.stringify(parentRunIndexPath)};
 const runDiscoveryIndexPath = ${JSON.stringify(runDiscoveryIndexPath)};
+const acceptedRunPath = ${JSON.stringify(acceptedRunPath)};
 const endpoint = args.find((arg) => arg.startsWith("repos/openclaw/openclaw/")) || "";
 const methodIndex = args.indexOf("--method");
 const method = methodIndex >= 0 ? args[methodIndex + 1] : "GET";
@@ -237,6 +356,22 @@ for (let index = 0; index < args.length; index += 1) {
 const hasNoCache = args.some(
   (arg, index) => ["-H", "--header"].includes(arg) && args[index + 1] === "Cache-Control: max-age=0",
 );
+const runMetadata = (id, state = parentRunStates[0]) => {
+  const accepted = fs.existsSync(acceptedRunPath) ? JSON.parse(fs.readFileSync(acceptedRunPath, "utf8")) : {};
+  return {
+    ...state, id, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: state.attempt ?? 1,
+    workflow_id: 17, head_branch: accepted.ref, event: "workflow_dispatch",
+    path: ".github/workflows/full-release-validation.yml" + (
+      ${JSON.stringify(options.runPathStyle ?? "bare")} === "short-ref" ? "@" + accepted.ref
+      : ${JSON.stringify(options.runPathStyle ?? "bare")} === "full-ref" ? "@refs/heads/" + accepted.ref : ""
+    ),
+    repository: { full_name: "openclaw/openclaw" },
+    head_repository: { full_name: "openclaw/openclaw" },
+    display_title: "Full Release Validation",
+    html_url: "https://github.com/openclaw/openclaw/actions/runs/" + id,
+    ...${JSON.stringify(options.runIdentityOverrides ?? {})},
+  };
+};
 if (args[0] === "api" && method === "GET" && !hasNoCache) {
   console.error("authoritative reads require Cache-Control: max-age=0");
   process.exit(18);
@@ -278,36 +413,116 @@ if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
     stdio: "inherit",
   });
   process.exit(result.status ?? 1);
-} else if (args[0] === "workflow" && args[1] === "run") {
+} else if ((args[0] === "workflow" && args[1] === "run") || (method === "POST" && endpoint.endsWith("/dispatches"))) {
+  const wireInputs = Object.fromEntries(args[0] === "workflow" ? fields : [...fields]
+    .filter(([key]) => key.startsWith("inputs[")).map(([key, value]) => [key.slice(7, -1), value]));
   const declaredInputs = new Set(JSON.parse(process.env.MOCK_WORKFLOW_INPUTS));
-  for (let index = 0; index < args.length; index += 1) {
-    if (args[index] !== "-f") continue;
-    const assignment = args[index + 1] || "";
-    const key = assignment.slice(0, assignment.indexOf("="));
+  for (const key of Object.keys(wireInputs)) {
     if (!declaredInputs.has(key)) {
       console.error("workflow input is not declared: " + key);
       process.exit(2);
     }
-    index += 1;
+  }
+  if (args[0] === "api") {
+    const directory = require("node:path").join(process.cwd(), ".artifacts", "full-release-validation");
+    const requestPath = process.env.MOCK_REQUEST_FILE || require("node:path").join(directory, fs.readdirSync(directory).find((name) => name.endsWith(".json")));
+    const intent = JSON.parse(fs.readFileSync(requestPath, "utf8"));
+    if (intent.phase !== "attempted" || JSON.stringify(intent.request.wireInputs) !== JSON.stringify(wireInputs) ||
+        (fs.statSync(requestPath).mode & 0o777) !== 0o600) {
+      throw new Error("POST must have an exact private retained attempted intent");
+    }
+    if (${JSON.stringify(options.reopenDuringDispatch ?? false)}) {
+      const before = fs.readFileSync(requestPath, "utf8");
+      const second = spawnSync(process.execPath, [${JSON.stringify(SCRIPT_PATH)}, "--request-file", requestPath], {
+        encoding: "utf8", env: process.env,
+      });
+      if (second.status !== 1 || !second.stderr.includes("dispatch=unknown") ||
+          fs.readFileSync(requestPath, "utf8") !== before) {
+        throw new Error("Concurrent request reopen must remain read-only and unresolved before acceptance");
+      }
+    }
+  }
+  if (${JSON.stringify(options.dispatchHttpStatus ?? 204)} !== 204) {
+    console.log("HTTP/2.0 " + ${JSON.stringify(options.dispatchHttpStatus ?? 204)} + " Rejected\\r\\nContent-Type: application/json\\r\\n\\r\\n{}");
+    process.exit(1);
   }
   if (${JSON.stringify(options.dispatchFailure ?? false)}) {
     console.error("configured workflow dispatch failure");
     process.exit(21);
   }
-  if (${JSON.stringify(options.dispatchReturnsRunUrl ?? true)}) {
+  fs.writeFileSync(acceptedRunPath, JSON.stringify({
+    inputs: wireInputs,
+    typedInputs: Object.fromEntries(Object.entries(wireInputs).map(([key, value]) => [
+      key, JSON.parse(process.env.MOCK_WORKFLOW_SCHEMA)[key].type === "boolean" ? value === "true" : value,
+    ])),
+    ref: args[0] === "workflow" ? args[args.indexOf("--ref") + 1] : fields.get("ref"),
+  }));
+  if (${JSON.stringify(options.acceptedDispatchFailure ?? false)}) {
+    console.error("connection reset by peer after server acceptance");
+    process.exit(1);
+  }
+  if (args[0] === "api") {
+    console.log("HTTP/2.0 204 No Content\\r\\nContent-Length: 0\\r\\n\\r\\n");
+  } else if (${JSON.stringify(options.dispatchReturnsRunUrl ?? true)}) {
     console.log("https://github.com/openclaw/openclaw/actions/runs/123");
   }
-} else if (args[0] === "api" && endpoint.endsWith("/actions/workflows/full-release-validation.yml/runs")) {
+} else if (args[0] === "api" && endpoint.endsWith("/actions/workflows/full-release-validation.yml")) {
+  console.log(JSON.stringify({ id: 17, path: ".github/workflows/full-release-validation.yml" }));
+} else if (args[0] === "api" && /\\/actions\\/workflows\\/(?:17|full-release-validation.yml)\\/runs$/.test(endpoint)) {
+  if (${JSON.stringify(options.inventoryError ?? "")}) {
+    console.error(${JSON.stringify(options.inventoryError ?? "")});
+    process.exit(1);
+  }
   const index = Number(fs.readFileSync(runDiscoveryIndexPath, "utf8"));
   fs.writeFileSync(runDiscoveryIndexPath, String(index + 1));
-  console.log(JSON.stringify({ workflow_runs: index < ${JSON.stringify(options.runDiscoveryMisses ?? 0)}
+  const ids = ${JSON.stringify(options.duplicateOnSecondPage ?? false)} ? Array.from({ length: 21 }, (_, i) => 123 + i)
+    : ${JSON.stringify(options.duplicateRuns ?? false)} ? [123, 124] : [123];
+  const runs = index < ${JSON.stringify(options.runDiscoveryMisses ?? 0)} || !fs.existsSync(acceptedRunPath)
     ? []
-    : [{ id: 123, head_sha: process.env.MOCK_WORKFLOW_SHA, created_at: "2026-08-28T00:00:00Z" }] }));
+    : ids.map((id) => runMetadata(id));
+  const page = Number(fields.get("page") || "1");
+  if (args.includes("--include")) {
+    let headers = "HTTP/2.0 200 OK\\r\\nContent-Type: application/json\\r\\n";
+    if (runs.length > page * 20 && !${JSON.stringify(options.incompletePagination ?? false)}) {
+      const query = new URLSearchParams({ page: String(page + 1), branch: fields.get("branch"), event: "workflow_dispatch", per_page: "20" });
+      headers += "Link: <https://api.github.com/repos/openclaw/openclaw/actions/workflows/17/runs?" + query + '>; rel="next"\\r\\n';
+    }
+    process.stdout.write(headers + "\\r\\n");
+  }
+  console.log(${JSON.stringify(options.malformedInventory ?? false)} ? "{" : JSON.stringify({ total_count: runs.length, workflow_runs: runs.slice((page - 1) * 20, page * 20) }));
 } else if (args[0] === "api" && endpoint.endsWith("/actions/runs/123")) {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8"));
-  const state = parentRunStates[Math.min(index, parentRunStates.length - 1)];
+  const state = parentRunStates[Math.max(0, Math.min(index, parentRunStates.length - 1))];
   fs.writeFileSync(parentRunIndexPath, String(index + 1));
-  console.log(JSON.stringify({ ...state, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: state.attempt ?? 1 }));
+  console.log(JSON.stringify(runMetadata(123, state)));
+} else if (args[0] === "api" && /\\/actions\\/artifacts\\/9001(?:\\/zip)?$/.test(endpoint)) {
+  if (method !== "GET" || args[args.indexOf("--hostname") + 1] !== "github.com" || args.includes("--include")) {
+    throw new Error("artifact reads require exact-host GET without response headers");
+  }
+  const archive = endpoint.endsWith("/zip");
+  if (${JSON.stringify(options.artifactReadError ?? "")} === (archive ? "archive" : "metadata")) {
+    console.error("artifact read denied (HTTP 403)");
+    process.exit(1);
+  }
+  require(${JSON.stringify(artifactFixturePath)})().then(({ metadata, bytes }) => {
+    if (!archive) {
+      console.log(${JSON.stringify(options.oversizedArtifactMetadata ?? false)}
+        ? JSON.stringify({ padding: "x".repeat(256 * 1024) })
+        : JSON.stringify({ ...metadata, ...${JSON.stringify(options.exactArtifactMetadata ?? {})} }));
+      return;
+    }
+    const failure = ${JSON.stringify(options.archiveFailure ?? "")};
+    if (failure === "oversized") bytes = Buffer.alloc(256 * 1024 + 1);
+    if (failure === "truncated") bytes = bytes.subarray(0, bytes.length - 1);
+    if (failure === "digest") bytes[0] ^= 1;
+    process.stdout.write(bytes);
+  });
+} else if (args[0] === "api" && endpoint.endsWith("/artifacts") && (fields.get("name") || "").startsWith("full-release-dispatch-inputs-")) {
+  require(${JSON.stringify(artifactFixturePath)})().then(({ metadata }) => {
+    const artifacts = ${JSON.stringify(options.witnessMissing ?? false)} ? []
+      : ${JSON.stringify(options.witnessDuplicate ?? false)} ? [metadata, metadata] : [metadata];
+    console.log(JSON.stringify({ total_count: artifacts.length, artifacts }));
+  });
 } else if (args[0] === "api" && endpoint.endsWith("/artifacts")) {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
   const state = parentRunStates[index];
@@ -346,27 +561,46 @@ if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
 `,
   );
   chmodSync(selectedGhPath, 0o755);
+  if (options.ghRoute === "path") {
+    writeFileSync(ghPath, readFileSync(selectedGhPath));
+  }
 
-  const run = (extraArgs: string[] = []) => {
+  const run = (extraArgs: string[] = [], recoveryOnly = false) => {
     const trustedRefIndex = extraArgs.indexOf("--trusted-workflow-ref");
     const trustedWorkflowRef =
       trustedRefIndex >= 0 ? (extraArgs[trustedRefIndex + 1] ?? "") : "main";
     const trustedWorkflowFullRef =
       trustedWorkflowRef === "main" ? "refs/heads/main" : `refs/tags/${trustedWorkflowRef}`;
+    const githubEnv = { ...process.env };
+    for (const key of Object.keys(githubEnv)) {
+      if (/^(?:GH|GITHUB)_.*TOKEN$/u.test(key) || key === "OPENCLAW_GH_BIN") {
+        delete githubEnv[key];
+      }
+    }
+    if (options.tokenPresent !== false) {
+      githubEnv.GH_TOKEN = "fixture-token";
+    }
+    if (options.ghRoute !== "path") {
+      githubEnv.OPENCLAW_GH_BIN = selectedGhPath;
+    }
     return spawnSync(
       process.execPath,
       [
         SCRIPT_PATH,
-        "--sha",
-        targetSha,
-        ...(options.includeTargetRef === false ? [] : ["--target-ref", releaseRef]),
+        ...(recoveryOnly
+          ? []
+          : [
+              "--sha",
+              targetSha,
+              ...(options.includeTargetRef === false ? [] : ["--target-ref", releaseRef]),
+            ]),
         ...extraArgs,
       ],
       {
         cwd: checkout,
         encoding: "utf8",
         env: {
-          ...process.env,
+          ...githubEnv,
           NODE_OPTIONS: [process.env.NODE_OPTIONS, "--import", preloadPath]
             .filter(Boolean)
             .join(" "),
@@ -379,9 +613,11 @@ if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
           MOCK_TRUSTED_WORKFLOW_REF: trustedWorkflowRef,
           MOCK_WAIT_CALLS: waitCallsPath,
           MOCK_WORKFLOW_INPUTS: JSON.stringify(declaredWorkflowInputs),
+          MOCK_WORKFLOW_SCHEMA: JSON.stringify(workflow.on?.workflow_dispatch?.inputs),
+          MOCK_REQUEST_FILE: extraArgs.includes("--request-file")
+            ? extraArgs[extraArgs.indexOf("--request-file") + 1]
+            : "",
           MOCK_WORKFLOW_SHA: workflowSha,
-          GH_TOKEN: "fixture-token",
-          OPENCLAW_GH_BIN: selectedGhPath,
           PATH: `${binDir}:${process.env.PATH}`,
         },
       },
@@ -398,14 +634,24 @@ if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
 
   return {
     checkout,
+    acceptedRunPath,
+    artifactTransportPath,
     cleanup: () => rmSync(root, { force: true, recursive: true }),
     ghCallsPath,
+    fetchCallsPath,
     gitCallsPath,
     origin,
     oldWorkflowSha,
     pathGhCallsPath,
     readCalls,
     readWaits,
+    requestPath: () => {
+      const directory = join(checkout, ".artifacts", "full-release-validation");
+      return join(
+        directory,
+        readdirSync(directory).find((name) => name.endsWith(".json"))!,
+      );
+    },
     releaseRef,
     run,
     selectedGhPath,
@@ -424,6 +670,13 @@ function ghApiMethod(args: string[]): string {
   return index >= 0 ? (args[index + 1] ?? "") : "GET";
 }
 
+function isWorkflowDispatch(args: string[]) {
+  return (
+    (args[0] === "workflow" && args[1] === "run") ||
+    (ghApiMethod(args) === "POST" && ghApiEndpoint(args).endsWith("/dispatches"))
+  );
+}
+
 function ghField(args: string[], name: string): string {
   const prefix = `${name}=`;
   return (
@@ -433,7 +686,27 @@ function ghField(args: string[], name: string): string {
   );
 }
 
+function dispatchedInputs(args: string[]): Record<string, string> {
+  return Object.fromEntries(
+    args.flatMap((argument, index) => {
+      if (args[index - 1] !== "-f") {
+        return [];
+      }
+      const assignment = /^inputs\[([^\]]+)\]=([\s\S]*)$/u.exec(argument);
+      return assignment ? [[assignment[1], assignment[2]]] : [];
+    }),
+  );
+}
+
 describe("full-release-validation-at-sha", () => {
+  it("normalizes full wire inputs without depending on key order or Boolean event representation", () => {
+    expect(dispatchInputsDigest({ text: "a=b\n$()", count: 3, flag: false, empty: "" })).toBe(
+      dispatchInputsDigest({ empty: "", flag: "false", count: "3", text: "a=b\n$()" }),
+    );
+    expect(dispatchInputsDigest({ flag: true })).not.toBe(dispatchInputsDigest({ flag: false }));
+    expect(dispatchInputsDigest({ flag: "" })).not.toBe(dispatchInputsDigest({}));
+  });
+
   it("parses release validation dispatch args", () => {
     expect(
       parseArgs([
@@ -850,13 +1123,11 @@ describe("full-release-validation-at-sha", () => {
       expect(fixture.readWaits()).toEqual([30_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(
-        calls.filter((args) =>
-          ghApiEndpoint(args).endsWith("/actions/workflows/full-release-validation.yml/runs"),
-        ),
-      ).toHaveLength(2);
+        calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/workflows/17/runs")),
+      ).toHaveLength(3);
       expect(
         calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/runs/123")),
-      ).toHaveLength(2);
+      ).toHaveLength(4);
     } finally {
       fixture.cleanup();
     }
@@ -870,14 +1141,484 @@ describe("full-release-validation-at-sha", () => {
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain("Could not determine Full Release Validation run id.");
+      expect(result.stderr).toContain("Could not determine Full Release Validation run id:");
       expect(fixture.readWaits()).toEqual([30_000, 60_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(
-        calls.filter((args) =>
-          ghApiEndpoint(args).endsWith("/actions/workflows/full-release-validation.yml/runs"),
-        ),
+        calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/workflows/17/runs")),
       ).toHaveLength(4);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("reconciles an accepted dispatch after its response is lost without another POST", () => {
+    const fixture = createDispatchFixture({ acceptedDispatchFailure: true });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(JSON.parse(readFileSync(fixture.acceptedRunPath, "utf8")).inputs.ref).toBe(
+        fixture.targetSha,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(
+        "Parent run: https://github.com/openclaw/openclaw/actions/runs/123",
+      );
+      expect(fixture.readCalls(fixture.ghCallsPath).filter(isWorkflowDispatch)).toHaveLength(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("leaves duplicate exact dispatch runs unresolved instead of adopting the first", () => {
+    const fixture = createDispatchFixture({ duplicateRuns: true, dispatchReturnsRunUrl: false });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stdout).toBe(1);
+      expect(result.stdout).not.toContain("ok release evidence");
+      expect(
+        fixture.readCalls(fixture.ghCallsPath).filter((args) => ghApiMethod(args) === "DELETE"),
+      ).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does not adopt a returned run URL when its workflow event is unrelated", () => {
+    const fixture = createDispatchFixture({ runIdentityOverrides: { event: "push" } });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stdout).toBe(1);
+      expect(result.stdout).not.toContain("ok release evidence");
+      expect(
+        fixture.readCalls(fixture.ghCallsPath).filter((args) => ghApiMethod(args) === "DELETE"),
+      ).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([false, true])(
+    "reopens the same retained request without mutations (explicit=%s)",
+    (explicit) => {
+      const fixture = createDispatchFixture({ acceptedDispatchFailure: true });
+      try {
+        expect(fixture.run(["--workflow-sha", fixture.workflowSha]).status).toBe(0);
+        const path = fixture.requestPath();
+        const before = readFileSync(path, "utf8");
+        const priorGh = fixture.readCalls(fixture.ghCallsPath).length;
+        const priorGit = fixture.readCalls(fixture.gitCallsPath).length;
+        const result = fixture.run(
+          explicit ? ["--reconcile-request", path] : ["--request-file", path],
+          true,
+        );
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain(
+          "dispatch=observed: https://github.com/openclaw/openclaw/actions/runs/123 attempt=1",
+        );
+        expect(readFileSync(path, "utf8")).toBe(before);
+        expect(statSync(path).mode & 0o777).toBe(0o600);
+        expect(fixture.readCalls(fixture.gitCallsPath)).toHaveLength(priorGit);
+        expect(
+          fixture
+            .readCalls(fixture.ghCallsPath)
+            .slice(priorGh)
+            .every((args) => args[0] === "api" && ghApiMethod(args) === "GET"),
+        ).toBe(true);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("refuses conflicting reopen inputs without consulting or mutating GitHub", () => {
+    const fixture = createDispatchFixture();
+    try {
+      expect(fixture.run(["--workflow-sha", fixture.workflowSha]).status).toBe(0);
+      const path = fixture.requestPath();
+      const calls = readFileSync(fixture.ghCallsPath, "utf8");
+      const gitCalls = readFileSync(fixture.gitCallsPath, "utf8");
+      const result = fixture.run(["--request-file", path, "-f", "provider=anthropic"], true);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("conflict with the retained request");
+      expect(readFileSync(fixture.ghCallsPath, "utf8")).toBe(calls);
+      expect(readFileSync(fixture.gitCallsPath, "utf8")).toBe(gitCalls);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each(["missing", "truncated", "oversized", "symlink", "parent symlink", "public"] as const)(
+    "refuses a %s request before any remote or Git access",
+    (kind) => {
+      const fixture = createDispatchFixture();
+      try {
+        let path = join(fixture.checkout, "request.json");
+        if (kind === "truncated") {
+          writeFileSync(path, '{"kind":', { mode: 0o600 });
+        } else if (kind === "oversized") {
+          writeFileSync(path, "x".repeat(129 * 1024), { mode: 0o600 });
+        } else if (kind === "symlink") {
+          symlinkSync(join(fixture.checkout, "missing.json"), path);
+        } else if (kind === "parent symlink") {
+          symlinkSync(fixture.checkout, join(fixture.checkout, "linked"));
+          path = join(fixture.checkout, "linked", "request.json");
+        } else if (kind === "public") {
+          writeFileSync(path, "{}\n", { mode: 0o644 });
+        }
+        const result = fixture.run(["--reconcile-request", path], true);
+        expect(result.status).toBe(1);
+        expect(fixture.readCalls(fixture.ghCallsPath)).toEqual([]);
+        expect(fixture.readCalls(fixture.gitCallsPath)).toEqual([]);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "refuses witness-incapable frozen tooling before remote creation (contract1=%s)",
+    (contractOne) => {
+      const fixture = createDispatchFixture({
+        workflowSource: (contractOne
+          ? CONTRACT_ONE_WORKFLOW_SOURCE
+          : CURRENT_WORKFLOW_SOURCE
+        ).replace('  FULL_RELEASE_DISPATCH_WITNESS_CONTRACT: "1"\n', ""),
+      });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          `Tooling SHA ${fixture.workflowSha} does not support FULL_RELEASE_DISPATCH_WITNESS_CONTRACT=1`,
+        );
+        expect(fixture.readCalls(fixture.ghCallsPath)).toEqual([]);
+        expect(fixture.readCalls(fixture.gitCallsPath).some((args) => args[0] === "push")).toBe(
+          false,
+        );
+        expect(
+          runGit(fixture.origin, [
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/heads/release-ci",
+            "refs/heads/validation",
+          ]),
+        ).toBe("");
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "intent write fails",
+      options: { failIntentWrite: true },
+      status: 1,
+      phase: "prepared",
+    },
+    {
+      name: "process exits before POST",
+      options: { stopBeforeDispatch: true },
+      status: 77,
+      phase: "attempted",
+    },
+  ])("does not redispatch when $name", ({ options, status, phase }) => {
+    const fixture = createDispatchFixture(options);
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(status);
+      const path = fixture.requestPath();
+      expect(JSON.parse(readFileSync(path, "utf8")).phase).toBe(phase);
+      const before = readFileSync(path, "utf8");
+      const recovery = fixture.run(["--reconcile-request", path], true);
+      expect(recovery.status).toBe(1);
+      expect(recovery.stderr).toContain("dispatch=unknown");
+      expect(readFileSync(path, "utf8")).toBe(before);
+      expect(fixture.readCalls(fixture.ghCallsPath).filter(isWorkflowDispatch)).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("allows only the claimed caller to POST when another caller reopens concurrently", () => {
+    const fixture = createDispatchFixture({ reopenDuringDispatch: true });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(fixture.readCalls(fixture.ghCallsPath).filter(isWorkflowDispatch)).toHaveLength(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    { ghRoute: "path" as const, tokenPresent: false },
+    { ghRoute: "path" as const, tokenPresent: true },
+    { ghRoute: "explicit" as const, tokenPresent: true },
+  ])(
+    "reads witness bytes through $ghRoute CLI without Node fetch (token=$tokenPresent)",
+    ({ ghRoute, tokenPresent }) => {
+      const fixture = createDispatchFixture({ ghRoute, tokenPresent });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status, result.stderr).toBe(0);
+        const calls = fixture.readCalls(fixture.ghCallsPath);
+        expect(calls.filter((args) => args[0] === "auth")).toEqual([]);
+        expect(readFileSync(fixture.fetchCallsPath, "utf8")).toBe("");
+        const reads = readFileSync(fixture.artifactTransportPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(reads).toHaveLength(2);
+        expect(reads[0]).toMatchObject({ timeout: 60_000, maxBuffer: 128 * 1024 });
+        expect(reads[1]).toMatchObject({
+          encoding: null,
+          timeout: 60_000,
+          maxBuffer: 256 * 1024,
+        });
+        for (const { args } of reads) {
+          expect(ghApiMethod(args)).toBe("GET");
+          expect(args[args.indexOf("--hostname") + 1]).toBe("github.com");
+          expect(args).toContain("Cache-Control: max-age=0");
+          expect(args).not.toContain("--include");
+        }
+        expect(ghApiEndpoint(reads[0].args)).toBe("repos/openclaw/openclaw/actions/artifacts/9001");
+        expect(ghApiEndpoint(reads[1].args)).toBe(
+          "repos/openclaw/openclaw/actions/artifacts/9001/zip",
+        );
+        expect(fixture.readCalls(fixture.pathGhCallsPath)).toEqual(ghRoute === "path" ? calls : []);
+        expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8")).phase).toBe("observed");
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    { name: "nonpositive ID", artifactMetadata: { id: 0 } },
+    { name: "string ID", artifactMetadata: { id: "9001" } },
+    { name: "unsafe ID", artifactMetadata: { id: Number.MAX_SAFE_INTEGER + 1 } },
+    { name: "zero size", artifactMetadata: { size_in_bytes: 0 } },
+    { name: "string size", artifactMetadata: { size_in_bytes: "100" } },
+    { name: "oversized declaration", artifactMetadata: { size_in_bytes: 256 * 1024 + 1 } },
+    { name: "invalid digest", artifactMetadata: { digest: "sha256:invalid" } },
+    { name: "expired flag", artifactMetadata: { expired: true } },
+    { name: "elapsed expiry", artifactMetadata: { expires_at: "2000-01-01T00:00:00Z" } },
+    { name: "invalid expiry", artifactMetadata: { expires_at: "invalid" } },
+    { name: "changed ID", exactArtifactMetadata: { id: 9002 } },
+    { name: "changed name", exactArtifactMetadata: { name: "other" } },
+    { name: "changed size", exactArtifactMetadata: { size_in_bytes: 1 } },
+    { name: "changed digest", exactArtifactMetadata: { digest: `sha256:${"0".repeat(64)}` } },
+    { name: "changed expiry", exactArtifactMetadata: { expires_at: "2098-01-01T00:00:00Z" } },
+    { name: "newly expired", exactArtifactMetadata: { expired: true } },
+    { name: "changed run", exactArtifactMetadata: { workflow_run: { id: 124 } } },
+    {
+      name: "changed SHA",
+      exactArtifactMetadata: { workflow_run: { id: 123, head_sha: "c".repeat(40) } },
+    },
+    { name: "oversized metadata", oversizedArtifactMetadata: true },
+    { name: "denied metadata", artifactReadError: "metadata" as const },
+    { name: "denied archive", artifactReadError: "archive" as const },
+    { name: "oversized archive", archiveFailure: "oversized" as const },
+    { name: "truncated archive", archiveFailure: "truncated" as const },
+    { name: "corrupt ZIP with matching digest", archiveFailure: "corrupt" as const },
+    { name: "mismatched archive digest", archiveFailure: "digest" as const },
+  ])("refuses witness $name without fallback or remote cleanup", ({ name: _name, ...options }) => {
+    const fixture = createDispatchFixture({
+      ...options,
+      ghRoute: "path",
+      tokenPresent: false,
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stdout).toBe(1);
+      expect(result.stderr).toContain("dispatch=unknown");
+      expect(result.stdout).not.toContain("ok release evidence");
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter(isWorkflowDispatch)).toHaveLength(1);
+      expect(calls.filter((args) => ghApiMethod(args) === "DELETE")).toEqual([]);
+      expect(calls.filter((args) => args[0] === "auth")).toEqual([]);
+      expect(readFileSync(fixture.fetchCallsPath, "utf8")).toBe("");
+      expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8")).phase).toBe("attempted");
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ]).split("\n"),
+      ).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each(["bare", "short-ref", "full-ref"] as const)(
+    "accepts the %s exact workflow path representation",
+    (runPathStyle) => {
+      const fixture = createDispatchFixture({ runPathStyle });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status, result.stderr).toBe(0);
+        expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8"))).toMatchObject({
+          phase: "observed",
+          run: { id: 123, attempt: 1 },
+        });
+        expect(fixture.readCalls(fixture.ghCallsPath).filter(isWorkflowDispatch)).toHaveLength(1);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    { name: "second-page duplicate", options: { duplicateOnSecondPage: true } },
+    {
+      name: "missing next page",
+      options: { duplicateOnSecondPage: true, incompletePagination: true },
+    },
+    { name: "missing witness", options: { witnessMissing: true } },
+    { name: "duplicate witness", options: { witnessDuplicate: true } },
+    { name: "API denial", options: { inventoryError: "HTTP 403: forbidden" } },
+    { name: "API outage", options: { inventoryError: "HTTP 503: unavailable" } },
+    { name: "malformed inventory", options: { malformedInventory: true } },
+    {
+      name: "wrong repository",
+      options: { runIdentityOverrides: { repository: { full_name: "example/other" } } },
+    },
+    { name: "wrong workflow", options: { runIdentityOverrides: { workflow_id: 18 } } },
+    {
+      name: "wrong path",
+      options: { runIdentityOverrides: { path: ".github/workflows/other.yml" } },
+    },
+    {
+      name: "foreign short-ref suffix",
+      options: {
+        runIdentityOverrides: { path: ".github/workflows/full-release-validation.yml@main" },
+      },
+    },
+    {
+      name: "foreign full-ref suffix",
+      options: {
+        runIdentityOverrides: {
+          path: ".github/workflows/full-release-validation.yml@refs/heads/main",
+        },
+      },
+    },
+    {
+      name: "foreign tag suffix",
+      options: {
+        runIdentityOverrides: {
+          path: ".github/workflows/full-release-validation.yml@refs/tags/main",
+        },
+      },
+    },
+    { name: "wrong transport", options: { runIdentityOverrides: { head_branch: "main" } } },
+    { name: "wrong tooling SHA", options: { runIdentityOverrides: { head_sha: "c".repeat(40) } } },
+    { name: "wrong witness attempt", options: { witnessOverrides: { runAttempt: "2" } } },
+  ])("leaves $name unresolved without verification or cleanup", ({ options }) => {
+    const fixture = createDispatchFixture(options);
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stdout).toBe(1);
+      expect(result.stderr).toContain("dispatch=unknown");
+      expect(result.stdout).not.toContain("ok release evidence");
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter(isWorkflowDispatch)).toHaveLength(1);
+      expect(calls.filter((args) => ghApiMethod(args) === "DELETE")).toEqual([]);
+      if (options.duplicateOnSecondPage && !options.incompletePagination) {
+        expect(calls.some((args) => ghField(args, "page") === "2")).toBe(true);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each(Object.keys(parseYaml(CURRENT_WORKFLOW_SOURCE).on.workflow_dispatch.inputs))(
+    "does not adopt a run with a different %s input witness",
+    (key) => {
+      const fixture = createDispatchFixture({ witnessInputs: { [key]: "__different_input__" } });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status, result.stdout).toBe(1);
+        expect(result.stderr).toContain(
+          "Dispatch input witness does not match the complete retained request",
+        );
+        expect(
+          fixture.readCalls(fixture.ghCallsPath).filter((args) => ghApiMethod(args) === "DELETE"),
+        ).toEqual([]);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    ["beta", false],
+    ["stable", true],
+    ["full", true],
+  ] as const)(
+    "retains raw defaults separately from effective %s soak",
+    (profile, effectiveSoak) => {
+      const fixture = createDispatchFixture();
+      try {
+        const result = fixture.run([
+          "--workflow-sha",
+          fixture.workflowSha,
+          "-f",
+          `release_profile=${profile}`,
+        ]);
+        expect(result.status, result.stderr).toBe(0);
+        const record = JSON.parse(readFileSync(fixture.requestPath(), "utf8"));
+        expect(record.request).toMatchObject({
+          effectiveSoak,
+          inputs: {
+            run_release_soak: false,
+            fail_fast: false,
+            reuse_evidence: true,
+            live_suite_filter: "",
+            cross_os_suite_filter: "",
+          },
+          wireInputs: { run_release_soak: "false", fail_fast: "false", reuse_evidence: "true" },
+        });
+        expect(record.run).toEqual({ id: 123, attempt: 1 });
+        expect(record.error).toBe("none");
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each([403, 422])(
+    "retains HTTP %s rejection without adopting or redispatching",
+    (dispatchHttpStatus) => {
+      const fixture = createDispatchFixture({ dispatchHttpStatus });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain("dispatch=rejected");
+        const path = fixture.requestPath();
+        expect(JSON.parse(readFileSync(path, "utf8")).phase).toBe("rejected");
+        const calls = readFileSync(fixture.ghCallsPath, "utf8");
+        const recovery = fixture.run(["--reconcile-request", path], true);
+        expect(recovery.status).toBe(1);
+        expect(recovery.stderr).toContain("dispatch=rejected");
+        expect(readFileSync(fixture.ghCallsPath, "utf8")).toBe(calls);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("does not retain or mutate a request in dry-run mode", () => {
+    const fixture = createDispatchFixture();
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha, "--dry-run"]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("(dry run; not written)");
+      expect(fixture.readCalls(fixture.ghCallsPath)).toEqual([]);
+      expect(fixture.readCalls(fixture.gitCallsPath).some((args) => args[0] === "push")).toBe(
+        false,
+      );
     } finally {
       fixture.cleanup();
     }
@@ -985,7 +1726,7 @@ describe("full-release-validation-at-sha", () => {
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(source).toContain("timeout: GH_READ_TIMEOUT_MS");
-    expect(source).toContain("const dispatchOutput = runGh(dispatchArgs");
+    expect(source).toContain("dispatchOutput = runGh(dispatchArgs");
     expect(source).not.toContain('run("gh"');
   });
 
@@ -1114,7 +1855,7 @@ describe("full-release-validation-at-sha", () => {
       expect(ghCalls.filter((call) => call[0] === "api" && ghApiMethod(call) !== "GET")).toEqual(
         [],
       );
-      expect(ghCalls.filter((call) => call[0] === "workflow")).toEqual([]);
+      expect(ghCalls.filter(isWorkflowDispatch)).toEqual([]);
     } finally {
       fixture.cleanup();
     }
@@ -1135,9 +1876,7 @@ describe("full-release-validation-at-sha", () => {
         "allow_unreleased_changelog=true",
       ]);
       expect(result.status, result.stderr).toBe(0);
-      expect(fixture.readCalls(fixture.ghCallsPath).some((call) => call[0] === "workflow")).toBe(
-        true,
-      );
+      expect(fixture.readCalls(fixture.ghCallsPath).some(isWorkflowDispatch)).toBe(true);
     } finally {
       fixture.cleanup();
     }
@@ -1211,6 +1950,8 @@ describe("full-release-validation-at-sha", () => {
             `ref=refs/heads/${targetBranch}`,
             "-f",
             `sha=${fixture.targetSha}`,
+            "--hostname",
+            "github.com",
           ],
           [
             "api",
@@ -1221,30 +1962,17 @@ describe("full-release-validation-at-sha", () => {
             `ref=refs/heads/${workflowBranch}`,
             "-f",
             `sha=${fixture.workflowSha}`,
+            "--hostname",
+            "github.com",
           ],
         ]);
-        const dispatch = ghCalls.find((args) => args[0] === "workflow" && args[1] === "run");
-        expect(dispatch?.slice(0, 5)).toEqual([
-          "workflow",
-          "run",
-          "full-release-validation.yml",
-          "--ref",
-          workflowBranch,
-        ]);
-        const inputArgs = dispatch?.slice(5) ?? [];
-        expect(inputArgs.length % 2).toBe(0);
-        const dispatchInputs: Record<string, string> = {};
-        for (let index = 0; index < inputArgs.length; index += 2) {
-          expect(inputArgs[index]).toBe("-f");
-          const assignment = inputArgs[index + 1];
-          const separatorIndex = assignment?.indexOf("=") ?? -1;
-          if (!assignment || separatorIndex <= 0) {
-            throw new Error(`invalid workflow input assignment: ${String(assignment)}`);
-          }
-          dispatchInputs[assignment.slice(0, separatorIndex)] = assignment.slice(
-            separatorIndex + 1,
-          );
-        }
+        const dispatch = ghCalls.find(isWorkflowDispatch) ?? [];
+        expect(ghApiMethod(dispatch)).toBe("POST");
+        expect(ghApiEndpoint(dispatch)).toBe(
+          "repos/openclaw/openclaw/actions/workflows/full-release-validation.yml/dispatches",
+        );
+        expect(ghField(dispatch, "ref")).toBe(workflowBranch);
+        const dispatchInputs = dispatchedInputs(dispatch);
         expect(dispatchInputs).toMatchObject({
           ref: fixture.targetSha,
           expected_sha: fixture.targetSha,
@@ -1282,8 +2010,22 @@ describe("full-release-validation-at-sha", () => {
         expect(
           ghCalls.filter((args) => args[0] === "api" && ghApiMethod(args) === "DELETE"),
         ).toEqual([
-          ["api", "--method", "DELETE", `repos/openclaw/openclaw/git/refs/heads/${workflowBranch}`],
-          ["api", "--method", "DELETE", `repos/openclaw/openclaw/git/refs/heads/${targetBranch}`],
+          [
+            "api",
+            "--method",
+            "DELETE",
+            `repos/openclaw/openclaw/git/refs/heads/${workflowBranch}`,
+            "--hostname",
+            "github.com",
+          ],
+          [
+            "api",
+            "--method",
+            "DELETE",
+            `repos/openclaw/openclaw/git/refs/heads/${targetBranch}`,
+            "--hostname",
+            "github.com",
+          ],
         ]);
         expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
           [
@@ -1331,21 +2073,14 @@ describe("full-release-validation-at-sha", () => {
       ]);
       expect(result.status, result.stderr).toBe(0);
       const calls = fixture.readCalls(fixture.ghCallsPath);
-      const dispatch = calls.find((args) => args[0] === "workflow" && args[1] === "run");
-      const transportRef = dispatch?.[4] ?? "";
+      const dispatch = calls.find(isWorkflowDispatch) ?? [];
+      const transportRef = ghField(dispatch, "ref");
       expect(transportRef).toMatch(
         new RegExp(`^release-ci/${fixture.workflowSha.slice(0, 12)}-[0-9]+$`, "u"),
       );
       expect(transportRef).not.toBe(fixture.targetSha);
       expect(transportRef).not.toBe(fixture.workflowSha);
-      const inputs = Object.fromEntries(
-        (dispatch ?? [])
-          .filter((_value, index, args) => args[index - 1] === "-f")
-          .map((assignment) => {
-            const separator = assignment.indexOf("=");
-            return [assignment.slice(0, separator), assignment.slice(separator + 1)];
-          }),
-      );
+      const inputs = dispatchedInputs(dispatch);
       expect(inputs).toMatchObject({
         ref: fixture.targetSha,
         expected_sha: fixture.targetSha,
@@ -1367,53 +2102,39 @@ describe("full-release-validation-at-sha", () => {
   });
 
   it.each([
-    { failure: "target" as const, created: 0, deleted: 0 },
-    { failure: "workflow" as const, created: 1, deleted: 1 },
-  ])(
-    "cleans only refs created before a $failure ref creation failure",
-    ({ failure, created, deleted }) => {
-      const fixture = createDispatchFixture({ createRefFailure: failure });
-      try {
-        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
-        expect(result.status).toBe(1);
-        expect(result.stderr).toContain(`configured ${failure} ref creation failure`);
-        const calls = fixture.readCalls(fixture.ghCallsPath);
-        const createCalls = calls.filter(
-          (args) => args[0] === "api" && ghApiMethod(args) === "POST",
-        );
-        const deleteCalls = calls.filter(
-          (args) => args[0] === "api" && ghApiMethod(args) === "DELETE",
-        );
-        expect(createCalls).toHaveLength(created + 1);
-        expect(deleteCalls).toHaveLength(deleted);
-        if (failure === "workflow") {
-          const targetRef = ghField(createCalls[0] ?? [], "ref");
-          expect(deleteCalls).toEqual([
-            [
-              "api",
-              "--method",
-              "DELETE",
-              `repos/openclaw/openclaw/git/refs/${targetRef.slice("refs/".length)}`,
-            ],
-          ]);
-        }
-        expect(calls.some((args) => args[0] === "workflow" && args[1] === "run")).toBe(false);
-        expect(
-          fixture.readCalls(fixture.gitCallsPath).filter((args) => args[0] === "push"),
-        ).toEqual([]);
-        expect(
-          runGit(fixture.origin, [
-            "for-each-ref",
-            "--format=%(refname)",
-            "refs/heads/release-ci",
-            "refs/heads/validation",
-          ]),
-        ).toBe("");
-      } finally {
-        fixture.cleanup();
-      }
-    },
-  );
+    { failure: "target" as const, created: 0 },
+    { failure: "workflow" as const, created: 1 },
+  ])("retains refs when $failure ref creation has an ambiguous failure", ({ failure, created }) => {
+    const fixture = createDispatchFixture({ createRefFailure: failure });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`configured ${failure} ref creation failure`);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      const createCalls = calls.filter((args) => args[0] === "api" && ghApiMethod(args) === "POST");
+      const deleteCalls = calls.filter(
+        (args) => args[0] === "api" && ghApiMethod(args) === "DELETE",
+      );
+      expect(createCalls).toHaveLength(created + 1);
+      expect(deleteCalls).toHaveLength(0);
+      expect(calls.some(isWorkflowDispatch)).toBe(false);
+      expect(fixture.readCalls(fixture.gitCallsPath).filter((args) => args[0] === "push")).toEqual(
+        [],
+      );
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ])
+          .split("\n")
+          .filter(Boolean),
+      ).toHaveLength(created);
+    } finally {
+      fixture.cleanup();
+    }
+  });
 
   it("uploads a local-only candidate before creating its temporary ref", () => {
     const fixture = createDispatchFixture({
@@ -1453,7 +2174,12 @@ describe("full-release-validation-at-sha", () => {
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain("configured workflow dispatch failure");
+      expect(result.stderr).toContain("dispatch=unknown");
+      expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8"))).toMatchObject({
+        phase: "attempted",
+        error: "unclassified",
+        run: null,
+      });
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(calls.filter((args) => args[0] === "api" && ghApiMethod(args) === "DELETE")).toEqual(
         [],
@@ -1509,10 +2235,10 @@ describe("full-release-validation-at-sha", () => {
       const artifactDownloads = calls
         .map((args, index) => ({ args, index }))
         .filter(({ args }) => args[0] === "run" && args[1] === "download");
-      expect(parentPolls).toHaveLength(4);
+      expect(parentPolls).toHaveLength(6);
       expect(artifactDownloads).toHaveLength(4);
-      expect(artifactDownloads[1]?.index).toBeGreaterThan(parentPolls[1]?.index ?? Infinity);
-      expect(artifactDownloads[1]?.index).toBeLessThan(parentPolls[2]?.index ?? -Infinity);
+      expect(artifactDownloads[1]?.index).toBeGreaterThan(parentPolls[3]?.index ?? Infinity);
+      expect(artifactDownloads[1]?.index).toBeLessThan(parentPolls[4]?.index ?? -Infinity);
       expect(result.stdout).toContain("Parent run status: queued/pending");
       expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
         "refs/heads/main\nrefs/heads/release/2026.8.1",
@@ -1538,7 +2264,7 @@ describe("full-release-validation-at-sha", () => {
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(
         calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/runs/123")),
-      ).toHaveLength(5);
+      ).toHaveLength(7);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(2);
     } finally {
       fixture.cleanup();
@@ -1578,7 +2304,7 @@ describe("full-release-validation-at-sha", () => {
     }
   });
 
-  it("does not redownload a validated decision, and resets readiness for a new attempt", () => {
+  it("does not redownload a validated decision or adopt a newer parent attempt", () => {
     const fixture = createDispatchFixture({
       parentRunStates: [
         { conclusion: null, status: "in_progress", artifactReady: true, decisionState: "passed" },
@@ -1596,16 +2322,20 @@ describe("full-release-validation-at-sha", () => {
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
       expect(result.status, result.stderr).toBe(1);
-      expect(result.stderr).toContain("blocked_diagnostics_running");
-      expect(fixture.readWaits()).toEqual([120_000, 120_000, 120_000, 120_000]);
+      expect(result.stderr).toContain(
+        "does not match the exact retained workflow/ref/event/attempt identity",
+      );
+      expect(fixture.readWaits()).toEqual([120_000, 120_000]);
       const downloads = fixture
         .readCalls(fixture.ghCallsPath)
         .filter((args) => args[0] === "run" && args[1] === "download");
       expect(downloads.map((args) => args[args.indexOf("--name") + 1])).toEqual([
         "full-release-decision-123-1",
-        "full-release-decision-123-2",
-        "full-release-decision-123-2",
       ]);
+      expect(JSON.parse(readFileSync(fixture.requestPath(), "utf8")).run).toEqual({
+        id: 123,
+        attempt: 1,
+      });
     } finally {
       fixture.cleanup();
     }
@@ -1624,7 +2354,7 @@ describe("full-release-validation-at-sha", () => {
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(1);
       expect(calls.filter((args) => ghApiEndpoint(args).endsWith("/jobs"))).toHaveLength(1);
-      expect(calls.filter((args) => ghApiEndpoint(args).endsWith("/artifacts"))).toHaveLength(10);
+      expect(calls.filter((args) => ghApiEndpoint(args).endsWith("/artifacts"))).toHaveLength(11);
       expect(fixture.readWaits()).toEqual(Array(10).fill(120_000));
     } finally {
       fixture.cleanup();
@@ -1764,12 +2494,8 @@ describe("full-release-validation-at-sha", () => {
         "origin",
         `refs/tags/${fixture.trustedWorkflowTag}`,
       ]);
-      const dispatch = fixture
-        .readCalls(fixture.ghCallsPath)
-        .find((args) => args[0] === "workflow" && args[1] === "run");
-      const trustedIdentity = dispatch
-        ?.find((arg) => arg.startsWith("trusted_workflow_json="))
-        ?.slice("trusted_workflow_json=".length);
+      const dispatch = fixture.readCalls(fixture.ghCallsPath).find(isWorkflowDispatch);
+      const trustedIdentity = dispatchedInputs(dispatch ?? []).trusted_workflow_json;
       expect(JSON.parse(trustedIdentity ?? "{}")).toEqual({
         ref: fixture.trustedWorkflowTag,
         fullRef: `refs/tags/${fixture.trustedWorkflowTag}`,
@@ -1790,14 +2516,10 @@ describe("full-release-validation-at-sha", () => {
         fixture.trustedWorkflowTag,
       ]);
       expect(result.status, result.stderr).toBe(0);
-      const dispatch = fixture
-        .readCalls(fixture.ghCallsPath)
-        .find((args) => args[0] === "workflow" && args[1] === "run");
-      const assignments = (dispatch ?? [])
-        .filter((_value, index, values) => values[index - 1] === "-f")
-        .map((value) => value.split("=", 1)[0]);
-      expect(assignments).not.toContain("trusted_workflow_json");
-      expect(dispatch).toContain("reuse_evidence=false");
+      const dispatch = fixture.readCalls(fixture.ghCallsPath).find(isWorkflowDispatch);
+      const inputs = dispatchedInputs(dispatch ?? []);
+      expect(inputs).not.toHaveProperty("trusted_workflow_json");
+      expect(inputs.reuse_evidence).toBe("false");
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/142924

## What Problem This Solves

Fixes an issue where release operators using the exact-SHA helper lose recoverable dispatch intent when GitHub accepts a root validation but the client loses its response. The previous selector could also adopt the first same-SHA candidate or a returned run URL without proving an exact unique request match.

Related: https://github.com/openclaw/openclaw/issues/131726. This bounded repair does not close the broader release-reliability issue.

## Why This Change Was Made

The helper retains a private per-request artifact before remote mutation and issues at most one workflow dispatch POST for that request. Reopening the same artifact is read-only; adoption requires complete bounded inventory, exact workflow/ref/event/run/attempt identity, and a complete input digest witness.

The witness reads the bounded event file directly and uploads only safe GitHub context plus a canonical normalized-wire SHA-256 digest. Typed and wire inputs are retained in the private local request artifact, never uploaded as witness data. The immutable workflow SHA binds their types.

Artifact reads stay on the selected GitHub CLI, including its credential-owning PATH route, with bounded metadata and raw ZIP reads. Exact identity matching accepts GitHub's bare, short-ref-qualified, and full-ref-qualified workflow path forms only when they match the retained request.

Release context: frozen tooling without the witness capability fails before remote creation. This does not upgrade Tooling SHAs, weaken protected identity checks, dispatch release work, change publication authority, or introduce a global request registry. Normal-fix release context is recorded here rather than in the release-owned changelog.

## User Impact

Operators can reopen a retained request with `--reconcile-request` without creating another run, changing refs, or rewriting the request. Missing or ambiguous evidence remains explicitly unknown; a newer attempt cannot silently replace the retained one.

Existing frozen validations retain their status route. New requests need witness-capable tooling selected through the release owner's existing approval process. The helper still requires strict release-evidence verification before successful foreground cleanup.

## Evidence

- Three original-defect regressions failed against unchanged production, then passed: accepted-then-lost response, duplicate exact runs, and a misleading returned run URL.
- Final scoped owner/artifact tests: 176 passed through `node scripts/run-vitest.mjs` after both corrections.
- Three transport regressions failed on the prior implementation, then 28 route/refusal cases passed: tokenless PATH, token-present PATH, explicit binary, immutable artifact metadata, expiry, byte limits, truncated/corrupt ZIP, and digest mismatch.
- Short-ref regression failed before the matcher correction; all three exact path forms and foreign-suffix refusals pass after correction.
- Actual workflow-writer tests cover every input/default, ordering, primitive wire normalization, shell metacharacters, malformed/oversized events, and absence of synthetic private values from artifact/env/stdout.
- Required changed-gate checks completed cumulatively, including scripts and root-test typechecks, lint, formatting, and guards. Workflow validation including zizmor and `git diff --check` passed.
- Fresh final independent autoreview is scoped-clean at P0-P2 after both approved corrections. The signed commit's patch is byte-identical to the reviewed and tested candidate.

Qualification: GitHub acceptance and archive behavior were exercised through the existing local selected-executable fixture and synthetic archive bytes. No live FRV or hosted no-op dispatch was performed. Hosted accepted-then-lost-response recovery remains unproven; these fixtures do not prove hosting or attribute historical hosted failures.

On September 9, 2026, the release owner explicitly accepted controlled first use of reviewed head `566b22349064a7ed7d757275ad796ff670c0a031`, including the hosted-contract uncertainty, witness-capable frozen-tooling transition, and witness-upload admission dependency. This resolves the previously pending landing decision, not the hosted proof gap. Exact-head CI, native landing guards, immutable identity checks, and final privileged-writer checks remain mandatory. This acceptance does not authorize an actual FRV dispatch, hosted release, registry mutation, or package publication.

Deferred pre-existing limitation: supplied input values still enter the root CLI and GitHub CLI process arguments, as on the base revision. This PR protects the retained file and hosted witness; it does not claim complete argv privacy or introduce another payload/CLI contract.
