### PR TITLE
fix(ui): stop marking known zero usage cost as missing

### DIFF
--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   emptyTotals,
   emptyUsageResponses,
   chartTotals as totals,
-} from "../pages/usage/usage-fixtures.test-support.ts";
+} from "../pages/usage/test-helpers/usage-fixtures.test-support.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   takeControlUiViewportScreenshot,

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -1,7 +1,21 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import {
+  createCostAnalysisResponses,
+  createRecordedCostResponses,
+  createUsageDailyEntries,
+  dailyEntry,
+  dayOffset,
+  emptyTotals,
+  emptyUsageResponses,
+  chartTotals as totals,
+} from "../pages/usage/usage-fixtures.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiViewportScreenshot,
+  waitForControlUiProofSurface,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,90 +28,155 @@ const suite = createControlUiE2eSuite({
 
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
 
-const totals = {
-  input: 1_200_000,
-  output: 300_000,
-  cacheRead: 2_400_000,
-  cacheWrite: 100_000,
-  totalTokens: 4_000_000,
-  totalCost: 32,
-  inputCost: 12,
-  outputCost: 12,
-  cacheReadCost: 6,
-  cacheWriteCost: 2,
-  missingCostEntries: 0,
-};
-
-const emptyTotals = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  totalCost: 0,
-  inputCost: 0,
-  outputCost: 0,
-  cacheReadCost: 0,
-  cacheWriteCost: 0,
-  missingCostEntries: 0,
-};
-
-function dayOffset(offset: number): string {
-  const date = new Date();
-  date.setHours(12, 0, 0, 0);
-  date.setDate(date.getDate() + offset);
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-}
-
-function dailyEntry(offset: number, totalCost: number, totalTokens: number) {
-  return {
-    ...totals,
-    date: dayOffset(offset),
-    input: totalTokens,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens,
-    totalCost,
-    inputCost: totalCost,
-    outputCost: 0,
-    cacheReadCost: 0,
-    cacheWriteCost: 0,
-  };
-}
-
-const daily = [
-  dailyEntry(-89, 5, 500_000),
-  dailyEntry(-29, 7, 700_000),
-  dailyEntry(-6, 9, 900_000),
-  dailyEntry(0, 11, 1_100_000),
-];
-
-function emptyUsageResponses() {
-  const updatedAt = Date.now();
-  const date = dayOffset(0);
-  return {
-    "sessions.usage": {
-      updatedAt,
-      startDate: date,
-      endDate: date,
-      sessions: [],
-      totals: emptyTotals,
-      aggregates: {
-        messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
-        tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
-        byModel: [],
-        byProvider: [],
-        byAgent: [],
-        byChannel: [],
-        daily: [],
-      },
-    },
-    "usage.cost": { updatedAt, days: 1, daily: [], totals: emptyTotals },
-  };
-}
+const daily = createUsageDailyEntries();
 
 suite.define(() => {
+  it("shows the recorded cost hint through ordinary Usage filters", async () => {
+    const normalHint = "Average cost per message when providers report costs.";
+    const missingHint = `${normalHint} Cost data is missing for some or all sessions in this range.`;
+    const updatedAt = Date.now();
+    const date = dayOffset(0);
+    const empty = emptyUsageResponses();
+    const responses = createRecordedCostResponses(updatedAt, date, empty);
+    const initialResponses = structuredClone(responses);
+    const artifactDir = recordVisuals
+      ? createControlUiE2eArtifactDir("usage-known-zero-cost", suite.artifactDir)
+      : null;
+    const observations: Array<{
+      stage: string;
+      query: string;
+      hint: string;
+      value: string;
+      labels: string[];
+      visible: boolean;
+    }> = [];
+    const screenshots: string[] = [];
+    const diagnostics: Array<{ stage: string; geometryFile: string; screenshot: string }> = [];
+    await suite.withPage(
+      {
+        locale: "en-US",
+        timezoneId: "UTC",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        await page.clock.setFixedTime(new Date(updatedAt));
+        const gateway = await installMockGateway(page, {
+          communityInviteDismissed: true,
+          methodResponses: responses,
+        });
+        await page.goto(`${suite.server.baseUrl}usage`);
+        const query = page.locator(".usage-query-input");
+        const hintButton = page.locator("#usage-summary-hint-average-cost");
+        const card = page.locator(".usage-summary-card").filter({ has: hintButton });
+        const tooltipHost = hintButton.locator("xpath=..");
+        const tooltip = tooltipHost.locator("wa-tooltip");
+        const tooltipBody = tooltip.locator('[part="body"]');
+        const popup = tooltip.locator('wa-popup [part="popup"]');
+        const hintContent = tooltipHost.locator('[slot="content"]');
+        const value = card.locator(".usage-summary-value");
+        const steps = [
+          { stage: "mixed", query: "", count: 3, value: "$0.03" },
+          { stage: "known-zero", query: 'label:"Known zero"', count: 1, value: "$0.00" },
+          { stage: "cleared", query: "", count: 3, value: "$0.03" },
+          { stage: "positive", query: 'label:"Known positive"', count: 1, value: "$0.10" },
+          { stage: "unknown", query: 'label:"Unpriced usage"', count: 1, value: "$0.00" },
+        ];
+        for (const step of steps) {
+          if (step.stage !== "mixed") {
+            await query.fill(step.query);
+            await query.press("Enter");
+          }
+          await expect.poll(() => page.locator(".session-bar-title").count()).toBe(step.count);
+          await expect.poll(async () => (await value.textContent())?.trim()).toBe(step.value);
+          await card.evaluate((element) =>
+            element.scrollIntoView({ block: "center", behavior: "instant" }),
+          );
+          await hintButton.click();
+          await expect.poll(() => tooltip.getAttribute("open")).toBe("");
+          await expect.poll(() => tooltipBody.isVisible()).toBe(true);
+          await expect.poll(() => hintContent.isVisible()).toBe(true);
+          await waitForControlUiProofSurface(popup, [hintContent, value]);
+          const geometry: Array<{
+            name: string;
+            bounds: Awaited<ReturnType<typeof card.boundingBox>>;
+          }> = [];
+          for (const [name, surface] of [
+            ["card", card],
+            ["tooltip-body", tooltipBody],
+            ["hint-content", hintContent],
+          ] as const) {
+            geometry.push({ name, bounds: await surface.boundingBox() });
+          }
+          if (artifactDir) {
+            const geometryFile = path.join(artifactDir, `${step.stage}-geometry.json`);
+            const screenshot = path.join(artifactDir, `${step.stage}.png`);
+            await writeFile(geometryFile, JSON.stringify({ stage: step.stage, geometry }, null, 2));
+            await writeFile(
+              screenshot,
+              await takeControlUiViewportScreenshot(page, popup, [hintButton, hintContent, value]),
+            );
+            diagnostics.push({ stage: step.stage, geometryFile, screenshot });
+            if (["mixed", "known-zero"].includes(step.stage)) {
+              screenshots.push(screenshot);
+            }
+          }
+          for (const { name, bounds } of geometry) {
+            if (!bounds) {
+              throw new Error(`Expected visible cost hint bounds: ${step.stage}/${name}`);
+            }
+            const label = `${step.stage}/${name}`;
+            expect(bounds.width, `${label} width`).toBeGreaterThan(0);
+            expect(bounds.height, `${label} height`).toBeGreaterThan(0);
+            expect(bounds.x, `${label} left`).toBeGreaterThanOrEqual(0);
+            expect(bounds.y, `${label} top`).toBeGreaterThanOrEqual(0);
+            expect(bounds.x + bounds.width, `${label} right`).toBeLessThanOrEqual(1440);
+            expect(bounds.y + bounds.height, `${label} bottom`).toBeLessThanOrEqual(900);
+          }
+          const observed = {
+            stage: step.stage,
+            query: await query.inputValue(),
+            hint: (await hintContent.textContent())?.trim() ?? "",
+            value: (await value.textContent())?.trim() ?? "",
+            labels: (await page.locator(".session-bar-title").allTextContents()).toSorted(),
+            visible: await tooltipBody.isVisible(),
+          };
+          observations.push(observed);
+          if (step.stage !== "known-zero") {
+            expect(observed.hint).toBe(step.stage === "positive" ? normalHint : missingHint);
+          }
+          await hintButton.press("Escape");
+          await expect.poll(() => tooltip.getAttribute("open")).toBeNull();
+          await expect.poll(() => tooltipBody.isVisible()).toBe(false);
+        }
+        expect(responses).toEqual(initialResponses);
+        const requests = await gateway.getRequests();
+        const forbidden = requests.filter(({ method }) =>
+          ["chat.send", "config.set", "config.patch", "sessions.patch"].includes(method),
+        );
+        expect(forbidden).toEqual([]);
+        expect(requests.some(({ method }) => method === "sessions.usage")).toBe(true);
+        expect(requests.some(({ method }) => method === "usage.status")).toBe(true);
+        const record = {
+          observations,
+          screenshots,
+          diagnostics,
+          responses,
+          responsesUnchanged: true,
+          forbiddenRequests: forbidden,
+          requests: requests.map(({ method }) => method),
+        };
+        if (artifactDir) {
+          await writeFile(path.join(artifactDir, "receipts.json"), JSON.stringify(record, null, 2));
+        }
+        expect(
+          observations.find(({ stage }) => stage === "known-zero")?.hint,
+          "USAGE_KNOWN_ZERO_BROWSER",
+        ).toBe(normalHint);
+      },
+    );
+  });
+
   it.each([
     { timeZone: "utc", quarterIndex: 8 },
     { timeZone: "local", quarterIndex: 28 },
@@ -655,227 +734,7 @@ suite.define(() => {
       },
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "agents.list": {
-              agents: [
-                { id: "main", name: "Main" },
-                { id: "writer", name: "Writer" },
-              ],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
-            "sessions.usage": {
-              updatedAt: Date.now(),
-              startDate: dayOffset(-89),
-              endDate: dayOffset(0),
-              sessions: [
-                {
-                  key: "agent:main:cost-analysis",
-                  label: "Cost analysis",
-                  agentId: "main",
-                  modelProvider: "openai",
-                  model: "gpt-5.5",
-                  updatedAt: Date.now(),
-                  usage: {
-                    ...totals,
-                    activityDates: daily.map((entry) => entry.date),
-                    dailyBreakdown: daily.map((entry) => ({
-                      ...entry,
-                      cost: entry.totalCost,
-                      tokens: entry.totalTokens,
-                    })),
-                    messageCounts: {
-                      total: 40,
-                      user: 20,
-                      assistant: 20,
-                      toolCalls: 12,
-                      toolResults: 12,
-                      errors: 0,
-                    },
-                    modelUsage: [
-                      {
-                        provider: "openai",
-                        model: "gpt-5.5",
-                        count: 30,
-                        totals: { ...totals, totalCost: 22 },
-                      },
-                      {
-                        provider: "anthropic",
-                        model: "claude-opus-4-6",
-                        count: 10,
-                        totals: { ...totals, totalCost: 10 },
-                      },
-                    ],
-                  },
-                },
-              ],
-              totals,
-              aggregates: {
-                messages: {
-                  total: 40,
-                  user: 20,
-                  assistant: 20,
-                  toolCalls: 12,
-                  toolResults: 12,
-                  errors: 0,
-                },
-                tools: { totalCalls: 12, uniqueTools: 2, tools: [{ name: "exec", count: 8 }] },
-                byModel: [
-                  {
-                    provider: "openai",
-                    model: "gpt-5.5",
-                    count: 30,
-                    totals: { ...totals, totalCost: 22 },
-                  },
-                  {
-                    provider: "anthropic",
-                    model: "claude-opus-4-6",
-                    count: 10,
-                    totals: { ...totals, totalCost: 10 },
-                  },
-                ],
-                byProvider: [
-                  { provider: "openai", count: 30, totals: { ...totals, totalCost: 22 } },
-                  { provider: "anthropic", count: 10, totals: { ...totals, totalCost: 10 } },
-                ],
-                byAgent: [{ agentId: "main", totals }],
-                byChannel: [],
-                daily: daily.map((entry) => ({
-                  date: entry.date,
-                  tokens: entry.totalTokens,
-                  cost: entry.totalCost,
-                  messages: 10,
-                  toolCalls: 3,
-                  errors: 0,
-                })),
-              },
-            },
-            "usage.cost": {
-              updatedAt: Date.now(),
-              days: 90,
-              daily,
-              totals,
-            },
-            "usage.status": {
-              updatedAt: Date.now(),
-              providers: [
-                {
-                  provider: "openai",
-                  displayName: "OpenAI",
-                  plan: "Admin API",
-                  windows: [],
-                  billing: [
-                    { type: "spend", label: "30-day API spend", amount: 98.75, unit: "USD" },
-                  ],
-                  costHistory: {
-                    unit: "USD",
-                    periodDays: 30,
-                    daily: [
-                      {
-                        date: dayOffset(-6),
-                        amount: 38.5,
-                        requests: 12_300,
-                        inputTokens: 4_200_000,
-                        cacheReadTokens: 2_100_000,
-                        cacheWriteTokens: 0,
-                        outputTokens: 850_000,
-                        totalTokens: 5_050_000,
-                      },
-                      {
-                        date: dayOffset(0),
-                        amount: 60.25,
-                        requests: 18_450,
-                        inputTokens: 6_100_000,
-                        cacheReadTokens: 3_400_000,
-                        cacheWriteTokens: 0,
-                        outputTokens: 1_200_000,
-                        totalTokens: 7_300_000,
-                      },
-                    ],
-                    models: [
-                      {
-                        name: "gpt-5.5",
-                        requests: 30_750,
-                        inputTokens: 10_300_000,
-                        cacheReadTokens: 5_500_000,
-                        cacheWriteTokens: 0,
-                        outputTokens: 2_050_000,
-                        totalTokens: 12_350_000,
-                      },
-                    ],
-                    categories: [{ name: "Responses", amount: 98.75 }],
-                  },
-                },
-                {
-                  provider: "anthropic",
-                  displayName: "Anthropic",
-                  plan: "Admin API",
-                  windows: [],
-                  billing: [
-                    { type: "spend", label: "30-day API spend", amount: 42.4, unit: "USD" },
-                  ],
-                  costHistory: {
-                    unit: "USD",
-                    periodDays: 30,
-                    daily: [
-                      {
-                        date: dayOffset(-6),
-                        amount: 17.15,
-                        inputTokens: 1_800_000,
-                        cacheReadTokens: 900_000,
-                        cacheWriteTokens: 200_000,
-                        outputTokens: 350_000,
-                        totalTokens: 3_250_000,
-                      },
-                      {
-                        date: dayOffset(0),
-                        amount: 25.25,
-                        inputTokens: 2_600_000,
-                        cacheReadTokens: 1_400_000,
-                        cacheWriteTokens: 300_000,
-                        outputTokens: 500_000,
-                        totalTokens: 4_800_000,
-                      },
-                    ],
-                    models: [
-                      {
-                        name: "claude-opus-4-8",
-                        inputTokens: 4_400_000,
-                        cacheReadTokens: 2_300_000,
-                        cacheWriteTokens: 500_000,
-                        outputTokens: 850_000,
-                        totalTokens: 8_050_000,
-                      },
-                    ],
-                    categories: [{ name: "Claude API", amount: 42.4 }],
-                  },
-                },
-                {
-                  provider: "openrouter",
-                  displayName: "OpenRouter",
-                  plan: "Production",
-                  windows: [{ label: "API key budget", usedPercent: 25 }],
-                  billing: [
-                    {
-                      type: "balance",
-                      label: "Account balance",
-                      amount: 64.5,
-                      unit: "USD",
-                    },
-                    {
-                      type: "budget",
-                      label: "API key budget",
-                      used: 5,
-                      limit: 20,
-                      unit: "USD",
-                    },
-                  ],
-                  summary: "$1.25 today · $5.00 this month",
-                },
-              ],
-            },
-          },
+          methodResponses: createCostAnalysisResponses(daily),
         });
 
         await page.goto(`${suite.server.baseUrl}usage`);

--- a/ui/src/pages/usage/test-helpers/usage-fixtures.test-support.ts
+++ b/ui/src/pages/usage/test-helpers/usage-fixtures.test-support.ts
@@ -1,4 +1,4 @@
-import type { UsageSessionEntry, UsageTotals } from "./types.ts";
+import type { UsageSessionEntry, UsageTotals } from "../types.ts";
 
 export const chartTotals = {
   input: 1_200_000,

--- a/ui/src/pages/usage/usage-fixtures.test-support.ts
+++ b/ui/src/pages/usage/usage-fixtures.test-support.ts
@@ -1,0 +1,417 @@
+import type { UsageSessionEntry, UsageTotals } from "./types.ts";
+
+export const chartTotals = {
+  input: 1_200_000,
+  output: 300_000,
+  cacheRead: 2_400_000,
+  cacheWrite: 100_000,
+  totalTokens: 4_000_000,
+  totalCost: 32,
+  inputCost: 12,
+  outputCost: 12,
+  cacheReadCost: 6,
+  cacheWriteCost: 2,
+  missingCostEntries: 0,
+};
+
+export const emptyTotals = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  inputCost: 0,
+  outputCost: 0,
+  cacheReadCost: 0,
+  cacheWriteCost: 0,
+  missingCostEntries: 0,
+};
+
+export function dayOffset(offset: number): string {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + offset);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function dailyEntry(offset: number, totalCost: number, totalTokens: number) {
+  return {
+    ...chartTotals,
+    date: dayOffset(offset),
+    input: totalTokens,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens,
+    totalCost,
+    inputCost: totalCost,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+  };
+}
+
+export function emptyUsageResponses() {
+  const updatedAt = Date.now();
+  const date = dayOffset(0);
+  return {
+    "sessions.usage": {
+      updatedAt,
+      startDate: date,
+      endDate: date,
+      sessions: [],
+      totals: emptyTotals,
+      aggregates: {
+        messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+        tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+        byModel: [],
+        byProvider: [],
+        byAgent: [],
+        byChannel: [],
+        daily: [],
+      },
+    },
+    "usage.cost": { updatedAt, days: 1, daily: [], totals: emptyTotals },
+  };
+}
+
+export const zeroCost = {
+  input: 1_000,
+  output: 500,
+  cacheRead: 200,
+  cacheWrite: 0,
+  totalTokens: 1_700,
+  totalCost: 0,
+  inputCost: 0,
+  outputCost: 0,
+  cacheReadCost: 0,
+  cacheWriteCost: 0,
+  missingCostEntries: 0,
+} satisfies UsageTotals;
+
+export function usageSession(
+  key: string,
+  agentId: string,
+  provider: string,
+  totalsOverrides: Partial<UsageTotals> = {},
+): UsageSessionEntry {
+  const totals: UsageTotals = {
+    input: 100,
+    output: 20,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 120,
+    totalCost: 1,
+    inputCost: 0.8,
+    outputCost: 0.2,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+    ...totalsOverrides,
+  };
+  return {
+    key,
+    label: `${agentId} session`,
+    agentId,
+    modelProvider: provider,
+    model: `${provider}-model`,
+    updatedAt: Date.now(),
+    usage: {
+      ...totals,
+      messageCounts: {
+        total: 2,
+        user: 1,
+        assistant: 1,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      },
+      modelUsage: [{ provider, model: `${provider}-model`, count: 1, totals }],
+    },
+  };
+}
+
+export function createUsageDailyEntries() {
+  return [
+    dailyEntry(-89, 5, 500_000),
+    dailyEntry(-29, 7, 700_000),
+    dailyEntry(-6, 9, 900_000),
+    dailyEntry(0, 11, 1_100_000),
+  ];
+}
+
+export function createRecordedCostResponses(
+  updatedAt: number,
+  date: string,
+  empty: ReturnType<typeof emptyUsageResponses>,
+) {
+  const knownTotals = { ...zeroCost };
+  const messages = { total: 2, user: 1, assistant: 1, toolCalls: 0, toolResults: 0, errors: 0 };
+  const sessions = [
+    { label: "Known zero", totalCost: 0, missingCostEntries: 0 },
+    { label: "Known positive", totalCost: 0.2, missingCostEntries: 0 },
+    { label: "Unpriced usage", totalCost: 0, missingCostEntries: 1 },
+  ].map(({ label, totalCost, missingCostEntries }, index) => ({
+    key: `agent:main:cost-hint-${index}`,
+    label,
+    agentId: "main",
+    updatedAt,
+    usage: {
+      ...knownTotals,
+      totalCost,
+      inputCost: totalCost,
+      missingCostEntries,
+      activityDates: [date],
+      firstActivity: updatedAt - 1_000,
+      lastActivity: updatedAt,
+      durationMs: 1_000,
+      messageCounts: messages,
+    },
+  }));
+  const combined = {
+    ...knownTotals,
+    input: 3_000,
+    output: 1_500,
+    cacheRead: 600,
+    totalTokens: 5_100,
+    totalCost: 0.2,
+    inputCost: 0.2,
+    missingCostEntries: 1,
+  };
+  const responses = {
+    "sessions.usage": {
+      ...empty["sessions.usage"],
+      updatedAt,
+      sessions,
+      totals: combined,
+      aggregates: {
+        ...empty["sessions.usage"].aggregates,
+        messages: { ...messages, total: 6, user: 3, assistant: 3 },
+      },
+    },
+    "usage.cost": { updatedAt, days: 1, daily: [{ date, ...combined }], totals: combined },
+    "usage.status": { updatedAt, providers: [] },
+  };
+  return responses;
+}
+
+export function createCostAnalysisResponses(daily: ReturnType<typeof createUsageDailyEntries>) {
+  return {
+    "agents.list": {
+      agents: [
+        { id: "main", name: "Main" },
+        { id: "writer", name: "Writer" },
+      ],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    },
+    "sessions.usage": {
+      updatedAt: Date.now(),
+      startDate: dayOffset(-89),
+      endDate: dayOffset(0),
+      sessions: [
+        {
+          key: "agent:main:cost-analysis",
+          label: "Cost analysis",
+          agentId: "main",
+          modelProvider: "openai",
+          model: "gpt-5.5",
+          updatedAt: Date.now(),
+          usage: {
+            ...chartTotals,
+            activityDates: daily.map((entry) => entry.date),
+            dailyBreakdown: daily.map((entry) => ({
+              ...entry,
+              cost: entry.totalCost,
+              tokens: entry.totalTokens,
+            })),
+            messageCounts: {
+              total: 40,
+              user: 20,
+              assistant: 20,
+              toolCalls: 12,
+              toolResults: 12,
+              errors: 0,
+            },
+            modelUsage: [
+              {
+                provider: "openai",
+                model: "gpt-5.5",
+                count: 30,
+                totals: { ...chartTotals, totalCost: 22 },
+              },
+              {
+                provider: "anthropic",
+                model: "claude-opus-4-6",
+                count: 10,
+                totals: { ...chartTotals, totalCost: 10 },
+              },
+            ],
+          },
+        },
+      ],
+      totals: chartTotals,
+      aggregates: {
+        messages: {
+          total: 40,
+          user: 20,
+          assistant: 20,
+          toolCalls: 12,
+          toolResults: 12,
+          errors: 0,
+        },
+        tools: { totalCalls: 12, uniqueTools: 2, tools: [{ name: "exec", count: 8 }] },
+        byModel: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            count: 30,
+            totals: { ...chartTotals, totalCost: 22 },
+          },
+          {
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            count: 10,
+            totals: { ...chartTotals, totalCost: 10 },
+          },
+        ],
+        byProvider: [
+          { provider: "openai", count: 30, totals: { ...chartTotals, totalCost: 22 } },
+          { provider: "anthropic", count: 10, totals: { ...chartTotals, totalCost: 10 } },
+        ],
+        byAgent: [{ agentId: "main", totals: chartTotals }],
+        byChannel: [],
+        daily: daily.map((entry) => ({
+          date: entry.date,
+          tokens: entry.totalTokens,
+          cost: entry.totalCost,
+          messages: 10,
+          toolCalls: 3,
+          errors: 0,
+        })),
+      },
+    },
+    "usage.cost": {
+      updatedAt: Date.now(),
+      days: 90,
+      daily,
+      totals: chartTotals,
+    },
+    "usage.status": {
+      updatedAt: Date.now(),
+      providers: [
+        {
+          provider: "openai",
+          displayName: "OpenAI",
+          plan: "Admin API",
+          windows: [],
+          billing: [{ type: "spend", label: "30-day API spend", amount: 98.75, unit: "USD" }],
+          costHistory: {
+            unit: "USD",
+            periodDays: 30,
+            daily: [
+              {
+                date: dayOffset(-6),
+                amount: 38.5,
+                requests: 12_300,
+                inputTokens: 4_200_000,
+                cacheReadTokens: 2_100_000,
+                cacheWriteTokens: 0,
+                outputTokens: 850_000,
+                totalTokens: 5_050_000,
+              },
+              {
+                date: dayOffset(0),
+                amount: 60.25,
+                requests: 18_450,
+                inputTokens: 6_100_000,
+                cacheReadTokens: 3_400_000,
+                cacheWriteTokens: 0,
+                outputTokens: 1_200_000,
+                totalTokens: 7_300_000,
+              },
+            ],
+            models: [
+              {
+                name: "gpt-5.5",
+                requests: 30_750,
+                inputTokens: 10_300_000,
+                cacheReadTokens: 5_500_000,
+                cacheWriteTokens: 0,
+                outputTokens: 2_050_000,
+                totalTokens: 12_350_000,
+              },
+            ],
+            categories: [{ name: "Responses", amount: 98.75 }],
+          },
+        },
+        {
+          provider: "anthropic",
+          displayName: "Anthropic",
+          plan: "Admin API",
+          windows: [],
+          billing: [{ type: "spend", label: "30-day API spend", amount: 42.4, unit: "USD" }],
+          costHistory: {
+            unit: "USD",
+            periodDays: 30,
+            daily: [
+              {
+                date: dayOffset(-6),
+                amount: 17.15,
+                inputTokens: 1_800_000,
+                cacheReadTokens: 900_000,
+                cacheWriteTokens: 200_000,
+                outputTokens: 350_000,
+                totalTokens: 3_250_000,
+              },
+              {
+                date: dayOffset(0),
+                amount: 25.25,
+                inputTokens: 2_600_000,
+                cacheReadTokens: 1_400_000,
+                cacheWriteTokens: 300_000,
+                outputTokens: 500_000,
+                totalTokens: 4_800_000,
+              },
+            ],
+            models: [
+              {
+                name: "claude-opus-4-8",
+                inputTokens: 4_400_000,
+                cacheReadTokens: 2_300_000,
+                cacheWriteTokens: 500_000,
+                outputTokens: 850_000,
+                totalTokens: 8_050_000,
+              },
+            ],
+            categories: [{ name: "Claude API", amount: 42.4 }],
+          },
+        },
+        {
+          provider: "openrouter",
+          displayName: "OpenRouter",
+          plan: "Production",
+          windows: [{ label: "API key budget", usedPercent: 25 }],
+          billing: [
+            {
+              type: "balance",
+              label: "Account balance",
+              amount: 64.5,
+              unit: "USD",
+            },
+            {
+              type: "budget",
+              label: "API key budget",
+              used: 5,
+              limit: 20,
+              unit: "USD",
+            },
+          ],
+          summary: "$1.25 today · $5.00 this month",
+        },
+      ],
+    },
+  };
+}

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -4,8 +4,8 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { buildAggregatesFromSessions } from "./metrics.ts";
 import { buildUsageFilterOptions } from "./query.ts";
+import { usageSession, zeroCost } from "./test-helpers/usage-fixtures.test-support.ts";
 import type { UsageProps, UsageSessionEntry, UsageTotals } from "./types.ts";
-import { usageSession, zeroCost } from "./usage-fixtures.test-support.ts";
 import { renderUsage } from "./view.ts";
 
 const noop = vi.fn();

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -5,51 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import { buildAggregatesFromSessions } from "./metrics.ts";
 import { buildUsageFilterOptions } from "./query.ts";
 import type { UsageProps, UsageSessionEntry, UsageTotals } from "./types.ts";
+import { usageSession, zeroCost } from "./usage-fixtures.test-support.ts";
 import { renderUsage } from "./view.ts";
 
 const noop = vi.fn();
-
-function usageSession(
-  key: string,
-  agentId: string,
-  provider: string,
-  totalsOverrides: Partial<UsageTotals> = {},
-): UsageSessionEntry {
-  const totals: UsageTotals = {
-    input: 100,
-    output: 20,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 120,
-    totalCost: 1,
-    inputCost: 0.8,
-    outputCost: 0.2,
-    cacheReadCost: 0,
-    cacheWriteCost: 0,
-    missingCostEntries: 0,
-    ...totalsOverrides,
-  };
-  return {
-    key,
-    label: `${agentId} session`,
-    agentId,
-    modelProvider: provider,
-    model: `${provider}-model`,
-    updatedAt: Date.now(),
-    usage: {
-      ...totals,
-      messageCounts: {
-        total: 2,
-        user: 1,
-        assistant: 1,
-        toolCalls: 0,
-        toolResults: 0,
-        errors: 0,
-      },
-      modelUsage: [{ provider, model: `${provider}-model`, count: 1, totals }],
-    },
-  };
-}
 
 function insightCard(container: ParentNode, title: string): Element | undefined {
   return Array.from(container.querySelectorAll(".usage-insight-card")).find(
@@ -166,6 +125,136 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
     ...overrides,
   };
 }
+
+describe("Usage recorded cost availability", () => {
+  const normalHint = "Average cost per message when providers report costs.";
+  const missingHint = `${normalHint} Cost data is missing for some or all sessions in this range.`;
+  function summary(props: UsageProps) {
+    const before = structuredClone(props.data);
+    const container = document.createElement("div");
+    render(renderUsage(props), container);
+    const button = container.querySelector("#usage-summary-hint-average-cost");
+    const result = {
+      hint: button?.parentElement?.querySelector('[slot="content"]')?.textContent?.trim() ?? null,
+      value:
+        button
+          ?.closest(".usage-summary-card")
+          ?.querySelector(".usage-summary-value")
+          ?.textContent?.trim() ?? null,
+      empty: container.querySelector(".usage-empty-state") !== null,
+    };
+    expect(props.data).toEqual(before);
+    render(null, container);
+    return result;
+  }
+
+  it.each([
+    { label: "known zero", totalCost: 0, missingCostEntries: 0, hint: normalHint, value: "$0.00" },
+    {
+      label: "known positive",
+      totalCost: 0.2,
+      missingCostEntries: 0,
+      hint: normalHint,
+      value: "$0.10",
+    },
+    {
+      label: "unknown zero",
+      totalCost: 0,
+      missingCostEntries: 1,
+      hint: missingHint,
+      value: "$0.00",
+    },
+    {
+      label: "mixed positive",
+      totalCost: 0.2,
+      missingCostEntries: 1,
+      hint: missingHint,
+      value: "$0.10",
+    },
+  ])(
+    "renders the recorded cost hint for $label",
+    ({ totalCost, missingCostEntries, hint, value }) => {
+      const session = usageSession("agent:main:cost", "main", "fixture", {
+        ...zeroCost,
+        totalCost,
+        inputCost: totalCost,
+        missingCostEntries,
+      });
+      const base = createUsageProps();
+      const observed = summary({
+        ...base,
+        data: {
+          ...base.data,
+          sessions: [session],
+          totals: session.usage,
+          aggregates: buildAggregatesFromSessions([session]),
+        },
+      });
+      expect(observed.value).toBe(value);
+      expect(observed.empty).toBe(false);
+      expect(observed.hint, "USAGE_KNOWN_ZERO_HINT").toBe(hint);
+    },
+  );
+
+  it.each(["query", "session", "day"] as const)(
+    "restores the missing-cost hint after clearing the known-zero %s filter",
+    (scope) => {
+      const known = usageSession("agent:main:known", "main", "fixture", zeroCost);
+      const unknown = usageSession("agent:main:unknown", "main", "fixture", {
+        ...zeroCost,
+        missingCostEntries: 1,
+      });
+      known.label = "Known zero";
+      unknown.label = "Unpriced usage";
+      if (!known.usage || !unknown.usage) {
+        throw new Error("Expected complete usage fixtures");
+      }
+      const knownDay = { ...zeroCost, date: "2026-05-14", tokens: 1_700, cost: 0 };
+      const unknownDay = { ...knownDay, date: "2026-05-13", missingCostEntries: 1 };
+      known.usage.activityDates = [knownDay.date];
+      known.usage.dailyBreakdown = [knownDay];
+      unknown.usage.activityDates = [unknownDay.date];
+      unknown.usage.dailyBreakdown = [unknownDay];
+      const sessions = [known, unknown];
+      const base = createUsageProps();
+      const data = {
+        ...base.data,
+        sessions,
+        totals: {
+          ...zeroCost,
+          input: 2_000,
+          output: 1_000,
+          cacheRead: 400,
+          totalTokens: 3_400,
+          missingCostEntries: 1,
+        },
+        aggregates: buildAggregatesFromSessions(sessions),
+        costDaily: [unknownDay, knownDay],
+      };
+      const filtered: Partial<UsageProps["filters"]> =
+        scope === "query"
+          ? { query: 'label:"Known zero"', queryDraft: 'label:"Known zero"' }
+          : scope === "session"
+            ? { selectedSessions: [known.key] }
+            : { selectedDays: [knownDay.date] };
+      const observations = [{}, filtered, {}].map((filter) =>
+        summary({
+          ...base,
+          data,
+          filters: { ...base.filters, startDate: unknownDay.date, ...filter },
+        }),
+      );
+      expect(observations.map(({ value, empty }) => ({ value, empty }))).toEqual([
+        { value: "$0.00", empty: false },
+        { value: "$0.00", empty: false },
+        { value: "$0.00", empty: false },
+      ]);
+      expect(observations[0]?.hint).toBe(missingHint);
+      expect(observations[2]?.hint).toBe(missingHint);
+      expect(observations[1]?.hint, "USAGE_KNOWN_ZERO_FILTER").toBe(normalHint);
+    },
+  );
+});
 
 it.each([
   { query: "provider:openai" },
@@ -909,7 +998,11 @@ describe("renderUsage", () => {
       cacheRead: 0,
       cacheWrite: 0,
       missingCostEntries: 0,
-    };
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+    } satisfies UsageTotals;
     const container = document.createElement("div");
     render(
       renderUsage(
@@ -917,13 +1010,14 @@ describe("renderUsage", () => {
           data: {
             ...createUsageProps().data,
             // The gateway always returns a totals object, even with no usage.
-            totals: zeroTotals as UsageProps["data"]["totals"],
+            totals: zeroTotals,
           },
         }),
       ),
       container,
     );
     expect(container.querySelector(".usage-empty-state")).not.toBeNull();
+    expect(container.querySelector("#usage-summary-hint-average-cost")).toBeNull();
   });
 
   it("does not render the empty state under an error callout", () => {

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -289,17 +289,7 @@ export function renderUsage(props: UsageProps) {
     !data.error &&
     data.sessions.length === 0 &&
     (data.totals?.totalTokens ?? 0) === 0;
-  const hasMissingCost =
-    (insightTotals?.missingCostEntries ?? 0) > 0 ||
-    (insightTotals
-      ? insightTotals.totalTokens > 0 &&
-        insightTotals.totalCost === 0 &&
-        insightTotals.input +
-          insightTotals.output +
-          insightTotals.cacheRead +
-          insightTotals.cacheWrite >
-          0
-      : false);
+  const hasMissingCost = (insightTotals?.missingCostEntries ?? 0) > 0;
   const datePresets = [
     { label: t("usage.presets.today"), days: 1 },
     { label: t("usage.presets.last7d"), days: 7 },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing recorded zero-cost usage would see a false missing-cost warning in **Avg Cost / Msg** when the report contains tokens and explicitly records zero missing-cost entries.

## Why This Change Was Made

The tooltip now follows the canonical `missingCostEntries` count. It removes the duplicate heuristic that treated positive token usage with zero total cost as missing cost data. Accounting, report fields and numeric formatting are unchanged; production code shrinks by ten lines.

Regression coverage uses the existing renderer and real Usage page with synthetic completed reports. Shared DTO setup lives in Usage’s feature-local `test-helpers` directory, keeping test data out of production text scans and the existing test owners within their line limits. Fixture moves preserve values, assertions, order, date calls and object relationships; tests and support total +370 lines.

## User Impact

Known zero cost keeps its `$0.00` display and normal help text. Unknown costs still warn, including mixed reports containing positive costs. Filtering by query, session or day and then clearing the filter preserves that distinction.

## Evidence

The [browser baseline](https://github.com/steipete/openclaw/actions/runs/34310080906/job/102334792677) demonstrated the false hint; the renderer baseline recorded four intended failures and four passing controls. The [candidate](https://github.com/steipete/openclaw/actions/runs/34316928126/job/102355024876) passed all eight renderer cases and the five-state browser flow, including positive, mixed, cleared-filter and unknown-cost controls. The complete synthetic captures were inspected.

The attached before and after screenshots show the same synthetic report with recorded zero cost and zero missing entries, in that order.

The earlier capture-preparation and test-owner line-limit failures remain recorded. [Required CI](https://github.com/openclaw/openclaw/actions/runs/34342008291) then identified synthetic fixture labels in the production raw-copy scan; the helper now follows the existing test-only directory boundary, without changing scanner rules, baselines or locales. Both fresh committed-head source reviews found no actionable P0–P2 findings. Runtime evidence remains tied to its original hashes and applies through verified fixture/import equivalence; it is not final-tree execution. Final static validation and new-head required CI remain pending. This proof establishes received-report presentation, not live billing or provider execution.

![Before: recorded zero cost incorrectly shows the missing-cost warning](https://github.com/user-attachments/assets/b2beeda0-0767-4627-a6dd-aabc03522c14)

![After: recorded zero cost keeps $0.00 and the normal cost hint](https://github.com/user-attachments/assets/7f5b0600-a177-44ac-82b6-6c78a61a869d)