### PR TITLE
fix(ui): avoid cutting skill installs short after two minutes

### DIFF
--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -857,7 +857,6 @@ describe("skill mutations", () => {
           name: "GitHub",
           installId: "install-123",
           dangerouslyForceUnsafeInstall: true,
-          timeoutMs: 120000,
         },
       ],
       expectedMessage: "Installed from registry",
@@ -1230,7 +1229,6 @@ describe("skill mutations", () => {
       name: "GitHub",
       installId: "install-123",
       dangerouslyForceUnsafeInstall: true,
-      timeoutMs: 120000,
     });
   });
 
@@ -1311,7 +1309,6 @@ describe("skill mutations", () => {
         name: "GitHub",
         installId: "install-123",
         dangerouslyForceUnsafeInstall: false,
-        timeoutMs: 120000,
       },
     },
     {

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -556,7 +556,6 @@ export async function installSkill(
       name,
       installId,
       dangerouslyForceUnsafeInstall,
-      timeoutMs: 120000,
     });
     return {
       kind: "success",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a skill from the Control UI would see an installation failure when the dependency command needed more than two minutes.

## Why This Change Was Made

The UI now leaves timeout selection to the existing skill installer. It keeps the installer's five-minute per-command default, explicit timeout bounds, policy checks and failure handling.

## User Impact

Slower dependency commands can use the installer's existing budget. Agent selection, pending-operation ownership and status refresh keep their current behavior.

## Evidence

The rebuilt Control UI and real Gateway were exercised with a disclosed local external installer simulation. The same declared 150-second command was used before and after the fix, with fresh state and real clocks.

| Observation | Baseline `f9781f6e5b25` | Candidate `fcb6c80cab21` |
| --- | --- | --- |
| UI request timeout | 120,000 ms | Omitted |
| Installer outcome | Terminated at 119.982 seconds; exit 143 | Completed at 150.108 seconds; exit 0 |
| Installed executable | Absent | Present and independently ran successfully |
| Rendered result | Installation failure | Eligible / Installed after real status refresh |

| Before | After |
| --- | --- |
| ![Actual Control UI installation failure](https://github.com/user-attachments/assets/1bc24ebc-735a-438e-8b4f-e0b2067f0b82) | ![Actual Control UI Installed result](https://github.com/user-attachments/assets/98667524-c736-425e-9fb5-41007d8c6a0a) |

The images are privacy crops of the actual UI result strips. The retained process and request timeline supplies elapsed-time evidence.

- A separate 330-second command was stopped at 299.956 seconds, left no executable, and showed the existing failure.
- Independent behavior acceptance passed all 13 declared runtime cases, including policy warning/block, ignored legacy force, explicit 1,000/10,000 ms values, rejected 999 ms, command/prerequisite failure, hidden skill, agent switch and browser reload. Reload retired the old UI result while the server command completed; Refresh then discovered the executable.
- Three updated request assertions fail on baseline for the shorter override. The candidate passes all 43 UI tests and 41 lifecycle/fallback tests, formatting and scoped lint. Independent source review found no actionable defect. The diff deletes four lines across two files.
- This simulation proves timeout ownership, process termination, artifact discovery and UI settlement. It does not measure real package-manager performance. Untouched installer families and internal timeout clamps were separately reviewed in source.
- The contributor also reported a rebuilt-UI macOS/Homebrew `hello` install at `2b35d238`, with a declared 125-second pre-command delay, successful response after 128.239 seconds and the Installed UI. That separate report is preserved here; the independent proof above uses the controlled local process.

Exact-candidate hosted checks: [CI run](https://github.com/openclaw/openclaw/actions/runs/34347988386). Final landing remains gated on those checks and the exact-head review.
