### PR TITLE
improve(test): speed up authorized evidence checks

### DIFF
--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -1,9 +1,9 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
   assertAuthorizedEligibilityPlanDigest,
@@ -19,6 +19,8 @@ import {
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const seedDirs = useAutoCleanupTempDirTracker(afterAll);
+let fixtureSeed: ReturnType<typeof buildFixturePolicy> | undefined;
 
 type ParsedWorkflow = {
   jobs?: Record<
@@ -84,7 +86,14 @@ function commit(root: string, message: string): string {
 }
 
 function fixturePolicy(): { policy: AuthorizedBetaFocusedPolicy; root: string } {
+  const seed = (fixtureSeed ??= buildFixturePolicy(seedDirs.make("authorized-beta-focused-seed-")));
   const root = tempDirs.make("authorized-beta-focused-");
+  // Copy the complete Git state so each case owns its refs, hooks, index, and objects.
+  cpSync(seed.root, root, { recursive: true, mode: 0 });
+  return { root, policy: structuredClone(seed.policy) };
+}
+
+function buildFixturePolicy(root: string): { policy: AuthorizedBetaFocusedPolicy; root: string } {
   execFileSync("git", ["init", "-q"], { cwd: root });
   execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: root });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The focused authorized beta evidence tests take longer than necessary to return
feedback, slowing repeated local validation of the release-evidence workflow.

## Why This Change Was Made

Replace 34 builds of the same three-commit fixture with one lazy, file-owned
seed and give each fixture call a fresh recursive
copy of its complete working tree and `.git`, plus an independently cloned
policy. Per-case cleanup still removes each copy; file teardown removes the
seed. Copies use `cpSync` with `mode: 0`, without FICLONE, hardlinks, alternates
or shared mutable Git state.

The change is limited to `test/scripts/authorized-beta-focused-evidence.test.ts`.
Production code, case bodies, assertions, real case-specific Git operations and
verification behavior remain unchanged.

## User Impact

No product behavior changes. Developers get faster feedback from this selected
tooling test file while retaining its isolation and validation coverage. These
measurements do not establish a whole-CI or CI-job runtime improvement.

## Evidence

Three matched whole-file before/after pairs ran on the same host with the same
command, dependencies and default project geometry. All six invocations passed
the same 49 cases with no skips. Every candidate invocation includes seed
construction and teardown; no instrumentation was included in timed runs.

| Pair | Case time before (s) | Case time after (s) | Invocation before (s) | Invocation after (s) |
| --- | --- | --- | --- | --- |
| 1 | 12.330 | 5.616 | 16.25 | 12.90 |
| 2 | 10.361 | 4.687 | 13.21 | 7.26 |
| 3 | 10.388 | 4.954 | 12.62 | 7.41 |

Median summed case time fell from **10.388 to 4.954 seconds (52.3%)**; median
outer invocation fell from **13.21 to 7.41 seconds (43.9%)**. Every pair improved.
Startup/host variation is visible, especially in the first pair. Case time
includes test work and is not a setup-only measurement.

- Two additional untimed whole-file censuses passed 49/49. Setup Git commands
  fell from **510 to 15**, and setup commits from **102 to 3**. All **177
  case-body Git commands**, including seven commits, retained their normalized
  argument order and exit statuses.
- Untimed isolation controls mutated one copy's working file, index, ref,
  config, hook, existing Git object and nested policy. The seed and a fresh
  copy remained unchanged. All 43 regular files had independent file identities;
  there were no alternates or shared Git common directory.
- The real validator accepted the fresh copy and rejected wrong-tree,
  path-count and projection policies with their intended diagnostics. Existing
  shallow candidate absence/exact fetch, hook non-execution, and failed-verifier
  worktree cleanup cases remained unchanged and passed.
- Actual per-case and file-teardown cleanup callbacks removed their owned
  directories. Both census invocation temp roots were also verified removed.
- Focused command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/authorized-beta-focused-evidence.test.ts`.
- `node scripts/check-changed.mjs -- test/scripts/authorized-beta-focused-evidence.test.ts` passed, including root-test typechecking, script lint and focused test-file lint.
- Formatting and `git diff --check` passed. Fresh independent P2 review was
  scoped-clean, with no actionable findings.
