### PR TITLE
fix(redaction): replay persisted redaction masks as re-derive placeholders (#142821)

### DIFF
--- a/packages/agent-core/src/harness/session/session-replay-redaction.test.ts
+++ b/packages/agent-core/src/harness/session/session-replay-redaction.test.ts
@@ -1,0 +1,163 @@
+// Replay must never present persisted redaction masks as real values (#142821).
+// Persisted transcripts store "***" / partial (first6…last4) masks produced by the
+// default-on shape/name battery; resumed, reconciled, or compacted context is rebuilt
+// from that store, and models copy the masks into new commands, files, and replies.
+import { describe, expect, it } from "vitest";
+import type { SessionTreeEntry } from "../types.js";
+import { buildSessionContext, projectSessionEntryMessage } from "./session.js";
+
+const timestamp = "2026-09-02T00:00:00.000Z";
+
+function assistantToolEntry(
+  id: string,
+  parentId: string | null,
+  toolCallId: string,
+  name: string,
+  args: Record<string, unknown>,
+): SessionTreeEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "assistant",
+      api: "openai-responses",
+      content: [{ type: "toolCall", id: toolCallId, name, arguments: args }],
+      provider: "test-provider",
+      model: "test-model",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: Date.parse(timestamp),
+    },
+  };
+}
+
+function toolResultEntry(
+  id: string,
+  parentId: string,
+  toolCallId: string,
+  content: unknown,
+): SessionTreeEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "toolResult",
+      toolCallId,
+      toolName: "exec",
+      content,
+      timestamp: Date.parse(timestamp),
+    } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
+  };
+}
+
+function readToolCallArgs(entry: SessionTreeEntry): Record<string, unknown> {
+  const message = (entry as { message: { content: Array<{ arguments?: unknown }> } }).message;
+  return (message.content[0]?.arguments ?? {}) as Record<string, unknown>;
+}
+
+describe("replay redaction provenance (#142821)", () => {
+  it("does not replay persisted masks as real tool-call argument values", () => {
+    const stored = assistantToolEntry("m1", null, "call_1", "feishu_doc", {
+      action: "read",
+      doc_token: "***",
+      page_token: "***",
+      note: "keep me",
+    });
+    const replayed = projectSessionEntryMessage(stored);
+    const args = readToolCallArgs({ message: replayed } as SessionTreeEntry);
+    expect(args.doc_token).not.toBe("***");
+    expect(args.page_token).not.toBe("***");
+    expect(args.note).toBe("keep me");
+    // The replacement must tell the model to re-derive instead of reusing it.
+    expect(String(args.doc_token)).toMatch(/re-derive/i);
+  });
+
+  it("does not replay embedded masks inside persisted command text", () => {
+    const stored = assistantToolEntry("m1", null, "call_1", "exec", {
+      command: 'APP_ID = "cli_abc"\nAPP_SECRET = "***"',
+    });
+    const replayed = projectSessionEntryMessage(stored);
+    const args = readToolCallArgs({ message: replayed } as SessionTreeEntry);
+    expect(String(args.command)).not.toContain('"***"');
+    expect(String(args.command)).toContain("cli_abc");
+  });
+
+  it("replaces partial masks with a re-derive placeholder", () => {
+    const stored = assistantToolEntry("m1", null, "call_1", "feishu_bitable_list_records", {
+      app_token: "G8B3AB…Cn5c",
+      page_size: 50,
+    });
+    const replayed = projectSessionEntryMessage(stored);
+    const args = readToolCallArgs({ message: replayed } as SessionTreeEntry);
+    expect(String(args.app_token)).toMatch(/re-derive/i);
+    expect(args.page_size).toBe(50);
+  });
+
+  it("rebuilds session context without bare masks", () => {
+    const user = {
+      type: "message",
+      id: "u1",
+      parentId: null,
+      timestamp,
+      message: {
+        role: "user",
+        content: "add a line to the doc we just made",
+        timestamp: Date.parse(timestamp),
+      },
+    } as unknown as SessionTreeEntry;
+    const assistant = assistantToolEntry("m1", "u1", "call_1", "feishu_doc", {
+      action: "read",
+      doc_token: "***",
+    });
+    const result = toolResultEntry("t1", "m1", "call_1", "sk-buggy…9f3a");
+    const context = buildSessionContext([user, assistant, result]);
+    const serialized = JSON.stringify(context.messages);
+    expect(serialized).not.toContain('"***"');
+    expect(serialized).not.toContain("sk-buggy…9f3a");
+  });
+
+  it("leaves markdown emphasis and benign values intact", () => {
+    const stored = {
+      type: "message",
+      id: "m1",
+      parentId: null,
+      timestamp,
+      message: {
+        role: "assistant",
+        api: "openai-responses",
+        content: [{ type: "text", text: "fix ***bold italic*** now" }],
+        provider: "test-provider",
+        model: "test-model",
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.parse(timestamp),
+      },
+    } as unknown as SessionTreeEntry;
+    const replayed = projectSessionEntryMessage(stored);
+    expect(JSON.stringify(replayed)).toContain("***bold italic***");
+  });
+
+  it("returns the identical reference when no masks are present", () => {
+    const stored = assistantToolEntry("m1", null, "call_1", "read", { path: "/tmp/notes.md" });
+    const message = (stored as { message: unknown }).message;
+    expect(projectSessionEntryMessage(stored)).toBe(message);
+  });
+});

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -11,6 +11,113 @@ import { selectResetKeptEntries } from "./tool-result-pairing.js";
 
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 
+/**
+ * Placeholder replayed in place of persisted redaction masks (#142821).
+ *
+ * Persisted transcripts store "***" / partial (first6…last4) masks produced by the
+ * default-on shape/name battery. Replaying those bytes as real values makes models
+ * copy masks into new tool calls, files, and replies, so replay swaps them for an
+ * explicit re-derive instruction. The text carries no "*" or "…" runs, which keeps
+ * this replacement idempotent.
+ */
+export const REPLAY_REDACTED_VALUE_PLACEHOLDER = "[redacted: re-derive this value, do not reuse]";
+
+// Keys whose exact bytes replay depends on (tool/result pairing, dedupe identity).
+// Persist preserves them unredacted, so replay must never rewrite them either.
+// ponytail: denylist, not allowlist — every other string position is mask-eligible.
+const REPLAY_PRESERVED_KEYS = new Set([
+  "idempotencyKey",
+  "toolCallId",
+  "parentToolCallId",
+  "runId",
+  "scopeId",
+  "afterEntryId",
+  "id",
+  // Opaque provider replay blobs carry their own persist-time validation; Anthropic
+  // compaction data is free-form provider text where "***" can be legitimate.
+  "providerReplay",
+]);
+
+function sanitizeReplayedString(value: string): string {
+  if (!value.includes("***") && !value.includes("…")) {
+    return value;
+  }
+  let next = value;
+  if (next.includes("***")) {
+    // Border-aware so markdown emphasis ("***bold italic***", "**bold**") survives.
+    next = next.replace(
+      /(^|[\s"'([{=:\n\r])\*\*\*(?=[\s"'()\]},.;:!?…\n\r]|$)/gu,
+      `$1${REPLAY_REDACTED_VALUE_PLACEHOLDER}`,
+    );
+  }
+  if (next.includes("…")) {
+    // ponytail: whole-token heuristic — U+2026 never appears in real
+    // credential-shaped replay values; prose ellipsis lacks the trailing token.
+    next = next.replace(
+      /[A-Za-z0-9+/=_:.,-]{2,}…[A-Za-z0-9+/=_:.,-]{2,}/gu,
+      REPLAY_REDACTED_VALUE_PLACEHOLDER,
+    );
+  }
+  return next;
+}
+
+function isPlainReplayObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Swap persisted redaction masks for a re-derive placeholder throughout a replayed
+ * message, preserving object identity when nothing matches.
+ */
+export function sanitizeReplayedRedactionMasks<T>(
+  value: T,
+  seen = new WeakMap<object, unknown>(),
+): T {
+  if (typeof value === "string") {
+    return sanitizeReplayedString(value) as T;
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const cached = seen.get(value);
+  if (cached !== undefined) {
+    return cached as T;
+  }
+  if (Array.isArray(value)) {
+    let next: unknown[] | undefined;
+    value.forEach((item, index) => {
+      const sanitized = sanitizeReplayedRedactionMasks(item, seen);
+      if (sanitized !== item && next === undefined) {
+        next = [...value];
+      }
+      if (next !== undefined) {
+        next[index] = sanitized;
+      }
+    });
+    const result = (next ?? value) as T;
+    seen.set(value, result);
+    return result;
+  }
+  if (!isPlainReplayObject(value)) {
+    return value;
+  }
+  let next: Record<string, unknown> | undefined;
+  for (const [key, item] of Object.entries(value)) {
+    if (REPLAY_PRESERVED_KEYS.has(key)) {
+      continue;
+    }
+    const sanitized = sanitizeReplayedRedactionMasks(item, seen);
+    if (sanitized !== item) {
+      next ??= { ...value };
+      next[key] = sanitized;
+    }
+  }
+  const result = (next ?? value) as T;
+  seen.set(value, result);
+  return result;
+}
+
 /** The same semantic cut is used before payload acquisition and when building messages. */
 function resolveSessionContextWindow(
   entries: readonly { id: string; type: string; firstKeptEntryId?: string }[],
@@ -33,26 +140,32 @@ export function projectSessionEntryMessage(entry: SessionTreeEntry): AgentMessag
   switch (entry.type) {
     case "message":
       // Display-only history stays persisted but never enters replay or summarization.
-      return "excludeFromContext" in entry.message && entry.message.excludeFromContext === true
-        ? undefined
-        : entry.message;
+      if ("excludeFromContext" in entry.message && entry.message.excludeFromContext === true) {
+        return undefined;
+      }
+      // Persisted redaction masks must never replay as real values (#142821).
+      return sanitizeReplayedRedactionMasks(entry.message);
     case "custom_message":
-      return asAgentMessage(
-        createCustomMessage(
-          entry.customType,
-          entry.content,
-          entry.display,
-          entry.details,
-          entry.timestamp,
+      return sanitizeReplayedRedactionMasks(
+        asAgentMessage(
+          createCustomMessage(
+            entry.customType,
+            entry.content,
+            entry.display,
+            entry.details,
+            entry.timestamp,
+          ),
         ),
       );
     case "branch_summary":
-      return asAgentMessage(
-        createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp),
+      return sanitizeReplayedRedactionMasks(
+        asAgentMessage(createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp)),
       );
     case "compaction":
-      return asAgentMessage(
-        createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp),
+      return sanitizeReplayedRedactionMasks(
+        asAgentMessage(
+          createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp),
+        ),
       );
     default:
       return undefined;
@@ -112,9 +225,10 @@ export function* iterateSessionContextMessages<T extends SessionTreeEntry>(
       continue;
     }
     // Explicit reset retention can include otherwise excluded user/assistant messages.
+    // The direct path bypasses projectSessionEntryMessage, so it sanitizes here (#142821).
     let message =
       context === "reset-retained" && hydrated.type === "message"
-        ? hydrated.message
+        ? sanitizeReplayedRedactionMasks(hydrated.message)
         : projectSessionEntryMessage(hydrated);
     if (!message) {
       continue;


### PR DESCRIPTION
## What Problem This Solves

Default-on model-visible transcript redaction persists shape/name-based masks
(`***`, `first6…last4`) into the transcript store, and every replay path
(restart, resume, reconcile, compaction) feeds those masks back to the model as
if they were real values. The model then copies masks into new tool calls
(`doc_token: "***"` → HTTP 400), regenerated scripts (`APP_SECRET = "***"`),
and replies — and it cannot comply with instructions to stop, because the
ground truth is gone from its context.

This change keeps persist-time redaction exactly as-is (all 86 existing
transcript-redact assertions still pass) and instead makes the shared replay
choke point replay-safe: `projectSessionEntryMessage` /
`iterateSessionContextMessages` in `packages/agent-core/src/harness/session/session.ts`
now swap persisted masks for an explicit
`[redacted: re-derive this value, do not reuse]` placeholder. Live in-turn
values are untouched (execution still uses pre-persistence truth).

Deliberately preserved: tool/result pairing and dedupe identity keys,
`providerReplay` opaque blobs, markdown emphasis (`***bold italic***`),
benign values, and object identity when no masks are present.

## Evidence

New regression test
`packages/agent-core/src/harness/session/session-replay-redaction.test.ts`:

- Before fix: 4 failed / 2 passed (masks replayed verbatim into args, command
  text, partials, rebuilt context).
- After fix: 6 / 6 pass.
- Sabotage (fix reverted): back to 4 failed / 2 passed — the test catches it.

No-regression runs (single-file, `--maxWorkers=1 --no-file-parallelism`):

- `session-context.test.ts`: 12 / 12
- `compaction.test.ts`: 48 / 48; `branch-summarization.test.ts`: 12 / 12
- `transcript-redact.test.ts`: 86 / 86 (persist behavior unchanged)
- `transcript-append-redact.test.ts`: 15 / 15
- `session-manager-codec.test.ts`: 17 / 17
- `messages.test.ts` (harness): 9 / 9
- `session-transcript-projection-rebuild.test.ts`: 8 / 8
- `agent-session-runtime-projection.test.ts`: 4 failed / 6 passed both before
  and after the change — pre-existing Windows EPERM temp-cleanup flakes,
  identical counts on the clean baseline (verified via `git stash`).
- `oxfmt --check`: clean; `oxlint`: no findings. Full-project `tsc --noEmit`
  OOMs on this box (4 GB heap, environment limit, unrelated to this diff).

Closes #142821
