### PR TITLE
refactor(qa-lab): share YAML validation diagnostics

### DIFF
--- a/extensions/qa-lab/src/qa-yaml.ts
+++ b/extensions/qa-lab/src/qa-yaml.ts
@@ -1,0 +1,16 @@
+import type { z } from "zod";
+
+function formatZodIssuePath(pathLocal: PropertyKey[]) {
+  return pathLocal.length ? pathLocal.map(String).join(".") : "<root>";
+}
+
+export function parseQaYamlWithContext<T>(schema: z.ZodType<T>, value: unknown, label: string): T {
+  const parsed = schema.safeParse(value);
+  if (parsed.success) {
+    return parsed.data;
+  }
+  const issues = parsed.error.issues
+    .map((issue) => `${formatZodIssuePath(issue.path)}: ${issue.message}`)
+    .join("; ");
+  throw new Error(`${label}: ${issues}`);
+}

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -4,6 +4,7 @@ import YAML from "yaml";
 import { z } from "zod";
 import { isRepoRootRelativeRef } from "./cli-paths.js";
 import { qaCoverageIdSchema } from "./coverage-id.js";
+import { parseQaYamlWithContext } from "./qa-yaml.js";
 import { resolveQaRepoPath, type QaRepoPathKind } from "./repo-path.js";
 import { qaScenarioModuleFlow } from "./scenario-module-flow.js";
 
@@ -434,21 +435,6 @@ function readTextFile(relativePath: string): string {
     return "";
   }
   return fs.readFileSync(resolved, "utf8");
-}
-
-function formatZodIssuePath(pathLocal: PropertyKey[]) {
-  return pathLocal.length ? pathLocal.map(String).join(".") : "<root>";
-}
-
-function parseQaYamlWithContext<T>(schema: z.ZodType<T>, value: unknown, label: string): T {
-  const parsed = schema.safeParse(value);
-  if (parsed.success) {
-    return parsed.data;
-  }
-  const issues = parsed.error.issues
-    .map((issue) => `${formatZodIssuePath(issue.path)}: ${issue.message}`)
-    .join("; ");
-  throw new Error(`${label}: ${issues}`);
 }
 
 function parseQaYamlFileWithContext<T>(schema: z.ZodType<T>, relativePath: string): T {

--- a/extensions/qa-lab/src/scorecard-taxonomy.test.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import YAML, { YAMLParseError } from "yaml";
+import {
+  readQaMaturityTaxonomySource,
+  readQaScorecardProfileOptions,
+  readValidatedQaMaturityScoreSources,
+} from "./scorecard-taxonomy.js";
+
+describe("QA maturity YAML readers", () => {
+  it("returns trimmed, defaulted taxonomy data without unknown keys", async () => {
+    await withTempDir("qa-taxonomy-", async (dir) => {
+      const taxonomyPath = path.join(dir, "taxonomy.yaml");
+      fs.writeFileSync(
+        taxonomyPath,
+        YAML.stringify({
+          version: 1,
+          title: " Fixture ",
+          ignored: true,
+          profiles: [{ id: " fixture ", description: " Sample ", ignored: true }],
+        }),
+      );
+
+      expect(readQaMaturityTaxonomySource(taxonomyPath)).toEqual({
+        version: 1,
+        title: "Fixture",
+        profiles: [
+          {
+            id: "fixture",
+            description: "Sample",
+            includeAllCategories: false,
+            channelDriver: "qa-channel",
+            categoryIds: [],
+            coverageIds: [],
+          },
+        ],
+        levels: [],
+        surfaces: [],
+      });
+    });
+  });
+
+  it.each([
+    {
+      name: "root",
+      value: null,
+      issues: "<root>: Invalid input: expected object, received null",
+    },
+    {
+      name: "ordered nested",
+      value: {
+        version: 1,
+        title: "Fixture",
+        profiles: [
+          { id: "fixture", description: 3 },
+          { id: "UPPER", description: "Sample" },
+        ],
+      },
+      issues:
+        "profiles.0.description: Invalid input: expected string, received number; " +
+        "profiles.1.id: scorecard ids must use lowercase dotted or dashed tokens",
+    },
+  ])("preserves $name diagnostics and caller-specific labels", async ({ value, issues }) => {
+    await withTempDir("qa-taxonomy-", async (dir) => {
+      const taxonomyPath = path.join(dir, "taxonomy.yaml");
+      fs.writeFileSync(taxonomyPath, YAML.stringify(value));
+
+      expect(() => readQaMaturityTaxonomySource(taxonomyPath)).toThrow(
+        new Error(`${taxonomyPath}: ${issues}`),
+      );
+      expect(() => readQaScorecardProfileOptions("fixture", dir)).toThrow(
+        new Error(`taxonomy.yaml: ${issues}`),
+      );
+    });
+  });
+
+  it("keeps scores strict while bypassing taxonomy reads when supplied", async () => {
+    await withTempDir("qa-taxonomy-", async (dir) => {
+      const taxonomyPath = path.join(dir, "taxonomy.yaml");
+      const scoresPath = path.join(dir, "scores.yaml");
+      fs.writeFileSync(taxonomyPath, "version: 1\ntitle: Fixture\n");
+      const taxonomy = readQaMaturityTaxonomySource(taxonomyPath);
+      const scores = {
+        version: 1,
+        process_version: 1,
+        counts: { active_surfaces: 0, category_scores: 0 },
+        rollups: {
+          surface_average: {
+            quality: { score: 0, label: "Experimental" },
+            completeness: { score: 0, label: "Experimental" },
+          },
+          category_average: {
+            quality: { score: 0, label: "Experimental" },
+            completeness: { score: 0, label: "Experimental" },
+          },
+        },
+        surfaces: [],
+      };
+      const params = {
+        taxonomy,
+        taxonomyPath: path.join(dir, "missing.yaml"),
+        scoresPath,
+      };
+      fs.writeFileSync(scoresPath, YAML.stringify({ ...scores, unexpected: true }));
+      expect(() => readValidatedQaMaturityScoreSources(params)).toThrow(
+        new Error(`${scoresPath}: <root>: Unrecognized key: "unexpected"`),
+      );
+    });
+  });
+
+  it("leaves YAML decoding failures unwrapped", async () => {
+    await withTempDir("qa-taxonomy-", async (dir) => {
+      const taxonomyPath = path.join(dir, "taxonomy.yaml");
+      fs.writeFileSync(taxonomyPath, "version: [\n");
+
+      expect(() => readQaMaturityTaxonomySource(taxonomyPath)).toThrow(YAMLParseError);
+      expect(() => readQaScorecardProfileOptions("fixture", dir)).toThrow(YAMLParseError);
+    });
+  });
+});

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import YAML from "yaml";
 import { z } from "zod";
 import { qaCoverageIdSchema } from "./coverage-id.js";
+import { parseQaYamlWithContext } from "./qa-yaml.js";
 import { resolveQaRepoPath, type QaRepoPathKind } from "./repo-path.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 
@@ -508,34 +509,12 @@ function repoRootFromPath(filePath: string) {
   return path.dirname(filePath);
 }
 
-function formatZodIssuePath(pathLocal: PropertyKey[]) {
-  return pathLocal.length ? pathLocal.map(String).join(".") : "<root>";
-}
-
-function parseQaMaturityTaxonomy(value: unknown, label = QA_MATURITY_TAXONOMY_PATH) {
-  const parsed = qaMaturityTaxonomySchema.safeParse(value);
-  if (parsed.success) {
-    return parsed.data;
-  }
-  const issues = parsed.error.issues
-    .map((issue) => `${formatZodIssuePath(issue.path)}: ${issue.message}`)
-    .join("; ");
-  throw new Error(`${label}: ${issues}`);
-}
-
-function parseQaMaturityScores(value: unknown, label = QA_MATURITY_SCORES_PATH) {
-  const parsed = qaMaturityScoresSchema.safeParse(value);
-  if (parsed.success) {
-    return parsed.data;
-  }
-  const issues = parsed.error.issues
-    .map((issue) => `${formatZodIssuePath(issue.path)}: ${issue.message}`)
-    .join("; ");
-  throw new Error(`${label}: ${issues}`);
-}
-
 export function readQaMaturityTaxonomySource(taxonomyPath = QA_MATURITY_TAXONOMY_PATH) {
-  return parseQaMaturityTaxonomy(YAML.parse(fs.readFileSync(taxonomyPath, "utf8")), taxonomyPath);
+  return parseQaYamlWithContext(
+    qaMaturityTaxonomySchema,
+    YAML.parse(fs.readFileSync(taxonomyPath, "utf8")),
+    taxonomyPath,
+  );
 }
 
 export function readValidatedQaMaturityScoreSources(params?: {
@@ -547,7 +526,11 @@ export function readValidatedQaMaturityScoreSources(params?: {
   const taxonomyPath = params?.taxonomyPath ?? QA_MATURITY_TAXONOMY_PATH;
   const scoresPath = params?.scoresPath ?? QA_MATURITY_SCORES_PATH;
   const taxonomy = params?.taxonomy ?? readQaMaturityTaxonomySource(taxonomyPath);
-  const scores = parseQaMaturityScores(YAML.parse(fs.readFileSync(scoresPath, "utf8")), scoresPath);
+  const scores = parseQaYamlWithContext(
+    qaMaturityScoresSchema,
+    YAML.parse(fs.readFileSync(scoresPath, "utf8")),
+    scoresPath,
+  );
   const warnings = validateQaMaturityScoresAgainstTaxonomy({
     coverageScores: params?.coverageScores,
     scores,
@@ -564,7 +547,8 @@ function readQaMaturityTaxonomy(repoRoot: string | undefined) {
   if (!taxonomyPath || !fs.existsSync(taxonomyPath)) {
     return null;
   }
-  return parseQaMaturityTaxonomy(
+  return parseQaYamlWithContext(
+    qaMaturityTaxonomySchema,
     YAML.parse(fs.readFileSync(taxonomyPath, "utf8")) as unknown,
     QA_MATURITY_TAXONOMY_PATH,
   );


### PR DESCRIPTION
Closes #143011

## What Problem This Solves

QA Lab maintains three equivalent YAML validation and diagnostic-formatting paths across scenario, taxonomy, and maturity-score loading. This is a maintainer-requested duplication cleanup so future diagnostic maintenance has one owner, not a claim of a reproduced user-facing bug.

## Why This Change Was Made

Share the existing generic validator inside QA Lab and remove the two fixed-schema wrappers. YAML decoding, schema ownership, parsed output, and caller-specific diagnostic labels remain unchanged. The helper has no runtime dependencies and is not exported through a public barrel or the Plugin SDK.

## User Impact

No intended behavior change. Existing normalization, strictness, root and nested issue formatting, error ordering, and malformed-YAML exceptions remain intact. No schema, configuration, dependency, cache, or public API changes. Exception stack locations may change.

## Evidence

- Five public-reader characterization cases passed before the production extraction.
- Independent review through P2 found no actionable defects in the four-file patch.
- All 146 focused tests passed across five files, including seven actual maturity renderer CLI cases and the channel-normalization contract.
- All selected changed-file gates passed, including production/test typechecks, formatting, type-aware lint, export scans, and zero runtime import cycles. Declaration preparation initially rejected ancestor dependency lookup in a nested worktree; moving the same task checkout outside the ancestor installation resolved it, and the failed lint surface plus remaining guards passed without code or guard changes.
- Separate Blacksmith Testbox proof passed the same 146 tests on source `ab7b4f3819641de6166182cf0508a7982dcf57a6`, verified by the native source-capsule receiver. Wrapper exit code 0. Run: https://github.com/openclaw/openclaw/actions/runs/34335904654
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/34336410765

## Review Follow-Up

The stored-data-model flag is a false positive for this extraction. An AST-based comparison of the immutable base and head found all 44 top-level variable/type/interface declarations in `scenario-catalog.ts` and all 53 in `scorecard-taxonomy.ts` byte-identical, including every schema and default. No writer, serialized format, schema, or persistent-store behavior changed, so migration or upgrade proof is not applicable. The reader characterizations and real renderer cases protect the unchanged input/output contract.

The linked Testbox workflow can report cancelled after the owned lease is stopped. The proof above comes from the completed inner test run, native source verification, and wrapper exit code 0, not the workflow's cleanup status. The lease was stopped successfully after all 146 tests passed.
