### PR TITLE
refactor(tests): remove duplicate warm chat metadata scenario

### DIFF
--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -691,42 +691,33 @@ describe("refreshChat", () => {
     },
   );
 
-  it.each(["missing", "empty"])(
-    "revalidates a warm %s snapshot when startup omits metadata",
-    async (kind) => {
-      const ready = { id: "model", name: "Model", provider: "test", available: true };
-      const host = makeChatHost({
-        requestHandlers: {
-          "chat.startup": async () => ({ messages: [] }),
-          "chat.metadata": async () => ({ commands: [] }),
-          "models.list": async () => ({ models: [ready] }),
-        },
-      });
-      const client = expectDefined(host.client, "chat client");
-      const scope = { agentId: "main", sessionKey: host.sessionKey };
-      const release = subscribeChatMetadata(client, scope, () => {});
-      beginChatMetadataPublication(client, scope).publish({
-        commands: [],
-        models:
-          kind === "empty"
-            ? []
-            : [{ ...ready, available: false, unavailableReason: "missing-auth" }],
-      });
-      await refreshPageChat(asChatPageHost(host), {
-        startup: true,
-        awaitHistory: true,
-        deferBranches: true,
-      });
-      try {
-        await waitForFast(() => expect(host.chatModelCatalog).toEqual([ready]));
-        expect(asChatPageHost(host).chatModelsLoading).toBe(false);
-        expect(host.request).toHaveBeenCalledWith("chat.metadata", scope);
-      } finally {
-        release();
-        retireChatMetadataRequests(asChatPageHost(host));
-      }
-    },
-  );
+  it("revalidates warm command metadata when startup omits metadata", async () => {
+    const ready = { id: "model", name: "Model", provider: "test", available: true };
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.startup": async () => ({ messages: [] }),
+        "chat.metadata": async () => ({ commands: [] }),
+        "models.list": async () => ({ models: [ready] }),
+      },
+    });
+    const client = expectDefined(host.client, "chat client");
+    const scope = { agentId: "main", sessionKey: host.sessionKey };
+    const release = subscribeChatMetadata(client, scope, () => {});
+    beginChatMetadataPublication(client, scope).publish({ commands: [] });
+    await refreshPageChat(asChatPageHost(host), {
+      startup: true,
+      awaitHistory: true,
+      deferBranches: true,
+    });
+    try {
+      await waitForFast(() => expect(host.chatModelCatalog).toEqual([ready]));
+      expect(asChatPageHost(host).chatModelsLoading).toBe(false);
+      expect(host.request).toHaveBeenCalledWith("chat.metadata", scope);
+    } finally {
+      release();
+      retireChatMetadataRequests(asChatPageHost(host));
+    }
+  });
 
   it.each([
     [


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The chat refresh suite runs the same warm metadata recovery scenario twice. The original unavailable-versus-empty model distinction became obsolete when #142165 moved catalog reads to their direct owner and excluded models from the commands cache.

## Why This Change Was Made

Keep one warm commands-cache case for startup responses that omit metadata. Preserve its catalog, loading-state, and revalidation assertions and subscription cleanup. The separate store regression still proves legacy model fields are discarded; the competing startup/direct catalog regression remains unchanged.

## User Impact

No user-visible behavior changes. This removes one duplicate test invocation and nine net test lines.

## Evidence

The complete chat-send and chat-metadata-store suites passed before (363 tests) and after (362 tests), with zero skips. Raw result comparison confirms exactly the two obsolete rows were replaced by one case; every other test name and order is unchanged. The mapped changed-file gate and fresh independent P2 review passed. No full-suite runtime improvement is claimed.
