### PR TITLE
fix(ui): correct session multi-select shortcut help

### DIFF
--- a/ui/src/components/keyboard-shortcuts-dialog.test.ts
+++ b/ui/src/components/keyboard-shortcuts-dialog.test.ts
@@ -26,6 +26,13 @@ describe("keyboard shortcuts dialog", () => {
     expect(
       Array.from(dialog.shadowRoot?.querySelectorAll("h3") ?? [], (heading) => heading.textContent),
     ).toEqual(["General", "Chat", "Panels", "Sidebar", "Image viewer", "Approvals"]);
+    const selectionRow = Array.from(
+      dialog.shadowRoot?.querySelectorAll(".shortcut-row") ?? [],
+    ).find((row) => row.textContent?.includes("Select multiple sessions"));
+    expect(
+      Array.from(selectionRow?.querySelectorAll("kbd") ?? [], (key) => key.textContent),
+    ).toEqual(["Alt", "Click"]);
+
     const sendRow = () =>
       Array.from(dialog.shadowRoot?.querySelectorAll(".shortcut-row") ?? []).find((row) =>
         row.textContent?.includes("Send message"),

--- a/ui/src/lib/keyboard-shortcut-catalog.test.ts
+++ b/ui/src/lib/keyboard-shortcut-catalog.test.ts
@@ -140,7 +140,10 @@ describe("keyboard shortcut catalog presentation", () => {
       "↑",
     ]);
     expect(formatKeyboardShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.toggleSessionSelect, true)).toBe(
-      "⌘Click",
+      "⌥Click",
+    );
+    expect(formatKeyboardShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.toggleSessionSelect, false)).toBe(
+      "Alt+Click",
     );
     expect(formatKeyboardShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.extendSessionSelect, false)).toBe(
       "Shift+Click",

--- a/ui/src/lib/keyboard-shortcut-contract.ts
+++ b/ui/src/lib/keyboard-shortcut-contract.ts
@@ -36,7 +36,7 @@ export const KEYBOARD_SHORTCUT_COMBOS = {
   zoomOut: { modifiers: [], key: "-" },
   zoomReset: { modifiers: [], key: "0" },
   // Display-only mouse chords; never keyboard-matched.
-  toggleSessionSelect: { modifiers: ["mod"], key: "Click" },
+  toggleSessionSelect: { modifiers: ["alt"], key: "Click" },
   extendSessionSelect: { modifiers: ["shift"], key: "Click" },
 } as const satisfies Record<string, ShortcutDefinition<string>>;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following the Control UI keyboard-shortcut help were told to use Cmd/Ctrl+Click to select multiple sessions, but those clicks retain browser link behavior. Selection already uses Alt/Option+Click.

## Why This Change Was Made

Change only the display binding for `toggleSessionSelect` from `mod` to `alt` in `ui/src/lib/keyboard-shortcut-contract.ts`, aligning help with the existing sidebar click handler. Extend the existing catalog and dialog presentation tests without changing runtime selection, navigation, configuration, or dependencies.

## User Impact

Shortcut help now shows Option+Click on Apple platforms and Alt+Click elsewhere. Alt toggling, Shift range selection, Cmd/Ctrl browser link behavior, and plain-click navigation remain unchanged.

## Evidence

- Refreshed official Vitest 5 coverage selected the catalog, dialog, and sidebar multi-select/context-menu cases through `node scripts/run-vitest.mjs run`. With identical tests, selection, order, and dot reporter, the matched baseline had exactly two intended label failures and 33 passes; the candidate passed all 35. Both excluded 334 unrelated cases.
- An earlier baseline had those two label failures plus an unchanged batch-archive failure: 32 passed, three failed, 334 excluded. The archive case passed in the matched replay and candidate. Its initial failure remains unexplained and is not claimed fixed by this PR.
- Targeted formatting and lint passed for the corrected three files and restored sidebar interactions file. UI typechecking (`tsgo:ui`) passed. Fresh scoped review found no actionable issues. Production LOC: +1/-1, net 0; tests: +11/-1, net +10.
- Inspected real-component Chromium captures at 1280x900 and 390x844 showed Cmd/Ctrl before and Option/Alt after, with no page errors. These exercise simulated platform formatting, not native platform input. The inspected before/after captures are retained locally and are not attached.
- The existing Alt-click archive flow in `ui/src/e2e/session-management.archive.e2e.test.ts` passed against baseline and candidate: one pass and ten exclusions each. Three selected rows produced one `sessions.patchMany`, no individual patch, abort, or wait calls, and visible archive confirmation for all three sessions.

The browser evidence predates the test-only relocation into `ui/src/components/keyboard-shortcuts-dialog.test.ts`. Production, harness, and build inputs were verified unchanged, so that evidence remains applicable; those browser flows were not rerun for the relocated tests.

Draft for review only. No full-suite, hosted-CI, native-client, Linux-host, or physical-IME qualification is claimed.
