### PR TITLE
fix(ui): keep command palette background readable

### DIFF
--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -94,6 +94,8 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     }
 
     :host(.palette) wa-dialog {
+      --openclaw-modal-backdrop-filter: none;
+      --wa-color-overlay-modal: color-mix(in oklab, black 12%, transparent);
       --show-duration: 0ms;
       --hide-duration: 0ms;
     }

--- a/ui/src/e2e/command-palette-first-open.e2e.test.ts
+++ b/ui/src/e2e/command-palette-first-open.e2e.test.ts
@@ -7,6 +7,23 @@ import {
 
 const suite = createControlUiE2eSuite({ name: "command palette first open" });
 
+async function readPaletteBackdrop(page: import("playwright").Page) {
+  return await page.locator("openclaw-modal-dialog.cmd-palette-overlay").evaluate((modal) => {
+    const dialog = modal.shadowRoot
+      ?.querySelector("wa-dialog")
+      ?.shadowRoot?.querySelector("dialog");
+    if (!(dialog instanceof HTMLDialogElement)) {
+      throw new Error("Expected the command palette dialog");
+    }
+    const style = getComputedStyle(dialog, "::backdrop");
+    const alphaMatch = style.backgroundColor.match(/\/\s*([\d.]+)\s*\)$/u);
+    return {
+      alpha: alphaMatch ? Number(alphaMatch[1]) : style.backgroundColor === "transparent" ? 0 : 1,
+      filter: style.backdropFilter,
+    };
+  });
+}
+
 suite.define(() => {
   it.each([
     { height: 900, width: 1280 },
@@ -34,6 +51,9 @@ suite.define(() => {
         await shell.waitFor({ state: "visible" });
         await paletteModule.request;
         expect(await shell.getAttribute("aria-label")).toBe("Loading…");
+        const loadingBackdrop = await readPaletteBackdrop(page);
+        expect(loadingBackdrop.filter).toBe("none");
+        expect(loadingBackdrop.alpha).toBeLessThanOrEqual(0.2);
         await page
           .locator("openclaw-router-outlet .lazy-view-state--loading")
           .waitFor({ state: "attached" });
@@ -42,6 +62,9 @@ suite.define(() => {
         chatModule.release();
         paletteModule.release();
         await page.locator(".cmd-palette__input:not([disabled])").waitFor({ state: "visible" });
+        const loadedBackdrop = await readPaletteBackdrop(page);
+        expect(loadedBackdrop.filter).toBe("none");
+        expect(loadedBackdrop.alpha).toBeLessThanOrEqual(0.2);
       } finally {
         paletteModule.release();
         chatModule.release();


### PR DESCRIPTION
Closes #142881

## What Problem This Solves

Fixes an issue where users opening the command palette with Cmd/Ctrl+K could no longer read the underlying session context because the palette blurred the entire background.

## Why This Change Was Made

The command palette now overrides the shared modal backdrop through the existing palette styling seam: blur is disabled and a subtle 12% theme-aware dim remains. The change is palette-specific, so other modal backdrops and palette interaction behavior remain unchanged.

## User Impact

Users can keep session names, messages, and composer context legible while using the command palette in light or dark mode.

## Evidence

### Dark theme

| Before | After |
| --- | --- |
| ![Command palette before the fix in dark mode; underlying sessions are blurred](https://github.com/user-attachments/assets/a2dd1bce-f055-4911-9d8b-0004e9792af3) | ![Command palette after the fix in dark mode; underlying sessions remain readable](https://github.com/user-attachments/assets/c95700c0-9a3d-41ec-b028-8d33fe37b533) |

### Light theme

| Before | After |
| --- | --- |
| ![Command palette before the fix in light mode; underlying sessions are blurred](https://github.com/user-attachments/assets/5cbe95c4-b555-4cdc-b0ab-fbfb2ca10d90) | ![Command palette after the fix in light mode; underlying sessions remain readable](https://github.com/user-attachments/assets/f5f565fa-9213-4b6f-a2e1-45f0a76dcb0d) |

The screenshots are sanitized and were personally inspected. They exercise the actual production Control UI in isolated Playwright Chromium against the mocked Gateway fixture. This is not authenticated live-Gateway proof.

**Live-proof limitation:** the existing-session Chrome attach failed because Chrome was not running and `~/.config/google-chrome/DevToolsActivePort` was unavailable. This task also explicitly prohibited an operator Gateway restart or live-config mutation, so no live Gateway was changed to obtain substitute proof.

- Verified the native palette backdrop computes to `backdrop-filter: none` with 12% dimming in both themes.
- Verified keyboard navigation, focus trapping, Escape dismissal, outside-click dismissal, and focus restoration.
- Verified a generic modal retains its existing `blur(4px)` backdrop.
- Focused component tests: 62 passed.
- Command palette E2E: 2 passed across desktop and phone viewports, including loading and loaded states.
- `node scripts/check-changed.mjs`: passed.
- Independent autoreview through P2: scoped clean.
