### PR TITLE
feat: open new sessions with a keyboard shortcut

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -91,7 +91,7 @@ struct OpenClawApp: App {
                 Button("New Thread") {
                     DashboardManager.shared.dispatchNativeCommand(.newSession)
                 }
-                .keyboardShortcut("n", modifiers: [.command, .shift])
+                .keyboardShortcut("n", modifiers: [.command, .option])
             }
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -91,7 +91,7 @@ struct OpenClawApp: App {
                 Button("New Thread") {
                     DashboardManager.shared.dispatchNativeCommand(.newSession)
                 }
-                .keyboardShortcut("n", modifiers: [.command, .option])
+                .keyboardShortcut("n", modifiers: [.command, .shift])
             }
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {

--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -11,6 +11,15 @@ sidebarTitle: "Sessions and sidebar"
 
 The sidebar organizes every session, and the New session page starts new ones.
 
+Open **New session** for the current agent with **⌘⌥N** (Command+Option+N) on Mac
+or **Ctrl+Alt+N** on Windows/Linux, including while typing in the chat composer.
+This opens the draft page without sending a message or clearing your current chat
+draft. In the Mac app, **⌘N** still opens a new Gateway window.
+
+If your keyboard layout or a system shortcut prevents the chord from reaching
+OpenClaw, use the sidebar's **+** button. Option-only and AltGr character entry
+remain available for typing.
+
 ## New session names
 
 In **New session**, pausing typing for one second prepares a session name in the

--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -11,10 +11,11 @@ sidebarTitle: "Sessions and sidebar"
 
 The sidebar organizes every session, and the New session page starts new ones.
 
-Open **New session** for the current agent with **⌘⌥N** (Command+Option+N) on Mac
+In the web UI, open **New session** for the current agent with **⌘⌥N** (Command+Option+N) on Mac
 or **Ctrl+Alt+N** on Windows/Linux, including while typing in the chat composer.
 This opens the draft page without sending a message or clearing your current chat
-draft. In the Mac app, **⌘N** still opens a new Gateway window.
+draft. The native Mac app keeps **⌘⇧N** for **New Thread** and **⌘N** for a new
+Gateway window; its menu shortcuts do not change.
 
 If your keyboard layout or a system shortcut prevents the chord from reaching
 OpenClaw, use the sidebar's **+** button. Option-only and AltGr character entry

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -426,6 +426,13 @@ export class ShellChromeOwner {
       window.dispatchEvent(new CustomEvent(KEYBOARD_SHORTCUTS_REQUEST_EVENT));
       return;
     }
+    if (matchesShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.newSession, event)) {
+      event.preventDefault();
+      if (!event.repeat) {
+        this.handleNativeNewSession();
+      }
+      return;
+    }
     if (matchesShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.debugOverlay, event)) {
       const target = event.target;
       if (

--- a/ui/src/app/app-shell-new-session.test.ts
+++ b/ui/src/app/app-shell-new-session.test.ts
@@ -1,0 +1,87 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "./app-host.ts";
+import { resetAppHostTestGlobals, type ShellKeyboardState } from "./app-host.test-support.ts";
+import type { ApplicationContext } from "./context.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetAppHostTestGlobals();
+});
+
+describe("new-session keyboard shortcut", () => {
+  it.each(["MacIntel", "Win32", "Linux x86_64"])(
+    "opens the selected agent's draft from an editor on %s",
+    (platform) => {
+      vi.spyOn(navigator, "platform", "get").mockReturnValue(platform);
+      const navigate = vi.fn();
+      const shell = document.createElement("openclaw-app-shell") as unknown as ShellKeyboardState;
+      shell.runtime = {
+        context: {
+          navigate,
+          agentSelection: { state: { selectedId: "research" } },
+          gateway: {
+            snapshot: {
+              client: {},
+              phase: "connected",
+              hello: {
+                auth: { role: "operator", scopes: ["operator.write"] },
+                features: { methods: ["sessions.create"] },
+              },
+            },
+          },
+        } as unknown as ApplicationContext,
+      };
+      const editor = document.createElement("textarea");
+      editor.value = "Keep this unsent draft";
+      editor.addEventListener("keydown", shell.handleDocumentKeydown);
+      const modifiers =
+        platform === "MacIntel" ? { metaKey: true, altKey: true } : { ctrlKey: true, altKey: true };
+      for (const init of [
+        { key: "n", code: "KeyN" },
+        ...(platform === "MacIntel" ? [{ key: "˜", code: "KeyN" }] : []),
+      ]) {
+        const event = new KeyboardEvent("keydown", { ...init, ...modifiers, cancelable: true });
+        editor.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+        expect(navigate).toHaveBeenCalledExactlyOnceWith("new-session", {
+          search: "?agent=research",
+        });
+        navigate.mockClear();
+      }
+      for (const init of [
+        { shiftKey: true },
+        { altKey: false },
+        { metaKey: false, ctrlKey: false },
+        { key: "Dead" },
+        { modifierAltGraph: true },
+        ...(platform === "MacIntel" ? [] : [{ key: "ñ" }]),
+        { metaKey: true, ctrlKey: true },
+        { metaKey: !modifiers.metaKey, ctrlKey: !modifiers.ctrlKey },
+        { isComposing: true },
+        { keyCode: 229 },
+      ]) {
+        const event = new KeyboardEvent("keydown", {
+          key: "n",
+          code: "KeyN",
+          ...modifiers,
+          ...init,
+          cancelable: true,
+        });
+        editor.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(false);
+      }
+      const repeated = new KeyboardEvent("keydown", {
+        key: "n",
+        ...modifiers,
+        repeat: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(repeated);
+      expect(repeated.defaultPrevented).toBe(true);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(editor.value).toBe("Keep this unsent draft");
+    },
+  );
+});

--- a/ui/src/app/app-shell-new-session.test.ts
+++ b/ui/src/app/app-shell-new-session.test.ts
@@ -40,7 +40,13 @@ describe("new-session keyboard shortcut", () => {
         platform === "MacIntel" ? { metaKey: true, altKey: true } : { ctrlKey: true, altKey: true };
       for (const init of [
         { key: "n", code: "KeyN" },
-        ...(platform === "MacIntel" ? [{ key: "˜", code: "KeyN" }] : []),
+        ...(platform === "MacIntel"
+          ? [
+              { key: "˜", code: "KeyN" },
+              { key: "n", code: "KeyN", modifierAltGraph: true },
+              { key: "˜", code: "KeyN", modifierAltGraph: true },
+            ]
+          : []),
       ]) {
         const event = new KeyboardEvent("keydown", { ...init, ...modifiers, cancelable: true });
         editor.dispatchEvent(event);
@@ -55,7 +61,9 @@ describe("new-session keyboard shortcut", () => {
         { altKey: false },
         { metaKey: false, ctrlKey: false },
         { key: "Dead" },
-        { modifierAltGraph: true },
+        ...(platform === "MacIntel"
+          ? [{ modifierAltGraph: true, metaKey: false }]
+          : [{ modifierAltGraph: true }]),
         ...(platform === "MacIntel" ? [] : [{ key: "ñ" }]),
         { metaKey: true, ctrlKey: true },
         { metaKey: !modifiers.metaKey, ctrlKey: !modifiers.ctrlKey },

--- a/ui/src/e2e/new-session-page.shortcut.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.shortcut.e2e.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from "vitest";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  controlUiSessionPath,
+  createNewSessionPageE2eSuite,
+  createdSessionListResult,
+  installMockGateway,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+
+suite.define(() => {
+  it("opens a draft for the current agent without sending or discarding the chat draft", async () => {
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const sessionKey = "agent:research:existing-session";
+      const gateway = await installMockGateway(page, {
+        sessionKey,
+        methodResponses: {
+          "agents.list": {
+            agents: [{ id: "main" }, { id: "research" }],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "sessions.list": createdSessionListResult(sessionKey),
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}${controlUiSessionPath(sessionKey).slice(1)}`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("Keep this unsent chat draft");
+      // This proves the page's keyboard/navigation boundary, not browser-reserved accelerators.
+      await composer.press("ControlOrMeta+Alt+n");
+      await page.waitForURL((url) => url.pathname === "/new" && url.search === "?agent=research");
+      await page.locator(".new-session-page__message").waitFor();
+      await expect
+        .poll(() =>
+          page.locator(".new-session-page__select--agent .agent-select__label").textContent(),
+        )
+        .toBe("research");
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+
+      await page.goBack();
+      await expect.poll(() => composer.inputValue()).toBe("Keep this unsent chat draft");
+    });
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -164,6 +164,7 @@ export const en: TranslationMap & {
       debugOverlay: "Toggle debug overlay",
       appearanceSettings: "Open appearance settings",
       startNewSession: "Start new session (from the new-session page)",
+      newSession: "Open new session for the current agent",
       closeDialog: "Close dialog or exit settings",
       sendMessage: "Send message",
       newline: "Insert new line",

--- a/ui/src/lib/keyboard-shortcut-catalog.test.ts
+++ b/ui/src/lib/keyboard-shortcut-catalog.test.ts
@@ -156,6 +156,7 @@ describe("keyboard shortcut catalog presentation", () => {
         .find((entry) => entry.id === id)?.combos;
 
     expect(entryCombos("startNewSession")).toEqual([KEYBOARD_SHORTCUT_COMBOS.modifiedEnter]);
+    expect(entryCombos("newSession")).toEqual([KEYBOARD_SHORTCUT_COMBOS.newSession]);
     expect(entryCombos("sendMessage")).toEqual([KEYBOARD_SHORTCUT_COMBOS.modifiedEnter]);
   });
 

--- a/ui/src/lib/keyboard-shortcut-catalog.test.ts
+++ b/ui/src/lib/keyboard-shortcut-catalog.test.ts
@@ -79,6 +79,41 @@ describe("keyboard shortcut catalog matching", () => {
     }
   });
 
+  it.each([
+    "browserPanel",
+    "tasksPanel",
+    "desktopPanel",
+    "discussionPanel",
+    "dashboardPanel",
+    "reviewPanel",
+  ] as const)("preserves Firefox Mac Command+Option for %s without consuming AltGr", (name) => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+    const combo = KEYBOARD_SHORTCUT_COMBOS[name];
+    const keyboard = {
+      key: "¨",
+      code: `Key${combo.key.toUpperCase()}`,
+      metaKey: true,
+      altKey: true,
+      shiftKey: true,
+      modifierAltGraph: true,
+    };
+    expect(matchesShortcutCombo(combo, new KeyboardEvent("keydown", keyboard))).toBe(true);
+    for (const platform of ["MacIntel", "Win32", "Linux x86_64"]) {
+      vi.spyOn(navigator, "platform", "get").mockReturnValue(platform);
+      expect(
+        matchesShortcutCombo(
+          combo,
+          new KeyboardEvent("keydown", {
+            ...keyboard,
+            key: combo.key,
+            metaKey: false,
+            ctrlKey: true,
+          }),
+        ),
+      ).toBe(false);
+    }
+  });
+
   it("matches physical Backquote and Comma keys independently of their produced characters", () => {
     const terminal = new KeyboardEvent("keydown", {
       key: "ö",

--- a/ui/src/lib/keyboard-shortcut-catalog.ts
+++ b/ui/src/lib/keyboard-shortcut-catalog.ts
@@ -25,6 +25,7 @@ function keyboardShortcutSection(id: string, entries: readonly KeyboardShortcutE
 const KEYBOARD_SHORTCUT_SECTIONS = [
   keyboardShortcutSection("general", [
     keyboardShortcutEntry("commandPalette", KEYBOARD_SHORTCUT_COMBOS.commandPalette),
+    keyboardShortcutEntry("newSession", KEYBOARD_SHORTCUT_COMBOS.newSession),
     keyboardShortcutEntry("keyboardShortcuts", KEYBOARD_SHORTCUT_COMBOS.keyboardShortcuts),
     keyboardShortcutEntry("toggleSidebar", KEYBOARD_SHORTCUT_COMBOS.toggleSidebar),
     keyboardShortcutEntry("debugOverlay", KEYBOARD_SHORTCUT_COMBOS.debugOverlay),

--- a/ui/src/lib/keyboard-shortcut-contract.ts
+++ b/ui/src/lib/keyboard-shortcut-contract.ts
@@ -81,12 +81,13 @@ export function formatKeyboardShortcutCombo(
 // Most mod-chords accept either modifier. Platform-specific chords reserve
 // native editing keys (Mac Ctrl+B/F/K) for the focused text field.
 export function matchesShortcutCombo(combo: KeyboardShortcutCombo, event: KeyboardEvent): boolean {
-  // AltGr is text input even on layouts where it reports Control+Alt.
+  // Firefox reports Mac Option as AltGraph, including Command+Option shortcuts.
+  // Keep rejecting AltGr text input outside that explicit Command chord.
   if (
     event.isComposing ||
     event.key === "Dead" ||
     event.keyCode === 229 ||
-    event.getModifierState("AltGraph")
+    (event.getModifierState("AltGraph") && !(isApplePlatform() && event.metaKey && event.altKey))
   ) {
     return false;
   }

--- a/ui/src/lib/keyboard-shortcut-contract.ts
+++ b/ui/src/lib/keyboard-shortcut-contract.ts
@@ -9,6 +9,7 @@ type ShortcutDefinition<Key extends string> = {
 
 export const KEYBOARD_SHORTCUT_COMBOS = {
   commandPalette: { modifiers: ["mod"], key: "k", platformSpecific: true },
+  newSession: { modifiers: ["mod", "alt"], key: "n", platformSpecific: true },
   keyboardShortcuts: { modifiers: ["mod"], key: "/" },
   toggleSidebar: { modifiers: ["mod"], key: "b", platformSpecific: true },
   debugOverlay: { modifiers: ["mod", "shift"], key: "d" },
@@ -80,7 +81,13 @@ export function formatKeyboardShortcutCombo(
 // Most mod-chords accept either modifier. Platform-specific chords reserve
 // native editing keys (Mac Ctrl+B/F/K) for the focused text field.
 export function matchesShortcutCombo(combo: KeyboardShortcutCombo, event: KeyboardEvent): boolean {
-  if (event.isComposing || event.key === "Dead" || event.keyCode === 229) {
+  // AltGr is text input even on layouts where it reports Control+Alt.
+  if (
+    event.isComposing ||
+    event.key === "Dead" ||
+    event.keyCode === 229 ||
+    event.getModifierState("AltGraph")
+  ) {
     return false;
   }
   const wantsMod = combo.modifiers.includes("mod");


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/142952

## What Problem This Solves

Opening a new Control UI session currently requires pointer navigation. Add a keyboard shortcut that opens the New Session page for the selected agent, including from the chat composer, without sending or discarding the current draft.

## Why This Change Was Made

Use Command+Option+N on macOS and Control+Alt+N on Windows/Linux through the existing shared shortcut contract and New Session action. Leave native Mac menu shortcuts unchanged: Command+Shift+N for New Thread and Command+N for New Gateway Window. The web UI uses a different chord because browser window shortcuts constrain its choices. Preserve composition, dead-key and AltGr text entry; reuse existing modal and session-access gates.

## User Impact

- Open New Session for the current agent using the keyboard.
- Return to the original chat with its unsent draft intact.
- Discover the shortcut in keyboard help and session documentation.

## Evidence

- Regression failed on the original code for all three platform mappings, then passed with the change.
- 66 focused unit tests and one bundled-browser E2E passed. The E2E verifies agent selection, no `sessions.create` or `chat.send` request, and draft preservation after Back.
- Real XTest Control+Alt+N input in a normal Linux Chromium window opened `/new?agent=research` without opening another page. Video proof below.
- UI production build, UI/native i18n verification, and `node scripts/check-changed.mjs` passed, including typechecks, lint, dead-export scans and portable native helper tests.
- Autoreview completed. Its physical-key fallback concern is disproven by the existing Command+Option fallback in `keyboard-shortcut-contract.ts` and the passing `˜`/`KeyN` regression.

Limitations: normal Mac browser and Windows OS-level input are not verified. Native Mac source is unchanged from the PR base; no native accelerator transition is proposed. The recorded live UI proof uses this worktree's built UI with an isolated, previously built sibling Gateway, not an exact-head Gateway build. Chrome on Mac assigns Command+Option+N to Split View; inspected Chromium dispatch source treats that command as non-reserved, but macOS delivery still needs live verification.

### Recorded keyboard proof

Real OS-level Control+Alt+N in a normal Chromium window on Linux, navigating from Appearance settings to New Session for `research`. This recording proves browser delivery and selected-agent navigation; draft preservation is covered separately by the browser E2E.

https://github.com/user-attachments/assets/9b14e8f7-8cd4-4e0d-ba40-a9d518609b7f

### Maintainer decision

Preserve the existing ergonomic native Mac shortcuts. Only the web UI receives the new binding; matching native and browser accelerators is not a goal. The native MenuBar.swift change has been reverted. This resolves the review’s native shortcut compatibility concern without retiring Command+Shift+N. The existing Linux recording remains applicable because web behavior is unchanged.
