### PR TITLE
docs: close the reciprocal-link gaps that need zh-CN glossary sources

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -3694,5 +3694,53 @@
   {
     "source": "Rollback and recovery",
     "target": "回滚与恢复"
+  },
+  {
+    "source": "Standing orders",
+    "target": "常设指令"
+  },
+  {
+    "source": "Standing intents",
+    "target": "常设意图"
+  },
+  {
+    "source": "Multi-agent routing",
+    "target": "多智能体路由"
+  },
+  {
+    "source": "Agent bindings",
+    "target": "智能体绑定"
+  },
+  {
+    "source": "System prompt",
+    "target": "系统提示词"
+  },
+  {
+    "source": "Usage tracking",
+    "target": "用量追踪"
+  },
+  {
+    "source": "Honcho memory",
+    "target": "Honcho 记忆"
+  },
+  {
+    "source": "Managed worktrees",
+    "target": "托管工作树"
+  },
+  {
+    "source": "Typing indicators",
+    "target": "正在输入指示器"
+  },
+  {
+    "source": "Session management deep dive",
+    "target": "会话管理深入解析"
+  },
+  {
+    "source": "Personal agent benchmark pack",
+    "target": "个人智能体基准包"
+  },
+  {
+    "source": "Docker",
+    "target": "Docker"
   }
 ]

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -159,4 +159,6 @@ This page is an index. Each section below moved to a child page, and every ancho
 - [Automation](/automation) — all automation mechanisms at a glance
 - [Background Tasks](/automation/tasks) — task ledger for automation runs
 - [Heartbeat](/gateway/heartbeat) — periodic main-session turns
+- [Standing intents](/concepts/standing-intents) — event-triggered work instead of a schedule
+- [Standing orders](/automation/standing-orders) — the operating authority a scheduled run acts under
 - [Timezone](/concepts/timezone) — timezone configuration

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -798,3 +798,4 @@ resolved agent workspace rather than assuming the default workspace.
 - [Webhooks](/automation/cron-jobs#webhooks)
 - [Configuration](/gateway/config-hooks#hooks)
 - [Agent workspace](/concepts/agent-workspace)
+- [Standing orders](/automation/standing-orders)

--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -202,3 +202,5 @@ This is consistent across channels.
 - [Groups](/channels/groups)
 - [Broadcast groups](/channels/broadcast-groups)
 - [Pairing](/channels/pairing)
+- [Multi-agent routing](/concepts/multi-agent)
+- [Agent bindings](/concepts/agent-bindings)

--- a/docs/channels/qa-channel.md
+++ b/docs/channels/qa-channel.md
@@ -105,6 +105,7 @@ Builds the QA site, starts the Docker-backed gateway + QA Lab stack, and prints 
 ## Related
 
 - [QA overview](/concepts/qa-e2e-automation) - overall stack, transport adapters, the Matrix live lane, and scenario authoring
+- [Personal agent benchmark pack](/concepts/personal-agent-benchmark-pack) - the scenario pack that runs on this channel
 - [Pairing](/channels/pairing)
 - [Groups](/channels/groups)
 - [Channels overview](/channels)

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -242,3 +242,4 @@ Suggested `.gitignore` starter:
 - [Sandboxing](/gateway/sandboxing) - workspace access in sandboxed environments
 - [Session](/concepts/session) - session storage paths
 - [Standing orders](/automation/standing-orders) - persistent instructions in workspace files
+- [System prompt](/concepts/system-prompt) - where workspace files are injected into the prompt

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -155,3 +155,4 @@ At minimum, set:
 - [Multi-agent routing](/concepts/multi-agent)
 - [Session management](/concepts/session)
 - [Group chats](/channels/group-messages)
+- [System prompt](/concepts/system-prompt)

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -447,6 +447,7 @@ The slot is exclusive at run time - only one registered context engine is resolv
 
 - [Compaction](/concepts/compaction) - summarizing long conversations
 - [Context](/concepts/context) - how context is built for agent turns
+- [Honcho memory](/concepts/memory-honcho) - the Honcho-backed context engine
 - [Plugin Architecture](/plugins/architecture) - registering context engine plugins
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -447,7 +447,7 @@ The slot is exclusive at run time - only one registered context engine is resolv
 
 - [Compaction](/concepts/compaction) - summarizing long conversations
 - [Context](/concepts/context) - how context is built for agent turns
-- [Honcho memory](/concepts/memory-honcho) - the Honcho-backed context engine
+- [Honcho memory](/concepts/memory-honcho) - a memory plugin a context engine can draw on
 - [Plugin Architecture](/plugins/architecture) - registering context engine plugins
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview

--- a/docs/concepts/main-session.md
+++ b/docs/concepts/main-session.md
@@ -138,3 +138,4 @@ the originating room. See [Session management](/concepts/session#group-and-room-
 - [Channel routing](/channels/channel-routing) — how agents and sessions are selected
 - [Memory](/concepts/memory) — durable memory layers
 - [Multi-agent](/concepts/multi-agent) — running several isolated agents
+- [Session management deep dive](/reference/session-management-compaction) — the disk budget, archival, and compaction keys

--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -186,3 +186,8 @@ The bundled [Workboard plugin](/plugins/workboard) can materialize a card worksp
 `path` identifies the source git checkout. `branch` is optional and becomes the base ref. For a full-host caller, Workboard creates or reuses `wb-<card-id>`, runs the subagent with the managed checkout as its working directory, and writes the resolved path and branch back to the card. Gateway clients need `operator.admin` for full-host materialization. On run end, Workboard removes the checkout only when it is provably lossless; dirty work or unpushed commits remain available.
 
 For a workspace-bound caller, `path` and the repository root must exactly match the target agent workspace. Workboard then runs directly in that directory and records a directory workspace instead of host-materializing a managed worktree. The target must use a writable, non-shared Docker sandbox for the same workspace, its live container hash must match the requested mounts and policy, and it must not expose elevated execution, host control, host-wide sessions, persisted host/node execution, or unclassified plugin and MCP tools. If the target policy or live container is broader, dispatch leaves the card unclaimed and reports the incompatible state.
+
+## Related
+
+- [Workboard plugin](/plugins/workboard) — cards that materialize a managed worktree
+- [Configuration reference](/gateway/config-runtime#worktreeroot) — where `worktreeRoot` is set

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -466,4 +466,5 @@ the same policy under `streaming.progress`:
 - [Progress drafts](/concepts/progress-drafts) - visible work-in-progress messages that update during long turns
 - [Messages](/concepts/messages) - message lifecycle and delivery
 - [Retry](/concepts/retry) - retry behavior on delivery failure
+- [Typing indicators](/concepts/typing-indicators) - typing state shown while a turn is in flight
 - [Channels](/channels) - per-channel streaming support

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -106,3 +106,4 @@ entry points at the page that now holds the content.
 - [Configuration](/gateway/configuration) — common tasks and quick setup
 - [Configuration examples](/gateway/configuration-examples)
 - [Model providers](/concepts/model-providers) — provider setup and model catalogs
+- [Agent bindings](/concepts/agent-bindings) — how channel accounts and users select an agent

--- a/docs/platforms/easyrunner.md
+++ b/docs/platforms/easyrunner.md
@@ -119,5 +119,6 @@ SecretRef, plugin, or channel auth failures.
 ## Related
 
 - [Platforms](/platforms) — the VPS and hosting index this page sits under
+- [Docker](/install/docker) — the container image and environment variables this Compose file uses
 - [Trusted proxy auth](/gateway/trusted-proxy-auth) — the auth mode used behind Caddy
 - [Gateway runbook](/gateway) — operating the Gateway once it is up

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -106,3 +106,4 @@ Manual Cron refreshes and successful job changes supersede older reads, so an in
 
 - [macOS app](/platforms/macos)
 - [Menu bar icon](/platforms/mac/icon)
+- [Usage tracking](/concepts/usage-tracking)

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -490,3 +490,4 @@ owner.
 - [Plugins](/tools/plugin)
 - [Manage plugins](/plugins/manage-plugins)
 - [Sessions](/concepts/session)
+- [Managed worktrees](/concepts/managed-worktrees)

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -377,3 +377,4 @@ Related docs:
 
 - [Token use and costs](/reference/token-use)
 - [API usage and costs](/reference/api-usage-costs)
+- [Usage tracking](/concepts/usage-tracking)

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -166,6 +166,7 @@ still resolves. Each entry points at the page that now holds the content.
 ## Related
 
 - [ACP agents - setup](/tools/acp-agents-setup)
+- [Agent bindings](/concepts/agent-bindings)
 - [Agent send](/tools/agent-send)
 - [CLI Backends](/gateway/cli-backends)
 - [Codex harness](/plugins/codex-harness)


### PR DESCRIPTION
## What

Follow-up to #143022. That PR fixed the link findings whose labels already existed as glossary sources and **dropped the rest**, because I had told it not to touch `docs/.i18n/glossary.zh-CN.json` — a constraint that is not satisfiable for a back-link PR. This lands the dropped half.

`scripts/check-docs-i18n-glossary.mts` (`LIST_ITEM_LINK_RE` at line 12, the `glossary.has(term)` gate at line 215) requires every **newly introduced list-item link label** in a changed English doc to already exist as a `source` in `docs/.i18n/glossary.zh-CN.json`. A Related-section back-link is exactly such a label, so adding one requires appending its glossary source.

17 files, +70 / -0. Every hunk adds a link. No prose rewritten, no page moved, no heading or anchor changed, no route added or removed.

### Fixed

| Finding | Change |
| --- | --- |
| `r3-1023` | `automation/cron-jobs.md` and `automation/hooks.md` now link back to Standing orders. |
| `r3-1475` | `automation/cron-jobs.md` now links Standing intents. |
| `r3-1379` | `channels/channel-routing.md` now links back to Multi-agent routing. |
| `r3-1479` | `tools/acp-agents.md`, `gateway/config-agents.md` and `channels/channel-routing.md` now link back to Agent bindings. |
| `r3-1399` | `concepts/agent.md` and `concepts/agent-workspace.md` now link back to System prompt. Timezone stays out of scope — see below. |
| `r3-1403` | `reference/prompt-caching.md` and `platforms/mac/menu-bar.md` now link back to Usage tracking. |
| `r3-1478` | `concepts/context-engine.md` now links back to Honcho memory. |
| `r3-1391` | `concepts/managed-worktrees.md` gains a Related section; `plugins/workboard.md` links back to Managed worktrees. |
| `r3-1495` | `concepts/streaming.md` now links back to Typing indicators. |
| `r5-0011` | `concepts/main-session.md` Related now links the session-management deep dive, which documents the disk budget the page describes without naming. |
| `r3-1482` (qa-channel half) | `channels/qa-channel.md` now links back to the Personal agent benchmark pack. |
| `r3-1887` (Docker row) | `platforms/easyrunner.md` Related now links the Docker install page. |

### Glossary sources added (12, append-only)

| Source | Target | For |
| --- | --- | --- |
| `Standing orders` | 常设指令 | r3-1023 |
| `Standing intents` | 常设意图 | r3-1475 |
| `Multi-agent routing` | 多智能体路由 | r3-1379 |
| `Agent bindings` | 智能体绑定 | r3-1479 |
| `System prompt` | 系统提示词 | r3-1399 |
| `Usage tracking` | 用量追踪 | r3-1403 |
| `Honcho memory` | Honcho 记忆 | r3-1478 |
| `Managed worktrees` | 托管工作树 | r3-1391 |
| `Typing indicators` | 正在输入指示器 | r3-1495 |
| `Session management deep dive` | 会话管理深入解析 | r5-0011 |
| `Personal agent benchmark pack` | 个人智能体基准包 | r3-1482 |
| `Docker` | Docker | r3-1887 |

Every label is the target page's own `title:`, and every one except `Agent bindings` and `Typing indicators` is already in use as a link label elsewhere in `docs/` — none was coined to satisfy the checker. Targets follow the file's existing conventions (`多智能体路由` matches `Configuration — per-agent entries and multi-agent routing`; `Docker` stays Latin like `OpenClaw`, `Heartbeat`, `Hooks`).

**Append-only, verified set-wise** (ours/theirs labels are inverted during a rebase, so this is checked as sets, not as a diff). After rebasing onto `b07d30ae5e0`, which had itself gained 7 glossary entries from a concurrent PR, `.audit/glossary-union.py` reported `base=907 stage2=914 stage3=919 merged=926 appended=12 lost=0 dupes=0`. Re-verified independently against `origin/main`: 914 → 926 entries, the union is a **true superset** (0 sources on main lost, 0 existing targets rewritten, main's 914 preserved byte-identical and in order), 0 duplicate sources, and all 12 of mine present.

### Refuted — #143022 listed 14 needed sources; only 12 hold

- **`Workboard` was not needed.** #143022's table says `r3-1391` needs a `Workboard` source. The page's actual title is **"Workboard plugin"**, which is *already* a glossary source, and `managed-worktrees.md` already uses that exact label in its own prose (line 176). Using the page title closes the finding with no new source. Adding `Workboard` would have been coining a second label for a page that already has one.

- **`Memory search` was not needed — `r3-1489` is already fully closed.** #143022 lists a "memory-search half" of `r3-1489` still open. The ledger's `fix` field for that finding is only *"Add a link to the session tool page in a Related section"*, which #143022 did. The ledger's own evidence concedes the other direction already resolves — *"This page links only /concepts/memory-search at line 57"*. On the current tree that link is at line 61, inside a dedicated `## Session search vs. memory search` section, labelled `` `memory_search` ``. Reciprocity with memory-search is closed by a more informative link than a Related row would be; a `- [Memory search](…)` entry would duplicate it. No change, no source.

- **`Session management and compaction` → `Session management deep dive`.** #143022 proposed the former. It appears exactly once in `docs/` (`reference/api-usage-costs.md:122`) and is not the page's title; the page's `title:` is **"Session management deep dive"**. `main-session.md`'s Related already carries `Session management` → `/concepts/session`, so the deep-dive label also reads as the natural distinction between the two rows. Used the page title.

- **`r3-1399` — Timezone stays out of scope**, on the same reasoning #143022 gave: `concepts/timezone.md` is linked from `system-prompt.md` prose, not from its Related section, so it is not a Related-reciprocity gap.

- **`r5-0011` — link half only.** Naming `maxDiskBytes` in `main-session.md` would be a prose change; this PR is link-only.

- **`r3-1495` — back-link half only.** Adding new outbound links from `typing-indicators.md` to the heartbeat and group-message pages is new linking, not a defect. Note its Related block is a `CardGroup`, not a list, so the outbound half would not have needed a glossary source at all.

### Constraint proven both ways

Reverting **only** `docs/.i18n/glossary.zh-CN.json` to `origin/main`, with the 16 doc files unchanged:

```
$ npx tsx scripts/check-docs-i18n-glossary.mts --base origin/main
docs:check-i18n-glossary: missing zh-CN glossary entries for changed doc labels:
- docs/automation/cron-jobs.md:162 link label "Standing intents"
- docs/automation/cron-jobs.md:163 link label "Standing orders"
- docs/automation/hooks.md:801 link label "Standing orders"
- docs/channels/channel-routing.md:205 link label "Multi-agent routing"
- docs/channels/channel-routing.md:206 link label "Agent bindings"
- docs/channels/qa-channel.md:108 link label "Personal agent benchmark pack"
  … 12 labels total …
exit=1
```

With the appended sources, exit=0. `Workboard plugin` and `Configuration reference` are absent from that failure list — the direct evidence that they were already sources.

## Validators

Rebased onto `origin/main` at `b07d30ae5e0`. Baseline **re-measured** in a detached worktree at that sha after the rebase — the pre-rebase numbers are not carried forward.

| Check | Baseline | This branch |
| --- | --- | --- |
| `pnpm check:docs` (the CI docs job's own aggregate) | — | **exit 0** |
| ↳ `format-docs.mts --check` | — | clean, 1108 files |
| ↳ `markdownlint-cli2 config/markdownlint-cli2.jsonc` | — | 0 issues, 1107 files |
| ↳ `lint:templates` | — | 0 issues |
| ↳ `check-docs-mdx.mjs` | — | pass |
| ↳ `check-docs-i18n-glossary.mts` | — | pass |
| ↳ `docs-link-audit.mjs` | `broken_links=0` (11354 checked) | `broken_links=0` (11373 checked; +19 = the 19 links added) |
| ↳ `check-docs-config-examples.mjs` | — | pass |
| `docs-link-audit.mjs --anchors` | `broken_links=42` | `broken_links=42`, error set **byte-identical** to baseline (`diff` empty) |
| `vitest tooling src/scripts/docs-link-audit.test.ts` | **1 failed / 24 passed** | **1 failed / 24 passed** — same pre-existing `preserves Mint component targets for raw component apostrophes` assertion, reproduced at the base sha |
| `vitest full-core-unit-src src/docs/` | — | 8 files, 16 tests, all pass |

The 42 anchor errors are the known pre-existing baseline: 3 `#windows-app-node` and 39 `/clawhub/*` route-not-found false positives (those routes are mirrored from a separate repo that CI checks out and a local worktree does not).

## Notes

- Does not touch `docs/docs.json`. No new page or directory, so no `.github/labeler.yml` glob gap is created.
- No CODEOWNERS team owns any of the 17 files (the `docs/` rules are `@openclaw/openclaw-secops` on `docs/security/`, `docs/gateway/` auth/secrets/sandbox pages and `docs/cli/` approvals/sandbox/security/secrets, plus release-managers on `docs/reference/RELEASING.md` — none matched).
- Non-docs references to the changed files are `taxonomy.yaml` route entries and `qa/scenarios/**` YAML; none pins Related-section content, and no heading or anchor changed.
- Each Related entry follows its own file's local convention (em dash, hyphen, or bare) and its ordering, rather than one imposed style.

## Review round 2 (`edb6e7fd81f`)

- **P3 "Describe Honcho as a memory plugin" — accepted and fixed** in `edb6e7fd81f`. The finding is right: the Honcho integration declares `kind: "memory"`, and this very page states at `docs/concepts/context-engine.md:428` that *"Memory plugins (`plugins.slots.memory`) are separate from context engines"*. Calling it "the Honcho-backed context engine" contradicted the page two paragraphs above the Related block. The link is unchanged; the description now reads **"a memory plugin a context engine can draw on"**, which is the relationship line 428 actually describes ("a context engine might use memory plugin data during assembly") and therefore also states why the entry belongs in this page's Related section.

- **P1 "Resolve merge risk" — resolved.** The branch was 9 commits behind; `origin/main` had moved to `b07d30ae5e0` and had itself gained 7 glossary entries from a concurrent PR, so the snapshot's conflict was real and is the expected one on this file. Rebased with `.audit/rebase-onto-main.sh`, which unions the glossary on `source`: `base=907 stage2=914 stage3=919 merged=926 appended=12 lost=0 dupes=0`. Both branches' entries are preserved — verified set-wise against `origin/main`, not by reading the union script's ours/theirs labels, which are inverted during a rebase.

- **Every validator re-run on the rebased head against a freshly measured baseline at `b07d30ae5e0`**; no earlier green was carried forward. `pnpm check:docs` exit 0, `broken_links=0`, `--anchors` still 42 with a byte-identical error set, and the one pre-existing `vitest tooling` failure reproduced at the new base sha.
