### PR TITLE
refactor: reuse Doctor successful-update test fixtures

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -4017,27 +4017,15 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
     };
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.updateNpmInstalledPlugins.mockResolvedValue({
-      changed: true,
-      config: {
-        plugins: {
-          installs: {
-            demo: {
-              source: "npm",
-              spec: "@openclaw/plugin-demo@1.0.0",
-              installPath: "/tmp/openclaw-plugins/demo",
-            },
-          },
+    mocks.updateNpmInstalledPlugins.mockResolvedValue(
+      successfulUpdate("demo", {
+        demo: {
+          source: "npm",
+          spec: "@openclaw/plugin-demo@1.0.0",
+          installPath: "/tmp/openclaw-plugins/demo",
         },
-      },
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "updated",
-          message: "Updated demo.",
-        },
-      ],
-    });
+      }),
+    );
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -4081,27 +4069,15 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       reviewToken: review.reviewToken,
     });
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.updateNpmInstalledPlugins.mockResolvedValue({
-      changed: true,
-      config: {
-        plugins: {
-          installs: {
-            demo: {
-              source: "clawhub",
-              spec: "clawhub:@openclaw/plugin-demo@1.0.0",
-              installPath: "/tmp/openclaw-plugins/demo",
-            },
-          },
+    mocks.updateNpmInstalledPlugins.mockResolvedValue(
+      successfulUpdate("demo", {
+        demo: {
+          source: "clawhub",
+          spec: "clawhub:@openclaw/plugin-demo@1.0.0",
+          installPath: "/tmp/openclaw-plugins/demo",
         },
-      },
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "updated",
-          message: "Updated demo.",
-        },
-      ],
-    });
+      }),
+    );
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -4143,27 +4119,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         config: Record<string, unknown>;
       }) => {
         params.logger?.warn?.(repairWarning);
-        return {
-          changed: true,
-          config: {
-            plugins: {
-              installs: {
-                demo: {
-                  source: "npm",
-                  spec: "@openclaw/plugin-demo@1.0.0",
-                  installPath: "/tmp/openclaw-plugins/demo",
-                },
-              },
-            },
+        return successfulUpdate("demo", {
+          demo: {
+            source: "npm",
+            spec: "@openclaw/plugin-demo@1.0.0",
+            installPath: "/tmp/openclaw-plugins/demo",
           },
-          outcomes: [
-            {
-              pluginId: "demo",
-              status: "updated",
-              message: "Updated demo.",
-            },
-          ],
-        };
+        });
       },
     );
 
@@ -4205,27 +4167,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         config: Record<string, unknown>;
       }) => {
         params.logger?.warn?.(coloredReviewNotice);
-        return {
-          changed: true,
-          config: {
-            plugins: {
-              installs: {
-                demo: {
-                  source: "clawhub",
-                  spec: "clawhub:@openclaw/plugin-demo@1.0.0",
-                  installPath: "/tmp/openclaw-plugins/demo",
-                },
-              },
-            },
+        return successfulUpdate("demo", {
+          demo: {
+            source: "clawhub",
+            spec: "clawhub:@openclaw/plugin-demo@1.0.0",
+            installPath: "/tmp/openclaw-plugins/demo",
           },
-          outcomes: [
-            {
-              pluginId: "demo",
-              status: "updated",
-              message: "Updated demo.",
-            },
-          ],
-        };
+        });
       },
     );
 
@@ -4271,27 +4219,15 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       ],
     });
-    mocks.updateNpmInstalledPlugins.mockResolvedValue({
-      changed: true,
-      config: {
-        plugins: {
-          installs: {
-            demo: {
-              source: "npm",
-              spec: "@openclaw/plugin-demo@1.0.0",
-              installPath: "/tmp/openclaw-plugins/demo",
-            },
-          },
+    mocks.updateNpmInstalledPlugins.mockResolvedValue(
+      successfulUpdate("demo", {
+        demo: {
+          source: "npm",
+          spec: "@openclaw/plugin-demo@1.0.0",
+          installPath: "/tmp/openclaw-plugins/demo",
         },
-      },
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "updated",
-          message: "Updated demo.",
-        },
-      ],
-    });
+      }),
+    );
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");


### PR DESCRIPTION
## What Problem This Solves

Five Doctor plugin-repair tests repeat the successful-update result structure already supplied by the suite’s existing helper, making the input fixtures harder to maintain.

## Why This Change Was Made

Use `successfulUpdate` for those five inputs while keeping each install record explicit. The helper is unchanged, and both warning-producing callbacks still warn before constructing their return values. This removes 64 net test lines without changing assertions or scenarios.

## User Impact

No user-visible behavior change. Doctor’s repair, consent, warning classification, and install-record persistence coverage remains intact.

## Evidence

The complete owning suite passed all 140 tests before and after, with identical ordered case names. Structural expansion reproduced the original test AST; value checks preserved field order, absence, fresh object graphs, and both warning-before-return sequences. Mapped changed checks passed, and independent review found no actionable issues. No runtime improvement is claimed.
