### PR TITLE
improve(test): reduce npm security scan fixture setup

### DIFF
--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -423,26 +423,31 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
       const fixtureKey = `${packageName}:dangerous-exec:${fixturePath}`;
       const spawnProbe =
         'import { spawn } from "node:child_process";\nspawn(process.execPath, []);\n';
+      const artifacts = new Map<boolean, ReturnType<typeof writePluginArtifact>>();
       for (const context of ["", "release/2026.9.1", "release/2026.9.2", "release/2026.9.3"]) {
         const requiresLegacyDoctor =
           context === "release/2026.9.1" || context === "release/2026.9.2";
-        const artifact = writePluginArtifact({
-          extensionId: "codex",
-          packageName,
-          files: {
-            "src/app-server/transport-stdio.ts": spawnProbe,
-            "src/app-server/sandbox-exec-server/sandbox-child.ts": spawnProbe,
-            "src/app-server/transport-process-snapshot.ts": spawnProbe,
-            ...(requiresLegacyDoctor ? { "src/doctor.ts": spawnProbe } : {}),
-            ...(count === null
-              ? {}
-              : {
-                  [fixturePath]:
-                    'import { spawn } from "node:child_process";\n' +
-                    "spawn(process.execPath, []);\n".repeat(count),
-                }),
-          },
-        });
+        let artifact = artifacts.get(requiresLegacyDoctor);
+        if (!artifact) {
+          artifact = writePluginArtifact({
+            extensionId: "codex",
+            packageName,
+            files: {
+              "src/app-server/transport-stdio.ts": spawnProbe,
+              "src/app-server/sandbox-exec-server/sandbox-child.ts": spawnProbe,
+              "src/app-server/transport-process-snapshot.ts": spawnProbe,
+              ...(requiresLegacyDoctor ? { "src/doctor.ts": spawnProbe } : {}),
+              ...(count === null
+                ? {}
+                : {
+                    [fixturePath]:
+                      'import { spawn } from "node:child_process";\n' +
+                      "spawn(process.execPath, []);\n".repeat(count),
+                  }),
+            },
+          });
+          artifacts.set(requiresLegacyDoctor, artifact);
+        }
         const scanned = await scanPublishablePluginPackages([artifact.artifact], context);
         expect(scanned.scanErrors).toEqual([]);
         const result = scanned.packageResults[0]!;


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`, not a fork. Repository permissions govern
maintainer access; GitHub reports `maintainerCanModify: false`.

</details>

## What Problem This Solves

The plugin npm security-scan tests repeatedly package identical inputs while
checking current and frozen release policies, adding avoidable test setup work.

## Why This Change Was Made

Keep two lazily created npm artifacts within each doctor-test count row, keyed
by whether that release context requires the legacy doctor source. Each context
still runs the real scanner with fresh staging. Artifacts are not shared between
rows, and all assertions and context ordering remain unchanged.

## User Impact

Faster developer test execution, with no product behavior or release-policy
change. The target now performs 8 real npm packs instead of 16, retaining all
16 scans and all 29 tests in the owner file.

## Evidence

- Two alternating full-file baseline/candidate pairs on Linux, with the same
  Node 24.19.0/npm 12.0.2/Git 2.53.0, dependencies and cache policy:
  17.85s -> 15.30s and 18.06s -> 15.29s wall; 29/29 tests passed each time.
  Mean local reduction: 2.66s (14.8%). Unrelated typechecking was active during
  both baseline and candidate samples on this shared host; this is not an
  uncontended measurement or a hosted CI speedup claim.
- Separate diagnostics confirmed 16 -> 8 actual npm pack processes and all
  16 scans. Complete context reports, npm pack reports, packed paths/content,
  source inventories and tarball hashes matched baseline.
- All eight candidate artifacts have independent per-row roots. Reused input
  hashes remain unchanged; every scan still creates and cleans a unique staging
  directory.
- Negative control: collapsing the legacy/non-legacy distinction fails all four
  count rows at the existing frozen-policy assertion.
- Independent P2 autoreview: scoped-clean, no findings.
- Required changed-file gate passed, including root-test typechecking, formatting,
  script linting, targeted test-file linting, and repository guards.
- No production, policy, dependency, coverage, or concurrency changes.
