### PR TITLE
fix(mcp): close plugin resources after accepted stdio work finishes

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -170,6 +170,8 @@ Gateway shutdown also joins actual harness, MCP, LSP, embedding, and media clean
 
 Executable CLI cleanup reports each disposer that exceeds five seconds and proceeds with later cleanup without canceling the pending work. On macOS with Node's system CA support enabled, automatic exit after command completion waits for this pending cleanup to finish. Explicit command exit requests and the update exit watchdog retain their bounded behavior.
 
+Standalone plugin and Codex supervision MCP stdio services retain their discovered registrations through accepted tool work, harness cleanup, and nested SDK provider lookups. Terminal shutdown cancels and joins handlers before releasing these registrations and awaiting their resource disposers. Transport-close and registration-disposal failures reach the serving caller. Programmatic servers created from supplied tools leave those resources with the caller; closing and reconnecting the same server does not dispose them.
+
 Hot registry publication does not wait for retired host cleanup; terminal shutdown also joins cleanup already started by earlier registry replacements before resetting shared state. Activation and rollback apply only to their captured registry version. An activation superseded by a lifecycle callback reports an error.
 
 The cache rule is documented in [Plugin architecture internals](/plugins/architecture-internals#plugin-cache-boundary): Gateway retains one cache generation, while explicit management operations use isolated generations of the same cache. There are no wall-clock TTLs for Gateway metadata.

--- a/src/mcp/codex-supervision-tools-serve.test.ts
+++ b/src/mcp/codex-supervision-tools-serve.test.ts
@@ -8,37 +8,37 @@ import {
   serveCodexSupervisionToolsMcp,
 } from "./codex-supervision-tools-serve.js";
 
-type EnsureStandalonePluginToolRegistryLoaded =
-  typeof import("../plugins/tools.js").ensureStandalonePluginToolRegistryLoaded;
-type ConnectToolsMcpServerToStdio =
-  typeof import("./tools-stdio-server.js").connectToolsMcpServerToStdio;
-
-const ensureStandalonePluginToolRegistryLoadedMock = vi.hoisted(() =>
-  vi.fn<EnsureStandalonePluginToolRegistryLoaded>(() => undefined),
+const acquireStandalonePluginToolRegistryMock = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/tools.js").acquireStandalonePluginToolRegistry>(),
 );
 const resolvePluginToolsMock = vi.hoisted(() => vi.fn<() => AnyAgentTool[]>(() => []));
-const connectToolsMcpServerToStdioMock = vi.hoisted(() =>
-  vi.fn<ConnectToolsMcpServerToStdio>(async () => {}),
+const getRuntimeConfigMock = vi.hoisted(() =>
+  vi.fn<() => import("../config/config.js").OpenClawConfig>(() => ({})),
 );
-const disposeRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn(async () => {}));
 
-vi.mock("../agents/harness/registry.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../agents/harness/registry.js")>();
-  return { ...actual, disposeRegisteredAgentHarnesses: disposeRegisteredAgentHarnessesMock };
-});
-
+vi.mock("../config/config.js", () => ({ getRuntimeConfig: getRuntimeConfigMock }));
 vi.mock("../plugins/tools.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/tools.js")>();
   return {
     ...actual,
-    ensureStandalonePluginToolRegistryLoaded: ensureStandalonePluginToolRegistryLoadedMock,
-    resolvePluginTools: resolvePluginToolsMock,
+    acquireStandalonePluginToolRegistry: acquireStandalonePluginToolRegistryMock,
   };
 });
-
 vi.mock("./tools-stdio-server.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./tools-stdio-server.js")>();
-  return { ...actual, connectToolsMcpServerToStdio: connectToolsMcpServerToStdioMock };
+  const serve: typeof actual.serveRegisteredToolsMcpServer = async (params) => {
+    const { LegacyPluginSdkResourceHost } = await import("../plugins/legacy-sdk-resource-host.js");
+    const host = new LegacyPluginSdkResourceHost();
+    const acquisition = await host.run(params.acquireRegistry);
+    try {
+      const server = params.createServer(acquisition.resolveTools(), host);
+      await server.close();
+    } finally {
+      await acquisition.release();
+      await host.close();
+    }
+  };
+  return { ...actual, serveRegisteredToolsMcpServer: serve };
 });
 
 const TOOL_NAMES = [
@@ -64,17 +64,18 @@ function createTools(): AnyAgentTool[] {
 
 describe("createCodexSupervisionToolsMcpServer", () => {
   beforeEach(() => {
-    ensureStandalonePluginToolRegistryLoadedMock.mockClear();
+    acquireStandalonePluginToolRegistryMock.mockReset().mockImplementation(async () => ({
+      resolveTools: resolvePluginToolsMock,
+      release: async () => {},
+    }));
+    getRuntimeConfigMock.mockReset().mockReturnValue({});
     resolvePluginToolsMock.mockReset();
     resolvePluginToolsMock.mockReturnValue([]);
-    connectToolsMcpServerToStdioMock.mockClear();
-    disposeRegisteredAgentHarnessesMock.mockClear();
   });
 
   it("fails closed when the external Codex plugin tools are unavailable", () => {
     expect(() =>
       createCodexSupervisionToolsMcpServer({
-        config: {},
         tools: [],
       }),
     ).toThrow("Install or update @openclaw/codex");
@@ -82,7 +83,8 @@ describe("createCodexSupervisionToolsMcpServer", () => {
 
   it("lists official tools through the trusted standalone owner context", async () => {
     resolvePluginToolsMock.mockReturnValue(createTools());
-    const server = createCodexSupervisionToolsMcpServer({ config: {} });
+    await serveCodexSupervisionToolsMcp();
+    const server = createCodexSupervisionToolsMcpServer({ tools: createTools() });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client(
       { name: "codex-supervision-owner-test", version: "0.0.0" },
@@ -93,12 +95,7 @@ describe("createCodexSupervisionToolsMcpServer", () => {
     try {
       const listed = await client.listTools();
       expect(listed.tools.map((tool) => tool.name)).toEqual(TOOL_NAMES);
-      expect(ensureStandalonePluginToolRegistryLoadedMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          context: expect.objectContaining({ senderIsOwner: true }),
-        }),
-      );
-      expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect(acquireStandalonePluginToolRegistryMock).toHaveBeenCalledWith(
         expect.objectContaining({
           context: expect.objectContaining({ senderIsOwner: true }),
         }),
@@ -109,27 +106,26 @@ describe("createCodexSupervisionToolsMcpServer", () => {
     }
   });
 
-  it("preserves normalized Codex endpoint config while forcing bridge activation", () => {
+  it("preserves normalized Codex endpoint config while forcing bridge activation", async () => {
     resolvePluginToolsMock.mockReturnValue(createTools());
 
-    createCodexSupervisionToolsMcpServer({
-      config: {
-        plugins: {
-          allow: [" CODEX "],
-          deny: ["CoDeX"],
-          entries: {
-            " CODEX ": {
-              config: {
-                appServer: { transport: "websocket", url: "ws://127.0.0.1:4500" },
-                supervision: { enabled: false },
-              },
+    getRuntimeConfigMock.mockReturnValue({
+      plugins: {
+        allow: [" CODEX "],
+        deny: ["CoDeX"],
+        entries: {
+          " CODEX ": {
+            config: {
+              appServer: { transport: "websocket", url: "ws://127.0.0.1:4500" },
+              supervision: { enabled: false },
             },
           },
         },
       },
     });
+    await serveCodexSupervisionToolsMcp();
 
-    const context = ensureStandalonePluginToolRegistryLoadedMock.mock.calls[0]?.[0]?.context;
+    const context = acquireStandalonePluginToolRegistryMock.mock.calls[0]?.[0]?.context;
     expect(context?.config?.plugins).toMatchObject({
       allow: ["codex"],
       deny: [],
@@ -144,16 +140,5 @@ describe("createCodexSupervisionToolsMcpServer", () => {
       },
     });
     expect(context?.config?.plugins?.entries).not.toHaveProperty(" CODEX ");
-  });
-
-  it("disposes the Codex harness when the stdio bridge shuts down", async () => {
-    resolvePluginToolsMock.mockReturnValue(createTools());
-
-    await serveCodexSupervisionToolsMcp();
-
-    const shutdown = connectToolsMcpServerToStdioMock.mock.calls[0]?.[1]?.onShutdown;
-    expect(shutdown).toBe(disposeRegisteredAgentHarnessesMock);
-    await shutdown?.();
-    expect(disposeRegisteredAgentHarnessesMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/mcp/codex-supervision-tools-serve.ts
+++ b/src/mcp/codex-supervision-tools-serve.ts
@@ -6,15 +6,18 @@
  */
 import { pathToFileURL } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
-import { ensureStandalonePluginToolRegistryLoaded, resolvePluginTools } from "../plugins/tools.js";
-import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
+import type { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import {
+  acquireStandalonePluginToolRegistry,
+  type PluginToolRegistryAcquisition,
+} from "../plugins/tools.js";
+import { createToolsMcpServer, serveRegisteredToolsMcpServer } from "./tools-stdio-server.js";
 
 const LEGACY_TOOL_NAMES = [
   "codex_endpoint_probe",
@@ -55,7 +58,9 @@ function withCodexSupervisionEnabled(config: OpenClawConfig): OpenClawConfig {
   return next;
 }
 
-function resolveCodexSupervisionTools(config: OpenClawConfig): AnyAgentTool[] {
+async function acquireCodexSupervisionTools(
+  config: OpenClawConfig,
+): Promise<PluginToolRegistryAcquisition> {
   const context = {
     config,
     runtimeConfig: config,
@@ -65,18 +70,17 @@ function resolveCodexSupervisionTools(config: OpenClawConfig): AnyAgentTool[] {
     ...TRUSTED_STANDALONE_MCP_OWNER_CONTEXT,
   };
   const toolAllowlist = [...LEGACY_TOOL_NAMES];
-  const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
-    context,
-    toolAllowlist,
-    env: process.env,
-  });
-  return resolvePluginTools({
+  const acquisition = await acquireStandalonePluginToolRegistry({
     context,
     toolAllowlist,
     suppressNameConflicts: true,
-    runtimeRegistry,
     env: process.env,
-  }).filter((tool) => LEGACY_TOOL_NAME_SET.has(tool.name));
+  });
+  return {
+    ...acquisition,
+    resolveTools: () =>
+      acquisition.resolveTools().filter((tool) => LEGACY_TOOL_NAME_SET.has(tool.name)),
+  };
 }
 
 function requireCompleteCodexSupervisionToolSet(tools: readonly AnyAgentTool[]): void {
@@ -94,21 +98,21 @@ function requireCompleteCodexSupervisionToolSet(tools: readonly AnyAgentTool[]):
   );
 }
 
-export function createCodexSupervisionToolsMcpServer(
-  params: { config?: OpenClawConfig; tools?: AnyAgentTool[] } = {},
-): Server {
-  const config = withCodexSupervisionEnabled(params.config ?? getRuntimeConfig());
-  const tools = params.tools ?? resolveCodexSupervisionTools(config);
-  requireCompleteCodexSupervisionToolSet(tools);
-  return createToolsMcpServer({ name: "openclaw-codex-supervisor", tools });
+export function createCodexSupervisionToolsMcpServer(params: {
+  tools: AnyAgentTool[];
+  sdkResourceHost?: LegacyPluginSdkResourceHost;
+}): Server {
+  requireCompleteCodexSupervisionToolSet(params.tools);
+  return createToolsMcpServer({ name: "openclaw-codex-supervisor", ...params });
 }
 
 export async function serveCodexSupervisionToolsMcp(): Promise<void> {
   routeLogsToStderr();
-  const config = withCodexSupervisionEnabled(getRuntimeConfig());
-  const tools = resolveCodexSupervisionTools(config);
-  await connectToolsMcpServerToStdio(createCodexSupervisionToolsMcpServer({ config, tools }), {
-    onShutdown: disposeRegisteredAgentHarnesses,
+  await serveRegisteredToolsMcpServer({
+    acquireRegistry: () =>
+      acquireCodexSupervisionTools(withCodexSupervisionEnabled(getRuntimeConfig())),
+    createServer: (tools, sdkResourceHost) =>
+      createCodexSupervisionToolsMcpServer({ tools, sdkResourceHost }),
   });
 }
 

--- a/src/mcp/plugin-tools-handlers.cancel.test.ts
+++ b/src/mcp/plugin-tools-handlers.cancel.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { consumeTrackedToolExecutionStarted } from "../agents/agent-tools.before-tool-call.state.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
 import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { createToolsMcpServer } from "./tools-stdio-server.js";
 
@@ -81,9 +82,11 @@ describe("plugin tools MCP cancellation", () => {
     }
   });
 
-  it.each(["handler", "descendant"] as const)(
-    "joins native %s work before close releases its database and permits reconnect",
-    async (mode) => {
+  it.each(
+    ["handler", "descendant"].flatMap((mode) => [false, true].map((hosted) => ({ mode, hosted }))),
+  )(
+    "joins native $mode work before close and reconnect (SDK host: $hosted)",
+    async ({ mode, hosted }) => {
       let database = new DatabaseSync(":memory:");
       const started = createDeferred();
       const finish = createDeferred();
@@ -117,7 +120,8 @@ describe("plugin tools MCP cancellation", () => {
           return { content: [{ type: "text", text: "accepted" }], details: {} };
         },
       };
-      const server = createToolsMcpServer({ name: "native-drain", tools: [tool] });
+      const sdkResourceHost = hosted ? new LegacyPluginSdkResourceHost() : undefined;
+      const server = createToolsMcpServer({ name: "native-drain", tools: [tool], sdkResourceHost });
       const clients: Client[] = [];
       const connect = async () => {
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -196,6 +200,7 @@ describe("plugin tools MCP cancellation", () => {
         await siblingClose;
         await Promise.all(clients.map((client) => client.close()));
         await server.close();
+        await sdkResourceHost?.close();
         if (database.isOpen) {
           database.close();
         }

--- a/src/mcp/plugin-tools-handlers.cancel.test.ts
+++ b/src/mcp/plugin-tools-handlers.cancel.test.ts
@@ -4,12 +4,12 @@ import { setImmediate as nextTurn } from "node:timers/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Type } from "typebox";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { consumeTrackedToolExecutionStarted } from "../agents/agent-tools.before-tool-call.state.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
-import { trackAsyncWork } from "../shared/async-work-scope.js";
+import { getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
 import { createToolsMcpServer } from "./tools-stdio-server.js";
 
 describe("plugin tools MCP cancellation", () => {
@@ -201,6 +201,179 @@ describe("plugin tools MCP cancellation", () => {
         await Promise.all(clients.map((client) => client.close()));
         await server.close();
         await sdkResourceHost?.close();
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+    },
+  );
+
+  it.each(
+    [false, true].flatMap((hosted) =>
+      ["send-pending", "response-completed"].map((phase) => ({ hosted, phase })),
+    ),
+  )(
+    "keeps late descendant cancellation during $phase (SDK host: $hosted)",
+    async ({ hosted, phase }) => {
+      const database = new DatabaseSync(":memory:");
+      const host = hosted ? new LegacyPluginSdkResourceHost() : undefined;
+      const lateListener = createDeferred();
+      const listening = createDeferred();
+      const finish = createDeferred();
+      const workAborted = createDeferred();
+      const responseEntered = createDeferred();
+      const releaseResponse = createDeferred();
+      const transportClosed = createDeferred();
+      const reads: unknown[] = [];
+      let requestSignal: AbortSignal | undefined;
+      let workSignal: AbortSignal | undefined;
+      let descendant: Promise<void> | undefined;
+      let descendantFinished = false;
+      let responseId: number | string | undefined;
+      let abortCount = 0;
+      let observedReason: unknown;
+      let closeFinished = false;
+      const tool: AnyAgentTool = {
+        name: "cached_native_work",
+        label: "Cached native work",
+        description: "Returns a cached result while accepted native work remains",
+        parameters: Type.Object({}),
+        execute: async (_id, _params, signal) => {
+          const ownerSignal = getAsyncWorkSignal();
+          if (!signal || !ownerSignal) {
+            throw new Error("Expected request and work signals");
+          }
+          requestSignal = signal;
+          workSignal = ownerSignal;
+          descendant = trackAsyncWork(async () => {
+            await lateListener.promise;
+            const observeAbort = () => {
+              abortCount++;
+              observedReason = signal.reason;
+            };
+            const observeWorkAbort = () => workAborted.resolve();
+            signal.addEventListener("abort", observeAbort, { once: true });
+            ownerSignal.addEventListener("abort", observeWorkAbort, { once: true });
+            if (signal.aborted) {
+              observeAbort();
+            }
+            if (ownerSignal.aborted) {
+              observeWorkAbort();
+            }
+            listening.resolve();
+            try {
+              await finish.promise;
+              if (phase === "response-completed") {
+                await workAborted.promise;
+              }
+              reads.push(database.prepare("SELECT 42 AS value").get());
+            } finally {
+              signal.removeEventListener("abort", observeAbort);
+              ownerSignal.removeEventListener("abort", observeWorkAbort);
+              descendantFinished = true;
+            }
+          });
+          void descendant.catch(() => {});
+          return { content: [{ type: "text", text: "cached result" }], details: {} };
+        },
+      };
+      const server = createToolsMcpServer({
+        name: "native-response-tail",
+        tools: [tool],
+        sdkResourceHost: host,
+      });
+      const client = new Client({ name: "native-response-client", version: "0.0.0" });
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client exposes callback properties, not EventTarget.
+      client.onclose = () => transportClosed.resolve();
+      const [outbound, inbound] = InMemoryTransport.createLinkedPair();
+      const sendRequest = outbound.send.bind(outbound);
+      const requestSpy = vi.spyOn(outbound, "send").mockImplementation(async (message, options) => {
+        if ("method" in message && message.method === "tools/call" && "id" in message) {
+          responseId = message.id;
+        }
+        return await sendRequest(message, options);
+      });
+      const sendResponse = inbound.send.bind(inbound);
+      const responseSpy = vi.spyOn(inbound, "send").mockImplementation(async (message, options) => {
+        if ("result" in message && message.id === responseId) {
+          responseEntered.resolve();
+          if (phase === "send-pending") {
+            await releaseResponse.promise;
+          }
+        }
+        return await sendResponse(message, options);
+      });
+      let call: Promise<unknown> | undefined;
+      let closing: Promise<void> | undefined;
+      const reason = "cancel while response transport is pending";
+      try {
+        await Promise.all([server.connect(inbound), client.connect(outbound)]);
+        const controller = new AbortController();
+        call = client.callTool({ name: tool.name }, undefined, { signal: controller.signal }).then(
+          (result) => ({ result }),
+          (error: unknown) => ({ error }),
+        );
+        await Promise.race([
+          responseEntered.promise,
+          call.then(() => {
+            throw new Error("The call settled before response sending began");
+          }),
+        ]);
+        expect(descendantFinished).toBe(false);
+        if (phase === "response-completed") {
+          expect(await call).toMatchObject({ result: { content: [{ text: "cached result" }] } });
+          await client.ping();
+        }
+        expect(workSignal?.aborted).toBe(false);
+        lateListener.resolve();
+        await listening.promise;
+        if (phase === "send-pending") {
+          controller.abort(reason);
+        } else {
+          if (responseId === undefined) {
+            throw new Error("Expected the actual request ID");
+          }
+          await client.notification({
+            method: "notifications/cancelled",
+            params: { requestId: responseId, reason },
+          });
+        }
+        // A public ping reply follows the preceding cancellation notification.
+        await client.ping();
+        expect(abortCount).toBe(phase === "send-pending" ? 1 : 0);
+        expect(requestSignal?.aborted).toBe(phase === "send-pending");
+        expect(observedReason).toBe(phase === "send-pending" ? reason : undefined);
+        expect(workSignal?.aborted).toBe(false);
+        releaseResponse.resolve();
+        await call;
+        await client.ping();
+        closing = server.close().then(() => {
+          database.close();
+          closeFinished = true;
+        });
+        await transportClosed.promise;
+        await nextTurn();
+        expect(workSignal?.aborted).toBe(true);
+        expect(closeFinished).toBe(false);
+        expect(database.isOpen).toBe(true);
+        finish.resolve();
+        await descendant;
+        await closing;
+        expect(reads).toEqual([{ value: 42 }]);
+        expect(database.isOpen).toBe(false);
+      } finally {
+        lateListener.resolve();
+        finish.resolve();
+        workAborted.resolve();
+        releaseResponse.resolve();
+        await descendant;
+        await closing;
+        await server.close();
+        await client.close();
+        await call;
+        await host?.close();
+        requestSpy.mockRestore();
+        responseSpy.mockRestore();
         if (database.isOpen) {
           database.close();
         }

--- a/src/mcp/plugin-tools-mcp-client.test.ts
+++ b/src/mcp/plugin-tools-mcp-client.test.ts
@@ -2,7 +2,6 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginToolsMcpServer } from "./plugin-tools-serve.js";
 
 describe("plugin tools MCP client bridge", () => {
@@ -25,7 +24,6 @@ describe("plugin tools MCP client bridge", () => {
     } as unknown as AnyAgentTool;
 
     const server = createPluginToolsMcpServer({
-      config: { plugins: { enabled: true } } as OpenClawConfig,
       tools: [tool],
     });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -72,7 +70,6 @@ describe("plugin tools MCP client bridge", () => {
       }),
     } as unknown as AnyAgentTool;
     const server = createPluginToolsMcpServer({
-      config: { plugins: { enabled: true } } as OpenClawConfig,
       tools: [tool],
     });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/src/mcp/plugin-tools-registration.stdio.test.ts
+++ b/src/mcp/plugin-tools-registration.stdio.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
@@ -6,6 +5,9 @@ import { runNodeScript } from "../../test/helpers/run-node-script.js";
 
 const lifetime = createFixtureLifetime();
 const repository = fileURLToPath(new URL("../../", import.meta.url));
+const runner = fileURLToPath(
+  new URL("../../test/fixtures/mcp-registration/runner.mjs", import.meta.url),
+);
 afterAll(() => lifetime.cleanup());
 
 describe("standalone MCP registration lifetime", () => {
@@ -15,12 +17,7 @@ describe("standalone MCP registration lifetime", () => {
       lifetime.run(async () => {
         const root = lifetime.createTempDir("openclaw-mcp-registration-");
         const result = await runNodeScript(
-          [
-            path.join(repository, "test/fixtures/mcp-registration/runner.mjs"),
-            repository,
-            mode,
-            root,
-          ],
+          [runner, repository, mode, root],
           { PATH: process.env.PATH },
           120_000,
           { cwd: repository, requireProcessTreeExit: true, maxBuffer: 1024 * 1024 },

--- a/src/mcp/plugin-tools-registration.stdio.test.ts
+++ b/src/mcp/plugin-tools-registration.stdio.test.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
+
+const lifetime = createFixtureLifetime();
+const repository = fileURLToPath(new URL("../../", import.meta.url));
+afterAll(() => lifetime.cleanup());
+
+describe("standalone MCP registration lifetime", () => {
+  it.each(["plain", "nested", "close-failure"])(
+    "%s: joins native tool work and physical registration disposal before terminal return",
+    (mode) =>
+      lifetime.run(async () => {
+        const root = lifetime.createTempDir("openclaw-mcp-registration-");
+        const result = await runNodeScript(
+          [
+            path.join(repository, "test/fixtures/mcp-registration/runner.mjs"),
+            repository,
+            mode,
+            root,
+          ],
+          { PATH: process.env.PATH },
+          120_000,
+          { cwd: repository, requireProcessTreeExit: true, maxBuffer: 1024 * 1024 },
+        );
+        expect(result.error, result.stderr).toBeUndefined();
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(JSON.parse(result.stdout)).toMatchObject({ ok: true });
+      }),
+    135_000,
+  );
+});

--- a/src/mcp/plugin-tools-registration.test.ts
+++ b/src/mcp/plugin-tools-registration.test.ts
@@ -1,0 +1,301 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { markPluginRegistryActive } from "../plugins/registry-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { acquireStandalonePluginToolRegistry } from "../plugins/tools.js";
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import { createCodexSupervisionToolsMcpServer } from "./codex-supervision-tools-serve.js";
+import { createToolsMcpServer, serveRegisteredToolsMcpServer } from "./tools-stdio-server.js";
+
+let sequence = 0;
+function nativePlugin(options: { failDisposal?: boolean; abortSdk?: boolean } = {}) {
+  useNoBundledPlugins();
+  const key = `__mcp_registration_native_${sequence++}`;
+  const state: {
+    database?: DatabaseSync;
+    disposals: number;
+    factories: number;
+    workspaceDir?: string;
+    aborted: Deferred;
+    started: Deferred;
+    finish: Deferred;
+    abortReason?: unknown;
+    abortFailure?: unknown;
+    abortRead?: unknown;
+  } = {
+    disposals: 0,
+    factories: 0,
+    aborted: createDeferredCore(),
+    started: createDeferredCore(),
+    finish: createDeferredCore(),
+  };
+  Object.defineProperty(globalThis, key, { value: state, configurable: true });
+  const plugin = writePlugin({
+    id: "mcp-native",
+    body: `const { DatabaseSync } = require("node:sqlite");
+const { resolvePluginProviders } = require("openclaw/plugin-sdk/provider-catalog-runtime");
+module.exports = { id: "mcp-native", register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const db = state.database = new DatabaseSync(":memory:");
+  api.lifecycle.registerRuntimeLifecycle({ id: "native", dispose() {
+    state.disposals++;
+    db.close();
+    if (${options.failDisposal === true}) throw new Error("synthetic registration disposal failure");
+  }});
+  api.registerProvider({ id: "mcp-native", label: "Native", auth: [],
+    isCacheTtlEligible() { state.abortRead = db.prepare("SELECT 42 AS n").get().n; return true; }
+  });
+  api.registerTool(() => {
+    state.factories++;
+    return { name: "mcp_native_read", label: "Native read", description: "Native read",
+      parameters: { type: "object", properties: {} },
+      async execute(_id, _params, signal) {
+        if (${options.abortSdk === true}) {
+          signal.addEventListener("abort", () => {
+            state.abortReason = signal.reason;
+            try {
+              const provider = resolvePluginProviders({ config: api.config, env: process.env,
+                workspaceDir: state.workspaceDir, onlyPluginIds: ["mcp-native"], registryScope: "loaded"
+              }).find((entry) => entry.id === "mcp-native");
+              if (!provider || provider.isCacheTtlEligible({ provider: "mcp-native", modelId: "abort" }) !== true) {
+                throw new Error("Abort callback lost its admitted provider registry");
+              }
+            } catch (error) { state.abortFailure = error; }
+            finally { state.aborted.resolve(); }
+          }, { once: true });
+          state.started.resolve();
+          await state.finish.promise;
+        }
+        return { content: [{ type: "text", text: String(db.prepare("SELECT 42 AS n").get().n) }] }; }
+    };
+  }, { names: ["mcp_native_read"] });
+}};`,
+  });
+  state.workspaceDir = plugin.dir;
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: plugin.id,
+      providers: [plugin.id],
+      contracts: { tools: ["mcp_native_read"] },
+      configSchema: { type: "object", properties: {}, additionalProperties: false },
+    }),
+  );
+  return {
+    state,
+    acquire: () =>
+      acquireStandalonePluginToolRegistry({
+        context: {
+          workspaceDir: plugin.dir,
+          config: {
+            plugins: {
+              allow: [plugin.id],
+              load: { paths: [plugin.file] },
+              slots: { memory: "none" },
+            },
+          },
+        },
+      }),
+    cleanup() {
+      if (state.database?.isOpen) {
+        state.database.close();
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+function causes(error: unknown): unknown[] {
+  if (error instanceof AggregateError) {
+    return error.errors.flatMap(causes);
+  }
+  return error instanceof Error && error.cause !== undefined ? causes(error.cause) : [error];
+}
+
+describe("MCP serving registration ownership", () => {
+  it("keeps supplied tools usable across close/reconnect until their caller releases registration", async () => {
+    const fixture = nativePlugin();
+    const acquisition = await fixture.acquire();
+    const server = createToolsMcpServer({
+      name: "native-reconnect",
+      tools: acquisition.resolveTools(),
+    });
+    try {
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const [outbound, inbound] = InMemoryTransport.createLinkedPair();
+        const client = new Client({ name: "native-client", version: "0.0.0" });
+        try {
+          await Promise.all([server.connect(inbound), client.connect(outbound)]);
+          expect(await client.callTool({ name: "mcp_native_read" })).toMatchObject({
+            content: [{ text: "42" }],
+          });
+        } finally {
+          await server.close();
+          await client.close();
+        }
+        expect(fixture.state.database?.isOpen).toBe(true);
+        expect(fixture.state.disposals).toBe(0);
+      }
+      await acquisition.release();
+      expect(fixture.state.database?.isOpen).toBe(false);
+      expect(fixture.state.disposals).toBe(1);
+    } finally {
+      await server.close();
+      await acquisition.release();
+      fixture.cleanup();
+    }
+  });
+
+  it("releases the native registration when supervision tool validation fails before connection", async () => {
+    const fixture = nativePlugin();
+    try {
+      await expect(
+        serveRegisteredToolsMcpServer({
+          acquireRegistry: fixture.acquire,
+          createServer: (tools) => createCodexSupervisionToolsMcpServer({ tools }),
+        }),
+      ).rejects.toThrow("Install or update @openclaw/codex");
+      expect(fixture.state.factories).toBe(1);
+      expect(fixture.state.database?.isOpen).toBe(false);
+      expect(fixture.state.disposals).toBe(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does not revive an acquired view when the same registry objects are reactivated", async () => {
+    const fixture = nativePlugin();
+    const acquisition = await fixture.acquire();
+    try {
+      expect(acquisition.resolveTools()).toHaveLength(1);
+      expect(fixture.state.factories).toBe(1);
+      await acquisition.release();
+      markPluginRegistryActive(acquisition.registry);
+      expect(() => acquisition.resolveTools()).toThrow("Plugin tool registry has been released");
+      expect(fixture.state.factories).toBe(1);
+      expect(fixture.state.database?.isOpen).toBe(false);
+    } finally {
+      await acquisition.release();
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps peer cancellation SDK borrows with the admitted host under a foreign ambient host", async () => {
+    const fixture = nativePlugin({ abortSdk: true });
+    const admittedHost = new LegacyPluginSdkResourceHost();
+    const foreignHost = new LegacyPluginSdkResourceHost();
+    const acquisition = await admittedHost.run(fixture.acquire);
+    const server = withPluginRuntimeRegistryScope(acquisition.registry, () =>
+      createToolsMcpServer({
+        name: "native-peer-cancel",
+        tools: admittedHost.run(acquisition.resolveTools),
+        sdkResourceHost: admittedHost,
+      }),
+    );
+    const [outbound, inbound] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "native-peer", version: "0.0.0" });
+    let call: Promise<unknown> | undefined;
+    try {
+      await Promise.all([server.connect(inbound), client.connect(outbound)]);
+      const controller = new AbortController();
+      call = client
+        .callTool({ name: "mcp_native_read" }, undefined, { signal: controller.signal })
+        .catch((error: unknown) => error);
+      await Promise.race([
+        fixture.state.started.promise,
+        call.then(() => {
+          throw new Error("The tool completed before native work started");
+        }),
+      ]);
+      // The peer shares the registry but owns a different SDK lifetime.
+      foreignHost.run(() =>
+        withPluginRuntimeRegistryScope(acquisition.registry, () =>
+          controller.abort("peer cancellation reason"),
+        ),
+      );
+      await fixture.state.aborted.promise;
+      fixture.state.finish.resolve();
+      await server.close();
+      await call;
+      expect(fixture.state.abortReason).toBe("peer cancellation reason");
+      expect(fixture.state.abortFailure).toBeUndefined();
+      expect(fixture.state.abortRead).toBe(42);
+      await acquisition.release();
+      await admittedHost.close();
+      expect(fixture.state.database?.isOpen).toBe(false);
+      expect(fixture.state.disposals).toBe(1);
+    } finally {
+      fixture.state.finish.resolve();
+      await server.close();
+      await client.close();
+      await call;
+      await acquisition.release();
+      await admittedHost.close();
+      await foreignHost.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("preserves real SDK connect and transport-close errors while joining a failed native disposer once", async () => {
+    const fixture = nativePlugin({ failDisposal: true });
+    const [outbound, inbound] = InMemoryTransport.createLinkedPair();
+    const transportClose = inbound.close.bind(inbound);
+    vi.spyOn(inbound, "close").mockImplementation(async () => {
+      await transportClose();
+      throw new Error("synthetic transport close failure");
+    });
+    const previousOnClose = vi.fn();
+    let connection: Promise<void> | undefined;
+    let server: ReturnType<typeof createToolsMcpServer> | undefined;
+    try {
+      const failure = await serveRegisteredToolsMcpServer({
+        acquireRegistry: fixture.acquire,
+        createServer(tools, sdkResourceHost) {
+          server = createToolsMcpServer({ name: "failed-native", tools, sdkResourceHost });
+          // The SDK rejects a second connection while this real transport is attached.
+          // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes a callback property, not EventTarget.
+          server.onclose = previousOnClose;
+          connection = server.connect(inbound);
+          return server;
+        },
+      }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await connection;
+      const messages = causes(failure).map(String);
+      expect(messages).toHaveLength(3);
+      expect(messages.filter((message) => message.includes("Already connected"))).toHaveLength(1);
+      expect(
+        messages.filter((message) => message.includes("synthetic transport close failure")),
+      ).toHaveLength(1);
+      expect(
+        messages.filter((message) => message.includes("synthetic registration disposal failure")),
+      ).toHaveLength(1);
+      expect(fixture.state.database?.isOpen).toBe(false);
+      expect(fixture.state.disposals).toBe(1);
+      expect(previousOnClose).toHaveBeenCalledOnce();
+      expect(server?.onclose).toBe(previousOnClose);
+    } finally {
+      await outbound.close();
+      fixture.cleanup();
+    }
+  });
+});

--- a/src/mcp/plugin-tools-registration.test.ts
+++ b/src/mcp/plugin-tools-registration.test.ts
@@ -253,6 +253,58 @@ describe("MCP serving registration ownership", () => {
     }
   });
 
+  it.each([false, true])(
+    "joins owned stdio self-close without replacing the caller callback (throws: %s)",
+    async (throws) => {
+      const fixture = nativePlugin();
+      const closeError = new Error("caller close callback failed");
+      let callbacks = 0;
+      const onclose = () => {
+        callbacks++;
+        if (throws) {
+          throw closeError;
+        }
+      };
+      let server: ReturnType<typeof createToolsMcpServer> | undefined;
+      let selfClose: Promise<unknown> | undefined;
+      try {
+        const servingFailure = await serveRegisteredToolsMcpServer({
+          acquireRegistry: fixture.acquire,
+          createServer(tools, sdkResourceHost) {
+            server = createToolsMcpServer({ name: "native-self-close", tools, sdkResourceHost });
+            // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes callback properties, not EventTarget.
+            server.onclose = onclose;
+            const created = server;
+            queueMicrotask(() => {
+              const transport = created.transport;
+              if (!transport) {
+                throw new Error("Expected the connected owned stdio transport");
+              }
+              selfClose = transport.close().then(
+                () => undefined,
+                (error: unknown) => error,
+              );
+            });
+            return server;
+          },
+        }).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        expect(await selfClose).toBe(throws ? closeError : undefined);
+        expect(servingFailure).toBe(throws ? closeError : undefined);
+        expect(callbacks).toBe(1);
+        expect(server?.onclose).toBe(onclose);
+        expect(fixture.state.database?.isOpen).toBe(false);
+        expect(fixture.state.disposals).toBe(1);
+      } finally {
+        await selfClose;
+        await server?.close();
+        fixture.cleanup();
+      }
+    },
+  );
+
   it("preserves real SDK connect and transport-close errors while joining a failed native disposer once", async () => {
     const fixture = nativePlugin({ failDisposal: true });
     const [outbound, inbound] = InMemoryTransport.createLinkedPair();

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -23,9 +23,14 @@ import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
 
 const callGatewayTool = vi.hoisted(() => vi.fn());
 const connectToolsMcpServerToStdioMock = vi.hoisted(() => vi.fn());
-const createToolsMcpServerMock = vi.hoisted(() => vi.fn(() => ({ close: vi.fn() })));
+const createToolsMcpServerMock = vi.hoisted(() =>
+  vi.fn<typeof import("./tools-stdio-server.js").createToolsMcpServer>(),
+);
 const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({ plugins: { enabled: true } })));
-const ensureStandalonePluginToolRegistryLoadedMock = vi.hoisted(() => vi.fn());
+const acquireStandalonePluginToolRegistryMock = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/tools.js").acquireStandalonePluginToolRegistry>(),
+);
+const releasePluginToolsMock = vi.hoisted(() => vi.fn(async () => {}));
 const resolvePluginToolsMock = vi.hoisted(() => vi.fn<() => AnyAgentTool[]>(() => []));
 const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
 
@@ -49,14 +54,36 @@ vi.mock("../plugins/tools.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/tools.js")>();
   return {
     ...actual,
-    ensureStandalonePluginToolRegistryLoaded: ensureStandalonePluginToolRegistryLoadedMock,
-    resolvePluginTools: resolvePluginToolsMock,
+    acquireStandalonePluginToolRegistry: acquireStandalonePluginToolRegistryMock,
   };
 });
 
-vi.mock("./tools-stdio-server.js", () => ({
-  connectToolsMcpServerToStdio: connectToolsMcpServerToStdioMock,
-  createToolsMcpServer: createToolsMcpServerMock,
+vi.mock("./tools-stdio-server.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./tools-stdio-server.js")>();
+  createToolsMcpServerMock.mockImplementation(actual.createToolsMcpServer);
+  const serve: typeof actual.serveRegisteredToolsMcpServer = async (params) => {
+    const { LegacyPluginSdkResourceHost } = await import("../plugins/legacy-sdk-resource-host.js");
+    const host = new LegacyPluginSdkResourceHost();
+    const acquisition = await host.run(params.acquireRegistry);
+    const server = params.createServer(acquisition.resolveTools(), host);
+    try {
+      await connectToolsMcpServerToStdioMock(server);
+    } finally {
+      await server.close();
+      await acquisition.release();
+      await host.close();
+    }
+  };
+  return {
+    ...actual,
+    createToolsMcpServer: createToolsMcpServerMock,
+    serveRegisteredToolsMcpServer: serve,
+  };
+});
+
+acquireStandalonePluginToolRegistryMock.mockImplementation(async () => ({
+  resolveTools: resolvePluginToolsMock,
+  release: releasePluginToolsMock,
 }));
 
 afterEach(() => {
@@ -64,7 +91,11 @@ afterEach(() => {
   callGatewayTool.mockReset();
   connectToolsMcpServerToStdioMock.mockReset();
   createToolsMcpServerMock.mockClear();
-  ensureStandalonePluginToolRegistryLoadedMock.mockReset();
+  acquireStandalonePluginToolRegistryMock.mockReset().mockImplementation(async () => ({
+    resolveTools: resolvePluginToolsMock,
+    release: releasePluginToolsMock,
+  }));
+  releasePluginToolsMock.mockClear();
   getRuntimeConfigMock.mockClear();
   resolvePluginToolsMock.mockReset();
   resolvePluginToolsMock.mockReturnValue([]);
@@ -98,46 +129,51 @@ describe("plugin tools MCP server", () => {
   ])(
     "passes $agentSessionKey owner into plugin tool factories",
     async ({ agentSessionKey, agentId, owner }) => {
-      const { resolvePluginToolsForMcp } = await import("./plugin-tools-serve.js");
+      const { acquirePluginToolsForMcp } = await import("./plugin-tools-serve.js");
       const runtimeRegistry = createMockPluginRegistry([]);
-      ensureStandalonePluginToolRegistryLoadedMock.mockReturnValue(runtimeRegistry);
+      acquireStandalonePluginToolRegistryMock.mockResolvedValue({
+        registry: runtimeRegistry,
+        resolveTools: resolvePluginToolsMock,
+        release: releasePluginToolsMock,
+      });
       const config = { plugins: { enabled: true } } as never;
 
-      resolvePluginToolsForMcp({
-        config,
-        agentSessionKey,
-        agentId,
-      });
+      const acquisition = await acquirePluginToolsForMcp({ config, agentSessionKey, agentId });
+      acquisition.resolveTools();
+      await acquisition.release();
 
       const expectedContext = {
         config,
         agentId: owner,
         sessionKey: agentSessionKey,
       };
-      expect(ensureStandalonePluginToolRegistryLoadedMock).toHaveBeenCalledWith({
+      expect(acquireStandalonePluginToolRegistryMock).toHaveBeenCalledWith({
         context: expectedContext,
+        suppressNameConflicts: true,
       });
-      expect(resolvePluginToolsMock).toHaveBeenCalledWith(
-        expect.objectContaining({ context: expectedContext, runtimeRegistry }),
-      );
+      expect(resolvePluginToolsMock).toHaveBeenCalledOnce();
     },
   );
 
   it("rejects a non-agent session identity from the managed bridge", async () => {
-    const { resolvePluginToolsForMcp } = await import("./plugin-tools-serve.js");
+    const { acquirePluginToolsForMcp } = await import("./plugin-tools-serve.js");
 
-    expect(() =>
-      resolvePluginToolsForMcp({
+    await expect(
+      acquirePluginToolsForMcp({
         config: { plugins: { enabled: true } } as never,
         agentSessionKey: "research-session",
       }),
-    ).toThrow("must be a canonical agent session key");
+    ).rejects.toThrow("must be a canonical agent session key");
   });
 
   it("routes logs to stderr before resolving tools for stdio", async () => {
     const { servePluginToolsMcp } = await import("./plugin-tools-serve.js");
     const runtimeRegistry = createMockPluginRegistry([]);
-    ensureStandalonePluginToolRegistryLoadedMock.mockReturnValue(runtimeRegistry);
+    acquireStandalonePluginToolRegistryMock.mockResolvedValue({
+      registry: runtimeRegistry,
+      resolveTools: resolvePluginToolsMock,
+      release: releasePluginToolsMock,
+    });
     resolvePluginToolsMock.mockReturnValue([
       {
         name: "memory_recall",
@@ -151,14 +187,12 @@ describe("plugin tools MCP server", () => {
     await servePluginToolsMcp();
 
     expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
-    expect(ensureStandalonePluginToolRegistryLoadedMock).toHaveBeenCalledWith({
+    expect(acquireStandalonePluginToolRegistryMock).toHaveBeenCalledWith({
       context: { config: { plugins: { enabled: true } } },
+      suppressNameConflicts: true,
     });
     expect(resolvePluginToolsMock).toHaveBeenCalledTimes(1);
-    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ runtimeRegistry }),
-    );
-    expect(ensureStandalonePluginToolRegistryLoadedMock.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(acquireStandalonePluginToolRegistryMock.mock.invocationCallOrder[0]).toBeLessThan(
       resolvePluginToolsMock.mock.invocationCallOrder[0] ?? 0,
     );
     expect(routeLogsToStderrMock.mock.invocationCallOrder[0]).toBeLessThan(
@@ -179,12 +213,9 @@ describe("plugin tools MCP server", () => {
 
     await servePluginToolsMcp();
 
-    const loadPolicy = requireToolPolicyParams(ensureStandalonePluginToolRegistryLoadedMock);
+    const loadPolicy = requireToolPolicyParams(acquireStandalonePluginToolRegistryMock);
     expect(loadPolicy.toolAllowlist).toContain("memory_search");
     expect(loadPolicy.toolDenylist).toEqual(["memory_forget"]);
-    const resolvePolicy = requireToolPolicyParams(resolvePluginToolsMock);
-    expect(resolvePolicy.toolAllowlist).toContain("memory_search");
-    expect(resolvePolicy.toolDenylist).toEqual(["memory_forget"]);
   });
 
   it("enforces global and managed-agent plugin tool policy", async () => {
@@ -210,9 +241,9 @@ describe("plugin tools MCP server", () => {
         execute: deniedExecute,
       },
     ] as unknown as AnyAgentTool[]);
-    const { resolvePluginToolsForMcp } = await import("./plugin-tools-serve.js");
+    const { acquirePluginToolsForMcp } = await import("./plugin-tools-serve.js");
 
-    const tools = resolvePluginToolsForMcp({
+    const acquisition = await acquirePluginToolsForMcp({
       config: {
         plugins: { enabled: true },
         tools: {
@@ -230,30 +261,29 @@ describe("plugin tools MCP server", () => {
       } as never,
       agentSessionKey: "agent:research:acp:session-1",
     });
-    const handlers = createPluginToolsMcpHandlers(tools);
+    const handlers = createPluginToolsMcpHandlers(acquisition.resolveTools());
 
-    await expect(handlers.listTools()).resolves.toMatchObject({
-      tools: [{ name: "plugin_allowed" }],
-    });
-    await expect(handlers.callTool({ name: "plugin_denied" })).resolves.toMatchObject({
-      isError: true,
-      content: [{ text: "Unknown tool: plugin_denied" }],
-    });
-    expect(deniedExecute).not.toHaveBeenCalled();
+    try {
+      await expect(handlers.listTools()).resolves.toMatchObject({
+        tools: [{ name: "plugin_allowed" }],
+      });
+      await expect(handlers.callTool({ name: "plugin_denied" })).resolves.toMatchObject({
+        isError: true,
+        content: [{ text: "Unknown tool: plugin_denied" }],
+      });
+      expect(deniedExecute).not.toHaveBeenCalled();
 
-    await expect(handlers.callTool({ name: "plugin_allowed" })).resolves.toMatchObject({
-      content: [{ text: "allowed executor ran" }],
-    });
-    expect(allowedExecute).toHaveBeenCalledOnce();
+      await expect(handlers.callTool({ name: "plugin_allowed" })).resolves.toMatchObject({
+        content: [{ text: "allowed executor ran" }],
+      });
+      expect(allowedExecute).toHaveBeenCalledOnce();
 
-    for (const policyMock of [
-      ensureStandalonePluginToolRegistryLoadedMock,
-      resolvePluginToolsMock,
-    ]) {
-      expect(requireToolPolicyParams(policyMock)).toMatchObject({
+      expect(requireToolPolicyParams(acquireStandalonePluginToolRegistryMock)).toMatchObject({
         toolAllowlist: ["plugin_allowed", "plugin_denied"],
         toolDenylist: ["plugin_globally_denied", "plugin_denied"],
       });
+    } finally {
+      await acquisition.release();
     }
   });
 

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -27,10 +27,14 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import type { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
-import { ensureStandalonePluginToolRegistryLoaded, resolvePluginTools } from "../plugins/tools.js";
+import {
+  acquireStandalonePluginToolRegistry,
+  type PluginToolRegistryAcquisition,
+} from "../plugins/tools.js";
 import { resolveToolsMcpAgentId, resolveToolsMcpSessionContext } from "./agent-session-env.js";
-import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
+import { createToolsMcpServer, serveRegisteredToolsMcpServer } from "./tools-stdio-server.js";
 
 function resolvePluginToolPolicy(
   config: OpenClawConfig,
@@ -76,51 +80,35 @@ function resolvePluginToolPolicy(
   };
 }
 
-export function resolvePluginToolsForMcp(params: {
+export async function acquirePluginToolsForMcp(params: {
   config: OpenClawConfig;
   agentSessionKey?: string;
   agentId?: string;
-}): AnyAgentTool[] {
+}): Promise<PluginToolRegistryAcquisition> {
   const sessionContext = resolveToolsMcpSessionContext(params);
   const context = { config: params.config, ...sessionContext };
   const { steps, ...pluginToolPolicy } = resolvePluginToolPolicy(params.config, sessionContext);
-  const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
-    context,
-    ...pluginToolPolicy,
-  });
-  const tools = resolvePluginTools({
+  const acquisition = await acquireStandalonePluginToolRegistry({
     context,
     ...pluginToolPolicy,
     suppressNameConflicts: true,
-    runtimeRegistry,
   });
-  return steps
-    ? applyToolPolicyPipeline({
-        tools,
-        toolMeta: getPluginToolMeta,
-        warn: logWarn,
-        steps,
-      })
-    : tools;
+  return {
+    ...acquisition,
+    resolveTools: () => {
+      const tools = acquisition.resolveTools();
+      return steps
+        ? applyToolPolicyPipeline({ tools, toolMeta: getPluginToolMeta, warn: logWarn, steps })
+        : tools;
+    },
+  };
 }
 
-export function createPluginToolsMcpServer(
-  params: {
-    config?: OpenClawConfig;
-    tools?: AnyAgentTool[];
-    agentSessionKey?: string;
-    agentId?: string;
-  } = {},
-): Server {
-  const cfg = params.config ?? getRuntimeConfig();
-  const tools =
-    params.tools ??
-    resolvePluginToolsForMcp({
-      config: cfg,
-      agentSessionKey: params.agentSessionKey,
-      agentId: params.agentId,
-    });
-  return createToolsMcpServer({ name: "openclaw-plugin-tools", tools });
+export function createPluginToolsMcpServer(params: {
+  tools: AnyAgentTool[];
+  sdkResourceHost?: LegacyPluginSdkResourceHost;
+}): Server {
+  return createToolsMcpServer({ name: "openclaw-plugin-tools", ...params });
 }
 
 export async function servePluginToolsMcp(): Promise<void> {
@@ -128,14 +116,16 @@ export async function servePluginToolsMcp(): Promise<void> {
   // tool discovery before the transport is connected.
   routeLogsToStderr();
 
-  const config = getRuntimeConfig();
-  const tools = resolvePluginToolsForMcp({ config, agentId: resolveToolsMcpAgentId() });
-  const server = createPluginToolsMcpServer({ config, tools });
-  if (tools.length === 0) {
-    process.stderr.write("plugin-tools-serve: no plugin tools found\n");
-  }
-
-  await connectToolsMcpServerToStdio(server);
+  await serveRegisteredToolsMcpServer({
+    acquireRegistry: () =>
+      acquirePluginToolsForMcp({ config: getRuntimeConfig(), agentId: resolveToolsMcpAgentId() }),
+    createServer: (tools, sdkResourceHost) => {
+      if (tools.length === 0) {
+        process.stderr.write("plugin-tools-serve: no plugin tools found\n");
+      }
+      return createPluginToolsMcpServer({ tools, sdkResourceHost });
+    },
+  });
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -117,8 +117,7 @@ export async function connectToolsMcpServerToStdio(server: Server): Promise<void
   // MCP stdio requires stdout to stay protocol-only.
   routeLogsToStderr();
 
-  const transport = new StdioServerTransport();
-  const previousOnClose = server.onclose;
+  const closeFailures = new Set<unknown>();
   let shuttingDown = false;
   const shutdownComplete = createDeferredCore<unknown[]>();
   const shutdown = () => {
@@ -130,30 +129,30 @@ export async function connectToolsMcpServerToStdio(server: Server): Promise<void
     process.stdin.off("close", shutdown);
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
-    if (server.onclose === onServerClose) {
-      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes a callback property, not EventTarget.
-      server.onclose = previousOnClose;
-    }
     void (async () => {
       try {
         await server.close();
-        shutdownComplete.resolve([]);
       } catch (error) {
-        shutdownComplete.resolve([error]);
+        closeFailures.add(error);
+      } finally {
+        shutdownComplete.resolve([...closeFailures]);
       }
     })();
   };
-  const onServerClose = () => {
-    try {
-      previousOnClose?.call(server);
-    } finally {
-      shutdown();
+  class OwnedStdioTransport extends StdioServerTransport {
+    override async close(): Promise<void> {
+      try {
+        await super.close();
+      } catch (error) {
+        // SDK self-close can consume this rejection before the serving owner sees it.
+        closeFailures.add(error);
+        throw error;
+      } finally {
+        shutdown();
+      }
     }
-  };
-
-  // Transport closure is terminal for this stdio owner, not for the reusable Server class.
-  // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes a callback property, not EventTarget.
-  server.onclose = onServerClose;
+  }
+  const transport = new OwnedStdioTransport();
   process.stdin.once("end", shutdown);
   process.stdin.once("close", shutdown);
   process.once("SIGINT", shutdown);

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -1,4 +1,5 @@
 // MCP stdio server exposes OpenClaw tools over the MCP stdio transport.
+import { AsyncLocalStorage } from "node:async_hooks";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -8,8 +9,10 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import type { PluginToolRegistryAcquisition } from "../plugins/tools.js";
 import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { VERSION } from "../version.js";
@@ -50,39 +53,58 @@ class ToolsMcpServer extends Server {
   }
 }
 
-export function createToolsMcpServer(params: { name: string; tools: AnyAgentTool[] }): Server {
+export function createToolsMcpServer(params: {
+  name: string;
+  tools: AnyAgentTool[];
+  sdkResourceHost?: LegacyPluginSdkResourceHost;
+}): Server {
   const handlers = createPluginToolsMcpHandlers(params.tools);
   const server = new ToolsMcpServer(
     { name: params.name, version: VERSION },
     { capabilities: { tools: {} } },
   );
+  const servingContext = params.sdkResourceHost?.run(() => AsyncLocalStorage.snapshot());
+  const runInServingContext = <T>(run: () => T): T =>
+    servingContext ? servingContext(run) : run();
 
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
-    return await server.runRequest(handlers.listTools, extra.signal);
+    return await runInServingContext(() => server.runRequest(handlers.listTools, extra.signal));
   });
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    return await server.runRequest(
-      async () => await handlers.callTool(request.params, extra.signal),
-      extra.signal,
+    // Restore serving authority before runRequest installs the accepted-work scope.
+    return await runInServingContext(() =>
+      server.runRequest(async () => {
+        if (!params.sdkResourceHost) {
+          return await handlers.callTool(request.params, extra.signal);
+        }
+        const controller = new AbortController();
+        const requestContext = AsyncLocalStorage.snapshot();
+        // Protocol cancellation can arrive under another request or process event's context.
+        const abort = () => requestContext(() => controller.abort(extra.signal.reason));
+        extra.signal.addEventListener("abort", abort, { once: true });
+        try {
+          if (extra.signal.aborted) {
+            abort();
+          }
+          return await handlers.callTool(request.params, controller.signal);
+        } finally {
+          extra.signal.removeEventListener("abort", abort);
+        }
+      }, extra.signal),
     );
   });
 
   return server;
 }
 
-export async function connectToolsMcpServerToStdio(
-  server: Server,
-  options: { onShutdown?: () => Promise<void> | void } = {},
-): Promise<void> {
+export async function connectToolsMcpServerToStdio(server: Server): Promise<void> {
   // MCP stdio requires stdout to stay protocol-only.
   routeLogsToStderr();
 
   const transport = new StdioServerTransport();
+  const previousOnClose = server.onclose;
   let shuttingDown = false;
-  let resolveShutdown: (() => void) | undefined;
-  const shutdownComplete = new Promise<void>((resolve) => {
-    resolveShutdown = resolve;
-  });
+  const shutdownComplete = createDeferredCore<unknown[]>();
   const shutdown = () => {
     if (shuttingDown) {
       return;
@@ -92,39 +114,101 @@ export async function connectToolsMcpServerToStdio(
     process.stdin.off("close", shutdown);
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
+    if (server.onclose === onServerClose) {
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes a callback property, not EventTarget.
+      server.onclose = previousOnClose;
+    }
     void (async () => {
-      let shutdownError: unknown;
       try {
         await server.close();
+        shutdownComplete.resolve([]);
       } catch (error) {
-        shutdownError = error;
-      }
-      try {
-        await options.onShutdown?.();
-      } catch (error) {
-        shutdownError ??= error;
-      } finally {
-        resolveShutdown?.();
-      }
-      if (shutdownError) {
-        process.stderr.write(`MCP stdio shutdown failed: ${formatErrorMessage(shutdownError)}\n`);
+        shutdownComplete.resolve([error]);
       }
     })();
   };
+  const onServerClose = () => {
+    try {
+      previousOnClose?.call(server);
+    } finally {
+      shutdown();
+    }
+  };
 
+  // Transport closure is terminal for this stdio owner, not for the reusable Server class.
+  // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Server exposes a callback property, not EventTarget.
+  server.onclose = onServerClose;
   process.stdin.once("end", shutdown);
   process.stdin.once("close", shutdown);
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
 
+  const failures: unknown[] = [];
   try {
     await server.connect(transport);
   } catch (error) {
+    failures.push(error);
     shutdown();
-    await shutdownComplete;
-    throw error;
   }
-  if (options.onShutdown) {
-    await shutdownComplete;
+  failures.push(...(await shutdownComplete.promise));
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "MCP connection and transport shutdown failed");
+  }
+}
+
+/** Owns discovered registrations and nested SDK borrows for one terminal stdio service. */
+export async function serveRegisteredToolsMcpServer(params: {
+  acquireRegistry: () => Promise<PluginToolRegistryAcquisition>;
+  createServer: (tools: AnyAgentTool[], sdkResourceHost: LegacyPluginSdkResourceHost) => Server;
+}): Promise<void> {
+  const sdkResourceHost = new LegacyPluginSdkResourceHost();
+  let acquisition: PluginToolRegistryAcquisition | undefined;
+
+  const failures: unknown[] = [];
+  try {
+    await sdkResourceHost.run(async () => {
+      acquisition = await params.acquireRegistry();
+      const owned = acquisition;
+      await withPluginRuntimeRegistryScope(owned.registry, async () => {
+        const server = params.createServer(owned.resolveTools(), sdkResourceHost);
+        await connectToolsMcpServerToStdio(server);
+      });
+    });
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await sdkResourceHost.run(async () => {
+      const registry = acquisition?.registry;
+      if (registry?.agentHarnesses.length) {
+        try {
+          const { disposeRegisteredAgentHarnesses } = await import("../agents/harness/registry.js");
+          await withPluginRuntimeRegistryScope(registry, disposeRegisteredAgentHarnesses);
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      // SDK results may retain the same source; both owners must release before physical disposal.
+      const released = await Promise.allSettled([
+        Promise.resolve().then(() => acquisition?.release()),
+        Promise.resolve().then(() => sdkResourceHost.close()),
+      ]);
+      for (const result of released) {
+        if (result.status === "rejected") {
+          failures.push(result.reason);
+        }
+      }
+    });
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "MCP serving and registration cleanup failed");
   }
 }

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -22,13 +22,14 @@ class ToolsMcpServer extends Server {
   #work = new AsyncWorkScope();
   #closing: Promise<void> | undefined;
 
-  runRequest<T>(run: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  runRequest<T>(run: (work: AsyncWorkScope) => Promise<T>, signal: AbortSignal): Promise<T> {
     // SDK request callbacks are queued in microtasks and may enter after transport closure.
     if (this.#closing || !this.transport) {
       return Promise.reject(McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed"));
     }
     signal.throwIfAborted();
-    return this.#work.track(run);
+    const work = this.#work;
+    return work.track(() => run(work));
   }
 
   override close(): Promise<void> {
@@ -73,23 +74,38 @@ export function createToolsMcpServer(params: {
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     // Restore serving authority before runRequest installs the accepted-work scope.
     return await runInServingContext(() =>
-      server.runRequest(async () => {
+      server.runRequest(async (parentWork) => {
         if (!params.sdkResourceHost) {
           return await handlers.callTool(request.params, extra.signal);
         }
+        const work = new AsyncWorkScope();
         const controller = new AbortController();
-        const requestContext = AsyncLocalStorage.snapshot();
+        const requestContext = work.run(() => AsyncLocalStorage.snapshot());
         // Protocol cancellation can arrive under another request or process event's context.
         const abort = () => requestContext(() => controller.abort(extra.signal.reason));
+        const closeWork = () => requestContext(() => work.beginClose(parentWork.signal.reason));
         extra.signal.addEventListener("abort", abort, { once: true });
-        try {
-          if (extra.signal.aborted) {
-            abort();
-          }
-          return await handlers.callTool(request.params, controller.signal);
-        } finally {
-          extra.signal.removeEventListener("abort", abort);
+        parentWork.signal.addEventListener("abort", closeWork, { once: true });
+        if (extra.signal.aborted) {
+          abort();
         }
+        if (parentWork.signal.aborted) {
+          closeWork();
+        }
+        const result = work.track(() => handlers.callTool(request.params, controller.signal));
+        // The result stays early; only the server parent owns this descendant-cleanup tail.
+        void parentWork.track(async () => {
+          try {
+            await AsyncWorkScope.runWhenAllIdle(
+              () => [work],
+              () => requestContext(() => work.drain()),
+            );
+          } finally {
+            extra.signal.removeEventListener("abort", abort);
+            parentWork.signal.removeEventListener("abort", closeWork);
+          }
+        });
+        return await result;
       }, extra.signal),
     );
   });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -19,7 +19,11 @@ import {
 } from "./compat/conversation-read-tools.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import { createInstalledPluginEnabledPredicate } from "./installed-plugin-index.js";
-import { loadPluginRegistryHandle, type PluginLoadOptions } from "./loader.js";
+import {
+  acquirePluginRegistryForInspection,
+  loadPluginRegistryHandle,
+  type PluginLoadOptions,
+} from "./loader.js";
 import {
   isManifestPluginAvailableForControlPlane,
   loadManifestContractSnapshot,
@@ -658,6 +662,15 @@ type PreparedPluginToolRuntime = {
   registry?: PluginRegistry;
 };
 
+type PluginToolLoadState = {
+  context: ReturnType<typeof resolvePluginRuntimeLoadContext>;
+  env: NodeJS.ProcessEnv;
+  loadOptions: PluginLoadOptions;
+  onlyPluginIds: string[];
+  allowlist: PluginToolAllowlist;
+  snapshot: PluginMetadataManifestView;
+};
+
 function resolvePluginToolLoadState(params: {
   context: OpenClawPluginToolContext;
   toolAllowlist?: string[];
@@ -666,16 +679,7 @@ function resolvePluginToolLoadState(params: {
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
   preparedRuntime?: PreparedPluginToolRuntime;
-}):
-  | {
-      context: ReturnType<typeof resolvePluginRuntimeLoadContext>;
-      env: NodeJS.ProcessEnv;
-      loadOptions: PluginLoadOptions;
-      onlyPluginIds: string[];
-      allowlist: PluginToolAllowlist;
-      snapshot: PluginMetadataManifestView;
-    }
-  | undefined {
+}): PluginToolLoadState | undefined {
   const env = params.env ?? process.env;
   const baseConfig = applyTestPluginDefaults(params.context.config ?? {}, env);
   const preparedLoadContext = params.preparedRuntime?.loadContext;
@@ -746,7 +750,7 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
   });
 }
 
-export function resolvePluginTools(params: {
+type PluginToolResolutionParams = {
   context: OpenClawPluginToolContext;
   existingToolNames?: Set<string>;
   clientCaps?: string[];
@@ -758,14 +762,63 @@ export function resolvePluginTools(params: {
   env?: NodeJS.ProcessEnv;
   runtimeRegistry?: PluginRegistry;
   preparedRuntime?: PreparedPluginToolRuntime;
-}): AnyAgentTool[] {
+};
+
+export type PluginToolRegistryAcquisition = {
+  registry?: PluginRegistry;
+  resolveTools: () => AnyAgentTool[];
+  release: () => Promise<void>;
+};
+
+/** The serving owner retains this view before invoking factories or applying tool policy. */
+export async function acquireStandalonePluginToolRegistry(
+  params: Omit<PluginToolResolutionParams, "runtimeRegistry" | "preparedRuntime">,
+): Promise<PluginToolRegistryAcquisition> {
+  const loadState = resolvePluginToolLoadState(params);
+  if (!loadState || loadState.onlyPluginIds.length === 0) {
+    return { resolveTools: () => [], release: async () => {} };
+  }
+  const acquisition = await acquirePluginRegistryForInspection(loadState.loadOptions);
+  const hasAuthority = capturePluginLifecycleAuthority(acquisition.registry, undefined, {
+    scopedRuntime: true,
+  });
+  return {
+    ...acquisition,
+    resolveTools: () => {
+      if (!hasAuthority?.()) {
+        throw new Error("Plugin tool registry has been released");
+      }
+      return resolvePluginToolsFromRegistry(params, loadState, acquisition.registry);
+    },
+  };
+}
+
+export function resolvePluginTools(params: PluginToolResolutionParams): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
   const loadState = resolvePluginToolLoadState(params);
-  if (!loadState) {
+  if (!loadState || loadState.onlyPluginIds.length === 0) {
     return [];
   }
-  const { context, env, onlyPluginIds, allowlist, loadOptions, snapshot } = loadState;
+  const runtimeRegistry =
+    loadState.context === params.preparedRuntime?.loadContext
+      ? params.preparedRuntime.registry
+      : params.runtimeRegistry;
+  const registry = resolvePluginToolRegistry({
+    loadOptions: loadState.loadOptions,
+    onlyPluginIds: loadState.onlyPluginIds,
+    runtimeRegistry,
+    manifestPlugins: loadState.snapshot.plugins,
+  });
+  return resolvePluginToolsFromRegistry(params, loadState, registry);
+}
+
+function resolvePluginToolsFromRegistry(
+  params: PluginToolResolutionParams,
+  loadState: PluginToolLoadState,
+  registry: PluginRegistry | undefined,
+): AnyAgentTool[] {
+  const { context, env, onlyPluginIds, allowlist, snapshot } = loadState;
   const tools: AnyAgentTool[] = [];
   const existing = params.existingToolNames ?? new Set<string>();
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolPolicyName(tool)));
@@ -775,19 +828,6 @@ export function resolvePluginTools(params: {
   const pluginToolOwnersByName = new Map<string, string>();
   const denylist = normalizeDenylist(params.toolDenylist);
   const clientCaps = new Set(params.clientCaps ?? []);
-  const runtimeRegistry =
-    context === params.preparedRuntime?.loadContext
-      ? params.preparedRuntime.registry
-      : params.runtimeRegistry;
-  if (onlyPluginIds.length === 0) {
-    return tools;
-  }
-  const registry = resolvePluginToolRegistry({
-    loadOptions,
-    onlyPluginIds,
-    runtimeRegistry,
-    manifestPlugins: snapshot.plugins,
-  });
   if (!registry) {
     context.logger.warn(
       `plugin tool registry unavailable for plugin ids [${onlyPluginIds.join(", ")}]`,

--- a/test/fixtures/mcp-registration/plugin.cjs
+++ b/test/fixtures/mcp-registration/plugin.cjs
@@ -1,0 +1,127 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { DatabaseSync } = require("node:sqlite");
+const { resolvePluginProviders } = require("openclaw/plugin-sdk/provider-catalog-runtime");
+
+const ID = "mcp-registration-fixture";
+const TOOL = "mcp_native_hold";
+const emit = (phase, extra = {}) =>
+  process.stderr.write(`MCP_OWNERSHIP_PROOF ${JSON.stringify({ phase, ...extra })}\n`);
+
+module.exports = {
+  id: ID,
+  name: "Native MCP registration fixture",
+  register(api) {
+    if (!["full", "discovery", "tool-discovery"].includes(api.registrationMode)) {
+      throw new Error(`Unsupported fixture registration mode: ${api.registrationMode}`);
+    }
+    const { databasePath, gateDir, workspaceDir, nestedStages = [] } = api.pluginConfig;
+    const database = new DatabaseSync(databasePath);
+    database.exec(
+      "CREATE TABLE IF NOT EXISTS events (seq INTEGER PRIMARY KEY, phase TEXT NOT NULL)",
+    );
+    const record = (phase) => database.prepare("INSERT INTO events (phase) VALUES (?)").run(phase);
+    const waitForGate = (name) =>
+      new Promise((resolve, reject) => {
+        const target = path.join(gateDir, name);
+        const done = () => {
+          if (fs.existsSync(target)) {
+            watcher.close();
+            resolve();
+          }
+        };
+        const watcher = fs.watch(gateDir, done);
+        watcher.once("error", reject);
+        done();
+      });
+    const provider = {
+      id: ID,
+      label: "Native MCP provider fixture",
+      auth: [],
+      isCacheTtlEligible(context) {
+        record(`sdk:${context.modelId}`);
+        return database.prepare("SELECT 42 AS value").get().value === 42;
+      },
+    };
+    const probeSdk = (stage) => {
+      if (!nestedStages.includes(stage)) {
+        return;
+      }
+      const selected = resolvePluginProviders({
+        config: api.config,
+        env: process.env,
+        onlyPluginIds: [ID],
+        workspaceDir,
+        registryScope: "loaded",
+      }).find((entry) => entry.id === ID);
+      if (!selected || selected.isCacheTtlEligible({ provider: ID, modelId: stage }) !== true) {
+        throw new Error(`Nested SDK provider lookup failed at ${stage}`);
+      }
+      emit(`sdk:${stage}`);
+    };
+    api.registerProvider(provider);
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "native-database",
+      cleanup() {
+        record("semantic-cleanup");
+        emit("semantic-cleanup");
+      },
+      async dispose() {
+        record("dispose-entered");
+        emit("dispose-entered", { databaseOpen: database.isOpen });
+        await waitForGate("dispose.release");
+        record("dispose-completed");
+        database.close();
+        emit("disposed", { databaseOpen: database.isOpen });
+      },
+    });
+    if (nestedStages.includes("harness")) {
+      api.registerAgentHarness({
+        id: "mcp-registration-fixture-harness",
+        label: "Native MCP cleanup fixture",
+        supports: () => ({ supported: false }),
+        runAttempt: async () => {
+          throw new Error("The fixture harness must not execute a model");
+        },
+        dispose: async () => {
+          probeSdk("harness");
+          record("harness-disposed");
+          emit("harness-disposed");
+        },
+      });
+    }
+    api.registerTool(
+      () => {
+        probeSdk("factory");
+        return {
+          name: TOOL,
+          label: "Hold a native SQLite operation",
+          description: "Synthetic ownership proof",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          async execute(_callId, _params, signal) {
+            probeSdk("handler");
+            record("tool-entered");
+            signal.addEventListener(
+              "abort",
+              () => {
+                probeSdk("abort");
+                record("request-aborted");
+                emit("request-aborted", { databaseOpen: database.isOpen });
+              },
+              { once: true },
+            );
+            const gate = waitForGate("tool.release");
+            emit("tool-entered");
+            await gate;
+            record("tool-written");
+            emit("tool-written");
+            return { content: [{ type: "text", text: "native write completed" }], details: {} };
+          },
+        };
+      },
+      { names: [TOOL] },
+    );
+    record("registered");
+    emit("registered", { registrationMode: api.registrationMode });
+  },
+};

--- a/test/fixtures/mcp-registration/plugin.cjs
+++ b/test/fixtures/mcp-registration/plugin.cjs
@@ -1,5 +1,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
+const { setTimeout: delay } = require("node:timers/promises");
 const { DatabaseSync } = require("node:sqlite");
 const { resolvePluginProviders } = require("openclaw/plugin-sdk/provider-catalog-runtime");
 
@@ -21,19 +22,13 @@ module.exports = {
       "CREATE TABLE IF NOT EXISTS events (seq INTEGER PRIMARY KEY, phase TEXT NOT NULL)",
     );
     const record = (phase) => database.prepare("INSERT INTO events (phase) VALUES (?)").run(phase);
-    const waitForGate = (name) =>
-      new Promise((resolve, reject) => {
-        const target = path.join(gateDir, name);
-        const done = () => {
-          if (fs.existsSync(target)) {
-            watcher.close();
-            resolve();
-          }
-        };
-        const watcher = fs.watch(gateDir, done);
-        watcher.once("error", reject);
-        done();
-      });
+    const waitForGate = async (name) => {
+      const target = path.join(gateDir, name);
+      // Observe the durable gate itself; file-watch notifications can be missed.
+      while (!fs.existsSync(target)) {
+        await delay(50);
+      }
+    };
     const provider = {
       id: ID,
       label: "Native MCP provider fixture",

--- a/test/fixtures/mcp-registration/runner.mjs
+++ b/test/fixtures/mcp-registration/runner.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+const [repository, mode = "plain", fixtureRoot] = process.argv.slice(2);
+assert.ok(repository, "Pass the new task worktree as the first argument");
+assert.ok(["plain", "nested", "close-failure"].includes(mode));
+const repo = fs.realpathSync(repository);
+const require = createRequire(path.join(repo, "package.json"));
+const { Client } = await import(
+  pathToFileURL(require.resolve("@modelcontextprotocol/sdk/client/index.js"))
+);
+const { StdioClientTransport } = await import(
+  pathToFileURL(require.resolve("@modelcontextprotocol/sdk/client/stdio.js"))
+);
+assert.ok(fixtureRoot, "The process owner must supply the temporary directory");
+const root = fs.realpathSync(fixtureRoot);
+const pluginDir = path.join(root, "plugin");
+const stateDir = path.join(root, "state");
+const gateDir = path.join(root, "gates");
+const workspaceDir = path.join(root, "workspace");
+for (const dir of [pluginDir, stateDir, gateDir, workspaceDir, path.join(root, "home")]) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+const databasePath = path.join(root, "registration.sqlite");
+const pluginFile = path.join(pluginDir, "index.cjs");
+fs.copyFileSync(new URL("./plugin.cjs", import.meta.url), pluginFile);
+const id = "mcp-registration-fixture";
+const tool = "mcp_native_hold";
+fs.writeFileSync(
+  path.join(pluginDir, "package.json"),
+  JSON.stringify({
+    name: "mcp-registration-fixture",
+    version: "0.0.0",
+    main: "index.cjs",
+    openclaw: { extensions: ["./index.cjs"] },
+  }),
+);
+fs.writeFileSync(
+  path.join(pluginDir, "openclaw.plugin.json"),
+  JSON.stringify({
+    id,
+    name: "Native MCP registration fixture",
+    providers: [id],
+    contracts: { tools: [tool] },
+    configSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["databasePath", "gateDir", "workspaceDir"],
+      properties: {
+        databasePath: { type: "string" },
+        gateDir: { type: "string" },
+        workspaceDir: { type: "string" },
+        nestedStages: {
+          type: "array",
+          items: { enum: ["factory", "handler", "abort", "harness"] },
+        },
+      },
+    },
+  }),
+);
+const configFile = path.join(stateDir, "openclaw.json");
+fs.writeFileSync(
+  configFile,
+  JSON.stringify({
+    agents: { defaults: { workspace: workspaceDir } },
+    plugins: {
+      enabled: true,
+      allow: [id],
+      load: { paths: [pluginFile] },
+      slots: { memory: "none" },
+      entries: {
+        [id]: {
+          enabled: true,
+          config: {
+            databasePath,
+            gateDir,
+            workspaceDir,
+            nestedStages: mode === "nested" ? ["factory", "handler", "abort", "harness"] : [],
+          },
+        },
+      },
+    },
+    tools: { allow: [tool] },
+  }),
+);
+fs.symlinkSync(path.join(repo, "node_modules"), path.join(root, "node_modules"), "dir");
+const bootstrap = path.join(root, "serve.mjs");
+const closeFault =
+  mode === "close-failure"
+    ? `
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+const close = StdioServerTransport.prototype.close;
+StdioServerTransport.prototype.close = async function() {
+  await close.call(this);
+  throw new Error("synthetic transport close failure");
+};
+`
+    : "";
+fs.writeFileSync(
+  bootstrap,
+  `${closeFault}
+import { servePluginToolsMcp } from ${JSON.stringify(pathToFileURL(path.join(repo, "src/mcp/plugin-tools-serve.ts")).href)};
+try {
+  await servePluginToolsMcp();
+  process.stderr.write('MCP_OWNERSHIP_PROOF {"phase":"serve-returned"}\\n');
+} catch (error) {
+  process.stderr.write('MCP_OWNERSHIP_PROOF ' + JSON.stringify({phase: "serve-failed", error: String(error)}) + '\\n');
+  process.exitCode = 1;
+}
+`,
+);
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  cwd: repo,
+  args: ["--import", path.join(repo, "scripts/tsx.mjs"), bootstrap],
+  stderr: "pipe",
+  env: {
+    HOME: path.join(root, "home"),
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: configFile,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  },
+});
+const client = new Client(
+  { name: "native-registration-proof", version: "0.0.0" },
+  { capabilities: {} },
+);
+const phases = [];
+const listeners = new Map();
+let closed = false;
+let resolveClosed;
+const closedPromise = new Promise((resolve) => {
+  resolveClosed = resolve;
+});
+// oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client exposes a callback property, not EventTarget.
+client.onclose = () => {
+  closed = true;
+  resolveClosed();
+  for (const [phase, listener] of listeners) {
+    listener.reject(new Error(`Child closed before ${phase}`));
+  }
+  listeners.clear();
+};
+let stderr = "";
+let buffered = "";
+transport.stderr.on("data", (chunk) => {
+  stderr += chunk.toString();
+  buffered += chunk.toString();
+  for (;;) {
+    const end = buffered.indexOf("\n");
+    if (end < 0) {
+      break;
+    }
+    const line = buffered.slice(0, end);
+    buffered = buffered.slice(end + 1);
+    if (!line.startsWith("MCP_OWNERSHIP_PROOF ")) {
+      continue;
+    }
+    const event = JSON.parse(line.slice("MCP_OWNERSHIP_PROOF ".length));
+    phases.push(event);
+    listeners.get(event.phase)?.resolve(event);
+    listeners.delete(event.phase);
+  }
+});
+const waitFor = (phase) => {
+  const seen = phases.find((event) => event.phase === phase);
+  if (seen) {
+    return Promise.resolve(seen);
+  }
+  if (closed) {
+    return Promise.reject(new Error(`Child already closed before ${phase}`));
+  }
+  return new Promise((resolve, reject) => {
+    listeners.set(phase, { resolve, reject });
+  });
+};
+const release = (name) => fs.writeFileSync(path.join(gateDir, name), "release\n");
+const rows = () => {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return database
+      .prepare("SELECT phase FROM events ORDER BY seq")
+      .all()
+      .map((row) => row.phase);
+  } finally {
+    database.close();
+  }
+};
+let callResult;
+let result;
+try {
+  await client.connect(transport);
+  assert.deepEqual(
+    (await client.listTools()).tools.map((entry) => entry.name),
+    [tool],
+  );
+  callResult = client.callTool({ name: tool, arguments: {} }).then(
+    (value) => ({ value }),
+    (error) => ({ error: String(error) }),
+  );
+  await waitFor("tool-entered");
+  assert.equal(
+    rows().filter((phase) => phase === "registered").length,
+    1,
+    "SDK lookup must use the original tool registry",
+  );
+  const ownedPid = transport.pid;
+  assert.ok(Number.isInteger(ownedPid), "SDK must expose the process it created");
+  process.kill(ownedPid, "SIGTERM");
+  assert.equal((await waitFor("request-aborted")).databaseOpen, true);
+  assert.ok(!rows().includes("dispose-entered"));
+  release("tool.release");
+  await waitFor("tool-written");
+  assert.equal((await waitFor("dispose-entered")).databaseOpen, true);
+  assert.ok(!phases.some((event) => event.phase === "serve-returned"));
+  release("dispose.release");
+  assert.equal((await waitFor("disposed")).databaseOpen, false);
+  if (mode === "close-failure") {
+    assert.match((await waitFor("serve-failed")).error, /synthetic transport close failure/);
+    assert.ok(!phases.some((event) => event.phase === "serve-returned"));
+  } else {
+    await waitFor("serve-returned");
+  }
+  await closedPromise;
+  await callResult;
+  const events = rows();
+  assert.equal(events.filter((phase) => phase === "registered").length, 1);
+  assert.ok(events.indexOf("tool-written") < events.indexOf("dispose-entered"));
+  assert.equal(events.at(-1), "dispose-completed");
+  assert.ok(!events.includes("semantic-cleanup"));
+  if (mode === "nested") {
+    for (const stage of ["factory", "handler", "abort", "harness"]) {
+      assert.ok(events.includes(`sdk:${stage}`));
+    }
+    assert.ok(events.indexOf("tool-written") < events.indexOf("harness-disposed"));
+    assert.ok(events.indexOf("harness-disposed") < events.indexOf("dispose-entered"));
+  }
+  result = { ok: true, mode, events, phases, root };
+} catch (error) {
+  result = { ok: false, mode, error: String(error), phases, root };
+  process.exitCode = 1;
+} finally {
+  release("tool.release");
+  release("dispose.release");
+  await client.close();
+  await callResult;
+  fs.writeFileSync(path.join(root, "stderr.log"), stderr);
+  fs.writeFileSync(path.join(root, "result.json"), JSON.stringify(result, null, 2));
+}
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where standalone plugin-tool MCP services could leave plugin registrations open after shutdown, or lose the registration/SDK context needed by a cancelled tool's remaining work. A failed transport close could also be reported as successful serving.

## Why This Change Was Made

The stdio serving owner acquires its registration view before invoking tool factories and keeps it through accepted handlers, cooperating descendants, and harness cleanup. It then releases both the primary registration and nested SDK claims. Tool projection uses the original view and cannot revive a released registry.

Managed request cancellation keeps its original reason and serving context. Its relay remains connected while accepted descendants finish, including the MCP SDK's response-send backpressure window. Returning a cached tool result stays early; it does not cancel valid work. The reusable Server and caller-supplied tools retain their existing ownership/reconnect behavior.

## User Impact

Stopping either standalone plugin-tool service joins its admitted work before closing registration resources. Connection, transport-close and registration-disposal failures remain visible. Per-tool plugin identity in generic abort callbacks is a separate follow-up; this change covers serving registry, SDK host and work ownership.

## Evidence

- Native before/after failures cover plain/nested registration release, stale-view reactivation, cancellation under a foreign host, response-send backpressure, and combined connection/transport/disposal errors.
- The original 57 targeted cases and two additional transport self-close cases are covered by completed runs. Full 13-path checks and fresh independent Codex review through P2 passed. A fresh ordinary build completed in 200.6 seconds.
- Three actual compiled stdio scenarios passed with native SQLite, delayed tool writes and delayed disposal: plain, nested SDK lookups from factory/handler/abort/harness cleanup, and transport-close failure. All owned process trees joined under the existing 120-second deadline; observed runs took 1.41, 1.08 and 1.30 seconds.
- Two earlier fixture runs missed file-watch notifications despite their release files existing. The fixture now observes durable gate state using the repository's polling approach; deadlines and assertions are unchanged. Those failures, and an earlier unverified external process-owner attempt, remain excluded from passing proof.

CI previously hit the independent Telegram loopback failure fixed in #143197. This branch now includes that fix and removes the temporary investigation code. All ownership production files match the compiled proof; 21 post-refresh composition tests passed across native registrations, cancellation, stdio and the real Telegram HTTP fixture.
