### PR TITLE
fix(config): correct bootstrapTotalMaxChars default comment to 60000

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -188,7 +188,7 @@ export type AgentDefaultsConfig = {
   contextInjection?: AgentContextInjection;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
-  /** Max total chars across all injected bootstrap files (default: 150000). */
+  /** Max total chars across all injected bootstrap files (default: 60000). */
   bootstrapTotalMaxChars?: number;
   /** Experimental agent-default flags. Keep off unless you are intentionally testing a preview surface. */
   experimental?: {


### PR DESCRIPTION
## What Problem This Solves

`src/config/types.agent-defaults.ts:191` documents `bootstrapTotalMaxChars` as `(default: 150000)`, but the runtime default is `60_000`. Anyone reading the type comment gets a wrong budget number, while docs, help text, and the resolver all agree on `60000`.

## Change

One-line TSDoc fix: `(default: 150000)` -> `(default: 60000)` in `src/config/types.agent-defaults.ts:191`. Comment-only; zero runtime behavior change.

## Evidence

- Resolver: `src/agents/embedded-agent-helpers/bootstrap.ts:90` — `const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 60_000;`, `resolveBootstrapTotalMaxChars()` falls back to it.
- Docs: `docs/gateway/config-agents/workspace-and-bootstrap.md:136` (`Default: 60000`), `docs/reference/token-use.md:27-28` (`60000`), `src/config/schema.help.models.ts:165` (`60000`).
- Repo-wide `150000` code search: no other bootstrap-related hit (remaining hits are unrelated test fixtures).
- After-fix source check (terminal output):

```
$ grep -n '150000\|60000' src/config/types.agent-defaults.ts
191:  /** Max total chars across all injected bootstrap files (default: 60000). */
$ grep -n 'DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS =' src/agents/embedded-agent-helpers/bootstrap.ts
90:const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 60_000;
```
