### PR TITLE
fix(ci): retain postpublish diagnostics when verification fails

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1181,6 +1181,18 @@ jobs:
       # Artifact bytes may belong to an FRV child; the input run still authorizes npm dispatch.
       PREFLIGHT_ARTIFACT_RUN_ID: ${{ needs.resolve_release_target.outputs.preflight_artifact_run_id }}
       ANDROID_RELEASE_NOTE: ${{ needs.resolve_release_target.outputs.android_release_note }}
+      TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+      PARENT_WORKFLOW_SHA: ${{ github.workflow_sha }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
+      PLUGINS: ${{ inputs.plugins }}
+      WAIT_FOR_CLAWHUB: ${{ inputs.wait_for_clawhub && 'true' || 'false' }}
+      NPM_TELEGRAM_RUN_ID: ${{ inputs.npm_telegram_run_id }}
+      RELEASE_EVIDENCE_MODE: ${{ inputs.release_evidence_mode }}
+      FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
+      FULL_RELEASE_VALIDATION_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}
+      FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+      FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.focused_release_evidence_run_attempt }}
     permissions:
       actions: write
       attestations: write
@@ -1278,6 +1290,14 @@ jobs:
           # Node resolves --import tsx from the process cwd. Point that root at
           # the trusted harness install instead of the frozen target checkout.
           ln -s .release-harness/node_modules node_modules
+
+      - name: Initialize postpublish diagnostics
+        env:
+          POSTPUBLISH_EVIDENCE_DIR: ${{ runner.temp }}/openclaw-release-postpublish-evidence
+        run: |
+          set -euo pipefail
+          source "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-publish-children.sh"
+          record_postpublish_diagnostics initialize
 
       - name: Verify all prepared plugin bytes before publication
         if: inputs.prepared_plugins != ''
@@ -1771,6 +1791,7 @@ jobs:
           retention-days: 30
 
       - name: Complete publish workflows
+        id: complete
         if: ${{ always() && !cancelled() && steps.core_start.outputs.plugin_npm_completed == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1921,9 +1942,11 @@ jobs:
 
           if [[ "${release_target_current}" == "true" && ( ( -n "${openclaw_npm_run_id}" && "${openclaw_failed}" == "0" ) || "${openclaw_npm_already_published}" == "true" ) ]]; then
             verify_published_release
+            record_postpublish_diagnostics assets-start
             upload_dependency_evidence_release_asset
             upload_release_evidence_assets
             append_release_proof_to_github_release
+            record_postpublish_diagnostics assets-success
             if [[ "${failed}" == "0" ]]; then
               echo "- GitHub release: kept draft until required publication checks complete" >> "$GITHUB_STEP_SUMMARY"
             else
@@ -1934,12 +1957,39 @@ jobs:
             exit 1
           fi
 
+      - name: Record postpublish outcome
+        if: ${{ always() }}
+        env:
+          POSTPUBLISH_EVIDENCE_DIR: ${{ runner.temp }}/openclaw-release-postpublish-evidence
+          CHILD_PLUGIN_NPM_RUN_ID: ${{ steps.children.outputs.plugin_npm_run_id }}
+          CHILD_PLUGIN_CLAWHUB_RUN_ID: ${{ steps.children.outputs.plugin_clawhub_run_id }}
+          CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID: ${{ steps.children.outputs.plugin_clawhub_bootstrap_run_id }}
+          CHILD_OPENCLAW_NPM_RUN_ID: ${{ steps.core_start.outputs.openclaw_npm_run_id }}
+          CORE_START_OUTCOME: ${{ steps.core_start.outcome }}
+          COMPLETION_OUTCOME: ${{ steps.complete.outcome }}
+          PUBLISH_JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          if [[ -f "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-publish-children.sh" ]]; then
+            source "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-publish-children.sh"
+            record_postpublish_diagnostics terminal
+          fi
+
+      - name: Upload postpublish diagnostics
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-release-postpublish-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/openclaw-release-postpublish-evidence/release-postpublish-diagnostics.json
+          if-no-files-found: warn
+
       - name: Upload postpublish evidence
-        if: ${{ always() && inputs.publish_openclaw_npm }}
+        if: ${{ always() && inputs.publish_openclaw_npm && (steps.complete.outcome == 'success' || steps.complete.outputs.postpublish_evidence_ready == 'true') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
-          path: ${{ runner.temp }}/openclaw-release-postpublish-evidence
+          path: ${{ runner.temp }}/openclaw-release-postpublish-evidence/release-postpublish-evidence.json
           if-no-files-found: error
 
   verify_core_npm_registry:

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -370,6 +370,7 @@ jobs:
           install-bun: "false"
 
       - name: Install trusted plugin tooling dependencies
+        if: inputs.prepared_artifact == ''
         working-directory: .release-tooling
         env:
           CI: "true"

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -589,7 +589,7 @@ class PostpublishDiagnostics {
 
 // Called only by the existing publish helper. This records local observations;
 // it cannot invoke a registry, GitHub mutation, retry, or publication command.
-export function recordReleasePublishDiagnostics(event: string): void {
+function recordReleasePublishDiagnostics(event: string): void {
   try {
     const env = process.env;
     if (!env.POSTPUBLISH_EVIDENCE_DIR) {
@@ -2132,4 +2132,8 @@ export async function verifyBetaRelease(
     diagnostic.fail(error);
     throw error;
   }
+}
+
+if (import.meta.main) {
+  recordReleasePublishDiagnostics(process.argv[2] ?? "");
 }

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -1,9 +1,18 @@
 import { execFileSync } from "node:child_process";
 // Release Beta Verifier script supports OpenClaw repository automation.
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 import { isRecord as isJsonRecord } from "../../packages/normalization-core/src/record-coerce.ts";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.ts";
 import { readPublicationArtifactArchive, sha256Digest } from "./actions-artifact-archive.mjs";
@@ -96,6 +105,557 @@ const NPM_VIEW_ATTEMPTS = 30;
 const NPM_VIEW_RETRY_MAX_DELAY_MS = 10_000;
 const RELEASE_COMMAND_TIMEOUT_MS = 120_000;
 const RELEASE_COMMAND_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+
+const DIAGNOSTIC_FILE = "release-postpublish-diagnostics.json";
+const DIAGNOSTIC_MAX_BYTES = 128 * 1024;
+const DIAGNOSTIC_MAX_PACKAGES = 256;
+const diagnosticStates = z.enum([
+  "unattempted",
+  "skipped",
+  "started",
+  "success",
+  "failure",
+  "unknown",
+]);
+const diagnosticError = z.object({
+  class: z.enum([
+    "registry-not-visible",
+    "selector-mismatch",
+    "identity-mismatch",
+    "transport",
+    "malformed-response",
+    "command-failure",
+    "evidence-write-failure",
+  ]),
+  status: z.number().int().min(0).max(255).nullable(),
+});
+const diagnosticPackage = z.object({
+  name: z
+    .string()
+    .max(128)
+    .regex(/^@openclaw\/[a-z0-9][a-z0-9._-]*$/u),
+  state: diagnosticStates,
+  publication: z.enum(["unknown", "observed"]),
+  error: diagnosticError.nullable(),
+});
+const diagnosticStage = z.object({
+  state: diagnosticStates,
+  publication: z.enum(["unknown", "observed"]),
+  error: diagnosticError.nullable(),
+  packages: z.array(diagnosticPackage).max(DIAGNOSTIC_MAX_PACKAGES),
+  packagesTruncated: z.boolean(),
+});
+const diagnosticStageNames = [
+  "checkout",
+  "githubRelease",
+  "coreNpm",
+  "postpublish",
+  "pluginNpm",
+  "clawHub",
+  "fullReleaseValidation",
+  "pluginNpmRun",
+  "pluginClawHubRun",
+  "pluginClawHubBootstrap",
+  "openclawNpm",
+  "npmTelegram",
+  "evidence",
+  "binding",
+  "assets",
+] as const;
+const diagnosticChildNames = [
+  "fullReleaseValidation",
+  "openclawNpm",
+  "pluginNpm",
+  "pluginClawHub",
+  "pluginClawHubBootstrap",
+  "npmTelegram",
+] as const;
+type DiagnosticStageName = (typeof diagnosticStageNames)[number];
+type DiagnosticChildName = (typeof diagnosticChildNames)[number];
+const diagnosticId = z.string().max(20).regex(POSITIVE_INTEGER_PATTERN).nullable();
+const diagnosticSha = z.string().regex(COMMIT_SHA_PATTERN).nullable();
+const diagnosticRef = z
+  .string()
+  .max(200)
+  .regex(/^(?:refs\/(?:heads|tags)\/)?[A-Za-z0-9][A-Za-z0-9._/-]*$/u)
+  .nullable();
+const diagnosticOutcome = z.enum([
+  "success",
+  "failure",
+  "cancelled",
+  "skipped",
+  "timed_out",
+  "action_required",
+  "neutral",
+  "stale",
+  "unknown",
+]);
+const diagnosticSchema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("release-postpublish-diagnostics"),
+  invocationId: z.string().uuid(),
+  context: z.object({
+    repository: z
+      .string()
+      .max(200)
+      .regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u)
+      .nullable(),
+    releaseVersion: z
+      .string()
+      .max(80)
+      .regex(/^[0-9]+(?:\.[0-9]+){2}(?:-[a-z0-9.-]+)?$/u)
+      .nullable(),
+    releaseTag: z
+      .string()
+      .max(81)
+      .regex(/^v[0-9]+(?:\.[0-9]+){2}(?:-[a-z0-9.-]+)?$/u)
+      .nullable(),
+    npmDistTag: z.enum(["latest", "beta", "alpha", "extended-stable"]).nullable(),
+    requestedSourceSha: diagnosticSha,
+    toolingSha: diagnosticSha,
+    suppliedToolingSha: diagnosticSha,
+    suppliedToolingRef: diagnosticRef,
+    parentRunId: diagnosticId,
+    parentRunAttempt: diagnosticId,
+    validationEvidence: z.object({
+      mode: z.enum(["full-release-validation", "authorized-beta-focused-v1"]).nullable(),
+      runId: diagnosticId,
+      runAttempt: diagnosticId,
+    }),
+  }),
+  selection: z.object({
+    plugins: z.array(diagnosticPackage.shape.name).max(DIAGNOSTIC_MAX_PACKAGES),
+    pluginsTruncated: z.boolean(),
+    workflowRef: diagnosticRef,
+    clawHubWorkflowRef: diagnosticRef,
+  }),
+  verification: diagnosticStates,
+  currentStage: z.enum(diagnosticStageNames).nullable(),
+  stages: z.record(z.enum(diagnosticStageNames), diagnosticStage),
+  children: z.record(
+    z.enum(diagnosticChildNames),
+    z.object({
+      suppliedRunId: diagnosticId,
+      runAttempt: diagnosticId,
+      producerRunAttempt: diagnosticId,
+      status: z.enum([
+        "queued",
+        "in_progress",
+        "completed",
+        "waiting",
+        "pending",
+        "requested",
+        "unknown",
+      ]),
+      conclusion: diagnosticOutcome,
+      failedJobCount: z.number().int().min(0).max(10000).nullable(),
+      readbackArtifactId: diagnosticId,
+      packageArtifactId: diagnosticId,
+    }),
+  ),
+  jobOutcomeBeforeArtifactUploads: diagnosticOutcome,
+  stepOutcomes: z.object({
+    coreStart: diagnosticOutcome,
+    completion: diagnosticOutcome,
+  }),
+});
+type PostpublishDiagnostic = z.infer<typeof diagnosticSchema>;
+
+function diagnosticValue<T>(schema: z.ZodType<T>, value: unknown): T | null {
+  const parsed = schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function diagnosticFailure(
+  error: unknown,
+  stage: DiagnosticStageName,
+): z.infer<typeof diagnosticError> {
+  const code = isJsonRecord(error) ? error.code : undefined;
+  const status = isJsonRecord(error) ? error.status : undefined;
+  // Classify locally, but never retain command text, URLs, stderr, or stack traces.
+  const message = error instanceof Error ? error.message : "";
+  const failureClass =
+    stage === "evidence" || stage === "binding"
+      ? "evidence-write-failure"
+      : isNpmPropagationError(error)
+        ? "registry-not-visible"
+        : code === "ETIMEDOUT" || code === "ECONNRESET" || code === "ENOTFOUND"
+          ? "transport"
+          : /invalid JSON|unsupported JSON|response body/u.test(message)
+            ? "malformed-response"
+            : /dist-tag|ClawHub tag/u.test(message)
+              ? "selector-mismatch"
+              : /expected|mismatch|Unknown or non-publishable/u.test(message)
+                ? "identity-mismatch"
+                : "command-failure";
+  return {
+    class: failureClass,
+    status:
+      typeof status === "number" && Number.isInteger(status) && status >= 0 && status <= 255
+        ? status
+        : null,
+  };
+}
+
+class PostpublishDiagnostics {
+  readonly data: PostpublishDiagnostic;
+  private path: string | undefined;
+  private warned = false;
+  private packageName: string | undefined;
+
+  constructor(
+    args: ReleaseVerifyBetaArgs,
+    rootDir: string,
+    mode: "initialize" | "verify" | "observe",
+  ) {
+    let toolingSha: string | undefined;
+    try {
+      toolingSha = runReleaseVerifierCommand("git", ["rev-parse", "HEAD"], {
+        cwd: TRUSTED_TOOLING_ROOT,
+      });
+    } catch {
+      // A diagnostic never substitutes a supplied workflow SHA for unread tooling.
+    }
+    const env = process.env;
+    const emptyStage = (): z.infer<typeof diagnosticStage> => ({
+      state: "unattempted",
+      publication: "unknown",
+      error: null,
+      packages: [],
+      packagesTruncated: false,
+    });
+    this.data = {
+      schemaVersion: 1,
+      kind: "release-postpublish-diagnostics",
+      invocationId: randomUUID(),
+      context: {
+        repository: diagnosticValue(diagnosticSchema.shape.context.shape.repository, args.repo),
+        releaseVersion: diagnosticValue(
+          diagnosticSchema.shape.context.shape.releaseVersion,
+          args.version,
+        ),
+        releaseTag: diagnosticValue(diagnosticSchema.shape.context.shape.releaseTag, args.tag),
+        npmDistTag: diagnosticValue(diagnosticSchema.shape.context.shape.npmDistTag, args.distTag),
+        requestedSourceSha: diagnosticValue(diagnosticSha, args.releaseSha),
+        toolingSha: diagnosticValue(diagnosticSha, toolingSha),
+        suppliedToolingSha: diagnosticValue(diagnosticSha, env.GITHUB_WORKFLOW_SHA),
+        suppliedToolingRef: diagnosticValue(diagnosticRef, env.GITHUB_REF),
+        parentRunId: diagnosticValue(diagnosticId, env.GITHUB_RUN_ID),
+        parentRunAttempt: diagnosticValue(diagnosticId, env.GITHUB_RUN_ATTEMPT),
+        validationEvidence: {
+          mode: diagnosticValue(
+            diagnosticSchema.shape.context.shape.validationEvidence.shape.mode,
+            env.RELEASE_EVIDENCE_MODE,
+          ),
+          runId: diagnosticValue(
+            diagnosticId,
+            env.RELEASE_EVIDENCE_MODE === "authorized-beta-focused-v1"
+              ? env.FOCUSED_RELEASE_EVIDENCE_RUN_ID
+              : env.FULL_RELEASE_VALIDATION_RUN_ID,
+          ),
+          runAttempt: diagnosticValue(
+            diagnosticId,
+            env.RELEASE_EVIDENCE_MODE === "authorized-beta-focused-v1"
+              ? env.FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT
+              : env.FULL_RELEASE_VALIDATION_RUN_ATTEMPT,
+          ),
+        },
+      },
+      selection: {
+        plugins: args.pluginSelection
+          .slice(0, DIAGNOSTIC_MAX_PACKAGES)
+          .filter((name) => diagnosticPackage.shape.name.safeParse(name).success),
+        pluginsTruncated:
+          args.pluginSelection.length > DIAGNOSTIC_MAX_PACKAGES ||
+          args.pluginSelection.some(
+            (name) => !diagnosticPackage.shape.name.safeParse(name).success,
+          ),
+        workflowRef: diagnosticValue(diagnosticRef, args.workflowRef),
+        clawHubWorkflowRef: diagnosticValue(diagnosticRef, args.clawHubWorkflowRef),
+      },
+      verification: "unattempted",
+      currentStage: null,
+      stages: Object.fromEntries(
+        diagnosticStageNames.map((name) => [name, emptyStage()]),
+      ) as PostpublishDiagnostic["stages"],
+      children: Object.fromEntries(
+        diagnosticChildNames.map((name) => [
+          name,
+          {
+            suppliedRunId: diagnosticValue(diagnosticId, args.workflowRuns[name]),
+            runAttempt: null,
+            producerRunAttempt: null,
+            status: "unknown",
+            conclusion: "unknown",
+            failedJobCount: null,
+            readbackArtifactId: null,
+            packageArtifactId: null,
+          },
+        ]),
+      ) as PostpublishDiagnostic["children"],
+      jobOutcomeBeforeArtifactUploads: "unknown",
+      stepOutcomes: { coreStart: "unknown", completion: "unknown" },
+    };
+    if (!args.evidenceOut) {
+      return;
+    }
+    this.path = resolve(dirname(resolve(rootDir, args.evidenceOut)), DIAGNOSTIC_FILE);
+    let existing: PostpublishDiagnostic | undefined;
+    try {
+      const stat = lstatSync(this.path);
+      if (!stat.isFile() || stat.size > DIAGNOSTIC_MAX_BYTES) {
+        throw new Error("Invalid diagnostic file.");
+      }
+      existing = diagnosticSchema.parse(JSON.parse(readFileSync(this.path, "utf8")));
+      if (
+        mode === "initialize" ||
+        !this.data.context.parentRunId ||
+        !this.data.context.parentRunAttempt ||
+        JSON.stringify(existing.context) !== JSON.stringify(this.data.context) ||
+        (mode === "verify" && existing.verification !== "unattempted")
+      ) {
+        throw new Error("Diagnostic belongs to another invocation.");
+      }
+      const selection = this.data.selection;
+      const children = this.data.children;
+      this.data = existing;
+      if (mode === "verify") {
+        this.data.selection = selection;
+      }
+      for (const name of diagnosticChildNames) {
+        const supplied = children[name].suppliedRunId;
+        if (
+          supplied &&
+          this.data.children[name].suppliedRunId &&
+          supplied !== this.data.children[name].suppliedRunId
+        ) {
+          throw new Error("Diagnostic child identity changed.");
+        }
+        this.data.children[name].suppliedRunId ??= supplied;
+      }
+    } catch (error) {
+      if (!isJsonRecord(error) || error.code !== "ENOENT") {
+        this.warn();
+        this.path = undefined;
+        return;
+      }
+      if (mode === "observe") {
+        this.warn();
+        this.path = undefined;
+        return;
+      }
+    }
+    if (mode !== "observe") {
+      for (const [stage, skipped] of [
+        ["githubRelease", args.skipGitHubRelease],
+        ["postpublish", args.skipPostpublish],
+        ["clawHub", args.skipClawHub],
+        ["evidence", false],
+      ] as const) {
+        this.data.stages[stage].state = skipped ? "skipped" : "unattempted";
+      }
+      for (const name of diagnosticChildNames) {
+        this.data.stages[this.workflowStage(name)].state = args.workflowRuns[name]
+          ? "unattempted"
+          : "skipped";
+      }
+    }
+    this.save(existing === undefined);
+  }
+
+  private warn() {
+    if (!this.warned) {
+      console.error(
+        "Warning: postpublish diagnostics unavailable or incomplete; inspect the primary result.",
+      );
+      this.warned = true;
+    }
+  }
+
+  save(create = false) {
+    if (!this.path) {
+      return;
+    }
+    const temporary = `${this.path}.${randomUUID()}.tmp`;
+    try {
+      const bytes = `${JSON.stringify(diagnosticSchema.parse(this.data), null, 2)}\n`;
+      if (Buffer.byteLength(bytes) > DIAGNOSTIC_MAX_BYTES) {
+        throw new Error("Diagnostic exceeds byte bound.");
+      }
+      mkdirSync(dirname(this.path), { recursive: true });
+      writeFileSync(temporary, bytes, { flag: "wx", mode: 0o600 });
+      if (create) {
+        linkSync(temporary, this.path);
+      } else {
+        renameSync(temporary, this.path);
+      }
+    } catch {
+      this.warn();
+      if (create) {
+        this.path = undefined;
+      }
+    } finally {
+      try {
+        rmSync(temporary, { force: true });
+      } catch {
+        this.warn();
+      }
+    }
+  }
+
+  workflowStage(name: DiagnosticChildName): DiagnosticStageName {
+    return name === "pluginNpm"
+      ? "pluginNpmRun"
+      : name === "pluginClawHub"
+        ? "pluginClawHubRun"
+        : name;
+  }
+
+  observeRun(name: DiagnosticChildName, run: JsonRecord, failedJobCount: number) {
+    const child = this.data.children[name];
+    child.status =
+      diagnosticValue(diagnosticSchema.shape.children.valueType.shape.status, run.status) ??
+      "unknown";
+    child.conclusion = diagnosticValue(diagnosticOutcome, run.conclusion) ?? "unknown";
+    child.failedJobCount = Math.min(10000, failedJobCount);
+    this.save();
+  }
+
+  start(stage: DiagnosticStageName) {
+    this.packageName = undefined;
+    this.data.currentStage = stage;
+    this.data.stages[stage].state = "started";
+    if (!["evidence", "binding", "assets"].includes(stage)) {
+      this.data.verification = "started";
+    }
+    this.save();
+  }
+
+  success(stage: DiagnosticStageName, publication = false) {
+    this.data.stages[stage].state = "success";
+    if (publication) {
+      this.data.stages[stage].publication = "observed";
+    }
+    this.packageName = undefined;
+    this.save();
+  }
+
+  packages(stage: "pluginNpm" | "clawHub", packages: readonly { packageName: string }[]) {
+    this.data.stages[stage].packages = packages
+      .slice(0, DIAGNOSTIC_MAX_PACKAGES)
+      .filter((plugin) => diagnosticPackage.shape.name.safeParse(plugin.packageName).success)
+      .map((plugin) => ({
+        name: plugin.packageName,
+        state: "unattempted",
+        publication: "unknown",
+        error: null,
+      }));
+    this.data.stages[stage].packagesTruncated =
+      this.data.stages[stage].packages.length !== packages.length;
+    this.save();
+  }
+
+  package(stage: "pluginNpm" | "clawHub", name: string, state: "started" | "success") {
+    this.packageName = name;
+    const entry = this.data.stages[stage].packages.find((item) => item.name === name);
+    if (entry) {
+      entry.state = state;
+      if (state === "success") {
+        entry.publication = "observed";
+      }
+    }
+    this.save();
+  }
+
+  fail(error: unknown) {
+    const stage = this.data.currentStage;
+    if (!stage) {
+      return;
+    }
+    const entry = this.data.stages[stage];
+    entry.state = "failure";
+    entry.error = diagnosticFailure(error, stage);
+    const item = entry.packages.find((candidate) => candidate.name === this.packageName);
+    if (item) {
+      item.state = "failure";
+      item.error = entry.error;
+    }
+    if (!["evidence", "binding", "assets"].includes(stage)) {
+      this.data.verification = "failure";
+    }
+    this.save();
+  }
+}
+
+// Called only by the existing publish helper. This records local observations;
+// it cannot invoke a registry, GitHub mutation, retry, or publication command.
+export function recordReleasePublishDiagnostics(event: string): void {
+  try {
+    const env = process.env;
+    if (!env.POSTPUBLISH_EVIDENCE_DIR) {
+      return;
+    }
+    const args = parseReleaseVerifyBetaArgs([
+      env.RELEASE_TAG?.replace(/^v/u, "") ?? "",
+      "--evidence-out",
+      resolve(env.POSTPUBLISH_EVIDENCE_DIR, "release-postpublish-evidence.json"),
+      "--skip-github-release",
+    ]);
+    args.repo = env.GITHUB_REPOSITORY ?? DEFAULT_REPO;
+    args.distTag = env.RELEASE_NPM_DIST_TAG ?? "";
+    args.releaseSha = env.TARGET_SHA;
+    args.pluginSelection = parsePluginReleaseSelection(env.PLUGINS);
+    args.workflowRef = env.CHILD_WORKFLOW_REF;
+    args.skipClawHub = env.WAIT_FOR_CLAWHUB === "false";
+    args.workflowRuns = {
+      openclawNpm: env.CHILD_OPENCLAW_NPM_RUN_ID,
+      pluginNpm: env.CHILD_PLUGIN_NPM_RUN_ID,
+      pluginClawHub: env.CHILD_PLUGIN_CLAWHUB_RUN_ID,
+      pluginClawHubBootstrap: env.CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID,
+      npmTelegram: env.NPM_TELEGRAM_RUN_ID,
+    };
+    const diagnostic = new PostpublishDiagnostics(
+      args,
+      ".",
+      event === "initialize" ? "initialize" : "observe",
+    );
+    if (event === "binding-start") {
+      diagnostic.start("binding");
+    } else if (event === "binding-success") {
+      diagnostic.success("binding");
+    } else if (event === "assets-start") {
+      diagnostic.start("assets");
+    } else if (event === "assets-success") {
+      diagnostic.success("assets");
+    } else if (event === "terminal") {
+      diagnostic.data.stepOutcomes = {
+        coreStart: diagnosticValue(diagnosticOutcome, env.CORE_START_OUTCOME) ?? "unknown",
+        completion: diagnosticValue(diagnosticOutcome, env.COMPLETION_OUTCOME) ?? "unknown",
+      };
+      diagnostic.data.jobOutcomeBeforeArtifactUploads =
+        diagnosticValue(diagnosticOutcome, env.PUBLISH_JOB_STATUS) ?? "unknown";
+      const stage = diagnostic.data.currentStage;
+      if (stage && diagnostic.data.stages[stage].state === "started") {
+        // A failed parent cannot prove a registry check or publication failed.
+        if (
+          (stage === "binding" || stage === "assets") &&
+          diagnostic.data.stepOutcomes.completion === "failure"
+        ) {
+          diagnostic.data.stages[stage].state = "failure";
+          diagnostic.data.stages[stage].error = { class: "command-failure", status: null };
+        } else {
+          diagnostic.data.stages[stage].state = "unknown";
+        }
+        if (diagnostic.data.verification === "started") {
+          diagnostic.data.verification = "unknown";
+        }
+      }
+      diagnostic.save();
+    }
+  } catch {
+    console.error("Warning: postpublish diagnostics unavailable; primary result unchanged.");
+  }
+}
 
 function compareCodeUnits(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -616,6 +1176,7 @@ function verifyWorkflowRun(params: {
   allowedHeadBranches?: string[];
   advisory?: boolean;
   rerunFailed: boolean;
+  observe?: (run: JsonRecord, failedJobCount: number) => void;
 }): WorkflowRunSummary {
   const raw = runReleaseVerifierCommand("gh", [
     "run",
@@ -660,6 +1221,7 @@ function verifyWorkflowRun(params: {
       jobConclusion !== undefined && jobConclusion !== "success" && jobConclusion !== "skipped"
     );
   });
+  params.observe?.(run, failedJobs.length);
   if (failedJobs.length > 0 && params.rerunFailed) {
     runReleaseVerifierCommand("gh", ["run", "rerun", params.id, "--repo", params.repo, "--failed"]);
     throw new Error(
@@ -1206,6 +1768,7 @@ async function verifyClawHubBootstrapRun(params: {
   releaseSha: string;
   version: string;
   expectedPackages: string[];
+  observeAttempt?: (run: ReturnType<typeof requireClawHubBootstrapRunBinding>) => void;
 }): Promise<WorkflowRunSummary> {
   const run = readGitHubApiJson(
     params.repo,
@@ -1213,6 +1776,7 @@ async function verifyClawHubBootstrapRun(params: {
     "Plugin ClawHub New run",
   );
   const runBinding = requireClawHubBootstrapRunBinding(run, params.runId);
+  params.observeAttempt?.(runBinding);
   const terminalRunAttempt = runBinding.terminalRunAttempt;
   const readbackName = `clawhub-bootstrap-readback-${params.runId}-${terminalRunAttempt}`;
   const artifactList = readGitHubApiJson(
@@ -1305,196 +1869,267 @@ export async function verifyBetaRelease(
   options: { rootDir?: string } = {},
 ): Promise<string[]> {
   const rootDir = options.rootDir ?? resolve(".");
-  const rootVersion = readRootPackageVersion(rootDir);
-  if (rootVersion !== args.version) {
-    throw new Error(`package.json version is ${rootVersion}; expected ${args.version}.`);
-  }
-  if (args.releaseSha !== undefined) {
-    const checkedOutSha = runReleaseVerifierCommand("git", ["rev-parse", "HEAD"], {
-      cwd: rootDir,
-    });
-    if (checkedOutSha !== args.releaseSha) {
-      throw new Error(`release checkout SHA is ${checkedOutSha}; expected ${args.releaseSha}.`);
+  const diagnostic = new PostpublishDiagnostics(args, rootDir, "verify");
+  try {
+    diagnostic.start("checkout");
+    const rootVersion = readRootPackageVersion(rootDir);
+    if (rootVersion !== args.version) {
+      throw new Error(`package.json version is ${rootVersion}; expected ${args.version}.`);
     }
-  }
-
-  const lines: string[] = [];
-  const releaseUrl = args.skipGitHubRelease ? undefined : verifyGitHubRelease(args);
-  if (releaseUrl === undefined) {
-    lines.push("GitHub release skipped: final release page is created after verification");
-  } else {
-    lines.push(`GitHub release OK: ${releaseUrl}`);
-  }
-
-  const openclawNpm = await verifyNpmPackage("openclaw", args.version, args.distTag);
-  lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
-
-  if (!args.skipPostpublish) {
-    const postpublishVerifier = resolveOpenClawNpmPostpublishVerifier(
-      rootDir,
-      args.postpublishVerifier,
-    );
-    execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version], {
-      stdio: "inherit",
-    });
-    lines.push("openclaw postpublish verifier OK");
-  }
-
-  const npmPlugins = collectPublishablePluginPackages(rootDir, {
-    packageNames: args.pluginSelection.length > 0 ? args.pluginSelection : undefined,
-  });
-  assertSelectedPackagesResolved({
-    label: "npm plugin",
-    selection: args.pluginSelection,
-    packages: npmPlugins,
-  });
-  for (const plugin of npmPlugins) {
-    await verifyNpmPackage(plugin.packageName, args.version, args.distTag);
-  }
-  lines.push(`plugin npm OK: ${npmPlugins.length}`);
-
-  const clawHubPlugins = args.skipClawHub
-    ? []
-    : collectClawHubPublishablePluginPackages(rootDir, {
-        packageNames: args.pluginSelection.length > 0 ? args.pluginSelection : undefined,
+    if (args.releaseSha !== undefined) {
+      const checkedOutSha = runReleaseVerifierCommand("git", ["rev-parse", "HEAD"], {
+        cwd: rootDir,
       });
-  if (args.skipClawHub) {
-    lines.push("ClawHub skipped");
-  } else {
-    assertSelectedPackagesResolved({
-      label: "ClawHub plugin",
-      selection: args.pluginSelection,
-      packages: clawHubPlugins,
-    });
-    for (const plugin of clawHubPlugins) {
-      await verifyClawHubPackage({
-        registry: args.registry,
-        packageName: plugin.packageName,
-        version: args.version,
-        distTag: args.distTag,
-      });
+      if (checkedOutSha !== args.releaseSha) {
+        throw new Error(`release checkout SHA is ${checkedOutSha}; expected ${args.releaseSha}.`);
+      }
     }
-    lines.push(`ClawHub OK: ${clawHubPlugins.length}`);
-  }
+    diagnostic.success("checkout");
 
-  const workflowRuns: WorkflowRunSummary[] = [];
-  const allowedReleaseWorkflowHeadBranches = args.workflowRef
-    ? ["main", args.workflowRef]
-    : ["main"];
-  if (args.workflowRuns.fullReleaseValidation !== undefined) {
-    workflowRuns.push(
-      verifyWorkflowRun({
-        id: args.workflowRuns.fullReleaseValidation,
-        label: "Full Release Validation",
-        repo: args.repo,
-        expectedWorkflowName: "Full Release Validation",
-        allowedHeadBranches: allowedReleaseWorkflowHeadBranches,
-        rerunFailed: false,
-      }),
-    );
-  }
-  if (args.workflowRuns.pluginNpm !== undefined) {
-    workflowRuns.push(
-      verifyWorkflowRun({
-        id: args.workflowRuns.pluginNpm,
-        label: "Plugin NPM Release",
-        repo: args.repo,
-        expectedWorkflowName: "Plugin NPM Release",
-        expectedHeadBranch: args.workflowRef,
-        rerunFailed: false,
-      }),
-    );
-  }
-  if (args.workflowRuns.pluginClawHub !== undefined) {
-    const clawHubWorkflowRef = args.clawHubWorkflowRef ?? args.workflowRef;
-    workflowRuns.push(
-      verifyWorkflowRun({
-        id: args.workflowRuns.pluginClawHub,
-        label: "Plugin ClawHub Release",
-        repo: args.repo,
-        expectedWorkflowName: "Plugin ClawHub Release",
-        expectedHeadBranch: clawHubWorkflowRef,
-        rerunFailed: args.rerunFailedClawHub,
-      }),
-    );
-  }
-  if (args.workflowRuns.pluginClawHubBootstrap !== undefined) {
-    workflowRuns.push(
-      await verifyClawHubBootstrapRun({
-        repo: args.repo,
-        runId: args.workflowRuns.pluginClawHubBootstrap,
-        releaseSha: requireCommitSha(args.releaseSha, "release SHA"),
-        version: args.version,
-        expectedPackages: args.clawHubBootstrapPlugins,
-      }),
-    );
-  }
-  if (args.workflowRuns.openclawNpm !== undefined) {
-    workflowRuns.push(
-      verifyWorkflowRun({
-        id: args.workflowRuns.openclawNpm,
-        label: "OpenClaw NPM Release",
-        repo: args.repo,
-        expectedWorkflowName: "OpenClaw NPM Release",
-        expectedHeadBranch: args.workflowRef,
-        rerunFailed: false,
-      }),
-    );
-  }
-  if (args.workflowRuns.npmTelegram !== undefined) {
-    workflowRuns.push(
-      verifyWorkflowRun({
-        id: args.workflowRuns.npmTelegram,
-        label: "NPM Telegram Beta E2E",
-        repo: args.repo,
-        expectedWorkflowName: "NPM Telegram Beta E2E",
-        allowedHeadBranches: allowedReleaseWorkflowHeadBranches,
-        advisory: true,
-        rerunFailed: false,
-      }),
-    );
-  }
-  for (const run of workflowRuns) {
-    if (run.advisory) {
-      lines.push(
-        `${run.label} advisory: ${run.id} (${run.advisory.status}/${run.advisory.conclusion}; failed jobs: ${run.advisory.failedJobs.join(", ") || "none"})${run.url ? ` ${run.url}` : ""}`,
-      );
+    const lines: string[] = [];
+    if (!args.skipGitHubRelease) {
+      diagnostic.start("githubRelease");
+    }
+    const releaseUrl = args.skipGitHubRelease ? undefined : verifyGitHubRelease(args);
+    if (!args.skipGitHubRelease) {
+      diagnostic.success("githubRelease", true);
+    }
+    if (releaseUrl === undefined) {
+      lines.push("GitHub release skipped: final release page is created after verification");
     } else {
-      lines.push(
-        `${run.label} OK: ${run.id} (${formatDuration(run.durationSeconds)})${run.url ? ` ${run.url}` : ""}`,
-      );
+      lines.push(`GitHub release OK: ${releaseUrl}`);
     }
-  }
 
-  if (args.evidenceOut !== undefined) {
-    const evidencePath = resolve(rootDir, args.evidenceOut);
-    mkdirSync(dirname(evidencePath), { recursive: true });
-    writeFileSync(
-      evidencePath,
-      `${JSON.stringify(
-        {
-          version: 1,
-          releaseVersion: args.version,
-          releaseTag: args.tag,
-          npmDistTag: args.distTag,
-          pluginSelection: args.pluginSelection,
-          openclawNpmIntegrity: openclawNpm.integrity,
-          openclawNpmTarball: openclawNpm.tarball,
-          npmRegistrySignaturesVerified: args.skipPostpublish ? null : true,
-          npmProvenanceAttestationMatched: args.skipPostpublish ? null : true,
-          githubReleaseUrl: releaseUrl ?? null,
-          pluginNpmPackageCount: npmPlugins.length,
-          clawHubPackageCount: clawHubPlugins.length,
-          workflowRuns,
-          clawHubBootstrapEvidence:
-            workflowRuns.find((run) => run.bootstrapEvidence)?.bootstrapEvidence ?? null,
-        },
-        null,
-        2,
-      )}\n`,
-    );
-    lines.push(`release evidence written: ${args.evidenceOut}`);
-  }
+    diagnostic.start("coreNpm");
+    const openclawNpm = await verifyNpmPackage("openclaw", args.version, args.distTag);
+    diagnostic.success("coreNpm", true);
+    lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
 
-  return lines;
+    if (!args.skipPostpublish) {
+      diagnostic.start("postpublish");
+      const postpublishVerifier = resolveOpenClawNpmPostpublishVerifier(
+        rootDir,
+        args.postpublishVerifier,
+      );
+      execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version], {
+        stdio: "inherit",
+      });
+      lines.push("openclaw postpublish verifier OK");
+      diagnostic.success("postpublish");
+    }
+
+    diagnostic.start("pluginNpm");
+    const npmPlugins = collectPublishablePluginPackages(rootDir, {
+      packageNames: args.pluginSelection.length > 0 ? args.pluginSelection : undefined,
+    });
+    diagnostic.packages("pluginNpm", npmPlugins);
+    assertSelectedPackagesResolved({
+      label: "npm plugin",
+      selection: args.pluginSelection,
+      packages: npmPlugins,
+    });
+    for (const plugin of npmPlugins) {
+      diagnostic.package("pluginNpm", plugin.packageName, "started");
+      await verifyNpmPackage(plugin.packageName, args.version, args.distTag);
+      diagnostic.package("pluginNpm", plugin.packageName, "success");
+    }
+    diagnostic.success("pluginNpm");
+    lines.push(`plugin npm OK: ${npmPlugins.length}`);
+
+    if (!args.skipClawHub) {
+      diagnostic.start("clawHub");
+    }
+    const clawHubPlugins = args.skipClawHub
+      ? []
+      : collectClawHubPublishablePluginPackages(rootDir, {
+          packageNames: args.pluginSelection.length > 0 ? args.pluginSelection : undefined,
+        });
+    if (args.skipClawHub) {
+      lines.push("ClawHub skipped");
+    } else {
+      diagnostic.packages("clawHub", clawHubPlugins);
+      assertSelectedPackagesResolved({
+        label: "ClawHub plugin",
+        selection: args.pluginSelection,
+        packages: clawHubPlugins,
+      });
+      for (const plugin of clawHubPlugins) {
+        diagnostic.package("clawHub", plugin.packageName, "started");
+        await verifyClawHubPackage({
+          registry: args.registry,
+          packageName: plugin.packageName,
+          version: args.version,
+          distTag: args.distTag,
+        });
+        diagnostic.package("clawHub", plugin.packageName, "success");
+      }
+      diagnostic.success("clawHub");
+      lines.push(`ClawHub OK: ${clawHubPlugins.length}`);
+    }
+
+    const workflowRuns: WorkflowRunSummary[] = [];
+    const allowedReleaseWorkflowHeadBranches = args.workflowRef
+      ? ["main", args.workflowRef]
+      : ["main"];
+    if (args.workflowRuns.fullReleaseValidation !== undefined) {
+      diagnostic.start("fullReleaseValidation");
+      workflowRuns.push(
+        verifyWorkflowRun({
+          id: args.workflowRuns.fullReleaseValidation,
+          label: "Full Release Validation",
+          repo: args.repo,
+          expectedWorkflowName: "Full Release Validation",
+          allowedHeadBranches: allowedReleaseWorkflowHeadBranches,
+          rerunFailed: false,
+          observe: (run, count) => diagnostic.observeRun("fullReleaseValidation", run, count),
+        }),
+      );
+      diagnostic.success("fullReleaseValidation");
+    }
+    if (args.workflowRuns.pluginNpm !== undefined) {
+      diagnostic.start("pluginNpmRun");
+      workflowRuns.push(
+        verifyWorkflowRun({
+          id: args.workflowRuns.pluginNpm,
+          label: "Plugin NPM Release",
+          repo: args.repo,
+          expectedWorkflowName: "Plugin NPM Release",
+          expectedHeadBranch: args.workflowRef,
+          rerunFailed: false,
+          observe: (run, count) => diagnostic.observeRun("pluginNpm", run, count),
+        }),
+      );
+      diagnostic.success("pluginNpmRun");
+    }
+    if (args.workflowRuns.pluginClawHub !== undefined) {
+      diagnostic.start("pluginClawHubRun");
+      const clawHubWorkflowRef = args.clawHubWorkflowRef ?? args.workflowRef;
+      workflowRuns.push(
+        verifyWorkflowRun({
+          id: args.workflowRuns.pluginClawHub,
+          label: "Plugin ClawHub Release",
+          repo: args.repo,
+          expectedWorkflowName: "Plugin ClawHub Release",
+          expectedHeadBranch: clawHubWorkflowRef,
+          rerunFailed: args.rerunFailedClawHub,
+          observe: (run, count) => diagnostic.observeRun("pluginClawHub", run, count),
+        }),
+      );
+      diagnostic.success("pluginClawHubRun");
+    }
+    if (args.workflowRuns.pluginClawHubBootstrap !== undefined) {
+      diagnostic.start("pluginClawHubBootstrap");
+      workflowRuns.push(
+        await verifyClawHubBootstrapRun({
+          repo: args.repo,
+          runId: args.workflowRuns.pluginClawHubBootstrap,
+          releaseSha: requireCommitSha(args.releaseSha, "release SHA"),
+          version: args.version,
+          expectedPackages: args.clawHubBootstrapPlugins,
+          observeAttempt: (run) => {
+            Object.assign(diagnostic.data.children.pluginClawHubBootstrap, {
+              runAttempt: run.terminalRunAttempt,
+              status: "completed",
+              conclusion: "success",
+            });
+            diagnostic.save();
+          },
+        }),
+      );
+      const bootstrap = workflowRuns.at(-1)?.bootstrapEvidence;
+      if (bootstrap) {
+        Object.assign(diagnostic.data.children.pluginClawHubBootstrap, {
+          runAttempt: bootstrap.terminalRunAttempt,
+          producerRunAttempt: bootstrap.producerRunAttempt,
+          readbackArtifactId: bootstrap.readbackArtifactId,
+          packageArtifactId: bootstrap.packageArtifactId,
+          status: "completed",
+          conclusion: "success",
+        });
+      }
+      diagnostic.success("pluginClawHubBootstrap");
+    }
+    if (args.workflowRuns.openclawNpm !== undefined) {
+      diagnostic.start("openclawNpm");
+      workflowRuns.push(
+        verifyWorkflowRun({
+          id: args.workflowRuns.openclawNpm,
+          label: "OpenClaw NPM Release",
+          repo: args.repo,
+          expectedWorkflowName: "OpenClaw NPM Release",
+          expectedHeadBranch: args.workflowRef,
+          rerunFailed: false,
+          observe: (run, count) => diagnostic.observeRun("openclawNpm", run, count),
+        }),
+      );
+      diagnostic.success("openclawNpm");
+    }
+    if (args.workflowRuns.npmTelegram !== undefined) {
+      diagnostic.start("npmTelegram");
+      workflowRuns.push(
+        verifyWorkflowRun({
+          id: args.workflowRuns.npmTelegram,
+          label: "NPM Telegram Beta E2E",
+          repo: args.repo,
+          expectedWorkflowName: "NPM Telegram Beta E2E",
+          allowedHeadBranches: allowedReleaseWorkflowHeadBranches,
+          advisory: true,
+          rerunFailed: false,
+          observe: (run, count) => diagnostic.observeRun("npmTelegram", run, count),
+        }),
+      );
+      diagnostic.success("npmTelegram");
+    }
+    for (const run of workflowRuns) {
+      if (run.advisory) {
+        lines.push(
+          `${run.label} advisory: ${run.id} (${run.advisory.status}/${run.advisory.conclusion}; failed jobs: ${run.advisory.failedJobs.join(", ") || "none"})${run.url ? ` ${run.url}` : ""}`,
+        );
+      } else {
+        lines.push(
+          `${run.label} OK: ${run.id} (${formatDuration(run.durationSeconds)})${run.url ? ` ${run.url}` : ""}`,
+        );
+      }
+    }
+
+    diagnostic.data.verification = "success";
+    diagnostic.save();
+    if (args.evidenceOut !== undefined) {
+      diagnostic.start("evidence");
+      const evidencePath = resolve(rootDir, args.evidenceOut);
+      mkdirSync(dirname(evidencePath), { recursive: true });
+      writeFileSync(
+        evidencePath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            releaseVersion: args.version,
+            releaseTag: args.tag,
+            npmDistTag: args.distTag,
+            pluginSelection: args.pluginSelection,
+            openclawNpmIntegrity: openclawNpm.integrity,
+            openclawNpmTarball: openclawNpm.tarball,
+            npmRegistrySignaturesVerified: args.skipPostpublish ? null : true,
+            npmProvenanceAttestationMatched: args.skipPostpublish ? null : true,
+            githubReleaseUrl: releaseUrl ?? null,
+            pluginNpmPackageCount: npmPlugins.length,
+            clawHubPackageCount: clawHubPlugins.length,
+            workflowRuns,
+            clawHubBootstrapEvidence:
+              workflowRuns.find((run) => run.bootstrapEvidence)?.bootstrapEvidence ?? null,
+          },
+          null,
+          2,
+        )}\n`,
+        { flag: "wx" },
+      );
+      diagnostic.success("evidence");
+      lines.push(`release evidence written: ${args.evidenceOut}`);
+    }
+
+    return lines;
+  } catch (error) {
+    diagnostic.fail(error);
+    throw error;
+  }
 }

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -5,6 +5,24 @@ set -euo pipefail
 openclaw_npm_expected_workflow_ref="${GITHUB_REF}"
 openclaw_npm_expected_workflow_sha="${PARENT_WORKFLOW_SHA}"
 
+record_postpublish_diagnostics() {
+  CHILD_PLUGIN_NPM_RUN_ID="${plugin_npm_run_id:-${CHILD_PLUGIN_NPM_RUN_ID:-}}" \
+    CHILD_PLUGIN_CLAWHUB_RUN_ID="${plugin_clawhub_run_id:-${CHILD_PLUGIN_CLAWHUB_RUN_ID:-}}" \
+    CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID="${plugin_clawhub_bootstrap_run_id:-${CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID:-}}" \
+    CHILD_OPENCLAW_NPM_RUN_ID="${openclaw_npm_run_id:-${CHILD_OPENCLAW_NPM_RUN_ID:-}}" \
+    node --import tsx --input-type=module - "$1" <<'NODE' || echo "Warning: postpublish diagnostics unavailable; primary result unchanged." >&2
+import { pathToFileURL } from "node:url";
+try {
+  const { recordReleasePublishDiagnostics } = await import(pathToFileURL(
+    `${process.env.GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-beta-verifier.ts`,
+  ).href);
+  recordReleasePublishDiagnostics(process.argv[2]);
+} catch {
+  console.error("Warning: postpublish diagnostics unavailable; primary result unchanged.");
+}
+NODE
+}
+
 is_stable_release() {
   [[ "${RELEASE_TAG}" != *"-alpha."* && "${RELEASE_TAG}" != *"-beta."* ]]
 }
@@ -1033,14 +1051,19 @@ upload_release_evidence_assets() {
 }
 
 verify_published_release() {
-  local release_version evidence_path clawhub_runtime_state_path bootstrap_run_arg_present
+  local release_version evidence_path canonical_evidence_path clawhub_runtime_state_path bootstrap_run_arg_present
   local expected_attempt expected_id run_attempt run_id run_label run_url target_sha
   local validation_file workflow_ref telegram_waiver
   local -a verify_args
 
   release_version="${RELEASE_TAG#v}"
-  evidence_path="${POSTPUBLISH_EVIDENCE_DIR}/release-postpublish-evidence.json"
+  canonical_evidence_path="${POSTPUBLISH_EVIDENCE_DIR}/release-postpublish-evidence.json"
+  evidence_path="${POSTPUBLISH_EVIDENCE_DIR}/release-postpublish-evidence.pending.json"
   mkdir -p "${POSTPUBLISH_EVIDENCE_DIR}"
+  if [[ -e "${canonical_evidence_path}" || -L "${canonical_evidence_path}" ]]; then
+    echo "Postpublish success evidence already exists; use a fresh invocation output directory." >&2
+    return 1
+  fi
 
   verify_args=(
     "${release_version}"
@@ -1092,6 +1115,7 @@ verify_published_release() {
       "${GITHUB_WORKSPACE}/.release-harness/scripts/release-verify-beta.ts" \
       "${verify_args[@]}"
 
+  record_postpublish_diagnostics binding-start
   if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
     validation_file="${FOCUSED_RELEASE_EVIDENCE_DIR}/evidence.json"
     run_id="$(jq -er '.producer.runId | select(type == "string" and test("^[1-9][0-9]*$"))' "${validation_file}")"
@@ -1143,10 +1167,14 @@ verify_published_release() {
       }]
     ' \
     "${evidence_path}" > "${evidence_path}.next"
-  mv "${evidence_path}.next" "${evidence_path}"
+  # Expose a success receipt only after both verifier and parent binding pass.
+  # The no-clobber link also refuses a stale receipt without deleting history.
+  ln "${evidence_path}.next" "${canonical_evidence_path}"
+  record_postpublish_diagnostics binding-success
+  echo "postpublish_evidence_ready=true" >> "$GITHUB_OUTPUT"
   {
     echo "- Postpublish verification: passed"
-    echo "- Postpublish evidence: \`${evidence_path}\`"
+    echo "- Postpublish evidence: \`${canonical_evidence_path}\`"
   } >> "$GITHUB_STEP_SUMMARY"
 }
 

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -10,17 +10,8 @@ record_postpublish_diagnostics() {
     CHILD_PLUGIN_CLAWHUB_RUN_ID="${plugin_clawhub_run_id:-${CHILD_PLUGIN_CLAWHUB_RUN_ID:-}}" \
     CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID="${plugin_clawhub_bootstrap_run_id:-${CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID:-}}" \
     CHILD_OPENCLAW_NPM_RUN_ID="${openclaw_npm_run_id:-${CHILD_OPENCLAW_NPM_RUN_ID:-}}" \
-    node --import tsx --input-type=module - "$1" <<'NODE' || echo "Warning: postpublish diagnostics unavailable; primary result unchanged." >&2
-import { pathToFileURL } from "node:url";
-try {
-  const { recordReleasePublishDiagnostics } = await import(pathToFileURL(
-    `${process.env.GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-beta-verifier.ts`,
-  ).href);
-  recordReleasePublishDiagnostics(process.argv[2]);
-} catch {
-  console.error("Warning: postpublish diagnostics unavailable; primary result unchanged.");
-}
-NODE
+    node --import tsx "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-beta-verifier.ts" "$1" \
+    || echo "Warning: postpublish diagnostics unavailable; primary result unchanged." >&2
 }
 
 is_stable_release() {

--- a/scripts/plugin-npm-prepared-release.mjs
+++ b/scripts/plugin-npm-prepared-release.mjs
@@ -19,6 +19,7 @@ import {
 } from "./lib/npm-publish-plan.mjs";
 import { collectExtensionPackageJsonCandidates } from "./lib/plugin-publication-candidates.ts";
 import { isPluginPublicationEnabled } from "./lib/plugin-publication-target.mjs";
+import { parseReleaseVersion } from "./lib/release-version.mjs";
 import { verifyPluginPublicationArtifact } from "./plugin-publication-artifact.mjs";
 
 export const PREPARED_NPM_MANIFEST = "plugin-npm-prepared.json";
@@ -196,10 +197,17 @@ export function validatePreparedNpmRelease(manifest, expected) {
       ROUTES.has(value.route),
       "Prepared npm route requires separately authorized repair tooling.",
     );
-    requireValue(
-      value.route !== "npm-token-bootstrap" || entry.channel === "beta",
-      "Prepared npm token bootstrap requires an approved beta package.",
-    );
+    if (value.route === "npm-token-bootstrap") {
+      const parsed = parseReleaseVersion(entry.version);
+      requireValue(
+        entry.channel === "beta" ||
+          (parsed?.channel === "stable" &&
+            parsed.patch < 33 &&
+            manifest.npmDistTag === "default" &&
+            entry.publishTag === "latest"),
+        "Prepared npm token bootstrap requires beta or regular stable/latest qualification.",
+      );
+    }
     requireValue(
       JSON.stringify(normalizeProducer(tuple)) === JSON.stringify(producer),
       "Prepared npm package producer differs from the sealed release.",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -304,9 +304,10 @@ function createReleasePublishFixture(
   mkdirSync(helperDir, { recursive: true });
   writeFileSync(join(root, "package.json"), JSON.stringify({ type: "module" }));
   symlinkSync(resolve("node_modules"), join(root, "node_modules"), "dir");
-  writeFileSync(
+  symlinkSync(
+    resolve("scripts/lib/release-beta-verifier.ts"),
     join(helperDir, "release-beta-verifier.ts"),
-    `export * from ${JSON.stringify(pathToFileURL(resolve("scripts/lib/release-beta-verifier.ts")).href)};\n`,
+    "file",
   );
   writeFileSync(eventsPath, "");
   writeFileSync(outputPath, "");
@@ -3889,6 +3890,13 @@ if (args[0] === "view") {
   it("retains cancelled or skipped verification without authorizing recovery", () => {
     const fixture = createReleasePublishFixture();
     const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+    const diagnosticPath = join(fixture.root, "evidence/release-postpublish-diagnostics.json");
+    const imported = fixture.run({
+      run: `node --import tsx --input-type=module -e 'await import("./.release-harness/scripts/lib/release-beta-verifier.ts")' diagnostic-import initialize`,
+    });
+    expect(imported.status, imported.stderr).toBe(0);
+    expect(imported.stderr).toBe("");
+    expect(existsSync(diagnosticPath)).toBe(false);
     const initialized = fixture.run(workflowStep(job, "Initialize postpublish diagnostics"));
     expect(initialized.status, initialized.stderr).toBe(0);
     const terminal = fixture.run(workflowStep(job, "Record postpublish outcome"), {
@@ -3897,9 +3905,7 @@ if (args[0] === "view") {
       PUBLISH_JOB_STATUS: "cancelled",
     });
     expect(terminal.status, terminal.stderr).toBe(0);
-    const diagnostic = JSON.parse(
-      readFileSync(join(fixture.root, "evidence/release-postpublish-diagnostics.json"), "utf8"),
-    );
+    const diagnostic = JSON.parse(readFileSync(diagnosticPath, "utf8"));
     expect(diagnostic.verification).toBe("unattempted");
     expect(diagnostic.jobOutcomeBeforeArtifactUploads).toBe("cancelled");
     expect(fixture.events()).toEqual([""]);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -302,6 +302,12 @@ function createReleasePublishFixture(
   const outputPath = join(root, "output");
   const helperDir = join(root, ".release-harness/scripts/lib");
   mkdirSync(helperDir, { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ type: "module" }));
+  symlinkSync(resolve("node_modules"), join(root, "node_modules"), "dir");
+  writeFileSync(
+    join(helperDir, "release-beta-verifier.ts"),
+    `export * from ${JSON.stringify(pathToFileURL(resolve("scripts/lib/release-beta-verifier.ts")).href)};\n`,
+  );
   writeFileSync(eventsPath, "");
   writeFileSync(outputPath, "");
   writeFileSync(
@@ -372,6 +378,8 @@ ${functions}
           GITHUB_RUN_ID: "44",
           GITHUB_RUN_ATTEMPT: "2",
           GITHUB_REF: "refs/heads/main",
+          GITHUB_WORKFLOW_SHA: "d".repeat(40),
+          POSTPUBLISH_EVIDENCE_DIR: join(root, "evidence"),
           PUBLISH_EVENTS: eventsPath,
           TARGET_SHA: "a".repeat(40),
           CHILD_WORKFLOW_REF: "main",
@@ -387,6 +395,8 @@ ${functions}
           PLUGIN_SDK_API_ACKNOWLEDGEMENT: "",
           PUBLISH_OPENCLAW_NPM: "true",
           WAIT_FOR_CLAWHUB: "true",
+          PLUGINS: "",
+          NPM_TELEGRAM_RUN_ID: "",
           CHILD_PLUGIN_NPM_RUN_ID: "101",
           CHILD_PLUGIN_CLAWHUB_RUN_ID: "202",
           CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID: "303",
@@ -3650,6 +3660,13 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
     ({ env, bootstrapCompleted, approvesClawHub }) => {
       const fixture = createReleasePublishFixture();
       const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+      const initialize = job.steps?.find(
+        (step) => step.name === "Initialize postpublish diagnostics",
+      );
+      if (initialize) {
+        const initialized = fixture.run(initialize);
+        expect(initialized.status, initialized.stderr).toBe(0);
+      }
       const start = fixture.run(workflowStep(job, "Start core npm publication"));
       expect(start.status, start.stderr).toBe(0);
       const completed = fixture.run(workflowStep(job, "Complete publish workflows"), env);
@@ -3678,6 +3695,13 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
         MOCK_CORE_RESULT: "1",
       });
       const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+      const initialize = job.steps?.find(
+        (step) => step.name === "Initialize postpublish diagnostics",
+      );
+      if (initialize) {
+        const initialized = fixture.run(initialize);
+        expect(initialized.status, initialized.stderr).toBe(0);
+      }
       const start = fixture.run(workflowStep(job, "Start core npm publication"));
       expect(start.status, start.stderr).toBe(1);
       if (failedPublisher === "plugin") {
@@ -3699,6 +3723,31 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
         expect(fixture.events()).toContain("wait:openclaw-npm-release.yml:terminal:false");
         expect(fixture.events().some((event) => event.startsWith("verify:"))).toBe(false);
       }
+      const terminal = job.steps?.find((step) => step.name === "Record postpublish outcome");
+      if (terminal) {
+        const recorded = fixture.run(terminal, {
+          CORE_START_OUTCOME: "failure",
+          COMPLETION_OUTCOME: failedPublisher === "plugin" ? "skipped" : "failure",
+          PUBLISH_JOB_STATUS: "failure",
+        });
+        expect(recorded.status, recorded.stderr).toBe(0);
+      }
+      expect(
+        JSON.parse(
+          readFileSync(join(fixture.root, "evidence/release-postpublish-diagnostics.json"), "utf8"),
+        ),
+      ).toMatchObject({
+        verification: "unattempted",
+        context: { parentRunId: "44", parentRunAttempt: "2" },
+        stages: { coreNpm: { state: "unattempted" } },
+        children: {
+          pluginNpm: { suppliedRunId: "101", runAttempt: null },
+          openclawNpm: { suppliedRunId: failedPublisher === "core" ? "404" : null },
+        },
+      });
+      expect(existsSync(join(fixture.root, "evidence/release-postpublish-evidence.json"))).toBe(
+        false,
+      );
     },
   );
 
@@ -3719,6 +3768,187 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
     expect(events).toContain(
       "verify:0:bootstrap=false:workflow=refs/tags/release-publish/aaaaaaaaaaaa-42",
     );
+  });
+
+  it.each(["success", "binding", "assets"] as const)(
+    "keeps verifier success separate from postpublish %s completion",
+    (outcome) => {
+      const version = "2026.9.1-beta.1";
+      const fixture = createReleasePublishFixture(
+        {
+          PUBLISH_OPENCLAW_NPM: "false",
+          CHILD_PLUGIN_CLAWHUB_RUN_ID: "",
+          CHILD_PLUGIN_CLAWHUB_BOOTSTRAP_RUN_ID: "",
+        },
+        {
+          functions: `
+${shellFunctionSource(readFileSync("scripts/lib/release-publish-children.sh", "utf8"), "verify_published_release")}
+clawhub_workflow_ref=main
+bootstrap_plugins=""
+write_clawhub_runtime_state() { printf '%s\\n' '{"verifierArgs":["--skip-clawhub"]}' > "$1"; }
+${outcome === "assets" ? "upload_release_evidence_assets() { echo asset-upload-denied >&2; return 17; }" : ""}
+`,
+        },
+      );
+      writeFileSync(
+        join(fixture.root, "package.json"),
+        JSON.stringify({ type: "module", version }),
+      );
+      mkdirSync(join(fixture.root, "extensions"));
+      mkdirSync(join(fixture.root, "scripts"));
+      writeFileSync(join(fixture.root, "scripts/openclaw-npm-postpublish-verify.ts"), "");
+      copyFileSync(
+        resolve("scripts/release-verify-beta.ts"),
+        join(fixture.root, ".release-harness/scripts/release-verify-beta.ts"),
+      );
+      const bin = join(fixture.root, "bin");
+      mkdirSync(bin);
+      writeFileSync(
+        join(bin, "git"),
+        `#!/bin/sh
+if [ "$PWD" = "$GITHUB_WORKSPACE" ] && [ "$*" = "rev-parse HEAD" ]; then printf '%s\\n' "$TARGET_SHA"; else exec /usr/bin/git "$@"; fi
+`,
+        { mode: 0o755 },
+      );
+      for (const command of ["npm", "gh"]) {
+        writeFileSync(
+          join(bin, command),
+          `#!${process.execPath}
+const args = process.argv.slice(2);
+if (args[0] === "view") {
+  console.log(JSON.stringify({ version: "${version}", "dist-tags.beta": "${version}", "dist.integrity": "sha512-fixture", "dist.tarball": "https://example.invalid/openclaw.tgz" }));
+} else if (args[0] === "run" && args[1] === "view") {
+  console.log(JSON.stringify({ workflowName: args[2] === "101" ? "Plugin NPM Release" : "OpenClaw NPM Release", headBranch: "main", event: "workflow_dispatch", status: "completed", conclusion: "success", jobs: [] }));
+} else { throw new Error("Unexpected verifier mutation: " + args.join(" ")); }
+`,
+          { mode: 0o755 },
+        );
+      }
+      const manifest = join(fixture.root, "manifest");
+      mkdirSync(manifest);
+      writeFileSync(
+        join(manifest, "full-release-validation-manifest.json"),
+        JSON.stringify({
+          runId: "66",
+          runAttempt: outcome === "binding" ? "4" : "3",
+          workflowRef: "release-ci/tooling",
+          targetSha: "a".repeat(40),
+        }),
+      );
+      const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+      const env = {
+        PATH: `${bin}:${process.env.PATH}`,
+        FULL_RELEASE_VALIDATION_MANIFEST_DIR: manifest,
+        CHILD_OPENCLAW_NPM_RUN_ID: "404",
+      };
+      const initialized = fixture.run(workflowStep(job, "Initialize postpublish diagnostics"), env);
+      expect(initialized.status, initialized.stderr).toBe(0);
+      const completed = fixture.run(workflowStep(job, "Complete publish workflows"), env);
+      expect(completed.status, completed.stderr).toBe(
+        outcome === "success" ? 0 : outcome === "assets" ? 17 : 1,
+      );
+      const terminal = fixture.run(workflowStep(job, "Record postpublish outcome"), {
+        ...env,
+        COMPLETION_OUTCOME: outcome === "success" ? "success" : "failure",
+        PUBLISH_JOB_STATUS: outcome === "success" ? "success" : "failure",
+      });
+      expect(terminal.status, terminal.stderr).toBe(0);
+      const diagnostic = JSON.parse(
+        readFileSync(join(fixture.root, "evidence/release-postpublish-diagnostics.json"), "utf8"),
+      );
+      expect(diagnostic.verification).toBe("success");
+      expect(diagnostic.stages.coreNpm.state).toBe("success");
+      expect(diagnostic.stages.binding.state).toBe(outcome === "binding" ? "failure" : "success");
+      expect(diagnostic.stages.assets.state).toBe(
+        outcome === "binding" ? "unattempted" : outcome === "assets" ? "failure" : "success",
+      );
+      expect(diagnostic.jobOutcomeBeforeArtifactUploads).toBe(
+        outcome === "success" ? "success" : "failure",
+      );
+      const canonical = join(fixture.root, "evidence/release-postpublish-evidence.json");
+      expect(existsSync(canonical)).toBe(outcome !== "binding");
+      if (outcome !== "binding") {
+        const receipt = JSON.parse(readFileSync(canonical, "utf8"));
+        expect(receipt).toMatchObject({
+          version: 1,
+          releasePublishRunId: "44",
+          workflowRuns: expect.arrayContaining([
+            expect.objectContaining({
+              id: "66",
+              runAttempt: "3",
+              targetSha: "a".repeat(40),
+            }),
+          ]),
+        });
+        expect(receipt.kind).toBeUndefined();
+        expect(fixture.outputs().postpublish_evidence_ready).toBe("true");
+      }
+    },
+  );
+
+  it("retains cancelled or skipped verification without authorizing recovery", () => {
+    const fixture = createReleasePublishFixture();
+    const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+    const initialized = fixture.run(workflowStep(job, "Initialize postpublish diagnostics"));
+    expect(initialized.status, initialized.stderr).toBe(0);
+    const terminal = fixture.run(workflowStep(job, "Record postpublish outcome"), {
+      CORE_START_OUTCOME: "skipped",
+      COMPLETION_OUTCOME: "skipped",
+      PUBLISH_JOB_STATUS: "cancelled",
+    });
+    expect(terminal.status, terminal.stderr).toBe(0);
+    const diagnostic = JSON.parse(
+      readFileSync(join(fixture.root, "evidence/release-postpublish-diagnostics.json"), "utf8"),
+    );
+    expect(diagnostic.verification).toBe("unattempted");
+    expect(diagnostic.jobOutcomeBeforeArtifactUploads).toBe("cancelled");
+    expect(fixture.events()).toEqual([""]);
+  });
+
+  it("selects diagnostics separately without accepting them as successful evidence", () => {
+    const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+    const initialize = workflowStep(job, "Initialize postpublish diagnostics");
+    expect(job.steps!.indexOf(initialize)).toBeLessThan(
+      job.steps!.indexOf(workflowStep(job, "Verify all prepared plugin bytes before publication")),
+    );
+    const diagnostics = workflowStep(job, "Upload postpublish diagnostics");
+    expect(diagnostics.if).toBe("${{ always() }}");
+    expect(diagnostics["continue-on-error"]).toBe(true);
+    expect(diagnostics.uses).toBe(UPLOAD_ARTIFACT_V7);
+    expect(diagnostics.with).toMatchObject({
+      name: "openclaw-release-postpublish-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}",
+      path: "${{ runner.temp }}/openclaw-release-postpublish-evidence/release-postpublish-diagnostics.json",
+      "if-no-files-found": "warn",
+    });
+    const success = workflowStep(job, "Upload postpublish evidence");
+    expect(success.with?.path).toBe(
+      "${{ runner.temp }}/openclaw-release-postpublish-evidence/release-postpublish-evidence.json",
+    );
+    expect(success.with?.["if-no-files-found"]).toBe("error");
+    expect(success.if).toContain("steps.complete.outcome == 'success'");
+    const fixture = createReleasePublishFixture(
+      {},
+      {
+        functions: shellFunctionSource(
+          readFileSync("scripts/lib/release-publish-children.sh", "utf8"),
+          "upload_release_evidence_assets",
+        ),
+      },
+    );
+    const initialized = fixture.run(initialize);
+    expect(initialized.status, initialized.stderr).toBe(0);
+    const manifestDir = join(fixture.root, "manifest");
+    mkdirSync(manifestDir);
+    writeFileSync(join(manifestDir, "full-release-validation-manifest.json"), "{}");
+    const assets = fixture.run(
+      {
+        run: 'source "$GITHUB_WORKSPACE/.release-harness/scripts/lib/release-publish-children.sh"\nupload_release_evidence_assets',
+      },
+      { FULL_RELEASE_VALIDATION_MANIFEST_DIR: manifestDir },
+    );
+    expect(assets.status).toBe(1);
+    expect(assets.stderr).toContain("Postpublish release evidence is missing");
+    expect(fixture.events()).toEqual([""]);
   });
 
   it("fetches release diagnostics only for completed failed jobs", () => {
@@ -11910,7 +12140,7 @@ promote_windows_release_assets
     expect(postpublishEvidence.with).toMatchObject({
       "if-no-files-found": "error",
       name: "openclaw-release-postpublish-evidence-${{ inputs.tag }}",
-      path: "${{ runner.temp }}/openclaw-release-postpublish-evidence",
+      path: "${{ runner.temp }}/openclaw-release-postpublish-evidence/release-postpublish-evidence.json",
     });
     expect(postpublishEvidence.uses).toBe(UPLOAD_ARTIFACT_V7);
 

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -500,6 +500,22 @@ process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY
     const sourceSetup = step(preview, "Setup Node environment");
     const preparedSetup = step(preview, "Setup trusted Node for prepared publication");
     const preparedPlan = step(preview, "Read qualified npm preparation");
+    const toolingInstall = step(preview, "Install trusted plugin tooling dependencies");
+    const preparationSteps = previewSteps.filter((candidate) =>
+      [sourceSetup, preparedSetup, preparedPlan, toolingInstall].includes(candidate),
+    );
+    for (const preparedArtifact of ["", "qualified-preparation"]) {
+      const enabled = preparationSteps.filter(
+        (candidate) =>
+          !candidate.if ||
+          runInNewContext(candidate.if, { inputs: { prepared_artifact: preparedArtifact } }),
+      );
+      expect(enabled.map((candidate) => candidate.name)).toEqual(
+        preparedArtifact
+          ? ["Setup trusted Node for prepared publication", "Read qualified npm preparation"]
+          : ["Setup Node environment", "Install trusted plugin tooling dependencies"],
+      );
+    }
     expect(sourceSetup.uses).toBe("./.github/actions/setup-node-env");
     expect(sourceSetup.if).toBe("inputs.prepared_artifact == ''");
     expect(preparedSetup.if).toBe("inputs.prepared_artifact != ''");

--- a/test/scripts/plugin-npm-prepared-release.test.ts
+++ b/test/scripts/plugin-npm-prepared-release.test.ts
@@ -99,12 +99,21 @@ function expectations() {
   };
 }
 
-function preparation() {
-  const matrix = [plugin("demo"), plugin("existing", true)] as const;
+function preparation(
+  packageFields: Partial<
+    Pick<ReturnType<typeof plugin>, "version" | "channel" | "publishTag">
+  > = {},
+  route = "npm-oidc",
+  npmDistTag = "default",
+) {
+  const matrix = [
+    { ...plugin("demo"), ...packageFields },
+    { ...plugin("existing", true), ...packageFields },
+  ] as const;
   const artifact = (entry: ReturnType<typeof plugin>, id: number) =>
     metadata(
       id,
-      `plugin-npm-package-${entry.extensionId}-${entry.version}-npm-oidc-${producer.runId}-${producer.runAttempt}`,
+      `plugin-npm-package-${entry.extensionId}-${entry.version}-${route}-${producer.runId}-${producer.runAttempt}`,
     );
   const artifacts = [artifact(matrix[0], 1), artifact(matrix[1], 2)] satisfies [
     ReturnType<typeof metadata>,
@@ -127,6 +136,7 @@ function preparation() {
   };
   return {
     ...expectations(),
+    npmDistTag,
     producer,
     matrix,
     artifacts,
@@ -227,6 +237,70 @@ describe("prepared plugin npm publication", () => {
       artifactId: 2,
     });
   });
+
+  it.each([
+    ["beta bootstrap", version, "beta", "beta", "default", "npm-token-bootstrap"],
+    ["regular stable bootstrap", "2026.9.32", "stable", "latest", "default", "npm-token-bootstrap"],
+    [
+      "regular stable correction bootstrap",
+      "2026.9.32-1",
+      "stable",
+      "latest",
+      "default",
+      "npm-token-bootstrap",
+    ],
+    ["alpha OIDC", "2026.9.3-alpha.1", "alpha", "alpha", "default", "npm-oidc"],
+    [
+      "extended-stable OIDC",
+      "2026.9.33",
+      "stable",
+      "extended-stable",
+      "extended-stable",
+      "npm-oidc",
+    ],
+    ["stable readback", "2026.9.32", "stable", "latest", "default", "npm-readback"],
+  ])(
+    "seals %s without granting publication authority",
+    (_name, packageVersion, channel, publishTag, npmDistTag, route) => {
+      const input = preparation(
+        { version: packageVersion, channel, publishTag },
+        route,
+        npmDistTag,
+      );
+      const manifest = createPreparedNpmRelease(input);
+      expect(manifest.packages).toHaveLength(input.matrix.length);
+      for (const entry of manifest.packages) {
+        expect(entry).toMatchObject({ version: packageVersion, channel, publishTag, route });
+      }
+      expect(
+        validatePreparedNpmRelease(manifest, { ...expectations(), npmDistTag }).packages,
+      ).toEqual(manifest.packages);
+    },
+  );
+
+  it.each([
+    ["first extended-stable patch on latest", "2026.9.33", "stable", "latest", "default"],
+    ["later extended-stable patch on latest", "2026.9.34", "stable", "latest", "default"],
+    ["extended-stable correction on latest", "2026.9.33-1", "stable", "latest", "default"],
+    ["alpha", "2026.9.3-alpha.1", "alpha", "alpha", "default"],
+    ["explicit extended-stable", "2026.9.33", "stable", "extended-stable", "extended-stable"],
+  ])(
+    "rejects bootstrap preparation for %s",
+    (_name, packageVersion, channel, publishTag, npmDistTag) => {
+      const packageFields = { version: packageVersion, channel, publishTag };
+      expect(() =>
+        createPreparedNpmRelease(preparation(packageFields, "npm-token-bootstrap", npmDistTag)),
+      ).toThrow("Prepared npm token bootstrap");
+      const manifest = createPreparedNpmRelease(preparation(packageFields, "npm-oidc", npmDistTag));
+      for (const entry of manifest.packages) {
+        entry.route = "npm-token-bootstrap";
+        entry.artifact.artifactName = `plugin-npm-package-${entry.extensionId}-${entry.version}-npm-token-bootstrap-${producer.runId}-${producer.runAttempt}`;
+      }
+      expect(() => validatePreparedNpmRelease(manifest, { ...expectations(), npmDistTag })).toThrow(
+        "Prepared npm token bootstrap",
+      );
+    },
+  );
 
   it.each(["missing-artifact", "prior-attempt", "failed-job", "conflicting-artifact"])(
     "refuses to seal %s instead of falling back to an older success",

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -1,7 +1,8 @@
+import { spawnSync } from "node:child_process";
 // Release Beta Verifier tests cover release beta verifier script behavior.
 /* oxlint-disable typescript/no-base-to-string -- fetch mock normalizes standard RequestInfo inputs for URL assertions. */
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { crc32 } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -19,6 +20,7 @@ import {
   validateClawHubBootstrapEvidence,
   verifyBetaRelease,
 } from "../../scripts/lib/release-beta-verifier.ts";
+import { writePublishablePluginFixture } from "../helpers/publishable-plugin-fixture.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = createTempDirTracker();
@@ -96,7 +98,11 @@ afterEach(() => {
 describe("verifyBetaRelease workflow outcomes", () => {
   const version = "2026.5.10-beta.3";
 
-  function workflowFixture(overrides: Record<string, unknown> = {}, telegram = true) {
+  function workflowFixture(
+    overrides: Record<string, unknown> = {},
+    telegram = true,
+    npmError?: string,
+  ) {
     const rootDir = tempDirs.make("release-workflow-outcome-");
     const binDir = join(rootDir, "bin");
     mkdirSync(binDir);
@@ -119,10 +125,24 @@ describe("verifyBetaRelease workflow outcomes", () => {
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
-if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] === "openclaw@${version}") {
+fs.appendFileSync(path.join(path.dirname(process.argv[1]), "commands.jsonl"), JSON.stringify([path.basename(process.argv[1]), ...args]) + "\\n");
+if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].endsWith("@${version}")) {
+  if (${JSON.stringify(npmError ?? "")}) {
+    process.stderr.write(${JSON.stringify(npmError ?? "")});
+    process.exit(7);
+  }
+  const failures = path.join(path.dirname(process.argv[1]), "npm-failures.json");
+  if (fs.existsSync(failures)) {
+    const failure = JSON.parse(fs.readFileSync(failures, "utf8"))[args[1]];
+    if (failure) { process.stderr.write(failure); process.exit(9); }
+  }
   console.log(JSON.stringify({version: "${version}", "dist-tags.beta": "${version}", "dist.integrity": "sha512-test", "dist.tarball": "https://example.invalid/openclaw.tgz"}));
 } else if (args[0] === "run" && args[1] === "view" && args[2] === "44") {
   process.stdout.write(fs.readFileSync(path.join(path.dirname(process.argv[1]), "run.json")));
+} else if (args[0] === "api" && args[1].endsWith("/actions/runs/34")) {
+  process.stdout.write(fs.readFileSync(path.join(path.dirname(process.argv[1]), "bootstrap.json")));
+} else if (args[0] === "api" && args[1].includes("/actions/runs/34/artifacts?")) {
+  console.log(JSON.stringify({ artifacts: [] }));
 } else {
   throw new Error("Unexpected release verifier command: " + args.join(" "));
 }
@@ -145,8 +165,300 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
       "--evidence-out",
       "evidence.json",
     ]);
-    return { args, rootDir };
+    return { args, rootDir, binDir };
   }
+
+  function runCli(fixture: ReturnType<typeof workflowFixture>, extra: string[] = [], preload = "") {
+    const timers = join(fixture.rootDir, "timers.mjs");
+    // Keep the production retry budget; only the isolated fixture's clock advances.
+    writeFileSync(
+      timers,
+      `const delay = globalThis.setTimeout; globalThis.setTimeout = (fn, ms, ...args) => delay(fn, 0, ...args);\n${preload}`,
+    );
+    return spawnSync(
+      process.execPath,
+      [
+        "--import",
+        resolve("node_modules/tsx/dist/loader.mjs"),
+        "--import",
+        timers,
+        resolve("scripts/release-verify-beta.ts"),
+        version,
+        "--skip-postpublish",
+        "--skip-github-release",
+        "--skip-clawhub",
+        "--openclaw-npm-run",
+        "44",
+        "--evidence-out",
+        "evidence.json",
+        ...extra,
+      ],
+      {
+        cwd: fixture.rootDir,
+        encoding: "utf8",
+        timeout: 20_000,
+        env: { PATH: `${fixture.binDir}:${process.env.PATH}` },
+      },
+    );
+  }
+
+  it.each(["E404", "ETARGET"])(
+    "retains CLI diagnostics after core npm %s exhaustion without a success receipt",
+    (code) => {
+      const privateUrl = new URL("https://example.invalid/");
+      privateUrl.username = "fixture-user";
+      privateUrl.password = "fixture-password";
+      privateUrl.searchParams.set("token", "fixture-token");
+      const secret = `synthetic-secret /private/operator/token ${privateUrl.href}`;
+      const fixture = workflowFixture({}, false, `${code}: ${secret}`);
+      const result = runCli(fixture);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain(code);
+      expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+      const text = readFileSync(
+        join(fixture.rootDir, "release-postpublish-diagnostics.json"),
+        "utf8",
+      );
+      const diagnostic = JSON.parse(text);
+      expect(diagnostic).toMatchObject({
+        kind: "release-postpublish-diagnostics",
+        verification: "failure",
+        stages: {
+          coreNpm: { state: "failure", error: { class: "registry-not-visible", status: 7 } },
+          pluginNpm: { state: "unattempted" },
+          openclawNpm: { state: "unattempted" },
+        },
+        children: { openclawNpm: { suppliedRunId: "44", runAttempt: null } },
+      });
+      expect(text).not.toMatch(/synthetic-secret|private\/operator|password|token=secret/u);
+      const commands = readFileSync(join(fixture.binDir, "commands.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(commands).toHaveLength(30);
+      expect(commands.every((args) => args[0] === "npm" && args[1] === "view")).toBe(true);
+    },
+  );
+
+  it("retains successful core readback when the CLI later rejects a workflow", () => {
+    const fixture = workflowFixture({ conclusion: "failure" }, false);
+    const result = runCli(fixture);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("OpenClaw NPM Release: run 44 is completed/failure");
+    expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+    expect(
+      JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      ),
+    ).toMatchObject({
+      verification: "failure",
+      stages: {
+        coreNpm: { state: "success", publication: "observed" },
+        openclawNpm: { state: "failure" },
+        evidence: { state: "unattempted" },
+      },
+      children: { openclawNpm: { suppliedRunId: "44", runAttempt: null } },
+    });
+  });
+
+  it("initializes CLI diagnostics before checkout version verification", () => {
+    const fixture = workflowFixture({}, false);
+    writeFileSync(join(fixture.rootDir, "package.json"), JSON.stringify({ version: "2026.1.1" }));
+    const result = runCli(fixture);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("package.json version is 2026.1.1");
+    expect(
+      JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      ),
+    ).toMatchObject({
+      verification: "failure",
+      stages: { checkout: { state: "failure" }, coreNpm: { state: "unattempted" } },
+    });
+    expect(existsSync(join(fixture.binDir, "commands.jsonl"))).toBe(false);
+  });
+
+  it.each([true, false])(
+    "retains only bound bootstrap attempts before later artifact failure (bound=%s)",
+    (bound) => {
+      const fixture = workflowFixture({}, false);
+      const releaseSha = "a".repeat(40);
+      writeFileSync(join(fixture.binDir, "git"), `#!/bin/sh\nprintf '%s\\n' '${releaseSha}'\n`, {
+        mode: 0o755,
+      });
+      writeFileSync(
+        join(fixture.binDir, "bootstrap.json"),
+        JSON.stringify({
+          id: bound ? 34 : 35,
+          name: "Plugin ClawHub New",
+          event: "workflow_dispatch",
+          head_branch: "main",
+          head_sha: "b".repeat(40),
+          run_attempt: 3,
+          path: ".github/workflows/plugin-clawhub-new.yml",
+          status: "completed",
+          conclusion: "success",
+        }),
+      );
+      const result = runCli(fixture, [
+        "--release-sha",
+        releaseSha,
+        "--plugin-clawhub-bootstrap-run",
+        "34",
+        "--clawhub-bootstrap-plugins",
+        "@openclaw/example",
+      ]);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain(
+        bound ? "must have exactly one clawhub-bootstrap-readback-34-3" : "run id is 35",
+      );
+      const diagnostic = JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      );
+      expect(diagnostic.stages.pluginClawHubBootstrap.state).toBe("failure");
+      expect(diagnostic.children.pluginClawHubBootstrap).toMatchObject({
+        suppliedRunId: "34",
+        runAttempt: bound ? "3" : null,
+        producerRunAttempt: null,
+        status: bound ? "completed" : "unknown",
+        conclusion: bound ? "success" : "unknown",
+      });
+      expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+    },
+  );
+
+  it.each(["npm", "clawhub"] as const)(
+    "retains completed packages and later unattempted packages after %s fails",
+    async (surface) => {
+      const fixture = workflowFixture({}, false);
+      for (const extensionId of ["first", "middle", "last"]) {
+        writePublishablePluginFixture(fixture.rootDir, {
+          version,
+          extensionId,
+          publishTo: "both",
+        });
+      }
+      // The collector's order is alphabetical: first, last, middle.
+      if (surface === "npm") {
+        writeFileSync(
+          join(fixture.binDir, "npm-failures.json"),
+          JSON.stringify({
+            [`@openclaw/last@${version}`]: "EACCES: synthetic-secret",
+          }),
+        );
+      } else {
+        fixture.args.skipClawHub = false;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (input: string) => {
+            if (input.includes(encodeURIComponent("@openclaw/last"))) {
+              return new Response("synthetic-secret", { status: 403 });
+            }
+            return Response.json({ package: { tags: { beta: version } } });
+          }),
+        );
+      }
+      await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow();
+      const diagnostic = JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      );
+      const stage = diagnostic.stages[surface === "npm" ? "pluginNpm" : "clawHub"];
+      expect(stage.state).toBe("failure");
+      expect(stage.packages).toMatchObject([
+        { name: "@openclaw/first", state: "success", publication: "observed" },
+        { name: "@openclaw/last", state: "failure", publication: "unknown" },
+        { name: "@openclaw/middle", state: "unattempted", publication: "unknown" },
+      ]);
+      expect(diagnostic.stages.coreNpm.state).toBe("success");
+      expect(diagnostic.stages.openclawNpm.state).toBe("unattempted");
+      expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+    },
+  );
+
+  it("keeps the primary CLI failure when diagnostic initialization cannot write", () => {
+    const fixture = workflowFixture({ conclusion: "failure" }, false);
+    mkdirSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"));
+    const result = runCli(fixture);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("diagnostics unavailable");
+    expect(result.stderr).toContain("OpenClaw NPM Release: run 44 is completed/failure");
+    expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+  });
+
+  it("retains the last valid atomic diagnostic when updates and the verifier both fail", () => {
+    const fixture = workflowFixture({}, false, "EACCES: primary-registry-denial");
+    const result = runCli(
+      fixture,
+      [],
+      `
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const link = fs.linkSync;
+fs.linkSync = (source, target) => {
+  link(source, target);
+  fs.copyFileSync(target, target + ".original");
+};
+fs.renameSync = () => { throw new Error("synthetic-secret update failure"); };
+syncBuiltinESMExports();
+`,
+    );
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("primary-registry-denial");
+    expect(result.stderr).toContain("diagnostics unavailable");
+    expect(result.stderr).not.toContain("synthetic-secret");
+    const diagnosticPath = join(fixture.rootDir, "release-postpublish-diagnostics.json");
+    expect(readFileSync(diagnosticPath)).toEqual(readFileSync(`${diagnosticPath}.original`));
+    expect(JSON.parse(readFileSync(diagnosticPath, "utf8")).verification).toBe("unattempted");
+    expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+  });
+
+  it.each(["stale", "unwritable"] as const)(
+    "does not turn a %s success-output path into a successful CLI result",
+    (mode) => {
+      const fixture = workflowFixture({}, false);
+      const evidencePath = join(fixture.rootDir, "evidence.json");
+      if (mode === "stale") {
+        writeFileSync(evidencePath, "previous invocation\n");
+      } else {
+        mkdirSync(evidencePath);
+      }
+      const result = runCli(fixture);
+      expect(result.status, result.stderr).toBe(1);
+      const diagnostic = JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      );
+      expect(diagnostic).toMatchObject({
+        verification: "success",
+        stages: { evidence: { state: "failure", error: { class: "evidence-write-failure" } } },
+      });
+      if (mode === "stale") {
+        expect(readFileSync(evidencePath, "utf8")).toBe("previous invocation\n");
+      }
+    },
+  );
+
+  it("bounds and validates selected diagnostic metadata without retaining hostile inputs", () => {
+    const fixture = workflowFixture({}, false);
+    writeFileSync(join(fixture.rootDir, "package.json"), JSON.stringify({ version: "2026.1.1" }));
+    const names = Array.from({ length: 300 }, (_, i) => `@openclaw/plugin-${i}`);
+    const result = runCli(fixture, [
+      "--plugins",
+      names.join(","),
+      "--workflow-ref",
+      "https://example.invalid/?token=synthetic-secret",
+    ]);
+    expect(result.status).toBe(1);
+    const text = readFileSync(
+      join(fixture.rootDir, "release-postpublish-diagnostics.json"),
+      "utf8",
+    );
+    const diagnostic = JSON.parse(text);
+    expect(diagnostic.selection.plugins).toHaveLength(256);
+    expect(diagnostic.selection.pluginsTruncated).toBe(true);
+    expect(diagnostic.selection.workflowRef).toBeNull();
+    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(128 * 1024);
+    expect(text).not.toMatch(/password|token=|synthetic-secret/u);
+  });
 
   it.each([
     { status: "completed", conclusion: "failure" },
@@ -174,6 +486,16 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
           },
         }),
       ]);
+      const diagnostic = JSON.parse(
+        readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+      );
+      expect(diagnostic.children.npmTelegram).toMatchObject({
+        status: run.status,
+        conclusion: run.conclusion,
+        runAttempt: null,
+      });
+      expect(diagnostic.stages.clawHub.state).toBe("skipped");
+      expect(diagnostic.stages.githubRelease.state).toBe("skipped");
     },
   );
 


### PR DESCRIPTION
Fixes #142937

Stacked on https://github.com/openclaw/openclaw/pull/136466 at
`90cbb53e448b4904d9df074e60f204a12381cc38`; base branch
`codex/release-ready-button`. This PR contains only the five-owner diagnostics
change. Landing waits for the prerequisite and hosted proof acceptance before
native restacking and landing.

## What Problem This Solves

Fixes an issue where release operators lose postpublish verification progress
when npm readback or a later verification stage fails. A failed publisher can
also skip the verifier entirely, leaving no record distinguishing unattempted
verification from successful readback.

## Why This Change Was Made

Record a separate, bounded, attempt-bound diagnostic in the existing evidence
directory before risky work and after individual stage observations. Standalone
CLI invocations write it beside their existing `--evidence-out` path. Retain
completed package checks, original child identities and known attempts without
inferring that a missing registry result means publication never happened.

Keep the successful evidence schema unchanged. Stage that receipt until its
existing validation and parent binding finish, then expose the canonical success
filename. Diagnostic-only output cannot satisfy success upload or release-asset
checks. No publisher, workflow dispatch, rerun, retry budget or controller is added.

## User Impact

Operators can distinguish verification failure, partial progress, skipped work
and verification that was never attempted. Successful registry readback remains
visible when later binding or asset work fails. Original errors and command
statuses remain authoritative.

`jobOutcomeBeforeArtifactUploads` is the job state observed before artifact
uploads, not the final job or workflow result. Diagnostic uploads are best effort;
inspect actual step/job state for later upload failures. Missing diagnostics or
an interrupted stage remain unknown and never authorize republishing.

Standalone verification refuses to overwrite an existing `--evidence-out` file.
For repeat verification, use a fresh per-invocation output directory so both the
success receipt and diagnostic sibling have fresh paths; retain earlier evidence.
These are named operator artifacts, not a runtime store migration. The existing
successful evidence schema is unchanged.

## Evidence

- Six real CLI/helper regressions failed on the prerequisite before the change
  because diagnostics were absent after the intended primary failure.
- The full owner-suite run passed 471 tests; its sole environmental failure was
  a missing ZIP executable. That case passed after task-local tool provisioning.
- Focused repairs and sibling proof provide cumulative passing coverage for all
  474 distinct owner tests, not one all-green single-pass run. Cases include
  core npm exhaustion, later workflow/package failure,
  publisher failure before verification, stale/unwritable success output,
  atomic diagnostic write failure, binding and asset failures, cancellation,
  metadata bounds, redaction and diagnostic-only success rejection.
- A further real CLI regression demonstrated loss of an already-bound bootstrap
  attempt before a later artifact lookup failure; it passes after preserving
  that existing observation. A changed-run-ID control remains unknown.
- Workflow validation, changed gates, scripts/root-test typechecks, lint,
  formatting and shell syntax pass. Fresh independent review is scoped-clean
  through P2.
- Initial CI found the new diagnostic export unused because Knip could not
  resolve the shell's computed import:
  https://github.com/openclaw/openclaw/actions/runs/34325084242/job/102380565817.
  The helper now invokes the same module directly behind its entrypoint guard;
  the function is private, with no Knip waiver or configuration change. All three
  unused-export scans and 33 focused CLI/helper cases pass locally.
- The existing cancellation case also proves imports remain inert with a valid
  diagnostic environment: removing the entrypoint guard produced an unexpected
  artifact; restoring it passes before the real initializer/observer runs.

No real package publication, release, FRV execution or hosted artifact upload
was run. Hosted always/skip/failure artifact behavior remains a separate proof
gate. This change does not complete the broader all-surface publication status
or producer-diagnostics follow-ups.
