### PR TITLE
refactor(tests): share cron context-window result fixtures

### DIFF
--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -451,6 +451,26 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
   });
 
   describe("context token fallback", () => {
+    function makeResultWithoutContextWindow() {
+      return {
+        result: {
+          result: {
+            payloads: [{ text: "test output" }],
+            meta: {
+              agentMeta: {
+                provider: "openai",
+                model: "gpt-5.4",
+                agentHarnessId: "codex",
+              },
+            },
+          },
+        },
+        provider: "openai",
+        model: "gpt-5.4",
+        attempts: [],
+      };
+    }
+
     it("prefers the harness-reported runtime window and provenance", async () => {
       const session = makeCronSession({
         sessionEntry: makeCronSessionEntry({
@@ -501,23 +521,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(undefined);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase();
 
@@ -538,23 +542,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(512_000);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase();
 
@@ -575,23 +563,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(512_000);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase();
 
@@ -612,23 +584,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(512_000);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase({
         cfg: {
@@ -662,23 +618,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(undefined);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase();
 
@@ -704,23 +644,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       });
       resolveCronSessionMock.mockReturnValue(session);
       resolveContextTokensForModelMock.mockReturnValue(undefined);
-      runWithModelFallbackMock.mockResolvedValueOnce({
-        result: {
-          result: {
-            payloads: [{ text: "test output" }],
-            meta: {
-              agentMeta: {
-                provider: "openai",
-                model: "gpt-5.4",
-                agentHarnessId: "codex",
-              },
-            },
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.4",
-        attempts: [],
-      });
+      runWithModelFallbackMock.mockResolvedValueOnce(makeResultWithoutContextWindow());
 
       const result = await runSkillFilterCase();
 


### PR DESCRIPTION
## What Problem This Solves

Six cron context-window provenance scenarios repeat the same model-fallback result input, obscuring the session differences each case is testing.

## Why This Change Was Made

Use a narrow local constructor for that exact result shape. It preserves provider, model and harness identity while keeping the context-window fields absent. Every call allocates fresh objects and arrays at the original mock-registration point. Harness defaults and independent expected values remain unchanged.

## User Impact

No production behavior changes. This maintainer-requested test consolidation removes 76 net lines without removing cases or changing context-window policy.

## Evidence

- The complete skill-filter suite passed before and after: 23 cases, zero pending, identical ordered case names and statuses.
- Expanding all six inputs restores the original test syntax. Each call retains six fresh objects and two arrays, preserving values, field absence, key order, descriptors, prototypes and mutation isolation.
- Mapped changed gate, deslop and fresh P2 review passed. No runtime savings are claimed.
