### PR TITLE
fix: keep composer text readable while typing past its height limit

### DIFF
--- a/ui/src/e2e/composer-text-readability.e2e.test.ts
+++ b/ui/src/e2e/composer-text-readability.e2e.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Composer text readability" });
+
+suite.define(() => {
+  it.each([
+    { route: "chat", width: 1280 },
+    { route: "new", width: 1280 },
+    { route: "chat", width: 390 },
+    { route: "new", width: 390 },
+  ])("keeps overflowing $route text readable at $width px", async ({ route, width }) => {
+    const artifactDir = createControlUiE2eArtifactDir(`composer-${route}-${width}`);
+    await suite.withPage(
+      { viewport: { width, height: 900 }, recordVideo: { dir: artifactDir } },
+      async ({ page }) => {
+        await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}${route}`);
+        const textarea = page.locator(".agent-chat__composer-combobox textarea");
+        const lines = Array.from(
+          { length: 20 },
+          (_, index) => `Line ${index + 1}: Keep text readable`,
+        );
+        await textarea.fill(lines.slice(0, 2).join("\n"));
+        // Grow through the height cap using native editing, without forcing scrollTop.
+        for (const line of lines.slice(2)) {
+          await textarea.press("Shift+Enter");
+          await page.keyboard.insertText(line);
+          expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).toBe("none");
+        }
+        await expect.poll(() => textarea.inputValue()).toBe(lines.join("\n"));
+        await expect.poll(() => textarea.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+        await page.screenshot({ path: `${artifactDir}/typing-last-line.png` });
+        expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).toBe("none");
+        expect(await textarea.evaluate((el) => getComputedStyle(el).overflowY)).toBe("auto");
+
+        const typingScrollTop = await textarea.evaluate((el) => el.scrollTop);
+        await textarea.hover();
+        await page.mouse.wheel(0, -80);
+        await expect
+          .poll(() => textarea.evaluate((el) => el.scrollTop))
+          .toBeLessThan(typingScrollTop);
+        await expect
+          .poll(() => textarea.evaluate((el) => getComputedStyle(el).maskImage))
+          .not.toBe("none");
+        await page.screenshot({ path: `${artifactDir}/scrolling-draft.png` });
+        // Typing again after scrolling must clear the fade before native caret scrolling.
+        await textarea.press("y");
+        await expect
+          .poll(() => textarea.evaluate((el) => getComputedStyle(el).maskImage))
+          .toBe("none");
+
+        await textarea.press("ControlOrMeta+Home");
+        await expect
+          .poll(() =>
+            textarea.evaluate((el) => ({
+              caret: (el as HTMLTextAreaElement).selectionStart,
+              firstLineVisible: el.scrollTop < Number.parseFloat(getComputedStyle(el).lineHeight),
+            })),
+          )
+          .toEqual({ caret: 0, firstLineVisible: true });
+        expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).not.toBe("none");
+        await textarea.press("ArrowDown");
+        await textarea.press("x");
+        expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).toBe("none");
+        await textarea.press("ControlOrMeta+End");
+        await textarea.press("Shift+Enter");
+        await textarea.press("x");
+        expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).toBe("none");
+        await expect.poll(() => textarea.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+
+        await textarea.fill("Short draft");
+        await expect
+          .poll(() => textarea.evaluate((el) => getComputedStyle(el).overflowY))
+          .toBe("hidden");
+        expect(await textarea.evaluate((el) => getComputedStyle(el).maskImage)).toBe("none");
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -17,7 +17,8 @@ const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
 type ComposerTextareaResizeObserverState = {
   observer: ResizeObserver | null;
   adjustmentFrame: number | null;
-  onScroll: () => void;
+  editing: boolean;
+  events: AbortController;
 };
 
 type ComposerPopoverAnchorObserverState = {
@@ -128,7 +129,8 @@ function updateTextareaOverflow(el: HTMLTextAreaElement) {
   const scrollable = el.scrollHeight > el.clientHeight + 1;
   // Two 16px fades need enough vertical runway not to overlap into a narrow
   // opaque strip on short drafts. Small overflows still scroll, just unfaded.
-  const canFade = scrollable && el.clientHeight >= 64;
+  const canFade =
+    scrollable && el.clientHeight >= 64 && !composerTextareaResizeObservers.get(el)?.editing;
   const fadeTop = canFade && el.scrollTop > 1;
   const fadeBottom = canFade && el.scrollTop + el.clientHeight < el.scrollHeight - 1;
   el.style.overflowY = scrollable ? "auto" : "hidden";
@@ -174,16 +176,24 @@ export function observeTextareaOverflow(el: HTMLTextAreaElement) {
   if (composerTextareaResizeObservers.has(el)) {
     return;
   }
+  const state: ComposerTextareaResizeObserverState = {
+    observer: null,
+    adjustmentFrame: null,
+    editing: false,
+    events: new AbortController(),
+  };
   let width = el.getBoundingClientRect().width;
   const onScroll = () => updateTextareaOverflow(el);
-  const observer =
+  state.observer =
     typeof ResizeObserver === "function"
       ? new ResizeObserver(() => {
           const nextWidth = el.getBoundingClientRect().width;
           if (nextWidth !== width) {
             width = nextWidth;
-            const state = composerTextareaResizeObservers.get(el);
-            if (state && state.adjustmentFrame === null) {
+            if (
+              composerTextareaResizeObservers.get(el) === state &&
+              state.adjustmentFrame === null
+            ) {
               state.adjustmentFrame = requestAnimationFrame(() => {
                 state.adjustmentFrame = null;
                 if (composerTextareaResizeObservers.get(el) === state) {
@@ -196,9 +206,35 @@ export function observeTextareaOverflow(el: HTMLTextAreaElement) {
           updateTextareaOverflow(el);
         })
       : null;
-  el.addEventListener("scroll", onScroll, { passive: true });
-  observer?.observe(el);
-  composerTextareaResizeObservers.set(el, { observer, adjustmentFrame: null, onScroll });
+  // Native caret scrolling can leave the active line inside the fade. Keep
+  // editing unfaded until explicit navigation; a scroll event alone cannot
+  // distinguish the browser following the caret from the user browsing text.
+  const onInteraction = (event: Event) => {
+    if (
+      event instanceof KeyboardEvent &&
+      (event.isComposing ||
+        !/^(ArrowUp|ArrowDown|ArrowLeft|ArrowRight|PageUp|PageDown|Home|End)$/u.test(event.key))
+    ) {
+      return;
+    }
+    state.editing = ["beforeinput", "input", "compositionstart"].includes(event.type);
+    updateTextareaOverflow(el);
+  };
+  const eventOptions = { passive: true, signal: state.events.signal };
+  for (const type of [
+    "beforeinput",
+    "input",
+    "compositionstart",
+    "wheel",
+    "pointerdown",
+    "keydown",
+    "blur",
+  ]) {
+    el.addEventListener(type, onInteraction, eventOptions);
+  }
+  el.addEventListener("scroll", onScroll, eventOptions);
+  composerTextareaResizeObservers.set(el, state);
+  state.observer?.observe(el);
   updateTextareaOverflow(el);
 }
 
@@ -209,7 +245,7 @@ export function disconnectTextareaOverflowObserver(el: HTMLTextAreaElement) {
     return;
   }
   state.observer?.disconnect();
-  el.removeEventListener("scroll", state.onScroll);
+  state.events.abort();
   if (state.adjustmentFrame !== null) {
     cancelAnimationFrame(state.adjustmentFrame);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users typing multiline drafts in Chat or New Session would see their active bottom line faded after the textarea reached its height limit. Manually scrolling made the text readable, but continuing to type could bring the fade back.

## Why This Change Was Made

Retains the existing edge gradients when browsing a long draft while suppressing them during editing. The shared textarea observer now distinguishes editing from explicit navigation: native caret-driven scroll and resize events preserve editing mode; wheel, pointer, keyboard navigation, or blur restore the scroll fades. All added event listeners are removed with the observer.

The native scroll position, height cap, resizing, and gradient CSS are unchanged. Removing the gradients entirely would lose the useful overflow cue; changing the bottom-distance threshold alone would not protect edits elsewhere in a long draft.

Production LOC: +45/-9 (net +36); tests: +82/-0. The added owner-local state and event lifecycle distinguish native caret scrolling from deliberate browsing without a timer, scroll-position workaround, configuration option, or separate flow per composer.

## User Impact

Users can keep typing past the composer height limit without manually scrolling to reveal their current line. Scrolling through the draft still shows the existing edge fades. Applies to Chat and New Session at desktop and narrow viewport widths.

## Evidence

- Real Chromium rendering with the deterministic mock Gateway: all four cases fail against the original owner on the gradient assertion and pass with the fix.
- The regression types line by line through the height cap, scrolls with the mouse wheel, resumes typing, navigates within the draft, adds another line, and shrinks to a short draft.
- Chat and New Session at 1280px and 390px: **4 browser tests passed**.
- Existing composer behavior, sizing, and lifecycle coverage: **415 tests passed**.
- Changed-scope guards, formatting, core-test/UI typechecking, i18n, and export scans passed. The initial lint pass caught a shadowed observer variable; after correction, focused lint, style lint, UI typechecking, and both test shards passed.
- Fresh autoreview of the final patch: no actionable P0–P2 findings.
- No live operator Gateway deployment or configuration changes. Visual captures are from the running browser test surface, not an authenticated provider flow.

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts ui/src/pages/new-session/composer.test.ts ui/src/e2e/composer-text-readability.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-composer-dom.ts ui/src/e2e/composer-text-readability.e2e.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/chat/components/chat-composer-dom.ts ui/src/e2e/composer-text-readability.e2e.test.ts
node --import ./scripts/tsx.mjs scripts/run-stylelint.mts ui/src/pages/chat/components/chat-composer-dom.ts ui/src/e2e/composer-text-readability.e2e.test.ts
node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo
git diff --check
```

### Visual proof

The attached crops show only the composer text; no draft text was altered. The before capture stops at the first failing line, while the fixed run continues to 20 lines.

**Before: active seventh line fades at the height limit**

![Before: active seventh line fades at the height limit](https://github.com/user-attachments/assets/2603366d-029e-4702-9c30-3ec8050dc345)

**After: active bottom line stays readable while typing**

![After: active bottom line stays readable while typing](https://github.com/user-attachments/assets/47afe142-1018-4c9c-a8a6-ee6866f7dba7)

**After: edge fades return during deliberate scrolling**

![After: edge fades return during deliberate scrolling](https://github.com/user-attachments/assets/8edd70d4-0d5a-4b78-b6dc-84f156f3315b)
