### PR TITLE
fix(tests): close acquisition databases after module resets

### DIFF
--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -12,7 +12,6 @@ import { WebSocketServer } from "../../packages/gateway-client/src/websocket.tes
 import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { runVitestShutdownCommand } from "../../test/helpers/vitest-shutdown-command.js";
-import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   buildMinimalGatewayHelloOkPayload,
   closeMinimalGatewayServer,
@@ -257,6 +256,7 @@ export async function verifyCompositeAcquisition({
   failure,
   shutdown,
 }: CompositeAcquisitionCase): Promise<void> {
+  const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
   await withOpenClawTestState(
     {
       label: "composite-acquisition",
@@ -487,6 +487,7 @@ describe("raw Gateway helper acquisition ownership", () => {
     },
     { helper: "device request", behavior: "no response", error: "timeout" },
   ] as const)("$helper owns cleanup after $behavior", async ({ helper, behavior, error }) => {
+    const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
     await withOpenClawTestState({ label: "raw-acquisition" }, async () => {
       await withAcquisitionPeer(behavior, async (peer) => {
         const { openTrackedWs } = await import("./device-authz.test-helpers.js");
@@ -552,6 +553,7 @@ describe("raw Gateway helper acquisition ownership", () => {
   });
 
   it("retains the native error until awaited webchat preparation finishes", async () => {
+    const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
     await withOpenClawTestState({ label: "webchat-preparation" }, async () => {
       await withAcquisitionPeer("reply", async (peer) => {
         const preparing = createDeferred();
@@ -595,6 +597,7 @@ describe("raw Gateway helper acquisition ownership", () => {
   });
 
   it("restores the token environment when server startup rejects before acquisition", async () => {
+    const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
     await withOpenClawTestState(
       {
         label: "server-start-rejection",
@@ -641,6 +644,7 @@ describe("raw Gateway helper acquisition ownership", () => {
   it.each(["success", "rejection"] as const)(
     "owns returned-server selectors through close %s",
     async (shutdown) => {
+      const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
       await withOpenClawTestState(
         {
           label: "returned-client-server",
@@ -690,6 +694,7 @@ describe("raw Gateway helper acquisition ownership", () => {
   );
 
   it("joins the one-shot device socket close before returning its response", async () => {
+    const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
     await withOpenClawTestState({ label: "device-acquisition-response" }, async () => {
       await withAcquisitionPeer("reply", async (peer) => {
         const { connectDeviceAuthReq } = await import("./test-helpers.e2e.js");


### PR DESCRIPTION
## What Problem This Solves

Gateway acquisition tests can remove their temporary state while a database opened by a reloaded module remains live. The original behavior assertions pass despite the leaked handle.

## Why This Change Was Made

Import the state fixture at its six acquisition sites so cleanup uses the same module generation as the dynamic clients. This preserves the existing resets, assertions, socket deadlines, and exported fork helper without loading the fixture in parent cases that only delegate to a fork.

## User Impact

No production behavior changes. Test fixtures close their database handles before removing temporary state.

## Evidence

- The original ordered two-case diagnostic passed its behavior assertions but observed one handle still open after cleanup; the fixed diagnostic observed zero before safety cleanup and unlink.
- All 31 cases, including the three child-process scenarios, pass with their original names and order.
- Mapped checks and fresh independent P2 review pass.

No database was proactively opened by the diagnostic, and no WAL guard or timer was changed or triggered. No claim is made about the cause of an earlier full-suite process termination.
