### PR TITLE
fix(agents): keep accepted image jobs alive through provider cleanup

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -387,7 +387,6 @@ src/agents/tool-loop-detection.test.ts
 src/agents/tool-search.test.ts
 src/agents/tools/cron-tool.test.ts
 src/agents/tools/image-generate-tool.test.ts
-src/agents/tools/image-generate-tool.ts
 src/agents/tools/image-tool.test.ts
 src/agents/tools/image-tool.ts
 src/agents/tools/media-generate-background-shared.test.ts

--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -61,6 +61,16 @@ completed video assets and result metadata. Video assets may contain buffers or
 provider-hosted URLs. Downloads after the call returns belong to the caller;
 registration disposal must not invalidate those completed artifacts.
 
+For `image_generate` tools prepared from an owned inspection, resources remain
+held through preflight and, once accepted, through generation, image saving, and
+any rollback. A `started` result acknowledges acceptance; it does not mean the
+work or cleanup has finished. If the original inspection retires during
+preflight, new task admission is rejected. Prepare tools from the current provider
+setup before retrying.
+An already accepted task keeps its captured resources until its work settles.
+Raw prepared registries retain their existing host lifetime; this does not enable
+automatic physical disposal for all prepared runtimes.
+
 Executable CLI command registration also uses an owned, uncached registry. Its
 resources remain available through asynchronous registration, command actions,
 and their tracked cleanup, then `dispose()` runs. Closing command preparation

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -4,6 +4,7 @@ import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { stableStringify } from "@openclaw/normalization-core";
+import type { Result } from "@openclaw/normalization-core/result";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -12,6 +13,8 @@ import {
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { getPluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
+import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
@@ -191,17 +194,23 @@ export async function prepareWorkspaceBuildGroup(
   const preferBuiltPluginArtifacts =
     reusablePluginGeneration?.preferBuiltPluginArtifacts ??
     options.preferBuiltPluginArtifacts === true;
-  const { inboundPluginRegistry, runtimePluginRegistry } = prepareWorkspacePluginRegistries(
-    input,
-    pluginMetadataSnapshot,
-    loadInboundPluginRegistry,
-    preferBuiltPluginArtifacts,
-    reusablePluginGeneration,
-    options.getConfiguredHarnessRuntimes,
-    options.basePluginIds,
-  );
+  const { inboundPluginRegistry, runtimePluginRegistry, primaryRegistry } =
+    prepareWorkspacePluginRegistries(
+      input,
+      pluginMetadataSnapshot,
+      loadInboundPluginRegistry,
+      preferBuiltPluginArtifacts,
+      reusablePluginGeneration,
+      options.getConfiguredHarnessRuntimes,
+      options.basePluginIds,
+    );
   const reuseRuntimeFacts =
     reusablePluginGeneration && runtimePluginRegistry === reusablePluginGeneration.pluginRegistry;
+  const resources = primaryRegistry && getPluginRegistryInspectionResources(primaryRegistry);
+  const mediaCapabilityProviderSource =
+    primaryRegistry && resources
+      ? Object.freeze({ registry: primaryRegistry, resources })
+      : undefined;
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   prepareOwnedPluginLoadContext(
     input,
@@ -452,6 +461,7 @@ export async function prepareWorkspaceBuildGroup(
       inboundPluginRegistry,
       inlineProviderModels,
       mediaCapabilityProviders,
+      mediaCapabilityProviderSource,
       messageToolCatalog,
       pluginMetadataSnapshot,
       preparedStaticProviderCatalog,
@@ -473,13 +483,54 @@ export async function prepareWorkspaceBuildGroup(
       pluginGeneration,
     };
   };
-  return await withPluginRuntimeGenerationScope(
-    {
-      metadataSnapshot: pluginMetadataSnapshot,
-      pluginRegistry: runtimePluginRegistry,
-    },
-    prepare,
+  const run = () =>
+    withPluginRuntimeGenerationScope(
+      {
+        metadataSnapshot: pluginMetadataSnapshot,
+        pluginRegistry: runtimePluginRegistry,
+      },
+      prepare,
+    );
+  if (!mediaCapabilityProviderSource) {
+    return await run();
+  }
+  const isSourceCurrent = capturePluginLifecycleAuthority(
+    mediaCapabilityProviderSource.registry,
+    undefined,
+    { scopedRuntime: true },
   );
+  if (!isSourceCurrent?.()) {
+    throw new Error("Prepared media capability provider source is retired");
+  }
+  const claim = mediaCapabilityProviderSource.resources.retain();
+  let outcome: Result<Awaited<ReturnType<typeof prepare>>, unknown>;
+  try {
+    outcome = { ok: true, value: await run() };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+  try {
+    // The caller still owns the original inspection; construction owns its actual awaited work.
+    await claim.release();
+  } catch (cleanupError) {
+    outcome = {
+      ok: false,
+      error: outcome.ok
+        ? cleanupError
+        : new AggregateError(
+            [outcome.error, cleanupError],
+            "Prepared construction and registration cleanup failed",
+            { cause: outcome.error },
+          ),
+    };
+  }
+  if (!outcome.ok) {
+    throw outcome.error;
+  }
+  if (!isSourceCurrent()) {
+    throw new Error("Prepared media capability provider source is retired");
+  }
+  return outcome.value;
 }
 
 export function captureModelsJsonContents(agentDir: string): string | null {

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -30,7 +30,10 @@ import type {
   PreparedConfiguredRuntimeModel,
   PreparedRuntimeCapabilityModel,
 } from "./prepared-model-runtime.configured.js";
-import { buildPreparedPluginModelCatalog } from "./prepared-model-runtime.plugin-generation.js";
+import {
+  acquirePreparedMediaCapabilityProviders,
+  buildPreparedPluginModelCatalog,
+} from "./prepared-model-runtime.plugin-generation.js";
 import type {
   PreparedModelCatalogInventory,
   PreparedModelRuntimeCatalogMode,
@@ -307,8 +310,13 @@ export function createPreparedModelRuntimeSnapshot(
   catalogAccess: PreparedModelRuntimeCatalogAccess,
 ): PreparedModelRuntimeSnapshot {
   const { credentials, input } = agentFacts;
-  const { mediaCapabilityProviders, messageToolCatalog, pluginMetadataSnapshot, pluginRegistry } =
-    pluginGeneration;
+  const {
+    mediaCapabilityProviders,
+    mediaCapabilityProviderSource,
+    messageToolCatalog,
+    pluginMetadataSnapshot,
+    pluginRegistry,
+  } = pluginGeneration;
   const { configuredRuntimeModels, inlineProviderModels, templateModelRegistry } = catalogFacts;
   const modelCatalog = materializePreparedModelCatalog(
     catalogFacts.modelCatalog,
@@ -342,6 +350,15 @@ export function createPreparedModelRuntimeSnapshot(
     ...(pluginRegistry ? { pluginRegistry } : {}),
     ...(messageToolCatalog ? { messageToolCatalog } : {}),
     ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
+    ...(mediaCapabilityProviderSource && mediaCapabilityProviders
+      ? {
+          acquireMediaCapabilityProviders: () =>
+            acquirePreparedMediaCapabilityProviders(
+              mediaCapabilityProviderSource,
+              mediaCapabilityProviders,
+            ),
+        }
+      : {}),
     modelCatalog: catalogAccess.withRefreshStatus(modelCatalog),
     readFullModelCatalog: catalogAccess.readFullModelCatalog,
     loadFullModelCatalog: catalogAccess.loadFullModelCatalog,

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -6,6 +6,7 @@ import {
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
@@ -16,6 +17,7 @@ import {
 import { registryContainsRuntimePluginIds } from "../plugins/active-runtime-registry.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
 import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
@@ -25,6 +27,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import type { DiscoverAuthStorageOptions } from "./agent-auth-discovery.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
+import { prepareWorkspaceBuildGroup } from "./prepared-model-runtime.facts.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -47,6 +50,81 @@ describe("prepared reply dispatch runtime", () => {
       loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
     ).resolves.toBeUndefined();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
+  });
+
+  it("holds inspected input through accepted preparation and refuses a retired result", async () => {
+    const database = new DatabaseSync(state.path("prepared-registration.sqlite"));
+    database.exec(
+      "CREATE TABLE observations (value INTEGER); INSERT INTO observations VALUES (42)",
+    );
+    const registry = createEmptyPluginRegistry();
+    const resources = new PluginRegistryInspectionResources();
+    resources.attach(registry);
+    let disposalCount = 0;
+    resources.runRegistration("prepared-native", () => {
+      resources.register("prepared-native", {
+        id: "sqlite",
+        dispose: () => {
+          disposalCount += 1;
+          database.close();
+        },
+      });
+    });
+    const entered = createDeferred();
+    const finish = createDeferred();
+    let observedValue: unknown;
+    mocks.prepareStaticCatalog.mockImplementationOnce(async () => {
+      entered.resolve();
+      await finish.promise;
+      observedValue = database.prepare("SELECT value FROM observations").get()?.value;
+      return { entries: [] };
+    });
+    const config = {};
+    const metadata = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    });
+    const preparation = prepareWorkspaceBuildGroup(
+      [
+        {
+          config,
+          agentDir: state.agentDir("default"),
+          workspaceDir: state.workspaceDir,
+          env: state.env,
+          skipCredentials: true,
+        },
+      ],
+      "static",
+      {},
+      () => registry,
+      undefined,
+      metadata,
+    );
+    const outcome = preparation.catch((error: unknown) => error);
+    try {
+      await Promise.race([
+        entered.promise,
+        preparation.then(() => {
+          throw new Error("Preparation completed before its static catalog dependency");
+        }),
+      ]);
+      await resources.release();
+      expect(database.isOpen).toBe(true);
+      expect(disposalCount).toBe(0);
+      finish.resolve();
+      expect(await outcome).toEqual(
+        new Error("Prepared media capability provider source is retired"),
+      );
+      expect(observedValue).toBe(42);
+      expect(database.isOpen).toBe(false);
+      expect(disposalCount).toBe(1);
+    } finally {
+      finish.resolve();
+      await Promise.allSettled([outcome, resources.release()]);
+      if (database.isOpen) {
+        database.close();
+      }
+    }
   });
 
   it("carries newly selected provider auth into a derived generation and its refresh", async () => {

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -27,6 +27,7 @@ export type PreparedInboundRegistryLoader = (
   input: PreparedInboundRegistryInput,
   metadataSnapshot: PluginMetadataSnapshot,
   configuredHarnessRuntimes?: readonly string[],
+  onPrimaryRegistry?: (registry: PluginRegistry) => void,
 ) => PluginRegistry;
 
 function inboundRegistryIdentity(input: PreparedInboundRegistryInput): string {
@@ -61,6 +62,7 @@ export function loadPreparedInboundPluginRegistry(
   input: PreparedInboundRegistryInput,
   metadataSnapshot = prepareOwnedPluginLoadContext(input, input.env ?? process.env, undefined),
   configuredHarnessRuntimes?: readonly string[],
+  onPrimaryRegistry?: (registry: PluginRegistry) => void,
 ): PluginRegistry {
   const activeRegistry = getActivePluginRegistry();
   // Identity is the generation authority. Manifest equivalence alone could let a
@@ -83,15 +85,21 @@ export function loadPreparedInboundPluginRegistry(
       : undefined;
   const registry =
     reusableGatewayRegistry ??
-    loadAgentRuntimePluginRegistryHandle({
-      config: input.config,
-      env: input.env ?? process.env,
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-      ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-      metadataSnapshot,
-      preferBuiltPluginArtifacts: true,
-      configuredHarnessRuntimes,
-    });
+    loadAgentRuntimePluginRegistryHandle(
+      {
+        config: input.config,
+        env: input.env ?? process.env,
+        ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+        ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+        metadataSnapshot,
+        preferBuiltPluginArtifacts: true,
+        configuredHarnessRuntimes,
+      },
+      onPrimaryRegistry,
+    );
+  if (reusableGatewayRegistry) {
+    onPrimaryRegistry?.(reusableGatewayRegistry);
+  }
   prepareOwnedPluginLoadContext(input, input.env ?? process.env, registry, metadataSnapshot, true);
   return registry;
 }
@@ -100,20 +108,31 @@ export function loadPreparedInboundPluginRegistry(
 export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLoader {
   const registries = new Map<
     string,
-    { metadataSnapshot: PluginMetadataSnapshot; registry: PluginRegistry }
+    {
+      metadataSnapshot: PluginMetadataSnapshot;
+      registry: PluginRegistry;
+      primaryRegistry: PluginRegistry;
+    }
   >();
-  return (input, metadataSnapshot, configuredHarnessRuntimes) => {
+  return (input, metadataSnapshot, configuredHarnessRuntimes, onPrimaryRegistry) => {
     const key = inboundRegistryIdentity(input);
     const existing = registries.get(key);
     if (existing?.metadataSnapshot === metadataSnapshot) {
+      onPrimaryRegistry?.(existing.primaryRegistry);
       return existing.registry;
     }
+    let primaryRegistry: PluginRegistry | undefined;
     const registry = loadPreparedInboundPluginRegistry(
       input,
       metadataSnapshot,
       configuredHarnessRuntimes,
+      (source) => {
+        primaryRegistry = source;
+      },
     );
-    registries.set(key, { metadataSnapshot, registry });
+    primaryRegistry ??= registry;
+    registries.set(key, { metadataSnapshot, registry, primaryRegistry });
+    onPrimaryRegistry?.(primaryRegistry);
     return registry;
   };
 }
@@ -130,6 +149,7 @@ export function prepareWorkspacePluginRegistries(
 ): {
   runtimePluginRegistry?: PluginRegistry;
   inboundPluginRegistry?: PluginRegistry;
+  primaryRegistry?: PluginRegistry;
 } {
   // Read-only catalog owners stay runtime-free. Executable probes opt in to provider runtime,
   // while non-core harness probes carry the exact selected plugin generation.
@@ -137,36 +157,53 @@ export function prepareWorkspacePluginRegistries(
     return {};
   }
   // Resolve batch facts only for a registry load; read-only and reused registries need no scan.
+  let primaryRegistry: PluginRegistry | undefined;
   const inboundPluginRegistry = input.readOnly
     ? undefined
     : (reusableGeneration?.inboundPluginRegistry ??
-      loadInboundRegistry?.(input, metadataSnapshot, getConfiguredHarnessRuntimes?.()));
+      loadInboundRegistry?.(input, metadataSnapshot, getConfiguredHarnessRuntimes?.(), (source) => {
+        primaryRegistry = source;
+      }));
   const baseRegistry = reusableGeneration?.pluginRegistry ?? inboundPluginRegistry;
+  primaryRegistry ??= reusableGeneration?.mediaCapabilityProviderSource?.registry ?? baseRegistry;
+  let loadedPrimaryRegistry: PluginRegistry | undefined;
   const runtimePluginRegistry =
     input.runtimePluginSelections || !baseRegistry
-      ? loadAgentRuntimePluginRegistryHandle({
-          ...(input.loadRuntimePlugins
-            ? { basePluginIds: [] }
-            : baseRegistry
-              ? { basePluginIds: listRuntimePluginIdsFromRegistry(baseRegistry) }
-              : basePluginIds !== undefined
-                ? { basePluginIds }
-                : {}),
-          ...(reusableGeneration?.pluginRegistry
-            ? { reusableRegistry: reusableGeneration.pluginRegistry }
-            : {}),
-          config: input.config,
-          env: input.env ?? process.env,
-          ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-          ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-          metadataSnapshot,
-          ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
-          selections: input.runtimePluginSelections,
-          configuredHarnessRuntimes: getConfiguredHarnessRuntimes?.(),
-        })
+      ? loadAgentRuntimePluginRegistryHandle(
+          {
+            ...(input.loadRuntimePlugins
+              ? { basePluginIds: [] }
+              : baseRegistry
+                ? { basePluginIds: listRuntimePluginIdsFromRegistry(baseRegistry) }
+                : basePluginIds !== undefined
+                  ? { basePluginIds }
+                  : {}),
+            ...(reusableGeneration?.pluginRegistry
+              ? { reusableRegistry: reusableGeneration.pluginRegistry }
+              : {}),
+            config: input.config,
+            env: input.env ?? process.env,
+            ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+            ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+            metadataSnapshot,
+            ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
+            selections: input.runtimePluginSelections,
+            configuredHarnessRuntimes: getConfiguredHarnessRuntimes?.(),
+          },
+          (source) => {
+            loadedPrimaryRegistry =
+              reusableGeneration && source === reusableGeneration.pluginRegistry
+                ? (reusableGeneration.mediaCapabilityProviderSource?.registry ?? source)
+                : source;
+          },
+        )
       : baseRegistry;
   return {
     runtimePluginRegistry,
+    primaryRegistry:
+      runtimePluginRegistry === baseRegistry
+        ? (primaryRegistry ?? runtimePluginRegistry)
+        : (loadedPrimaryRegistry ?? runtimePluginRegistry),
     ...(inboundPluginRegistry ? { inboundPluginRegistry } : {}),
   };
 }

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -1,4 +1,5 @@
 import { registryContainsRuntimePluginIds } from "../plugins/active-runtime-registry.js";
+import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
 import { resolveAgentRuntimePluginLoadPlan } from "./harness/runtime-plugin-load-plan.js";
@@ -7,7 +8,37 @@ import type {
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
   PreparedModelRuntimePluginGeneration,
+  PreparedMediaCapabilityProviderAcquisition,
+  PreparedMediaCapabilityProviderSource,
 } from "./prepared-model-runtime.types.js";
+
+/** Retains the original source and checks its captured authority only for new admission. */
+export function acquirePreparedMediaCapabilityProviders(
+  source: PreparedMediaCapabilityProviderSource,
+  providers: PreparedMediaCapabilityProviderAcquisition["providers"],
+): PreparedMediaCapabilityProviderAcquisition {
+  const isCurrent = capturePluginLifecycleAuthority(source.registry, undefined, {
+    scopedRuntime: true,
+  });
+  let released = false;
+  const assertOpen = () => {
+    if (released || !isCurrent?.()) {
+      throw new Error(
+        "The media provider setup changed before generation started. Retry the request with the current provider setup.",
+      );
+    }
+  };
+  assertOpen();
+  const claim = source.resources.retain();
+  return {
+    providers,
+    assertOpen,
+    release: () => {
+      released = true;
+      return claim.release();
+    },
+  };
+}
 
 // Lineage is cache identity only. Derived generations still require the exact open
 // parent lease at admission; they never become configured publication authority.
@@ -62,6 +93,7 @@ export function createPreparedPluginGeneration(params: {
   inboundPluginRegistry: PreparedModelRuntimePluginGeneration["inboundPluginRegistry"];
   inlineProviderModels: PreparedModelRuntimePluginGeneration["inlineProviderModels"];
   mediaCapabilityProviders: PreparedModelRuntimePluginGeneration["mediaCapabilityProviders"];
+  mediaCapabilityProviderSource?: PreparedModelRuntimePluginGeneration["mediaCapabilityProviderSource"];
   messageToolCatalog: PreparedModelRuntimePluginGeneration["messageToolCatalog"];
   pluginMetadataSnapshot: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"];
   preparedStaticProviderCatalog: PreparedModelRuntimePluginGeneration["preparedStaticProviderCatalog"];
@@ -83,6 +115,7 @@ export function createPreparedPluginGeneration(params: {
       pluginMetadataSnapshot: params.pluginMetadataSnapshot,
       pluginRegistry: params.runtimePluginRegistry,
       mediaCapabilityProviders: params.mediaCapabilityProviders,
+      mediaCapabilityProviderSource: params.mediaCapabilityProviderSource,
       messageToolCatalog: params.messageToolCatalog,
       preparedStaticProviderCatalog: params.preparedStaticProviderCatalog,
     });
@@ -103,6 +136,9 @@ export function createPreparedPluginGeneration(params: {
     ...(params.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
     ...(params.mediaCapabilityProviders
       ? { mediaCapabilityProviders: params.mediaCapabilityProviders }
+      : {}),
+    ...(params.mediaCapabilityProviderSource
+      ? { mediaCapabilityProviderSource: params.mediaCapabilityProviderSource }
       : {}),
     ...(params.preparedStaticProviderCatalog
       ? { preparedStaticProviderCatalog: params.preparedStaticProviderCatalog }

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -180,7 +180,9 @@ describe("prepared model runtime snapshots", () => {
     expect(lease.snapshot.pluginRegistry?.agentHarnesses.map((entry) => entry.harness.id)).toEqual([
       "codex",
     ]);
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith(
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.map(([params]) => params),
+    ).toContainEqual(
       expect.objectContaining({
         selections: [{ provider: "openai", modelId: "gpt-5.6", runtime: "codex" }],
       }),
@@ -203,9 +205,9 @@ describe("prepared model runtime snapshots", () => {
         mocks.pluginMetadataSnapshot as never,
       ).runtimePluginRegistry,
     ).toBe(pluginRegistry);
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith(
-      expect.objectContaining({ selections: undefined }),
-    );
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.map(([params]) => params),
+    ).toContainEqual(expect.objectContaining({ selections: undefined }));
   });
 
   it("reactivates a standalone read-only owner after a publication boundary", async () => {
@@ -268,7 +270,9 @@ describe("prepared model runtime snapshots", () => {
       workspaceDir: "/tmp/prepared-model-runtime-plugin-workspace",
     });
 
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith({
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.map(([params]) => params),
+    ).toContainEqual({
       config: {},
       configuredHarnessRuntimes: [],
       env: process.env,

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -5,6 +5,7 @@ import type { prepareMediaCapabilityProviders } from "../plugins/capability-prov
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import type { PluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
@@ -17,10 +18,22 @@ import type { ModelRegistry } from "./sessions/model-registry.js";
 
 export type PreparedModelRuntimeCatalogMode = "live" | "static";
 
+export type PreparedMediaCapabilityProviderSource = Readonly<{
+  registry: PluginRegistry;
+  resources: Pick<PluginRegistryInspectionResources, "retain">;
+}>;
+
+export type PreparedMediaCapabilityProviderAcquisition = Readonly<{
+  providers: ReturnType<typeof prepareMediaCapabilityProviders>;
+  assertOpen: () => void;
+  release: () => Promise<void>;
+}>;
+
 export type PreparedModelRuntimePluginGeneration = Readonly<{
   pluginMetadataSnapshot: PluginMetadataSnapshot;
   messageToolCatalog?: PreparedMessageToolCatalog;
   mediaCapabilityProviders?: ReturnType<typeof prepareMediaCapabilityProviders>;
+  mediaCapabilityProviderSource?: PreparedMediaCapabilityProviderSource;
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
   /** Captured static rows; cleared when catalog discovery expands the provider registry. */
   providerStaticModels?: readonly ProviderRuntimeModel[];
@@ -53,6 +66,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   metadataSnapshot: PluginMetadataSnapshot;
   messageToolCatalog?: PreparedMessageToolCatalog;
   mediaCapabilityProviders?: ReturnType<typeof prepareMediaCapabilityProviders>;
+  /** Borrows an inspected source; raw prepared hosts retain their existing external ownership. */
+  acquireMediaCapabilityProviders?: () => PreparedMediaCapabilityProviderAcquisition;
   /** Registry value owned by this generation; omitted from read-only builds. */
   pluginRegistry?: PluginRegistry;
   allowGatewaySubagentBinding: boolean;

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -127,17 +127,24 @@ describe("agent runtime plugin registries", () => {
 
   it("adopts full-only runtime capabilities from the active composition-root registry", () => {
     const activeRegistry = createEmptyPluginRegistry();
+    const primaryRegistry = createEmptyPluginRegistry();
     const contextEnginesAdopted = { handle: "context-engines" };
     const presentersAdopted = { handle: "presenters" };
+    const onPrimaryRegistry = vi.fn();
+    hoisted.loadPluginRegistryHandle.mockReturnValue(primaryRegistry);
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
     hoisted.adoptRuntimeContextEngineRegistrations.mockReturnValue(contextEnginesAdopted);
     hoisted.adoptRuntimeWidgetPresenterRegistrations.mockReturnValue(presentersAdopted);
 
     expect(
-      loadAgentRuntimePluginRegistryHandle({ config: {} as never, workspaceDir: "/tmp/workspace" }),
+      loadAgentRuntimePluginRegistryHandle(
+        { config: {}, workspaceDir: "/tmp/workspace" },
+        onPrimaryRegistry,
+      ),
     ).toBe(presentersAdopted);
+    expect(onPrimaryRegistry).toHaveBeenCalledExactlyOnceWith(primaryRegistry);
     expect(hoisted.adoptRuntimeContextEngineRegistrations).toHaveBeenCalledWith(
-      { handle: true },
+      primaryRegistry,
       activeRegistry,
     );
     expect(hoisted.adoptRuntimeWidgetPresenterRegistrations).toHaveBeenCalledWith(

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -107,6 +107,7 @@ function resolveAgentRuntimePluginRegistryLoad(
 /** Loads the registry handle owned by an agent prepared-runtime generation. */
 export function loadAgentRuntimePluginRegistryHandle(
   params: AgentRuntimePluginRegistryParams,
+  onPrimaryRegistry?: (registry: PluginRegistry) => void,
 ): PluginRegistry {
   const loadOptions = resolveAgentRuntimePluginRegistryLoad(params);
   if (
@@ -114,11 +115,14 @@ export function loadAgentRuntimePluginRegistryHandle(
     loadOptions.onlyPluginIds !== undefined &&
     registryContainsRuntimePluginIds(params.reusableRegistry, loadOptions.onlyPluginIds)
   ) {
+    onPrimaryRegistry?.(params.reusableRegistry);
     return params.reusableRegistry;
   }
   // Discovery-only load: full mode can replace process-global sandbox backends.
   // Adopt full-only runtime capabilities from the matching composition-root owners.
   const pluginRegistry = loadPluginRegistryHandle({ ...loadOptions, activate: false });
+  // Media providers remain owned by this source when full-only donors require a copy.
+  onPrimaryRegistry?.(pluginRegistry);
   const activeRegistry = getActivePluginRegistry();
   if (!activeRegistry) {
     return pluginRegistry;

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -4,7 +4,6 @@
  * Handles provider listing, task status, and duplicate-guard output for the image generation tool.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { listRuntimeImageGenerationProviders } from "../../image-generation/runtime.js";
 import type { ImageGenerationProvider } from "../../image-generation/types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
@@ -83,14 +82,14 @@ function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider)
 /** Builds the image-generation provider listing result shown to the agent. */
 export function createImageGenerateListActionResult(params: {
   cfg?: OpenClawConfig;
+  providers: ImageGenerationProvider[];
   workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): ImageGenerateActionResult {
-  const providers = listRuntimeImageGenerationProviders({ config: params.cfg });
   return createMediaGenerateProviderListActionResult({
     kind: "image_generation",
-    providers,
+    providers: params.providers,
     emptyText: "No image-generation providers are registered.",
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,

--- a/src/agents/tools/image-generate-tool.execution.ts
+++ b/src/agents/tools/image-generate-tool.execution.ts
@@ -1,0 +1,424 @@
+/** Owns the exact provider view through image generation and media persistence. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { generateImage } from "../../image-generation/runtime.js";
+import type {
+  ImageGenerationIgnoredOverride,
+  ImageGenerationBackground,
+  ImageGenerationOutputFormat,
+  ImageGenerationProvider,
+  ImageGenerationProviderOptions,
+  ImageGenerationQuality,
+  ImageGenerationResolution,
+  ImageGenerationSourceImage,
+} from "../../image-generation/types.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { getImageMetadata } from "../../media/media-services.js";
+import { saveMediaBuffer } from "../../media/store.js";
+import { acquirePluginCapabilityProviders } from "../../plugins/capability-provider-acquisition.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import {
+  formatGeneratedAttachmentLines,
+  sanitizeGeneratedMediaDisplayText,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
+import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.types.js";
+import { ToolInputError } from "./common.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
+import {
+  imageGenerationTaskLifecycle,
+  type ImageGenerationTaskHandle,
+} from "./media-generate-background.js";
+import {
+  buildMediaReferenceDetails,
+  buildTaskRunDetails,
+  createCapabilityProviderRuntimeDeps,
+  loadMediaToolReferences,
+  resolveMediaToolSandboxConfig,
+} from "./media-tool-shared.js";
+
+const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
+const GENERATED_IMAGE_MEDIA_SUBDIR = "tool-image-generation";
+
+export async function acquireImageGenerationToolProviders(params: {
+  cfg: OpenClawConfig;
+  prepared?: PreparedModelRuntimeSnapshot;
+}) {
+  const work = new AsyncWorkScope();
+  const prepared = params.prepared;
+  const inGeneration = <T>(run: () => T): T =>
+    prepared
+      ? withPluginRuntimeGenerationScope(
+          { metadataSnapshot: prepared.metadataSnapshot, pluginRegistry: prepared.pluginRegistry },
+          run,
+        )
+      : run();
+  let captured:
+    | ReturnType<NonNullable<PreparedModelRuntimeSnapshot["acquireMediaCapabilityProviders"]>>
+    | undefined;
+  let cold:
+    | Awaited<ReturnType<typeof acquirePluginCapabilityProviders<"imageGenerationProviders">>>
+    | undefined;
+  let releaseCompletion: Promise<void> | undefined;
+  const release = () =>
+    (releaseCompletion ??= Promise.resolve().then(async () => {
+      work.beginClose();
+      try {
+        await work.runWhenIdle(async () => {
+          const errors: unknown[] = [];
+          // A copied prepared registry can contribute callbacks without a second physical claim.
+          // Drain the cold view's work before surrendering its original prepared source.
+          for (const owner of [cold, captured]) {
+            try {
+              await owner?.release();
+            } catch (error) {
+              errors.push(error);
+            }
+          }
+          if (errors.length > 0) {
+            throw new AggregateError(errors, "Image provider resource cleanup failed");
+          }
+        });
+      } finally {
+        await work.drain();
+      }
+    }));
+  try {
+    const providers = await work.track(async () => {
+      captured = prepared?.acquireMediaCapabilityProviders?.();
+      const known = captured
+        ? captured.providers.imageGenerationProviders
+        : prepared?.mediaCapabilityProviders?.imageGenerationProviders;
+      if (known !== undefined) {
+        return [...known];
+      }
+      cold = await inGeneration(() =>
+        acquirePluginCapabilityProviders({ key: "imageGenerationProviders", cfg: params.cfg }),
+      );
+      return cold.providers;
+    });
+    return {
+      providers,
+      assertOpen: () => {
+        if (releaseCompletion) {
+          throw new Error("Image provider resources have been released");
+        }
+        captured?.assertOpen();
+        cold?.assertOpen();
+      },
+      run: <T>(run: () => T | Promise<T>) =>
+        releaseCompletion
+          ? Promise.reject(new Error("Image provider resources have been released"))
+          : work.track(() => inGeneration(() => (cold ? cold.run(run) : run()))),
+      release,
+    };
+  } catch (error) {
+    let cleanupFailure: { error: unknown } | undefined;
+    try {
+      await release();
+    } catch (cleanupError) {
+      cleanupFailure = { error: cleanupError };
+    }
+    if (cleanupFailure) {
+      throw new AggregateError(
+        [error, cleanupFailure.error],
+        "Image provider acquisition and cleanup failed",
+        {
+          cause: error,
+        },
+      );
+    }
+    throw error;
+  }
+}
+
+function formatIgnoredImageGenerationOverride(override: ImageGenerationIgnoredOverride): string {
+  return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(override.value)}`;
+}
+
+type ExecutedImageGeneration = {
+  provider: string;
+  model: string;
+  count: number;
+  attachments: AgentGeneratedAttachment[];
+  contentText: string;
+  details: Record<string, unknown>;
+  wakeResult: string;
+};
+
+export async function executeImageGenerationJob(params: {
+  effectiveCfg: OpenClawConfig;
+  prompt: string;
+  agentDir?: string;
+  model?: string;
+  size?: string;
+  aspectRatio?: string;
+  resolution?: ImageGenerationResolution;
+  inferredResolution?: ImageGenerationResolution;
+  quality?: ImageGenerationQuality;
+  outputFormat?: ImageGenerationOutputFormat;
+  background?: ImageGenerationBackground;
+  count: number;
+  inputImages: ImageGenerationSourceImage[];
+  timeoutMs?: number;
+  providerOptions?: ImageGenerationProviderOptions;
+  ssrfPolicy?: SsrFPolicy;
+  filename?: string;
+  loadedReferenceImages: Array<{ resolvedImage: string; rewrittenFrom?: string }>;
+  taskHandle?: ImageGenerationTaskHandle | null;
+  autoProviderFallback?: boolean;
+  providers: ImageGenerationProvider[];
+}) {
+  if (params.taskHandle) {
+    imageGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Generating image",
+    });
+  }
+  const result = await generateImage(
+    {
+      cfg: params.effectiveCfg,
+      prompt: params.prompt,
+      agentDir: params.agentDir,
+      modelOverride: params.model,
+      autoProviderFallback: params.autoProviderFallback,
+      size: params.size,
+      aspectRatio: params.aspectRatio,
+      resolution: params.resolution,
+      inferredResolution: params.inferredResolution,
+      quality: params.quality,
+      outputFormat: params.outputFormat,
+      background: params.background,
+      count: params.count,
+      inputImages: params.inputImages,
+      timeoutMs: params.timeoutMs,
+      providerOptions: params.providerOptions,
+      ssrfPolicy: params.ssrfPolicy,
+    },
+    createCapabilityProviderRuntimeDeps(params.providers),
+  );
+  if (params.taskHandle) {
+    imageGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Saving generated image",
+    });
+  }
+  const ignoredOverrides = result.ignoredOverrides ?? [];
+  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
+  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
+  const warning =
+    ignoredOverrides.length > 0
+      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredImageGenerationOverride).join(", ")}.`
+      : undefined;
+  const normalizedSize =
+    result.normalization?.size?.applied ??
+    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
+      ? result.metadata.normalizedSize
+      : undefined);
+  const normalizedAspectRatio =
+    result.normalization?.aspectRatio?.applied ??
+    (typeof result.metadata?.normalizedAspectRatio === "string" &&
+    result.metadata.normalizedAspectRatio.trim()
+      ? result.metadata.normalizedAspectRatio
+      : undefined);
+  const normalizedResolution =
+    result.normalization?.resolution?.applied ??
+    (typeof result.metadata?.normalizedResolution === "string" &&
+    result.metadata.normalizedResolution.trim()
+      ? result.metadata.normalizedResolution
+      : undefined);
+  const appliedResolution = result.appliedResolution ?? normalizedResolution;
+  const sizeTranslatedToAspectRatio =
+    result.normalization?.aspectRatio?.derivedFrom === "size" ||
+    (!normalizedSize &&
+      typeof result.metadata?.requestedSize === "string" &&
+      result.metadata.requestedSize === params.size &&
+      Boolean(normalizedAspectRatio));
+
+  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "image");
+  const savedImages = await persistGeneratedMediaBatch({
+    subdir: GENERATED_IMAGE_MEDIA_SUBDIR,
+    mode: "concurrent",
+    saves: result.images.map((image) => async () => {
+      const savedMedia = await saveMediaBuffer(
+        image.buffer,
+        image.mimeType,
+        GENERATED_IMAGE_MEDIA_SUBDIR,
+        mediaMaxBytes,
+        params.filename || image.fileName,
+      );
+      return { value: savedMedia, savedMedia };
+    }),
+  });
+
+  const revisedPrompts = result.images
+    .map((image) => image.revisedPrompt?.trim())
+    .filter((entry): entry is string => Boolean(entry));
+  const attachments = savedImages.map((image) => ({
+    type: "image" as const,
+    path: image.path,
+    mimeType: image.contentType,
+    name: image.id,
+    sizeBytes: image.size,
+  }));
+  const lines = [
+    `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
+    ...(warning ? [`Warning: ${warning}`] : []),
+    ...formatGeneratedAttachmentLines(attachments),
+  ];
+  return {
+    provider: result.provider,
+    model: result.model,
+    count: savedImages.length,
+    attachments,
+    contentText: lines.join("\n"),
+    wakeResult: lines.join("\n"),
+    details: {
+      provider: result.provider,
+      model: result.model,
+      count: savedImages.length,
+      media: {
+        mediaUrls: savedImages.map((image) => image.path),
+        attachments,
+      },
+      attachments,
+      paths: savedImages.map((image) => image.path),
+      ...buildTaskRunDetails(params.taskHandle),
+      ...buildMediaReferenceDetails({
+        entries: params.loadedReferenceImages,
+        singleKey: "image",
+        pluralKey: "images",
+        getResolvedInput: (entry) => entry.resolvedImage,
+      }),
+      ...(appliedResolution ? { resolution: appliedResolution } : {}),
+      ...(normalizedSize || (params.size && !sizeTranslatedToAspectRatio)
+        ? { size: normalizedSize ?? params.size }
+        : {}),
+      ...(normalizedAspectRatio || params.aspectRatio
+        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
+        : {}),
+      ...(params.quality ? { quality: params.quality } : {}),
+      ...(params.outputFormat ? { outputFormat: params.outputFormat } : {}),
+      ...(params.background ? { background: params.background } : {}),
+      ...(params.filename ? { filename: params.filename } : {}),
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      attempts: result.attempts,
+      ...(result.normalization ? { normalization: result.normalization } : {}),
+      metadata: result.metadata,
+      ...(warning ? { warning } : {}),
+      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
+      ...(revisedPrompts.length > 0 ? { revisedPrompts } : {}),
+    },
+  } satisfies ExecutedImageGeneration;
+}
+
+export async function loadImageGenerationReferences(params: {
+  imageInputs: string[];
+  maxBytes: number;
+  workspaceDir?: string;
+  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
+  ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
+}): Promise<
+  Array<{
+    sourceImage: ImageGenerationSourceImage;
+    resolvedImage: string;
+    rewrittenFrom?: string;
+  }>
+> {
+  const loaded = await loadMediaToolReferences<ImageGenerationSourceImage>({
+    inputs: params.imageInputs,
+    toolName: "image_generate",
+    expectedKind: "image",
+    sandbox: params.sandboxConfig,
+    workspaceDir: params.workspaceDir,
+    maxBytes: params.maxBytes,
+    ssrfPolicy: params.ssrfPolicy,
+    signal: params.signal,
+    mapMedia: (media) => ({
+      buffer: media.buffer,
+      mimeType:
+        ("contentType" in media && media.contentType) ||
+        ("mimeType" in media && media.mimeType) ||
+        "image/png",
+    }),
+  });
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
+    Object.assign(
+      { sourceImage: source, resolvedImage: resolvedInput },
+      rewrittenFrom ? { rewrittenFrom } : {},
+    ),
+  );
+}
+
+export async function inferImageGenerationResolution(
+  images: ImageGenerationSourceImage[],
+  signal?: AbortSignal,
+): Promise<ImageGenerationResolution> {
+  let maxDimension = 0;
+  for (const image of images) {
+    signal?.throwIfAborted();
+    const meta = await getImageMetadata(image.buffer);
+    signal?.throwIfAborted();
+    const dimension = Math.max(meta?.width ?? 0, meta?.height ?? 0);
+    maxDimension = Math.max(maxDimension, dimension);
+  }
+  if (maxDimension >= 3000) {
+    return "4K";
+  }
+  if (maxDimension >= 1500) {
+    return "2K";
+  }
+  return DEFAULT_RESOLUTION;
+}
+
+const SUPPORTED_ASPECT_RATIOS = new Set([
+  "1:1",
+  "2:1",
+  "20:9",
+  "19.5:9",
+  "2:3",
+  "3:2",
+  "2.35:1",
+  "3:4",
+  "4:3",
+  "4:5",
+  "5:4",
+  "9:16",
+  "9:19.5",
+  "9:20",
+  "16:9",
+  "21:9",
+  "1:2",
+  "4:1",
+  "1:4",
+  "8:1",
+  "1:8",
+]);
+
+export function normalizeImageGenerationAspectRatio(raw: string | undefined): string | undefined {
+  const normalized = raw?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (SUPPORTED_ASPECT_RATIOS.has(normalized)) {
+    return normalized;
+  }
+  throw new ToolInputError(
+    "aspectRatio must be one of 1:1, 2:1, 20:9, 19.5:9, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 9:19.5, 9:20, 16:9, 21:9, 1:2, 4:1, 1:4, 8:1, or 1:8",
+  );
+}
+
+export function normalizeImageGenerationResolution(
+  raw: string | undefined,
+): ImageGenerationResolution | undefined {
+  const normalized = raw?.trim().toUpperCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "1K" || normalized === "2K" || normalized === "4K") {
+    return normalized;
+  }
+  throw new ToolInputError("resolution must be one of 1K, 2K, or 4K");
+}

--- a/src/agents/tools/image-generate-tool.resources.test.ts
+++ b/src/agents/tools/image-generate-tool.resources.test.ts
@@ -1,0 +1,389 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as mediaStore from "../../media/store.js";
+import * as webMedia from "../../media/web-media.js";
+import { acquirePluginRegistryForInspection } from "../../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resetRecentMediaGenerationDuplicateGuardsForTests } from "../media-generation-task-status-shared.test-support.js";
+import { prepareConfiguredRuntimeFacts } from "../prepared-model-runtime.configured-catalog.js";
+import { prepareWorkspaceBuildGroup } from "../prepared-model-runtime.facts.js";
+import { createPreparedModelRuntimeSnapshot } from "../prepared-model-runtime.full-catalog.js";
+import { ModelRegistry } from "../sessions/model-registry.js";
+import { createImageGenerateTool } from "./image-generate-tool.js";
+import { imageGenerationTaskLifecycle } from "./media-generate-background.js";
+
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMQVDL+DwACFAFmBODefwAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+function createNativeFixture(edit = false) {
+  const dir = makePluginLoaderTempDir();
+  const key = `__openclaw_prepared_image_${path.basename(dir)}`;
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    generated: number;
+    projected: number;
+  }> = [];
+  const generated = createDeferredCore();
+  const resumeGeneration = createDeferredCore();
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: { connections, generated, resumeGeneration, png },
+  });
+  const id = "prepared-image-resource";
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, generated: 0, projected: 0 };
+    state.connections.push(connection);
+    const read = () => database.prepare("SELECT 42 AS value").get().value;
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "prepared-image-database",
+      dispose() {
+        read();
+        connection.disposals++;
+        database.close();
+      },
+    });
+    api.registerImageGenerationProvider({
+      id: ${JSON.stringify(id)},
+      defaultModel: "fixture-image",
+      isConfigured() { return read() === 42; },
+      capabilities: { generate: { maxCount: 2 }, edit: { enabled: ${edit}, maxInputImages: ${edit ? 1 : 0} } },
+      async generateImage(request) {
+        read();
+        connection.generated++;
+        state.generated.resolve();
+        await state.resumeGeneration.promise;
+        read();
+        return {
+          images: Array.from({ length: request.count ?? 1 }, (_, index) => ({
+            buffer: state.png,
+            mimeType: "image/png",
+            fileName: "native-" + index + ".png",
+            get revisedPrompt() {
+              connection.projected++;
+              return "native value " + read();
+            },
+          })),
+        };
+      },
+    });
+  },
+};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { imageGenerationProviders: [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const config: OpenClawConfig = {
+    agents: { defaults: { mediaModels: { image: { primary: `${id}/fixture-image` } } } },
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  return {
+    dir,
+    config,
+    connections,
+    generated,
+    resumeGeneration,
+    withEnvironment: (run: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        run,
+      ),
+    cleanup() {
+      resumeGeneration.resolve();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+async function prepareSnapshot(
+  fixture: ReturnType<typeof createNativeFixture>,
+  registry: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>>["registry"],
+) {
+  const prepared = await prepareWorkspaceBuildGroup(
+    [
+      {
+        agentId: "main",
+        agentDir: path.join(fixture.dir, "agent"),
+        workspaceDir: fixture.dir,
+        config: fixture.config,
+        skipCredentials: true,
+      },
+    ],
+    "static",
+    { includeCredentialProviders: false },
+    () => registry,
+  );
+  const facts = prepared.agentFacts[0]!;
+  const catalog = prepareConfiguredRuntimeFacts({
+    agentFacts: facts,
+    workspaceFacts: prepared.pluginGeneration,
+    templateModelRegistry: ModelRegistry.inMemory(facts.templateAuthStorage),
+    configuredRuntimeModels: facts.configuredRuntimeModels,
+  });
+  return createPreparedModelRuntimeSnapshot(undefined, facts, prepared.pluginGeneration, catalog, {
+    isCurrent: () => true,
+    withRefreshStatus: (value) => value,
+    readFullModelCatalog: () => catalog.modelCatalog,
+    loadFullModelCatalog: async () => catalog.modelCatalog,
+    loadAuth: async () => {
+      throw new Error("The synthetic image provider does not request model credentials");
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetRecentMediaGenerationDuplicateGuardsForTests();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("prepared image job registration resources", () => {
+  it("refuses new paid admission when the prepared owner releases during reference loading", async () => {
+    const fixture = createNativeFixture(true);
+    const referenceStarted = createDeferredCore();
+    const resumeReference = createDeferredCore();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const first = await acquirePluginRegistryForInspection({ config: fixture.config });
+        const referencePath = path.join(fixture.dir, "reference.png");
+        fs.writeFileSync(referencePath, png);
+        const snapshot = await prepareSnapshot(fixture, first.registry);
+        const createTask = vi.spyOn(imageGenerationTaskLifecycle, "createTaskRun").mockReturnValue({
+          taskId: "preflight-image-task",
+          runId: "preflight-image-run",
+          requesterSessionKey: "agent:main:discord:direct:synthetic-image",
+          taskLabel: "Synthetic image edit",
+        });
+        const schedule = vi.fn();
+        const loadReference = webMedia.loadWebMedia;
+        vi.spyOn(webMedia, "loadWebMedia").mockImplementation(async (...args) => {
+          referenceStarted.resolve();
+          await resumeReference.promise;
+          return loadReference(...args);
+        });
+        const tool = createImageGenerateTool({
+          config: fixture.config,
+          agentDir: snapshot.agentDir,
+          workspaceDir: fixture.dir,
+          preparedModelRuntime: snapshot,
+          agentSessionKey: "agent:main:discord:direct:synthetic-image",
+          scheduleBackgroundWork: schedule,
+        });
+        const outcome = tool!
+          .execute("preflight-image-call", { prompt: "Synthetic image edit", image: referencePath })
+          .then(
+            (value) => ({ value, error: undefined }),
+            (error: unknown) => ({ value: undefined, error }),
+          );
+        try {
+          await Promise.race([
+            referenceStarted.promise,
+            outcome.then(() => {
+              throw new Error("Image preflight settled before reading its reference");
+            }),
+          ]);
+          await first.release();
+          resumeReference.resolve();
+          const result = await outcome;
+          expect(result.error).toBeInstanceOf(Error);
+          expect(result.value).toBeUndefined();
+          expect(createTask).not.toHaveBeenCalled();
+          expect(schedule).not.toHaveBeenCalled();
+          expect(fixture.connections[0]!.generated).toBe(0);
+          expect(fixture.connections[0]!.database.isOpen).toBe(false);
+          expect(fixture.connections[0]!.disposals).toBe(1);
+        } finally {
+          resumeReference.resolve();
+          await outcome;
+          await first.release();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each(["queued", "saving", "rollback"] as const)(
+    "retains the admitted provider through %s after its parent releases",
+    async (phase) => {
+      const fixture = createNativeFixture();
+      const saveStarted = createDeferredCore();
+      const resumeSave = createDeferredCore();
+      const rollbackStarted = createDeferredCore();
+      const resumeRollback = createDeferredCore();
+      const scheduled: Array<() => Promise<void>> = [];
+      let completion: Promise<void> | undefined;
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const first = await acquirePluginRegistryForInspection({ config: fixture.config });
+          let successor: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+          try {
+            const snapshot = await prepareSnapshot(fixture, first.registry);
+            expect(snapshot.mediaCapabilityProviders?.imageGenerationProviders).toHaveLength(1);
+            const connection = fixture.connections[0]!;
+            const sessionKey = "agent:main:discord:direct:synthetic-image";
+            vi.spyOn(imageGenerationTaskLifecycle, "createTaskRun").mockReturnValue({
+              taskId: "image-resource-task",
+              runId: "image-resource-run",
+              requesterSessionKey: sessionKey,
+              requesterAgentId: "main",
+              taskLabel: "Synthetic image resource proof",
+            });
+            vi.spyOn(imageGenerationTaskLifecycle, "recordTaskProgress").mockImplementation(
+              () => {},
+            );
+            const completed = vi
+              .spyOn(imageGenerationTaskLifecycle, "completeTaskRun")
+              .mockImplementation(() => {});
+            const failed = vi
+              .spyOn(imageGenerationTaskLifecycle, "failTaskRun")
+              .mockImplementation(() => {});
+            vi.spyOn(imageGenerationTaskLifecycle, "wakeTaskCompletion").mockResolvedValue({
+              status: "delivered",
+            });
+            const save = mediaStore.saveMediaBuffer;
+            const remove = mediaStore.deleteMediaBuffer;
+            let saveCalls = 0;
+            let savedPath: string | undefined;
+            vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async (...args) => {
+              saveCalls++;
+              if (phase === "rollback" && saveCalls === 1) {
+                throw new Error("synthetic first image persistence failure");
+              }
+              saveStarted.resolve();
+              await resumeSave.promise;
+              const saved = await save(...args);
+              savedPath = saved.path;
+              return saved;
+            });
+            vi.spyOn(mediaStore, "deleteMediaBuffer").mockImplementation(async (...args) => {
+              rollbackStarted.resolve();
+              await resumeRollback.promise;
+              return remove(...args);
+            });
+            const tool = createImageGenerateTool({
+              config: fixture.config,
+              agentDir: snapshot.agentDir,
+              workspaceDir: fixture.dir,
+              preparedModelRuntime: snapshot,
+              agentSessionKey: sessionKey,
+              scheduleBackgroundWork: (work) => scheduled.push(work),
+            });
+            expect(tool).not.toBeNull();
+            const started = await tool!.execute("image-resource-call", {
+              prompt: "Synthetic image resource proof",
+              count: phase === "rollback" ? 2 : 1,
+            });
+            expect(started.details).toMatchObject({ status: "started" });
+            expect(scheduled).toHaveLength(1);
+            expect(connection.generated).toBe(0);
+            if (phase === "queued") {
+              await first.release();
+            }
+            successor = await acquirePluginRegistryForInspection({ config: fixture.config });
+            setActivePluginRegistry(successor.registry);
+            expect(fixture.connections).toHaveLength(2);
+            if (phase === "queued") {
+              expect(connection.database.isOpen).toBe(true);
+            }
+            completion = scheduled[0]!();
+            await Promise.race([
+              fixture.generated.promise,
+              completion.then(() => {
+                throw new Error("Image task settled without invoking its prepared provider");
+              }),
+            ]);
+            fixture.resumeGeneration.resolve();
+            await Promise.race([
+              saveStarted.promise,
+              completion.then(() => {
+                throw new Error("Image task settled before persisting its output");
+              }),
+            ]);
+            await first.release();
+            expect(connection.database.isOpen).toBe(true);
+            expect(connection.disposals).toBe(0);
+            expect(fixture.connections[1]!.generated).toBe(0);
+            resumeSave.resolve();
+            if (phase === "rollback") {
+              await rollbackStarted.promise;
+              expect(connection.database.isOpen).toBe(true);
+              expect(savedPath && fs.existsSync(savedPath)).toBe(true);
+              resumeRollback.resolve();
+            }
+            await completion;
+            expect(connection.database.isOpen).toBe(false);
+            expect(connection.disposals).toBe(1);
+            expect(fixture.connections[1]!.database.isOpen).toBe(true);
+            if (phase === "rollback") {
+              expect(failed).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  error: expect.objectContaining({
+                    message: "synthetic first image persistence failure",
+                  }),
+                }),
+              );
+              expect(completed).not.toHaveBeenCalled();
+              expect(savedPath && fs.existsSync(savedPath)).toBe(false);
+            } else {
+              expect(failed).not.toHaveBeenCalled();
+              expect(completed).toHaveBeenCalledOnce();
+              expect(connection.projected).toBeGreaterThan(0);
+              expect(fs.readFileSync(savedPath!)).toEqual(png);
+            }
+          } finally {
+            fixture.resumeGeneration.resolve();
+            resumeSave.resolve();
+            resumeRollback.resolve();
+            await completion;
+            await first.release();
+            await successor?.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+});

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -40,6 +40,8 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => (
 }));
 
 let imageGenerationRuntime: typeof import("../../image-generation/runtime.js");
+let imageGenerationExecution: typeof import("./image-generate-tool.execution.js");
+let mediaGenerationRegistry: typeof import("../../media-generation/registry.js");
 let imageOps: typeof import("../../media/media-services.js");
 let splitMediaFromOutput: typeof import("../../media/parse.js").splitMediaFromOutput;
 let mediaStore: typeof import("../../media/store.js");
@@ -352,6 +354,8 @@ describe("createImageGenerateTool", () => {
       };
     });
     imageGenerationRuntime = await import("../../image-generation/runtime.js");
+    imageGenerationExecution = await import("./image-generate-tool.execution.js");
+    mediaGenerationRegistry = await import("../../media-generation/registry.js");
     imageOps = await import("../../media/media-services.js");
     ({ splitMediaFromOutput } = await import("../../media/parse.js"));
     mediaStore = await import("../../media/store.js");
@@ -363,6 +367,19 @@ describe("createImageGenerateTool", () => {
   });
 
   beforeEach(() => {
+    // These fixtures cover routing and limits; the native suite proves actual resource ownership.
+    vi.spyOn(imageGenerationExecution, "acquireImageGenerationToolProviders").mockImplementation(
+      async ({ cfg }) => ({
+        providers: imageGenerationRuntime.listRuntimeImageGenerationProviders({ config: cfg }),
+        assertOpen() {},
+        run: async (run) => await run(),
+        release: async () => {},
+      }),
+    );
+    vi.spyOn(mediaGenerationRegistry, "withImageGenerationProviders").mockImplementation(
+      async (cfg, run) =>
+        await run(imageGenerationRuntime.listRuntimeImageGenerationProviders({ config: cfg })),
+    );
     for (const envVar of GENERATION_PROVIDER_ENV_VARS) {
       vi.stubEnv(envVar, "");
     }
@@ -1262,6 +1279,9 @@ describe("createImageGenerateTool", () => {
   });
 
   it("returns active status for a duplicate image request with the same prompt", async () => {
+    const acquireProviders = vi.mocked(
+      imageGenerationExecution.acquireImageGenerationToolProviders,
+    );
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
@@ -1304,6 +1324,7 @@ describe("createImageGenerateTool", () => {
     });
 
     expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(acquireProviders).not.toHaveBeenCalled();
     expect(resultText(result)).toContain(
       "Image generation task task-existing-image is already running",
     );

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -5,37 +5,21 @@ import { findCapabilityProviderById } from "../../../packages/media-generation-c
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveImageGenerationMaxInputImages } from "../../image-generation/capabilities.js";
-import {
-  generateImage,
-  listRuntimeImageGenerationProviders,
-} from "../../image-generation/runtime.js";
 import type {
-  ImageGenerationIgnoredOverride,
-  ImageGenerationBackground,
   ImageGenerationOpenAIOptions,
-  ImageGenerationOutputFormat,
   ImageGenerationProvider,
   ImageGenerationProviderOptions,
-  ImageGenerationQuality,
   ImageGenerationResolution,
-  ImageGenerationSourceImage,
 } from "../../image-generation/types.js";
-import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseImageGenerationModelRef } from "../../media-generation/model-ref.js";
+import { withImageGenerationProviders } from "../../media-generation/registry.js";
 import { resolveCapabilityModelCandidates } from "../../media-generation/runtime-shared.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { getImageMetadata } from "../../media/media-services.js";
-import { saveMediaBuffer } from "../../media/store.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { createEnumOptionParser } from "../../shared/enum-option.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import {
-  formatGeneratedAttachmentLines,
-  sanitizeGeneratedMediaDisplayText,
-  type AgentGeneratedAttachment,
-} from "../generated-attachments.js";
 import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { optionalStringEnum } from "../schema/string-enum.js";
@@ -45,12 +29,19 @@ import {
   readPositiveIntegerParam,
   readToolStringParam,
 } from "./common.js";
-import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import {
   createImageGenerateDuplicateGuardResult,
   createImageGenerateListActionResult,
   createImageGenerateStatusActionResult,
 } from "./image-generate-tool.actions.js";
+import {
+  acquireImageGenerationToolProviders,
+  executeImageGenerationJob,
+  loadImageGenerationReferences,
+  inferImageGenerationResolution,
+  normalizeImageGenerationAspectRatio,
+  normalizeImageGenerationResolution,
+} from "./image-generate-tool.execution.js";
 import {
   createDefaultMediaGenerateBackgroundScheduler,
   type MediaGenerateAsyncStartCallback,
@@ -64,11 +55,8 @@ import {
 import {
   applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
-  buildTaskRunDetails,
-  createCapabilityProviderRuntimeDeps,
   hasExplicitMediaModel,
   hasGenerationToolAvailability,
-  loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
   resolveMediaToolSandboxConfig,
@@ -83,38 +71,13 @@ import type { AnyAgentTool, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
-const GENERATED_IMAGE_MEDIA_SUBDIR = "tool-image-generation";
 const DEFAULT_MAX_INPUT_IMAGES = 10;
 const MAX_REFERENCE_IMAGE_INPUTS = 14;
-const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
 const SUPPORTED_QUALITIES = ["low", "medium", "high", "auto"] as const;
 const SUPPORTED_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const SUPPORTED_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const SUPPORTED_OPENAI_MODERATIONS = ["low", "auto"] as const;
 const SUPPORTED_FAL_CREATIVITY = ["raw", "low", "medium", "high"] as const;
-const SUPPORTED_ASPECT_RATIOS = new Set([
-  "1:1",
-  "2:1",
-  "20:9",
-  "19.5:9",
-  "2:3",
-  "3:2",
-  "2.35:1",
-  "3:4",
-  "4:3",
-  "4:5",
-  "5:4",
-  "9:16",
-  "9:19.5",
-  "9:20",
-  "16:9",
-  "21:9",
-  "1:2",
-  "4:1",
-  "1:4",
-  "8:1",
-  "1:8",
-]);
 
 const log = createSubsystemLogger("agents/tools/image-generate");
 
@@ -230,30 +193,6 @@ function resolveRequestedCount(args: Record<string, unknown>): number {
     throw new ToolInputError(`count must be between 1 and ${MAX_COUNT}`);
   }
   return count;
-}
-
-function normalizeResolution(raw: string | undefined): ImageGenerationResolution | undefined {
-  const normalized = raw?.trim().toUpperCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized === "1K" || normalized === "2K" || normalized === "4K") {
-    return normalized;
-  }
-  throw new ToolInputError("resolution must be one of 1K, 2K, or 4K");
-}
-
-function normalizeAspectRatio(raw: string | undefined): string | undefined {
-  const normalized = raw?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  if (SUPPORTED_ASPECT_RATIOS.has(normalized)) {
-    return normalized;
-  }
-  throw new ToolInputError(
-    "aspectRatio must be one of 1:1, 2:1, 20:9, 19.5:9, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 9:19.5, 9:20, 16:9, 21:9, 1:2, 4:1, 1:4, 8:1, or 1:8",
-  );
 }
 
 const parseImageOption = createEnumOptionParser(ToolInputError);
@@ -392,10 +331,6 @@ function modelDisablesImageResolution(
   return provider.capabilities.geometry?.resolutionsByModel?.[modelId]?.length === 0;
 }
 
-function formatIgnoredImageGenerationOverride(override: ImageGenerationIgnoredOverride): string {
-  return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(override.value)}`;
-}
-
 function validateImageGenerationCapabilities(params: {
   provider: ImageGenerationProvider | undefined;
   count: number;
@@ -437,248 +372,10 @@ function validateImageGenerationCapabilities(params: {
 
 type ImageGenerateSandboxConfig = MediaToolSandbox;
 
-async function loadReferenceImages(params: {
-  imageInputs: string[];
-  maxBytes: number;
-  workspaceDir?: string;
-  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
-  ssrfPolicy?: SsrFPolicy;
-  signal?: AbortSignal;
-}): Promise<
-  Array<{
-    sourceImage: ImageGenerationSourceImage;
-    resolvedImage: string;
-    rewrittenFrom?: string;
-  }>
-> {
-  const loaded = await loadMediaToolReferences<ImageGenerationSourceImage>({
-    inputs: params.imageInputs,
-    toolName: "image_generate",
-    expectedKind: "image",
-    sandbox: params.sandboxConfig,
-    workspaceDir: params.workspaceDir,
-    maxBytes: params.maxBytes,
-    ssrfPolicy: params.ssrfPolicy,
-    signal: params.signal,
-    mapMedia: (media) => ({
-      buffer: media.buffer,
-      mimeType:
-        ("contentType" in media && media.contentType) ||
-        ("mimeType" in media && media.mimeType) ||
-        "image/png",
-    }),
-  });
-  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
-    Object.assign(
-      { sourceImage: source, resolvedImage: resolvedInput },
-      rewrittenFrom ? { rewrittenFrom } : {},
-    ),
-  );
-}
-
-async function inferResolutionFromInputImages(
-  images: ImageGenerationSourceImage[],
-  signal?: AbortSignal,
-): Promise<ImageGenerationResolution> {
-  let maxDimension = 0;
-  for (const image of images) {
-    signal?.throwIfAborted();
-    const meta = await getImageMetadata(image.buffer);
-    signal?.throwIfAborted();
-    const dimension = Math.max(meta?.width ?? 0, meta?.height ?? 0);
-    maxDimension = Math.max(maxDimension, dimension);
-  }
-  if (maxDimension >= 3000) {
-    return "4K";
-  }
-  if (maxDimension >= 1500) {
-    return "2K";
-  }
-  return DEFAULT_RESOLUTION;
-}
-
-type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[number];
-
-type ExecutedImageGeneration = {
-  provider: string;
-  model: string;
-  count: number;
-  attachments: AgentGeneratedAttachment[];
-  contentText: string;
-  details: Record<string, unknown>;
-  wakeResult: string;
-};
-
 const defaultScheduleImageGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
   toolName: "image_generate",
   onCrash: (message, meta) => log.error(message, meta),
 });
-
-async function executeImageGenerationJob(params: {
-  effectiveCfg: OpenClawConfig;
-  prompt: string;
-  agentDir?: string;
-  model?: string;
-  size?: string;
-  aspectRatio?: string;
-  resolution?: ImageGenerationResolution;
-  inferredResolution?: ImageGenerationResolution;
-  quality?: ImageGenerationQuality;
-  outputFormat?: ImageGenerationOutputFormat;
-  background?: ImageGenerationBackground;
-  count: number;
-  inputImages: ImageGenerationSourceImage[];
-  timeoutMs?: number;
-  providerOptions?: ImageGenerationProviderOptions;
-  ssrfPolicy?: SsrFPolicy;
-  filename?: string;
-  loadedReferenceImages: LoadedReferenceImage[];
-  taskHandle?: ImageGenerationTaskHandle | null;
-  autoProviderFallback?: boolean;
-  providers?: ImageGenerationProvider[];
-}) {
-  if (params.taskHandle) {
-    imageGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Generating image",
-    });
-  }
-  const result = await generateImage(
-    {
-      cfg: params.effectiveCfg,
-      prompt: params.prompt,
-      agentDir: params.agentDir,
-      modelOverride: params.model,
-      autoProviderFallback: params.autoProviderFallback,
-      size: params.size,
-      aspectRatio: params.aspectRatio,
-      resolution: params.resolution,
-      inferredResolution: params.inferredResolution,
-      quality: params.quality,
-      outputFormat: params.outputFormat,
-      background: params.background,
-      count: params.count,
-      inputImages: params.inputImages,
-      timeoutMs: params.timeoutMs,
-      providerOptions: params.providerOptions,
-      ssrfPolicy: params.ssrfPolicy,
-    },
-    createCapabilityProviderRuntimeDeps(params.providers),
-  );
-  if (params.taskHandle) {
-    imageGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Saving generated image",
-    });
-  }
-  const ignoredOverrides = result.ignoredOverrides ?? [];
-  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
-  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
-  const warning =
-    ignoredOverrides.length > 0
-      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredImageGenerationOverride).join(", ")}.`
-      : undefined;
-  const normalizedSize =
-    result.normalization?.size?.applied ??
-    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
-      ? result.metadata.normalizedSize
-      : undefined);
-  const normalizedAspectRatio =
-    result.normalization?.aspectRatio?.applied ??
-    (typeof result.metadata?.normalizedAspectRatio === "string" &&
-    result.metadata.normalizedAspectRatio.trim()
-      ? result.metadata.normalizedAspectRatio
-      : undefined);
-  const normalizedResolution =
-    result.normalization?.resolution?.applied ??
-    (typeof result.metadata?.normalizedResolution === "string" &&
-    result.metadata.normalizedResolution.trim()
-      ? result.metadata.normalizedResolution
-      : undefined);
-  const appliedResolution = result.appliedResolution ?? normalizedResolution;
-  const sizeTranslatedToAspectRatio =
-    result.normalization?.aspectRatio?.derivedFrom === "size" ||
-    (!normalizedSize &&
-      typeof result.metadata?.requestedSize === "string" &&
-      result.metadata.requestedSize === params.size &&
-      Boolean(normalizedAspectRatio));
-
-  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "image");
-  const savedImages = await persistGeneratedMediaBatch({
-    subdir: GENERATED_IMAGE_MEDIA_SUBDIR,
-    mode: "concurrent",
-    saves: result.images.map((image) => async () => {
-      const savedMedia = await saveMediaBuffer(
-        image.buffer,
-        image.mimeType,
-        GENERATED_IMAGE_MEDIA_SUBDIR,
-        mediaMaxBytes,
-        params.filename || image.fileName,
-      );
-      return { value: savedMedia, savedMedia };
-    }),
-  });
-
-  const revisedPrompts = result.images
-    .map((image) => image.revisedPrompt?.trim())
-    .filter((entry): entry is string => Boolean(entry));
-  const attachments = savedImages.map((image) => ({
-    type: "image" as const,
-    path: image.path,
-    mimeType: image.contentType,
-    name: image.id,
-    sizeBytes: image.size,
-  }));
-  const lines = [
-    `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
-    ...(warning ? [`Warning: ${warning}`] : []),
-    ...formatGeneratedAttachmentLines(attachments),
-  ];
-  return {
-    provider: result.provider,
-    model: result.model,
-    count: savedImages.length,
-    attachments,
-    contentText: lines.join("\n"),
-    wakeResult: lines.join("\n"),
-    details: {
-      provider: result.provider,
-      model: result.model,
-      count: savedImages.length,
-      media: {
-        mediaUrls: savedImages.map((image) => image.path),
-        attachments,
-      },
-      attachments,
-      paths: savedImages.map((image) => image.path),
-      ...buildTaskRunDetails(params.taskHandle),
-      ...buildMediaReferenceDetails({
-        entries: params.loadedReferenceImages,
-        singleKey: "image",
-        pluralKey: "images",
-        getResolvedInput: (entry) => entry.resolvedImage,
-      }),
-      ...(appliedResolution ? { resolution: appliedResolution } : {}),
-      ...(normalizedSize || (params.size && !sizeTranslatedToAspectRatio)
-        ? { size: normalizedSize ?? params.size }
-        : {}),
-      ...(normalizedAspectRatio || params.aspectRatio
-        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
-        : {}),
-      ...(params.quality ? { quality: params.quality } : {}),
-      ...(params.outputFormat ? { outputFormat: params.outputFormat } : {}),
-      ...(params.background ? { background: params.background } : {}),
-      ...(params.filename ? { filename: params.filename } : {}),
-      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
-      attempts: result.attempts,
-      ...(result.normalization ? { normalization: result.normalization } : {}),
-      metadata: result.metadata,
-      ...(warning ? { warning } : {}),
-      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
-      ...(revisedPrompts.length > 0 ? { revisedPrompts } : {}),
-    },
-  } satisfies ExecutedImageGeneration;
-}
 
 export function createImageGenerateTool(options?: {
   config?: OpenClawConfig;
@@ -729,12 +426,15 @@ export function createImageGenerateTool(options?: {
       const params = args as Record<string, unknown>;
       const action = resolveGenerateAction(params);
       if (action === "list") {
-        return createImageGenerateListActionResult({
-          cfg,
-          workspaceDir: options?.workspaceDir,
-          agentDir: options?.agentDir,
-          authStore: options?.authProfileStore,
-        });
+        return withImageGenerationProviders(cfg, (providers) =>
+          createImageGenerateListActionResult({
+            cfg,
+            providers,
+            workspaceDir: options?.workspaceDir,
+            agentDir: options?.agentDir,
+            authStore: options?.authProfileStore,
+          }),
+        );
       }
       if (action === "status") {
         return createImageGenerateStatusActionResult(
@@ -744,216 +444,279 @@ export function createImageGenerateTool(options?: {
       }
 
       const model = readToolStringParam(params, "model");
-      const imageGenerationModelConfig = resolveCapabilityModelConfigForTool({
-        cfg,
-        workspaceDir: options?.workspaceDir,
-        agentDir: options?.agentDir,
-        authStore: options?.authProfileStore,
-        modelConfig: cfg.agents?.defaults?.mediaModels?.image,
-        modelOverride: model,
-        providers: () => listRuntimeImageGenerationProviders({ config: cfg }),
-      });
-      if (!imageGenerationModelConfig) {
-        throw new ToolInputError("No image-generation model configured.");
-      }
       const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.image);
-      const effectiveCfg =
-        applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig) ?? cfg;
-      const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
-      const prompt = readToolStringParam(params, "prompt", { required: true });
-
-      const activeDuplicateGuardResult = createImageGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, agentId: options?.requesterAgentId },
-      );
-      if (activeDuplicateGuardResult) {
-        return activeDuplicateGuardResult;
-      }
-
-      const imageInputs = normalizeReferenceImages(params);
-      const filename = readToolStringParam(params, "filename");
-      const size = readToolStringParam(params, "size");
-      const aspectRatio = normalizeAspectRatio(readToolStringParam(params, "aspectRatio"));
-      const explicitResolution = normalizeResolution(readToolStringParam(params, "resolution"));
-      const timeoutMs = readGenerationTimeoutMs(params) ?? imageGenerationModelConfig.timeoutMs;
-      const quality = parseImageOption(
-        readToolStringParam(params, "quality"),
-        SUPPORTED_QUALITIES,
-        "quality",
-      );
-      const outputFormat = parseImageOption(
-        readToolStringParam(params, "outputFormat"),
-        SUPPORTED_OUTPUT_FORMATS,
-        "outputFormat",
-      );
-      const background = parseImageOption(
-        readToolStringParam(params, "background"),
-        SUPPORTED_BACKGROUNDS,
-        "background",
-      );
-      const providerOptions = normalizeProviderOptions(params);
-      const imageGenerationProviders =
-        preparedProviders ?? listRuntimeImageGenerationProviders({ config: effectiveCfg });
-      const selectedProvider = resolveSelectedImageGenerationProvider({
-        providers: imageGenerationProviders,
-        imageGenerationModelConfig,
-        modelOverride: model,
-      });
-      const explicitModelRef = parseImageGenerationModelRef(model);
-      const primaryModelRef = parseImageGenerationModelRef(imageGenerationModelConfig.primary);
-      const selectedModelId = resolveSelectedImageGenerationModelId({
-        selectedProvider,
-        imageGenerationModelConfig,
-        modelOverride: model,
-        explicitModelRef,
-        primaryModelRef,
-      });
-      const imageGenerationCandidates = resolveCapabilityModelCandidates({
-        cfg: effectiveCfg,
-        modelConfig: effectiveCfg.agents?.defaults?.mediaModels?.image,
-        modelOverride: model,
-        parseModelRef: parseImageGenerationModelRef,
-        agentDir: options?.agentDir,
-        listProviders: () => imageGenerationProviders,
-        autoProviderFallback: explicitModelConfig ? false : undefined,
-      });
-      const maxInputImages = resolveReachableImageGenerationMaxInputImages({
-        providers: imageGenerationProviders,
-        candidates: imageGenerationCandidates,
-      });
-      const count = resolveRequestedCount(params);
-      const requestKey = buildMediaGenerationRequestKey({
-        tool: "image_generate",
-        prompt,
-        provider: selectedProvider?.id ?? explicitModelRef?.provider ?? primaryModelRef?.provider,
-        model:
-          model !== undefined
-            ? (explicitModelRef?.model ?? model)
-            : (primaryModelRef?.model ??
-              imageGenerationModelConfig.primary ??
-              selectedProvider?.defaultModel),
-        count,
-        imageInputs,
-        size,
-        aspectRatio,
-        resolution: explicitResolution,
-        quality,
-        outputFormat,
-        background,
-        filename,
-        providerOptions,
-      });
-      const duplicateGuardResult = createImageGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, requestKey, agentId: options?.requesterAgentId },
-      );
-      if (duplicateGuardResult) {
-        return duplicateGuardResult;
-      }
-      validateImageGenerationCapabilities({
-        provider: selectedProvider,
-        count,
-        inputImageCount: imageInputs.length,
-        maxInputImages,
-        size,
-        aspectRatio,
-        resolution: explicitResolution,
-        explicitResolution: Boolean(explicitResolution),
-      });
-      const referenceMaxBytes = resolveGeneratedMediaMaxBytes(effectiveCfg, "image");
-      const loadedReferenceImages = await loadReferenceImages({
-        imageInputs,
-        maxBytes: referenceMaxBytes,
-        workspaceDir: options?.workspaceDir,
-        sandboxConfig,
-        ssrfPolicy: remoteMediaSsrfPolicy,
-        signal,
-      });
-      const inputImages = loadedReferenceImages.map((entry) => entry.sourceImage);
-      const modeCaps =
-        inputImages.length > 0
-          ? selectedProvider?.capabilities.edit
-          : selectedProvider?.capabilities.generate;
-      const inferredResolution =
-        size || explicitResolution
-          ? undefined
-          : inputImages.length > 0
-            ? await inferResolutionFromInputImages(inputImages, signal)
-            : undefined;
-      const resolution =
-        explicitResolution ??
-        (modeCaps?.supportsResolution === false ||
-        modelDisablesImageResolution(selectedProvider, selectedModelId)
-          ? undefined
-          : inferredResolution);
-      validateImageGenerationCapabilities({
-        provider: selectedProvider,
-        count,
-        inputImageCount: inputImages.length,
-        maxInputImages,
-        size,
-        aspectRatio,
-        resolution,
-        explicitResolution: Boolean(explicitResolution),
-      });
-      // Accepted tasks own their paid work independently; cancellation applies only before admission.
-      signal?.throwIfAborted();
-      return runMediaGenerationTask({
-        lifecycle: imageGenerationTaskLifecycle,
-        generationLabel: "image",
-        sessionKey: options?.agentSessionKey,
-        requesterAgentId: options?.requesterAgentId,
-        requesterOrigin: options?.requesterOrigin,
-        prompt,
-        requestKey,
-        providerId: selectedProvider?.id,
-        config: effectiveCfg,
-        scheduleBackgroundWork,
-        onAsyncTaskStarted: options?.onAsyncTaskStarted,
-        onFailure: (message, meta) => log.warn(message, meta),
-        detailExtras: {
-          ...buildMediaReferenceDetails({
-            entries: loadedReferenceImages,
-            singleKey: "image",
-            pluralKey: "images",
-            getResolvedInput: (entry) => entry.resolvedImage,
-          }),
-          ...(model ? { model } : {}),
-          ...(resolution ? { resolution } : {}),
-          ...(size ? { size } : {}),
-          ...(aspectRatio ? { aspectRatio } : {}),
-          ...(quality ? { quality } : {}),
-          ...(outputFormat ? { outputFormat } : {}),
-          ...(background ? { background } : {}),
-          ...(filename ? { filename } : {}),
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        },
-        run: (taskHandle) =>
-          executeImageGenerationJob({
-            effectiveCfg,
+      const configuredModel =
+        model || explicitModelConfig
+          ? resolveCapabilityModelConfigForTool({
+              cfg,
+              modelConfig: cfg.agents?.defaults?.mediaModels?.image,
+              modelOverride: model,
+              providers: [],
+            })
+          : null;
+      const readRequest = () => {
+        const prompt = readToolStringParam(params, "prompt", { required: true });
+        return {
+          prompt,
+          duplicate: createImageGenerateDuplicateGuardResult(options?.agentSessionKey, {
             prompt,
-            agentDir: options?.agentDir,
-            model,
-            size,
-            aspectRatio,
-            resolution: explicitResolution,
-            inferredResolution,
-            quality,
-            outputFormat,
-            background,
-            count,
-            inputImages,
-            timeoutMs,
-            providerOptions,
-            ssrfPolicy: remoteMediaSsrfPolicy,
-            filename,
-            loadedReferenceImages,
-            taskHandle,
-            autoProviderFallback: explicitModelConfig ? false : undefined,
-            providers: imageGenerationProviders,
+            agentId: options?.requesterAgentId,
           }),
+        };
+      };
+      const configuredRequest = configuredModel ? readRequest() : undefined;
+      if (configuredRequest?.duplicate) {
+        return configuredRequest.duplicate;
+      }
+      const acquired = await acquireImageGenerationToolProviders({
+        cfg: configuredModel
+          ? (applyAgentDefaultModelConfig(cfg, "image", configuredModel) ?? cfg)
+          : cfg,
+        prepared: options?.preparedModelRuntime,
       });
+      const imageGenerationProviders = acquired.providers;
+      const prepare = async () => {
+        const imageGenerationModelConfig =
+          configuredModel ??
+          resolveCapabilityModelConfigForTool({
+            cfg,
+            workspaceDir: options?.workspaceDir,
+            agentDir: options?.agentDir,
+            authStore: options?.authProfileStore,
+            modelConfig: cfg.agents?.defaults?.mediaModels?.image,
+            modelOverride: model,
+            providers: imageGenerationProviders,
+          });
+        if (!imageGenerationModelConfig) {
+          throw new ToolInputError("No image-generation model configured.");
+        }
+        const effectiveCfg =
+          applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig) ?? cfg;
+        const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        if (duplicate) {
+          return { kind: "result" as const, result: duplicate };
+        }
+
+        const imageInputs = normalizeReferenceImages(params);
+        const filename = readToolStringParam(params, "filename");
+        const size = readToolStringParam(params, "size");
+        const aspectRatio = normalizeImageGenerationAspectRatio(
+          readToolStringParam(params, "aspectRatio"),
+        );
+        const explicitResolution = normalizeImageGenerationResolution(
+          readToolStringParam(params, "resolution"),
+        );
+        const timeoutMs = readGenerationTimeoutMs(params) ?? imageGenerationModelConfig.timeoutMs;
+        const quality = parseImageOption(
+          readToolStringParam(params, "quality"),
+          SUPPORTED_QUALITIES,
+          "quality",
+        );
+        const outputFormat = parseImageOption(
+          readToolStringParam(params, "outputFormat"),
+          SUPPORTED_OUTPUT_FORMATS,
+          "outputFormat",
+        );
+        const background = parseImageOption(
+          readToolStringParam(params, "background"),
+          SUPPORTED_BACKGROUNDS,
+          "background",
+        );
+        const providerOptions = normalizeProviderOptions(params);
+        const selectedProvider = resolveSelectedImageGenerationProvider({
+          providers: imageGenerationProviders,
+          imageGenerationModelConfig,
+          modelOverride: model,
+        });
+        const explicitModelRef = parseImageGenerationModelRef(model);
+        const primaryModelRef = parseImageGenerationModelRef(imageGenerationModelConfig.primary);
+        const selectedModelId = resolveSelectedImageGenerationModelId({
+          selectedProvider,
+          imageGenerationModelConfig,
+          modelOverride: model,
+          explicitModelRef,
+          primaryModelRef,
+        });
+        const imageGenerationCandidates = resolveCapabilityModelCandidates({
+          cfg: effectiveCfg,
+          modelConfig: effectiveCfg.agents?.defaults?.mediaModels?.image,
+          modelOverride: model,
+          parseModelRef: parseImageGenerationModelRef,
+          agentDir: options?.agentDir,
+          listProviders: () => imageGenerationProviders,
+          autoProviderFallback: explicitModelConfig ? false : undefined,
+        });
+        const maxInputImages = resolveReachableImageGenerationMaxInputImages({
+          providers: imageGenerationProviders,
+          candidates: imageGenerationCandidates,
+        });
+        const count = resolveRequestedCount(params);
+        const requestKey = buildMediaGenerationRequestKey({
+          tool: "image_generate",
+          prompt,
+          provider: selectedProvider?.id ?? explicitModelRef?.provider ?? primaryModelRef?.provider,
+          model:
+            model !== undefined
+              ? (explicitModelRef?.model ?? model)
+              : (primaryModelRef?.model ??
+                imageGenerationModelConfig.primary ??
+                selectedProvider?.defaultModel),
+          count,
+          imageInputs,
+          size,
+          aspectRatio,
+          resolution: explicitResolution,
+          quality,
+          outputFormat,
+          background,
+          filename,
+          providerOptions,
+        });
+        const duplicateGuardResult = createImageGenerateDuplicateGuardResult(
+          options?.agentSessionKey,
+          { prompt, requestKey, agentId: options?.requesterAgentId },
+        );
+        if (duplicateGuardResult) {
+          return { kind: "result" as const, result: duplicateGuardResult };
+        }
+        validateImageGenerationCapabilities({
+          provider: selectedProvider,
+          count,
+          inputImageCount: imageInputs.length,
+          maxInputImages,
+          size,
+          aspectRatio,
+          resolution: explicitResolution,
+          explicitResolution: Boolean(explicitResolution),
+        });
+        const referenceMaxBytes = resolveGeneratedMediaMaxBytes(effectiveCfg, "image");
+        const loadedReferenceImages = await loadImageGenerationReferences({
+          imageInputs,
+          maxBytes: referenceMaxBytes,
+          workspaceDir: options?.workspaceDir,
+          sandboxConfig,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          signal,
+        });
+        const inputImages = loadedReferenceImages.map((entry) => entry.sourceImage);
+        const modeCaps =
+          inputImages.length > 0
+            ? selectedProvider?.capabilities.edit
+            : selectedProvider?.capabilities.generate;
+        const inferredResolution =
+          size || explicitResolution
+            ? undefined
+            : inputImages.length > 0
+              ? await inferImageGenerationResolution(inputImages, signal)
+              : undefined;
+        const resolution =
+          explicitResolution ??
+          (modeCaps?.supportsResolution === false ||
+          modelDisablesImageResolution(selectedProvider, selectedModelId)
+            ? undefined
+            : inferredResolution);
+        validateImageGenerationCapabilities({
+          provider: selectedProvider,
+          count,
+          inputImageCount: inputImages.length,
+          maxInputImages,
+          size,
+          aspectRatio,
+          resolution,
+          explicitResolution: Boolean(explicitResolution),
+        });
+        return {
+          kind: "task" as const,
+          params: {
+            lifecycle: imageGenerationTaskLifecycle,
+            generationLabel: "image" as const,
+            sessionKey: options?.agentSessionKey,
+            requesterAgentId: options?.requesterAgentId,
+            requesterOrigin: options?.requesterOrigin,
+            prompt,
+            requestKey,
+            providerId: selectedProvider?.id,
+            config: effectiveCfg,
+            scheduleBackgroundWork,
+            onAsyncTaskStarted: options?.onAsyncTaskStarted,
+            onFailure: (message: string, meta?: Record<string, unknown>) => log.warn(message, meta),
+            detailExtras: {
+              ...buildMediaReferenceDetails({
+                entries: loadedReferenceImages,
+                singleKey: "image",
+                pluralKey: "images",
+                getResolvedInput: (entry) => entry.resolvedImage,
+              }),
+              ...(model ? { model } : {}),
+              ...(resolution ? { resolution } : {}),
+              ...(size ? { size } : {}),
+              ...(aspectRatio ? { aspectRatio } : {}),
+              ...(quality ? { quality } : {}),
+              ...(outputFormat ? { outputFormat } : {}),
+              ...(background ? { background } : {}),
+              ...(filename ? { filename } : {}),
+              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+            },
+            run: (taskHandle: ImageGenerationTaskHandle | null) =>
+              executeImageGenerationJob({
+                effectiveCfg,
+                prompt,
+                agentDir: options?.agentDir,
+                model,
+                size,
+                aspectRatio,
+                resolution: explicitResolution,
+                inferredResolution,
+                quality,
+                outputFormat,
+                background,
+                count,
+                inputImages,
+                timeoutMs,
+                providerOptions,
+                ssrfPolicy: remoteMediaSsrfPolicy,
+                filename,
+                loadedReferenceImages,
+                taskHandle,
+                autoProviderFallback: explicitModelConfig ? false : undefined,
+                providers: imageGenerationProviders,
+              }),
+          },
+        };
+      };
+      let prepared: Awaited<ReturnType<typeof prepare>>;
+      try {
+        acquired.assertOpen();
+        prepared = await acquired.run(prepare);
+        if (prepared.kind === "task") {
+          // Admission is fenced after preflight; accepted work retains resources independently.
+          signal?.throwIfAborted();
+          acquired.assertOpen();
+        }
+      } catch (error) {
+        let cleanupFailure: { error: unknown } | undefined;
+        try {
+          await acquired.release();
+        } catch (cleanupError) {
+          cleanupFailure = { error: cleanupError };
+        }
+        if (cleanupFailure) {
+          throw new AggregateError(
+            [error, cleanupFailure.error],
+            "Image preflight and cleanup failed",
+            {
+              cause: error,
+            },
+          );
+        }
+        throw error;
+      }
+      if (prepared.kind === "result") {
+        await acquired.release();
+        return prepared.result;
+      }
+      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tools/media-generate-background.ts
+++ b/src/agents/tools/media-generate-background.ts
@@ -23,6 +23,12 @@ import {
   type MediaGenerationTaskHandle,
 } from "./media-generate-background-shared.js";
 
+/** Transferred resources belong to queued work through actual generation and persistence. */
+export type MediaGenerationTaskResources = {
+  run: <T>(run: () => T | Promise<T>) => Promise<T>;
+  release: () => Promise<void>;
+};
+
 /** Owns task admission and the shared foreground or detached generation lifecycle. */
 export async function runMediaGenerationTask<T extends MediaGenerationExecutionResult>(params: {
   lifecycle: ReturnType<typeof createMediaGenerationTaskLifecycle>;
@@ -39,76 +45,130 @@ export async function runMediaGenerationTask<T extends MediaGenerationExecutionR
   onFailure: (message: string, meta?: Record<string, unknown>) => void;
   detailExtras?: Record<string, unknown>;
   messages?: Array<string | undefined>;
+  resources?: MediaGenerationTaskResources;
   run: (
     handle: MediaGenerationTaskHandle | null,
   ) => Promise<T & { contentText: string; details: Record<string, unknown> }>;
 }) {
-  const { generationLabel, lifecycle } = params;
-  const toolName = `${generationLabel}_generate`;
-  const progressSummary = `Generating ${generationLabel}`;
-  const title = `${generationLabel.charAt(0).toUpperCase()}${generationLabel.slice(1)}`;
-  const handle = lifecycle.createTaskRun({
-    sessionKey: params.sessionKey,
-    requesterAgentId: params.requesterAgentId,
-    requesterOrigin: params.requesterOrigin,
-    prompt: params.prompt,
-    providerId: params.providerId,
-  });
-
-  if (handle && shouldDetachMediaGenerationTask(params.sessionKey, params.requesterAgentId)) {
-    recordRecentMediaGenerationTaskStartForSession({
-      sessionKey: params.sessionKey,
-      agentId: params.requesterAgentId,
-      taskKind: `${generationLabel}_generation`,
-      sourcePrefix: toolName,
-      taskId: handle.taskId,
-      runId: handle.runId,
-      taskLabel: params.prompt,
-      requestKey: params.requestKey,
-      providerId: params.providerId,
-      progressSummary,
-    });
-    scheduleMediaGenerationTaskCompletion({
-      lifecycle,
-      handle,
-      scheduleBackgroundWork: params.scheduleBackgroundWork,
-      progressSummary,
-      config: params.config,
-      toolName: `${title} generation`,
-      onWakeFailure: params.onFailure,
-      run: () => params.run(handle),
-    });
-    await notifyMediaGenerationAsyncTaskStarted({
-      callback: params.onAsyncTaskStarted,
-      message: `${title} generation started; wait for the generated ${generationLabel} completion event.`,
-      toolName,
-      handle,
-      onFailure: params.onFailure,
-    });
-    return buildMediaGenerationStartedToolResult({
-      toolName,
-      generationLabel,
-      completionLabel: generationLabel,
-      taskHandle: handle,
-      detailExtras: params.detailExtras,
-      messages: params.messages,
-    });
-  }
-
+  const resources = params.resources;
+  let resourcesTransferred = false;
+  const run = resources
+    ? async (handle: MediaGenerationTaskHandle | null) => {
+        resourcesTransferred = true;
+        let executed: T & { contentText: string; details: Record<string, unknown> };
+        try {
+          executed = await resources.run(() => params.run(handle));
+        } catch (error) {
+          let cleanupFailure: { error: unknown } | undefined;
+          try {
+            await resources.release();
+          } catch (cleanupError) {
+            cleanupFailure = { error: cleanupError };
+          }
+          if (cleanupFailure) {
+            throw new AggregateError(
+              [error, cleanupFailure.error],
+              "Media generation and cleanup failed",
+              {
+                cause: error,
+              },
+            );
+          }
+          throw error;
+        }
+        await resources.release();
+        return executed;
+      }
+    : params.run;
   try {
-    const executed = await params.run(handle);
-    lifecycle.completeTaskRun({
-      handle,
-      provider: executed.provider,
-      model: executed.model,
-      count: executed.count,
+    const { generationLabel, lifecycle } = params;
+    const toolName = `${generationLabel}_generate`;
+    const progressSummary = `Generating ${generationLabel}`;
+    const title = `${generationLabel.charAt(0).toUpperCase()}${generationLabel.slice(1)}`;
+    const handle = lifecycle.createTaskRun({
+      sessionKey: params.sessionKey,
+      requesterAgentId: params.requesterAgentId,
+      requesterOrigin: params.requesterOrigin,
+      prompt: params.prompt,
+      providerId: params.providerId,
     });
-    return {
-      content: [{ type: "text" as const, text: executed.contentText }],
-      details: executed.details,
-    };
+
+    if (handle && shouldDetachMediaGenerationTask(params.sessionKey, params.requesterAgentId)) {
+      recordRecentMediaGenerationTaskStartForSession({
+        sessionKey: params.sessionKey,
+        agentId: params.requesterAgentId,
+        taskKind: `${generationLabel}_generation`,
+        sourcePrefix: toolName,
+        taskId: handle.taskId,
+        runId: handle.runId,
+        taskLabel: params.prompt,
+        requestKey: params.requestKey,
+        providerId: params.providerId,
+        progressSummary,
+      });
+      scheduleMediaGenerationTaskCompletion({
+        lifecycle,
+        handle,
+        scheduleBackgroundWork: params.scheduleBackgroundWork,
+        progressSummary,
+        config: params.config,
+        toolName: `${title} generation`,
+        onWakeFailure: params.onFailure,
+        run: () => run(handle),
+      });
+      resourcesTransferred = true;
+      await notifyMediaGenerationAsyncTaskStarted({
+        callback: params.onAsyncTaskStarted,
+        message: `${title} generation started; wait for the generated ${generationLabel} completion event.`,
+        toolName,
+        handle,
+        onFailure: params.onFailure,
+      });
+      return buildMediaGenerationStartedToolResult({
+        toolName,
+        generationLabel,
+        completionLabel: generationLabel,
+        taskHandle: handle,
+        detailExtras: params.detailExtras,
+        messages: params.messages,
+      });
+    }
+
+    try {
+      const executed = await run(handle);
+      lifecycle.completeTaskRun({
+        handle,
+        provider: executed.provider,
+        model: executed.model,
+        count: executed.count,
+      });
+      return {
+        content: [{ type: "text" as const, text: executed.contentText }],
+        details: executed.details,
+      };
+    } catch (error) {
+      lifecycle.failTaskRun({ handle, error });
+      throw error;
+    }
   } catch (error) {
-    lifecycle.failTaskRun({ handle, error });
+    // Admission or scheduling can fail before the callback owns the resource claim.
+    if (resources && !resourcesTransferred) {
+      let cleanupFailure: { error: unknown } | undefined;
+      try {
+        await resources.release();
+      } catch (cleanupError) {
+        cleanupFailure = { error: cleanupError };
+      }
+      if (cleanupFailure) {
+        throw new AggregateError(
+          [error, cleanupFailure.error],
+          "Media admission and cleanup failed",
+          {
+            cause: error,
+          },
+        );
+      }
+    }
     throw error;
   }
 }

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -38,7 +38,6 @@ import {
   applyEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
 } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
-import type { loadPreparedInboundPluginRegistry } from "../agents/prepared-model-runtime.inbound-registry.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { resolveSandboxContext } from "../agents/sandbox.js";
 import {
@@ -128,11 +127,17 @@ type PrepareTriggerRuntime = (params: {
   signal?: AbortSignal;
 }) => Promise<PreparedTriggerRuntime>;
 
+type LoadTriggerPluginRegistry = (input: {
+  config: OpenClawConfig;
+  workspaceDir: string;
+  allowGatewaySubagentBinding: boolean;
+}) => PluginRegistry;
+
 type CronTriggerEvaluatorDeps = {
   config: OpenClawConfig;
   runHeadless?: typeof runCodeModeScriptHeadless;
   prepareRuntime?: PrepareTriggerRuntime;
-  loadPluginRegistry?: typeof loadPreparedInboundPluginRegistry;
+  loadPluginRegistry?: LoadTriggerPluginRegistry;
   resolveGatewayContext?: GatewayContextResolver;
 };
 
@@ -149,7 +154,7 @@ function resolveTriggerAgentId(config: OpenClawConfig, agentId?: string): string
 
 async function prepareTriggerRuntime(
   params: Parameters<PrepareTriggerRuntime>[0],
-  loadPluginRegistry: typeof loadPreparedInboundPluginRegistry = loadAgentRuntimePluginRegistryHandle,
+  loadPluginRegistry: LoadTriggerPluginRegistry = loadAgentRuntimePluginRegistryHandle,
 ): Promise<PreparedTriggerRuntime> {
   params.signal?.throwIfAborted();
   const agentId = resolveTriggerAgentId(params.runtimeConfig, params.agentId);

--- a/src/plugins/capability-provider-acquisition.ts
+++ b/src/plugins/capability-provider-acquisition.ts
@@ -7,41 +7,60 @@ import {
 } from "./capability-provider-runtime.js";
 import { acquirePluginRegistryForInspection, isPluginRegistryLoadInFlight } from "./loader.js";
 import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
+import { capturePluginLifecycleAuthority } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
 
 /** Acquires only fresh registrations; existing raw hosts keep their own custody. */
-export async function withAcquiredPluginCapabilityProviders<
+export async function acquirePluginCapabilityProviders<
   K extends Parameters<typeof preparePluginCapabilityProviderResolution>[0]["key"],
-  T,
->(
-  params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0],
-  run: (providers: CapabilityProviderFor<K>[]) => T | Promise<T>,
-): Promise<T> {
+>(params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0]) {
   const work = new AsyncWorkScope();
   const releases: Array<() => Promise<void>> = [];
   const retained = new Set<PluginRegistry>();
-  const release = () =>
-    Promise.allSettled(releases.map(async (dispose) => await dispose())).then((results) => {
-      const errors = results.flatMap((result) =>
-        result.status === "rejected" ? [result.reason] : [],
+  const authorities = new Map<PluginRegistry, (() => boolean) | undefined>();
+  const captureAuthority = (registry: PluginRegistry) => {
+    if (!authorities.has(registry)) {
+      authorities.set(
+        registry,
+        capturePluginLifecycleAuthority(registry, undefined, { scopedRuntime: true }),
       );
-      if (errors.length > 0) {
-        throw new AggregateError(errors, "Capability registration cleanup failed");
-      }
-    });
+    }
+  };
+  const dispose = () =>
+    Promise.allSettled(releases.map(async (releaseClaim) => await releaseClaim())).then(
+      (results) => {
+        const errors = results.flatMap((result) =>
+          result.status === "rejected" ? [result.reason] : [],
+        );
+        if (errors.length > 0) {
+          throw new AggregateError(errors, "Capability registration cleanup failed");
+        }
+      },
+    );
   const retain = (registry: PluginRegistry | undefined) => {
     if (!registry || retained.has(registry)) {
       return;
     }
     retained.add(registry);
+    captureAuthority(registry);
     const resources = getPluginRegistryInspectionResources(registry);
     if (resources) {
       releases.push(resources.retain().release);
     }
   };
-  let outcome: Result<T, unknown>;
+  let releaseCompletion: Promise<void> | undefined;
+  const release = () =>
+    (releaseCompletion ??= Promise.resolve().then(async () => {
+      work.beginClose();
+      try {
+        // Getters and provider callbacks may admit work beyond their direct return value.
+        await work.runWhenIdle(dispose);
+      } finally {
+        await work.drain();
+      }
+    }));
   try {
-    const value = await work.track(async () => {
+    const providers = await work.track(async () => {
       const resolution = preparePluginCapabilityProviderResolution(params, retain);
       let entries: PluginRegistry[K] = [];
       if (resolution.load) {
@@ -53,6 +72,7 @@ export async function withAcquiredPluginCapabilityProviders<
             const acquired = await acquirePluginRegistryForInspection(loadOptions);
             releases.push(acquired.release);
             registry = acquired.registry;
+            captureAuthority(registry);
           }
         }
         const fallback = load.fallback(registry);
@@ -63,21 +83,41 @@ export async function withAcquiredPluginCapabilityProviders<
             pluginIds: fallback.pluginIds,
           });
           releases.push(captured.release);
+          captureAuthority(captured.registry);
           entries = load.merge(entries, captured.registry);
         }
       }
-      return await run(resolution.resolve(entries));
+      return resolution.resolve(entries);
     });
-    outcome = { ok: true, value };
+    return {
+      providers,
+      run: <T>(run: () => T | Promise<T>) =>
+        releaseCompletion
+          ? Promise.reject(new Error("Capability provider acquisition has been released"))
+          : work.track(run),
+      assertOpen: () => {
+        if (releaseCompletion || [...authorities.values()].some((isCurrent) => !isCurrent?.())) {
+          throw new Error(
+            "The provider setup changed while preparing this request. Retry with the current provider setup.",
+          );
+        }
+      },
+      release,
+    };
   } catch (error) {
-    outcome = { ok: false, error };
+    return await finishCapabilityOperation<never>({ ok: false, error }, release);
   }
+}
+
+async function finishCapabilityOperation<T>(
+  outcome: Result<T, unknown>,
+  release: () => Promise<void>,
+): Promise<T> {
+  let result = outcome;
   try {
-    work.beginClose();
-    // Acquisition getters and provider callbacks share the same admitted work owner.
-    await work.runWhenIdle(release);
+    await release();
   } catch (cleanupError) {
-    outcome = {
+    result = {
       ok: false,
       error: outcome.ok
         ? cleanupError
@@ -87,11 +127,27 @@ export async function withAcquiredPluginCapabilityProviders<
             { cause: outcome.error },
           ),
     };
-  } finally {
-    await work.drain();
   }
-  if (!outcome.ok) {
-    throw outcome.error;
+  if (!result.ok) {
+    throw result.error;
   }
-  return outcome.value;
+  return result.value;
+}
+
+/** Keeps callback-shaped operations on the same acquisition and actual-work owner. */
+export async function withAcquiredPluginCapabilityProviders<
+  K extends Parameters<typeof preparePluginCapabilityProviderResolution>[0]["key"],
+  T,
+>(
+  params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0],
+  run: (providers: CapabilityProviderFor<K>[]) => T | Promise<T>,
+): Promise<T> {
+  const acquired = await acquirePluginCapabilityProviders(params);
+  let outcome: Result<T, unknown>;
+  try {
+    outcome = { ok: true, value: await acquired.run(() => run(acquired.providers)) };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+  return await finishCapabilityOperation(outcome, acquired.release);
 }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where an accepted `image_generate` job could lose its plugin resources after returning `started`, while generation, image persistence, or rollback was still running. Preparing tools and checking remote image references could also outlive the original provider registration.

## Why This Change Was Made

Carry the original inspection's resource ownership through prepared facts, preflight, and the actual accepted job. A retired source cannot admit a new task, while an already accepted task retains its captured providers until work and cleanup finish. Shared capability acquisition now exposes the same existing ownership operation for this longer lifetime.

Existing execution and image-geometry helpers move into an execution module to keep the tool readable; their behavior is unchanged. The oversized-file exception is removed. Raw prepared registries retain their host-owned lifetime; this does not enable general prepared-cache disposal.

## User Impact

Background image generation keeps working after its originating preparation is released. A source retired during preflight produces a retryable setup failure before task admission. `started` remains an immediate acceptance result, and completed media remains available after provider cleanup.

## Evidence

- Native before/after regressions cover queued generation, saving, rollback, retirement during a held HTTP preflight, and retirement during actual preparation.
- Focused resource, runtime, policy, background-task and Cron suites passed. The full changed-file gate and independent Codex review through P2 passed; ordinary build completed in 219 seconds.
- The built public agent-harness SDK accepted a synthetic SQLite-backed image job in 16.6 ms. After source A retired and B was published, A persisted a real PNG and closed exactly once; B was never invoked. A separate held HTTP preflight rejected admission after retirement. Native SQLite reopening succeeded.
- The probe used source-produced prepared facts with the built SDK, not a fully packaged CLI. With no delivery runtime attached, the durable task reached its existing blocked-delivery state with media retained; real channel delivery was not tested.
- Rebased production files are byte-identical to the reviewed and built candidate. Focused composition verification covers the subsequently landed Video and inventory consumers.
