### PR TITLE
docs(channels): split the iMessage page by reader job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -141,6 +141,7 @@
       - any-glob-to-any-file:
           - "extensions/imessage/**"
           - "docs/channels/imessage.md"
+          - "docs/channels/imessage/**"
 "channel: line":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -3532,6 +3532,38 @@
     "target": "Telegram 故障排查"
   },
   {
+    "source": "iMessage setup",
+    "target": "iMessage 设置"
+  },
+  {
+    "source": "Enabling the imsg private API",
+    "target": "启用 imsg 私有 API"
+  },
+  {
+    "source": "iMessage access control and routing",
+    "target": "iMessage 访问控制与路由"
+  },
+  {
+    "source": "iMessage deployment patterns",
+    "target": "iMessage 部署模式"
+  },
+  {
+    "source": "iMessage media and attachments",
+    "target": "iMessage 媒体与附件"
+  },
+  {
+    "source": "iMessage private API actions",
+    "target": "iMessage 私有 API 操作"
+  },
+  {
+    "source": "iMessage message behavior",
+    "target": "iMessage 消息行为"
+  },
+  {
+    "source": "iMessage troubleshooting",
+    "target": "iMessage 故障排查"
+  },
+  {
     "source": "Microsoft Teams setup",
     "target": "Microsoft Teams 设置"
   },

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -9,7 +9,7 @@ title: "iMessage"
 <Note>
 For the usual OpenClaw iMessage deployment, run the Gateway and `imsg` on the same signed-in macOS Messages host. If your Gateway runs elsewhere, point `channels.imessage.cliPath` at a transparent SSH wrapper that runs `imsg` on the Mac.
 
-**Inbound recovery is automatic.** After a bridge or gateway restart, iMessage replays the messages missed while it was down and suppresses the stale "backlog bomb" Apple can flush after a Push recovery, deduping so nothing is dispatched twice. There is no config to enable — see [Inbound recovery after a bridge or gateway restart](#inbound-recovery-after-a-bridge-or-gateway-restart).
+**Inbound recovery is automatic.** After a bridge or gateway restart, iMessage replays the messages missed while it was down and suppresses the stale "backlog bomb" Apple can flush after a Push recovery, deduping so nothing is dispatched twice. There is no config to enable — see [Inbound recovery after a bridge or gateway restart](/channels/imessage/messaging#inbound-recovery-after-a-bridge-or-gateway-restart).
 </Note>
 
 <Warning>
@@ -20,853 +20,106 @@ Status: native external CLI integration. The Gateway spawns `imsg rpc` and speak
 
 For the common local setup, OpenClaw setup can offer a user-confirmed Homebrew install or update for `imsg` on the signed-in Messages Mac. Manual setup and SSH-wrapper topologies remain operator-managed: install or update `imsg` in the same user context that will run the Gateway or wrapper.
 
-## Install the plugin
-
-Install the official iMessage plugin on the Gateway host, then restart the Gateway:
-
-```bash
-openclaw plugins install @openclaw/imessage
-```
-
 <CardGroup cols={3}>
-  <Card title="Private API actions" icon="wand-sparkles" href="#private-api-actions">
-    Replies, tapbacks, effects, polls, attachments, and group management.
+  <Card title="Setup" icon="rocket" href="/channels/imessage/setup">
+    Install the plugin, set up `imsg`, and grant the macOS permissions.
   </Card>
-  <Card title="Pairing" icon="link" href="/channels/pairing">
-    iMessage DMs default to pairing mode.
+  <Card title="Private API" icon="wand-sparkles" href="/channels/imessage/private-api">
+    Disable SIP, inject the helper, and unlock the native actions.
   </Card>
-  <Card title="Remote Mac" icon="terminal" href="#remote-mac-over-ssh">
-    Use an SSH wrapper when the Gateway is not running on the Messages Mac.
-  </Card>
-  <Card title="Configuration reference" icon="settings" href="/gateway/config-channels#imessage">
-    Full iMessage field reference.
+  <Card title="Troubleshooting" icon="wrench" href="/channels/imessage/troubleshooting">
+    Fixes for silent inbound, ignored chats, and failed attachments.
   </Card>
 </CardGroup>
 
-## Quick setup
-
-<Tabs>
-  <Tab title="Local Mac (fast path)">
-    <Steps>
-      <Step title="Install and verify imsg">
-
-```bash
-brew install steipete/tap/imsg
-brew update && brew upgrade imsg
-imsg rpc --help
-imsg launch
-openclaw channels status --probe
-```
-
-        When the local setup wizard detects a missing default `imsg` command, it can prompt to install `steipete/tap/imsg` through Homebrew. If it detects a Homebrew-managed `imsg`, it can prompt to reinstall or update it. Custom `cliPath` wrappers are not modified.
-
-      </Step>
-
-      <Step title="Configure OpenClaw">
-
-```json5
-{
-  channels: {
-    imessage: {
-      enabled: true,
-      cliPath: "/usr/local/bin/imsg",
-      dbPath: "/Users/user/Library/Messages/chat.db",
-    },
-  },
-}
-```
-
-      </Step>
-
-      <Step title="Start gateway">
-
-```bash
-openclaw gateway
-```
-
-      </Step>
-
-      <Step title="Approve first DM pairing (default dmPolicy)">
-
-```bash
-openclaw pairing list imessage
-openclaw pairing approve imessage <CODE>
-```
-
-        Pairing requests expire after 1 hour.
-      </Step>
-    </Steps>
-
-  </Tab>
-
-  <Tab title="Remote Mac over SSH">
-    Most setups do not need SSH. Use this topology only when the Gateway cannot run on the signed-in Messages Mac. Point `cliPath` at a stdio-compatible wrapper on the **Gateway host** that SSHes to the Messages Mac and runs `imsg`. Use the wrapper's absolute path so service launches do not depend on shell home expansion.
-    Install and update `imsg` on that remote Mac, not on the Gateway host:
-
-```bash
-ssh messages-mac 'brew install steipete/tap/imsg && brew update && brew upgrade imsg'
-```
-
-```bash
-#!/usr/bin/env bash
-exec ssh -T messages-mac imsg "$@"
-```
-
-    Recommended config when attachments are enabled:
-
-```json5
-{
-  channels: {
-    imessage: {
-      enabled: true,
-      cliPath: "/home/openclaw/.openclaw/scripts/imsg-ssh",
-      remoteHost: "user@messages-mac", // Mac that runs Messages.app and imsg
-      // This path is interpreted on the Messages Mac, not on the Gateway host.
-      dbPath: "/Users/user/Library/Messages/chat.db",
-      includeAttachments: true,
-      // Optional: extra allowed attachment roots (merged with the default
-      // /Users/*/Library/Messages/Attachments).
-      attachmentRoots: ["/Users/*/Library/Messages/Attachments"],
-      remoteAttachmentRoots: ["/Users/*/Library/Messages/Attachments"],
-    },
-  },
-}
-```
-
-    `remoteHost` identifies the Messages Mac. OpenClaw uses it for both inbound attachment fetches and outbound attachment staging. For outbound files, OpenClaw creates an owner-only temporary path on that Mac, copies the file over the existing strict SSH/SCP transport, passes only the remote path to `imsg`, and attempts removal after success, failure, or timeout. A failed cleanup SSH call emits a warning and can leave the owner-only temporary directory behind.
-
-    An explicit `remoteHost` is recommended and wins when set. For compatibility, OpenClaw auto-detects the existing transparent `exec ssh ... imsg "$@"` wrapper shape once per process and reuses that host across monitoring, probes, sends, and private actions. Auto-detection covers only the simple documented transparent wrapper; option-rich wrappers such as ProxyJump/ProxyCommand must configure `remoteHost`.
-    `remoteHost` must be `host` or `user@host` (no spaces or SSH options); unsafe values are ignored.
-    OpenClaw uses strict host-key checking for SSH/SCP, so the Messages Mac host key must already exist in `~/.ssh/known_hosts` on the Gateway host.
-    Attachment paths are validated against allowed roots (`attachmentRoots` / `remoteAttachmentRoots`).
-
-<Warning>
-Any `cliPath` wrapper or SSH proxy you put in front of `imsg` MUST behave like a transparent stdio pipe for long-lived JSON-RPC. OpenClaw exchanges small newline-framed JSON-RPC messages over the wrapper's stdin/stdout for the lifetime of the channel:
-
-- Forward each stdin chunk/line **as soon as bytes are available** — don't wait for EOF.
-- Forward each stdout chunk/line promptly in the reverse direction.
-- Preserve newlines.
-- Avoid fixed-size blocking reads (`read(4096)`, `cat | buffer`, default shell `read`) that can starve small frames.
-- Keep stderr separate from the JSON-RPC stdout stream.
-
-A wrapper that buffers stdin until a large block fills will produce symptoms that look like an iMessage outage — `imsg rpc timeout (chats.list)` or repeated channel restarts — even though `imsg rpc` itself is healthy. `ssh -T host imsg "$@"` (above) is safe because it forwards OpenClaw's `cliPath` arguments such as `rpc` and `--db`. Pipelines like `ssh host imsg | grep -v '^DEBUG'` are NOT — line-buffered tools can still hold frames; use `stdbuf -oL -eL` on every stage if you must filter.
-</Warning>
-
-  </Tab>
-</Tabs>
-
-## Requirements and permissions (macOS)
-
-- Messages must be signed in on the Mac running `imsg`.
-- Full Disk Access is required for the process context running OpenClaw/`imsg` (Messages DB access).
-- Automation permission is required to send messages through Messages.app.
-- For advanced actions (react / edit / unsend / threaded reply / effects / polls / group ops), System Integrity Protection must be disabled — see [Enabling the imsg private API](#enabling-the-imsg-private-api). Basic text and media send/receive work without it.
-
-<Tip>
-Permissions are granted per process context. If the gateway runs headless (LaunchAgent/SSH), run a one-time interactive command in that same context to trigger prompts:
-
-```bash
-imsg chats --limit 1
-# or
-imsg send <handle> "test"
-```
-
-</Tip>
-
-<Accordion title="SSH wrapper sends fail with AppleEvents -1743">
-  A remote-SSH setup can read chats, pass `channels status --probe`, and process inbound messages while outbound sends still fail with an AppleEvents authorization error:
-
-```text
-Not authorized to send Apple events to Messages. (-1743)
-```
-
-Check the signed-in Mac user's TCC database or System Settings > Privacy & Security > Automation. If the Automation entry is recorded for `/usr/libexec/sshd-keygen-wrapper` instead of the `imsg` or local shell process, macOS may not expose a usable Messages toggle for that SSH server-side client:
-
-```text
-kTCCServiceAppleEvents | /usr/libexec/sshd-keygen-wrapper | auth_value=0 | com.apple.MobileSMS
-```
-
-In that state, repeating `tccutil reset AppleEvents` or rerunning `imsg send` through the same SSH wrapper may keep failing because the process context that needs Messages Automation is the SSH wrapper, not an app the UI can grant.
-
-Use one of the supported `imsg` process contexts instead:
-
-- Run the Gateway, or at least the `imsg` bridge, in the logged-in Messages user's local session.
-- Start the Gateway with a LaunchAgent for that user after granting Full Disk Access and Automation from the same session.
-- If you keep the two-user SSH topology, verify that a real outbound `imsg send` succeeds through the exact wrapper before enabling the channel. If it cannot be granted Automation, reconfigure to a single-user `imsg` setup instead of relying on the SSH wrapper for sends.
-
-</Accordion>
-
-## Enabling the imsg private API
-
-`imsg` ships in two operational modes. For OpenClaw, Private API mode is the recommended setup because it gives the channel the native iMessage actions users expect. Basic mode remains useful for low-risk installs, initial verification, or hosts where SIP cannot be disabled.
-
-- **Basic mode** (default, no SIP changes needed): outbound text and media via `send`, inbound watch/history, chat list. This is what you get out of the box from a fresh `brew install steipete/tap/imsg` plus the standard macOS permissions above.
-- **Private API mode**: `imsg` injects a helper dylib into `Messages.app` to call internal `IMCore` functions. This unlocks `react`, `edit`, `unsend`, `reply` (threaded), `sendWithEffect`, `poll` and `poll-vote` (native Messages polls), `renameGroup`, `setGroupIcon`, `addParticipant`, `removeParticipant`, `leaveGroup`, plus typing indicators and read receipts.
-
-The recommended action surface on this page requires Private API mode. The `imsg` README is explicit about the requirement:
-
-> Advanced features such as `read`, `typing`, `launch`, bridge-backed rich send, message mutation, and chat management are opt-in. They require SIP to be disabled and a helper dylib to be injected into `Messages.app`. `imsg launch` refuses to inject when SIP is enabled.
-
-The helper-injection technique uses `imsg`'s own dylib to reach Messages private APIs. There is no third-party server or BlueBubbles runtime in the OpenClaw iMessage path.
-
-<Warning>
-**Disabling SIP is a real security tradeoff.** SIP is one of macOS's core protections against running modified system code; turning it off system-wide opens up additional attack surface and side effects. Notably, **disabling SIP on Apple Silicon Macs also disables the ability to install and run iOS apps on your Mac**.
-
-Treat this as a deliberate operational choice, especially on a primary personal Mac. For production-quality OpenClaw iMessage, prefer a dedicated Mac or bot macOS user where you are comfortable enabling the bridge. If your threat model cannot tolerate SIP being off anywhere, the iMessage plugin is limited to basic mode — text and media send/receive only, no reactions / edit / unsend / effects / group ops.
-</Warning>
-
-### Setup
-
-1. **Install (or upgrade) `imsg`** on the Mac that runs Messages.app:
-
-   ```bash
-   brew install steipete/tap/imsg
-   brew update && brew upgrade imsg
-   imsg --version
-   imsg status --json
-   ```
-
-   The `imsg status --json` output reports `bridge_version`, `rpc_methods`, and per-method `selectors` so you can see what the current build supports before you start.
-
-2. **Disable System Integrity Protection, and (on modern macOS) Library Validation.** Injecting a non-Apple helper dylib into the Apple-signed `Messages.app` needs SIP off **and** library validation relaxed. The Recovery-mode SIP step is macOS-version-specific:
-   - **macOS 10.13-10.15 (Sierra-Catalina):** disable Library Validation via Terminal, reboot to Recovery Mode, run `csrutil disable`, restart.
-   - **macOS 11+ (Big Sur and later), Intel:** Recovery Mode (or Internet Recovery), `csrutil disable`, restart.
-   - **macOS 11+, Apple Silicon:** power-button startup sequence to enter Recovery; on recent macOS versions hold the **Left Shift** key when you click Continue, then `csrutil disable`. Virtual-machine setups follow a separate flow, so take a VM snapshot first.
-
-   **On macOS 11 and later, `csrutil disable` alone is usually not enough.** Apple still enforces library validation against `Messages.app` as a platform binary, so an adhoc-signed helper is rejected (`Library Validation failed: ... platform binary, but mapped file is not`) even with SIP off. After disabling SIP, also disable library validation and reboot:
-
-   ```bash
-   sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true
-   ```
-
-   **macOS 26 (Tahoe), verified on 26.5.1:** SIP off **plus** the `DisableLibraryValidation` command above is sufficient to inject the helper across 26.0 through 26.5.x. **No boot-args are required.** The plist is the decisive factor and the most common missing step when injection fails on Tahoe:
-   - **With the plist:** `imsg launch` injects and `imsg status` reports `advanced_features: true`.
-   - **Without the plist (even with SIP off):** `imsg launch` fails with `Failed to launch: Timeout waiting for Messages.app to initialize`. AMFI rejects the adhoc helper at load, so the bridge never becomes ready and the launch times out. That timeout is the symptom most people hit on Tahoe; the fix is the plist above, not anything more drastic.
-
-   If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state before assuming the SIP step itself failed. If those settings are correct and the bridge still cannot inject, collect `imsg status --json` plus the `imsg launch` output and report it to the `imsg` project instead of weakening additional system-wide security controls.
-
-3. **Inject the helper.** With SIP disabled and Messages.app signed in:
-
-   ```bash
-   imsg launch
-   ```
-
-   `imsg launch` refuses to inject when SIP is still enabled, so this also doubles as a confirmation that step 2 took.
-
-4. **Verify the bridge from OpenClaw:**
-
-   ```bash
-   openclaw channels status --probe
-   ```
-
-   The iMessage entry should report `works`, and `imsg status --json | jq '{rpc_methods, selectors}'` should show the capabilities exposed by your macOS build. Poll creation requires `selectors.pollPayloadMessage`; voting requires both `selectors.pollVoteMessage` and the `poll.vote` RPC method. The OpenClaw plugin advertises only actions supported by the cached probe, while an empty cache stays optimistic and probes on first dispatch.
-
-If `openclaw channels status --probe` reports the channel as `works` but specific actions throw "iMessage `<action>` requires the imsg private API bridge" at dispatch time, run `imsg launch` again — the helper can fall out (Messages.app restart, OS update, etc.) and the cached `available: true` status will keep advertising actions until the next probe refreshes.
-
-### When SIP stays enabled
-
-If disabling SIP is not acceptable for your threat model:
-
-- `imsg` falls back to basic mode — text + media + receive only.
-- The OpenClaw plugin still advertises text/media send and inbound monitoring; it hides `react`, `edit`, `unsend`, `reply`, `sendWithEffect`, and group ops from the action surface (per the per-method capability gate).
-- You can run a separate non-Apple-Silicon Mac (or a dedicated bot Mac) with SIP off for the iMessage workload, while keeping SIP enabled on your primary devices. See [Dedicated bot macOS user (separate iMessage identity)](#deployment-patterns) below.
-
-## Access control and routing
-
-<Tabs>
-  <Tab title="DM policy">
-    `channels.imessage.dmPolicy` controls direct messages:
-
-    - `pairing` (default)
-    - `allowlist` (requires at least one `allowFrom` entry)
-    - `open` (requires `allowFrom` to include `"*"`)
-    - `disabled`
-
-    Allowlist field: `channels.imessage.allowFrom`.
-
-    Allowlist entries must identify senders: handles or static sender access groups (`accessGroup:<name>`). Use `channels.imessage.groupAllowFrom` for chat targets such as `chat_id:*`, `chat_guid:*`, or `chat_identifier:*`; use `channels.imessage.groups` for numeric `chat_id` registry keys.
-
-  </Tab>
-
-  <Tab title="Group policy + mentions">
-    `channels.imessage.groupPolicy` controls group handling:
-
-    - `allowlist` (default)
-    - `open`
-    - `disabled`
-
-    Group sender allowlist: `channels.imessage.groupAllowFrom`.
-
-    `groupAllowFrom` entries can also reference static sender access groups (`accessGroup:<name>`).
-
-    Runtime fallback: if `groupAllowFrom` is unset, iMessage group sender checks use `allowFrom`; set `groupAllowFrom` when DM and group admission should differ. An explicitly empty `groupAllowFrom: []` does not fall back — it blocks all group senders under `allowlist`.
-    Runtime note: if `channels.imessage` is completely missing, runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
-
-    <Warning>
-    Group routing under `groupPolicy: "allowlist"` runs **two** gates back-to-back:
-
-    1. **Sender allowlist** (`channels.imessage.groupAllowFrom`) — handle, `accessGroup:<name>`, `chat_guid`, `chat_identifier`, or `chat_id`. An empty effective list (no `groupAllowFrom` and no `allowFrom` fallback) blocks every group sender.
-    2. **Group registry** (`channels.imessage.groups`) — enforced once the map has entries: the chat must match an explicit per-`chat_id` entry or a `groups: { "*": { ... } }` wildcard. When `groups` is empty or missing, the sender allowlist alone decides admission.
-
-    If no effective group sender allowlist is configured, every group message is dropped before the registry gate. Each gate has its own `warn`-level signal at the default log level, and each names a different fix:
-
-    - one-time per account at startup, when the effective group sender allowlist is empty: `imessage: groupPolicy="allowlist" for account "<id>" but no group sender allowlist is configured ...` — fix by setting `channels.imessage.groupAllowFrom` (or `allowFrom`); adding `groups` entries alone leaves gate 1 blocking every sender.
-    - one-time per `chat_id` at runtime, when a sender passed gate 1 but the chat is missing from a populated `groups` registry: `imessage: dropping group message from chat_id=<id> ...` — fix by adding that `chat_id` (or `"*"`) under `channels.imessage.groups`.
-
-    DMs are unaffected — they take a different code path.
-
-    Recommended config for group flow under `groupPolicy: "allowlist"`:
-
-    ```json5
-    {
-      channels: {
-        imessage: {
-          groupPolicy: "allowlist",
-          groupAllowFrom: ["+15555550123"],
-          groups: { "*": { "requireMention": true } },
-        },
-      },
-    }
-    ```
-
-    `groupAllowFrom` alone admits those senders in any group; add the `groups` block to scope which chats are allowed (and to set per-chat options like `requireMention`).
-    </Warning>
-
-    Mention gating for groups:
-
-    - iMessage has no native mention metadata
-    - mention detection uses `agents.entries.*.groupChat.mentionPatterns`, then `messages.groupChat.mentionPatterns`; when neither is set, patterns are derived from the routed agent's `identity.name` and `identity.emoji`
-    - groups require a mention by default, even when no patterns were explicitly configured; an allowlisted sender's message can therefore be skipped unless it contains the agent's name or emoji
-    - an explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived patterns; iMessage cannot enforce mention gating when no usable patterns remain
-    - control commands from authorized senders bypass mention gating
-
-    To process every message from allowed senders in one group, set that chat's `requireMention` to `false`:
-
-    ```json5
-    {
-      channels: {
-        imessage: {
-          groupPolicy: "allowlist",
-          groupAllowFrom: ["+15555550123", "+15555550124"],
-          groups: {
-            "*": {},
-            "123": { requireMention: false },
-          },
-        },
-      },
-    }
-    ```
-
-    Replace `123` with the numeric chat ID from `imsg chats --limit 20 --json`. Edit the map already supplying that account's group policy: `channels.imessage.groups`, or `channels.imessage.accounts.<account-id>.groups` when it overrides the root map. This also applies to `accounts.default.groups`; merely having an account entry does not mean its own `groups` map is needed. An empty account map inherits the root map only when at most one account is configured.
-
-    Preserve the existing wildcard and every per-group setting, changing only the target chat's `requireMention`. Account maps replace the whole inherited map, so if you intentionally create an account-specific override, first copy the complete inherited map, including all wildcard and per-group policies. When no map previously applied, `"*": {}` preserves admission to other groups while keeping their default mention requirement. Keep a restricted map restricted. `groupAllowFrom` still controls sender access.
-
-    A skipped message with no mention produces a warning at the default log level with the chat ID and the `requireMention: false` fix. Repeated warnings for the same chat are suppressed by a bounded in-memory cache; restarting the channel or evicting a cache entry allows the warning again.
-
-    Per-group `systemPrompt`:
-
-    Each entry under `channels.imessage.groups.*` accepts an optional `systemPrompt` string, injected into the agent's system prompt on every turn that handles a message in that group. Resolution mirrors `channels.whatsapp.groups`:
-
-    1. **Group-specific system prompt** (`groups["<chat_id>"].systemPrompt`): used when the specific group entry exists in the map **and** its `systemPrompt` key is defined. If `systemPrompt` is an empty string (`""`) the wildcard is suppressed and no system prompt is applied to that group.
-    2. **Group wildcard system prompt** (`groups["*"].systemPrompt`): used when the specific group entry is absent from the map entirely, or when it exists but defines no `systemPrompt` key.
-
-    ```json5
-    {
-      channels: {
-        imessage: {
-          groupPolicy: "allowlist",
-          groupAllowFrom: ["+15555550123"],
-          groups: {
-            "*": { systemPrompt: "Use British spelling." },
-            "8421": {
-              requireMention: true,
-              systemPrompt: "This is the on-call rotation chat. Keep replies under 3 sentences.",
-            },
-            "9907": {
-              // explicit suppression: the wildcard "Use British spelling." does not apply here
-              systemPrompt: "",
-            },
-          },
-        },
-      },
-    }
-    ```
-
-    Per-group prompts only apply to group messages — direct messages are unaffected.
-
-  </Tab>
-
-  <Tab title="Sessions and deterministic replies">
-    - DMs use direct routing; groups use group routing.
-    - With default `session.dmScope=main`, iMessage DMs collapse into the agent main session.
-    - Group sessions are isolated (`agent:<agentId>:imessage:group:<chat_id>`).
-    - Replies route back to iMessage using originating channel/target metadata.
-
-    Group-ish thread behavior:
-
-    Some multi-participant iMessage threads can arrive with `is_group=false`.
-    If that `chat_id` is explicitly configured under `channels.imessage.groups`, OpenClaw treats it as group traffic (group gating + group session isolation).
-
-  </Tab>
-</Tabs>
-
-## ACP conversation bindings
-
-iMessage chats can be bound to ACP sessions.
-
-Fast operator flow:
-
-- Run `/acp spawn codex --bind here` inside the DM or allowed group chat.
-- Future messages in that same iMessage conversation route to the spawned ACP session.
-- `/new` and `/reset` reset the same bound ACP session in place.
-- `/acp close` closes the ACP session and removes the binding.
-
-Configured persistent bindings use top-level `bindings[]` entries with `type: "acp"` and `match.channel: "imessage"`.
-
-`match.peer.id` can use:
-
-- normalized DM handle such as `+15555550123` or `user@example.com`
-- `chat_id:<id>` (recommended for stable group bindings)
-- `chat_guid:<guid>`
-- `chat_identifier:<identifier>`
-
-Example:
-
-```json5
-{
-  agents: {
-    entries: {
-      codex: {
-        default: true,
-        runtime: {
-          type: "acp",
-          acp: { agent: "codex", backend: "acpx", mode: "persistent" },
-        },
-      },
-    },
-  },
-  bindings: [
-    {
-      type: "acp",
-      agentId: "codex",
-      match: {
-        channel: "imessage",
-        accountId: "default",
-        peer: { kind: "group", id: "chat_id:123" },
-      },
-      acp: { label: "codex-group" },
-    },
-  ],
-}
-```
-
-See [ACP Agents](/tools/acp-agents) for shared ACP binding behavior.
-
-## Deployment patterns
-
-<AccordionGroup>
-  <Accordion title="Dedicated bot macOS user (separate iMessage identity)">
-    Use a dedicated Apple ID and macOS user so bot traffic is isolated from your personal Messages profile.
-
-    Typical flow:
-
-    1. Create/sign in a dedicated macOS user.
-    2. Sign into Messages with the bot Apple ID in that user.
-    3. Install `imsg` in that user.
-    4. Create an SSH wrapper so OpenClaw can run `imsg` in that user context.
-    5. Point `channels.imessage.accounts.<id>.cliPath` and `.dbPath` to that user profile.
-
-    First run may require GUI approvals (Automation + Full Disk Access) in that bot user session.
-
-  </Accordion>
-
-  <Accordion title="Remote Mac over Tailscale (example)">
-    Common topology:
-
-    - gateway runs on Linux/VM
-    - iMessage + `imsg` runs on a Mac in your tailnet
-    - `cliPath` wrapper uses SSH to run `imsg`
-    - `remoteHost` enables inbound fetches and owner-only outbound staging over SSH/SCP
-
-    Example:
-
-    ```json5
-    {
-      channels: {
-        imessage: {
-          enabled: true,
-          cliPath: "/home/openclaw/.openclaw/scripts/imsg-ssh",
-          remoteHost: "bot@mac-mini.tailnet-1234.ts.net",
-          includeAttachments: true,
-          dbPath: "/Users/bot/Library/Messages/chat.db",
-        },
-      },
-    }
-    ```
-
-    ```bash
-    #!/usr/bin/env bash
-    exec ssh -T bot@mac-mini.tailnet-1234.ts.net imsg "$@"
-    ```
-
-    `cliPath` is an absolute, Gateway-local wrapper path. `remoteHost` and `dbPath` refer to the Messages Mac; do not rewrite the remote database path using the Gateway user's home directory.
-
-    Use SSH keys so both SSH and SCP are non-interactive.
-    Ensure the host key is trusted first (for example `ssh bot@mac-mini.tailnet-1234.ts.net`) so `known_hosts` is populated.
-
-  </Accordion>
-
-  <Accordion title="Multi-account pattern">
-    iMessage supports per-account config under `channels.imessage.accounts`.
-
-    Each account can override fields such as `cliPath`, `dbPath`, `allowFrom`, `dmPolicy`, `groupPolicy`, `mediaMaxMb`, history settings, and attachment root allowlists. Omitted account policies inherit the channel root; explicit account policies win. If neither scope sets them, DMs use `pairing` and groups use `allowlist`.
-
-  </Accordion>
-
-  <Accordion title="Direct-message history">
-    Set `channels.imessage.dmHistoryLimit` to seed new direct-message sessions with recent decoded `imsg` history for that conversation. Use `channels.imessage.dms["<sender>"].historyLimit` for per-sender overrides, including `0` to disable history for a sender.
-
-    iMessage DM history is fetched on demand from `imsg`. Leaving `dmHistoryLimit` unset disables global DM history seeding, but a positive per-sender `channels.imessage.dms["<sender>"].historyLimit` still enables seeding for that sender.
-
-  </Accordion>
-</AccordionGroup>
-
-## Media, chunking, and delivery targets
-
-<AccordionGroup>
-  <Accordion title="Attachments and media">
-    - inbound attachment ingestion is **off by default** — set `channels.imessage.includeAttachments: true` to forward photos, voice memos, video, and other attachments to the agent. With it disabled, attachment-only iMessages are dropped before reaching the agent and may produce no `Inbound message` log line at all.
-    - remote inbound attachment paths can be fetched via SCP when `remoteHost` is set
-    - outbound files are staged into an owner-only temporary path on the configured or auto-detected Messages Mac, passed to `imsg` by that remote path, and cleaned up best-effort after success, failure, or timeout; cleanup failure emits a warning and can leave owner-only residue
-    - attachment paths must match allowed roots:
-      - `channels.imessage.attachmentRoots` (local)
-      - `channels.imessage.remoteAttachmentRoots` (remote SCP mode)
-      - configured roots extend the default root pattern `/Users/*/Library/Messages/Attachments` (merged, not replaced)
-    - SCP uses strict host-key checking (`StrictHostKeyChecking=yes`)
-    - outbound media size uses `channels.imessage.mediaMaxMb` (default 16 MB)
-
-  </Accordion>
-
-  <Accordion title="Outbound text and chunking">
-    - text chunk limit: `channels.imessage.textChunkLimit` (default 4000)
-    - chunk mode: `channels.imessage.streaming.chunkMode`
-      - `length` (default)
-      - `newline` (paragraph-first splitting)
-    - outbound markdown bold/italic/underline/strikethrough is converted to native styled text (macOS 15+ recipients render the styling; older recipients see plain text without the markers); markdown tables are converted per the channel markdown table mode
-    - `channels.imessage.sendTransport` (`auto` default, `bridge`, `applescript`) selects how `imsg` delivers sends
-
-  </Accordion>
-
-  <Accordion title="Addressing formats">
-    Preferred explicit targets:
-
-    - `chat_id:123` (recommended for stable routing)
-    - `chat_guid:...`
-    - `chat_identifier:...`
-
-    Direct handles are also supported:
-
-    - `+1555...`
-    - `tel:+1555...`
-    - `imessage:+1555...`
-    - `sms:+1555...`
-    - `user@example.com`
-
-    Use a service-qualified target for a contact name or mixed alphanumeric alias:
-
-    - `auto:<contact>` lets Messages choose iMessage or SMS
-    - `imessage:<contact>` requires iMessage
-    - `sms:<contact>` requires SMS
-
-    Bare contact names and mixed alphanumeric aliases are rejected instead of being converted to
-    a phone number. If an existing automation uses one, add `auto:`, `imessage:`, or `sms:` to
-    make the intended delivery service explicit.
-
-    ```bash
-    imsg chats --limit 20
-    ```
-
-  </Accordion>
-</AccordionGroup>
-
-## Private API actions
-
-When `imsg launch` is running and `openclaw channels status --probe` reports `privateApi.available: true`, the message tool can use iMessage-native actions in addition to normal text sends.
-
-All actions are enabled by default; use `channels.imessage.actions` to turn individual actions off:
-
-```json5
-{
-  channels: {
-    imessage: {
-      actions: {
-        reactions: true,
-        edit: true,
-        unsend: true,
-        reply: true,
-        sendWithEffect: true,
-        sendAttachment: true,
-        renameGroup: true,
-        setGroupIcon: true,
-        addParticipant: true,
-        removeParticipant: true,
-        leaveGroup: true,
-        polls: true,
-      },
-    },
-  },
-}
-```
-
-<AccordionGroup>
-  <Accordion title="Available actions">
-    - **react**: Add/remove iMessage tapbacks (`messageId`, `emoji`, `remove`). Supported tapbacks map to love, like, dislike, laugh, emphasize, and question. Removing without an emoji clears whichever tapback was set.
-    - **reply**: Send a threaded reply to an existing message (`messageId`, `text` or `message`, plus `chatGuid`, `chatId`, `chatIdentifier`, or `to`). Local reply-with-attachment additionally needs an `imsg` build whose `send-rich` supports `--file`. With remote `imsg` v0.13.4, attachment replies use JSON-RPC and support the whole message or part index `0`; nonzero attachment part indices are not supported by the RPC method.
-    - **sendWithEffect**: Send text with an iMessage effect (`text` or `message`, `effect` or `effectId`). Short names: slam, loud, gentle, invisibleink, confetti, lasers, fireworks, balloon, heart, echo, happybirthday, shootingstar, sparkles, spotlight.
-    - **edit**: Edit a sent message on supported macOS/private API versions (`messageId`, `text` or `newText`). Only messages the gateway itself sent can be edited.
-    - **unsend**: Retract a sent message on supported macOS/private API versions (`messageId`). Only messages the gateway itself sent can be unsent.
-    - **upload-file**: Send media/files (`buffer` as base64 or a hydrated `media`/`path`/`filePath`, `filename`, optional `asVoice`). Legacy alias: `sendAttachment`.
-    - **renameGroup**, **setGroupIcon**, **addParticipant**, **removeParticipant**, **leaveGroup**: Manage group chats when the current target is a group conversation. These mutate the host's Messages identity, so they require an owner sender or an `operator.admin` Gateway client.
-    - **poll**: Create a native Apple Messages poll (`pollQuestion`, `pollOption` repeated 2 to 12 times, plus `chatGuid`, `chatId`, `chatIdentifier`, or `to`). Recipients on iOS/iPadOS/macOS 26+ see and vote on it natively; older OS versions get a "Sent a poll" text fallback. Requires `selectors.pollPayloadMessage`.
-    - **poll-vote**: Vote on an existing poll (`pollId` or `messageId`, plus exactly one of `pollOptionIndex`, `pollOptionId`, or `pollOptionText`). Requires `selectors.pollVoteMessage` and the `poll.vote` RPC method. Remote `imsg` v0.13.4 RPC accepts only the option ID, so remote setups must use `pollOptionId`; index and text selectors remain available to local setups.
-
-    Accepted inbound polls are rendered for the agent with the question, option labels, vote counts, and the poll message ID needed by `poll-vote`. Remote accounts also include each stable option ID and direct the agent to use `pollOptionId`.
-
-  </Accordion>
-
-  <Accordion title="Message IDs">
-    Inbound iMessage context includes both short `MessageSid` values and full message GUIDs (`MessageSidFull`) when available. Short IDs are scoped to the recent SQLite-backed reply cache and are checked against the current chat before use. If a short ID expires, retry with its `MessageSidFull` while targeting the conversation that supplied it. Full IDs do not bypass conversation or account binding, so replace an ID from another chat with one from the current target. Remote delegated calls can reject stale full IDs when current-conversation evidence is unavailable.
-
-  </Accordion>
-
-  <Accordion title="Capability detection">
-    OpenClaw hides private API actions only when the cached probe status says the bridge is unavailable. If the status is unknown, actions remain visible and dispatch probes lazily so the first action can succeed after `imsg launch` without a separate manual status refresh.
-
-  </Accordion>
-
-  <Accordion title="Read receipts and typing">
-    When the private API bridge is up, accepted inbound chats are marked read and direct chats show a typing bubble as soon as the turn is accepted, while the agent prepares context and generates. Disable read-marking with:
-
-    ```json5
-    {
-      channels: {
-        imessage: {
-          sendReadReceipts: false,
-        },
-      },
-    }
-    ```
-
-    Older `imsg` builds that pre-date the per-method capability list gate off typing/read silently; OpenClaw logs a one-time warning per restart so the missing receipt is attributable.
-
-  </Accordion>
-
-  <Accordion title="Inbound tapbacks">
-    OpenClaw subscribes to iMessage tapbacks and routes accepted reactions as system events instead of normal message text, so a user tapback does not trigger an ordinary reply loop.
-
-    Notification mode is controlled by `channels.imessage.reactionNotifications`:
-
-    - `"own"` (default): notify only when users react to bot-authored messages.
-    - `"all"`: notify for all inbound tapbacks from authorized senders.
-    - `"off"`: ignore inbound tapbacks.
-
-    Per-account overrides use `channels.imessage.accounts.<id>.reactionNotifications`.
-
-  </Accordion>
-
-  <Accordion title="Approval polls and reactions">
-    When `approvals.exec.enabled` or `approvals.plugin.enabled` is true and the request routes natively to iMessage, the gateway delivers an approval prompt with native controls:
-
-    - On a probed private API bridge with poll and caption-suppression support, the prompt includes a Messages poll with each allowed decision. Older `imsg` releases without `poll send --no-comment` stay on text controls.
-    - If polls are disabled with `channels.imessage.actions.polls: false`, the bridge lacks poll support, the poll send fails, or fewer than two decisions are available, the prompt keeps the text and tapback controls.
-    - The text fallback maps `👍` (Like) to `allow-once` and `👎` (Dislike) to `deny`. It also includes `/approve <id> <decision>` commands, including `allow-always` when the request permits it.
-
-    Poll votes and reactions require the acting user's handle to be an explicit approver. The approver list is read from `channels.imessage.allowFrom` (or `channels.imessage.accounts.<id>.allowFrom`); add the user's phone number in E.164 form or their Apple ID email (chat targets such as `chat_id:*` are not valid approver entries). The wildcard entry `"*"` is honored but allows any sender to approve; an empty approver list disables poll and reaction shortcuts entirely. These shortcuts intentionally bypass `reactionNotifications`, `dmPolicy`, and `groupAllowFrom` because the explicit-approver allowlist is the only gate that matters for approval resolution.
-
-    Native poll controls are currently limited to channel-native delivery in the originating iMessage session or an iMessage approver DM. Explicit forwarding targets selected by `approvals.exec.mode: "targets"` (and the target half of `"both"`) continue to use the existing forwarded approval message instead of an iMessage poll.
-
-    `/approve` text command authorization follows the same list: when `channels.imessage.allowFrom` is non-empty, `/approve <id> <decision>` is authorized against that approver list (not the broader DM allowlist), and senders permitted on the DM allowlist but not in `allowFrom` receive an explicit denial. When `allowFrom` is empty, the same-chat fallback stays in effect and `/approve` authorizes anyone the DM allowlist permits. Add every operator who should approve — via `/approve` or via reactions — to `allowFrom`.
-
-    Operator notes:
-    - Poll and reaction bindings are stored both in memory and in the gateway's persistent keyed store (TTL matched to the approval expiry), and the gateway also polls pending prompts for tapbacks. After a gateway restart, a tap on an old control is recognized and swallowed instead of entering agent chat, but the restart ends the in-flight command; request a new approval rather than expecting the old control to resume it.
-    - The operator's own `is_from_me=true` tapback (for example from a paired Apple device) resolves the approval when that handle is an explicit approver.
-    - Approval prompts route into a group conversation only when explicit approvers are configured; otherwise any group member could approve.
-    - Legacy text-style tapbacks (`Liked "…"` plain text from very old Apple clients) cannot resolve approvals because they carry no message GUID; reaction resolution requires the structured tapback metadata that current macOS / iOS clients emit.
-
-  </Accordion>
-
-  <Accordion title="Question reactions (1️⃣ / 2️⃣ / 3️⃣ / 4️⃣)">
-    For an `ask_user` prompt with one non-secret, single-select question and one to four options, OpenClaw adds numbered emoji choices. React to the delivered prompt with the matching number to answer it. The reaction must carry the stable GUID of the bot-authored message; OpenClaw then maps the number to the canonical option through the Gateway. Stale or duplicate taps are ignored.
-
-    Multi-question, multi-select, and free-text prompts remain text-reply-only. Question reactions follow normal iMessage DM/group admission rules. They are recognized even when general `reactionNotifications` is `"off"`, without turning unrelated reactions into agent events.
-
-  </Accordion>
-</AccordionGroup>
-
-## Config writes
-
-iMessage allows channel-initiated config writes by default (for `/config set|unset` when `commands.config: true`).
-
-Disable:
-
-```json5
-{
-  channels: {
-    imessage: {
-      configWrites: false,
-    },
-  },
-}
-```
-
-<a id="coalescing-split-send-dms-command--url-in-one-composition"></a>
-
-## Coalescing split-send DMs (command + URL in one composition)
-
-Apple can store a command and its URL preview as separate physical `chat.db` rows. `imsg` 0.13.1 and newer coalesces those rows before watch, history, or search returns the message, so OpenClaw receives one logical inbound message without adding channel-specific DM latency.
-
-No iMessage coalescing setting is needed. The retired `channels.imessage.coalesceSameSenderDms` key is removed by `openclaw doctor --fix`. Generic `messages.inbound` debounce remains available when you intentionally want to batch rapid text messages across a channel.
-
-If command-plus-URL sends arrive as separate agent turns, update `imsg` on the Messages Mac:
-
-```bash
-brew update && brew upgrade imsg
-```
-
-## Inbound recovery after a bridge or gateway restart
-
-iMessage recovers messages missed while the gateway was down, and at the same time suppresses the stale "backlog bomb" Apple can flush after a Push recovery. The default behavior is always on, built on durable ingress plus an age fence.
-
-- **Durable replay protection.** Before advancing the recovery cursor, OpenClaw journals each raw row in the shared SQLite ingress queue with its Apple GUID as the event ID. A completed row leaves a tombstone for about 4 hours, capped at 10,000 entries, so a replay with the same GUID is dropped even after a restart. A pending row stays recoverable until dispatch adopts it.
-- **Downtime recovery.** On startup the monitor remembers the last durably admitted `chat.db` rowid (a persisted per-account cursor) and passes it to `imsg watch.subscribe` as `since_rowid`, so imsg replays rows that were not yet journaled and then tails live. Rows journaled before a crash resume from SQLite. Replay is bounded to the most recent 500 rows and to messages up to ~2 hours old, and GUID tombstones drop anything already handled.
-- **Stale-backlog age fence.** Rows above the startup boundary are genuinely live; one whose send date is more than ~15 minutes older than its arrival is the Push-flush backlog and is suppressed. Replayed rows (at or below the boundary) use the wider recovery window instead, so a recently-missed message is delivered while ancient history is not.
-
-Recovery works over both local and remote `cliPath` setups, because `since_rowid` replay runs over the same `imsg` RPC connection. The difference is the window: when the gateway can read `chat.db` (local), it anchors the startup rowid boundary, caps the replay span, and delivers missed messages up to a couple of hours old. Over a remote SSH `cliPath` it cannot read the database, so the replay is uncapped and every row uses the live age fence — it still recovers recently-missed messages and still suppresses old backlog, just with the narrower live window. Run the gateway on the Messages Mac for the wider recovery window.
-
-### Operator-visible signal
-
-Suppressed backlog is logged at the default level, never silently dropped (the `recovery` flag shows which window applied):
-
-```text
-imessage: suppressed stale inbound backlog account=<id> sent=<iso> recovery=<bool> (<N> suppressed since start)
-```
-
-### Migration
-
-`channels.imessage.catchup.*` is deprecated — downtime recovery is automatic and needs no config for new setups. Existing configs with `catchup.enabled: true` remain honored as a compatibility profile for the recovery replay window. Disabled catchup blocks (`enabled: false` or no `enabled: true`) are retired; `openclaw doctor --fix` removes those.
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="imsg not found or RPC unsupported">
-    Validate the binary and RPC support:
-
-    ```bash
-    imsg rpc --help
-    imsg status --json
-    openclaw channels status --probe
-    ```
-
-    If the probe reports RPC unsupported, update `imsg`. If private API actions are unavailable, run `imsg launch` in the logged-in macOS user session and probe again. If the Gateway is not running on macOS, use the Remote Mac over SSH setup above instead of the default local `imsg` path.
-
-  </Accordion>
-
-  <Accordion title="Messages send but inbound iMessages do not arrive">
-    First prove whether the message reached the local Mac. If `chat.db` does not change, OpenClaw cannot receive the message even when `imsg status --json` reports a healthy bridge.
-
-```bash
-imsg chats --limit 10 --json
-imsg watch --chat-id <chat-id> --json
-sqlite3 ~/Library/Messages/chat.db \
-  "select datetime(max(date)/1000000000 + 978307200, 'unixepoch', 'localtime'), max(ROWID) from message;"
-```
-
-    If phone-sent messages create no new rows, repair the macOS Messages and Apple Push layer before changing OpenClaw config. A one-shot service refresh is often enough:
-
-```bash
-launchctl kickstart -k system/com.apple.apsd
-launchctl kickstart -k gui/$(id -u)/com.apple.CommCenter
-launchctl kickstart -k gui/$(id -u)/com.apple.identityservicesd
-launchctl kickstart -k gui/$(id -u)/com.apple.imagent
-imsg launch
-openclaw gateway restart
-```
-
-    Send a fresh iMessage from the phone and confirm a new `chat.db` row or `imsg watch` event before debugging OpenClaw sessions. Do not run this as a periodic bridge-relaunch loop; repeated `imsg launch` plus gateway restarts during active work can interrupt deliveries and strand in-flight channel runs.
-
-  </Accordion>
-
-  <Accordion title="Gateway is not running on macOS">
-    The default `cliPath: "imsg"` must run on the Mac signed into Messages. On Linux or Windows, set `channels.imessage.cliPath` to a wrapper script that SSHes to that Mac and runs `imsg "$@"`.
-
-```bash
-#!/usr/bin/env bash
-exec ssh -T messages-mac imsg "$@"
-```
-
-    Then run:
-
-```bash
-openclaw channels status --probe --channel imessage
-```
-
-  </Accordion>
-
-  <Accordion title="DMs are ignored">
-    Check:
-
-    - `channels.imessage.dmPolicy`
-    - `channels.imessage.allowFrom`
-    - pairing approvals (`openclaw pairing list imessage`)
-
-  </Accordion>
-
-  <Accordion title="Group messages are ignored">
-    Check:
-
-    - `channels.imessage.groupPolicy`
-    - `channels.imessage.groupAllowFrom`
-    - `channels.imessage.groups` allowlist behavior
-    - mention gating: explicit patterns or the routed agent's identity name/emoji; set `requireMention: false` for the chat in the effective root or account `groups` map to process all messages from allowed senders
-
-  </Accordion>
-
-  <Accordion title="Remote attachments fail">
-    Check:
-
-    - `channels.imessage.remoteHost`
-    - `channels.imessage.remoteAttachmentRoots`
-    - SSH/SCP key auth from the gateway host
-    - host key exists in `~/.ssh/known_hosts` on the gateway host
-    - remote path readability on the Mac running Messages
-
-  </Accordion>
-
-  <Accordion title="macOS permission prompts were missed">
-    Re-run in an interactive GUI terminal in the same user/session context and approve prompts:
-
-    ```bash
-    imsg chats --limit 1
-    imsg send <handle> "test"
-    ```
-
-    Confirm Full Disk Access + Automation are granted for the process context that runs OpenClaw/`imsg`.
-
-  </Accordion>
-</AccordionGroup>
-
-## Configuration reference pointers
-
-- [Configuration reference - iMessage](/gateway/config-channels#imessage)
-- [Gateway configuration](/gateway/configuration)
-- [Pairing](/channels/pairing)
+## What each page covers
+
+- [iMessage setup](/channels/imessage/setup) — install the plugin, set up `imsg` on the Messages Mac, and grant Full Disk Access and Automation.
+- [Enabling the imsg private API](/channels/imessage/private-api) — the SIP and library-validation procedure, helper injection, and what stays available when SIP stays on.
+- [iMessage access control and routing](/channels/imessage/access-control) — DM and group policy, mention gating, per-group prompts, ACP bindings, and config writes.
+- [iMessage deployment patterns](/channels/imessage/deployment) — dedicated bot macOS user, remote Mac over Tailscale, multi-account, and DM history.
+- [iMessage media and attachments](/channels/imessage/media) — attachment ingestion and staging, outbound chunking, and delivery target formats.
+- [iMessage private API actions](/channels/imessage/rich-messages) — tapbacks, threaded replies, effects, native polls, approval controls, and question reactions.
+- [iMessage message behavior](/channels/imessage/messaging) — split-send DM coalescing and automatic inbound recovery after a restart.
+- [iMessage troubleshooting](/channels/imessage/troubleshooting) — symptom-first fixes and the configuration reference links.
+
+## Where each section moved
+
+Every section heading from the previous single-page version keeps its anchor here, so an existing link such as `/channels/imessage#troubleshooting` still resolves. Each entry points at the page that now holds the content.
+
+- <a id="install-the-plugin" />[Install the plugin](/channels/imessage/setup#install-the-plugin)
+- <a id="quick-setup" />[Quick setup](/channels/imessage/setup#quick-setup)
+- <a id="requirements-and-permissions-(macos)" />[Requirements and permissions (macOS)](</channels/imessage/setup#requirements-and-permissions-(macos)>)
+- <a id="enabling-the-imsg-private-api" />[Enabling the imsg private API](/channels/imessage/private-api#enabling-the-imsg-private-api)
+- <a id="setup" />[Setup](/channels/imessage/private-api#setup)
+- <a id="when-sip-stays-enabled" />[When SIP stays enabled](/channels/imessage/private-api#when-sip-stays-enabled)
+- <a id="access-control-and-routing" />[Access control and routing](/channels/imessage/access-control#access-control-and-routing)
+- <a id="acp-conversation-bindings" />[ACP conversation bindings](/channels/imessage/access-control#acp-conversation-bindings)
+- <a id="deployment-patterns" />[Deployment patterns](/channels/imessage/deployment#deployment-patterns)
+- <a id="media%2C-chunking%2C-and-delivery-targets" />[Media, chunking, and delivery targets](/channels/imessage/media#media%2C-chunking%2C-and-delivery-targets)
+- <a id="private-api-actions" />[Private API actions](/channels/imessage/rich-messages#private-api-actions)
+- <a id="config-writes" />[Config writes](/channels/imessage/access-control#config-writes)
+- <a id="coalescing-split-send-dms-command--url-in-one-composition" />[Coalescing split-send DMs (command + URL in one composition)](/channels/imessage/messaging#coalescing-split-send-dms-command--url-in-one-composition)
+- <a id="coalescing-split-send-dms-(command-%2B-url-in-one-composition)" />[Coalescing split-send DMs (command + URL in one composition)](</channels/imessage/messaging#coalescing-split-send-dms-(command-%2B-url-in-one-composition)>)
+- <a id="inbound-recovery-after-a-bridge-or-gateway-restart" />[Inbound recovery after a bridge or gateway restart](/channels/imessage/messaging#inbound-recovery-after-a-bridge-or-gateway-restart)
+- <a id="operator-visible-signal" />[Operator-visible signal](/channels/imessage/messaging#operator-visible-signal)
+- <a id="migration" />[Migration](/channels/imessage/messaging#migration)
+- <a id="troubleshooting" />[Troubleshooting](/channels/imessage/troubleshooting#troubleshooting)
+- <a id="configuration-reference-pointers" />[Configuration reference pointers](/channels/imessage/troubleshooting#configuration-reference-pointers)
+- <a id="requirements-and-permissions-macos" />[Requirements and permissions (macOS)](/channels/imessage/setup#requirements-and-permissions-macos)
+- <a id="media-chunking-and-delivery-targets" />[Media, chunking, and delivery targets](/channels/imessage/media#media-chunking-and-delivery-targets)
+- <a id="coalescing-split-send-dms-command-+-url-in-one-composition" />[Coalescing split-send DMs (command + URL in one composition)](/channels/imessage/messaging#coalescing-split-send-dms-command-+-url-in-one-composition)
+- <a id="local-mac-fast-path" />[Local Mac (fast path)](/channels/imessage/setup#local-mac-fast-path)
+- <a id="install-and-verify-imsg" />[Install and verify imsg](/channels/imessage/setup#install-and-verify-imsg)
+- <a id="configure-openclaw" />[Configure OpenClaw](/channels/imessage/setup#configure-openclaw)
+- <a id="start-gateway" />[Start gateway](/channels/imessage/setup#start-gateway)
+- <a id="approve-first-dm-pairing-default-dmpolicy" />[Approve first DM pairing (default dmPolicy)](/channels/imessage/setup#approve-first-dm-pairing-default-dmpolicy)
+- <a id="remote-mac-over-ssh" />[Remote Mac over SSH](/channels/imessage/setup#remote-mac-over-ssh)
+- <a id="ssh-wrapper-sends-fail-with-appleevents-1743" />[SSH wrapper sends fail with AppleEvents -1743](/channels/imessage/setup#ssh-wrapper-sends-fail-with-appleevents-1743)
+- <a id="dm-policy" />[DM policy](/channels/imessage/access-control#dm-policy)
+- <a id="group-policy-%2B-mentions" />[Group policy + mentions](/channels/imessage/access-control#group-policy-%2B-mentions)
+- <a id="sessions-and-deterministic-replies" />[Sessions and deterministic replies](/channels/imessage/access-control#sessions-and-deterministic-replies)
+- <a id="dedicated-bot-macos-user-separate-imessage-identity" />[Dedicated bot macOS user (separate iMessage identity)](/channels/imessage/deployment#dedicated-bot-macos-user-separate-imessage-identity)
+- <a id="remote-mac-over-tailscale-example" />[Remote Mac over Tailscale (example)](/channels/imessage/deployment#remote-mac-over-tailscale-example)
+- <a id="multi-account-pattern" />[Multi-account pattern](/channels/imessage/deployment#multi-account-pattern)
+- <a id="direct-message-history" />[Direct-message history](/channels/imessage/deployment#direct-message-history)
+- <a id="attachments-and-media" />[Attachments and media](/channels/imessage/media#attachments-and-media)
+- <a id="outbound-text-and-chunking" />[Outbound text and chunking](/channels/imessage/media#outbound-text-and-chunking)
+- <a id="addressing-formats" />[Addressing formats](/channels/imessage/media#addressing-formats)
+- <a id="available-actions" />[Available actions](/channels/imessage/rich-messages#available-actions)
+- <a id="message-ids" />[Message IDs](/channels/imessage/rich-messages#message-ids)
+- <a id="capability-detection" />[Capability detection](/channels/imessage/rich-messages#capability-detection)
+- <a id="read-receipts-and-typing" />[Read receipts and typing](/channels/imessage/rich-messages#read-receipts-and-typing)
+- <a id="inbound-tapbacks" />[Inbound tapbacks](/channels/imessage/rich-messages#inbound-tapbacks)
+- <a id="approval-polls-and-reactions" />[Approval polls and reactions](/channels/imessage/rich-messages#approval-polls-and-reactions)
+- <a id="question-reactions-1-2-3-4" />[Question reactions (1️⃣ / 2️⃣ / 3️⃣ / 4️⃣)](/channels/imessage/rich-messages#question-reactions-1-2-3-4)
+- <a id="imsg-not-found-or-rpc-unsupported" />[imsg not found or RPC unsupported](/channels/imessage/troubleshooting#imsg-not-found-or-rpc-unsupported)
+- <a id="messages-send-but-inbound-imessages-do-not-arrive" />[Messages send but inbound iMessages do not arrive](/channels/imessage/troubleshooting#messages-send-but-inbound-imessages-do-not-arrive)
+- <a id="gateway-is-not-running-on-macos" />[Gateway is not running on macOS](/channels/imessage/troubleshooting#gateway-is-not-running-on-macos)
+- <a id="dms-are-ignored" />[DMs are ignored](/channels/imessage/troubleshooting#dms-are-ignored)
+- <a id="group-messages-are-ignored" />[Group messages are ignored](/channels/imessage/troubleshooting#group-messages-are-ignored)
+- <a id="remote-attachments-fail" />[Remote attachments fail](/channels/imessage/troubleshooting#remote-attachments-fail)
+- <a id="macos-permission-prompts-were-missed" />[macOS permission prompts were missed](/channels/imessage/troubleshooting#macos-permission-prompts-were-missed)
 
 ## Related
 
-- [Channels Overview](/channels) — all supported channels
-- [BlueBubbles removal and the imsg iMessage path](/announcements/bluebubbles-imessage) — announcement and migration summary
-- [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) — config translation table and step-by-step cutover
-- [Pairing](/channels/pairing) — DM authentication and pairing flow
-- [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
-- [Security](/gateway/security) — access model and hardening
+<CardGroup cols={2}>
+  <Card title="Channels Overview" icon="list" href="/channels">
+    All supported channels.
+  </Card>
+  <Card title="Coming from BlueBubbles" icon="right-left" href="/channels/imessage-from-bluebubbles">
+    Config translation table and step-by-step cutover.
+  </Card>
+  <Card title="Pairing" icon="link" href="/channels/pairing">
+    DM authentication and pairing flow.
+  </Card>
+  <Card title="Groups" icon="users" href="/channels/groups">
+    Group chat behavior and mention gating.
+  </Card>
+  <Card title="Channel Routing" icon="route" href="/channels/channel-routing">
+    Session routing for messages.
+  </Card>
+  <Card title="Configuration reference" icon="sliders" href="/gateway/config-channels#imessage">
+    Full iMessage field reference.
+  </Card>
+</CardGroup>

--- a/docs/channels/imessage/access-control.md
+++ b/docs/channels/imessage/access-control.md
@@ -1,0 +1,218 @@
+---
+summary: "iMessage DM and group policy, mention gating, per-group prompts, ACP bindings, and config writes"
+read_when:
+  - Deciding who can message the bot
+  - Debugging ignored DMs or ignored group messages
+  - Binding an iMessage chat to an ACP session
+title: "iMessage access control and routing"
+sidebarTitle: "Access control"
+---
+
+Who is admitted, how messages route to sessions, and which chats can write config.
+
+## Access control and routing
+
+<Tabs>
+  <Tab title="DM policy">
+    `channels.imessage.dmPolicy` controls direct messages:
+
+    - `pairing` (default)
+    - `allowlist` (requires at least one `allowFrom` entry)
+    - `open` (requires `allowFrom` to include `"*"`)
+    - `disabled`
+
+    Allowlist field: `channels.imessage.allowFrom`.
+
+    Allowlist entries must identify senders: handles or static sender access groups (`accessGroup:<name>`). Use `channels.imessage.groupAllowFrom` for chat targets such as `chat_id:*`, `chat_guid:*`, or `chat_identifier:*`; use `channels.imessage.groups` for numeric `chat_id` registry keys.
+
+  </Tab>
+
+  <Tab title="Group policy + mentions">
+    `channels.imessage.groupPolicy` controls group handling:
+
+    - `allowlist` (default)
+    - `open`
+    - `disabled`
+
+    Group sender allowlist: `channels.imessage.groupAllowFrom`.
+
+    `groupAllowFrom` entries can also reference static sender access groups (`accessGroup:<name>`).
+
+    Runtime fallback: if `groupAllowFrom` is unset, iMessage group sender checks use `allowFrom`; set `groupAllowFrom` when DM and group admission should differ. An explicitly empty `groupAllowFrom: []` does not fall back — it blocks all group senders under `allowlist`.
+    Runtime note: if `channels.imessage` is completely missing, runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
+
+    <Warning>
+    Group routing under `groupPolicy: "allowlist"` runs **two** gates back-to-back:
+
+    1. **Sender allowlist** (`channels.imessage.groupAllowFrom`) — handle, `accessGroup:<name>`, `chat_guid`, `chat_identifier`, or `chat_id`. An empty effective list (no `groupAllowFrom` and no `allowFrom` fallback) blocks every group sender.
+    2. **Group registry** (`channels.imessage.groups`) — enforced once the map has entries: the chat must match an explicit per-`chat_id` entry or a `groups: { "*": { ... } }` wildcard. When `groups` is empty or missing, the sender allowlist alone decides admission.
+
+    If no effective group sender allowlist is configured, every group message is dropped before the registry gate. Each gate has its own `warn`-level signal at the default log level, and each names a different fix:
+
+    - one-time per account at startup, when the effective group sender allowlist is empty: `imessage: groupPolicy="allowlist" for account "<id>" but no group sender allowlist is configured ...` — fix by setting `channels.imessage.groupAllowFrom` (or `allowFrom`); adding `groups` entries alone leaves gate 1 blocking every sender.
+    - one-time per `chat_id` at runtime, when a sender passed gate 1 but the chat is missing from a populated `groups` registry: `imessage: dropping group message from chat_id=<id> ...` — fix by adding that `chat_id` (or `"*"`) under `channels.imessage.groups`.
+
+    DMs are unaffected — they take a different code path.
+
+    Recommended config for group flow under `groupPolicy: "allowlist"`:
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15555550123"],
+          groups: { "*": { "requireMention": true } },
+        },
+      },
+    }
+    ```
+
+    `groupAllowFrom` alone admits those senders in any group; add the `groups` block to scope which chats are allowed (and to set per-chat options like `requireMention`).
+    </Warning>
+
+    Mention gating for groups:
+
+    - iMessage has no native mention metadata
+    - mention detection uses `agents.entries.*.groupChat.mentionPatterns`, then `messages.groupChat.mentionPatterns`; when neither is set, patterns are derived from the routed agent's `identity.name` and `identity.emoji`
+    - groups require a mention by default, even when no patterns were explicitly configured; an allowlisted sender's message can therefore be skipped unless it contains the agent's name or emoji
+    - an explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived patterns; iMessage cannot enforce mention gating when no usable patterns remain
+    - control commands from authorized senders bypass mention gating
+
+    To process every message from allowed senders in one group, set that chat's `requireMention` to `false`:
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15555550123", "+15555550124"],
+          groups: {
+            "*": {},
+            "123": { requireMention: false },
+          },
+        },
+      },
+    }
+    ```
+
+    Replace `123` with the numeric chat ID from `imsg chats --limit 20 --json`. Edit the map already supplying that account's group policy: `channels.imessage.groups`, or `channels.imessage.accounts.<account-id>.groups` when it overrides the root map. This also applies to `accounts.default.groups`; merely having an account entry does not mean its own `groups` map is needed. An empty account map inherits the root map only when at most one account is configured.
+
+    Preserve the existing wildcard and every per-group setting, changing only the target chat's `requireMention`. Account maps replace the whole inherited map, so if you intentionally create an account-specific override, first copy the complete inherited map, including all wildcard and per-group policies. When no map previously applied, `"*": {}` preserves admission to other groups while keeping their default mention requirement. Keep a restricted map restricted. `groupAllowFrom` still controls sender access.
+
+    A skipped message with no mention produces a warning at the default log level with the chat ID and the `requireMention: false` fix. Repeated warnings for the same chat are suppressed by a bounded in-memory cache; restarting the channel or evicting a cache entry allows the warning again.
+
+    Per-group `systemPrompt`:
+
+    Each entry under `channels.imessage.groups.*` accepts an optional `systemPrompt` string, injected into the agent's system prompt on every turn that handles a message in that group. Resolution mirrors `channels.whatsapp.groups`:
+
+    1. **Group-specific system prompt** (`groups["<chat_id>"].systemPrompt`): used when the specific group entry exists in the map **and** its `systemPrompt` key is defined. If `systemPrompt` is an empty string (`""`) the wildcard is suppressed and no system prompt is applied to that group.
+    2. **Group wildcard system prompt** (`groups["*"].systemPrompt`): used when the specific group entry is absent from the map entirely, or when it exists but defines no `systemPrompt` key.
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15555550123"],
+          groups: {
+            "*": { systemPrompt: "Use British spelling." },
+            "8421": {
+              requireMention: true,
+              systemPrompt: "This is the on-call rotation chat. Keep replies under 3 sentences.",
+            },
+            "9907": {
+              // explicit suppression: the wildcard "Use British spelling." does not apply here
+              systemPrompt: "",
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    Per-group prompts only apply to group messages — direct messages are unaffected.
+
+  </Tab>
+
+  <Tab title="Sessions and deterministic replies">
+    - DMs use direct routing; groups use group routing.
+    - With default `session.dmScope=main`, iMessage DMs collapse into the agent main session.
+    - Group sessions are isolated (`agent:<agentId>:imessage:group:<chat_id>`).
+    - Replies route back to iMessage using originating channel/target metadata.
+
+    Group-ish thread behavior:
+
+    Some multi-participant iMessage threads can arrive with `is_group=false`.
+    If that `chat_id` is explicitly configured under `channels.imessage.groups`, OpenClaw treats it as group traffic (group gating + group session isolation).
+
+  </Tab>
+</Tabs>
+
+## ACP conversation bindings
+
+iMessage chats can be bound to ACP sessions.
+
+Fast operator flow:
+
+- Run `/acp spawn codex --bind here` inside the DM or allowed group chat.
+- Future messages in that same iMessage conversation route to the spawned ACP session.
+- `/new` and `/reset` reset the same bound ACP session in place.
+- `/acp close` closes the ACP session and removes the binding.
+
+Configured persistent bindings use top-level `bindings[]` entries with `type: "acp"` and `match.channel: "imessage"`.
+
+`match.peer.id` can use:
+
+- normalized DM handle such as `+15555550123` or `user@example.com`
+- `chat_id:<id>` (recommended for stable group bindings)
+- `chat_guid:<guid>`
+- `chat_identifier:<identifier>`
+
+Example:
+
+```json5
+{
+  agents: {
+    entries: {
+      codex: {
+        default: true,
+        runtime: {
+          type: "acp",
+          acp: { agent: "codex", backend: "acpx", mode: "persistent" },
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "imessage",
+        accountId: "default",
+        peer: { kind: "group", id: "chat_id:123" },
+      },
+      acp: { label: "codex-group" },
+    },
+  ],
+}
+```
+
+See [ACP Agents](/tools/acp-agents) for shared ACP binding behavior.
+
+## Config writes
+
+iMessage allows channel-initiated config writes by default (for `/config set|unset` when `commands.config: true`).
+
+Disable:
+
+```json5
+{
+  channels: {
+    imessage: {
+      configWrites: false,
+    },
+  },
+}
+```

--- a/docs/channels/imessage/deployment.md
+++ b/docs/channels/imessage/deployment.md
@@ -1,0 +1,80 @@
+---
+summary: "Dedicated bot macOS user, remote Mac over Tailscale, multi-account, and DM history patterns"
+read_when:
+  - Choosing where to run the Gateway and imsg
+  - Isolating bot traffic from a personal iMessage identity
+  - Running more than one iMessage account
+title: "iMessage deployment patterns"
+sidebarTitle: "Deployment patterns"
+---
+
+Topologies for running `imsg` next to a signed-in Messages account, and the config each one needs.
+
+## Deployment patterns
+
+<AccordionGroup>
+  <Accordion title="Dedicated bot macOS user (separate iMessage identity)">
+    Use a dedicated Apple ID and macOS user so bot traffic is isolated from your personal Messages profile.
+
+    Typical flow:
+
+    1. Create/sign in a dedicated macOS user.
+    2. Sign into Messages with the bot Apple ID in that user.
+    3. Install `imsg` in that user.
+    4. Create an SSH wrapper so OpenClaw can run `imsg` in that user context.
+    5. Point `channels.imessage.accounts.<id>.cliPath` and `.dbPath` to that user profile.
+
+    First run may require GUI approvals (Automation + Full Disk Access) in that bot user session.
+
+  </Accordion>
+
+  <Accordion title="Remote Mac over Tailscale (example)">
+    Common topology:
+
+    - gateway runs on Linux/VM
+    - iMessage + `imsg` runs on a Mac in your tailnet
+    - `cliPath` wrapper uses SSH to run `imsg`
+    - `remoteHost` enables inbound fetches and owner-only outbound staging over SSH/SCP
+
+    Example:
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          enabled: true,
+          cliPath: "/home/openclaw/.openclaw/scripts/imsg-ssh",
+          remoteHost: "bot@mac-mini.tailnet-1234.ts.net",
+          includeAttachments: true,
+          dbPath: "/Users/bot/Library/Messages/chat.db",
+        },
+      },
+    }
+    ```
+
+    ```bash
+    #!/usr/bin/env bash
+    exec ssh -T bot@mac-mini.tailnet-1234.ts.net imsg "$@"
+    ```
+
+    `cliPath` is an absolute, Gateway-local wrapper path. `remoteHost` and `dbPath` refer to the Messages Mac; do not rewrite the remote database path using the Gateway user's home directory.
+
+    Use SSH keys so both SSH and SCP are non-interactive.
+    Ensure the host key is trusted first (for example `ssh bot@mac-mini.tailnet-1234.ts.net`) so `known_hosts` is populated.
+
+  </Accordion>
+
+  <Accordion title="Multi-account pattern">
+    iMessage supports per-account config under `channels.imessage.accounts`.
+
+    Each account can override fields such as `cliPath`, `dbPath`, `allowFrom`, `dmPolicy`, `groupPolicy`, `mediaMaxMb`, history settings, and attachment root allowlists. Omitted account policies inherit the channel root; explicit account policies win. If neither scope sets them, DMs use `pairing` and groups use `allowlist`.
+
+  </Accordion>
+
+  <Accordion title="Direct-message history">
+    Set `channels.imessage.dmHistoryLimit` to seed new direct-message sessions with recent decoded `imsg` history for that conversation. Use `channels.imessage.dms["<sender>"].historyLimit` for per-sender overrides, including `0` to disable history for a sender.
+
+    iMessage DM history is fetched on demand from `imsg`. Leaving `dmHistoryLimit` unset disables global DM history seeding, but a positive per-sender `channels.imessage.dms["<sender>"].historyLimit` still enables seeding for that sender.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/channels/imessage/media.md
+++ b/docs/channels/imessage/media.md
@@ -1,0 +1,69 @@
+---
+summary: "iMessage attachment ingestion, outbound staging, text chunking, and delivery target formats"
+read_when:
+  - Enabling inbound attachments
+  - Tuning outbound text chunking
+  - Choosing an addressing format for a send
+title: "iMessage media and attachments"
+sidebarTitle: "Media and attachments"
+---
+
+How attachments move in and out, how outbound text is chunked, and which delivery targets iMessage accepts.
+
+## Media, chunking, and delivery targets
+
+<AccordionGroup>
+  <Accordion title="Attachments and media">
+    - inbound attachment ingestion is **off by default** — set `channels.imessage.includeAttachments: true` to forward photos, voice memos, video, and other attachments to the agent. With it disabled, attachment-only iMessages are dropped before reaching the agent and may produce no `Inbound message` log line at all.
+    - remote inbound attachment paths can be fetched via SCP when `remoteHost` is set
+    - outbound files are staged into an owner-only temporary path on the configured or auto-detected Messages Mac, passed to `imsg` by that remote path, and cleaned up best-effort after success, failure, or timeout; cleanup failure emits a warning and can leave owner-only residue
+    - attachment paths must match allowed roots:
+      - `channels.imessage.attachmentRoots` (local)
+      - `channels.imessage.remoteAttachmentRoots` (remote SCP mode)
+      - configured roots extend the default root pattern `/Users/*/Library/Messages/Attachments` (merged, not replaced)
+    - SCP uses strict host-key checking (`StrictHostKeyChecking=yes`)
+    - outbound media size uses `channels.imessage.mediaMaxMb` (default 16 MB)
+
+  </Accordion>
+
+  <Accordion title="Outbound text and chunking">
+    - text chunk limit: `channels.imessage.textChunkLimit` (default 4000)
+    - chunk mode: `channels.imessage.streaming.chunkMode`
+      - `length` (default)
+      - `newline` (paragraph-first splitting)
+    - outbound markdown bold/italic/underline/strikethrough is converted to native styled text (macOS 15+ recipients render the styling; older recipients see plain text without the markers); markdown tables are converted per the channel markdown table mode
+    - `channels.imessage.sendTransport` (`auto` default, `bridge`, `applescript`) selects how `imsg` delivers sends
+
+  </Accordion>
+
+  <Accordion title="Addressing formats">
+    Preferred explicit targets:
+
+    - `chat_id:123` (recommended for stable routing)
+    - `chat_guid:...`
+    - `chat_identifier:...`
+
+    Direct handles are also supported:
+
+    - `+1555...`
+    - `tel:+1555...`
+    - `imessage:+1555...`
+    - `sms:+1555...`
+    - `user@example.com`
+
+    Use a service-qualified target for a contact name or mixed alphanumeric alias:
+
+    - `auto:<contact>` lets Messages choose iMessage or SMS
+    - `imessage:<contact>` requires iMessage
+    - `sms:<contact>` requires SMS
+
+    Bare contact names and mixed alphanumeric aliases are rejected instead of being converted to
+    a phone number. If an existing automation uses one, add `auto:`, `imessage:`, or `sms:` to
+    make the intended delivery service explicit.
+
+    ```bash
+    imsg chats --limit 20
+    ```
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/channels/imessage/messaging.md
+++ b/docs/channels/imessage/messaging.md
@@ -1,0 +1,46 @@
+---
+summary: "Split-send DM coalescing and automatic inbound recovery after a bridge or gateway restart"
+read_when:
+  - Debugging a command and its URL arriving as two turns
+  - Understanding what happens to messages sent while the gateway was down
+title: "iMessage message behavior"
+sidebarTitle: "Message behavior"
+---
+
+What OpenClaw does to inbound iMessages before an agent sees them.
+
+<a id="coalescing-split-send-dms-command--url-in-one-composition"></a>
+
+## Coalescing split-send DMs (command + URL in one composition)
+
+Apple can store a command and its URL preview as separate physical `chat.db` rows. `imsg` 0.13.1 and newer coalesces those rows before watch, history, or search returns the message, so OpenClaw receives one logical inbound message without adding channel-specific DM latency.
+
+No iMessage coalescing setting is needed. The retired `channels.imessage.coalesceSameSenderDms` key is removed by `openclaw doctor --fix`. Generic `messages.inbound` debounce remains available when you intentionally want to batch rapid text messages across a channel.
+
+If command-plus-URL sends arrive as separate agent turns, update `imsg` on the Messages Mac:
+
+```bash
+brew update && brew upgrade imsg
+```
+
+## Inbound recovery after a bridge or gateway restart
+
+iMessage recovers messages missed while the gateway was down, and at the same time suppresses the stale "backlog bomb" Apple can flush after a Push recovery. The default behavior is always on, built on durable ingress plus an age fence.
+
+- **Durable replay protection.** Before advancing the recovery cursor, OpenClaw journals each raw row in the shared SQLite ingress queue with its Apple GUID as the event ID. A completed row leaves a tombstone for about 4 hours, capped at 10,000 entries, so a replay with the same GUID is dropped even after a restart. A pending row stays recoverable until dispatch adopts it.
+- **Downtime recovery.** On startup the monitor remembers the last durably admitted `chat.db` rowid (a persisted per-account cursor) and passes it to `imsg watch.subscribe` as `since_rowid`, so imsg replays rows that were not yet journaled and then tails live. Rows journaled before a crash resume from SQLite. Replay is bounded to the most recent 500 rows and to messages up to ~2 hours old, and GUID tombstones drop anything already handled.
+- **Stale-backlog age fence.** Rows above the startup boundary are genuinely live; one whose send date is more than ~15 minutes older than its arrival is the Push-flush backlog and is suppressed. Replayed rows (at or below the boundary) use the wider recovery window instead, so a recently-missed message is delivered while ancient history is not.
+
+Recovery works over both local and remote `cliPath` setups, because `since_rowid` replay runs over the same `imsg` RPC connection. The difference is the window: when the gateway can read `chat.db` (local), it anchors the startup rowid boundary, caps the replay span, and delivers missed messages up to a couple of hours old. Over a remote SSH `cliPath` it cannot read the database, so the replay is uncapped and every row uses the live age fence — it still recovers recently-missed messages and still suppresses old backlog, just with the narrower live window. Run the gateway on the Messages Mac for the wider recovery window.
+
+### Operator-visible signal
+
+Suppressed backlog is logged at the default level, never silently dropped (the `recovery` flag shows which window applied):
+
+```text
+imessage: suppressed stale inbound backlog account=<id> sent=<iso> recovery=<bool> (<N> suppressed since start)
+```
+
+### Migration
+
+`channels.imessage.catchup.*` is deprecated — downtime recovery is automatic and needs no config for new setups. Existing configs with `catchup.enabled: true` remain honored as a compatibility profile for the recovery replay window. Disabled catchup blocks (`enabled: false` or no `enabled: true`) are retired; `openclaw doctor --fix` removes those.

--- a/docs/channels/imessage/private-api.md
+++ b/docs/channels/imessage/private-api.md
@@ -1,0 +1,86 @@
+---
+summary: "Disable SIP and library validation, inject the imsg helper, and verify the private API bridge"
+read_when:
+  - Enabling iMessage reactions, edits, effects, polls, or group actions
+  - Deciding whether to disable System Integrity Protection
+  - Debugging a failed imsg launch
+title: "Enabling the imsg private API"
+sidebarTitle: "Private API"
+---
+
+Private API mode unlocks the native iMessage actions. It needs SIP off, library validation relaxed, and a successful helper injection.
+
+## Enabling the imsg private API
+
+`imsg` ships in two operational modes. For OpenClaw, Private API mode is the recommended setup because it gives the channel the native iMessage actions users expect. Basic mode remains useful for low-risk installs, initial verification, or hosts where SIP cannot be disabled.
+
+- **Basic mode** (default, no SIP changes needed): outbound text and media via `send`, inbound watch/history, chat list. This is what you get out of the box from a fresh `brew install steipete/tap/imsg` plus the standard [macOS permissions](/channels/imessage/setup#requirements-and-permissions-macos).
+- **Private API mode**: `imsg` injects a helper dylib into `Messages.app` to call internal `IMCore` functions. This unlocks `react`, `edit`, `unsend`, `reply` (threaded), `sendWithEffect`, `poll` and `poll-vote` (native Messages polls), `renameGroup`, `setGroupIcon`, `addParticipant`, `removeParticipant`, `leaveGroup`, plus typing indicators and read receipts.
+
+The recommended action surface on this page requires Private API mode. The `imsg` README is explicit about the requirement:
+
+> Advanced features such as `read`, `typing`, `launch`, bridge-backed rich send, message mutation, and chat management are opt-in. They require SIP to be disabled and a helper dylib to be injected into `Messages.app`. `imsg launch` refuses to inject when SIP is enabled.
+
+The helper-injection technique uses `imsg`'s own dylib to reach Messages private APIs. There is no third-party server or BlueBubbles runtime in the OpenClaw iMessage path.
+
+<Warning>
+**Disabling SIP is a real security tradeoff.** SIP is one of macOS's core protections against running modified system code; turning it off system-wide opens up additional attack surface and side effects. Notably, **disabling SIP on Apple Silicon Macs also disables the ability to install and run iOS apps on your Mac**.
+
+Treat this as a deliberate operational choice, especially on a primary personal Mac. For production-quality OpenClaw iMessage, prefer a dedicated Mac or bot macOS user where you are comfortable enabling the bridge. If your threat model cannot tolerate SIP being off anywhere, the iMessage plugin is limited to basic mode — text and media send/receive only, no reactions / edit / unsend / effects / group ops.
+</Warning>
+
+### Setup
+
+1. **Install (or upgrade) `imsg`** on the Mac that runs Messages.app:
+
+   ```bash
+   brew install steipete/tap/imsg
+   brew update && brew upgrade imsg
+   imsg --version
+   imsg status --json
+   ```
+
+   The `imsg status --json` output reports `bridge_version`, `rpc_methods`, and per-method `selectors` so you can see what the current build supports before you start.
+
+2. **Disable System Integrity Protection, and (on modern macOS) Library Validation.** Injecting a non-Apple helper dylib into the Apple-signed `Messages.app` needs SIP off **and** library validation relaxed. The Recovery-mode SIP step is macOS-version-specific:
+   - **macOS 10.13-10.15 (Sierra-Catalina):** disable Library Validation via Terminal, reboot to Recovery Mode, run `csrutil disable`, restart.
+   - **macOS 11+ (Big Sur and later), Intel:** Recovery Mode (or Internet Recovery), `csrutil disable`, restart.
+   - **macOS 11+, Apple Silicon:** power-button startup sequence to enter Recovery; on recent macOS versions hold the **Left Shift** key when you click Continue, then `csrutil disable`. Virtual-machine setups follow a separate flow, so take a VM snapshot first.
+
+   **On macOS 11 and later, `csrutil disable` alone is usually not enough.** Apple still enforces library validation against `Messages.app` as a platform binary, so an adhoc-signed helper is rejected (`Library Validation failed: ... platform binary, but mapped file is not`) even with SIP off. After disabling SIP, also disable library validation and reboot:
+
+   ```bash
+   sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true
+   ```
+
+   **macOS 26 (Tahoe), verified on 26.5.1:** SIP off **plus** the `DisableLibraryValidation` command above is sufficient to inject the helper across 26.0 through 26.5.x. **No boot-args are required.** The plist is the decisive factor and the most common missing step when injection fails on Tahoe:
+   - **With the plist:** `imsg launch` injects and `imsg status` reports `advanced_features: true`.
+   - **Without the plist (even with SIP off):** `imsg launch` fails with `Failed to launch: Timeout waiting for Messages.app to initialize`. AMFI rejects the adhoc helper at load, so the bridge never becomes ready and the launch times out. That timeout is the symptom most people hit on Tahoe; the fix is the plist above, not anything more drastic.
+
+   If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state before assuming the SIP step itself failed. If those settings are correct and the bridge still cannot inject, collect `imsg status --json` plus the `imsg launch` output and report it to the `imsg` project instead of weakening additional system-wide security controls.
+
+3. **Inject the helper.** With SIP disabled and Messages.app signed in:
+
+   ```bash
+   imsg launch
+   ```
+
+   `imsg launch` refuses to inject when SIP is still enabled, so this also doubles as a confirmation that step 2 took.
+
+4. **Verify the bridge from OpenClaw:**
+
+   ```bash
+   openclaw channels status --probe
+   ```
+
+   The iMessage entry should report `works`, and `imsg status --json | jq '{rpc_methods, selectors}'` should show the capabilities exposed by your macOS build. Poll creation requires `selectors.pollPayloadMessage`; voting requires both `selectors.pollVoteMessage` and the `poll.vote` RPC method. The OpenClaw plugin advertises only actions supported by the cached probe, while an empty cache stays optimistic and probes on first dispatch.
+
+If `openclaw channels status --probe` reports the channel as `works` but specific actions throw "iMessage `<action>` requires the imsg private API bridge" at dispatch time, run `imsg launch` again — the helper can fall out (Messages.app restart, OS update, etc.) and the cached `available: true` status will keep advertising actions until the next probe refreshes.
+
+### When SIP stays enabled
+
+If disabling SIP is not acceptable for your threat model:
+
+- `imsg` falls back to basic mode — text + media + receive only.
+- The OpenClaw plugin still advertises text/media send and inbound monitoring; it hides `react`, `edit`, `unsend`, `reply`, `sendWithEffect`, and group ops from the action surface (per the per-method capability gate).
+- You can run a separate non-Apple-Silicon Mac (or a dedicated bot Mac) with SIP off for the iMessage workload, while keeping SIP enabled on your primary devices. See [Dedicated bot macOS user (separate iMessage identity)](/channels/imessage/deployment#deployment-patterns).

--- a/docs/channels/imessage/rich-messages.md
+++ b/docs/channels/imessage/rich-messages.md
@@ -1,0 +1,125 @@
+---
+summary: "iMessage tapbacks, threaded replies, effects, native polls, approval controls, and question reactions"
+read_when:
+  - Using reactions, edits, effects, or polls from an agent
+  - Wiring exec approvals to iMessage
+  - Debugging a missing action on the message tool
+title: "iMessage private API actions"
+sidebarTitle: "Private API actions"
+---
+
+The action surface a probed private API bridge adds on top of plain text sends.
+
+## Private API actions
+
+When `imsg launch` is running and `openclaw channels status --probe` reports `privateApi.available: true`, the message tool can use iMessage-native actions in addition to normal text sends.
+
+All actions are enabled by default; use `channels.imessage.actions` to turn individual actions off:
+
+```json5
+{
+  channels: {
+    imessage: {
+      actions: {
+        reactions: true,
+        edit: true,
+        unsend: true,
+        reply: true,
+        sendWithEffect: true,
+        sendAttachment: true,
+        renameGroup: true,
+        setGroupIcon: true,
+        addParticipant: true,
+        removeParticipant: true,
+        leaveGroup: true,
+        polls: true,
+      },
+    },
+  },
+}
+```
+
+<AccordionGroup>
+  <Accordion title="Available actions">
+    - **react**: Add/remove iMessage tapbacks (`messageId`, `emoji`, `remove`). Supported tapbacks map to love, like, dislike, laugh, emphasize, and question. Removing without an emoji clears whichever tapback was set.
+    - **reply**: Send a threaded reply to an existing message (`messageId`, `text` or `message`, plus `chatGuid`, `chatId`, `chatIdentifier`, or `to`). Local reply-with-attachment additionally needs an `imsg` build whose `send-rich` supports `--file`. With remote `imsg` v0.13.4, attachment replies use JSON-RPC and support the whole message or part index `0`; nonzero attachment part indices are not supported by the RPC method.
+    - **sendWithEffect**: Send text with an iMessage effect (`text` or `message`, `effect` or `effectId`). Short names: slam, loud, gentle, invisibleink, confetti, lasers, fireworks, balloon, heart, echo, happybirthday, shootingstar, sparkles, spotlight.
+    - **edit**: Edit a sent message on supported macOS/private API versions (`messageId`, `text` or `newText`). Only messages the gateway itself sent can be edited.
+    - **unsend**: Retract a sent message on supported macOS/private API versions (`messageId`). Only messages the gateway itself sent can be unsent.
+    - **upload-file**: Send media/files (`buffer` as base64 or a hydrated `media`/`path`/`filePath`, `filename`, optional `asVoice`). Legacy alias: `sendAttachment`.
+    - **renameGroup**, **setGroupIcon**, **addParticipant**, **removeParticipant**, **leaveGroup**: Manage group chats when the current target is a group conversation. These mutate the host's Messages identity, so they require an owner sender or an `operator.admin` Gateway client.
+    - **poll**: Create a native Apple Messages poll (`pollQuestion`, `pollOption` repeated 2 to 12 times, plus `chatGuid`, `chatId`, `chatIdentifier`, or `to`). Recipients on iOS/iPadOS/macOS 26+ see and vote on it natively; older OS versions get a "Sent a poll" text fallback. Requires `selectors.pollPayloadMessage`.
+    - **poll-vote**: Vote on an existing poll (`pollId` or `messageId`, plus exactly one of `pollOptionIndex`, `pollOptionId`, or `pollOptionText`). Requires `selectors.pollVoteMessage` and the `poll.vote` RPC method. Remote `imsg` v0.13.4 RPC accepts only the option ID, so remote setups must use `pollOptionId`; index and text selectors remain available to local setups.
+
+    Accepted inbound polls are rendered for the agent with the question, option labels, vote counts, and the poll message ID needed by `poll-vote`. Remote accounts also include each stable option ID and direct the agent to use `pollOptionId`.
+
+  </Accordion>
+
+  <Accordion title="Message IDs">
+    Inbound iMessage context includes both short `MessageSid` values and full message GUIDs (`MessageSidFull`) when available. Short IDs are scoped to the recent SQLite-backed reply cache and are checked against the current chat before use. If a short ID expires, retry with its `MessageSidFull` while targeting the conversation that supplied it. Full IDs do not bypass conversation or account binding, so replace an ID from another chat with one from the current target. Remote delegated calls can reject stale full IDs when current-conversation evidence is unavailable.
+
+  </Accordion>
+
+  <Accordion title="Capability detection">
+    OpenClaw hides private API actions only when the cached probe status says the bridge is unavailable. If the status is unknown, actions remain visible and dispatch probes lazily so the first action can succeed after `imsg launch` without a separate manual status refresh.
+
+  </Accordion>
+
+  <Accordion title="Read receipts and typing">
+    When the private API bridge is up, accepted inbound chats are marked read and direct chats show a typing bubble as soon as the turn is accepted, while the agent prepares context and generates. Disable read-marking with:
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          sendReadReceipts: false,
+        },
+      },
+    }
+    ```
+
+    Older `imsg` builds that pre-date the per-method capability list gate off typing/read silently; OpenClaw logs a one-time warning per restart so the missing receipt is attributable.
+
+  </Accordion>
+
+  <Accordion title="Inbound tapbacks">
+    OpenClaw subscribes to iMessage tapbacks and routes accepted reactions as system events instead of normal message text, so a user tapback does not trigger an ordinary reply loop.
+
+    Notification mode is controlled by `channels.imessage.reactionNotifications`:
+
+    - `"own"` (default): notify only when users react to bot-authored messages.
+    - `"all"`: notify for all inbound tapbacks from authorized senders.
+    - `"off"`: ignore inbound tapbacks.
+
+    Per-account overrides use `channels.imessage.accounts.<id>.reactionNotifications`.
+
+  </Accordion>
+
+  <Accordion title="Approval polls and reactions">
+    When `approvals.exec.enabled` or `approvals.plugin.enabled` is true and the request routes natively to iMessage, the gateway delivers an approval prompt with native controls:
+
+    - On a probed private API bridge with poll and caption-suppression support, the prompt includes a Messages poll with each allowed decision. Older `imsg` releases without `poll send --no-comment` stay on text controls.
+    - If polls are disabled with `channels.imessage.actions.polls: false`, the bridge lacks poll support, the poll send fails, or fewer than two decisions are available, the prompt keeps the text and tapback controls.
+    - The text fallback maps `👍` (Like) to `allow-once` and `👎` (Dislike) to `deny`. It also includes `/approve <id> <decision>` commands, including `allow-always` when the request permits it.
+
+    Poll votes and reactions require the acting user's handle to be an explicit approver. The approver list is read from `channels.imessage.allowFrom` (or `channels.imessage.accounts.<id>.allowFrom`); add the user's phone number in E.164 form or their Apple ID email (chat targets such as `chat_id:*` are not valid approver entries). The wildcard entry `"*"` is honored but allows any sender to approve; an empty approver list disables poll and reaction shortcuts entirely. These shortcuts intentionally bypass `reactionNotifications`, `dmPolicy`, and `groupAllowFrom` because the explicit-approver allowlist is the only gate that matters for approval resolution.
+
+    Native poll controls are currently limited to channel-native delivery in the originating iMessage session or an iMessage approver DM. Explicit forwarding targets selected by `approvals.exec.mode: "targets"` (and the target half of `"both"`) continue to use the existing forwarded approval message instead of an iMessage poll.
+
+    `/approve` text command authorization follows the same list: when `channels.imessage.allowFrom` is non-empty, `/approve <id> <decision>` is authorized against that approver list (not the broader DM allowlist), and senders permitted on the DM allowlist but not in `allowFrom` receive an explicit denial. When `allowFrom` is empty, the same-chat fallback stays in effect and `/approve` authorizes anyone the DM allowlist permits. Add every operator who should approve — via `/approve` or via reactions — to `allowFrom`.
+
+    Operator notes:
+    - Poll and reaction bindings are stored both in memory and in the gateway's persistent keyed store (TTL matched to the approval expiry), and the gateway also polls pending prompts for tapbacks. After a gateway restart, a tap on an old control is recognized and swallowed instead of entering agent chat, but the restart ends the in-flight command; request a new approval rather than expecting the old control to resume it.
+    - The operator's own `is_from_me=true` tapback (for example from a paired Apple device) resolves the approval when that handle is an explicit approver.
+    - Approval prompts route into a group conversation only when explicit approvers are configured; otherwise any group member could approve.
+    - Legacy text-style tapbacks (`Liked "…"` plain text from very old Apple clients) cannot resolve approvals because they carry no message GUID; reaction resolution requires the structured tapback metadata that current macOS / iOS clients emit.
+
+  </Accordion>
+
+  <Accordion title="Question reactions (1️⃣ / 2️⃣ / 3️⃣ / 4️⃣)">
+    For an `ask_user` prompt with one non-secret, single-select question and one to four options, OpenClaw adds numbered emoji choices. React to the delivered prompt with the matching number to answer it. The reaction must carry the stable GUID of the bot-authored message; OpenClaw then maps the number to the canonical option through the Gateway. Stale or duplicate taps are ignored.
+
+    Multi-question, multi-select, and free-text prompts remain text-reply-only. Question reactions follow normal iMessage DM/group admission rules. They are recognized even when general `reactionNotifications` is `"off"`, without turning unrelated reactions into agent events.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/channels/imessage/setup.md
+++ b/docs/channels/imessage/setup.md
@@ -1,0 +1,187 @@
+---
+summary: "Install the iMessage plugin, set up imsg on the Messages Mac, and grant macOS permissions"
+read_when:
+  - Setting up the iMessage channel for the first time
+  - Running the Gateway against a remote Messages Mac
+  - Granting Full Disk Access and Automation
+title: "iMessage setup"
+sidebarTitle: "Setup"
+---
+
+Install the plugin, install and verify `imsg` on the signed-in Messages Mac, configure the channel, and grant the macOS permissions it needs.
+
+## Install the plugin
+
+Install the official iMessage plugin on the Gateway host, then restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/imessage
+```
+
+<CardGroup cols={3}>
+  <Card title="Private API actions" icon="wand-sparkles" href="/channels/imessage/rich-messages#private-api-actions">
+    Replies, tapbacks, effects, polls, attachments, and group management.
+  </Card>
+  <Card title="Pairing" icon="link" href="/channels/pairing">
+    iMessage DMs default to pairing mode.
+  </Card>
+  <Card title="Remote Mac" icon="terminal" href="#remote-mac-over-ssh">
+    Use an SSH wrapper when the Gateway is not running on the Messages Mac.
+  </Card>
+  <Card title="Configuration reference" icon="settings" href="/gateway/config-channels#imessage">
+    Full iMessage field reference.
+  </Card>
+</CardGroup>
+
+## Quick setup
+
+<Tabs>
+  <Tab title="Local Mac (fast path)">
+    <Steps>
+      <Step title="Install and verify imsg">
+
+```bash
+brew install steipete/tap/imsg
+brew update && brew upgrade imsg
+imsg rpc --help
+imsg launch
+openclaw channels status --probe
+```
+
+        When the local setup wizard detects a missing default `imsg` command, it can prompt to install `steipete/tap/imsg` through Homebrew. If it detects a Homebrew-managed `imsg`, it can prompt to reinstall or update it. Custom `cliPath` wrappers are not modified.
+
+      </Step>
+
+      <Step title="Configure OpenClaw">
+
+```json5
+{
+  channels: {
+    imessage: {
+      enabled: true,
+      cliPath: "/usr/local/bin/imsg",
+      dbPath: "/Users/user/Library/Messages/chat.db",
+    },
+  },
+}
+```
+
+      </Step>
+
+      <Step title="Start gateway">
+
+```bash
+openclaw gateway
+```
+
+      </Step>
+
+      <Step title="Approve first DM pairing (default dmPolicy)">
+
+```bash
+openclaw pairing list imessage
+openclaw pairing approve imessage <CODE>
+```
+
+        Pairing requests expire after 1 hour.
+      </Step>
+    </Steps>
+
+  </Tab>
+
+  <Tab title="Remote Mac over SSH">
+    Most setups do not need SSH. Use this topology only when the Gateway cannot run on the signed-in Messages Mac. Point `cliPath` at a stdio-compatible wrapper on the **Gateway host** that SSHes to the Messages Mac and runs `imsg`. Use the wrapper's absolute path so service launches do not depend on shell home expansion.
+    Install and update `imsg` on that remote Mac, not on the Gateway host:
+
+```bash
+ssh messages-mac 'brew install steipete/tap/imsg && brew update && brew upgrade imsg'
+```
+
+```bash
+#!/usr/bin/env bash
+exec ssh -T messages-mac imsg "$@"
+```
+
+    Recommended config when attachments are enabled:
+
+```json5
+{
+  channels: {
+    imessage: {
+      enabled: true,
+      cliPath: "/home/openclaw/.openclaw/scripts/imsg-ssh",
+      remoteHost: "user@messages-mac", // Mac that runs Messages.app and imsg
+      // This path is interpreted on the Messages Mac, not on the Gateway host.
+      dbPath: "/Users/user/Library/Messages/chat.db",
+      includeAttachments: true,
+      // Optional: extra allowed attachment roots (merged with the default
+      // /Users/*/Library/Messages/Attachments).
+      attachmentRoots: ["/Users/*/Library/Messages/Attachments"],
+      remoteAttachmentRoots: ["/Users/*/Library/Messages/Attachments"],
+    },
+  },
+}
+```
+
+    `remoteHost` identifies the Messages Mac. OpenClaw uses it for both inbound attachment fetches and outbound attachment staging. For outbound files, OpenClaw creates an owner-only temporary path on that Mac, copies the file over the existing strict SSH/SCP transport, passes only the remote path to `imsg`, and attempts removal after success, failure, or timeout. A failed cleanup SSH call emits a warning and can leave the owner-only temporary directory behind.
+
+    An explicit `remoteHost` is recommended and wins when set. For compatibility, OpenClaw auto-detects the existing transparent `exec ssh ... imsg "$@"` wrapper shape once per process and reuses that host across monitoring, probes, sends, and private actions. Auto-detection covers only the simple documented transparent wrapper; option-rich wrappers such as ProxyJump/ProxyCommand must configure `remoteHost`.
+    `remoteHost` must be `host` or `user@host` (no spaces or SSH options); unsafe values are ignored.
+    OpenClaw uses strict host-key checking for SSH/SCP, so the Messages Mac host key must already exist in `~/.ssh/known_hosts` on the Gateway host.
+    Attachment paths are validated against allowed roots (`attachmentRoots` / `remoteAttachmentRoots`).
+
+<Warning>
+Any `cliPath` wrapper or SSH proxy you put in front of `imsg` MUST behave like a transparent stdio pipe for long-lived JSON-RPC. OpenClaw exchanges small newline-framed JSON-RPC messages over the wrapper's stdin/stdout for the lifetime of the channel:
+
+- Forward each stdin chunk/line **as soon as bytes are available** — don't wait for EOF.
+- Forward each stdout chunk/line promptly in the reverse direction.
+- Preserve newlines.
+- Avoid fixed-size blocking reads (`read(4096)`, `cat | buffer`, default shell `read`) that can starve small frames.
+- Keep stderr separate from the JSON-RPC stdout stream.
+
+A wrapper that buffers stdin until a large block fills will produce symptoms that look like an iMessage outage — `imsg rpc timeout (chats.list)` or repeated channel restarts — even though `imsg rpc` itself is healthy. `ssh -T host imsg "$@"` (above) is safe because it forwards OpenClaw's `cliPath` arguments such as `rpc` and `--db`. Pipelines like `ssh host imsg | grep -v '^DEBUG'` are NOT — line-buffered tools can still hold frames; use `stdbuf -oL -eL` on every stage if you must filter.
+</Warning>
+
+  </Tab>
+</Tabs>
+
+## Requirements and permissions (macOS)
+
+- Messages must be signed in on the Mac running `imsg`.
+- Full Disk Access is required for the process context running OpenClaw/`imsg` (Messages DB access).
+- Automation permission is required to send messages through Messages.app.
+- For advanced actions (react / edit / unsend / threaded reply / effects / polls / group ops), System Integrity Protection must be disabled — see [Enabling the imsg private API](/channels/imessage/private-api#enabling-the-imsg-private-api). Basic text and media send/receive work without it.
+
+<Tip>
+Permissions are granted per process context. If the gateway runs headless (LaunchAgent/SSH), run a one-time interactive command in that same context to trigger prompts:
+
+```bash
+imsg chats --limit 1
+# or
+imsg send <handle> "test"
+```
+
+</Tip>
+
+<Accordion title="SSH wrapper sends fail with AppleEvents -1743">
+  A remote-SSH setup can read chats, pass `channels status --probe`, and process inbound messages while outbound sends still fail with an AppleEvents authorization error:
+
+```text
+Not authorized to send Apple events to Messages. (-1743)
+```
+
+Check the signed-in Mac user's TCC database or System Settings > Privacy & Security > Automation. If the Automation entry is recorded for `/usr/libexec/sshd-keygen-wrapper` instead of the `imsg` or local shell process, macOS may not expose a usable Messages toggle for that SSH server-side client:
+
+```text
+kTCCServiceAppleEvents | /usr/libexec/sshd-keygen-wrapper | auth_value=0 | com.apple.MobileSMS
+```
+
+In that state, repeating `tccutil reset AppleEvents` or rerunning `imsg send` through the same SSH wrapper may keep failing because the process context that needs Messages Automation is the SSH wrapper, not an app the UI can grant.
+
+Use one of the supported `imsg` process contexts instead:
+
+- Run the Gateway, or at least the `imsg` bridge, in the logged-in Messages user's local session.
+- Start the Gateway with a LaunchAgent for that user after granting Full Disk Access and Automation from the same session.
+- If you keep the two-user SSH topology, verify that a real outbound `imsg send` succeeds through the exact wrapper before enabling the channel. If it cannot be granted Automation, reconfigure to a single-user `imsg` setup instead of relying on the SSH wrapper for sends.
+
+</Accordion>

--- a/docs/channels/imessage/troubleshooting.md
+++ b/docs/channels/imessage/troubleshooting.md
@@ -1,0 +1,126 @@
+---
+summary: "Fixes for a missing imsg binary, silent inbound, ignored DMs and groups, and failed remote attachments"
+read_when:
+  - Debugging iMessage send or receive
+  - Recovering a bridge that stopped delivering messages
+title: "iMessage troubleshooting"
+sidebarTitle: "Troubleshooting"
+---
+
+Symptom-first fixes for the iMessage channel, plus the configuration reference links.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="imsg not found or RPC unsupported">
+    Validate the binary and RPC support:
+
+    ```bash
+    imsg rpc --help
+    imsg status --json
+    openclaw channels status --probe
+    ```
+
+    If the probe reports RPC unsupported, update `imsg`. If private API actions are unavailable, run `imsg launch` in the logged-in macOS user session and probe again. If the Gateway is not running on macOS, use the [Remote Mac over SSH](/channels/imessage/setup#remote-mac-over-ssh) setup instead of the default local `imsg` path.
+
+  </Accordion>
+
+  <Accordion title="Messages send but inbound iMessages do not arrive">
+    First prove whether the message reached the local Mac. If `chat.db` does not change, OpenClaw cannot receive the message even when `imsg status --json` reports a healthy bridge.
+
+```bash
+imsg chats --limit 10 --json
+imsg watch --chat-id <chat-id> --json
+sqlite3 ~/Library/Messages/chat.db \
+  "select datetime(max(date)/1000000000 + 978307200, 'unixepoch', 'localtime'), max(ROWID) from message;"
+```
+
+    If phone-sent messages create no new rows, repair the macOS Messages and Apple Push layer before changing OpenClaw config. A one-shot service refresh is often enough:
+
+```bash
+launchctl kickstart -k system/com.apple.apsd
+launchctl kickstart -k gui/$(id -u)/com.apple.CommCenter
+launchctl kickstart -k gui/$(id -u)/com.apple.identityservicesd
+launchctl kickstart -k gui/$(id -u)/com.apple.imagent
+imsg launch
+openclaw gateway restart
+```
+
+    Send a fresh iMessage from the phone and confirm a new `chat.db` row or `imsg watch` event before debugging OpenClaw sessions. Do not run this as a periodic bridge-relaunch loop; repeated `imsg launch` plus gateway restarts during active work can interrupt deliveries and strand in-flight channel runs.
+
+  </Accordion>
+
+  <Accordion title="Gateway is not running on macOS">
+    The default `cliPath: "imsg"` must run on the Mac signed into Messages. On Linux or Windows, set `channels.imessage.cliPath` to a wrapper script that SSHes to that Mac and runs `imsg "$@"`.
+
+```bash
+#!/usr/bin/env bash
+exec ssh -T messages-mac imsg "$@"
+```
+
+    Then run:
+
+```bash
+openclaw channels status --probe --channel imessage
+```
+
+  </Accordion>
+
+  <Accordion title="DMs are ignored">
+    Check:
+
+    - `channels.imessage.dmPolicy`
+    - `channels.imessage.allowFrom`
+    - pairing approvals (`openclaw pairing list imessage`)
+
+  </Accordion>
+
+  <Accordion title="Group messages are ignored">
+    Check:
+
+    - `channels.imessage.groupPolicy`
+    - `channels.imessage.groupAllowFrom`
+    - `channels.imessage.groups` allowlist behavior
+    - mention gating: explicit patterns or the routed agent's identity name/emoji; set `requireMention: false` for the chat in the effective root or account `groups` map to process all messages from allowed senders
+
+  </Accordion>
+
+  <Accordion title="Remote attachments fail">
+    Check:
+
+    - `channels.imessage.remoteHost`
+    - `channels.imessage.remoteAttachmentRoots`
+    - SSH/SCP key auth from the gateway host
+    - host key exists in `~/.ssh/known_hosts` on the gateway host
+    - remote path readability on the Mac running Messages
+
+  </Accordion>
+
+  <Accordion title="macOS permission prompts were missed">
+    Re-run in an interactive GUI terminal in the same user/session context and approve prompts:
+
+    ```bash
+    imsg chats --limit 1
+    imsg send <handle> "test"
+    ```
+
+    Confirm Full Disk Access + Automation are granted for the process context that runs OpenClaw/`imsg`.
+
+  </Accordion>
+</AccordionGroup>
+
+## Configuration reference pointers
+
+- [Configuration reference - iMessage](/gateway/config-channels#imessage)
+- [Gateway configuration](/gateway/configuration)
+- [Pairing](/channels/pairing)
+
+## Related
+
+- [Channels Overview](/channels) — all supported channels
+- [BlueBubbles removal and the imsg iMessage path](/announcements/bluebubbles-imessage) — announcement and migration summary
+- [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) — config translation table and step-by-step cutover
+- [Pairing](/channels/pairing) — DM authentication and pairing flow
+- [Groups](/channels/groups) — group chat behavior and mention gating
+- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Security](/gateway/security) — access model and hardening

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1506,6 +1506,14 @@
                     "group": "iMessage",
                     "pages": [
                       "channels/imessage",
+                      "channels/imessage/setup",
+                      "channels/imessage/private-api",
+                      "channels/imessage/access-control",
+                      "channels/imessage/deployment",
+                      "channels/imessage/media",
+                      "channels/imessage/rich-messages",
+                      "channels/imessage/messaging",
+                      "channels/imessage/troubleshooting",
                       "channels/imessage-from-bluebubbles"
                     ]
                   },


### PR DESCRIPTION
## What changed

`docs/channels/imessage.md` was 49,383 characters, 873 lines, 15 H2 + 3 H3 plus ~25 more anchored sections hidden inside `Tabs`, `Steps` and `AccordionGroup`s, mixing quick setup, an SIP procedure, an action reference, recovery internals and troubleshooting on one page. It is now an index plus eight children under `docs/channels/imessage/`, matching the shape of `docs/channels/slack/`, `docs/channels/discord/`, `docs/channels/telegram/` and `docs/channels/msteams/` (all four on `main`; verified with `test -d`, not from an open PR).

| Page | Bytes | Sections |
| --- | --- | --- |
| `channels/imessage` (index) | 11,751 | intro, page map, anchor map, related |
| `channels/imessage/setup` | 8,383 | Install the plugin, Quick setup, Requirements and permissions (macOS) |
| `channels/imessage/private-api` | 7,430 | Enabling the imsg private API |
| `channels/imessage/access-control` | 9,838 | Access control and routing, ACP conversation bindings, Config writes |
| `channels/imessage/deployment` | 3,312 | Deployment patterns |
| `channels/imessage/media` | 3,187 | Media, chunking, and delivery targets |
| `channels/imessage/rich-messages` | 10,173 | Private API actions |
| `channels/imessage/messaging` | 3,951 | Coalescing split-send DMs, Inbound recovery after a bridge or gateway restart |
| `channels/imessage/troubleshooting` | 4,743 | Troubleshooting, Configuration reference pointers, Related |

On sibling names: `setup`, `access-control`, `media`, `messaging` and `troubleshooting` match the sibling directories directly, and `rich-messages` matches what Slack, Discord and Telegram put on that page (reactions, effects, polls, approvals) even though iMessage keeps its own `## Private API actions` heading. `private-api` and `deployment` have **no sibling analogue** — the SIP/library-validation enablement procedure and the "which Mac runs `imsg`" topologies are iMessage-specific, so they are named for what they hold rather than forced onto `authentication`/`transports`.

## Losslessness, proven

Every child, with its frontmatter and one-line lede removed and the five declared edits below reversed, reassembles in original section order into a byte-identical copy of the original page body from the first H2 onward:

```
original body from first H2 : ba6fe0504b220df9433c0c0d5510d6050d5c1f1a7121b786b218dbe6ee2d5723  (47,376 bytes)
rebuilt from the 8 children : ba6fe0504b220df9433c0c0d5510d6050d5c1f1a7121b786b218dbe6ee2d5723  (47,376 bytes)
index preamble identical to the original preamble (1,664 bytes), minus 1 declared edit: true
fences: 33 original, 33 new, one-for-one on info string + body sha256
table rows: 0 original, 0 new (the page has no markdown tables)
words: 6,488 -> 7,706 (grew only; the anchor map, the page map and the ledes)
```

The preamble (`<Note>`, `<Warning>`, the status paragraph) stays on the index, byte-identical apart from one declared link retarget. No heading text, heading level, code fence or sentence was rewritten or reordered, and no block moved between children: each child holds a contiguous run of original H2 sections in original relative order.

A section boundary here is not simply the `## ` line: the authored `<a id="coalescing-split-send-dms-command--url-in-one-composition"></a>` stub sits one blank line **above** its heading, so it is carried with the section it labels rather than left at the tail of the preceding one. (The first revision of this PR got that wrong and stranded the stub at the end of `access-control.md`; ClawSweeper caught it, and the byte-identity proof above passes under either rule, which is exactly why it did not catch it for me.)

## Anchors

Per-anchor redirects are impossible here — `redirectSource()` in `scripts/lib/docs-redirects.mjs` throws on any source containing `[?#]` — so every pre-split id is preserved on the index instead.

Ids were enumerated with the repository's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`), not a slug approximation. That matters twice on this page: punctuated H2s emit both a percent-encoded id and a cleaned alias (`requirements-and-permissions-(macos)` / `requirements-and-permissions-macos`, `media%2C-chunking%2C-and-delivery-targets` / `media-chunking-and-delivery-targets`, and the coalescing heading which emits a **third** form because it also carries an authored `<a id>` stub), and `Tab`, `Step` and `Accordion` titles mint 31 further ids that no heading scan would find.

- **54** pre-split ids, 0 collisions.
- **53** are carried as authored `<a id="…" />` stubs under **Where each section moved**, each linking to the page that now holds the content.
- **1** (`#related`) is not stubbed, because the index publishes that heading itself; stubbing it would raise a duplicate authored/canonical id.
- Asserted after the split: all 54 original ids resolve on the new index, `collisions` is empty on the index and on every one of the eight children, each id is owned by exactly one child, and the children introduce **no** new ids beyond the originals.

Five anchored inbound links exist tree-wide (`git grep -n "imessage#" origin/main`): four in `docs/channels/imessage-from-bluebubbles.md` and one in `docs/channels/troubleshooting.md`. All five keep resolving through the index stubs and are left untouched.

## Prose diff

`.audit/check-orphan-refs.py` reported 5 directional references on the original page. Three ("(above)" for the SSH wrapper, and two "above" for the `DisableLibraryValidation` plist) point at targets that stayed on the same child, so they are untouched. The other two crossed a new page boundary and are fixed. Together with three same-page `#` links whose targets landed on a different page, this is the entire prose diff — five edits, listed here and reversed in the losslessness check above:

1. `private-api.md` — "plus the standard macOS permissions above." → "plus the standard [macOS permissions](/channels/imessage/setup#requirements-and-permissions-macos)." (orphaned; Requirements is now on `setup`)
2. `troubleshooting.md` — "use the Remote Mac over SSH setup above instead" → "use the [Remote Mac over SSH](/channels/imessage/setup#remote-mac-over-ssh) setup instead" (orphaned; that Tab is now on `setup`)
3. `private-api.md` — "See [Dedicated bot macOS user …](#deployment-patterns) below." → "See [Dedicated bot macOS user …](/channels/imessage/deployment#deployment-patterns)." (link retarget; "below" dropped because it was orphaned by the same move)
4. `setup.md` — the intro card `href="#private-api-actions"` → `/channels/imessage/rich-messages#private-api-actions` (link retarget, no text change)
5. `setup.md` — "see [Enabling the imsg private API](#enabling-the-imsg-private-api)" → `/channels/imessage/private-api#…` (link retarget, no text change)

Plus one on the index itself: the `<Note>`'s `#inbound-recovery-after-a-bridge-or-gateway-restart` now points at `/channels/imessage/messaging#…`.

`.audit/check-orphan-refs.py` over all nine new pages reports 3 candidates, all same-page.

## Pins and inbound references

`.audit/docs-test-pins.py` reported 15 hits; an independent `git grep -n "channels/imessage" origin/main` with no path filter reported 76 lines across 40 files. Every one classified:

- **Updated**: `docs/docs.json` navigation (index + 8 children inserted into the existing iMessage group, mirroring the Slack/Telegram/Teams groups); `.github/labeler.yml` (added `docs/channels/imessage/**` — see below); `docs/.i18n/glossary.zh-CN.json` (8 new source terms for the new page titles, which are also the index's link labels).
- **No change needed, route still resolves** (`/channels/imessage` is still a page): 5 `taxonomy.yaml` `docs:` entries — all plain paths, **no `#anchor`**, and `render-maturity-docs.ts --check` passes; `docs/maturity/taxonomy.md` (6); `docs/channels/index.md`, `docs/channels/pairing.md`, `docs/channels/troubleshooting.md`, `docs/channels/imessage-from-bluebubbles.md` (5), `docs/announcements/bluebubbles-imessage.md` (3), `docs/help/faq-first-run.md` (4), `docs/install/macos-vm.md` (3), `docs/reference/rpc.md` (2), `docs/gateway/config-channels/personal-messaging.md` (2), `docs/gateway/configuration.md`, `docs/plugins/reference/imessage.md`, `docs/start/*` (3), `docs/releases/*` (6), `CHANGELOG.md` (4); `docs/.i18n/zh-Hans-navigation.json` (bare `zh-CN/channels/imessage`; the Slack and Teams splits added no children there either, and no `docs/zh-CN/channels/slack/` mirror exists); `extensions/imessage/**` (5), `scripts/lib/official-external-channel-catalog.json`, `scripts/github/barnacle-auto-response.mjs` (a `docs.openclaw.ai/channels/imessage` URL in a bot reply), `scripts/docs-i18n/taxonomy_source_test.go`, and the `docsPath: "/channels/imessage"` assertions in `src/agents/tools/message-tool.test.ts` (3), `src/channels/bundled-channel-catalog-read.test.ts`, `src/commands/agents.providers.test.ts`, `src/gateway/hooks.test.ts`, `src/plugins/official-external-plugin-catalog.test.ts`, `test/official-channel-catalog.test.ts`, `test/scripts/barnacle-auto-response.test.ts`.

No contract test reads this file and asserts literal strings — every code-side hit asserts the **route** `/channels/imessage`, which is unchanged — so there is no reason to refuse the split (contrast `sdk-subpaths.md`).

`src/docs/channel-config-examples.test.ts` reads `git ls-files -- "docs/channels/*.md"`; that pathspec **recurses** (87 tracked files today, including `docs/channels/slack/*`), so the eight new children are validated by it. It runs green (below).

Path-allowlist check beyond tests: `docs/channels/imessage.md` is **not** in `RELEASE_METADATA_PATHS` (or `CONFIG_DOC_BASELINE_PATHS`) in `scripts/changed-lanes.mts`, so `scripts/check-release-metadata-only.mts` is not implicated.

## The CI gap this split creates

`.github/labeler.yml` had a file-exact glob for this page:

```yaml
"channel: imessage":
  - changed-files:
      - any-glob-to-any-file:
          - "extensions/imessage/**"
          - "docs/channels/imessage.md"
```

The new directory would have gone unlabelled, so `docs/channels/imessage/**` is added here, exactly as the Slack, Discord, Telegram and Teams splits did. `test/scripts/labeler-extension-coverage.test.ts` and `test/scripts/labeler-label-cap.test.ts` both pass.

## CODEOWNERS

Simulated last-match-wins over `.github/CODEOWNERS` for every touched path. No rule matches `docs/channels/imessage*`, `docs/docs.json`, `docs/.i18n/**` or `.github/labeler.yml`. Working controls: `/.github/CODEOWNERS` → `@steipete`, `/docs/cli/secrets.md` → `@openclaw/openclaw-secops`, `/docs/reference/RELEASING.md` → `@openclaw/openclaw-release-managers`, `/SECURITY.md` → `@openclaw/openclaw-secops`. **No maintainer team owns this change.**

## Validators

Every step of `check:docs` (`package.json`), run on the staged tree after the rebase onto `4023edc`:

```
node --import ./scripts/tsx.mjs scripts/format-docs.mts --check      exit 0   (1109 files clean)
npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc        exit 0   (1108 files, 0 issues)
npx markdownlint-cli2 --config config/markdownlint-templates.jsonc   exit 0   (12 files, 0 issues)
node scripts/check-docs-mdx.mjs docs README.md                       exit 0   (1122 files)
node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts exit 0
node scripts/docs-link-audit.mjs                                     exit 0   (11,366 links, 0 broken)
node scripts/check-docs-config-examples.mjs                          exit 0   (1,218 fences validated)
```

Also run:

```
node scripts/docs-link-audit.mjs --anchors    42 errors, byte-identical to the same run in a detached
                                              worktree at 4023edc (3 maturity/#windows-app-node + 39
                                              /clawhub/* false positives; none iMessage)
node --import ./scripts/tsx.mjs scripts/qa/render-maturity-docs.ts --check    exit 0
npx vitest run --config test/vitest/vitest.unit-src.config.ts src/docs/       8 files, 16 passed
npx vitest run --config test/vitest/vitest.tooling.config.ts \
  src/scripts/docs-link-audit.test.ts test/scripts/labeler-extension-coverage.test.ts \
  test/scripts/labeler-label-cap.test.ts test/scripts/docs-source-anchors.test.ts
                                                              4 files, 41 passed, 1 failed
```

That one failure is `preserves Mint component targets for raw component apostrophes…` in `src/scripts/docs-link-audit.test.ts`, a slug-normalization case unrelated to this change. Reproduced identically in a detached worktree at `4023edc`, so it is pre-existing. File counts were checked against the number of files intended in every vitest run.

`.audit/ste-lint.py` over all nine pages: **89** hard violations against **87** on the original single page. All three hard violations the index adds sit on anchor-map rows that repeat original heading text verbatim (`DMs are ignored`, `Group messages are ignored`, `macOS permission prompts were missed`); the split's own new prose adds none.

## Ledger findings

Closed by this PR:

- **major / ux (`r3-0049`)** — "mixes quick setup, SIP procedures, action reference, recovery internals, and troubleshooting in one 49k-character page". Now one index and eight children, each a single reader job; the largest child is 10,173 bytes.

## ClawSweeper findings

- **[P2] Move the coalescing anchor with its explanation** — **fixed** in the revision that follows the review. The authored `<a id="coalescing-split-send-dms-command--url-in-one-composition"></a>` stub had been left at the tail of `access-control.md` while its `## Coalescing split-send DMs …` heading moved to `messaging.md`, so the legacy anchor resolved but landed on the wrong page. The stub now sits directly above that heading on `messaging.md`, and the index entry points at `/channels/imessage/messaging#coalescing-split-send-dms-command--url-in-one-composition`. The section splitter now attaches a preceding `<a id="…"></a>` line to the section it labels, and the losslessness proof was re-run under that rule: still byte-identical (`ba6fe050…`, 47,376 bytes), still 54 ids on the index with 0 collisions, and `parseDocsDocument` now reports `messaging` as the owner of that id. Every validator above was re-run on the fixed tree.

Rebutted with evidence:

- **minor / link (`r3-1053`)** — "The Remote Mac card links to `#remote-mac-over-ssh`, which is a Tab title and not a heading… No heading or `<a id>` with that id exists on the page." This is **incorrect**. `parseDocsDocument` mints ids from `Tab` titles (`tabOpen` → `mintSlug(title, tabs)` in `scripts/lib/docs-markdown.mjs`), and `remote-mac-over-ssh` is in the id list for the pre-split page. `docs-link-audit.mjs --anchors` reports no error for it, before or after. No fix is needed; the id is carried onto the index as a stub like the other 52.

Deferred, with reasons — each needs a prose rewrite, which this PR excludes by design so the byte-identical proof above stays checkable:

- **major / ux (`r3-0050`)** — Quick setup runs `imsg launch` before the page states the SIP requirement. The split moves the two apart onto `setup` and `private-api` and cross-links them, but the ordering fix inside Quick setup is a rewrite.
- **major / accuracy (`r3-0051`)** — the quick-setup config hardcodes `/usr/local/bin/imsg` and `/Users/user/…`.
- **minor / ux (`r3-1051`)** — two callouts and a status line precede any statement of purpose.
- **minor / ia (`r3-1052`)** — "Quick setup" (H2) and "Setup" (H3) are both present; they now sit on different pages, but the H3 rename is a text change.
- **minor / ste (`r3-1054`)** — 1.6 hard violations per 100 words on the original.
- **minor / ux (`r3-1055`)** — the SSH wrapper script appears three times on the page (now spread across `setup`, `deployment` and `troubleshooting`) and once on `config-channels`.

Not auto-merged, per instruction.
