### PR TITLE
docs(tools): split the text-to-speech page by reader job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@
           - "extensions/azure-speech/**"
           - "docs/providers/azure-speech.md"
           - "docs/tools/tts.md"
+          - "docs/tools/tts/**"
 "plugin: geolocation":
   - changed-files:
       - any-glob-to-any-file:
@@ -587,6 +588,7 @@
           - "extensions/fish-audio-speech/**"
           - "docs/providers/fish-audio.md"
           - "docs/tools/tts.md"
+          - "docs/tools/tts/**"
 "extensions: kilocode":
   - changed-files:
       - any-glob-to-any-file:
@@ -698,6 +700,7 @@
       - any-glob-to-any-file:
           - "extensions/tts-local-cli/**"
           - "docs/tools/tts.md"
+          - "docs/tools/tts/**"
 "extensions: venice":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -3794,5 +3794,33 @@
   {
     "source": "Docker",
     "target": "Docker"
+  },
+  {
+    "source": "Text-to-speech quickstart",
+    "target": "文本转语音快速上手"
+  },
+  {
+    "source": "Text-to-speech configuration",
+    "target": "文本转语音配置"
+  },
+  {
+    "source": "Text-to-speech personas",
+    "target": "文本转语音人设"
+  },
+  {
+    "source": "Text-to-speech commands and directives",
+    "target": "文本转语音命令与指令"
+  },
+  {
+    "source": "Text-to-speech output and Auto-TTS behavior",
+    "target": "文本转语音输出与自动 TTS 行为"
+  },
+  {
+    "source": "Text-to-speech field reference",
+    "target": "文本转语音字段参考"
+  },
+  {
+    "source": "Text-to-speech agent tool and Gateway RPC",
+    "target": "文本转语音代理工具与 Gateway RPC"
   }
 ]

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1648,6 +1648,34 @@
     "target": "文本转语音"
   },
   {
+    "source": "Text-to-speech quickstart",
+    "target": "文本转语音快速上手"
+  },
+  {
+    "source": "Text-to-speech configuration",
+    "target": "文本转语音配置"
+  },
+  {
+    "source": "Text-to-speech personas",
+    "target": "文本转语音人设"
+  },
+  {
+    "source": "Text-to-speech commands and directives",
+    "target": "文本转语音命令与指令"
+  },
+  {
+    "source": "Text-to-speech output and Auto-TTS behavior",
+    "target": "文本转语音输出与自动 TTS 行为"
+  },
+  {
+    "source": "Text-to-speech field reference",
+    "target": "文本转语音字段参考"
+  },
+  {
+    "source": "Text-to-speech agent tool and Gateway RPC",
+    "target": "文本转语音代理工具与 Gateway RPC"
+  },
+  {
     "source": "Linux app",
     "target": "Linux 应用"
   },
@@ -3794,33 +3822,5 @@
   {
     "source": "Docker",
     "target": "Docker"
-  },
-  {
-    "source": "Text-to-speech quickstart",
-    "target": "文本转语音快速上手"
-  },
-  {
-    "source": "Text-to-speech configuration",
-    "target": "文本转语音配置"
-  },
-  {
-    "source": "Text-to-speech personas",
-    "target": "文本转语音人设"
-  },
-  {
-    "source": "Text-to-speech commands and directives",
-    "target": "文本转语音命令与指令"
-  },
-  {
-    "source": "Text-to-speech output and Auto-TTS behavior",
-    "target": "文本转语音输出与自动 TTS 行为"
-  },
-  {
-    "source": "Text-to-speech field reference",
-    "target": "文本转语音字段参考"
-  },
-  {
-    "source": "Text-to-speech agent tool and Gateway RPC",
-    "target": "文本转语音代理工具与 Gateway RPC"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1931,6 +1931,18 @@
                       "tools/music-generation",
                       "tools/pdf",
                       "tools/tts",
+                      {
+                        "group": "Text to speech",
+                        "pages": [
+                          "tools/tts/quickstart",
+                          "tools/tts/configuration",
+                          "tools/tts/personas",
+                          "tools/tts/commands",
+                          "tools/tts/output",
+                          "tools/tts/field-reference",
+                          "tools/tts/api"
+                        ]
+                      },
                       "tools/video-generation"
                     ]
                   },

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -1,11 +1,11 @@
 ---
-summary: "Text-to-speech for outbound replies — providers, personas, slash commands, and per-channel output"
+summary: "Index of the OpenClaw text-to-speech documentation, one page per reader job"
+title: "Text-to-speech"
+sidebarTitle: "Text to speech (TTS)"
 read_when:
   - Enabling text-to-speech for replies
   - Configuring a TTS provider, fallback chain, or persona
   - Using /tts commands or directives
-title: "Text-to-speech"
-sidebarTitle: "Text to speech (TTS)"
 ---
 
 OpenClaw converts outbound replies into native voice messages on Feishu, Matrix,
@@ -17,1109 +17,196 @@ same synthesis path). Provider-native `realtime` Talk sessions synthesize
 speech inside the realtime provider instead; `transcription` sessions never
 synthesize an assistant voice reply.
 
-## Quick start
-
-<Steps>
-  <Step title="Pick a provider">
-    OpenAI and ElevenLabs are the most reliable hosted options. Microsoft and
-    Local CLI work without an API key. See the [provider matrix](#supported-providers)
-    for the full list.
-  </Step>
-  <Step title="Set the API key">
-    Export the env var for your provider (for example `OPENAI_API_KEY`,
-    `ELEVENLABS_API_KEY`). Microsoft and Local CLI need no key.
-  </Step>
-  <Step title="Enable in config">
-    Set `tts.auto: "always"` and `tts.provider`:
-
-    ```json5
-    {
-      tts: {
-        auto: "always",
-        provider: "elevenlabs",
-      },
-    }
-    ```
-
-  </Step>
-  <Step title="Try it in chat">
-    `/tts status` shows the current state. `/tts audio Hello from OpenClaw`
-    sends a one-off audio reply.
-  </Step>
-</Steps>
-
-<Note>
-Auto-TTS is **off** by default. When `tts.provider` is unset,
-OpenClaw picks the first configured provider in registry auto-select order.
-The built-in `tts` agent tool is explicit-intent only: ordinary chat stays
-text unless the user asks for audio, uses `/tts`, or enables Auto-TTS/directive
-speech.
-</Note>
-
-## Supported providers
-
-| Provider          | Auth                                                                                                             | Notes                                                                                       |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **Azure Speech**  | `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` (also `AZURE_SPEECH_API_KEY`, `SPEECH_KEY`, `SPEECH_REGION`)          | Native Ogg/Opus voice-note output and telephony.                                            |
-| **DeepInfra**     | `DEEPINFRA_API_KEY`                                                                                              | OpenAI-compatible TTS. Defaults to `hexgrad/Kokoro-82M`.                                    |
-| **ElevenLabs**    | `ELEVENLABS_API_KEY` or `XI_API_KEY`                                                                             | Voice cloning, multilingual, deterministic via `seed`; streamed for Discord voice playback. |
-| **Fish Audio**    | `FISH_API_KEY` or `FISH_AUDIO_API_KEY`                                                                           | S2.1 hosted TTS, expressive tags, voice discovery, streaming, and telephony.                |
-| **Google Gemini** | `GEMINI_API_KEY` or `GOOGLE_API_KEY`                                                                             | Gemini API batch TTS; persona-aware via `promptTemplate: "audio-profile-v1"`.               |
-| **Gradium**       | `GRADIUM_API_KEY`                                                                                                | Voice-note and telephony output.                                                            |
-| **Inworld**       | `INWORLD_API_KEY`                                                                                                | Streaming TTS API. Native Opus voice-note and PCM telephony.                                |
-| **Local CLI**     | none                                                                                                             | Runs a configured local TTS command.                                                        |
-| **Microsoft**     | none                                                                                                             | Public Edge neural TTS via `node-edge-tts`. Best-effort, no SLA.                            |
-| **MiniMax**       | `MINIMAX_API_KEY` (or Token Plan: `MINIMAX_OAUTH_TOKEN`, `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`)      | T2A v2 API. Defaults to `speech-2.8-hd`.                                                    |
-| **OpenAI**        | `OPENAI_API_KEY`                                                                                                 | Also used for auto-summary; supports persona `instructions`.                                |
-| **OpenRouter**    | `OPENROUTER_API_KEY` (can reuse `models.providers.openrouter.apiKey`)                                            | Default model `hexgrad/kokoro-82m`.                                                         |
-| **Volcengine**    | `VOLCENGINE_TTS_API_KEY` or `BYTEPLUS_SEED_SPEECH_API_KEY` (legacy AppID/token: `VOLCENGINE_TTS_APPID`/`_TOKEN`) | BytePlus Seed Speech HTTP API.                                                              |
-| **Vydra**         | `VYDRA_API_KEY`                                                                                                  | Shared image, video, and speech provider.                                                   |
-| **xAI**           | `XAI_API_KEY`                                                                                                    | xAI batch TTS. Native Opus voice-note is **not** supported.                                 |
-| **Xiaomi MiMo**   | `XIAOMI_API_KEY`                                                                                                 | MiMo TTS through Xiaomi chat completions.                                                   |
-
-If multiple providers are configured, the selected one is used first and the
-others are fallback options. Auto-summary uses `summaryModel` (or
-`agents.defaults.model.primary`), so that provider must also be authenticated
-if you keep summaries enabled.
-
-<Warning>
-The bundled **Microsoft** provider uses Microsoft Edge's online neural TTS
-service via `node-edge-tts`. It is a public web service without a published
-SLA or quota — treat it as best-effort. The legacy provider id `edge` is
-normalized to `microsoft` and `openclaw doctor --fix` rewrites persisted
-config; new configs should always use `microsoft`.
-</Warning>
-
-## Configuration
-
-TTS config lives under `tts` in `~/.openclaw/openclaw.json`. Pick a
-preset and adapt the provider block. The `speakerVoice`/`speakerVoiceId`
-fields shown below are canonical; each provider's own `voice`/`voiceId`/
-`voiceName` field names still work as legacy aliases.
-
-OpenRouter and DeepInfra use the first nonblank value from `speakerVoice`,
-`speakerVoiceId`, `voice`, and `voiceId`, in that order, before the provider default.
-Talk applies the same order to its provider block; when all four fields are absent
-or blank, it keeps the base TTS voice.
-
-<Tabs>
-  <Tab title="Azure Speech">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "azure-speech",
-    providers: {
-      "azure-speech": {
-        apiKey: "${AZURE_SPEECH_KEY}",
-        region: "eastus",
-        speakerVoice: "en-US-JennyNeural",
-        lang: "en-US",
-        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-        voiceNoteOutputFormat: "ogg-24khz-16bit-mono-opus",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="ElevenLabs">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "elevenlabs",
-    providers: {
-      elevenlabs: {
-        apiKey: "${ELEVENLABS_API_KEY}",
-        model: "eleven_multilingual_v2",
-        speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Fish Audio">
-```json5
-{
-  tts: {
-    auto: "tagged",
-    provider: "fish-audio",
-    providers: {
-      "fish-audio": {
-        apiKey: "${FISH_API_KEY}",
-        model: "s2.1-pro",
-        speakerVoiceId: "802e3bc2b27e49c2995d23ef70e6ac89",
-        latency: "balanced",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Google Gemini">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "google",
-    providers: {
-      google: {
-        apiKey: "${GEMINI_API_KEY}",
-        model: "gemini-3.1-flash-tts-preview",
-        speakerVoice: "Kore",
-        // Optional natural-language style prompts:
-        // audioProfile: "Speak in a calm, podcast-host tone.",
-        // speakerName: "Alex",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Gradium">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "gradium",
-    providers: {
-      gradium: {
-        apiKey: "${GRADIUM_API_KEY}",
-        speakerVoiceId: "YTpq7expH9539ERJ",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Inworld">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "inworld",
-    providers: {
-      inworld: {
-        apiKey: "${INWORLD_API_KEY}",
-        modelId: "inworld-tts-1.5-max",
-        speakerVoiceId: "Sarah",
-        temperature: 0.7,
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Local CLI">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "tts-local-cli",
-    providers: {
-      "tts-local-cli": {
-        command: "say",
-        args: ["-o", "{{OutputPath}}", "{{Text}}"],
-        outputFormat: "wav",
-        timeoutMs: 120000,
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Microsoft (no key)">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "microsoft",
-    providers: {
-      microsoft: {
-        enabled: true,
-        speakerVoice: "en-US-MichelleNeural",
-        lang: "en-US",
-        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-        rate: "+0%",
-        pitch: "+0%",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="MiniMax">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "minimax",
-    providers: {
-      minimax: {
-        apiKey: "${MINIMAX_API_KEY}",
-        model: "speech-2.8-hd",
-        speakerVoiceId: "English_expressive_narrator",
-        speed: 1.0,
-        vol: 1.0,
-        pitch: 0,
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="OpenAI + ElevenLabs">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "openai",
-    summaryModel: "openai/gpt-4.1-mini",
-    modelOverrides: { enabled: true },
-    providers: {
-      openai: {
-        apiKey: "${OPENAI_API_KEY}",
-        model: "gpt-4o-mini-tts",
-        speakerVoice: "alloy",
-      },
-      elevenlabs: {
-        apiKey: "${ELEVENLABS_API_KEY}",
-        model: "eleven_multilingual_v2",
-        speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
-        voiceSettings: { stability: 0.5, similarityBoost: 0.75, style: 0.0, useSpeakerBoost: true, speed: 1.0 },
-        applyTextNormalization: "auto",
-        languageCode: "en",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="OpenRouter">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "openrouter",
-    providers: {
-      openrouter: {
-        apiKey: "${OPENROUTER_API_KEY}",
-        model: "hexgrad/kokoro-82m",
-        speakerVoice: "af_alloy",
-        responseFormat: "mp3",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Volcengine">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "volcengine",
-    providers: {
-      volcengine: {
-        apiKey: "${VOLCENGINE_TTS_API_KEY}",
-        resourceId: "seed-tts-1.0",
-        speakerVoice: "en_female_anna_mars_bigtts",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="xAI">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "xai",
-    providers: {
-      xai: {
-        apiKey: "${XAI_API_KEY}",
-        speakerVoiceId: "eve",
-        language: "en",
-        responseFormat: "mp3",
-      },
-    },
-  },
-}
-```
-  </Tab>
-  <Tab title="Xiaomi MiMo">
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "xiaomi",
-    providers: {
-      xiaomi: {
-        apiKey: "${XIAOMI_API_KEY}",
-        model: "mimo-v2.5-tts",
-        speakerVoice: "mimo_default",
-        format: "mp3",
-      },
-    },
-  },
-}
-```
-  </Tab>
-</Tabs>
-
-For Xiaomi `mimo-v2.5-tts-voicedesign`, omit `speakerVoice` and set `style` to
-the voice-design prompt. OpenClaw sends that prompt as the TTS `user` message
-and does not send `audio.voice` for the voicedesign model.
-
-### Local Speech Swift and speech-core
-
-[Speech Swift](https://github.com/soniqo/speech-swift) and
-[speech-core](https://github.com/soniqo/speech-core) provide local speech
-inference across macOS, Linux, and Windows. Use the OpenAI-compatible HTTP
-provider when Speech Swift and OpenClaw run on the same Mac. Use Local CLI for
-direct executable integration on any supported host.
-
-Install `ffmpeg` when a channel needs OpenClaw to convert WAV output to Opus or
-raw PCM.
-
-<Tabs>
-  <Tab title="macOS HTTP">
-<Warning>
-This HTTP setup requires Speech Swift v0.0.23 or later. If Homebrew already
-installed an older version, run `brew update && brew upgrade speech` first.
-</Warning>
-
-Start Speech Swift's local server:
-
-```bash
-brew install speech
-speech-server --port 8080
-```
-
-Point the OpenAI speech provider at its loopback endpoint. `responseFormat`
-must be `wav` because the local endpoint does not emit compressed audio:
-
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "openai",
-    providers: {
-      openai: {
-        apiKey: "local",
-        baseUrl: "http://127.0.0.1:8080/v1",
-        model: "tts-1",
-        speakerVoice: "alloy",
-        responseFormat: "wav",
-      },
-    },
-  },
-}
-```
-
-`tts-1` selects Kokoro. Speech Swift registry aliases such as `qwen3-tts`,
-`cosyvoice`, and `voxcpm2` select other local engines. The placeholder API key
-is required by OpenClaw's provider configuration but is not validated by the
-loopback server.
-</Tab>
-<Tab title="macOS CLI">
-The Homebrew `speech` executable can write directly to OpenClaw's
-per-invocation output path:
-
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "tts-local-cli",
-    providers: {
-      "tts-local-cli": {
-        command: "speech",
-        args: ["speak", "{{Text}}", "--output", "{{OutputPath}}"],
-        outputFormat: "wav",
-        timeoutMs: 120000,
-      },
-    },
-  },
-}
-```
-
-  </Tab>
-  <Tab title="Linux CLI">
-Install a speech-core Linux release package, download the ONNX model set once,
-and verify synthesis before starting OpenClaw:
-
-```bash
-speech download-models
-speech speak "Hello from OpenClaw" hello.wav
-```
-
-Then configure the packaged Kokoro command:
-
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "tts-local-cli",
-    providers: {
-      "tts-local-cli": {
-        command: "speech",
-        args: ["speak", "{{Text}}", "{{OutputPath}}"],
-        outputFormat: "wav",
-        timeoutMs: 120000,
-      },
-    },
-  },
-}
-```
-
-See the [speech-core Linux CLI reference](https://github.com/soniqo/speech-core/blob/main/docs/cli.md)
-for release packages and model-directory settings.
-</Tab>
-<Tab title="Windows CLI">
-Download the speech-core Windows release, extract it, and install the ONNX
-models once:
-
-```powershell
-$Version = "0.0.11"
-$Url = "https://github.com/soniqo/speech-core/releases/download/v$Version/speech-$Version-windows-x64.zip"
-Invoke-WebRequest $Url -OutFile speech.zip
-Expand-Archive speech.zip
-Set-Location "speech\speech-$Version-windows-x64\bin"
-Set-ExecutionPolicy -Scope Process Bypass
-.\speech_download_models.ps1
-```
-
-Then point Local CLI at the packaged Kokoro executable:
-
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "tts-local-cli",
-    providers: {
-      "tts-local-cli": {
-        command: "C:\\path\\to\\speech-0.0.11-windows-x64\\bin\\speech_synthesize.exe",
-        args: ["{{OutputPath}}", "{{Text}}", "en"],
-        outputFormat: "wav",
-        timeoutMs: 120000,
-      },
-    },
-  },
-}
-```
-
-See the [speech-core Windows CLI reference](https://github.com/soniqo/speech-core/blob/main/docs/cli.md)
-for the packaged server, model cache, and standalone command syntax.
-
-  </Tab>
-</Tabs>
-
-### Per-agent voice overrides
-
-Use `agents.entries.*.tts` when one agent should speak with a different provider,
-voice, model, persona, or auto-TTS mode. The agent block deep-merges over
-`tts`, so provider credentials can stay in the global provider config:
-
-```json5
-{
-  tts: {
-    auto: "always",
-    provider: "elevenlabs",
-    providers: {
-      elevenlabs: { apiKey: "${ELEVENLABS_API_KEY}", model: "eleven_multilingual_v2" },
-    },
-  },
-  agents: {
-    entries: {
-      reader: {
-        default: true,
-        tts: {
-          providers: {
-            elevenlabs: { speakerVoiceId: "EXAVITQu4vr4xnSDxMaL" },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-To pin a per-agent persona, set `agents.entries.*.tts.persona` alongside provider
-config — it overrides the global `tts.persona` for that agent only.
-
-Precedence order for automatic replies, `/tts audio`, `/tts status`, and the
-`tts` agent tool:
-
-1. `tts`
-2. active `agents.entries.*.tts`
-3. channel override, when the channel supports `channels.<channel>.tts`
-4. account override, when the channel passes `channels.<channel>.accounts.<id>.tts`
-5. local `/tts` preferences for this host
-6. inline `[[tts:...]]` directives when [model overrides](#model-driven-directives) are enabled
-
-Channel and account overrides use the same shape as `tts` and
-deep-merge over the earlier layers, so shared provider credentials can stay in
-`tts` while a channel or bot account changes only speaker voice, model, persona,
-or auto mode:
-
-```json5
-{
-  tts: {
-    provider: "openai",
-    providers: {
-      openai: { apiKey: "${OPENAI_API_KEY}", model: "gpt-4o-mini-tts" },
-    },
-  },
-  channels: {
-    feishu: {
-      accounts: {
-        english: {
-          tts: {
-            providers: {
-              openai: { speakerVoice: "shimmer" },
-            },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-## Personas
-
-A **persona** is a stable spoken identity that can be applied deterministically
-across providers. It can prefer one provider, define provider-neutral prompt
-intent, and carry provider-specific bindings for voices, models, prompt
-templates, seeds, and voice settings.
-
-### Minimal persona
-
-```json5
-{
-  tts: {
-    auto: "always",
-    persona: "narrator",
-    personas: {
-      narrator: {
-        label: "Narrator",
-        provider: "elevenlabs",
-        providers: {
-          elevenlabs: {
-            speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
-            modelId: "eleven_multilingual_v2",
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-### Full persona (provider-specific shaping)
-
-```json5
-{
-  tts: {
-    auto: "always",
-    persona: "alfred",
-    personas: {
-      alfred: {
-        label: "Alfred",
-        description: "Dry, warm British butler narrator.",
-        provider: "google",
-        fallbackPolicy: "preserve-persona",
-        providers: {
-          google: {
-            model: "gemini-3.1-flash-tts-preview",
-            speakerVoice: "Algieba",
-            promptTemplate: "audio-profile-v1",
-          },
-          openai: { model: "gpt-4o-mini-tts", speakerVoice: "cedar" },
-          elevenlabs: {
-            speakerVoiceId: "voice_id",
-            modelId: "eleven_multilingual_v2",
-            seed: 42,
-            voiceSettings: {
-              stability: 0.65,
-              similarityBoost: 0.8,
-              style: 0.25,
-              useSpeakerBoost: true,
-              speed: 0.95,
-            },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-### Persona resolution
-
-The active persona is selected deterministically:
-
-1. `/tts persona <id>` local preference, if set.
-2. `tts.persona`, if set.
-3. No persona.
-
-Provider selection runs explicit-first:
-
-1. Direct overrides (CLI, gateway, Talk, allowed TTS directives).
-2. `/tts provider <id>` local preference.
-3. Active persona's `provider`.
-4. `tts.provider`.
-5. Registry auto-select.
-
-For each provider attempt, OpenClaw merges configs in this order:
-
-1. `tts.providers.<id>`
-2. `tts.personas.<persona>.providers.<id>`
-3. Trusted request overrides
-4. Allowed model-emitted TTS directive overrides
-
-### Custom persona shaping
-
-Provider-neutral `personas.<id>.prompt.*` config is retired. Doctor removes
-those fields and points to the speech-provider seam. Put built-in provider
-settings under `personas.<id>.providers.<provider>` (for example Google
-`personaPrompt` or OpenAI `instructions`). For custom shaping, implement a
-speech provider plugin with `prepareSynthesis(ctx)` and return adjusted text,
-provider config, or overrides before `synthesize()` runs. This keeps expressive
-prompt construction in provider code where request semantics are known.
-
-### Fallback policy
-
-`fallbackPolicy` controls behavior when a persona has **no binding** for the
-attempted provider:
-
-| Policy              | Behavior                                                                                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `preserve-persona`  | **Default.** Provider-neutral prompt fields stay available; the provider may use them or ignore them.                                            |
-| `provider-defaults` | Persona is omitted from prompt preparation for that attempt; the provider uses its neutral defaults while fallback to other providers continues. |
-| `fail`              | Skip that provider attempt with `reasonCode: "not_configured"` and `personaBinding: "missing"`. Fallback providers are still tried.              |
-
-The whole TTS request only fails when **every** attempted provider is skipped
-or fails.
-
-Talk session provider selection is session-scoped. A Talk client should choose
-provider ids, model ids, voice ids, and locales from `talk.catalog` and pass
-them through the Talk session or handoff request. Opening a voice session should
-not mutate `tts` or global Talk provider defaults.
-
-## Model-driven directives
-
-By default, the assistant **can** emit `[[tts:...]]` directives to override
-voice, model, or speed for a single reply, plus an optional
-`[[tts:text]]...[[/tts:text]]` block for expressive cues that should appear in
-audio only:
-
-```text
-Here you go.
-
-[[tts:speakerVoiceId=pMsXgVXv3BLzUgSXRplE model=eleven_v3 speed=1.1]]
-[[tts:text]](laughs) Read the song once more.[[/tts:text]]
-```
-
-When `tts.auto` is `"tagged"`, **directives are required** to trigger
-audio. Streaming block delivery strips directives from visible text before the
-channel sees them, even when split across adjacent blocks.
-
-`provider=...` is ignored unless `modelOverrides.allowProvider: true`. When a
-reply declares `provider=...`, the other keys in that directive are parsed
-only by that provider; unsupported keys are stripped and reported as TTS
-directive warnings.
-
-**Available directive keys:**
-
-- `provider` (registered provider id; requires `allowProvider: true`)
-- `speakerVoice` / `speakerVoiceId` (legacy aliases: `voice`, `voiceName`, `voice_name`, `google_voice`, `voiceId`)
-- `model` / `google_model`
-- `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
-- `vol` / `volume` (MiniMax volume, `(0, 10]`)
-- `pitch` (MiniMax integer pitch, −12 to 12; fractional values are truncated)
-- `emotion` (Volcengine emotion tag)
-- `applyTextNormalization` (`auto|on|off`)
-- `languageCode` (ISO 639-1)
-- `seed`
-
-**Disable model overrides entirely:**
-
-```json5
-{ tts: { modelOverrides: { enabled: false } } }
-```
-
-**Allow provider switching while keeping other knobs configurable:**
-
-```json5
-{ tts: { modelOverrides: { enabled: true, allowProvider: true, allowSeed: false } } }
-```
-
-## Slash commands
-
-Single command `/tts`. On Discord, OpenClaw also registers `/voice` because
-`/tts` is a built-in Discord command — text `/tts ...` still works.
-
-```text
-/tts off | on | status
-/tts chat on | off | default
-/tts latest
-/tts provider <id>
-/tts persona <id> | off
-/tts limit <chars>
-/tts summary off
-/tts audio <text>
-```
-
-<Note>
-Commands require an authorized sender (allowlist/owner rules apply) and either
-`commands.text` or native command registration must be enabled.
-</Note>
-
-Behavior notes:
-
-- `/tts on` writes the local TTS preference to `always`; `/tts off` writes it to `off`.
-- `/tts chat on|off|default` writes a session-scoped auto-TTS override for the current chat.
-- `/tts persona <id>` writes the local persona preference; `/tts persona off` clears it.
-- `/tts latest` reads the latest assistant reply from the current session transcript and sends it as audio once. It stores only a hash of that reply on the session entry to suppress duplicate voice sends.
-- `/tts audio` generates a one-off audio reply (does **not** toggle TTS on).
-- `/tts limit <chars>` accepts **100–4096** (4096 is the Telegram caption/message max); values outside that range are rejected.
-- `limit` and `summary` are stored in **local prefs**, not the main config.
-- `/tts status` includes fallback diagnostics for the latest attempt — `Fallback: <primary> -> <used>`, `Attempts: ...`, and per-attempt detail (`provider:outcome(reasonCode) latency`).
-- `/status` shows the active TTS mode plus configured provider, model, voice, and sanitized custom endpoint metadata when TTS is enabled.
-
-## Per-user preferences
-
-Slash commands write local overrides to the TTS preferences path. The default is
-`~/.openclaw/settings/tts.json`; override it with `OPENCLAW_TTS_PREFS`. Doctor
-moves the retired global `tts.prefsPath` value into shared machine state.
-Advanced multi-agent setups may still set `agents.entries.<id>.tts.prefsPath`
-when agents intentionally use separate preference stores.
-
-| Stored field | Effect                                                                           |
-| ------------ | -------------------------------------------------------------------------------- |
-| `auto`       | Local auto-TTS override (`always`, `off`, …)                                     |
-| `provider`   | Local primary provider override                                                  |
-| `persona`    | Local persona override                                                           |
-| `maxLength`  | Summary/truncation threshold (default `1500` chars, `/tts limit` range 100–4096) |
-| `summarize`  | Summary toggle (default `true`)                                                  |
-
-These override the effective config from `tts` plus the active
-`agents.entries.*.tts` block for that host.
-
-## Output formats
-
-TTS voice delivery is channel-capability driven. Channel plugins advertise
-whether voice-style TTS should ask providers for a native `voice-note` target or
-keep normal `audio-file` synthesis, and whether the channel transcodes
-non-native output before sending.
-
-One-off speech requests from the agent tool and `/tts` commands use the same
-channel delivery rules as automatic replies.
-
-Telegram also advertises captioned final TTS. With `tts.mode: "final"` and
-Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
-until synthesis finishes and sent as the voice-note caption. Text beyond
-Telegram's caption limit follows the voice note as a normal text message. If
-synthesis or a proven pre-send delivery step fails, OpenClaw sends the visible
-text instead. `tagged` mode keeps its normal streaming behavior, and text
-inside a `[[tts:text]]` block remains audio-only.
-
-After synthesis, OpenClaw persists batch TTS output in the media store under
-`tool-speech-synthesis`. The reply uses that stable media path instead of a
-provider temporary file, and normal media maintenance prunes expired output.
-Local CLI providers may still use `{{OutputPath}}` as scratch space before
-OpenClaw imports the completed bytes. See [Media playback](/nodes/media-playback)
-for inline-player formats and limits.
-
-| Target                                | Format                                                                                                                                |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Feishu / Matrix / Telegram / WhatsApp | Voice-note replies prefer **Opus** (`opus_48000_64` from ElevenLabs, `opus` from OpenAI). 48 kHz / 64 kbps balances clarity and size. |
-| Other channels                        | **MP3** (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI). 44.1 kHz / 128 kbps is the default balance for speech.                  |
-| Talk / telephony                      | Provider-native **PCM** (Inworld 22050 Hz, Google 24 kHz), or `ulaw_8000` from Gradium for telephony.                                 |
-
-Per-provider notes:
-
-- **Feishu / WhatsApp transcoding:** when a voice-note reply lands as MP3/WebM/WAV/M4A or another likely audio file, the channel plugin transcodes it to 48 kHz Ogg/Opus with `ffmpeg` (`libopus`, 64 kbps) before sending the native voice message. WhatsApp sends the result through the Baileys `audio` payload with `ptt: true` and `audio/ogg; codecs=opus`. On transcode failure: Feishu catches the error and falls back to sending the original file as a plain attachment; WhatsApp has no fallback, so the send itself fails rather than posting an incompatible PTT payload.
-- **MiniMax:** MP3 (`speech-2.8-hd` model, 32 kHz sample rate) for normal audio attachments; transcoded to 48 kHz Opus with `ffmpeg` for channel-advertised voice-note targets.
-- **Xiaomi MiMo:** MP3 by default, or WAV when configured; transcoded to 48 kHz Opus with `ffmpeg` for channel-advertised voice-note targets.
-- **Local CLI:** uses the configured `outputFormat`. Voice-note targets are converted to Ogg/Opus and telephony output is converted to raw 16 kHz mono PCM with `ffmpeg`.
-- **Google Gemini:** returns raw 24 kHz PCM. OpenClaw wraps it as WAV for audio attachments, transcodes it to 48 kHz Opus for voice-note targets, and returns PCM directly for Talk/telephony.
-- **Gradium:** WAV for audio attachments, Opus for voice-note targets, and `ulaw_8000` at 8 kHz for telephony.
-- **Inworld:** MP3 for normal audio attachments, native `OGG_OPUS` for voice-note targets, and raw `PCM` at 22050 Hz for Talk/telephony.
-- **xAI:** MP3 by default; audio-file synthesis may use `mp3`, `wav`, `pcm`, `mulaw`, or `alaw` for both buffered and streaming output. Voice-note targets use MP3 for streaming and buffered fallback because xAI's `pcm`, `mulaw`, and `alaw` outputs are headerless raw audio. Buffered synthesis uses xAI's batch REST `/v1/tts` endpoint; `textToSpeechStream` uses native `wss://api.x.ai/v1/tts`. This is not the realtime voice contract. Native Opus voice-note format is not supported.
-- **Microsoft:** uses `microsoft.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
-  - The bundled transport accepts an `outputFormat`, but not all formats are available from the service.
-  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus).
-  - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need guaranteed Opus voice messages.
-  - If the configured Microsoft output format fails, OpenClaw retries with MP3.
-  - When no explicit voice override is set and the default English voice is used, OpenClaw auto-switches to a Chinese neural voice (`zh-CN-XiaoxiaoNeural`, `zh-CN` locale) if the reply text is CJK-dominant.
-
-OpenAI and ElevenLabs choose output formats per channel as listed above. An
-explicit OpenAI `responseFormat` overrides that selection; a format that is not
-voice-note compatible may be delivered as an audio file or transcoded by a
-channel that supports conversion.
-
-## Auto-TTS behavior
-
-When `tts.auto` is enabled, OpenClaw:
-
-- Keeps terminal slash and plugin command replies text-only, including with
-  `auto: "always"`. Explicit speech requests such as `/tts audio` and `/tts latest`
-  still send audio. Commands that continue into an assistant run keep the normal
-  auto-TTS behavior for the assistant's answer.
-- Skips TTS if the reply already contains structured media.
-- Skips very short replies (under 10 chars).
-- Skips replies dominated by fenced code; inline code and surrounding prose remain eligible for speech.
-- Summarizes long replies when summaries are enabled, using
-  `summaryModel` (or `agents.defaults.model.primary`).
-- Attaches the generated audio to the reply.
-- In `mode: "final"`, sends TTS after streamed text completes. Channels without
-  captioned-final support receive an audio-only supplement; Telegram puts text
-  within its caption limit on the voice note and sends overflow as follow-up
-  text. Generated media goes through the same channel media normalization as
-  normal reply attachments.
-
-If the reply exceeds `maxLength`, OpenClaw never skips audio outright:
-
-- **Summary on** (default) and a summary model is available: summarizes the
-  text to roughly `maxLength` chars, then synthesizes the summary.
-- **Summary off**, summarization fails, or no API key is available for the
-  summary model: truncates the text to `maxLength` chars and synthesizes the
-  truncated text.
-
-```text
-Reply -> TTS enabled?
-  no  -> send text
-  yes -> has media / short?
-          yes -> send text
-          no  -> length > limit?
-                   no  -> TTS -> attach audio
-                   yes -> summary enabled and available?
-                            no  -> truncate -> TTS -> attach audio
-                            yes -> summarize -> TTS -> attach audio
-```
-
-## Field reference
-
-<AccordionGroup>
-  <Accordion title="Top-level tts.*">
-    <ParamField path="auto" type='"off" | "always" | "inbound" | "tagged"'>
-      Auto-TTS mode. `inbound` only sends audio after an inbound voice message; `tagged` only sends audio when the reply includes `[[tts:...]]` directives or a `[[tts:text]]` block.
-    </ParamField>
-    <ParamField path="enabled" type="boolean" deprecated>
-      Legacy toggle. `openclaw doctor --fix` migrates this to `auto`.
-    </ParamField>
-    <ParamField path="mode" type='"final" | "all"' default="final">
-      `"all"` includes tool/block replies in addition to final replies.
-    </ParamField>
-    <ParamField path="provider" type="string">
-      Speech provider id. When unset, OpenClaw uses the first configured provider in registry auto-select order. Legacy `provider: "edge"` is rewritten to `"microsoft"` by `openclaw doctor --fix`.
-    </ParamField>
-    <ParamField path="persona" type="string">
-      Active persona id from `personas`. Normalized to lowercase.
-    </ParamField>
-    <ParamField path="personas.<id>" type="object">
-      Stable spoken identity. Fields: `label`, `description`, `provider`, `fallbackPolicy`, `providers.<provider>`. See [Personas](#personas).
-    </ParamField>
-    <ParamField path="summaryModel" type="string">
-      Cheap model for auto-summary; defaults to `agents.defaults.model.primary`. Accepts `provider/model` or a configured model alias.
-    </ParamField>
-    <ParamField path="modelOverrides" type="object">
-      Allow the model to emit TTS directives. `enabled` defaults to `true`; `allowProvider` defaults to `false`.
-    </ParamField>
-    <ParamField path="providers.<id>" type="object">
-      Provider-owned settings keyed by speech provider id. Legacy direct blocks (`tts.openai`, `.elevenlabs`, `.microsoft`, `.edge`) are rewritten by `openclaw doctor --fix`; commit only `tts.providers.<id>`.
-    </ParamField>
-    <ParamField path="maxTextLength" type="number" default="4096">
-      Hard cap for TTS input characters. `/tts audio`, `tts.convert`, and `tts.speak` fail if exceeded.
-    </ParamField>
-    <ParamField path="timeoutMs" type="number" default="30000">
-      Request timeout in milliseconds. A per-call `timeoutMs` (agent tool, gateway) wins when set; otherwise an explicitly configured `tts.timeoutMs` wins over any plugin-authored provider default.
-    </ParamField>
-  </Accordion>
-
-Provider `apiKey` fields, including `personas.<id>.providers.<provider>.apiKey`,
-can be raw strings or SecretRefs in global, per-agent, and Discord voice TTS config.
-During cold Gateway startup, an unavailable TTS SecretRef marks the built-in TTS capability
-configured-unavailable instead of stopping the Gateway. `tts.speak` then returns
-`UNAVAILABLE` with reason `SECRET_SURFACE_UNAVAILABLE`, and no provider request is
-sent. Status and doctor list the degraded TTS owner and its config paths. The
-explicit refs remain in the runtime snapshot, so environment or profile
-credentials cannot silently select a different account. Reloads and config-write
-preflight apply the owner-aware degradation policy: an unchanged eligible TTS
-owner may keep its last-known-good credentials as stale, while a new or changed
-failure becomes cold without blocking healthy owners. Structurally invalid refs
-and resolved values still fail startup or reject the update.
-
-  <Accordion title="Azure Speech">
-    <ParamField path="apiKey" type="string">Env: `AZURE_SPEECH_KEY`, `AZURE_SPEECH_API_KEY`, or `SPEECH_KEY`.</ParamField>
-    <ParamField path="region" type="string">Azure Speech region (e.g. `eastus`). Env: `AZURE_SPEECH_REGION` or `SPEECH_REGION`.</ParamField>
-    <ParamField path="endpoint" type="string">Optional Azure Speech endpoint override (alias `baseUrl`).</ParamField>
-    <ParamField path="speakerVoice" type="string">Azure voice ShortName. Default `en-US-JennyNeural`. Legacy alias: `voice`.</ParamField>
-    <ParamField path="lang" type="string">SSML language code. Default `en-US`.</ParamField>
-    <ParamField path="outputFormat" type="string">Azure `X-Microsoft-OutputFormat` for standard audio. Default `audio-24khz-48kbitrate-mono-mp3`.</ParamField>
-    <ParamField path="voiceNoteOutputFormat" type="string">Azure `X-Microsoft-OutputFormat` for voice-note output. Default `ogg-24khz-16bit-mono-opus`.</ParamField>
-  </Accordion>
-
-  <Accordion title="ElevenLabs">
-    <ParamField path="apiKey" type="string">Falls back to `ELEVENLABS_API_KEY` or `XI_API_KEY`.</ParamField>
-    <ParamField path="model" type="string">Model id. Default `eleven_multilingual_v2`. Legacy ids `eleven_turbo_v2_5`/`eleven_turbo_v2` are normalized to the matching `flash` model.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">ElevenLabs voice id. Default `pMsXgVXv3BLzUgSXRplE`. Legacy alias: `voiceId`.</ParamField>
-    <ParamField path="voiceSettings" type="object">
-      `stability`, `similarityBoost`, `style` (each `0..1`, defaults `0.5`/`0.75`/`0`), `useSpeakerBoost` (`true|false`, default `true`), `speed` (`0.5..2.0`, default `1.0`).
-    </ParamField>
-    <ParamField path="applyTextNormalization" type='"auto" | "on" | "off"'>Text normalization mode.</ParamField>
-    <ParamField path="languageCode" type="string">2-letter ISO 639-1 (e.g. `en`, `de`).</ParamField>
-    <ParamField path="seed" type="number">Integer `0..4294967295` for best-effort determinism.</ParamField>
-    <ParamField path="baseUrl" type="string">Override ElevenLabs API base URL.</ParamField>
-  </Accordion>
-
-  <Accordion title="Google Gemini">
-    <ParamField path="apiKey" type="string">Falls back to `GEMINI_API_KEY` / `GOOGLE_API_KEY`. If omitted, TTS can reuse `models.providers.google.apiKey` before env fallback.</ParamField>
-    <ParamField path="model" type="string">Gemini TTS model. Default `gemini-3.1-flash-tts-preview`.</ParamField>
-    <ParamField path="speakerVoice" type="string">Gemini prebuilt voice name. Default `Kore`. Legacy aliases: `voiceName`, `voice`.</ParamField>
-    <ParamField path="audioProfile" type="string">Natural-language style prompt prepended before spoken text.</ParamField>
-    <ParamField path="speakerName" type="string">Optional speaker label prepended before spoken text when your prompt uses a named speaker.</ParamField>
-    <ParamField path="promptTemplate" type='"audio-profile-v1"'>Set to `audio-profile-v1` to wrap active persona prompt fields in a deterministic Gemini TTS prompt structure.</ParamField>
-    <ParamField path="personaPrompt" type="string">Google-specific extra persona prompt text appended to the template's Director's Notes.</ParamField>
-    <ParamField path="baseUrl" type="string">Only `https://generativelanguage.googleapis.com` is accepted.</ParamField>
-  </Accordion>
-
-  <Accordion title="Gradium">
-    <ParamField path="apiKey" type="string">Env: `GRADIUM_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">HTTPS Gradium API URL on `api.gradium.ai`. Default `https://api.gradium.ai`.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">Default Emma (`YTpq7expH9539ERJ`). Legacy alias: `voiceId`.</ParamField>
-  </Accordion>
-
-  <Accordion title="Inworld">
-    ### Inworld primary
-
-    <ParamField path="apiKey" type="string">Env: `INWORLD_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.inworld.ai`.</ParamField>
-    <ParamField path="modelId" type="string">Default `inworld-tts-1.5-max`. Also: `inworld-tts-1.5-mini`, `inworld-tts-1-max`, `inworld-tts-1`.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">Default `Sarah`. Legacy alias: `voiceId`.</ParamField>
-    <ParamField path="temperature" type="number">Sampling temperature `0..2` (exclusive of 0).</ParamField>
-
-  </Accordion>
-
-  <Accordion title="Local CLI (tts-local-cli)">
-    <ParamField path="command" type="string">Local executable or command string for CLI TTS.</ParamField>
-    <ParamField path="args" type="string[]">Command arguments. Supports `{{Text}}`, `{{OutputPath}}`, `{{OutputDir}}`, `{{OutputBase}}` placeholders.</ParamField>
-    <ParamField path="outputFormat" type='"mp3" | "opus" | "wav"'>Expected CLI output format. Default `mp3` for audio attachments.</ParamField>
-    <ParamField path="timeoutMs" type="number">Command timeout in milliseconds. Overrides the resolved TTS request timeout when set. When omitted, follows the request timeout; the plugin default is `120000`.</ParamField>
-    <ParamField path="cwd" type="string">Optional command working directory.</ParamField>
-    <ParamField path="env" type="Record<string, string>">Optional environment overrides for the command.</ParamField>
-
-    Command stdout and generated or converted audio are limited to 50 MiB. Diagnostic stderr is limited to 1 MiB. OpenClaw terminates the command and fails synthesis when either limit is exceeded.
-
-  </Accordion>
-
-  <Accordion title="Microsoft (no API key)">
-    <ParamField path="enabled" type="boolean" default="true">Allow Microsoft speech usage.</ParamField>
-    <ParamField path="speakerVoice" type="string">Microsoft neural voice name (e.g. `en-US-MichelleNeural`). Legacy alias: `voice`. If the default English voice is in effect and reply text is CJK-dominant, OpenClaw auto-switches to `zh-CN-XiaoxiaoNeural`.</ParamField>
-    <ParamField path="lang" type="string">Language code (e.g. `en-US`).</ParamField>
-    <ParamField path="outputFormat" type="string">Microsoft output format. Default `audio-24khz-48kbitrate-mono-mp3`. Not all formats are supported by the bundled Edge-backed transport.</ParamField>
-    <ParamField path="rate / pitch / volume" type="string">Percent strings (e.g. `+10%`, `-5%`).</ParamField>
-    <ParamField path="saveSubtitles" type="boolean">Write JSON subtitles alongside the audio file.</ParamField>
-    <ParamField path="proxy" type="string">Proxy URL for Microsoft speech requests.</ParamField>
-    <ParamField path="timeoutMs" type="number">Request timeout override (ms).</ParamField>
-    <ParamField path="edge.*" type="object" deprecated>Legacy alias. Run `openclaw doctor --fix` to rewrite persisted config to `providers.microsoft`.</ParamField>
-  </Accordion>
-
-  <Accordion title="MiniMax">
-    <ParamField path="apiKey" type="string">Falls back to `MINIMAX_API_KEY`. Token Plan auth via `MINIMAX_OAUTH_TOKEN`, `MINIMAX_CODE_PLAN_KEY`, or `MINIMAX_CODING_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.minimax.io`. Env: `MINIMAX_API_HOST`.</ParamField>
-    <ParamField path="model" type="string">Default `speech-2.8-hd`. Env: `MINIMAX_TTS_MODEL`.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">Default `English_expressive_narrator`. Env: `MINIMAX_TTS_VOICE_ID`. Legacy alias: `voiceId`.</ParamField>
-    <ParamField path="speed" type="number">`0.5..2.0`. Default `1.0`.</ParamField>
-    <ParamField path="vol" type="number">`(0, 10]`. Default `1.0`.</ParamField>
-    <ParamField path="pitch" type="number">Integer `-12..12`. Default `0`. Fractional values are truncated before the request.</ParamField>
-  </Accordion>
-
-  <Accordion title="OpenAI">
-    <ParamField path="apiKey" type="string">Falls back to `OPENAI_API_KEY`.</ParamField>
-    <ParamField path="model" type="string">OpenAI TTS model id. Default `gpt-4o-mini-tts`.</ParamField>
-    <ParamField path="speakerVoice" type="string">Voice name (e.g. `alloy`, `cedar`). Default `coral`. Legacy alias: `voice`.</ParamField>
-    <ParamField path="instructions" type="string">Explicit OpenAI `instructions` field. When set, persona prompt fields are **not** auto-mapped.</ParamField>
-    <ParamField path="responseFormat" type='"mp3" | "opus" | "wav"'>Explicit response format. When omitted, OpenClaw selects Opus for voice-note targets and MP3 otherwise. Use `wav` for compatible local endpoints that do not encode compressed audio.</ParamField>
-    <ParamField path="extraBody / extra_body" type="Record<string, unknown>">Extra JSON fields merged into `/audio/speech` request bodies after generated OpenAI TTS fields. Use this for OpenAI-compatible endpoints such as Kokoro that require provider-specific keys like `lang`; unsafe prototype keys are ignored.</ParamField>
-    <ParamField path="baseUrl" type="string">
-      Override the OpenAI TTS endpoint. Resolution order: config → `OPENAI_TTS_BASE_URL` → `https://api.openai.com/v1`. Non-default values are treated as OpenAI-compatible TTS endpoints, so custom model and voice names are accepted, and `speed` loses its `0.25..4.0` range check.
-    </ParamField>
-  </Accordion>
-
-  <Accordion title="OpenRouter">
-    <ParamField path="apiKey" type="string">Env: `OPENROUTER_API_KEY`. Can reuse `models.providers.openrouter.apiKey`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://openrouter.ai/api/v1`. Legacy `https://openrouter.ai/v1` is normalized.</ParamField>
-    <ParamField path="model" type="string">Default `hexgrad/kokoro-82m`. Alias: `modelId`.</ParamField>
-    <ParamField path="speakerVoice" type="string">Default `af_alloy`. Legacy aliases: `voice`, `voiceId`.</ParamField>
-    <ParamField path="responseFormat" type='"mp3" | "pcm"'>Default `mp3`.</ParamField>
-    <ParamField path="speed" type="number">Provider-native speed override.</ParamField>
-  </Accordion>
-
-  <Accordion title="Volcengine (BytePlus Seed Speech)">
-    <ParamField path="apiKey" type="string">Env: `VOLCENGINE_TTS_API_KEY` or `BYTEPLUS_SEED_SPEECH_API_KEY`.</ParamField>
-    <ParamField path="resourceId" type="string">Default `seed-tts-1.0`. Env: `VOLCENGINE_TTS_RESOURCE_ID`. Use `seed-tts-2.0` when your project has TTS 2.0 entitlement.</ParamField>
-    <ParamField path="appKey" type="string">App key header. Default `aGjiRDfUWi`. Env: `VOLCENGINE_TTS_APP_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Override the Seed Speech TTS HTTP endpoint. Env: `VOLCENGINE_TTS_BASE_URL`.</ParamField>
-    <ParamField path="speakerVoice" type="string">Voice type. Default `en_female_anna_mars_bigtts`. Env: `VOLCENGINE_TTS_VOICE`. Legacy alias: `voice`.</ParamField>
-    <ParamField path="speedRatio" type="number">Provider-native speed ratio, `0.2..3`.</ParamField>
-    <ParamField path="emotion" type="string">Provider-native emotion tag.</ParamField>
-    <ParamField path="appId / token / cluster" type="string" deprecated>Legacy Volcengine Speech Console fields. Env: `VOLCENGINE_TTS_APPID`, `VOLCENGINE_TTS_TOKEN`, `VOLCENGINE_TTS_CLUSTER` (default `volcano_tts`).</ParamField>
-  </Accordion>
-
-  <Accordion title="xAI">
-    <ParamField path="apiKey" type="string">Env: `XAI_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.x.ai/v1`. Env: `XAI_BASE_URL`.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">Default `eve`. With auth, `openclaw infer tts voices --provider xai` fetches the current built-in catalog; without auth it lists offline fallbacks `ara`, `eve`, `leo`, `rex`, and `sal`. Account custom voice IDs are forwarded even when absent from the built-in list. Legacy alias: `voiceId`.</ParamField>
-    <ParamField path="language" type="string">BCP-47 language code or `auto`. Default `en`.</ParamField>
-    <ParamField path="responseFormat" type='"mp3" | "wav" | "pcm" | "mulaw" | "alaw"'>Default `mp3`.</ParamField>
-    <ParamField path="speed" type="number">Provider-native speed override, `0.7..1.5`.</ParamField>
-  </Accordion>
-
-  <Accordion title="Xiaomi MiMo">
-    <ParamField path="apiKey" type="string">Env: `XIAOMI_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.xiaomimimo.com/v1`. Env: `XIAOMI_BASE_URL`.</ParamField>
-    <ParamField path="model" type="string">Default `mimo-v2.5-tts`. Env: `XIAOMI_TTS_MODEL`. Also supports `mimo-v2.5-tts-voicedesign`.</ParamField>
-    <ParamField path="speakerVoice" type="string">Default `mimo_default` for preset-voice models. Env: `XIAOMI_TTS_VOICE`. Legacy alias: `voice`. Not sent for `mimo-v2.5-tts-voicedesign`.</ParamField>
-    <ParamField path="format" type='"mp3" | "wav"'>Default `mp3`. Env: `XIAOMI_TTS_FORMAT`.</ParamField>
-    <ParamField path="style" type="string">Optional natural-language style instruction sent as the user message; not spoken. For `mimo-v2.5-tts-voicedesign`, this is the voice-design prompt; OpenClaw supplies a default when omitted.</ParamField>
-  </Accordion>
-</AccordionGroup>
-
-## Agent tool
-
-The `tts` tool converts text to speech and returns an audio attachment for
-reply delivery. On Feishu, Matrix, Telegram, and WhatsApp, the audio is
-delivered as a voice message rather than a file attachment. Feishu and
-WhatsApp can transcode non-Opus TTS output on this path when `ffmpeg` is
-available.
-
-WhatsApp sends audio through Baileys as a PTT voice note (`audio` with
-`ptt: true`) and sends visible text **separately** from PTT audio because
-clients do not consistently render captions on voice notes.
-
-The tool accepts optional `channel` and `timeoutMs` fields; `timeoutMs` is a
-per-call provider request timeout in milliseconds. Per-call values override
-`tts.timeoutMs`; configured TTS timeouts override any plugin-authored
-provider default.
-
-## Gateway RPC
-
-| Method            | Purpose                                      |
-| ----------------- | -------------------------------------------- |
-| `tts.status`      | Read current TTS state and last attempt.     |
-| `tts.enable`      | Set local auto preference to `always`.       |
-| `tts.disable`     | Set local auto preference to `off`.          |
-| `tts.convert`     | One-off text → audio.                        |
-| `tts.setProvider` | Set local provider preference.               |
-| `tts.personas`    | List configured personas and the active one. |
-| `tts.setPersona`  | Set local persona preference.                |
-| `tts.providers`   | List configured providers and status.        |
+This page is an index. Text-to-speech is documented on seven pages, one per
+reader job. Open the page that matches your task.
+
+| Page                                                         | Read it when                                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| [Text-to-speech quickstart](/tools/tts/quickstart)           | You are turning TTS on, choosing a provider, and testing it from chat.                       |
+| [Text-to-speech configuration](/tools/tts/configuration)     | You need the `tts` config block, a provider snippet, a local engine, or override precedence. |
+| [Text-to-speech personas](/tools/tts/personas)               | You want one stable spoken identity, its provider bindings, and its fallback policy.         |
+| [Commands and directives](/tools/tts/commands)               | You need `[[tts:...]]` directives, the `/tts` commands, or where local preferences live.     |
+| [Output and Auto-TTS behavior](/tools/tts/output)            | You need the audio format per channel, transcoding rules, or when Auto-TTS summarizes.       |
+| [Text-to-speech field reference](/tools/tts/field-reference) | You need the type, default, env var, or legacy alias for one TTS field.                      |
+| [Agent tool and Gateway RPC](/tools/tts/api)                 | You are calling TTS from an agent tool call or a Gateway RPC method.                         |
+
+## Where each section moved
+
+Every section heading from the previous single-page version keeps its anchor
+here, so an existing link such as `/tools/tts#per-agent-voice-overrides` still
+resolves. Each entry points at the page that now holds the content.
+
+- <a id="quick-start" />[Quick start](/tools/tts/quickstart#quick-start)
+- <a id="supported-providers" />[Supported providers](/tools/tts/quickstart#supported-providers)
+- <a id="configuration" />[Configuration](/tools/tts/configuration#configuration)
+- <a id="local-speech-swift-and-speech-core" />[Local Speech Swift and speech-core](/tools/tts/configuration#local-speech-swift-and-speech-core)
+- <a id="per-agent-voice-overrides" />[Per-agent voice overrides](/tools/tts/configuration#per-agent-voice-overrides)
+- <a id="personas" />[Personas](/tools/tts/personas#personas)
+- <a id="minimal-persona" />[Minimal persona](/tools/tts/personas#minimal-persona)
+- <a id="full-persona-(provider-specific-shaping)" />[Full persona (provider-specific shaping)](</tools/tts/personas#full-persona-(provider-specific-shaping)>)
+- <a id="persona-resolution" />[Persona resolution](/tools/tts/personas#persona-resolution)
+- <a id="custom-persona-shaping" />[Custom persona shaping](/tools/tts/personas#custom-persona-shaping)
+- <a id="fallback-policy" />[Fallback policy](/tools/tts/personas#fallback-policy)
+- <a id="model-driven-directives" />[Model-driven directives](/tools/tts/commands#model-driven-directives)
+- <a id="slash-commands" />[Slash commands](/tools/tts/commands#slash-commands)
+- <a id="per-user-preferences" />[Per-user preferences](/tools/tts/commands#per-user-preferences)
+- <a id="output-formats" />[Output formats](/tools/tts/output#output-formats)
+- <a id="auto-tts-behavior" />[Auto-TTS behavior](/tools/tts/output#auto-tts-behavior)
+- <a id="field-reference" />[Field reference](/tools/tts/field-reference#field-reference)
+- <a id="inworld-primary" />[Inworld primary](/tools/tts/field-reference#inworld-primary)
+- <a id="agent-tool" />[Agent tool](/tools/tts/api#agent-tool)
+- <a id="gateway-rpc" />[Gateway RPC](/tools/tts/api#gateway-rpc)
+- <a id="full-persona-provider-specific-shaping" />[Full persona (provider-specific shaping)](/tools/tts/personas#full-persona-provider-specific-shaping)
+
+## Component anchors
+
+The previous single-page version also minted an anchor for every step, tab,
+accordion, and field. Those anchors are preserved here so that any deep link
+into the old page still resolves. Nine accordion anchors lost a `-1` suffix
+when the tab that shared their slug moved to a different page; the stub below
+keeps the old id and points at the new one.
+
+**Quickstart**
+
+- <a id="pick-a-provider" />[Pick a provider](/tools/tts/quickstart#pick-a-provider)
+- <a id="set-the-api-key" />[Set the API key](/tools/tts/quickstart#set-the-api-key)
+- <a id="enable-in-config" />[Enable in config](/tools/tts/quickstart#enable-in-config)
+- <a id="try-it-in-chat" />[Try it in chat](/tools/tts/quickstart#try-it-in-chat)
+
+**Configuration**
+
+- <a id="azure-speech" />[Azure Speech](/tools/tts/configuration#azure-speech)
+- <a id="elevenlabs" />[ElevenLabs](/tools/tts/configuration#elevenlabs)
+- <a id="fish-audio" />[Fish Audio](/tools/tts/configuration#fish-audio)
+- <a id="google-gemini" />[Google Gemini](/tools/tts/configuration#google-gemini)
+- <a id="gradium" />[Gradium](/tools/tts/configuration#gradium)
+- <a id="inworld" />[Inworld](/tools/tts/configuration#inworld)
+- <a id="local-cli" />[Local CLI](/tools/tts/configuration#local-cli)
+- <a id="microsoft-no-key" />[Microsoft (no key)](/tools/tts/configuration#microsoft-no-key)
+- <a id="minimax" />[MiniMax](/tools/tts/configuration#minimax)
+- <a id="openai-%2B-elevenlabs" />[OpenAI + ElevenLabs](/tools/tts/configuration#openai-%2B-elevenlabs)
+- <a id="openrouter" />[OpenRouter](/tools/tts/configuration#openrouter)
+- <a id="volcengine" />[Volcengine](/tools/tts/configuration#volcengine)
+- <a id="xai" />[xAI](/tools/tts/configuration#xai)
+- <a id="xiaomi-mimo" />[Xiaomi MiMo](/tools/tts/configuration#xiaomi-mimo)
+- <a id="macos-http" />[macOS HTTP](/tools/tts/configuration#macos-http)
+- <a id="macos-cli" />[macOS CLI](/tools/tts/configuration#macos-cli)
+- <a id="linux-cli" />[Linux CLI](/tools/tts/configuration#linux-cli)
+- <a id="windows-cli" />[Windows CLI](/tools/tts/configuration#windows-cli)
+
+**Field reference**
+
+- <a id="top-level-tts" />[Top-level tts.*](/tools/tts/field-reference#top-level-tts)
+- <a id="param-auto" />[Top-level tts.* → `auto`](/tools/tts/field-reference#param-auto)
+- <a id="param-enabled" />[Top-level tts.* → `enabled`](/tools/tts/field-reference#param-enabled)
+- <a id="param-mode" />[Top-level tts.* → `mode`](/tools/tts/field-reference#param-mode)
+- <a id="param-provider" />[Top-level tts.* → `provider`](/tools/tts/field-reference#param-provider)
+- <a id="param-persona" />[Top-level tts.* → `persona`](/tools/tts/field-reference#param-persona)
+- <a id="param-personas-id" />[Top-level tts.* → `personas.<id>`](/tools/tts/field-reference#param-personas-id)
+- <a id="param-summary-model" />[Top-level tts.* → `summaryModel`](/tools/tts/field-reference#param-summary-model)
+- <a id="param-model-overrides" />[Top-level tts.* → `modelOverrides`](/tools/tts/field-reference#param-model-overrides)
+- <a id="param-providers-id" />[Top-level tts.* → `providers.<id>`](/tools/tts/field-reference#param-providers-id)
+- <a id="param-max-text-length" />[Top-level tts.* → `maxTextLength`](/tools/tts/field-reference#param-max-text-length)
+- <a id="param-timeout-ms" />[Top-level tts.* → `timeoutMs`](/tools/tts/field-reference#param-timeout-ms)
+- <a id="azure-speech-1" />[Azure Speech](/tools/tts/field-reference#azure-speech)
+- <a id="param-api-key" />[Azure Speech → `apiKey`](/tools/tts/field-reference#param-api-key)
+- <a id="param-region" />[Azure Speech → `region`](/tools/tts/field-reference#param-region)
+- <a id="param-endpoint" />[Azure Speech → `endpoint`](/tools/tts/field-reference#param-endpoint)
+- <a id="param-speaker-voice" />[Azure Speech → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice)
+- <a id="param-lang" />[Azure Speech → `lang`](/tools/tts/field-reference#param-lang)
+- <a id="param-output-format" />[Azure Speech → `outputFormat`](/tools/tts/field-reference#param-output-format)
+- <a id="param-voice-note-output-format" />[Azure Speech → `voiceNoteOutputFormat`](/tools/tts/field-reference#param-voice-note-output-format)
+- <a id="elevenlabs-1" />[ElevenLabs](/tools/tts/field-reference#elevenlabs)
+- <a id="param-api-key-1" />[ElevenLabs → `apiKey`](/tools/tts/field-reference#param-api-key-1)
+- <a id="param-model" />[ElevenLabs → `model`](/tools/tts/field-reference#param-model)
+- <a id="param-speaker-voice-id" />[ElevenLabs → `speakerVoiceId`](/tools/tts/field-reference#param-speaker-voice-id)
+- <a id="param-voice-settings" />[ElevenLabs → `voiceSettings`](/tools/tts/field-reference#param-voice-settings)
+- <a id="param-apply-text-normalization" />[ElevenLabs → `applyTextNormalization`](/tools/tts/field-reference#param-apply-text-normalization)
+- <a id="param-language-code" />[ElevenLabs → `languageCode`](/tools/tts/field-reference#param-language-code)
+- <a id="param-seed" />[ElevenLabs → `seed`](/tools/tts/field-reference#param-seed)
+- <a id="param-base-url" />[ElevenLabs → `baseUrl`](/tools/tts/field-reference#param-base-url)
+- <a id="google-gemini-1" />[Google Gemini](/tools/tts/field-reference#google-gemini)
+- <a id="param-api-key-2" />[Google Gemini → `apiKey`](/tools/tts/field-reference#param-api-key-2)
+- <a id="param-model-1" />[Google Gemini → `model`](/tools/tts/field-reference#param-model-1)
+- <a id="param-speaker-voice-1" />[Google Gemini → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-1)
+- <a id="param-audio-profile" />[Google Gemini → `audioProfile`](/tools/tts/field-reference#param-audio-profile)
+- <a id="param-speaker-name" />[Google Gemini → `speakerName`](/tools/tts/field-reference#param-speaker-name)
+- <a id="param-prompt-template" />[Google Gemini → `promptTemplate`](/tools/tts/field-reference#param-prompt-template)
+- <a id="param-persona-prompt" />[Google Gemini → `personaPrompt`](/tools/tts/field-reference#param-persona-prompt)
+- <a id="param-base-url-1" />[Google Gemini → `baseUrl`](/tools/tts/field-reference#param-base-url-1)
+- <a id="gradium-1" />[Gradium](/tools/tts/field-reference#gradium)
+- <a id="param-api-key-3" />[Gradium → `apiKey`](/tools/tts/field-reference#param-api-key-3)
+- <a id="param-base-url-2" />[Gradium → `baseUrl`](/tools/tts/field-reference#param-base-url-2)
+- <a id="param-speaker-voice-id-1" />[Gradium → `speakerVoiceId`](/tools/tts/field-reference#param-speaker-voice-id-1)
+- <a id="inworld-1" />[Inworld](/tools/tts/field-reference#inworld)
+- <a id="param-api-key-4" />[Inworld → `apiKey`](/tools/tts/field-reference#param-api-key-4)
+- <a id="param-base-url-3" />[Inworld → `baseUrl`](/tools/tts/field-reference#param-base-url-3)
+- <a id="param-model-id" />[Inworld → `modelId`](/tools/tts/field-reference#param-model-id)
+- <a id="param-speaker-voice-id-2" />[Inworld → `speakerVoiceId`](/tools/tts/field-reference#param-speaker-voice-id-2)
+- <a id="param-temperature" />[Inworld → `temperature`](/tools/tts/field-reference#param-temperature)
+- <a id="local-cli-tts-local-cli" />[Local CLI (tts-local-cli)](/tools/tts/field-reference#local-cli-tts-local-cli)
+- <a id="param-command" />[Local CLI (tts-local-cli) → `command`](/tools/tts/field-reference#param-command)
+- <a id="param-args" />[Local CLI (tts-local-cli) → `args`](/tools/tts/field-reference#param-args)
+- <a id="param-output-format-1" />[Local CLI (tts-local-cli) → `outputFormat`](/tools/tts/field-reference#param-output-format-1)
+- <a id="param-timeout-ms-1" />[Local CLI (tts-local-cli) → `timeoutMs`](/tools/tts/field-reference#param-timeout-ms-1)
+- <a id="param-cwd" />[Local CLI (tts-local-cli) → `cwd`](/tools/tts/field-reference#param-cwd)
+- <a id="param-env" />[Local CLI (tts-local-cli) → `env`](/tools/tts/field-reference#param-env)
+- <a id="microsoft-no-api-key" />[Microsoft (no API key)](/tools/tts/field-reference#microsoft-no-api-key)
+- <a id="param-enabled-1" />[Microsoft (no API key) → `enabled`](/tools/tts/field-reference#param-enabled-1)
+- <a id="param-speaker-voice-2" />[Microsoft (no API key) → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-2)
+- <a id="param-lang-1" />[Microsoft (no API key) → `lang`](/tools/tts/field-reference#param-lang-1)
+- <a id="param-output-format-2" />[Microsoft (no API key) → `outputFormat`](/tools/tts/field-reference#param-output-format-2)
+- <a id="param-rate-pitch-volume" />[Microsoft (no API key) → `rate / pitch / volume`](/tools/tts/field-reference#param-rate-pitch-volume)
+- <a id="param-save-subtitles" />[Microsoft (no API key) → `saveSubtitles`](/tools/tts/field-reference#param-save-subtitles)
+- <a id="param-proxy" />[Microsoft (no API key) → `proxy`](/tools/tts/field-reference#param-proxy)
+- <a id="param-timeout-ms-2" />[Microsoft (no API key) → `timeoutMs`](/tools/tts/field-reference#param-timeout-ms-2)
+- <a id="param-edge" />[Microsoft (no API key) → `edge.*`](/tools/tts/field-reference#param-edge)
+- <a id="minimax-1" />[MiniMax](/tools/tts/field-reference#minimax)
+- <a id="param-api-key-5" />[MiniMax → `apiKey`](/tools/tts/field-reference#param-api-key-5)
+- <a id="param-base-url-4" />[MiniMax → `baseUrl`](/tools/tts/field-reference#param-base-url-4)
+- <a id="param-model-2" />[MiniMax → `model`](/tools/tts/field-reference#param-model-2)
+- <a id="param-speaker-voice-id-3" />[MiniMax → `speakerVoiceId`](/tools/tts/field-reference#param-speaker-voice-id-3)
+- <a id="param-speed" />[MiniMax → `speed`](/tools/tts/field-reference#param-speed)
+- <a id="param-vol" />[MiniMax → `vol`](/tools/tts/field-reference#param-vol)
+- <a id="param-pitch" />[MiniMax → `pitch`](/tools/tts/field-reference#param-pitch)
+- <a id="openai" />[OpenAI](/tools/tts/field-reference#openai)
+- <a id="param-api-key-6" />[OpenAI → `apiKey`](/tools/tts/field-reference#param-api-key-6)
+- <a id="param-model-3" />[OpenAI → `model`](/tools/tts/field-reference#param-model-3)
+- <a id="param-speaker-voice-3" />[OpenAI → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-3)
+- <a id="param-instructions" />[OpenAI → `instructions`](/tools/tts/field-reference#param-instructions)
+- <a id="param-response-format" />[OpenAI → `responseFormat`](/tools/tts/field-reference#param-response-format)
+- <a id="param-extra-body-extra-body" />[OpenAI → `extraBody / extra_body`](/tools/tts/field-reference#param-extra-body-extra-body)
+- <a id="param-base-url-5" />[OpenAI → `baseUrl`](/tools/tts/field-reference#param-base-url-5)
+- <a id="openrouter-1" />[OpenRouter](/tools/tts/field-reference#openrouter)
+- <a id="param-api-key-7" />[OpenRouter → `apiKey`](/tools/tts/field-reference#param-api-key-7)
+- <a id="param-base-url-6" />[OpenRouter → `baseUrl`](/tools/tts/field-reference#param-base-url-6)
+- <a id="param-model-4" />[OpenRouter → `model`](/tools/tts/field-reference#param-model-4)
+- <a id="param-speaker-voice-4" />[OpenRouter → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-4)
+- <a id="param-response-format-1" />[OpenRouter → `responseFormat`](/tools/tts/field-reference#param-response-format-1)
+- <a id="param-speed-1" />[OpenRouter → `speed`](/tools/tts/field-reference#param-speed-1)
+- <a id="volcengine-byteplus-seed-speech" />[Volcengine (BytePlus Seed Speech)](/tools/tts/field-reference#volcengine-byteplus-seed-speech)
+- <a id="param-api-key-8" />[Volcengine (BytePlus Seed Speech) → `apiKey`](/tools/tts/field-reference#param-api-key-8)
+- <a id="param-resource-id" />[Volcengine (BytePlus Seed Speech) → `resourceId`](/tools/tts/field-reference#param-resource-id)
+- <a id="param-app-key" />[Volcengine (BytePlus Seed Speech) → `appKey`](/tools/tts/field-reference#param-app-key)
+- <a id="param-base-url-7" />[Volcengine (BytePlus Seed Speech) → `baseUrl`](/tools/tts/field-reference#param-base-url-7)
+- <a id="param-speaker-voice-5" />[Volcengine (BytePlus Seed Speech) → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-5)
+- <a id="param-speed-ratio" />[Volcengine (BytePlus Seed Speech) → `speedRatio`](/tools/tts/field-reference#param-speed-ratio)
+- <a id="param-emotion" />[Volcengine (BytePlus Seed Speech) → `emotion`](/tools/tts/field-reference#param-emotion)
+- <a id="param-app-id-token-cluster" />[Volcengine (BytePlus Seed Speech) → `appId / token / cluster`](/tools/tts/field-reference#param-app-id-token-cluster)
+- <a id="xai-1" />[xAI](/tools/tts/field-reference#xai)
+- <a id="param-api-key-9" />[xAI → `apiKey`](/tools/tts/field-reference#param-api-key-9)
+- <a id="param-base-url-8" />[xAI → `baseUrl`](/tools/tts/field-reference#param-base-url-8)
+- <a id="param-speaker-voice-id-4" />[xAI → `speakerVoiceId`](/tools/tts/field-reference#param-speaker-voice-id-4)
+- <a id="param-language" />[xAI → `language`](/tools/tts/field-reference#param-language)
+- <a id="param-response-format-2" />[xAI → `responseFormat`](/tools/tts/field-reference#param-response-format-2)
+- <a id="param-speed-2" />[xAI → `speed`](/tools/tts/field-reference#param-speed-2)
+- <a id="xiaomi-mimo-1" />[Xiaomi MiMo](/tools/tts/field-reference#xiaomi-mimo)
+- <a id="param-api-key-10" />[Xiaomi MiMo → `apiKey`](/tools/tts/field-reference#param-api-key-10)
+- <a id="param-base-url-9" />[Xiaomi MiMo → `baseUrl`](/tools/tts/field-reference#param-base-url-9)
+- <a id="param-model-5" />[Xiaomi MiMo → `model`](/tools/tts/field-reference#param-model-5)
+- <a id="param-speaker-voice-6" />[Xiaomi MiMo → `speakerVoice`](/tools/tts/field-reference#param-speaker-voice-6)
+- <a id="param-format" />[Xiaomi MiMo → `format`](/tools/tts/field-reference#param-format)
+- <a id="param-style" />[Xiaomi MiMo → `style`](/tools/tts/field-reference#param-style)
 
 ## Service links
 

--- a/docs/tools/tts/api.md
+++ b/docs/tools/tts/api.md
@@ -1,0 +1,37 @@
+---
+summary: "The tts agent tool and the Gateway TTS RPC methods"
+title: "Text-to-speech agent tool and Gateway RPC"
+read_when:
+  - You are calling TTS from an agent tool call
+  - You need the Gateway tts.* RPC method list
+---
+
+## Agent tool
+
+The `tts` tool converts text to speech and returns an audio attachment for
+reply delivery. On Feishu, Matrix, Telegram, and WhatsApp, the audio is
+delivered as a voice message rather than a file attachment. Feishu and
+WhatsApp can transcode non-Opus TTS output on this path when `ffmpeg` is
+available.
+
+WhatsApp sends audio through Baileys as a PTT voice note (`audio` with
+`ptt: true`) and sends visible text **separately** from PTT audio because
+clients do not consistently render captions on voice notes.
+
+The tool accepts optional `channel` and `timeoutMs` fields; `timeoutMs` is a
+per-call provider request timeout in milliseconds. Per-call values override
+`tts.timeoutMs`; configured TTS timeouts override any plugin-authored
+provider default.
+
+## Gateway RPC
+
+| Method            | Purpose                                      |
+| ----------------- | -------------------------------------------- |
+| `tts.status`      | Read current TTS state and last attempt.     |
+| `tts.enable`      | Set local auto preference to `always`.       |
+| `tts.disable`     | Set local auto preference to `off`.          |
+| `tts.convert`     | One-off text → audio.                        |
+| `tts.setProvider` | Set local provider preference.               |
+| `tts.personas`    | List configured personas and the active one. |
+| `tts.setPersona`  | Set local persona preference.                |
+| `tts.providers`   | List configured providers and status.        |

--- a/docs/tools/tts/commands.md
+++ b/docs/tools/tts/commands.md
@@ -1,0 +1,108 @@
+---
+summary: "Model-emitted TTS directives, the /tts slash commands, and per-user preferences"
+title: "Text-to-speech commands and directives"
+read_when:
+  - You want the model to change voice or speed for one reply
+  - You need the /tts command surface
+  - You are looking for where local TTS preferences are stored
+---
+
+## Model-driven directives
+
+By default, the assistant **can** emit `[[tts:...]]` directives to override
+voice, model, or speed for a single reply, plus an optional
+`[[tts:text]]...[[/tts:text]]` block for expressive cues that should appear in
+audio only:
+
+```text
+Here you go.
+
+[[tts:speakerVoiceId=pMsXgVXv3BLzUgSXRplE model=eleven_v3 speed=1.1]]
+[[tts:text]](laughs) Read the song once more.[[/tts:text]]
+```
+
+When `tts.auto` is `"tagged"`, **directives are required** to trigger
+audio. Streaming block delivery strips directives from visible text before the
+channel sees them, even when split across adjacent blocks.
+
+`provider=...` is ignored unless `modelOverrides.allowProvider: true`. When a
+reply declares `provider=...`, the other keys in that directive are parsed
+only by that provider; unsupported keys are stripped and reported as TTS
+directive warnings.
+
+**Available directive keys:**
+
+- `provider` (registered provider id; requires `allowProvider: true`)
+- `speakerVoice` / `speakerVoiceId` (legacy aliases: `voice`, `voiceName`, `voice_name`, `google_voice`, `voiceId`)
+- `model` / `google_model`
+- `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
+- `vol` / `volume` (MiniMax volume, `(0, 10]`)
+- `pitch` (MiniMax integer pitch, −12 to 12; fractional values are truncated)
+- `emotion` (Volcengine emotion tag)
+- `applyTextNormalization` (`auto|on|off`)
+- `languageCode` (ISO 639-1)
+- `seed`
+
+**Disable model overrides entirely:**
+
+```json5
+{ tts: { modelOverrides: { enabled: false } } }
+```
+
+**Allow provider switching while keeping other knobs configurable:**
+
+```json5
+{ tts: { modelOverrides: { enabled: true, allowProvider: true, allowSeed: false } } }
+```
+
+## Slash commands
+
+Single command `/tts`. On Discord, OpenClaw also registers `/voice` because
+`/tts` is a built-in Discord command — text `/tts ...` still works.
+
+```text
+/tts off | on | status
+/tts chat on | off | default
+/tts latest
+/tts provider <id>
+/tts persona <id> | off
+/tts limit <chars>
+/tts summary off
+/tts audio <text>
+```
+
+<Note>
+Commands require an authorized sender (allowlist/owner rules apply) and either
+`commands.text` or native command registration must be enabled.
+</Note>
+
+Behavior notes:
+
+- `/tts on` writes the local TTS preference to `always`; `/tts off` writes it to `off`.
+- `/tts chat on|off|default` writes a session-scoped auto-TTS override for the current chat.
+- `/tts persona <id>` writes the local persona preference; `/tts persona off` clears it.
+- `/tts latest` reads the latest assistant reply from the current session transcript and sends it as audio once. It stores only a hash of that reply on the session entry to suppress duplicate voice sends.
+- `/tts audio` generates a one-off audio reply (does **not** toggle TTS on).
+- `/tts limit <chars>` accepts **100–4096** (4096 is the Telegram caption/message max); values outside that range are rejected.
+- `limit` and `summary` are stored in **local prefs**, not the main config.
+- `/tts status` includes fallback diagnostics for the latest attempt — `Fallback: <primary> -> <used>`, `Attempts: ...`, and per-attempt detail (`provider:outcome(reasonCode) latency`).
+- `/status` shows the active TTS mode plus configured provider, model, voice, and sanitized custom endpoint metadata when TTS is enabled.
+
+## Per-user preferences
+
+Slash commands write local overrides to the TTS preferences path. The default is
+`~/.openclaw/settings/tts.json`; override it with `OPENCLAW_TTS_PREFS`. Doctor
+moves the retired global `tts.prefsPath` value into shared machine state.
+Advanced multi-agent setups may still set `agents.entries.<id>.tts.prefsPath`
+when agents intentionally use separate preference stores.
+
+| Stored field | Effect                                                                           |
+| ------------ | -------------------------------------------------------------------------------- |
+| `auto`       | Local auto-TTS override (`always`, `off`, …)                                     |
+| `provider`   | Local primary provider override                                                  |
+| `persona`    | Local persona override                                                           |
+| `maxLength`  | Summary/truncation threshold (default `1500` chars, `/tts limit` range 100–4096) |
+| `summarize`  | Summary toggle (default `true`)                                                  |
+
+These override the effective config from `tts` plus the active
+`agents.entries.*.tts` block for that host.

--- a/docs/tools/tts/configuration.md
+++ b/docs/tools/tts/configuration.md
@@ -1,0 +1,508 @@
+---
+summary: "The tts config block, per-provider settings, local speech engines, and override precedence"
+title: "Text-to-speech configuration"
+read_when:
+  - You are writing the tts block in openclaw.json
+  - You need the config snippet for one speech provider
+  - You want a local Speech Swift or speech-core engine
+  - You need per-agent, per-channel, or per-account voice overrides
+---
+
+## Configuration
+
+TTS config lives under `tts` in `~/.openclaw/openclaw.json`. Pick a
+preset and adapt the provider block. The `speakerVoice`/`speakerVoiceId`
+fields shown below are canonical; each provider's own `voice`/`voiceId`/
+`voiceName` field names still work as legacy aliases.
+
+OpenRouter and DeepInfra use the first nonblank value from `speakerVoice`,
+`speakerVoiceId`, `voice`, and `voiceId`, in that order, before the provider default.
+Talk applies the same order to its provider block; when all four fields are absent
+or blank, it keeps the base TTS voice.
+
+<Tabs>
+  <Tab title="Azure Speech">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "azure-speech",
+    providers: {
+      "azure-speech": {
+        apiKey: "${AZURE_SPEECH_KEY}",
+        region: "eastus",
+        speakerVoice: "en-US-JennyNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        voiceNoteOutputFormat: "ogg-24khz-16bit-mono-opus",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="ElevenLabs">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "elevenlabs",
+    providers: {
+      elevenlabs: {
+        apiKey: "${ELEVENLABS_API_KEY}",
+        model: "eleven_multilingual_v2",
+        speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Fish Audio">
+```json5
+{
+  tts: {
+    auto: "tagged",
+    provider: "fish-audio",
+    providers: {
+      "fish-audio": {
+        apiKey: "${FISH_API_KEY}",
+        model: "s2.1-pro",
+        speakerVoiceId: "802e3bc2b27e49c2995d23ef70e6ac89",
+        latency: "balanced",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Google Gemini">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "google",
+    providers: {
+      google: {
+        apiKey: "${GEMINI_API_KEY}",
+        model: "gemini-3.1-flash-tts-preview",
+        speakerVoice: "Kore",
+        // Optional natural-language style prompts:
+        // audioProfile: "Speak in a calm, podcast-host tone.",
+        // speakerName: "Alex",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Gradium">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "gradium",
+    providers: {
+      gradium: {
+        apiKey: "${GRADIUM_API_KEY}",
+        speakerVoiceId: "YTpq7expH9539ERJ",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Inworld">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "inworld",
+    providers: {
+      inworld: {
+        apiKey: "${INWORLD_API_KEY}",
+        modelId: "inworld-tts-1.5-max",
+        speakerVoiceId: "Sarah",
+        temperature: 0.7,
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Local CLI">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "tts-local-cli",
+    providers: {
+      "tts-local-cli": {
+        command: "say",
+        args: ["-o", "{{OutputPath}}", "{{Text}}"],
+        outputFormat: "wav",
+        timeoutMs: 120000,
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Microsoft (no key)">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "microsoft",
+    providers: {
+      microsoft: {
+        enabled: true,
+        speakerVoice: "en-US-MichelleNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        rate: "+0%",
+        pitch: "+0%",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="MiniMax">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "minimax",
+    providers: {
+      minimax: {
+        apiKey: "${MINIMAX_API_KEY}",
+        model: "speech-2.8-hd",
+        speakerVoiceId: "English_expressive_narrator",
+        speed: 1.0,
+        vol: 1.0,
+        pitch: 0,
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="OpenAI + ElevenLabs">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "openai",
+    summaryModel: "openai/gpt-4.1-mini",
+    modelOverrides: { enabled: true },
+    providers: {
+      openai: {
+        apiKey: "${OPENAI_API_KEY}",
+        model: "gpt-4o-mini-tts",
+        speakerVoice: "alloy",
+      },
+      elevenlabs: {
+        apiKey: "${ELEVENLABS_API_KEY}",
+        model: "eleven_multilingual_v2",
+        speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
+        voiceSettings: { stability: 0.5, similarityBoost: 0.75, style: 0.0, useSpeakerBoost: true, speed: 1.0 },
+        applyTextNormalization: "auto",
+        languageCode: "en",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="OpenRouter">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "openrouter",
+    providers: {
+      openrouter: {
+        apiKey: "${OPENROUTER_API_KEY}",
+        model: "hexgrad/kokoro-82m",
+        speakerVoice: "af_alloy",
+        responseFormat: "mp3",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Volcengine">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "volcengine",
+    providers: {
+      volcengine: {
+        apiKey: "${VOLCENGINE_TTS_API_KEY}",
+        resourceId: "seed-tts-1.0",
+        speakerVoice: "en_female_anna_mars_bigtts",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="xAI">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "xai",
+    providers: {
+      xai: {
+        apiKey: "${XAI_API_KEY}",
+        speakerVoiceId: "eve",
+        language: "en",
+        responseFormat: "mp3",
+      },
+    },
+  },
+}
+```
+  </Tab>
+  <Tab title="Xiaomi MiMo">
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "xiaomi",
+    providers: {
+      xiaomi: {
+        apiKey: "${XIAOMI_API_KEY}",
+        model: "mimo-v2.5-tts",
+        speakerVoice: "mimo_default",
+        format: "mp3",
+      },
+    },
+  },
+}
+```
+  </Tab>
+</Tabs>
+
+For Xiaomi `mimo-v2.5-tts-voicedesign`, omit `speakerVoice` and set `style` to
+the voice-design prompt. OpenClaw sends that prompt as the TTS `user` message
+and does not send `audio.voice` for the voicedesign model.
+
+### Local Speech Swift and speech-core
+
+[Speech Swift](https://github.com/soniqo/speech-swift) and
+[speech-core](https://github.com/soniqo/speech-core) provide local speech
+inference across macOS, Linux, and Windows. Use the OpenAI-compatible HTTP
+provider when Speech Swift and OpenClaw run on the same Mac. Use Local CLI for
+direct executable integration on any supported host.
+
+Install `ffmpeg` when a channel needs OpenClaw to convert WAV output to Opus or
+raw PCM.
+
+<Tabs>
+  <Tab title="macOS HTTP">
+<Warning>
+This HTTP setup requires Speech Swift v0.0.23 or later. If Homebrew already
+installed an older version, run `brew update && brew upgrade speech` first.
+</Warning>
+
+Start Speech Swift's local server:
+
+```bash
+brew install speech
+speech-server --port 8080
+```
+
+Point the OpenAI speech provider at its loopback endpoint. `responseFormat`
+must be `wav` because the local endpoint does not emit compressed audio:
+
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "openai",
+    providers: {
+      openai: {
+        apiKey: "local",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "tts-1",
+        speakerVoice: "alloy",
+        responseFormat: "wav",
+      },
+    },
+  },
+}
+```
+
+`tts-1` selects Kokoro. Speech Swift registry aliases such as `qwen3-tts`,
+`cosyvoice`, and `voxcpm2` select other local engines. The placeholder API key
+is required by OpenClaw's provider configuration but is not validated by the
+loopback server.
+</Tab>
+<Tab title="macOS CLI">
+The Homebrew `speech` executable can write directly to OpenClaw's
+per-invocation output path:
+
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "tts-local-cli",
+    providers: {
+      "tts-local-cli": {
+        command: "speech",
+        args: ["speak", "{{Text}}", "--output", "{{OutputPath}}"],
+        outputFormat: "wav",
+        timeoutMs: 120000,
+      },
+    },
+  },
+}
+```
+
+  </Tab>
+  <Tab title="Linux CLI">
+Install a speech-core Linux release package, download the ONNX model set once,
+and verify synthesis before starting OpenClaw:
+
+```bash
+speech download-models
+speech speak "Hello from OpenClaw" hello.wav
+```
+
+Then configure the packaged Kokoro command:
+
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "tts-local-cli",
+    providers: {
+      "tts-local-cli": {
+        command: "speech",
+        args: ["speak", "{{Text}}", "{{OutputPath}}"],
+        outputFormat: "wav",
+        timeoutMs: 120000,
+      },
+    },
+  },
+}
+```
+
+See the [speech-core Linux CLI reference](https://github.com/soniqo/speech-core/blob/main/docs/cli.md)
+for release packages and model-directory settings.
+</Tab>
+<Tab title="Windows CLI">
+Download the speech-core Windows release, extract it, and install the ONNX
+models once:
+
+```powershell
+$Version = "0.0.11"
+$Url = "https://github.com/soniqo/speech-core/releases/download/v$Version/speech-$Version-windows-x64.zip"
+Invoke-WebRequest $Url -OutFile speech.zip
+Expand-Archive speech.zip
+Set-Location "speech\speech-$Version-windows-x64\bin"
+Set-ExecutionPolicy -Scope Process Bypass
+.\speech_download_models.ps1
+```
+
+Then point Local CLI at the packaged Kokoro executable:
+
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "tts-local-cli",
+    providers: {
+      "tts-local-cli": {
+        command: "C:\\path\\to\\speech-0.0.11-windows-x64\\bin\\speech_synthesize.exe",
+        args: ["{{OutputPath}}", "{{Text}}", "en"],
+        outputFormat: "wav",
+        timeoutMs: 120000,
+      },
+    },
+  },
+}
+```
+
+See the [speech-core Windows CLI reference](https://github.com/soniqo/speech-core/blob/main/docs/cli.md)
+for the packaged server, model cache, and standalone command syntax.
+
+  </Tab>
+</Tabs>
+
+### Per-agent voice overrides
+
+Use `agents.entries.*.tts` when one agent should speak with a different provider,
+voice, model, persona, or auto-TTS mode. The agent block deep-merges over
+`tts`, so provider credentials can stay in the global provider config:
+
+```json5
+{
+  tts: {
+    auto: "always",
+    provider: "elevenlabs",
+    providers: {
+      elevenlabs: { apiKey: "${ELEVENLABS_API_KEY}", model: "eleven_multilingual_v2" },
+    },
+  },
+  agents: {
+    entries: {
+      reader: {
+        default: true,
+        tts: {
+          providers: {
+            elevenlabs: { speakerVoiceId: "EXAVITQu4vr4xnSDxMaL" },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+To pin a per-agent persona, set `agents.entries.*.tts.persona` alongside provider
+config — it overrides the global `tts.persona` for that agent only.
+
+Precedence order for automatic replies, `/tts audio`, `/tts status`, and the
+`tts` agent tool:
+
+1. `tts`
+2. active `agents.entries.*.tts`
+3. channel override, when the channel supports `channels.<channel>.tts`
+4. account override, when the channel passes `channels.<channel>.accounts.<id>.tts`
+5. local `/tts` preferences for this host
+6. inline `[[tts:...]]` directives when [model overrides](/tools/tts/commands#model-driven-directives) are enabled
+
+Channel and account overrides use the same shape as `tts` and
+deep-merge over the earlier layers, so shared provider credentials can stay in
+`tts` while a channel or bot account changes only speaker voice, model, persona,
+or auto mode:
+
+```json5
+{
+  tts: {
+    provider: "openai",
+    providers: {
+      openai: { apiKey: "${OPENAI_API_KEY}", model: "gpt-4o-mini-tts" },
+    },
+  },
+  channels: {
+    feishu: {
+      accounts: {
+        english: {
+          tts: {
+            providers: {
+              openai: { speakerVoice: "shimmer" },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```

--- a/docs/tools/tts/field-reference.md
+++ b/docs/tools/tts/field-reference.md
@@ -1,0 +1,196 @@
+---
+summary: "Every tts.* and tts.providers.<id>.* configuration field"
+title: "Text-to-speech field reference"
+read_when:
+  - You need the type, default, or env var for one TTS field
+  - You are checking a legacy field alias
+  - You are validating a provider block
+---
+
+## Field reference
+
+<AccordionGroup>
+  <Accordion title="Top-level tts.*">
+    <ParamField path="auto" type='"off" | "always" | "inbound" | "tagged"'>
+      Auto-TTS mode. `inbound` only sends audio after an inbound voice message; `tagged` only sends audio when the reply includes `[[tts:...]]` directives or a `[[tts:text]]` block.
+    </ParamField>
+    <ParamField path="enabled" type="boolean" deprecated>
+      Legacy toggle. `openclaw doctor --fix` migrates this to `auto`.
+    </ParamField>
+    <ParamField path="mode" type='"final" | "all"' default="final">
+      `"all"` includes tool/block replies in addition to final replies.
+    </ParamField>
+    <ParamField path="provider" type="string">
+      Speech provider id. When unset, OpenClaw uses the first configured provider in registry auto-select order. Legacy `provider: "edge"` is rewritten to `"microsoft"` by `openclaw doctor --fix`.
+    </ParamField>
+    <ParamField path="persona" type="string">
+      Active persona id from `personas`. Normalized to lowercase.
+    </ParamField>
+    <ParamField path="personas.<id>" type="object">
+      Stable spoken identity. Fields: `label`, `description`, `provider`, `fallbackPolicy`, `providers.<provider>`. See [Personas](/tools/tts/personas#personas).
+    </ParamField>
+    <ParamField path="summaryModel" type="string">
+      Cheap model for auto-summary; defaults to `agents.defaults.model.primary`. Accepts `provider/model` or a configured model alias.
+    </ParamField>
+    <ParamField path="modelOverrides" type="object">
+      Allow the model to emit TTS directives. `enabled` defaults to `true`; `allowProvider` defaults to `false`.
+    </ParamField>
+    <ParamField path="providers.<id>" type="object">
+      Provider-owned settings keyed by speech provider id. Legacy direct blocks (`tts.openai`, `.elevenlabs`, `.microsoft`, `.edge`) are rewritten by `openclaw doctor --fix`; commit only `tts.providers.<id>`.
+    </ParamField>
+    <ParamField path="maxTextLength" type="number" default="4096">
+      Hard cap for TTS input characters. `/tts audio`, `tts.convert`, and `tts.speak` fail if exceeded.
+    </ParamField>
+    <ParamField path="timeoutMs" type="number" default="30000">
+      Request timeout in milliseconds. A per-call `timeoutMs` (agent tool, gateway) wins when set; otherwise an explicitly configured `tts.timeoutMs` wins over any plugin-authored provider default.
+    </ParamField>
+  </Accordion>
+
+Provider `apiKey` fields, including `personas.<id>.providers.<provider>.apiKey`,
+can be raw strings or SecretRefs in global, per-agent, and Discord voice TTS config.
+During cold Gateway startup, an unavailable TTS SecretRef marks the built-in TTS capability
+configured-unavailable instead of stopping the Gateway. `tts.speak` then returns
+`UNAVAILABLE` with reason `SECRET_SURFACE_UNAVAILABLE`, and no provider request is
+sent. Status and doctor list the degraded TTS owner and its config paths. The
+explicit refs remain in the runtime snapshot, so environment or profile
+credentials cannot silently select a different account. Reloads and config-write
+preflight apply the owner-aware degradation policy: an unchanged eligible TTS
+owner may keep its last-known-good credentials as stale, while a new or changed
+failure becomes cold without blocking healthy owners. Structurally invalid refs
+and resolved values still fail startup or reject the update.
+
+  <Accordion title="Azure Speech">
+    <ParamField path="apiKey" type="string">Env: `AZURE_SPEECH_KEY`, `AZURE_SPEECH_API_KEY`, or `SPEECH_KEY`.</ParamField>
+    <ParamField path="region" type="string">Azure Speech region (e.g. `eastus`). Env: `AZURE_SPEECH_REGION` or `SPEECH_REGION`.</ParamField>
+    <ParamField path="endpoint" type="string">Optional Azure Speech endpoint override (alias `baseUrl`).</ParamField>
+    <ParamField path="speakerVoice" type="string">Azure voice ShortName. Default `en-US-JennyNeural`. Legacy alias: `voice`.</ParamField>
+    <ParamField path="lang" type="string">SSML language code. Default `en-US`.</ParamField>
+    <ParamField path="outputFormat" type="string">Azure `X-Microsoft-OutputFormat` for standard audio. Default `audio-24khz-48kbitrate-mono-mp3`.</ParamField>
+    <ParamField path="voiceNoteOutputFormat" type="string">Azure `X-Microsoft-OutputFormat` for voice-note output. Default `ogg-24khz-16bit-mono-opus`.</ParamField>
+  </Accordion>
+
+  <Accordion title="ElevenLabs">
+    <ParamField path="apiKey" type="string">Falls back to `ELEVENLABS_API_KEY` or `XI_API_KEY`.</ParamField>
+    <ParamField path="model" type="string">Model id. Default `eleven_multilingual_v2`. Legacy ids `eleven_turbo_v2_5`/`eleven_turbo_v2` are normalized to the matching `flash` model.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">ElevenLabs voice id. Default `pMsXgVXv3BLzUgSXRplE`. Legacy alias: `voiceId`.</ParamField>
+    <ParamField path="voiceSettings" type="object">
+      `stability`, `similarityBoost`, `style` (each `0..1`, defaults `0.5`/`0.75`/`0`), `useSpeakerBoost` (`true|false`, default `true`), `speed` (`0.5..2.0`, default `1.0`).
+    </ParamField>
+    <ParamField path="applyTextNormalization" type='"auto" | "on" | "off"'>Text normalization mode.</ParamField>
+    <ParamField path="languageCode" type="string">2-letter ISO 639-1 (e.g. `en`, `de`).</ParamField>
+    <ParamField path="seed" type="number">Integer `0..4294967295` for best-effort determinism.</ParamField>
+    <ParamField path="baseUrl" type="string">Override ElevenLabs API base URL.</ParamField>
+  </Accordion>
+
+  <Accordion title="Google Gemini">
+    <ParamField path="apiKey" type="string">Falls back to `GEMINI_API_KEY` / `GOOGLE_API_KEY`. If omitted, TTS can reuse `models.providers.google.apiKey` before env fallback.</ParamField>
+    <ParamField path="model" type="string">Gemini TTS model. Default `gemini-3.1-flash-tts-preview`.</ParamField>
+    <ParamField path="speakerVoice" type="string">Gemini prebuilt voice name. Default `Kore`. Legacy aliases: `voiceName`, `voice`.</ParamField>
+    <ParamField path="audioProfile" type="string">Natural-language style prompt prepended before spoken text.</ParamField>
+    <ParamField path="speakerName" type="string">Optional speaker label prepended before spoken text when your prompt uses a named speaker.</ParamField>
+    <ParamField path="promptTemplate" type='"audio-profile-v1"'>Set to `audio-profile-v1` to wrap active persona prompt fields in a deterministic Gemini TTS prompt structure.</ParamField>
+    <ParamField path="personaPrompt" type="string">Google-specific extra persona prompt text appended to the template's Director's Notes.</ParamField>
+    <ParamField path="baseUrl" type="string">Only `https://generativelanguage.googleapis.com` is accepted.</ParamField>
+  </Accordion>
+
+  <Accordion title="Gradium">
+    <ParamField path="apiKey" type="string">Env: `GRADIUM_API_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">HTTPS Gradium API URL on `api.gradium.ai`. Default `https://api.gradium.ai`.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">Default Emma (`YTpq7expH9539ERJ`). Legacy alias: `voiceId`.</ParamField>
+  </Accordion>
+
+  <Accordion title="Inworld">
+    ### Inworld primary
+
+    <ParamField path="apiKey" type="string">Env: `INWORLD_API_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://api.inworld.ai`.</ParamField>
+    <ParamField path="modelId" type="string">Default `inworld-tts-1.5-max`. Also: `inworld-tts-1.5-mini`, `inworld-tts-1-max`, `inworld-tts-1`.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">Default `Sarah`. Legacy alias: `voiceId`.</ParamField>
+    <ParamField path="temperature" type="number">Sampling temperature `0..2` (exclusive of 0).</ParamField>
+
+  </Accordion>
+
+  <Accordion title="Local CLI (tts-local-cli)">
+    <ParamField path="command" type="string">Local executable or command string for CLI TTS.</ParamField>
+    <ParamField path="args" type="string[]">Command arguments. Supports `{{Text}}`, `{{OutputPath}}`, `{{OutputDir}}`, `{{OutputBase}}` placeholders.</ParamField>
+    <ParamField path="outputFormat" type='"mp3" | "opus" | "wav"'>Expected CLI output format. Default `mp3` for audio attachments.</ParamField>
+    <ParamField path="timeoutMs" type="number">Command timeout in milliseconds. Overrides the resolved TTS request timeout when set. When omitted, follows the request timeout; the plugin default is `120000`.</ParamField>
+    <ParamField path="cwd" type="string">Optional command working directory.</ParamField>
+    <ParamField path="env" type="Record<string, string>">Optional environment overrides for the command.</ParamField>
+
+    Command stdout and generated or converted audio are limited to 50 MiB. Diagnostic stderr is limited to 1 MiB. OpenClaw terminates the command and fails synthesis when either limit is exceeded.
+
+  </Accordion>
+
+  <Accordion title="Microsoft (no API key)">
+    <ParamField path="enabled" type="boolean" default="true">Allow Microsoft speech usage.</ParamField>
+    <ParamField path="speakerVoice" type="string">Microsoft neural voice name (e.g. `en-US-MichelleNeural`). Legacy alias: `voice`. If the default English voice is in effect and reply text is CJK-dominant, OpenClaw auto-switches to `zh-CN-XiaoxiaoNeural`.</ParamField>
+    <ParamField path="lang" type="string">Language code (e.g. `en-US`).</ParamField>
+    <ParamField path="outputFormat" type="string">Microsoft output format. Default `audio-24khz-48kbitrate-mono-mp3`. Not all formats are supported by the bundled Edge-backed transport.</ParamField>
+    <ParamField path="rate / pitch / volume" type="string">Percent strings (e.g. `+10%`, `-5%`).</ParamField>
+    <ParamField path="saveSubtitles" type="boolean">Write JSON subtitles alongside the audio file.</ParamField>
+    <ParamField path="proxy" type="string">Proxy URL for Microsoft speech requests.</ParamField>
+    <ParamField path="timeoutMs" type="number">Request timeout override (ms).</ParamField>
+    <ParamField path="edge.*" type="object" deprecated>Legacy alias. Run `openclaw doctor --fix` to rewrite persisted config to `providers.microsoft`.</ParamField>
+  </Accordion>
+
+  <Accordion title="MiniMax">
+    <ParamField path="apiKey" type="string">Falls back to `MINIMAX_API_KEY`. Token Plan auth via `MINIMAX_OAUTH_TOKEN`, `MINIMAX_CODE_PLAN_KEY`, or `MINIMAX_CODING_API_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://api.minimax.io`. Env: `MINIMAX_API_HOST`.</ParamField>
+    <ParamField path="model" type="string">Default `speech-2.8-hd`. Env: `MINIMAX_TTS_MODEL`.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">Default `English_expressive_narrator`. Env: `MINIMAX_TTS_VOICE_ID`. Legacy alias: `voiceId`.</ParamField>
+    <ParamField path="speed" type="number">`0.5..2.0`. Default `1.0`.</ParamField>
+    <ParamField path="vol" type="number">`(0, 10]`. Default `1.0`.</ParamField>
+    <ParamField path="pitch" type="number">Integer `-12..12`. Default `0`. Fractional values are truncated before the request.</ParamField>
+  </Accordion>
+
+  <Accordion title="OpenAI">
+    <ParamField path="apiKey" type="string">Falls back to `OPENAI_API_KEY`.</ParamField>
+    <ParamField path="model" type="string">OpenAI TTS model id. Default `gpt-4o-mini-tts`.</ParamField>
+    <ParamField path="speakerVoice" type="string">Voice name (e.g. `alloy`, `cedar`). Default `coral`. Legacy alias: `voice`.</ParamField>
+    <ParamField path="instructions" type="string">Explicit OpenAI `instructions` field. When set, persona prompt fields are **not** auto-mapped.</ParamField>
+    <ParamField path="responseFormat" type='"mp3" | "opus" | "wav"'>Explicit response format. When omitted, OpenClaw selects Opus for voice-note targets and MP3 otherwise. Use `wav` for compatible local endpoints that do not encode compressed audio.</ParamField>
+    <ParamField path="extraBody / extra_body" type="Record<string, unknown>">Extra JSON fields merged into `/audio/speech` request bodies after generated OpenAI TTS fields. Use this for OpenAI-compatible endpoints such as Kokoro that require provider-specific keys like `lang`; unsafe prototype keys are ignored.</ParamField>
+    <ParamField path="baseUrl" type="string">
+      Override the OpenAI TTS endpoint. Resolution order: config → `OPENAI_TTS_BASE_URL` → `https://api.openai.com/v1`. Non-default values are treated as OpenAI-compatible TTS endpoints, so custom model and voice names are accepted, and `speed` loses its `0.25..4.0` range check.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="OpenRouter">
+    <ParamField path="apiKey" type="string">Env: `OPENROUTER_API_KEY`. Can reuse `models.providers.openrouter.apiKey`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://openrouter.ai/api/v1`. Legacy `https://openrouter.ai/v1` is normalized.</ParamField>
+    <ParamField path="model" type="string">Default `hexgrad/kokoro-82m`. Alias: `modelId`.</ParamField>
+    <ParamField path="speakerVoice" type="string">Default `af_alloy`. Legacy aliases: `voice`, `voiceId`.</ParamField>
+    <ParamField path="responseFormat" type='"mp3" | "pcm"'>Default `mp3`.</ParamField>
+    <ParamField path="speed" type="number">Provider-native speed override.</ParamField>
+  </Accordion>
+
+  <Accordion title="Volcengine (BytePlus Seed Speech)">
+    <ParamField path="apiKey" type="string">Env: `VOLCENGINE_TTS_API_KEY` or `BYTEPLUS_SEED_SPEECH_API_KEY`.</ParamField>
+    <ParamField path="resourceId" type="string">Default `seed-tts-1.0`. Env: `VOLCENGINE_TTS_RESOURCE_ID`. Use `seed-tts-2.0` when your project has TTS 2.0 entitlement.</ParamField>
+    <ParamField path="appKey" type="string">App key header. Default `aGjiRDfUWi`. Env: `VOLCENGINE_TTS_APP_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">Override the Seed Speech TTS HTTP endpoint. Env: `VOLCENGINE_TTS_BASE_URL`.</ParamField>
+    <ParamField path="speakerVoice" type="string">Voice type. Default `en_female_anna_mars_bigtts`. Env: `VOLCENGINE_TTS_VOICE`. Legacy alias: `voice`.</ParamField>
+    <ParamField path="speedRatio" type="number">Provider-native speed ratio, `0.2..3`.</ParamField>
+    <ParamField path="emotion" type="string">Provider-native emotion tag.</ParamField>
+    <ParamField path="appId / token / cluster" type="string" deprecated>Legacy Volcengine Speech Console fields. Env: `VOLCENGINE_TTS_APPID`, `VOLCENGINE_TTS_TOKEN`, `VOLCENGINE_TTS_CLUSTER` (default `volcano_tts`).</ParamField>
+  </Accordion>
+
+  <Accordion title="xAI">
+    <ParamField path="apiKey" type="string">Env: `XAI_API_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://api.x.ai/v1`. Env: `XAI_BASE_URL`.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">Default `eve`. With auth, `openclaw infer tts voices --provider xai` fetches the current built-in catalog; without auth it lists offline fallbacks `ara`, `eve`, `leo`, `rex`, and `sal`. Account custom voice IDs are forwarded even when absent from the built-in list. Legacy alias: `voiceId`.</ParamField>
+    <ParamField path="language" type="string">BCP-47 language code or `auto`. Default `en`.</ParamField>
+    <ParamField path="responseFormat" type='"mp3" | "wav" | "pcm" | "mulaw" | "alaw"'>Default `mp3`.</ParamField>
+    <ParamField path="speed" type="number">Provider-native speed override, `0.7..1.5`.</ParamField>
+  </Accordion>
+
+  <Accordion title="Xiaomi MiMo">
+    <ParamField path="apiKey" type="string">Env: `XIAOMI_API_KEY`.</ParamField>
+    <ParamField path="baseUrl" type="string">Default `https://api.xiaomimimo.com/v1`. Env: `XIAOMI_BASE_URL`.</ParamField>
+    <ParamField path="model" type="string">Default `mimo-v2.5-tts`. Env: `XIAOMI_TTS_MODEL`. Also supports `mimo-v2.5-tts-voicedesign`.</ParamField>
+    <ParamField path="speakerVoice" type="string">Default `mimo_default` for preset-voice models. Env: `XIAOMI_TTS_VOICE`. Legacy alias: `voice`. Not sent for `mimo-v2.5-tts-voicedesign`.</ParamField>
+    <ParamField path="format" type='"mp3" | "wav"'>Default `mp3`. Env: `XIAOMI_TTS_FORMAT`.</ParamField>
+    <ParamField path="style" type="string">Optional natural-language style instruction sent as the user message; not spoken. For `mimo-v2.5-tts-voicedesign`, this is the voice-design prompt; OpenClaw supplies a default when omitted.</ParamField>
+  </Accordion>
+</AccordionGroup>

--- a/docs/tools/tts/output.md
+++ b/docs/tools/tts/output.md
@@ -1,0 +1,101 @@
+---
+summary: "Per-channel audio formats, transcoding, and what Auto-TTS sends"
+title: "Text-to-speech output and Auto-TTS behavior"
+read_when:
+  - You need the audio format a channel receives
+  - You are debugging voice-note delivery or transcoding
+  - You want to know when Auto-TTS summarizes or truncates a reply
+---
+
+## Output formats
+
+TTS voice delivery is channel-capability driven. Channel plugins advertise
+whether voice-style TTS should ask providers for a native `voice-note` target or
+keep normal `audio-file` synthesis, and whether the channel transcodes
+non-native output before sending.
+
+One-off speech requests from the agent tool and `/tts` commands use the same
+channel delivery rules as automatic replies.
+
+Telegram also advertises captioned final TTS. With `tts.mode: "final"` and
+Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
+until synthesis finishes and sent as the voice-note caption. Text beyond
+Telegram's caption limit follows the voice note as a normal text message. If
+synthesis or a proven pre-send delivery step fails, OpenClaw sends the visible
+text instead. `tagged` mode keeps its normal streaming behavior, and text
+inside a `[[tts:text]]` block remains audio-only.
+
+After synthesis, OpenClaw persists batch TTS output in the media store under
+`tool-speech-synthesis`. The reply uses that stable media path instead of a
+provider temporary file, and normal media maintenance prunes expired output.
+Local CLI providers may still use `{{OutputPath}}` as scratch space before
+OpenClaw imports the completed bytes. See [Media playback](/nodes/media-playback)
+for inline-player formats and limits.
+
+| Target                                | Format                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Feishu / Matrix / Telegram / WhatsApp | Voice-note replies prefer **Opus** (`opus_48000_64` from ElevenLabs, `opus` from OpenAI). 48 kHz / 64 kbps balances clarity and size. |
+| Other channels                        | **MP3** (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI). 44.1 kHz / 128 kbps is the default balance for speech.                  |
+| Talk / telephony                      | Provider-native **PCM** (Inworld 22050 Hz, Google 24 kHz), or `ulaw_8000` from Gradium for telephony.                                 |
+
+Per-provider notes:
+
+- **Feishu / WhatsApp transcoding:** when a voice-note reply lands as MP3/WebM/WAV/M4A or another likely audio file, the channel plugin transcodes it to 48 kHz Ogg/Opus with `ffmpeg` (`libopus`, 64 kbps) before sending the native voice message. WhatsApp sends the result through the Baileys `audio` payload with `ptt: true` and `audio/ogg; codecs=opus`. On transcode failure: Feishu catches the error and falls back to sending the original file as a plain attachment; WhatsApp has no fallback, so the send itself fails rather than posting an incompatible PTT payload.
+- **MiniMax:** MP3 (`speech-2.8-hd` model, 32 kHz sample rate) for normal audio attachments; transcoded to 48 kHz Opus with `ffmpeg` for channel-advertised voice-note targets.
+- **Xiaomi MiMo:** MP3 by default, or WAV when configured; transcoded to 48 kHz Opus with `ffmpeg` for channel-advertised voice-note targets.
+- **Local CLI:** uses the configured `outputFormat`. Voice-note targets are converted to Ogg/Opus and telephony output is converted to raw 16 kHz mono PCM with `ffmpeg`.
+- **Google Gemini:** returns raw 24 kHz PCM. OpenClaw wraps it as WAV for audio attachments, transcodes it to 48 kHz Opus for voice-note targets, and returns PCM directly for Talk/telephony.
+- **Gradium:** WAV for audio attachments, Opus for voice-note targets, and `ulaw_8000` at 8 kHz for telephony.
+- **Inworld:** MP3 for normal audio attachments, native `OGG_OPUS` for voice-note targets, and raw `PCM` at 22050 Hz for Talk/telephony.
+- **xAI:** MP3 by default; audio-file synthesis may use `mp3`, `wav`, `pcm`, `mulaw`, or `alaw` for both buffered and streaming output. Voice-note targets use MP3 for streaming and buffered fallback because xAI's `pcm`, `mulaw`, and `alaw` outputs are headerless raw audio. Buffered synthesis uses xAI's batch REST `/v1/tts` endpoint; `textToSpeechStream` uses native `wss://api.x.ai/v1/tts`. This is not the realtime voice contract. Native Opus voice-note format is not supported.
+- **Microsoft:** uses `microsoft.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
+  - The bundled transport accepts an `outputFormat`, but not all formats are available from the service.
+  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus).
+  - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need guaranteed Opus voice messages.
+  - If the configured Microsoft output format fails, OpenClaw retries with MP3.
+  - When no explicit voice override is set and the default English voice is used, OpenClaw auto-switches to a Chinese neural voice (`zh-CN-XiaoxiaoNeural`, `zh-CN` locale) if the reply text is CJK-dominant.
+
+OpenAI and ElevenLabs choose output formats per channel as listed above. An
+explicit OpenAI `responseFormat` overrides that selection; a format that is not
+voice-note compatible may be delivered as an audio file or transcoded by a
+channel that supports conversion.
+
+## Auto-TTS behavior
+
+When `tts.auto` is enabled, OpenClaw:
+
+- Keeps terminal slash and plugin command replies text-only, including with
+  `auto: "always"`. Explicit speech requests such as `/tts audio` and `/tts latest`
+  still send audio. Commands that continue into an assistant run keep the normal
+  auto-TTS behavior for the assistant's answer.
+- Skips TTS if the reply already contains structured media.
+- Skips very short replies (under 10 chars).
+- Skips replies dominated by fenced code; inline code and surrounding prose remain eligible for speech.
+- Summarizes long replies when summaries are enabled, using
+  `summaryModel` (or `agents.defaults.model.primary`).
+- Attaches the generated audio to the reply.
+- In `mode: "final"`, sends TTS after streamed text completes. Channels without
+  captioned-final support receive an audio-only supplement; Telegram puts text
+  within its caption limit on the voice note and sends overflow as follow-up
+  text. Generated media goes through the same channel media normalization as
+  normal reply attachments.
+
+If the reply exceeds `maxLength`, OpenClaw never skips audio outright:
+
+- **Summary on** (default) and a summary model is available: summarizes the
+  text to roughly `maxLength` chars, then synthesizes the summary.
+- **Summary off**, summarization fails, or no API key is available for the
+  summary model: truncates the text to `maxLength` chars and synthesizes the
+  truncated text.
+
+```text
+Reply -> TTS enabled?
+  no  -> send text
+  yes -> has media / short?
+          yes -> send text
+          no  -> length > limit?
+                   no  -> TTS -> attach audio
+                   yes -> summary enabled and available?
+                            no  -> truncate -> TTS -> attach audio
+                            yes -> summarize -> TTS -> attach audio
+```

--- a/docs/tools/tts/personas.md
+++ b/docs/tools/tts/personas.md
@@ -1,0 +1,129 @@
+---
+summary: "Persona definitions, provider bindings, resolution order, and fallback policy"
+title: "Text-to-speech personas"
+read_when:
+  - You want one stable spoken identity across providers
+  - You need the persona and provider resolution order
+  - You are choosing a persona fallback policy
+---
+
+## Personas
+
+A **persona** is a stable spoken identity that can be applied deterministically
+across providers. It can prefer one provider, define provider-neutral prompt
+intent, and carry provider-specific bindings for voices, models, prompt
+templates, seeds, and voice settings.
+
+### Minimal persona
+
+```json5
+{
+  tts: {
+    auto: "always",
+    persona: "narrator",
+    personas: {
+      narrator: {
+        label: "Narrator",
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            speakerVoiceId: "EXAVITQu4vr4xnSDxMaL",
+            modelId: "eleven_multilingual_v2",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### Full persona (provider-specific shaping)
+
+```json5
+{
+  tts: {
+    auto: "always",
+    persona: "alfred",
+    personas: {
+      alfred: {
+        label: "Alfred",
+        description: "Dry, warm British butler narrator.",
+        provider: "google",
+        fallbackPolicy: "preserve-persona",
+        providers: {
+          google: {
+            model: "gemini-3.1-flash-tts-preview",
+            speakerVoice: "Algieba",
+            promptTemplate: "audio-profile-v1",
+          },
+          openai: { model: "gpt-4o-mini-tts", speakerVoice: "cedar" },
+          elevenlabs: {
+            speakerVoiceId: "voice_id",
+            modelId: "eleven_multilingual_v2",
+            seed: 42,
+            voiceSettings: {
+              stability: 0.65,
+              similarityBoost: 0.8,
+              style: 0.25,
+              useSpeakerBoost: true,
+              speed: 0.95,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### Persona resolution
+
+The active persona is selected deterministically:
+
+1. `/tts persona <id>` local preference, if set.
+2. `tts.persona`, if set.
+3. No persona.
+
+Provider selection runs explicit-first:
+
+1. Direct overrides (CLI, gateway, Talk, allowed TTS directives).
+2. `/tts provider <id>` local preference.
+3. Active persona's `provider`.
+4. `tts.provider`.
+5. Registry auto-select.
+
+For each provider attempt, OpenClaw merges configs in this order:
+
+1. `tts.providers.<id>`
+2. `tts.personas.<persona>.providers.<id>`
+3. Trusted request overrides
+4. Allowed model-emitted TTS directive overrides
+
+### Custom persona shaping
+
+Provider-neutral `personas.<id>.prompt.*` config is retired. Doctor removes
+those fields and points to the speech-provider seam. Put built-in provider
+settings under `personas.<id>.providers.<provider>` (for example Google
+`personaPrompt` or OpenAI `instructions`). For custom shaping, implement a
+speech provider plugin with `prepareSynthesis(ctx)` and return adjusted text,
+provider config, or overrides before `synthesize()` runs. This keeps expressive
+prompt construction in provider code where request semantics are known.
+
+### Fallback policy
+
+`fallbackPolicy` controls behavior when a persona has **no binding** for the
+attempted provider:
+
+| Policy              | Behavior                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `preserve-persona`  | **Default.** Provider-neutral prompt fields stay available; the provider may use them or ignore them.                                            |
+| `provider-defaults` | Persona is omitted from prompt preparation for that attempt; the provider uses its neutral defaults while fallback to other providers continues. |
+| `fail`              | Skip that provider attempt with `reasonCode: "not_configured"` and `personaBinding: "missing"`. Fallback providers are still tried.              |
+
+The whole TTS request only fails when **every** attempted provider is skipped
+or fails.
+
+Talk session provider selection is session-scoped. A Talk client should choose
+provider ids, model ids, voice ids, and locales from `talk.catalog` and pass
+them through the Talk session or handoff request. Opening a voice session should
+not mutate `tts` or global Talk provider defaults.

--- a/docs/tools/tts/quickstart.md
+++ b/docs/tools/tts/quickstart.md
@@ -1,0 +1,81 @@
+---
+summary: "Turn on text-to-speech, pick a provider, and send a first audio reply"
+title: "Text-to-speech quickstart"
+read_when:
+  - You are enabling text-to-speech for the first time
+  - You need the list of supported speech providers and their auth env vars
+  - You want to confirm TTS works from chat
+---
+
+## Quick start
+
+<Steps>
+  <Step title="Pick a provider">
+    OpenAI and ElevenLabs are the most reliable hosted options. Microsoft and
+    Local CLI work without an API key. See the [provider matrix](#supported-providers)
+    for the full list.
+  </Step>
+  <Step title="Set the API key">
+    Export the env var for your provider (for example `OPENAI_API_KEY`,
+    `ELEVENLABS_API_KEY`). Microsoft and Local CLI need no key.
+  </Step>
+  <Step title="Enable in config">
+    Set `tts.auto: "always"` and `tts.provider`:
+
+    ```json5
+    {
+      tts: {
+        auto: "always",
+        provider: "elevenlabs",
+      },
+    }
+    ```
+
+  </Step>
+  <Step title="Try it in chat">
+    `/tts status` shows the current state. `/tts audio Hello from OpenClaw`
+    sends a one-off audio reply.
+  </Step>
+</Steps>
+
+<Note>
+Auto-TTS is **off** by default. When `tts.provider` is unset,
+OpenClaw picks the first configured provider in registry auto-select order.
+The built-in `tts` agent tool is explicit-intent only: ordinary chat stays
+text unless the user asks for audio, uses `/tts`, or enables Auto-TTS/directive
+speech.
+</Note>
+
+## Supported providers
+
+| Provider          | Auth                                                                                                             | Notes                                                                                       |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Azure Speech**  | `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` (also `AZURE_SPEECH_API_KEY`, `SPEECH_KEY`, `SPEECH_REGION`)          | Native Ogg/Opus voice-note output and telephony.                                            |
+| **DeepInfra**     | `DEEPINFRA_API_KEY`                                                                                              | OpenAI-compatible TTS. Defaults to `hexgrad/Kokoro-82M`.                                    |
+| **ElevenLabs**    | `ELEVENLABS_API_KEY` or `XI_API_KEY`                                                                             | Voice cloning, multilingual, deterministic via `seed`; streamed for Discord voice playback. |
+| **Fish Audio**    | `FISH_API_KEY` or `FISH_AUDIO_API_KEY`                                                                           | S2.1 hosted TTS, expressive tags, voice discovery, streaming, and telephony.                |
+| **Google Gemini** | `GEMINI_API_KEY` or `GOOGLE_API_KEY`                                                                             | Gemini API batch TTS; persona-aware via `promptTemplate: "audio-profile-v1"`.               |
+| **Gradium**       | `GRADIUM_API_KEY`                                                                                                | Voice-note and telephony output.                                                            |
+| **Inworld**       | `INWORLD_API_KEY`                                                                                                | Streaming TTS API. Native Opus voice-note and PCM telephony.                                |
+| **Local CLI**     | none                                                                                                             | Runs a configured local TTS command.                                                        |
+| **Microsoft**     | none                                                                                                             | Public Edge neural TTS via `node-edge-tts`. Best-effort, no SLA.                            |
+| **MiniMax**       | `MINIMAX_API_KEY` (or Token Plan: `MINIMAX_OAUTH_TOKEN`, `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`)      | T2A v2 API. Defaults to `speech-2.8-hd`.                                                    |
+| **OpenAI**        | `OPENAI_API_KEY`                                                                                                 | Also used for auto-summary; supports persona `instructions`.                                |
+| **OpenRouter**    | `OPENROUTER_API_KEY` (can reuse `models.providers.openrouter.apiKey`)                                            | Default model `hexgrad/kokoro-82m`.                                                         |
+| **Volcengine**    | `VOLCENGINE_TTS_API_KEY` or `BYTEPLUS_SEED_SPEECH_API_KEY` (legacy AppID/token: `VOLCENGINE_TTS_APPID`/`_TOKEN`) | BytePlus Seed Speech HTTP API.                                                              |
+| **Vydra**         | `VYDRA_API_KEY`                                                                                                  | Shared image, video, and speech provider.                                                   |
+| **xAI**           | `XAI_API_KEY`                                                                                                    | xAI batch TTS. Native Opus voice-note is **not** supported.                                 |
+| **Xiaomi MiMo**   | `XIAOMI_API_KEY`                                                                                                 | MiMo TTS through Xiaomi chat completions.                                                   |
+
+If multiple providers are configured, the selected one is used first and the
+others are fallback options. Auto-summary uses `summaryModel` (or
+`agents.defaults.model.primary`), so that provider must also be authenticated
+if you keep summaries enabled.
+
+<Warning>
+The bundled **Microsoft** provider uses Microsoft Edge's online neural TTS
+service via `node-edge-tts`. It is a public web service without a published
+SLA or quota — treat it as best-effort. The legacy provider id `edge` is
+normalized to `microsoft` and `openclaw doctor --fix` rewrites persisted
+config; new configs should always use `microsoft`.
+</Warning>


### PR DESCRIPTION
## What

`docs/tools/tts.md` was **52,867 characters** — well over the 20k threshold. This splits it into `docs/tools/tts/` with seven children, one per reader job, and keeps the parent as an index.

Shape matches the sibling precedent `docs/tools/code-mode/`, which is on `main` (verified with `test -d`, not an open PR): index frontmatter + lede, a "Page / Read it when" table, `## Where each section moved` anchor stubs, `## Related` last.

| Page | Chars |
| --- | --- |
| `docs/tools/tts.md` (index) | 19,672 |
| `tts/quickstart.md` — Quick start, Supported providers | 6,234 |
| `tts/configuration.md` — Configuration, Local Speech Swift/speech-core, Per-agent voice overrides | 11,592 |
| `tts/personas.md` — Personas and resolution/fallback | 4,416 |
| `tts/commands.md` — Model-driven directives, Slash commands, Per-user preferences | 4,818 |
| `tts/output.md` — Output formats, Auto-TTS behavior | 7,326 |
| `tts/field-reference.md` — the `tts.*` field reference | 16,637 |
| `tts/api.md` — Agent tool, Gateway RPC | 1,700 |

Every page is under 20k. The index is 19,672 because ~11.5k of it is the anchor-compatibility block described below — machine-facing, clearly demarcated, and a direct function of how many anchors the original page minted. The index's actual reader content is ~8k.

### Two size decisions, stated deliberately

- **The 16-row provider matrix stays whole** on `quickstart.md`. Splitting a lookup table to satisfy a character budget makes it useless; the quick start's own "See the [provider matrix](#supported-providers)" also stays an in-page link this way.
- **`field-reference.md` keeps the whole `<AccordionGroup>`** (16,637 chars). It is one lookup structure, and — see anchors below — keeping it intact is what preserves 111 `param-*` anchor ids with their disambiguating counters.

## Losslessness, proven

Children are verbatim contiguous slices of the original at **unchanged heading levels** (every child's top level is `##`, as in the original), so no heading-level restoration is needed and no ledes were added.

Reassembling `lede + 7 children + Service links + Related` in document order and diffing against the original body:

```
original body sha256   : 858a1e28bfe740fe792dccbb75f69185c11dd383830fcfb1546ff16194594a1c
unified diff vs reassembly: 2 changed lines (both declared below)
reassembly with those 2 edits reverted == original body: True
fenced blocks: 31 -> 31, identical on info string + body sha256
table rows: 45 -> 45
words: 5,466 -> 6,715 (grew only)
```

### The entire prose diff

Exactly two lines, both in-page anchors that became cross-page. `redirectSource()` in `scripts/lib/docs-redirects.mjs` throws on any source containing `[?#]`, so per-anchor redirects are impossible and these had to be rewritten in place:

- `configuration.md` — `[model overrides](#model-driven-directives)` → `(/tools/tts/commands#model-driven-directives)`
- `field-reference.md` — `See [Personas](#personas).` → `(/tools/tts/personas#personas)`

`python3 .audit/check-orphan-refs.py` finds two directional references; both stayed on the page holding their target and needed no change:

- `configuration.md:14` "shown below" → the provider tabs, same page
- `output.md:57` "listed above" → the format table, same page

## Anchors: 156/156 preserved

Ids were enumerated with the repo's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`), not a slug approximation.

- **156** pre-split ids; **156** resolve on the index.
- **2** are still published by the index itself and are therefore *not* stubbed (`service-links`, `related`) — a stub would be a duplicate authored/canonical id.
- **154** are authored `<a id="…" />` stubs: 21 section-level (in `## Where each section moved`) and 133 component-level (in `## Component anchors`). Each stub links to its real destination, labelled from the component's own `title`/`path` attribute (`Gradium → apiKey`, not `param-api-key-3`), so a reader who lands on an old deep link sees where to go.
- **Collisions are empty on all eight pages.**

Two cases worth flagging:

1. **Dual ids on a punctuated heading.** `### Full persona (provider-specific shaping)` mints both `full-persona-(provider-specific-shaping)` and the cleaned `full-persona-provider-specific-shaping`. Both are stubbed. `format-docs` rewrote the parenthesised destination as an angle-bracket URL, which is why that one line looks different.
2. **Nine accordion ids lost a `-1` suffix.** Pre-split, `<Tab title="Azure Speech">` took `azure-speech` and the later `<Accordion title="Azure Speech">` was pushed to `azure-speech-1`. The tab and the accordion now live on different pages, so the accordion takes the bare slug. The nine orphaned ids — `azure-speech-1`, `elevenlabs-1`, `google-gemini-1`, `gradium-1`, `inworld-1`, `minimax-1`, `openrouter-1`, `xai-1`, `xiaomi-mimo-1` — are stubbed on the index pointing at their new bare-slug anchors. This is also why the whole `AccordionGroup` had to stay on one page: splitting it would have shifted the 111 `param-*` counters too.

## Pins: all 58 `git grep "tools/tts"` hits classified

Ran both `python3 .audit/docs-test-pins.py` (7 "tests") and an independent `git grep -n "tools/tts" origin/main` with no path filter (58 hits). The script's "test(s)" label is loose — most of what it lists is not a test.

- **32 hits are not docs routes at all**: `src/agents/tools/tts-tool*.ts` module specifiers plus `config/assertion-safety-baseline.txt` and `qa/scenarios/runtime/tools/tts.yaml`, which reference that source file. No action.
- **16 route references to `/tools/tts` with no fragment** (whatsapp, media-playback, voice-call, azure-speech, elevenlabs, gradium ×2, inworld, media-overview ×2, slash-commands, generated `maturity/taxonomy.md` ×2, and two `docs.json` redirect destinations). All still land on the index. No action.
- **2 route references with a fragment**, the ones that actually mattered:
  - `docs/gateway/config-agents/entries-and-multi-agent.md:21` → `/tools/tts#per-agent-voice-overrides`. Resolves via the index stub.
  - `docs/providers/inworld.md:79` → `/tools/tts#inworld-primary`. Resolves via the index stub. (See "refuted finding" below.)
- **5 `docsPath: "/tools/tts"` in `src/commands/doctor/shared/deprecation-compat.ts`** and **1 URL in `src/config/schema.hints.ts`** — routes, still resolve to the index. No action.
- **`taxonomy.yaml` ×2** (`3798`, `10541`) list `docs/tools/tts.md` as a file path with **no `#anchor`**; the index file still exists, so both still resolve. Left untouched — `taxonomy.yaml` has no entry for the `code-mode` children either, so adding them would be a new convention, and it keeps generated `docs/maturity/taxonomy.md` churn-free.
- **`qa/scenarios/media/*.yaml` ×2** and **`test/e2e/qa-lab/runtime/media-talk-gateway.ts` ×2** carry `docs/tools/tts.md` as `docsRefs` metadata. I checked the qa-lab file specifically for the `sdk-subpaths.md` refusal condition: its only `readFile` is `readJsonLines`, which reads JSONL event logs, and `docsRefs` is passed through to the scenario record at line 822. **No contract test reads the page and asserts literal strings, so the split is not refused.**
- **`.github/labeler.yml` ×3** glob `docs/tools/tts.md` to label PRs `plugin: azure-speech`, `extensions: fish-audio`, `extensions: tts-local-cli`. The provider content those labels track now lives in the children, so I added `docs/tools/tts/**` alongside each existing glob. This is the one behavioural change in the PR and it preserves existing labelling rather than extending it.

## Nav and i18n

- `docs/docs.json`: added a nested `{"group": "Text to speech", "pages": [...]}` after `tools/tts` in **Media and documents**, exactly mirroring how `tools/code-mode` is listed.
- `docs/.i18n/glossary.zh-CN.json`: +7 entries for the new child titles (the `code-mode` split added its 8 the same way). Verified 0 duplicate `source` values.

`tools/tts` is also cross-listed under **Media capabilities** in the nodes section — the nav lists the page in two groups. That is pre-existing and out of scope here; the second entry still points at the index.

## Validators

All run on the **staged** tree.

| Check | Result |
| --- | --- |
| `node scripts/check-docs-mdx.mjs docs README.md` | pass (1041 files) |
| `node scripts/docs-link-audit.mjs` | `broken_links=0` (10,626 internal links) |
| `node scripts/docs-link-audit.mjs --anchors` | `broken_links=42` — **all pre-existing**, see below |
| `npx tsx scripts/format-docs.mts --check` | clean (1028 files) |
| `npx tsx scripts/check-docs-i18n-glossary.mts` | pass |
| `npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc` | **0 issues in 0 files** (1027 files) |
| `node scripts/check-docs-config-examples.mjs` | pass |
| `npx vitest --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts src/docs/` | 24 passed, 1 failed — **pre-existing** |

Both failures were **reproduced at the base sha** (`31aa554`) in a detached worktree rather than assumed:

- `--anchors`: the failing set is **byte-identical** between base and this branch (`diff` of the sorted failure lines is empty). None of the 42 mention TTS. They are 39 `/clawhub*` route failures plus 3 `maturity/#windows-app-node`.
- vitest: same single failure at base and on the branch — `docs-link-audit > preserves Mint component targets for raw component apostrophes normalized af…`, an `ass-guide`/`as-s-guide` slug assertion unrelated to this change.

## CODEOWNERS

Simulated last-match-wins with working controls. The controls resolve (`docs/security/overview.md` → `@openclaw/openclaw-secops`; `docs/gateway/secrets.md` → `@openclaw/openclaw-secops`; `docs/reference/RELEASING.md` → `@openclaw/openclaw-release-managers`), so the simulation is live rather than vacuously empty.

**No maintainer team owns any path in this PR** — not the index, not the seven children, not `docs/docs.json`, `docs/.i18n/glossary.zh-CN.json`, or `.github/labeler.yml`. `docs/tools/code-mode/output.md` is likewise unowned, consistent with the precedent.

## A refuted ledger finding

Ledger `r3-2191` (minor/link, open) says `docs/providers/inworld.md:79` links to `/tools/tts#inworld-primary` and that the anchor "does not exist". **That is wrong on `origin/main`.** `### Inworld primary` is indented inside the Inworld `<Accordion>`, so a `^#` grep misses it, but `parseDocsDocument` mints `inworld-primary` and the anchor auditor reports no failure for that link at the base sha. The anchor existed before this PR and still resolves after it.
