### PR TITLE
refactor(tests): remove duplicate model usage aggregation test

### DIFF
--- a/skills/model-usage/scripts/test_model_usage.py
+++ b/skills/model-usage/scripts/test_model_usage.py
@@ -66,18 +66,6 @@ class TestModelUsage(TestCase):
         self.assertIsNone(coerce_finite_cost(None))
         self.assertIsNone(coerce_finite_cost({}))
 
-    def test_aggregate_costs_includes_numeric_strings(self):
-        entries = [
-            {
-                "date": "2026-05-25",
-                "modelBreakdowns": [
-                    {"modelName": "claude-sonnet-4-6", "cost": 1.50},
-                    {"modelName": "claude-sonnet-4-6", "cost": "1.75"},
-                ],
-            }
-        ]
-        self.assertEqual(aggregate_costs(entries), {"claude-sonnet-4-6": 3.25})
-
     def test_aggregate_costs_ignores_bool_and_non_finite(self):
         entries = [
             {


### PR DESCRIPTION
Related: #139428

## Landing Status

Exact-head CI run [34336311086](https://github.com/openclaw/openclaw/actions/runs/34336311086/attempts/4), attempt 4, passed after rerunning the unrelated Discord timeout. No production, test, or workflow changes were made to address it. The landing hold is lifted.

## What Problem This Solves

The model-usage helper suite checks the same numeric-string cost total twice. This removes one redundant case from the maintainer-requested test audit.

## Why This Change Was Made

Remove only `test_aggregate_costs_includes_numeric_strings`. The neighboring `test_aggregate_costs_ignores_bool_and_non_finite` retains the same `1.50 + "1.75" = 3.25` assertion while also checking invalid-cost rejection.

No production code, imports, helpers, fixtures, or configuration change.

## User Impact

No user-visible behavior change. All 12 remaining tests in the file are retained.

## Evidence

- Full `skills/model-usage/scripts/test_model_usage.py` run: 12 passed, including the retained aggregate-cost case, using task-local Python 3.14.4 and `skills/pyproject.toml`.
- Configured Ruff check of the target file: passed.
- Exact-path `node scripts/check-changed.mjs -- skills/model-usage/scripts/test_model_usage.py`: complete 25-step plan passed, including all typechecks, full lint, and import-cycle checks.
- `git diff --check` and fresh scanned P2 autoreview: passed; no findings.
- Exact-head [CI run 34332780972](https://github.com/openclaw/openclaw/actions/runs/34332780972), attempt 1: passed.
- [skills-python job](https://github.com/openclaw/openclaw/actions/runs/34332780972/job/102406060254): CPython 3.12.14, configured Ruff passed, and all 27 skills tests passed. The actual PR merge checkout `d3ea4d079f3738c8c599ef41d8e45a0fe58b3942` has the exact B03 delta over its CI base and matching test, owner, and Python configuration blobs. Local Python 3.14.4 proof is recorded separately.
