### PR TITLE
fix(docs): keep mirrored ClawHub routes resolvable in anchor audits

### DIFF
--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -462,6 +462,14 @@ function parseAuditUrl(
 }
 
 /**
+ * Explains that a fragment into a ClawHub-mirrored route could not be checked
+ * because the upstream source is absent from this checkout.
+ */
+function mirroredFragmentReason(terminal: string, hash: string) {
+  return `fragment unverified without the ClawHub source checkout (terminal: ${terminal}${hash}); set ${CLAWHUB_REPO_ENV}`;
+}
+
+/**
  * Audits local docs links against route, file, and redirect indexes.
  */
 export function auditDocsLinks(
@@ -545,6 +553,22 @@ export function auditDocsLinks(
           link: record.source,
           reason: `redirect fragment not found: ${record.destination}`,
         });
+        continue;
+      }
+      // A redirect into a ClawHub-mirrored route now resolves off the navigation
+      // declaration, which proves the route but not the fragment. Say so instead
+      // of letting the destination fragment go silently unchecked.
+      if (!page && destination.hash) {
+        const terminal = normalizeRoute(destination.pathname);
+        if (index.mirroredRoutes.has(terminal)) {
+          unverifiedMirroredFragments++;
+          broken.push({
+            file: "docs.json",
+            line: 0,
+            link: record.source,
+            reason: mirroredFragmentReason(terminal, destination.hash),
+          });
+        }
       }
     }
   }
@@ -586,18 +610,22 @@ export function auditDocsLinks(
       // Markdown page exists locally. Its existence is proven by the declaration;
       // only its fragments need the real source checkout.
       const mirroredOnly = !page && index.mirroredRoutes.has(terminal);
-      if (mirroredOnly && !destination.hash) {
+      if (mirroredOnly) {
+        // Plain mode does not inspect fragments at all, so a declared mirrored
+        // route resolves there whether or not the link carries one. Only anchor
+        // mode reports the fragment it cannot verify without the source.
+        if (options.anchors && destination.hash) {
+          unverifiedMirroredFragments++;
+          broken.push({
+            file: rel,
+            line,
+            link: raw,
+            reason: mirroredFragmentReason(terminal, destination.hash),
+          });
+        }
         continue;
       }
-      if (mirroredOnly) {
-        unverifiedMirroredFragments++;
-        broken.push({
-          file: rel,
-          line,
-          link: raw,
-          reason: `fragment unverified without the ClawHub source checkout (terminal: ${terminal}${destination.hash}); set ${CLAWHUB_REPO_ENV}`,
-        });
-      } else if (
+      if (
         !page &&
         (options.anchors || !resolved.ok) &&
         !index.relAllFiles.has(url.pathname.slice(1))

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -10,7 +10,11 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import MarkdownIt from "markdown-it";
 import type { Nodes } from "mdast";
-import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
+import {
+  CLAWHUB_REPO_ENV,
+  resolveClawHubRepoPath,
+  syncClawHubDocsTree,
+} from "./docs-sync-publish.mjs";
 import { parseDocsDocument, resolveDocsFragment } from "./lib/docs-markdown.mjs";
 import {
   addRoute,
@@ -346,13 +350,27 @@ function buildAuditIndex(
     routes.add(normalizeRoute(permalink));
   }
 
+  // Without a ClawHub checkout the mirrored tree is absent, so its pages cannot be
+  // parsed. The navigation still declares the published routes, so keep them
+  // resolvable and remember which ones are only backed by that declaration.
+  const mirroredRoutes = new Set<string>();
   if (options.allowExternalClawHubRoutes === true) {
     for (const route of collectMirroredDocsRoutes(docsConfig.navigation)) {
       routes.add(route);
+      mirroredRoutes.add(route);
     }
   }
 
-  return { docsDir, docsConfig, redirects, allFiles, relAllFiles, markdownFiles, routes };
+  return {
+    docsDir,
+    docsConfig,
+    redirects,
+    allFiles,
+    relAllFiles,
+    markdownFiles,
+    routes,
+    mirroredRoutes,
+  };
 }
 
 let defaultAuditIndex: ReturnType<typeof buildAuditIndex> | undefined;
@@ -446,7 +464,7 @@ function parseAuditUrl(
 /**
  * Audits local docs links against route, file, and redirect indexes.
  */
-function auditDocsLinks(
+export function auditDocsLinks(
   options: { docsDir?: string; allowExternalClawHubRoutes?: boolean; anchors?: boolean } = {},
 ) {
   const docsDir = options.docsDir ?? DOCS_DIR;
@@ -455,6 +473,7 @@ function auditDocsLinks(
   });
   const broken: Array<{ file: string; line: number; link: string; reason: string }> = [];
   let checked = 0;
+  let unverifiedMirroredFragments = 0;
 
   // The publisher writes physical/index routes; frontmatter permalinks do not
   // create pages. Only emitted pages and configured redirects can prove fragments.
@@ -492,7 +511,10 @@ function auditDocsLinks(
   if (options.anchors) {
     const records = resolveRedirects({
       redirects: index.docsConfig.redirects ?? [],
-      pages: [...pages.keys()].map((route) => ({ route, markdownRoute: `${route}.md` })),
+      pages: [...pages.keys(), ...index.mirroredRoutes].map((route) => ({
+        route,
+        markdownRoute: `${route}.md`,
+      })),
       localeCodes: ["en"],
       prefixes: [],
       publicPath: (route: string) => route,
@@ -560,7 +582,22 @@ function auditDocsLinks(
       const terminal = pageRoute(destination.pathname).replace(/^\/en(?:\/|$)/, "/");
       const page = pages.get(terminal);
       const resolved = resolveRoute(route, { redirects: index.redirects, routes: index.routes });
-      if (
+      // A route the navigation mirrors from ClawHub is published even though no
+      // Markdown page exists locally. Its existence is proven by the declaration;
+      // only its fragments need the real source checkout.
+      const mirroredOnly = !page && index.mirroredRoutes.has(terminal);
+      if (mirroredOnly && !destination.hash) {
+        continue;
+      }
+      if (mirroredOnly) {
+        unverifiedMirroredFragments++;
+        broken.push({
+          file: rel,
+          line,
+          link: raw,
+          reason: `fragment unverified without the ClawHub source checkout (terminal: ${terminal}${destination.hash}); set ${CLAWHUB_REPO_ENV}`,
+        });
+      } else if (
         !page &&
         (options.anchors || !resolved.ok) &&
         !index.relAllFiles.has(url.pathname.slice(1))
@@ -612,7 +649,7 @@ function auditDocsLinks(
     });
   }
 
-  return { checked, broken, collisions };
+  return { checked, broken, collisions, unverifiedMirroredFragments };
 }
 
 /** Runs the docs link audit CLI. */
@@ -631,7 +668,7 @@ function runDocsLinkAuditCli() {
 
   const mirroredDocsDir = prepareMirroredDocsDir(DOCS_DIR);
   try {
-    const { checked, broken, collisions } = auditDocsLinks({
+    const { checked, broken, collisions, unverifiedMirroredFragments } = auditDocsLinks({
       docsDir: mirroredDocsDir.dir,
       allowExternalClawHubRoutes: !mirroredDocsDir.mirroredClawHub,
       anchors: args.includes("--anchors"),
@@ -642,6 +679,15 @@ function runDocsLinkAuditCli() {
       console.log(
         `omitted_compatibility_aliases=${collisions.filter((item) => item.reason === "compatibility alias collision").length}`,
       );
+      console.log(`mirrored_clawhub_docs=${mirroredDocsDir.mirroredClawHub ? "yes" : "no"}`);
+      if (!mirroredDocsDir.mirroredClawHub) {
+        console.error(
+          `docs:check-links: ClawHub docs are authored in openclaw/clawhub and are absent from this checkout. ` +
+            `/clawhub/** routes were accepted from docs.json navigation and their fragments were not checked` +
+            `${unverifiedMirroredFragments > 0 ? ` (${unverifiedMirroredFragments} reported unverified)` : ""}. ` +
+            `Set ${CLAWHUB_REPO_ENV} to a ClawHub checkout to verify them.`,
+        );
+      }
     }
 
     for (const item of broken) {

--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -18,7 +18,7 @@ const SLUGIFY_PACKAGE = "@sindresorhus/slugify";
 const INTERNAL_DOCS_DIRS = ["internal"];
 const DEFAULT_CLAWHUB_SOURCE_REPO = "openclaw/clawhub";
 const CLAWHUB_DOCS_TARGET_DIR = "clawhub";
-const CLAWHUB_REPO_ENV = "OPENCLAW_DOCS_SYNC_CLAWHUB_REPO";
+export const CLAWHUB_REPO_ENV = "OPENCLAW_DOCS_SYNC_CLAWHUB_REPO";
 const DEFAULT_CLAWHUB_REPO_CANDIDATES = [
   path.resolve(ROOT, "..", "clawhub-docs-clawhub"),
   path.resolve(ROOT, "..", "clawhub"),

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -436,14 +436,21 @@ describe("docs-link-audit", () => {
   describe("ClawHub routes mirrored from openclaw/clawhub", () => {
     // /clawhub/** pages are authored upstream and injected by the publisher, so a
     // checkout without the ClawHub source has the navigation entries but no pages.
-    const buildDocsTree = (tempDirs: string[], link: string) => {
-      const docsRoot = path.join(makeTempDir(tempDirs, "docs-clawhub-mirror-"), "docs");
+    const buildDocsTree = (
+      tempDirs: string[],
+      link: string,
+      options: { redirects?: Array<{ source: string; destination: string }>; root?: string } = {},
+    ) => {
+      const docsRoot = path.join(
+        options.root ?? makeTempDir(tempDirs, "docs-clawhub-mirror-"),
+        "docs",
+      );
       fs.mkdirSync(docsRoot, { recursive: true });
       fs.writeFileSync(
         path.join(docsRoot, "docs.json"),
         JSON.stringify({
           navigation: [{ group: "ClawHub", pages: ["clawhub/index", "clawhub/publishing"] }],
-          redirects: [{ source: "/tools/clawhub", destination: "/clawhub" }],
+          redirects: options.redirects ?? [{ source: "/tools/clawhub", destination: "/clawhub" }],
         }),
       );
       fs.writeFileSync(path.join(docsRoot, "page.md"), `## Page\n\n[hub](${link})\n`);
@@ -477,6 +484,104 @@ describe("docs-link-audit", () => {
         expect(result.broken).toHaveLength(1);
         expect(result.broken[0]?.reason).toContain("fragment unverified");
         expect(result.broken[0]?.reason).toContain("OPENCLAW_DOCS_SYNC_CLAWHUB_REPO");
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("leaves fragments into mirrored routes alone in plain mode", () => {
+      const tempDirs: string[] = [];
+      try {
+        // Plain mode has never inspected fragments; the declared route is proof
+        // enough, so the unverifiable fragment must not become a broken link.
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/clawhub/publishing#package-publish-source"),
+          allowExternalClawHubRoutes: true,
+        });
+        expect(result.broken).toEqual([]);
+        expect(result.unverifiedMirroredFragments).toBe(0);
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("exits clean from the CLI in plain mode for a fragment into a mirrored route", () => {
+      const tempDirs: string[] = [];
+      try {
+        // Nest the fixture so `<root>/../clawhub` cannot accidentally resolve and
+        // turn the allowance off: this run must be the source-absent shape.
+        const fixtureRoot = path.join(makeTempDir(tempDirs, "docs-clawhub-mirror-cli-"), "repo");
+        const home = path.join(fixtureRoot, "home");
+        buildDocsTree(tempDirs, "/clawhub/publishing#package-publish-source", {
+          root: fixtureRoot,
+        });
+        fs.mkdirSync(home, { recursive: true });
+        const result = spawnSync(
+          process.execPath,
+          [fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url))],
+          {
+            cwd: fixtureRoot,
+            encoding: "utf8",
+            env: {
+              PATH: process.env.PATH,
+              HOME: home,
+              USERPROFILE: home,
+              TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+            },
+            timeout: 30_000,
+          },
+        );
+        expect(result.error).toBeUndefined();
+        expect(result.stdout).toContain("broken_links=0\n");
+        expect(result.stdout).not.toContain("fragment unverified");
+        expect(result.status).toBe(0);
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("reports unverified fragments in redirect destinations into mirrored routes", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/page", {
+            redirects: [
+              {
+                source: "/tools/clawhub",
+                destination: "/clawhub/publishing#package-publish-source",
+              },
+            ],
+          }),
+          allowExternalClawHubRoutes: true,
+          anchors: true,
+        });
+        expect(result.unverifiedMirroredFragments).toBe(1);
+        expect(result.broken).toHaveLength(1);
+        expect(result.broken[0]?.file).toBe("docs.json");
+        expect(result.broken[0]?.link).toBe("/tools/clawhub");
+        expect(result.broken[0]?.reason).toContain("fragment unverified");
+        expect(result.broken[0]?.reason).toContain("OPENCLAW_DOCS_SYNC_CLAWHUB_REPO");
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("keeps mirrored redirect destinations silent in plain mode", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/page", {
+            redirects: [
+              {
+                source: "/tools/clawhub",
+                destination: "/clawhub/publishing#package-publish-source",
+              },
+            ],
+          }),
+          allowExternalClawHubRoutes: true,
+        });
+        expect(result.broken).toEqual([]);
+        expect(result.unverifiedMirroredFragments).toBe(0);
       } finally {
         cleanupTempDirs(tempDirs);
       }

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -9,7 +9,7 @@ import { createDocsMarkdown, parseDocsDocument } from "../../scripts/lib/docs-ma
 import { normalizeRoute } from "../../scripts/lib/docs-published-routes.mts";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
-const { prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
+const { auditDocsLinks, prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
   await import("../../scripts/docs-link-audit.mts");
 
 type AuditCliCase = {
@@ -432,6 +432,87 @@ describe("docs-link-audit", () => {
       }
     },
   );
+
+  describe("ClawHub routes mirrored from openclaw/clawhub", () => {
+    // /clawhub/** pages are authored upstream and injected by the publisher, so a
+    // checkout without the ClawHub source has the navigation entries but no pages.
+    const buildDocsTree = (tempDirs: string[], link: string) => {
+      const docsRoot = path.join(makeTempDir(tempDirs, "docs-clawhub-mirror-"), "docs");
+      fs.mkdirSync(docsRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(docsRoot, "docs.json"),
+        JSON.stringify({
+          navigation: [{ group: "ClawHub", pages: ["clawhub/index", "clawhub/publishing"] }],
+          redirects: [{ source: "/tools/clawhub", destination: "/clawhub" }],
+        }),
+      );
+      fs.writeFileSync(path.join(docsRoot, "page.md"), `## Page\n\n[hub](${link})\n`);
+      return docsRoot;
+    };
+
+    it("accepts declared mirrored routes in anchors mode when the source is absent", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/clawhub/publishing"),
+          allowExternalClawHubRoutes: true,
+          anchors: true,
+        });
+        expect(result.broken).toEqual([]);
+        expect(result.unverifiedMirroredFragments).toBe(0);
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("reports fragments into mirrored routes as unverified rather than missing", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/clawhub/publishing#package-publish-source"),
+          allowExternalClawHubRoutes: true,
+          anchors: true,
+        });
+        expect(result.unverifiedMirroredFragments).toBe(1);
+        expect(result.broken).toHaveLength(1);
+        expect(result.broken[0]?.reason).toContain("fragment unverified");
+        expect(result.broken[0]?.reason).toContain("OPENCLAW_DOCS_SYNC_CLAWHUB_REPO");
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("still reports undeclared routes under /clawhub as missing", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/clawhub/not-in-navigation"),
+          allowExternalClawHubRoutes: true,
+          anchors: true,
+        });
+        expect(result.broken).toHaveLength(1);
+        expect(result.broken[0]?.reason).toContain("route/file not found");
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+
+    it("does not accept mirrored routes when the allowance is off", () => {
+      const tempDirs: string[] = [];
+      try {
+        const result = auditDocsLinks({
+          docsDir: buildDocsTree(tempDirs, "/clawhub/publishing"),
+          allowExternalClawHubRoutes: false,
+          anchors: true,
+        });
+        expect(result.broken.some((item) => item.reason.includes("route/file not found"))).toBe(
+          true,
+        );
+      } finally {
+        cleanupTempDirs(tempDirs);
+      }
+    });
+  });
 
   it("normalizes route fragments away", () => {
     expect(normalizeRoute("/plugins/building-plugins#registering-agent-tools")).toBe(


### PR DESCRIPTION
## Summary

`node scripts/docs-link-audit.mjs --anchors` reports 42 broken links on a clean `main` when the checkout has no ClawHub source beside it, while plain mode reports 0. All 39 `/clawhub/**` findings are false positives. **No docs content is changed by this PR** — the links are correct as authored.

## Diagnosis

`/clawhub/**` pages are authored in [openclaw/clawhub](https://github.com/openclaw/clawhub/tree/main/docs), not here. `scripts/docs-sync-publish.mjs` replaces the whole publish `docs/clawhub/` tree from that source, and `docs/AGENTS.md` (added in #138157, which removed the last local copies) says explicitly not to keep authored copies in this repo. `docs/docs.json` declares the twelve `/clawhub/**` navigation entries and three redirects into `/clawhub`; those are real published routes on `docs.openclaw.ai`.

`buildAuditIndex` already handles this: when no ClawHub checkout is resolvable it sets `allowExternalClawHubRoutes` and adds the navigation-declared routes to `routes`, so `resolveRoute` succeeds. But the link check discarded that allowance in anchors mode:

```ts
if (!page && (options.anchors || !resolved.ok) && !index.relAllFiles.has(...))
```

`options.anchors` short-circuits ahead of `resolved.ok`, so anchors mode demanded a parsed Markdown page and ignored the allowance that plain mode honours. Same for redirect resolution, which built its `pages` list from parsed pages only — hence the three `Redirect has no terminal Markdown page: /clawdhub -> /clawhub` errors.

The intent behind the short-circuit is sound: a route declaration cannot prove a *fragment*. But it can prove the *route*, and 39 of the 39 findings are fragment-less links.

## Fix

- Accept a declared mirrored route when the link carries no fragment.
- Count declared mirrored routes as terminal pages for redirect resolution.
- **In anchors mode only**, report a fragment into a mirrored route as `fragment unverified without the ClawHub source checkout; set OPENCLAW_DOCS_SYNC_CLAWHUB_REPO`, instead of the misleading `route/file not found`. Plain mode has never inspected fragments, so it keeps resolving the declared route and stays silent.
- Report the same for a **redirect destination** that lands on a mirrored route with a fragment, so an unreferenced redirect is not silently unchecked.
- Print `mirrored_clawhub_docs=yes|no` in anchors mode and warn on stderr when the source is absent, so reduced coverage is visible rather than silent.

When the ClawHub source *is* present, `mirroredRoutes` is empty and behaviour is byte-identical to before.

## Results

Run against the repo as authored (no `/clawhub/**` link here carries a fragment today):

| run | before | after |
| --- | --- | --- |
| `--anchors`, no ClawHub source | 42 | **3** |
| `--anchors`, with ClawHub source | 4 | 4 (unchanged) |
| plain, no ClawHub source (what CI runs) | 0 | 0 (unchanged) |
| plain, with ClawHub source | 0 | 0 (unchanged) |

Each of the three unchanged rows is **byte-identical** to `main`, diagnostics included.

The remaining 3 are the pre-existing `maturity/#windows-app-node` failures. The 4th in the with-source run is `clawhub/publishing.md:216 :: /clawhub/cli#package-publish-source` — a real broken anchor **in `openclaw/clawhub`**, not fixable from this repo. I have not filed it upstream; it is reported to the docs-audit orchestrator for routing to `openclaw/clawhub`.

### Fragment-bearing link (the plain-mode edge case)

Temporarily adding a page containing `[publishing](/clawhub/publishing#package-publish-source)`:

| run | `main` | first revision of this PR | current |
| --- | --- | --- | --- |
| plain, no ClawHub source | 0 (exit 0) | **1 (exit 1)** | 0 (exit 0), identical to `main` |
| plain, with ClawHub source | 0 | 0 | 0 |
| `--anchors`, no source | 43 | 4 | 4 |
| `--anchors`, with source | 5 | 5 | 5 |

### Fragment-bearing redirect destination

Temporarily rewriting the `/tools/clawhub` redirect to `/clawhub/publishing#package-publish-source`, `--anchors` with no ClawHub source:

```
main    docs.json:unknown :: /tools/clawhub :: Redirect has no terminal Markdown page: /tools/clawhub -> /clawhub/publishing
first   (no line mentioning /tools/clawhub — silently unchecked)
current docs.json:unknown :: /tools/clawhub :: fragment unverified without the ClawHub source checkout (terminal: /clawhub/publishing#package-publish-source); set OPENCLAW_DOCS_SYNC_CLAWHUB_REPO
```

Plain mode reports 0 in all three.

## Why CI did not catch this

It is not a CI regression — there was nothing to catch. `check:docs` runs plain `docs:check-links`, which correctly reports 0, and both lanes (`.github/workflows/ci.yml`, `.github/workflows/docs.yml`) check out `openclaw/clawhub` into `clawhub-source` and set `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO`, so even anchors mode would be clean there.

Two related gaps worth recording, neither introduced here:

1. **`docs:check-links:anchors` is not run by any workflow.** It appears only in `package.json`, `CHANGELOG.md`, and three docs pages describing it as a manual step. Anchor regressions are ungated, which is why the three `#windows-app-node` failures have survived. Turning it on would need those fixed first, so I have not done it here.
2. **The audit silently auto-discovers `<repo>/../clawhub`** via `DEFAULT_CLAWHUB_REPO_CANDIDATES`. Coverage therefore depends on the directory *beside* the checkout, with no output saying which mode ran. That is what made this look like a regression: the same command reports 4 from a clone with a sibling `clawhub/` and 42 from a git worktree without one. The new `mirrored_clawhub_docs=` line makes that visible.

## Validation

`pnpm check:docs` — the aggregate the CI docs job runs — passes (exit 0), with and without `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` set.

Tests: `src/scripts/docs-link-audit.test.ts` under `test/vitest/vitest.tooling.config.ts`, 32 passed / 1 pre-existing failure (`preserves Mint component targets…`, `as-s-guide`; reproduced unchanged at `origin/main`, where the file is 24 passed / 1 failed).

Eight hermetic tests cover: mirrored route accepted; fragment reported unverified in anchors mode; **fragment left alone in plain mode, both through `auditDocsLinks` and through the real CLI**; **redirect destination fragment reported unverified in anchors mode and silent in plain mode**; undeclared `/clawhub/*` route still reported missing; allowance-off still reporting missing. Three of the four added in the current revision fail against the previous revision of this PR.

`pnpm check:test-types` reports the same 8 pre-existing `src/infra/*` errors with and without this change (identical error set); none are in the audited files.
