### PR TITLE
feat(gateway): add paired operator HTTPS connections

### DIFF
--- a/docs/gateway/protocol/transport.md
+++ b/docs/gateway/protocol/transport.md
@@ -1,9 +1,10 @@
 ---
-summary: "Gateway WS transport: packages, frame shapes, limits, and WebRTC Talk control"
+summary: "Gateway transports: WebSocket, paired-operator HTTP, frame limits, and WebRTC Talk control"
 read_when:
   - Choosing the gateway protocol or client package to install
   - Sizing frames, payload limits, or compression behavior
   - Implementing Gateway-controlled WebRTC Talk
+  - Connecting an already-paired operator over HTTPS polling
 title: "Gateway protocol transport"
 sidebarTitle: "Transport and framing"
 doc-schema-version: 1
@@ -97,6 +98,132 @@ HTTP scope failures mirror the `MISSING_SCOPE` object under `error.details` and
 use HTTP status `403`.
 
 Side-effecting methods require idempotency keys (see schema).
+
+## Operator HTTP transport
+
+Already-paired operator clients can carry the same Gateway request, response,
+and event frames over HTTPS instead of WebSocket. This is a transport building
+block, not a complete standalone Apple Watch or Wear OS setup flow. Initial
+pairing, native credential provisioning, and background execution are separate
+client responsibilities.
+
+Use `<basePath>/api/operator/connections`, where `basePath` is the configured
+Control UI base path, or empty when none is configured. HTTPS is required except
+on direct loopback. A trusted HTTPS proxy must forward `X-Forwarded-Proto: https`.
+Requests and responses use JSON and `Cache-Control: no-store`; do not follow
+redirects with credentials.
+
+### Begin and authenticate
+
+Send `POST` to the base route with `{}`. A `201` response contains:
+
+```json validate=false
+{
+  "connectionId": "connection-id",
+  "connectionKey": "connection-local-key",
+  "challenge": { "nonce": "challenge-nonce", "ts": 1788912000000 },
+  "handshakeExpiresAtMs": 1788912010000,
+  "limits": {
+    "maxPreauthPayloadBytes": 65536,
+    "maxPayloadBytes": 26214400,
+    "maxBufferedBytes": 52428800,
+    "maxQueuedFrames": 256,
+    "maxBatchFrames": 64,
+    "maxPollWaitMs": 25000,
+    "idleTimeoutMs": 60000,
+    "maxConnections": 256
+  }
+}
+```
+
+Every subsequent request requires
+`Authorization: Bearer <connectionKey>`. This random 256-bit key identifies one
+in-memory connection; it is not a paired-device credential. Never put it in a
+URL, cookie, or log. Begin does not authenticate the device.
+
+Submit a standard signed `connect` frame to
+`POST <base>/{connectionId}/frames`, using `challenge.nonce` for the device
+signature. The signed POST supplies the actual authentication ingress. Its
+envelope starts with `clientSeq: 1` and `ack: 0`:
+
+```json validate=false
+{
+  "clientSeq": 1,
+  "ack": 0,
+  "frame": { "type": "req", "id": "connect", "method": "connect", "params": {} }
+}
+```
+
+Replace `params` with the normal [signed connect parameters](/gateway/protocol/auth).
+This transport requires `role: "operator"`, a signed device identity, and only
+`auth.deviceToken`. Shared secrets, bootstrap tokens, and ambient proxy or
+Tailscale identity cannot replace device-token verification. Connect does not
+issue a new credential. Existing profile and session-access policy still applies;
+deployments requiring a verified person cannot use a device token as that identity.
+
+Requested and effective scopes are limited to `operator.read`, `operator.write`,
+`operator.approvals`, and `operator.talk`. Admin, pairing, questions, and Talk
+secret scopes are excluded. Methods use the ordinary Gateway authorization
+policy; the transport does not maintain a separate RPC allowlist.
+
+### Send, poll, and acknowledge
+
+- Frame submission returns `202 { "acceptedClientSeq": 1 }`. This confirms
+  sequence reservation, not RPC completion. Wait for this receipt before sending
+  the next sequence; RPC responses may complete out of order.
+- Retry an uncertain submission only on the same logical connection, with the
+  same `clientSeq` and frame. The last accepted frame is deduplicated by JSON
+  value, independent of object key order and envelope ACK. Gaps, older sequences,
+  and conflicting retries return `409`.
+- Poll with `POST <base>/{connectionId}/poll` and
+  `{ "ack": 0, "waitMs": 25000 }`. Only one poll may be active. `waitMs: 0`
+  returns immediately.
+- A `200` poll returns `{acceptedClientSeq, frames:[{cursor,frame}]}`.
+  Output cursors start at 1 and are unrelated to Gateway event `seq`.
+  `hello-ok.server.connId` equals the begin response's `connectionId`.
+- ACK is cumulative and monotonic; repeating it is allowed. It cannot exceed a
+  cursor whose containing response finished writing. Unacknowledged output may
+  replay; acknowledge only after processing it.
+- `device.scopes.waitUpgrade` uses the existing external approval flow. Persist
+  an approved replacement device token and its scopes **before ACK or reconnect**.
+  Ordinary reapproval may rotate that token without closing the current narrow
+  connection. Explicit token rotation, revocation, or device removal retires it
+  and suppresses queued and replayable authenticated output.
+- Cancelling a poll does not cancel an RPC. Server send completion means the
+  containing HTTP response finished writing, not that output was enqueued or
+  acknowledged. Repeated aborted writes eventually retire the connection.
+
+Connections expire after 60 seconds without accepted transport activity.
+The handshake has its own deadline reported by begin. Payload and buffer limits
+match WebSocket limits; the queue additionally caps frame count and poll batches.
+Begin shares the Gateway's per-client preauth budget, and at most 256 logical
+HTTP connections, including retained closed connections, exist per runtime.
+
+### Closure and recovery
+
+`DELETE <base>/{connectionId>` returns `204` and retires the connection.
+A poll can return `closed: {code, reason, resyncRequired: true}`. On closure,
+overflow, or Gateway restart, create a new connection and resynchronize state.
+Do not automatically replay an uncertain write across logical connections.
+
+Transport errors have `{error:{code,message,resyncRequired?}}`. Common statuses
+are `400` invalid envelope, `401` missing or invalid connection key, `403`
+disallowed ingress or insecure transport, `404` missing/expired connection,
+`409` sequence/ACK/poll conflict, `410` frame submission to a closed connection,
+`413` payload limit, `408` body timeout, `429` connection capacity, and `503`
+Gateway shutdown. RPC errors remain ordinary Gateway response frames.
+
+Ingress is bound to the original client IP, listener attribution, Host, Origin,
+and forwarding/scope headers. Network movement or a changed forwarding policy
+closes the logical connection, even if the new path would be more trusted.
+Reconnect with a fresh signed challenge; there is no network-handoff continuity
+or promotion to local authority. Current origin policy is checked again after
+awaited work and before dispatch and output.
+
+Authenticated output is discarded on retirement, including hello and upgrade
+grants. Only explicitly classified rejected-handshake output may remain briefly
+available for terminal delivery. All connection keys, sequence state, and output
+queues are in memory and are lost on restart.
 
 ## Gateway-controlled WebRTC Talk
 

--- a/src/gateway/operator-http.ts
+++ b/src/gateway/operator-http.ts
@@ -1,0 +1,339 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { TLSSocket } from "node:tls";
+import { stableStringify } from "@openclaw/normalization-core";
+import { z } from "zod";
+import { sendHttpRequestRejection } from "../infra/http-request-lifecycle.js";
+import { normalizeControlUiBasePath } from "./control-ui-shared.js";
+import { readJsonBody } from "./hooks.js";
+import { sendJson } from "./http-common.js";
+import { attachGatewayConnection, type GatewayConnectionOptions } from "./server/connection.js";
+import {
+  OPERATOR_HTTP_LIMITS,
+  type OperatorHttpBeginResponse,
+  type OperatorHttpErrorCode,
+  type OperatorHttpErrorResponse,
+  type OperatorHttpFramesRequest,
+  type OperatorHttpFramesResponse,
+  type OperatorHttpPollRequest,
+} from "./server/operator-http-contract.js";
+import { captureGatewayOperatorHttpIngress } from "./server/operator-http-ingress.js";
+import { GatewayOperatorHttpTransport } from "./server/operator-http-transport.js";
+import type { PreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+
+const ackSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
+const beginSchema = z.strictObject({});
+const framesSchema = z.strictObject({
+  clientSeq: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  ack: ackSchema,
+  frame: z.unknown().refine((value) => value !== undefined),
+}) satisfies z.ZodType<OperatorHttpFramesRequest>;
+const pollSchema = z.strictObject({
+  ack: ackSchema,
+  waitMs: z.number().int().min(0).max(OPERATOR_HTTP_LIMITS.maxPollWaitMs),
+}) satisfies z.ZodType<OperatorHttpPollRequest>;
+const ENVELOPE_ALLOWANCE_BYTES = 1024;
+
+export type OperatorHttpRequestHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => Promise<boolean>;
+
+function reject(
+  response: ServerResponse,
+  status: number,
+  code: OperatorHttpErrorCode,
+  message: string,
+  resyncRequired?: true,
+): void {
+  const body: OperatorHttpErrorResponse = {
+    error: { code, message, ...(resyncRequired ? { resyncRequired } : {}) },
+  };
+  sendJson(response, status, body);
+}
+
+/** Ephemeral transport only: pairing, grants and RPC authority stay with their existing owners. */
+export function createGatewayOperatorHttpRuntime(
+  options: GatewayConnectionOptions & {
+    basePath: string;
+    preauthConnectionBudget: PreauthConnectionBudget;
+  },
+): { handleRequest: OperatorHttpRequestHandler; close: () => void } {
+  const base = `${normalizeControlUiBasePath(options.basePath)}/api/operator/connections`;
+  const sessions = new Map<string, { key: Buffer; transport: GatewayOperatorHttpTransport }>();
+  const originCheckMetrics = { hostHeaderFallbackAccepted: 0 };
+  let closed = false;
+  const handleRequest: OperatorHttpRequestHandler = async (request, response) => {
+    const url = URL.parse(request.url ?? "/", "http://localhost");
+    if (!url || (url.pathname !== base && !url.pathname.startsWith(`${base}/`))) {
+      return false;
+    }
+    response.setHeader("Cache-Control", "no-store");
+    const ingress = captureGatewayOperatorHttpIngress(request);
+    if (!ingress?.isCurrent()) {
+      reject(response, 403, "ingress_changed", "Connection ingress is not allowed", true);
+      return true;
+    }
+    const encrypted = request.socket instanceof TLSSocket && request.socket.encrypted;
+    const trustedHttps =
+      ingress.attribution.kind === "tailscale-serve" ||
+      ingress.attribution.kind === "tailscale-funnel" ||
+      (ingress.attribution.kind === "trusted-proxy" &&
+        request.headers["x-forwarded-proto"] === "https");
+    if (!encrypted && !trustedHttps && ingress.attribution.kind !== "direct-local") {
+      reject(response, 403, "https_required", "Operator connections require HTTPS");
+      return true;
+    }
+    if (url.search) {
+      reject(response, 400, "invalid_request", "Query parameters are not accepted");
+      return true;
+    }
+    if (closed || options.connectionWork.isClosing) {
+      reject(response, 503, "unavailable", "Gateway is closing", true);
+      return true;
+    }
+    const parts = url.pathname.slice(base.length).split("/").filter(Boolean);
+    const id = parts[0] ?? "";
+    const beginning = url.pathname === base;
+    if (
+      (!beginning && parts.length !== 1 && parts.length !== 2) ||
+      (!beginning && !/^[0-9a-f-]{36}$/.test(id)) ||
+      (parts.length === 2 && parts[1] !== "frames" && parts[1] !== "poll") ||
+      url.pathname.endsWith("/")
+    ) {
+      reject(response, 404, "connection_not_found", "Connection not found; reconnect", true);
+      return true;
+    }
+    const expectedMethod = !beginning && parts.length === 1 ? "DELETE" : "POST";
+    if (request.method !== expectedMethod) {
+      response.setHeader("Allow", expectedMethod);
+      reject(response, 405, "method_not_allowed", `Use ${expectedMethod}`);
+      return true;
+    }
+    const session = beginning ? undefined : sessions.get(id);
+    if (!beginning) {
+      const bearer = request.headers.authorization;
+      const token =
+        typeof bearer === "string" && /^Bearer [A-Za-z0-9_-]{43}$/.test(bearer)
+          ? Buffer.from(bearer.slice(7), "base64url")
+          : undefined;
+      if (!token) {
+        reject(response, 401, "unauthorized", "Connection key required");
+        return true;
+      }
+      if (!session) {
+        reject(response, 404, "connection_not_found", "Connection not found; reconnect", true);
+        return true;
+      }
+      if (token.length !== session.key.length || !timingSafeEqual(token, session.key)) {
+        reject(response, 401, "unauthorized", "Invalid connection key");
+        return true;
+      }
+      if (!session.transport.admit(ingress)) {
+        reject(response, 403, "ingress_changed", "Connection ingress changed; reconnect", true);
+        return true;
+      }
+      if (expectedMethod === "DELETE") {
+        session.transport.terminate();
+        response.statusCode = 204;
+        response.end();
+        return true;
+      }
+    }
+    if (
+      request.headers["content-type"]?.split(";")[0]?.trim().toLowerCase() !== "application/json" ||
+      request.headers["content-encoding"] !== undefined
+    ) {
+      reject(response, 400, "invalid_request", "An uncompressed application/json body is required");
+      return true;
+    }
+    const limit = session?.transport.authenticated
+      ? OPERATOR_HTTP_LIMITS.maxPayloadBytes
+      : OPERATOR_HTTP_LIMITS.maxPreauthPayloadBytes;
+    const body = await readJsonBody(
+      request,
+      parts[1] === "frames" ? limit + ENVELOPE_ALLOWANCE_BYTES : 1024,
+    );
+    if (!body.ok) {
+      const status =
+        body.error === "payload too large"
+          ? 413
+          : body.error === "request body timeout"
+            ? 408
+            : 400;
+      const error: OperatorHttpErrorResponse = {
+        error: {
+          code:
+            status === 413
+              ? "payload_too_large"
+              : status === 408
+                ? "request_timeout"
+                : "invalid_request",
+          message: body.error,
+        },
+      };
+      await sendHttpRequestRejection(
+        request,
+        response,
+        status,
+        JSON.stringify(error),
+        "application/json; charset=utf-8",
+      );
+      return true;
+    }
+    if (closed || options.connectionWork.isClosing) {
+      reject(response, 503, "unavailable", "Gateway is closing", true);
+      return true;
+    }
+    if (response.destroyed) {
+      return true;
+    }
+    if (!ingress.isCurrent() || (session && !session.transport.admit(ingress))) {
+      reject(response, 403, "ingress_changed", "Connection ingress changed; reconnect", true);
+      return true;
+    }
+    if (beginning) {
+      if (!beginSchema.safeParse(body.value).success) {
+        reject(response, 400, "invalid_request", "Begin requires an empty JSON object");
+        return true;
+      }
+      if (
+        sessions.size >= OPERATOR_HTTP_LIMITS.maxConnections ||
+        !options.preauthConnectionBudget.acquire(ingress.attribution.clientIp)
+      ) {
+        reject(response, 429, "connection_limit", "Connection capacity exceeded; retry later");
+        return true;
+      }
+      let connectionId: string | undefined = undefined;
+      let holdsPreauthBudget = true;
+      const releasePreauth = () => {
+        if (holdsPreauthBudget) {
+          holdsPreauthBudget = false;
+          options.preauthConnectionBudget.release(ingress.attribution.clientIp);
+        }
+      };
+      const transport = new GatewayOperatorHttpTransport(ingress, () => {
+        releasePreauth();
+        if (connectionId) {
+          sessions.delete(connectionId);
+        }
+      });
+      let connection: ReturnType<typeof attachGatewayConnection>;
+      try {
+        connection = attachGatewayConnection({
+          ...options,
+          socket: transport,
+          connectionKind: "gateway",
+          operatorDeviceTokenOnly: true,
+          request,
+          ingressAttribution: ingress.attribution,
+          releasePreauth: (reason) => {
+            // Rejected HTTP connections retain terminal state after owner close.
+            // Keep that state charged to its IP until the transport removes it.
+            if (reason === "authenticated") {
+              releasePreauth();
+            }
+          },
+          addresses: {},
+          pluginNodeCapabilities: [],
+          originCheckMetrics,
+          resolveFrameIngress: transport.resolveFrameIngress,
+          prepareAuthenticatedReceive: () => ({ ok: true, value: () => {} }),
+          attachTransport: (owner) => transport.bindOwner(owner),
+        });
+      } catch (error) {
+        transport.terminate();
+        releasePreauth();
+        throw error;
+      }
+      if (!connection) {
+        transport.terminate();
+        releasePreauth();
+        reject(response, 503, "unavailable", "Gateway connection unavailable", true);
+        return true;
+      }
+      connectionId = connection.connId;
+      const key = randomBytes(32);
+      sessions.set(connectionId, { key, transport });
+      const result: OperatorHttpBeginResponse = {
+        connectionId,
+        connectionKey: key.toString("base64url"),
+        challenge: connection.challenge,
+        handshakeExpiresAtMs: connection.handshakeExpiresAtMs,
+        limits: OPERATOR_HTTP_LIMITS,
+      };
+      response.once("close", () => {
+        if (!response.writableFinished) {
+          transport.terminate();
+        }
+      });
+      sendJson(response, 201, result);
+      return true;
+    }
+    if (!session) {
+      return true;
+    }
+    if (parts[1] === "frames") {
+      const parsed = framesSchema.safeParse(body.value);
+      if (!parsed.success) {
+        reject(response, 400, "invalid_request", "Invalid frame envelope");
+        return true;
+      }
+      if (session.transport.readyState !== 1) {
+        reject(response, 410, "connection_closed", "Connection closed; reconnect", true);
+        return true;
+      }
+      const frame = stableStringify(parsed.data.frame);
+      if (Buffer.byteLength(frame) > limit) {
+        reject(response, 413, "payload_too_large", "Gateway frame exceeds connection limit");
+        return true;
+      }
+      if (!session.transport.acknowledge(parsed.data.ack)) {
+        reject(
+          response,
+          409,
+          "ack_conflict",
+          "ACK must be monotonic and refer to delivered output",
+        );
+        return true;
+      }
+      if (!session.transport.accept(parsed.data.clientSeq, frame, ingress)) {
+        reject(
+          response,
+          409,
+          "sequence_conflict",
+          "Retry the identical last frame or send the next clientSeq",
+        );
+        return true;
+      }
+      const result: OperatorHttpFramesResponse = {
+        acceptedClientSeq: session.transport.acceptedClientSeq,
+      };
+      sendJson(response, 202, result);
+      return true;
+    }
+    const parsed = pollSchema.safeParse(body.value);
+    if (!parsed.success) {
+      reject(response, 400, "invalid_request", "Invalid poll envelope");
+      return true;
+    }
+    if (!session.transport.acknowledge(parsed.data.ack)) {
+      reject(response, 409, "ack_conflict", "ACK must be monotonic and refer to delivered output");
+      return true;
+    }
+    if (!(await session.transport.pollFrames(response, ingress, parsed.data.waitMs))) {
+      reject(response, 409, "poll_conflict", "Only one poll may be active");
+    }
+    return true;
+  };
+  return {
+    handleRequest,
+    close: () => {
+      closed = true;
+      for (const session of sessions.values()) {
+        session.transport.terminate();
+      }
+      sessions.clear();
+    },
+  };
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -164,6 +164,7 @@ export function createGatewayHttpServer(opts: {
   handleHooksRequest: HooksRequestHandler;
   handleMcpOAuthCallbackRequest?: McpOAuthCallbackHandler;
   handleWatchNodeRequest?: WatchNodeHttpRequestHandler;
+  handleOperatorRequest?: import("./operator-http.js").OperatorHttpRequestHandler;
   handlePluginRequest?: PluginHttpRequestHandler;
   shouldEnforcePluginGatewayAuth?: (pathContext: PluginRoutePathContext) => boolean;
   isPluginAuthenticatedRoute?: (pathContext: PluginRoutePathContext) => boolean;
@@ -320,6 +321,11 @@ export function createGatewayHttpServer(opts: {
         tailscaleWhois: (ip) =>
           readTailscaleWhoisIdentity(ip, undefined, { cacheTtlMs: 0, errorTtlMs: 0 }),
       });
+      // Logical connections own their work. A long poll must never retain an
+      // HTTP root-work lease or be intercepted by a configurable hook path.
+      if (await opts.handleOperatorRequest?.(req, res)) {
+        return;
+      }
       const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
       if (scopedNodeCapability.malformedScopedPath) {
         sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
@@ -385,14 +391,9 @@ export function createGatewayHttpServer(opts: {
           root: controlUiRoot,
         }) ?? false;
       const handleStandaloneControlUiRequest = async () => {
-        if (!controlUiEnabled) {
+        if (!controlUiEnabled || !(await handleControlUiRequest())) {
           respondNotFound(res);
-          return true;
         }
-        if (await handleControlUiRequest()) {
-          return true;
-        }
-        respondNotFound(res);
         return true;
       };
       const requestStages: GatewayHttpRequestStage[] = [

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -545,7 +545,7 @@ export async function handleGatewayRequest(
       };
       opts.sessionMutationCommitGuard?.();
       entry?.assertOpen();
-      if (signal?.aborted) {
+      if (signal?.aborted || hasCurrentClientAuthority?.() === false) {
         return;
       }
       // No await between the final fence, ownership handoff, and actual invocation.

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -148,6 +148,7 @@ export async function createGatewayHttpTransport(params: {
   startListening: () => Promise<void>;
   wss: WebSocketServer;
   preauthConnectionBudget: PreauthConnectionBudget;
+  operatorHttpRequestHandler: { current?: import("./operator-http.js").OperatorHttpRequestHandler };
   portalService: GatewayPortalService;
   getTailscaleIngressEndpoint: () => GatewayTailscaleIngressEndpoint | undefined;
   getMcpAppSandboxPort: () => number | undefined;
@@ -318,6 +319,9 @@ export async function createGatewayHttpTransport(params: {
     },
   });
   const preauthConnectionBudget = createPreauthConnectionBudget();
+  const operatorHttpRequestHandler: {
+    current?: import("./operator-http.js").OperatorHttpRequestHandler;
+  } = {};
 
   const httpServers: HttpServer[] = [];
   const gatewayHttpServers: HttpServer[] = [];
@@ -340,6 +344,8 @@ export async function createGatewayHttpTransport(params: {
       openAiChatCompletionsEnabled: params.openAiChatCompletionsEnabled,
       openResponsesEnabled: params.openResponsesEnabled,
       handleWatchNodeRequest: params.handleWatchNodeRequest,
+      handleOperatorRequest: (req, res) =>
+        operatorHttpRequestHandler.current?.(req, res) ?? Promise.resolve(false),
       handleHooksRequest,
       handleMcpOAuthCallbackRequest,
       handlePluginRequest,
@@ -571,6 +577,7 @@ export async function createGatewayHttpTransport(params: {
     startListening,
     wss,
     preauthConnectionBudget,
+    operatorHttpRequestHandler,
     portalService,
     getTailscaleIngressEndpoint: () => tailscaleIngressEndpoint,
     getMcpAppSandboxPort: () => mcpAppSandboxPort,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -148,8 +148,9 @@ export async function finishGatewayStartup(params: {
     "gateway.ws-imports",
     () => import("./server-ws-runtime.js"),
   );
-  await startupTrace.measure("gateway.ws-attach", () =>
+  const operatorHttp = await startupTrace.measure("gateway.ws-attach", () =>
     attachGatewayWsHandlers({
+      controlUiBasePath,
       wss,
       clients,
       connectionWork: runtime.connectionWork,
@@ -180,6 +181,8 @@ export async function finishGatewayStartup(params: {
       context: gatewayRequestContext,
     }),
   );
+  runtime.operatorHttpRequestHandler.current = operatorHttp.handleRequest;
+  registerGatewayLifetimeSidecars([{ stop: operatorHttp.close }]);
   await startupTrace.measure("http.listen", () => startListening());
   kernel.setDispatchReady(true);
   startupTrace.mark("http.bound");

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -1,6 +1,8 @@
+import { createGatewayOperatorHttpRuntime } from "./operator-http.js";
 // WebSocket runtime adapter wires a built GatewayRequestContext into the lower
 // level connection handler and shared gateway WebSocket plumbing.
 import type { GatewayRequestContext } from "./server-methods/types.js";
+import type { GatewayConnectionOptions } from "./server/connection.js";
 import {
   attachGatewayWsConnectionHandler,
   type AttachGatewayWsConnectionHandlerParams,
@@ -17,16 +19,13 @@ type GatewayWsRuntimeParams = Omit<
 };
 
 /** Attaches websocket handlers for an already-created gateway request context. */
-export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
-  attachGatewayWsConnectionHandler({
-    wss: params.wss,
+export function attachGatewayWsHandlers(
+  params: GatewayWsRuntimeParams & { controlUiBasePath: string },
+) {
+  const connectionOptions: GatewayConnectionOptions = {
     clients: params.clients,
     connectionWork: params.connectionWork,
     bootId: params.bootId,
-    preauthConnectionBudget: params.preauthConnectionBudget,
-    port: params.port,
-    gatewayHost: params.gatewayHost,
-    pluginSurfaceScheme: params.pluginSurfaceScheme,
     getPluginNodeCapabilities: params.getPluginNodeCapabilities,
     getResolvedAuth: params.getResolvedAuth,
     getRequiredSharedGatewaySessionGeneration: params.getRequiredSharedGatewaySessionGeneration,
@@ -44,10 +43,13 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     logWsControl: params.logWsControl,
     extraHandlers: params.extraHandlers,
     getMethodRegistry: params.getMethodRegistry,
-    ...(params.workerConnectionService
-      ? { workerConnectionService: params.workerConnectionService }
-      : {}),
     broadcast: params.broadcast,
     buildRequestContext: () => params.context,
+  };
+  attachGatewayWsConnectionHandler({ ...params, ...connectionOptions });
+  return createGatewayOperatorHttpRuntime({
+    ...connectionOptions,
+    basePath: params.controlUiBasePath,
+    preauthConnectionBudget: params.preauthConnectionBudget,
   });
 }

--- a/src/gateway/server/connection-transport.ts
+++ b/src/gateway/server/connection-transport.ts
@@ -1,7 +1,21 @@
+import type { IncomingMessage } from "node:http";
 import type { Result } from "@openclaw/normalization-core/result";
+import type { GatewayAttributedIngress } from "../ingress-attribution.js";
 import type { GatewayRole } from "../role-policy.js";
 
 export type GatewayConnectionFrame = Buffer | ArrayBuffer | Buffer[];
+
+export type GatewayConnectionDelivery = {
+  /** Only the handshake owner can retain a rejection after transport retirement. */
+  rejectedHandshake?: true;
+  isCurrent?: () => boolean;
+};
+
+export type GatewayConnectionIngress = {
+  request: IncomingMessage;
+  attribution: GatewayAttributedIngress;
+  isCurrent: () => boolean;
+};
 
 /** Ordered frames and transport retirement, independent of the physical connection. */
 export type GatewayConnectionTransport = {
@@ -14,6 +28,11 @@ export type GatewayConnectionTransport = {
    * Enqueueing alone must not report success; completion is not a peer ACK.
    */
   send(frame: string, callback?: (error?: Error) => void): void;
+  sendWithContext?: (
+    frame: string,
+    callback: ((error?: Error) => void) | undefined,
+    delivery: GatewayConnectionDelivery | undefined,
+  ) => void;
   /** Preserve accepted frame ordering before graceful close; terminate may discard them. */
   close(code?: number, reason?: string): void;
   terminate(): void;
@@ -23,6 +42,19 @@ export type GatewayConnectionTransport = {
   once(event: "message", listener: (data: GatewayConnectionFrame) => void): unknown;
   once(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
 };
+
+export function sendGatewayConnectionFrame(
+  socket: GatewayConnectionTransport,
+  frame: string,
+  callback?: (error?: Error) => void,
+  delivery?: GatewayConnectionDelivery,
+): void {
+  if (socket.sendWithContext) {
+    socket.sendWithContext(frame, callback, delivery);
+  } else {
+    socket.send(frame, callback);
+  }
+}
 
 /** Validate transport-owned receive limits before registration; activate only after it. */
 export type PrepareGatewayAuthenticatedReceive = (

--- a/src/gateway/server/connection.ts
+++ b/src/gateway/server/connection.ts
@@ -36,9 +36,11 @@ import type { WebSocketHeartbeatDiagnostics } from "../websocket-keepalive.js";
 import { formatForLog, logWs } from "../ws-log.js";
 import { refreshClientPresence } from "./client-presence.js";
 import type {
+  GatewayConnectionDelivery,
   GatewayConnectionTransport,
   PrepareGatewayAuthenticatedReceive,
 } from "./connection-transport.js";
+import { sendGatewayConnectionFrame } from "./connection-transport.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
 import { broadcastPresenceSnapshot } from "./presence-events.js";
 import { sanitizeWsLogValue, stringMetaValue } from "./ws-connection-diagnostics.js";
@@ -118,7 +120,7 @@ type AttachGatewayConnectionParams = GatewayConnectionOptions & {
   connectionKind: NonNullable<GatewayWsClient["connectionKind"]>;
   request: IncomingMessage;
   ingressAttribution: GatewayIngressAttribution | undefined;
-  releasePreauth: () => void;
+  releasePreauth: (reason: "authenticated" | "closed") => void;
   addresses: Pick<
     GatewayWsMessageHandlerParams,
     "remoteAddr" | "remotePort" | "localAddr" | "localPort" | "endpoint"
@@ -127,6 +129,8 @@ type AttachGatewayConnectionParams = GatewayConnectionOptions & {
   pluginSurfaceBaseUrl?: string;
   originCheckMetrics: WsOriginCheckMetrics;
   prepareAuthenticatedReceive: PrepareGatewayAuthenticatedReceive;
+  operatorDeviceTokenOnly?: true;
+  resolveFrameIngress?: GatewayWsMessageHandlerParams["resolveFrameIngress"];
   attachTransport?: (lifecycle: GatewayConnectionLifecycle) => (() => void) | void;
   onAuthenticated?: (
     client: GatewayWsClient,
@@ -169,8 +173,9 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
     buildRequestContext,
   } = params;
   if (connectionWork.isClosing) {
+    params.releasePreauth("closed");
     socket.terminate();
-    return;
+    return undefined;
   }
   let client: GatewayWsClient | null = null,
     closed = false;
@@ -218,12 +223,12 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
     }
   };
 
-  const releasePreauthBudget = () => {
+  const releasePreauthBudget = (reason: "authenticated" | "closed") => {
     if (!holdsPreauthBudget) {
       return;
     }
     holdsPreauthBudget = false;
-    params.releasePreauth();
+    params.releasePreauth(reason);
   };
 
   const setLastFrameMeta = (meta: { type?: string; method?: string; id?: string }) => {
@@ -240,6 +245,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
   const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({
     configuredTimeoutMs: params.preauthHandshakeTimeoutMs,
   });
+  const handshakeExpiresAtMs = openedAt + handshakeTimeoutMs;
   const handshakeTimer = setTimeout(() => {
     if (!client) {
       handshakeState = "failed";
@@ -269,7 +275,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
     stopKeepalive?.();
     cleanupTransport?.();
     cleanupTransport = undefined;
-    releasePreauthBudget();
+    releasePreauthBudget("closed");
     try {
       socket.close(code, reason);
     } catch {
@@ -293,7 +299,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
     close(1012, connectionKind === "worker" ? "gateway-shutdown" : "service restart");
   });
 
-  const send = (obj: unknown) => {
+  const send = (obj: unknown, delivery?: GatewayConnectionDelivery) => {
     if (closed) {
       return { kind: "unavailable" } as const;
     }
@@ -323,7 +329,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
       return { kind: "serialization", error } as const;
     }
     try {
-      socket.send(encoded);
+      sendGatewayConnectionFrame(socket, encoded, undefined, delivery);
       return { kind: "sent" } as const;
     } catch {
       socket.terminate();
@@ -333,7 +339,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
   };
 
   const connectNonce = randomUUID();
-  if (connectionKind === "gateway") {
+  if (connectionKind === "gateway" && !params.operatorDeviceTokenOnly) {
     send({
       type: "event",
       event: "connect.challenge",
@@ -557,7 +563,7 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
         }
       }
     }
-    releasePreauthBudget();
+    releasePreauthBudget("authenticated");
     next.connectionSignal = connectionController.signal;
     client = next;
     clients.add(next);
@@ -603,19 +609,21 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
   };
   cleanupTransport = params.attachTransport?.(connectionLifecycle);
   if (connectionKind === "worker") {
-    return;
+    return undefined;
   }
 
   if (!ingressAttribution || ingressAttribution.kind === "unattributable-proxy") {
     setCloseCause("missing-ingress-attribution");
     logWsControl.warn(`gateway websocket missing prepared ingress attribution conn=${connId}`);
     close(1008, "gateway ingress attribution required");
-    return;
+    return undefined;
   }
 
   attachGatewayWsMessageHandlerOnDemand({
     ...connectionLifecycle,
     socket,
+    operatorDeviceTokenOnly: params.operatorDeviceTokenOnly,
+    resolveFrameIngress: params.resolveFrameIngress,
     prepareAuthenticatedReceive: params.prepareAuthenticatedReceive,
     upgradeReq,
     ingressAttribution,
@@ -649,4 +657,5 @@ export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
     originCheckMetrics,
     logHealth,
   });
+  return { connId, challenge: { nonce: connectNonce, ts: openedAt }, handshakeExpiresAtMs };
 }

--- a/src/gateway/server/operator-http-contract.ts
+++ b/src/gateway/server/operator-http-contract.ts
@@ -1,0 +1,53 @@
+import {
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  MAX_PREAUTH_PAYLOAD_BYTES,
+} from "../server-constants.js";
+
+export const OPERATOR_HTTP_LIMITS = Object.freeze({
+  maxPreauthPayloadBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+  maxPayloadBytes: MAX_PAYLOAD_BYTES,
+  maxBufferedBytes: MAX_BUFFERED_BYTES,
+  maxQueuedFrames: 256,
+  maxBatchFrames: 64,
+  maxPollWaitMs: 25_000,
+  idleTimeoutMs: 60_000,
+  maxConnections: 256,
+});
+
+export type OperatorHttpBeginResponse = {
+  connectionId: string;
+  connectionKey: string;
+  challenge: { nonce: string; ts: number };
+  handshakeExpiresAtMs: number;
+  limits: typeof OPERATOR_HTTP_LIMITS;
+};
+
+export type OperatorHttpFramesRequest = { clientSeq: number; ack: number; frame: unknown };
+export type OperatorHttpFramesResponse = { acceptedClientSeq: number };
+export type OperatorHttpPollRequest = { ack: number; waitMs: number };
+export type OperatorHttpClosed = { code: number; reason: string; resyncRequired: true };
+export type OperatorHttpPollResponse = {
+  acceptedClientSeq: number;
+  frames: Array<{ cursor: number; frame: unknown }>;
+  closed?: OperatorHttpClosed;
+};
+
+export type OperatorHttpErrorCode =
+  | "invalid_request"
+  | "unauthorized"
+  | "https_required"
+  | "ingress_changed"
+  | "connection_not_found"
+  | "connection_closed"
+  | "sequence_conflict"
+  | "ack_conflict"
+  | "poll_conflict"
+  | "payload_too_large"
+  | "request_timeout"
+  | "connection_limit"
+  | "unavailable"
+  | "method_not_allowed";
+export type OperatorHttpErrorResponse = {
+  error: { code: OperatorHttpErrorCode; message: string; resyncRequired?: true };
+};

--- a/src/gateway/server/operator-http-ingress.ts
+++ b/src/gateway/server/operator-http-ingress.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import { getRuntimeConfig } from "../../config/io.js";
+import { readPreparedGatewayIngressAttribution } from "../ingress-attribution.js";
+import type { GatewayConnectionIngress } from "./connection-transport.js";
+import { checkGatewayWsBrowserOrigin } from "./ws-origin-policy.js";
+
+export type GatewayOperatorHttpIngress = GatewayConnectionIngress & { binding: string };
+
+/** Capture actual listener-prepared facts, never a synthetic upgrade request. */
+export function captureGatewayOperatorHttpIngress(
+  request: IncomingMessage,
+): GatewayOperatorHttpIngress | undefined {
+  const attribution = readPreparedGatewayIngressAttribution(request);
+  if (!attribution || attribution.kind === "unattributable-proxy") {
+    return undefined;
+  }
+  const forwardingPolicy = () => {
+    const gateway = getRuntimeConfig().gateway;
+    return JSON.stringify([gateway?.trustedProxies ?? [], gateway?.allowRealIpFallback === true]);
+  };
+  const policy = forwardingPolicy();
+  const headers = () =>
+    JSON.stringify(
+      Object.entries(request.headers)
+        .filter(
+          ([name]) =>
+            name === "host" ||
+            name === "origin" ||
+            name === "forwarded" ||
+            name === "x-real-ip" ||
+            name === "x-openclaw-scopes" ||
+            name.startsWith("x-forwarded-") ||
+            name.startsWith("tailscale-"),
+        )
+        .toSorted(([a], [b]) => a.localeCompare(b)),
+    );
+  const admittedHeaders = headers();
+  const host = request.headers.host;
+  const origin = request.headers.origin;
+  const browserOrigin = {
+    requestHost: host,
+    origin,
+    isLocalClient: attribution.kind === "direct-local",
+  };
+  const binding = createHash("sha256")
+    .update(
+      JSON.stringify([
+        attribution.kind,
+        attribution.clientIp,
+        request.socket.remoteAddress,
+        admittedHeaders,
+      ]),
+    )
+    .digest("hex");
+  return Object.freeze({
+    request,
+    attribution,
+    binding,
+    // A changed forwarding policy requires reconnect, even if it would grant
+    // more trust. Retained frames never reinterpret their original ingress.
+    isCurrent: () =>
+      policy === forwardingPolicy() &&
+      admittedHeaders === headers() &&
+      (origin === undefined || checkGatewayWsBrowserOrigin(browserOrigin, getRuntimeConfig()).ok),
+  });
+}

--- a/src/gateway/server/operator-http-transport.test.ts
+++ b/src/gateway/server/operator-http-transport.test.ts
@@ -1,0 +1,189 @@
+import { once } from "node:events";
+import { createServer, IncomingMessage, request as httpRequest } from "node:http";
+import { Socket } from "node:net";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { GatewayConnectionWork } from "../server-connection-work.js";
+import { OPERATOR_HTTP_LIMITS } from "./operator-http-contract.js";
+import type { OperatorHttpPollResponse } from "./operator-http-contract.js";
+import type { GatewayOperatorHttpIngress } from "./operator-http-ingress.js";
+import { GatewayOperatorHttpTransport } from "./operator-http-transport.js";
+
+describe("operator HTTP delivery lifecycle", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function createTransport() {
+    const request = new IncomingMessage(new Socket());
+    const ingress: GatewayOperatorHttpIngress = {
+      request,
+      binding: "test-ingress",
+      attribution: {
+        kind: "direct-local",
+        clientIp: "127.0.0.1",
+        rateLimit: { subject: { key: "127.0.0.1" }, resetOnSuccess: true },
+      },
+      isCurrent: () => true,
+    };
+    const remove = vi.fn();
+    const transport = new GatewayOperatorHttpTransport(ingress, remove);
+    transport.bindOwner({
+      getClient: () => null,
+      isClosed: () => false,
+      close: transport.close.bind(transport),
+    });
+    return { transport, ingress, remove };
+  }
+
+  test.each(["expiry", "terminate"])(
+    "settles an undelivered terminal callback on %s and drains tracked work",
+    async (mode) => {
+      vi.useFakeTimers();
+      const { transport, remove } = createTransport();
+      const work = new GatewayConnectionWork();
+      const callback = vi.fn();
+      const delivered = new Promise<void>((resolve) => {
+        transport.sendWithContext(
+          JSON.stringify({ type: "res", id: "connect", ok: false }),
+          (error) => {
+            callback(error);
+            resolve();
+          },
+          { rejectedHandshake: true },
+        );
+      });
+      void work.track(() => delivered);
+      transport.close(1008, "handshake rejected");
+      expect(callback).not.toHaveBeenCalled();
+      if (mode === "expiry") {
+        await vi.advanceTimersByTimeAsync(OPERATOR_HTTP_LIMITS.idleTimeoutMs);
+      } else {
+        transport.terminate();
+      }
+      await work.drain();
+      expect(callback).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+      expect(remove).toHaveBeenCalledOnce();
+      expect(transport.bufferedAmount).toBe(0);
+    },
+  );
+
+  test("removes once without retaining a timer when a failed delivery terminates reentrantly", async () => {
+    vi.useFakeTimers();
+    const { transport, remove } = createTransport();
+    const callback = vi.fn(() => transport.terminate());
+    transport.send('{"type":"event","event":"tick"}', callback);
+    transport.close(4001, "authority changed");
+    transport.terminate();
+    await vi.advanceTimersByTimeAsync(OPERATOR_HTTP_LIMITS.idleTimeoutMs);
+    expect(callback).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(remove).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("reports explicit resync and fails every callback when frame capacity is exceeded", () => {
+    const { transport } = createTransport();
+    const callbacks = Array.from({ length: 257 }, () => vi.fn());
+    const closed = vi.fn();
+    transport.on("close", closed);
+    try {
+      for (const callback of callbacks) {
+        transport.send('{"type":"event","event":"tick"}', callback);
+      }
+      expect(transport.readyState).toBe(3);
+      expect(closed).toHaveBeenCalledExactlyOnceWith(1009, expect.any(Buffer));
+      expect(transport.bufferedAmount).toBe(0);
+      for (const callback of callbacks) {
+        expect(callback).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+      }
+    } finally {
+      transport.terminate();
+    }
+  });
+
+  test("uses response finish for delivery, retains replay until ACK, and caps poll batches", async () => {
+    const { transport, ingress } = createTransport();
+    const callback = vi.fn();
+    const server = createServer((request, response) => {
+      response.setHeader("Cache-Control", "no-store");
+      void transport.pollFrames(response, ingress, 0);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP listener");
+    }
+    const poll = async (): Promise<OperatorHttpPollResponse> =>
+      await (
+        await fetch(`http://127.0.0.1:${address.port}`, { signal: AbortSignal.timeout(5000) })
+      ).json();
+    try {
+      for (let index = 0; index < 65; index++) {
+        transport.send(
+          JSON.stringify({ type: "event", event: "tick", seq: 1000 + index }),
+          callback,
+        );
+      }
+      expect(callback).not.toHaveBeenCalled();
+      expect(transport.acknowledge(1)).toBe(false);
+      const first = await poll();
+      expect(first.frames).toHaveLength(64);
+      expect(first.frames[0]).toMatchObject({ cursor: 1, frame: { seq: 1000 } });
+      expect(callback).toHaveBeenCalledTimes(64);
+      expect((await poll()).frames).toEqual(first.frames);
+      expect(callback).toHaveBeenCalledTimes(64);
+      expect(transport.acknowledge(64)).toBe(true);
+      expect(transport.acknowledge(63)).toBe(false);
+      expect((await poll()).frames).toEqual([
+        { cursor: 65, frame: { type: "event", event: "tick", seq: 1064 } },
+      ]);
+      expect(callback).toHaveBeenCalledTimes(65);
+      expect(transport.acknowledge(65)).toBe(true);
+      expect(transport.bufferedAmount).toBe(0);
+    } finally {
+      transport.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  test("keeps aborted writes retryable without reporting delivery, then bounds retries", async () => {
+    const { transport, ingress } = createTransport();
+    const callback = vi.fn();
+    let pollCompleted = Promise.resolve(false);
+    const server = createServer((request, response) => {
+      pollCompleted = transport.pollFrames(response, ingress, 0);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP listener");
+    }
+    try {
+      transport.send(JSON.stringify({ payload: "x".repeat(8 * 1024 * 1024) }), callback);
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await new Promise<void>((resolve, reject) => {
+          const request = httpRequest({ host: "127.0.0.1", port: address.port }, (response) => {
+            response.pause();
+            request.destroy();
+            resolve();
+          });
+          request.once("error", reject);
+          request.end();
+        });
+        await pollCompleted;
+        if (attempt < 2) {
+          expect(callback).not.toHaveBeenCalled();
+          expect(transport.readyState).toBe(1);
+        }
+      }
+      expect(callback).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+      expect(transport.readyState).toBe(3);
+    } finally {
+      transport.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/src/gateway/server/operator-http-transport.ts
+++ b/src/gateway/server/operator-http-transport.ts
@@ -1,0 +1,336 @@
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { ServerResponse } from "node:http";
+import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import type {
+  GatewayConnectionDelivery,
+  GatewayConnectionFrame,
+  GatewayConnectionIngress,
+  GatewayConnectionTransport,
+} from "./connection-transport.js";
+import {
+  OPERATOR_HTTP_LIMITS,
+  type OperatorHttpClosed,
+  type OperatorHttpPollResponse,
+} from "./operator-http-contract.js";
+import type { GatewayOperatorHttpIngress } from "./operator-http-ingress.js";
+import type { GatewayWsClient } from "./ws-types.js";
+
+const MAX_ABORTED_DELIVERIES = 3;
+
+type QueuedFrame = {
+  cursor: number;
+  frame: unknown;
+  bytes: number;
+  callback?: (error?: Error) => void;
+  delivery?: GatewayConnectionDelivery;
+};
+type ConnectionOwner = {
+  getClient: () => GatewayWsClient | null;
+  isClosed: () => boolean;
+  close: (code?: number, reason?: string) => void;
+};
+type Poll = {
+  response: ServerResponse;
+  ingress: GatewayOperatorHttpIngress;
+  timer?: ReturnType<typeof setTimeout>;
+  finish: () => void;
+  writing: boolean;
+  batch?: QueuedFrame[];
+};
+
+/** One ephemeral logical connection. HTTP receipt and peer ACK are distinct boundaries. */
+export class GatewayOperatorHttpTransport
+  extends EventEmitter
+  implements GatewayConnectionTransport
+{
+  readyState = 1;
+  bufferedAmount = 0;
+  acceptedClientSeq = 0;
+  private lastFrame?: string;
+  private cursor = 0;
+  private deliveredCursor = 0;
+  private acknowledgedCursor = 0;
+  private queue: QueuedFrame[] = [];
+  private poll?: Poll;
+  private owner?: ConnectionOwner;
+  private abortedDeliveries = 0;
+  private closed?: OperatorHttpClosed;
+  private disposed = false;
+  private readonly frameIngress = new WeakMap<GatewayConnectionFrame, GatewayConnectionIngress>();
+  private idleTimer: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly initialIngress: GatewayOperatorHttpIngress,
+    private readonly remove: () => void,
+  ) {
+    super();
+    this.idleTimer = setTimeout(() => this.expire(), OPERATOR_HTTP_LIMITS.idleTimeoutMs);
+    this.idleTimer.unref();
+  }
+
+  bindOwner(owner: ConnectionOwner): void {
+    this.owner = owner;
+  }
+
+  resolveFrameIngress = (data: GatewayConnectionFrame): GatewayConnectionIngress => {
+    const ingress = this.frameIngress.get(data);
+    if (!ingress) {
+      throw new Error("Missing operator HTTP frame ingress");
+    }
+    return ingress;
+  };
+
+  get authenticated(): boolean {
+    return Boolean(this.owner?.getClient());
+  }
+
+  private expire(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.close(1001, "connection expired");
+    clearTimeout(this.idleTimer);
+    const retained = this.queue;
+    this.queue = [];
+    this.bufferedAmount = 0;
+    if (this.poll?.writing) {
+      this.poll.response.destroy();
+    }
+    for (const entry of retained) {
+      const callback = entry.callback;
+      entry.callback = undefined;
+      callback?.(new Error("Terminal delivery expired"));
+    }
+    this.remove();
+  }
+
+  private touch(): void {
+    if (!this.closed) {
+      this.idleTimer.refresh();
+    }
+  }
+
+  private authorityCurrent(): boolean {
+    const client = this.owner?.getClient();
+    return (
+      !this.closed &&
+      this.owner?.isClosed() !== true &&
+      !client?.invalidated &&
+      this.initialIngress.isCurrent()
+    );
+  }
+
+  admit(ingress: GatewayOperatorHttpIngress): boolean {
+    if (
+      ingress.binding !== this.initialIngress.binding ||
+      !ingress.isCurrent() ||
+      (!this.closed && !this.authorityCurrent())
+    ) {
+      this.close(4001, "connection ingress or authority changed");
+      return false;
+    }
+    this.touch();
+    return true;
+  }
+
+  acknowledge(ack: number): boolean {
+    if (ack < this.acknowledgedCursor || ack > this.deliveredCursor) {
+      return false;
+    }
+    this.acknowledgedCursor = ack;
+    while (this.queue[0] && this.queue[0].cursor <= ack) {
+      this.bufferedAmount -= this.queue.shift()!.bytes;
+    }
+    return true;
+  }
+
+  accept(clientSeq: number, frame: string, ingress: GatewayOperatorHttpIngress): boolean {
+    if (this.closed) {
+      return false;
+    }
+    const fingerprint = createHash("sha256").update(frame).digest("hex");
+    if (clientSeq === this.acceptedClientSeq) {
+      return fingerprint === this.lastFrame;
+    }
+    if (clientSeq !== this.acceptedClientSeq + 1) {
+      return false;
+    }
+    // Reserve before emitting: a retry cannot dispatch while the first copy awaits.
+    this.acceptedClientSeq = clientSeq;
+    this.lastFrame = fingerprint;
+    const data = Buffer.from(frame);
+    this.frameIngress.set(data, ingress);
+    this.emit("message", data);
+    return true;
+  }
+
+  send(frame: string, callback?: (error?: Error) => void): void {
+    this.sendWithContext(frame, callback, undefined);
+  }
+
+  sendWithContext(
+    encoded: string,
+    callback: ((error?: Error) => void) | undefined,
+    delivery: GatewayConnectionDelivery | undefined,
+  ): void {
+    if (!this.authorityCurrent() || delivery?.isCurrent?.() === false) {
+      callback?.(new Error("Connection retired before delivery"));
+      this.close(4001, "connection authority changed");
+      return;
+    }
+    const bytes = Buffer.byteLength(encoded);
+    if (
+      bytes > MAX_PAYLOAD_BYTES ||
+      this.bufferedAmount + bytes > MAX_BUFFERED_BYTES ||
+      this.queue.length >= OPERATOR_HTTP_LIMITS.maxQueuedFrames
+    ) {
+      callback?.(new Error("Operator HTTP output overflow"));
+      this.close(1009, "output overflow; resync required");
+      return;
+    }
+    this.queue.push({
+      cursor: ++this.cursor,
+      frame: JSON.parse(encoded),
+      bytes,
+      callback,
+      delivery,
+    });
+    this.bufferedAmount += bytes;
+    this.flushPoll();
+  }
+
+  async pollFrames(
+    response: ServerResponse,
+    ingress: GatewayOperatorHttpIngress,
+    waitMs: number,
+  ): Promise<boolean> {
+    if (this.poll) {
+      return false;
+    }
+    await new Promise<void>((resolve) => {
+      const poll: Poll = { response, ingress, finish: resolve, writing: false };
+      this.poll = poll;
+      const cancelled = () => {
+        if (this.poll !== poll) {
+          return;
+        }
+        this.releasePoll(poll);
+        if (poll.writing && ++this.abortedDeliveries >= MAX_ABORTED_DELIVERIES) {
+          this.close(1006, "delivery failed; resync required");
+        }
+      };
+      response.once("close", cancelled);
+      response.once("error", cancelled);
+      poll.finish = () => {
+        response.off("close", cancelled);
+        response.off("error", cancelled);
+        resolve();
+      };
+      if (waitMs > 0) {
+        poll.timer = setTimeout(() => this.flushPoll(true), waitMs);
+        poll.timer.unref();
+      }
+      this.flushPoll(waitMs === 0);
+    });
+    return true;
+  }
+
+  private releasePoll(poll: Poll): void {
+    clearTimeout(poll.timer);
+    if (this.poll === poll) {
+      this.poll = undefined;
+    }
+    poll.finish();
+  }
+
+  private flushPoll(force = false): void {
+    const poll = this.poll;
+    if (!poll || poll.writing) {
+      return;
+    }
+    if (
+      !this.closed &&
+      (!poll.ingress.isCurrent() ||
+        !this.authorityCurrent() ||
+        this.queue.some((entry) => entry.delivery?.isCurrent?.() === false))
+    ) {
+      this.close(4001, "connection authority changed");
+      return;
+    }
+    if (!force && !this.closed && this.queue.length === 0) {
+      return;
+    }
+    const batch = this.queue.slice(0, OPERATOR_HTTP_LIMITS.maxBatchFrames);
+    const response = poll.response;
+    if (response.destroyed) {
+      this.releasePoll(poll);
+      return;
+    }
+    poll.writing = true;
+    poll.batch = batch;
+    clearTimeout(poll.timer);
+    response.once("finish", () => {
+      if (this.poll !== poll) {
+        return;
+      }
+      this.abortedDeliveries = 0;
+      this.releasePoll(poll);
+      for (const entry of batch) {
+        if (!this.queue.includes(entry)) {
+          continue;
+        }
+        this.deliveredCursor = Math.max(this.deliveredCursor, entry.cursor);
+        const callback = entry.callback;
+        entry.callback = undefined;
+        callback?.();
+      }
+    });
+    response.statusCode = 200;
+    response.setHeader("Content-Type", "application/json; charset=utf-8");
+    const body: OperatorHttpPollResponse = {
+      acceptedClientSeq: this.acceptedClientSeq,
+      frames: batch.map(({ cursor, frame }) => ({ cursor, frame })),
+      ...(this.closed ? { closed: this.closed } : {}),
+    };
+    response.end(JSON.stringify(body));
+  }
+
+  close(code = 1000, reason = "connection closed"): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = { code, reason, resyncRequired: true };
+    this.readyState = 3;
+    clearTimeout(this.idleTimer);
+    // Rejections are explicitly classified by the handshake owner. No response
+    // shape, request id or credential-looking payload can authorize terminal replay.
+    const terminal = this.owner?.getClient()
+      ? []
+      : this.queue.filter((entry) => entry.delivery?.rejectedHandshake).slice(0, 1);
+    const discarded = this.queue.filter((entry) => !terminal.includes(entry));
+    this.queue = terminal;
+    this.bufferedAmount = terminal.reduce((total, entry) => total + entry.bytes, 0);
+    if (this.poll?.writing && this.poll.batch?.some((entry) => !terminal.includes(entry))) {
+      this.poll.response.destroy();
+    }
+    for (const entry of discarded) {
+      const callback = entry.callback;
+      entry.callback = undefined;
+      callback?.(new Error("Connection retired before delivery"));
+    }
+    this.emit("close", code, Buffer.from(reason));
+    this.flushPoll(true);
+    // Failing a queued callback can synchronously terminate this transport.
+    if (!this.disposed) {
+      this.idleTimer = setTimeout(() => this.expire(), OPERATOR_HTTP_LIMITS.idleTimeoutMs);
+      this.idleTimer.unref();
+    }
+  }
+
+  terminate(): void {
+    this.close(1006, "connection terminated");
+    this.expire();
+  }
+}

--- a/src/gateway/server/operator-http.server.test.ts
+++ b/src/gateway/server/operator-http.server.test.ts
@@ -1,0 +1,613 @@
+import { once } from "node:events";
+import { request as httpRequest } from "node:http";
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import {
+  PROTOCOL_VERSION,
+  type RequestFrame,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { getRuntimeConfig, setRuntimeConfigSnapshot } from "../../config/io.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+} from "../../infra/device-identity.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getActiveGatewayRootWorkCount } from "../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { buildDeviceAuthPayloadV3 } from "../device-auth.js";
+import { issueOperatorToken } from "../device-authz.test-helpers.js";
+import * as hooks from "../hooks.js";
+import { createGatewayOperatorHttpRuntime } from "../operator-http.js";
+import { GatewayConnectionWork } from "../server-connection-work.js";
+import { createGatewayHttpServer } from "../server-http.js";
+import * as lazyHandlers from "../server-methods/lazy-core-handlers.js";
+import type { GatewayRequestHandler } from "../server-methods/types.js";
+import {
+  installGatewayTestHooks,
+  rpcReq,
+  startConnectedServerWithClient,
+} from "../test-helpers.js";
+import type {
+  OperatorHttpBeginResponse,
+  OperatorHttpPollResponse,
+} from "./operator-http-contract.js";
+import { createPreauthConnectionBudget } from "./preauth-connection-budget.js";
+import * as preauthBudget from "./preauth-connection-budget.js";
+import type { GatewayWsClient } from "./ws-types.js";
+
+installGatewayTestHooks({ scope: "suite" });
+await import("../server.js");
+
+describe("paired operator HTTP transport", () => {
+  let started: Awaited<ReturnType<typeof startConnectedServerWithClient>>;
+  const connections = new Set<OperatorHttpBeginResponse>();
+  const client = {
+    id: GATEWAY_CLIENT_IDS.TEST,
+    mode: GATEWAY_CLIENT_MODES.TEST,
+    version: "test",
+    platform: "test",
+  };
+  const responseSchema = z.object({
+    type: z.literal("res"),
+    id: z.string(),
+    ok: z.boolean(),
+    payload: z.unknown().optional(),
+    error: z.object({ code: z.string(), message: z.string() }).passthrough().optional(),
+  });
+  beforeAll(async () => {
+    const budget = createPreauthConnectionBudget(1);
+    const factory = vi
+      .spyOn(preauthBudget, "createPreauthConnectionBudget")
+      .mockReturnValueOnce(budget);
+    try {
+      started = await startConnectedServerWithClient("secret");
+    } finally {
+      factory.mockRestore();
+    }
+  });
+  afterEach(async () => {
+    await Promise.all(
+      [...connections].map((connection) => exchange(connection, "", undefined, "DELETE")),
+    );
+    connections.clear();
+  });
+  afterAll(async () => {
+    started.ws.close();
+    await started.server.close();
+    started.envSnapshot.restore();
+  });
+
+  function exchange(
+    connection: OperatorHttpBeginResponse | undefined,
+    suffix: string,
+    body?: unknown,
+    method = "POST",
+    headers?: Record<string, string>,
+    signal = AbortSignal.timeout(10_000),
+  ) {
+    const base = `http://127.0.0.1:${started.port}/api/operator/connections`;
+    return fetch(`${base}${connection ? `/${connection.connectionId}` : ""}${suffix}`, {
+      method,
+      redirect: "error",
+      signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(connection ? { Authorization: `Bearer ${connection.connectionKey}` } : {}),
+        ...headers,
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  }
+
+  async function begin() {
+    const response = await exchange(undefined, "", {});
+    expect(response.status).toBe(201);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const connection: OperatorHttpBeginResponse = await response.json();
+    connections.add(connection);
+    expect(connection.connectionKey).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(connection.handshakeExpiresAtMs).toBeGreaterThan(connection.challenge.ts);
+    return connection;
+  }
+
+  function signedConnect(
+    connection: OperatorHttpBeginResponse,
+    paired: Awaited<ReturnType<typeof issueOperatorToken>>,
+    scopes: string[],
+  ): RequestFrame {
+    const identity = loadOrCreateDeviceIdentity({ path: paired.identityPath });
+    const signedAtMs = Date.now();
+    const nonce = connection.challenge.nonce;
+    return {
+      type: "req",
+      id: "connect",
+      method: "connect",
+      params: {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client,
+        role: "operator",
+        scopes,
+        auth: { deviceToken: paired.token },
+        device: {
+          id: identity.deviceId,
+          publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+          nonce,
+          signedAt: signedAtMs,
+          signature: signDevicePayload(
+            identity.privateKeyPem,
+            buildDeviceAuthPayloadV3({
+              deviceId: identity.deviceId,
+              clientId: client.id,
+              clientMode: client.mode,
+              platform: client.platform,
+              role: "operator",
+              scopes,
+              token: paired.token,
+              nonce,
+              signedAtMs,
+            }),
+          ),
+        },
+      },
+    };
+  }
+
+  async function open(name: string, scopes = ["operator.read"]) {
+    const paired = await issueOperatorToken({
+      name: `http-${name}`,
+      approvedScopes: scopes,
+      clientId: client.id,
+      clientMode: client.mode,
+    });
+    const connection = await begin();
+    let clientSeq = 0;
+    let ack = 0;
+    const post = async (frame: RequestFrame) => {
+      const response = await exchange(connection, "/frames", {
+        clientSeq: ++clientSeq,
+        ack,
+        frame,
+      });
+      expect(response.status).toBe(202);
+      expect(await response.json()).toEqual({ acceptedClientSeq: clientSeq });
+    };
+    const poll = async (acknowledge = true) => {
+      const response = await exchange(connection, "/poll", { ack, waitMs: 2000 });
+      expect(response.status).toBe(200);
+      const result: OperatorHttpPollResponse = await response.json();
+      if (acknowledge && result.frames.length) {
+        ack = result.frames.at(-1)!.cursor;
+      }
+      return result;
+    };
+    const receive = async (id: string, acknowledge = true) => {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const result = await poll(acknowledge);
+        for (const entry of result.frames) {
+          const parsed = responseSchema.safeParse(entry.frame);
+          if (parsed.success && parsed.data.id === id) {
+            return parsed.data;
+          }
+        }
+        expect(result.closed).toBeUndefined();
+      }
+      throw new Error(`No HTTP response for ${id}`);
+    };
+    const call = async (method: string, params: unknown = {}) => {
+      const id = `request-${clientSeq + 1}`;
+      await post({ type: "req", id, method, params });
+      return await receive(id);
+    };
+    await post(signedConnect(connection, paired, scopes));
+    const hello = await receive("connect");
+    expect(hello).toMatchObject({
+      ok: true,
+      payload: {
+        server: { connId: connection.connectionId },
+        auth: { method: "device-token", scopes },
+      },
+    });
+    return {
+      connection,
+      paired,
+      post,
+      poll,
+      receive,
+      call,
+      get ack() {
+        return ack;
+      },
+    };
+  }
+
+  test("uses the shared RPC and subscription policy without administrative authority", async () => {
+    const operator = await open("ordinary");
+    expect(await operator.call("health")).toMatchObject({ ok: true });
+    expect(await operator.call("sessions.subscribe")).toMatchObject({ ok: true });
+    expect(await operator.call("config.get")).toMatchObject({ ok: true });
+    expect(await operator.call("config.set", { raw: "{}" })).toMatchObject({
+      ok: false,
+      error: { code: "FORBIDDEN", details: { missingScope: "operator.admin" } },
+    });
+    expect(await operator.call("device.pair.list")).toMatchObject({ ok: false });
+    expect((await rpcReq(started.ws, "health")).ok).toBe(true);
+  });
+
+  test.each(["operator.admin", "operator.pairing"])(
+    "rejects %s at shared connect admission",
+    async (scope) => {
+      const paired = await issueOperatorToken({
+        name: `http-denied-${scope}`,
+        approvedScopes: [scope],
+        clientId: client.id,
+        clientMode: client.mode,
+      });
+      const connection = await begin();
+      expect(
+        (
+          await exchange(connection, "/frames", {
+            clientSeq: 1,
+            ack: 0,
+            frame: signedConnect(connection, paired, [scope]),
+          })
+        ).status,
+      ).toBe(202);
+      const response = await exchange(connection, "/poll", { ack: 0, waitMs: 2000 });
+      const result: OperatorHttpPollResponse = await response.json();
+      expect(result.frames).toEqual([
+        {
+          cursor: 1,
+          frame: expect.objectContaining({ type: "res", id: "connect", ok: false }),
+        },
+      ]);
+    },
+  );
+
+  test("does not use shared gateway auth instead of explicit device auth", async () => {
+    const connection = await begin();
+    await exchange(connection, "/frames", {
+      clientSeq: 1,
+      ack: 0,
+      frame: {
+        type: "req",
+        id: "connect",
+        method: "connect",
+        params: {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client,
+          role: "operator",
+          scopes: ["operator.read"],
+          auth: { token: "secret" },
+        },
+      },
+    });
+    const response = await exchange(connection, "/poll", { ack: 0, waitMs: 2000 });
+    const result: OperatorHttpPollResponse = await response.json();
+    expect(result.frames[0]?.frame).toMatchObject({ id: "connect", ok: false });
+  });
+
+  test("holds rejected preauth capacity until final removal, but releases authenticated capacity", async () => {
+    const connection = await begin();
+    await exchange(connection, "/frames", {
+      clientSeq: 1,
+      ack: 0,
+      frame: { type: "req", id: "connect", method: "connect", params: {} },
+    });
+    const rejected = await exchange(connection, "/poll", { ack: 0, waitMs: 2000 });
+    expect(await rejected.json()).toMatchObject({
+      frames: [{ cursor: 1, frame: { id: "connect", ok: false } }],
+      closed: { resyncRequired: true },
+    });
+    const exhausted = await exchange(undefined, "", {});
+    if (exhausted.status === 201) {
+      connections.add(await exhausted.json());
+    }
+    expect(exhausted.status).toBe(429);
+    expect((await exchange(connection, "", undefined, "DELETE")).status).toBe(204);
+    expect((await exchange(connection, "", undefined, "DELETE")).status).toBe(404);
+    const authenticated = await open("budget-release");
+    await begin();
+    expect(await authenticated.call("health")).toMatchObject({ ok: true });
+  });
+
+  test("binds connect to the actual POST ingress instead of begin headers", async () => {
+    const connection = await begin();
+    const response = await exchange(
+      connection,
+      "/frames",
+      {
+        clientSeq: 1,
+        ack: 0,
+        frame: { type: "req", id: "connect", method: "connect", params: {} },
+      },
+      "POST",
+      { Origin: `http://127.0.0.1:${started.port}` },
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "ingress_changed", resyncRequired: true },
+    });
+  });
+
+  test("does not retain root work while a poll waits and permits only one poll", async () => {
+    const operator = await open("idle-poll");
+    const output = await operator.poll();
+    const cursor = output.frames.at(-1)?.cursor ?? 1;
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    const pending = exchange(operator.connection, "/poll", { ack: cursor, waitMs: 25_000 });
+    await vi.waitFor(async () => {
+      const second = await exchange(operator.connection, "/poll", { ack: cursor, waitMs: 0 });
+      expect(second.status).toBe(409);
+      expect(await second.json()).toMatchObject({ error: { code: "poll_conflict" } });
+    });
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    await exchange(operator.connection, "", undefined, "DELETE");
+    expect((await pending).status).toBe(200);
+  });
+
+  test("fences a forwarding policy change during awaited handler preparation", async () => {
+    const operator = await open("awaited-policy");
+    const config = getRuntimeConfig();
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const prepare = lazyHandlers.prepareGatewayRequestHandler;
+    const invoked = vi.fn<GatewayRequestHandler>();
+    const blocked = vi
+      .spyOn(lazyHandlers, "prepareGatewayRequestHandler")
+      .mockImplementationOnce(async (...args) => {
+        invoked.mockImplementation(await prepare(...args));
+        entered.resolve();
+        await release.promise;
+        return invoked;
+      });
+    try {
+      await operator.post({ type: "req", id: "blocked", method: "health", params: {} });
+      await entered.promise;
+      setRuntimeConfigSnapshot({
+        ...config,
+        gateway: { ...config.gateway, trustedProxies: ["192.0.2.10"] },
+      });
+      release.resolve();
+      await vi.waitFor(() => expect(blocked).toHaveResolved());
+      // Restore only after the queued request has crossed its final dispatch fence.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(invoked).not.toHaveBeenCalled();
+      setRuntimeConfigSnapshot(config);
+      const response = await exchange(operator.connection, "/poll", {
+        ack: operator.ack,
+        waitMs: 0,
+      });
+      // A queued broadcaster send may terminate its transport on delivery failure.
+      if (response.status === 404) {
+        expect(await response.json()).toMatchObject({
+          error: { code: "connection_not_found", resyncRequired: true },
+        });
+      } else {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          frames: [],
+          closed: { resyncRequired: true },
+        });
+      }
+    } finally {
+      release.resolve();
+      blocked.mockRestore();
+      setRuntimeConfigSnapshot(config);
+    }
+  });
+
+  test("does not claim preauth capacity when shutdown starts during the begin body", async () => {
+    const clients = new Set<GatewayWsClient>();
+    const work = new GatewayConnectionWork();
+    const budget = createPreauthConnectionBudget(1);
+    const acquire = vi.spyOn(budget, "acquire");
+    const release = vi.spyOn(budget, "release");
+    const readBody = vi.spyOn(hooks, "readJsonBody");
+    const log = createSubsystemLogger("gateway/operator-http-test");
+    const auth = { mode: "token", token: "secret", allowTailscale: false } as const;
+    const runtime = createGatewayOperatorHttpRuntime({
+      basePath: "",
+      bootId: "shutdown-test",
+      clients,
+      connectionWork: work,
+      preauthConnectionBudget: budget,
+      getResolvedAuth: () => auth,
+      gatewayMethods: [],
+      events: [],
+      extraHandlers: {},
+      broadcast: () => {},
+      refreshHealthSnapshot: async () => {
+        throw new Error("No handshake may start");
+      },
+      buildRequestContext: () => {
+        throw new Error("No connection may register");
+      },
+      logGateway: log,
+      logHealth: log,
+      logWsControl: log,
+    });
+    const server = createGatewayHttpServer({
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      resolvedAuth: auth,
+      handleHooksRequest: async () => false,
+      handleOperatorRequest: runtime.handleRequest,
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP listener");
+    }
+    const received = createDeferredCore<{ status?: number; body: string }>();
+    const request = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: address.port,
+        path: "/api/operator/connections",
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Content-Length": "2" },
+      },
+      (response) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.once("end", () => received.resolve({ status: response.statusCode, body }));
+        response.once("error", received.reject);
+      },
+    );
+    request.once("error", received.reject);
+    try {
+      request.write("{");
+      await vi.waitFor(() => expect(readBody).toHaveBeenCalledOnce());
+      work.beginClose();
+      runtime.close();
+      request.end("}");
+      const response = await received.promise;
+      expect(response.status).toBe(503);
+      expect(JSON.parse(response.body)).toMatchObject({
+        error: { code: "unavailable", resyncRequired: true },
+      });
+      expect(acquire).not.toHaveBeenCalled();
+      expect(release).not.toHaveBeenCalled();
+      expect(budget.acquire("127.0.0.1")).toBe(true);
+      budget.release("127.0.0.1");
+      await work.drain();
+    } finally {
+      request.destroy();
+      runtime.close();
+      readBody.mockRestore();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  test("deduplicates the same client sequence independently of ACK and rejects conflicts", async () => {
+    const operator = await open("sequence");
+    const frame: RequestFrame = { type: "req", id: "health", method: "health", params: {} };
+    await operator.post(frame);
+    const output = await operator.poll(false);
+    const last = output.frames.at(-1);
+    expect(last).toBeDefined();
+    const repeated = await exchange(operator.connection, "/frames", {
+      clientSeq: 2,
+      ack: last!.cursor,
+      frame: { params: {}, method: "health", id: "health", type: "req" },
+    });
+    expect(repeated.status).toBe(202);
+    for (const body of [
+      { clientSeq: 2, ack: last!.cursor, frame: { ...frame, id: "different" } },
+      { clientSeq: 4, ack: last!.cursor, frame },
+      { clientSeq: 3, ack: last!.cursor + 1, frame },
+    ]) {
+      expect((await exchange(operator.connection, "/frames", body)).status).toBe(409);
+    }
+    const noDuplicate = await exchange(operator.connection, "/poll", {
+      ack: last!.cursor,
+      waitMs: 0,
+    });
+    expect(await noDuplicate.json()).toMatchObject({ acceptedClientSeq: 2, frames: [] });
+  });
+
+  test("recovers a pending RPC after cancelling an empty poll and external approval rotates its token", async () => {
+    const operator = await open("upgrade");
+    const registration = await operator.call("device.scopes.requestUpgrade", {
+      scopes: ["operator.read", "operator.write"],
+    });
+    expect(registration.ok).toBe(true);
+    const { requestId } = z.object({ requestId: z.string() }).parse(registration.payload);
+    await operator.post({
+      type: "req",
+      id: "wait",
+      method: "device.scopes.waitUpgrade",
+      params: { requestId },
+    });
+    const controller = new AbortController();
+    const pendingPoll = exchange(
+      operator.connection,
+      "/poll",
+      { ack: operator.ack, waitMs: 25_000 },
+      "POST",
+      undefined,
+      controller.signal,
+    ).then(
+      () => "unexpected delivery",
+      (error: unknown) => (error instanceof Error ? error.name : "unknown error"),
+    );
+    try {
+      await vi.waitFor(async () => {
+        const second = await exchange(operator.connection, "/poll", {
+          ack: operator.ack,
+          waitMs: 0,
+        });
+        expect(second.status).toBe(409);
+      });
+    } finally {
+      controller.abort();
+    }
+    expect(await pendingPoll).toBe("AbortError");
+    await vi.waitFor(async () => {
+      const empty = await exchange(operator.connection, "/poll", { ack: operator.ack, waitMs: 0 });
+      expect(empty.status).toBe(200);
+      expect(await empty.json()).toMatchObject({ frames: [] });
+    });
+    expect((await rpcReq(started.ws, "device.pair.approve", { requestId })).ok).toBe(true);
+    const result = await operator.receive("wait", false);
+    expect(result.ok).toBe(true);
+    const grant = z
+      .object({
+        status: z.literal("approved"),
+        deviceToken: z.string(),
+        scopes: z.array(z.string()),
+      })
+      .parse(result.payload);
+    expect(grant.deviceToken).not.toBe(operator.paired.token);
+    expect(grant.scopes).toEqual(["operator.read", "operator.write"]);
+    const replay = await operator.poll(false);
+    expect(replay.frames.map(({ frame }) => frame)).toContainEqual(result);
+  });
+
+  test.each(["device.token.revoke", "device.token.rotate", "device.pair.remove"])(
+    "%s suppresses replay of an approved grant",
+    async (method) => {
+      const operator = await open(method);
+      const registration = await operator.call("device.scopes.requestUpgrade", {
+        scopes: ["operator.read", "operator.write"],
+      });
+      const { requestId } = z.object({ requestId: z.string() }).parse(registration.payload);
+      await operator.post({
+        type: "req",
+        id: "wait",
+        method: "device.scopes.waitUpgrade",
+        params: { requestId },
+      });
+      expect((await rpcReq(started.ws, "device.pair.approve", { requestId })).ok).toBe(true);
+      expect((await operator.receive("wait", false)).ok).toBe(true);
+      expect(
+        (
+          await rpcReq(started.ws, method, {
+            deviceId: operator.paired.deviceId,
+            ...(method === "device.pair.remove" ? {} : { role: "operator" }),
+          })
+        ).ok,
+      ).toBe(true);
+      expect(await operator.poll(false)).toMatchObject({
+        frames: [],
+        closed: { resyncRequired: true },
+      });
+    },
+  );
+});

--- a/src/gateway/server/operator-http.server.test.ts
+++ b/src/gateway/server/operator-http.server.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import { request as httpRequest } from "node:http";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
@@ -28,7 +29,10 @@ import { createGatewayHttpServer } from "../server-http.js";
 import * as lazyHandlers from "../server-methods/lazy-core-handlers.js";
 import type { GatewayRequestHandler } from "../server-methods/types.js";
 import {
+  gatewayReplyMock,
   installGatewayTestHooks,
+  mockGetReplyFromConfigOnce,
+  prepareGatewayReplyRuntimeForTest,
   rpcReq,
   startConnectedServerWithClient,
 } from "../test-helpers.js";
@@ -165,6 +169,13 @@ describe("paired operator HTTP transport", () => {
       clientId: client.id,
       clientMode: client.mode,
     });
+    return connectPaired(paired, scopes);
+  }
+
+  async function connectPaired(
+    paired: Awaited<ReturnType<typeof issueOperatorToken>>,
+    scopes: string[],
+  ) {
     const connection = await begin();
     let clientSeq = 0;
     let ack = 0;
@@ -223,6 +234,9 @@ describe("paired operator HTTP transport", () => {
       get ack() {
         return ack;
       },
+      get nextClientSeq() {
+        return clientSeq + 1;
+      },
     };
   }
 
@@ -237,6 +251,292 @@ describe("paired operator HTTP transport", () => {
     });
     expect(await operator.call("device.pair.list")).toMatchObject({ ok: false });
     expect((await rpcReq(started.ws, "health")).ok).toBe(true);
+  });
+
+  test("enforces canonical chat and approval effects across scope upgrade and established revocation", async () => {
+    const operator = await open("scope-effects", ["operator.read", "operator.talk"]);
+    const approvalIds = new Set<string>();
+    const runIds = new Set<string>();
+    let sessionKey: string | undefined;
+    let pendingUpgradeId: string | undefined;
+    const failures: Error[] = [];
+    const phaseResults: string[] = [];
+    const bodyStartedAt = performance.now();
+    let bodyPassed = false;
+    const cleanupPhase = async (phase: string, run: () => Promise<void>) => {
+      const startedAt = performance.now();
+      let passed = false;
+      try {
+        await run();
+        passed = true;
+      } catch (cause) {
+        failures.push(new Error(phase, { cause }));
+      } finally {
+        phaseResults.push(
+          `${phase}: ${passed ? "passed" : "failed"} (${Math.round(performance.now() - startedAt)}ms)`,
+        );
+      }
+    };
+    try {
+      const created = await rpcReq(started.ws, "sessions.create", {
+        agentId: "main",
+        key: `agent:main:http-scope-effects:${randomUUID()}`,
+      });
+      expect(created.ok).toBe(true);
+      sessionKey = z.object({ key: z.string().min(1) }).parse(created.payload).key;
+      const history = async () => {
+        const result = await rpcReq(started.ws, "chat.history", { sessionKey });
+        expect(result.ok).toBe(true);
+        return z.object({ messages: z.array(z.unknown()) }).parse(result.payload).messages;
+      };
+      const pendingApproval = async () => {
+        const id = randomUUID();
+        approvalIds.add(id);
+        expect(
+          await rpcReq(started.ws, "exec.approval.request", {
+            id,
+            command: "printf scope-effects",
+            sessionKey,
+            twoPhase: true,
+            suppressDelivery: true,
+            requireDeliveryRoute: false,
+          }),
+        ).toMatchObject({
+          ok: true,
+          payload: { id, status: "accepted", deliveryRoute: "none" },
+        });
+        expect(await rpcReq(started.ws, "approval.get", { id })).toMatchObject({
+          ok: true,
+          payload: { approval: { id, presentation: { kind: "exec" }, status: "pending" } },
+        });
+        return id;
+      };
+      const firstApproval = await pendingApproval();
+      const emptyHistory = await history();
+      expect(emptyHistory).toEqual([]);
+      const forbiddenRunId = randomUUID();
+      runIds.add(forbiddenRunId);
+      expect(
+        await operator.call("chat.send", {
+          sessionKey,
+          message: "read-only chat must not persist",
+          idempotencyKey: forbiddenRunId,
+        }),
+      ).toMatchObject({
+        ok: false,
+        error: { code: "FORBIDDEN", details: { missingScope: "operator.write" } },
+      });
+      expect(
+        await operator.call("approval.resolve", {
+          id: firstApproval,
+          kind: "exec",
+          decision: "deny",
+        }),
+      ).toMatchObject({
+        ok: false,
+        error: { code: "FORBIDDEN", details: { missingScope: "operator.approvals" } },
+      });
+      expect(await history()).toEqual(emptyHistory);
+      expect(await rpcReq(started.ws, "approval.get", { id: firstApproval })).toMatchObject({
+        ok: true,
+        payload: { approval: { id: firstApproval, status: "pending" } },
+      });
+
+      const scopes = ["operator.read", "operator.talk", "operator.write", "operator.approvals"];
+      const registration = await operator.call("device.scopes.requestUpgrade", { scopes });
+      expect(registration.ok).toBe(true);
+      const { requestId } = z.object({ requestId: z.string() }).parse(registration.payload);
+      pendingUpgradeId = requestId;
+      await operator.post({
+        type: "req",
+        id: "scope-effects-upgrade",
+        method: "device.scopes.waitUpgrade",
+        params: { requestId },
+      });
+      expect((await rpcReq(started.ws, "device.pair.approve", { requestId })).ok).toBe(true);
+      pendingUpgradeId = undefined;
+      const result = await operator.receive("scope-effects-upgrade");
+      expect(result.ok).toBe(true);
+      const grant = z
+        .object({
+          status: z.literal("approved"),
+          deviceToken: z.string().min(1),
+          scopes: z.array(z.string()),
+        })
+        .parse(result.payload);
+      expect(grant.deviceToken).not.toBe(operator.paired.token);
+      expect(grant.scopes.toSorted()).toEqual(scopes.toSorted());
+      expect((await exchange(operator.connection, "", undefined, "DELETE")).status).toBe(204);
+      connections.delete(operator.connection);
+      const upgraded = await connectPaired(
+        { ...operator.paired, token: grant.deviceToken },
+        grant.scopes,
+      );
+
+      // HTTP bypasses rpcReq's reply-runtime preparation, not the real chat dispatcher.
+      await prepareGatewayReplyRuntimeForTest();
+      const userText = "authorized HTTP user turn";
+      const assistantText = "authorized HTTP assistant reply";
+      mockGetReplyFromConfigOnce(async () => ({ text: assistantText }));
+      const runId = randomUUID();
+      runIds.add(runId);
+      expect(
+        await upgraded.call("chat.send", { sessionKey, message: userText, idempotencyKey: runId }),
+      ).toMatchObject({ ok: true, payload: { runId, status: "started" } });
+      expect(await upgraded.call("agent.wait", { runId, timeoutMs: 1000 })).toMatchObject({
+        ok: true,
+        payload: { runId, status: "ok" },
+      });
+      const writtenHistory = await history();
+      expect(writtenHistory).toMatchObject([
+        { role: "user", content: userText },
+        { role: "assistant", content: [{ type: "text", text: assistantText }] },
+      ]);
+      expect(
+        await upgraded.call("approval.resolve", {
+          id: firstApproval,
+          kind: "exec",
+          decision: "deny",
+        }),
+      ).toMatchObject({
+        ok: true,
+        payload: {
+          applied: true,
+          approval: {
+            id: firstApproval,
+            presentation: { kind: "exec" },
+            status: "denied",
+            resolver: { kind: "device", id: operator.paired.deviceId },
+          },
+        },
+      });
+      expect(await rpcReq(started.ws, "approval.get", { id: firstApproval })).toMatchObject({
+        ok: true,
+        payload: {
+          approval: {
+            id: firstApproval,
+            status: "denied",
+            resolver: { kind: "device", id: operator.paired.deviceId },
+          },
+        },
+      });
+
+      const secondApproval = await pendingApproval();
+      const beforeRevocation = await history();
+      expect(beforeRevocation).toEqual(writtenHistory);
+      const revoked = await rpcReq(started.ws, "device.token.revoke", {
+        deviceId: operator.paired.deviceId,
+        role: "operator",
+      });
+      expect(revoked).toMatchObject({
+        ok: true,
+        payload: {
+          deviceId: operator.paired.deviceId,
+          role: "operator",
+          revokedAtMs: expect.any(Number),
+        },
+      });
+      const revokedRunId = randomUUID();
+      runIds.add(revokedRunId);
+      const nextClientSeq = upgraded.nextClientSeq;
+      for (const frame of [
+        {
+          type: "req",
+          id: "revoked-chat",
+          method: "chat.send",
+          params: {
+            sessionKey,
+            message: "revoked chat must not persist",
+            idempotencyKey: revokedRunId,
+          },
+        },
+        {
+          type: "req",
+          id: "revoked-approval",
+          method: "approval.resolve",
+          params: { id: secondApproval, kind: "exec", decision: "deny" },
+        },
+      ] satisfies RequestFrame[]) {
+        const rejected = await exchange(upgraded.connection, "/frames", {
+          clientSeq: nextClientSeq,
+          ack: upgraded.ack,
+          frame,
+        });
+        expect(rejected.status).toBe(410);
+        expect(await rejected.json()).toEqual({
+          error: {
+            code: "connection_closed",
+            message: "Connection closed; reconnect",
+            resyncRequired: true,
+          },
+        });
+        expect(await upgraded.poll()).toMatchObject({
+          acceptedClientSeq: nextClientSeq - 1,
+          frames: [],
+          closed: { resyncRequired: true },
+        });
+      }
+      expect(await history()).toEqual(beforeRevocation);
+      expect(await rpcReq(started.ws, "approval.get", { id: secondApproval })).toMatchObject({
+        ok: true,
+        payload: { approval: { id: secondApproval, status: "pending" } },
+      });
+      bodyPassed = true;
+    } catch (cause) {
+      failures.push(new Error("body", { cause }));
+    } finally {
+      phaseResults.push(
+        `body: ${bodyPassed ? "passed" : "failed"} (${Math.round(performance.now() - bodyStartedAt)}ms)`,
+      );
+      try {
+        await cleanupPhase("fixture settlement", async () => {
+          const cleanup = await Promise.allSettled([
+            ...(pendingUpgradeId
+              ? [
+                  rpcReq(started.ws, "device.pair.reject", { requestId: pendingUpgradeId }).then(
+                    (result) => expect(result.ok).toBe(true),
+                  ),
+                ]
+              : []),
+            ...[...approvalIds].map(async (id) => {
+              expect(
+                (
+                  await rpcReq(started.ws, "approval.resolve", {
+                    id,
+                    kind: "exec",
+                    decision: "deny",
+                  })
+                ).ok,
+              ).toBe(true);
+            }),
+            ...[...runIds].map(async (runId) => {
+              expect((await rpcReq(started.ws, "chat.abort", { sessionKey, runId })).ok).toBe(true);
+            }),
+          ]);
+          expect(cleanup.filter((settled) => settled.status === "rejected")).toEqual([]);
+        });
+        await cleanupPhase("root drain", async () => {
+          await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        });
+        if (sessionKey) {
+          await cleanupPhase("session deletion", async () => {
+            expect((await rpcReq(started.ws, "sessions.delete", { key: sessionKey })).ok).toBe(
+              true,
+            );
+          });
+        } else {
+          phaseResults.push("session deletion: not-attempted (no session key)");
+        }
+      } finally {
+        gatewayReplyMock.mockReset();
+        gatewayReplyMock.mockResolvedValue(undefined);
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(phaseResults.join("; "), {
+        cause: new AggregateError(failures, "scope/effect matrix failures"),
+      });
+    }
   });
 
   test.each(["operator.admin", "operator.pairing"])(

--- a/src/gateway/server/ws-connection/auth-context.operator-http.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.operator-http.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, vi } from "vitest";
+import type { GatewayAuthResult } from "../../auth.js";
+import { resolveConnectAuthDecision } from "./auth-context.js";
+
+describe("required operator device-token authentication", () => {
+  test.each<NonNullable<GatewayAuthResult["method"]>>([
+    "none",
+    "token",
+    "trusted-proxy",
+    "tailscale",
+  ])(
+    "verifies the explicit device credential instead of inheriting %s authority",
+    async (method) => {
+      for (const valid of [false, true]) {
+        const verifyDeviceToken = vi.fn(async () => ({
+          ok: valid,
+          reason: valid ? undefined : "token-mismatch",
+        }));
+        const verifyBootstrapToken = vi.fn(async () => ({ ok: true }));
+        const decision = await resolveConnectAuthDecision({
+          state: {
+            authResult: { ok: true, method, user: "ambient@example.test" },
+            authOk: true,
+            authMethod: method,
+            sharedAuthOk: true,
+            pendingSharedAuthFailure: false,
+            deviceTokenCandidate: "explicit-device-token",
+            deviceTokenCandidateSource: "explicit-device-token",
+            bootstrapTokenCandidate: "must-not-replace-device-proof",
+          },
+          requireDeviceToken: true,
+          hasDeviceIdentity: true,
+          deviceId: "paired-device",
+          publicKey: "paired-public-key",
+          role: "operator",
+          scopes: ["operator.read"],
+          verifyDeviceToken,
+          verifyBootstrapToken,
+        });
+        expect(verifyDeviceToken).toHaveBeenCalledExactlyOnceWith({
+          deviceId: "paired-device",
+          token: "explicit-device-token",
+          role: "operator",
+          scopes: ["operator.read"],
+        });
+        expect(verifyBootstrapToken).not.toHaveBeenCalled();
+        expect(decision.authOk).toBe(valid);
+        expect(decision.authResult.user).toBeUndefined();
+        if (valid) {
+          expect(decision.authResult).toEqual({ ok: true, method: "device-token" });
+          expect(decision.authMethod).toBe("device-token");
+        }
+      }
+    },
+  );
+});

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -57,6 +57,7 @@ type ResolveConnectAuthDecisionParams = {
   role: string;
   scopes: string[];
   requireBootstrapToken?: boolean;
+  requireDeviceToken?: boolean;
   rateLimiter?: AuthRateLimiter;
   clientIp?: string;
   verifyBootstrapToken: (params: {
@@ -238,8 +239,19 @@ async function resolveConnectAuthDecisionCore(
   if (authResult.reason === PROXY_ATTRIBUTION_REQUIRED_REASON) {
     return await finish();
   }
+  // A transport requiring a device credential cannot inherit a successful
+  // auth-none, proxy or Tailscale decision instead of verifying that credential.
+  if (params.requireDeviceToken) {
+    authOk = false;
+    if (params.state.deviceTokenCandidateSource !== "explicit-device-token") {
+      authResult = { ok: false, reason: "device_token_mismatch" };
+      return await finish();
+    }
+  }
 
-  const bootstrapTokenCandidate = params.state.bootstrapTokenCandidate;
+  const bootstrapTokenCandidate = params.requireDeviceToken
+    ? undefined
+    : params.state.bootstrapTokenCandidate;
   if (params.hasDeviceIdentity && params.deviceId && params.publicKey && bootstrapTokenCandidate) {
     // Per-IP gate on the bootstrap-token verify path.
     // verifyDeviceBootstrapToken is mutex-serialized and runs fs read + fs
@@ -322,6 +334,9 @@ async function resolveConnectAuthDecisionCore(
     if (tokenCheck.ok) {
       authOk = true;
       authMethod = "device-token";
+      if (params.requireDeviceToken) {
+        authResult = { ok: true, method: "device-token" };
+      }
       if (tokenCheck.issuer?.kind === "shared-gateway-auth") {
         deviceTokenSharedGatewaySessionGeneration = tokenCheck.issuer.generation;
       }

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -83,18 +83,22 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
     client: GatewayWsClient,
     frameBytes: number,
     admission?: "continuation",
+    isIngressCurrent?: () => boolean,
   ): Promise<void> => {
     // After handshake, accept only req frames
     if (!validateRequestFrame(parsed)) {
-      send({
-        type: "res",
-        id: (parsed as { id?: unknown })?.id ?? "invalid",
-        ok: false,
-        error: errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid request frame: ${formatValidationErrors(validateRequestFrame.errors)}`,
-        ),
-      });
+      send(
+        {
+          type: "res",
+          id: (parsed as { id?: unknown })?.id ?? "invalid",
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid request frame: ${formatValidationErrors(validateRequestFrame.errors)}`,
+          ),
+        },
+        { isCurrent: isIngressCurrent },
+      );
       return;
     }
     const req = parsed;
@@ -102,6 +106,10 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
     logWs("in", "req", { connId, id: req.id, method: req.method });
     const context = buildRequestContext();
     const hasCurrentClientAuthority = () => {
+      if (isIngressCurrent?.() === false) {
+        close(4001, "connection ingress changed");
+        return false;
+      }
       if (closeInvalidatedClient(client, req.method)) {
         return false;
       }
@@ -136,13 +144,17 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       try {
         let responseOk = ok;
         let responseError = error;
-        let sendResult = send({ type: "res", id: req.id, ok, payload, error });
+        const delivery = { isCurrent: isIngressCurrent };
+        let sendResult = send({ type: "res", id: req.id, ok, payload, error }, delivery);
         if (sendResult.kind === "serialization") {
           const detail = formatForLog(sendResult.error);
           logGateway.error(`response serialization failed method=${req.method}: ${detail}`);
           responseOk = false;
           responseError = errorShape(ErrorCodes.UNAVAILABLE, "response serialization failed");
-          sendResult = send({ type: "res", id: req.id, ok: responseOk, error: responseError });
+          sendResult = send(
+            { type: "res", id: req.id, ok: responseOk, error: responseError },
+            delivery,
+          );
         }
         diagnostics?.response(
           sendResult.kind === "sent" ? (responseOk ? "ok" : "error") : "unavailable",

--- a/src/gateway/server/ws-connection/connect-admission.ts
+++ b/src/gateway/server/ws-connection/connect-admission.ts
@@ -30,7 +30,13 @@ import {
   isOperatorUiClient,
 } from "../../../utils/message-channel.js";
 import { ControlUiGitHubError } from "../../control-ui-github-api.js";
-import type { OperatorScope } from "../../operator-scopes.js";
+import {
+  APPROVALS_SCOPE,
+  READ_SCOPE,
+  TALK_SCOPE,
+  WRITE_SCOPE,
+  type OperatorScope,
+} from "../../operator-scopes.js";
 import { normalizeChromeExtensionOrigin } from "../../origin-check.js";
 import { parseGatewayRole } from "../../role-policy.js";
 import { authenticatedProfileUnavailableError } from "../../server-methods/gateway-client-identity.js";
@@ -42,6 +48,13 @@ import type {
   AuthenticatedGatewayConnect,
   GatewayConnectPhaseContext,
 } from "./message-handler-types.js";
+
+export const HTTP_OPERATOR_SCOPES: readonly string[] = [
+  READ_SCOPE,
+  WRITE_SCOPE,
+  APPROVALS_SCOPE,
+  TALK_SCOPE,
+];
 
 function hasCredential(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
@@ -76,16 +89,19 @@ export async function rejectGatewayStartupConnect(
   const { close } = context.handler;
   const { frame, markHandshakeFailure, sendFrame } = context;
   markHandshakeFailure(GATEWAY_STARTUP_PENDING_CLOSE_CAUSE);
-  await sendFrame({
-    type: "res",
-    id: frame.id,
-    ok: false,
-    error: errorShape(ErrorCodes.UNAVAILABLE, "gateway starting; retry shortly", {
-      retryable: true,
-      retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
-      details: gatewayStartupUnavailableDetails(),
-    }),
-  }).catch(() => {});
+  await sendFrame(
+    {
+      type: "res",
+      id: frame.id,
+      ok: false,
+      error: errorShape(ErrorCodes.UNAVAILABLE, "gateway starting; retry shortly", {
+        retryable: true,
+        retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
+        details: gatewayStartupUnavailableDetails(),
+      }),
+    },
+    { rejectedHandshake: true },
+  ).catch(() => {});
   queueMicrotask(() => close(GATEWAY_STARTUP_CLOSE_CODE, GATEWAY_STARTUP_CLOSE_REASON));
 }
 
@@ -185,6 +201,9 @@ export function resolveGatewayConnectPolicyFailure(
   context: GatewayConnectPhaseContext,
   state: AuthenticatedGatewayConnect,
 ): { kind: "auth" } | { kind: "origin"; reason: string } | undefined {
+  if (context.handler.isIngressCurrent?.() === false) {
+    return { kind: "auth" };
+  }
   if (
     state.sessionUsesSharedGatewayAuth &&
     context.handler.getRequiredSharedGatewaySessionGeneration &&
@@ -287,6 +306,20 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
   const scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
   connectParams.role = role;
   connectParams.scopes = scopes;
+  if (
+    context.handler.operatorDeviceTokenOnly &&
+    (role !== "operator" ||
+      !connectParams.device ||
+      !hasCredential(connectParams.auth?.deviceToken) ||
+      Object.keys(connectParams.auth ?? {}).some((key) => key !== "deviceToken") ||
+      !scopes.every((scope) => HTTP_OPERATOR_SCOPES.includes(scope)))
+  ) {
+    const message = "HTTP connections require a paired operator device token and bounded scopes";
+    markHandshakeFailure("operator-transport-admission");
+    sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, message);
+    close(1008, message);
+    return undefined;
+  }
 
   const isBrowserCopilot = isBrowserCopilotClient(connectParams.client);
   const browserCopilotOrigin = isBrowserCopilot

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -55,6 +55,27 @@ import type {
 
 const unauthorizedHandshakeLogLimiter = new HandshakeAuthLogLimiter();
 
+export async function revalidateGatewayOperatorDeviceToken(
+  context: GatewayConnectPhaseContext,
+  state: AuthenticatedGatewayConnect,
+): Promise<boolean> {
+  // Close the pre-registration race here. Once registered, canonical
+  // invalidation owns the grant; ordinary reapproval may rotate its token.
+  const token = context.connectParams.auth?.deviceToken;
+  if (!state.device || !token) {
+    return false;
+  }
+  const verified = await verifyDeviceToken({
+    deviceId: state.device.id,
+    token,
+    role: state.role,
+    scopes: state.scopes,
+    requiredSharedGatewaySessionGeneration:
+      context.handler.getRequiredSharedGatewaySessionGeneration?.(),
+  });
+  return verified.ok && !context.handler.isClosed();
+}
+
 export async function authenticateGatewayConnect(
   context: GatewayConnectPhaseContext,
 ): Promise<AuthenticatedGatewayConnect | undefined> {
@@ -149,12 +170,13 @@ async function authenticateGatewayConnectCore(
     clientIp: browserRateLimitClientIp,
   });
   const {
-    sharedAuthOk,
+    sharedAuthOk: resolvedSharedAuthOk,
     pendingSharedAuthFailure,
     bootstrapTokenCandidate,
     deviceTokenCandidate,
     deviceTokenCandidateSource,
   } = connectAuthState;
+  const sharedAuthOk = !context.handler.operatorDeviceTokenOnly && resolvedSharedAuthOk;
   let { authResult, authOk, authMethod } = connectAuthState;
   let rejectedPendingSharedAuthFailure = pendingSharedAuthFailure;
   const settleRejectedSharedAuthFailure = async () => {
@@ -378,6 +400,7 @@ async function authenticateGatewayConnectCore(
     role,
     scopes,
     requireBootstrapToken: startupBootstrapConnect,
+    requireDeviceToken: context.handler.operatorDeviceTokenOnly,
     rateLimiter: authRateLimiter,
     clientIp: browserRateLimitClientIp,
     async verifyBootstrapToken({
@@ -524,13 +547,15 @@ async function authenticateGatewayConnectCore(
     scopes = applyConnectionScopeCap({ scopes, upgradeReq });
     connectParams.scopes = scopes;
   }
-  const controlUiPairingKind = shouldSkipControlUiPairing({
-    isControlUi,
-    device,
-    role,
-    authMode: resolvedAuth.mode,
-    authMethod,
-  });
+  const controlUiPairingKind = context.handler.operatorDeviceTokenOnly
+    ? null
+    : shouldSkipControlUiPairing({
+        isControlUi,
+        device,
+        role,
+        authMode: resolvedAuth.mode,
+        authMethod,
+      });
 
   return {
     resolvedAuth,

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -10,7 +10,7 @@ import {
   ConnectErrorDetailCodes,
   type ConnectPairingRequiredReason,
 } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
-import { ErrorCodes, errorShape } from "../../../../packages/gateway-protocol/src/index.js";
+import { ErrorCodes } from "../../../../packages/gateway-protocol/src/index.js";
 import { getRuntimeConfigSnapshot } from "../../../config/runtime-snapshot.js";
 import {
   approveBootstrapDevicePairing,
@@ -65,14 +65,12 @@ export async function authorizeGatewayConnectDevice(
     connId,
     buildRequestContext,
     close,
-    send,
     setHandshakeState,
     setCloseCause,
     logGateway,
     requestOrigin,
   } = context.handler;
   const {
-    frame,
     connectParams,
     configSnapshot,
     reportedClientIp,
@@ -106,12 +104,11 @@ export async function authorizeGatewayConnectDevice(
     if (closeCause) {
       setCloseCause(closeCause.cause, closeCause.meta);
     }
-    send({
-      type: "res",
-      id: frame.id,
-      ok: false,
-      error: errorShape(ErrorCodes.NOT_PAIRED, message, details ? { details } : undefined),
-    });
+    context.sendHandshakeErrorResponse(
+      ErrorCodes.NOT_PAIRED,
+      message,
+      details ? { details } : undefined,
+    );
     close(1008, truncateCloseReason(closeReason ?? message));
   };
   const roleConfiguredHumanOperator = role === "operator" && Boolean(configSnapshot.gateway?.roles);
@@ -164,6 +161,10 @@ export async function authorizeGatewayConnectDevice(
       reason: ConnectPairingRequiredReason,
       existingPairedDevice: Awaited<ReturnType<typeof getPairedDevice>> | null = null,
     ) => {
+      if (context.handler.operatorDeviceTokenOnly) {
+        failPairingHandshake({ message: "HTTP connections require an already-paired device" });
+        return false;
+      }
       const pairingStateAllowsRequestedAccess = (
         pairedCandidate: Awaited<ReturnType<typeof getPairedDevice>>,
         requestedScopes = scopes,
@@ -550,7 +551,8 @@ export async function authorizeGatewayConnectDevice(
   // Device tokens do not carry profile identity and existing broader grants may be reused.
   // Team-role operators must reauthenticate as their verified person on every connection.
   const { deviceToken, bootstrapDeviceTokens } =
-    roleConfiguredHumanOperator && authResult.user?.trim()
+    context.handler.operatorDeviceTokenOnly ||
+    (roleConfiguredHumanOperator && authResult.user?.trim())
       ? { deviceToken: null, bootstrapDeviceTokens: [] }
       : await issueGatewayConnectDeviceTokens({
           state: { ...state, scopes, handoffBootstrapProfile },

--- a/src/gateway/server/ws-connection/connect-device-proof.ts
+++ b/src/gateway/server/ws-connection/connect-device-proof.ts
@@ -1,6 +1,6 @@
 // Gateway WebSocket device proof binds the signed identity to the connect request.
 import { resolveDeviceAuthConnectErrorDetailCode } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
-import { ErrorCodes, errorShape } from "../../../../packages/gateway-protocol/src/index.js";
+import { ErrorCodes } from "../../../../packages/gateway-protocol/src/index.js";
 import {
   deriveDeviceIdFromPublicKey,
   normalizeDevicePublicKeyBase64Url,
@@ -29,8 +29,8 @@ export function verifyGatewayConnectDeviceProof(
   if (!device) {
     return { ok: true, devicePublicKey: null, deviceAuthPayloadVersion: null };
   }
-  const { frame, connectParams } = context;
-  const { send, close, setHandshakeState, setCloseCause } = context.handler;
+  const { connectParams } = context;
+  const { close, setHandshakeState, setCloseCause } = context.handler;
   const rejectDeviceAuthInvalid = (reason: string, message: string) => {
     emitGatewayAuthSecurityEvent({
       action: "gateway.auth.failed",
@@ -51,13 +51,8 @@ export function verifyGatewayConnectDeviceProof(
       client: connectParams.client.id,
       deviceId: device.id,
     });
-    send({
-      type: "res",
-      id: frame.id,
-      ok: false,
-      error: errorShape(ErrorCodes.INVALID_REQUEST, message, {
-        details: { code: resolveDeviceAuthConnectErrorDetailCode(reason), reason },
-      }),
+    context.sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, message, {
+      details: { code: resolveDeviceAuthConnectErrorDetailCode(reason), reason },
     });
     close(1008, message);
   };

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -48,10 +48,12 @@ import { truncateCloseReason } from "../close-reason.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import {
   rejectGatewayConnectOrigin,
+  HTTP_OPERATOR_SCOPES,
   rejectUnavailableProfileConnect,
   resolveEffectiveConnectionScopes,
   resolveGatewayConnectPolicyFailure,
 } from "./connect-admission.js";
+import { revalidateGatewayOperatorDeviceToken } from "./connect-auth.js";
 import { sendGatewayHello } from "./connect-hello.js";
 import { prepareGatewayNodeConnect } from "./connect-node-session.js";
 import {
@@ -72,10 +74,6 @@ type AuthenticatedNodePairingAdmission = NonNullable<
 > & {
   authenticated: { nodeId: string; publicKey: string; token: string };
 };
-
-function isReleasedVersion(version: string): boolean {
-  return RELEASED_VERSION_RE.test(version);
-}
 
 export async function attachAuthenticatedGatewayConnect(
   context: GatewayConnectPhaseContext,
@@ -99,6 +97,7 @@ export async function attachAuthenticatedGatewayConnect(
     logWsControl,
     requestHost,
     requestOrigin,
+    operatorDeviceTokenOnly,
   } = context.handler;
   const {
     connectParams,
@@ -243,15 +242,16 @@ export async function attachAuthenticatedGatewayConnect(
           context.configSnapshot,
         )
       : undefined;
-  const scopes = rolePolicy
-    ? effectiveScopes.scopes.filter((scope) =>
+  const scopes = effectiveScopes.scopes.filter(
+    (scope) =>
+      (!operatorDeviceTokenOnly || HTTP_OPERATOR_SCOPES.includes(scope)) &&
+      (!rolePolicy ||
         roleScopesAllow({
           role: "operator",
           requestedScopes: [scope],
           allowedScopes: rolePolicy.scopes,
-        }),
-      )
-    : effectiveScopes.scopes;
+        })),
+  );
   state.scopes = scopes;
   connectParams.scopes = scopes;
   const addedIdentityScopes = effectiveScopes.addedIdentityScopes.filter((scope) =>
@@ -484,8 +484,8 @@ export async function attachAuthenticatedGatewayConnect(
         clientVersion &&
         gatewayVersion &&
         clientVersion !== gatewayVersion &&
-        isReleasedVersion(gatewayVersion) &&
-        isReleasedVersion(clientVersion)
+        RELEASED_VERSION_RE.test(gatewayVersion) &&
+        RELEASED_VERSION_RE.test(clientVersion)
       ) {
         logWsControl.info(
           `node version mismatch conn=${connId} client=${formatForLog(clientLabel)} clientVersion=${formatForLog(clientVersion)} gatewayVersion=${gatewayVersion}; closing for supervisor restart`,
@@ -525,6 +525,10 @@ export async function attachAuthenticatedGatewayConnect(
     }
   }
 
+  if (operatorDeviceTokenOnly && !(await revalidateGatewayOperatorDeviceToken(context, state))) {
+    close(4001, "device authorization changed");
+    return;
+  }
   const policyFailure = resolveGatewayConnectPolicyFailure(context, state);
   if (policyFailure) {
     await releasePendingNodePairingCleanup();

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -20,6 +20,9 @@ import type { GatewayConnectionWork } from "../../server-connection-work.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import type {
   GatewayConnectionTransport,
+  GatewayConnectionDelivery,
+  GatewayConnectionFrame,
+  GatewayConnectionIngress,
   PrepareGatewayAuthenticatedReceive,
 } from "../connection-transport.js";
 import type { GatewayWsBrowserOrigin, GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
@@ -38,6 +41,10 @@ type WsSendResult = { kind: "sent" | "unavailable" } | { kind: "serialization"; 
 
 export type GatewayWsMessageHandlerParams = {
   socket: GatewayConnectionTransport;
+  /** HTTP transport admission is narrower than the general Gateway handshake. */
+  operatorDeviceTokenOnly?: true;
+  resolveFrameIngress?: (data: GatewayConnectionFrame) => GatewayConnectionIngress;
+  isIngressCurrent?: () => boolean;
   prepareAuthenticatedReceive: PrepareGatewayAuthenticatedReceive;
   connectionWork: GatewayConnectionWork;
   upgradeReq: IncomingMessage;
@@ -73,7 +80,7 @@ export type GatewayWsMessageHandlerParams = {
   buildRequestContext: () => GatewayRequestContext;
   nodeLifecycleDispatch: GatewayNodeLifecycleDispatchTracker;
   refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
-  send: (obj: unknown) => WsSendResult;
+  send: (obj: unknown, delivery?: GatewayConnectionDelivery) => WsSendResult;
   close: (code?: number, reason?: string) => void;
   isClosed: () => boolean;
   clearHandshakeTimer: () => void;
@@ -113,7 +120,7 @@ export type GatewayConnectPhaseContext = {
     message: string,
     options?: Parameters<typeof errorShape>[2],
   ) => void;
-  sendFrame: (obj: unknown) => Promise<void>;
+  sendFrame: (obj: unknown, delivery?: GatewayConnectionDelivery) => Promise<void>;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
   runDetachedConnectWork: (run: () => Promise<void>, onError: (error: unknown) => void) => void;
   pendingNodePairingCleanup: {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -41,7 +41,11 @@ import { resolveNodePairingClientIpSource } from "../../node-pairing-auto-approv
 import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
-import type { GatewayConnectionFrame } from "../connection-transport.js";
+import {
+  sendGatewayConnectionFrame,
+  type GatewayConnectionDelivery,
+  type GatewayConnectionFrame,
+} from "../connection-transport.js";
 import { resolveGatewayWsBrowserOrigin } from "../ws-origin-policy.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
 import { isStartupNodeConnect } from "./connect-admission.js";
@@ -53,10 +57,7 @@ import type {
   GatewayConnectPhaseContext,
   GatewayWsMessageHandlerParams,
 } from "./message-handler-types.js";
-export type {
-  GatewayWsMessageHandlerParams,
-  WsOriginCheckMetrics,
-} from "./message-handler-types.js";
+export type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 
 const GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS = 1_000;
 const GATEWAY_WORK_ADMISSION_CLOSE_CODE = 1013;
@@ -78,14 +79,7 @@ function claimsWorkerConnectionIdentity(value: unknown): boolean {
 export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerParams) {
   const {
     socket,
-    ingressAttribution,
     connId,
-    remoteAddr,
-    endpoint,
-    forwardedFor,
-    requestHost,
-    requestOrigin,
-    requestUserAgent,
     rateLimiter,
     browserRateLimiter,
     buildRequestContext,
@@ -100,70 +94,28 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     logWsControl,
   } = params;
 
-  const sendFrame = async (obj: unknown): Promise<void> =>
+  const sendFrame = async (obj: unknown, delivery?: GatewayConnectionDelivery): Promise<void> =>
     await new Promise<void>((resolve, reject) => {
-      socket.send(JSON.stringify(obj), (err) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve();
-      });
+      sendGatewayConnectionFrame(
+        socket,
+        JSON.stringify(obj),
+        (err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        },
+        delivery,
+      );
     });
 
-  const configSnapshot = getRuntimeConfig();
-  const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-  const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
-  const clientIp = ingressAttribution.clientIp;
-  const peerLabel = endpoint ?? remoteAddr ?? "n/a";
-
-  const hasProxyHeaders =
-    ingressAttribution.kind === "trusted-proxy" ||
-    ingressAttribution.kind === "tailscale-serve" ||
-    ingressAttribution.kind === "tailscale-funnel";
-  const remoteIsTrustedProxy =
-    ingressAttribution.kind === "trusted-proxy" ||
-    ingressAttribution.kind === "tailscale-serve" ||
-    ingressAttribution.kind === "tailscale-funnel";
-  const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = ingressAttribution.kind === "direct-local";
-  const reportedClientIp = isLocalClient
-    ? undefined
-    : clientIp && !isLoopbackAddress(clientIp)
-      ? clientIp
-      : undefined;
-  const reportedClientIpSource = resolveNodePairingClientIpSource({
-    reportedClientIp,
-    hasProxyHeaders,
-    remoteIsTrustedProxy,
-    remoteIsLoopback: isLoopbackAddress(remoteAddr),
-  });
-
-  if (!hostIsLocalish && isLoopbackAddress(remoteAddr) && !hasProxyHeaders) {
-    logWsControl.warn(
-      "Loopback connection with non-local Host header. " +
-        "Treating it as remote. If you're behind a reverse proxy, " +
-        "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
-    );
-  }
-
+  const initialConfig = getRuntimeConfig();
   const isWebchatConnect = (p: ConnectParams | null | undefined) => isWebchatClient(p?.client);
   const authenticatedRequestDispatcher = createGatewayAuthenticatedRequestDispatcher({
     handler: params,
     isWebchatConnect,
   });
-  const browserSecurity = resolveHandshakeBrowserSecurityContext({
-    requestOrigin,
-    clientIp: ingressAttribution.rateLimit.subject.key,
-    rateLimiter,
-    browserRateLimiter,
-  });
-  const {
-    hasBrowserOriginHeader,
-    enforceOriginCheckForAnyClient,
-    rateLimitClientIp: browserRateLimitClientIp,
-    authRateLimiter,
-  } = browserSecurity;
   const runDetachedConnectWork = (run: () => Promise<void>, onError: (error: unknown) => void) => {
     // Connect-triggered mutations outlive hello-ok. Give each tail its own
     // root lease so suspension cannot report ready while one is still active.
@@ -178,6 +130,83 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     if (isClosed()) {
       return;
     }
+    const ingress = params.resolveFrameIngress?.(data);
+    if (ingress?.isCurrent() === false) {
+      close(4001, "connection ingress changed");
+      return;
+    }
+    const header = (name: string) => {
+      const value = ingress?.request.headers[name];
+      return Array.isArray(value) ? value[0] : value;
+    };
+    const handler = ingress
+      ? {
+          ...params,
+          upgradeReq: ingress.request,
+          ingressAttribution: ingress.attribution,
+          remoteAddr: ingress.request.socket.remoteAddress,
+          forwardedFor: header("x-forwarded-for"),
+          realIp: header("x-real-ip"),
+          requestHost: header("host"),
+          requestOrigin: header("origin"),
+          requestUserAgent: header("user-agent"),
+          isIngressCurrent: ingress.isCurrent,
+        }
+      : params;
+    const {
+      ingressAttribution,
+      remoteAddr,
+      endpoint,
+      forwardedFor,
+      requestHost,
+      requestOrigin,
+      requestUserAgent,
+    } = handler;
+    const configSnapshot = ingress ? getRuntimeConfig() : initialConfig;
+    const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+    const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+    const clientIp = ingressAttribution.clientIp;
+    const peerLabel = endpoint ?? remoteAddr ?? "n/a";
+    const hasProxyHeaders =
+      ingressAttribution.kind === "trusted-proxy" ||
+      ingressAttribution.kind === "tailscale-serve" ||
+      ingressAttribution.kind === "tailscale-funnel";
+    const isLocalClient = ingressAttribution.kind === "direct-local";
+    const reportedClientIp = isLocalClient
+      ? undefined
+      : clientIp && !isLoopbackAddress(clientIp)
+        ? clientIp
+        : undefined;
+    const reportedClientIpSource = resolveNodePairingClientIpSource({
+      reportedClientIp,
+      hasProxyHeaders,
+      remoteIsTrustedProxy: hasProxyHeaders,
+      remoteIsLoopback: isLoopbackAddress(remoteAddr),
+    });
+    if (
+      !getClient() &&
+      !isLocalishHost(requestHost) &&
+      isLoopbackAddress(remoteAddr) &&
+      !hasProxyHeaders
+    ) {
+      logWsControl.warn(
+        "Loopback connection with non-local Host header. " +
+          "Treating it as remote. If you're behind a reverse proxy, " +
+          "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
+      );
+    }
+    const {
+      hasBrowserOriginHeader,
+      enforceOriginCheckForAnyClient,
+      rateLimitClientIp: browserRateLimitClientIp,
+      authRateLimiter,
+    } = resolveHandshakeBrowserSecurityContext({
+      requestOrigin,
+      clientIp: ingressAttribution.rateLimit.subject.key,
+      rateLimiter,
+      browserRateLimiter,
+    });
+    const delivery = { isCurrent: ingress?.isCurrent };
 
     const preauthPayloadBytes = !getClient() ? rawDataByteLength(data) : undefined;
     if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
@@ -296,12 +325,15 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           });
           if (isRequestFrame) {
             const req = parsed;
-            send({
-              type: "res",
-              id: req.id,
-              ok: false,
-              error: errorShape(ErrorCodes.INVALID_REQUEST, handshakeError),
-            });
+            send(
+              {
+                type: "res",
+                id: req.id,
+                ok: false,
+                error: errorShape(ErrorCodes.INVALID_REQUEST, handshakeError),
+              },
+              { ...delivery, rejectedHandshake: true },
+            );
           } else {
             logWsControl.warn(
               `invalid handshake conn=${connId} peer=${formatForLog(peerLabel)} remote=${remoteAddr ?? "?"} fwd=${formatForLog(forwardedFor ?? "n/a")} origin=${formatForLog(requestOrigin ?? "n/a")} host=${formatForLog(requestHost ?? "n/a")} ua=${formatForLog(requestUserAgent ?? "n/a")}`,
@@ -339,16 +371,19 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           message: string,
           options?: Parameters<typeof errorShape>[2],
         ) => {
-          send({
-            type: "res",
-            id: frame.id,
-            ok: false,
-            error: errorShape(code, message, options),
-          });
+          send(
+            {
+              type: "res",
+              id: frame.id,
+              ok: false,
+              error: errorShape(code, message, options),
+            },
+            { ...delivery, rejectedHandshake: true },
+          );
         };
 
         const phaseContext = {
-          handler: params,
+          handler,
           frame,
           connectParams,
           configSnapshot,
@@ -373,7 +408,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           clientMeta,
           markHandshakeFailure,
           sendHandshakeErrorResponse,
-          sendFrame,
+          sendFrame: (obj: unknown, options?: GatewayConnectionDelivery) =>
+            sendFrame(obj, { ...delivery, ...options }),
           isWebchatConnect,
           runDetachedConnectWork,
           pendingNodePairingCleanup,
@@ -396,6 +432,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         client,
         rawDataByteLength(data),
         admission,
+        ingress?.isCurrent,
       );
     } catch (err) {
       await releasePendingNodePairingCleanup();
@@ -463,20 +500,27 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       method: "connect",
       phase,
     });
-    await sendFrame({
-      type: "res",
-      id: parsed.id,
-      ok: false,
-      error: errorShape(ErrorCodes.UNAVAILABLE, `connect unavailable during gateway ${operation}`, {
-        retryable: true,
-        retryAfterMs: GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS,
-        details: {
-          method: "connect",
-          reason,
-          phase,
-        },
-      }),
-    }).catch(() => {});
+    await sendFrame(
+      {
+        type: "res",
+        id: parsed.id,
+        ok: false,
+        error: errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `connect unavailable during gateway ${operation}`,
+          {
+            retryable: true,
+            retryAfterMs: GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS,
+            details: {
+              method: "connect",
+              reason,
+              phase,
+            },
+          },
+        ),
+      },
+      { rejectedHandshake: true },
+    ).catch(() => {});
     queueMicrotask(() =>
       close(GATEWAY_WORK_ADMISSION_CLOSE_CODE, `gateway ${operation} in progress`),
     );


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/142916

Stack base: https://github.com/openclaw/openclaw/pull/142931

Current qualification: **draft, not merge-ready**. Signed `79ac553afc522863f453308687bfbb446f188c2a` adds executed sequential HTTP chat/approval effects across scope upgrade and established-connection revocation. All 15 tests in the final full-file run passed. Concurrent admission invalidation remains unexecuted, and earlier fixture RPC timeouts remain unexplained.

## What Problem This Solves

Already-paired watch clients need direct conversation and approval access over HTTPS without duplicating Gateway authentication or requiring an ordinary WebSocket connection.

This is the second PR in the Gateway/Apple Watch stack tracked in https://github.com/openclaw/openclaw/issues/142916. Native watch onboarding and conversation UI follow separately.

## Why This Change Was Made

Add bounded, in-memory operator connections at `<basePath>/api/operator/connections`, using the connection owner extracted by the parent PR. Begin returns a challenge; subsequent authenticated HTTP requests carry ordinary Gateway frames, ordered submission sequences, and cumulative output acknowledgments.

Admission requires a signed, already-paired device and explicit device-token authentication. The transport permits only read, write, approval, and Talk scopes. Shared secrets, bootstrap credentials, ambient proxy authentication, administrative scopes, and pairing scopes cannot replace that contract. Existing method authorization and device invalidation remain authoritative.

Each request retains its actual prepared ingress through awaited work. Queued authenticated output is discarded on retirement. Poll cancellation does not cancel accepted RPCs; uncertain submissions can be retried only within the same logical connection. Approved replacement credentials must be saved before acknowledgment or reconnect.

Rejected connections retain their per-IP capacity charge until final removal. Expiry, termination, failed delivery, and reentrant cleanup settle outstanding callbacks and release owned resources.

## User Impact

Already-paired clients can use the documented HTTPS transport without a second authentication or RPC policy. HTTPS is required except on direct loopback. Strict ingress binding deliberately requires reconnecting after an IP or forwarding-policy change; seamless network handoff is not claimed.

This does not provision watch credentials, redeem setup codes, change persistence, add configuration options, change protocol versions, or enable independent-app metadata. All connection keys, queues, and sequence state are ephemeral. Physical-watch and background qualification remain separate.

Production delta against the corrected foundation: +1,174/-185, net +989 lines, supplying the new HTTP ingress, bounded transport lifecycle, and canonical authority/delivery integration. Tests add 1,158 lines; docs are +128/-1. No exemptions or baselines were weakened.

## Evidence

- 265 regression tests passed across 26 files, including WebSocket operator/node/worker paths, auth rotation, scope upgrades, admission, dispatch lifetime, and the existing 21 Watch HTTP tests.
- The final behavioral rerun passed 54 tests across eight files, including the new HTTP transport, ambient-auth rejection, capacity accounting, cancellation, replay, and existing HTTP/connection consumers. These counts overlap and are not additive.
- The retained-preauth-capacity and reentrant-removal regressions were reproduced failing before repair and passed afterward.
- Current production types, both Gateway test-type shards, core boundary checks, targeted lint, dead-export scans, MDX validation, and `git diff --check` passed.
- `pnpm build` passed before the final type-only checks and unused-export removal; current types, lint, and export checks passed afterward.
- Fresh autoreview and its required secret scans passed on the final candidate, with no P0 findings.
- The original feature candidate and independently installed proof checkout had identical changed source for the behavioral validation above.
- The foundation's static CI correction is integrated at `ba88244d42ff56aaa4c7afeaf97d19c5ec241d99`, preserving the original signed feature commit. The sole merge conflict retained HTTP ingress attribution and switched the role import to the dependency-free type owner. Strict typechecking, formatting, role-import checks, and whitespace validation passed; executable behavior is unchanged.

- Signed `79ac553afc522863f453308687bfbb446f188c2a` adds 300 test lines and no production changes. The real Gateway and dispatcher reject chat and approval mutations under limited scopes, then persist actual user/assistant history and an approval decision after a rotated grant is approved and the same device reconnects. After established-connection revocation, fresh correctly sequenced HTTP frames receive 410 without changing history or the pending approval. Only reply generation is stubbed; the approval fixture never executes a command or delivers externally. Existing cancellation, replay, and policy-fencing tests remain unchanged.
- The final uninstrumented candidate passed all 15 tests in the original full-file order in 150.75 seconds; the effects matrix completed in 8.817 seconds, including cleanup. The parent and independently installed proof checkout matched byte-for-byte. Final Gateway test types, targeted lint, formatting, and whitespace checks passed. Independent plan review and one frozen P0 autoreview found no blocker; the complete outgoing-object secret scan found no credentials. These counts overlap the earlier runs and are not additive.
- Earlier iterations encountered 10-second `sessions.create` and `sessions.delete` fixture RPC timeouts. Their cause remains unexplained: no production repair, timeout increase, prewarming, or claim of flakiness is made. Temporary passive preparation diagnostics were removed before the single final run. Primary and cleanup failures are now reported separately so teardown cannot mask a body failure.

The complete `check:changed` pipeline was not rerun end-to-end after its intermediate failures; the affected checks passed separately. No exact-head CI, physical-watch behavior, or performance improvement is claimed by this draft.

### Remaining Qualification

Concurrent credential invalidation between verification and connection registration still needs an executed regression in the original execution order. The additional qualification attempt could not execute on the available testing backend. Existing established-connection revocation tests do not prove this admission interleaving. No reproduced defect or passing result is claimed for that gap; this PR remains draft.

Security-operations owner review is requested for the bounded contract: signed, already-paired device-token admission; the read/write/approvals/Talk scope ceiling; prepared-ingress and logical-connection binding; and revocation, retirement, and bounded resource cleanup. The owner is asked to specify the required disposition of the missing verification-to-registration proof before merge. This request records no completed owner review, approval, or waiver of that proof.
