### PR TITLE
refactor(agents): use prepared metadata for runtime plugin plans

### DIFF
--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -21,10 +21,6 @@ import type {
   PluginMetadataSnapshotPluginIdScope,
 } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
-  loadPluginRegistrySnapshot,
-  normalizePluginsConfigWithRegistry,
-} from "../../plugins/plugin-registry.js";
-import {
   resolveActivatableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
@@ -63,23 +59,16 @@ function restrictiveAllowlistOmitsPlugin(config: OpenClawConfig | undefined, plu
 
 function resolveSelectedMemoryPluginIds(params: {
   config: OpenClawConfig | undefined;
-  workspaceDir: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot: PluginMetadataSnapshot;
 }): string[] {
-  // Honor config-owned test defaults before discovery forces an implicit memory owner.
   if (isTestDefaultMemorySlotDisabled(params.config ?? {})) {
     return [];
   }
-  const registry =
-    params.metadataSnapshot?.index ??
-    loadPluginRegistrySnapshot({ config: params.config, workspaceDir: params.workspaceDir });
   // The generation owns aliases; activation still follows this call's config.
-  const plugins = params.metadataSnapshot
-    ? normalizePluginsConfigWithResolverCore(
-        params.config?.plugins,
-        params.metadataSnapshot.normalizePluginId,
-      )
-    : normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const plugins = normalizePluginsConfigWithResolverCore(
+    params.config?.plugins,
+    params.metadataSnapshot.normalizePluginId,
+  );
   const memorySlot = plugins.slots.memory;
   if (
     typeof memorySlot !== "string" ||
@@ -87,7 +76,9 @@ function resolveSelectedMemoryPluginIds(params: {
   ) {
     return [];
   }
-  const plugin = registry.plugins.find((entry) => entry.pluginId === memorySlot);
+  const plugin = params.metadataSnapshot.index.plugins.find(
+    (entry) => entry.pluginId === memorySlot,
+  );
   if (!plugin?.startup.memory) {
     return [];
   }
@@ -321,12 +312,11 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
   workspaceDir: string;
   basePluginIds?: readonly string[];
   selections: readonly AgentHarnessPluginSelection[];
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot: PluginMetadataSnapshot;
 }): { config?: OpenClawConfig; pluginIds?: string[] } {
   let config = params.config;
   const memoryPluginIds = resolveSelectedMemoryPluginIds({
     config: params.config,
-    workspaceDir: params.workspaceDir,
     metadataSnapshot: params.metadataSnapshot,
   });
   const contextEnginePluginId = resolveSelectedContextEnginePluginId(params.config);

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -53,6 +53,31 @@ function installedProviderRecord(
   };
 }
 
+function createMemoryPlanMetadataSnapshot() {
+  const manifestRegistry = makeRegistry(
+    ["memory-core", "memory-lancedb"].map((id) => ({
+      id,
+      channels: [],
+      origin: "bundled" as const,
+    })),
+  );
+  for (const plugin of manifestRegistry.plugins) {
+    plugin.kind = "memory";
+  }
+  const snapshot = createPluginMetadataSnapshot({ manifestRegistry });
+  snapshot.index.plugins = manifestRegistry.plugins.map((plugin) =>
+    Object.assign(installedProviderRecord(plugin.id), {
+      origin: plugin.origin,
+      rootDir: plugin.rootDir,
+      manifestPath: plugin.manifestPath,
+      manifestHash: plugin.id,
+      enabled: true,
+      startup: { sidecar: false, memory: true, agentHarnesses: [] },
+    }),
+  );
+  return restorePluginMetadataSnapshot(snapshot);
+}
+
 function attachPreparedPluginFacts(
   pluginRegistry: ReturnType<typeof createEmptyPluginRegistry>,
   config: OpenClawConfig,
@@ -438,6 +463,7 @@ describe("harness runtime plugins", () => {
 
   it("force-activates a default-disabled harness owner selected for a run", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: {},
       workspaceDir: "/tmp/workspace",
       selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
@@ -451,6 +477,7 @@ describe("harness runtime plugins", () => {
     mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(["openai"]);
     mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce(["openai"]);
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { allow: ["openai"] } },
       workspaceDir: "/tmp/workspace",
       selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "openclaw" }],
@@ -550,6 +577,7 @@ describe("harness runtime plugins", () => {
     mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce(["openai"]);
     mocks.resolveManifestActivationPlan.mockReturnValueOnce({ entries: [] });
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { allow: ["openai"] } },
       workspaceDir: "/tmp/workspace",
       selections: [{ provider: "openai", modelId: "gpt-5" }],
@@ -561,6 +589,7 @@ describe("harness runtime plugins", () => {
 
   it("includes and enables the context-engine owner in the prepared load plan", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { slots: { contextEngine: "custom-context-engine" } } },
       workspaceDir: "/tmp/workspace",
       basePluginIds: [],
@@ -624,6 +653,7 @@ describe("harness runtime plugins", () => {
       const plan = resolveAgentRuntimePluginLoadPlan({
         config,
         workspaceDir: "/tmp/workspace",
+        metadataSnapshot: createMemoryPlanMetadataSnapshot(),
         selections: [],
       });
 
@@ -678,6 +708,7 @@ describe("harness runtime plugins", () => {
 
   it("keeps standalone activation unrestricted when no complete startup base exists", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: {
         plugins: {
           entries: { "custom-context-engine": { enabled: true } },
@@ -699,6 +730,7 @@ describe("harness runtime plugins", () => {
       entries: [{ pluginId: "custom-harness-plugin", origin: "workspace" }],
     });
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { allow: ["custom-harness-plugin"] } },
       workspaceDir: "/tmp/workspace",
       selections: [
@@ -712,6 +744,7 @@ describe("harness runtime plugins", () => {
 
   it("preserves startup-scoped plugins when selected owners synthesize an allowlist", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { slots: { memory: "memory-core" } } },
       workspaceDir: "/tmp/workspace",
       basePluginIds: ["telegram"],
@@ -724,6 +757,7 @@ describe("harness runtime plugins", () => {
 
   it("does not restore stale startup plugins excluded by a restrictive reload allowlist", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { allow: ["codex"] } },
       workspaceDir: "/tmp/workspace",
       basePluginIds: ["telegram"],
@@ -738,6 +772,7 @@ describe("harness runtime plugins", () => {
     mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(["openai"]);
     mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce(["openai"]);
     const plan = resolveAgentRuntimePluginLoadPlan({
+      metadataSnapshot: createMemoryPlanMetadataSnapshot(),
       config: { plugins: { allow: ["codex"] } },
       workspaceDir: "/tmp/workspace",
       selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],


### PR DESCRIPTION
## What Problem This Solves

The internal runtime-plugin planner still allowed callers to omit metadata and discover memory plugins itself, even though both production callers already prepare and supply that metadata. This left an unused discovery path to maintain and let direct tests exercise a different contract from production.

## Why This Change Was Made

Require the existing metadata snapshot on the internal planner and its private memory selector. Remove the fallback registry load, fallback alias normalization, unused workspace argument, and imports. The independently called harness-owner APIs keep their existing optional metadata contract. Production shrinks by 10 lines.

## User Impact

No user-visible behavior change. Memory selection continues to use the prepared generation's aliases and the current configuration's activation policy. The internal type contract now matches the production callers.

## Evidence

The 79 owner and sibling cases passed before and after the production cleanup. After correcting a lint issue in the new fixture, all 45 affected cases passed again with the existing assertions unchanged. All 29 canonical changed-file checks and fresh independent review passed on the final patch.

Related: #134290.

A clean Linux installation, the full `pnpm build`, and the plugin asset check passed on the exact patch. All 16 build stages and 152 SDK subpath checks passed; generated assets matched the committed source.
