### PR TITLE
fix(tests): close reloaded token fixture database caches

### DIFF
--- a/src/gateway/agent-runtime-identity-token.test.ts
+++ b/src/gateway/agent-runtime-identity-token.test.ts
@@ -22,6 +22,7 @@ import {
 const envSnapshot = captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
 
 const tempHomes: string[] = [];
+const reloadedStateDatabaseClosers = new Set<() => void>();
 
 function operationalRun(runId = "run-1") {
   const operationalRunInstance = { instanceId: `instance-${runId}`, runId } as const;
@@ -76,7 +77,10 @@ async function importRuntimeTokenModule(): Promise<
   typeof import("./agent-runtime-identity-token.js")
 > {
   vi.resetModules();
-  return await import("./agent-runtime-identity-token.js");
+  const runtimeToken = await import("./agent-runtime-identity-token.js");
+  const stateDb = await import("../state/openclaw-state-db.js");
+  reloadedStateDatabaseClosers.add(stateDb.closeOpenClawStateDatabaseForTest);
+  return runtimeToken;
 }
 
 function validateDelegatedAuthority(
@@ -95,6 +99,10 @@ function validateDelegatedAuthority(
 afterEach(() => {
   resetAgentRunRegistryForTest();
   closeOpenClawStateDatabaseForTest();
+  for (const closeDatabase of reloadedStateDatabaseClosers) {
+    closeDatabase();
+  }
+  reloadedStateDatabaseClosers.clear();
   execApprovalsStoreTesting.reset();
   vi.resetModules();
   envSnapshot.restore();

--- a/src/gateway/operator-approval-runtime-token.test.ts
+++ b/src/gateway/operator-approval-runtime-token.test.ts
@@ -11,6 +11,7 @@ import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 const envSnapshot = captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
 
 const tempHomes: string[] = [];
+const reloadedStateDatabaseClosers = new Set<() => void>();
 
 function useTempHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approval-runtime-"));
@@ -42,11 +43,18 @@ async function importRuntimeTokenModule(): Promise<
   typeof import("./operator-approval-runtime-token.js")
 > {
   vi.resetModules();
-  return await import("./operator-approval-runtime-token.js");
+  const runtimeToken = await import("./operator-approval-runtime-token.js");
+  const stateDb = await import("../state/openclaw-state-db.js");
+  reloadedStateDatabaseClosers.add(stateDb.closeOpenClawStateDatabaseForTest);
+  return runtimeToken;
 }
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  for (const closeDatabase of reloadedStateDatabaseClosers) {
+    closeDatabase();
+  }
+  reloadedStateDatabaseClosers.clear();
   execApprovalsStoreTesting.reset();
   vi.resetModules();
   envSnapshot.restore();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Gateway token tests reload modules to exercise restart boundaries, but teardown closes only the database cache imported before those resets. Reloaded cache generations can retain live SQLite handles when the temporary fixture directories are removed.

## Why This Change Was Made

Track the state-database closer from every reloaded token-module generation and invoke all of them before module reset and directory removal. Retain the original static closer because that cache is also used. Multi-import cases close every acquired generation, not just the latest one.

## User Impact

No production behavior change. This repairs resource ownership in two test fixtures and adds 16 net test lines. SQLite storage semantics, maintenance timers and the WAL safety tripwire are unchanged.

## Evidence

- Both complete suites passed normally before and after: 20 cases with identical per-file order.
- Original-generation observations found 21 live reloaded handles after the old closer across 19 cases, including two cases with multiple generations.
- Candidate diagnostic copies passed all 20 cases and verified the same observed handles were closed before unlink and before emergency cleanup. Observers did not proactively open databases; all temporary copies and roots were removed afterward.
- Full mapped changed checks, diff-scoped cleanup and fresh independent P2 review passed with no findings.

Local proof used Node 24.20 on macOS. This confirms the fixture cleanup bug; it does not identify the exact database behind the previously captured Linux WAL tripwire event. No runtime improvement is claimed.
