### PR TITLE
fix(i18n): map Skills to المهارات in Arabic glossary

### DIFF
--- a/ui/src/i18n/.i18n/glossary.ar.json
+++ b/ui/src/i18n/.i18n/glossary.ar.json
@@ -13,7 +13,7 @@
   },
   {
     "source": "Skills",
-    "target": "Skills"
+    "target": "المهارات"
   },
   {
     "source": "Tailscale",


### PR DESCRIPTION
## Summary
- Map `Skills -> المهارات` in the Arabic Control UI glossary so future locale syncs preserve the term.
- Minimal revival of the glossary part of #84028 (closed by stale bot). The old `ar.ts` direct edits and manual `ar.tm.jsonl` resync are intentionally dropped: `locales/*.ts` are now virtual stubs generated from `.i18n/*.tm.jsonl` via `control-ui-locale-refresh.yml`.

## What Problem This Solves

Current `glossary.ar.json` maps `Skills -> Skills`, so the AI-generated Arabic translation memory keeps the English fallback for Skills surfaces instead of the Arabic term, producing inconsistent terminology in the Control UI.

## Evidence

- `ui/src/i18n/.i18n/glossary.ar.json:16` on current main still has `Skills -> Skills` (all other brand terms are intentionally preserved in English; Skills is the Arabic-readable outlier).
- The refresh workflow (`control-ui-locale-refresh.yml`) lists glossary files as invalidation paths and renders glossary entries as required terminology (`scripts/control-ui-i18n.ts`), so the glossary is the correct human-owned input; generated `ar.tm.jsonl` stays bot-owned and out of this diff.
- Branch based on upstream `main` (fork synced identical before branching); the merge-base-to-head diff touches only that one glossary target.
- Old branches cleaned in fork: `fix/chat-identity-live-refresh` (merged via #142581), `proof/pr-142581-evidence`, `codex/ar-control-ui-translations` (superseded).

## Validation
- `pnpm ui:i18n:check` expected to trigger refresh for `ar` on merge (bot-owned `ar.tm.jsonl` update follows automatically, not in this PR).

## Note on cached translations (for reviewers)
- Per `scripts/lib/control-ui-i18n-sync-plan.ts`, an ordinary post-merge sync reuses cached translations, so existing `Skills` strings in `ar.tm.jsonl` may persist until a forced or selected-key refresh runs. This PR intentionally touches only the human-owned glossary; generated memory stays bot-owned and out of this diff.
- The author has no OpenAI API key, so a real generation run (`sync --locale ar`) could not be executed from the fork. Request: a maintainer runs the refresh for `ar` after merge (or confirms cached `Skills` entries are covered), or advises if a forced-refresh flag should accompany this change.
