### PR TITLE
improve: reduce repeated work during shell completion generation

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -28,8 +28,9 @@ import {
   type CompletionShell,
 } from "./completion-runtime.js";
 import { publishOutputFileAtomically } from "./output-file.runtime.js";
-import { getCoreCliCommandNames, registerCoreCliByName } from "./program/command-registry-core.js";
+import { getCoreCliCompletionGroups } from "./program/command-registry-core.js";
 import { getProgramContext } from "./program/program-context.js";
+import { removeCommandGroupNames } from "./program/register-command-groups.js";
 import { getSubCliEntries, registerSubCliByNameCore } from "./program/register.subclis-core.js";
 
 export function getCompletionScript(shell: CompletionShell, program: Command): string {
@@ -207,8 +208,9 @@ export function registerCompletionCli(program: Command) {
       // Our CLI defaults to lazy registration for perf; force-register core commands here.
       const ctx = getProgramContext(program);
       if (ctx) {
-        for (const name of getCoreCliCommandNames()) {
-          await registerCoreCliByName(program, ctx, name);
+        for (const entry of getCoreCliCompletionGroups(ctx)) {
+          removeCommandGroupNames(program, entry);
+          await entry.register(program);
         }
       }
 

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -22,8 +22,7 @@ const outputFileMocks = vi.hoisted(() => ({
   publishOutputFileAtomically: vi.fn<PublishOutputFileAtomically>(),
 }));
 const stderrWrites = vi.hoisted(() => vi.fn());
-const getCoreCliCommandNamesMock = vi.hoisted(() => vi.fn(() => []));
-const registerCoreCliByNameMock = vi.hoisted(() => vi.fn());
+const getCoreCliCompletionGroupsMock = vi.hoisted(() => vi.fn(() => []));
 const getProgramContextMock = vi.hoisted(() => vi.fn(() => null));
 const getSubCliEntriesMock = vi.hoisted(() =>
   vi.fn(() => [
@@ -56,8 +55,7 @@ vi.mock("./output-file.runtime.js", async () => {
 });
 
 vi.mock("./program/command-registry-core.js", () => ({
-  getCoreCliCommandNames: getCoreCliCommandNamesMock,
-  registerCoreCliByName: registerCoreCliByNameMock,
+  getCoreCliCompletionGroups: getCoreCliCompletionGroupsMock,
 }));
 
 vi.mock("./program/program-context.js", () => ({
@@ -110,8 +108,7 @@ async function writeCompletionCacheForShell(shell: CompletionShell): Promise<str
 
 function expectCompletionInstallationToSkipRegistration(): void {
   expect(getProgramContextMock).not.toHaveBeenCalled();
-  expect(getCoreCliCommandNamesMock).not.toHaveBeenCalled();
-  expect(registerCoreCliByNameMock).not.toHaveBeenCalled();
+  expect(getCoreCliCompletionGroupsMock).not.toHaveBeenCalled();
   expect(getSubCliEntriesMock).not.toHaveBeenCalled();
   expect(registerSubCliByNameMock).not.toHaveBeenCalled();
   expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
@@ -130,8 +127,7 @@ describe("completion-cli write-state", () => {
       actual.publishOutputFileAtomically,
     );
     stderrWrites.mockReset();
-    getCoreCliCommandNamesMock.mockClear();
-    registerCoreCliByNameMock.mockClear();
+    getCoreCliCompletionGroupsMock.mockClear();
     getProgramContextMock.mockClear();
     getSubCliEntriesMock.mockClear();
     registerSubCliByNameMock.mockClear();

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -12,6 +12,7 @@ import {
   getCoreCliCommandNamesCore,
 } from "./core-command-descriptors.js";
 import {
+  findCommandGroupEntry,
   registerCommandGroupByName,
   registerCommandGroups,
   type CommandGroupEntry,
@@ -93,8 +94,15 @@ function resolveCoreCommandGroups(ctx: ProgramContext): CommandGroupEntry[] {
   return buildCommandGroupEntries(descriptors, visibleEntrySpecs, ctx);
 }
 
-export function getCoreCliCommandNames(): string[] {
-  return getCoreCliCommandNamesCore();
+export function getCoreCliCompletionGroups(ctx: ProgramContext): CommandGroupEntry[] {
+  const entries = resolveCoreCommandGroups(ctx);
+  // Keep separated visits: an intervening group affects Commander's final output order.
+  return getCoreCliCommandNamesCore()
+    .map((name) => findCommandGroupEntry(entries, name))
+    .filter(
+      (entry, index, groups): entry is CommandGroupEntry =>
+        entry !== undefined && entry !== groups[index - 1],
+    );
 }
 
 export async function registerCoreCliByName(

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -51,12 +51,11 @@ vi.mock("./register.setup.js", () => ({
   },
 }));
 
+import { registerCoreCliByName, registerCoreCliCommands } from "./command-registry-core.js";
 import {
-  getCoreCliCommandNames,
-  registerCoreCliByName,
-  registerCoreCliCommands,
-} from "./command-registry-core.js";
-import { getCoreCliCommandsWithSubcommands } from "./core-command-descriptors.js";
+  getCoreCliCommandNamesCore,
+  getCoreCliCommandsWithSubcommands,
+} from "./core-command-descriptors.js";
 
 const testProgramContext: ProgramContext = {
   programVersion: "0.0.0-test",
@@ -80,7 +79,7 @@ describe("command-registry", () => {
   };
 
   it("includes both agent and agents in core CLI command names", () => {
-    const names = getCoreCliCommandNames();
+    const names = getCoreCliCommandNamesCore();
     expect(names).toContain("setup");
     expect(names).toContain("crestodian"); // hidden alias
     expect(names).toContain("mcp");
@@ -90,11 +89,11 @@ describe("command-registry", () => {
 
   it("only exposes Claws after an explicit process opt-in", () => {
     vi.stubEnv("OPENCLAW_EXPERIMENTAL_CLAWS", "");
-    expect(getCoreCliCommandNames()).not.toContain("claws");
+    expect(getCoreCliCommandNamesCore()).not.toContain("claws");
     expect(getCoreCliCommandsWithSubcommands()).not.toContain("claws");
 
     vi.stubEnv("OPENCLAW_EXPERIMENTAL_CLAWS", "1");
-    expect(getCoreCliCommandNames()).toContain("claws");
+    expect(getCoreCliCommandNamesCore()).toContain("claws");
     expect(getCoreCliCommandsWithSubcommands()).toContain("claws");
 
     vi.unstubAllEnvs();
@@ -163,7 +162,7 @@ describe("command-registry", () => {
 
     expect(await registerCoreCliByName(program, testProgramContext, "doctor")).toBe(true);
 
-    const names = getCoreCliCommandNames();
+    const names = getCoreCliCommandNamesCore();
     expect(names).toContain("doctor");
     expect(names).toContain("dashboard");
     expect(names).toContain("reset");

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -5,9 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cliCommandCatalog } from "../command-catalog.js";
 import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
-import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry-core.js";
+import { registerCoreCliByName } from "./command-registry-core.js";
 import { createProgramContext } from "./context.js";
-import { getCoreCliCommandDescriptors } from "./core-command-descriptors.js";
+import {
+  getCoreCliCommandDescriptors,
+  getCoreCliCommandNamesCore,
+} from "./core-command-descriptors.js";
 import { registerSubCliByName, registerSubCliCommands } from "./register.subclis.js";
 import { getSubCliEntriesCore } from "./subcli-descriptors.js";
 
@@ -224,7 +227,7 @@ async function registerAllBuiltInCommands(): Promise<Command> {
   const ctx = createProgramContext();
   const argv = ["node", "openclaw", "completion"];
 
-  for (const name of getCoreCliCommandNames()) {
+  for (const name of getCoreCliCommandNamesCore()) {
     await registerCoreCliByName(program, ctx, name);
   }
   for (const entry of getSubCliEntriesCore()) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Shell completion generation and cache refresh perform unnecessary preparation before producing scripts, including refreshes triggered by update or Doctor.

## Why This Change Was Made

Prepare the core command groups once and skip adjacent repeat registrations, retaining separated revisits such as `status → audit → status` to preserve command ordering. Ordinary by-name and lazy registration, sub-CLI/plugin handling, and cached installation remain unchanged; the small increase of **10 production lines**, with **two fewer test lines**, removes repeated construction of discarded command groups.

## User Impact

Completion generation does less redundant preparation, with no intended change to commands, aliases, options, script ordering or installation behavior. Fourteen built CLI invocations preserved all 56 complete shell files, including Claws-enabled controls. Timings varied between first and repeated invocations; this is not a universal startup-speed claim.

## Evidence

- Formatting passed. Six existing test files completed with **60 tests passed and 32 skipped**; the skips are native Fish/PowerShell runtime cases, not passing shell-execution proof.
- All seven local guards not covered by ordinary CI passed. Both ordinary baseline and candidate builds passed and their complete output inventories were retained. Managed review through P2 returned no findings.
- Fixed built-CLI comparison, with plugin command registration and compile caching disabled equally in both builds, and OS caches unflushed:

  | Order | First baseline → candidate | Mean of two repeats, baseline → candidate |
  | --- | --- | --- |
  | Baseline then candidate | 1.782692 → 1.477565 s (17.12% faster) | 1.479208 → 1.483817 s (0.31% slower) |
  | Candidate then baseline | 1.766213 → 1.494129 s (15.40% faster) | 1.483774 → 1.492201 s (0.57% slower) |

  “First” means the first process in each phase, not guaranteed cold OS caches; C1 retains the candidate image from C0. These are small fixed samples, not statistical-significance or Gateway-throughput claims. All stdout/stderr was empty. Claws-on invocations were correctness controls only.
- Peak kernel child RSS was 403.06 MiB; peak sampled process-tree RSS was 454.50 MiB. Repeated system CPU increased 0.82%/3.19% and sampled tree RSS increased 1.67%/2.53% in the two orders. No memory improvement is claimed.
- **R1 failed** because its harness confused Zsh dispatch order with alphabetically sorted visible command lists. One successful baseline invocation and all four outputs remain preserved outside R2. R2 corrected only the shell-specific expectation. An oversized evidence-binder argument was refused before either Claws process launched; only the two remaining controls continued under the original deadline, with no repeated default runs. All processes closed and the candidate build was restored.
- Independent audit verified all 14 native/outer receipts, 56 complete scripts, source bindings and both timing orders. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34337481341) passed; independent coverage audit verified all 22 ordinary obligations. Merged as [34d7970](https://github.com/openclaw/openclaw/commit/34d7970e82a9c81b099314de1715b31ff741149a).
