### PR TITLE
feat: connect UI development to a Gateway

### DIFF
--- a/docs/web/control-ui/development.md
+++ b/docs/web/control-ui/development.md
@@ -41,6 +41,33 @@ pnpm ui:dev
 
 Then point the UI at your Gateway WS URL (e.g. `ws://127.0.0.1:18789`).
 
+To use the real Gateway's capabilities, media, and native plugin UI while
+developing, select its URL when starting Vite:
+
+```bash
+OPENCLAW_UI_DEV_GATEWAY_URL=http://127.0.0.1:18789 pnpm ui:dev --host 127.0.0.1 --port 5173
+```
+
+Configured development binds to loopback by default. Open `http://127.0.0.1:5173` and use the Gateway's normal authentication and
+device pairing. The target accepts `http://`, `https://`, `ws://`, or `wss://`,
+including a configured Gateway base path. Keep credentials out of this setting.
+Add the exact browser origin to `gateway.controlUi.allowedOrigins` when needed;
+the development proxy preserves the browser's Origin and does not provide
+authentication credentials.
+
+Vite serves the UI and its hot reload connection, and proxies Gateway requests.
+The UI keeps credentials and saved settings scoped to the actual Gateway. An
+owner pairing handoff can be delivered on the dev page while retaining its
+original Gateway destination and fragment. To use another Gateway, restart
+Vite with the new target; an already-open page cannot forward requests through
+the replacement target. Reload the page after restarting Vite.
+
+UI edits use Vite's normal hot reload or page reload. Start the Gateway's source
+watch separately when developing its implementation. Stopping Vite stops its
+proxy, without stopping the Gateway or deleting either application's state.
+Without `OPENCLAW_UI_DEV_GATEWAY_URL`, `pnpm ui:dev` retains its existing
+standalone connection behavior. This setting does not affect `pnpm ui:build`.
+
 For a standalone preview with synthetic data, use:
 
 ```bash

--- a/ui/config/control-ui-dev-gateway.ts
+++ b/ui/config/control-ui-dev-gateway.ts
@@ -1,0 +1,60 @@
+import type { ProxyOptions } from "vite";
+import type { ControlUiDevGateway } from "../src/dev-gateway.ts";
+
+/** Vite owns transport; the Gateway still owns authentication and route policy. */
+export function createControlUiDevGateway(
+  target: string | undefined,
+): { gateway: ControlUiDevGateway; proxy: Record<string, ProxyOptions> } | undefined {
+  if (!target?.trim()) {
+    return undefined;
+  }
+  let url: URL;
+  try {
+    url = new URL(target.trim());
+  } catch {
+    throw new Error(
+      "OPENCLAW_UI_DEV_GATEWAY_URL must be an absolute HTTP(S) or WS(S) Gateway URL.",
+    );
+  }
+  if (
+    !["http:", "https:", "ws:", "wss:"].includes(url.protocol) ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      "OPENCLAW_UI_DEV_GATEWAY_URL must not contain credentials, a query, or a fragment.",
+    );
+  }
+  url.protocol = url.protocol === "https:" || url.protocol === "wss:" ? "wss:" : "ws:";
+  const gatewayUrl = url.href.replace(/\/$/u, "");
+  // A retired page cannot send credentials to a replacement upstream on the same Vite port.
+  const proxyPath = `/__openclaw_dev_gateway__/${encodeURIComponent(gatewayUrl)}`;
+  url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+  return {
+    gateway: { gatewayUrl, proxyPath },
+    proxy: {
+      [`${proxyPath}/`]: {
+        target: url.origin,
+        changeOrigin: true,
+        ws: true,
+        rewrite: (requestPath) => requestPath.slice(proxyPath.length),
+        cookieDomainRewrite: "",
+        configure(proxy) {
+          proxy.on("proxyRes", (response) => {
+            const cookies = response.headers["set-cookie"];
+            if (cookies) {
+              response.headers["set-cookie"] = cookies.map((cookie) =>
+                cookie.replace(
+                  /(;\s*path=)(\/[^;]*)/iu,
+                  (_match, attribute: string, value: string) => `${attribute}${proxyPath}${value}`,
+                ),
+              );
+            }
+          });
+        },
+      },
+    },
+  };
+}

--- a/ui/src/api/gateway-browser-socket.ts
+++ b/ui/src/api/gateway-browser-socket.ts
@@ -3,12 +3,13 @@ import {
   type GatewayProtocolSocket,
   type GatewayProtocolSocketHandlers,
 } from "@openclaw/gateway-client/browser";
+import { gatewayWebSocketTransportUrl } from "../dev-gateway.ts";
 
 export function createBrowserGatewaySocket(
   url: string,
   handlers: GatewayProtocolSocketHandlers,
 ): GatewayProtocolSocket {
-  const socket = new WebSocket(url);
+  const socket = new WebSocket(gatewayWebSocketTransportUrl(url));
   let opening = true;
   let openingTimeoutReason: string | undefined;
   let openingTimer: ReturnType<typeof setTimeout> | undefined;

--- a/ui/src/app/browser.ts
+++ b/ui/src/app/browser.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation, RouterHistory } from "@openclaw/uirouter";
 import { CONTROL_UI_BASE_PATH_ATTRIBUTE } from "../../../src/gateway/control-ui-bootstrap-contract.js";
 import { inferBasePathFromPathname, normalizeBasePath } from "../app-route-paths.ts";
+import { uiDevGatewayResourceBasePath } from "../dev-gateway.ts";
 import { isNativeEmbedHost } from "./native-web-chrome.ts";
 
 type WindowWithControlUiBasePath = Window &
@@ -25,7 +26,7 @@ function readControlUiResourceBasePath(): string | null {
 export function resolveControlUiPaths(pathname: string) {
   const resourceBasePath = readControlUiResourceBasePath();
   const basePath = resourceBasePath || inferBasePathFromPathname(pathname);
-  return [basePath, resourceBasePath ?? basePath] as const;
+  return [basePath, uiDevGatewayResourceBasePath() ?? resourceBasePath ?? basePath] as const;
 }
 
 function readLocation(): RouteLocation {

--- a/ui/src/app/config.test.ts
+++ b/ui/src/app/config.test.ts
@@ -40,6 +40,43 @@ afterEach(() => {
 });
 
 describe("createApplicationConfigCapability", () => {
+  it("keeps capabilities available when development plugin grants contain invalid URLs", async () => {
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", {
+      gatewayUrl: "ws://gateway.example/mount",
+      proxyPath: "/dev-gateway",
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        terminalEnabled: true,
+        cliAgentsEnabled: true,
+        pluginFrameGrants: [
+          {
+            pluginId: "fixture",
+            path: "/mount/plugins/fixture/",
+            match: "prefix",
+            unrecognized: "discard",
+          },
+          { pluginId: "malformed", path: "http://[", match: "prefix" },
+          { pluginId: "foreign", path: "https://other.example/panel", match: "exact" },
+          { path: "/missing-owner", match: "prefix" },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const config = createApplicationConfigCapability({ resourceBasePath: "/dev-gateway/mount" });
+    await expect(config.refresh()).resolves.toMatchObject({
+      terminalEnabled: true,
+      cliAgentsEnabled: true,
+      pluginFrameGrants: [
+        { pluginId: "fixture", path: "/dev-gateway/mount/plugins/fixture/", match: "prefix" },
+        { pluginId: "malformed", path: "http://[", match: "prefix" },
+        { pluginId: "foreign", path: "https://other.example/panel", match: "exact" },
+      ],
+    });
+    expect(config.current.pluginFrameGrants[0]).not.toHaveProperty("unrecognized");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("keeps invitations hidden until bootstrap enables them and accepts later opt-outs", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -8,6 +8,7 @@ import {
   type ControlUiEnvironment,
   type ControlUiPluginFrameGrantAck,
 } from "../../../src/gateway/control-ui-bootstrap-contract.js";
+import { uiDevGatewayResourceUrl } from "../dev-gateway.ts";
 import { normalizeAssistantIdentity } from "../lib/assistant-identity.ts";
 import { resolveControlUiAuthCandidates } from "./control-ui-auth.ts";
 import { canReloadControlUiDocument } from "./document-reload-guard.ts";
@@ -117,12 +118,18 @@ function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): Applicati
     terminalEnabled: Boolean(parsed.terminalEnabled),
     cliAgentsEnabled: Boolean(parsed.cliAgentsEnabled),
     pluginAssetsRequireAuth: parsed.pluginAssetsRequireAuth !== false,
-    pluginFrameGrants: (parsed.pluginFrameGrants ?? []).filter(
-      (grant): grant is ControlUiPluginFrameGrantAck =>
-        typeof grant?.pluginId === "string" &&
-        typeof grant.path === "string" &&
-        (grant.match === "exact" || grant.match === "prefix"),
-    ),
+    pluginFrameGrants: (parsed.pluginFrameGrants ?? [])
+      .filter(
+        (grant): grant is ControlUiPluginFrameGrantAck =>
+          typeof grant?.pluginId === "string" &&
+          typeof grant.path === "string" &&
+          (grant.match === "exact" || grant.match === "prefix"),
+      )
+      .map((grant) => ({
+        pluginId: grant.pluginId,
+        path: uiDevGatewayResourceUrl(grant.path),
+        match: grant.match,
+      })),
   };
 }
 

--- a/ui/src/app/dev-gateway.node.test.ts
+++ b/ui/src/app/dev-gateway.node.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer as createViteServer } from "vite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { getFreePort } from "../../../src/test-utils/ports.js";
+import { createControlUiDevGateway } from "../../config/control-ui-dev-gateway.ts";
+import controlUiViteConfig from "../../vite.config.ts";
+import {
+  gatewayWebSocketTransportUrl,
+  hasSameOriginGatewayTransport,
+  isConfiguredUiDevGateway,
+  uiDevGatewayResourceBasePath,
+  uiDevGatewayResourceUrl,
+} from "../dev-gateway.ts";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("configured UI development Gateway", () => {
+  it("proxies HTTP and WebSocket resources without replacing auth, Origin, or Vite", async () => {
+    const requests: Array<{ path: string; authorization?: string; origin?: string }> = [];
+    const upstream = createServer((request, response) => {
+      requests.push({
+        path: request.url ?? "",
+        authorization: request.headers.authorization,
+        origin: request.headers.origin,
+      });
+      if (request.headers.authorization !== "Bearer fixture-credential") {
+        response.writeHead(401).end();
+        return;
+      }
+      response.setHeader("Content-Type", "application/json");
+      response.setHeader("Set-Cookie", [
+        "fixture=opaque; Path=/__openclaw__/plugins/control-ui/demo/; HttpOnly; Secure; SameSite=Strict",
+        "other=opaque; Path=/api/demo/; HttpOnly",
+      ]);
+      response.end(JSON.stringify({ owner: "gateway", path: request.url }));
+    });
+    const sockets = new WebSocketServer({ server: upstream });
+    sockets.on("connection", (socket, request) => {
+      requests.push({ path: request.url ?? "", origin: request.headers.origin });
+      socket.on("message", (data) => socket.send(data));
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamUrl = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+    vi.stubEnv("OPENCLAW_UI_DEV_GATEWAY_URL", upstreamUrl);
+    const config = controlUiViteConfig({ command: "serve" });
+    const uiPort = await getFreePort();
+    const uiOrigin = `http://127.0.0.1:${uiPort}`;
+    const server = await createViteServer({
+      ...config,
+      configFile: false,
+      root: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.."),
+      logLevel: "silent",
+      optimizeDeps: { noDiscovery: true, include: [] },
+      server: { ...config.server, port: uiPort },
+    });
+    const gateway = createControlUiDevGateway(upstreamUrl)!.gateway;
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", gateway);
+    vi.stubGlobal("location", new URL(uiOrigin));
+    let socket: WebSocket | undefined;
+    try {
+      await server.listen();
+      expect(server.httpServer?.address()).toMatchObject({ address: "127.0.0.1" });
+      const resourcePath = `${uiDevGatewayResourceBasePath()}/control-ui-config.json`;
+      const denied = await fetch(`${uiOrigin}${resourcePath}`);
+      expect(denied.status).toBe(401);
+      const response = await fetch(`${uiOrigin}${resourcePath}`, {
+        headers: { Authorization: "Bearer fixture-credential", Origin: uiOrigin },
+      });
+      expect(await response.json()).toEqual({ owner: "gateway", path: "/control-ui-config.json" });
+      expect(requests.at(-1)).toEqual({
+        path: "/control-ui-config.json",
+        authorization: "Bearer fixture-credential",
+        origin: uiOrigin,
+      });
+      expect(response.headers.getSetCookie()).toEqual([
+        `fixture=opaque; Path=${gateway.proxyPath}/__openclaw__/plugins/control-ui/demo/; HttpOnly; Secure; SameSite=Strict`,
+        `other=opaque; Path=${gateway.proxyPath}/api/demo/; HttpOnly`,
+      ]);
+      const plugin = await fetch(
+        `${uiOrigin}${uiDevGatewayResourceUrl("/plugins/demo/custom-resource")}`,
+        {
+          headers: { Authorization: "Bearer fixture-credential" },
+        },
+      );
+      expect(await plugin.json()).toEqual({
+        owner: "gateway",
+        path: "/plugins/demo/custom-resource",
+      });
+
+      const gatewayRequests = requests.length;
+      const vite = await fetch(`${uiOrigin}/@vite/client`);
+      expect(vite.status).toBe(200);
+      expect(await vite.text()).toContain("vite-hmr");
+      expect(requests).toHaveLength(gatewayRequests);
+
+      const previousGateway = createControlUiDevGateway("http://127.0.0.1:1")!.gateway;
+      const retired = await fetch(
+        `${uiOrigin}${previousGateway.proxyPath}/control-ui-config.json`,
+        {
+          headers: { Authorization: "Bearer retired-credential" },
+        },
+      );
+      await retired.body?.cancel();
+      expect(requests).toHaveLength(gatewayRequests);
+
+      socket = new WebSocket(gatewayWebSocketTransportUrl(gateway.gatewayUrl), {
+        origin: uiOrigin,
+      });
+      await once(socket, "open");
+      const message = once(socket, "message");
+      socket.send("normal-gateway-frame");
+      expect(String((await message)[0])).toBe("normal-gateway-frame");
+      expect(requests.at(-1)).toEqual({ path: "/", origin: uiOrigin });
+    } finally {
+      socket?.terminate();
+      for (const client of sockets.clients) {
+        client.terminate();
+      }
+      await server.close();
+      await new Promise<void>((resolve) => {
+        sockets.close(() => resolve());
+      });
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        upstream.close(() => resolve());
+      });
+    }
+  });
+
+  it("keeps logical Gateway identity while translating its resource base and socket", () => {
+    const configured = createControlUiDevGateway("https://gateway.example/openclaw/")!.gateway;
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", configured);
+    vi.stubGlobal("location", new URL("http://localhost:5173/"));
+    expect(configured.gatewayUrl).toBe("wss://gateway.example/openclaw");
+    expect(isConfiguredUiDevGateway("wss://gateway.example/openclaw/")).toBe(true);
+    expect(isConfiguredUiDevGateway("wss://other.example/openclaw")).toBe(false);
+    expect(hasSameOriginGatewayTransport(configured.gatewayUrl)).toBe(true);
+    expect(hasSameOriginGatewayTransport("wss://other.example/openclaw")).toBe(false);
+    expect(gatewayWebSocketTransportUrl(configured.gatewayUrl)).toBe(
+      `ws://localhost:5173${configured.proxyPath}/openclaw`,
+    );
+    expect(gatewayWebSocketTransportUrl("wss://other.example/openclaw")).toBe(
+      "wss://other.example/openclaw",
+    );
+    expect(uiDevGatewayResourceBasePath()).toBe(`${configured.proxyPath}/openclaw`);
+    const asset = uiDevGatewayResourceUrl("https://gateway.example/openclaw/avatar/main?v=2");
+    expect(asset).toBe(`${configured.proxyPath}/openclaw/avatar/main?v=2`);
+    expect(uiDevGatewayResourceUrl(asset)).toBe(asset);
+    expect(uiDevGatewayResourceUrl("https://other.example/avatar/main")).toBe(
+      "https://other.example/avatar/main",
+    );
+    expect(uiDevGatewayResourceUrl("http://[")).toBe("http://[");
+  });
+
+  it.each([
+    "not a URL",
+    "file:///tmp/gateway",
+    Object.assign(new URL("http://fixture.invalid"), {
+      username: "fixture",
+      password: "credential",
+    }).href,
+    "http://localhost:18789?token=credential",
+    "http://localhost:18789#token=credential",
+  ])("rejects an invalid or credential-bearing dev target without echoing it (%#)", (target) => {
+    expect(() => createControlUiDevGateway(target)).toThrow(/OPENCLAW_UI_DEV_GATEWAY_URL/);
+    expect(() => createControlUiDevGateway(target)).not.toThrow(target);
+  });
+
+  it("does not enable the transport in bundled builds or unconfigured development", () => {
+    vi.stubEnv("OPENCLAW_UI_DEV_GATEWAY_URL", "http://localhost:18789");
+    expect(controlUiViteConfig({ command: "build" }).server?.proxy).toBeUndefined();
+    vi.stubEnv("OPENCLAW_UI_DEV_GATEWAY_URL", "");
+    expect(controlUiViteConfig({ command: "serve" }).server?.proxy).toBeUndefined();
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", undefined);
+    expect(gatewayWebSocketTransportUrl("ws://localhost:18789")).toBe("ws://localhost:18789");
+    expect(uiDevGatewayResourceUrl("/avatar/main")).toBe("/avatar/main");
+  });
+});

--- a/ui/src/app/gateway-store.auth.test.ts
+++ b/ui/src/app/gateway-store.auth.test.ts
@@ -46,6 +46,26 @@ describe("createApplicationGateway authentication diagnostics", () => {
     vi.useRealTimers();
   });
 
+  it("rejects a different development target before accepting its credentials or opening a client", () => {
+    const configured = store.gateway.connection.gatewayUrl;
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", { gatewayUrl: configured, proxyPath: "/dev-proxy" });
+    store.gateway.connect({ token: "configured-credential" });
+    store.current().opts.onHello?.({ ...HELLO, snapshot: { authMode: "token" } });
+    const connection = { ...store.gateway.connection };
+
+    store.gateway.connect({ gatewayUrl: "wss://other.example", token: "other-credential" });
+    expect(store.clients).toHaveLength(1);
+    expect(store.current().stopped).toBe(1);
+    expect(store.gateway.connection).toEqual(connection);
+    expect(loadSettings().token).toBe("configured-credential");
+    expect(store.gateway.snapshot.phase).toBe("offline");
+    expect(store.gateway.snapshot.lastError).toContain("OPENCLAW_UI_DEV_GATEWAY_URL");
+
+    store.gateway.connect();
+    expect(store.clients).toHaveLength(2);
+    expect(store.current().opts).toMatchObject({ url: configured, token: "configured-credential" });
+  });
+
   it.each(["token", "password", "trusted-proxy", undefined] as const)(
     "persists the submitted secret only after a token-mode hello (%s)",
     (authMode) => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -21,6 +21,7 @@ import {
   type GatewayHelloOk,
 } from "../api/gateway.ts";
 import { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } from "../build-info.ts";
+import { configuredUiDevGateway, isConfiguredUiDevGateway } from "../dev-gateway.ts";
 import { t } from "../i18n/index.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
 import { readConnectionAuthReason } from "../lib/connection-hints.ts";
@@ -50,7 +51,7 @@ import {
   resolveGatewayCredentialsForUrlEdit,
 } from "./settings.ts";
 import { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
-import { readPresenceEntries, resolveSelfPresenceUser } from "./user-profile.ts";
+import { readPresenceEntries, resolveSelfPresenceUser, sameSelfUser } from "./user-profile.ts";
 
 type GatewayClientFactory = (opts: GatewayBrowserClientOptions) => GatewayBrowserClient;
 type CanvasSurfaceLeaseModule = typeof import("./canvas-surface-lease.runtime.ts");
@@ -68,19 +69,6 @@ function readSuspensionPhase(payload: unknown): ApplicationGatewaySnapshot["susp
     phase === "prepared"
     ? phase
     : undefined;
-}
-
-function sameSelfUser(
-  left: ApplicationGatewaySnapshot["selfUser"],
-  right: ApplicationGatewaySnapshot["selfUser"],
-): boolean {
-  return (
-    left?.id === right?.id &&
-    left?.identity?.id === right?.identity?.id &&
-    left?.email === right?.email &&
-    left?.name === right?.name &&
-    left?.avatarUrl === right?.avatarUrl
-  );
 }
 
 export function createApplicationGateway(
@@ -339,6 +327,17 @@ export function createApplicationGateway(
   };
 
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {
+    const requestedGatewayUrl = overrides.gatewayUrl ?? connection.gatewayUrl;
+    if (configuredUiDevGateway() && !isConfiguredUiDevGateway(requestedGatewayUrl)) {
+      gateway.stop();
+      setSnapshot({
+        ...snapshot,
+        phase: "offline",
+        lastError:
+          "This development server targets a different Gateway. Restart ui:dev with OPENCLAW_UI_DEV_GATEWAY_URL set to that Gateway, or reconnect to the configured Gateway.",
+      });
+      return;
+    }
     setUnavailableDeadline("suspensionPhase");
     stopped = false;
     const { sessionKey: requestedSessionKey, ...connectionOverrides } = overrides;

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -123,6 +123,24 @@ describe("resolveApplicationStartupSettings", () => {
 describe("loadSettings default gateway URL derivation", () => {
   installSettingsStorageLifecycle();
 
+  it("keeps development credentials scoped to the upstream when the Vite target changes", () => {
+    setTestLocation({ protocol: "http:", host: "localhost:5173", pathname: "/" });
+    const first = "ws://localhost:18789";
+    const second = "ws://localhost:18790";
+    saveSettings(makeUiSettings(first));
+    persistSessionToken(first, "first-credential");
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", { gatewayUrl: second, proxyPath: "/dev-second" });
+    expect(loadSettings()).toMatchObject({ gatewayUrl: second, token: "" });
+    persistSessionToken(second, "second-credential");
+    expect(loadSettings()).toMatchObject({ gatewayUrl: second, token: "second-credential" });
+    expect(resolvePageGatewaySettings(makeUiSettings(first))).toMatchObject({
+      gatewayUrl: second,
+      token: "second-credential",
+    });
+    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", { gatewayUrl: first, proxyPath: "/dev-first" });
+    expect(loadSettings()).toMatchObject({ gatewayUrl: first, token: "first-credential" });
+  });
+
   it("keeps IPv6 dev-page default gateway hosts dialable", () => {
     setTestLocation({ protocol: "http:", host: "[::1]:5173", pathname: "/" });
     // A vite client script marks the page as dev, which reroutes the default

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -5,6 +5,7 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { DEFAULT_SIDEBAR_ENTRIES, normalizeSidebarEntries } from "../app-navigation.ts";
+import { configuredUiDevGateway } from "../dev-gateway.ts";
 import { isSupportedLocale } from "../i18n/index.ts";
 import { normalizeBoardSessionViews, type BoardSessionViews } from "../lib/board/settings.ts";
 import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts";
@@ -249,6 +250,10 @@ function deriveDefaultGatewayUrl(): { pageUrl: string; effectiveUrl: string } {
   const proto = location.protocol === "https:" ? "wss" : "ws";
   const basePath = resolveControlUiPaths(location.pathname)[0];
   const pageUrl = `${proto}://${location.host}${basePath}`;
+  const devGateway = configuredUiDevGateway();
+  if (devGateway) {
+    return { pageUrl, effectiveUrl: devGateway.gatewayUrl };
+  }
   if (!isViteDevPage()) {
     return { pageUrl, effectiveUrl: pageUrl };
   }
@@ -441,7 +446,9 @@ export function loadSettings(gatewayUrl = livePreferenceOwner?.gatewayUrl()): Ui
   return { ...preferences, token: loadSessionToken(preferences.gatewayUrl) };
 }
 
-export function loadUiPreferences(targetGatewayUrl?: string): UiPreferences {
+export function loadUiPreferences(
+  targetGatewayUrl = configuredUiDevGateway()?.gatewayUrl,
+): UiPreferences {
   const cached = unpersistedSettings;
   if (
     cached &&

--- a/ui/src/app/user-profile.ts
+++ b/ui/src/app/user-profile.ts
@@ -3,6 +3,19 @@ import type { PresenceEntry } from "../api/types.ts";
 export type AuthenticatedUser = NonNullable<PresenceEntry["user"]>;
 export type PresencePayload = { presence: readonly PresenceEntry[] };
 
+export function sameSelfUser(
+  left: AuthenticatedUser | null | undefined,
+  right: AuthenticatedUser | null | undefined,
+): boolean {
+  return (
+    left?.id === right?.id &&
+    left?.identity?.id === right?.identity?.id &&
+    left?.email === right?.email &&
+    left?.name === right?.name &&
+    left?.avatarUrl === right?.avatarUrl
+  );
+}
+
 export function readPresenceEntries(value: unknown): PresenceEntry[] | undefined {
   if (!value || typeof value !== "object") {
     return undefined;

--- a/ui/src/dev-gateway.ts
+++ b/ui/src/dev-gateway.ts
@@ -1,0 +1,71 @@
+/** Logical Gateway identity stays separate from its development-server transport. */
+export type ControlUiDevGateway = {
+  gatewayUrl: string;
+  proxyPath: string;
+};
+
+declare global {
+  var OPENCLAW_UI_DEV_GATEWAY: ControlUiDevGateway | undefined;
+}
+
+export function configuredUiDevGateway(): ControlUiDevGateway | undefined {
+  return globalThis.OPENCLAW_UI_DEV_GATEWAY;
+}
+
+export function isConfiguredUiDevGateway(url: string): boolean {
+  const configured = configuredUiDevGateway();
+  if (!configured) {
+    return false;
+  }
+  try {
+    return new URL(url).href.replace(/\/$/u, "") === configured.gatewayUrl;
+  } catch {
+    return false;
+  }
+}
+
+export function uiDevGatewayResourceBasePath(): string | undefined {
+  const configured = configuredUiDevGateway();
+  return configured
+    ? `${configured.proxyPath}${new URL(configured.gatewayUrl).pathname.replace(/\/$/u, "")}`
+    : undefined;
+}
+
+export function gatewayWebSocketTransportUrl(url: string): string {
+  const configured = configuredUiDevGateway();
+  if (!configured || !isConfiguredUiDevGateway(url)) {
+    return url;
+  }
+  const transport = new URL(`${configured.proxyPath}${new URL(url).pathname}`, location.href);
+  transport.protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  return transport.href;
+}
+
+export function hasSameOriginGatewayTransport(url: string): boolean {
+  try {
+    const transport = new URL(gatewayWebSocketTransportUrl(url), location.href);
+    transport.protocol = transport.protocol.replace(/^ws/u, "http");
+    return transport.origin === location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/** Translate only resources belonging to the configured Gateway, once. */
+export function uiDevGatewayResourceUrl(value: string): string {
+  const configured = configuredUiDevGateway();
+  if (!configured || value.startsWith(`${configured.proxyPath}/`)) {
+    return value;
+  }
+  const gateway = new URL(configured.gatewayUrl.replace(/^ws/u, "http"));
+  let resource: URL;
+  try {
+    resource = new URL(value, gateway);
+  } catch {
+    // The resource owner still rejects malformed metadata; unrelated config remains usable.
+    return value;
+  }
+  return resource.origin === gateway.origin
+    ? `${configured.proxyPath}${resource.pathname}${resource.search}${resource.hash}`
+    : value;
+}

--- a/ui/src/lib/identity-avatar-context.ts
+++ b/ui/src/lib/identity-avatar-context.ts
@@ -1,4 +1,5 @@
 import { normalizeBasePath } from "../app-route-paths.ts";
+import { isConfiguredUiDevGateway } from "../dev-gateway.ts";
 
 // Gateway startup owns connection context; avatar presentation stays in lazy views.
 let appGatewayOrigin: string | null = null;
@@ -72,7 +73,10 @@ export function setAvatarGatewayOrigin(
   authTokens: readonly string[] = [],
   resourceBasePath = "",
 ): void {
-  const nextOrigin = toHttpOrigin(gatewayUrl);
+  const nextOrigin =
+    gatewayUrl && isConfiguredUiDevGateway(gatewayUrl)
+      ? (globalThis.location?.origin ?? null)
+      : toHttpOrigin(gatewayUrl);
   const documentOrigin = globalThis.location?.origin;
   const nextResourceBasePath =
     nextOrigin && documentOrigin === nextOrigin ? normalizeBasePath(resourceBasePath) : "";

--- a/ui/src/lib/identity-avatar.test.ts
+++ b/ui/src/lib/identity-avatar.test.ts
@@ -99,6 +99,67 @@ describe("resolveAvatar profile URL origin restriction", () => {
 });
 
 describe("resolveAvatar gateway origin trust", () => {
+  it.each(["", "/openclaw"])(
+    "preserves development avatar mounts and origin trust at %s",
+    (basePath) => {
+      const gatewayUrl = `wss://gateway.example${basePath}`;
+      const proxyPath = `/__openclaw_dev_gateway__/${encodeURIComponent(gatewayUrl)}`;
+      const resourceBasePath = `${proxyPath}${basePath}`;
+      const uiOrigin = "http://localhost:5173";
+      vi.stubGlobal("location", new URL(uiOrigin));
+      vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", { gatewayUrl, proxyPath });
+      setAvatarGatewayOrigin(gatewayUrl, [], resourceBasePath);
+
+      for (const profileAvatarUrl of new Set([
+        "/api/users/p1/avatar?v=2#fragment",
+        `${basePath}/api/users/p1/avatar?v=2#fragment`,
+        `${resourceBasePath}/api/users/p1/avatar?v=2#fragment`,
+        "https://gateway.example/api/users/p1/avatar?v=2#fragment",
+        `https://gateway.example${basePath}/api/users/p1/avatar?v=2#fragment`,
+        `${uiOrigin}${resourceBasePath}/api/users/p1/avatar?v=2#fragment`,
+      ])) {
+        expect(resolveAvatar({ id: "p1", profileAvatarUrl }), profileAvatarUrl).toEqual({
+          kind: "profile",
+          url: `${uiOrigin}${resourceBasePath}/api/users/p1/avatar?v=2`,
+        });
+      }
+      expect(resolveAvatar({ id: "p1", identity: { type: "profile", id: "p1" } })).toEqual({
+        kind: "profile",
+        url: `${uiOrigin}${resourceBasePath}/api/users/p1/avatar`,
+      });
+      for (const profileAvatarUrl of [
+        `${basePath}/avatar/research?v=3`,
+        `${resourceBasePath}/avatar/research?v=3`,
+        `https://gateway.example${basePath}/avatar/research?v=3`,
+      ]) {
+        expect(
+          resolveAvatar({
+            id: "research",
+            identity: { type: "agent", id: "research" },
+            profileAvatarUrl,
+          }),
+        ).toEqual({ kind: "profile", url: `${uiOrigin}${resourceBasePath}/avatar/research?v=3` });
+      }
+      for (const profileAvatarUrl of [
+        "https://other.example/api/users/p1/avatar",
+        `https://other.example${basePath}/api/users/p1/avatar`,
+        `https://other.example${resourceBasePath}/api/users/p1/avatar`,
+        `${basePath}/api/users/p1/avatar/extra`,
+      ]) {
+        expect(resolveAvatar({ id: "p1", profileAvatarUrl }), profileAvatarUrl).toMatchObject({
+          kind: "initials",
+        });
+      }
+      if (basePath) {
+        expect(
+          resolveAvatar({ id: "research", profileAvatarUrl: "/avatar/research" }),
+        ).toMatchObject({
+          kind: "initials",
+        });
+      }
+    },
+  );
+
   it.each([
     ["https://gw.example.com", "", "/avatar/research", "/avatar/research"],
     [

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -6,7 +6,7 @@ import {
   buildControlUiUserAvatarPath,
   canonicalizeControlUiUserAvatarPath,
 } from "../../../src/gateway/control-ui-user-avatar-route.js";
-import { uiDevGatewayResourceUrl } from "../dev-gateway.ts";
+import { configuredUiDevGateway, uiDevGatewayResourceUrl } from "../dev-gateway.ts";
 import { formatSenderLabel, type SenderIdentity } from "./chat/sender-label.ts";
 import { fnv1aUtf16 } from "./fnv1a.ts";
 import { takeGraphemes } from "./graphemes.ts";
@@ -30,7 +30,19 @@ export function resolveTrustedAvatarUrl(
   resourceBasePath = readAvatarGatewayContext().resourceBasePath,
 ): string | null {
   try {
-    const parsed = new URL(uiDevGatewayResourceUrl(value), ORIGIN_PROBE);
+    let parsed = new URL(value, ORIGIN_PROBE);
+    const devGateway = configuredUiDevGateway();
+    if (devGateway) {
+      // User-profile routes can omit the Gateway mount; add it before the transport prefix.
+      const gatewayBasePath = new URL(devGateway.gatewayUrl).pathname.replace(/\/$/u, "");
+      const userPath = canonicalizeControlUiUserAvatarPath(parsed.pathname, gatewayBasePath);
+      if (userPath) {
+        parsed.pathname = `${gatewayBasePath}${userPath}`;
+      }
+      const avatarUrl =
+        parsed.origin === ORIGIN_PROBE ? `${parsed.pathname}${parsed.search}` : parsed.href;
+      parsed = new URL(uiDevGatewayResourceUrl(avatarUrl), ORIGIN_PROBE);
+    }
     const relativeRoute = parsed.origin === ORIGIN_PROBE;
     const userPath = canonicalizeControlUiUserAvatarPath(parsed.pathname, resourceBasePath);
     const agentPath = parseControlUiResourcePath("agentAvatar", parsed.pathname, resourceBasePath);

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -6,6 +6,7 @@ import {
   buildControlUiUserAvatarPath,
   canonicalizeControlUiUserAvatarPath,
 } from "../../../src/gateway/control-ui-user-avatar-route.js";
+import { uiDevGatewayResourceUrl } from "../dev-gateway.ts";
 import { formatSenderLabel, type SenderIdentity } from "./chat/sender-label.ts";
 import { fnv1aUtf16 } from "./fnv1a.ts";
 import { takeGraphemes } from "./graphemes.ts";
@@ -29,7 +30,7 @@ export function resolveTrustedAvatarUrl(
   resourceBasePath = readAvatarGatewayContext().resourceBasePath,
 ): string | null {
   try {
-    const parsed = new URL(value, ORIGIN_PROBE);
+    const parsed = new URL(uiDevGatewayResourceUrl(value), ORIGIN_PROBE);
     const relativeRoute = parsed.origin === ORIGIN_PROBE;
     const userPath = canonicalizeControlUiUserAvatarPath(parsed.pathname, resourceBasePath);
     const agentPath = parseControlUiResourcePath("agentAvatar", parsed.pathname, resourceBasePath);

--- a/ui/src/pages/plugin/plugin-page.test.ts
+++ b/ui/src/pages/plugin/plugin-page.test.ts
@@ -238,6 +238,35 @@ describe("PluginPage", () => {
     }
   });
 
+  it.each(["", "/openclaw"])(
+    "uses the development transport for a plugin frame and its auth probe at base %s",
+    async (basePath) => {
+      const gatewayUrl = `ws://gateway.example${basePath}`;
+      const proxyPath = `/__openclaw_dev_gateway__/${encodeURIComponent(gatewayUrl)}`;
+      vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", { gatewayUrl, proxyPath });
+      const path = `${basePath}/plugins/external/panel?view=activity#settings`;
+      const refresh = vi.fn(async () =>
+        externalPluginConfig([
+          {
+            pluginId: "external-plugin",
+            path: `${proxyPath}${basePath}/plugins/external`,
+            match: "prefix",
+          },
+        ]),
+      );
+      const page = createExternalPluginPage(refresh, true, path);
+      document.body.append(page);
+      try {
+        await waitForFast(() =>
+          expect(page.querySelector("iframe")?.getAttribute("src")).toBe(`${proxyPath}${path}`),
+        );
+        expect(page.probeCalls).toEqual([`${proxyPath}${path}`]);
+      } finally {
+        page.remove();
+      }
+    },
+  );
+
   it("keeps the frame unmounted when browser policy blocks the sandbox cookie", async () => {
     const refresh = vi.fn(async () => externalPluginConfig());
     const page = createExternalPluginPage(refresh);

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -20,6 +20,7 @@ import {
 } from "../../app/stale-chunk-reload.ts";
 import { renderLazyViewError } from "../../components/lazy-view-error.ts";
 import { renderLoadingState } from "../../components/loading-state.ts";
+import { uiDevGatewayResourceUrl } from "../../dev-gateway.ts";
 import { t } from "../../i18n/index.ts";
 import { registerLoginEnglish } from "../../i18n/locales/en-login.ts";
 import { resolveEmbedSandbox } from "../../lib/chat/tool-display.ts";
@@ -578,7 +579,9 @@ export class PluginPage extends OpenClawLightDomContentsElement {
 
   private tabInfo(): GatewayControlUiPluginTab | undefined {
     const tabs = this.context?.gateway.snapshot.hello?.controlUiTabs ?? [];
-    return tabs.find((tab) => tab.pluginId === this.pluginId && tab.id === this.tabId);
+    const tab = tabs.find((entry) => entry.pluginId === this.pluginId && entry.id === this.tabId);
+    const path = tab?.path && uiDevGatewayResourceUrl(tab.path);
+    return tab && path && path !== tab.path ? { ...tab, path } : tab;
   }
 
   override render() {

--- a/ui/src/pages/plugins/icon-loader.ts
+++ b/ui/src/pages/plugins/icon-loader.ts
@@ -1,5 +1,6 @@
 import { buildControlUiResourcePath } from "../../../../src/gateway/control-ui-resource-routes.js";
 import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
+import { hasSameOriginGatewayTransport } from "../../dev-gateway.ts";
 
 const ALLOWED_PLUGIN_ICON_MIME_TYPES = new Set(["image/png", "image/svg+xml", "image/x-icon"]);
 const PLUGIN_ICON_RASTER_SIZE = 256;
@@ -65,20 +66,6 @@ type PluginIconAuthSource = Parameters<typeof resolveControlUiAuthCandidates>[0]
 
 function normalizeMimeType(contentType: string | null): string {
   return contentType?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-}
-
-function gatewayIsSameOrigin(gatewayUrl: string): boolean {
-  try {
-    const url = new URL(gatewayUrl, window.location.href);
-    if (url.protocol === "ws:") {
-      url.protocol = "http:";
-    } else if (url.protocol === "wss:") {
-      url.protocol = "https:";
-    }
-    return url.origin === window.location.origin;
-  } catch {
-    return false;
-  }
 }
 
 function parseSvgNumber(value: string): number | null {
@@ -329,7 +316,7 @@ async function fetchProxiedIconBlobUrl(
   params: FetchProxiedIconParams,
   routeUrl: string,
 ): Promise<string | null> {
-  if (!gatewayIsSameOrigin(params.gatewayUrl)) {
+  if (!hasSameOriginGatewayTransport(params.gatewayUrl)) {
     return null;
   }
   const authCandidates = resolveControlUiAuthCandidates(params.auth);

--- a/ui/src/plugins/control-ui-loader.ts
+++ b/ui/src/plugins/control-ui-loader.ts
@@ -2,13 +2,14 @@ import { controlUiPluginAssetPrefix } from "../../../src/gateway/control-ui-plug
 import type { ControlUiDisposer, ControlUiPlugin } from "../../../src/plugin-sdk/control-ui.js";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
+import { uiDevGatewayResourceUrl } from "../dev-gateway.ts";
 import { createControlUiPluginHost } from "./control-ui-host.ts";
 import type { ControlUiPluginOwner, ControlUiPluginRuntime } from "./control-ui-runtime.ts";
 // Native views and contributions must be defined before activation can publish registrations.
 import "./control-ui-view.runtime.ts";
 
 function assetUrl(path: string, prefix: string): string {
-  const url = new URL(path, window.location.href);
+  const url = new URL(uiDevGatewayResourceUrl(path), window.location.href);
   if (url.origin !== window.location.origin || !url.pathname.startsWith(prefix)) {
     throw new Error("Native plugin assets must be served by this Control UI Gateway.");
   }

--- a/ui/src/plugins/control-ui-runtime.ts
+++ b/ui/src/plugins/control-ui-runtime.ts
@@ -15,6 +15,7 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { readGatewayOperatorAccess } from "../app/operator-access.ts";
+import { hasSameOriginGatewayTransport } from "../dev-gateway.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import type {
@@ -172,7 +173,7 @@ export class ControlUiPluginRuntime implements ControlUiPluginCapability {
       if (catalog.plugins.length) {
         const gatewayUrl = new URL(client.gatewayUrl, window.location.href);
         gatewayUrl.protocol = gatewayUrl.protocol.replace(/^ws/u, "http");
-        if (gatewayUrl.origin !== window.location.origin) {
+        if (!hasSameOriginGatewayTransport(client.gatewayUrl)) {
           this.loadingCatalog = null;
           const error = new Error(
             `Native plugin UI requires the Control UI served by the connected Gateway. Open ${gatewayUrl.origin} and reconnect there.`,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/gateway/control-ui-asset-manifest.ts";
 import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../src/gateway/control-ui-root-assets.ts";
 import { controlUiCodeSplitting } from "./config/control-ui-chunking.ts";
+import { createControlUiDevGateway } from "./config/control-ui-dev-gateway.ts";
 import { controlUiHoverGuardPlugin } from "./config/control-ui-hover-guard.ts";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
 import { controlUiSocialCardPlugin } from "./config/control-ui-social-card.ts";
@@ -562,17 +563,26 @@ function controlUiAssetManifestPlugin(buildOutDir: string): Plugin {
   };
 }
 
-export default function controlUiViteConfig(options: { outDir?: string } = {}): UserConfig {
+export default function controlUiViteConfig(
+  options: { outDir?: string; command?: "serve" | "build" } = {},
+): UserConfig {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
   const bootstrapConfigPath =
     base === "./" ? "/control-ui-config.json" : `${base}control-ui-config.json`;
   const buildInfo = resolveControlUiBuildInfo();
+  const devGateway =
+    options.command === "serve"
+      ? createControlUiDevGateway(process.env.OPENCLAW_UI_DEV_GATEWAY_URL)
+      : undefined;
   const buildOutDir = options.outDir ?? outDir;
   return {
     base,
     define: {
       "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify(buildInfo),
+      "globalThis.OPENCLAW_UI_DEV_GATEWAY": devGateway
+        ? JSON.stringify(devGateway.gateway)
+        : "undefined",
     },
     publicDir: path.resolve(here, "public"),
     css: {
@@ -613,9 +623,10 @@ export default function controlUiViteConfig(options: { outDir?: string } = {}): 
       chunkSizeWarningLimit: 1024,
     },
     server: {
-      host: true,
+      host: devGateway ? "127.0.0.1" : true,
       port: 5173,
       strictPort: true,
+      ...(devGateway ? { proxy: devGateway.proxy } : {}),
     },
     plugins: [
       controlUiSocialCardPlugin(),
@@ -627,6 +638,9 @@ export default function controlUiViteConfig(options: { outDir?: string } = {}): 
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {
+          if (devGateway) {
+            return;
+          }
           server.middlewares.use(bootstrapConfigPath, (_req, res) => {
             res.setHeader("Content-Type", "application/json");
             res.end(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where developers could connect `pnpm ui:dev` to a real Gateway over WebSocket while its enabled capabilities, media, and native plugin UI remained unavailable.

## Why This Change Was Made

Adds `OPENCLAW_UI_DEV_GATEWAY_URL` to route Gateway HTTP and WebSocket traffic through Vite. The browser retains the actual Gateway identity for credentials and settings, while an upstream-specific proxy path and scoped cookie paths prevent a stale page from forwarding credentials to a replacement target. Gateway authentication and browser Origin checks remain in place.

## User Impact

```bash
OPENCLAW_UI_DEV_GATEWAY_URL=http://127.0.0.1:18789 pnpm ui:dev --host 127.0.0.1 --port 5173
```

Developers can use the selected Gateway's capabilities while retaining Vite's normal reload behavior and the Gateway's existing login and owner pairing flows. Selecting another upstream requires restarting the dev server. Unconfigured development and production builds retain their existing behavior.

## Evidence

- 148 focused owner tests passed, including HTTP/WebSocket proxying, Origin/auth forwarding, scoped cookies, stale proxy rejection, malformed grants, and root/mounted avatar and plugin paths.
- UI typecheck, targeted lint, formatting, file-size and assertion checks passed remotely. Hosted CI passed on the final head, including all UI and real-Gateway E2E lanes.
- Real source Gateways verified normal dashboard handoff and device pairing, capabilities, native plugin activation, protected iframe/media/avatar resources, Vite HMR, and paired reload at root and separate Gateway/UI mounts.
- Reusing the same Vite URL for a replacement Gateway required separate pairing and sent no prior Gateway HTTP or WebSocket credentials. A saved foreign Gateway and a foreign handoff also produced no foreign credential requests or socket attempts.

## Visual evidence

| Before | After |
| --- | --- |
| ![The Vite Control UI cannot activate the native plugin panel on the baseline](https://github.com/user-attachments/assets/999cfb55-7f9d-4e23-a612-4600ec9d0a12) | ![The native plugin fixture activates through the configured Gateway transport](https://github.com/user-attachments/assets/6ea57a45-dff1-435f-87bc-7edab9f511a5) |

### Native plugin stays connected through Vite HMR and reconnects after a paired reload

https://github.com/user-attachments/assets/f55f687e-dd29-4c2e-9a40-91208dd54efa

### Visual verification

- Baseline: 20e0ed521c00fd38b1d4d003636fa4ddd3bf2066
- Exact head: `82699a7c3fcb2462dcf4b4bb4b92e03aa0095a39`
- Scenario: Open the native plugin fixture through pnpm ui:dev, update an imported module through Vite HMR, then reload using the normally paired browser.
- Runtime/build: OpenClaw 2026.9.3 source Gateway with qaRuntime and static assets rebuilt at 82699a7; Node 24.19.0; Chromium 144; pnpm 12.3.4
- Gateway capabilities: terminalEnabled and cliAgentsEnabled: false on baseline; true with configured transport
- Native plugin: Baseline panel unavailable; final plugin activated at root and mounted Gateway/UI paths
- HMR and reload: Imported module 1 -> 2 retained the same document and Gateway client; paired reload reconnected
- Protected HTTP resources: Native assets, plugin iframe, profile avatar, and media loaded; unauthenticated frame and plugin requests returned 401
- Stored foreign target and handoff: Configured target selected; 0 foreign credential requests and 0 foreign socket attempts
- Same UI URL, replacement Gateway: New Gateway required its own pairing; distinct credentials; 0 leaked HTTP/WS credentials across 38 second-Gateway frames; stale proxy prefix did not reach the replacement
- Equivalent before/after fixture, route, viewport, light theme, scale, and scroll position; isolated loopback ports differ.
- Final remote builds and proof were guarded by complete tracked-source fingerprints. The preserved baseline uses the pre-change source build.
- Both screenshots and the complete recording were manually inspected; the focused clip retains real timing and factual HMR/reload cues.
