### PR TITLE
refactor(media): remove unused audio recipe argument

### DIFF
--- a/src/media/audio-transcode.ts
+++ b/src/media/audio-transcode.ts
@@ -145,7 +145,7 @@ export async function transcodeAudioBuffer(params: {
   if (source === target) {
     return { ok: false, reason: "noop-same-container" };
   }
-  const recipe = pickAfconvertRecipe(source, target);
+  const recipe = pickAfconvertRecipe(target);
   if (!recipe) {
     return { ok: false, reason: "no-recipe" };
   }
@@ -181,7 +181,7 @@ function normalizeContainerExt(ext: string): string | undefined {
   return /^[a-z0-9]{1,12}$/.test(trimmed) ? trimmed : undefined;
 }
 
-function pickAfconvertRecipe(_source: string, target: string): string[] | undefined {
+function pickAfconvertRecipe(target: string): string[] | undefined {
   if (target === "caf") {
     // Opus-in-CAF matches native Messages voice memo attachments.
     return ["-f", "caff", "-d", "opus@24000", "-c", "1"];


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch through repository permissions.

</details>

## What Problem This Solves

Maintainer-requested dead-code cleanup: the private audio recipe selector accepts an unused source-extension argument. This is a mechanical refactor, not a user-facing bug fix.

## Why This Change Was Made

Remove the unused parameter and its sole call-site argument. Keep source-extension validation, same-container handling, target recipe selection, converter invocation, and temporary-file cleanup unchanged.

## User Impact

No user-visible behavior or public API change. The public `sourceExtension` option remains unchanged.

## Evidence

- Complete audio-transcode suite: 12 tests passed in one file.
- One-file changed-check selection and execution: 28/28 checks passed.
- Script, production, and full-tree unused-export scans: zero entries in all three.
- Fresh full-context review completed with no actionable findings.
- Native commands and owned shutdown succeeded. Portal-sync timeout warnings were retained as reporting failures.
- Linux tests cover the mocked converter boundary, not native `afconvert`, successful native conversion, or Messages compatibility.
