### PR TITLE
fix(node-host): preserve quoted args in cmd /d /s /c exec (#142847)

### DIFF
--- a/src/node-host/invoke.run-command.test.ts
+++ b/src/node-host/invoke.run-command.test.ts
@@ -4,6 +4,77 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing } from "./invoke.test-support.js";
 
+describe("runCommand windows cmd payload (#142847)", () => {
+  it("wraps the canonical cmd /d /s /c payload verbatim on win32", () => {
+    expect(
+      testing.resolveWindowsCmdPayloadSpawn(
+        ["cmd.exe", "/d", "/s", "/c", 'echo "https://x/"'],
+        "win32",
+      ),
+    ).toEqual({
+      argv: ["cmd.exe", "/d", "/s", "/c", '"echo "https://x/""'],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("matches full cmd paths and case-insensitive switches", () => {
+    expect(
+      testing.resolveWindowsCmdPayloadSpawn(
+        ["C:\\Windows\\System32\\cmd.exe", "/D", "/S", "/C", 'echo "a"'],
+        "win32",
+      ),
+    ).toEqual({
+      argv: ["C:\\Windows\\System32\\cmd.exe", "/D", "/S", "/C", '"echo "a""'],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("leaves non-canonical argv and non-Windows hosts untouched", () => {
+    expect(
+      testing.resolveWindowsCmdPayloadSpawn(["cmd.exe", "/d", "/s", "/c", 'echo "a"'], "linux"),
+    ).toEqual({ argv: ["cmd.exe", "/d", "/s", "/c", 'echo "a"'] });
+    expect(
+      testing.resolveWindowsCmdPayloadSpawn(["powershell.exe", "-c", 'echo "a"'], "win32"),
+    ).toEqual({
+      argv: ["powershell.exe", "-c", 'echo "a"'],
+    });
+    expect(
+      testing.resolveWindowsCmdPayloadSpawn(["cmd.exe", "/d", "/c", 'echo "a"'], "win32"),
+    ).toEqual({ argv: ["cmd.exe", "/d", "/c", 'echo "a"'] });
+    expect(testing.resolveWindowsCmdPayloadSpawn(["cmd.exe"], "win32")).toEqual({
+      argv: ["cmd.exe"],
+    });
+  });
+
+  it.runIf(process.platform === "win32")(
+    "preserves quoted args through the real spawn",
+    async () => {
+      const quoted = await testing.runCommand(
+        ["cmd.exe", "/d", "/s", "/c", 'echo "https://tenant.example.com/"'],
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(quoted.success).toBe(true);
+      expect(quoted.stdout.trim()).toBe('"https://tenant.example.com/"');
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "runs a quoted executable payload end to end",
+    async () => {
+      const nested = await testing.runCommand(
+        ["cmd.exe", "/d", "/s", "/c", '"C:\\Windows\\System32\\cmd.exe" /c echo "tail"'],
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(nested.success).toBe(true);
+      expect(nested.stdout.trim()).toBe('"tail"');
+    },
+  );
+});
+
 describe("runCommand", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/node-host/invoke.test-support.ts
+++ b/src/node-host/invoke.test-support.ts
@@ -3,6 +3,10 @@ import "./invoke.js";
 
 type NodeHostInvokeTestApi = {
   clarifyNodeExecCwdSpawnError(error: NodeJS.ErrnoException, cwd: string | undefined): string;
+  resolveWindowsCmdPayloadSpawn(
+    argv: string[],
+    platform?: NodeJS.Platform,
+  ): { argv: string[]; windowsVerbatimArguments?: boolean };
   runCommand(
     argv: string[],
     cwd: string | undefined,
@@ -21,6 +25,9 @@ function getTestApi(): NodeHostInvokeTestApi {
 export const testing: NodeHostInvokeTestApi = {
   clarifyNodeExecCwdSpawnError(error, cwd) {
     return getTestApi().clarifyNodeExecCwdSpawnError(error, cwd);
+  },
+  resolveWindowsCmdPayloadSpawn(argv, platform) {
+    return getTestApi().resolveWindowsCmdPayloadSpawn(argv, platform);
   },
   runCommand(argv, cwd, env, timeoutMs, signal) {
     return getTestApi().runCommand(argv, cwd, env, timeoutMs, signal);

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -270,6 +270,26 @@ function isCmdExeInvocation(argv: string[]): boolean {
   return base === "cmd.exe" || base === "cmd";
 }
 
+// Wrap a pre-built `cmd.exe /d /s /c` command line in one extra quote envelope
+// and mark it verbatim, mirroring Node's own shell:true serialization. Only the
+// canonical five-element shape is touched; everything else passes through (#142847).
+function resolveWindowsCmdPayloadSpawn(
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): { argv: string[]; windowsVerbatimArguments?: boolean } {
+  if (platform !== "win32" || argv.length !== 5 || !isCmdExeInvocation(argv)) {
+    return { argv };
+  }
+  const flags = [argv[1] ?? "", argv[2] ?? "", argv[3] ?? ""].map((flag) =>
+    normalizeLowercaseStringOrEmpty(flag.trim()),
+  );
+  if (flags[0] !== "/d" || flags[1] !== "/s" || flags[2] !== "/c") {
+    return { argv };
+  }
+  const head = [argv[0] ?? "", argv[1] ?? "", argv[2] ?? "", argv[3] ?? ""];
+  return { argv: [...head, `"${argv[4] ?? ""}"`], windowsVerbatimArguments: true };
+}
+
 function resolveExecAsk(value?: string): ExecAsk {
   return value === "off" || value === "on-miss" || value === "always" ? value : DEFAULT_ASK;
 }
@@ -349,7 +369,12 @@ async function runCommand(
   signal?: AbortSignal,
 ): Promise<RunResult> {
   try {
-    const result = await runCommandWithTimeout(argv, {
+    // A pre-built `cmd.exe /d /s /c` command line must travel verbatim inside
+    // one extra quote envelope: Node's default per-argument quoting would
+    // otherwise backslash-escape the payload's quotes, and cmd's /s handling
+    // strips the outer pair (#142847).
+    const spawn = resolveWindowsCmdPayloadSpawn(argv);
+    const result = await runCommandWithTimeout(spawn.argv, {
       baseEnv: env,
       cwd,
       killProcessTree: true,
@@ -359,6 +384,7 @@ async function runCommand(
       input: Buffer.alloc(0),
       signal,
       timeoutMs: timeoutMs && timeoutMs > 0 ? timeoutMs : undefined,
+      ...(spawn.windowsVerbatimArguments === true ? { windowsVerbatimArguments: true } : {}),
     });
     const timedOut = result.termination === "timeout";
     const exitCode = result.code ?? undefined;
@@ -1120,6 +1146,7 @@ async function sendNodeEvent(client: NodeHostClient, event: string, payload: unk
 
 const testing = {
   clarifyNodeExecCwdSpawnError,
+  resolveWindowsCmdPayloadSpawn,
   runCommand,
 } as const;
 


### PR DESCRIPTION
## What Problem This Solves

Native `exec` on a Windows node host mangles quoted arguments. `runCommand()` in `src/node-host/invoke.ts` hands the pre-built `cmd.exe /d /s /c` payload argv straight to `runCommandWithTimeout()` without `windowsVerbatimArguments`, so Node applies its default per-argument quoting and inserts backslashes in front of every quote the payload contains. The command that runs is not the command that was sent: a quoted URL arrives with a leading backslash and trailing literal quote (surfaced downstream as a DNS failure), and a payload that both starts and ends with a quote (quoted exe path + quoted arg) fails outright. The core exec path is unaffected because it resolves `windowsVerbatimArguments`; only the node-host path was missing it.

The fix is the narrow option (a) from the issue: at the node-host boundary, `resolveWindowsCmdPayloadSpawn()` detects the canonical five-element `[cmd.exe, /d, /s, /c, payload]` shape (full paths and case-insensitive switches included, via the existing `isCmdExeInvocation` helper), wraps the payload in one extra quote envelope for cmd's `/s` handling, and passes `windowsVerbatimArguments: true`. Verbatim alone is not sufficient (issue case 5); wrap + verbatim is. Everything else — PowerShell, direct executables, non-canonical argv, non-Windows hosts, env/cwd/timeout/process-tree/approval handling — is untouched.

## Evidence

Measured on Windows 11, Node v26.4.0, raw `spawnSync("cmd.exe", ["/d","/s","/c", payload])`:

- `echo "https://tenant.example.com/"` — upstream (no verbatim): `\\\"https://tenant.example.com/\\\"` (mangled); wrap + verbatim: `"https://tenant.example.com/"` (correct).
- `"C:\Windows\System32\cmd.exe" /c echo "tail"` — upstream: exit 1 (`'\\\"C:...' is not recognized...`); verbatim-only: exit 1 (`The directory name is invalid.`); wrap + verbatim: `"tail"`, exit 0.

TDD on `src/node-host/invoke.run-command.test.ts` (5 new tests: wrap shape, full-path/case-insensitive match, non-canonical passthrough, 2 live-spawn end-to-end):

- Red (fix stashed): 5 failed | 10 passed | 2 skipped.
- Green (fix applied): 15 passed | 2 skipped (skips are the pre-existing non-win32-only kill tests), ~6 s.
- Sabotage (fix reverted, tests kept): back to 5 failed — the tests genuinely guard the fix.

No regressions in adjacent suites: `src/infra/node-shell.test.ts` 3 passed; `src/process/windows-command.test.ts` 66 passed; `src/node-host/invoke-system-run.test.ts` 2 failed | 71 passed | 19 skipped — byte-identical counts on the clean tree (pre-existing `./run.sh` cwd-approval failures on Windows, unrelated). `oxfmt --check` passes on all touched files; `git diff --check` clean; oxlint lane exits 0. Full-project tsgo typecheck was attempted but exceeds this machine's time budget (killed after 420 s with no stray processes left); the diff only uses already-imported helpers and existing option shapes.

Closes #142847
