### PR TITLE
improve(plugins): reuse metadata during contribution discovery

### DIFF
--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -11,8 +11,10 @@ import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import {
   loadPluginManifestRegistryForPluginRegistry,
+  listPluginContributionIds,
   resolveManifestContractOwnerPluginId,
   resolveManifestContractPluginIds,
+  resolvePluginContributionOwners,
 } from "./plugin-registry-contributions.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { buildDeclaredProviderOwnerIndex } from "./provider-owner-index.js";
@@ -105,6 +107,43 @@ function createSnapshot(params: {
 }
 
 describe("loadPluginManifestRegistryForPluginRegistry current snapshot", () => {
+  it("reuses current manifests for contribution listing and owner lookup", () => {
+    const config: OpenClawConfig = {
+      plugins: { entries: { disabled: { enabled: false } } },
+    };
+    const env = {
+      HOME: "/tmp/openclaw-test-home",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    };
+    const workspaceDir = "/workspace";
+    setCurrentPluginMetadataSnapshot(createSnapshot({ config, workspaceDir }), {
+      config,
+      env,
+      workspaceDir,
+    });
+    const readFile = vi.spyOn(fs, "readFileSync");
+    const readDirectory = vi.spyOn(fs, "readdirSync");
+    const statFile = vi.spyOn(fs, "statSync");
+    const lstatFile = vi.spyOn(fs, "lstatSync");
+    const openFile = vi.spyOn(fs, "openSync");
+    const params = { config, env, workspaceDir, contribution: "contracts" as const };
+
+    const ids = listPluginContributionIds(params);
+    const owners = resolvePluginContributionOwners({ ...params, matches: "webSearchProviders" });
+    const allOwners = resolvePluginContributionOwners({
+      ...params,
+      matches: "webSearchProviders",
+      includeDisabled: true,
+    });
+
+    for (const read of [readFile, readDirectory, statFile, lstatFile, openFile]) {
+      expect(read).not.toHaveBeenCalled();
+    }
+    expect(ids).toEqual(["webSearchProviders"]);
+    expect(owners).toEqual(["enabled"]);
+    expect(allOwners).toEqual(["disabled", "enabled"]);
+  });
+
   it("reuses an allowlisted published snapshot for configless manifest reads", () => {
     const config: OpenClawConfig = { plugins: { allow: ["enabled"] } };
     const env = {

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -25,7 +25,6 @@ import {
   type PluginRegistryIdNormalizerOptions,
 } from "./plugin-registry-id-normalizer.js";
 import {
-  loadPluginRegistrySnapshot,
   loadPluginRegistrySnapshotWithMetadata,
   type LoadPluginRegistryParams,
   type PluginRegistrySnapshot,
@@ -136,40 +135,26 @@ function createContributionPluginFilter(
   return createInstalledPluginEnabledPredicate(index.plugins, params.config, params.env);
 }
 
-function loadContributionManifestRegistry(
-  params: LoadPluginRegistryParams & {
-    index: PluginRegistrySnapshot;
-    includeDisabled?: boolean;
-  },
-): PluginManifestRegistry {
-  const pluginIds = params.index.plugins.map((plugin) => plugin.pluginId);
+function listContributionManifestPlugins(
+  params: PluginRegistryContributionOptions,
+): readonly PluginManifestRecord[] {
+  const lookUpTable = params.lookUpTable;
+  if (lookUpTable) {
+    const includePlugin = createContributionPluginFilter(params, lookUpTable.index);
+    return lookUpTable.plugins.filter((plugin) => includePlugin(plugin.id));
+  }
+  const { snapshot: index, manifestRegistry } = loadPluginRegistrySnapshotWithMetadata(params);
+  const pluginIds = index.plugins.map((plugin) => plugin.pluginId);
   return loadPluginManifestRegistryForInstalledIndex({
-    index: params.index,
+    index,
+    manifestRegistry,
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
     pluginIds: params.includeDisabled
       ? pluginIds
-      : pluginIds.filter(
-          createInstalledPluginEnabledPredicate(params.index.plugins, params.config, params.env),
-        ),
+      : pluginIds.filter(createContributionPluginFilter(params, index)),
     includeDisabled: true,
-  });
-}
-
-function listContributionManifestPlugins(
-  params: PluginRegistryContributionOptions & {
-    index: PluginRegistrySnapshot;
-  },
-): readonly PluginManifestRecord[] {
-  const plugins = params.lookUpTable?.plugins;
-  if (plugins) {
-    const includePlugin = createContributionPluginFilter(params, params.index);
-    return plugins.filter((plugin) => includePlugin(plugin.id));
-  }
-  return loadContributionManifestRegistry({
-    ...params,
-    index: params.index,
   }).plugins;
 }
 
@@ -205,8 +190,7 @@ export function normalizePluginsConfigWithRegistry(
 export function listPluginContributionIds(
   params: ListPluginContributionIdsParams,
 ): readonly string[] {
-  const index = params.lookUpTable?.index ?? loadPluginRegistrySnapshot(params);
-  const plugins = listContributionManifestPlugins({ ...params, index });
+  const plugins = listContributionManifestPlugins(params);
   return normalizeSortedUniqueStringEntries(
     plugins.flatMap((plugin) => listPluginManifestContributionIds(plugin, params.contribution)),
   );
@@ -215,8 +199,8 @@ export function listPluginContributionIds(
 export function resolvePluginContributionOwners(
   params: ResolvePluginContributionOwnersParams,
 ): readonly string[] {
-  const index = params.lookUpTable?.index ?? loadPluginRegistrySnapshot(params);
   if (params.lookUpTable && typeof params.matches === "string") {
+    const index = params.lookUpTable.index;
     const owners = params.lookUpTable.owners[params.contribution].get(params.matches);
     if (!owners) {
       return [];
@@ -229,7 +213,7 @@ export function resolvePluginContributionOwners(
     typeof params.matches === "string"
       ? (contributionId: string) => contributionId === params.matches
       : params.matches;
-  const plugins = listContributionManifestPlugins({ ...params, index });
+  const plugins = listContributionManifestPlugins(params);
   return normalizeSortedUniqueStringEntries(
     plugins.flatMap((plugin) =>
       listPluginManifestContributionIds(plugin, params.contribution).some(matcher)


### PR DESCRIPTION
## What Problem This Solves

Plugin contribution discovery could recheck manifest files even when a matching metadata snapshot was already available. This adds unnecessary work to callers such as channel setup, which asks for installed channel IDs without supplying its own lookup table.

## Why This Change Was Made

Contribution lookup now carries the installed index and its prepared manifest registry together through the existing adapter. One shared selection path replaces a private wrapper and duplicate index loads, removing 16 production lines. Current enablement policy, disabled-owner inspection, raw declarations, indexed aliases, and explicit-index fallback retain their existing behavior.

## User Impact

Metadata-backed contribution discovery reuses the published inventory without checking its manifest files again. Channel and provider selection remain unchanged; this change adds no configuration or cache. No end-to-end timing improvement is claimed.

## Evidence

The regression failed on the previous code because contribution lookups performed two filesystem checks against already-published manifests. The identical test passes after the repair and checks both the returned IDs/owners and the absence of filesystem access. All 93 cases across five owner and sibling suites passed, including explicit-index reconstruction, raw/indexed matching, and enablement-policy controls.

Independent review found no actionable P0–P2 issue.

All 29 selected changed-file checks passed.

Related: #141193, #142818.
