### PR TITLE
improve(tests): speed up phone recovery E2E tests

### DIFF
--- a/ui/src/e2e/phone-stale-build-recovery.e2e.test.ts
+++ b/ui/src/e2e/phone-stale-build-recovery.e2e.test.ts
@@ -32,6 +32,7 @@ const proofBuildId = proofIdentity.expectedRevisionSha
   : "phone-proof-local-artifact";
 const suite = createControlUiE2eSuite({
   name: "Control UI phone stale-build recovery E2E",
+  startServer: () => startPhoneProofServer(proofBuildId),
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
@@ -52,9 +53,7 @@ suite.define(() => {
   ] as const)(
     "rearms one bounded build recovery after the visible refresh action with $serviceWorker service-worker state",
     async ({ serviceWorker, serviceWorkers }) => {
-      const proofServer = await startPhoneProofServer(proofBuildId);
-      await using proofServerCleanup = phoneProofCleanup(() => proofServer.close());
-      void proofServerCleanup;
+      const proofServer = suite.server;
       const context = await suite.browser.newContext({
         hasTouch: true,
         isMobile: true,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled.

</details>

## What Problem This Solves

The phone stale-build recovery E2E file recompiles the same production fixture for each of its two service-worker scenarios, adding avoidable compiler work to every full-file run.

## Why This Change Was Made

Use the existing suite-owned server lifecycle to build and serve the fixture once, before Chromium starts. Both scenarios retain separate browser contexts, their existing disposal, ordering, waits, and assertions. The suite now closes the shared server after both cases; production code, build configuration, and the global bundled build are unchanged.

## User Impact

Test-only improvement with no product behavior change. Phone fixture compilations drop from two to one per file without sharding, skipped cases, reduced assertions, or shared browser state.

## Evidence

- Two alternating baseline/candidate full-file pairs with real Chromium: all four invocations passed both cases with zero skips. Instrumented wall times were **62.636 -> 45.805 seconds** and **62.189 -> 45.969 seconds**; mean **62.412 -> 45.887 seconds**, about **26.48% lower**.
- Timings include invocation/bootstrap, the unchanged global build, setup, both cases, teardown, and observation overhead. Actual phone compiler subprocess counts were **2 -> 1**; compiler-time reductions were **16.119 seconds** and **15.073 seconds**. Extra baseline artifact hashing accounted for only **0.136 seconds** and **0.196 seconds** of the respective deltas.
- Full artifact-tree snapshots remained unchanged within each server lifetime, including between cases. The first context's actual close completed before the second context opened. Both observation reports completed in every run, and representative before/after screenshots were inspected.
- Bounded fault probes covered startup failure, Chromium launch failure after server acquisition, and first-case failure after context allocation. The second case still passed after the first-case fault. No owned listeners, processes, or build directories remained.
- Existing cleanup coverage passed: 14 suite-lifecycle cases and four phone-helper cases. The initial combined command passed the 14 cases but failed browser preflight because the retained browser runtime environment was missing; only the helper surface was retried, with the retained environment and explicit `test/vitest/vitest.ui.config.ts`, and passed.
- Targeted formatting and the actual changed gate passed; changed gate exit 0 in **281.90 seconds**. Fresh independent review was scoped-clean.

These are instrumented local measurements at `a48a9f4cb98402ebc580b34aa74c32021a055876` with the exact candidate test diff, not hosted CI or Windows speedup claims. Artifact hashes establish within-lifetime immutability, not baseline/candidate byte equality. An initial baseline attempt failed before cases because an external temporary path exceeded Chromium's Unix socket limit; it was preserved and excluded, and every reported pair used the same corrected harness.
