### PR TITLE
docs: close reciprocal-link gaps in concepts, nodes, and platforms

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -236,3 +236,4 @@ settlement, or ownerless state.
 - [Compaction](/concepts/compaction) - how long conversations are summarized
 - [Exec Approvals](/tools/exec-approvals) - approval gates for shell commands
 - [Thinking](/tools/thinking) - thinking/reasoning level configuration
+- [Agent runtimes](/concepts/agent-runtimes) - alternate harness runtimes that drive this loop

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -69,25 +69,25 @@ Standard files OpenClaw expects inside the workspace:
 
 <AccordionGroup>
   <Accordion title="AGENTS.md - operating instructions">
-    Operating instructions for the agent and how it should use memory. Loaded at the start of every session. Good place for rules, priorities, and "how to behave" details.
+    Operating instructions for the agent and how it should use memory. Loaded at the start of every session. Good place for rules, priorities, and "how to behave" details. Template: [AGENTS.md](/reference/templates/AGENTS).
   </Accordion>
   <Accordion title="SOUL.md - persona and tone">
     Persona, tone, and boundaries. Loaded every session. Guide: [SOUL.md personality guide](/concepts/soul).
   </Accordion>
   <Accordion title="USER.md - directive-based user model (optional)">
-    Stable preferences, communication style, relationships, and active-project context. Write entries as dated active or superseded directives. Loaded every session with a separate 4,000-character budget. See [User model](/concepts/user-model).
+    Stable preferences, communication style, relationships, and active-project context. Write entries as dated active or superseded directives. Loaded every session with a separate 4,000-character budget. See [User model](/concepts/user-model). Template: [USER.md](/reference/templates/USER).
   </Accordion>
   <Accordion title="IDENTITY.md - name, vibe, emoji">
-    The agent's name, vibe, and emoji. Created/updated during the bootstrap ritual.
+    The agent's name, vibe, and emoji. Created/updated during the bootstrap ritual. Template: [IDENTITY.md](/reference/templates/IDENTITY).
   </Accordion>
   <Accordion title="AGENTS.md Tools section - local tool conventions">
-    The `## Tools` section holds local environment notes and conventions. It does not control tool availability; it is only guidance.
+    The `## Tools` section holds local environment notes and conventions. It does not control tool availability; it is only guidance. Template: [TOOLS.md](/reference/templates/TOOLS).
   </Accordion>
   <Accordion title="BOOT.md - startup checklist">
-    Optional startup checklist run on Gateway startup when the [boot-md hook](/automation/hooks#boot-md) is enabled. Enabling a different internal hook does not enable `boot-md`. Keep it short; use the message tool for outbound sends.
+    Optional startup checklist run on Gateway startup when the [boot-md hook](/automation/hooks#boot-md) is enabled. Enabling a different internal hook does not enable `boot-md`. Keep it short; use the message tool for outbound sends. Template: [BOOT.md](/reference/templates/BOOT).
   </Accordion>
   <Accordion title="BOOTSTRAP.md - first-run ritual">
-    One-time first-run ritual. Only created for a brand-new workspace. Delete it after the ritual is complete.
+    One-time first-run ritual. Only created for a brand-new workspace. Delete it after the ritual is complete. Template: [BOOTSTRAP.md](/reference/templates/BOOTSTRAP).
   </Accordion>
   <Accordion title="memory/YYYY-MM-DD.md - daily memory log">
     Daily memory log (one file per day). Recommended to read today + yesterday on session start.

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -81,7 +81,7 @@ Standard files OpenClaw expects inside the workspace:
     The agent's name, vibe, and emoji. Created/updated during the bootstrap ritual. Template: [IDENTITY.md](/reference/templates/IDENTITY).
   </Accordion>
   <Accordion title="AGENTS.md Tools section - local tool conventions">
-    The `## Tools` section holds local environment notes and conventions. It does not control tool availability; it is only guidance. Template: [TOOLS.md](/reference/templates/TOOLS).
+    The `## Tools` section holds local environment notes and conventions. It does not control tool availability; it is only guidance. Template: [AGENTS.md Tools section](/reference/templates/AGENTS#tools).
   </Accordion>
   <Accordion title="BOOT.md - startup checklist">
     Optional startup checklist run on Gateway startup when the [boot-md hook](/automation/hooks#boot-md) is enabled. Enabling a different internal hook does not enable `boot-md`. Keep it short; use the message tool for outbound sends. Template: [BOOT.md](/reference/templates/BOOT).

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -265,5 +265,6 @@ For advanced configuration (reserve tokens, identifier preservation, custom cont
 - [Session](/concepts/session): session management and lifecycle.
 - [Session pruning](/concepts/session-pruning): trimming tool results.
 - [Context](/concepts/context): how context is built for agent turns.
+- [Context engines](/concepts/context-engine): pluggable context assembly.
 - [Hooks](/automation/hooks#event-types): internal compaction events (`session:compact:before`, `session:compact:after`).
 - [Plugin hooks](/plugins/hooks/reference#hook-catalog): typed compaction hooks (`before_compaction`, `after_compaction`).

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -423,15 +423,15 @@ authority in a future session.
 Memory architecture is mostly convention over configuration; these are the
 knobs that exist:
 
-| Concern                         | Where                                                           | Reference                                                |
-| ------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
-| Dreaming enable, cadence, model | `plugins.entries.memory-core.config.dreaming`                   | [Dreaming](/concepts/dreaming)                           |
-| Session admission exclusions    | `plugins.entries.memory-core.config.memoryPolicy`               | [Provenance & deletion](/concepts/memory-provenance)     |
-| Search providers, hybrid tuning | `memory.search`                                                 | [Memory config](/reference/memory-config)                |
-| Escalation lane mode, scope     | `plugins.entries.active-memory`                                 | [Active memory](/concepts/active-memory)                 |
-| Cross-conversation recall       | `agents.entries.<id>.memory.search.rememberAcrossConversations` | [Active memory](/concepts/active-memory)                 |
-| Flush behavior                  | `agents.defaults.compaction.memoryFlush`                        | [Memory overview](/concepts/memory)                      |
-| Memory plugin selection         | `plugins.slots.memory`                                          | [Builtin](/concepts/memory-builtin), [Plugins](/plugins) |
+| Concern                         | Where                                                           | Reference                                                     |
+| ------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
+| Dreaming enable, cadence, model | `plugins.entries.memory-core.config.dreaming`                   | [Dreaming](/concepts/dreaming)                                |
+| Session admission exclusions    | `plugins.entries.memory-core.config.memoryPolicy`               | [Provenance & deletion](/concepts/memory-provenance)          |
+| Search providers, hybrid tuning | `memory.search`                                                 | [Memory config](/reference/memory-config)                     |
+| Escalation lane mode, scope     | `plugins.entries.active-memory`                                 | [Active memory](/concepts/active-memory)                      |
+| Cross-conversation recall       | `agents.entries.<id>.memory.search.rememberAcrossConversations` | [Active memory](/concepts/active-memory)                      |
+| Flush behavior                  | `agents.defaults.compaction.memoryFlush`                        | [Memory overview](/concepts/memory)                           |
+| Memory plugin selection         | `plugins.slots.memory`                                          | [Builtin](/concepts/memory-builtin), [Plugins](/tools/plugin) |
 
 ## Related
 

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -406,3 +406,5 @@ See [Gateway configuration](/gateway/configuration) for:
 - `agents.defaults.imageModel` routing
 
 See [Models](/concepts/models) for the broader model selection and fallback overview.
+
+See [Model providers](/concepts/model-providers) for provider setup, credentials, and per-provider model catalogs.

--- a/docs/concepts/personal-agent-benchmark-pack.md
+++ b/docs/concepts/personal-agent-benchmark-pack.md
@@ -70,3 +70,8 @@ plugin workflow checks.
 
 Avoid adding a new runner, plugin, dependency, live transport, or model judge
 until the scenario catalog has enough stable cases to justify that surface.
+
+## Related
+
+- [QA channel](/channels/qa-channel) — the synthetic channel these scenarios run on
+- [QA overview](/concepts/qa-e2e-automation) — the wider QA stack and scenario authoring

--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -81,3 +81,4 @@ late result without authorizing another send.
 
 - [Model failover](/concepts/model-failover)
 - [Command queue](/concepts/queue)
+- [Streaming and chunking](/concepts/streaming)

--- a/docs/concepts/session-search.md
+++ b/docs/concepts/session-search.md
@@ -60,3 +60,7 @@ for CJK substring matching is a future improvement.
 Use `sessions_search` for exact words or phrases from raw session transcripts. Use
 [`memory_search`](/concepts/memory-search) for durable memory files and semantic recall. The
 experimental session-memory corpus is the semantic complement to this exact transcript search.
+
+## Related
+
+- [Session tools](/concepts/session-tool) — the `sessions_*` tool surface that exposes this search

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -105,3 +105,4 @@ entry points at the page that now holds the content.
 - [Configuration reference](/gateway/configuration-reference) — all other config keys
 - [Configuration](/gateway/configuration) — common tasks and quick setup
 - [Configuration examples](/gateway/configuration-examples)
+- [Model providers](/concepts/model-providers) — provider setup and model catalogs

--- a/docs/nodes/camera.md
+++ b/docs/nodes/camera.md
@@ -222,3 +222,6 @@ Requires macOS **Screen Recording** permission (TCC).
 - [Image and media support](/nodes/images)
 - [Media understanding](/nodes/media-understanding)
 - [Location command](/nodes/location-command)
+- [Computer use](/nodes/computer-use)
+- [Node troubleshooting](/nodes/troubleshooting)
+- [Nodes overview](/nodes)

--- a/docs/nodes/location-command.md
+++ b/docs/nodes/location-command.md
@@ -133,3 +133,4 @@ Linux uses the same stable errors: `LOCATION_DISABLED`, `LOCATION_TIMEOUT`, and 
 - [Channel location parsing](/channels/location)
 - [Camera capture](/nodes/camera)
 - [Talk mode](/nodes/talk)
+- [Node troubleshooting](/nodes/troubleshooting)

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -431,3 +431,8 @@ openclaw doctor --lint --only core/doctor/local-audio-acceleration --severity-mi
 
 - [Configuration](/gateway/configuration)
 - [Image & media support](/nodes/images)
+- [Audio and voice notes](/nodes/audio)
+- [Camera capture](/nodes/camera)
+- [Media playback](/nodes/media-playback)
+- [Talk mode](/nodes/talk)
+- [Voice wake](/nodes/voicewake)

--- a/docs/platforms/easyrunner.md
+++ b/docs/platforms/easyrunner.md
@@ -115,3 +115,9 @@ SecretRef, plugin, or channel auth failures.
 - Browser or channel plugins fail: check whether the required external
   binaries, network egress, and mounted credentials are available inside the
   container.
+
+## Related
+
+- [Platforms](/platforms) — the VPS and hosting index this page sits under
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) — the auth mode used behind Caddy
+- [Gateway runbook](/gateway) — operating the Gateway once it is up

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -257,6 +257,7 @@ own docs.
 | Inspect Mac node commands and app IPC    | [macOS IPC](/platforms/mac/xpc)                                                             |
 | Capture logs                             | [macOS logging](/platforms/mac/logging)                                                     |
 | Build from source                        | [macOS dev setup](/platforms/mac/dev-setup)                                                 |
+| Browse and install skills from the app   | [Skills in the macOS app](/platforms/mac/skills)                                            |
 
 ## Related
 

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -479,3 +479,4 @@ For the load pipeline, registry model, provider runtime hooks, Gateway HTTP rout
 - [Building plugins](/plugins/building-plugins)
 - [Plugin manifest](/plugins/manifest)
 - [Plugin SDK setup](/plugins/sdk-setup)
+- [Context engines](/concepts/context-engine)

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -631,5 +631,6 @@ path even if the Codex turn has no assistant text.
 - [Native Codex plugins](/plugins/codex-native-plugins)
 - [Plugin hooks](/plugins/hooks)
 - [Agent harness plugins](/plugins/sdk-agent-harness)
+- [Agent runtimes](/concepts/agent-runtimes)
 - [Diagnostics export](/gateway/diagnostics)
 - [Trajectory export](/tools/trajectory)

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -431,3 +431,4 @@ resolve here.
 - [Plugin SDK setup](/plugins/sdk-setup)
 - [Building plugins](/plugins/building-plugins)
 - [Building channel plugins](/plugins/sdk-channel-plugins)
+- [Model providers](/concepts/model-providers)

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -462,3 +462,4 @@ reload behavior, and legacy cleanup, see
 - [Building plugins](/plugins/building-plugins) - native plugin authoring guide
 - [Plugin SDK overview](/plugins/sdk-overview) - runtime registration, hooks, and API fields
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata
+- [Context engines](/concepts/context-engine) - pluggable context assembly plugins


### PR DESCRIPTION
## What

Link-only fixes for open `link`-kind audit findings in `docs/concepts/`, `docs/nodes/`, `docs/platforms/` and `docs/automation/`. Every hunk adds or retargets a link. No surrounding prose was rewritten, no page was moved, no route was added or removed.

18 files, +50 / -15.

### Fixed

| Finding | Change |
| --- | --- |
| r3-1381 | `docs/concepts/memory-architecture.md` linked `/plugins`, which has no page on disk and resolved only through the `docs.json` redirect to `/tools/plugin`. Now links `/tools/plugin` directly. |
| r3-1346 | Back-links to Model providers from `concepts/model-failover.md`, `gateway/config-agents.md`, `plugins/sdk-provider-plugins.md`. |
| r3-1377 / r3-1489 | `concepts/session-search.md` had no Related section; added one linking Session tools, which links here. |
| r3-1409 | Back-links to Context engines from `concepts/compaction.md`, `plugins/architecture.md`, `tools/plugin.md`. |
| r3-1411 | Back-links to Agent runtimes from `concepts/agent-loop.md`, `plugins/codex-harness-runtime.md`. |
| r3-1385 | Back-link to Streaming and chunking from `concepts/retry.md`. |
| r3-1482 | `concepts/personal-agent-benchmark-pack.md` had no Related section; added one linking QA channel and QA overview. |
| r3-1796 / r3-1806 | `nodes/media-understanding.md` Related listed 2 of the pages that link to it; added audio, camera, media playback, talk, voice wake. |
| r3-1790 / r3-1802 / r3-1818 | `nodes/camera.md` Related now links the nodes hub, computer use, and node troubleshooting — all three link to camera. |
| r3-1836 | `nodes/location-command.md` Related now links node troubleshooting, which links here. |
| r3-1886 | `platforms/macos.md` detail-page table now has a row for `/platforms/mac/skills`, which links the hub but was unreachable from it. |
| r3-1887 | `platforms/easyrunner.md` had no Related block; added one. |
| r5-0224 | Workspace file map in `concepts/agent-workspace.md` now links each template page; five of those templates already link back here. |

### Refuted

- **r5-0269 — the proposed fix is the one that breaks.** The finding says `/tools/thinking#fast-mode-%2Ffast` in `concepts/model-providers.md` should become `#fast-mode-fast`. `docs-link-audit.mjs --anchors` accepts the current encoded anchor and **rejects** the proposed one:

  ```
  concepts/model-providers.md:174 :: /tools/thinking#fast-mode-fast :: fragment not found
  ```

  The punctuated heading `## Fast mode (/fast)` publishes the encoded id, not the cleaned one. Left as-is.

- **r3-1790 — mostly stale.** The finding cites `docs/nodes/index.md:883` and five outbound targets. `nodes/index.md` is now 124 lines (the page was split since the audit ran) and no longer links `/gateway/pairing`, `/tools/exec`, or `/tools/exec-approvals` at all, so there is no reciprocity gap to close for those three. Only the `/nodes/camera` half still holds; that is fixed above. `/gateway/protocol` is a protocol reference linked from many pages and is not back-linked here.

### Narrowed, with reasons

- **r3-1346** — no back-link added from `gateway/configuration.md`. Model providers links it only as a generic "see also" for config examples; a topical Related entry on a 968-line configuration hub is noise, not reciprocity.
- **r3-1409** — no back-link added from `plugins/manifest.md`. Its Related block is a `CardGroup` that navigates to manifest child pages only; a concepts link would break that set.
- **r3-1399** — the finding's summary says two Related targets, its evidence names three. `concepts/timezone.md` is linked from prose (`system-prompt.md:194`), not from Related, so it is not a Related-reciprocity gap.
- **r3-1385** — `plugins/sdk-channel-outbound.md` has no Related section at all; creating one on an out-of-shard SDK reference page is a structural change this finding does not justify.
- **r3-1495** — only the missing back-link half is in scope. Adding new outbound links to the heartbeat and group-message pages is new linking, not a defect.
- **r5-0011** — only the link half applies; naming `maxDiskBytes` in `main-session.md` would be a prose change. See "Blocked" below for why even the link half is not here.

### Blocked on the zh-CN glossary — not fixed here

`scripts/check-docs-i18n-glossary.mts` requires that any **newly introduced list-item link label** in a changed English doc already exist as a `source` in `docs/.i18n/glossary.zh-CN.json` (`LIST_ITEM_LINK_RE` at line 12, the `glossary.has(term)` gate at line 215). A back-link PR introduces exactly such labels, so this check and a "no glossary edits" constraint are mutually exclusive.

Where an established glossary term names the target page, this PR uses it — "Context engines", "Streaming and chunking", "Audio and voice notes", "QA overview". Where no glossary entry exists for the page name, the fix is **omitted rather than relabelled**, because a made-up label would be worse than a missing link:

| Finding | Needs glossary source |
| --- | --- |
| r3-1023 | `Standing orders` |
| r3-1475 | `Standing intents` |
| r3-1379 | `Multi-agent routing` |
| r3-1479 | `Agent bindings` |
| r3-1399 | `System prompt` |
| r3-1403 | `Usage tracking` |
| r3-1478 | `Honcho memory` |
| r3-1391 | `Workboard`, `Managed worktrees` |
| r3-1495 | `Typing indicators` |
| r3-1482 (qa-channel half) | `Personal agent benchmark pack` |
| r3-1489 (memory-search half) | `Memory search` |
| r5-0011 | `Session management and compaction` |
| r3-1887 (Docker row) | `Docker` |

Adding those 14 sources plus their zh-CN targets is a one-file follow-up.

## Validators

Baseline measured in a detached worktree at the base sha `20e0ed521c0`, not quoted from a brief.

| Check | Baseline | This branch |
| --- | --- | --- |
| `check-docs-mdx.mjs docs README.md` | pass (1070) | pass (1071) |
| `docs-link-audit.mjs` | `broken_links=0` | `broken_links=0` |
| `docs-link-audit.mjs --anchors` | `broken_links=42` | `broken_links=42`, error set byte-identical |
| `format-docs.mts --check` | clean | clean |
| `check-docs-i18n-glossary.mts` | clean | clean |
| `markdownlint-cli2 --config config/markdownlint-cli2.jsonc` | — | 0 issues, 1057 files |
| `markdownlint-cli2 --config config/markdownlint-templates.jsonc` | — | 0 issues, 12 files |
| `check-docs-config-examples.mjs` | — | pass |
| `vitest tooling src/scripts/docs-link-audit.test.ts` | **1 failed / 24 passed** | **1 failed / 24 passed** — same pre-existing apostrophe-slug assertion, reproduced at the base sha |
| `vitest full-core-unit-src src/docs/` | — | 8 files, 16 tests, all pass |

The 42 anchor errors are the known baseline: 3 `#windows-app-node` and 39 `/clawhub/*` route-not-found errors already on `main`.

## Notes

- Does not touch `docs/docs.json` or `docs/.i18n/glossary.zh-CN.json`.
- No new page or directory, so no `.github/labeler.yml` glob gap is created.
- No CODEOWNERS team owns any of the 18 files.
- `docs/concepts/memory-architecture.md` shows a whole-table diff: one link target changed width, and `format-docs.mts` re-aligns the table. No cell content changed except that link.
