### PR TITLE
refactor(tests): reuse Memory Wiki source-state fixtures

### DIFF
--- a/extensions/memory-wiki/src/source-sync-state.test.ts
+++ b/extensions/memory-wiki/src/source-sync-state.test.ts
@@ -353,19 +353,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     expect(removed).toBe(1);
@@ -412,19 +400,7 @@ describe("memory wiki source sync state", () => {
         vaultRoot,
         group: "bridge",
         activeKeys: new Set(),
-        state: {
-          version: 1,
-          entries: {
-            "sync-key": {
-              group: "bridge",
-              pagePath,
-              sourcePath: "/tmp/source.md",
-              sourceUpdatedAtMs: 0,
-              sourceSize: 0,
-              renderFingerprint: "fp",
-            },
-          },
-        },
+        state: createImportedSourceState(pagePath),
       });
 
       expect(removed).toBe(1);
@@ -691,19 +667,7 @@ describe("memory wiki source sync state", () => {
           vaultRoot,
           group: "bridge",
           activeKeys: new Set(),
-          state: {
-            version: 1,
-            entries: {
-              "sync-key": {
-                group: "bridge",
-                pagePath,
-                sourcePath: "/tmp/source.md",
-                sourceUpdatedAtMs: 0,
-                sourceSize: 0,
-                renderFingerprint: "fp",
-              },
-            },
-          },
+          state: createImportedSourceState(pagePath),
         }),
       ).resolves.toBe(1);
     }
@@ -722,19 +686,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     const salvageDir = path.join(vaultRoot, ".salvage");
@@ -771,19 +723,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     expect(removed).toBe(1);
@@ -802,19 +742,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     expect(removed).toBe(1);
@@ -943,19 +871,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     // Salvage write failed — the page must NOT be removed.
@@ -992,19 +908,7 @@ describe("memory wiki source sync state", () => {
       vaultRoot,
       group: "bridge",
       activeKeys: new Set(),
-      state: {
-        version: 1,
-        entries: {
-          "sync-key": {
-            group: "bridge",
-            pagePath,
-            sourcePath: "/tmp/source.md",
-            sourceUpdatedAtMs: 0,
-            sourceSize: 0,
-            renderFingerprint: "fp",
-          },
-        },
-      },
+      state: createImportedSourceState(pagePath),
     });
 
     // Restore permission so cleanup can proceed.


### PR DESCRIPTION
## What Problem This Solves

Eight Memory Wiki pruning scenarios repeat a source-state fixture already provided by the same test file’s local helper.

## Why This Change Was Made

Reuse `createImportedSourceState(pagePath)` at those eight input sites. The existing helper and its six prior callers remain unchanged. Each loop and table iteration still gets fresh state, entries and entry objects; pruning mutations cannot leak into another invocation. Expected results, filesystem fixtures and permission checks remain independent.

## User Impact

No production behavior changes. This maintainer-requested test consolidation removes 96 net lines without removing cases or changing SQLite state semantics.

## Evidence

- Both complete source-state and malformed-notes suites passed before and after: 30 cases, zero pending, identical ordered case names and statuses, including the permission-sensitive case.
- Expanding the eight helper calls restores the original test syntax. Twelve constructions preserve values, key order, descriptors, prototypes and deletion isolation; the helper and six existing call sites are unchanged.
- Mapped changed gate, deslop and fresh P2 review passed. No test-runtime savings are claimed.
