### PR TITLE
docs(cli): split the oversized gateway CLI page into docs/cli/gateway/

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -3256,6 +3256,26 @@
     "target": "配置 — 聊天命令"
   },
   {
+    "source": "Run the Gateway",
+    "target": "运行 Gateway 网关"
+  },
+  {
+    "source": "Restart and supervision",
+    "target": "重启与进程监管"
+  },
+  {
+    "source": "Query a running Gateway",
+    "target": "查询运行中的 Gateway 网关"
+  },
+  {
+    "source": "Manage the Gateway service",
+    "target": "管理 Gateway 网关服务"
+  },
+  {
+    "source": "Discover gateways (Bonjour)",
+    "target": "发现 Gateway 网关（Bonjour）"
+  },
+  {
     "source": "Microsoft Teams setup",
     "target": "Microsoft Teams 设置"
   },

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -9,7 +9,7 @@ title: "Gateway"
 sidebarTitle: "Gateway"
 ---
 
-The Gateway is OpenClaw's WebSocket server (channels, nodes, sessions, hooks). All subcommands below live under `openclaw gateway ...`.
+The Gateway is OpenClaw's WebSocket server (channels, nodes, sessions, hooks). All subcommands on the pages listed here live under `openclaw gateway ...`.
 
 <CardGroup cols={3}>
   <Card title="Bonjour discovery" href="/gateway/bonjour">
@@ -23,801 +23,125 @@ The Gateway is OpenClaw's WebSocket server (channels, nodes, sessions, hooks). A
   </Card>
 </CardGroup>
 
-## Run the Gateway
-
-```bash
-openclaw gateway
-openclaw gateway run   # equivalent, explicit form
-```
-
-<AccordionGroup>
-  <Accordion title="Startup behavior">
-    - Refuses to start unless `gateway.mode=local` is set in `~/.openclaw/openclaw.json`. Use `--allow-unconfigured` for ad-hoc/dev runs; it bypasses the guard without writing or repairing config.
-    - Startup automatically applies deterministic, prompt-free legacy-key migrations to eligible invalid single-file configs, including in non-interactive service runs. It writes only after full validation, including plugins, and keeps the previous config in the `.bak` ring. Configs using `$include`, Nix-managed configs, and configs written by a newer version are excluded. See [Legacy config key migrations](/gateway/doctor#detailed-behavior-and-rationale).
-    - If automatic migration cannot make the config valid, an interactive terminal can offer to run `openclaw doctor --fix` and retry startup once after consent. Non-interactive runs print the command instead. If the repaired config is still invalid, startup remains stopped.
-    - `openclaw onboard --mode local` and `openclaw setup` write `gateway.mode=local`. If the config file exists but `gateway.mode` is missing, that is treated as damaged/clobbered config and the Gateway refuses to guess `local` for you — re-run onboarding, set the key manually, or pass `--allow-unconfigured`.
-    - Binding beyond loopback without auth is blocked.
-    - `--bind` values `lan`, `tailnet`, and `custom` resolve over IPv4-only paths today; IPv6-only bring-your-own-host setups need an IPv4 sidecar or proxy in front of the Gateway.
-    - `SIGUSR1` triggers an in-process restart when authorized. `commands.restart` (default: enabled) gates externally-sent `SIGUSR1`; set it to `false` to block manual OS-signal restarts. The agent-facing `gateway` tool is read-only; agents request restart through the `openclaw` delegation tool. Effective Full Access, including Default (Full Access), authorizes permitted delegated changes without an approval prompt; restricted runs require human approval. See [Delegated setup and repair](/gateway/permission-modes#delegated-setup-and-repair).
-    - `SIGINT`/`SIGTERM` stop the process but do not restore custom terminal state — if you wrap the CLI in a TUI or raw-mode input, restore the terminal yourself before exit.
-
-  </Accordion>
-</AccordionGroup>
-
-### Options
-
-<ParamField path="--port <port>" type="number">
-  WebSocket port (default from config/env; usually `18789`).
-</ParamField>
-<ParamField path="--bind <mode>" type="string">
-  Bind mode: `loopback` (default), `lan`, `tailnet`, `auto`, `custom`.
-</ParamField>
-<ParamField path="--token <token>" type="string">
-  Shared token for `connect.params.auth.token`. Defaults to `OPENCLAW_GATEWAY_TOKEN` when set.
-</ParamField>
-<ParamField path="--auth <mode>" type="string">
-  Auth mode: `none`, `token`, `password`, `trusted-proxy`.
-</ParamField>
-<ParamField path="--password <password>" type="string">
-  Password for `--auth password`.
-</ParamField>
-<ParamField path="--password-file <path>" type="string">
-  Read the Gateway password from a file.
-</ParamField>
-<ParamField path="--tailscale <mode>" type="string">
-  Tailscale exposure: `off`, `serve`, `funnel`.
-</ParamField>
-<ParamField path="--allow-unconfigured" type="boolean">
-  Start without enforcing `gateway.mode=local`. Ad-hoc/dev bootstrap only; does not persist or repair config.
-</ParamField>
-<ParamField path="--dev" type="boolean">
-  Create a dev config + workspace if missing (skips `BOOTSTRAP.md`).
-</ParamField>
-<ParamField path="--ambient-channels" type="boolean">
-  Allow the Gateway to auto-configure channels from ambient environment variables. By default, channels require an explicit `channels.<id>` config block.
-</ParamField>
-<ParamField path="--dev-ambient-channels" type="boolean">
-  Deprecated alias for `--ambient-channels`.
-</ParamField>
-<ParamField path="--reset" type="boolean">
-  Reset dev config, credentials, sessions, and workspace. Requires `--dev`.
-</ParamField>
-<ParamField path="--force" type="boolean">
-  Kill any existing listener on the target port before starting. In a non-interactive shell, this refuses to kill a verified Gateway listener; use `--dev` or an isolated `--profile` with a free port instead.
-</ParamField>
-<ParamField path="--verbose" type="boolean">
-  Verbose logging to stdout/stderr.
-</ParamField>
-<ParamField path="--cli-backend-logs" type="boolean">
-  Only show CLI backend logs in the console (also enables stdout/stderr).
-</ParamField>
-<ParamField path="--ws-log <style>" type="string" default="auto">
-  WebSocket log style: `auto`, `full`, `compact`.
-</ParamField>
-<ParamField path="--compact" type="boolean">
-  Alias for `--ws-log compact`.
-</ParamField>
-<ParamField path="--raw-stream" type="boolean">
-  Log raw model stream events to JSONL.
-</ParamField>
-<ParamField path="--raw-stream-path <path>" type="string">
-  Raw stream JSONL path.
-</ParamField>
-
-`--claude-cli-logs` is a deprecated alias for `--cli-backend-logs`.
-
-For `--bind custom`, set `gateway.customBindHost` to an IPv4 address. Any address other than `127.0.0.1` or `0.0.0.0` also requires `127.0.0.1` on the same port for same-host clients; startup fails if either listener cannot bind. Wildcard `0.0.0.0` does not add a separate required alias. IPv6-only bring-your-own-host setups need an IPv4 sidecar or proxy in front of the Gateway.
-
-## Reveal the configured token
-
-Run this on the Gateway host when a client needs the configured shared token:
-
-```bash
-openclaw gateway auth-token --show
-```
-
-The command resolves `gateway.auth.token`, `OPENCLAW_GATEWAY_TOKEN`, and configured SecretRefs, then prints only the token. It requires an interactive terminal and refuses redirected or piped output so the credential does not silently enter command logs. Treat the terminal output as a secret.
-
-If no persistent token is configured, run `openclaw doctor --generate-gateway-token`, restart the Gateway, and then rerun the command. Generic `openclaw config get` output remains redacted, including `--json`.
-
-## Restart the Gateway
-
-```bash
-openclaw gateway restart
-openclaw gateway restart --safe
-openclaw gateway restart --safe --skip-deferral
-openclaw gateway restart --force
-openclaw gateway restart --wait 30s
-```
-
-`--safe` asks the running Gateway to preflight active work and schedule one coalesced restart after that work drains. The wait is bounded to 5 minutes; when the budget expires the restart is forced. `--safe` cannot combine with `--force` or `--wait`.
-
-`--skip-deferral` bypasses only the safe-restart active-work deferral gate. It can move the Gateway into shutdown even while active-work blockers are reported, but the close-stage pending-reply drain still applies before the process exits. It requires `--safe` — use it when a deferral is stuck on a runaway task and reply delivery can still be allowed to settle.
-
-`--wait <duration>` overrides the drain budget for a plain (non-safe) restart. Accepts bare milliseconds or unit suffixes `ms`, `s`, `m`, `h`, `d` (e.g. `30s`, `5m`, `1h30m`); `--wait 0` waits indefinitely. Not compatible with `--force` or `--safe`.
-
-`--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
-
-On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
-
-On macOS, when `openclaw gateway restart`, `stop`, `install`, or `uninstall` runs inside the managed LaunchAgent's process tree, including an agent's shell command, OpenClaw detects that from launchd's service environment or, when a hand-written plist omits those variables, from process ancestry against the PID launchd reports for the job. Restart hands off to a detached helper so `kickstart -k` cannot kill the caller. Stop, install, and uninstall refuse and ask you to run the command from an external shell.
-
-External terminals without Gateway-service markers, externally supervised Gateways, node services, and non-Windows callers keep their existing routing. Explicit `--force`, `--wait`, `--preserve-definition`, or `--skip-deferral` also retain their existing behavior and validation; they do not implicitly enable `--safe`.
-
-<Warning>
-Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.
-</Warning>
-
-### Install identity
-
-Service management (`install`, `start`, `stop`, `restart`, `uninstall`, Doctor service repair, and self-update service handling) belongs to the install that owns the host service. That is the canonical `.openclaw` directory under the OS account home, or the `.openclaw-<profile>` directory a named profile projects there. Named profiles use distinct native service identities.
-
-`OPENCLAW_HOME`, or an `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` that points elsewhere, is treated as isolated state and skipped. A relocated or copied state tree cannot adopt and rewrite the account's host service.
-
-On macOS and Windows, native service-managed profile names must be lowercase. Runtime-only profiles may still use uppercase, but case-distinct names such as `Main` and `main` share paths on normal case-insensitive filesystems and cannot safely own separate native services. On macOS, the lowercase names `gateway` and `node` are also unavailable for native service management because their historical LaunchAgent labels collide with the default Gateway and node-host services.
-
-Named profiles must also use the native service identity derived from `OPENCLAW_PROFILE`. Unset `OPENCLAW_LAUNCHD_LABEL`, `OPENCLAW_SYSTEMD_UNIT`, or `OPENCLAW_WINDOWS_TASK_NAME` before service management; custom identities remain available for the default profile or runtime-only/external-supervisor setups.
-
-On Linux, `openclaw gateway install --force` refuses a sealed systemd service
-definition, or one whose write authority cannot be verified, before changing
-configuration, authentication tokens, or service files. The error keeps its
-`SERVICE_DEFINITION_SEALED` or `SERVICE_DEFINITION_UNKNOWN` prefix and adds a
-reason tag and next action, without printing private paths, config, environment values,
-or underlying inspection errors.
-
-For `[unsafe-permissions]`, inspect the named artifact category locally. The
-service directory is `~/.config/systemd/user`; on a fresh install, its nearest
-existing ancestor may be `~/.config`. The service state directory belongs to the
-selected profile. Check directory metadata, not file contents:
-
-```bash
-ls -ld ~/.config ~/.config/systemd ~/.config/systemd/user
-```
-
-Missing directories are normal on a fresh install. After confirming the affected
-path is yours and is not intentionally shared, remove group/other write access
-with `chmod go-w <path>` and retry the same command. Mode `0700` is appropriate
-for private directories. Do not recursively chmod, take ownership of system
-paths, or use `sudo`/`--force` to bypass the check. Foreign-owned files and sealed
-mounts require the deployment owner; inspection failures require restoring
-filesystem or native service-manager access first.
-
-Type-wide `service.d` defaults are inspected as shared read-only inputs and do
-not require write access. Root-owned selected units and unit-specific drop-ins
-remain protected.
-
-### External supervisors
-
-Set `OPENCLAW_SUPERVISOR_MODE=external` only when another process manager owns the Gateway lifecycle. In this mode:
-
-- `openclaw gateway restart` preserves the existing safe, forced, and bounded-wait behavior while targeting the verified running Gateway instead of launchd, systemd, or Task Scheduler. Exact-lock restart delivery runs inside that Gateway, so a replacement CLI does not migrate shared state before the old process hands off.
-- Native service install, start, stop, and uninstall operations are refused with guidance to use the external supervisor.
-- OpenClaw self-update is refused so the supervisor can stop the Gateway, replace and finalize the runtime, and restart it safely.
-- A fresh-process restart writes a bounded SQLite handoff before clean exit. If persistence fails, the Gateway falls back to an in-process restart instead of exiting without a consumable handoff.
-
-An external supervisor can also claim durable ownership of shared-state writes:
-
-```bash
-OPENCLAW_SUPERVISOR_MODE=external \
-  openclaw database ownership claim --manager gateway-supervisor --json
-```
-
-Before claiming, stop and verify every older Gateway, CLI, Doctor, updater, and native app process that can write the shared state database. Pre-contract processes do not understand the ownership row and cannot be retroactively fenced. Claim only after every remaining writer uses ownership-aware code and carries `OPENCLAW_SUPERVISOR_MODE=external`.
-
-The claim is idempotent for the same stable manager identifier and refuses a different manager. There is no automatic claim or unclaim path. Once claimed, unmarked writable shared-state opens fail before permissions, schema migration, additive repair, compaction, or other mutation. Read-only access remains available. This is protection against accidental unmarked same-user writers, not an authentication or lease protocol.
-
-For upgrades and rollbacks, have the supervisor create a consolidated WAL-consistent copied snapshot with no SQLite sidecars, then run the target release's own `openclaw database preflight <copied-state.sqlite> --json` before activation. Numeric schema versions alone do not prove that a same-version additive shape is compatible. See [Database schemas](/reference/database-schemas).
-
-`OPENCLAW_SERVICE_REPAIR_POLICY=external` remains a separate Doctor repair policy. It does not declare runtime ownership; supervisors that need both behaviors should set both variables.
-
-External supervisors can negotiate and consume restart handoffs through the hidden machine contract:
-
-```bash
-openclaw gateway restart-handoff capabilities --json
-openclaw gateway restart-handoff consume --expected-pid <pid> --json
-```
-
-Protocol version `1` supports the `consume` operation. Consumption validates the expected PID and bounded handoff fields inside one immediate SQLite transaction. An accepted handoff is deleted before success is returned, so concurrent or replayed consumers cannot both accept it. A PID mismatch is retained for the matching owner; missing, expired, and invalid rows do not authorize a restart.
-
-Valid machine requests return JSON with exit code `0`, including non-restart results. Invalid arguments return `reason: "invalid-expected-pid"` with exit code `2`; state-store failures return `reason: "store-unavailable"` with exit code `1`. Supervisors should probe `capabilities` on the exact runtime or launcher they will use rather than infer support from an OpenClaw version string or read the private SQLite schema directly.
-
-External supervisor implementations should also apply these acceptance rules:
-
-- Bound capability probes with a timeout that accounts for full CLI cold-start latency on the deployed runtime and storage, rather than assuming warm-start timing.
-- If capability negotiation or handoff consumption refuses replacement, exit promptly with a nonzero status so the process manager's recovery policy can run. Do not remain alive without a Gateway child or listener.
-- Treat supervisor process liveness as distinct from replacement startup and channel readiness. Report success only after the new Gateway owns its listener and `/startupz` returns `status: "started"`; monitor `/readyz` separately for configured-channel health, while `/healthz` proves liveness only.
-
-### Gateway profiling
-
-- `OPENCLAW_GATEWAY_STARTUP_TRACE=1` logs phase timings during startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings (installed-index, manifest registry, startup planning, owner-map work).
-- `OPENCLAW_GATEWAY_RESTART_TRACE=1` logs `restart trace:` lines for restart signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics. Ordinary stops also start a fresh trace with `stop.signal.received` and `stop.drain` timing. Named shutdown steps and coarse close phases emit `.begin` before waiting, then a duration when they settle; an unmatched begin identifies an entered phase that has not settled. These phases do not time every nested cleanup operation individually.
-- `OPENCLAW_DIAGNOSTICS=timeline` with `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<path>` writes a best-effort JSONL startup diagnostics timeline for external QA harnesses (equivalent to config `diagnostics.flags: ["timeline"]`; the path is still env-only). Add `OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1` to include event-loop samples.
-- `pnpm build` then `pnpm test:startup:gateway -- --runs 5 --warmup 1` benchmarks Gateway startup against the built CLI entry: first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing.
-- `pnpm build` then `pnpm test:restart:gateway -- --case skipChannels --runs 1 --restarts 5` benchmarks in-process restart on macOS or Linux (not supported on Windows; restart requires `SIGUSR1`). Uses `SIGUSR1`, enables both traces in the child process, and records next `/healthz`, next `/readyz`, downtime, ready timing, CPU, RSS, and restart trace metrics.
-- `/healthz` is liveness; `/readyz` is usable readiness. Treat trace lines and benchmark output as owner-attribution signal, not a complete performance conclusion from one span or sample.
-
-Without tracing, stops and restarts report nonzero active-work category counts at
-the first drain snapshot and at most once every 30 seconds while still pending.
-These reports omit task identities and request origins; categories can overlap.
-An ordinary stop logs `active-work drain settled; beginning server close` before
-teardown, including after a drain timeout or failure. Diagnostics do not change
-drain budgets or the service manager's stop deadline.
-
-A client disconnect leaves interactive setup available for reconnect. A Gateway
-stop or restart closes setup prompts before draining work. Settings writes already
-in progress may finish, but setup will not wait for another answer during shutdown.
-After the Gateway starts again, reopen setup and check the saved settings.
-
-## Query a running Gateway
-
-All query commands use WebSocket RPC.
-
-<Tabs>
-  <Tab title="Output modes">
-    - Default: human-readable (colored in TTY).
-    - `--json`: machine-readable JSON (no styling/spinner).
-    - `--no-color` (or `NO_COLOR=1`): disable ANSI while keeping human layout.
-
-  </Tab>
-  <Tab title="Shared options">
-    - `--url <url>`: Gateway WebSocket URL.
-    - `--token <token>`: Gateway token.
-    - `--password <password>`: Gateway password.
-    - `--timeout <ms>`: timeout/budget (default varies per command; see each command below).
-    - `--expect-final`: wait for a "final" response (agent calls).
-
-  </Tab>
-</Tabs>
-
-<Note>
-When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
-</Note>
-
-### `gateway health`
-
-```bash
-openclaw gateway health --url ws://127.0.0.1:18789
-openclaw gateway health --port 18789
-```
-
-`/healthz` is a liveness probe: it returns as soon as the server can answer HTTP. `/readyz` is stricter and stays red while startup plugin sidecars, channels, or configured hooks are still settling. Local or authenticated detailed `/readyz` responses include an `eventLoop` diagnostic block (delay, utilization, CPU-core ratio, `degraded` flag).
-
-<ParamField path="--port <port>" type="number">
-  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call.
-</ParamField>
-
-### `gateway usage-cost`
-
-Fetch usage-cost summaries from session logs.
-
-```bash
-openclaw gateway usage-cost
-openclaw gateway usage-cost --days 7
-openclaw gateway usage-cost --agent work --json
-openclaw gateway usage-cost --all-agents
-openclaw gateway usage-cost --json
-```
-
-Human-readable output warns that totals may be incomplete when the usage cache is
-refreshing, partial, or stale. The command returns the available snapshot from
-one request; run it again later to check for refreshed totals. JSON output preserves
-the `cacheStatus` object so scripts can inspect the same state.
-
-<ParamField path="--days <days>" type="number" default="30">
-  Number of days to include.
-</ParamField>
-<ParamField path="--agent <id>" type="string">
-  Scope the summary to one configured agent id.
-</ParamField>
-<ParamField path="--all-agents" type="boolean">
-  Aggregate across all configured agents. Cannot combine with `--agent`.
-</ParamField>
-
-### `gateway stability`
-
-Fetch the recent diagnostic stability recorder from a running Gateway.
-
-```bash
-openclaw gateway stability
-openclaw gateway stability --type payload.large
-openclaw gateway stability --bundle latest
-openclaw gateway stability --bundle latest --export
-openclaw gateway stability --json
-```
-
-<ParamField path="--limit <limit>" type="number" default="25">
-  Maximum recent events to include (max `1000`).
-</ParamField>
-<ParamField path="--type <type>" type="string">
-  Filter by diagnostic event type, e.g. `payload.large` or `diagnostic.memory.pressure`.
-</ParamField>
-<ParamField path="--since-seq <seq>" type="number">
-  Include only events after a diagnostic sequence number.
-</ParamField>
-<ParamField path="--bundle [path]" type="string">
-  Read a persisted stability bundle instead of calling the running Gateway. `--bundle latest` (or bare `--bundle`) picks the newest bundle under the state directory; you can also pass a bundle JSON path directly.
-</ParamField>
-<ParamField path="--export" type="boolean">
-  Write a shareable support diagnostics zip instead of printing stability details.
-</ParamField>
-<ParamField path="--output <path>" type="string">
-  Output path for `--export`.
-</ParamField>
-
-<AccordionGroup>
-  <Accordion title="Privacy and bundle behavior">
-    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, approval ids, channel/plugin names, and redacted session summaries. They exclude chat text, webhook bodies, tool outputs, raw request/response bodies, tokens, cookies, secret values, hostnames, and raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
-    - Fatal Gateway exits, shutdown timeouts, and restart startup failures write the same diagnostic snapshot to `~/.openclaw/logs/stability/openclaw-stability-*.json` when the recorder has events. Inspect the newest bundle with `openclaw gateway stability --bundle latest`; `--limit`, `--type`, and `--since-seq` apply to bundle output too.
-
-  </Accordion>
-</AccordionGroup>
-
-### `gateway diagnostics export`
-
-Write a local diagnostics zip designed for bug reports. For the privacy model and bundle contents, see [Diagnostics Export](/gateway/diagnostics).
-
-```bash
-openclaw gateway diagnostics export
-openclaw gateway diagnostics export --output openclaw-diagnostics.zip
-openclaw gateway diagnostics export --json
-```
-
-<ParamField path="--output <path>" type="string">
-  Output zip path. Defaults to a support export under the state directory.
-</ParamField>
-<ParamField path="--log-lines <count>" type="number" default="5000">
-  Maximum sanitized log lines to include.
-</ParamField>
-<ParamField path="--log-bytes <bytes>" type="number" default="1000000">
-  Maximum log bytes to inspect.
-</ParamField>
-<ParamField path="--url <url>" type="string">
-  Gateway WebSocket URL for the health snapshot.
-</ParamField>
-<ParamField path="--token <token>" type="string">
-  Gateway token for the health snapshot.
-</ParamField>
-<ParamField path="--password <password>" type="string">
-  Gateway password for the health snapshot.
-</ParamField>
-<ParamField path="--timeout <ms>" type="number" default="3000">
-  Status/health snapshot timeout.
-</ParamField>
-<ParamField path="--no-stability-bundle" type="boolean">
-  Skip persisted stability bundle lookup.
-</ParamField>
-<ParamField path="--json" type="boolean">
-  Print the written path, size, and manifest as JSON.
-</ParamField>
-
-The export bundles: `manifest.json` (file inventory), `summary.md` (Markdown summary), `diagnostics.json` (top-level config/logs/discovery/stability/status/health summary), `config/sanitized.json`, `status/gateway-status.json`, `health/gateway-health.json`, `logs/openclaw-sanitized.jsonl`, and `stability/latest.json` when a bundle exists.
-
-It is designed to be shared. It keeps operational details useful for debugging — safe log fields, subsystem names, status codes, durations, configured modes, ports, plugin/provider ids, non-secret feature settings, and redacted operational log messages — and omits or redacts chat text, webhook bodies, tool outputs, credentials, cookies, account/message identifiers, prompt/instruction text, hostnames, and secret values. When a log message looks like user/chat/tool payload text (e.g. "user said", "chat text", "tool output", "webhook body"), the export keeps only the fact that a message was omitted plus its byte count.
-
-### `gateway status`
-
-Shows the Gateway service (launchd/systemd/schtasks) plus an optional connectivity/auth probe.
-
-```bash
-openclaw gateway status
-openclaw gateway status --json
-openclaw gateway status --require-rpc
-openclaw gateway status --port 19001
-```
-
-<ParamField path="--url <url>" type="string">
-  Probe this explicit WebSocket URL instead of the service-derived target. Cannot combine with `--port`.
-</ParamField>
-<ParamField path="--port <port>" type="number">
-  Select a local Gateway port using the invoking CLI config for auth and TLS. Accepts `gateway --port 19001 status` and `gateway status --port 19001`; an explicit status port wins. Native service details remain visible as diagnostics but do not select the probe target.
-</ParamField>
-<ParamField path="--token <token>" type="string">
-  Token auth for the probe.
-</ParamField>
-<ParamField path="--password <password>" type="string">
-  Password auth for the probe.
-</ParamField>
-<ParamField path="--timeout <ms>" type="number" default="10000">
-  Probe timeout.
-</ParamField>
-<ParamField path="--no-probe" type="boolean">
-  Skip the connectivity probe (service-only view).
-</ParamField>
-<ParamField path="--deep" type="boolean">
-  Scan system-level services too.
-</ParamField>
-<ParamField path="--require-rpc" type="boolean">
-  Upgrade the connectivity probe to a read probe and exit non-zero if it fails. Cannot combine with `--no-probe`.
-</ParamField>
-
-<AccordionGroup>
-  <Accordion title="Status semantics">
-    - Stays available for diagnostics even when the local CLI config is missing or invalid.
-    - Default output proves service state, WebSocket connect, and the auth capability visible at handshake time — not read/write/admin operations.
-    - Probes are non-mutating for first-time device auth: they reuse an existing cached device token when one exists, but never create a new CLI device identity or read-only pairing record just to check status.
-    - Resolves configured auth SecretRefs for probe auth when possible. If a required SecretRef is unresolved, `--json` reports `rpc.authWarning` when probe connectivity/auth fails; pass `--token`/`--password` explicitly or fix the secret source. Unresolved-auth warnings are suppressed once the probe succeeds.
-    - JSON output includes `gateway.version` when the running Gateway reports it; `--require-rpc` can fall back to the `status.runtimeVersion` RPC payload if the handshake probe cannot supply version metadata.
-    - Use `--require-rpc` in scripts/automation when a listening service is not enough and you need read-scope RPC to be healthy too.
-    - `--deep` scans for extra launchd/systemd/schtasks installs; when multiple gateway-like services are found, human output prints cleanup hints (usually run one gateway per machine) and reports a recent supervisor restart handoff when relevant.
-    - `--deep` confirms exact npm targets before suggesting repairs for official-plugin version drift. Unpublished versions or registry failures are reported without an update command; retry deep status after registry access or the release cohort is restored. Ordinary status and readiness checks do not query npm for drift repairs.
-    - `--deep` also runs config validation in plugin-aware mode (`pluginValidation: "full"`) and surfaces plugin manifest warnings (e.g. missing channel config metadata). Default `gateway status` keeps the fast read-only path that skips plugin validation.
-    - On Linux, status reports the effective service currently loaded by systemd, including loaded drop-ins. If the unit or a drop-in changed on disk, `Systemd reload: pending` means you must run `systemctl --user daemon-reload` (or `sudo systemctl daemon-reload` for a system service) before those changes take effect.
-    - Human output includes the resolved file log path plus CLI-vs-service config paths/validity to help diagnose profile or state-dir drift.
-    - Install and reinstall guidance follows the invoking shell's installation rules, not the stored service environment or probe target. Nix mode, external supervision, noncanonical installation identity, and Linux sudo/user-manager mismatches show the install refusal instead of an unusable command. A diagnostic-only target is not itself a refusal. Nix mode blocks installation, not starting an existing service.
-    - Human output includes `Gateway heap:` with configured service heap controls and a separate install-time recommendation based on memory visible to the CLI. JSON output exposes the same report as `service.gatewayHeap`. Neither is a measurement of the running Gateway's V8 heap ceiling; use runtime memory diagnostics for that.
-
-  </Accordion>
-  <Accordion title="Linux systemd auth-drift checks">
-    - Service auth drift checks read both `Environment=` and `EnvironmentFile=` from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
-    - Resolves `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
-    - Token-drift checks skip config token resolution when token auth is not effectively active (`gateway.auth.mode` explicitly `password`/`none`/`trusted-proxy`, or mode unset where password can win and no token candidate can win).
-
-  </Accordion>
-</AccordionGroup>
-
-### `gateway probe`
-
-The "debug everything" command. It always probes:
-
-- your configured remote gateway (if set), and
-- localhost (loopback), **even if remote is configured**.
-
-Passing `--url` adds that explicit target ahead of both. Human output labels targets `URL (explicit)`, `Remote (configured)` / `Remote (configured, inactive)`, and `Local loopback`.
-
-<Note>
-If multiple probe targets are reachable, all are printed. An SSH tunnel, TLS/proxy URL, and configured remote URL can point at the same gateway even with different transport ports; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Running multiple gateways is supported for isolated profiles (e.g. a rescue bot), but most installs run a single gateway.
-</Note>
-
-```bash
-openclaw gateway probe
-openclaw gateway probe --json
-openclaw gateway probe --port 18789
-```
-
-<ParamField path="--port <port>" type="number">
-  Use this port for the local loopback probe target and SSH tunnel remote port. Without `--url`, this selects only the local loopback target instead of configured gateway environment URL, environment port, or remote targets.
-</ParamField>
-
-<AccordionGroup>
-  <Accordion title="Interpretation">
-    - `Reachable: yes` means at least one target accepted a WebSocket connect.
-    - `Capability: read-only|write-capable|admin-capable|pairing-pending|connect-only` reports what the probe could prove about auth, separate from reachability.
-    - `Read probe: ok` means read-scope detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
-    - `Read probe: limited - missing scope: operator.read` means connect succeeded but read-scope RPC is limited. Reported as **degraded** reachability, not full failure.
-    - `Read probe: failed` after `Connect: ok` means the WebSocket connected but follow-up read diagnostics timed out or failed — also **degraded**, not unreachable.
-    - Like `gateway status`, probe reuses existing cached device auth but does not create first-time device identity or pairing state.
-    - Exit code is non-zero only when no probed target is reachable.
-
-  </Accordion>
-  <Accordion title="JSON output">
-    Top level:
-
-    - `ok`: at least one target is reachable.
-    - `degraded`: at least one target accepted a connection but did not complete full detail RPC diagnostics.
-    - `capability`: best capability seen across reachable targets (`read_only`, `write_capable`, `admin_capable`, `pairing_pending`, `connected_no_operator_scope`, or `unknown`).
-    - `primaryTargetId`: best target to treat as the active winner, in order: explicit URL, SSH tunnel, configured remote, local loopback.
-    - `warnings[]`: best-effort warning records with `code`, `message`, optional `targetIds`.
-    - `network`: local loopback/tailnet URL hints derived from current config and host networking.
-    - `discovery.timeoutMs` / `discovery.count`: the actual discovery budget/result count used for this probe pass.
-
-    Per target (`targets[].connect`): `ok` (reachability + degraded classification), `rpcOk` (full detail RPC success), `scopeLimited` (detail RPC failed on missing operator scope).
-
-    Per target (`targets[].auth`): `role` and `scopes` reported in `hello-ok` when available, plus the surfaced `capability` classification.
-
-  </Accordion>
-  <Accordion title="Common warning codes">
-    - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
-    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this.
-    - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
-    - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
-    - `local_tls_runtime_unavailable`: local Gateway TLS is enabled but OpenClaw could not load the local certificate fingerprint.
-
-  </Accordion>
-</AccordionGroup>
-
-#### Remote over SSH (Mac app parity)
-
-The macOS app "Remote over SSH" mode uses a local port-forward so a loopback-only remote gateway becomes reachable at `ws://127.0.0.1:<port>`.
-
-CLI equivalent:
-
-```bash
-openclaw gateway probe --ssh user@gateway-host
-```
-
-<ParamField path="--ssh <target>" type="string">
-  `user@host` or `user@host:port` (port defaults to `22`).
-</ParamField>
-
-OpenClaw launches only an SSH client found in OS-managed system directories. On native Windows,
-install the **OpenSSH Client** optional feature; Windows places it under
-`%SystemRoot%\System32\OpenSSH`.
-
-<ParamField path="--ssh-identity <path>" type="string">
-  Identity file.
-</ParamField>
-<ParamField path="--ssh-auto" type="boolean">
-  Pick the first discovered gateway host as SSH target from the resolved discovery endpoint (`local.` plus the configured wide-area domain, if any). TXT-only hints are ignored.
-</ParamField>
-
-Config defaults (optional): `gateway.remote.sshTarget`, `gateway.remote.sshIdentity`.
-
-### `gateway call <method>`
-
-Low-level RPC helper.
-
-```bash
-openclaw gateway call status
-openclaw gateway call health --port 18999
-openclaw gateway call logs.tail --params '{"limit": 200}'
-```
-
-<ParamField path="--params <json>" type="string" default="{}">
-  JSON object string for params.
-</ParamField>
-<ParamField path="--url <url>" type="string">
-  Gateway WebSocket URL.
-</ParamField>
-<ParamField path="--port <port>" type="number">
-  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`.
-</ParamField>
-<ParamField path="--token <token>" type="string">
-  Gateway token.
-</ParamField>
-<ParamField path="--password <password>" type="string">
-  Gateway password.
-</ParamField>
-<ParamField path="--timeout <ms>" type="number" default="10000">
-  Timeout budget.
-</ParamField>
-<ParamField path="--expect-final" type="boolean">
-  Mainly for agent-style RPCs that stream intermediate events before a final payload.
-</ParamField>
-<ParamField path="--json" type="boolean">
-  Machine-readable JSON output.
-</ParamField>
-
-`openclaw.setup.detect` uses a 40-second default so the Gateway can finish its
-bounded AI-access scan. An explicit `--timeout` still takes precedence.
-
-<Note>
-`--params` must be valid JSON, and each method validates its own param shape (extra/misnamed fields are rejected). Use `--port` for a custom-port local Gateway; explicit `--url` targets still require explicit credentials.
-</Note>
-
-### `gateway suspend`
-
-Prepare an idle Gateway for a cooperative host freeze or snapshot. Without
-`--wait`, active work returns a nonzero exit with blocker details. With
-`--wait`, the CLI retries until the bounded deadline using one stable request
-ID. The value must be a non-negative number of seconds; an empty value is rejected.
-Use `--wait 0` for a single attempt without polling.
-
-```bash
-openclaw gateway suspend
-openclaw gateway suspend --request-id snapshot-2026-08-11 --wait 30
-openclaw gateway suspend --port 18999 --json
-```
-
-The ready output includes the suspension ID, lease expiry, and the matching
-resume command. Common RPC options such as `--url`, `--token`, `--password`,
-`--timeout`, `--json`, and `--port` are supported.
-
-### `gateway resume <suspensionId>`
-
-Release a prepared suspension after thaw or when the host operation is
-abandoned.
-
-```bash
-openclaw gateway resume <suspensionId>
-openclaw gateway resume <suspensionId> --port 18999 --json
-```
-
-An already expired or resumed lease is a successful no-op. A different active
-suspension ID is rejected.
-
-## Manage the Gateway service
-
-```bash
-openclaw gateway install
-openclaw gateway start
-openclaw gateway stop
-openclaw gateway restart
-openclaw gateway uninstall
-```
-
-`gateway stop` remains available when plugin configuration needs Doctor migration.
-It still validates core configuration and refuses configuration written by a newer
-OpenClaw binary. Start and restart continue to validate plugin configuration.
-
-### Recover an unreadable native service definition
-
-If installation or a managed update reports `SERVICE_DEFINITION_UNKNOWN`, first
-restore access to the service files and native service manager. `--force` does not
-bypass unknown service facts. Inspect the selected service with
-`openclaw gateway status --deep` from the account and profile that own it.
-
-For a malformed definition or unsupported environment syntax, privately back up
-the service files and any values stored only in its environment. Correct unresolved
-or unsupported values before reinstalling; OpenClaw cannot infer their intended
-values. Then, from an external shell using the same account and profile:
-
-```bash
-openclaw gateway uninstall
-openclaw gateway install
-openclaw gateway health
-```
-
-Uninstall removes the native registration and launcher, preserving configuration,
-plugin installations, session state, and workspaces. Reinstallation rebuilds the
-service environment from the current configuration and installation inputs;
-service-only values must be supplied again. If native service status is itself
-unavailable, uninstall also refuses: restore native manager access first instead
-of deleting state or bypassing inspection.
-
-### Lifecycle requests from Gateway chat
-
-Gateway-hosted OpenClaw chat controls the exact Gateway serving that session.
-An approved start request reports **Gateway already running** without discovering
-or starting another service. Restart keeps the safe local restart behavior.
-
-An approved stop reports **Scheduled Gateway stop** after the host has prepared
-the stop for its exact instance. This acknowledges scheduling, not completed
-termination. An exclusive foreground host drains work, finishes teardown, and
-exits successfully without discovering or changing an installed service. A host
-managed by launchd or systemd verifies native ownership and prepares an executor,
-then drains work and finishes teardown before asking the native manager to stop
-the service. The requesting operation can finish its audit, history, and response
-submission during that drain;
-this does not guarantee that the client receives the response before disconnecting.
-
-After the normal grace period, stop cancels the remaining runs owned by that
-Gateway and waits for their commands and cleanup to settle. Ordinary stop does
-not schedule restart recovery. A required cleanup failure produces a nonzero exit and
-prevents an in-process replacement, including when startup failed before the
-Gateway became ready.
-
-Ownership or preparation failures leave the Gateway serving and return an error.
-Linux uses an independent transient control scope, in the owning systemd manager,
-so the stop command survives service cgroup termination. On macOS, hosted stop
-requests ordinary `launchctl bootout` without changing persistent enablement.
-If the native manager sends `SIGTERM` during the final stop handoff, the host
-finishes its graceful exit after joining cleanup, including the owned stop client.
-
-On Windows, a run loop that exclusively owns the Gateway process also uses
-graceful process exit under Task Scheduler. It does not select or stop a task by
-name. The generated task supervisor waits for the child process tree to exit and
-propagates the child exit result through the launcher. Its
-[`RestartOnFailure` policy](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-restartonfailure-settingstype-element)
-does not restart a successful task exit. Custom wrappers can have different exit
-or restart behavior; check their policy separately. This stop path does not change
-the task definition or its restart policy. Externally supervised Gateways direct
-stop requests to their supervisor.
-
-If systemd definitively refuses a stop after teardown and the same native instance
-remains active with no pending job, the host logs the failed stop and starts a fresh
-Gateway generation in the same process. An uncertain native result is recorded as
-a failed shutdown, without claiming success or starting an in-process replacement.
-After an unexpected disconnect, check `openclaw gateway status` and the native
-service logs from an external shell before retrying. Standalone CLI lifecycle
-commands retain their service-management behavior.
-
-### Install with a wrapper
-
-Use `--wrapper` when the managed service must start through another executable, for example a secrets manager shim or a run-as helper. The wrapper receives the normal Gateway args and is responsible for eventually exec'ing `openclaw` or Node with those args.
-
-```bash
-cat > ~/.local/bin/openclaw-doppler <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-exec doppler run --project my-project --config production -- openclaw "$@"
-EOF
-chmod +x ~/.local/bin/openclaw-doppler
-
-openclaw gateway install --wrapper ~/.local/bin/openclaw-doppler --force
-openclaw gateway restart
-```
-
-You can also set the wrapper through the environment. `gateway install` validates that the path is an executable file, writes the wrapper into the service `ProgramArguments`, and persists `OPENCLAW_WRAPPER` in the service environment for later forced reinstalls, updates, and doctor repairs.
-
-```bash
-OPENCLAW_WRAPPER="$HOME/.local/bin/openclaw-doppler" openclaw gateway install --force
-openclaw doctor
-```
-
-To remove a persisted wrapper, clear `OPENCLAW_WRAPPER` while reinstalling:
-
-```bash
-OPENCLAW_WRAPPER= openclaw gateway install --force
-openclaw gateway restart
-```
-
-<AccordionGroup>
-  <Accordion title="Command options">
-    - `gateway status`: `--url`, `--port`, `--token`, `--password`, `--timeout`, `--no-probe`, `--require-rpc`, `--deep`, `--json`
-    - `gateway install`: `--port`, `--runtime <node|bun>` (default: `node`), `--token`, `--wrapper <path>`, `--force`, `--json`
-    - `gateway restart`: `--safe`, `--skip-deferral`, `--force`, `--wait <duration>`, `--preserve-definition`, `--json`
-    - `gateway uninstall|start`: `--json`
-    - `gateway stop`: `--disable`, `--force`, `--json`
-
-  </Accordion>
-  <Accordion title="Service runtime">
-    - Node is the primary, default, and recommended managed Gateway runtime.
-    - Bun 1.4+ with WAL-reset-safe `node:sqlite` is available as an explicit opt-in with `gateway install --runtime bun`.
-
-  </Accordion>
-  <Accordion title="Lifecycle behavior">
-    - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
-    - If no managed service is installed, `gateway start` prints install hints and exits nonzero. `gateway restart` can first recover an installed-but-unloaded LaunchAgent or a verified unmanaged Gateway; if neither a managed service nor recovery handles the action, it prints the same hints and exits nonzero. Stopping an absent service remains a successful no-op.
-    - If `gateway start` or `gateway restart` needs to repair a stale service definition, the command refuses when the invoking shell resolves a different state directory, config path, or port than the installed service. Match or unset the conflicting environment overrides, or use `openclaw gateway install --force` to retarget the service intentionally.
-    - On Linux, `gateway start` and `gateway restart` also refuse ineffective repairs when an operator-owned systemd drop-in overrides the command or working directory. Inspect the effective unit with `systemctl --user cat <unit>.service`, then update or remove that drop-in. `gateway install --force` rewrites only the managed base unit and warns if the override remains; `Environment=` drop-ins remain supported.
-    - `gateway restart --preserve-definition` restarts only an inspectable native service, skips automatic definition repair, and checks health at the installed launcher's port. It does not recover an unmanaged listener and cannot be combined with `--safe` or external supervision. On macOS it can bootstrap an unloaded readable plist without rewriting the plist, environment, wrapper, or permissions; denied native activation fails without file repair. On Windows it also retains existing Startup entries. The legacy `daemon restart` command accepts the same option. Older CLIs reject the option before running restart or repair.
-    - During writable Linux service installs or refreshes, keep the unit and state directories stationary and avoid concurrent manual edits. OpenClaw serializes its own writers and aborts on detected changes, but cannot coordinate arbitrary filesystem edits. Moving or replacing a parent directory mid-publication can leave a temporary file inside the moved directory; inspect it before retrying.
-    - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
-    - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.
-    - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery stays active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots.
-    - Gateway lifecycle mutations append best-effort key-value audit records to `<state-dir>/logs/gateway-restart.log`, including CLI start, stop, and restart operations, safe restart requests, supervisor restarts, and detached handoffs.
-    - Lifecycle commands accept `--json` for scripting.
-    - A restart that completes native activation or accepted recovery but fails its health check emits `action: "restart"`, `ok: false`, and `result: "restart-health-failed"`, retaining its error, hints, warnings, and exit code 1. This diagnostic does not authorize another activation. Refusals, unexpected exceptions, and definition repair without confirmed activation do not emit this result. A scheduled restart reports acceptance, without claiming successor health.
-
-  </Accordion>
-  <Accordion title="Managed Gateway heap sizing">
-    - For a managed Node Gateway without an existing heap setting, `gateway install` places `--max-old-space-size` in Node's launch arguments, before the entry script. It explicitly clears `NODE_OPTIONS` in the service environment so ambient service-manager preload/debug flags cannot leak into the Gateway. Plain spawned Node processes do not inherit the new automatic budget through `NODE_OPTIONS`; Node's fork and Worker inheritance rules are unchanged.
-    - Capacity is the smaller of valid physical RAM and a valid constraint reported by Node, never fluctuating free RAM. With no usable capacity reading, Node keeps its native default. The installer targets 50% of capacity, with a nominal 2048 MiB floor and a cap of the greater of 8192 MiB or 25% of capacity. A final 75% capacity cap reserves native-memory headroom and can put small-host budgets below the nominal floor.
-    - Examples: 32 GiB capacity selects 8 GiB old space; 64 GiB selects 16 GiB; 128 GiB selects 32 GiB. Old space is only part of V8's total heap, and neither is a limit on total process memory (RSS). Raising the ceiling does not preallocate that memory.
-    - Existing managed service heap controls are preserved across forced reinstalls and doctor repairs, including absolute old-space, percentage old-space, and total-heap flags. Only heap flags survive managed `NODE_OPTIONS` sanitization; arbitrary preload/debug flags do not. Put intentional preload/debug settings in an operator-owned systemd `Environment=` drop-in, or set them inside an [installed wrapper](#install-with-a-wrapper) before it launches Node. Do not edit the generated service environment for those settings. Existing stored numbers are preserved even when they resemble an older automatic default or exceed the new recommendation.
-    - When an operator-owned service override controls `NODE_OPTIONS` (including an empty value or reset), regeneration does not add a new automatic heap argument. Operator values and drop-in files stay separate from the managed base. Existing managed argv controls remain: Node's argv wins over `NODE_OPTIONS` for the same option, and percentage old-space sizing takes precedence over absolute old-space sizing. Inspect both surfaces before changing a cap.
-    - Ambient installer `NODE_OPTIONS` and the installer's own Node arguments are not saved as Gateway heap settings. The budget is chosen at installation and takes effect when the service process starts; it is not recalculated while the Gateway runs. Upgrading OpenClaw alone does not resize a running Gateway, and foreground launches do not replace themselves to apply this policy.
-    - The installer's memory constraints can differ from the future service's constraints. Node/libuv reporting is platform-dependent and does not guarantee detection of every ancestor cgroup limit; inspect the actual service or container limits before increasing a budget.
-    - This policy applies to managed Node Gateway launches, not foreground `gateway run`, custom supervisors, Docker runtime commands, Bun, or node-host services. Those retain their own runtime configuration. See [memory troubleshooting](/gateway/troubleshooting#gateway-exits-during-high-memory-use) for explicit native Node settings.
-
-  </Accordion>
-  <Accordion title="Auth and SecretRefs at install time">
-    - When token auth requires a token and `gateway.auth.token` is SecretRef-managed, `gateway install` validates that the SecretRef is resolvable but does not persist the resolved token into service environment metadata.
-    - If token auth requires a token and the configured token SecretRef is unresolved, install fails closed instead of persisting fallback plaintext.
-    - For password auth on `gateway run`, prefer `OPENCLAW_GATEWAY_PASSWORD`, `--password-file`, or a SecretRef-backed `gateway.auth.password` over inline `--password`.
-    - In inferred auth mode, shell-only `OPENCLAW_GATEWAY_PASSWORD` does not relax install token requirements; use durable config (`gateway.auth.password` or config `env`) when installing a managed service.
-    - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.
-
-  </Accordion>
-</AccordionGroup>
-
-## Discover gateways (Bonjour)
-
-`gateway discover` scans for Gateway beacons (`_openclaw-gw._tcp`).
-
-- Multicast DNS-SD: `local.`
-- Unicast DNS-SD (wide-area Bonjour): choose a domain (example: `openclaw.internal.`) and set up split DNS + a DNS server; see [Bonjour](/gateway/bonjour).
-
-Only gateways with Bonjour discovery enabled (default) advertise the beacon.
-
-TXT hints on every beacon: `role` (gateway role hint), `transport` (transport hint, e.g. `gateway`), `gatewayPort` (WebSocket port, usually `18789`), `tailnetDns` (MagicDNS hostname, when available), `gatewayTls` / `gatewayTlsSha256` (TLS enabled + cert fingerprint). `sshPort` and `cliPath` are published only in full discovery mode (`discovery.mdns.mode: "full"`; default is `"minimal"`, which omits them — clients then default SSH targets to port `22`).
-
-### `gateway discover`
-
-```bash
-openclaw gateway discover
-```
-
-<ParamField path="--timeout <ms>" type="number" default="2000">
-  Per-command timeout (browse/resolve).
-</ParamField>
-<ParamField path="--json" type="boolean">
-  Machine-readable output (also disables styling/spinner).
-</ParamField>
-
-Examples:
-
-```bash
-openclaw gateway discover --timeout 4000
-openclaw gateway discover --json | jq '.beacons[].wsUrl'
-```
-
-<Note>
-- Scans `local.` plus the configured wide-area domain when one is enabled.
-- `wsUrl` in JSON output is derived from the resolved service endpoint, not from TXT-only hints such as `lanHost` or `tailnetDns`.
-- `discovery.mdns.mode` controls `sshPort`/`cliPath` publication on both `local.` mDNS and wide-area DNS-SD (see above).
-
-</Note>
+## Gateway CLI pages
+
+This page is an index. Five pages document `openclaw gateway`, one per reader
+job. Open the page that matches your task.
+
+| Page                                                            | Read it when                                                                       |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [Run the Gateway](/cli/gateway/running)                         | You are starting the Gateway, tuning its run options, or reading its shared token. |
+| [Restart and supervision](/cli/gateway/restart-and-supervision) | You are restarting the Gateway, or an external supervisor owns its lifecycle.      |
+| [Query a running Gateway](/cli/gateway/query)                   | You want health, status, stability, diagnostics, or a direct RPC call.             |
+| [Manage the Gateway service](/cli/gateway/service)              | You are installing, starting, stopping, or repairing the native service.           |
+| [Discover gateways (Bonjour)](/cli/gateway/discovery)           | You are looking for gateways over mDNS or wide-area DNS-SD.                        |
+
+## Where each section moved
+
+Every anchor from the previous single-page version still resolves here, so an
+existing link such as `/cli/gateway#manage-the-gateway-service` keeps working.
+Each entry points at the page that now holds the content.
+
+- <a id="run-the-gateway" />[Run the Gateway](/cli/gateway/running#run-the-gateway)
+- <a id="options" />[Options](/cli/gateway/running#options)
+- <a id="reveal-the-configured-token" />[Reveal the configured token](/cli/gateway/running#reveal-the-configured-token)
+- <a id="restart-the-gateway" />[Restart the Gateway](/cli/gateway/restart-and-supervision#restart-the-gateway)
+- <a id="install-identity" />[Install identity](/cli/gateway/restart-and-supervision#install-identity)
+- <a id="external-supervisors" />[External supervisors](/cli/gateway/restart-and-supervision#external-supervisors)
+- <a id="gateway-profiling" />[Gateway profiling](/cli/gateway/restart-and-supervision#gateway-profiling)
+- <a id="query-a-running-gateway" />[Query a running Gateway](/cli/gateway/query#query-a-running-gateway)
+- <a id="gateway-health" />[`gateway health`](/cli/gateway/query#gateway-health)
+- <a id="gateway-usage-cost" />[`gateway usage-cost`](/cli/gateway/query#gateway-usage-cost)
+- <a id="gateway-stability" />[`gateway stability`](/cli/gateway/query#gateway-stability)
+- <a id="gateway-diagnostics-export" />[`gateway diagnostics export`](/cli/gateway/query#gateway-diagnostics-export)
+- <a id="gateway-status" />[`gateway status`](/cli/gateway/query#gateway-status)
+- <a id="gateway-probe" />[`gateway probe`](/cli/gateway/query#gateway-probe)
+- <a id="remote-over-ssh-(mac-app-parity)" />[Remote over SSH (Mac app parity)](/cli/gateway/query#remote-over-ssh-%28mac-app-parity%29)
+- <a id="gateway-call-%3Cmethod%3E" />[`gateway call <method>`](/cli/gateway/query#gateway-call-%3Cmethod%3E)
+- <a id="gateway-suspend" />[`gateway suspend`](/cli/gateway/query#gateway-suspend)
+- <a id="gateway-resume-%3Csuspensionid%3E" />[`gateway resume <suspensionId>`](/cli/gateway/query#gateway-resume-%3Csuspensionid%3E)
+- <a id="manage-the-gateway-service" />[Manage the Gateway service](/cli/gateway/service#manage-the-gateway-service)
+- <a id="recover-an-unreadable-native-service-definition" />[Recover an unreadable native service definition](/cli/gateway/service#recover-an-unreadable-native-service-definition)
+- <a id="lifecycle-requests-from-gateway-chat" />[Lifecycle requests from Gateway chat](/cli/gateway/service#lifecycle-requests-from-gateway-chat)
+- <a id="install-with-a-wrapper" />[Install with a wrapper](/cli/gateway/service#install-with-a-wrapper)
+- <a id="discover-gateways-(bonjour)" />[Discover gateways (Bonjour)](/cli/gateway/discovery#discover-gateways-%28bonjour%29)
+- <a id="gateway-discover" />[`gateway discover`](/cli/gateway/discovery#gateway-discover)
+- <a id="remote-over-ssh-mac-app-parity" />[Remote over SSH (Mac app parity)](/cli/gateway/query#remote-over-ssh-mac-app-parity)
+- <a id="gateway-call-&lt;method&gt;" />[`gateway call <method>`](/cli/gateway/query#gateway-call-%3Cmethod%3E)
+- <a id="gateway-resume-&lt;suspensionid&gt;" />[`gateway resume <suspensionId>`](/cli/gateway/query#gateway-resume-%3Csuspensionid%3E)
+- <a id="discover-gateways-bonjour" />[Discover gateways (Bonjour)](/cli/gateway/discovery#discover-gateways-bonjour)
+
+Option, tab, and panel anchors:
+
+- <a id="startup-behavior" />[Startup behavior](/cli/gateway/running#startup-behavior)
+- <a id="param-port" />[`--port`](/cli/gateway/running#param-port)
+- <a id="param-bind" />[`--bind`](/cli/gateway/running#param-bind)
+- <a id="param-token" />[`--token`](/cli/gateway/running#param-token)
+- <a id="param-auth" />[`--auth`](/cli/gateway/running#param-auth)
+- <a id="param-password" />[`--password`](/cli/gateway/running#param-password)
+- <a id="param-tailscale" />[`--tailscale`](/cli/gateway/running#param-tailscale)
+- <a id="param-allow-unconfigured" />[`--allow-unconfigured`](/cli/gateway/running#param-allow-unconfigured)
+- <a id="param-dev" />[`--dev`](/cli/gateway/running#param-dev)
+- <a id="param-ambient-channels" />[`--ambient-channels`](/cli/gateway/running#param-ambient-channels)
+- <a id="param-dev-ambient-channels" />[`--dev-ambient-channels`](/cli/gateway/running#param-dev-ambient-channels)
+- <a id="param-reset" />[`--reset`](/cli/gateway/running#param-reset)
+- <a id="param-force" />[`--force`](/cli/gateway/running#param-force)
+- <a id="param-verbose" />[`--verbose`](/cli/gateway/running#param-verbose)
+- <a id="param-cli-backend-logs" />[`--cli-backend-logs`](/cli/gateway/running#param-cli-backend-logs)
+- <a id="param-ws-log" />[`--ws-log`](/cli/gateway/running#param-ws-log)
+- <a id="param-compact" />[`--compact`](/cli/gateway/running#param-compact)
+- <a id="param-raw-stream" />[`--raw-stream`](/cli/gateway/running#param-raw-stream)
+- <a id="output-modes" />[Output modes](/cli/gateway/query#output-modes)
+- <a id="shared-options" />[Shared options](/cli/gateway/query#shared-options)
+- <a id="param-port-1" />[`--port`](/cli/gateway/query#param-port)
+- <a id="param-days" />[`--days`](/cli/gateway/query#param-days)
+- <a id="param-agent" />[`--agent`](/cli/gateway/query#param-agent)
+- <a id="param-all-agents" />[`--all-agents`](/cli/gateway/query#param-all-agents)
+- <a id="param-limit" />[`--limit`](/cli/gateway/query#param-limit)
+- <a id="param-type" />[`--type`](/cli/gateway/query#param-type)
+- <a id="param-since-seq" />[`--since-seq`](/cli/gateway/query#param-since-seq)
+- <a id="param-bundle-path" />[`--bundle`](/cli/gateway/query#param-bundle-path)
+- <a id="param-export" />[`--export`](/cli/gateway/query#param-export)
+- <a id="privacy-and-bundle-behavior" />[Privacy and bundle behavior](/cli/gateway/query#privacy-and-bundle-behavior)
+- <a id="param-log-lines" />[`--log-lines`](/cli/gateway/query#param-log-lines)
+- <a id="param-log-bytes" />[`--log-bytes`](/cli/gateway/query#param-log-bytes)
+- <a id="param-url" />[`--url`](/cli/gateway/query#param-url)
+- <a id="param-token-1" />[`--token`](/cli/gateway/query#param-token)
+- <a id="param-password-1" />[`--password`](/cli/gateway/query#param-password)
+- <a id="param-timeout" />[`--timeout`](/cli/gateway/query#param-timeout)
+- <a id="param-no-stability-bundle" />[`--no-stability-bundle`](/cli/gateway/query#param-no-stability-bundle)
+- <a id="param-json" />[`--json`](/cli/gateway/query#param-json)
+- <a id="param-url-1" />[`--url`](/cli/gateway/query#param-url-1)
+- <a id="param-port-2" />[`--port`](/cli/gateway/query#param-port-1)
+- <a id="param-token-2" />[`--token`](/cli/gateway/query#param-token-1)
+- <a id="param-password-2" />[`--password`](/cli/gateway/query#param-password-1)
+- <a id="param-timeout-1" />[`--timeout`](/cli/gateway/query#param-timeout-1)
+- <a id="param-no-probe" />[`--no-probe`](/cli/gateway/query#param-no-probe)
+- <a id="param-deep" />[`--deep`](/cli/gateway/query#param-deep)
+- <a id="param-require-rpc" />[`--require-rpc`](/cli/gateway/query#param-require-rpc)
+- <a id="status-semantics" />[Status semantics](/cli/gateway/query#status-semantics)
+- <a id="linux-systemd-auth-drift-checks" />[Linux systemd auth-drift checks](/cli/gateway/query#linux-systemd-auth-drift-checks)
+- <a id="param-port-3" />[`--port`](/cli/gateway/query#param-port-2)
+- <a id="interpretation" />[Interpretation](/cli/gateway/query#interpretation)
+- <a id="json-output" />[JSON output](/cli/gateway/query#json-output)
+- <a id="common-warning-codes" />[Common warning codes](/cli/gateway/query#common-warning-codes)
+- <a id="param-ssh" />[`--ssh`](/cli/gateway/query#param-ssh)
+- <a id="param-ssh-auto" />[`--ssh-auto`](/cli/gateway/query#param-ssh-auto)
+- <a id="param-params" />[`--params`](/cli/gateway/query#param-params)
+- <a id="param-url-2" />[`--url`](/cli/gateway/query#param-url-2)
+- <a id="param-port-4" />[`--port`](/cli/gateway/query#param-port-3)
+- <a id="param-token-3" />[`--token`](/cli/gateway/query#param-token-2)
+- <a id="param-password-3" />[`--password`](/cli/gateway/query#param-password-2)
+- <a id="param-timeout-2" />[`--timeout`](/cli/gateway/query#param-timeout-2)
+- <a id="param-expect-final" />[`--expect-final`](/cli/gateway/query#param-expect-final)
+- <a id="param-json-1" />[`--json`](/cli/gateway/query#param-json-1)
+- <a id="command-options" />[Command options](/cli/gateway/service#command-options)
+- <a id="service-runtime" />[Service runtime](/cli/gateway/service#service-runtime)
+- <a id="lifecycle-behavior" />[Lifecycle behavior](/cli/gateway/service#lifecycle-behavior)
+- <a id="managed-gateway-heap-sizing" />[Managed Gateway heap sizing](/cli/gateway/service#managed-gateway-heap-sizing)
+- <a id="auth-and-secretrefs-at-install-time" />[Auth and SecretRefs at install time](/cli/gateway/service#auth-and-secretrefs-at-install-time)
+- <a id="param-timeout-3" />[`--timeout`](/cli/gateway/discovery#param-timeout)
+- <a id="param-json-2" />[`--json`](/cli/gateway/discovery#param-json)
 
 ## Related
 

--- a/docs/cli/gateway/discovery.md
+++ b/docs/cli/gateway/discovery.md
@@ -1,0 +1,47 @@
+---
+summary: "`openclaw gateway discover` and the Bonjour beacons and TXT hints it scans for"
+read_when:
+  - Discovering gateways via Bonjour (local + wide-area DNS-SD)
+title: "Discover gateways (Bonjour)"
+sidebarTitle: "Discovery"
+---
+
+Scanning for Gateway beacons over mDNS and wide-area DNS-SD. Part of the [`openclaw gateway`](/cli/gateway) reference.
+
+## Discover gateways (Bonjour)
+
+`gateway discover` scans for Gateway beacons (`_openclaw-gw._tcp`).
+
+- Multicast DNS-SD: `local.`
+- Unicast DNS-SD (wide-area Bonjour): choose a domain (example: `openclaw.internal.`) and set up split DNS + a DNS server; see [Bonjour](/gateway/bonjour).
+
+Only gateways with Bonjour discovery enabled (default) advertise the beacon.
+
+TXT hints on every beacon: `role` (gateway role hint), `transport` (transport hint, e.g. `gateway`), `gatewayPort` (WebSocket port, usually `18789`), `tailnetDns` (MagicDNS hostname, when available), `gatewayTls` / `gatewayTlsSha256` (TLS enabled + cert fingerprint). `sshPort` and `cliPath` are published only in full discovery mode (`discovery.mdns.mode: "full"`; default is `"minimal"`, which omits them — clients then default SSH targets to port `22`).
+
+### `gateway discover`
+
+```bash
+openclaw gateway discover
+```
+
+<ParamField path="--timeout <ms>" type="number" default="2000">
+  Per-command timeout (browse/resolve).
+</ParamField>
+<ParamField path="--json" type="boolean">
+  Machine-readable output (also disables styling/spinner).
+</ParamField>
+
+Examples:
+
+```bash
+openclaw gateway discover --timeout 4000
+openclaw gateway discover --json | jq '.beacons[].wsUrl'
+```
+
+<Note>
+- Scans `local.` plus the configured wide-area domain when one is enabled.
+- `wsUrl` in JSON output is derived from the resolved service endpoint, not from TXT-only hints such as `lanHost` or `tailnetDns`.
+- `discovery.mdns.mode` controls `sshPort`/`cliPath` publication on both `local.` mDNS and wide-area DNS-SD (see above).
+
+</Note>

--- a/docs/cli/gateway/query.md
+++ b/docs/cli/gateway/query.md
@@ -1,0 +1,378 @@
+---
+summary: "Query a running Gateway: health, usage-cost, stability, diagnostics export, status, probe, call, suspend, and resume"
+read_when:
+  - Checking whether a Gateway is healthy, ready, or reachable
+  - Exporting Gateway diagnostics or a support bundle
+  - Calling a Gateway RPC method or suspending a Gateway
+title: "Query a running Gateway"
+sidebarTitle: "Query"
+---
+
+The WebSocket RPC query subcommands and their shared options. Part of the [`openclaw gateway`](/cli/gateway) reference.
+
+## Query a running Gateway
+
+All query commands use WebSocket RPC.
+
+<Tabs>
+  <Tab title="Output modes">
+    - Default: human-readable (colored in TTY).
+    - `--json`: machine-readable JSON (no styling/spinner).
+    - `--no-color` (or `NO_COLOR=1`): disable ANSI while keeping human layout.
+
+  </Tab>
+  <Tab title="Shared options">
+    - `--url <url>`: Gateway WebSocket URL.
+    - `--token <token>`: Gateway token.
+    - `--password <password>`: Gateway password.
+    - `--timeout <ms>`: timeout/budget (default varies per command; see each command below).
+    - `--expect-final`: wait for a "final" response (agent calls).
+
+  </Tab>
+</Tabs>
+
+<Note>
+When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
+</Note>
+
+### `gateway health`
+
+```bash
+openclaw gateway health --url ws://127.0.0.1:18789
+openclaw gateway health --port 18789
+```
+
+`/healthz` is a liveness probe: it returns as soon as the server can answer HTTP. `/readyz` is stricter and stays red while startup plugin sidecars, channels, or configured hooks are still settling. Local or authenticated detailed `/readyz` responses include an `eventLoop` diagnostic block (delay, utilization, CPU-core ratio, `degraded` flag).
+
+<ParamField path="--port <port>" type="number">
+  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call.
+</ParamField>
+
+### `gateway usage-cost`
+
+Fetch usage-cost summaries from session logs.
+
+```bash
+openclaw gateway usage-cost
+openclaw gateway usage-cost --days 7
+openclaw gateway usage-cost --agent work --json
+openclaw gateway usage-cost --all-agents
+openclaw gateway usage-cost --json
+```
+
+Human-readable output warns that totals may be incomplete when the usage cache is
+refreshing, partial, or stale. The command returns the available snapshot from
+one request; run it again later to check for refreshed totals. JSON output preserves
+the `cacheStatus` object so scripts can inspect the same state.
+
+<ParamField path="--days <days>" type="number" default="30">
+  Number of days to include.
+</ParamField>
+<ParamField path="--agent <id>" type="string">
+  Scope the summary to one configured agent id.
+</ParamField>
+<ParamField path="--all-agents" type="boolean">
+  Aggregate across all configured agents. Cannot combine with `--agent`.
+</ParamField>
+
+### `gateway stability`
+
+Fetch the recent diagnostic stability recorder from a running Gateway.
+
+```bash
+openclaw gateway stability
+openclaw gateway stability --type payload.large
+openclaw gateway stability --bundle latest
+openclaw gateway stability --bundle latest --export
+openclaw gateway stability --json
+```
+
+<ParamField path="--limit <limit>" type="number" default="25">
+  Maximum recent events to include (max `1000`).
+</ParamField>
+<ParamField path="--type <type>" type="string">
+  Filter by diagnostic event type, e.g. `payload.large` or `diagnostic.memory.pressure`.
+</ParamField>
+<ParamField path="--since-seq <seq>" type="number">
+  Include only events after a diagnostic sequence number.
+</ParamField>
+<ParamField path="--bundle [path]" type="string">
+  Read a persisted stability bundle instead of calling the running Gateway. `--bundle latest` (or bare `--bundle`) picks the newest bundle under the state directory; you can also pass a bundle JSON path directly.
+</ParamField>
+<ParamField path="--export" type="boolean">
+  Write a shareable support diagnostics zip instead of printing stability details.
+</ParamField>
+<ParamField path="--output <path>" type="string">
+  Output path for `--export`.
+</ParamField>
+
+<AccordionGroup>
+  <Accordion title="Privacy and bundle behavior">
+    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, approval ids, channel/plugin names, and redacted session summaries. They exclude chat text, webhook bodies, tool outputs, raw request/response bodies, tokens, cookies, secret values, hostnames, and raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
+    - Fatal Gateway exits, shutdown timeouts, and restart startup failures write the same diagnostic snapshot to `~/.openclaw/logs/stability/openclaw-stability-*.json` when the recorder has events. Inspect the newest bundle with `openclaw gateway stability --bundle latest`; `--limit`, `--type`, and `--since-seq` apply to bundle output too.
+
+  </Accordion>
+</AccordionGroup>
+
+### `gateway diagnostics export`
+
+Write a local diagnostics zip designed for bug reports. For the privacy model and bundle contents, see [Diagnostics Export](/gateway/diagnostics).
+
+```bash
+openclaw gateway diagnostics export
+openclaw gateway diagnostics export --output openclaw-diagnostics.zip
+openclaw gateway diagnostics export --json
+```
+
+<ParamField path="--output <path>" type="string">
+  Output zip path. Defaults to a support export under the state directory.
+</ParamField>
+<ParamField path="--log-lines <count>" type="number" default="5000">
+  Maximum sanitized log lines to include.
+</ParamField>
+<ParamField path="--log-bytes <bytes>" type="number" default="1000000">
+  Maximum log bytes to inspect.
+</ParamField>
+<ParamField path="--url <url>" type="string">
+  Gateway WebSocket URL for the health snapshot.
+</ParamField>
+<ParamField path="--token <token>" type="string">
+  Gateway token for the health snapshot.
+</ParamField>
+<ParamField path="--password <password>" type="string">
+  Gateway password for the health snapshot.
+</ParamField>
+<ParamField path="--timeout <ms>" type="number" default="3000">
+  Status/health snapshot timeout.
+</ParamField>
+<ParamField path="--no-stability-bundle" type="boolean">
+  Skip persisted stability bundle lookup.
+</ParamField>
+<ParamField path="--json" type="boolean">
+  Print the written path, size, and manifest as JSON.
+</ParamField>
+
+The export bundles: `manifest.json` (file inventory), `summary.md` (Markdown summary), `diagnostics.json` (top-level config/logs/discovery/stability/status/health summary), `config/sanitized.json`, `status/gateway-status.json`, `health/gateway-health.json`, `logs/openclaw-sanitized.jsonl`, and `stability/latest.json` when a bundle exists.
+
+It is designed to be shared. It keeps operational details useful for debugging — safe log fields, subsystem names, status codes, durations, configured modes, ports, plugin/provider ids, non-secret feature settings, and redacted operational log messages — and omits or redacts chat text, webhook bodies, tool outputs, credentials, cookies, account/message identifiers, prompt/instruction text, hostnames, and secret values. When a log message looks like user/chat/tool payload text (e.g. "user said", "chat text", "tool output", "webhook body"), the export keeps only the fact that a message was omitted plus its byte count.
+
+### `gateway status`
+
+Shows the Gateway service (launchd/systemd/schtasks) plus an optional connectivity/auth probe.
+
+```bash
+openclaw gateway status
+openclaw gateway status --json
+openclaw gateway status --require-rpc
+openclaw gateway status --port 19001
+```
+
+<ParamField path="--url <url>" type="string">
+  Probe this explicit WebSocket URL instead of the service-derived target. Cannot combine with `--port`.
+</ParamField>
+<ParamField path="--port <port>" type="number">
+  Select a local Gateway port using the invoking CLI config for auth and TLS. Accepts `gateway --port 19001 status` and `gateway status --port 19001`; an explicit status port wins. Native service details remain visible as diagnostics but do not select the probe target.
+</ParamField>
+<ParamField path="--token <token>" type="string">
+  Token auth for the probe.
+</ParamField>
+<ParamField path="--password <password>" type="string">
+  Password auth for the probe.
+</ParamField>
+<ParamField path="--timeout <ms>" type="number" default="10000">
+  Probe timeout.
+</ParamField>
+<ParamField path="--no-probe" type="boolean">
+  Skip the connectivity probe (service-only view).
+</ParamField>
+<ParamField path="--deep" type="boolean">
+  Scan system-level services too.
+</ParamField>
+<ParamField path="--require-rpc" type="boolean">
+  Upgrade the connectivity probe to a read probe and exit non-zero if it fails. Cannot combine with `--no-probe`.
+</ParamField>
+
+<AccordionGroup>
+  <Accordion title="Status semantics">
+    - Stays available for diagnostics even when the local CLI config is missing or invalid.
+    - Default output proves service state, WebSocket connect, and the auth capability visible at handshake time — not read/write/admin operations.
+    - Probes are non-mutating for first-time device auth: they reuse an existing cached device token when one exists, but never create a new CLI device identity or read-only pairing record just to check status.
+    - Resolves configured auth SecretRefs for probe auth when possible. If a required SecretRef is unresolved, `--json` reports `rpc.authWarning` when probe connectivity/auth fails; pass `--token`/`--password` explicitly or fix the secret source. Unresolved-auth warnings are suppressed once the probe succeeds.
+    - JSON output includes `gateway.version` when the running Gateway reports it; `--require-rpc` can fall back to the `status.runtimeVersion` RPC payload if the handshake probe cannot supply version metadata.
+    - Use `--require-rpc` in scripts/automation when a listening service is not enough and you need read-scope RPC to be healthy too.
+    - `--deep` scans for extra launchd/systemd/schtasks installs; when multiple gateway-like services are found, human output prints cleanup hints (usually run one gateway per machine) and reports a recent supervisor restart handoff when relevant.
+    - `--deep` confirms exact npm targets before suggesting repairs for official-plugin version drift. Unpublished versions or registry failures are reported without an update command; retry deep status after registry access or the release cohort is restored. Ordinary status and readiness checks do not query npm for drift repairs.
+    - `--deep` also runs config validation in plugin-aware mode (`pluginValidation: "full"`) and surfaces plugin manifest warnings (e.g. missing channel config metadata). Default `gateway status` keeps the fast read-only path that skips plugin validation.
+    - On Linux, status reports the effective service currently loaded by systemd, including loaded drop-ins. If the unit or a drop-in changed on disk, `Systemd reload: pending` means you must run `systemctl --user daemon-reload` (or `sudo systemctl daemon-reload` for a system service) before those changes take effect.
+    - Human output includes the resolved file log path plus CLI-vs-service config paths/validity to help diagnose profile or state-dir drift.
+    - Install and reinstall guidance follows the invoking shell's installation rules, not the stored service environment or probe target. Nix mode, external supervision, noncanonical installation identity, and Linux sudo/user-manager mismatches show the install refusal instead of an unusable command. A diagnostic-only target is not itself a refusal. Nix mode blocks installation, not starting an existing service.
+    - Human output includes `Gateway heap:` with configured service heap controls and a separate install-time recommendation based on memory visible to the CLI. JSON output exposes the same report as `service.gatewayHeap`. Neither is a measurement of the running Gateway's V8 heap ceiling; use runtime memory diagnostics for that.
+
+  </Accordion>
+  <Accordion title="Linux systemd auth-drift checks">
+    - Service auth drift checks read both `Environment=` and `EnvironmentFile=` from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
+    - Resolves `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
+    - Token-drift checks skip config token resolution when token auth is not effectively active (`gateway.auth.mode` explicitly `password`/`none`/`trusted-proxy`, or mode unset where password can win and no token candidate can win).
+
+  </Accordion>
+</AccordionGroup>
+
+### `gateway probe`
+
+The "debug everything" command. It always probes:
+
+- your configured remote gateway (if set), and
+- localhost (loopback), **even if remote is configured**.
+
+Passing `--url` adds that explicit target ahead of both. Human output labels targets `URL (explicit)`, `Remote (configured)` / `Remote (configured, inactive)`, and `Local loopback`.
+
+<Note>
+If multiple probe targets are reachable, all are printed. An SSH tunnel, TLS/proxy URL, and configured remote URL can point at the same gateway even with different transport ports; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Running multiple gateways is supported for isolated profiles (e.g. a rescue bot), but most installs run a single gateway.
+</Note>
+
+```bash
+openclaw gateway probe
+openclaw gateway probe --json
+openclaw gateway probe --port 18789
+```
+
+<ParamField path="--port <port>" type="number">
+  Use this port for the local loopback probe target and SSH tunnel remote port. Without `--url`, this selects only the local loopback target instead of configured gateway environment URL, environment port, or remote targets.
+</ParamField>
+
+<AccordionGroup>
+  <Accordion title="Interpretation">
+    - `Reachable: yes` means at least one target accepted a WebSocket connect.
+    - `Capability: read-only|write-capable|admin-capable|pairing-pending|connect-only` reports what the probe could prove about auth, separate from reachability.
+    - `Read probe: ok` means read-scope detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
+    - `Read probe: limited - missing scope: operator.read` means connect succeeded but read-scope RPC is limited. Reported as **degraded** reachability, not full failure.
+    - `Read probe: failed` after `Connect: ok` means the WebSocket connected but follow-up read diagnostics timed out or failed — also **degraded**, not unreachable.
+    - Like `gateway status`, probe reuses existing cached device auth but does not create first-time device identity or pairing state.
+    - Exit code is non-zero only when no probed target is reachable.
+
+  </Accordion>
+  <Accordion title="JSON output">
+    Top level:
+
+    - `ok`: at least one target is reachable.
+    - `degraded`: at least one target accepted a connection but did not complete full detail RPC diagnostics.
+    - `capability`: best capability seen across reachable targets (`read_only`, `write_capable`, `admin_capable`, `pairing_pending`, `connected_no_operator_scope`, or `unknown`).
+    - `primaryTargetId`: best target to treat as the active winner, in order: explicit URL, SSH tunnel, configured remote, local loopback.
+    - `warnings[]`: best-effort warning records with `code`, `message`, optional `targetIds`.
+    - `network`: local loopback/tailnet URL hints derived from current config and host networking.
+    - `discovery.timeoutMs` / `discovery.count`: the actual discovery budget/result count used for this probe pass.
+
+    Per target (`targets[].connect`): `ok` (reachability + degraded classification), `rpcOk` (full detail RPC success), `scopeLimited` (detail RPC failed on missing operator scope).
+
+    Per target (`targets[].auth`): `role` and `scopes` reported in `hello-ok` when available, plus the surfaced `capability` classification.
+
+  </Accordion>
+  <Accordion title="Common warning codes">
+    - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
+    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this.
+    - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
+    - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
+    - `local_tls_runtime_unavailable`: local Gateway TLS is enabled but OpenClaw could not load the local certificate fingerprint.
+
+  </Accordion>
+</AccordionGroup>
+
+#### Remote over SSH (Mac app parity)
+
+The macOS app "Remote over SSH" mode uses a local port-forward so a loopback-only remote gateway becomes reachable at `ws://127.0.0.1:<port>`.
+
+CLI equivalent:
+
+```bash
+openclaw gateway probe --ssh user@gateway-host
+```
+
+<ParamField path="--ssh <target>" type="string">
+  `user@host` or `user@host:port` (port defaults to `22`).
+</ParamField>
+
+OpenClaw launches only an SSH client found in OS-managed system directories. On native Windows,
+install the **OpenSSH Client** optional feature; Windows places it under
+`%SystemRoot%\System32\OpenSSH`.
+
+<ParamField path="--ssh-identity <path>" type="string">
+  Identity file.
+</ParamField>
+<ParamField path="--ssh-auto" type="boolean">
+  Pick the first discovered gateway host as SSH target from the resolved discovery endpoint (`local.` plus the configured wide-area domain, if any). TXT-only hints are ignored.
+</ParamField>
+
+Config defaults (optional): `gateway.remote.sshTarget`, `gateway.remote.sshIdentity`.
+
+### `gateway call <method>`
+
+Low-level RPC helper.
+
+```bash
+openclaw gateway call status
+openclaw gateway call health --port 18999
+openclaw gateway call logs.tail --params '{"limit": 200}'
+```
+
+<ParamField path="--params <json>" type="string" default="{}">
+  JSON object string for params.
+</ParamField>
+<ParamField path="--url <url>" type="string">
+  Gateway WebSocket URL.
+</ParamField>
+<ParamField path="--port <port>" type="number">
+  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`.
+</ParamField>
+<ParamField path="--token <token>" type="string">
+  Gateway token.
+</ParamField>
+<ParamField path="--password <password>" type="string">
+  Gateway password.
+</ParamField>
+<ParamField path="--timeout <ms>" type="number" default="10000">
+  Timeout budget.
+</ParamField>
+<ParamField path="--expect-final" type="boolean">
+  Mainly for agent-style RPCs that stream intermediate events before a final payload.
+</ParamField>
+<ParamField path="--json" type="boolean">
+  Machine-readable JSON output.
+</ParamField>
+
+`openclaw.setup.detect` uses a 40-second default so the Gateway can finish its
+bounded AI-access scan. An explicit `--timeout` still takes precedence.
+
+<Note>
+`--params` must be valid JSON, and each method validates its own param shape (extra/misnamed fields are rejected). Use `--port` for a custom-port local Gateway; explicit `--url` targets still require explicit credentials.
+</Note>
+
+### `gateway suspend`
+
+Prepare an idle Gateway for a cooperative host freeze or snapshot. Without
+`--wait`, active work returns a nonzero exit with blocker details. With
+`--wait`, the CLI retries until the bounded deadline using one stable request
+ID. The value must be a non-negative number of seconds; an empty value is rejected.
+Use `--wait 0` for a single attempt without polling.
+
+```bash
+openclaw gateway suspend
+openclaw gateway suspend --request-id snapshot-2026-08-11 --wait 30
+openclaw gateway suspend --port 18999 --json
+```
+
+The ready output includes the suspension ID, lease expiry, and the matching
+resume command. Common RPC options such as `--url`, `--token`, `--password`,
+`--timeout`, `--json`, and `--port` are supported.
+
+### `gateway resume <suspensionId>`
+
+Release a prepared suspension after thaw or when the host operation is
+abandoned.
+
+```bash
+openclaw gateway resume <suspensionId>
+openclaw gateway resume <suspensionId> --port 18999 --json
+```
+
+An already expired or resumed lease is a successful no-op. A different active
+suspension ID is rejected.

--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -1,0 +1,139 @@
+---
+summary: "`openclaw gateway restart`, install identity, external process supervisors, and Gateway profiling"
+read_when:
+  - Restarting the Gateway safely, forcibly, or with a bounded wait
+  - Integrating an external Gateway process supervisor
+  - Profiling Gateway startup and restart timings
+title: "Restart and supervision"
+sidebarTitle: "Restart and supervision"
+---
+
+Restart flags, which install owns the host service, external supervisors, and profiling. Part of the [`openclaw gateway`](/cli/gateway) reference.
+
+## Restart the Gateway
+
+```bash
+openclaw gateway restart
+openclaw gateway restart --safe
+openclaw gateway restart --safe --skip-deferral
+openclaw gateway restart --force
+openclaw gateway restart --wait 30s
+```
+
+`--safe` asks the running Gateway to preflight active work and schedule one coalesced restart after that work drains. The wait is bounded to 5 minutes; when the budget expires the restart is forced. `--safe` cannot combine with `--force` or `--wait`.
+
+`--skip-deferral` bypasses only the safe-restart active-work deferral gate. It can move the Gateway into shutdown even while active-work blockers are reported, but the close-stage pending-reply drain still applies before the process exits. It requires `--safe` — use it when a deferral is stuck on a runaway task and reply delivery can still be allowed to settle.
+
+`--wait <duration>` overrides the drain budget for a plain (non-safe) restart. Accepts bare milliseconds or unit suffixes `ms`, `s`, `m`, `h`, `d` (e.g. `30s`, `5m`, `1h30m`); `--wait 0` waits indefinitely. Not compatible with `--force` or `--safe`.
+
+`--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
+
+On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
+
+On macOS, when `openclaw gateway restart`, `stop`, `install`, or `uninstall` runs inside the managed LaunchAgent's process tree, including an agent's shell command, OpenClaw detects that from launchd's service environment or, when a hand-written plist omits those variables, from process ancestry against the PID launchd reports for the job. Restart hands off to a detached helper so `kickstart -k` cannot kill the caller. Stop, install, and uninstall refuse and ask you to run the command from an external shell.
+
+External terminals without Gateway-service markers, externally supervised Gateways, node services, and non-Windows callers keep their existing routing. Explicit `--force`, `--wait`, `--preserve-definition`, or `--skip-deferral` also retain their existing behavior and validation; they do not implicitly enable `--safe`.
+
+<Warning>
+Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.
+</Warning>
+
+### Install identity
+
+Service management (`install`, `start`, `stop`, `restart`, `uninstall`, Doctor service repair, and self-update service handling) belongs to the install that owns the host service. That is the canonical `.openclaw` directory under the OS account home, or the `.openclaw-<profile>` directory a named profile projects there. Named profiles use distinct native service identities.
+
+`OPENCLAW_HOME`, or an `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` that points elsewhere, is treated as isolated state and skipped. A relocated or copied state tree cannot adopt and rewrite the account's host service.
+
+On macOS and Windows, native service-managed profile names must be lowercase. Runtime-only profiles may still use uppercase, but case-distinct names such as `Main` and `main` share paths on normal case-insensitive filesystems and cannot safely own separate native services. On macOS, the lowercase names `gateway` and `node` are also unavailable for native service management because their historical LaunchAgent labels collide with the default Gateway and node-host services.
+
+Named profiles must also use the native service identity derived from `OPENCLAW_PROFILE`. Unset `OPENCLAW_LAUNCHD_LABEL`, `OPENCLAW_SYSTEMD_UNIT`, or `OPENCLAW_WINDOWS_TASK_NAME` before service management; custom identities remain available for the default profile or runtime-only/external-supervisor setups.
+
+On Linux, `openclaw gateway install --force` refuses a sealed systemd service
+definition, or one whose write authority cannot be verified, before changing
+configuration, authentication tokens, or service files. The error keeps its
+`SERVICE_DEFINITION_SEALED` or `SERVICE_DEFINITION_UNKNOWN` prefix and adds a
+reason tag and next action, without printing private paths, config, environment values,
+or underlying inspection errors.
+
+For `[unsafe-permissions]`, inspect the named artifact category locally. The
+service directory is `~/.config/systemd/user`; on a fresh install, its nearest
+existing ancestor may be `~/.config`. The service state directory belongs to the
+selected profile. Check directory metadata, not file contents:
+
+```bash
+ls -ld ~/.config ~/.config/systemd ~/.config/systemd/user
+```
+
+Missing directories are normal on a fresh install. After confirming the affected
+path is yours and is not intentionally shared, remove group/other write access
+with `chmod go-w <path>` and retry the same command. Mode `0700` is appropriate
+for private directories. Do not recursively chmod, take ownership of system
+paths, or use `sudo`/`--force` to bypass the check. Foreign-owned files and sealed
+mounts require the deployment owner; inspection failures require restoring
+filesystem or native service-manager access first.
+
+Type-wide `service.d` defaults are inspected as shared read-only inputs and do
+not require write access. Root-owned selected units and unit-specific drop-ins
+remain protected.
+
+### External supervisors
+
+Set `OPENCLAW_SUPERVISOR_MODE=external` only when another process manager owns the Gateway lifecycle. In this mode:
+
+- `openclaw gateway restart` preserves the existing safe, forced, and bounded-wait behavior while targeting the verified running Gateway instead of launchd, systemd, or Task Scheduler. Exact-lock restart delivery runs inside that Gateway, so a replacement CLI does not migrate shared state before the old process hands off.
+- Native service install, start, stop, and uninstall operations are refused with guidance to use the external supervisor.
+- OpenClaw self-update is refused so the supervisor can stop the Gateway, replace and finalize the runtime, and restart it safely.
+- A fresh-process restart writes a bounded SQLite handoff before clean exit. If persistence fails, the Gateway falls back to an in-process restart instead of exiting without a consumable handoff.
+
+An external supervisor can also claim durable ownership of shared-state writes:
+
+```bash
+OPENCLAW_SUPERVISOR_MODE=external \
+  openclaw database ownership claim --manager gateway-supervisor --json
+```
+
+Before claiming, stop and verify every older Gateway, CLI, Doctor, updater, and native app process that can write the shared state database. Pre-contract processes do not understand the ownership row and cannot be retroactively fenced. Claim only after every remaining writer uses ownership-aware code and carries `OPENCLAW_SUPERVISOR_MODE=external`.
+
+The claim is idempotent for the same stable manager identifier and refuses a different manager. There is no automatic claim or unclaim path. Once claimed, unmarked writable shared-state opens fail before permissions, schema migration, additive repair, compaction, or other mutation. Read-only access remains available. This is protection against accidental unmarked same-user writers, not an authentication or lease protocol.
+
+For upgrades and rollbacks, have the supervisor create a consolidated WAL-consistent copied snapshot with no SQLite sidecars, then run the target release's own `openclaw database preflight <copied-state.sqlite> --json` before activation. Numeric schema versions alone do not prove that a same-version additive shape is compatible. See [Database schemas](/reference/database-schemas).
+
+`OPENCLAW_SERVICE_REPAIR_POLICY=external` remains a separate Doctor repair policy. It does not declare runtime ownership; supervisors that need both behaviors should set both variables.
+
+External supervisors can negotiate and consume restart handoffs through the hidden machine contract:
+
+```bash
+openclaw gateway restart-handoff capabilities --json
+openclaw gateway restart-handoff consume --expected-pid <pid> --json
+```
+
+Protocol version `1` supports the `consume` operation. Consumption validates the expected PID and bounded handoff fields inside one immediate SQLite transaction. An accepted handoff is deleted before success is returned, so concurrent or replayed consumers cannot both accept it. A PID mismatch is retained for the matching owner; missing, expired, and invalid rows do not authorize a restart.
+
+Valid machine requests return JSON with exit code `0`, including non-restart results. Invalid arguments return `reason: "invalid-expected-pid"` with exit code `2`; state-store failures return `reason: "store-unavailable"` with exit code `1`. Supervisors should probe `capabilities` on the exact runtime or launcher they will use rather than infer support from an OpenClaw version string or read the private SQLite schema directly.
+
+External supervisor implementations should also apply these acceptance rules:
+
+- Bound capability probes with a timeout that accounts for full CLI cold-start latency on the deployed runtime and storage, rather than assuming warm-start timing.
+- If capability negotiation or handoff consumption refuses replacement, exit promptly with a nonzero status so the process manager's recovery policy can run. Do not remain alive without a Gateway child or listener.
+- Treat supervisor process liveness as distinct from replacement startup and channel readiness. Report success only after the new Gateway owns its listener and `/startupz` returns `status: "started"`; monitor `/readyz` separately for configured-channel health, while `/healthz` proves liveness only.
+
+### Gateway profiling
+
+- `OPENCLAW_GATEWAY_STARTUP_TRACE=1` logs phase timings during startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings (installed-index, manifest registry, startup planning, owner-map work).
+- `OPENCLAW_GATEWAY_RESTART_TRACE=1` logs `restart trace:` lines for restart signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics. Ordinary stops also start a fresh trace with `stop.signal.received` and `stop.drain` timing. Named shutdown steps and coarse close phases emit `.begin` before waiting, then a duration when they settle; an unmatched begin identifies an entered phase that has not settled. These phases do not time every nested cleanup operation individually.
+- `OPENCLAW_DIAGNOSTICS=timeline` with `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<path>` writes a best-effort JSONL startup diagnostics timeline for external QA harnesses (equivalent to config `diagnostics.flags: ["timeline"]`; the path is still env-only). Add `OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1` to include event-loop samples.
+- `pnpm build` then `pnpm test:startup:gateway -- --runs 5 --warmup 1` benchmarks Gateway startup against the built CLI entry: first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing.
+- `pnpm build` then `pnpm test:restart:gateway -- --case skipChannels --runs 1 --restarts 5` benchmarks in-process restart on macOS or Linux (not supported on Windows; restart requires `SIGUSR1`). Uses `SIGUSR1`, enables both traces in the child process, and records next `/healthz`, next `/readyz`, downtime, ready timing, CPU, RSS, and restart trace metrics.
+- `/healthz` is liveness; `/readyz` is usable readiness. Treat trace lines and benchmark output as owner-attribution signal, not a complete performance conclusion from one span or sample.
+
+Without tracing, stops and restarts report nonzero active-work category counts at
+the first drain snapshot and at most once every 30 seconds while still pending.
+These reports omit task identities and request origins; categories can overlap.
+An ordinary stop logs `active-work drain settled; beginning server close` before
+teardown, including after a drain timeout or failure. Diagnostics do not change
+drain budgets or the service manager's stop deadline.
+
+A client disconnect leaves interactive setup available for reconnect. A Gateway
+stop or restart closes setup prompts before draining work. Settings writes already
+in progress may finish, but setup will not wait for another answer during shutdown.
+After the Gateway starts again, reopen setup and check the saved settings.

--- a/docs/cli/gateway/running.md
+++ b/docs/cli/gateway/running.md
@@ -1,0 +1,108 @@
+---
+summary: "`openclaw gateway` run options, startup behavior, and revealing the configured token"
+read_when:
+  - Running the Gateway from the CLI (dev or servers)
+  - Debugging Gateway auth, bind modes, and connectivity
+  - Reading the configured shared token on the Gateway host
+title: "Run the Gateway"
+sidebarTitle: "Running"
+---
+
+Starting the Gateway process and reading its configured token. Part of the [`openclaw gateway`](/cli/gateway) reference.
+
+## Run the Gateway
+
+```bash
+openclaw gateway
+openclaw gateway run   # equivalent, explicit form
+```
+
+<AccordionGroup>
+  <Accordion title="Startup behavior">
+    - Refuses to start unless `gateway.mode=local` is set in `~/.openclaw/openclaw.json`. Use `--allow-unconfigured` for ad-hoc/dev runs; it bypasses the guard without writing or repairing config.
+    - Startup automatically applies deterministic, prompt-free legacy-key migrations to eligible invalid single-file configs, including in non-interactive service runs. It writes only after full validation, including plugins, and keeps the previous config in the `.bak` ring. Configs using `$include`, Nix-managed configs, and configs written by a newer version are excluded. See [Legacy config key migrations](/gateway/doctor#detailed-behavior-and-rationale).
+    - If automatic migration cannot make the config valid, an interactive terminal can offer to run `openclaw doctor --fix` and retry startup once after consent. Non-interactive runs print the command instead. If the repaired config is still invalid, startup remains stopped.
+    - `openclaw onboard --mode local` and `openclaw setup` write `gateway.mode=local`. If the config file exists but `gateway.mode` is missing, that is treated as damaged/clobbered config and the Gateway refuses to guess `local` for you — re-run onboarding, set the key manually, or pass `--allow-unconfigured`.
+    - Binding beyond loopback without auth is blocked.
+    - `--bind` values `lan`, `tailnet`, and `custom` resolve over IPv4-only paths today; IPv6-only bring-your-own-host setups need an IPv4 sidecar or proxy in front of the Gateway.
+    - `SIGUSR1` triggers an in-process restart when authorized. `commands.restart` (default: enabled) gates externally-sent `SIGUSR1`; set it to `false` to block manual OS-signal restarts. The agent-facing `gateway` tool is read-only; agents request restart through the `openclaw` delegation tool. Effective Full Access, including Default (Full Access), authorizes permitted delegated changes without an approval prompt; restricted runs require human approval. See [Delegated setup and repair](/gateway/permission-modes#delegated-setup-and-repair).
+    - `SIGINT`/`SIGTERM` stop the process but do not restore custom terminal state — if you wrap the CLI in a TUI or raw-mode input, restore the terminal yourself before exit.
+
+  </Accordion>
+</AccordionGroup>
+
+### Options
+
+<ParamField path="--port <port>" type="number">
+  WebSocket port (default from config/env; usually `18789`).
+</ParamField>
+<ParamField path="--bind <mode>" type="string">
+  Bind mode: `loopback` (default), `lan`, `tailnet`, `auto`, `custom`.
+</ParamField>
+<ParamField path="--token <token>" type="string">
+  Shared token for `connect.params.auth.token`. Defaults to `OPENCLAW_GATEWAY_TOKEN` when set.
+</ParamField>
+<ParamField path="--auth <mode>" type="string">
+  Auth mode: `none`, `token`, `password`, `trusted-proxy`.
+</ParamField>
+<ParamField path="--password <password>" type="string">
+  Password for `--auth password`.
+</ParamField>
+<ParamField path="--password-file <path>" type="string">
+  Read the Gateway password from a file.
+</ParamField>
+<ParamField path="--tailscale <mode>" type="string">
+  Tailscale exposure: `off`, `serve`, `funnel`.
+</ParamField>
+<ParamField path="--allow-unconfigured" type="boolean">
+  Start without enforcing `gateway.mode=local`. Ad-hoc/dev bootstrap only; does not persist or repair config.
+</ParamField>
+<ParamField path="--dev" type="boolean">
+  Create a dev config + workspace if missing (skips `BOOTSTRAP.md`).
+</ParamField>
+<ParamField path="--ambient-channels" type="boolean">
+  Allow the Gateway to auto-configure channels from ambient environment variables. By default, channels require an explicit `channels.<id>` config block.
+</ParamField>
+<ParamField path="--dev-ambient-channels" type="boolean">
+  Deprecated alias for `--ambient-channels`.
+</ParamField>
+<ParamField path="--reset" type="boolean">
+  Reset dev config, credentials, sessions, and workspace. Requires `--dev`.
+</ParamField>
+<ParamField path="--force" type="boolean">
+  Kill any existing listener on the target port before starting. In a non-interactive shell, this refuses to kill a verified Gateway listener; use `--dev` or an isolated `--profile` with a free port instead.
+</ParamField>
+<ParamField path="--verbose" type="boolean">
+  Verbose logging to stdout/stderr.
+</ParamField>
+<ParamField path="--cli-backend-logs" type="boolean">
+  Only show CLI backend logs in the console (also enables stdout/stderr).
+</ParamField>
+<ParamField path="--ws-log <style>" type="string" default="auto">
+  WebSocket log style: `auto`, `full`, `compact`.
+</ParamField>
+<ParamField path="--compact" type="boolean">
+  Alias for `--ws-log compact`.
+</ParamField>
+<ParamField path="--raw-stream" type="boolean">
+  Log raw model stream events to JSONL.
+</ParamField>
+<ParamField path="--raw-stream-path <path>" type="string">
+  Raw stream JSONL path.
+</ParamField>
+
+`--claude-cli-logs` is a deprecated alias for `--cli-backend-logs`.
+
+For `--bind custom`, set `gateway.customBindHost` to an IPv4 address. Any address other than `127.0.0.1` or `0.0.0.0` also requires `127.0.0.1` on the same port for same-host clients; startup fails if either listener cannot bind. Wildcard `0.0.0.0` does not add a separate required alias. IPv6-only bring-your-own-host setups need an IPv4 sidecar or proxy in front of the Gateway.
+
+## Reveal the configured token
+
+Run this on the Gateway host when a client needs the configured shared token:
+
+```bash
+openclaw gateway auth-token --show
+```
+
+The command resolves `gateway.auth.token`, `OPENCLAW_GATEWAY_TOKEN`, and configured SecretRefs, then prints only the token. It requires an interactive terminal and refuses redirected or piped output so the credential does not silently enter command logs. Treat the terminal output as a secret.
+
+If no persistent token is configured, run `openclaw doctor --generate-gateway-token`, restart the Gateway, and then rerun the command. Generic `openclaw config get` output remains redacted, including `--json`.

--- a/docs/cli/gateway/service.md
+++ b/docs/cli/gateway/service.md
@@ -1,0 +1,177 @@
+---
+summary: "Install, start, stop, and uninstall the managed Gateway service, including wrappers, heap sizing, and install-time auth"
+read_when:
+  - Managing the Gateway as a native OS service
+  - Recovering an unreadable native service definition
+  - Installing the Gateway service through a wrapper
+title: "Manage the Gateway service"
+sidebarTitle: "Service"
+---
+
+Native service lifecycle, recovery, wrappers, and the managed-service option reference. Part of the [`openclaw gateway`](/cli/gateway) reference.
+
+## Manage the Gateway service
+
+```bash
+openclaw gateway install
+openclaw gateway start
+openclaw gateway stop
+openclaw gateway restart
+openclaw gateway uninstall
+```
+
+`gateway stop` remains available when plugin configuration needs Doctor migration.
+It still validates core configuration and refuses configuration written by a newer
+OpenClaw binary. Start and restart continue to validate plugin configuration.
+
+### Recover an unreadable native service definition
+
+If installation or a managed update reports `SERVICE_DEFINITION_UNKNOWN`, first
+restore access to the service files and native service manager. `--force` does not
+bypass unknown service facts. Inspect the selected service with
+`openclaw gateway status --deep` from the account and profile that own it.
+
+For a malformed definition or unsupported environment syntax, privately back up
+the service files and any values stored only in its environment. Correct unresolved
+or unsupported values before reinstalling; OpenClaw cannot infer their intended
+values. Then, from an external shell using the same account and profile:
+
+```bash
+openclaw gateway uninstall
+openclaw gateway install
+openclaw gateway health
+```
+
+Uninstall removes the native registration and launcher, preserving configuration,
+plugin installations, session state, and workspaces. Reinstallation rebuilds the
+service environment from the current configuration and installation inputs;
+service-only values must be supplied again. If native service status is itself
+unavailable, uninstall also refuses: restore native manager access first instead
+of deleting state or bypassing inspection.
+
+### Lifecycle requests from Gateway chat
+
+Gateway-hosted OpenClaw chat controls the exact Gateway serving that session.
+An approved start request reports **Gateway already running** without discovering
+or starting another service. Restart keeps the safe local restart behavior.
+
+An approved stop reports **Scheduled Gateway stop** after the host has prepared
+the stop for its exact instance. This acknowledges scheduling, not completed
+termination. An exclusive foreground host drains work, finishes teardown, and
+exits successfully without discovering or changing an installed service. A host
+managed by launchd or systemd verifies native ownership and prepares an executor,
+then drains work and finishes teardown before asking the native manager to stop
+the service. The requesting operation can finish its audit, history, and response
+submission during that drain;
+this does not guarantee that the client receives the response before disconnecting.
+
+After the normal grace period, stop cancels the remaining runs owned by that
+Gateway and waits for their commands and cleanup to settle. Ordinary stop does
+not schedule restart recovery. A required cleanup failure produces a nonzero exit and
+prevents an in-process replacement, including when startup failed before the
+Gateway became ready.
+
+Ownership or preparation failures leave the Gateway serving and return an error.
+Linux uses an independent transient control scope, in the owning systemd manager,
+so the stop command survives service cgroup termination. On macOS, hosted stop
+requests ordinary `launchctl bootout` without changing persistent enablement.
+If the native manager sends `SIGTERM` during the final stop handoff, the host
+finishes its graceful exit after joining cleanup, including the owned stop client.
+
+On Windows, a run loop that exclusively owns the Gateway process also uses
+graceful process exit under Task Scheduler. It does not select or stop a task by
+name. The generated task supervisor waits for the child process tree to exit and
+propagates the child exit result through the launcher. Its
+[`RestartOnFailure` policy](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-restartonfailure-settingstype-element)
+does not restart a successful task exit. Custom wrappers can have different exit
+or restart behavior; check their policy separately. This stop path does not change
+the task definition or its restart policy. Externally supervised Gateways direct
+stop requests to their supervisor.
+
+If systemd definitively refuses a stop after teardown and the same native instance
+remains active with no pending job, the host logs the failed stop and starts a fresh
+Gateway generation in the same process. An uncertain native result is recorded as
+a failed shutdown, without claiming success or starting an in-process replacement.
+After an unexpected disconnect, check `openclaw gateway status` and the native
+service logs from an external shell before retrying. Standalone CLI lifecycle
+commands retain their service-management behavior.
+
+### Install with a wrapper
+
+Use `--wrapper` when the managed service must start through another executable, for example a secrets manager shim or a run-as helper. The wrapper receives the normal Gateway args and is responsible for eventually exec'ing `openclaw` or Node with those args.
+
+```bash
+cat > ~/.local/bin/openclaw-doppler <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec doppler run --project my-project --config production -- openclaw "$@"
+EOF
+chmod +x ~/.local/bin/openclaw-doppler
+
+openclaw gateway install --wrapper ~/.local/bin/openclaw-doppler --force
+openclaw gateway restart
+```
+
+You can also set the wrapper through the environment. `gateway install` validates that the path is an executable file, writes the wrapper into the service `ProgramArguments`, and persists `OPENCLAW_WRAPPER` in the service environment for later forced reinstalls, updates, and doctor repairs.
+
+```bash
+OPENCLAW_WRAPPER="$HOME/.local/bin/openclaw-doppler" openclaw gateway install --force
+openclaw doctor
+```
+
+To remove a persisted wrapper, clear `OPENCLAW_WRAPPER` while reinstalling:
+
+```bash
+OPENCLAW_WRAPPER= openclaw gateway install --force
+openclaw gateway restart
+```
+
+<AccordionGroup>
+  <Accordion title="Command options">
+    - `gateway status`: `--url`, `--port`, `--token`, `--password`, `--timeout`, `--no-probe`, `--require-rpc`, `--deep`, `--json`
+    - `gateway install`: `--port`, `--runtime <node|bun>` (default: `node`), `--token`, `--wrapper <path>`, `--force`, `--json`
+    - `gateway restart`: `--safe`, `--skip-deferral`, `--force`, `--wait <duration>`, `--preserve-definition`, `--json`
+    - `gateway uninstall|start`: `--json`
+    - `gateway stop`: `--disable`, `--force`, `--json`
+
+  </Accordion>
+  <Accordion title="Service runtime">
+    - Node is the primary, default, and recommended managed Gateway runtime.
+    - Bun 1.4+ with WAL-reset-safe `node:sqlite` is available as an explicit opt-in with `gateway install --runtime bun`.
+
+  </Accordion>
+  <Accordion title="Lifecycle behavior">
+    - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
+    - If no managed service is installed, `gateway start` prints install hints and exits nonzero. `gateway restart` can first recover an installed-but-unloaded LaunchAgent or a verified unmanaged Gateway; if neither a managed service nor recovery handles the action, it prints the same hints and exits nonzero. Stopping an absent service remains a successful no-op.
+    - If `gateway start` or `gateway restart` needs to repair a stale service definition, the command refuses when the invoking shell resolves a different state directory, config path, or port than the installed service. Match or unset the conflicting environment overrides, or use `openclaw gateway install --force` to retarget the service intentionally.
+    - On Linux, `gateway start` and `gateway restart` also refuse ineffective repairs when an operator-owned systemd drop-in overrides the command or working directory. Inspect the effective unit with `systemctl --user cat <unit>.service`, then update or remove that drop-in. `gateway install --force` rewrites only the managed base unit and warns if the override remains; `Environment=` drop-ins remain supported.
+    - `gateway restart --preserve-definition` restarts only an inspectable native service, skips automatic definition repair, and checks health at the installed launcher's port. It does not recover an unmanaged listener and cannot be combined with `--safe` or external supervision. On macOS it can bootstrap an unloaded readable plist without rewriting the plist, environment, wrapper, or permissions; denied native activation fails without file repair. On Windows it also retains existing Startup entries. The legacy `daemon restart` command accepts the same option. Older CLIs reject the option before running restart or repair.
+    - During writable Linux service installs or refreshes, keep the unit and state directories stationary and avoid concurrent manual edits. OpenClaw serializes its own writers and aborts on detected changes, but cannot coordinate arbitrary filesystem edits. Moving or replacing a parent directory mid-publication can leave a temporary file inside the moved directory; inspect it before retrying.
+    - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
+    - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.
+    - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery stays active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots.
+    - Gateway lifecycle mutations append best-effort key-value audit records to `<state-dir>/logs/gateway-restart.log`, including CLI start, stop, and restart operations, safe restart requests, supervisor restarts, and detached handoffs.
+    - Lifecycle commands accept `--json` for scripting.
+    - A restart that completes native activation or accepted recovery but fails its health check emits `action: "restart"`, `ok: false`, and `result: "restart-health-failed"`, retaining its error, hints, warnings, and exit code 1. This diagnostic does not authorize another activation. Refusals, unexpected exceptions, and definition repair without confirmed activation do not emit this result. A scheduled restart reports acceptance, without claiming successor health.
+
+  </Accordion>
+  <Accordion title="Managed Gateway heap sizing">
+    - For a managed Node Gateway without an existing heap setting, `gateway install` places `--max-old-space-size` in Node's launch arguments, before the entry script. It explicitly clears `NODE_OPTIONS` in the service environment so ambient service-manager preload/debug flags cannot leak into the Gateway. Plain spawned Node processes do not inherit the new automatic budget through `NODE_OPTIONS`; Node's fork and Worker inheritance rules are unchanged.
+    - Capacity is the smaller of valid physical RAM and a valid constraint reported by Node, never fluctuating free RAM. With no usable capacity reading, Node keeps its native default. The installer targets 50% of capacity, with a nominal 2048 MiB floor and a cap of the greater of 8192 MiB or 25% of capacity. A final 75% capacity cap reserves native-memory headroom and can put small-host budgets below the nominal floor.
+    - Examples: 32 GiB capacity selects 8 GiB old space; 64 GiB selects 16 GiB; 128 GiB selects 32 GiB. Old space is only part of V8's total heap, and neither is a limit on total process memory (RSS). Raising the ceiling does not preallocate that memory.
+    - Existing managed service heap controls are preserved across forced reinstalls and doctor repairs, including absolute old-space, percentage old-space, and total-heap flags. Only heap flags survive managed `NODE_OPTIONS` sanitization; arbitrary preload/debug flags do not. Put intentional preload/debug settings in an operator-owned systemd `Environment=` drop-in, or set them inside an [installed wrapper](#install-with-a-wrapper) before it launches Node. Do not edit the generated service environment for those settings. Existing stored numbers are preserved even when they resemble an older automatic default or exceed the new recommendation.
+    - When an operator-owned service override controls `NODE_OPTIONS` (including an empty value or reset), regeneration does not add a new automatic heap argument. Operator values and drop-in files stay separate from the managed base. Existing managed argv controls remain: Node's argv wins over `NODE_OPTIONS` for the same option, and percentage old-space sizing takes precedence over absolute old-space sizing. Inspect both surfaces before changing a cap.
+    - Ambient installer `NODE_OPTIONS` and the installer's own Node arguments are not saved as Gateway heap settings. The budget is chosen at installation and takes effect when the service process starts; it is not recalculated while the Gateway runs. Upgrading OpenClaw alone does not resize a running Gateway, and foreground launches do not replace themselves to apply this policy.
+    - The installer's memory constraints can differ from the future service's constraints. Node/libuv reporting is platform-dependent and does not guarantee detection of every ancestor cgroup limit; inspect the actual service or container limits before increasing a budget.
+    - This policy applies to managed Node Gateway launches, not foreground `gateway run`, custom supervisors, Docker runtime commands, Bun, or node-host services. Those retain their own runtime configuration. See [memory troubleshooting](/gateway/troubleshooting#gateway-exits-during-high-memory-use) for explicit native Node settings.
+
+  </Accordion>
+  <Accordion title="Auth and SecretRefs at install time">
+    - When token auth requires a token and `gateway.auth.token` is SecretRef-managed, `gateway install` validates that the SecretRef is resolvable but does not persist the resolved token into service environment metadata.
+    - If token auth requires a token and the configured token SecretRef is unresolved, install fails closed instead of persisting fallback plaintext.
+    - For password auth on `gateway run`, prefer `OPENCLAW_GATEWAY_PASSWORD`, `--password-file`, or a SecretRef-backed `gateway.auth.password` over inline `--password`.
+    - In inferred auth mode, shell-only `OPENCLAW_GATEWAY_PASSWORD` does not relax install token requirements; use durable config (`gateway.auth.password` or config `env`) when installing a managed service.
+    - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2502,6 +2502,16 @@
                       "cli/daemon",
                       "cli/fleet",
                       "cli/gateway",
+                      {
+                        "group": "Gateway",
+                        "pages": [
+                          "cli/gateway/running",
+                          "cli/gateway/restart-and-supervision",
+                          "cli/gateway/query",
+                          "cli/gateway/service",
+                          "cli/gateway/discovery"
+                        ]
+                      },
                       "cli/health",
                       "cli/logs",
                       "cli/status"


### PR DESCRIPTION
Splits the oversized `docs/cli/gateway.md` (55,875 bytes) into `docs/cli/gateway/`
children and keeps the parent as an index. Closes ledger finding **r3-0120**
(blocking, split) and partially addresses **r3-0121** (no subcommand index).

Content-preserving: no section was rewritten, reordered, or "improved". The one
prose change outside the index scaffolding is a directional-reference repair,
declared below.

## Before / after

| Page | Bytes |
| --- | --- |
| `docs/cli/gateway.md` (before) | 55,875 |
| `docs/cli/gateway.md` (index, after) | 11,078 |
| `docs/cli/gateway/running.md` | 6,556 |
| `docs/cli/gateway/restart-and-supervision.md` | 13,036 |
| `docs/cli/gateway/query.md` | 20,259 |
| `docs/cli/gateway/service.md` | 15,469 |
| `docs/cli/gateway/discovery.md` | 1,944 |

Cut on the existing H2 boundaries, one reader job per child, in document order.

`query.md` lands 259 bytes over the 20k heuristic. The only cut that fits would
separate the shared-options `<Tabs>` block from the nine subcommand sections whose
`--timeout` defaults it explains ("see each command below"), so it stays whole.
Precedent on `main`: `docs/cli/update/how-updates-run.md` is 29,470 bytes.

Shape matches `docs/cli/doctor/` and `docs/cli/update/`, both on `main`
(`test -d` verified, not open PRs).

## Losslessness, proven

The pre-split page is rebuilt **byte-for-byte** from the index head/tail plus the
five children (heading levels are unchanged — every child already started at H2 —
and each child's frontmatter and one-line lede are removed):

```
pre-split  sha256: 0efba9073cfe316e22cecf4a4c94f6a74190f3660c8e5dade0ad377e73956072 (55875 bytes)
rebuilt    sha256: 0efba9073cfe316e22cecf4a4c94f6a74190f3660c8e5dade0ad377e73956072 (55875 bytes)
RESULT: BYTE-IDENTICAL
```

- Code fences: 23 before, 23 after, matched one-for-one on info string + body sha256.
- Table rows: 0 before, 0 after (the page uses `ParamField`/`Accordion`, not tables).
- Words: 7,192 → 8,148 (+956, all index scaffolding and child frontmatter/ledes).

## Anchors

Per-anchor redirects are impossible here — `redirectSource()` in
`scripts/lib/docs-redirects.mjs` throws on any source containing `[?#]` — so every
pre-split id is carried on the index as an authored `<a id="…" />` stub.

Ids were enumerated with the repo's own `parseDocsDocument`
(`scripts/lib/docs-markdown.mjs`), never a slug approximation.

- **98** pre-split ids. **97** stubbed, **1** (`related`) still published by the
  index itself, so it is not stubbed (that would be a duplicate authored/canonical id).
- 28 section stubs (25 headings + 4 compatibility aliases, minus the self-published
  `related`) and 69 component stubs (`Accordion`/`Tab`/`ParamField` titles mint ids too).
- Punctuated headings emit both an encoded and a cleaned id; both variants are
  stubbed, e.g. `remote-over-ssh-(mac-app-parity)` **and**
  `remote-over-ssh-mac-app-parity`.
- `ParamField` counter suffixes shift when a document is split, so the stub carries
  the **old** id and points at the **new** one — for example
  `<a id="param-port-3" />` → `/cli/gateway/query#param-port-2`. 12 ids shift this way.

Asserted with the repo's `parseDocsDocument` + `resolveDocsFragment`:

```
PASS  all 98 pre-split ids resolve on /cli/gateway  (missing: 0)
PASS  index collisions empty ([])
PASS  /cli/gateway/{running,restart-and-supervision,query,service,discovery} collisions empty
PASS  all 97 stub targets resolve on their child (broken: 0)
PASS  externally-linked anchor #restart-the-gateway resolves on /cli/gateway
PASS  externally-linked anchor #gateway-diagnostics-export resolves on /cli/gateway
PASS  externally-linked anchor #recover-an-unreadable-native-service-definition resolves on /cli/gateway
PASS  externally-linked anchor #manage-the-gateway-service resolves on /cli/gateway
PASS  externally-linked anchor #install-identity resolves on /cli/gateway
PASS  index publishes no duplicate id
```

The five externally-linked anchors are the ones referenced from outside this page
(`docs/cli/daemon.md`, `docs/gateway/diagnostics.md`,
`docs/gateway/doctor/state-and-sessions.md`, `docs/gateway/troubleshooting.md`,
`docs/install/updating.md`, `docs/releases/2026.9.2.md`, and — as a literal string
asserted by `src/cli/daemon-cli/install.test.ts:354` and emitted by
`src/cli/daemon-cli/shared.ts:57` — `#install-identity`).

Two stub ids contain `<`/`>`, which is illegal raw inside a JSX attribute. They use
the HTML entity form (`id="gateway-call-&lt;method&gt;"`), which decodes to the same
published id — verified against `parseDocsDocument`, and `check-docs-mdx` passes.
Link destinations percent-encode `()<>` so the markdown link parser sees a clean
destination; `resolveDocsFragment` tries the raw fragment first and then
`decodeURIComponent`, so both forms land on the same id.

## Orphaned prose — the entire prose diff

`python3 .audit/check-orphan-refs.py` over all six pages returned 3 candidates. Each
was checked by locating its target, not by reading the sentence:

| Hit | Verdict |
| --- | --- |
| `docs/cli/gateway.md:11` "All subcommands **below**" | **Genuinely orphaned** — the subcommands moved off the page. Fixed. |
| `docs/cli/gateway/query.md:27` "see each command **below**" | Valid. All nine subcommand sections are on `query.md` at lines 38+. |
| `docs/cli/gateway/discovery.md:45` "(see **above**)" | Valid. The TXT-hints paragraph it refers to is `discovery.md:20`. |

The single fix, which is the whole prose diff outside the index scaffolding:

```diff
-All subcommands below live under `openclaw gateway ...`.
+All subcommands on the pages listed here live under `openclaw gateway ...`.
```

## Pins

`python3 .audit/docs-test-pins.py docs/cli/gateway.md` reported "14 test(s) pin this
page". Its label is loose — 3 of the 14 are not tests. Every hit was read and
classified, alongside an independent `git grep -n "cli/gateway" origin/main` with no
path filter (73 route-form hits after excluding `src/cli/gateway-cli/**` source paths,
which the substring also matches):

| Hit | What it actually is | Effect |
| --- | --- | --- |
| `taxonomy.yaml` ×10 | YAML page lists, `- docs/cli/gateway.md`, **no `#anchor`** | Parent page still exists; `pnpm maturity:check` passes |
| `qa/scenarios/**` ×5 | Scenario `docs:` reference lists | Metadata only, parent still exists |
| `test/e2e/qa-lab/runtime/**` ×4 | `docsRefs: [...]` evidence metadata | Carried into evidence records, no content assertion |
| `src/cli/daemon-cli/register.ts`, `shared.ts`, `src/cli/gateway-cli/register.ts` | **Source**, not tests — CLI help text printing `/cli/gateway` and `#install-identity` | Route and anchor both preserved |
| `src/cli/daemon-cli/install.test.ts:354` | Test asserting the literal URL `https://docs.openclaw.ai/cli/gateway#install-identity` | Asserts CLI **output**, not the docs file. Anchor preserved on the index. |

**No contract test reads `docs/cli/gateway.md` and asserts literal strings**, so the
`sdk-subpaths.md` refusal precedent does not apply. Verified by grepping every
`readFile`/`readFileSync` under `src/`, `test/` and `scripts/` for docs paths — the
only readers are the docs validators themselves.

## CODEOWNERS

**`docs/cli/gateway.md` is not owned by anyone, and neither is `docs/cli/gateway/**`.**

`.github/CODEOWNERS` names `/docs/cli/approvals.md`, `/docs/cli/sandbox.md`,
`/docs/cli/security.md` and `/docs/cli/secrets.md` individually for
`@openclaw/openclaw-secops`, and has file-exact rules under `/docs/gateway/` plus a
`/docs/gateway/security/` directory rule — but there is **no** `/docs/cli/` directory
rule and **no** rule matching `docs/cli/gateway.md`. Last-match-wins was simulated
with two independent implementations, both with working controls:

```
PASS docs/cli/sandbox.md                   -> @openclaw/openclaw-secops        [line 60]
PASS docs/cli/security.md                  -> @openclaw/openclaw-secops        [line 61]
PASS docs/gateway/security/threat-model.md -> @openclaw/openclaw-secops        [line 58]
PASS docs/gateway/authentication.md        -> @openclaw/openclaw-secops        [line 53]
PASS docs/security/anything.md             -> @openclaw/openclaw-secops        [line 52]
PASS src/gateway/server-auth.ts            -> @openclaw/openclaw-secops        [line 34]
PASS src/gateway/deep/nested-auth.ts       -> @openclaw/openclaw-secops        [line 34]
PASS .github/CODEOWNERS                    -> @steipete                        [line 2]
PASS docs/reference/RELEASING.md           -> @openclaw/openclaw-release-managers [line 68]
PASS docs/cli/index.md                     -> (unowned)   [negative control]
PASS docs/gateway/multiple-gateways.md     -> (unowned)   [negative control]
PASS README.md                             -> (unowned)   [negative control]
CONTROLS ALL PASS

UNOWNED  docs/cli/gateway.md
UNOWNED  docs/cli/gateway/{index,service,anything-at-all}.md
```

This PR **changes nothing about ownership**. The gap is pre-existing and extending
CODEOWNERS is the owning team's decision, not a side effect of a docs split. If
secops should own the Gateway CLI page, that belongs in its own PR.

`.github/labeler.yml` likewise has no `docs/cli/**` glob, so no label is gained or
lost — the `gateway` label already only matched `docs/gateway/**`.

## Navigation

- `docs/docs.json`: added a `"Gateway"` group under `"Running the service"`,
  directly after `"cli/gateway"` — the exact shape `"cli/update"` and `"cli/doctor"`
  use.
- `docs/.i18n/zh-Hans-navigation.json`: **unchanged**. Neither the `doctor` nor the
  `update` split added child entries there (`grep -c 'zh-CN/cli/doctor/\|zh-CN/cli/update/'`
  → 0); that file is a curated list of translated pages.
- `docs/.i18n/glossary.zh-CN.json`: 5 entries appended for the new page titles, as
  `check-docs-i18n-glossary` requires. 819 entries, 0 duplicate sources.

## Validators

All run on the **staged** tree.

| Check | Result |
| --- | --- |
| `node scripts/check-docs-mdx.mjs` | pass (1027 files) |
| `node scripts/docs-link-audit.mjs` | pass — `checked_internal_links=10472 broken_links=0` |
| `node scripts/docs-link-audit.mjs --anchors` | 42 failures, **all pre-existing** |
| `npx tsx scripts/format-docs.mts --check` | pass (1015 files) |
| `npx tsx scripts/check-docs-i18n-glossary.mts` | pass |
| `npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc 'docs/**/*.md'` | pass — 1014 files, 0 issues |
| `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` | 24 passed, **1 pre-existing failure** |
| `npx vitest run --config test/vitest/vitest.unit-src.config.ts src/docs/` | 8 files, 16 tests, pass |
| `npx vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/render-maturity-docs.test.ts test/scripts/docs-sync-publish.test.ts` | 18 passed |
| `pnpm maturity:check` | pass |

Both pre-existing failures were **reproduced at the base sha**
(`873956eb69432f5b4ab7f286af2d15929dc69e09`) in a detached worktree, not assumed:

- `--anchors`: 42 failures at base, byte-identical to the branch output
  (`diff` is empty). 39 are unresolved `/clawhub/*` routes; 3 are
  `/maturity/taxonomy#windows-app-node`. **None involve `cli/gateway`.**
- `docs-link-audit.test.ts > preserves Mint component targets for raw component
  apostrophes`: fails identically at base
  (`expected [ 'ass-guide', … ] to deeply equal [ 'as-s-guide', … ]`).

### Simplified Technical English

`ste-lint.py --summary --max-words 20`:

- Pre-split page: **126** hard violations.
- The same text as the five child bodies: **132**. The delta is a checker artifact,
  not a regression — the byte-identical text concatenated back into one file scores
  126 again, so `ste-lint.py` over-counts by 6 purely as a function of file count.
- Child frontmatter and ledes add **0** hard violations.
- The index scores 4 hard violations, all of them the `;` inside the `&lt;`/`&gt;`
  HTML entities in two anchor-stub `id` attributes — the linter is reading inside an
  HTML tag, not prose. The index is 0.9 per 100 words, well under the 1.5 threshold.

Net prose regression: **zero**.

## Rebase

Rebased onto `fd6fdb3b96bf7c79b2a529602d74064f4d1b415e` (39 commits). Only
`docs/.i18n/glossary.zh-CN.json` conflicted; `docs/docs.json` auto-merged.
Resolved with `.audit/resolve-glossary.py` and verified **set-wise**, because the
resolver's ours/theirs labels are inverted during a rebase (it reported upstream's
858 entries as "branch" and this branch's 819 as "base"):

```
merged 863   unique 863   duplicate sources: 0
stage2 (upstream main) 858 entries — 0 missing from merged
stage3 (this branch)   819 entries — 0 missing from merged
true superset of BOTH sides: True     union size 863 == merged unique 863
all 5 of this PR's entries present: True
```

The glossary diff against the new base removes 0 lines. `docs/cli/gateway.md`
itself did not change on `main` across those 39 commits — its blob is still
`0efba90…`, so the byte-identical rebuild above still holds against the new base.

Every validator and both `.audit` scripts were re-run on the rebased tree, not
carried forward:

```
check-docs-mdx      pass (1069 files)
docs-link-audit     checked_internal_links=10871  broken_links=0
format-docs --check clean (1057 files)
check-docs-i18n-glossary  pass
markdownlint-cli2   0 issues in 0 files
anchor assertions   ALL ANCHOR CHECKS PASSED
losslessness        BYTE-IDENTICAL, 23/23 fences
check-orphan-refs   index now 0 candidates; the 2 remaining are the verified-valid
                    intra-page ones on query.md and discovery.md
ste-lint            unchanged (index 4 hard, all HTML-entity semicolons)
```

The directional-reference repair survived the rebase — re-checked rather than
assumed, since a rebase that re-extracts sections can silently restore the
pre-split wording.

## The CI docs job's own steps, run locally

`.github/workflows/ci.yml` `check-docs` was enumerated and every step run on the
rebased tree, rather than only the obvious link/format checks:

| `check-docs` step | Local result |
| --- | --- |
| `pnpm format:check` (`oxfmt --check`) | pass — 35,348 files, all correctly formatted |
| `pnpm config:docs:check` | pass — `docs/.generated/config-baseline.*` OK |
| `pnpm plugins:inventory:check` | pass |
| `pnpm check:docs` | **rc=0** |

`pnpm check:docs` is the composite `format:docs:check && lint:docs &&
lint:templates && docs:check-mdx && docs:check-i18n-glossary && docs:check-links
&& docs:check-config-examples` — note it runs `lint:templates` (12 files, 0 issues)
and `docs:check-config-examples` too, which are easy to miss when running the docs
checks individually.

`pnpm format:check` is the repo-wide `oxfmt`, **not** the docs-specific
`format-docs.mts` — both were run, because a docs formatter reporting clean is not
evidence the repo-wide one agrees.

`generated-doc-baselines` is `workflow_dispatch`-only and therefore **skips** on this
PR. Its docs-relevant step (`pnpm config:docs:check`) was run locally anyway and passes.
