### PR TITLE
fix(test): avoid competing full-worker builds in transform proofs

### DIFF
--- a/test/scripts/vitest-worker-artifacts.transforms.test.ts
+++ b/test/scripts/vitest-worker-artifacts.transforms.test.ts
@@ -6,10 +6,8 @@ import { createWorkerArtifactTest, workerProbe } from "./vitest-worker-artifacts
 
 const root = process.cwd();
 const it = createWorkerArtifactTest();
-// Each sequence rebuilds all workers; avoid contention on Windows CI runners.
-const concurrent = process.platform !== "win32";
-
-describe("fresh compiled subprocess invocation", { concurrent }, () => {
+// Each sequence rebuilds all workers; avoid competing builds within one runner.
+describe("fresh compiled subprocess invocation", { concurrent: false }, () => {
   it.for((["single", "projects"] as const).map((layout) => ({ layout })))(
     "preserves filesystem transforms across fresh generations, source mode, and edits ($layout)",
     ({ layout }, { workerArtifacts }) =>


### PR DESCRIPTION
Related: #142991

## What Problem This Solves

The two worker-transform proof sequences each build and launch several subprocess generations. Running both together on a small CI runner makes full-worker builds compete within each case's 120-second deadline. Both cases timed out after their fifth successful launch in an Image PR's CI run.

## Why This Change Was Made

Run these two sequences serially on every platform, extending their existing Windows behavior. Both layouts, all cache/source/edit transitions, every assertion, and the deadline remain unchanged.

## User Impact

This changes test scheduling only. It gives each case more deadline margin at the cost of a longer total run.

## Evidence

- Canonical single-file checks, formatting, and independent Codex review through P2 passed.
- A controlled Linux/Node 24.19 comparison used the same installed dependencies and source, pinned to two CPUs. Concurrent cases took 85.77/86.17 seconds; sequential cases took 64.51/58.34 seconds. The tightest deadline margin increased from 33.83 to 55.49 seconds. Total runtime increased from 88.79 to 125.18 seconds.
- Both comparison variants passed; this did not reproduce the original CI timeout. The comparison used base `34e0e5d7`, while the original CI used `0f32f846`; the test and runner owners match, but the complete compiled graph was not claimed identical across those two heads. The Testbox's hardware also differs from the original small CI runner.

Current main also removes one redundant build in #143009. This scheduling change preserves that five-launch sequence; the comparison above measured the earlier six-launch version.
