### PR TITLE
fix(sqlite): preserve fatal WAL diagnostics from worker threads

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -656,14 +656,14 @@ describe("sqlite WAL maintenance", () => {
     expect(close).not.toHaveBeenCalled();
     expect(maintenance.checkpoint()).toBe(false);
     expect(write).toHaveBeenCalledWith(
-      process.stderr.fd,
+      2,
       expect.stringContaining(`"sidecarPath":"${sidecarPath}"`),
     );
   });
 
-  it.runIf(process.platform === "linux")(
-    "preserves the replacement WAL family across fatal containment and reopen",
-    async () => {
+  it.runIf(process.platform === "linux").each(["main", "worker"] as const)(
+    "preserves the replacement WAL family across fatal containment and reopen from a %s thread",
+    async (thread) => {
       const tempDir = tempDirs.make("openclaw-sqlite-wal-replacement-");
       const databasePath = path.join(tempDir, "state.sqlite");
       const staleCloseMarker = path.join(tempDir, "stale-close-marker");
@@ -681,13 +681,16 @@ describe("sqlite WAL maintenance", () => {
         childScript,
         `
           import fs from "node:fs";
+          import { Worker } from "node:worker_threads";
           import { DatabaseSync } from "node:sqlite";
           import { configureSqliteWalMaintenance } from ${JSON.stringify(sqliteWalModuleUrl)};
 
           const role = process.argv[2];
           const databasePath = process.argv[3];
           const staleCloseMarker = process.argv[4];
-          if (role === "stale") {
+          if (role === "worker") {
+            new Worker(new URL(import.meta.url), { argv: ["stale", databasePath, staleCloseMarker] });
+          } else if (role === "stale") {
             const stale = new DatabaseSync(databasePath);
             setTimeout(() => {
               fs.writeFileSync(staleCloseMarker, stale.isOpen ? "open" : "closed");
@@ -716,7 +719,14 @@ describe("sqlite WAL maintenance", () => {
         let stderr = "";
         const child = spawn(
           process.execPath,
-          ["--import", "tsx", childScript, role, databasePath, staleCloseMarker],
+          [
+            "--import",
+            "tsx",
+            childScript,
+            role === "stale" && thread === "worker" ? "worker" : role,
+            databasePath,
+            staleCloseMarker,
+          ],
           {
             env: { ...process.env, OPENCLAW_TEST_CONSOLE: "1" },
             stdio: ["ignore", "pipe", "pipe"],
@@ -754,13 +764,37 @@ describe("sqlite WAL maintenance", () => {
         current = spawnRole("current", "current-ready");
         await current.ready;
 
-        const timeout = setTimeout(() => stale.child.kill("SIGKILL"), 20_000);
+        let containmentWatchdogFired = false;
+        const timeout = setTimeout(() => {
+          containmentWatchdogFired = true;
+          stale.child.kill("SIGKILL");
+        }, 20_000);
         const childResult = await stale.closed;
         clearTimeout(timeout);
 
         expect(childResult, stale.stderr()).toEqual({ code: null, signal: "SIGKILL" });
-        expect(stale.stderr()).toContain("SQLite WAL sidecar identity mismatch");
+        expect(containmentWatchdogFired).toBe(false);
         expect(fs.existsSync(staleCloseMarker)).toBe(false);
+        const fatalEvents = stale
+          .stderr()
+          .split("\n")
+          .filter((line) => line.startsWith("{"))
+          .map((line) => JSON.parse(line))
+          .filter((event) => event.event === "sqlite_wal_sidecar_identity_mismatch");
+        expect(fatalEvents).toHaveLength(1);
+        expect(fatalEvents[0]).toMatchObject({
+          level: "fatal",
+          subsystem: "infra/sqlite-wal",
+          message: "SQLite WAL sidecar identity mismatch; terminating without SQLite cleanup",
+          databasePath,
+          databaseLabel: "replacement-family-test",
+          pid: stale.child.pid,
+          descriptorDevice: expect.stringMatching(/^\d+$/u),
+          descriptorInode: expect.stringMatching(/^\d+$/u),
+        });
+        expect([`${databasePath}-wal`, `${databasePath}-shm`]).toContain(
+          fatalEvents[0].sidecarPath,
+        );
 
         current.child.kill("SIGKILL");
         await current.closed;
@@ -768,8 +802,11 @@ describe("sqlite WAL maintenance", () => {
         if (stale.child.exitCode === null && stale.child.signalCode === null) {
           stale.child.kill("SIGKILL");
         }
+        await stale.closed;
         if (current && current.child.exitCode === null && current.child.signalCode === null) {
           current.child.kill("SIGKILL");
+        }
+        if (current) {
           await current.closed;
         }
       }

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -463,8 +463,9 @@ function terminateForSqliteWalSplitBrain(
   databaseLabel: string | undefined,
 ): never {
   try {
+    // Worker stderr has no fd; write to the process sink before fatal containment.
     fs.writeSync(
-      process.stderr.fd,
+      2,
       `${JSON.stringify({
         level: "fatal",
         subsystem: "infra/sqlite-wal",


### PR DESCRIPTION
Related: #132844

## What Problem This Solves

The SQLite WAL containment tripwire could terminate a process without its structured fatal diagnostic when maintenance ran in a Worker thread. Node Workers do not expose `process.stderr.fd`, so the synchronous write threw before containment continued.

## Why This Change Was Made

Write synchronously to standard error descriptor 2. The diagnostic payload, sink-failure handling, SIGKILL/abort sequence, identity detector, and storage behavior remain unchanged. Extend the existing isolated replacement-WAL fixture to exercise both main-thread and Worker containment and join both owned children before cleanup.

## User Impact

Operators retain the fatal WAL mismatch diagnostic when containment originates in a Worker. This changes observability only; it neither weakens containment nor establishes the cause of any particular database mismatch.

## Evidence

- Actual Linux Node 24.19.0 regression: original main-thread case passes; original Worker case fails specifically because the fatal event array is empty. SIGKILL, absence of the fallback marker, and no parent-watchdog intervention are verified before that assertion.
- Repaired main and Worker cases pass, including structured diagnostic fields, replacement database integrity, and exact retained rows. The complete WAL, transaction, and busy-timeout suites pass 84 tests with no skips.
- Native receipts verify all four recovered runtime stages had joined, dead process groups.
- The remote transport was interrupted after those runtime stages. Their raw reports and receipts were recovered and independently verified, but no completed remote gate or final proof envelope is claimed. The remaining full mapped gate passed locally on the unchanged candidate.
- Fresh independent P2 review passed. Test growth is 37 net lines; production growth is one net line. No runtime savings claim.
