### PR TITLE
improve: reduce repeated work when loading Claude bundles

### DIFF
--- a/src/plugins/bundle-capability-support.ts
+++ b/src/plugins/bundle-capability-support.ts
@@ -14,7 +14,7 @@ export function isBundleCapabilitySupported(
     return true;
   }
   // Only the Claude reader merges agent directories into the runtime skill roots
-  // (`resolveClaudeSkillDirs`); Cursor detects `.cursor/agents` but never loads it.
+  // during manifest loading; Cursor detects `.cursor/agents` but never loads it.
   if (capability === "agents") {
     return format === "claude";
   }

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -224,51 +224,6 @@ function resolveClaudeComponentPaths(
   return mergeBundlePathLists(existingDefaults, declared);
 }
 
-function resolveClaudeSkillsRootDirs(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "skills", rootDir, ["skills"]);
-}
-
-function resolveClaudeCommandRootDirs(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "commands", rootDir, ["commands"]);
-}
-
-function resolveClaudeSkillDirs(raw: Record<string, unknown>, rootDir: string): string[] {
-  return mergeBundlePathLists(
-    resolveClaudeSkillsRootDirs(raw, rootDir),
-    resolveClaudeCommandRootDirs(raw, rootDir),
-    resolveClaudeAgentDirs(raw, rootDir),
-    resolveClaudeOutputStylePaths(raw, rootDir),
-  );
-}
-
-function resolveClaudeAgentDirs(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "agents", rootDir, ["agents"]);
-}
-
-function resolveClaudeHookPaths(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "hooks", rootDir, ["hooks/hooks.json"]);
-}
-
-function resolveClaudeMcpPaths(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "mcpServers", rootDir, [".mcp.json"]);
-}
-
-function resolveClaudeLspPaths(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "lspServers", rootDir, [".lsp.json"]);
-}
-
-function resolveClaudeOutputStylePaths(raw: Record<string, unknown>, rootDir: string): string[] {
-  return resolveClaudeComponentPaths(raw, "outputStyles", rootDir, ["output-styles"]);
-}
-
-function resolveClaudeSettingsFiles(_raw: Record<string, unknown>, rootDir: string): string[] {
-  return pluginCacheExistsSync(path.join(rootDir, "settings.json")) ? ["settings.json"] : [];
-}
-
-function hasClaudeHookCapability(raw: Record<string, unknown>, rootDir: string): boolean {
-  return hasInlineCapabilityValue(raw.hooks) || resolveClaudeHookPaths(raw, rootDir).length > 0;
-}
-
 function buildCodexCapabilities(raw: Record<string, unknown>, rootDir: string): string[] {
   const capabilities: string[] = [];
   if (resolveCodexSkillDirs(raw, rootDir).length > 0) {
@@ -288,38 +243,6 @@ function buildCodexCapabilities(raw: Record<string, unknown>, rootDir: string): 
     pluginCacheExistsSync(path.join(rootDir, ".app.json"))
   ) {
     capabilities.push("apps");
-  }
-  return capabilities;
-}
-
-function buildClaudeCapabilities(raw: Record<string, unknown>, rootDir: string): string[] {
-  const capabilities: string[] = [];
-  if (resolveClaudeSkillDirs(raw, rootDir).length > 0) {
-    capabilities.push("skills");
-  }
-  if (resolveClaudeCommandRootDirs(raw, rootDir).length > 0) {
-    capabilities.push("commands");
-  }
-  if (resolveClaudeAgentDirs(raw, rootDir).length > 0) {
-    capabilities.push("agents");
-  }
-  if (hasClaudeHookCapability(raw, rootDir)) {
-    capabilities.push("hooks");
-  }
-  if (hasInlineCapabilityValue(raw.mcpServers) || resolveClaudeMcpPaths(raw, rootDir).length > 0) {
-    capabilities.push("mcpServers");
-  }
-  if (hasInlineCapabilityValue(raw.lspServers) || resolveClaudeLspPaths(raw, rootDir).length > 0) {
-    capabilities.push("lspServers");
-  }
-  if (
-    hasInlineCapabilityValue(raw.outputStyles) ||
-    resolveClaudeOutputStylePaths(raw, rootDir).length > 0
-  ) {
-    capabilities.push("outputStyles");
-  }
-  if (resolveClaudeSettingsFiles(raw, rootDir).length > 0) {
-    capabilities.push("settings");
   }
   return capabilities;
 }
@@ -500,19 +423,63 @@ export function loadBundleManifest(params: {
     };
   }
 
+  const id = slugifyPluginId(name, params.rootDir);
+  const skillRoots = resolveClaudeComponentPaths(raw, "skills", params.rootDir, ["skills"]);
+  const commands = resolveClaudeComponentPaths(raw, "commands", params.rootDir, ["commands"]);
+  const agents = resolveClaudeComponentPaths(raw, "agents", params.rootDir, ["agents"]);
+  const outputStyles = resolveClaudeComponentPaths(raw, "outputStyles", params.rootDir, [
+    "output-styles",
+  ]);
+  const skills = mergeBundlePathLists(skillRoots, commands, agents, outputStyles);
+  const settingsFiles = pluginCacheExistsSync(path.join(params.rootDir, "settings.json"))
+    ? ["settings.json"]
+    : [];
+  const hooks = resolveClaudeComponentPaths(raw, "hooks", params.rootDir, ["hooks/hooks.json"]);
+  const activation = normalizeManifestActivation(raw.activation);
+  const capabilities: string[] = [];
+  if (skills.length > 0) {
+    capabilities.push("skills");
+  }
+  if (commands.length > 0) {
+    capabilities.push("commands");
+  }
+  if (agents.length > 0) {
+    capabilities.push("agents");
+  }
+  if (hasInlineCapabilityValue(raw.hooks) || hooks.length > 0) {
+    capabilities.push("hooks");
+  }
+  if (
+    hasInlineCapabilityValue(raw.mcpServers) ||
+    resolveClaudeComponentPaths(raw, "mcpServers", params.rootDir, [".mcp.json"]).length > 0
+  ) {
+    capabilities.push("mcpServers");
+  }
+  if (
+    hasInlineCapabilityValue(raw.lspServers) ||
+    resolveClaudeComponentPaths(raw, "lspServers", params.rootDir, [".lsp.json"]).length > 0
+  ) {
+    capabilities.push("lspServers");
+  }
+  if (hasInlineCapabilityValue(raw.outputStyles) || outputStyles.length > 0) {
+    capabilities.push("outputStyles");
+  }
+  if (settingsFiles.length > 0) {
+    capabilities.push("settings");
+  }
   return {
     ok: true,
     manifest: {
-      id: slugifyPluginId(name, params.rootDir),
+      id,
       name,
       description,
       version,
-      skills: resolveClaudeSkillDirs(raw, params.rootDir),
-      settingsFiles: resolveClaudeSettingsFiles(raw, params.rootDir),
-      hooks: resolveClaudeHookPaths(raw, params.rootDir),
+      skills,
+      settingsFiles,
+      hooks,
       bundleFormat: "claude",
-      activation: normalizeManifestActivation(raw.activation),
-      capabilities: buildClaudeCapabilities(raw, params.rootDir),
+      activation,
+      capabilities,
     },
     manifestPath: loaded.manifestPath,
   };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Loading Claude-format plugins repeats path normalization and default-path checks while assembling skill roots and capability flags. This adds unnecessary work to manifest loading and plugin discovery.

## Why This Change Was Made

Prepare component paths once during manifest loading, then reuse those local arrays for the ordered skill union and capability presence checks. Remove the obsolete private wrappers: **33 fewer production lines**, with no test changes.

Default-before-declared ordering, deduplication, inline capabilities, activation, fresh returned arrays and non-Claude readers remain unchanged. This introduces no new cache or filesystem-generation policy.

## User Impact

Claude bundle metadata requires less repeated preparation. The fixed measurements below improved in both orders, including the real discovery/registry composition. They do not establish whole-Gateway or cold-filesystem performance.

## Evidence

- **50 tests passed across three whole suites**, formatting passed, and all seven local supplements outside ordinary CI passed. Codex review through P2 found no actionable issue.
- Independent audit decoded all **1,692 complete returns and captured after-call request graphs**, preserving own undefined fields, ordered paths/capabilities, fixture files and Cursor controls.
- Median of twelve four-call batch means, in microseconds; baseline → candidate:

  | Actual entry / fixture | Forward µs | Reverse µs |
  | --- | ---: | ---: |
  | Manifest / empty, fresh cache | 148.443 → 108.427 | 129.354 → 110.464 |
  | Manifest / defaults, warm cache | 36.135 → 23.625 | 36.260 → 22.609 |
  | Manifest / declared paths, warm cache | 42.266 → 21.490 | 42.890 → 21.584 |
  | Manifest / overlapping paths, warm cache | 35.542 → 22.146 | 35.672 → 22.047 |
  | Manifest / inline values, fresh cache | 106.459 → 104.250 | 105.094 → 93.563 |
  | Manifest / mixed values, warm cache | 34.052 → 20.318 | 34.427 → 21.192 |
  | Discovery + registry / defaults, fresh cache | 358.896 → 311.995 | 340.891 → 333.672 |
  | Discovery + registry / overlap, warm cache | 47.375 → 36.958 | 47.438 → 39.880 |

  Fresh means a new operation plugin cache, not cold imports or OS caches; fixture files are preread. Warm composition reuses discovery but still reconstructs the registry and loads the manifest.
- All 16 medians improved, but adverse observations remain: 5/64 aggregate statistics, 17/192 indexed batches, 82/768 indexed calls and 2/16 initial calls. The reverse composed-defaults mean increased 1.79%, and maximum increased 41.75% (438.115 → 621.021 µs). Initial empty/default-composition calls increased 5.07%/3.18% in forward order. No outliers or failed samples were removed; the p95 of twelve batches equals their maximum, not a population-tail estimate.
- All measurement processes closed, synthetic fixtures were removed, and the candidate was restored. Process CPU/RSS includes fixture, import and capture costs; no heap-allocation claim is made. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34338082734) passed, with all 21 ordinary obligations independently verified. Merged as [23b5f67](https://github.com/openclaw/openclaw/commit/23b5f671d814b3b838f09ad0fdeafef259ae7e85).
