### PR TITLE
fix(ios): prevent history recall during composition or selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5110,6 +5110,7 @@ jobs:
             -resultBundlePath "$result_bundle" \
             -parallel-testing-enabled NO \
             -only-testing:OpenClawLogicTests/WatchVoiceTurnTrackerTests \
+            -only-testing:OpenClawTests/ChatComposerTextViewIOSTests \
             -only-testing:OpenClawTests/DelayedActionGateTests \
             -only-testing:OpenClawTests/IOSGatewayChatTransportTests \
             -only-testing:OpenClawTests/LocationServiceCallbackTests \

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -428,6 +428,8 @@ targets:
         group: Tests
       - path: ../shared/OpenClawKit/Tests/OpenClawKitTests/ChatSelectableTextViewTests.swift
         group: Tests
+      - path: ../shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+        group: Tests
       - path: ../shared/OpenClawKit/Tests/OpenClawKitTests/ChatPasteboardTests.swift
         group: Tests
       - path: WatchApp/Sources/WatchDeferredPayloadOrdering.swift

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -124,7 +124,11 @@ final class ChatComposerUITextView: UITextView {
         modifierFlags: UIKeyModifierFlags) -> Bool
     {
         let commandModifiers: UIKeyModifierFlags = [.shift, .control, .alternate, .command]
-        guard modifierFlags.isDisjoint(with: commandModifiers) else { return false }
+        // UIKit owns composition and selection even while history recall is active.
+        guard modifierFlags.isDisjoint(with: commandModifiers),
+              self.markedTextRange == nil,
+              self.selectedRange.length == 0
+        else { return false }
         switch keyCode {
         case .keyboardUpArrow:
             return self.onHistoryUp?(self.caretOnFirstLine) == true

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
@@ -58,9 +58,97 @@ struct ChatComposerTextViewIOSTests {
 
         #expect(upContexts == [true, false])
         #expect(downCalls == 1)
-        #expect(!textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: .shift))
+        for modifiers in [UIKeyModifierFlags.shift, .control, .alternate, .command] {
+            #expect(!textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: modifiers))
+            #expect(!textView.handleHardwareKey(.keyboardDownArrow, modifierFlags: modifiers))
+        }
+        #expect(upContexts == [true, false])
+        #expect(downCalls == 1)
         #expect(textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: .alphaShift))
         #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+
+        textView.onHistoryUp = { _ in false }
+        textView.onHistoryDown = { false }
+        #expect(!textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: []))
+        #expect(!textView.handleHardwareKey(.keyboardDownArrow, modifierFlags: []))
+    }
+
+    @Test(arguments: [UIKeyboardHIDUsage.keyboardUpArrow, .keyboardDownArrow], [false, true])
+    func arrowKeysPreserveEditorStateAndActiveRecall(
+        keyCode: UIKeyboardHIDUsage,
+        hasMarkedText: Bool) throws
+    {
+        let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
+        let draft = "  working draft\nstill editing  "
+        var history = ChatInputHistory()
+        history.record("older")
+        history.record("ka newer")
+        textView.text = try #require(history.previous(draft: draft))
+        try #require(history.cursor == 0)
+
+        var upCalls = 0
+        var downCalls = 0
+        textView.onHistoryUp = { _ in
+            upCalls += 1
+            guard let recalled = history.previous(draft: textView.text) else { return false }
+            textView.text = recalled
+            return true
+        }
+        textView.onHistoryDown = {
+            downCalls += 1
+            guard let recalled = history.next() else { return false }
+            textView.text = recalled
+            return true
+        }
+        defer {
+            textView.onHistoryUp = nil
+            textView.onHistoryDown = nil
+        }
+
+        textView.selectedRange = NSRange(location: 0, length: 2)
+        if hasMarkedText {
+            textView.setMarkedText("ka", selectedRange: NSRange(location: 2, length: 0))
+            let markedRange = try #require(textView.markedTextRange)
+            try #require(textView.selectedRange.length == 0)
+            try #require(textView.offset(from: textView.beginningOfDocument, to: markedRange.start) == 0)
+            try #require(textView.offset(from: markedRange.start, to: markedRange.end) == 2)
+            try #require(textView.text(in: markedRange) == "ka")
+        } else {
+            try #require(textView.markedTextRange == nil)
+            try #require(textView.selectedRange == NSRange(location: 0, length: 2))
+        }
+
+        let textBefore = textView.text
+        let selectionBefore = textView.selectedRange
+        let historyBefore = history
+        #expect(!textView.handleHardwareKey(keyCode, modifierFlags: []))
+        #expect(upCalls == 0)
+        #expect(downCalls == 0)
+        #expect(textView.text == textBefore)
+        #expect(textView.selectedRange == selectionBefore)
+        #expect(history == historyBefore)
+        if hasMarkedText {
+            let markedRange = try #require(textView.markedTextRange)
+            #expect(textView.offset(from: textView.beginningOfDocument, to: markedRange.start) == 0)
+            #expect(textView.offset(from: markedRange.start, to: markedRange.end) == 2)
+            #expect(textView.text(in: markedRange) == "ka")
+            textView.unmarkText()
+        } else {
+            textView.selectedRange = NSRange(location: 0, length: 0)
+        }
+        try #require(textView.markedTextRange == nil)
+        try #require(textView.selectedRange.length == 0)
+
+        #expect(textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: []))
+        #expect(textView.text == "older")
+        #expect(textView.handleHardwareKey(.keyboardDownArrow, modifierFlags: []))
+        #expect(textView.text == "ka newer")
+        #expect(textView.handleHardwareKey(.keyboardDownArrow, modifierFlags: []))
+        #expect(textView.text == draft)
+        #expect(!history.isRecalling)
+        #expect(history.stashedDraft == nil)
+        #expect(upCalls == 1)
+        #expect(downCalls == 2)
     }
 }
 #endif


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch.

</details>

## What Problem This Solves

Fixes an issue where users editing the iOS chat composer could replace marked composition text or a text selection with recalled history by pressing Up or Down, including while history recall was already active.

## Why This Change Was Made

Keep arrow keys with UIKit whenever marked text or a nonempty selection is present, before either history callback can run. Existing modifier exclusions, caret eligibility, callback results, responder routing, focus behavior, Return/newline behavior, and history-entry/draft-restoration policy remain unchanged.

## User Impact

Composition and selection stay editor-owned instead of invoking chat history. Eligible recall and exact stashed-draft restoration remain available after composition is unmarked or the selection is collapsed.

## Evidence

Completed on the unchanged source:

- Swift frontend parsing with an iOS target before and after the change. This was syntax-only; the host emitted a macOS SDK warning.
- Structured YAML checks confirmed the existing test source inclusion and the single focused-suite selector, with no unrelated configuration changes.
- The extracted simulator command passed `bash -n`; `git diff --check` and the workflow's `oxfmt --check` passed. App sources are excluded by the repository's oxfmt configuration.
- Independent review completed without actionable findings in the changed scope; final source verification confirmed the reviewed input was unchanged.

Authored, not executed: real UIKit responder tests independently cover Up/Down with selected text and marked text during active two-entry recall. They check unused callbacks, unchanged editor/history state, eligible recall after collapse/unmark, and exact draft restoration. Existing Return/newline and Caps Lock coverage is retained; modifier and rejecting-callback coverage is extended.

**Native proof remains UNRUN:** native typechecking/build, pre-fix failing and post-fix passing UIKit execution, physical IME/hardware-key dispatch, responder-chain routing, and the SwiftUI binding flow. This environment has Command Line Tools and Swift 6.3.3, but no Xcode, iOS SDK, or simulator. Parsing, YAML checks, source review, and ordinary PR CI are not substitutes.

The suite is included in the existing iOS test target and the existing full-manual tests-phase selector. Ordinary PR CI runs iOS smoke only and does **not** execute this suite. No manual CI or native run was dispatched for this draft.

Required focused command in a prepared Xcode/iOS simulator environment, on both the pre-fix and fixed source:

```bash
xcodebuild \
  -project apps/ios/OpenClaw.xcodeproj \
  -scheme OpenClaw \
  -configuration Debug \
  -destination "platform=iOS Simulator,id=${simulator_id}" \
  -parallel-testing-enabled NO \
  -only-testing:OpenClawTests/ChatComposerTextViewIOSTests \
  test
```
