### PR TITLE
docs(channels): split the Microsoft Teams page by reader job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -161,6 +161,7 @@
       - any-glob-to-any-file:
           - "extensions/msteams/**"
           - "docs/channels/msteams.md"
+          - "docs/channels/msteams/**"
 "channel: nextcloud-talk":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -3256,6 +3256,46 @@
     "target": "配置 — 聊天命令"
   },
   {
+    "source": "Microsoft Teams setup",
+    "target": "Microsoft Teams 设置"
+  },
+  {
+    "source": "Microsoft Teams access control",
+    "target": "Microsoft Teams 访问控制"
+  },
+  {
+    "source": "Microsoft Teams authentication",
+    "target": "Microsoft Teams 身份验证"
+  },
+  {
+    "source": "Microsoft Teams manifest and permissions",
+    "target": "Microsoft Teams 清单与权限"
+  },
+  {
+    "source": "Microsoft Teams configuration",
+    "target": "Microsoft Teams 配置"
+  },
+  {
+    "source": "Microsoft Teams message behavior",
+    "target": "Microsoft Teams 消息行为"
+  },
+  {
+    "source": "Microsoft Teams cards and actions",
+    "target": "Microsoft Teams 卡片与操作"
+  },
+  {
+    "source": "Microsoft Teams troubleshooting",
+    "target": "Microsoft Teams 故障排查"
+  },
+  {
+    "source": "Groups",
+    "target": "群组"
+  },
+  {
+    "source": "Security",
+    "target": "安全"
+  },
+  {
     "source": "ACP agents quickstart",
     "target": "ACP 智能体快速上手"
   },

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -5,1120 +5,139 @@ read_when:
 title: "Microsoft Teams"
 ---
 
-Status: text + DM attachments are supported; channel/group file sending requires `sharePointSiteId` + Graph permissions (see [Sending files in group chats](#sending-files-in-group-chats)). Polls and approval prompts are sent via Adaptive Cards. Message actions expose explicit `upload-file` for file-first sends.
-
-## Bundled plugin
-
-Microsoft Teams ships as a bundled plugin in current OpenClaw releases; no separate install is required in the normal packaged build.
-
-On an older build or a custom install that excludes bundled Teams, install the npm package directly:
-
-```bash
-openclaw plugins install @openclaw/msteams
-```
-
-Use the bare package to follow the current official release tag. Pin an exact version only when you need a reproducible install.
-
-Local checkout (running from a git repo):
-
-```bash
-openclaw plugins install ./path/to/local/msteams-plugin
-```
-
-Details: [Plugins](/tools/plugin)
-
-## Quick setup
-
-[`@microsoft/teams.cli`](https://www.npmjs.com/package/@microsoft/teams.cli) handles bot registration, manifest creation, and credential generation in one command.
-
-**1. Install and log in**
-
-```bash
-npm install -g @microsoft/teams.cli@preview
-teams login
-teams status   # verify you're logged in and see your tenant info
-```
-
-<Note>
-The Teams CLI is currently in preview. Commands and flags may change between releases.
-</Note>
-
-**2. Start a tunnel** (Teams cannot reach localhost)
-
-Install and authenticate the devtunnel CLI if needed ([getting started guide](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)).
-
-```bash
-# One-time setup (persistent URL across sessions):
-devtunnel create my-openclaw-bot --allow-anonymous
-devtunnel port create my-openclaw-bot -p 3978 --protocol auto
-
-# Each dev session:
-devtunnel host my-openclaw-bot
-# Your endpoint: https://<tunnel-id>.devtunnels.ms/api/messages
-```
-
-<Note>
-`--allow-anonymous` is required because Teams cannot authenticate with devtunnels. Each incoming bot request is still validated by the Teams SDK.
-</Note>
-
-Alternatives: `ngrok http 3978` or `tailscale funnel 3978` (URLs may change each session).
-
-**3. Create the app**
-
-```bash
-teams app create \
-  --name "OpenClaw" \
-  --endpoint "https://<your-tunnel-url>/api/messages"
-```
-
-This creates an Entra ID (Azure AD) application, generates a client secret, builds and uploads a Teams app manifest (with icons), and registers a Teams-managed bot (no Azure subscription needed). The output includes `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`, and a **Teams App ID**; it also offers to install the app in Teams directly.
-
-**4. Configure OpenClaw** using the credentials from the output:
-
-```json5
-{
-  channels: {
-    msteams: {
-      enabled: true,
-      appId: "<CLIENT_ID>",
-      appPassword: "<CLIENT_SECRET>",
-      tenantId: "<TENANT_ID>",
-      webhook: { port: 3978, path: "/api/messages" },
-    },
-  },
-}
-```
-
-Or use environment variables directly: `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID`.
-
-**5. Install the app in Teams**
-
-`teams app create` prompts you to install the app; select "Install in Teams". To get the install link later:
-
-```bash
-teams app get <teamsAppId> --install-link
-```
-
-**6. Verify everything works**
-
-```bash
-teams app doctor <teamsAppId>
-```
-
-Runs diagnostics across bot registration, AAD app config, manifest validity, and SSO setup.
-
-For production, consider [federated authentication](#federated-authentication-certificate-plus-managed-identity) (certificate or managed identity) instead of client secrets.
-
-<Note>
-Group chats are blocked by default (`channels.msteams.groupPolicy: "allowlist"`). To allow group replies, set `channels.msteams.groupAllowFrom`, or use `groupPolicy: "open"` to allow any member (mention-gated).
-</Note>
-
-## Goals
-
-- Talk to OpenClaw via Teams DMs, group chats, or channels.
-- Keep routing deterministic: replies always go back to the channel they arrived on.
-- Default to safe channel behavior (mentions required unless configured otherwise).
-
-## Config writes
-
-By default, Microsoft Teams can write config updates triggered by `/config set|unset` (requires `commands.config: true`).
-
-Disable with:
-
-```json5
-{
-  channels: { msteams: { configWrites: false } },
-}
-```
-
-## Access control (DMs + groups)
-
-Microsoft Teams has one account per channel configuration. Set policies directly under `channels.msteams`; an `accounts` map is not supported.
-
-**DM access**
-
-- Default: `channels.msteams.dmPolicy = "pairing"`. Unknown senders are ignored until approved.
-- `channels.msteams.allowFrom` should use stable AAD object IDs or static sender access groups such as `accessGroup:core-team`.
-- Do not rely on UPN/display-name matching for allowlists; they can change. OpenClaw disables direct name matching by default; opt in with `channels.msteams.dangerouslyAllowNameMatching: true`.
-- The wizard can resolve names to IDs via Microsoft Graph when credentials allow.
-
-**Group access**
-
-- Default: `channels.msteams.groupPolicy = "allowlist"` (blocked unless you add `groupAllowFrom`). Set `channels.msteams.groupPolicy` explicitly to choose another policy; the root schema default takes precedence over `channels.defaults.groupPolicy`.
-- `channels.msteams.groupAllowFrom` controls which senders, static sender access groups, or group/channel conversation IDs can trigger in group chats/channels (falls back to `channels.msteams.allowFrom`). Conversation IDs can use `19:...@thread.tacv2`, `19:...@thread.v2`, or `19:...@thread.skype`; preserve the exact ID casing. OpenClaw ignores `;messageid=...` suffixes. Conversation IDs never grant personal-DM access.
-- Set `groupPolicy: "open"` to allow any member (still mention-gated by default).
-- To block **all** channels, set `channels.msteams.groupPolicy: "disabled"`.
-
-Example:
-
-```json5
-{
-  channels: {
-    msteams: {
-      groupPolicy: "allowlist",
-      groupAllowFrom: ["00000000-0000-0000-0000-000000000000", "accessGroup:core-team"],
-    },
-  },
-}
-```
-
-**Team + channel allowlist**
-
-- Scope group/channel replies by listing teams and channels under `channels.msteams.teams`.
-- Use stable Teams conversation IDs from Teams links as keys, not mutable display names (see [Team and Channel IDs](#team-and-channel-ids-common-gotcha)).
-- When `groupPolicy="allowlist"` and a teams allowlist is present, only listed teams/channels are accepted (mention-gated).
-- `groupAllowFrom` authorizes group senders, not delegated Graph reads of other channels. If an existing configuration only sets `groupAllowFrom`, keep the default `groupPolicy: "allowlist"` and configure the target under `channels.msteams.teams.<team>.channels`.
-- Alternatively, deliberately set `groupPolicy: "open"` for broader delegated reads. This also admits **any group sender** (still mention-gated by default), so it is less restrictive than a scoped team/channel route.
-- Direct-operator reads and reads in the current conversation do not require an additional team/channel route.
-- The configure wizard accepts `Team/Channel` entries and stores them for you.
-- On startup, OpenClaw resolves team/channel and user allowlist names to IDs (when Graph permissions allow) and logs the mapping. Unresolved names are kept as typed but ignored for routing unless `channels.msteams.dangerouslyAllowNameMatching: true` is set.
-
-Example:
-
-```json5
-{
-  channels: {
-    msteams: {
-      groupPolicy: "allowlist",
-      groupAllowFrom: ["00000000-0000-0000-0000-000000000000"],
-      teams: {
-        "19:team-id@thread.tacv2": {
-          channels: {
-            "19:channel-id@thread.tacv2": { requireMention: true },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-<details>
-<summary><strong>Manual setup (without the Teams CLI)</strong></summary>
-
-### How it works
-
-1. Ensure the Microsoft Teams plugin is available (bundled in current releases).
-2. Create an **Azure Bot** (App ID + secret + tenant ID).
-3. Build a **Teams app package** referencing the bot, including the RSC permissions below.
-4. Upload/install the Teams app into a team (or personal scope for DMs).
-5. Configure `msteams` in `~/.openclaw/openclaw.json` (or env vars) and start the gateway.
-6. The gateway listens for Bot Framework webhook traffic on `/api/messages` by default.
-
-### Step 1: Create Azure Bot
-
-1. Go to [Create Azure Bot](https://portal.azure.com/#create/Microsoft.AzureBot)
-2. Fill in the **Basics** tab:
-
-   | Field              | Value                                                    |
-   | ------------------ | -------------------------------------------------------- |
-   | **Bot handle**     | Your bot name, e.g., `openclaw-msteams` (must be unique) |
-   | **Subscription**   | Select your Azure subscription                           |
-   | **Resource group** | Create new or use existing                               |
-   | **Pricing tier**   | **Free** for dev/testing                                 |
-   | **Type of App**    | **Single Tenant** (recommended; see note below)          |
-   | **Creation type**  | **Create new Microsoft App ID**                          |
-
-<Warning>
-Creation of new multi-tenant bots was deprecated after 2025-07-31. Use **Single Tenant** for new bots.
-</Warning>
-
-3. Click **Review + create** then **Create** (~1-2 minutes).
-
-### Step 2: Get credentials
-
-1. Azure Bot resource → **Configuration** → copy **Microsoft App ID** (your `appId`).
-2. **Manage Password** → App Registration → **Certificates & secrets** → **New client secret** → copy the **Value** (your `appPassword`).
-3. **Overview** → copy **Directory (tenant) ID** (your `tenantId`).
-
-### Step 3: Configure messaging endpoint
-
-1. Azure Bot → **Configuration**.
-2. Set **Messaging endpoint**:
-   - Production: `https://your-domain.com/api/messages`
-   - Local dev: use a tunnel (see [Local development](#local-development-tunneling))
-
-### Step 4: Enable Teams channel
-
-1. Azure Bot → **Channels**.
-2. Click **Microsoft Teams** → Configure → Save.
-3. Accept the Terms of Service.
-
-### Step 5: Build Teams app manifest
-
-- Include a `bot` entry with `botId = <App ID>`.
-- Scopes: `personal`, `team`, `groupChat`.
-- `supportsFiles: true` (required for personal-scope file handling).
-- Add RSC permissions (see [RSC permissions](#current-teams-rsc-permissions-manifest)).
-- Create icons: `outline.png` (32x32) and `color.png` (192x192).
-- Zip `manifest.json`, `outline.png`, and `color.png` together.
-
-### Step 6: Configure OpenClaw
-
-```json5
-{
-  channels: {
-    msteams: {
-      enabled: true,
-      appId: "<APP_ID>",
-      appPassword: "<APP_PASSWORD>",
-      tenantId: "<TENANT_ID>",
-      webhook: { port: 3978, path: "/api/messages" },
-    },
-  },
-}
-```
-
-Environment variables: `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID`.
-
-### Step 7: Run the gateway
-
-The Teams channel starts automatically when the plugin is available and `msteams` config has credentials.
-
-</details>
-
-## Federated authentication (certificate plus managed identity)
-
-For production, OpenClaw supports **federated authentication** as an alternative to client secrets, via `channels.msteams.authType: "federated"`. Two methods:
-
-### Option A: Certificate-based authentication
-
-Use a PEM certificate registered with your Entra ID app registration.
-
-**Setup:**
-
-1. Generate or obtain a certificate (PEM format with private key).
-2. Entra ID → App Registration → **Certificates & secrets** → **Certificates** → upload the public certificate.
-
-**Config:**
-
-```json5
-{
-  channels: {
-    msteams: {
-      enabled: true,
-      appId: "<APP_ID>",
-      tenantId: "<TENANT_ID>",
-      authType: "federated",
-      certificatePath: "/path/to/cert.pem",
-      webhook: { port: 3978, path: "/api/messages" },
-    },
-  },
-}
-```
-
-**Env vars:**
-
-- `MSTEAMS_AUTH_TYPE=federated`
-- `MSTEAMS_CERTIFICATE_PATH=/path/to/cert.pem`
-
-### Option B: Azure Managed Identity
-
-Use Azure Managed Identity for passwordless authentication on Azure infrastructure (AKS, App Service, Azure VMs).
-
-**How it works:**
-
-1. The bot pod/VM has a managed identity (system- or user-assigned).
-2. A federated identity credential links the managed identity to the Entra ID app registration.
-3. At runtime, OpenClaw uses `@azure/identity` to acquire tokens from the Azure IMDS endpoint.
-4. The token is passed to the Teams SDK for bot authentication.
-
-**Prerequisites:**
-
-- Azure infrastructure with managed identity enabled (AKS workload identity, App Service, VM).
-- Federated identity credential created on the Entra ID app registration.
-- Network access to IMDS (`169.254.169.254:80`) from the pod/VM.
-
-**Config (system-assigned managed identity):**
-
-```json5
-{
-  channels: {
-    msteams: {
-      enabled: true,
-      appId: "<APP_ID>",
-      tenantId: "<TENANT_ID>",
-      authType: "federated",
-      useManagedIdentity: true,
-      webhook: { port: 3978, path: "/api/messages" },
-    },
-  },
-}
-```
-
-**Config (user-assigned managed identity):** add `managedIdentityClientId: "<MI_CLIENT_ID>"` to the block above.
-
-**Env vars:**
-
-- `MSTEAMS_AUTH_TYPE=federated`
-- `MSTEAMS_USE_MANAGED_IDENTITY=true`
-- `MSTEAMS_MANAGED_IDENTITY_CLIENT_ID=<client-id>` (user-assigned only)
-
-### AKS Workload Identity setup
-
-For AKS deployments using workload identity:
-
-1. **Enable workload identity** on your AKS cluster.
-2. **Create a federated identity credential** on the Entra ID app registration:
-
-   ```bash
-   az ad app federated-credential create --id <APP_OBJECT_ID> --parameters '{
-     "name": "my-bot-workload-identity",
-     "issuer": "<AKS_OIDC_ISSUER_URL>",
-     "subject": "system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT>",
-     "audiences": ["api://AzureADTokenExchange"]
-   }'
-   ```
-
-3. **Annotate the Kubernetes service account** with the app client ID:
-
-   ```yaml
-   apiVersion: v1
-   kind: ServiceAccount
-   metadata:
-     name: my-bot-sa
-     annotations:
-       azure.workload.identity/client-id: "<APP_CLIENT_ID>"
-   ```
-
-4. **Label the pod** for workload identity injection:
-
-   ```yaml
-   metadata:
-     labels:
-       azure.workload.identity/use: "true"
-   ```
-
-5. **Allow network access** to IMDS (`169.254.169.254`): if using NetworkPolicy, add an egress rule for `169.254.169.254/32` on port 80.
-
-### Auth type comparison
-
-| Method               | Config                                         | Pros                               | Cons                                  |
-| -------------------- | ---------------------------------------------- | ---------------------------------- | ------------------------------------- |
-| **Client secret**    | `appPassword`                                  | Simple setup                       | Secret rotation required, less secure |
-| **Certificate**      | `authType: "federated"` + `certificatePath`    | No shared secret over network      | Certificate management overhead       |
-| **Managed Identity** | `authType: "federated"` + `useManagedIdentity` | Passwordless, no secrets to manage | Azure infrastructure required         |
-
-`certificateThumbprint` can be set alongside `certificatePath` but is not read by the auth path today; it is accepted for forward compatibility only.
-
-**Default:** when `authType` is unset, OpenClaw uses client-secret authentication (`appPassword`). Existing configs keep working unchanged.
-
-## Local development (tunneling)
-
-Teams cannot reach `localhost`. Use a persistent dev tunnel so the URL stays stable across sessions:
-
-```bash
-# One-time setup:
-devtunnel create my-openclaw-bot --allow-anonymous
-devtunnel port create my-openclaw-bot -p 3978 --protocol auto
-
-# Each dev session:
-devtunnel host my-openclaw-bot
-```
-
-Alternatives: `ngrok http 3978` or `tailscale funnel 3978` (URLs may change each session).
-
-If the tunnel URL changes, update the endpoint:
-
-```bash
-teams app update <teamsAppId> --endpoint "https://<new-url>/api/messages"
-```
-
-## Testing the bot
-
-**Run diagnostics:**
-
-```bash
-teams app doctor <teamsAppId>
-```
-
-Checks bot registration, AAD app, manifest, and SSO configuration in one pass.
-
-**Send a test message:**
-
-1. Install the Teams app (install link from `teams app get <id> --install-link`).
-2. Find the bot in Teams and send a DM.
-3. Check gateway logs for incoming activity.
-
-## Environment variables
-
-These auth-related config keys can be set via environment variables instead of `openclaw.json` (other config keys, such as `groupPolicy` or `historyLimit`, are config-only):
-
-| Env var                              | Config key                | Notes                               |
-| ------------------------------------ | ------------------------- | ----------------------------------- |
-| `MSTEAMS_APP_ID`                     | `appId`                   |                                     |
-| `MSTEAMS_APP_PASSWORD`               | `appPassword`             |                                     |
-| `MSTEAMS_TENANT_ID`                  | `tenantId`                |                                     |
-| `MSTEAMS_AUTH_TYPE`                  | `authType`                | `"secret"` or `"federated"`         |
-| `MSTEAMS_CERTIFICATE_PATH`           | `certificatePath`         | federated + certificate             |
-| `MSTEAMS_CERTIFICATE_THUMBPRINT`     | `certificateThumbprint`   | accepted, not required for auth     |
-| `MSTEAMS_USE_MANAGED_IDENTITY`       | `useManagedIdentity`      | federated + managed identity        |
-| `MSTEAMS_MANAGED_IDENTITY_CLIENT_ID` | `managedIdentityClientId` | user-assigned managed identity only |
-
-## Member info action
-
-OpenClaw exposes a Graph-backed `member-info` action for Microsoft Teams so agents and automations can resolve verified roster details for a configured conversation.
-
-Requirements:
-
-- `ChannelSettings.Read.Group` and `TeamMember.Read.Group` RSC permissions (already in the recommended manifest).
-
-The action is available whenever Graph credentials are configured; there is no separate `channels.msteams.actions.memberInfo` toggle.
-Standard-channel lookups return the matching team-roster identity, display name, email, and roles.
-In the current DM or group chat, the action can return the trusted sender's stable user ID.
-Private/shared-channel and non-current chat member lookups require additional roster permissions
-and are rejected by the default permission baseline.
-
-## History context
-
-- `channels.msteams.historyLimit` controls how many recent channel/group messages are wrapped into the prompt. Falls back to `messages.groupChat.historyLimit`, then defaults to 50. Set `0` to disable.
-- Graph thread context adds the parent and up to the oldest 50 replies alongside recent channel history. It excludes the triggering message and keeps history separate from the sender's command text, so commands quoted in history do not execute. Long fetched messages retain their beginning and end within the prompt's per-message limit.
-- Thread and quoted attachment context follow `channels.msteams.contextVisibility`, falling back to `channels.defaults.contextVisibility`, then `all`. Use `allowlist` to filter both by sender allowlists (`allowFrom` / `groupAllowFrom`), or `allowlist_quote` to filter thread history while permitting quoted context.
-- DM history can be limited with `channels.msteams.dmHistoryLimit` (user turns). Per-user overrides: `channels.msteams.dms["<user_id>"].historyLimit`.
-
-## Current Teams RSC permissions (manifest)
-
-These are the **existing resourceSpecific permissions** in our Teams app manifest. They only apply inside the team/chat where the app is installed.
-
-**For channels (team scope):**
-
-- `ChannelMessage.Read.Group` (Application) - receive all channel messages without @mention
-- `ChannelMessage.Send.Group` (Application)
-- `Member.Read.Group` (Application)
-- `Owner.Read.Group` (Application)
-- `ChannelSettings.Read.Group` (Application)
-- `TeamMember.Read.Group` (Application)
-- `TeamSettings.Read.Group` (Application)
-
-**For group chats:**
-
-- `ChatMessage.Read.Chat` (Application) - receive all group chat messages without @mention
-
-Add RSC permissions via the Teams CLI:
-
-```bash
-teams app rsc add <teamsAppId> ChannelMessage.Read.Group --type Application
-```
-
-## Example Teams manifest (redacted)
-
-Minimal, valid example with the required fields. Replace IDs and URLs.
-
-```json5
-{
-  $schema: "https://developer.microsoft.com/en-us/json-schemas/teams/v1.23/MicrosoftTeams.schema.json",
-  manifestVersion: "1.23",
-  version: "1.0.0",
-  id: "00000000-0000-0000-0000-000000000000",
-  name: { short: "OpenClaw" },
-  developer: {
-    name: "Your Org",
-    websiteUrl: "https://example.com",
-    privacyUrl: "https://example.com/privacy",
-    termsOfUseUrl: "https://example.com/terms",
-  },
-  description: { short: "OpenClaw in Teams", full: "OpenClaw in Teams" },
-  icons: { outline: "outline.png", color: "color.png" },
-  accentColor: "#5B6DEF",
-  bots: [
-    {
-      botId: "11111111-1111-1111-1111-111111111111",
-      scopes: ["personal", "team", "groupChat"],
-      isNotificationOnly: false,
-      supportsCalling: false,
-      supportsVideo: false,
-      supportsFiles: true,
-    },
-  ],
-  webApplicationInfo: {
-    id: "11111111-1111-1111-1111-111111111111",
-  },
-  authorization: {
-    permissions: {
-      resourceSpecific: [
-        { name: "ChannelMessage.Read.Group", type: "Application" },
-        { name: "ChannelMessage.Send.Group", type: "Application" },
-        { name: "Member.Read.Group", type: "Application" },
-        { name: "Owner.Read.Group", type: "Application" },
-        { name: "ChannelSettings.Read.Group", type: "Application" },
-        { name: "TeamMember.Read.Group", type: "Application" },
-        { name: "TeamSettings.Read.Group", type: "Application" },
-        { name: "ChatMessage.Read.Chat", type: "Application" },
-      ],
-    },
-  },
-}
-```
-
-### Manifest caveats (must-have fields)
-
-- `bots[].botId` **must** match the Azure Bot App ID.
-- `webApplicationInfo.id` **must** match the Azure Bot App ID.
-- `bots[].scopes` must include the surfaces you plan to use (`personal`, `team`, `groupChat`).
-- `bots[].supportsFiles: true` is required for file handling in personal scope.
-- `authorization.permissions.resourceSpecific` must include channel read/send for channel traffic.
-
-### Updating an existing app
-
-```bash
-# Download, edit, and re-upload the manifest
-teams app manifest download <teamsAppId> manifest.json
-# Edit manifest.json locally...
-teams app manifest upload manifest.json <teamsAppId>
-# Version is auto-bumped if content changed
-```
-
-After updating, reinstall the app in each team, and **fully quit and relaunch Teams** (not just close the window) to clear cached app metadata.
-
-<details>
-<summary>Manual manifest update (without CLI)</summary>
-
-1. Update `manifest.json` with the new settings.
-2. **Increment the `version` field** (e.g., `1.0.0` → `1.1.0`).
-3. **Re-zip** the manifest with icons (`manifest.json`, `outline.png`, `color.png`).
-4. Upload the new zip:
-   - **Teams Admin Center:** Teams apps → Manage apps → find your app → Upload new version.
-   - **Sideload:** Teams → Apps → Manage your apps → Upload a custom app.
-
-</details>
-
-## Capabilities: RSC only vs Graph
-
-### With **Teams RSC only** (app installed, no Graph API permissions)
-
-Works:
-
-- Read channel message **text** content.
-- Send channel message **text** content.
-- Receive **personal (DM)** file attachments.
-
-Does NOT work:
-
-- Channel/group **image or file contents** (payload only includes an HTML stub).
-- Downloading attachments stored in SharePoint/OneDrive.
-- Reading message history beyond the live webhook event.
-
-### With **Teams RSC + Microsoft Graph Application permissions**
-
-Adds:
-
-- Downloading hosted content (images pasted into messages).
-- Downloading file attachments stored in SharePoint/OneDrive.
-- Reading channel/chat message history via Graph.
-
-### RSC vs Graph API
-
-| Capability              | RSC permissions      | Graph API                           |
-| ----------------------- | -------------------- | ----------------------------------- |
-| **Real-time messages**  | Yes (via webhook)    | No (polling only)                   |
-| **Historical messages** | No                   | Yes (can query history)             |
-| **Setup complexity**    | App manifest only    | Requires admin consent + token flow |
-| **Works offline**       | No (must be running) | Yes (query anytime)                 |
-
-**Bottom line:** RSC is for real-time listening; Graph API is for historical access. To catch up on missed messages while offline, you need Graph API with `ChannelMessage.Read.All` (requires admin consent).
-
-## Graph-enabled media + history
-
-Enable only the Microsoft Graph application permissions needed for the Teams scopes and data you use:
-
-1. Entra ID (Azure AD) **App Registration** → add Graph **Application permissions**:
-   - `ChannelMessage.Read.All` for channel attachments and channel history.
-   - `Chat.Read.All` for group-chat attachments and group-chat history.
-   - `Files.Read.All` when attachment bytes must be downloaded from SharePoint/OneDrive storage; history-only setups do not need it.
-2. **Grant admin consent** for the tenant.
-3. Bump the Teams app **manifest version**, re-upload, and **reinstall the app in Teams**.
-4. **Fully quit and relaunch Teams** to clear cached app metadata.
-
-### Channel/group file recovery (`graphMediaFallback`)
-
-Teams can remove file markers from the HTML activity sent to a bot. In that case, the Bot Framework activity is indistinguishable from an ordinary HTML message; the complete attachment reference exists only on the Graph copy of the message.
-
-Enable the fallback after granting the permissions above:
-
-```json5
-{
-  channels: {
-    msteams: {
-      graphMediaFallback: true,
-    },
-  },
-}
-```
-
-This applies to channels and group chats only. It adds one Graph message lookup whenever an HTML activity produced no directly downloadable media, including ordinary or mention-only messages. The default is `false` so existing installations do not gain extra Graph traffic or permission errors automatically.
-
-**User mentions:** @mentions work out of the box for users already in the conversation. To dynamically search and mention users **not in the current conversation**, add `User.Read.All` (Application) permission and grant admin consent.
-
-## Known limitations
-
-### Webhook timeouts
-
-Teams delivers messages via HTTP webhook. OpenClaw applies fixed HTTP server
-timeouts to that webhook listener: 30s inactivity, 30s total request, and 15s
-to receive headers. Optional inbound media and context enrichment has a shared
-10-second budget. The SDK returns after the raw activity is durably appended;
-the agent turn drains independently and replies proactively. If request
-handling or durable admission misses the transport window, Teams may retry the
-activity, and the ingress tombstone rejects a repeated event ID.
-
-### Teams cloud and service URL support
-
-This SDK-backed Teams path is live-validated for Microsoft Teams public cloud.
-
-Inbound replies use the incoming Teams SDK turn context. Out-of-context proactive operations - sends, edits, deletes, cards, polls, file-consent messages, and queued long-running replies - use the stored conversation reference `serviceUrl`. Public cloud defaults to the Teams SDK public cloud environment and allows stored references on the public Teams Connector host: `https://smba.trafficmanager.net/`.
-
-Public cloud is the default. You do not need to set `channels.msteams.cloud` or `channels.msteams.serviceUrl` for normal public-cloud bots.
-
-For non-public Teams clouds, set `cloud` and the matching proactive boundary when Microsoft publishes one:
-
-- `channels.msteams.cloud` selects the Teams SDK cloud preset for authentication, JWT validation, token services, and Graph scope.
-- `channels.msteams.serviceUrl` selects the Bot Connector endpoint boundary used to validate stored conversation references before proactive sends, edits, deletes, cards, polls, file-consent messages, and queued long-running replies. It is required for USGov and DoD SDK clouds. For China/21Vianet, OpenClaw uses the SDK `China` preset and accepts stored/configured service URLs only on Azure China Bot Framework channel hosts.
-
-Microsoft publishes the global proactive Bot Connector endpoints in the [Create the conversation](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages?tabs=dotnet#create-the-conversation) section of the Teams proactive messaging docs. Use the incoming activity's `serviceUrl` when available; otherwise use Microsoft's table below.
-
-| Teams environment | OpenClaw config                                             | Proactive `serviceUrl`                             |
-| ----------------- | ----------------------------------------------------------- | -------------------------------------------------- |
-| Public            | no cloud/serviceUrl config needed                           | `https://smba.trafficmanager.net/teams`            |
-| GCC               | set `serviceUrl`; no separate Teams SDK cloud preset exists | `https://smba.infra.gcc.teams.microsoft.com/teams` |
-| GCC High          | `cloud: "USGov"` + `serviceUrl`                             | `https://smba.infra.gov.teams.microsoft.us/teams`  |
-| DoD               | `cloud: "USGovDoD"` + `serviceUrl`                          | `https://smba.infra.dod.teams.microsoft.us/teams`  |
-| China/21Vianet    | `cloud: "China"`                                            | use the incoming activity's `serviceUrl`           |
-
-Example for GCC, where Microsoft documents a separate proactive service URL but the Teams SDK exposes no separate GCC cloud preset:
-
-```json
-{
-  "channels": {
-    "msteams": {
-      "serviceUrl": "https://smba.infra.gcc.teams.microsoft.com/teams"
-    }
-  }
-}
-```
-
-Example for GCC High:
-
-```json
-{
-  "channels": {
-    "msteams": {
-      "cloud": "USGov",
-      "serviceUrl": "https://smba.infra.gov.teams.microsoft.us/teams"
-    }
-  }
-}
-```
-
-`channels.msteams.serviceUrl` is restricted to supported Microsoft Teams Bot Connector hosts. When a service URL is configured, OpenClaw checks that the stored conversation `serviceUrl` uses the same host before proactive sends, edits, deletes, cards, polls, or queued long-running replies run. With the default public-cloud config, OpenClaw fails closed if a stored conversation points outside the public Teams Connector host. Receive a fresh message from the conversation after changing cloud/service URL settings so the stored conversation reference is current.
-
-China/21Vianet has no separate global proactive `smba` URL in Microsoft's Teams proactive endpoint table. Configure `cloud: "China"` so the Teams SDK uses Azure China auth, token, and JWT endpoints. Proactive sends then require a stored conversation reference from an incoming China Teams activity, or an explicitly configured service URL, on the Azure China Bot Framework channel boundary (`*.botframework.azure.cn`). Graph-backed Teams helpers are disabled for `cloud: "China"` until OpenClaw routes Graph requests through the Azure China Graph endpoint.
-
-### Formatting
-
-Teams markdown is more limited than Slack or Discord:
-
-- Basic formatting works: **bold**, _italic_, `code`, links.
-- Text edits, file captions, and finalized streaming replies use the same Markdown conversion and user-mention formatting as normal messages. Streaming previews may show unfinished Markdown until the final reply replaces them.
-- Complex markdown (tables, nested lists) may not render correctly.
-- Adaptive Cards are supported for approval prompts, polls, and semantic presentation sends (see below).
-
-## Configuration
-
-Key settings (see [/gateway/configuration](/gateway/configuration) for shared channel patterns):
-
-- `channels.msteams.enabled`: enable/disable the channel.
-- `channels.msteams.appId`, `channels.msteams.appPassword`, `channels.msteams.tenantId`: bot credentials.
-- `channels.msteams.cloud`: Teams SDK cloud environment (`Public`, `USGov`, `USGovDoD`, or `China`; default `Public`). Set with `serviceUrl` for USGov/DoD SDK clouds; China uses the SDK preset and stored Azure China Bot Framework conversation references, with Graph-backed helpers disabled until Azure China Graph routing ships.
-- `channels.msteams.serviceUrl`: Bot Connector service URL boundary for SDK proactive operations. Public cloud uses the SDK default; set for GCC (`https://smba.infra.gcc.teams.microsoft.com/teams`), GCC High, or DoD. China accepts Azure China Bot Framework channel hosts when the stored conversation reference comes from Teams operated by 21Vianet.
-- `channels.msteams.webhook.port` (default `3978`).
-- `channels.msteams.webhook.path` (default `/api/messages`).
-- `channels.msteams.dmPolicy`: `pairing | allowlist | open | disabled` (default `pairing`).
-- `channels.msteams.allowFrom`: DM allowlist (AAD object IDs recommended). Stable AAD object IDs also authorize approval actions. The wizard resolves names to IDs during setup when Graph access is available.
-- `channels.msteams.defaultTo`: default outbound target; a stable AAD object ID can also authorize approval actions.
-- `channels.msteams.dangerouslyAllowNameMatching`: break-glass toggle to re-enable mutable UPN/display-name matching and direct team/channel name routing.
-- `channels.msteams.textChunkLimit`: outbound text chunk size in characters (default `4000`, and hard-capped at `4000` regardless of a higher configured value).
-- `channels.msteams.streaming.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
-- `channels.msteams.mediaAllowHosts`: allowlist for inbound attachment hosts (defaults to Microsoft/Teams domains: Graph, SharePoint/OneDrive, Teams CDN, Bot Framework, Azure Media Services).
-- `channels.msteams.mediaAuthAllowHosts`: allowlist for attaching Authorization headers on media retries (defaults to Graph + Bot Framework hosts).
-- `channels.msteams.graphMediaFallback`: opt into Graph message lookups when channel/group HTML omits file markers (default `false`; see [Channel/group file recovery](/channels/msteams#channel%2Fgroup-file-recovery-graphmediafallback)).
-- `channels.msteams.mediaMaxMb`: per-channel media size limit override in MB. Falls back to `agents.defaults.mediaMaxMb` when unset.
-- `channels.msteams.requireMention`: require @mention in channels/groups (default `true`).
-- `channels.msteams.replyStyle`: `thread | top-level` (see [Reply style](#reply-style-threads-vs-posts)).
-- `channels.msteams.teams.<teamId>.replyStyle`: per-team override.
-- `channels.msteams.teams.<teamId>.requireMention`: per-team override.
-- `channels.msteams.teams.<teamId>.tools`: default per-team tool policy overrides (`allow`/`deny`/`alsoAllow`) used when a channel override is missing.
-- `channels.msteams.teams.<teamId>.toolsBySender`: default per-team per-sender tool policy overrides (`"*"` wildcard supported).
-- `channels.msteams.teams.<teamId>.channels.<conversationId>.replyStyle`: per-channel override.
-- `channels.msteams.teams.<teamId>.channels.<conversationId>.requireMention`: per-channel override.
-- `channels.msteams.teams.<teamId>.channels.<conversationId>.tools`: per-channel tool policy overrides (`allow`/`deny`/`alsoAllow`).
-- `channels.msteams.teams.<teamId>.channels.<conversationId>.toolsBySender`: per-channel per-sender tool policy overrides (`"*"` wildcard supported).
-- `toolsBySender` keys should use explicit prefixes: `channel:`, `id:`, `e164:`, `username:`, `name:` (legacy unprefixed keys still map to `id:` only).
-- `channels.msteams.authType`: authentication type - `"secret"` (default) or `"federated"`.
-- `channels.msteams.certificatePath`: path to PEM certificate file (federated + certificate auth).
-- `channels.msteams.certificateThumbprint`: certificate thumbprint; accepted, not required for auth.
-- `channels.msteams.useManagedIdentity`: enable managed identity auth (federated mode).
-- `channels.msteams.managedIdentityClientId`: client ID for user-assigned managed identity.
-- `channels.msteams.sharePointSiteId`: SharePoint site ID for file uploads in group chats/channels (see [Sending files in group chats](#sending-files-in-group-chats)).
-- `channels.msteams.welcomeCard`, `channels.msteams.groupWelcomeCard`, `channels.msteams.promptStarters`: welcome Adaptive Card shown on first DM/group contact, and its suggested prompt buttons.
-- `channels.msteams.responsePrefix`: text prefixed to outbound replies.
-- `channels.msteams.feedbackEnabled` (default `true`), `channels.msteams.feedbackReflection` (default `true`), `channels.msteams.feedbackReflectionCooldownMs`: thumbs-up/down feedback on replies and the negative-feedback reflection follow-up.
-- `channels.msteams.sso`, `channels.msteams.delegatedAuth`: Bot Framework OAuth connection and delegated Graph scopes for SSO-backed flows; `sso.enabled: true` requires `sso.connectionName`.
-
-## Routing and sessions
-
-- Session keys follow the standard agent format (see [/concepts/session](/concepts/session)):
-  - Direct messages share the main session (`agent:<agentId>:main`) by default.
-  - Channel/group messages use conversation id:
-    - `agent:<agentId>:msteams:channel:<conversationId>`
-    - `agent:<agentId>:msteams:group:<conversationId>`
-
-## Reply style: threads vs posts
-
-Teams has two channel UI styles over the same underlying data model:
-
-| Style                    | Description                                               | Recommended `replyStyle` |
-| ------------------------ | --------------------------------------------------------- | ------------------------ |
-| **Posts** (classic)      | Messages appear as cards with threaded replies underneath | `thread` (default)       |
-| **Threads** (Slack-like) | Messages flow linearly, more like Slack                   | `top-level`              |
-
-**The problem:** the Teams API does not expose which UI style a channel uses. If you use the wrong `replyStyle`:
-
-- `thread` in a Threads-style channel → replies appear nested awkwardly.
-- `top-level` in a Posts-style channel → replies appear as separate top-level posts instead of in-thread.
-
-**Solution:** configure `replyStyle` per-channel based on how the channel is set up:
-
-```json5
-{
-  channels: {
-    msteams: {
-      replyStyle: "thread",
-      teams: {
-        "19:abc...@thread.tacv2": {
-          channels: {
-            "19:xyz...@thread.tacv2": {
-              replyStyle: "top-level",
-            },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-### Resolution precedence
-
-When the bot sends a reply into a channel, `replyStyle` is resolved from the most specific override down to the default. The first non-`undefined` value wins:
-
-1. **Per-channel** - `channels.msteams.teams.<teamId>.channels.<conversationId>.replyStyle`
-2. **Per-team** - `channels.msteams.teams.<teamId>.replyStyle`
-3. **Global** - `channels.msteams.replyStyle`
-4. **Implicit default** - derived from `requireMention`:
-   - `requireMention: true` → `thread`
-   - `requireMention: false` → `top-level`
-
-If you set `requireMention: false` globally without an explicit `replyStyle`, mentions in Posts-style channels surface as top-level posts even when the inbound was a thread reply. Pin `replyStyle: "thread"` at the global, team, or channel level to avoid surprises.
-
-For proactive sends into a stored channel conversation (queued tool-call replies, long-running agents), the same team/channel resolution applies; group chats and personal (DM) conversations always resolve to `top-level` for proactive sends regardless of `replyStyle`.
-
-### Thread context preservation
-
-When `replyStyle: "thread"` is in effect and the bot was @mentioned from inside a channel thread, OpenClaw re-attaches the original thread root to the outbound conversation reference (`19:...@thread.tacv2;messageid=<root>`) so the reply lands inside the same thread. This holds for both live (in-turn) sends and proactive sends made after the Bot Framework turn context has expired (e.g., long-running agents, queued tool-call replies via `mcp__openclaw__message`).
-
-The thread root is taken from the stored `threadId` on the conversation reference. Older stored references that predate `threadId` fall back to `activityId` (whatever inbound activity last seeded the conversation), so existing deployments keep working without a re-seed.
-
-When `replyStyle: "top-level"` is in effect, channel-thread inbounds are intentionally answered as new top-level posts; no thread suffix is attached. This is correct for Threads-style channels; top-level posts where you expected threaded replies means `replyStyle` is set incorrectly for that channel.
-
-## Attachments and images
-
-**Current limitations:**
-
-- **DMs:** images and file attachments work via Teams bot file APIs.
-- **Channels/groups:** attachments live in M365 storage (SharePoint/OneDrive). The webhook payload only includes an HTML stub, not the actual file bytes. **Graph API permissions are required** to download channel attachments.
-- For explicit file-first sends, use `action=upload-file` with `media` / `filePath` / `path`; optional `message` becomes the accompanying text/comment, and `filename` (or `title`) overrides the uploaded name.
-
-Without Graph permissions, channel messages with images arrive as text-only (the image content is not accessible to the bot).
-By default, OpenClaw only downloads media from Microsoft/Teams hostnames. Override with `channels.msteams.mediaAllowHosts` (use `["*"]` to allow any host).
-Authorization headers are only attached for hosts in `channels.msteams.mediaAuthAllowHosts` (defaults to Graph + Bot Framework hosts). Keep this list strict (avoid multi-tenant suffixes).
-
-## Sending files in group chats
-
-Bots can send files in DMs using the built-in FileConsentCard flow. **Sending files in group chats/channels** requires additional setup:
-
-| Context                  | How files are sent                           | Setup needed                                    |
-| ------------------------ | -------------------------------------------- | ----------------------------------------------- |
-| **DMs**                  | FileConsentCard → user accepts → bot uploads | Works out of the box                            |
-| **Group chats/channels** | Upload to SharePoint → native file card      | Requires `sharePointSiteId` + Graph permissions |
-| **Images (any context)** | Base64-encoded inline                        | Works out of the box                            |
-
-### Why group chats need SharePoint
-
-Bots use an application identity, while Microsoft Graph's `/me` resource [requires a signed-in user](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0). To send files in group chats/channels, the bot uploads to a **SharePoint site** and creates a sharing link.
-
-### Setup
-
-1. **Add Graph API permissions** in Entra ID (Azure AD) → App Registration:
-   - `Sites.ReadWrite.All` (Application) - upload files to SharePoint.
-   - `ChatMember.Read.All` (Application) - least-privileged tenant-wide permission for group-chat file sends. `Chat.Read.All` also works and already covers this when group-chat history is enabled. As a per-chat alternative, use the `ChatMember.Read.Chat` [resource-specific consent permission](https://learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent).
-2. **Grant admin consent** for the tenant.
-3. **Get your SharePoint site ID:**
-
-   ```bash
-   # Via Graph Explorer or curl with a valid token:
-   curl -H "Authorization: Bearer $TOKEN" \
-     "https://graph.microsoft.com/v1.0/sites/{hostname}:/{site-path}"
-
-   # Example: for a site at "contoso.sharepoint.com/sites/BotFiles"
-   curl -H "Authorization: Bearer $TOKEN" \
-     "https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/BotFiles"
-
-   # Response includes: "id": "contoso.sharepoint.com,guid1,guid2"
-   ```
-
-4. **Configure OpenClaw:**
-
-   ```json5
-   {
-     channels: {
-       msteams: {
-         // ... other config ...
-         sharePointSiteId: "contoso.sharepoint.com,guid1,guid2",
-       },
-     },
-   }
-   ```
-
-### Sharing behavior
-
-| Context and permission                                                  | Sharing behavior                                          |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| Channel + `Sites.ReadWrite.All`                                         | Organization-wide sharing link (anyone in org can access) |
-| Group chat + `Sites.ReadWrite.All` + a supported chat-member read grant | Per-user sharing link (only chat members can access)      |
-| Group chat without a supported chat-member read grant                   | Send fails closed                                         |
-
-Per-user sharing is more secure since only chat participants can access the file. OpenClaw requires a successful member lookup for group chats; timeouts, transport failures, empty results, and Graph API denials fail the send instead of widening access to the organization.
-
-### Fallback behavior
-
-| Scenario                                                         | Result                                           |
-| ---------------------------------------------------------------- | ------------------------------------------------ |
-| Group chat + file + SharePoint and member permissions configured | Upload to SharePoint, send a native file card    |
-| Group chat + file + missing SharePoint or member permissions     | Fail with an actionable configuration error      |
-| Channel + file + `sharePointSiteId` configured                   | Upload to SharePoint, send a native file card    |
-| Personal chat + file                                             | FileConsentCard flow (works without SharePoint)  |
-| Any context + image                                              | Base64-encoded inline (works without SharePoint) |
-
-### Files stored location
-
-Uploaded files are stored in a `/OpenClawShared/` folder in the configured SharePoint site's default document library.
-
-## Native approval cards
-
-Microsoft Teams can deliver exec and plugin approval requests as Adaptive Cards in the originating conversation. Each card describes the requested command or plugin action and provides only the decisions allowed for that request, such as **Approve once**, **Always allow**, and **Deny**. After a decision or expiration, OpenClaw updates the original card with its final status.
-
-Enable the existing top-level approval forwarding settings for each approval type you want to receive:
-
-```json5
-{
-  approvals: {
-    exec: { enabled: true, mode: "session" },
-    plugin: { enabled: true, mode: "session" },
-  },
-  channels: {
-    msteams: {
-      allowFrom: ["00000000-0000-0000-0000-000000000000"],
-    },
-  },
-}
-```
-
-`approvals.exec` and `approvals.plugin` are independent; enabling one does not enable the other. Native card delivery also requires a configured Teams bot and at least one approver resolved from `channels.msteams.allowFrom` or `channels.msteams.defaultTo`. Approvers must be stable AAD object IDs; display names, email addresses, group entries, and conversation IDs do not grant approval access. OpenClaw checks the clicking user's AAD object ID before resolving the request.
-
-No Teams-specific approval configuration is required. The existing `/approve <id> <decision>` command remains available as a text fallback when native delivery is unavailable. For forwarding modes and supported decisions, see [Approval forwarding to chat channels](/tools/exec-approvals-advanced#approval-forwarding-to-chat-channels).
-
-## Polls (Adaptive Cards)
-
-OpenClaw sends Teams polls as Adaptive Cards (there is no native Teams poll API).
-
-- CLI: `openclaw message poll --channel msteams --target conversation:<id> --poll-question "..." --poll-option "..." --poll-option "..."`.
-- Votes are recorded by the gateway in OpenClaw plugin-state SQLite under `state/openclaw.sqlite`.
-- Existing `msteams-polls.json` files are imported by `openclaw doctor --fix`, not by the running plugin.
-- The gateway must stay online to record votes.
-- Polls do not auto-post result summaries, and there is no poll-results CLI yet.
-
-## Presentation cards
-
-Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract.
-
-The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional. Buttons render as Adaptive Card submit or URL actions. Select menus are not native in the Teams renderer, so OpenClaw downgrades them to readable text before delivery.
-
-**Agent tool:**
-
-```json5
-{
-  action: "send",
-  channel: "msteams",
-  target: "user:<id>",
-  presentation: {
-    title: "Hello",
-    blocks: [{ type: "text", text: "Hello!" }],
-  },
-}
-```
-
-**CLI:**
-
-```bash
-openclaw message send --channel msteams \
-  --target "conversation:19:abc...@thread.tacv2" \
-  --presentation '{"title":"Hello","blocks":[{"type":"text","text":"Hello!"}]}'
-```
-
-For target format details, see [Target formats](#target-formats) below.
-
-## Target formats
-
-MSTeams targets use prefixes to distinguish between users and conversations:
-
-| Target type         | Format                           | Example                                                                                                |
-| ------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| User (by ID)        | `user:<aad-object-id>`           | `user:40a1a0ed-4ff2-4164-a219-55518990c197`                                                            |
-| User (by name)      | `user:<display-name>`            | `user:John Smith` (requires Graph API)                                                                 |
-| Group/channel       | `conversation:<conversation-id>` | `conversation:19:abc123...@thread.tacv2`                                                               |
-| Group/channel (raw) | `<conversation-id>`              | `19:abc123...@thread.tacv2`, `19:...@unq.gbl.spaces`, or a bare `a:`/`8:orgid:`/`29:` Bot Framework id |
-
-**CLI examples:**
-
-```bash
-# Send to a user by ID
-openclaw message send --channel msteams --target "user:40a1a0ed-..." --message "Hello"
-
-# Send to a user by display name (triggers Graph API lookup)
-openclaw message send --channel msteams --target "user:John Smith" --message "Hello"
-
-# Send to a group chat or channel
-openclaw message send --channel msteams --target "conversation:19:abc...@thread.tacv2" --message "Hello"
-
-# Send a presentation card to a conversation
-openclaw message send --channel msteams --target "conversation:19:abc...@thread.tacv2" \
-  --presentation '{"title":"Hello","blocks":[{"type":"text","text":"Hello"}]}'
-```
-
-**Agent tool examples:**
-
-```json5
-{
-  action: "send",
-  channel: "msteams",
-  target: "user:John Smith",
-  message: "Hello!",
-}
-```
-
-```json5
-{
-  action: "send",
-  channel: "msteams",
-  target: "conversation:19:abc...@thread.tacv2",
-  presentation: {
-    title: "Hello",
-    blocks: [{ type: "text", text: "Hello" }],
-  },
-}
-```
-
-<Note>
-Without the `user:` prefix, names default to group or team resolution. Always use `user:` when targeting people by display name.
-</Note>
-
-## Proactive messaging
-
-- Proactive messages are only possible **after** a user has interacted, because OpenClaw stores conversation references at that point.
-- See [/gateway/configuration](/gateway/configuration) for `dmPolicy` and allowlist gating.
-
-## Team and Channel IDs (Common Gotcha)
-
-The `groupId` query parameter in Teams URLs is **NOT** the team ID used for configuration. Extract IDs from the URL path instead:
-
-**Team URL:**
-
-```text
-https://teams.microsoft.com/l/team/19%3ABk4j...%40thread.tacv2/conversations?groupId=...
-                                    └────────────────────────────┘
-                                    Team conversation ID (URL-decode this)
-```
-
-**Channel URL:**
-
-```text
-https://teams.microsoft.com/l/channel/19%3A15bc...%40thread.tacv2/ChannelName?groupId=...
-                                      └─────────────────────────┘
-                                      Channel ID (URL-decode this)
-```
-
-**For config:**
-
-- Team key = path segment after `/team/` (URL-decoded, e.g., `19:Bk4j...@thread.tacv2`; older tenants may show `@thread.skype`, which is also valid).
-- Channel key = path segment after `/channel/` (URL-decoded).
-- **Ignore** the `groupId` query parameter for OpenClaw routing. It is the Microsoft Entra group ID, not the Bot Framework conversation ID used in incoming Teams activities.
-
-## Private channels
-
-Bots have limited support in private channels:
-
-| Feature                      | Standard channels | Private channels       |
-| ---------------------------- | ----------------- | ---------------------- |
-| Bot installation             | Yes               | Limited                |
-| Real-time messages (webhook) | Yes               | May not work           |
-| RSC permissions              | Yes               | May behave differently |
-| @mentions                    | Yes               | If bot is accessible   |
-| Graph API history            | Yes               | Yes (with permissions) |
-
-**Workarounds if private channels do not work:**
-
-1. Use standard channels for bot interactions.
-2. Use DMs; users can always message the bot directly.
-3. Use Graph API for historical access (requires `ChannelMessage.Read.All`).
-
-## Troubleshooting
-
-### Common issues
-
-- **Images not showing in channels:** Graph permissions or admin consent missing. Reinstall the Teams app and fully quit/reopen Teams.
-- **No responses in channel:** mentions are required by default; set `channels.msteams.requireMention=false` or configure per team/channel.
-- **Version mismatch (Teams still shows old manifest):** remove + re-add the app and fully quit Teams to refresh.
-- **401 Unauthorized from webhook:** expected when testing manually without an Azure JWT; means the endpoint is reachable but auth failed. Use Azure Web Chat to test properly.
-
-### Manifest upload errors
-
-- **"Icon file cannot be empty":** the manifest references icon files that are 0 bytes. Create valid PNG icons (32x32 for `outline.png`, 192x192 for `color.png`).
-- **"webApplicationInfo.Id already in use":** the app is still installed in another team/chat. Find and uninstall it first, or wait 5-10 minutes for propagation.
-- **"Something went wrong" on upload:** upload via [https://admin.teams.microsoft.com](https://admin.teams.microsoft.com) instead, open browser DevTools (F12) → Network tab, and check the response body for the actual error.
-- **Sideload failing:** try "Upload an app to your org's app catalog" instead of "Upload a custom app"; this often bypasses sideload restrictions.
-
-### RSC permissions not working
-
-1. Verify `webApplicationInfo.id` matches your bot's App ID exactly.
-2. Re-upload the app and reinstall in the team/chat.
-3. Check if your org admin has blocked RSC permissions.
-4. Confirm you are using the right scope: `ChannelMessage.Read.Group` for teams, `ChatMessage.Read.Chat` for group chats.
-
-## References
-
-- [Create Azure Bot](https://learn.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) - Azure Bot setup guide
-- [Teams Developer Portal](https://dev.teams.microsoft.com/apps) - create/manage Teams apps
-- [Teams app manifest schema](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema)
-- [Receive channel messages with RSC](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-messages-with-rsc)
-- [RSC permissions reference](https://learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent)
-- [Teams bot file handling](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) (channel/group requires Graph)
-- [Proactive messaging](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
-- [@microsoft/teams.cli](https://www.npmjs.com/package/@microsoft/teams.cli) - Teams CLI for bot management
+Status: text + DM attachments are supported; channel/group file sending requires `sharePointSiteId` + Graph permissions (see [Sending files in group chats](/channels/msteams/messaging#sending-files-in-group-chats)). Polls and approval prompts are sent via Adaptive Cards. Message actions expose explicit `upload-file` for file-first sends.
+
+<CardGroup cols={3}>
+  <Card title="Setup" icon="rocket" href="/channels/msteams/setup">
+    Register the bot and install the Teams app.
+  </Card>
+  <Card title="Pairing" icon="link" href="/channels/pairing">
+    Teams DMs default to pairing mode.
+  </Card>
+  <Card title="Channel troubleshooting" icon="wrench" href="/channels/troubleshooting">
+    Cross-channel diagnostics and repair playbooks.
+  </Card>
+</CardGroup>
+
+## What each page covers
+
+- [Microsoft Teams setup](/channels/msteams/setup) — install the plugin, register the bot and Teams app, and run against a dev tunnel.
+- [Microsoft Teams access control](/channels/msteams/access-control) — DM and group policy, team and channel allowlists, and conversation IDs.
+- [Microsoft Teams authentication](/channels/msteams/authentication) — certificate and managed identity auth instead of a client secret.
+- [Microsoft Teams manifest and permissions](/channels/msteams/manifest-and-permissions) — the app manifest, RSC permissions, and the Graph permissions each capability needs.
+- [Microsoft Teams configuration](/channels/msteams/configuration) — `channels.msteams` keys, environment variables, and history limits.
+- [Microsoft Teams message behavior](/channels/msteams/messaging) — session routing, reply style, attachments, and file sending.
+- [Microsoft Teams cards and actions](/channels/msteams/cards-and-actions) — approvals, polls, presentation cards, member info, and target formats.
+- [Microsoft Teams troubleshooting](/channels/msteams/troubleshooting) — known limitations, common failures, and reference links.
+
+## Where each section moved
+
+Every section heading from the previous single-page version keeps its anchor here, so an existing link such as `/channels/msteams#reply-style-threads-vs-posts` still resolves. Each entry points at the page that now holds the content.
+
+- <a id="bundled-plugin" />[Bundled plugin](/channels/msteams/setup#bundled-plugin)
+- <a id="quick-setup" />[Quick setup](/channels/msteams/setup#quick-setup)
+- <a id="goals" />[Goals](/channels/msteams/setup#goals)
+- <a id="config-writes" />[Config writes](/channels/msteams/access-control#config-writes)
+- <a id="access-control-(dms-%2B-groups)" />[Access control (DMs + groups)](</channels/msteams/access-control#access-control-(dms-%2B-groups)>)
+- <a id="access-control-dms-+-groups" />[Access control (DMs + groups)](/channels/msteams/access-control#access-control-dms-+-groups)
+- <a id="how-it-works" />[How it works](/channels/msteams/setup#how-it-works)
+- <a id="step-1%3A-create-azure-bot" />[Step 1: Create Azure Bot](/channels/msteams/setup#step-1%3A-create-azure-bot)
+- <a id="step-1-create-azure-bot" />[Step 1: Create Azure Bot](/channels/msteams/setup#step-1-create-azure-bot)
+- <a id="step-2%3A-get-credentials" />[Step 2: Get credentials](/channels/msteams/setup#step-2%3A-get-credentials)
+- <a id="step-2-get-credentials" />[Step 2: Get credentials](/channels/msteams/setup#step-2-get-credentials)
+- <a id="step-3%3A-configure-messaging-endpoint" />[Step 3: Configure messaging endpoint](/channels/msteams/setup#step-3%3A-configure-messaging-endpoint)
+- <a id="step-3-configure-messaging-endpoint" />[Step 3: Configure messaging endpoint](/channels/msteams/setup#step-3-configure-messaging-endpoint)
+- <a id="step-4%3A-enable-teams-channel" />[Step 4: Enable Teams channel](/channels/msteams/setup#step-4%3A-enable-teams-channel)
+- <a id="step-4-enable-teams-channel" />[Step 4: Enable Teams channel](/channels/msteams/setup#step-4-enable-teams-channel)
+- <a id="step-5%3A-build-teams-app-manifest" />[Step 5: Build Teams app manifest](/channels/msteams/setup#step-5%3A-build-teams-app-manifest)
+- <a id="step-5-build-teams-app-manifest" />[Step 5: Build Teams app manifest](/channels/msteams/setup#step-5-build-teams-app-manifest)
+- <a id="step-6%3A-configure-openclaw" />[Step 6: Configure OpenClaw](/channels/msteams/setup#step-6%3A-configure-openclaw)
+- <a id="step-6-configure-openclaw" />[Step 6: Configure OpenClaw](/channels/msteams/setup#step-6-configure-openclaw)
+- <a id="step-7%3A-run-the-gateway" />[Step 7: Run the gateway](/channels/msteams/setup#step-7%3A-run-the-gateway)
+- <a id="step-7-run-the-gateway" />[Step 7: Run the gateway](/channels/msteams/setup#step-7-run-the-gateway)
+- <a id="federated-authentication-(certificate-plus-managed-identity)" />[Federated authentication (certificate plus managed identity)](</channels/msteams/authentication#federated-authentication-(certificate-plus-managed-identity)>)
+- <a id="federated-authentication-certificate-plus-managed-identity" />[Federated authentication (certificate plus managed identity)](/channels/msteams/authentication#federated-authentication-certificate-plus-managed-identity)
+- <a id="option-a%3A-certificate-based-authentication" />[Option A: Certificate-based authentication](/channels/msteams/authentication#option-a%3A-certificate-based-authentication)
+- <a id="option-a-certificate-based-authentication" />[Option A: Certificate-based authentication](/channels/msteams/authentication#option-a-certificate-based-authentication)
+- <a id="option-b%3A-azure-managed-identity" />[Option B: Azure Managed Identity](/channels/msteams/authentication#option-b%3A-azure-managed-identity)
+- <a id="option-b-azure-managed-identity" />[Option B: Azure Managed Identity](/channels/msteams/authentication#option-b-azure-managed-identity)
+- <a id="aks-workload-identity-setup" />[AKS Workload Identity setup](/channels/msteams/authentication#aks-workload-identity-setup)
+- <a id="auth-type-comparison" />[Auth type comparison](/channels/msteams/authentication#auth-type-comparison)
+- <a id="local-development-(tunneling)" />[Local development (tunneling)](</channels/msteams/setup#local-development-(tunneling)>)
+- <a id="local-development-tunneling" />[Local development (tunneling)](/channels/msteams/setup#local-development-tunneling)
+- <a id="testing-the-bot" />[Testing the bot](/channels/msteams/setup#testing-the-bot)
+- <a id="environment-variables" />[Environment variables](/channels/msteams/configuration#environment-variables)
+- <a id="member-info-action" />[Member info action](/channels/msteams/cards-and-actions#member-info-action)
+- <a id="history-context" />[History context](/channels/msteams/configuration#history-context)
+- <a id="current-teams-rsc-permissions-(manifest)" />[Current Teams RSC permissions (manifest)](</channels/msteams/manifest-and-permissions#current-teams-rsc-permissions-(manifest)>)
+- <a id="current-teams-rsc-permissions-manifest" />[Current Teams RSC permissions (manifest)](/channels/msteams/manifest-and-permissions#current-teams-rsc-permissions-manifest)
+- <a id="example-teams-manifest-(redacted)" />[Example Teams manifest (redacted)](</channels/msteams/manifest-and-permissions#example-teams-manifest-(redacted)>)
+- <a id="example-teams-manifest-redacted" />[Example Teams manifest (redacted)](/channels/msteams/manifest-and-permissions#example-teams-manifest-redacted)
+- <a id="manifest-caveats-(must-have-fields)" />[Manifest caveats (must-have fields)](</channels/msteams/manifest-and-permissions#manifest-caveats-(must-have-fields)>)
+- <a id="manifest-caveats-must-have-fields" />[Manifest caveats (must-have fields)](/channels/msteams/manifest-and-permissions#manifest-caveats-must-have-fields)
+- <a id="updating-an-existing-app" />[Updating an existing app](/channels/msteams/manifest-and-permissions#updating-an-existing-app)
+- <a id="capabilities%3A-rsc-only-vs-graph" />[Capabilities: RSC only vs Graph](/channels/msteams/manifest-and-permissions#capabilities%3A-rsc-only-vs-graph)
+- <a id="capabilities-rsc-only-vs-graph" />[Capabilities: RSC only vs Graph](/channels/msteams/manifest-and-permissions#capabilities-rsc-only-vs-graph)
+- <a id="with-teams-rsc-only-(app-installed%2C-no-graph-api-permissions)" />[With **Teams RSC only** (app installed, no Graph API permissions)](</channels/msteams/manifest-and-permissions#with-teams-rsc-only-(app-installed%2C-no-graph-api-permissions)>)
+- <a id="with-teams-rsc-only-app-installed-no-graph-api-permissions" />[With **Teams RSC only** (app installed, no Graph API permissions)](/channels/msteams/manifest-and-permissions#with-teams-rsc-only-app-installed-no-graph-api-permissions)
+- <a id="with-teams-rsc-%2B-microsoft-graph-application-permissions" />[With **Teams RSC + Microsoft Graph Application permissions**](/channels/msteams/manifest-and-permissions#with-teams-rsc-%2B-microsoft-graph-application-permissions)
+- <a id="with-teams-rsc-+-microsoft-graph-application-permissions" />[With **Teams RSC + Microsoft Graph Application permissions**](/channels/msteams/manifest-and-permissions#with-teams-rsc-+-microsoft-graph-application-permissions)
+- <a id="rsc-vs-graph-api" />[RSC vs Graph API](/channels/msteams/manifest-and-permissions#rsc-vs-graph-api)
+- <a id="graph-enabled-media-%2B-history" />[Graph-enabled media + history](/channels/msteams/manifest-and-permissions#graph-enabled-media-%2B-history)
+- <a id="graph-enabled-media-+-history" />[Graph-enabled media + history](/channels/msteams/manifest-and-permissions#graph-enabled-media-+-history)
+- <a id="channel%2Fgroup-file-recovery-(graphmediafallback)" />[Channel/group file recovery (`graphMediaFallback`)](</channels/msteams/manifest-and-permissions#channel%2Fgroup-file-recovery-(graphmediafallback)>)
+- <a id="channel/group-file-recovery-graphmediafallback" />[Channel/group file recovery (`graphMediaFallback`)](/channels/msteams/manifest-and-permissions#channel/group-file-recovery-graphmediafallback)
+- <a id="known-limitations" />[Known limitations](/channels/msteams/troubleshooting#known-limitations)
+- <a id="webhook-timeouts" />[Webhook timeouts](/channels/msteams/troubleshooting#webhook-timeouts)
+- <a id="teams-cloud-and-service-url-support" />[Teams cloud and service URL support](/channels/msteams/troubleshooting#teams-cloud-and-service-url-support)
+- <a id="formatting" />[Formatting](/channels/msteams/troubleshooting#formatting)
+- <a id="configuration" />[Configuration](/channels/msteams/configuration#configuration)
+- <a id="routing-and-sessions" />[Routing and sessions](/channels/msteams/messaging#routing-and-sessions)
+- <a id="reply-style%3A-threads-vs-posts" />[Reply style: threads vs posts](/channels/msteams/messaging#reply-style%3A-threads-vs-posts)
+- <a id="reply-style-threads-vs-posts" />[Reply style: threads vs posts](/channels/msteams/messaging#reply-style-threads-vs-posts)
+- <a id="resolution-precedence" />[Resolution precedence](/channels/msteams/messaging#resolution-precedence)
+- <a id="thread-context-preservation" />[Thread context preservation](/channels/msteams/messaging#thread-context-preservation)
+- <a id="attachments-and-images" />[Attachments and images](/channels/msteams/messaging#attachments-and-images)
+- <a id="sending-files-in-group-chats" />[Sending files in group chats](/channels/msteams/messaging#sending-files-in-group-chats)
+- <a id="why-group-chats-need-sharepoint" />[Why group chats need SharePoint](/channels/msteams/messaging#why-group-chats-need-sharepoint)
+- <a id="setup" />[Setup](/channels/msteams/messaging#setup)
+- <a id="sharing-behavior" />[Sharing behavior](/channels/msteams/messaging#sharing-behavior)
+- <a id="fallback-behavior" />[Fallback behavior](/channels/msteams/messaging#fallback-behavior)
+- <a id="files-stored-location" />[Files stored location](/channels/msteams/messaging#files-stored-location)
+- <a id="native-approval-cards" />[Native approval cards](/channels/msteams/cards-and-actions#native-approval-cards)
+- <a id="polls-(adaptive-cards)" />[Polls (Adaptive Cards)](</channels/msteams/cards-and-actions#polls-(adaptive-cards)>)
+- <a id="polls-adaptive-cards" />[Polls (Adaptive Cards)](/channels/msteams/cards-and-actions#polls-adaptive-cards)
+- <a id="presentation-cards" />[Presentation cards](/channels/msteams/cards-and-actions#presentation-cards)
+- <a id="target-formats" />[Target formats](/channels/msteams/cards-and-actions#target-formats)
+- <a id="proactive-messaging" />[Proactive messaging](/channels/msteams/cards-and-actions#proactive-messaging)
+- <a id="team-and-channel-ids-(common-gotcha)" />[Team and Channel IDs (Common Gotcha)](</channels/msteams/access-control#team-and-channel-ids-(common-gotcha)>)
+- <a id="team-and-channel-ids-common-gotcha" />[Team and Channel IDs (Common Gotcha)](/channels/msteams/access-control#team-and-channel-ids-common-gotcha)
+- <a id="private-channels" />[Private channels](/channels/msteams/access-control#private-channels)
+- <a id="troubleshooting" />[Troubleshooting](/channels/msteams/troubleshooting#troubleshooting)
+- <a id="common-issues" />[Common issues](/channels/msteams/troubleshooting#common-issues)
+- <a id="manifest-upload-errors" />[Manifest upload errors](/channels/msteams/troubleshooting#manifest-upload-errors)
+- <a id="rsc-permissions-not-working" />[RSC permissions not working](/channels/msteams/troubleshooting#rsc-permissions-not-working)
+- <a id="references" />[References](/channels/msteams/troubleshooting#references)
 
 ## Related
 
-- [Channels Overview](/channels) - all supported channels
-- [Pairing](/channels/pairing) - DM authentication and pairing flow
-- [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
-- [Security](/gateway/security) - access model and hardening
+<CardGroup cols={2}>
+  <Card title="Channels Overview" icon="list" href="/channels">
+    All supported channels.
+  </Card>
+  <Card title="Pairing" icon="link" href="/channels/pairing">
+    DM authentication and pairing flow.
+  </Card>
+  <Card title="Groups" icon="users" href="/channels/groups">
+    Group chat behavior and mention gating.
+  </Card>
+  <Card title="Channel Routing" icon="route" href="/channels/channel-routing">
+    Session routing for messages.
+  </Card>
+  <Card title="Configuration reference" icon="sliders" href="/gateway/config-channels/workplace-chat">
+    Teams fields in the channel configuration reference.
+  </Card>
+  <Card title="Security" icon="shield" href="/gateway/security">
+    Access model and hardening.
+  </Card>
+</CardGroup>

--- a/docs/channels/msteams/access-control.md
+++ b/docs/channels/msteams/access-control.md
@@ -1,0 +1,129 @@
+---
+summary: "Microsoft Teams DM and group policy, team and channel allowlists, and conversation IDs"
+read_when:
+  - Deciding who may DM or mention the Teams bot
+  - Scoping replies to specific teams and channels
+  - Looking up a Teams team or channel ID
+title: "Microsoft Teams access control"
+sidebarTitle: "Access control"
+---
+
+Who may talk to the Teams bot, which teams and channels it answers in, and where the IDs those rules use come from.
+
+## Config writes
+
+By default, Microsoft Teams can write config updates triggered by `/config set|unset` (requires `commands.config: true`).
+
+Disable with:
+
+```json5
+{
+  channels: { msteams: { configWrites: false } },
+}
+```
+
+## Access control (DMs + groups)
+
+Microsoft Teams has one account per channel configuration. Set policies directly under `channels.msteams`; an `accounts` map is not supported.
+
+**DM access**
+
+- Default: `channels.msteams.dmPolicy = "pairing"`. Unknown senders are ignored until approved.
+- `channels.msteams.allowFrom` should use stable AAD object IDs or static sender access groups such as `accessGroup:core-team`.
+- Do not rely on UPN/display-name matching for allowlists; they can change. OpenClaw disables direct name matching by default; opt in with `channels.msteams.dangerouslyAllowNameMatching: true`.
+- The wizard can resolve names to IDs via Microsoft Graph when credentials allow.
+
+**Group access**
+
+- Default: `channels.msteams.groupPolicy = "allowlist"` (blocked unless you add `groupAllowFrom`). Set `channels.msteams.groupPolicy` explicitly to choose another policy; the root schema default takes precedence over `channels.defaults.groupPolicy`.
+- `channels.msteams.groupAllowFrom` controls which senders, static sender access groups, or group/channel conversation IDs can trigger in group chats/channels (falls back to `channels.msteams.allowFrom`). Conversation IDs can use `19:...@thread.tacv2`, `19:...@thread.v2`, or `19:...@thread.skype`; preserve the exact ID casing. OpenClaw ignores `;messageid=...` suffixes. Conversation IDs never grant personal-DM access.
+- Set `groupPolicy: "open"` to allow any member (still mention-gated by default).
+- To block **all** channels, set `channels.msteams.groupPolicy: "disabled"`.
+
+Example:
+
+```json5
+{
+  channels: {
+    msteams: {
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["00000000-0000-0000-0000-000000000000", "accessGroup:core-team"],
+    },
+  },
+}
+```
+
+**Team + channel allowlist**
+
+- Scope group/channel replies by listing teams and channels under `channels.msteams.teams`.
+- Use stable Teams conversation IDs from Teams links as keys, not mutable display names (see [Team and Channel IDs](#team-and-channel-ids-common-gotcha)).
+- When `groupPolicy="allowlist"` and a teams allowlist is present, only listed teams/channels are accepted (mention-gated).
+- `groupAllowFrom` authorizes group senders, not delegated Graph reads of other channels. If an existing configuration only sets `groupAllowFrom`, keep the default `groupPolicy: "allowlist"` and configure the target under `channels.msteams.teams.<team>.channels`.
+- Alternatively, deliberately set `groupPolicy: "open"` for broader delegated reads. This also admits **any group sender** (still mention-gated by default), so it is less restrictive than a scoped team/channel route.
+- Direct-operator reads and reads in the current conversation do not require an additional team/channel route.
+- The configure wizard accepts `Team/Channel` entries and stores them for you.
+- On startup, OpenClaw resolves team/channel and user allowlist names to IDs (when Graph permissions allow) and logs the mapping. Unresolved names are kept as typed but ignored for routing unless `channels.msteams.dangerouslyAllowNameMatching: true` is set.
+
+Example:
+
+```json5
+{
+  channels: {
+    msteams: {
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["00000000-0000-0000-0000-000000000000"],
+      teams: {
+        "19:team-id@thread.tacv2": {
+          channels: {
+            "19:channel-id@thread.tacv2": { requireMention: true },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+## Team and Channel IDs (Common Gotcha)
+
+The `groupId` query parameter in Teams URLs is **NOT** the team ID used for configuration. Extract IDs from the URL path instead:
+
+**Team URL:**
+
+```text
+https://teams.microsoft.com/l/team/19%3ABk4j...%40thread.tacv2/conversations?groupId=...
+                                    └────────────────────────────┘
+                                    Team conversation ID (URL-decode this)
+```
+
+**Channel URL:**
+
+```text
+https://teams.microsoft.com/l/channel/19%3A15bc...%40thread.tacv2/ChannelName?groupId=...
+                                      └─────────────────────────┘
+                                      Channel ID (URL-decode this)
+```
+
+**For config:**
+
+- Team key = path segment after `/team/` (URL-decoded, e.g., `19:Bk4j...@thread.tacv2`; older tenants may show `@thread.skype`, which is also valid).
+- Channel key = path segment after `/channel/` (URL-decoded).
+- **Ignore** the `groupId` query parameter for OpenClaw routing. It is the Microsoft Entra group ID, not the Bot Framework conversation ID used in incoming Teams activities.
+
+## Private channels
+
+Bots have limited support in private channels:
+
+| Feature                      | Standard channels | Private channels       |
+| ---------------------------- | ----------------- | ---------------------- |
+| Bot installation             | Yes               | Limited                |
+| Real-time messages (webhook) | Yes               | May not work           |
+| RSC permissions              | Yes               | May behave differently |
+| @mentions                    | Yes               | If bot is accessible   |
+| Graph API history            | Yes               | Yes (with permissions) |
+
+**Workarounds if private channels do not work:**
+
+1. Use standard channels for bot interactions.
+2. Use DMs; users can always message the bot directly.
+3. Use Graph API for historical access (requires `ChannelMessage.Read.All`).

--- a/docs/channels/msteams/authentication.md
+++ b/docs/channels/msteams/authentication.md
@@ -1,0 +1,136 @@
+---
+summary: "Certificate and managed identity authentication for the Microsoft Teams bot"
+read_when:
+  - Replacing a client secret with a certificate or managed identity
+  - Deploying the Teams bot on AKS with workload identity
+title: "Microsoft Teams authentication"
+sidebarTitle: "Authentication"
+---
+
+Federated authentication for the Teams bot, and how it compares with a client secret.
+
+## Federated authentication (certificate plus managed identity)
+
+For production, OpenClaw supports **federated authentication** as an alternative to client secrets, via `channels.msteams.authType: "federated"`. Two methods:
+
+### Option A: Certificate-based authentication
+
+Use a PEM certificate registered with your Entra ID app registration.
+
+**Setup:**
+
+1. Generate or obtain a certificate (PEM format with private key).
+2. Entra ID → App Registration → **Certificates & secrets** → **Certificates** → upload the public certificate.
+
+**Config:**
+
+```json5
+{
+  channels: {
+    msteams: {
+      enabled: true,
+      appId: "<APP_ID>",
+      tenantId: "<TENANT_ID>",
+      authType: "federated",
+      certificatePath: "/path/to/cert.pem",
+      webhook: { port: 3978, path: "/api/messages" },
+    },
+  },
+}
+```
+
+**Env vars:**
+
+- `MSTEAMS_AUTH_TYPE=federated`
+- `MSTEAMS_CERTIFICATE_PATH=/path/to/cert.pem`
+
+### Option B: Azure Managed Identity
+
+Use Azure Managed Identity for passwordless authentication on Azure infrastructure (AKS, App Service, Azure VMs).
+
+**How it works:**
+
+1. The bot pod/VM has a managed identity (system- or user-assigned).
+2. A federated identity credential links the managed identity to the Entra ID app registration.
+3. At runtime, OpenClaw uses `@azure/identity` to acquire tokens from the Azure IMDS endpoint.
+4. The token is passed to the Teams SDK for bot authentication.
+
+**Prerequisites:**
+
+- Azure infrastructure with managed identity enabled (AKS workload identity, App Service, VM).
+- Federated identity credential created on the Entra ID app registration.
+- Network access to IMDS (`169.254.169.254:80`) from the pod/VM.
+
+**Config (system-assigned managed identity):**
+
+```json5
+{
+  channels: {
+    msteams: {
+      enabled: true,
+      appId: "<APP_ID>",
+      tenantId: "<TENANT_ID>",
+      authType: "federated",
+      useManagedIdentity: true,
+      webhook: { port: 3978, path: "/api/messages" },
+    },
+  },
+}
+```
+
+**Config (user-assigned managed identity):** add `managedIdentityClientId: "<MI_CLIENT_ID>"` to the block above.
+
+**Env vars:**
+
+- `MSTEAMS_AUTH_TYPE=federated`
+- `MSTEAMS_USE_MANAGED_IDENTITY=true`
+- `MSTEAMS_MANAGED_IDENTITY_CLIENT_ID=<client-id>` (user-assigned only)
+
+### AKS Workload Identity setup
+
+For AKS deployments using workload identity:
+
+1. **Enable workload identity** on your AKS cluster.
+2. **Create a federated identity credential** on the Entra ID app registration:
+
+   ```bash
+   az ad app federated-credential create --id <APP_OBJECT_ID> --parameters '{
+     "name": "my-bot-workload-identity",
+     "issuer": "<AKS_OIDC_ISSUER_URL>",
+     "subject": "system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT>",
+     "audiences": ["api://AzureADTokenExchange"]
+   }'
+   ```
+
+3. **Annotate the Kubernetes service account** with the app client ID:
+
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: my-bot-sa
+     annotations:
+       azure.workload.identity/client-id: "<APP_CLIENT_ID>"
+   ```
+
+4. **Label the pod** for workload identity injection:
+
+   ```yaml
+   metadata:
+     labels:
+       azure.workload.identity/use: "true"
+   ```
+
+5. **Allow network access** to IMDS (`169.254.169.254`): if using NetworkPolicy, add an egress rule for `169.254.169.254/32` on port 80.
+
+### Auth type comparison
+
+| Method               | Config                                         | Pros                               | Cons                                  |
+| -------------------- | ---------------------------------------------- | ---------------------------------- | ------------------------------------- |
+| **Client secret**    | `appPassword`                                  | Simple setup                       | Secret rotation required, less secure |
+| **Certificate**      | `authType: "federated"` + `certificatePath`    | No shared secret over network      | Certificate management overhead       |
+| **Managed Identity** | `authType: "federated"` + `useManagedIdentity` | Passwordless, no secrets to manage | Azure infrastructure required         |
+
+`certificateThumbprint` can be set alongside `certificatePath` but is not read by the auth path today; it is accepted for forward compatibility only.
+
+**Default:** when `authType` is unset, OpenClaw uses client-secret authentication (`appPassword`). Existing configs keep working unchanged.

--- a/docs/channels/msteams/cards-and-actions.md
+++ b/docs/channels/msteams/cards-and-actions.md
@@ -1,0 +1,149 @@
+---
+summary: "Microsoft Teams Adaptive Card approvals, polls, presentation cards, member info, and targets"
+read_when:
+  - Sending approvals, polls, or presentation cards to Teams
+  - Addressing a Teams user or conversation from the CLI or message tool
+  - Resolving roster details for a Teams conversation
+title: "Microsoft Teams cards and actions"
+sidebarTitle: "Cards and actions"
+---
+
+The Adaptive Card surfaces OpenClaw sends to Teams, the Graph-backed roster lookup, and the target formats that address them.
+
+## Member info action
+
+OpenClaw exposes a Graph-backed `member-info` action for Microsoft Teams so agents and automations can resolve verified roster details for a configured conversation.
+
+Requirements:
+
+- `ChannelSettings.Read.Group` and `TeamMember.Read.Group` RSC permissions (already in the recommended manifest).
+
+The action is available whenever Graph credentials are configured; there is no separate `channels.msteams.actions.memberInfo` toggle.
+Standard-channel lookups return the matching team-roster identity, display name, email, and roles.
+In the current DM or group chat, the action can return the trusted sender's stable user ID.
+Private/shared-channel and non-current chat member lookups require additional roster permissions
+and are rejected by the default permission baseline.
+
+## Native approval cards
+
+Microsoft Teams can deliver exec and plugin approval requests as Adaptive Cards in the originating conversation. Each card describes the requested command or plugin action and provides only the decisions allowed for that request, such as **Approve once**, **Always allow**, and **Deny**. After a decision or expiration, OpenClaw updates the original card with its final status.
+
+Enable the existing top-level approval forwarding settings for each approval type you want to receive:
+
+```json5
+{
+  approvals: {
+    exec: { enabled: true, mode: "session" },
+    plugin: { enabled: true, mode: "session" },
+  },
+  channels: {
+    msteams: {
+      allowFrom: ["00000000-0000-0000-0000-000000000000"],
+    },
+  },
+}
+```
+
+`approvals.exec` and `approvals.plugin` are independent; enabling one does not enable the other. Native card delivery also requires a configured Teams bot and at least one approver resolved from `channels.msteams.allowFrom` or `channels.msteams.defaultTo`. Approvers must be stable AAD object IDs; display names, email addresses, group entries, and conversation IDs do not grant approval access. OpenClaw checks the clicking user's AAD object ID before resolving the request.
+
+No Teams-specific approval configuration is required. The existing `/approve <id> <decision>` command remains available as a text fallback when native delivery is unavailable. For forwarding modes and supported decisions, see [Approval forwarding to chat channels](/tools/exec-approvals-advanced#approval-forwarding-to-chat-channels).
+
+## Polls (Adaptive Cards)
+
+OpenClaw sends Teams polls as Adaptive Cards (there is no native Teams poll API).
+
+- CLI: `openclaw message poll --channel msteams --target conversation:<id> --poll-question "..." --poll-option "..." --poll-option "..."`.
+- Votes are recorded by the gateway in OpenClaw plugin-state SQLite under `state/openclaw.sqlite`.
+- Existing `msteams-polls.json` files are imported by `openclaw doctor --fix`, not by the running plugin.
+- The gateway must stay online to record votes.
+- Polls do not auto-post result summaries, and there is no poll-results CLI yet.
+
+## Presentation cards
+
+Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract.
+
+The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional. Buttons render as Adaptive Card submit or URL actions. Select menus are not native in the Teams renderer, so OpenClaw downgrades them to readable text before delivery.
+
+**Agent tool:**
+
+```json5
+{
+  action: "send",
+  channel: "msteams",
+  target: "user:<id>",
+  presentation: {
+    title: "Hello",
+    blocks: [{ type: "text", text: "Hello!" }],
+  },
+}
+```
+
+**CLI:**
+
+```bash
+openclaw message send --channel msteams \
+  --target "conversation:19:abc...@thread.tacv2" \
+  --presentation '{"title":"Hello","blocks":[{"type":"text","text":"Hello!"}]}'
+```
+
+For target format details, see [Target formats](#target-formats) below.
+
+## Target formats
+
+MSTeams targets use prefixes to distinguish between users and conversations:
+
+| Target type         | Format                           | Example                                                                                                |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| User (by ID)        | `user:<aad-object-id>`           | `user:40a1a0ed-4ff2-4164-a219-55518990c197`                                                            |
+| User (by name)      | `user:<display-name>`            | `user:John Smith` (requires Graph API)                                                                 |
+| Group/channel       | `conversation:<conversation-id>` | `conversation:19:abc123...@thread.tacv2`                                                               |
+| Group/channel (raw) | `<conversation-id>`              | `19:abc123...@thread.tacv2`, `19:...@unq.gbl.spaces`, or a bare `a:`/`8:orgid:`/`29:` Bot Framework id |
+
+**CLI examples:**
+
+```bash
+# Send to a user by ID
+openclaw message send --channel msteams --target "user:40a1a0ed-..." --message "Hello"
+
+# Send to a user by display name (triggers Graph API lookup)
+openclaw message send --channel msteams --target "user:John Smith" --message "Hello"
+
+# Send to a group chat or channel
+openclaw message send --channel msteams --target "conversation:19:abc...@thread.tacv2" --message "Hello"
+
+# Send a presentation card to a conversation
+openclaw message send --channel msteams --target "conversation:19:abc...@thread.tacv2" \
+  --presentation '{"title":"Hello","blocks":[{"type":"text","text":"Hello"}]}'
+```
+
+**Agent tool examples:**
+
+```json5
+{
+  action: "send",
+  channel: "msteams",
+  target: "user:John Smith",
+  message: "Hello!",
+}
+```
+
+```json5
+{
+  action: "send",
+  channel: "msteams",
+  target: "conversation:19:abc...@thread.tacv2",
+  presentation: {
+    title: "Hello",
+    blocks: [{ type: "text", text: "Hello" }],
+  },
+}
+```
+
+<Note>
+Without the `user:` prefix, names default to group or team resolution. Always use `user:` when targeting people by display name.
+</Note>
+
+## Proactive messaging
+
+- Proactive messages are only possible **after** a user has interacted, because OpenClaw stores conversation references at that point.
+- See [/gateway/configuration](/gateway/configuration) for `dmPolicy` and allowlist gating.

--- a/docs/channels/msteams/configuration.md
+++ b/docs/channels/msteams/configuration.md
@@ -1,0 +1,75 @@
+---
+summary: "Microsoft Teams configuration keys, environment variables, and history limits"
+read_when:
+  - Looking up a `channels.msteams` configuration key
+  - Setting Teams credentials from environment variables
+  - Tuning how much history reaches the prompt
+title: "Microsoft Teams configuration"
+sidebarTitle: "Configuration"
+---
+
+The `channels.msteams` settings, the environment variables that stand in for the auth keys, and the history context rules.
+
+## Environment variables
+
+These auth-related config keys can be set via environment variables instead of `openclaw.json` (other config keys, such as `groupPolicy` or `historyLimit`, are config-only):
+
+| Env var                              | Config key                | Notes                               |
+| ------------------------------------ | ------------------------- | ----------------------------------- |
+| `MSTEAMS_APP_ID`                     | `appId`                   |                                     |
+| `MSTEAMS_APP_PASSWORD`               | `appPassword`             |                                     |
+| `MSTEAMS_TENANT_ID`                  | `tenantId`                |                                     |
+| `MSTEAMS_AUTH_TYPE`                  | `authType`                | `"secret"` or `"federated"`         |
+| `MSTEAMS_CERTIFICATE_PATH`           | `certificatePath`         | federated + certificate             |
+| `MSTEAMS_CERTIFICATE_THUMBPRINT`     | `certificateThumbprint`   | accepted, not required for auth     |
+| `MSTEAMS_USE_MANAGED_IDENTITY`       | `useManagedIdentity`      | federated + managed identity        |
+| `MSTEAMS_MANAGED_IDENTITY_CLIENT_ID` | `managedIdentityClientId` | user-assigned managed identity only |
+
+## History context
+
+- `channels.msteams.historyLimit` controls how many recent channel/group messages are wrapped into the prompt. Falls back to `messages.groupChat.historyLimit`, then defaults to 50. Set `0` to disable.
+- Graph thread context adds the parent and up to the oldest 50 replies alongside recent channel history. It excludes the triggering message and keeps history separate from the sender's command text, so commands quoted in history do not execute. Long fetched messages retain their beginning and end within the prompt's per-message limit.
+- Thread and quoted attachment context follow `channels.msteams.contextVisibility`, falling back to `channels.defaults.contextVisibility`, then `all`. Use `allowlist` to filter both by sender allowlists (`allowFrom` / `groupAllowFrom`), or `allowlist_quote` to filter thread history while permitting quoted context.
+- DM history can be limited with `channels.msteams.dmHistoryLimit` (user turns). Per-user overrides: `channels.msteams.dms["<user_id>"].historyLimit`.
+
+## Configuration
+
+Key settings (see [/gateway/configuration](/gateway/configuration) for shared channel patterns):
+
+- `channels.msteams.enabled`: enable/disable the channel.
+- `channels.msteams.appId`, `channels.msteams.appPassword`, `channels.msteams.tenantId`: bot credentials.
+- `channels.msteams.cloud`: Teams SDK cloud environment (`Public`, `USGov`, `USGovDoD`, or `China`; default `Public`). Set with `serviceUrl` for USGov/DoD SDK clouds; China uses the SDK preset and stored Azure China Bot Framework conversation references, with Graph-backed helpers disabled until Azure China Graph routing ships.
+- `channels.msteams.serviceUrl`: Bot Connector service URL boundary for SDK proactive operations. Public cloud uses the SDK default; set for GCC (`https://smba.infra.gcc.teams.microsoft.com/teams`), GCC High, or DoD. China accepts Azure China Bot Framework channel hosts when the stored conversation reference comes from Teams operated by 21Vianet.
+- `channels.msteams.webhook.port` (default `3978`).
+- `channels.msteams.webhook.path` (default `/api/messages`).
+- `channels.msteams.dmPolicy`: `pairing | allowlist | open | disabled` (default `pairing`).
+- `channels.msteams.allowFrom`: DM allowlist (AAD object IDs recommended). Stable AAD object IDs also authorize approval actions. The wizard resolves names to IDs during setup when Graph access is available.
+- `channels.msteams.defaultTo`: default outbound target; a stable AAD object ID can also authorize approval actions.
+- `channels.msteams.dangerouslyAllowNameMatching`: break-glass toggle to re-enable mutable UPN/display-name matching and direct team/channel name routing.
+- `channels.msteams.textChunkLimit`: outbound text chunk size in characters (default `4000`, and hard-capped at `4000` regardless of a higher configured value).
+- `channels.msteams.streaming.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
+- `channels.msteams.mediaAllowHosts`: allowlist for inbound attachment hosts (defaults to Microsoft/Teams domains: Graph, SharePoint/OneDrive, Teams CDN, Bot Framework, Azure Media Services).
+- `channels.msteams.mediaAuthAllowHosts`: allowlist for attaching Authorization headers on media retries (defaults to Graph + Bot Framework hosts).
+- `channels.msteams.graphMediaFallback`: opt into Graph message lookups when channel/group HTML omits file markers (default `false`; see [Channel/group file recovery](/channels/msteams/manifest-and-permissions#channel%2Fgroup-file-recovery-graphmediafallback)).
+- `channels.msteams.mediaMaxMb`: per-channel media size limit override in MB. Falls back to `agents.defaults.mediaMaxMb` when unset.
+- `channels.msteams.requireMention`: require @mention in channels/groups (default `true`).
+- `channels.msteams.replyStyle`: `thread | top-level` (see [Reply style](/channels/msteams/messaging#reply-style-threads-vs-posts)).
+- `channels.msteams.teams.<teamId>.replyStyle`: per-team override.
+- `channels.msteams.teams.<teamId>.requireMention`: per-team override.
+- `channels.msteams.teams.<teamId>.tools`: default per-team tool policy overrides (`allow`/`deny`/`alsoAllow`) used when a channel override is missing.
+- `channels.msteams.teams.<teamId>.toolsBySender`: default per-team per-sender tool policy overrides (`"*"` wildcard supported).
+- `channels.msteams.teams.<teamId>.channels.<conversationId>.replyStyle`: per-channel override.
+- `channels.msteams.teams.<teamId>.channels.<conversationId>.requireMention`: per-channel override.
+- `channels.msteams.teams.<teamId>.channels.<conversationId>.tools`: per-channel tool policy overrides (`allow`/`deny`/`alsoAllow`).
+- `channels.msteams.teams.<teamId>.channels.<conversationId>.toolsBySender`: per-channel per-sender tool policy overrides (`"*"` wildcard supported).
+- `toolsBySender` keys should use explicit prefixes: `channel:`, `id:`, `e164:`, `username:`, `name:` (legacy unprefixed keys still map to `id:` only).
+- `channels.msteams.authType`: authentication type - `"secret"` (default) or `"federated"`.
+- `channels.msteams.certificatePath`: path to PEM certificate file (federated + certificate auth).
+- `channels.msteams.certificateThumbprint`: certificate thumbprint; accepted, not required for auth.
+- `channels.msteams.useManagedIdentity`: enable managed identity auth (federated mode).
+- `channels.msteams.managedIdentityClientId`: client ID for user-assigned managed identity.
+- `channels.msteams.sharePointSiteId`: SharePoint site ID for file uploads in group chats/channels (see [Sending files in group chats](/channels/msteams/messaging#sending-files-in-group-chats)).
+- `channels.msteams.welcomeCard`, `channels.msteams.groupWelcomeCard`, `channels.msteams.promptStarters`: welcome Adaptive Card shown on first DM/group contact, and its suggested prompt buttons.
+- `channels.msteams.responsePrefix`: text prefixed to outbound replies.
+- `channels.msteams.feedbackEnabled` (default `true`), `channels.msteams.feedbackReflection` (default `true`), `channels.msteams.feedbackReflectionCooldownMs`: thumbs-up/down feedback on replies and the negative-feedback reflection follow-up.
+- `channels.msteams.sso`, `channels.msteams.delegatedAuth`: Bot Framework OAuth connection and delegated Graph scopes for SSO-backed flows; `sso.enabled: true` requires `sso.connectionName`.

--- a/docs/channels/msteams/manifest-and-permissions.md
+++ b/docs/channels/msteams/manifest-and-permissions.md
@@ -1,0 +1,184 @@
+---
+summary: "Microsoft Teams app manifest, RSC permissions, and the Graph permissions each capability needs"
+read_when:
+  - Building or updating the Teams app manifest
+  - Deciding which RSC or Microsoft Graph permissions to grant
+  - Channel images or history are missing
+title: "Microsoft Teams manifest and permissions"
+sidebarTitle: "Manifest and permissions"
+---
+
+The Teams app manifest, the resource-specific consent permissions it declares, and the Microsoft Graph permissions that unlock media and history.
+
+## Current Teams RSC permissions (manifest)
+
+These are the **existing resourceSpecific permissions** in our Teams app manifest. They only apply inside the team/chat where the app is installed.
+
+**For channels (team scope):**
+
+- `ChannelMessage.Read.Group` (Application) - receive all channel messages without @mention
+- `ChannelMessage.Send.Group` (Application)
+- `Member.Read.Group` (Application)
+- `Owner.Read.Group` (Application)
+- `ChannelSettings.Read.Group` (Application)
+- `TeamMember.Read.Group` (Application)
+- `TeamSettings.Read.Group` (Application)
+
+**For group chats:**
+
+- `ChatMessage.Read.Chat` (Application) - receive all group chat messages without @mention
+
+Add RSC permissions via the Teams CLI:
+
+```bash
+teams app rsc add <teamsAppId> ChannelMessage.Read.Group --type Application
+```
+
+## Example Teams manifest (redacted)
+
+Minimal, valid example with the required fields. Replace IDs and URLs.
+
+```json5
+{
+  $schema: "https://developer.microsoft.com/en-us/json-schemas/teams/v1.23/MicrosoftTeams.schema.json",
+  manifestVersion: "1.23",
+  version: "1.0.0",
+  id: "00000000-0000-0000-0000-000000000000",
+  name: { short: "OpenClaw" },
+  developer: {
+    name: "Your Org",
+    websiteUrl: "https://example.com",
+    privacyUrl: "https://example.com/privacy",
+    termsOfUseUrl: "https://example.com/terms",
+  },
+  description: { short: "OpenClaw in Teams", full: "OpenClaw in Teams" },
+  icons: { outline: "outline.png", color: "color.png" },
+  accentColor: "#5B6DEF",
+  bots: [
+    {
+      botId: "11111111-1111-1111-1111-111111111111",
+      scopes: ["personal", "team", "groupChat"],
+      isNotificationOnly: false,
+      supportsCalling: false,
+      supportsVideo: false,
+      supportsFiles: true,
+    },
+  ],
+  webApplicationInfo: {
+    id: "11111111-1111-1111-1111-111111111111",
+  },
+  authorization: {
+    permissions: {
+      resourceSpecific: [
+        { name: "ChannelMessage.Read.Group", type: "Application" },
+        { name: "ChannelMessage.Send.Group", type: "Application" },
+        { name: "Member.Read.Group", type: "Application" },
+        { name: "Owner.Read.Group", type: "Application" },
+        { name: "ChannelSettings.Read.Group", type: "Application" },
+        { name: "TeamMember.Read.Group", type: "Application" },
+        { name: "TeamSettings.Read.Group", type: "Application" },
+        { name: "ChatMessage.Read.Chat", type: "Application" },
+      ],
+    },
+  },
+}
+```
+
+### Manifest caveats (must-have fields)
+
+- `bots[].botId` **must** match the Azure Bot App ID.
+- `webApplicationInfo.id` **must** match the Azure Bot App ID.
+- `bots[].scopes` must include the surfaces you plan to use (`personal`, `team`, `groupChat`).
+- `bots[].supportsFiles: true` is required for file handling in personal scope.
+- `authorization.permissions.resourceSpecific` must include channel read/send for channel traffic.
+
+### Updating an existing app
+
+```bash
+# Download, edit, and re-upload the manifest
+teams app manifest download <teamsAppId> manifest.json
+# Edit manifest.json locally...
+teams app manifest upload manifest.json <teamsAppId>
+# Version is auto-bumped if content changed
+```
+
+After updating, reinstall the app in each team, and **fully quit and relaunch Teams** (not just close the window) to clear cached app metadata.
+
+<details>
+<summary>Manual manifest update (without CLI)</summary>
+
+1. Update `manifest.json` with the new settings.
+2. **Increment the `version` field** (e.g., `1.0.0` → `1.1.0`).
+3. **Re-zip** the manifest with icons (`manifest.json`, `outline.png`, `color.png`).
+4. Upload the new zip:
+   - **Teams Admin Center:** Teams apps → Manage apps → find your app → Upload new version.
+   - **Sideload:** Teams → Apps → Manage your apps → Upload a custom app.
+
+</details>
+
+## Capabilities: RSC only vs Graph
+
+### With **Teams RSC only** (app installed, no Graph API permissions)
+
+Works:
+
+- Read channel message **text** content.
+- Send channel message **text** content.
+- Receive **personal (DM)** file attachments.
+
+Does NOT work:
+
+- Channel/group **image or file contents** (payload only includes an HTML stub).
+- Downloading attachments stored in SharePoint/OneDrive.
+- Reading message history beyond the live webhook event.
+
+### With **Teams RSC + Microsoft Graph Application permissions**
+
+Adds:
+
+- Downloading hosted content (images pasted into messages).
+- Downloading file attachments stored in SharePoint/OneDrive.
+- Reading channel/chat message history via Graph.
+
+### RSC vs Graph API
+
+| Capability              | RSC permissions      | Graph API                           |
+| ----------------------- | -------------------- | ----------------------------------- |
+| **Real-time messages**  | Yes (via webhook)    | No (polling only)                   |
+| **Historical messages** | No                   | Yes (can query history)             |
+| **Setup complexity**    | App manifest only    | Requires admin consent + token flow |
+| **Works offline**       | No (must be running) | Yes (query anytime)                 |
+
+**Bottom line:** RSC is for real-time listening; Graph API is for historical access. To catch up on missed messages while offline, you need Graph API with `ChannelMessage.Read.All` (requires admin consent).
+
+## Graph-enabled media + history
+
+Enable only the Microsoft Graph application permissions needed for the Teams scopes and data you use:
+
+1. Entra ID (Azure AD) **App Registration** → add Graph **Application permissions**:
+   - `ChannelMessage.Read.All` for channel attachments and channel history.
+   - `Chat.Read.All` for group-chat attachments and group-chat history.
+   - `Files.Read.All` when attachment bytes must be downloaded from SharePoint/OneDrive storage; history-only setups do not need it.
+2. **Grant admin consent** for the tenant.
+3. Bump the Teams app **manifest version**, re-upload, and **reinstall the app in Teams**.
+4. **Fully quit and relaunch Teams** to clear cached app metadata.
+
+### Channel/group file recovery (`graphMediaFallback`)
+
+Teams can remove file markers from the HTML activity sent to a bot. In that case, the Bot Framework activity is indistinguishable from an ordinary HTML message; the complete attachment reference exists only on the Graph copy of the message.
+
+Enable the fallback after granting the permissions above:
+
+```json5
+{
+  channels: {
+    msteams: {
+      graphMediaFallback: true,
+    },
+  },
+}
+```
+
+This applies to channels and group chats only. It adds one Graph message lookup whenever an HTML activity produced no directly downloadable media, including ordinary or mention-only messages. The default is `false` so existing installations do not gain extra Graph traffic or permission errors automatically.
+
+**User mentions:** @mentions work out of the box for users already in the conversation. To dynamically search and mention users **not in the current conversation**, add `User.Read.All` (Application) permission and grant admin consent.

--- a/docs/channels/msteams/messaging.md
+++ b/docs/channels/msteams/messaging.md
@@ -1,0 +1,160 @@
+---
+summary: "Microsoft Teams session routing, reply style, attachments, and file sending"
+read_when:
+  - Choosing between threaded and top-level replies
+  - Attachments arrive without content
+  - Sending files into a group chat or channel
+title: "Microsoft Teams message behavior"
+sidebarTitle: "Message behavior"
+---
+
+How replies are routed and threaded, and how attachments and files move in and out of Teams.
+
+## Routing and sessions
+
+- Session keys follow the standard agent format (see [/concepts/session](/concepts/session)):
+  - Direct messages share the main session (`agent:<agentId>:main`) by default.
+  - Channel/group messages use conversation id:
+    - `agent:<agentId>:msteams:channel:<conversationId>`
+    - `agent:<agentId>:msteams:group:<conversationId>`
+
+## Reply style: threads vs posts
+
+Teams has two channel UI styles over the same underlying data model:
+
+| Style                    | Description                                               | Recommended `replyStyle` |
+| ------------------------ | --------------------------------------------------------- | ------------------------ |
+| **Posts** (classic)      | Messages appear as cards with threaded replies underneath | `thread` (default)       |
+| **Threads** (Slack-like) | Messages flow linearly, more like Slack                   | `top-level`              |
+
+**The problem:** the Teams API does not expose which UI style a channel uses. If you use the wrong `replyStyle`:
+
+- `thread` in a Threads-style channel → replies appear nested awkwardly.
+- `top-level` in a Posts-style channel → replies appear as separate top-level posts instead of in-thread.
+
+**Solution:** configure `replyStyle` per-channel based on how the channel is set up:
+
+```json5
+{
+  channels: {
+    msteams: {
+      replyStyle: "thread",
+      teams: {
+        "19:abc...@thread.tacv2": {
+          channels: {
+            "19:xyz...@thread.tacv2": {
+              replyStyle: "top-level",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### Resolution precedence
+
+When the bot sends a reply into a channel, `replyStyle` is resolved from the most specific override down to the default. The first non-`undefined` value wins:
+
+1. **Per-channel** - `channels.msteams.teams.<teamId>.channels.<conversationId>.replyStyle`
+2. **Per-team** - `channels.msteams.teams.<teamId>.replyStyle`
+3. **Global** - `channels.msteams.replyStyle`
+4. **Implicit default** - derived from `requireMention`:
+   - `requireMention: true` → `thread`
+   - `requireMention: false` → `top-level`
+
+If you set `requireMention: false` globally without an explicit `replyStyle`, mentions in Posts-style channels surface as top-level posts even when the inbound was a thread reply. Pin `replyStyle: "thread"` at the global, team, or channel level to avoid surprises.
+
+For proactive sends into a stored channel conversation (queued tool-call replies, long-running agents), the same team/channel resolution applies; group chats and personal (DM) conversations always resolve to `top-level` for proactive sends regardless of `replyStyle`.
+
+### Thread context preservation
+
+When `replyStyle: "thread"` is in effect and the bot was @mentioned from inside a channel thread, OpenClaw re-attaches the original thread root to the outbound conversation reference (`19:...@thread.tacv2;messageid=<root>`) so the reply lands inside the same thread. This holds for both live (in-turn) sends and proactive sends made after the Bot Framework turn context has expired (e.g., long-running agents, queued tool-call replies via `mcp__openclaw__message`).
+
+The thread root is taken from the stored `threadId` on the conversation reference. Older stored references that predate `threadId` fall back to `activityId` (whatever inbound activity last seeded the conversation), so existing deployments keep working without a re-seed.
+
+When `replyStyle: "top-level"` is in effect, channel-thread inbounds are intentionally answered as new top-level posts; no thread suffix is attached. This is correct for Threads-style channels; top-level posts where you expected threaded replies means `replyStyle` is set incorrectly for that channel.
+
+## Attachments and images
+
+**Current limitations:**
+
+- **DMs:** images and file attachments work via Teams bot file APIs.
+- **Channels/groups:** attachments live in M365 storage (SharePoint/OneDrive). The webhook payload only includes an HTML stub, not the actual file bytes. **Graph API permissions are required** to download channel attachments.
+- For explicit file-first sends, use `action=upload-file` with `media` / `filePath` / `path`; optional `message` becomes the accompanying text/comment, and `filename` (or `title`) overrides the uploaded name.
+
+Without Graph permissions, channel messages with images arrive as text-only (the image content is not accessible to the bot).
+By default, OpenClaw only downloads media from Microsoft/Teams hostnames. Override with `channels.msteams.mediaAllowHosts` (use `["*"]` to allow any host).
+Authorization headers are only attached for hosts in `channels.msteams.mediaAuthAllowHosts` (defaults to Graph + Bot Framework hosts). Keep this list strict (avoid multi-tenant suffixes).
+
+## Sending files in group chats
+
+Bots can send files in DMs using the built-in FileConsentCard flow. **Sending files in group chats/channels** requires additional setup:
+
+| Context                  | How files are sent                           | Setup needed                                    |
+| ------------------------ | -------------------------------------------- | ----------------------------------------------- |
+| **DMs**                  | FileConsentCard → user accepts → bot uploads | Works out of the box                            |
+| **Group chats/channels** | Upload to SharePoint → native file card      | Requires `sharePointSiteId` + Graph permissions |
+| **Images (any context)** | Base64-encoded inline                        | Works out of the box                            |
+
+### Why group chats need SharePoint
+
+Bots use an application identity, while Microsoft Graph's `/me` resource [requires a signed-in user](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0). To send files in group chats/channels, the bot uploads to a **SharePoint site** and creates a sharing link.
+
+### Setup
+
+1. **Add Graph API permissions** in Entra ID (Azure AD) → App Registration:
+   - `Sites.ReadWrite.All` (Application) - upload files to SharePoint.
+   - `ChatMember.Read.All` (Application) - least-privileged tenant-wide permission for group-chat file sends. `Chat.Read.All` also works and already covers this when group-chat history is enabled. As a per-chat alternative, use the `ChatMember.Read.Chat` [resource-specific consent permission](https://learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent).
+2. **Grant admin consent** for the tenant.
+3. **Get your SharePoint site ID:**
+
+   ```bash
+   # Via Graph Explorer or curl with a valid token:
+   curl -H "Authorization: Bearer $TOKEN" \
+     "https://graph.microsoft.com/v1.0/sites/{hostname}:/{site-path}"
+
+   # Example: for a site at "contoso.sharepoint.com/sites/BotFiles"
+   curl -H "Authorization: Bearer $TOKEN" \
+     "https://graph.microsoft.com/v1.0/sites/contoso.sharepoint.com:/sites/BotFiles"
+
+   # Response includes: "id": "contoso.sharepoint.com,guid1,guid2"
+   ```
+
+4. **Configure OpenClaw:**
+
+   ```json5
+   {
+     channels: {
+       msteams: {
+         // ... other config ...
+         sharePointSiteId: "contoso.sharepoint.com,guid1,guid2",
+       },
+     },
+   }
+   ```
+
+### Sharing behavior
+
+| Context and permission                                                  | Sharing behavior                                          |
+| ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| Channel + `Sites.ReadWrite.All`                                         | Organization-wide sharing link (anyone in org can access) |
+| Group chat + `Sites.ReadWrite.All` + a supported chat-member read grant | Per-user sharing link (only chat members can access)      |
+| Group chat without a supported chat-member read grant                   | Send fails closed                                         |
+
+Per-user sharing is more secure since only chat participants can access the file. OpenClaw requires a successful member lookup for group chats; timeouts, transport failures, empty results, and Graph API denials fail the send instead of widening access to the organization.
+
+### Fallback behavior
+
+| Scenario                                                         | Result                                           |
+| ---------------------------------------------------------------- | ------------------------------------------------ |
+| Group chat + file + SharePoint and member permissions configured | Upload to SharePoint, send a native file card    |
+| Group chat + file + missing SharePoint or member permissions     | Fail with an actionable configuration error      |
+| Channel + file + `sharePointSiteId` configured                   | Upload to SharePoint, send a native file card    |
+| Personal chat + file                                             | FileConsentCard flow (works without SharePoint)  |
+| Any context + image                                              | Base64-encoded inline (works without SharePoint) |
+
+### Files stored location
+
+Uploaded files are stored in a `/OpenClawShared/` folder in the configured SharePoint site's default document library.

--- a/docs/channels/msteams/setup.md
+++ b/docs/channels/msteams/setup.md
@@ -1,0 +1,244 @@
+---
+summary: "Install the Microsoft Teams plugin, register the bot and Teams app, and run against a dev tunnel"
+read_when:
+  - Setting up the Microsoft Teams channel for the first time
+  - Registering an Azure Bot and Teams app by hand
+  - Running Teams against a local dev tunnel
+title: "Microsoft Teams setup"
+sidebarTitle: "Setup"
+---
+
+Install the plugin, register the bot and Teams app, point Teams at a reachable endpoint, and verify the result.
+
+## Bundled plugin
+
+Microsoft Teams ships as a bundled plugin in current OpenClaw releases; no separate install is required in the normal packaged build.
+
+On an older build or a custom install that excludes bundled Teams, install the npm package directly:
+
+```bash
+openclaw plugins install @openclaw/msteams
+```
+
+Use the bare package to follow the current official release tag. Pin an exact version only when you need a reproducible install.
+
+Local checkout (running from a git repo):
+
+```bash
+openclaw plugins install ./path/to/local/msteams-plugin
+```
+
+Details: [Plugins](/tools/plugin)
+
+## Quick setup
+
+[`@microsoft/teams.cli`](https://www.npmjs.com/package/@microsoft/teams.cli) handles bot registration, manifest creation, and credential generation in one command.
+
+**1. Install and log in**
+
+```bash
+npm install -g @microsoft/teams.cli@preview
+teams login
+teams status   # verify you're logged in and see your tenant info
+```
+
+<Note>
+The Teams CLI is currently in preview. Commands and flags may change between releases.
+</Note>
+
+**2. Start a tunnel** (Teams cannot reach localhost)
+
+Install and authenticate the devtunnel CLI if needed ([getting started guide](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)).
+
+```bash
+# One-time setup (persistent URL across sessions):
+devtunnel create my-openclaw-bot --allow-anonymous
+devtunnel port create my-openclaw-bot -p 3978 --protocol auto
+
+# Each dev session:
+devtunnel host my-openclaw-bot
+# Your endpoint: https://<tunnel-id>.devtunnels.ms/api/messages
+```
+
+<Note>
+`--allow-anonymous` is required because Teams cannot authenticate with devtunnels. Each incoming bot request is still validated by the Teams SDK.
+</Note>
+
+Alternatives: `ngrok http 3978` or `tailscale funnel 3978` (URLs may change each session).
+
+**3. Create the app**
+
+```bash
+teams app create \
+  --name "OpenClaw" \
+  --endpoint "https://<your-tunnel-url>/api/messages"
+```
+
+This creates an Entra ID (Azure AD) application, generates a client secret, builds and uploads a Teams app manifest (with icons), and registers a Teams-managed bot (no Azure subscription needed). The output includes `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`, and a **Teams App ID**; it also offers to install the app in Teams directly.
+
+**4. Configure OpenClaw** using the credentials from the output:
+
+```json5
+{
+  channels: {
+    msteams: {
+      enabled: true,
+      appId: "<CLIENT_ID>",
+      appPassword: "<CLIENT_SECRET>",
+      tenantId: "<TENANT_ID>",
+      webhook: { port: 3978, path: "/api/messages" },
+    },
+  },
+}
+```
+
+Or use environment variables directly: `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID`.
+
+**5. Install the app in Teams**
+
+`teams app create` prompts you to install the app; select "Install in Teams". To get the install link later:
+
+```bash
+teams app get <teamsAppId> --install-link
+```
+
+**6. Verify everything works**
+
+```bash
+teams app doctor <teamsAppId>
+```
+
+Runs diagnostics across bot registration, AAD app config, manifest validity, and SSO setup.
+
+For production, consider [federated authentication](/channels/msteams/authentication#federated-authentication-certificate-plus-managed-identity) (certificate or managed identity) instead of client secrets.
+
+<Note>
+Group chats are blocked by default (`channels.msteams.groupPolicy: "allowlist"`). To allow group replies, set `channels.msteams.groupAllowFrom`, or use `groupPolicy: "open"` to allow any member (mention-gated).
+</Note>
+
+## Goals
+
+- Talk to OpenClaw via Teams DMs, group chats, or channels.
+- Keep routing deterministic: replies always go back to the channel they arrived on.
+- Default to safe channel behavior (mentions required unless configured otherwise).
+
+<details>
+<summary><strong>Manual setup (without the Teams CLI)</strong></summary>
+
+### How it works
+
+1. Ensure the Microsoft Teams plugin is available (bundled in current releases).
+2. Create an **Azure Bot** (App ID + secret + tenant ID).
+3. Build a **Teams app package** referencing the bot, including the [RSC permissions](/channels/msteams/manifest-and-permissions#current-teams-rsc-permissions-manifest).
+4. Upload/install the Teams app into a team (or personal scope for DMs).
+5. Configure `msteams` in `~/.openclaw/openclaw.json` (or env vars) and start the gateway.
+6. The gateway listens for Bot Framework webhook traffic on `/api/messages` by default.
+
+### Step 1: Create Azure Bot
+
+1. Go to [Create Azure Bot](https://portal.azure.com/#create/Microsoft.AzureBot)
+2. Fill in the **Basics** tab:
+
+   | Field              | Value                                                    |
+   | ------------------ | -------------------------------------------------------- |
+   | **Bot handle**     | Your bot name, e.g., `openclaw-msteams` (must be unique) |
+   | **Subscription**   | Select your Azure subscription                           |
+   | **Resource group** | Create new or use existing                               |
+   | **Pricing tier**   | **Free** for dev/testing                                 |
+   | **Type of App**    | **Single Tenant** (recommended; see note below)          |
+   | **Creation type**  | **Create new Microsoft App ID**                          |
+
+<Warning>
+Creation of new multi-tenant bots was deprecated after 2025-07-31. Use **Single Tenant** for new bots.
+</Warning>
+
+3. Click **Review + create** then **Create** (~1-2 minutes).
+
+### Step 2: Get credentials
+
+1. Azure Bot resource → **Configuration** → copy **Microsoft App ID** (your `appId`).
+2. **Manage Password** → App Registration → **Certificates & secrets** → **New client secret** → copy the **Value** (your `appPassword`).
+3. **Overview** → copy **Directory (tenant) ID** (your `tenantId`).
+
+### Step 3: Configure messaging endpoint
+
+1. Azure Bot → **Configuration**.
+2. Set **Messaging endpoint**:
+   - Production: `https://your-domain.com/api/messages`
+   - Local dev: use a tunnel (see [Local development](#local-development-tunneling))
+
+### Step 4: Enable Teams channel
+
+1. Azure Bot → **Channels**.
+2. Click **Microsoft Teams** → Configure → Save.
+3. Accept the Terms of Service.
+
+### Step 5: Build Teams app manifest
+
+- Include a `bot` entry with `botId = <App ID>`.
+- Scopes: `personal`, `team`, `groupChat`.
+- `supportsFiles: true` (required for personal-scope file handling).
+- Add RSC permissions (see [RSC permissions](/channels/msteams/manifest-and-permissions#current-teams-rsc-permissions-manifest)).
+- Create icons: `outline.png` (32x32) and `color.png` (192x192).
+- Zip `manifest.json`, `outline.png`, and `color.png` together.
+
+### Step 6: Configure OpenClaw
+
+```json5
+{
+  channels: {
+    msteams: {
+      enabled: true,
+      appId: "<APP_ID>",
+      appPassword: "<APP_PASSWORD>",
+      tenantId: "<TENANT_ID>",
+      webhook: { port: 3978, path: "/api/messages" },
+    },
+  },
+}
+```
+
+Environment variables: `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID`.
+
+### Step 7: Run the gateway
+
+The Teams channel starts automatically when the plugin is available and `msteams` config has credentials.
+
+</details>
+
+## Local development (tunneling)
+
+Teams cannot reach `localhost`. Use a persistent dev tunnel so the URL stays stable across sessions:
+
+```bash
+# One-time setup:
+devtunnel create my-openclaw-bot --allow-anonymous
+devtunnel port create my-openclaw-bot -p 3978 --protocol auto
+
+# Each dev session:
+devtunnel host my-openclaw-bot
+```
+
+Alternatives: `ngrok http 3978` or `tailscale funnel 3978` (URLs may change each session).
+
+If the tunnel URL changes, update the endpoint:
+
+```bash
+teams app update <teamsAppId> --endpoint "https://<new-url>/api/messages"
+```
+
+## Testing the bot
+
+**Run diagnostics:**
+
+```bash
+teams app doctor <teamsAppId>
+```
+
+Checks bot registration, AAD app, manifest, and SSO configuration in one pass.
+
+**Send a test message:**
+
+1. Install the Teams app (install link from `teams app get <id> --install-link`).
+2. Find the bot in Teams and send a DM.
+3. Check gateway logs for incoming activity.

--- a/docs/channels/msteams/troubleshooting.md
+++ b/docs/channels/msteams/troubleshooting.md
@@ -1,0 +1,126 @@
+---
+summary: "Microsoft Teams known limitations, common failures, and reference links"
+read_when:
+  - The Teams bot is silent, or images do not arrive
+  - A manifest upload or RSC permission is rejected
+  - Checking what the Teams path does not support
+title: "Microsoft Teams troubleshooting"
+sidebarTitle: "Troubleshooting"
+---
+
+What the Teams path does not support, the failures operators hit most often, and where to read more.
+
+## Known limitations
+
+### Webhook timeouts
+
+Teams delivers messages via HTTP webhook. OpenClaw applies fixed HTTP server
+timeouts to that webhook listener: 30s inactivity, 30s total request, and 15s
+to receive headers. Optional inbound media and context enrichment has a shared
+10-second budget. The SDK returns after the raw activity is durably appended;
+the agent turn drains independently and replies proactively. If request
+handling or durable admission misses the transport window, Teams may retry the
+activity, and the ingress tombstone rejects a repeated event ID.
+
+### Teams cloud and service URL support
+
+This SDK-backed Teams path is live-validated for Microsoft Teams public cloud.
+
+Inbound replies use the incoming Teams SDK turn context. Out-of-context proactive operations - sends, edits, deletes, cards, polls, file-consent messages, and queued long-running replies - use the stored conversation reference `serviceUrl`. Public cloud defaults to the Teams SDK public cloud environment and allows stored references on the public Teams Connector host: `https://smba.trafficmanager.net/`.
+
+Public cloud is the default. You do not need to set `channels.msteams.cloud` or `channels.msteams.serviceUrl` for normal public-cloud bots.
+
+For non-public Teams clouds, set `cloud` and the matching proactive boundary when Microsoft publishes one:
+
+- `channels.msteams.cloud` selects the Teams SDK cloud preset for authentication, JWT validation, token services, and Graph scope.
+- `channels.msteams.serviceUrl` selects the Bot Connector endpoint boundary used to validate stored conversation references before proactive sends, edits, deletes, cards, polls, file-consent messages, and queued long-running replies. It is required for USGov and DoD SDK clouds. For China/21Vianet, OpenClaw uses the SDK `China` preset and accepts stored/configured service URLs only on Azure China Bot Framework channel hosts.
+
+Microsoft publishes the global proactive Bot Connector endpoints in the [Create the conversation](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages?tabs=dotnet#create-the-conversation) section of the Teams proactive messaging docs. Use the incoming activity's `serviceUrl` when available; otherwise use Microsoft's table below.
+
+| Teams environment | OpenClaw config                                             | Proactive `serviceUrl`                             |
+| ----------------- | ----------------------------------------------------------- | -------------------------------------------------- |
+| Public            | no cloud/serviceUrl config needed                           | `https://smba.trafficmanager.net/teams`            |
+| GCC               | set `serviceUrl`; no separate Teams SDK cloud preset exists | `https://smba.infra.gcc.teams.microsoft.com/teams` |
+| GCC High          | `cloud: "USGov"` + `serviceUrl`                             | `https://smba.infra.gov.teams.microsoft.us/teams`  |
+| DoD               | `cloud: "USGovDoD"` + `serviceUrl`                          | `https://smba.infra.dod.teams.microsoft.us/teams`  |
+| China/21Vianet    | `cloud: "China"`                                            | use the incoming activity's `serviceUrl`           |
+
+Example for GCC, where Microsoft documents a separate proactive service URL but the Teams SDK exposes no separate GCC cloud preset:
+
+```json
+{
+  "channels": {
+    "msteams": {
+      "serviceUrl": "https://smba.infra.gcc.teams.microsoft.com/teams"
+    }
+  }
+}
+```
+
+Example for GCC High:
+
+```json
+{
+  "channels": {
+    "msteams": {
+      "cloud": "USGov",
+      "serviceUrl": "https://smba.infra.gov.teams.microsoft.us/teams"
+    }
+  }
+}
+```
+
+`channels.msteams.serviceUrl` is restricted to supported Microsoft Teams Bot Connector hosts. When a service URL is configured, OpenClaw checks that the stored conversation `serviceUrl` uses the same host before proactive sends, edits, deletes, cards, polls, or queued long-running replies run. With the default public-cloud config, OpenClaw fails closed if a stored conversation points outside the public Teams Connector host. Receive a fresh message from the conversation after changing cloud/service URL settings so the stored conversation reference is current.
+
+China/21Vianet has no separate global proactive `smba` URL in Microsoft's Teams proactive endpoint table. Configure `cloud: "China"` so the Teams SDK uses Azure China auth, token, and JWT endpoints. Proactive sends then require a stored conversation reference from an incoming China Teams activity, or an explicitly configured service URL, on the Azure China Bot Framework channel boundary (`*.botframework.azure.cn`). Graph-backed Teams helpers are disabled for `cloud: "China"` until OpenClaw routes Graph requests through the Azure China Graph endpoint.
+
+### Formatting
+
+Teams markdown is more limited than Slack or Discord:
+
+- Basic formatting works: **bold**, _italic_, `code`, links.
+- Text edits, file captions, and finalized streaming replies use the same Markdown conversion and user-mention formatting as normal messages. Streaming previews may show unfinished Markdown until the final reply replaces them.
+- Complex markdown (tables, nested lists) may not render correctly.
+- Adaptive Cards are supported for approval prompts, polls, and semantic presentation sends (see [Cards and actions](/channels/msteams/cards-and-actions)).
+
+## Troubleshooting
+
+### Common issues
+
+- **Images not showing in channels:** Graph permissions or admin consent missing. Reinstall the Teams app and fully quit/reopen Teams.
+- **No responses in channel:** mentions are required by default; set `channels.msteams.requireMention=false` or configure per team/channel.
+- **Version mismatch (Teams still shows old manifest):** remove + re-add the app and fully quit Teams to refresh.
+- **401 Unauthorized from webhook:** expected when testing manually without an Azure JWT; means the endpoint is reachable but auth failed. Use Azure Web Chat to test properly.
+
+### Manifest upload errors
+
+- **"Icon file cannot be empty":** the manifest references icon files that are 0 bytes. Create valid PNG icons (32x32 for `outline.png`, 192x192 for `color.png`).
+- **"webApplicationInfo.Id already in use":** the app is still installed in another team/chat. Find and uninstall it first, or wait 5-10 minutes for propagation.
+- **"Something went wrong" on upload:** upload via [https://admin.teams.microsoft.com](https://admin.teams.microsoft.com) instead, open browser DevTools (F12) → Network tab, and check the response body for the actual error.
+- **Sideload failing:** try "Upload an app to your org's app catalog" instead of "Upload a custom app"; this often bypasses sideload restrictions.
+
+### RSC permissions not working
+
+1. Verify `webApplicationInfo.id` matches your bot's App ID exactly.
+2. Re-upload the app and reinstall in the team/chat.
+3. Check if your org admin has blocked RSC permissions.
+4. Confirm you are using the right scope: `ChannelMessage.Read.Group` for teams, `ChatMessage.Read.Chat` for group chats.
+
+## References
+
+- [Create Azure Bot](https://learn.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) - Azure Bot setup guide
+- [Teams Developer Portal](https://dev.teams.microsoft.com/apps) - create/manage Teams apps
+- [Teams app manifest schema](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema)
+- [Receive channel messages with RSC](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-messages-with-rsc)
+- [RSC permissions reference](https://learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent)
+- [Teams bot file handling](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) (channel/group requires Graph)
+- [Proactive messaging](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
+- [@microsoft/teams.cli](https://www.npmjs.com/package/@microsoft/teams.cli) - Teams CLI for bot management
+
+## Related
+
+- [Channels Overview](/channels) - all supported channels
+- [Pairing](/channels/pairing) - DM authentication and pairing flow
+- [Groups](/channels/groups) - group chat behavior and mention gating
+- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Security](/gateway/security) - access model and hardening

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1511,7 +1511,20 @@
                       "channels/matrix-push-rules"
                     ]
                   },
-                  "channels/msteams",
+                  {
+                    "group": "Microsoft Teams",
+                    "pages": [
+                      "channels/msteams",
+                      "channels/msteams/setup",
+                      "channels/msteams/access-control",
+                      "channels/msteams/authentication",
+                      "channels/msteams/manifest-and-permissions",
+                      "channels/msteams/configuration",
+                      "channels/msteams/messaging",
+                      "channels/msteams/cards-and-actions",
+                      "channels/msteams/troubleshooting"
+                    ]
+                  },
                   "channels/signal",
                   {
                     "group": "Slack",


### PR DESCRIPTION
## What changed

`docs/channels/msteams.md` was 56,760 characters, 1,125 lines, 31 H2 + 31 H3 headings, mixing tutorial, how-to, reference, explanation and troubleshooting on one page. It is now an index plus eight children under `docs/channels/msteams/`, matching the shape of `docs/channels/slack/` and `docs/channels/discord/` (both on `main`; verified with `test -d`, not from an open PR).

| Page | Bytes | Sections |
| --- | --- | --- |
| `channels/msteams` (index) | 14,313 | intro, page map, anchor map, related |
| `channels/msteams/setup` | 8,436 | Bundled plugin, Quick setup, Goals, Manual setup, Local development, Testing the bot |
| `channels/msteams/access-control` | 6,125 | Config writes, Access control (DMs + groups), Team and Channel IDs, Private channels |
| `channels/msteams/authentication` | 4,746 | Federated authentication (certificate plus managed identity) |
| `channels/msteams/manifest-and-permissions` | 7,436 | RSC permissions, Example manifest, Capabilities: RSC vs Graph, Graph-enabled media + history |
| `channels/msteams/configuration` | 8,084 | Environment variables, History context, Configuration |
| `channels/msteams/messaging` | 9,596 | Routing and sessions, Reply style, Attachments and images, Sending files in group chats |
| `channels/msteams/cards-and-actions` | 6,881 | Member info action, Native approval cards, Polls, Presentation cards, Target formats, Proactive messaging |
| `channels/msteams/troubleshooting` | 8,878 | Known limitations, Troubleshooting, References, Related |

## Losslessness, proven

Every child, with its frontmatter and one-line lede removed and the declared edits below reversed, reassembles in original section order into a byte-identical copy of the original page body:

```
original body sha256: ffa99dd878b6047a6035a1d11dcb269859c88d48730e64673f1878dd5577b449  (56,411 bytes)
rebuilt  body sha256: ffa99dd878b6047a6035a1d11dcb269859c88d48730e64673f1878dd5577b449  (56,411 bytes)
fences: 32 original, 32 new, one-for-one on info string + body sha256
table rows: 70 original, 70 new
words: 6,587 -> 7,999 (grew only; the anchor map and the ledes)
```

No heading text, heading level, code fence, table row or sentence was rewritten or reordered within a section. One contiguous block moved between children: the collapsed **Manual setup (without the Teams CLI)** `<details>` block, which sat under `## Access control (DMs + groups)` in the original, now lives on the setup page. That is the IA defect the split exists to fix; the block's bytes are unchanged.

## Anchors

Per-anchor redirects are impossible here — `redirectSource()` in `scripts/lib/docs-redirects.mjs` throws on any source containing `[?#]` — so every pre-split id is preserved on the index instead.

Ids were enumerated with the repository's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`), not a slug approximation, which matters because punctuated headings here emit both a percent-encoded id and a cleaned alias (`access-control-(dms-%2B-groups)` and `access-control-dms-+-groups`, and 21 more pairs).

- 85 pre-split ids, 0 collisions.
- 84 are carried as authored `<a id="…" />` stubs under **Where each section moved**, each linking to the page that now holds the content.
- 1 (`#related`) is not stubbed because the index publishes that heading itself; stubbing it would raise a duplicate authored/canonical id.
- Asserted after the split: all 85 original ids resolve on the new index, `collisions` is empty on the index and on every one of the eight children, and each id is owned by exactly one child.

## Prose diff

The link audit cannot see a directional cross-reference, so `.audit/check-orphan-refs.py` was run over all nine pages. It reported 7 candidates; 5 point at targets that are still on the same page. The 2 genuinely orphaned ones are the entire prose diff:

1. `setup.md` — "referencing the bot, including the RSC permissions below" — the RSC permissions section is now on `manifest-and-permissions`. Now links there.
2. `troubleshooting.md` — "semantic presentation sends (see below)" — approvals, polls and presentation cards are now on `cards-and-actions`. Now links there.

Six same-page `](#…)` links whose targets landed on a different child were retargeted (no text change): 2 to `messaging#sending-files-in-group-chats`, 1 to `authentication#federated-authentication-certificate-plus-managed-identity`, 1 to `manifest-and-permissions#current-teams-rsc-permissions-manifest`, 1 to `messaging#reply-style-threads-vs-posts`, and the page's absolute self-link to `manifest-and-permissions#channel%2Fgroup-file-recovery-graphmediafallback`.

## Pins and inbound references

`.audit/docs-test-pins.py` reported 8 hits; an independent `git grep -n "channels/msteams" origin/main` with no path filter reported 34. Every one classified:

- **Updated**: `docs/docs.json` navigation (index + 8 children, mirroring the Slack and Discord groups); `.github/labeler.yml` (added `docs/channels/msteams/**` to the `channel: msteams` label, matching what the Slack and Discord splits did); `docs/.i18n/glossary.zh-CN.json` (10 new source terms for the new titles and two link labels the checker now sees).
- **No change needed, route still resolves**: 6 `taxonomy.yaml` `docs:` entries (all plain paths, no `#anchor`; `maturity:check` passes, and the Slack split left its equivalents alone), `docs/maturity/taxonomy.md` (6), `docs/channels/index.md`, `docs/concepts/progress-drafts.md`, `docs/gateway/configuration.md`, `docs/gateway/config-channels/workplace-chat.md` (2), `docs/plugins/*` (3), `docs/releases/2026.8.1/messaging.md`, `docs/docs.json` redirect destination, `extensions/msteams/**` `docsPath` (3), `scripts/lib/official-external-channel-catalog.json`, `src/gateway/server.agent.gateway-server-agent-b.test.ts`, `scripts/docs-i18n/taxonomy_source_test.go`, `qa/scenarios/channels/msteams-thread-message-tool-final-dedupe.yaml` (`docsRefs`), `docs/.i18n/zh-Hans-navigation.json` (bare `zh-CN/channels/msteams`; the Slack split added no children there either, and no `docs/zh-CN/channels/slack/` mirror exists).
- **Not a docs reference**: `extensions/policy/src/doctor/register.models-and-mcp.test-utils.ts` (`oc://openclaw.config/channels/msteams/...` is a config path).

Only one anchored inbound link existed tree-wide (`git grep -n "msteams#" origin/main`) and it was the page's own self-link, retargeted above. No contract test reads this file and asserts literal strings, so there is no reason to refuse the split.

## CODEOWNERS

Simulated last-match-wins over `.github/CODEOWNERS` for every touched path. No rule matches `docs/channels/msteams*`, `docs/docs.json`, `docs/.i18n/**`, or `.github/labeler.yml`. Controls: `/docs/gateway/security/` and `/.github/CODEOWNERS` do match their own paths, so the simulation is working. No maintainer team owns this change.

## Validators

Every step of `check:docs` (`package.json`), run on the staged tree after the rebase onto `0b52342`:

```
node --import ./scripts/tsx.mjs scripts/format-docs.mts --check     exit 0   (1018 files clean)
npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc       exit 0   (1017 files, 0 issues)
npx markdownlint-cli2 --config config/markdownlint-templates.jsonc  exit 0
node scripts/check-docs-mdx.mjs docs README.md                      exit 0   (1031 files)
node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts exit 0
node scripts/docs-link-audit.mjs                                    exit 0   (10,476 links, 0 broken)
node scripts/check-docs-config-examples.mjs                         exit 0
```

Also run:

```
node scripts/docs-link-audit.mjs --anchors    42 errors, byte-identical to the same run at 0b52342 (all /clawhub and maturity routes; none msteams)
node --import ./scripts/tsx.mjs scripts/qa/render-maturity-docs.ts --check    exit 0  (validateTaxonomyDocsReferences passes)
npx vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/docs-source-anchors.test.ts    2 passed
npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts src/docs/    24 passed, 1 failed
```

That one vitest failure is `preserves Mint component targets for raw component apostrophes…`, a slug-normalization case unrelated to this change. Reproduced identically in a detached worktree at `0b52342`, so it is pre-existing.

`.audit/ste-lint.py` over all nine pages: 53 hard violations against 54 on the original single page. Hard violations did not increase.

## Ledger findings

Closed by this PR:

- **blocking / split** — the page mixed five content types across 31 H2 sections. Now one index and eight children, each a single reader job.
- **major / ia** — 62 headings, and the manual-setup H3 steps sat under the Access control H2. Largest child now has 13 headings; the manual-setup block moved to the setup page.
- **major / ux (partial)** — "manual setup hidden under Access control" is fixed. The rest of that finding asks to reorder the funnel and move `## Goals` to the top; that is a reordering this content-preserving split deliberately does not do.

Deferred, with reasons — each needs a prose rewrite, which this PR excludes by design so the byte-identical proof above stays checkable:

- **minor / ux** — the opening line is a capability status line, not a statement of purpose.
- **minor / accuracy** — "today", "yet", "until … ships" with no version scope (6 sites).
- **minor / ux** — tunnel commands, `teams app doctor`, and the env-var list each appear more than once.
- **minor / ux** — config-writes and history-limit rules are restated on both the Teams and Telegram pages with drift.
- **major / ux** — Quick setup never tells the reader to start the gateway. This one is a content addition, not a move.

Not auto-merged, per instruction.
