### PR TITLE
feat(auth): import declared credentials during provider login

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -24,6 +24,26 @@ catalog, API-key auth, and dynamic model resolution.
   details in core.
 </Tip>
 
+## Import an existing credential during sign-in
+
+An auth method can declare `credentialImport` with a `migrationProviderId`,
+an exact `itemId`, and a `credentialKind` (`api_key`, `oauth`, or `token`).
+`models auth login` asks that migration owner for an auth-only plan before
+starting interactive sign-in. `--force` and `--profile-id` skip import.
+
+The migration plugin declares its ID in `contracts.migrationProviders` and can
+export `buildMigrationProvider()` from a top-level `migration-provider-api.ts`
+public artifact. Keep that entry lightweight. Bundled plugins and enabled
+installed plugins can supply it without replacing the running plugin registry.
+
+The login caller selects only the declared auth item. Its details must contain
+the matching `provider` and `credentialKind`; a migrated result also supplies
+the saved `profileId`. The owner must honor cancellation, reread the selected
+source before persistence, and reject a changed credential. Login passes
+`configPatchMode: "none"` so import preserves model defaults and restrictions.
+Unavailable storage continues to interactive sign-in. A failed selected import
+stops the operation instead of silently starting a different login.
+
 ## Walkthrough
 
 <Steps>

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -45,8 +45,9 @@ the matching `provider` and `credentialKind`; a migrated result also supplies
 the saved `profileId`. The owner must honor cancellation, reread the selected
 source before persistence, and reject a changed credential. Login passes
 `configPatchMode: "none"` so import preserves model defaults and restrictions.
-Unavailable storage continues to interactive sign-in. A failed selected import
-stops the operation instead of silently starting a different login.
+Unavailable storage or an unusable matching OAuth profile continues to interactive
+sign-in. A matching account identity alone does not make expired credentials usable.
+A failed selected import stops the operation instead of silently starting a different login.
 
 ## Walkthrough
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -29,12 +29,16 @@ catalog, API-key auth, and dynamic model resolution.
 An auth method can declare `credentialImport` with a `migrationProviderId`,
 an exact `itemId`, and a `credentialKind` (`api_key`, `oauth`, or `token`).
 `models auth login` asks that migration owner for an auth-only plan before
-starting interactive sign-in. `--force` and `--profile-id` skip import.
+starting interactive sign-in. `--force`, `--profile-id`, and `--set-default` skip
+import. `--set-default` uses the auth method's recommended model through the normal
+sign-in flow.
 
 The migration plugin declares its ID in `contracts.migrationProviders` and can
 export `buildMigrationProvider()` from a top-level `migration-provider-api.ts`
 public artifact. Keep that entry lightweight. Bundled plugins and enabled
 installed plugins can supply it without replacing the running plugin registry.
+Explicitly disabled or denied migration owners cannot execute their artifacts.
+The existing bundled migration compatibility rules still apply.
 
 The login caller selects only the declared auth item. Its details must contain
 the matching `provider` and `credentialKind`; a migrated result also supplies

--- a/extensions/codex/migration-provider-api.ts
+++ b/extensions/codex/migration-provider-api.ts
@@ -1,0 +1,2 @@
+// Public migration artifact keeps explicit imports independent of harness startup.
+export { buildCodexMigrationProvider as buildMigrationProvider } from "./src/migration/provider.js";

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -224,7 +224,7 @@ function resolveManagedCodexAppServerCommandCandidates(
   return orderedCommandPaths;
 }
 
-function resolveManagedCodexPackageEntrypoint(pluginRoot: string): string | undefined {
+export function resolveManagedCodexPackageEntrypoint(pluginRoot: string): string | undefined {
   try {
     // Use the pinned package's official launcher on every OS. It owns platform
     // selection, manager environment markers, signal forwarding, and exit status.

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -46,7 +46,7 @@ import {
   releaseLeasedSharedCodexAppServerClient,
 } from "../app-server/shared-client.js";
 import { codexPluginActivationReportState, sanitizeAppsNeedingAuth } from "./apply-report.js";
-import { applyCodexAuthItems, type CodexAuthSource } from "./auth.js";
+import { applyCodexAuthItems, resolveCodexConfigPatchMode, type CodexAuthSource } from "./auth.js";
 import {
   buildCodexMigrationPlan,
   buildCodexPluginsConfigValue,
@@ -60,7 +60,6 @@ import { resolveCodexMigrationTargets } from "./targets.js";
 
 const CODEX_PLUGIN_AUTH_REQUIRED_REASON = "auth_required";
 const CODEX_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
-const CODEX_CONFIG_PATCH_MODE_RETURN = "return";
 const CODEX_PLUGIN_LOAD_WARNING =
   "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.";
 const TARGET_CODEX_MARKETPLACE_DISCOVERY_POLL_MS = 250;
@@ -80,7 +79,7 @@ class CodexPluginConfigConflictError extends Error {
 }
 
 function shouldReturnCodexPluginConfigPatch(ctx: MigrationProviderContext): boolean {
-  return ctx.providerOptions?.configPatchMode === CODEX_CONFIG_PATCH_MODE_RETURN;
+  return resolveCodexConfigPatchMode(ctx) === "return";
 }
 
 export function prepareTargetCodexAppServer(

--- a/extensions/codex/src/migration/auth.ts
+++ b/extensions/codex/src/migration/auth.ts
@@ -1,4 +1,5 @@
 // Codex plugin module implements auth behavior.
+import { createHash } from "node:crypto";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createMigrationItem,
@@ -14,7 +15,6 @@ import {
   buildApiKeyCredential,
   buildOpenAICodexCredentialExtra,
   buildOauthProviderAuthResult,
-  readCodexCliCredentialsCached,
   resolveOpenAICodexAuthIdentity,
   resolveOpenAICodexImportProfileName,
   updateAuthProfileStoreWithLock,
@@ -23,15 +23,19 @@ import {
   type OpenClawConfig,
   type ProviderAuthResult,
 } from "openclaw/plugin-sdk/provider-auth";
+import { decodeOpenAICodexJwtPayload } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import {
   isRecord,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readCodexCliActiveApiKeyAsync, readCodexCliCredentialsAsync } from "./cli-credentials.js";
 import { readJsonObject } from "./helpers.js";
 import type { CodexSource } from "./source.js";
 import type { resolveCodexMigrationTargets } from "./targets.js";
 
 const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_OAUTH_ITEM_ID = "auth:openai";
+const OPENAI_API_KEY_ITEM_ID = "auth:openai:api-key";
 const OPENAI_CODEX_DEFAULT_MODEL = "openai/gpt-5.6-sol";
 const CODEX_IMPORT_DISPLAY_NAME = "Codex import";
 const CODEX_REASON_AUTH_NOT_SELECTED = "auth credential migration not selected";
@@ -39,7 +43,8 @@ const CODEX_REASON_AUTH_PROFILE_EXISTS = "auth profile exists";
 const CODEX_REASON_AUTH_PROFILE_WRITE_FAILED = "failed to write auth profile";
 const CODEX_REASON_AUTH_NO_LONGER_PRESENT = "auth credential no longer present";
 const CODEX_REASON_MISSING_AUTH_METADATA = "missing auth metadata";
-const CODEX_CONFIG_PATCH_MODE_RETURN = "return";
+const CODEX_REASON_AUTH_STORAGE_NOT_IMPORTABLE = "credential storage is not importable";
+type CodexConfigPatchMode = "apply" | "none" | "return";
 
 type CodexMigrationTargets = ReturnType<typeof resolveCodexMigrationTargets>;
 export type CodexAuthSource = Pick<CodexSource, "codexHome" | "authPath" | "modelsCachePath">;
@@ -70,6 +75,25 @@ type CodexAuthConfigApplyResult = "configured" | "conflict" | "unavailable";
 
 class CodexAuthConfigConflict extends Error {}
 
+function authItemId(credential: CodexAuthCredential): string {
+  // Keep the shipped OAuth id while giving the API-key candidate its own selectable identity.
+  return credential.kind === "oauth" ? OPENAI_OAUTH_ITEM_ID : OPENAI_API_KEY_ITEM_ID;
+}
+
+function sourceCredentialFingerprint(credential: CodexAuthCredential): string {
+  const profile =
+    credential.kind === "oauth" ? credential.result.profiles[0]?.credential : undefined;
+  const source =
+    credential.kind === "api_key"
+      ? credential.key
+      : profile?.type === "oauth"
+        ? [profile.access, profile.refresh, profile.accountId, profile.idToken]
+        : undefined;
+  return createHash("sha256")
+    .update(JSON.stringify([credential.kind, source]))
+    .digest("hex");
+}
+
 async function readModelRefs(source: CodexAuthSource): Promise<string[]> {
   const cache = await readJsonObject(source.modelsCachePath);
   const models = Array.isArray(cache.models) ? cache.models : [];
@@ -92,11 +116,13 @@ async function readModelRefs(source: CodexAuthSource): Promise<string[]> {
 
 async function buildCodexOAuthCredential(
   source: CodexAuthSource,
+  includeConfigPatch: boolean,
+  options: { allowKeychainPrompt: boolean; signal?: AbortSignal },
 ): Promise<CodexAuthCredential | null> {
-  const credential = readCodexCliCredentialsCached({
+  const credential = await readCodexCliCredentialsAsync({
     codexHome: source.codexHome,
-    allowKeychainPrompt: false,
-    ttlMs: 0,
+    allowKeychainPrompt: options.allowKeychainPrompt,
+    ...(options.signal ? { signal: options.signal } : {}),
   });
   if (!credential) {
     return null;
@@ -105,14 +131,17 @@ async function buildCodexOAuthCredential(
     access: credential.access,
     accountId: credential.accountId,
   });
-  const modelRefs = await readModelRefs(source);
-  const configPatch = {
-    agents: {
-      defaults: {
-        models: Object.fromEntries(modelRefs.map((modelRef) => [modelRef, {}])),
-      },
-    },
-  } satisfies Partial<OpenClawConfig>;
+  const configPatch = includeConfigPatch
+    ? {
+        agents: {
+          defaults: {
+            models: Object.fromEntries(
+              (await readModelRefs(source)).map((modelRef) => [modelRef, {}]),
+            ),
+          },
+        },
+      }
+    : {};
   const result = buildOauthProviderAuthResult({
     providerId: OPENAI_PROVIDER_ID,
     defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
@@ -142,23 +171,45 @@ async function buildCodexOAuthCredential(
 
 async function buildCodexApiKeyCredential(
   source: CodexAuthSource,
+  allowKeychainPrompt: boolean,
+  signal?: AbortSignal,
 ): Promise<CodexAuthCredential | null> {
-  const raw = await readJsonObject(source.authPath);
-  const key = readString(raw.OPENAI_API_KEY);
-  if (!key) {
+  const credential = await readCodexCliActiveApiKeyAsync({
+    codexHome: source.codexHome,
+    allowKeychainPrompt,
+    ...(signal ? { signal } : {}),
+  });
+  if (!credential) {
     return null;
   }
   return {
     kind: "api_key",
     provider: OPENAI_PROVIDER_ID,
     profileId: "openai:codex-import",
-    key,
+    key: credential.key,
   };
 }
 
-async function readCodexAuthCredentials(source: CodexAuthSource): Promise<CodexAuthCredential[]> {
-  const oauth = await buildCodexOAuthCredential(source);
-  const apiKey = await buildCodexApiKeyCredential(source);
+async function readCodexAuthCredentials(
+  source: CodexAuthSource,
+  options: {
+    credentialKind?: CodexAuthCredential["kind"];
+    includeConfigPatch: boolean;
+    allowKeychainPrompt: boolean;
+    signal?: AbortSignal;
+  },
+): Promise<CodexAuthCredential[]> {
+  const oauth =
+    options.credentialKind === "api_key"
+      ? null
+      : await buildCodexOAuthCredential(source, options.includeConfigPatch, {
+          allowKeychainPrompt: options.allowKeychainPrompt,
+          ...(options.signal ? { signal: options.signal } : {}),
+        });
+  const apiKey =
+    options.credentialKind === "oauth"
+      ? null
+      : await buildCodexApiKeyCredential(source, options.allowKeychainPrompt, options.signal);
   return [oauth, apiKey].filter((entry): entry is CodexAuthCredential => entry !== null);
 }
 
@@ -166,19 +217,30 @@ function findMatchingOAuthProfile(
   store: AuthProfileStore,
   credential: OAuthCredential,
 ): string | undefined {
+  const subject = oauthSubject(credential);
+  if (!subject) {
+    return undefined;
+  }
   for (const [profileId, existing] of Object.entries(store.profiles)) {
     if (existing.type !== "oauth" || existing.provider !== credential.provider) {
       continue;
     }
-    if (credential.accountId && existing.accountId === credential.accountId) {
-      return profileId;
-    }
-    const canMatchByEmail = !credential.accountId || !existing.accountId;
-    if (canMatchByEmail && credential.email && existing.email === credential.email) {
+    const previous = oauthSubject(existing);
+    if (previous?.accountId === subject.accountId && previous.userId === subject.userId) {
       return profileId;
     }
   }
   return undefined;
+}
+
+function oauthSubject(credential: OAuthCredential) {
+  const claims = decodeOpenAICodexJwtPayload(credential.access)?.["https://api.openai.com/auth"];
+  if (!isRecord(claims)) {
+    return undefined;
+  }
+  const accountId = readString(claims.chatgpt_account_id);
+  const userId = readString(claims.chatgpt_user_id) ?? readString(claims.user_id);
+  return accountId && userId ? { accountId, userId } : undefined;
 }
 
 function findMatchingApiKeyProfile(
@@ -320,8 +382,20 @@ function applyApiKeyConfigToConfig(
   });
 }
 
-function shouldReturnAuthConfigPatch(ctx: MigrationProviderContext): boolean {
-  return ctx.providerOptions?.configPatchMode === CODEX_CONFIG_PATCH_MODE_RETURN;
+export function resolveCodexConfigPatchMode(ctx: MigrationProviderContext): CodexConfigPatchMode {
+  const mode = ctx.providerOptions?.configPatchMode;
+  return mode === "none" || mode === "return" ? mode : "apply";
+}
+
+function allowCodexKeychainPrompt(ctx: MigrationProviderContext): boolean {
+  return ctx.providerOptions?.allowKeychainPrompt === true;
+}
+
+function resolveRequestedCredentialKind(
+  ctx: MigrationProviderContext,
+): CodexAuthCredential["kind"] | undefined {
+  const kind = ctx.providerOptions?.credentialKind;
+  return kind === "oauth" || kind === "api_key" ? kind : undefined;
 }
 
 function authProfileConfigForCredential(
@@ -406,9 +480,37 @@ export async function buildCodexAuthItems(params: {
   source: CodexAuthSource;
   targets: CodexMigrationTargets;
 }): Promise<MigrationItem[]> {
-  const credentials = await readCodexAuthCredentials(params.source);
+  const configPatchMode = resolveCodexConfigPatchMode(params.ctx);
+  const credentials = await readCodexAuthCredentials(params.source, {
+    credentialKind: resolveRequestedCredentialKind(params.ctx),
+    includeConfigPatch: configPatchMode !== "none",
+    allowKeychainPrompt: allowCodexKeychainPrompt(params.ctx),
+    signal: params.ctx.signal,
+  });
   if (credentials.length === 0) {
-    return [];
+    const requestedKind = resolveRequestedCredentialKind(params.ctx);
+    if (!requestedKind) {
+      return [];
+    }
+    const credentialKind = requestedKind;
+    return [
+      createMigrationItem({
+        id: credentialKind === "oauth" ? OPENAI_OAUTH_ITEM_ID : OPENAI_API_KEY_ITEM_ID,
+        kind: "auth",
+        action: "skip",
+        source: params.source.codexHome,
+        status: "skipped",
+        sensitive: true,
+        reason: CODEX_REASON_AUTH_STORAGE_NOT_IMPORTABLE,
+        message:
+          "No supported Codex credential could be imported. Continue with sign-in to connect OpenClaw.",
+        details: {
+          provider: OPENAI_PROVIDER_ID,
+          credentialKind,
+          credentialImportUnavailable: true,
+        },
+      }),
+    ];
   }
   const store = loadAuthProfileStoreWithoutExternalProfiles(params.targets.agentDir);
   const skipped = !params.ctx.includeSecrets;
@@ -426,10 +528,10 @@ export async function buildCodexAuthItems(params: {
     const conflict =
       ((targetExists && !matchedExisting && !params.ctx.overwrite) || configConflict) && !skipped;
     return createMigrationItem({
-      id: `auth:${credential.provider}`,
+      id: authItemId(credential),
       kind: "auth",
       action: skipped ? "skip" : "create",
-      source: params.source.authPath,
+      source: params.source.codexHome,
       // Credentials land in the agent's SQLite auth profile store; naming the
       // retired JSON file here promised operators a file that is never created.
       target: `${params.targets.agentDir}/openclaw-agent.sqlite#auth_profile_store:${profileId}`,
@@ -442,13 +544,16 @@ export async function buildCodexAuthItems(params: {
           : undefined,
       message:
         credential.kind === "oauth"
-          ? "Import Codex OAuth credentials and configure OpenAI Codex models."
+          ? configPatchMode === "none"
+            ? "Import Codex OAuth credentials."
+            : "Import Codex OAuth credentials and configure OpenAI Codex models."
           : "Import Codex OpenAI API key.",
       details: {
         provider: credential.provider,
         profileId,
         sourceProfileId: credential.profileId,
-        sourceKind: "codex-auth-json",
+        sourceCredentialFingerprint: sourceCredentialFingerprint(credential),
+        sourceKind: "codex-native-selected-storage",
         credentialKind: credential.kind,
       },
     });
@@ -469,18 +574,33 @@ export async function applyCodexAuthItems(params: {
   const provider = typeof item.details?.provider === "string" ? item.details.provider : "";
   const sourceProfileId =
     typeof item.details?.sourceProfileId === "string" ? item.details.sourceProfileId : undefined;
-  if (!profileId || !provider) {
+  const credentialKind = item.details?.credentialKind;
+  if (!profileId || !provider || (credentialKind !== "oauth" && credentialKind !== "api_key")) {
     return [markMigrationItemError(item, CODEX_REASON_MISSING_AUTH_METADATA)];
   }
-  const credential = (await readCodexAuthCredentials(source)).find(
-    (candidate) => candidate.provider === provider,
+  const configPatchMode = resolveCodexConfigPatchMode(ctx);
+  // Re-read before persistence to fence a changed CLI login. macOS may ask twice,
+  // but importing stale credential bytes would violate the migration contract.
+  const credential = (
+    await readCodexAuthCredentials(source, {
+      credentialKind,
+      includeConfigPatch: configPatchMode !== "none",
+      allowKeychainPrompt: allowCodexKeychainPrompt(ctx),
+      signal: ctx.signal,
+    })
+  ).find(
+    (candidate) =>
+      candidate.provider === provider &&
+      candidate.kind === credentialKind &&
+      (!sourceProfileId || candidate.profileId === sourceProfileId),
   );
   if (!credential) {
     return [markMigrationItemSkipped(item, CODEX_REASON_AUTH_NO_LONGER_PRESENT)];
   }
-  if (credential.kind === "oauth" && sourceProfileId && credential.profileId !== sourceProfileId) {
+  if (item.details?.sourceCredentialFingerprint !== sourceCredentialFingerprint(credential)) {
     return [markMigrationItemSkipped(item, CODEX_REASON_AUTH_NO_LONGER_PRESENT)];
   }
+  ctx.signal?.throwIfAborted();
   const oauthProfile = credential.kind === "oauth" ? credential.result.profiles[0] : undefined;
   const oauthCredential =
     oauthProfile?.credential.type === "oauth" ? oauthProfile.credential : undefined;
@@ -500,6 +620,7 @@ export async function applyCodexAuthItems(params: {
     agentDir: targets.agentDir,
     stateDir: ctx.stateDir,
     updater: (freshStore) => {
+      ctx.signal?.throwIfAborted();
       const existing = freshStore.profiles[profileId];
       if (!ctx.overwrite && existing) {
         const matchedProfileId =
@@ -532,9 +653,10 @@ export async function applyCodexAuthItems(params: {
   if (!store?.profiles[profileId]) {
     return [markMigrationItemError(item, CODEX_REASON_AUTH_PROFILE_WRITE_FAILED)];
   }
-  const configResult = shouldReturnAuthConfigPatch(ctx)
-    ? "unavailable"
-    : await applyCodexAuthConfig(ctx, credential, profileId);
+  const configResult =
+    configPatchMode !== "apply"
+      ? "unavailable"
+      : await applyCodexAuthConfig(ctx, credential, profileId);
   if (configResult === "conflict") {
     return [markMigrationItemConflict(item, CODEX_REASON_AUTH_PROFILE_EXISTS)];
   }
@@ -545,12 +667,12 @@ export async function applyCodexAuthItems(params: {
       ...item.details,
       wroteAuthProfile: wrote,
       configUpdated: configResult === "configured",
-      ...(shouldReturnAuthConfigPatch(ctx) ? { configPatchReturned: true } : {}),
+      ...(configPatchMode === "return" ? { configPatchReturned: true } : {}),
     },
   };
   return [
     migratedItem,
-    ...(shouldReturnAuthConfigPatch(ctx)
+    ...(configPatchMode === "return"
       ? buildCodexAuthConfigPatchItems(ctx, migratedItem, credential, profileId)
       : []),
   ];

--- a/extensions/codex/src/migration/auth.ts
+++ b/extensions/codex/src/migration/auth.ts
@@ -15,6 +15,7 @@ import {
   buildApiKeyCredential,
   buildOpenAICodexCredentialExtra,
   buildOauthProviderAuthResult,
+  hasUsableOAuthCredential,
   resolveOpenAICodexAuthIdentity,
   resolveOpenAICodexImportProfileName,
   updateAuthProfileStoreWithLock,
@@ -40,6 +41,7 @@ const OPENAI_CODEX_DEFAULT_MODEL = "openai/gpt-5.6-sol";
 const CODEX_IMPORT_DISPLAY_NAME = "Codex import";
 const CODEX_REASON_AUTH_NOT_SELECTED = "auth credential migration not selected";
 const CODEX_REASON_AUTH_PROFILE_EXISTS = "auth profile exists";
+const CODEX_REASON_AUTH_PROFILE_UNUSABLE = "existing OAuth profile requires sign-in";
 const CODEX_REASON_AUTH_PROFILE_WRITE_FAILED = "failed to write auth profile";
 const CODEX_REASON_AUTH_NO_LONGER_PRESENT = "auth credential no longer present";
 const CODEX_REASON_MISSING_AUTH_METADATA = "missing auth metadata";
@@ -516,7 +518,7 @@ export async function buildCodexAuthItems(params: {
   const skipped = !params.ctx.includeSecrets;
   return credentials.map((credential) => {
     const { profileId, matchedExisting } = itemProfileTarget(credential, store);
-    const targetExists = Boolean(store.profiles[profileId]);
+    const existing = store.profiles[profileId];
     const configProfile = authProfileConfigForCredential(credential, profileId);
     const configConflict = configProfile
       ? hasAuthProfileConfigConflict(
@@ -526,24 +528,33 @@ export async function buildCodexAuthItems(params: {
         )
       : false;
     const conflict =
-      ((targetExists && !matchedExisting && !params.ctx.overwrite) || configConflict) && !skipped;
+      ((existing && !matchedExisting && !params.ctx.overwrite) || configConflict) && !skipped;
+    const unavailable =
+      !skipped &&
+      !conflict &&
+      !params.ctx.overwrite &&
+      existing?.type === "oauth" &&
+      !hasUsableOAuthCredential(existing);
     return createMigrationItem({
       id: authItemId(credential),
       kind: "auth",
-      action: skipped ? "skip" : "create",
+      action: skipped || unavailable ? "skip" : "create",
       source: params.source.codexHome,
       // Credentials land in the agent's SQLite auth profile store; naming the
       // retired JSON file here promised operators a file that is never created.
       target: `${params.targets.agentDir}/openclaw-agent.sqlite#auth_profile_store:${profileId}`,
-      status: skipped ? "skipped" : conflict ? "conflict" : "planned",
+      status: skipped || unavailable ? "skipped" : conflict ? "conflict" : "planned",
       sensitive: true,
       reason: skipped
         ? CODEX_REASON_AUTH_NOT_SELECTED
         : conflict
           ? CODEX_REASON_AUTH_PROFILE_EXISTS
-          : undefined,
-      message:
-        credential.kind === "oauth"
+          : unavailable
+            ? CODEX_REASON_AUTH_PROFILE_UNUSABLE
+            : undefined,
+      message: unavailable
+        ? "The existing OpenAI sign-in needs to be renewed. Continue with sign-in."
+        : credential.kind === "oauth"
           ? configPatchMode === "none"
             ? "Import Codex OAuth credentials."
             : "Import Codex OAuth credentials and configure OpenAI Codex models."
@@ -555,6 +566,7 @@ export async function buildCodexAuthItems(params: {
         sourceCredentialFingerprint: sourceCredentialFingerprint(credential),
         sourceKind: "codex-native-selected-storage",
         credentialKind: credential.kind,
+        credentialImportUnavailable: unavailable,
       },
     });
   });
@@ -615,6 +627,7 @@ export async function applyCodexAuthItems(params: {
     return [markMigrationItemConflict(item, CODEX_REASON_AUTH_PROFILE_EXISTS)];
   }
   let conflicted = false;
+  let unusable = false;
   let wrote = false;
   const store = await updateAuthProfileStoreWithLock({
     agentDir: targets.agentDir,
@@ -628,6 +641,8 @@ export async function applyCodexAuthItems(params: {
             ? findMatchingOAuthProfile(freshStore, oauthCredential!)
             : findMatchingApiKeyProfile(freshStore, credential.provider, credential.key);
         if (matchedProfileId === profileId) {
+          // A matching account cannot turn an expired or fenced profile into a successful login.
+          unusable = existing.type === "oauth" && !hasUsableOAuthCredential(existing);
           return false;
         }
         conflicted = true;
@@ -649,6 +664,9 @@ export async function applyCodexAuthItems(params: {
   });
   if (conflicted) {
     return [markMigrationItemConflict(item, CODEX_REASON_AUTH_PROFILE_EXISTS)];
+  }
+  if (unusable) {
+    return [markMigrationItemSkipped(item, CODEX_REASON_AUTH_PROFILE_UNUSABLE)];
   }
   if (!store?.profiles[profileId]) {
     return [markMigrationItemError(item, CODEX_REASON_AUTH_PROFILE_WRITE_FAILED)];

--- a/extensions/codex/src/migration/cli-credentials.ts
+++ b/extensions/codex/src/migration/cli-credentials.ts
@@ -1,0 +1,249 @@
+/** Explicit migration reads the storage selected by the native credential owner. */
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
+import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexAppServerClient } from "../app-server/client.js";
+import type { CodexExperimentalFeatureListResponse } from "../app-server/protocol-control-plane.js";
+import type {
+  CodexConfigReadResponse,
+  CodexConfigRequirementsReadResponse,
+  CodexGetAccountResponse,
+} from "../app-server/protocol.js";
+
+export type CodexCliCredential = {
+  type: "oauth";
+  provider: "openai";
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  idToken?: string;
+};
+
+export type CodexCliApiKeyCredential = { type: "api_key"; provider: "openai"; key: string };
+export type CodexCredentialReadOptions = {
+  codexHome: string;
+  allowKeychainPrompt: boolean;
+  signal?: AbortSignal;
+};
+
+async function readAuthFile(home: string): Promise<Record<string, unknown> | undefined> {
+  try {
+    return asOptionalRecord(
+      JSON.parse(await readSecretFile(path.join(home, "auth.json"), "Codex auth")),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function readDirectKeyring(
+  home: string,
+  signal: AbortSignal,
+): Promise<Record<string, unknown> | undefined> {
+  const account = `cli|${createHash("sha256").update(home).digest("hex").slice(0, 16)}`;
+  const result = await runCommandBuffered(
+    ["security", "find-generic-password", "-s", "Codex Auth", "-a", account, "-w"],
+    { timeoutMs: 60_000, maxCombinedOutputBytes: 16 * 1024, signal },
+  );
+  if (result.termination !== "exit" || result.code !== 0) {
+    return undefined;
+  }
+  try {
+    return asOptionalRecord(JSON.parse(result.stdout.toString("utf8")));
+  } catch {
+    return undefined;
+  }
+}
+
+async function readSelectedCredentialStorage(
+  options: CodexCredentialReadOptions,
+  requireApiKey: boolean,
+): Promise<Record<string, unknown> | undefined> {
+  options.signal?.throwIfAborted();
+  const home = await fs.realpath(options.codexHome).catch(() => path.resolve(options.codexHome));
+  const { CodexAppServerClient } = await import("../app-server/client.js");
+  const { resolveManagedCodexPackageEntrypoint, resolveManagedCodexNativeCommand } =
+    await import("../app-server/managed-binary.js");
+  const launcher = resolveManagedCodexPackageEntrypoint(
+    path.dirname(fileURLToPath(import.meta.url)),
+  );
+  const command = launcher ? resolveManagedCodexNativeCommand(launcher) : undefined;
+  if (!command) {
+    return undefined;
+  }
+  const signal = AbortSignal.any([
+    AbortSignal.timeout(
+      options.allowKeychainPrompt && process.platform === "darwin" ? 60_000 : 5_000,
+    ),
+    ...(options.signal ? [options.signal] : []),
+  ]);
+  const client = await CodexAppServerClient.start(
+    {
+      transport: "stdio",
+      command,
+      commandSource: "resolved-managed",
+      args: ["app-server"],
+      cwd: home,
+      homeScope: "user",
+      env: { CODEX_HOME: home },
+      clearEnv: ["OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"],
+    },
+    () => signal.throwIfAborted(),
+  ).catch(() => {
+    options.signal?.throwIfAborted();
+    return undefined;
+  });
+  if (!client) {
+    return undefined;
+  }
+  const abort = () => client.close();
+  signal.addEventListener("abort", abort, { once: true });
+  let credential: Record<string, unknown> | undefined;
+  try {
+    credential = await readNativeCredential(client, home, requireApiKey, options, signal);
+  } catch {
+    // Unsupported or unavailable native storage leaves interactive sign-in available.
+  }
+  signal.removeEventListener("abort", abort);
+  const closed = await client.closeAndWait({ forceKillDelayMs: 200, exitTimeoutMs: 300 });
+  if (!closed.exited || closed.cleanup !== "closed") {
+    throw new Error("The Codex credential reader could not stop. No credential was imported.", {
+      cause: options.signal?.reason,
+    });
+  }
+  options.signal?.throwIfAborted();
+  return credential;
+}
+
+async function readNativeCredential(
+  client: CodexAppServerClient,
+  home: string,
+  requireApiKey: boolean,
+  options: CodexCredentialReadOptions,
+  signal: AbortSignal,
+): Promise<Record<string, unknown> | undefined> {
+  signal.throwIfAborted();
+  await client.initialize();
+  if (client.getRuntimeIdentity()?.codexHome !== home) {
+    return undefined;
+  }
+  const revision = client.getModelCatalogRevision();
+  if (requireApiKey) {
+    const account = await client.request<CodexGetAccountResponse>(
+      "account/read",
+      { refreshToken: false },
+      { signal },
+    );
+    if (account.account?.type !== "apiKey" || account.requiresOpenaiAuth !== true) {
+      return undefined;
+    }
+  }
+  const configured = await client.request<CodexConfigReadResponse>(
+    "config/read",
+    { includeLayers: false, cwd: home },
+    { signal },
+  );
+  const required = await client.request<CodexConfigRequirementsReadResponse>(
+    "configRequirements/read",
+    {},
+    { signal },
+  );
+  // The native requirements override configuration; File is the pinned dependency's default.
+  const mode =
+    required.requirements?.cli_auth_credentials_store ??
+    configured.config.cli_auth_credentials_store ??
+    "file";
+  let record: Record<string, unknown> | undefined;
+  if (mode === "file") {
+    record = await readAuthFile(home);
+  } else if (
+    (mode === "keyring" || mode === "auto") &&
+    process.platform === "darwin" &&
+    options.allowKeychainPrompt
+  ) {
+    let cursor: string | undefined;
+    let encrypted: boolean | undefined;
+    do {
+      const features = await client.request<CodexExperimentalFeatureListResponse>(
+        "experimentalFeature/list",
+        { limit: 100, cursor },
+        { signal },
+      );
+      const storage = features.data.find((feature) => feature.name === "secret_auth_storage");
+      if (storage) {
+        encrypted = storage.enabled;
+        break;
+      }
+      cursor = features.nextCursor ?? undefined;
+    } while (cursor);
+    if (encrypted !== false) {
+      return undefined;
+    }
+    record = await readDirectKeyring(home, signal);
+  }
+  signal.throwIfAborted();
+  return !client.getCloseError() && client.getModelCatalogRevision() === revision
+    ? record
+    : undefined;
+}
+
+function jwtExpiry(token: string): number | undefined {
+  try {
+    const data = asOptionalRecord(
+      JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8")),
+    );
+    const exp = data?.exp;
+    return typeof exp === "number" && Number.isFinite(exp) && exp > 0 ? exp * 1000 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readCodexCliCredentialsAsync(
+  options: CodexCredentialReadOptions,
+): Promise<CodexCliCredential | undefined> {
+  const data = await readSelectedCredentialStorage(options, false);
+  const mode = typeof data?.auth_mode === "string" ? data.auth_mode.toLowerCase() : undefined;
+  if (!data || (mode !== undefined && mode !== "chatgpt" && mode !== "chatgptauthtokens")) {
+    return undefined;
+  }
+  const tokens = asOptionalRecord(data.tokens);
+  if (
+    typeof tokens?.access_token !== "string" ||
+    !tokens.access_token ||
+    typeof tokens.refresh_token !== "string" ||
+    !tokens.refresh_token
+  ) {
+    return undefined;
+  }
+  const lastRefresh =
+    typeof data.last_refresh === "string" ? Date.parse(data.last_refresh) : Number.NaN;
+  return {
+    type: "oauth",
+    provider: "openai",
+    access: tokens.access_token,
+    refresh: tokens.refresh_token,
+    expires:
+      jwtExpiry(tokens.access_token) ??
+      (Number.isFinite(lastRefresh) ? lastRefresh : Date.now()) + 60 * 60 * 1000,
+    ...(typeof tokens.account_id === "string" ? { accountId: tokens.account_id } : {}),
+    ...(typeof tokens.id_token === "string" ? { idToken: tokens.id_token } : {}),
+  };
+}
+
+export async function readCodexCliActiveApiKeyAsync(
+  options: CodexCredentialReadOptions,
+): Promise<CodexCliApiKeyCredential | undefined> {
+  const data = await readSelectedCredentialStorage(options, true);
+  const mode = typeof data?.auth_mode === "string" ? data.auth_mode.toLowerCase() : undefined;
+  if (!data || (mode !== undefined && mode !== "apikey" && mode !== "api_key")) {
+    return undefined;
+  }
+  const key = typeof data.OPENAI_API_KEY === "string" ? data.OPENAI_API_KEY.trim() : "";
+  return key ? { type: "api_key", provider: "openai", key } : undefined;
+}

--- a/extensions/codex/src/migration/cli-credentials.ts
+++ b/extensions/codex/src/migration/cli-credentials.ts
@@ -139,7 +139,10 @@ async function readNativeCredential(
       { refreshToken: false },
       { signal },
     );
-    if (account.account?.type !== "apiKey" || account.requiresOpenaiAuth !== true) {
+    if (
+      asOptionalRecord(account.account)?.type !== "apiKey" ||
+      account.requiresOpenaiAuth !== true
+    ) {
       return undefined;
     }
   }

--- a/extensions/codex/src/migration/cli-credentials.ts
+++ b/extensions/codex/src/migration/cli-credentials.ts
@@ -110,7 +110,8 @@ async function readSelectedCredentialStorage(
     // Unsupported or unavailable native storage leaves interactive sign-in available.
   }
   signal.removeEventListener("abort", abort);
-  const closed = await client.closeAndWait({ forceKillDelayMs: 200, exitTimeoutMs: 300 });
+  // 2026-09-09: the pinned native reader took five seconds to exit after replying.
+  const closed = await client.closeAndWait({ forceKillDelayMs: 6_000, exitTimeoutMs: 7_000 });
   if (!closed.exited || closed.cleanup !== "closed") {
     throw new Error("The Codex credential reader could not stop. No credential was imported.", {
       cause: options.signal?.reason,

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -535,27 +535,36 @@ export async function buildCodexMigrationPlan(
     ctx.itemKinds !== undefined &&
     ctx.itemKinds.length > 0 &&
     ctx.itemKinds.every((kind) => kind === "memory");
+  const authOnly =
+    ctx.itemKinds !== undefined &&
+    ctx.itemKinds.length > 0 &&
+    ctx.itemKinds.every((kind) => kind === "auth");
   const source = await discoverCodexSource({
     input: ctx.source,
     memoryOnly,
-    evaluatePluginMigrationEligibility: !memoryOnly,
+    authOnly,
+    evaluatePluginMigrationEligibility: !memoryOnly && !authOnly,
     verifyPluginApps: shouldVerifyPluginApps(ctx),
   });
-  if (!hasCodexSource(source)) {
+  if (!hasCodexSource(source) && !authOnly) {
     throw new Error(
       `Codex state was not found at ${source.root}. Pass --from <path> if it lives elsewhere.`,
     );
   }
   const items: MigrationItem[] = [];
-  items.push(
-    ...(await buildCodexMemoryItems({
-      memoryFiles: source.memoryFiles,
-      workspaceDir: targets.workspaceDir,
-      overwrite: ctx.overwrite,
-    })),
-  );
+  if (!authOnly) {
+    items.push(
+      ...(await buildCodexMemoryItems({
+        memoryFiles: source.memoryFiles,
+        workspaceDir: targets.workspaceDir,
+        overwrite: ctx.overwrite,
+      })),
+    );
+  }
   if (!memoryOnly) {
     items.push(...(await buildCodexAuthItems({ ctx, source, targets })));
+  }
+  if (!memoryOnly && !authOnly) {
     items.push(
       ...(await buildCodexSkillItems({
         skills: source.skills,

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -18,11 +18,54 @@ import { codexAppInventoryResponse } from "../app-server/app-inventory.test-help
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
+import { readCodexCliActiveApiKeyAsync } from "./cli-credentials.js";
 import { buildCodexMigrationProvider } from "./provider.js";
 import { discoverCodexSource } from "./source.js";
 
 const appServerRequest = vi.hoisted(() => vi.fn());
 const sourceAppServerClientScope = vi.hoisted(() => vi.fn());
+const credentialStorage = vi.hoisted(() => ({
+  mode: "file",
+  requiredMode: undefined as string | undefined,
+  accountType: "apiKey",
+}));
+
+vi.mock("../app-server/managed-binary.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../app-server/managed-binary.js")>()),
+  resolveManagedCodexPackageEntrypoint: () => "/fixture/codex.js",
+  resolveManagedCodexNativeCommand: () => "/fixture/codex",
+}));
+
+vi.mock("../app-server/client.js", () => ({
+  CodexAppServerClient: {
+    async start(options: { env: { CODEX_HOME: string } }) {
+      return {
+        initialize: async () => undefined,
+        getRuntimeIdentity: () => ({ codexHome: options.env.CODEX_HOME }),
+        getModelCatalogRevision: () => 0,
+        getCloseError: () => undefined,
+        close: () => undefined,
+        closeAndWait: async () => ({ exited: true, cleanup: "closed" }),
+        async request(method: string) {
+          if (method === "account/read") {
+            return { account: { type: credentialStorage.accountType }, requiresOpenaiAuth: true };
+          }
+          if (method === "config/read") {
+            return { config: { cli_auth_credentials_store: credentialStorage.mode } };
+          }
+          if (method === "configRequirements/read") {
+            return {
+              requirements: credentialStorage.requiredMode
+                ? { cli_auth_credentials_store: credentialStorage.requiredMode }
+                : null,
+            };
+          }
+          throw new Error(`Unexpected credential request: ${method}`);
+        },
+      };
+    },
+  },
+}));
 
 vi.mock("../app-server/request.js", () => ({
   requestCodexAppServerJson: appServerRequest,
@@ -202,6 +245,9 @@ afterEach(async () => {
 
 describe("buildCodexMigrationProvider", () => {
   beforeEach(() => {
+    credentialStorage.mode = "file";
+    credentialStorage.requiredMode = undefined;
+    credentialStorage.accountType = "apiKey";
     appServerRequest.mockRejectedValue(new Error("codex app-server unavailable"));
     sourceAppServerClientScope.mockImplementation(
       async (
@@ -804,6 +850,163 @@ describe("buildCodexMigrationProvider", () => {
     expect(sourceAppServerClientScope).toHaveBeenCalledTimes(1);
   });
 
+  it("imports only the selected API key without changing configuration", async () => {
+    const fixture = await createCodexFixture();
+    await writeFile(
+      path.join(fixture.codexHome, "auth.json"),
+      JSON.stringify({
+        auth_mode: "apikey",
+        OPENAI_API_KEY: "fixture-selected-key",
+      }),
+    );
+    const ctx = makeContext({
+      source: fixture.codexHome,
+      stateDir: fixture.stateDir,
+      workspaceDir: fixture.workspaceDir,
+      itemKinds: ["auth"],
+      includeSecrets: true,
+      providerOptions: { credentialKind: "api_key", configPatchMode: "none" },
+      config: {
+        agents: { defaults: { model: { primary: "other/model" }, models: { "other/model": {} } } },
+      },
+    });
+    const before = structuredClone(ctx.config);
+    const provider = buildCodexMigrationProvider();
+    const plan = await provider.plan(ctx);
+    expect(plan.items.map(({ id }) => id)).toEqual(["auth:openai:api-key"]);
+
+    const result = await provider.apply(ctx, plan);
+
+    expect(findItem(result.items, "auth:openai:api-key").status).toBe("migrated");
+    expect(loadTargetAuthStore(fixture).profiles["openai:codex-import"]).toMatchObject({
+      type: "api_key",
+      provider: "openai",
+      key: "fixture-selected-key",
+    });
+    expect(ctx.config).toEqual(before);
+  });
+
+  it.each(["changed", "cancelled"])("does not persist a %s selected import", async (change) => {
+    const fixture = await createCodexFixture();
+    const authPath = path.join(fixture.codexHome, "auth.json");
+    await writeFile(
+      authPath,
+      JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "fixture-first-key" }),
+    );
+    const ctx = makeContext({
+      source: fixture.codexHome,
+      stateDir: fixture.stateDir,
+      workspaceDir: fixture.workspaceDir,
+      itemKinds: ["auth"],
+      includeSecrets: true,
+      providerOptions: { credentialKind: "api_key", configPatchMode: "none" },
+    });
+    const provider = buildCodexMigrationProvider();
+    const plan = await provider.plan(ctx);
+    if (change === "changed") {
+      await writeFile(
+        authPath,
+        JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "fixture-second-key" }),
+      );
+      const result = await provider.apply(ctx, plan);
+      expect(findItem(result.items, "auth:openai:api-key").status).toBe("skipped");
+    } else {
+      ctx.signal = AbortSignal.abort(new Error("Sign-in cancelled"));
+      await expect(provider.apply(ctx, plan)).rejects.toThrow("Sign-in cancelled");
+    }
+    expect(loadTargetAuthStore(fixture).profiles["openai:codex-import"]).toBeUndefined();
+  });
+
+  it.each(["keyring", "auto", "ephemeral"])(
+    "does not borrow a file key when native requirements select %s storage",
+    async (mode) => {
+      const fixture = await createCodexFixture();
+      await writeFile(
+        path.join(fixture.codexHome, "auth.json"),
+        JSON.stringify({
+          auth_mode: "apikey",
+          OPENAI_API_KEY: "fixture-stale-file-key",
+        }),
+      );
+      credentialStorage.requiredMode = mode;
+
+      expect(
+        await readCodexCliActiveApiKeyAsync({
+          codexHome: fixture.codexHome,
+          allowKeychainPrompt: false,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it("does not import an inactive API key alongside native ChatGPT sign-in", async () => {
+    const fixture = await createCodexFixture();
+    await writeFile(
+      path.join(fixture.codexHome, "auth.json"),
+      JSON.stringify({
+        OPENAI_API_KEY: "fixture-inactive-key",
+      }),
+    );
+    credentialStorage.accountType = "chatgpt";
+    expect(
+      await readCodexCliActiveApiKeyAsync({
+        codexHome: fixture.codexHome,
+        allowKeychainPrompt: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not reuse another user's OAuth profile in the same ChatGPT workspace", async () => {
+    const fixture = await createCodexFixture();
+    const jwt = (user: string) =>
+      fakeJwt({
+        exp: 2_000_000_000,
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "shared-workspace",
+          chatgpt_user_id: user,
+        },
+      });
+    const existing = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: jwt("previous-user"),
+      refresh: "previous-refresh",
+      expires: 2_000_000_000_000,
+      accountId: "shared-workspace",
+    };
+    upsertAuthProfile({
+      profileId: "openai:account-shared-workspace",
+      credential: existing,
+      agentDir: targetAgentDir(fixture),
+    });
+    await writeFile(
+      path.join(fixture.codexHome, "auth.json"),
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: jwt("new-user"),
+          refresh_token: "new-refresh",
+          account_id: "shared-workspace",
+        },
+      }),
+    );
+    const provider = buildCodexMigrationProvider();
+    const ctx = makeContext({
+      source: fixture.codexHome,
+      stateDir: fixture.stateDir,
+      workspaceDir: fixture.workspaceDir,
+      itemKinds: ["auth"],
+      includeSecrets: true,
+      providerOptions: { credentialKind: "oauth", configPatchMode: "none" },
+    });
+    const plan = await provider.plan(ctx);
+    expect(findItem(plan.items, "auth:openai").status).toBe("conflict");
+    await provider.apply(ctx, plan);
+    expect(loadTargetAuthStore(fixture).profiles["openai:account-shared-workspace"]).toEqual(
+      existing,
+    );
+  });
+
   it("imports Codex auth.json OAuth into the selected agent and seeds cached models", async () => {
     const fixture = await createCodexFixture();
     const reportDir = path.join(fixture.root, "report");
@@ -996,7 +1199,7 @@ describe("buildCodexMigrationProvider", () => {
 
     const result = await provider.apply(ctx, plan);
 
-    expect(findItem(result.items, "auth:openai")).toEqual(
+    expect(findItem(result.items, "auth:openai:api-key")).toEqual(
       expect.objectContaining({
         status: "conflict",
         reason: "auth profile exists",

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -1039,6 +1039,100 @@ describe("buildCodexMigrationProvider", () => {
     );
   });
 
+  it.each([
+    {
+      state: "expired",
+      expires: 1_899_999_999_999,
+      planStatus: "skipped",
+      resultStatus: "skipped",
+    },
+    {
+      state: "usable",
+      expires: 2_000_000_000_000,
+      planStatus: "planned",
+      resultStatus: "migrated",
+    },
+    {
+      state: "expires before apply",
+      expires: 2_000_000_000_000,
+      planStatus: "planned",
+      resultStatus: "skipped",
+    },
+  ])(
+    "preserves a same-account OAuth profile that is $state",
+    async ({ state, expires, planStatus, resultStatus }) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(1_900_000_000_000);
+      try {
+        const fixture = await createCodexFixture();
+        credentialStorage.accountType = "chatgpt";
+        const claims = {
+          chatgpt_account_id: "same-account",
+          chatgpt_user_id: "same-user",
+        };
+        const profileId = "openai:existing-account";
+        const existing = {
+          type: "oauth" as const,
+          provider: "openai",
+          access: fakeJwt({ exp: expires / 1000, "https://api.openai.com/auth": claims }),
+          refresh: "old-refresh",
+          expires,
+          accountId: "same-account",
+        };
+        const unrelated = { type: "api_key" as const, provider: "other", key: "unrelated-key" };
+        upsertAuthProfile({ profileId, credential: existing, agentDir: targetAgentDir(fixture) });
+        upsertAuthProfile({
+          profileId: "other:retained",
+          credential: unrelated,
+          agentDir: targetAgentDir(fixture),
+        });
+        await writeFile(
+          path.join(fixture.codexHome, "auth.json"),
+          JSON.stringify({
+            auth_mode: "chatgpt",
+            tokens: {
+              access_token: fakeJwt({ exp: 2_100_000_000, "https://api.openai.com/auth": claims }),
+              refresh_token: "new-native-refresh",
+              account_id: "same-account",
+            },
+          }),
+        );
+        const ctx = makeContext({
+          source: fixture.codexHome,
+          stateDir: fixture.stateDir,
+          workspaceDir: fixture.workspaceDir,
+          itemKinds: ["auth"],
+          includeSecrets: true,
+          providerOptions: { credentialKind: "oauth", configPatchMode: "none" },
+          config: {
+            agents: { defaults: { model: "other/retained", workspace: fixture.workspaceDir } },
+          },
+        });
+        const configBefore = structuredClone(ctx.config);
+        const provider = buildCodexMigrationProvider();
+        const plan = await provider.plan(ctx);
+        expect(findItem(plan.items, "auth:openai").status).toBe(planStatus);
+        if (state === "expired") {
+          expect(findItem(plan.items, "auth:openai")).toMatchObject({
+            reason: "existing OAuth profile requires sign-in",
+            details: { credentialImportUnavailable: true },
+          });
+        }
+        if (state === "expires before apply") {
+          clock.mockReturnValue(2_000_000_000_001);
+        }
+        const result = await provider.apply(ctx, plan);
+        expect(findItem(result.items, "auth:openai").status).toBe(resultStatus);
+        expect(loadTargetAuthStore(fixture).profiles).toEqual({
+          [profileId]: existing,
+          "other:retained": unrelated,
+        });
+        expect(ctx.config).toEqual(configBefore);
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+
   it("imports Codex auth.json OAuth into the selected agent and seeds cached models", async () => {
     const fixture = await createCodexFixture();
     const reportDir = path.join(fixture.root, "report");

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -6,7 +6,10 @@ import {
   loadAuthProfileStoreForSecretsRuntime,
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
-import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
+import {
+  updateAuthProfileStoreWithLock,
+  upsertAuthProfile,
+} from "openclaw/plugin-sdk/provider-auth";
 import {
   resolvePreferredOpenClawTmpDir,
   tempWorkspace,
@@ -1059,7 +1062,7 @@ describe("buildCodexMigrationProvider", () => {
       resultStatus: "skipped",
     },
   ])(
-    "preserves a same-account OAuth profile that is $state",
+    "preserves a same-account local OAuth profile that is $state",
     async ({ state, expires, planStatus, resultStatus }) => {
       const clock = vi.spyOn(Date, "now").mockReturnValue(1_900_000_000_000);
       try {
@@ -1079,12 +1082,16 @@ describe("buildCodexMigrationProvider", () => {
           accountId: "same-account",
         };
         const unrelated = { type: "api_key" as const, provider: "other", key: "unrelated-key" };
-        upsertAuthProfile({ profileId, credential: existing, agentDir: targetAgentDir(fixture) });
-        upsertAuthProfile({
-          profileId: "other:retained",
-          credential: unrelated,
+        const seeded = await updateAuthProfileStoreWithLock({
           agentDir: targetAgentDir(fixture),
+          stateDir: fixture.stateDir,
+          updater(store) {
+            store.profiles[profileId] = existing;
+            store.profiles["other:retained"] = unrelated;
+            return true;
+          },
         });
+        expect(seeded?.profiles).toEqual({ [profileId]: existing, "other:retained": unrelated });
         await writeFile(
           path.join(fixture.codexHome, "auth.json"),
           JSON.stringify({

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -18,10 +18,12 @@ import { codexAppInventoryResponse } from "../app-server/app-inventory.test-help
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
+import type { CodexAppServerCloseResult } from "../app-server/transport.js";
 import { readCodexCliActiveApiKeyAsync } from "./cli-credentials.js";
 import { buildCodexMigrationProvider } from "./provider.js";
 import { discoverCodexSource } from "./source.js";
 
+const closeCredentialReader = vi.hoisted(() => vi.fn<() => Promise<CodexAppServerCloseResult>>());
 const appServerRequest = vi.hoisted(() => vi.fn());
 const sourceAppServerClientScope = vi.hoisted(() => vi.fn());
 const credentialStorage = vi.hoisted(() => ({
@@ -45,7 +47,7 @@ vi.mock("../app-server/client.js", () => ({
         getModelCatalogRevision: () => 0,
         getCloseError: () => undefined,
         close: () => undefined,
-        closeAndWait: async () => ({ exited: true, cleanup: "closed" }),
+        closeAndWait: closeCredentialReader,
         async request(method: string) {
           if (method === "account/read") {
             return { account: { type: credentialStorage.accountType }, requiresOpenaiAuth: true };
@@ -237,6 +239,7 @@ afterEach(async () => {
   vi.useRealTimers();
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
+  closeCredentialReader.mockReset();
   appServerRequest.mockReset();
   sourceAppServerClientScope.mockReset();
   defaultCodexAppInventoryCache.clear();
@@ -245,6 +248,7 @@ afterEach(async () => {
 
 describe("buildCodexMigrationProvider", () => {
   beforeEach(() => {
+    closeCredentialReader.mockResolvedValue({ exited: true, cleanup: "closed" });
     credentialStorage.mode = "file";
     credentialStorage.requiredMode = undefined;
     credentialStorage.accountType = "apiKey";
@@ -885,6 +889,34 @@ describe("buildCodexMigrationProvider", () => {
     });
     expect(ctx.config).toEqual(before);
   });
+
+  it.each([false, true])(
+    "does not persist credentials after uncertain reader cleanup (exited=%s)",
+    async (exited) => {
+      const fixture = await createCodexFixture();
+      await writeFile(
+        path.join(fixture.codexHome, "auth.json"),
+        JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "fixture-selected-key" }),
+      );
+      const ctx = makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        itemKinds: ["auth"],
+        includeSecrets: true,
+        providerOptions: { credentialKind: "api_key", configPatchMode: "none" },
+      });
+      const provider = buildCodexMigrationProvider();
+      const plan = await provider.plan(ctx);
+      closeCredentialReader.mockResolvedValue({ exited, cleanup: "uncertain" });
+
+      await expect(provider.apply(ctx, plan)).rejects.toThrow(
+        "The Codex credential reader could not stop. No credential was imported.",
+      );
+
+      expect(loadTargetAuthStore(fixture).profiles["openai:codex-import"]).toBeUndefined();
+    },
+  );
 
   it.each(["changed", "cancelled"])("does not persist a %s selected import", async (change) => {
     const fixture = await createCodexFixture();

--- a/extensions/codex/src/migration/provider.ts
+++ b/extensions/codex/src/migration/provider.ts
@@ -11,6 +11,12 @@ function isMemoryOnlyMigration(ctx: MigrationProviderContext): boolean {
   );
 }
 
+function isAuthOnlyMigration(ctx: MigrationProviderContext): boolean {
+  return Boolean(
+    ctx.itemKinds && ctx.itemKinds.length > 0 && ctx.itemKinds.every((kind) => kind === "auth"),
+  );
+}
+
 export function buildCodexMigrationProvider(
   params: {
     runtime?: MigrationProviderContext["runtime"];
@@ -21,15 +27,20 @@ export function buildCodexMigrationProvider(
     label: "Codex",
     description:
       "Import Codex memory and skills while keeping Codex native plugins and hooks explicit.",
-    supportedItemKinds: ["memory"],
+    supportedItemKinds: ["memory", "auth"],
     async detect(ctx) {
       const { discoverCodexSource, hasCodexSource } = await import("./source.js");
       const source = await discoverCodexSource({
         input: ctx.source,
         memoryOnly: isMemoryOnlyMigration(ctx),
+        authOnly: isAuthOnlyMigration(ctx),
       });
       const memoryOnly = isMemoryOnlyMigration(ctx);
-      const found = memoryOnly ? source.memoryFiles.length > 0 : hasCodexSource(source);
+      const found = memoryOnly
+        ? source.memoryFiles.length > 0
+        : isAuthOnlyMigration(ctx)
+          ? Boolean(source.authPath)
+          : hasCodexSource(source);
       return {
         found,
         source: source.root,
@@ -44,7 +55,7 @@ export function buildCodexMigrationProvider(
     },
     deferredApply: { retrySafe: true },
     prepareApply(ctx) {
-      if (isMemoryOnlyMigration(ctx)) {
+      if (isMemoryOnlyMigration(ctx) || isAuthOnlyMigration(ctx)) {
         return undefined;
       }
       return import("./apply.js").then(({ prepareTargetCodexAppServer }) =>

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -62,6 +62,7 @@ export type CodexSource = {
 type CodexSourceDiscoveryOptions = {
   input?: string;
   memoryOnly?: boolean;
+  authOnly?: boolean;
   evaluatePluginMigrationEligibility?: boolean;
   verifyPluginApps?: boolean;
 };
@@ -569,21 +570,22 @@ export async function discoverCodexSource(
   const authPath = path.join(codexHome, "auth.json");
   const modelsCachePath = path.join(codexHome, "models_cache.json");
   const hooksPath = path.join(codexHome, "hooks", "hooks.json");
-  const memoryFiles = await discoverCodexMemorySources(codexHome);
-  const codexSkills = options.memoryOnly
+  const skipAssets = options.memoryOnly === true || options.authOnly === true;
+  const memoryFiles = options.authOnly ? [] : await discoverCodexMemorySources(codexHome);
+  const codexSkills = skipAssets
     ? []
     : await discoverSkillDirs({
         root: codexSkillsDir,
         sourceLabel: "Codex skill",
         excludeSystem: true,
       });
-  const personalAgentSkills = options.memoryOnly
+  const personalAgentSkills = skipAssets
     ? []
     : await discoverSkillDirs({
         root: agentsSkillsDir,
         sourceLabel: "personal AgentSkill",
       });
-  const sourcePluginDiscovery: { plugins: CodexPluginSource[]; error?: string } = options.memoryOnly
+  const sourcePluginDiscovery: { plugins: CodexPluginSource[]; error?: string } = skipAssets
     ? { plugins: [] }
     : await discoverInstalledCuratedPlugins(codexHome, options);
   const sourcePluginNames = new Set(
@@ -591,17 +593,15 @@ export async function discoverCodexSource(
       plugin.pluginName ? [plugin.pluginName] : [],
     ),
   );
-  const cachedPlugins = (options.memoryOnly ? [] : await discoverPluginDirs(codexHome)).filter(
-    (plugin) => {
-      const normalizedName = sanitizePluginName(plugin.name);
-      return !sourcePluginNames.has(normalizedName);
-    },
-  );
+  const cachedPlugins = (skipAssets ? [] : await discoverPluginDirs(codexHome)).filter((plugin) => {
+    const normalizedName = sanitizePluginName(plugin.name);
+    return !sourcePluginNames.has(normalizedName);
+  });
   const plugins = [...sourcePluginDiscovery.plugins, ...cachedPlugins].toSorted((a, b) =>
     a.source.localeCompare(b.source),
   );
   const archivePaths: CodexArchiveSource[] = [];
-  if (!options.memoryOnly && (await exists(configPath))) {
+  if (!skipAssets && (await exists(configPath))) {
     archivePaths.push({
       id: "archive:config.toml",
       path: configPath,
@@ -609,7 +609,7 @@ export async function discoverCodexSource(
       message: "Codex config is archived for manual review; it is not activated automatically",
     });
   }
-  if (!options.memoryOnly && (await exists(hooksPath))) {
+  if (!skipAssets && (await exists(hooksPath))) {
     archivePaths.push({
       id: "archive:hooks/hooks.json",
       path: hooksPath,

--- a/extensions/openai/provider-contract-api.ts
+++ b/extensions/openai/provider-contract-api.ts
@@ -18,6 +18,16 @@ const OPENAI_ACCOUNT_WIZARD_GROUP = {
   groupLabel: "OpenAI",
   groupHint: "ChatGPT/Codex sign-in or API key",
 } as const;
+const CODEX_CHATGPT_IMPORT = {
+  migrationProviderId: "codex",
+  itemId: "auth:openai",
+  credentialKind: "oauth",
+} as const;
+const CODEX_API_KEY_IMPORT = {
+  migrationProviderId: "codex",
+  itemId: "auth:openai:api-key",
+  credentialKind: "api_key",
+} as const;
 
 function accountSubject(access: string): { accountId: string; userId: string } | undefined {
   const claims = asNonArrayRecord(
@@ -64,6 +74,7 @@ export function createOpenAIProvider(): ProviderPlugin {
         hint: OPENAI_CHATGPT_LOGIN_HINT,
         run: noopAuth,
         matchesPersonalAccount,
+        credentialImport: CODEX_CHATGPT_IMPORT,
         wizard: {
           choiceId: "openai",
           choiceLabel: OPENAI_CHATGPT_LOGIN_LABEL,
@@ -80,6 +91,7 @@ export function createOpenAIProvider(): ProviderPlugin {
         hint: OPENAI_CHATGPT_DEVICE_PAIRING_HINT,
         run: noopAuth,
         matchesPersonalAccount,
+        credentialImport: CODEX_CHATGPT_IMPORT,
         wizard: {
           choiceId: "openai-device-code",
           choiceLabel: OPENAI_CHATGPT_DEVICE_PAIRING_LABEL,
@@ -94,6 +106,7 @@ export function createOpenAIProvider(): ProviderPlugin {
         label: OPENAI_API_KEY_LABEL,
         hint: "Use your OpenAI API key directly",
         run: noopAuth,
+        credentialImport: CODEX_API_KEY_IMPORT,
         wizard: {
           choiceId: "openai-api-key",
           choiceLabel: OPENAI_API_KEY_LABEL,

--- a/src/commands/models.auth.provider-resolution.test.ts
+++ b/src/commands/models.auth.provider-resolution.test.ts
@@ -11,11 +11,14 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { summarizeMigrationItems } from "../plugin-sdk/migration.js";
+import * as migrationRuntime from "../plugins/migration-provider-runtime.js";
 import { pluginLoaderCacheState } from "../plugins/registry-lifecycle.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
-import type { ProviderPlugin } from "../plugins/types.js";
+import type { MigrationItem, MigrationPlan, ProviderPlugin } from "../plugins/types.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { getFreePort } from "../test-utils/ports.js";
+import { tryImportProviderCredential } from "./models/auth-credential-import.js";
 import { resolveRequestedLoginProviderOrThrow, runModelsAuthLoginFlowCore } from "./models/auth.js";
 
 function makeProvider(params: { id: string; label?: string; aliases?: string[] }): ProviderPlugin {
@@ -26,6 +29,159 @@ function makeProvider(params: { id: string; label?: string; aliases?: string[] }
     auth: [],
   };
 }
+
+describe("selected credential import", () => {
+  const method: ProviderPlugin["auth"][number] = {
+    id: "api-key",
+    label: "Key",
+    kind: "api_key",
+    run: async () => ({ profiles: [] }),
+    credentialImport: {
+      migrationProviderId: "fixture",
+      itemId: "auth:key",
+      credentialKind: "api_key",
+    },
+  };
+  const keyItem: MigrationItem = {
+    id: "auth:key",
+    kind: "auth",
+    action: "create",
+    status: "planned",
+    details: { provider: "fixture", credentialKind: "api_key", profileId: "fixture:imported" },
+  };
+
+  it("imports only the declared credential and preserves model configuration", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "other/model" },
+          models: { "other/model": {} },
+        },
+      },
+    };
+    const items: MigrationItem[] = [
+      keyItem,
+      { id: "auth:oauth", kind: "auth", action: "create", status: "planned" },
+    ];
+    const plan: MigrationPlan = {
+      providerId: "fixture",
+      source: "/fixture",
+      items,
+      summary: summarizeMigrationItems(items),
+    };
+    const persisted: string[] = [];
+    const resolve = vi
+      .spyOn(migrationRuntime, "withPluginMigrationProviders")
+      .mockImplementation(async (_params, run) =>
+        run([
+          {
+            id: "fixture",
+            label: "Fixture",
+            plan: () => plan,
+            apply(ctx, selected) {
+              if (!selected) {
+                throw new Error("Expected selected import plan");
+              }
+              expect(ctx.providerOptions?.configPatchMode).toBe("none");
+              const resultItems = selected.items.map((item) => {
+                if (item.status !== "planned") {
+                  return item;
+                }
+                persisted.push(item.id);
+                return { ...item, status: "migrated" as const };
+              });
+              return {
+                ...selected,
+                items: resultItems,
+                summary: summarizeMigrationItems(resultItems),
+              };
+            },
+          },
+        ]),
+      );
+    try {
+      const result = await tryImportProviderCredential({
+        method,
+        providerId: "fixture",
+        config,
+        agentId: "main",
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      });
+      expect(result).toMatchObject({
+        profileId: "fixture:imported",
+        provider: "fixture",
+        mode: "api_key",
+      });
+      expect(persisted).toEqual(["auth:key"]);
+      expect(config.agents?.defaults?.model).toEqual({ primary: "other/model" });
+      expect(config.agents?.defaults?.models).toEqual({ "other/model": {} });
+    } finally {
+      resolve.mockRestore();
+    }
+  });
+
+  it.each(["cancelled", "changed", "ambiguous", "wrong-provider"])(
+    "refuses a %s import without starting another sign-in",
+    async (failure) => {
+      const controller = new AbortController();
+      const items =
+        failure === "ambiguous"
+          ? [keyItem, keyItem]
+          : failure === "wrong-provider"
+            ? [{ ...keyItem, details: { ...keyItem.details, provider: "other" } }]
+            : [keyItem];
+      const plan: MigrationPlan = {
+        providerId: "fixture",
+        source: "/fixture",
+        items,
+        summary: summarizeMigrationItems(items),
+      };
+      const apply = vi.fn(() => ({ ...plan, items: [{ ...keyItem, status: "skipped" as const }] }));
+      const resolve = vi
+        .spyOn(migrationRuntime, "withPluginMigrationProviders")
+        .mockImplementation(async (_params, run) =>
+          run([
+            {
+              id: "fixture",
+              label: "Fixture",
+              plan: () => {
+                if (failure === "cancelled") {
+                  controller.abort(new Error("Sign-in cancelled"));
+                }
+                return plan;
+              },
+              apply,
+            },
+          ]),
+        );
+      try {
+        await expect(
+          tryImportProviderCredential({
+            method,
+            providerId: "fixture",
+            config: {},
+            agentId: "main",
+            signal: controller.signal,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          }),
+        ).rejects.toThrow(
+          failure === "cancelled"
+            ? "Sign-in cancelled"
+            : failure === "changed"
+              ? "changed during import"
+              : failure === "ambiguous"
+                ? "ambiguous item identity"
+                : "another provider",
+        );
+        if (failure !== "changed") {
+          expect(apply).not.toHaveBeenCalled();
+        }
+      } finally {
+        resolve.mockRestore();
+      }
+    },
+  );
+});
 
 describe("resolveRequestedLoginProviderOrThrow", () => {
   it("returns null and resolves provider by id/alias", () => {
@@ -61,117 +217,140 @@ describe("resolveRequestedLoginProviderOrThrow", () => {
   });
 });
 
-describe("models auth login --force", () => {
-  it("replaces expired shared and main-local profiles with the gateway stopped", async () => {
-    const state = await createOpenClawTestState({
-      label: "auth-force-login",
-      env: {
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
-        OPENCLAW_OAUTH_DIR: undefined,
-        OPENCLAW_GATEWAY_URL: undefined,
-        OPENCLAW_GATEWAY_PORT: undefined,
-        OPENCLAW_GATEWAY_TOKEN: undefined,
-        OPENCLAW_GATEWAY_PASSWORD: undefined,
-      },
-    });
-    try {
-      pluginLoaderCacheState.clear();
-      resetPluginRuntimeStateForTest();
-      const provider = "authstore-proof";
-      const freshId = `${provider}:fresh`;
-      const fresh = { type: "token" as const, provider, token: "fixture-fresh-token" };
-      const expired = { ...fresh, token: "fixture-expired-token", expires: 1 };
-      const unrelated = { type: "token" as const, provider: "other-proof", token: "fixture-other" };
-      const pluginDir = path.join(state.workspaceDir, ".openclaw", "extensions", provider);
-      await fs.mkdir(pluginDir, { recursive: true, mode: 0o755 });
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({
-          id: provider,
-          providers: [provider],
-          configSchema: { type: "object", additionalProperties: false, properties: {} },
-        }),
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "index.cjs"),
-        `module.exports = {
+describe("models auth login explicit credential selection", () => {
+  it.each(["force", "profile-id"])(
+    "bypasses import for --%s with the gateway stopped",
+    async (selection) => {
+      const state = await createOpenClawTestState({
+        label: "auth-force-login",
+        env: {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+          OPENCLAW_OAUTH_DIR: undefined,
+          OPENCLAW_GATEWAY_URL: undefined,
+          OPENCLAW_GATEWAY_PORT: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_GATEWAY_PASSWORD: undefined,
+        },
+      });
+      const importOwner = vi
+        .spyOn(migrationRuntime, "withPluginMigrationProviders")
+        .mockRejectedValue(
+          new Error("Explicit credential selection must not acquire an import owner"),
+        );
+      try {
+        pluginLoaderCacheState.clear();
+        resetPluginRuntimeStateForTest();
+        const provider = "authstore-proof";
+        const freshId = `${provider}:${selection === "profile-id" ? "selected" : "fresh"}`;
+        const fresh = { type: "token" as const, provider, token: "fixture-fresh-token" };
+        const expired = { ...fresh, token: "fixture-expired-token", expires: 1 };
+        const unrelated = {
+          type: "token" as const,
+          provider: "other-proof",
+          token: "fixture-other",
+        };
+        const pluginDir = path.join(state.workspaceDir, ".openclaw", "extensions", provider);
+        await fs.mkdir(pluginDir, { recursive: true, mode: 0o755 });
+        await fs.writeFile(
+          path.join(pluginDir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: provider,
+            providers: [provider],
+            configSchema: { type: "object", additionalProperties: false, properties: {} },
+          }),
+        );
+        await fs.writeFile(
+          path.join(pluginDir, "index.cjs"),
+          `module.exports = {
           id: ${JSON.stringify(provider)},
           register(api) {
             api.registerProvider({
               id: ${JSON.stringify(provider)}, label: "Auth store proof",
               auth: [{ id: "token", label: "Fixture token", kind: "token",
+                credentialImport: { migrationProviderId: ${JSON.stringify(provider)}, itemId: "auth:shared", credentialKind: "token" },
                 async run() {
-                  return ${JSON.stringify({ profiles: [{ profileId: freshId, credential: fresh }] })};
+                  return ${JSON.stringify({ profiles: [{ profileId: `${provider}:fresh`, credential: fresh }] })};
                 }
               }]
             });
           }
         };`,
-      );
-      const config: OpenClawConfig = {
-        agents: { list: [{ id: "main", workspace: state.workspaceDir }] },
-        plugins: { allow: [provider], entries: { [provider]: { enabled: true } } },
-        gateway: {
-          mode: "local",
-          port: await getFreePort(),
-          auth: { mode: "token", token: "fixture-gateway-token" },
-        },
-      };
-      await state.writeConfig(config);
-      saveAuthProfileStore(
-        {
+        );
+        const config: OpenClawConfig = {
+          agents: { list: [{ id: "main", workspace: state.workspaceDir }] },
+          plugins: { allow: [provider], entries: { [provider]: { enabled: true } } },
+          gateway: {
+            mode: "local",
+            port: await getFreePort(),
+            auth: { mode: "token", token: "fixture-gateway-token" },
+          },
+        };
+        await state.writeConfig(config);
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: { [`${provider}:shared`]: expired, "other-proof:shared": unrelated },
+          },
+          undefined,
+          { sharedStoreWrite: true, filterExternalAuthProfiles: false, syncExternalCli: false },
+        );
+        await state.writeAuthProfiles({
           version: 1,
-          profiles: { [`${provider}:shared`]: expired, "other-proof:shared": unrelated },
-        },
-        undefined,
-        { sharedStoreWrite: true, filterExternalAuthProfiles: false, syncExternalCli: false },
-      );
-      await state.writeAuthProfiles({
-        version: 1,
-        profiles: { [`${provider}:local`]: expired, "other-proof:local": unrelated },
-        order: { [provider]: [`${provider}:local`] },
-      });
-      const unexpectedPrompt = async (): Promise<never> => {
-        throw new Error("Unexpected interactive prompt in explicit fixture login");
-      };
-      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-      await runModelsAuthLoginFlowCore({
-        provider,
-        method: "token",
-        agent: "main",
-        force: true,
-        config,
-        runtime,
-        prompter: createWizardPrompter({
-          select: unexpectedPrompt,
-          text: unexpectedPrompt,
-          confirm: unexpectedPrompt,
-        }),
-      });
+          profiles: { [`${provider}:local`]: expired, "other-proof:local": unrelated },
+          order: { [provider]: [`${provider}:local`] },
+        });
+        const unexpectedPrompt = async (): Promise<never> => {
+          throw new Error("Unexpected interactive prompt in explicit fixture login");
+        };
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        await runModelsAuthLoginFlowCore({
+          provider,
+          method: "token",
+          agent: "main",
+          ...(selection === "force" ? { force: true } : { profileId: freshId }),
+          config,
+          runtime,
+          prompter: createWizardPrompter({
+            select: unexpectedPrompt,
+            text: unexpectedPrompt,
+            confirm: unexpectedPrompt,
+          }),
+        });
 
-      expect(loadPersistedAuthProfileStore()?.profiles).toEqual({
-        [freshId]: fresh,
-        "other-proof:shared": unrelated,
-      });
-      const local = loadPersistedAuthProfileStore(state.agentDir());
-      expect(local?.profiles).toEqual({ "other-proof:local": unrelated });
-      expect(local?.order?.[provider]).toBeUndefined();
-      expect(loadAuthProfileStoreWithoutExternalProfiles(state.agentDir()).profiles).toEqual({
-        [freshId]: fresh,
-        "other-proof:shared": unrelated,
-        "other-proof:local": unrelated,
-      });
-      expect(runtime.log).toHaveBeenCalledWith(
-        `Removed cached auth profiles for provider "${provider}" (--force). Running fresh auth flow.`,
-      );
-      expect(runtime.log).toHaveBeenCalledWith(`Auth profile: ${freshId} (${provider}/token)`);
-    } finally {
-      pluginLoaderCacheState.clear();
-      resetPluginRuntimeStateForTest();
-      clearRuntimeAuthProfileStoreSnapshots();
-      clearAuthProfileMigrationDiagnostics();
-      await state.cleanup();
-    }
-  });
+        expect(loadPersistedAuthProfileStore()?.profiles).toEqual({
+          ...(selection === "profile-id" ? { [`${provider}:shared`]: expired } : {}),
+          [freshId]: fresh,
+          "other-proof:shared": unrelated,
+        });
+        const local = loadPersistedAuthProfileStore(state.agentDir());
+        expect(local?.profiles).toEqual({
+          ...(selection === "profile-id" ? { [`${provider}:local`]: expired } : {}),
+          "other-proof:local": unrelated,
+        });
+        expect(loadAuthProfileStoreWithoutExternalProfiles(state.agentDir()).profiles).toEqual({
+          ...(selection === "profile-id"
+            ? { [`${provider}:shared`]: expired, [`${provider}:local`]: expired }
+            : {}),
+          [freshId]: fresh,
+          "other-proof:shared": unrelated,
+          "other-proof:local": unrelated,
+        });
+        if (selection === "force") {
+          expect(local?.order?.[provider]).toBeUndefined();
+          expect(runtime.log).toHaveBeenCalledWith(
+            `Removed cached auth profiles for provider "${provider}" (--force). Running fresh auth flow.`,
+          );
+        }
+        expect(runtime.log).toHaveBeenCalledWith(`Auth profile: ${freshId} (${provider}/token)`);
+      } finally {
+        importOwner.mockRestore();
+        pluginLoaderCacheState.clear();
+        resetPluginRuntimeStateForTest();
+        clearRuntimeAuthProfileStoreSnapshots();
+        clearAuthProfileMigrationDiagnostics();
+        await state.cleanup();
+      }
+    },
+  );
 });

--- a/src/commands/models.auth.provider-resolution.test.ts
+++ b/src/commands/models.auth.provider-resolution.test.ts
@@ -218,7 +218,7 @@ describe("resolveRequestedLoginProviderOrThrow", () => {
 });
 
 describe("models auth login explicit credential selection", () => {
-  it.each(["force", "profile-id"])(
+  it.each(["force", "profile-id", "set-default"])(
     "bypasses import for --%s with the gateway stopped",
     async (selection) => {
       const state = await createOpenClawTestState({
@@ -270,7 +270,7 @@ describe("models auth login explicit credential selection", () => {
               auth: [{ id: "token", label: "Fixture token", kind: "token",
                 credentialImport: { migrationProviderId: ${JSON.stringify(provider)}, itemId: "auth:shared", credentialKind: "token" },
                 async run() {
-                  return ${JSON.stringify({ profiles: [{ profileId: `${provider}:fresh`, credential: fresh }] })};
+                  return ${JSON.stringify({ profiles: [{ profileId: `${provider}:fresh`, credential: fresh }], defaultModel: `${provider}/recommended` })};
                 }
               }]
             });
@@ -278,7 +278,10 @@ describe("models auth login explicit credential selection", () => {
         };`,
         );
         const config: OpenClawConfig = {
-          agents: { list: [{ id: "main", workspace: state.workspaceDir }] },
+          agents: {
+            defaults: { model: { primary: "other-proof/existing" } },
+            list: [{ id: "main", workspace: state.workspaceDir }],
+          },
           plugins: { allow: [provider], entries: { [provider]: { enabled: true } } },
           gateway: {
             mode: "local",
@@ -308,7 +311,11 @@ describe("models auth login explicit credential selection", () => {
           provider,
           method: "token",
           agent: "main",
-          ...(selection === "force" ? { force: true } : { profileId: freshId }),
+          ...(selection === "force"
+            ? { force: true }
+            : selection === "profile-id"
+              ? { profileId: freshId }
+              : { setDefault: true }),
           config,
           runtime,
           prompter: createWizardPrompter({
@@ -318,18 +325,22 @@ describe("models auth login explicit credential selection", () => {
           }),
         });
 
+        const savedConfig = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+        expect(savedConfig.agents.defaults.model.primary).toBe(
+          selection === "set-default" ? "authstore-proof/recommended" : "other-proof/existing",
+        );
         expect(loadPersistedAuthProfileStore()?.profiles).toEqual({
-          ...(selection === "profile-id" ? { [`${provider}:shared`]: expired } : {}),
+          ...(selection !== "force" ? { [`${provider}:shared`]: expired } : {}),
           [freshId]: fresh,
           "other-proof:shared": unrelated,
         });
         const local = loadPersistedAuthProfileStore(state.agentDir());
         expect(local?.profiles).toEqual({
-          ...(selection === "profile-id" ? { [`${provider}:local`]: expired } : {}),
+          ...(selection !== "force" ? { [`${provider}:local`]: expired } : {}),
           "other-proof:local": unrelated,
         });
         expect(loadAuthProfileStoreWithoutExternalProfiles(state.agentDir()).profiles).toEqual({
-          ...(selection === "profile-id"
+          ...(selection !== "force"
             ? { [`${provider}:shared`]: expired, [`${provider}:local`]: expired }
             : {}),
           [freshId]: fresh,

--- a/src/commands/models.auth.provider-resolution.test.ts
+++ b/src/commands/models.auth.provider-resolution.test.ts
@@ -218,8 +218,8 @@ describe("resolveRequestedLoginProviderOrThrow", () => {
 });
 
 describe("models auth login explicit credential selection", () => {
-  it.each(["force", "profile-id", "set-default"])(
-    "bypasses import for --%s with the gateway stopped",
+  it.each(["force", "profile-id", "set-default", "unavailable-import"])(
+    "uses fresh authentication for %s with the gateway stopped",
     async (selection) => {
       const state = await createOpenClawTestState({
         label: "auth-force-login",
@@ -233,11 +233,42 @@ describe("models auth login explicit credential selection", () => {
           OPENCLAW_GATEWAY_PASSWORD: undefined,
         },
       });
-      const importOwner = vi
-        .spyOn(migrationRuntime, "withPluginMigrationProviders")
-        .mockRejectedValue(
+      const importOwner = vi.spyOn(migrationRuntime, "withPluginMigrationProviders");
+      if (selection === "unavailable-import") {
+        importOwner.mockImplementation(async (_params, run) =>
+          run([
+            {
+              id: "authstore-proof",
+              label: "Auth store proof",
+              plan() {
+                const items: MigrationItem[] = [
+                  {
+                    id: "auth:shared",
+                    kind: "auth",
+                    action: "skip",
+                    status: "skipped",
+                    message: "The existing sign-in needs to be renewed.",
+                    details: { credentialImportUnavailable: true },
+                  },
+                ];
+                return {
+                  providerId: "authstore-proof",
+                  source: "/fixture",
+                  items,
+                  summary: summarizeMigrationItems(items),
+                };
+              },
+              apply() {
+                throw new Error("Unavailable credentials cannot be applied");
+              },
+            },
+          ]),
+        );
+      } else {
+        importOwner.mockRejectedValue(
           new Error("Explicit credential selection must not acquire an import owner"),
         );
+      }
       try {
         pluginLoaderCacheState.clear();
         resetPluginRuntimeStateForTest();
@@ -315,7 +346,9 @@ describe("models auth login explicit credential selection", () => {
             ? { force: true }
             : selection === "profile-id"
               ? { profileId: freshId }
-              : { setDefault: true }),
+              : selection === "set-default"
+                ? { setDefault: true }
+                : {}),
           config,
           runtime,
           prompter: createWizardPrompter({

--- a/src/commands/models/auth-credential-import.ts
+++ b/src/commands/models/auth-credential-import.ts
@@ -1,0 +1,106 @@
+import { normalizeProviderId } from "../../agents/model-ref-shared.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withPluginMigrationProviders } from "../../plugins/migration-provider-runtime.js";
+import type { ProviderAuthMethod } from "../../plugins/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { buildMigrationContext } from "../migrate/context.js";
+import { applyMigrationItemSelection } from "../migrate/item-selection.js";
+
+type ImportedProviderCredential = {
+  profileId: string;
+  provider: string;
+  mode: "api_key" | "oauth" | "token";
+  configUpdated: boolean;
+};
+
+/** Imports only the credential item declared by the selected login method. */
+export async function tryImportProviderCredential(params: {
+  method: ProviderAuthMethod;
+  providerId: string;
+  config: OpenClawConfig;
+  agentId: string;
+  runtime: RuntimeEnv;
+  signal?: AbortSignal;
+  beforePersistentEffect?: () => void | Promise<void>;
+}): Promise<ImportedProviderCredential | { unavailableReason: string } | undefined> {
+  const spec = params.method.credentialImport;
+  if (!spec) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(params.providerId);
+  params.signal?.throwIfAborted();
+  return await withPluginMigrationProviders(
+    { providerId: spec.migrationProviderId, cfg: params.config },
+    async (providers) => {
+      const owner = providers.find((candidate) => candidate.id === spec.migrationProviderId);
+      if (!owner) {
+        return undefined;
+      }
+      const context = buildMigrationContext({
+        targetAgentId: params.agentId,
+        itemKinds: ["auth"],
+        includeSecrets: true,
+        configOverride: params.config,
+        providerOptions: {
+          allowKeychainPrompt: true,
+          credentialKind: spec.credentialKind,
+          configPatchMode: "none",
+        },
+        runtime: params.runtime,
+      });
+      if (params.signal) {
+        context.signal = params.signal;
+      }
+      const plan = await owner.plan(context);
+      const candidates = plan.items.filter((item) => item.id === spec.itemId);
+      if (candidates.length > 1) {
+        throw new Error("The credential import has an ambiguous item identity.");
+      }
+      const candidate = candidates[0];
+      if (
+        candidate?.status === "skipped" &&
+        candidate.details?.credentialImportUnavailable === true
+      ) {
+        return candidate.message ? { unavailableReason: candidate.message } : undefined;
+      }
+      if (
+        candidate?.kind !== "auth" ||
+        candidate.status !== "planned" ||
+        candidate.details?.credentialKind !== spec.credentialKind
+      ) {
+        return undefined;
+      }
+      if (
+        typeof candidate.details.provider !== "string" ||
+        normalizeProviderId(candidate.details.provider) !== provider
+      ) {
+        throw new Error("The credential import belongs to another provider.");
+      }
+      params.signal?.throwIfAborted();
+      await params.beforePersistentEffect?.();
+      params.signal?.throwIfAborted();
+      const result = await owner.apply(context, applyMigrationItemSelection(plan, [spec.itemId]));
+      const imported = result.items.find(
+        (item) => item.id === spec.itemId && item.kind === "auth" && item.status === "migrated",
+      );
+      const profileId = imported?.details?.profileId;
+      if (
+        typeof profileId !== "string" ||
+        !profileId.trim() ||
+        typeof imported?.details?.provider !== "string" ||
+        normalizeProviderId(imported.details.provider) !== provider ||
+        imported.details.credentialKind !== spec.credentialKind
+      ) {
+        throw new Error(
+          "The existing provider credential changed during import. Start the sign-in again.",
+        );
+      }
+      return {
+        profileId: profileId.trim(),
+        provider,
+        mode: spec.credentialKind,
+        configUpdated: imported.details.configUpdated === true,
+      };
+    },
+  );
+}

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -60,6 +60,7 @@ import type { WizardPrompter } from "../../wizard/prompts.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
 import { repairCopilotRuntimePluginInstallForModelSelection } from "../copilot-runtime-plugin-install.js";
+import { tryImportProviderCredential } from "./auth-credential-import.js";
 import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
 import { loadValidConfigOrThrow, resolveModelsTargetAgent, updateConfig } from "./shared.js";
 
@@ -426,23 +427,13 @@ async function persistProviderAuthResult(params: {
       ...(params.env?.OPENCLAW_STATE_DIR ? { stateDir: params.env.OPENCLAW_STATE_DIR } : {}),
     });
     const profile = expectDefined(persisted[0], "persisted auth profile");
-    const configuredSelection = resolveConfiguredAuthSelectionForProvider(
-      params.config,
-      profile.credential.provider,
-    );
     persistedProfiles.push(profile);
-    const promotion = await promoteAuthProfileInOrder({
+    await promotePersistedAuthProfile({
+      config: params.config,
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
-      createIfMissing: configuredSelection.createIfMissing,
-      ...(configuredSelection.order ? { createFromOrder: configuredSelection.order } : {}),
     });
-    if (!promotion.ok) {
-      throw new Error(
-        "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
-      );
-    }
   }
 
   // Auth login owns the credential store. Keep openclaw.json untouched unless
@@ -525,6 +516,27 @@ function resolveConfiguredAuthSelectionForProvider(
   return profileIds.length > 0
     ? { createIfMissing: true, order: profileIds }
     : { createIfMissing: false };
+}
+
+async function promotePersistedAuthProfile(params: {
+  config: OpenClawConfig;
+  agentDir: string;
+  provider: string;
+  profileId: string;
+}): Promise<void> {
+  const selection = resolveConfiguredAuthSelectionForProvider(params.config, params.provider);
+  const promotion = await promoteAuthProfileInOrder({
+    agentDir: params.agentDir,
+    provider: params.provider,
+    profileId: params.profileId,
+    createIfMissing: selection.createIfMissing,
+    ...(selection.order ? { createFromOrder: selection.order } : {}),
+  });
+  if (!promotion.ok) {
+    throw new Error(
+      "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
+    );
+  }
 }
 
 async function runProviderAuthMethod(params: {
@@ -893,6 +905,7 @@ export type ModelsAuthLoginFlowResult = {
   providerId: string;
   methodId: string;
   defaultModel?: string;
+  imported?: boolean;
   profiles: Array<{
     profileId: string;
     provider: string;
@@ -908,6 +921,7 @@ export type ModelsAuthLoginFlowOptions = LoginOptions & {
   isRemote?: boolean;
   signal?: AbortSignal;
   openUrl?: (url: string) => Promise<void>;
+  beforePersistentEffect?: () => void | Promise<void>;
 };
 
 /** Resolves a requested login provider or throws with available provider details. */
@@ -1035,6 +1049,44 @@ export async function runModelsAuthLoginFlowCore(
     throw new Error(
       `Unknown auth method. Run ${formatCliCommand("openclaw models auth login --provider " + selectedProvider.id)} without --method to choose interactively.`,
     );
+  }
+
+  const imported =
+    !opts.force && !opts.profileId
+      ? await tryImportProviderCredential({
+          method: chosenMethod,
+          providerId: selectedProvider.id,
+          config: context.config,
+          agentId: context.agentId,
+          runtime: opts.runtime,
+          signal: opts.signal,
+          beforePersistentEffect: opts.beforePersistentEffect,
+        })
+      : undefined;
+  if (imported && "unavailableReason" in imported) {
+    await prompter.note(imported.unavailableReason, "Existing CLI sign-in");
+  } else if (imported) {
+    await promotePersistedAuthProfile({
+      config: context.config,
+      agentDir: context.agentDir,
+      provider: imported.provider,
+      profileId: imported.profileId,
+    });
+    await refreshRunningGatewayAuthState(context.agentId, opts.runtime);
+    if (imported.configUpdated) {
+      logConfigUpdated(opts.runtime);
+    }
+    opts.runtime.log(
+      `Auth profile: ${imported.profileId} (${imported.provider}/${imported.mode}, imported)`,
+    );
+    return {
+      providerId: selectedProvider.id,
+      methodId: chosenMethod.id,
+      imported: true,
+      profiles: [
+        { profileId: imported.profileId, provider: imported.provider, mode: imported.mode },
+      ],
+    };
   }
 
   if (opts.force) {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1052,7 +1052,7 @@ export async function runModelsAuthLoginFlowCore(
   }
 
   const imported =
-    !opts.force && !opts.profileId
+    !opts.force && !opts.profileId && !opts.setDefault
       ? await tryImportProviderCredential({
           method: chosenMethod,
           providerId: selectedProvider.id,

--- a/src/plugins/manifest-contract-runtime.test.ts
+++ b/src/plugins/manifest-contract-runtime.test.ts
@@ -56,7 +56,7 @@ describe("resolveManifestContractRuntimePluginResolution", () => {
         contract: "webSearchProviders",
         value: "search",
       }),
-    ).toEqual({
+    ).toMatchObject({
       pluginIds: ["bundled-search", "external-search"],
       bundledCompatPluginIds: ["bundled-search"],
     });

--- a/src/plugins/manifest-contract-runtime.ts
+++ b/src/plugins/manifest-contract-runtime.ts
@@ -5,12 +5,13 @@ import {
   hasManifestContractValue,
   listAvailableManifestContractPlugins,
 } from "./manifest-contract-eligibility.js";
-import type { PluginManifestContractListKey } from "./manifest-registry.js";
+import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 type ManifestContractRuntimePluginResolution = {
   pluginIds: string[];
   bundledCompatPluginIds: string[];
+  plugins: PluginManifestRecord[];
 };
 
 export function resolveManifestContractRuntimePluginResolution(params: {
@@ -41,5 +42,6 @@ export function resolveManifestContractRuntimePluginResolution(params: {
   return {
     pluginIds: sortUniqueStrings(pluginIds),
     bundledCompatPluginIds: sortUniqueStrings(bundledCompatPluginIds),
+    plugins: allContractPlugins,
   };
 }

--- a/src/plugins/migration-provider-public-artifacts.ts
+++ b/src/plugins/migration-provider-public-artifacts.ts
@@ -1,0 +1,69 @@
+// Loads lightweight migration providers from their installed public artifacts.
+import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+import type { MigrationProviderPlugin } from "./migration-provider.types.js";
+import { loadPluginPublicArtifactModuleSync } from "./public-surface-loader.js";
+
+const MIGRATION_PROVIDER_ARTIFACT = "migration-provider-api.js";
+
+type MigrationProviderArtifactModule = {
+  buildMigrationProvider?: () => MigrationProviderPlugin;
+};
+
+export type MigrationProviderArtifactPlugin = Pick<
+  PluginManifestRecord,
+  "id" | "origin" | "rootDir" | "contracts"
+>;
+
+export function resolveMigrationProviderPublicArtifacts(params: {
+  plugins: readonly MigrationProviderArtifactPlugin[];
+  providerId: string;
+}): Array<{ pluginId: string; provider: MigrationProviderPlugin }> {
+  const providers: Array<{ pluginId: string; provider: MigrationProviderPlugin }> = [];
+  for (const plugin of params.plugins) {
+    const declared = plugin.contracts?.migrationProviders ?? [];
+    if (
+      (plugin.origin !== "bundled" && plugin.origin !== "global") ||
+      declared.length === 0 ||
+      !declared.includes(params.providerId)
+    ) {
+      continue;
+    }
+    let artifact: MigrationProviderArtifactModule;
+    try {
+      artifact = loadPluginPublicArtifactModuleSync<MigrationProviderArtifactModule>({
+        pluginRoot: plugin.rootDir,
+        artifactBasename: MIGRATION_PROVIDER_ARTIFACT,
+        origin: plugin.origin,
+      });
+    } catch (error) {
+      if (error instanceof MissingPublicSurfaceError) {
+        continue;
+      }
+      throw error;
+    }
+    if (typeof artifact.buildMigrationProvider !== "function") {
+      throw new Error(
+        `Plugin "${plugin.id}" has an invalid ${MIGRATION_PROVIDER_ARTIFACT}: buildMigrationProvider is required.`,
+      );
+    }
+    const provider = artifact.buildMigrationProvider();
+    if (
+      provider.id !== params.providerId ||
+      typeof provider.plan !== "function" ||
+      typeof provider.apply !== "function"
+    ) {
+      throw new Error(
+        `Plugin "${plugin.id}" returned an invalid migration provider from ${MIGRATION_PROVIDER_ARTIFACT}.`,
+      );
+    }
+    const existing = providers.find((entry) => entry.provider.id === provider.id);
+    if (existing) {
+      throw new Error(
+        `Multiple plugins declare migration provider "${provider.id}": ${existing.pluginId}, ${plugin.id}.`,
+      );
+    }
+    providers.push({ pluginId: plugin.id, provider });
+  }
+  return providers;
+}

--- a/src/plugins/migration-provider-public-artifacts.ts
+++ b/src/plugins/migration-provider-public-artifacts.ts
@@ -2,7 +2,10 @@
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { MigrationProviderPlugin } from "./migration-provider.types.js";
-import { loadPluginPublicArtifactModuleSync } from "./public-surface-loader.js";
+import {
+  loadBundledPluginPublicArtifactModuleSync,
+  loadPluginPublicArtifactModuleSync,
+} from "./public-surface-loader.js";
 
 const MIGRATION_PROVIDER_ARTIFACT = "migration-provider-api.js";
 
@@ -10,10 +13,8 @@ type MigrationProviderArtifactModule = {
   buildMigrationProvider?: () => MigrationProviderPlugin;
 };
 
-export type MigrationProviderArtifactPlugin = Pick<
-  PluginManifestRecord,
-  "id" | "origin" | "rootDir" | "contracts"
->;
+export type MigrationProviderArtifactPlugin = Pick<PluginManifestRecord, "id" | "contracts"> &
+  ({ origin: "bundled"; dirName: string } | { origin: "global"; rootDir: string });
 
 export function resolveMigrationProviderPublicArtifacts(params: {
   plugins: readonly MigrationProviderArtifactPlugin[];
@@ -22,20 +23,22 @@ export function resolveMigrationProviderPublicArtifacts(params: {
   const providers: Array<{ pluginId: string; provider: MigrationProviderPlugin }> = [];
   for (const plugin of params.plugins) {
     const declared = plugin.contracts?.migrationProviders ?? [];
-    if (
-      (plugin.origin !== "bundled" && plugin.origin !== "global") ||
-      declared.length === 0 ||
-      !declared.includes(params.providerId)
-    ) {
+    if (declared.length === 0 || !declared.includes(params.providerId)) {
       continue;
     }
     let artifact: MigrationProviderArtifactModule;
     try {
-      artifact = loadPluginPublicArtifactModuleSync<MigrationProviderArtifactModule>({
-        pluginRoot: plugin.rootDir,
-        artifactBasename: MIGRATION_PROVIDER_ARTIFACT,
-        origin: plugin.origin,
-      });
+      artifact =
+        plugin.origin === "bundled"
+          ? loadBundledPluginPublicArtifactModuleSync<MigrationProviderArtifactModule>({
+              dirName: plugin.dirName,
+              artifactBasename: MIGRATION_PROVIDER_ARTIFACT,
+            })
+          : loadPluginPublicArtifactModuleSync<MigrationProviderArtifactModule>({
+              pluginRoot: plugin.rootDir,
+              artifactBasename: MIGRATION_PROVIDER_ARTIFACT,
+              origin: plugin.origin,
+            });
     } catch (error) {
       if (error instanceof MissingPublicSurfaceError) {
         continue;

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -1,10 +1,15 @@
 // Covers migration provider runtime hooks supplied by plugins.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type MockManifestRegistry = {
   plugins: Array<Record<string, unknown>>;
@@ -149,6 +154,55 @@ describe("migration provider runtime", () => {
     withPluginMigrationProviders = runtime.withPluginMigrationProviders;
   });
 
+  it("uses the selected installed public artifact without acquiring or replacing a registry", async () => {
+    const rootDir = tempDirs.make("openclaw-migration-artifact-");
+    fs.writeFileSync(
+      path.join(rootDir, "migration-provider-api.js"),
+      `
+      export function buildMigrationProvider() {
+        return { id: "fixture-import", label: "Installed fixture",
+          plan: async () => ({ providerId: "fixture-import", source: "selected-install", items: [],
+            summary: { total: 0, planned: 0, migrated: 0, skipped: 0, conflicts: 0, errors: 0, sensitive: 0 } }),
+          apply: async (_ctx, plan) => plan };
+      }
+    `,
+    );
+    const active = createEmptyPluginRegistry();
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+    mocks.loadPluginRegistrySnapshot.mockReturnValue(
+      createMockPluginIndex([{ pluginId: "fixture", origin: "global", enabled: true }]),
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "fixture",
+          origin: "global",
+          rootDir,
+          contracts: { migrationProviders: ["fixture-import"] },
+        },
+      ],
+    });
+    mocks.listBundledPluginMetadata.mockReturnValue([
+      {
+        rootDir: "/unselected-bundled-fixture",
+        manifest: { id: "fixture", contracts: { migrationProviders: ["fixture-import"] } },
+      },
+    ] as never);
+
+    const label = await withPluginMigrationProviders(
+      {
+        providerId: "fixture-import",
+        cfg: { plugins: { entries: { fixture: { enabled: true } } } },
+      },
+      async (providers) => providers.find((provider) => provider.id === "fixture-import")?.label,
+    );
+
+    expect(label).toBe("Installed fixture");
+    expect(mocks.acquirePluginRegistryForInspection).not.toHaveBeenCalled();
+    expect(active.migrationProviders).toEqual([]);
+  });
+
   it("loads bundled migration providers through compat config", async () => {
     mocks.loadPluginRegistrySnapshot.mockReturnValue(
       createMockPluginIndex([
@@ -193,6 +247,7 @@ describe("migration provider runtime", () => {
           id: "migrate-hermes",
           contracts: { migrationProviders: ["hermes"] },
         },
+        rootDir: "/missing-migration-fixture",
       },
     ] as never);
 
@@ -329,6 +384,7 @@ describe("migration provider runtime", () => {
           id: "migrate-hermes",
           contracts: { migrationProviders: ["hermes"] },
         },
+        rootDir: "/missing-migration-fixture",
       },
     ] as never);
 

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -156,11 +156,19 @@ describe("migration provider runtime", () => {
     withPluginMigrationProviders = runtime.withPluginMigrationProviders;
   });
 
-  it.each(["global", "bundled"] as const)(
-    "uses the selected %s public artifact without acquiring or replacing a registry",
-    async (origin) => {
+  it.each([
+    { origin: "global", policy: "enabled", allowed: true },
+    { origin: "global", policy: "disabled", allowed: false },
+    { origin: "global", policy: "denied", allowed: false },
+    { origin: "bundled", policy: "enabled", allowed: true },
+    { origin: "bundled", policy: "disabled", allowed: false },
+    { origin: "bundled", policy: "denied", allowed: false },
+  ] as const)(
+    "enforces $policy owner policy before executing a $origin public artifact",
+    async ({ origin, policy, allowed }) => {
       const scanDir = tempDirs.make("openclaw-migration-artifact-");
       const rootDir = path.join(scanDir, "fixture-dir");
+      const executedPath = path.join(scanDir, "artifact-executed");
       fs.mkdirSync(rootDir);
       fs.writeFileSync(
         path.join(rootDir, "package.json"),
@@ -186,6 +194,8 @@ describe("migration provider runtime", () => {
       fs.writeFileSync(
         path.join(rootDir, "migration-provider-api.js"),
         `
+        import fs from "node:fs";
+        fs.writeFileSync(${JSON.stringify(executedPath)}, "executed");
         export function buildMigrationProvider() {
           return { id: "fixture-import", label: "Fixture public owner",
             plan: async () => ({ providerId: "fixture-import", source: "fixture", items: [],
@@ -222,12 +232,18 @@ describe("migration provider runtime", () => {
         const label = await withPluginMigrationProviders(
           {
             providerId: "fixture-import",
-            cfg: { plugins: { entries: { fixture: { enabled: true } } } },
+            cfg: {
+              plugins: {
+                entries: { fixture: { enabled: policy !== "disabled" } },
+                ...(policy === "denied" ? { deny: ["fixture"] } : {}),
+              },
+            },
           },
           async (providers) =>
             providers.find((provider) => provider.id === "fixture-import")?.label,
         );
-        expect(label).toBe("Fixture public owner");
+        expect(label).toBe(allowed ? "Fixture public owner" : undefined);
+        expect(fs.existsSync(executedPath)).toBe(allowed);
         expect(mocks.acquirePluginRegistryForInspection).not.toHaveBeenCalled();
         expect(active.migrationProviders).toEqual([]);
       } finally {

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -57,7 +57,9 @@ const mocks = vi.hoisted(() => ({
   })),
   acquirePluginRegistryForInspection: vi.fn(),
   release: vi.fn(async () => {}),
-  listBundledPluginMetadata: vi.fn(() => []),
+  listBundledPluginMetadata: vi.fn<
+    typeof import("./bundled-plugin-metadata.js").listBundledPluginMetadata
+  >(() => []),
 }));
 
 vi.mock("./loader.js", async (importOriginal) => ({
@@ -154,54 +156,85 @@ describe("migration provider runtime", () => {
     withPluginMigrationProviders = runtime.withPluginMigrationProviders;
   });
 
-  it("uses the selected installed public artifact without acquiring or replacing a registry", async () => {
-    const rootDir = tempDirs.make("openclaw-migration-artifact-");
-    fs.writeFileSync(
-      path.join(rootDir, "migration-provider-api.js"),
-      `
-      export function buildMigrationProvider() {
-        return { id: "fixture-import", label: "Installed fixture",
-          plan: async () => ({ providerId: "fixture-import", source: "selected-install", items: [],
-            summary: { total: 0, planned: 0, migrated: 0, skipped: 0, conflicts: 0, errors: 0, sensitive: 0 } }),
-          apply: async (_ctx, plan) => plan };
-      }
-    `,
-    );
-    const active = createEmptyPluginRegistry();
-    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
-    mocks.loadPluginRegistrySnapshot.mockReturnValue(
-      createMockPluginIndex([{ pluginId: "fixture", origin: "global", enabled: true }]),
-    );
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      diagnostics: [],
-      plugins: [
-        {
+  it.each(["global", "bundled"] as const)(
+    "uses the selected %s public artifact without acquiring or replacing a registry",
+    async (origin) => {
+      const scanDir = tempDirs.make("openclaw-migration-artifact-");
+      const rootDir = path.join(scanDir, "fixture-dir");
+      fs.mkdirSync(rootDir);
+      fs.writeFileSync(
+        path.join(rootDir, "package.json"),
+        JSON.stringify({
+          name: "@openclaw/fixture",
+          version: "1.0.0",
+          type: "module",
+          openclaw: { extensions: ["./index.js"] },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rootDir, "openclaw.plugin.json"),
+        JSON.stringify({
           id: "fixture",
-          origin: "global",
-          rootDir,
           contracts: { migrationProviders: ["fixture-import"] },
-        },
-      ],
-    });
-    mocks.listBundledPluginMetadata.mockReturnValue([
-      {
-        rootDir: "/unselected-bundled-fixture",
-        manifest: { id: "fixture", contracts: { migrationProviders: ["fixture-import"] } },
-      },
-    ] as never);
-
-    const label = await withPluginMigrationProviders(
-      {
-        providerId: "fixture-import",
-        cfg: { plugins: { entries: { fixture: { enabled: true } } } },
-      },
-      async (providers) => providers.find((provider) => provider.id === "fixture-import")?.label,
-    );
-
-    expect(label).toBe("Installed fixture");
-    expect(mocks.acquirePluginRegistryForInspection).not.toHaveBeenCalled();
-    expect(active.migrationProviders).toEqual([]);
-  });
+          configSchema: { type: "object", additionalProperties: false, properties: {} },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rootDir, "index.js"),
+        'throw new Error("Heavy plugin runtime loaded");',
+      );
+      fs.writeFileSync(
+        path.join(rootDir, "migration-provider-api.js"),
+        `
+        export function buildMigrationProvider() {
+          return { id: "fixture-import", label: "Fixture public owner",
+            plan: async () => ({ providerId: "fixture-import", source: "fixture", items: [],
+              summary: { total: 0, planned: 0, migrated: 0, skipped: 0, conflicts: 0, errors: 0, sensitive: 0 } }),
+            apply: async (_ctx, plan) => plan };
+        }
+      `,
+      );
+      const { listBundledPluginMetadata } = await vi.importActual<
+        typeof import("./bundled-plugin-metadata.js")
+      >("./bundled-plugin-metadata.js");
+      const bundled = listBundledPluginMetadata({ scanDir, includeChannelConfigs: false });
+      mocks.listBundledPluginMetadata.mockReturnValue(bundled);
+      const active = createEmptyPluginRegistry();
+      mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+      if (origin === "global") {
+        mocks.loadPluginRegistrySnapshot.mockReturnValue(
+          createMockPluginIndex([{ pluginId: "fixture", origin, enabled: true }]),
+        );
+        mocks.loadPluginManifestRegistry.mockReturnValue({
+          diagnostics: [],
+          plugins: [
+            {
+              id: "fixture",
+              origin,
+              rootDir,
+              contracts: { migrationProviders: ["fixture-import"] },
+            },
+          ],
+        });
+      }
+      vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", scanDir);
+      try {
+        const label = await withPluginMigrationProviders(
+          {
+            providerId: "fixture-import",
+            cfg: { plugins: { entries: { fixture: { enabled: true } } } },
+          },
+          async (providers) =>
+            providers.find((provider) => provider.id === "fixture-import")?.label,
+        );
+        expect(label).toBe("Fixture public owner");
+        expect(mocks.acquirePluginRegistryForInspection).not.toHaveBeenCalled();
+        expect(active.migrationProviders).toEqual([]);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it("loads bundled migration providers through compat config", async () => {
     mocks.loadPluginRegistrySnapshot.mockReturnValue(
@@ -247,7 +280,7 @@ describe("migration provider runtime", () => {
           id: "migrate-hermes",
           contracts: { migrationProviders: ["hermes"] },
         },
-        rootDir: "/missing-migration-fixture",
+        dirName: "missing-migration-fixture",
       },
     ] as never);
 
@@ -384,7 +417,7 @@ describe("migration provider runtime", () => {
           id: "migrate-hermes",
           contracts: { migrationProviders: ["hermes"] },
         },
-        rootDir: "/missing-migration-fixture",
+        dirName: "missing-migration-fixture",
       },
     ] as never);
 

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -5,6 +5,10 @@ import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
 import { acquirePluginRegistryForInspection } from "./loader.js";
 import { resolveManifestContractRuntimePluginResolution } from "./manifest-contract-runtime.js";
+import {
+  resolveMigrationProviderPublicArtifacts,
+  type MigrationProviderArtifactPlugin,
+} from "./migration-provider-public-artifacts.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import type { MigrationProviderPlugin } from "./types.js";
@@ -12,6 +16,7 @@ import type { MigrationProviderPlugin } from "./types.js";
 type MigrationProviderPluginResolution = {
   pluginIds: string[];
   bundledCompatPluginIds: string[];
+  publicPlugins: MigrationProviderArtifactPlugin[];
 };
 
 function bindMigrationProviderToRegistry(
@@ -47,6 +52,9 @@ function resolveMigrationProviderPluginResolution(params: {
   });
   const pluginIds = new Set(resolution.pluginIds);
   const bundledCompatPluginIds = new Set(resolution.bundledCompatPluginIds);
+  const publicPlugins: MigrationProviderArtifactPlugin[] = resolution.plugins.filter(
+    (plugin) => plugin.origin === "global" && pluginIds.has(plugin.id),
+  );
 
   // Install migration can persist a deliberately pruned bundled-plugin index.
   // Migration contracts still need manifest discovery to repair older indexes.
@@ -54,12 +62,19 @@ function resolveMigrationProviderPluginResolution(params: {
     const providerIds = plugin.manifest.contracts?.migrationProviders ?? [];
     if (
       providerIds.length === 0 ||
-      (params.providerId && !providerIds.includes(params.providerId))
+      (params.providerId && !providerIds.includes(params.providerId)) ||
+      publicPlugins.some((owner) => owner.id === plugin.manifest.id)
     ) {
       continue;
     }
     pluginIds.add(plugin.manifest.id);
     bundledCompatPluginIds.add(plugin.manifest.id);
+    publicPlugins.push({
+      id: plugin.manifest.id,
+      origin: "bundled",
+      rootDir: plugin.rootDir,
+      contracts: { migrationProviders: providerIds },
+    });
   }
 
   return {
@@ -67,6 +82,7 @@ function resolveMigrationProviderPluginResolution(params: {
     bundledCompatPluginIds: [...bundledCompatPluginIds].toSorted((left, right) =>
       left.localeCompare(right),
     ),
+    publicPlugins,
   };
 }
 
@@ -102,6 +118,15 @@ export async function withPluginMigrationProviders<T>(
     return await run(mergeMigrationProviders(activeProviders, []));
   }
   const resolution = resolveMigrationProviderPluginResolution(params);
+  if (params.providerId) {
+    const providers = resolveMigrationProviderPublicArtifacts({
+      plugins: resolution.publicPlugins,
+      providerId: params.providerId,
+    });
+    if (providers.length > 0) {
+      return await run(mergeMigrationProviders(activeProviders, providers));
+    }
+  }
   if (
     resolution.pluginIds.length === 0 ||
     getLoadedRuntimePluginRegistry({ requiredPluginIds: resolution.pluginIds })

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -3,7 +3,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
+import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
+import { normalizePluginsConfig } from "./config-state.js";
 import { acquirePluginRegistryForInspection } from "./loader.js";
+import { isManifestPluginOwnerAllowedByControlPlanePolicy } from "./manifest-contract-eligibility.js";
 import { resolveManifestContractRuntimePluginResolution } from "./manifest-contract-runtime.js";
 import {
   resolveMigrationProviderPublicArtifacts,
@@ -65,6 +68,7 @@ function resolveMigrationProviderPluginResolution(params: {
       : [],
   );
 
+  const normalizedConfig = normalizePluginsConfig(params.cfg?.plugins);
   // Install migration can persist a deliberately pruned bundled-plugin index.
   // Migration contracts still need manifest discovery to repair older indexes.
   for (const plugin of listBundledPluginMetadata({ includeChannelConfigs: false })) {
@@ -72,7 +76,17 @@ function resolveMigrationProviderPluginResolution(params: {
     if (
       providerIds.length === 0 ||
       (params.providerId && !providerIds.includes(params.providerId)) ||
-      publicPlugins.some((owner) => owner.id === plugin.manifest.id)
+      publicPlugins.some((owner) => owner.id === plugin.manifest.id) ||
+      !isManifestPluginOwnerAllowedByControlPlanePolicy({
+        plugin: {
+          id: plugin.manifest.id,
+          origin: "bundled",
+          channels: plugin.manifest.channels,
+        },
+        config: params.cfg,
+        normalizedConfig,
+        allowBundledProviderCompat: isBundledProviderCompatContract("migrationProviders"),
+      })
     ) {
       continue;
     }

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -52,8 +52,17 @@ function resolveMigrationProviderPluginResolution(params: {
   });
   const pluginIds = new Set(resolution.pluginIds);
   const bundledCompatPluginIds = new Set(resolution.bundledCompatPluginIds);
-  const publicPlugins: MigrationProviderArtifactPlugin[] = resolution.plugins.filter(
-    (plugin) => plugin.origin === "global" && pluginIds.has(plugin.id),
+  const publicPlugins: MigrationProviderArtifactPlugin[] = resolution.plugins.flatMap((plugin) =>
+    plugin.origin === "global" && pluginIds.has(plugin.id)
+      ? [
+          {
+            id: plugin.id,
+            origin: "global" as const,
+            rootDir: plugin.rootDir,
+            contracts: plugin.contracts,
+          },
+        ]
+      : [],
   );
 
   // Install migration can persist a deliberately pruned bundled-plugin index.
@@ -72,7 +81,7 @@ function resolveMigrationProviderPluginResolution(params: {
     publicPlugins.push({
       id: plugin.manifest.id,
       origin: "bundled",
-      rootDir: plugin.rootDir,
+      dirName: plugin.dirName,
       contracts: { migrationProviders: providerIds },
     });
   }

--- a/src/plugins/provider-authentication.types.ts
+++ b/src/plugins/provider-authentication.types.ts
@@ -170,6 +170,12 @@ export type ProviderAuthMethod = {
   kind: ProviderAuthKind;
   /** Provider-owned model used to validate app-guided secret setup. */
   starterModel?: string;
+  /** One-time import attempted only after the user starts this login method. */
+  credentialImport?: {
+    migrationProviderId: string;
+    itemId: string;
+    credentialKind: "oauth" | "api_key" | "token";
+  };
   /**
    * Optional wizard/onboarding metadata for this specific auth method.
    *


### PR DESCRIPTION
## What Problem This Solves

Login could prompt again for an existing supported credential or report successful reuse of an expired saved account.

## Why This Change Was Made

The migration owner selects the method’s declared credential kind, checks plugin policy before reading, and rechecks usability before saving under the existing lock. Explicit force, profile selection, and default-changing requests use normal sign-in.

## User Impact

Eligible credentials can be reused without another paste prompt, preserving profiles and model settings. Expired credentials require renewal. No schema change is required.

## Evidence

Compiled CLI checks reproduced the extra prompt and expired-profile false success. Candidate checks imported a usable credential and exposed it through the public auth list without changing source/config data. The expired case reached renewal but failed on unavailable network resolution, so completed authentication is unverified. Credential-import regressions passed. Live channel reuse and account validity were outside the captured proof.
