### PR TITLE
improve(test): reduce worker transform test time

### DIFF
--- a/test/scripts/vitest-worker-artifacts.transforms.test.ts
+++ b/test/scripts/vitest-worker-artifacts.transforms.test.ts
@@ -98,8 +98,8 @@ describe("fresh compiled subprocess invocation", { concurrent }, () => {
         expect(counts(), "unchanged parents must reuse filesystem transforms").toEqual([1, 1]);
         await launch("source");
         expect(counts()).toEqual([2, 2]);
-        await launch("compiled");
-        expect(counts()).toEqual([2, 2]);
+        // Switching back with a leaf edit also proves the unchanged parent reuses
+        // its compiled transform, without preparing another complete worker set.
         fs.writeFileSync(value, 'export const value: string = "second";');
         await launch("compiled", "second");
         expect(counts()).toEqual([3, 2]);


### PR DESCRIPTION
Related: #142911

## What Problem This Solves

The consolidated worker-transform test exhausted its 120-second Windows case budget during the sixth subprocess launch in [main CI](https://github.com/openclaw/openclaw/actions/runs/34330280215/job/102397192371). The first five launches passed their native execution and cache assertions.

## Why This Change Was Made

Combine the return from source mode with the existing leaf edit. Each layout now performs four complete worker builds and one source invocation, removing one redundant full build. This continues the setup reduction from #142911 by Vincent Koc.

The unchanged parent still proves compiled-cache reuse after source mode while the edited leaf proves content invalidation. Adjacent compiled generations retain unchanged leaf/parent reuse, and the final alias edit retains configuration invalidation. Vitest keys both ordinary modules using their ID, content and shared environment; OpenClaw contributes one uniform compiled-mode key. The removed standalone observation is unchanged-leaf reuse immediately after source mode, covered by those remaining checks under this owner contract.

## User Impact

Less repeated compilation in CI and local tooling tests. Both layouts, native SQLite/archive-worker execution, source/compiled URL checks, distinct generations, disposal checks and the 120-second deadline remain. Production code is unchanged; test delta is +2/-2.

## Evidence

- Matched local Node 24.19.0 / pnpm 12.3.4 full-file runs at the failing source: original 2/2 passed in 46.14s; candidate 2/2 passed in 36.46s (about 21% less wall time). This is one local pair, not a Windows or statistical speedup claim.
- Both layouts retain `C [1,1] -> C [1,1] -> S [2,2] -> C "second" [3,2] -> C "configured" [4,3]`; all launch assertions passed.
- Required changed checks passed, including root-test types and lint. Independent managed P2 review found no actionable findings.
- Native Windows [test-2](https://github.com/openclaw/openclaw/actions/runs/34335395737/job/102413788440) passed both cases at this exact head: `single` 97.365s, `projects` 92.461s, below the unchanged 120-second limit. All ten launch observations and eight distinct compiled-generation checks passed. This is one Windows validation run, not a matched-host speedup estimate.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34335395737) passed, including both Windows jobs and 48 compact Node jobs in the existing PR plan. No workflow or shard settings changed.
- GitHub initially reported a workflow startup failure with zero jobs. One documented close/reopen recovery started CI on the unchanged commit; no test retry was requested.
- The existing Windows launcher retained its temporary namespace because descendant completion is unverified for a non-group launch. This change does not claim runner-wide process or filesystem cleanup.
