### PR TITLE
fix(ci): run Android emulator workflows on Ubuntu KVM

### DIFF
--- a/.github/workflows/android-beta-release.yml
+++ b/.github/workflows/android-beta-release.yml
@@ -96,7 +96,7 @@ jobs:
       actions: read
       attestations: read
       contents: read
-    runs-on: macos-26-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: android-beta-release
     concurrency:
@@ -134,6 +134,40 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Prepare trusted Linux Android tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS/$RUNNER_ARCH" = "Linux/X64"
+          for executable in /usr/bin/apt-get /usr/bin/sudo /usr/bin/timeout; do
+            test -x "$executable"
+          done
+          /usr/bin/timeout --signal=TERM --kill-after=10s 300s \
+            /usr/bin/sudo env DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update
+          /usr/bin/timeout --signal=TERM --kill-after=10s 300s \
+            /usr/bin/sudo env DEBIAN_FRONTEND=noninteractive \
+            /usr/bin/apt-get install -y --no-install-recommends acl imagemagick
+          test -x /usr/bin/convert
+          test -x /usr/bin/identify
+
+          trusted_root="apps/android/build/mobile-release-ci/authority"
+          adapter_path="scripts/android-sips-linux.sh"
+          test "$(git -C "$trusted_root" rev-parse HEAD)" = "$GITHUB_WORKFLOW_SHA"
+          read -r adapter_mode adapter_type adapter_oid adapter_name < <(
+            git -C "$trusted_root" ls-tree HEAD -- "$adapter_path"
+          )
+          if [[ "$adapter_mode" != "100755" || "$adapter_type" != "blob" ||
+            "$adapter_name" != "$adapter_path" ]]; then
+            echo "::error::Trusted Linux screenshot adapter is not a committed executable file"
+            exit 1
+          fi
+          tool_dir="$RUNNER_TEMP/openclaw-android-tools"
+          adapter="$tool_dir/android-sips-linux.sh"
+          mkdir -p "$tool_dir"
+          git -C "$trusted_root" cat-file blob "$adapter_oid" >"$adapter"
+          chmod 700 "$adapter"
+          cmp -s "$trusted_root/$adapter_path" "$adapter"
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -147,8 +181,50 @@ jobs:
           cache-mode: off
           install-screenshot-emulators: "true"
 
-      - name: Verify Android emulator acceleration
-        run: emulator -accel-check
+      - name: Verify Linux KVM acceleration
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_kvm_acceleration() {
+            local output_file="$1"
+            local raw_output="${output_file}.raw"
+            local accel_status
+            local accel_timed_out=false
+
+            if /usr/bin/timeout --signal=TERM --kill-after=2s 15s \
+              emulator -accel-check >"$raw_output" 2>&1; then
+              accel_status=0
+            else
+              accel_status=$?
+            fi
+            if [[ "$accel_status" == "124" || "$accel_status" == "137" ]]; then
+              accel_timed_out=true
+            fi
+            head -c 16384 "$raw_output" >"$output_file"
+            rm -f "$raw_output"
+            {
+              printf '\nexit_status=%s\n' "$accel_status"
+              printf 'timed_out=%s\n' "$accel_timed_out"
+            } >>"$output_file"
+            cat "$output_file"
+            if [[ "$accel_status" -ne 0 || "$accel_timed_out" != "false" ]]; then
+              echo "::error::Android emulator acceleration check failed"
+              return 1
+            fi
+            if ! grep -Eiq '\bKVM\b.*\b(available|usable)\b' "$output_file"; then
+              echo "::error::Android emulator did not confirm usable KVM acceleration"
+              return 1
+            fi
+          }
+
+          test "$RUNNER_OS/$RUNNER_ARCH" = "Linux/X64"
+          test -c /dev/kvm
+          current_user="$(id -un)"
+          /usr/bin/sudo /usr/bin/setfacl -m "u:${current_user}:rw" /dev/kvm
+          /usr/bin/getfacl -cp /dev/kvm | grep -Fqx "user:${current_user}:rw-"
+          KVM_DEVICE=/dev/kvm /bin/bash -c \
+            'test -c "$KVM_DEVICE" && test -r "$KVM_DEVICE" && test -w "$KVM_DEVICE"'
+          verify_kvm_acceleration "$RUNNER_TEMP/android-emulator-kvm-check.txt"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
@@ -266,6 +342,7 @@ jobs:
           OPENCLAW_MOBILE_RELEASE_INTENT_PATH: ${{ runner.temp }}/mobile-release-intent-android/intent.json
           OPENCLAW_MOBILE_RELEASE_REF_MODE: intent
           OPENCLAW_MOBILE_RELEASE_TARGET_REF: ${{ needs.authorize.outputs.target_ref }}
+          SIPS: ${{ runner.temp }}/openclaw-android-tools/android-sips-linux.sh
           SUPPLY_CHANGES_NOT_SENT_FOR_REVIEW: "true"
           SUPPLY_RESCUE_CHANGES_NOT_SENT_FOR_REVIEW: "false"
         run: |

--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -87,7 +87,7 @@ jobs:
 
   diagnose:
     needs: validate-target
-    runs-on: macos-26-intel
+    runs-on: macos-26-large
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/android-emulator-diagnostic.yml
+++ b/.github/workflows/android-emulator-diagnostic.yml
@@ -87,7 +87,7 @@ jobs:
 
   diagnose:
     needs: validate-target
-    runs-on: macos-26-large
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:
       contents: read
@@ -113,11 +113,11 @@ jobs:
             printf 'runner_arch=%s\n' "$RUNNER_ARCH"
             printf 'runner_image=%s\n' "${ImageOS:-unknown}"
             printf 'runner_image_version=%s\n' "${ImageVersion:-unknown}"
-            printf 'host_cpu=%s\n' "$(sysctl -n machdep.cpu.brand_string)"
-            printf 'host_logical_cpus=%s\n' "$(sysctl -n hw.logicalcpu)"
-            printf 'host_memory_bytes=%s\n' "$(sysctl -n hw.memsize)"
+            printf 'host_cpu=%s\n' "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)"
+            printf 'host_logical_cpus=%s\n' "$(getconf _NPROCESSORS_ONLN)"
+            printf 'host_memory_bytes=%s\n' "$(awk '/^MemTotal:/ { printf "%.0f\n", $2 * 1024 }' /proc/meminfo)"
             uname -a
-            sw_vers
+            cat /etc/os-release
           } >"$DIAGNOSTIC_DIR/runner.txt"
 
       - name: Checkout trusted Android tooling
@@ -126,7 +126,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           persist-credentials: false
-          sparse-checkout: .github/actions/setup-android-toolchain
+          sparse-checkout: |
+            .github/actions/setup-android-toolchain
+            scripts/android-sips-linux.sh
           path: .mobile-release-tooling
 
       - name: Setup Android toolchain
@@ -134,6 +136,97 @@ jobs:
         with:
           cache-mode: "off"
           install-screenshot-emulators: "true"
+
+      - name: Prepare trusted Linux Android tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS/$RUNNER_ARCH" = "Linux/X64"
+          for executable in /usr/bin/apt-get /usr/bin/sudo /usr/bin/timeout; do
+            test -x "$executable"
+          done
+          /usr/bin/timeout --signal=TERM --kill-after=10s 300s \
+            /usr/bin/sudo env DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update
+          /usr/bin/timeout --signal=TERM --kill-after=10s 300s \
+            /usr/bin/sudo env DEBIAN_FRONTEND=noninteractive \
+            /usr/bin/apt-get install -y --no-install-recommends acl imagemagick
+          test -x /usr/bin/convert
+          test -x /usr/bin/identify
+
+          trusted_root=".mobile-release-tooling"
+          adapter_path="scripts/android-sips-linux.sh"
+          test "$(git -C "$trusted_root" rev-parse HEAD)" = "$GITHUB_WORKFLOW_SHA"
+          read -r adapter_mode adapter_type adapter_oid adapter_name < <(
+            git -C "$trusted_root" ls-tree HEAD -- "$adapter_path"
+          )
+          if [[ "$adapter_mode" != "100755" || "$adapter_type" != "blob" ||
+            "$adapter_name" != "$adapter_path" ]]; then
+            echo "::error::Trusted Linux screenshot adapter is not a committed executable file"
+            exit 1
+          fi
+          tool_dir="$RUNNER_TEMP/openclaw-android-tools"
+          adapter="$tool_dir/android-sips-linux.sh"
+          mkdir -p "$tool_dir"
+          git -C "$trusted_root" cat-file blob "$adapter_oid" >"$adapter"
+          chmod 700 "$adapter"
+          cmp -s "$trusted_root/$adapter_path" "$adapter"
+
+          smoke_dir="$DIAGNOSTIC_DIR/image-conversion-smoke"
+          mkdir -p "$smoke_dir"
+          for dimensions in 1440x2560 454x454; do
+            /usr/bin/convert -size "$dimensions" 'xc:rgba(24,120,200,0.5)' \
+              "$smoke_dir/input-${dimensions}.png"
+            "$adapter" -s format jpeg -s formatOptions best \
+              "$smoke_dir/input-${dimensions}.png" --out "$smoke_dir/output-${dimensions}.jpg"
+            /usr/bin/identify -ping \
+              -format 'format=%m width=%w height=%h colorspace=%[colorspace] type=%[type] channels=%[channels] quality=%Q\n' \
+              "$smoke_dir/output-${dimensions}.jpg" >"$smoke_dir/output-${dimensions}.txt"
+          done
+
+      - name: Verify Linux KVM acceleration
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_kvm_acceleration() {
+            local output_file="$1"
+            local raw_output="${output_file}.raw"
+            local accel_status
+            local accel_timed_out=false
+
+            if /usr/bin/timeout --signal=TERM --kill-after=2s 15s \
+              emulator -accel-check >"$raw_output" 2>&1; then
+              accel_status=0
+            else
+              accel_status=$?
+            fi
+            if [[ "$accel_status" == "124" || "$accel_status" == "137" ]]; then
+              accel_timed_out=true
+            fi
+            head -c 16384 "$raw_output" >"$output_file"
+            rm -f "$raw_output"
+            {
+              printf '\nexit_status=%s\n' "$accel_status"
+              printf 'timed_out=%s\n' "$accel_timed_out"
+            } >>"$output_file"
+            cat "$output_file"
+            if [[ "$accel_status" -ne 0 || "$accel_timed_out" != "false" ]]; then
+              echo "::error::Android emulator acceleration check failed"
+              return 1
+            fi
+            if ! grep -Eiq '\bKVM\b.*\b(available|usable)\b' "$output_file"; then
+              echo "::error::Android emulator did not confirm usable KVM acceleration"
+              return 1
+            fi
+          }
+
+          test "$RUNNER_OS/$RUNNER_ARCH" = "Linux/X64"
+          test -c /dev/kvm
+          current_user="$(id -un)"
+          /usr/bin/sudo /usr/bin/setfacl -m "u:${current_user}:rw" /dev/kvm
+          /usr/bin/getfacl -cp /dev/kvm | grep -Fqx "user:${current_user}:rw-"
+          KVM_DEVICE=/dev/kvm /bin/bash -c \
+            'test -c "$KVM_DEVICE" && test -r "$KVM_DEVICE" && test -w "$KVM_DEVICE"'
+          verify_kvm_acceleration "$DIAGNOSTIC_DIR/emulator-kvm-check.txt"
 
       - name: Run phone emulator diagnostic
         shell: bash

--- a/scripts/android-sips-linux.sh
+++ b/scripts/android-sips-linux.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+fail() {
+  printf 'android-sips-linux: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+if [[ $# -ne 9 ||
+  "$1" != "-s" || "$2" != "format" || "$3" != "jpeg" ||
+  "$4" != "-s" || "$5" != "formatOptions" || "$6" != "best" ||
+  "$8" != "--out" ]]; then
+  fail "unsupported arguments" 2
+fi
+
+input_path="$7"
+output_path="$9"
+convert_bin="/usr/bin/convert"
+identify_bin="/usr/bin/identify"
+
+[[ "$input_path" == /* && "$output_path" == /* ]] ||
+  fail "input and output paths must be absolute" 2
+[[ "$input_path" != "$output_path" ]] || fail "input and output paths must differ" 2
+[[ -f "$input_path" && ! -L "$input_path" ]] || fail "input is not a regular file"
+[[ ! -e "$output_path" && ! -L "$output_path" ]] || fail "output already exists"
+[[ -d "${output_path%/*}" ]] || fail "output directory does not exist"
+
+[[ -x "$convert_bin" && -x "$identify_bin" ]] ||
+  fail "fixed ImageMagick executables are unavailable" 2
+
+if ! input_dimensions="$("$identify_bin" -ping -format '%w %h' "$input_path" 2>/dev/null)"; then
+  fail "input is not a readable image"
+fi
+read -r input_width input_height extra <<<"$input_dimensions"
+[[ "$input_width" =~ ^[1-9][0-9]*$ && "$input_height" =~ ^[1-9][0-9]*$ && -z "${extra:-}" ]] ||
+  fail "input dimensions are invalid"
+
+umask 077
+temporary_dir="$(mktemp -d "${output_path}.tmp.XXXXXX")"
+temporary_output="$temporary_dir/output.jpg"
+cleanup() {
+  rm -rf "$temporary_dir"
+}
+trap cleanup EXIT
+
+if ! "$convert_bin" "$input_path" \
+  -colorspace sRGB \
+  -background white \
+  -alpha remove \
+  -alpha off \
+  -type TrueColor \
+  -quality 95 \
+  "jpeg:$temporary_output" >/dev/null 2>&1; then
+  fail "ImageMagick conversion failed"
+fi
+
+if ! output_description="$(
+  "$identify_bin" -ping -format '%m|%w|%h|%[colorspace]|%[type]|%[channels]|%Q' \
+    "$temporary_output" 2>/dev/null
+)"; then
+  fail "converted output is not a readable image"
+fi
+IFS='|' read -r output_format output_width output_height output_colorspace \
+  output_type output_channels output_quality <<<"$output_description"
+output_colorspace="$(printf '%s' "$output_colorspace" | tr '[:upper:]' '[:lower:]')"
+output_channels="$(printf '%s' "$output_channels" | tr '[:upper:]' '[:lower:]')"
+
+[[ "$output_format" == "JPEG" ]] || fail "converted output is not JPEG"
+[[ "$output_width" == "$input_width" && "$output_height" == "$input_height" ]] ||
+  fail "converted output dimensions changed"
+[[ "$output_colorspace" == "srgb" ]] || fail "converted output is not sRGB"
+[[ "$output_type" == "TrueColor" ]] || fail "converted output is not true color"
+[[ "$output_channels" != *a* ]] || fail "converted output retained an alpha channel"
+[[ "$output_quality" =~ ^[0-9]+$ && "$output_quality" -ge 90 ]] ||
+  fail "converted output quality is too low"
+
+mv "$temporary_output" "$output_path"

--- a/test/scripts/android-screenshots.test.ts
+++ b/test/scripts/android-screenshots.test.ts
@@ -216,6 +216,9 @@ exit 97
         );
         expect(description.status, description.stderr).toBe(0);
         const [format, size, colorspace, type, channels, quality] = description.stdout.split("|");
+        if (!colorspace || !channels) {
+          throw new Error("Expected JPEG colorspace and channel metadata");
+        }
         expect(format).toBe("JPEG");
         expect(size).toBe(dimensions);
         expect(colorspace.toLowerCase()).toBe("srgb");

--- a/test/scripts/android-screenshots.test.ts
+++ b/test/scripts/android-screenshots.test.ts
@@ -1,16 +1,26 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT = "scripts/android-screenshots.sh";
+const LINUX_SIPS_ADAPTER = "scripts/android-sips-linux.sh";
+const IMAGEMAGICK_CONVERT = "/usr/bin/convert";
+const IMAGEMAGICK_IDENTIFY = "/usr/bin/identify";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runAndroidScreenshots(args: string[], env: NodeJS.ProcessEnv = {}) {
   return spawnSync("bash", [SCRIPT, ...args], {
     encoding: "utf8",
     env: { ...process.env, ...env },
+  });
+}
+
+function runLinuxSipsAdapter(args: string[]) {
+  return spawnSync("bash", [LINUX_SIPS_ADAPTER, ...args], {
+    encoding: "utf8",
+    env: process.env,
   });
 }
 
@@ -147,4 +157,72 @@ exit 97
       "--keep-emulator requires --form-factor phone or --form-factor wear",
     );
   });
+
+  it("rejects unsupported Linux SIPS arguments", () => {
+    const wrongArguments = runLinuxSipsAdapter(["--help"]);
+    expect(wrongArguments.status).toBe(2);
+    expect(wrongArguments.stderr).toContain("unsupported arguments");
+  });
+
+  it.runIf(existsSync(IMAGEMAGICK_CONVERT) && existsSync(IMAGEMAGICK_IDENTIFY))(
+    "converts real phone and Wear PNGs to full-size true-color sRGB JPEGs",
+    () => {
+      const root = tempDirs.make("openclaw android sips real ");
+      const malformedInput = path.join(root, "malformed input.png");
+      const malformedOutput = path.join(root, "malformed output.jpg");
+      writeFileSync(malformedInput, "not an image", "utf8");
+      const malformed = runLinuxSipsAdapter([
+        "-s",
+        "format",
+        "jpeg",
+        "-s",
+        "formatOptions",
+        "best",
+        malformedInput,
+        "--out",
+        malformedOutput,
+      ]);
+      expect(malformed.status).not.toBe(0);
+      expect(malformed.stderr).toContain("input is not a readable image");
+      expect(existsSync(malformedOutput)).toBe(false);
+
+      for (const dimensions of ["1440x2560", "454x454"]) {
+        const input = path.join(root, `input ${dimensions}.png`);
+        const output = path.join(root, `output ${dimensions}.jpg`);
+        const fixture = spawnSync(
+          IMAGEMAGICK_CONVERT,
+          ["-size", dimensions, "xc:rgba(24,120,200,0.5)", input],
+          { encoding: "utf8" },
+        );
+        expect(fixture.status, fixture.stderr).toBe(0);
+
+        const result = runLinuxSipsAdapter([
+          "-s",
+          "format",
+          "jpeg",
+          "-s",
+          "formatOptions",
+          "best",
+          input,
+          "--out",
+          output,
+        ]);
+        expect(result.status, result.stderr).toBe(0);
+
+        const description = spawnSync(
+          IMAGEMAGICK_IDENTIFY,
+          ["-ping", "-format", "%m|%wx%h|%[colorspace]|%[type]|%[channels]|%Q", output],
+          { encoding: "utf8" },
+        );
+        expect(description.status, description.stderr).toBe(0);
+        const [format, size, colorspace, type, channels, quality] = description.stdout.split("|");
+        expect(format).toBe("JPEG");
+        expect(size).toBe(dimensions);
+        expect(colorspace.toLowerCase()).toBe("srgb");
+        expect(type).toBe("TrueColor");
+        expect(channels.toLowerCase()).not.toContain("a");
+        expect(Number(quality)).toBeGreaterThanOrEqual(90);
+      }
+    },
+  );
 });

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -117,6 +117,15 @@ function emptyCommit(repository: string, message: string): string {
   return git(repository, "rev-parse", "HEAD");
 }
 
+function extractKvmFunction(source: string): string {
+  const start = source.indexOf("verify_kvm_acceleration() {");
+  const end = source.indexOf('\n\ntest "$RUNNER_OS/$RUNNER_ARCH"', start);
+  if (start < 0 || end <= start) {
+    throw new Error("missing bounded KVM acceleration function");
+  }
+  return source.slice(start, end);
+}
+
 function writeBaseReleaseFiles(repository: string): void {
   writeFile(repository, "apps/mobile/version.json", '{\n  "version": "2026.9.1"\n}\n');
   writeFile(
@@ -1828,6 +1837,10 @@ describe("mobile release authority", () => {
       (step) => step.name === "Checkout trusted Android tooling",
     );
     const setupIndex = steps.findIndex((step) => step.name === "Setup Android toolchain");
+    const toolingIndex = steps.findIndex(
+      (step) => step.name === "Prepare trusted Linux Android tooling",
+    );
+    const kvmIndex = steps.findIndex((step) => step.name === "Verify Linux KVM acceleration");
     const diagnosticIndex = steps.findIndex(
       (step) => step.name === "Run phone emulator diagnostic",
     );
@@ -1852,7 +1865,7 @@ describe("mobile release authority", () => {
     expect(validationJob["timeout-minutes"]).toBe(5);
     expect(job.permissions).toEqual({ contents: "read" });
     expect(job.needs).toBe("validate-target");
-    expect(job["runs-on"]).toBe("macos-26-large");
+    expect(job["runs-on"]).toBe("ubuntu-24.04");
     expect(job["timeout-minutes"]).toBe(25);
     expect(job.env).toEqual({
       ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180",
@@ -1869,7 +1882,9 @@ describe("mobile release authority", () => {
     expect(initializeIndex).toBe(0);
     expect(trustedCheckoutIndex).toBe(initializeIndex + 1);
     expect(setupIndex).toBe(trustedCheckoutIndex + 1);
-    expect(diagnosticIndex).toBe(setupIndex + 1);
+    expect(toolingIndex).toBe(setupIndex + 1);
+    expect(kvmIndex).toBe(toolingIndex + 1);
+    expect(diagnosticIndex).toBe(kvmIndex + 1);
     expect(artifactIndex).toBe(diagnosticIndex + 1);
     expect(validationSteps[validateIndex]?.env).toEqual({
       TARGET_SHA: "${{ inputs.target_sha }}",
@@ -1887,14 +1902,15 @@ describe("mobile release authority", () => {
       'echo "DIAGNOSTIC_DIR=$DIAGNOSTIC_DIR" >>"$GITHUB_ENV"',
     );
     expect(steps[initializeIndex]?.run).toContain(
-      "printf 'host_cpu=%s\\n' \"$(sysctl -n machdep.cpu.brand_string)\"",
+      "printf 'host_cpu=%s\\n' \"$(awk -F: '/^model name/",
     );
     expect(steps[initializeIndex]?.run).toContain(
-      "printf 'host_logical_cpus=%s\\n' \"$(sysctl -n hw.logicalcpu)\"",
+      "printf 'host_logical_cpus=%s\\n' \"$(getconf _NPROCESSORS_ONLN)\"",
     );
     expect(steps[initializeIndex]?.run).toContain(
-      "printf 'host_memory_bytes=%s\\n' \"$(sysctl -n hw.memsize)\"",
+      "printf 'host_memory_bytes=%s\\n' \"$(awk '/^MemTotal:/",
     );
+    expect(steps[initializeIndex]?.run).toContain("cat /etc/os-release");
     expect(validationSteps[validationTrustedCheckoutIndex]).toMatchObject({
       uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       with: {
@@ -1926,7 +1942,8 @@ describe("mobile release authority", () => {
         ref: "${{ github.workflow_sha }}",
         "fetch-depth": 1,
         "persist-credentials": false,
-        "sparse-checkout": ".github/actions/setup-android-toolchain",
+        "sparse-checkout":
+          ".github/actions/setup-android-toolchain\nscripts/android-sips-linux.sh\n",
         path: ".mobile-release-tooling",
       },
     });
@@ -1938,6 +1955,108 @@ describe("mobile release authority", () => {
       },
     });
     expect(JSON.stringify(steps)).not.toContain("candidate/");
+
+    const tooling = steps[toolingIndex]?.run ?? "";
+    expect(tooling).toContain(
+      "/usr/bin/apt-get install -y --no-install-recommends acl imagemagick",
+    );
+    expect(tooling).toContain(
+      'test "$(git -C "$trusted_root" rev-parse HEAD)" = "$GITHUB_WORKFLOW_SHA"',
+    );
+    expect(tooling).toContain('adapter_path="scripts/android-sips-linux.sh"');
+    expect(tooling).toContain('git -C "$trusted_root" cat-file blob "$adapter_oid" >"$adapter"');
+    expect(tooling).toContain('cmp -s "$trusted_root/$adapter_path" "$adapter"');
+    expect(tooling).toContain('"$adapter" -s format jpeg -s formatOptions best');
+    expect(tooling).toContain("for dimensions in 1440x2560 454x454; do");
+    expect(tooling).toContain(
+      '"$smoke_dir/input-${dimensions}.png" --out "$smoke_dir/output-${dimensions}.jpg"',
+    );
+    expect(tooling).not.toContain("candidate/");
+
+    const kvm = steps[kvmIndex]?.run ?? "";
+    expect(kvm).toContain("verify_kvm_acceleration() {");
+    expect(kvm).toMatch(
+      /\/usr\/bin\/timeout --signal=TERM --kill-after=2s 15s \\\n\s+emulator -accel-check/u,
+    );
+    expect(kvm).not.toContain("--foreground");
+    expect(kvm).toContain("test -c /dev/kvm");
+    expect(kvm).toContain('/usr/bin/sudo /usr/bin/setfacl -m "u:${current_user}:rw" /dev/kvm');
+    expect(kvm).toContain(
+      '\'test -c "$KVM_DEVICE" && test -r "$KVM_DEVICE" && test -w "$KVM_DEVICE"\'',
+    );
+    expect(kvm).toContain("grep -Eiq '\\bKVM\\b.*\\b(available|usable)\\b'");
+    expect(kvm).not.toContain("chmod 666");
+    expect(kvm).not.toContain("-accel off");
+
+    const runKvmFixture = (emulatorSource: string, timeoutMode = "run") => {
+      const root = tempRoots.make("openclaw-android-kvm-");
+      const bin = path.join(root, "bin");
+      const output = path.join(root, "kvm.txt");
+      const sentinel = path.join(root, "sentinel");
+      fs.mkdirSync(bin);
+      const timeout = path.join(bin, "timeout");
+      fs.writeFileSync(
+        timeout,
+        [
+          "#!/bin/bash",
+          "set -euo pipefail",
+          'if [[ "${KVM_TIMEOUT_MODE:-run}" == "timeout" ]]; then exit 124; fi',
+          "shift 3",
+          'exec "$@"',
+          "",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      fs.writeFileSync(path.join(bin, "emulator"), emulatorSource, { mode: 0o755 });
+      const kvmFunction = extractKvmFunction(kvm).replace(
+        "/usr/bin/timeout",
+        '"$TEST_TIMEOUT_BIN"',
+      );
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            kvmFunction,
+            'verify_kvm_acceleration "$KVM_OUTPUT"',
+            'printf "boot-or-signing\\n" >"$KVM_SENTINEL"',
+          ].join("\n"),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            KVM_OUTPUT: output,
+            KVM_SENTINEL: sentinel,
+            KVM_TIMEOUT_MODE: timeoutMode,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            TEST_TIMEOUT_BIN: timeout,
+          },
+          timeout: 5_000,
+        },
+      );
+      return { output: fs.readFileSync(output, "utf8"), result, sentinel };
+    };
+
+    const usableKvm = runKvmFixture(
+      "#!/bin/bash\nprintf 'KVM (version 12) is installed and usable.\\n'\n",
+    );
+    expect(usableKvm.result.status, usableKvm.result.stderr).toBe(0);
+    expect(fs.readFileSync(usableKvm.sentinel, "utf8")).toBe("boot-or-signing\n");
+
+    const unavailableKvm = runKvmFixture(
+      "#!/bin/bash\nprintf 'acceleration unavailable\\n'\nexit 7\n",
+    );
+    expect(unavailableKvm.result.status).not.toBe(0);
+    expect(unavailableKvm.output).toContain("exit_status=7");
+    expect(fs.existsSync(unavailableKvm.sentinel)).toBe(false);
+
+    const timedOutKvm = runKvmFixture("#!/bin/bash\nexit 99\n", "timeout");
+    expect(timedOutKvm.result.status).not.toBe(0);
+    expect(timedOutKvm.output).toContain("exit_status=124");
+    expect(timedOutKvm.output).toContain("timed_out=true");
+    expect(fs.existsSync(timedOutKvm.sentinel)).toBe(false);
 
     const parityScript = validationSteps[parityIndex]?.run ?? "";
     expect(parityScript).toContain("git -C .mobile-release-tooling ls-tree");
@@ -2501,7 +2620,7 @@ fi
         file: ".github/workflows/android-beta-release.yml",
         name: "Android Beta Release",
         platform: "android",
-        releaseRunner: "macos-26-intel",
+        releaseRunner: "ubuntu-24.04",
         signingCheckoutName: "Checkout encrypted Android signing assets",
         signingCheckoutRevalidateName:
           "Revalidate release authority immediately before Android signing checkout",
@@ -2511,6 +2630,8 @@ fi
         setupBeforeSigning: [
           "Setup Node environment",
           "Setup Android toolchain",
+          "Prepare trusted Linux Android tooling",
+          "Verify Linux KVM acceleration",
           "Setup Ruby",
           "Install locked Fastlane bundle",
         ],
@@ -2700,22 +2821,65 @@ fi
       expect(release.steps[recordIndex]?.with?.operation).toBe("record");
 
       if (platform === "android") {
+        const nodeEnvironmentIndex = release.steps.findIndex(
+          (step) => step.name === "Setup Node environment",
+        );
         const androidSetupIndex = release.steps.findIndex(
           (step) => step.name === "Setup Android toolchain",
         );
-        const accelerationCheckIndex = release.steps.findIndex(
-          (step) => step.name === "Verify Android emulator acceleration",
+        const toolingIndex = release.steps.findIndex(
+          (step) => step.name === "Prepare trusted Linux Android tooling",
         );
+        const accelerationCheckIndex = release.steps.findIndex(
+          (step) => step.name === "Verify Linux KVM acceleration",
+        );
+        const toolingStep = release.steps[toolingIndex];
+        const accelerationStep = release.steps[accelerationCheckIndex];
         const rubyStep = release.steps.find((step) => step.name === "Setup Ruby");
         const bundleStep = release.steps.find(
           (step) => step.name === "Install locked Fastlane bundle",
         );
+        const uploadStep = release.steps.find((step) => step.name === "Upload Android beta");
+        expect(toolingIndex).toBeGreaterThanOrEqual(0);
+        expect(toolingIndex).toBeLessThan(nodeEnvironmentIndex);
+        expect(androidSetupIndex).toBe(nodeEnvironmentIndex + 1);
         expect(androidSetupIndex).toBeGreaterThanOrEqual(0);
         expect(accelerationCheckIndex).toBe(androidSetupIndex + 1);
         expect(accelerationCheckIndex).toBeLessThan(signingRevalidateIndex);
-        expect(release.steps[accelerationCheckIndex]?.run?.trim()).toBe("emulator -accel-check");
-        expect(release.steps[accelerationCheckIndex]?.if).toBeUndefined();
-        expect(release.steps[accelerationCheckIndex]?.["continue-on-error"]).toBeUndefined();
+        expect(toolingStep?.run).toContain(
+          "/usr/bin/apt-get install -y --no-install-recommends acl imagemagick",
+        );
+        expect(toolingStep?.run).toContain(
+          'trusted_root="apps/android/build/mobile-release-ci/authority"',
+        );
+        expect(toolingStep?.run).toContain(
+          'test "$(git -C "$trusted_root" rev-parse HEAD)" = "$GITHUB_WORKFLOW_SHA"',
+        );
+        expect(toolingStep?.run).toContain(
+          'git -C "$trusted_root" cat-file blob "$adapter_oid" >"$adapter"',
+        );
+        expect(toolingStep?.run).toContain('cmp -s "$trusted_root/$adapter_path" "$adapter"');
+        expect(toolingStep?.run).not.toContain("$GITHUB_ENV");
+        expect(accelerationStep?.run).toContain("verify_kvm_acceleration() {");
+        expect(extractKvmFunction(accelerationStep?.run ?? "")).toBe(
+          extractKvmFunction(
+            (
+              parse(
+                fs.readFileSync(".github/workflows/android-emulator-diagnostic.yml", "utf8"),
+              ) as {
+                jobs: { diagnose: { steps: Array<{ name: string; run?: string }> } };
+              }
+            ).jobs.diagnose.steps.find((step) => step.name === "Verify Linux KVM acceleration")
+              ?.run ?? "",
+          ),
+        );
+        expect(accelerationStep?.if).toBeUndefined();
+        expect(accelerationStep?.["continue-on-error"]).toBeUndefined();
+        expect(uploadStep?.env).toMatchObject({
+          SIPS: "${{ runner.temp }}/openclaw-android-tools/android-sips-linux.sh",
+        });
+        expect(uploadStep?.env).not.toHaveProperty("OPENCLAW_ANDROID_IMAGEMAGICK_CONVERT");
+        expect(uploadStep?.env).not.toHaveProperty("OPENCLAW_ANDROID_IMAGEMAGICK_IDENTIFY");
         expect(rubyStep?.with).toMatchObject({
           "bundler-cache": false,
           "ruby-version": "3.4.10",

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -1852,7 +1852,7 @@ describe("mobile release authority", () => {
     expect(validationJob["timeout-minutes"]).toBe(5);
     expect(job.permissions).toEqual({ contents: "read" });
     expect(job.needs).toBe("validate-target");
-    expect(job["runs-on"]).toBe("macos-26-intel");
+    expect(job["runs-on"]).toBe("macos-26-large");
     expect(job["timeout-minutes"]).toBe(25);
     expect(job.env).toEqual({
       ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "180",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Android emulator diagnostic and protected beta-release workflow depended on macOS runners even though the Android phone and Wear emulator path can run on standard GitHub-hosted Ubuntu x64 with KVM.

## Why This Change Was Made

Both emulator jobs now use `ubuntu-24.04` and fail closed on Linux/x64 identity, `/dev/kvm` availability, current-user device access, bounded `emulator -accel-check`, and confirmed KVM acceleration before boot. The protected beta workflow performs this admission before signing-token or key access.

A trusted-main Linux image adapter replaces the macOS-only `sips` dependency for the existing fixed screenshot conversion contract. The workflow copies committed adapter bytes from the trusted tooling checkout into runner-owned temporary storage before candidate tooling runs, preserving them across candidate workspace cleanup.

Manual dispatch, exact candidate validation, permissions, protected environment approval, authority and recorder checks, image/toolchain selection, boot arguments, original 180-second readiness gates, permanent diagnostic failure latch, 900-second observation ceiling, cleanup, and artifact retention remain unchanged.

## User Impact

No product behavior or release destination changes. Maintainers can qualify the existing Android phone and Wear screenshot/build path on standard hosted Linux runners without paid macOS capacity. This PR does not authorize an Android release, store upload, production promotion, credential change, or diagnostic dispatch.

## Evidence

- Scope is exactly both Android workflow files, the trusted Linux screenshot adapter, and their two existing test owners.
- Two workflow cases and 13 screenshot cases passed.
- One real ImageMagick conversion case was skipped because the local converter prerequisite was unavailable; it was not reported as passed.
- Actionlint, Bash syntax, formatting, oxlint, and diff checks passed.
- Fresh scoped P0/P1 autoreview: no findings, confidence 0.93.
- The follow-up metadata guard passed the screenshot owner suite and format/diff checks.
- Local TypeScript checking refused the external shared dependency symlink before type analysis. Hosted exact-head test types remain required.
- Local `check:workflows` stopped while its temporary Python environment could not resolve `pre-commit==4.6.2`; the interpreter-versus-index cause is unproven. Hosted exact-head workflow checks remain required.
- Production/tooling LOC: `+256/-9` (net +247), covering two fail-closed KVM admissions and one strict trusted screenshot adapter.
- Test LOC: `+257/-12` (net +245).
- Runtime proof remains pending: hosted Linux KVM use, emulator boot, real image conversion, phone/Wear screenshots, signing, and archive creation are not established by the local tests.
- Frozen release candidate and release authority are unchanged.

Punchcard-Session: calm-meadow-summit-7q
