### PR TITLE
fix(test): prevent host systemd units from breaking handoff tests

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -80,6 +80,20 @@ vi.mock("./tmp-openclaw-dir.js", async (importOriginal) => ({
 const tempDirs = new Set<string>();
 const managedProcessCleanups = new Set<() => Promise<void>>();
 
+async function createUserSystemdFixture() {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-"));
+  tempDirs.add(home);
+  const unitPath = path.join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+  await fs.mkdir(path.dirname(unitPath), { recursive: true });
+  await fs.writeFile(unitPath, "[Service]\nExecStart=/usr/bin/true\n");
+  const systemdRunPath = path.join(home, "systemd-run");
+  await fs.writeFile(systemdRunPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  return {
+    systemdRunPath,
+    env: { HOME: home, PATH: home, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
+  };
+}
+
 beforeEach(async () => {
   // Helpers in one fixture share a coordinator without touching the operator's database.
   const coordinatorDir = await fs.realpath(
@@ -404,10 +418,7 @@ describe("managed service update handoff", () => {
     });
     let env: NodeJS.ProcessEnv | undefined;
     if (failure === "launcher exit") {
-      const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
-      tempDirs.add(binDir);
-      await fs.writeFile(path.join(binDir, "systemd-run"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-      env = { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" };
+      env = (await createUserSystemdFixture()).env;
     }
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
@@ -500,10 +511,7 @@ describe("managed service update handoff", () => {
   it("launches systemd handoffs through a transient user scope", async () => {
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
-    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
-    tempDirs.add(binDir);
-    const systemdRunPath = path.join(binDir, "systemd-run");
-    await fs.writeFile(systemdRunPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    const { env, systemdRunPath } = await createUserSystemdFixture();
 
     const result = await startManagedServiceUpdateHandoff({
       root: MOCK_INSTALL_ROOT,
@@ -517,8 +525,7 @@ describe("managed service update handoff", () => {
       channel: "beta",
       supervisor: "systemd",
       env: {
-        PATH: binDir,
-        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service",
+        ...env,
         INVOCATION_ID: "gateway-invocation",
         KEEP_ME: "1",
       },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This is a same-repository branch; maintainers with repository write access can
update it.

</details>

## What Problem This Solves

Resolves a problem where two managed-handoff tests fail on Linux development
hosts with a system-wide Gateway unit before exercising their intended
user-scope launcher behavior.

## Why This Change Was Made

Both fixtures omitted a home directory, so the real scope resolver could find
only the host's system unit. A shared local fixture now gives each case a fresh
private home, canonical user-unit file, and fake `systemd-run`, using the
existing temporary-directory cleanup.

The production scope guard, launcher assertions, existing environment fields, and real
notice timeout are unchanged.

## User Impact

Test-only repair: the two cases can exercise their intended behavior regardless
of a host system-wide Gateway installation. No Gateway runtime or operator
service changes.

## Evidence

- Unchanged full owner: **162 passed, 2 failed**. Both failures reached the
  system-scope guard before their intended launcher behavior.
- Focused unchanged reproduction: **2 failed** with that same guard error.
- The same two cases with this fixture repair: **2 passed**, with all original
  assertions retained. Runner and owned temporary-resource cleanup completed.
- `git diff --check` passed.
- Changed gate passed for the one-file `coreTests` scope: formatting, core-test
  typecheck, lint, repository guards, and dead-export checks.
- Fresh scoped P2 review: `scoped-clean`, no actionable P0-P2 findings.
- Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34335481756),
  including the required `openclaw/ci-gate`.

Focused reproduction and verification command:

```sh
node scripts/run-vitest.mjs run \
  src/infra/update-managed-service-handoff-lifecycle.test.ts \
  -t 'rejects launcher exit and cleans up the sensitive handoff|launches systemd handoffs through a transient user scope'
```

Local proof was collected on Linux with Node 24.19.0 and Vitest 5.0.0. The full
owner has not been rerun locally after the repair. This is not a timing
optimization, and no performance gain is claimed.
