### PR TITLE
fix(agents): keep prepared music jobs alive through provider cleanup

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -61,8 +61,8 @@ completed video assets and result metadata. Video assets may contain buffers or
 provider-hosted URLs. Downloads after the call returns belong to the caller;
 registration disposal must not invalidate those completed artifacts.
 
-For `image_generate` tools prepared from an owned inspection, resources remain
-held through preflight and, once accepted, through generation, image saving, and
+For `image_generate` and `music_generate` tools prepared from an owned inspection,
+resources remain held through preflight and, once accepted, through generation, media saving, and
 any rollback. A `started` result acknowledges acceptance; it does not mean the
 work or cleanup has finished. If the original inspection retires during
 preflight, new task admission is rejected. Prepare tools from the current provider

--- a/src/agents/tools/image-generate-tool.execution.ts
+++ b/src/agents/tools/image-generate-tool.execution.ts
@@ -15,15 +15,11 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { getImageMetadata } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import { acquirePluginCapabilityProviders } from "../../plugins/capability-provider-acquisition.js";
-import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
-import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import {
   formatGeneratedAttachmentLines,
   sanitizeGeneratedMediaDisplayText,
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
-import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.types.js";
 import { ToolInputError } from "./common.js";
 import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import {
@@ -40,98 +36,6 @@ import {
 
 const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
 const GENERATED_IMAGE_MEDIA_SUBDIR = "tool-image-generation";
-
-export async function acquireImageGenerationToolProviders(params: {
-  cfg: OpenClawConfig;
-  prepared?: PreparedModelRuntimeSnapshot;
-}) {
-  const work = new AsyncWorkScope();
-  const prepared = params.prepared;
-  const inGeneration = <T>(run: () => T): T =>
-    prepared
-      ? withPluginRuntimeGenerationScope(
-          { metadataSnapshot: prepared.metadataSnapshot, pluginRegistry: prepared.pluginRegistry },
-          run,
-        )
-      : run();
-  let captured:
-    | ReturnType<NonNullable<PreparedModelRuntimeSnapshot["acquireMediaCapabilityProviders"]>>
-    | undefined;
-  let cold:
-    | Awaited<ReturnType<typeof acquirePluginCapabilityProviders<"imageGenerationProviders">>>
-    | undefined;
-  let releaseCompletion: Promise<void> | undefined;
-  const release = () =>
-    (releaseCompletion ??= Promise.resolve().then(async () => {
-      work.beginClose();
-      try {
-        await work.runWhenIdle(async () => {
-          const errors: unknown[] = [];
-          // A copied prepared registry can contribute callbacks without a second physical claim.
-          // Drain the cold view's work before surrendering its original prepared source.
-          for (const owner of [cold, captured]) {
-            try {
-              await owner?.release();
-            } catch (error) {
-              errors.push(error);
-            }
-          }
-          if (errors.length > 0) {
-            throw new AggregateError(errors, "Image provider resource cleanup failed");
-          }
-        });
-      } finally {
-        await work.drain();
-      }
-    }));
-  try {
-    const providers = await work.track(async () => {
-      captured = prepared?.acquireMediaCapabilityProviders?.();
-      const known = captured
-        ? captured.providers.imageGenerationProviders
-        : prepared?.mediaCapabilityProviders?.imageGenerationProviders;
-      if (known !== undefined) {
-        return [...known];
-      }
-      cold = await inGeneration(() =>
-        acquirePluginCapabilityProviders({ key: "imageGenerationProviders", cfg: params.cfg }),
-      );
-      return cold.providers;
-    });
-    return {
-      providers,
-      assertOpen: () => {
-        if (releaseCompletion) {
-          throw new Error("Image provider resources have been released");
-        }
-        captured?.assertOpen();
-        cold?.assertOpen();
-      },
-      run: <T>(run: () => T | Promise<T>) =>
-        releaseCompletion
-          ? Promise.reject(new Error("Image provider resources have been released"))
-          : work.track(() => inGeneration(() => (cold ? cold.run(run) : run()))),
-      release,
-    };
-  } catch (error) {
-    let cleanupFailure: { error: unknown } | undefined;
-    try {
-      await release();
-    } catch (cleanupError) {
-      cleanupFailure = { error: cleanupError };
-    }
-    if (cleanupFailure) {
-      throw new AggregateError(
-        [error, cleanupFailure.error],
-        "Image provider acquisition and cleanup failed",
-        {
-          cause: error,
-        },
-      );
-    }
-    throw error;
-  }
-}
 
 function formatIgnoredImageGenerationOverride(override: ImageGenerationIgnoredOverride): string {
   return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(override.value)}`;

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -40,7 +40,7 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => (
 }));
 
 let imageGenerationRuntime: typeof import("../../image-generation/runtime.js");
-let imageGenerationExecution: typeof import("./image-generate-tool.execution.js");
+let mediaGenerationToolProviders: typeof import("./media-generation-tool-providers.js");
 let mediaGenerationRegistry: typeof import("../../media-generation/registry.js");
 let imageOps: typeof import("../../media/media-services.js");
 let splitMediaFromOutput: typeof import("../../media/parse.js").splitMediaFromOutput;
@@ -354,7 +354,7 @@ describe("createImageGenerateTool", () => {
       };
     });
     imageGenerationRuntime = await import("../../image-generation/runtime.js");
-    imageGenerationExecution = await import("./image-generate-tool.execution.js");
+    mediaGenerationToolProviders = await import("./media-generation-tool-providers.js");
     mediaGenerationRegistry = await import("../../media-generation/registry.js");
     imageOps = await import("../../media/media-services.js");
     ({ splitMediaFromOutput } = await import("../../media/parse.js"));
@@ -368,14 +368,15 @@ describe("createImageGenerateTool", () => {
 
   beforeEach(() => {
     // These fixtures cover routing and limits; the native suite proves actual resource ownership.
-    vi.spyOn(imageGenerationExecution, "acquireImageGenerationToolProviders").mockImplementation(
-      async ({ cfg }) => ({
-        providers: imageGenerationRuntime.listRuntimeImageGenerationProviders({ config: cfg }),
-        assertOpen() {},
-        run: async (run) => await run(),
-        release: async () => {},
-      }),
-    );
+    vi.spyOn(
+      mediaGenerationToolProviders,
+      "acquireImageGenerationToolProviders",
+    ).mockImplementation(async ({ cfg }) => ({
+      providers: imageGenerationRuntime.listRuntimeImageGenerationProviders({ config: cfg }),
+      assertOpen() {},
+      run: async (run) => await run(),
+      release: async () => {},
+    }));
     vi.spyOn(mediaGenerationRegistry, "withImageGenerationProviders").mockImplementation(
       async (cfg, run) =>
         await run(imageGenerationRuntime.listRuntimeImageGenerationProviders({ config: cfg })),
@@ -1280,7 +1281,7 @@ describe("createImageGenerateTool", () => {
 
   it("returns active status for a duplicate image request with the same prompt", async () => {
     const acquireProviders = vi.mocked(
-      imageGenerationExecution.acquireImageGenerationToolProviders,
+      mediaGenerationToolProviders.acquireImageGenerationToolProviders,
     );
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -35,7 +35,6 @@ import {
   createImageGenerateStatusActionResult,
 } from "./image-generate-tool.actions.js";
 import {
-  acquireImageGenerationToolProviders,
   executeImageGenerationJob,
   loadImageGenerationReferences,
   inferImageGenerationResolution,
@@ -52,6 +51,7 @@ import {
   runMediaGenerationTask,
   type ImageGenerationTaskHandle,
 } from "./media-generate-background.js";
+import { acquireImageGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,

--- a/src/agents/tools/media-generate-tool.resources.test.ts
+++ b/src/agents/tools/media-generate-tool.resources.test.ts
@@ -23,16 +23,22 @@ import { prepareWorkspaceBuildGroup } from "../prepared-model-runtime.facts.js";
 import { createPreparedModelRuntimeSnapshot } from "../prepared-model-runtime.full-catalog.js";
 import { ModelRegistry } from "../sessions/model-registry.js";
 import { createImageGenerateTool } from "./image-generate-tool.js";
-import { imageGenerationTaskLifecycle } from "./media-generate-background.js";
+import {
+  imageGenerationTaskLifecycle,
+  musicGenerationTaskLifecycle,
+} from "./media-generate-background.js";
+import { createMusicGenerateTool } from "./music-generate-tool.js";
 
 const png = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMQVDL+DwACFAFmBODefwAAAABJRU5ErkJggg==",
   "base64",
 );
 
-function createNativeFixture(edit = false) {
+type GenerationKind = "image" | "music";
+
+function createNativeFixture(kind: GenerationKind, edit = false, trackCount = 1) {
   const dir = makePluginLoaderTempDir();
-  const key = `__openclaw_prepared_image_${path.basename(dir)}`;
+  const key = `__openclaw_prepared_${kind}_${path.basename(dir)}`;
   const connections: Array<{
     database: DatabaseSync;
     disposals: number;
@@ -43,9 +49,15 @@ function createNativeFixture(edit = false) {
   const resumeGeneration = createDeferredCore();
   Object.defineProperty(globalThis, key, {
     configurable: true,
-    value: { connections, generated, resumeGeneration, png },
+    value: {
+      connections,
+      generated,
+      resumeGeneration,
+      png,
+      audio: Buffer.from("synthetic native music 42"),
+    },
   });
-  const id = "prepared-image-resource";
+  const id = `prepared-${kind}-resource`;
   const plugin = writePlugin({
     dir,
     id,
@@ -59,13 +71,16 @@ module.exports = {
     state.connections.push(connection);
     const read = () => database.prepare("SELECT 42 AS value").get().value;
     api.lifecycle.registerRuntimeLifecycle({
-      id: "prepared-image-database",
+      id: "prepared-media-database",
       dispose() {
         read();
         connection.disposals++;
         database.close();
       },
     });
+${
+  kind === "image"
+    ? `
     api.registerImageGenerationProvider({
       id: ${JSON.stringify(id)},
       defaultModel: "fixture-image",
@@ -90,6 +105,33 @@ module.exports = {
         };
       },
     });
+`
+    : `
+    api.registerMusicGenerationProvider({
+      id: ${JSON.stringify(id)},
+      defaultModel: "fixture-music",
+      isConfigured() { return read() === 42; },
+      capabilities: { generate: { maxTracks: 2 }, edit: { enabled: ${edit}, maxInputImages: ${edit ? 1 : 0} } },
+      async generateMusic() {
+        read();
+        connection.generated++;
+        state.generated.resolve();
+        await state.resumeGeneration.promise;
+        read();
+        return {
+          tracks: Array.from({ length: ${trackCount} }, (_, index) => ({
+            buffer: state.audio,
+            mimeType: "audio/mpeg",
+            get fileName() {
+              connection.projected++;
+              return "native-" + index + "-" + read() + ".mp3";
+            },
+          })),
+        };
+      },
+    });
+`
+}
   },
 };`,
   });
@@ -97,17 +139,18 @@ module.exports = {
     path.join(dir, "openclaw.plugin.json"),
     JSON.stringify({
       id,
-      contracts: { imageGenerationProviders: [id] },
+      contracts: { [`${kind}GenerationProviders`]: [id] },
       configSchema: { type: "object", additionalProperties: false, properties: {} },
     }),
   );
   const config: OpenClawConfig = {
-    agents: { defaults: { mediaModels: { image: { primary: `${id}/fixture-image` } } } },
+    agents: { defaults: { mediaModels: { [kind]: { primary: `${id}/fixture-${kind}` } } } },
     plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
   };
   return {
     dir,
     config,
+    output: kind === "image" ? png : Buffer.from("synthetic native music 42"),
     connections,
     generated,
     resumeGeneration,
@@ -163,7 +206,7 @@ async function prepareSnapshot(
     readFullModelCatalog: () => catalog.modelCatalog,
     loadFullModelCatalog: async () => catalog.modelCatalog,
     loadAuth: async () => {
-      throw new Error("The synthetic image provider does not request model credentials");
+      throw new Error("The synthetic media provider does not request model credentials");
     },
   });
 }
@@ -176,9 +219,11 @@ afterEach(() => {
 });
 afterAll(cleanupPluginLoaderFixturesForTest);
 
-describe("prepared image job registration resources", () => {
+describe.each(["image", "music"] as const)("prepared %s job registration resources", (kind) => {
+  const createTool = kind === "image" ? createImageGenerateTool : createMusicGenerateTool;
+  const lifecycle = kind === "image" ? imageGenerationTaskLifecycle : musicGenerationTaskLifecycle;
   it("refuses new paid admission when the prepared owner releases during reference loading", async () => {
-    const fixture = createNativeFixture(true);
+    const fixture = createNativeFixture(kind, true);
     const referenceStarted = createDeferredCore();
     const resumeReference = createDeferredCore();
     try {
@@ -188,11 +233,11 @@ describe("prepared image job registration resources", () => {
         const referencePath = path.join(fixture.dir, "reference.png");
         fs.writeFileSync(referencePath, png);
         const snapshot = await prepareSnapshot(fixture, first.registry);
-        const createTask = vi.spyOn(imageGenerationTaskLifecycle, "createTaskRun").mockReturnValue({
+        const createTask = vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
           taskId: "preflight-image-task",
           runId: "preflight-image-run",
-          requesterSessionKey: "agent:main:discord:direct:synthetic-image",
-          taskLabel: "Synthetic image edit",
+          requesterSessionKey: "agent:main:discord:direct:synthetic-media",
+          taskLabel: "Synthetic media edit",
         });
         const schedule = vi.fn();
         const loadReference = webMedia.loadWebMedia;
@@ -201,16 +246,16 @@ describe("prepared image job registration resources", () => {
           await resumeReference.promise;
           return loadReference(...args);
         });
-        const tool = createImageGenerateTool({
+        const tool = createTool({
           config: fixture.config,
           agentDir: snapshot.agentDir,
           workspaceDir: fixture.dir,
           preparedModelRuntime: snapshot,
-          agentSessionKey: "agent:main:discord:direct:synthetic-image",
+          agentSessionKey: "agent:main:discord:direct:synthetic-media",
           scheduleBackgroundWork: schedule,
         });
         const outcome = tool!
-          .execute("preflight-image-call", { prompt: "Synthetic image edit", image: referencePath })
+          .execute("preflight-image-call", { prompt: "Synthetic media edit", image: referencePath })
           .then(
             (value) => ({ value, error: undefined }),
             (error: unknown) => ({ value: undefined, error }),
@@ -219,7 +264,7 @@ describe("prepared image job registration resources", () => {
           await Promise.race([
             referenceStarted.promise,
             outcome.then(() => {
-              throw new Error("Image preflight settled before reading its reference");
+              throw new Error("Media preflight settled before reading its reference");
             }),
           ]);
           await first.release();
@@ -246,7 +291,7 @@ describe("prepared image job registration resources", () => {
   it.each(["queued", "saving", "rollback"] as const)(
     "retains the admitted provider through %s after its parent releases",
     async (phase) => {
-      const fixture = createNativeFixture();
+      const fixture = createNativeFixture(kind, false, phase === "rollback" ? 2 : 1);
       const saveStarted = createDeferredCore();
       const resumeSave = createDeferredCore();
       const rollbackStarted = createDeferredCore();
@@ -260,26 +305,22 @@ describe("prepared image job registration resources", () => {
           let successor: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
           try {
             const snapshot = await prepareSnapshot(fixture, first.registry);
-            expect(snapshot.mediaCapabilityProviders?.imageGenerationProviders).toHaveLength(1);
+            expect(snapshot.mediaCapabilityProviders?.[`${kind}GenerationProviders`]).toHaveLength(
+              1,
+            );
             const connection = fixture.connections[0]!;
-            const sessionKey = "agent:main:discord:direct:synthetic-image";
-            vi.spyOn(imageGenerationTaskLifecycle, "createTaskRun").mockReturnValue({
+            const sessionKey = "agent:main:discord:direct:synthetic-media";
+            vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
               taskId: "image-resource-task",
               runId: "image-resource-run",
               requesterSessionKey: sessionKey,
               requesterAgentId: "main",
-              taskLabel: "Synthetic image resource proof",
+              taskLabel: "Synthetic media resource proof",
             });
-            vi.spyOn(imageGenerationTaskLifecycle, "recordTaskProgress").mockImplementation(
-              () => {},
-            );
-            const completed = vi
-              .spyOn(imageGenerationTaskLifecycle, "completeTaskRun")
-              .mockImplementation(() => {});
-            const failed = vi
-              .spyOn(imageGenerationTaskLifecycle, "failTaskRun")
-              .mockImplementation(() => {});
-            vi.spyOn(imageGenerationTaskLifecycle, "wakeTaskCompletion").mockResolvedValue({
+            vi.spyOn(lifecycle, "recordTaskProgress").mockImplementation(() => {});
+            const completed = vi.spyOn(lifecycle, "completeTaskRun").mockImplementation(() => {});
+            const failed = vi.spyOn(lifecycle, "failTaskRun").mockImplementation(() => {});
+            vi.spyOn(lifecycle, "wakeTaskCompletion").mockResolvedValue({
               status: "delivered",
             });
             const save = mediaStore.saveMediaBuffer;
@@ -289,7 +330,7 @@ describe("prepared image job registration resources", () => {
             vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async (...args) => {
               saveCalls++;
               if (phase === "rollback" && saveCalls === 1) {
-                throw new Error("synthetic first image persistence failure");
+                throw new Error("synthetic first media persistence failure");
               }
               saveStarted.resolve();
               await resumeSave.promise;
@@ -302,7 +343,7 @@ describe("prepared image job registration resources", () => {
               await resumeRollback.promise;
               return remove(...args);
             });
-            const tool = createImageGenerateTool({
+            const tool = createTool({
               config: fixture.config,
               agentDir: snapshot.agentDir,
               workspaceDir: fixture.dir,
@@ -312,7 +353,7 @@ describe("prepared image job registration resources", () => {
             });
             expect(tool).not.toBeNull();
             const started = await tool!.execute("image-resource-call", {
-              prompt: "Synthetic image resource proof",
+              prompt: "Synthetic media resource proof",
               count: phase === "rollback" ? 2 : 1,
             });
             expect(started.details).toMatchObject({ status: "started" });
@@ -331,14 +372,14 @@ describe("prepared image job registration resources", () => {
             await Promise.race([
               fixture.generated.promise,
               completion.then(() => {
-                throw new Error("Image task settled without invoking its prepared provider");
+                throw new Error("Media task settled without invoking its prepared provider");
               }),
             ]);
             fixture.resumeGeneration.resolve();
             await Promise.race([
               saveStarted.promise,
               completion.then(() => {
-                throw new Error("Image task settled before persisting its output");
+                throw new Error("Media task settled before persisting its output");
               }),
             ]);
             await first.release();
@@ -360,7 +401,7 @@ describe("prepared image job registration resources", () => {
               expect(failed).toHaveBeenCalledWith(
                 expect.objectContaining({
                   error: expect.objectContaining({
-                    message: "synthetic first image persistence failure",
+                    message: "synthetic first media persistence failure",
                   }),
                 }),
               );
@@ -370,7 +411,7 @@ describe("prepared image job registration resources", () => {
               expect(failed).not.toHaveBeenCalled();
               expect(completed).toHaveBeenCalledOnce();
               expect(connection.projected).toBeGreaterThan(0);
-              expect(fs.readFileSync(savedPath!)).toEqual(png);
+              expect(fs.readFileSync(savedPath!)).toEqual(fixture.output);
             }
           } finally {
             fixture.resumeGeneration.resolve();

--- a/src/agents/tools/media-generation-tool-providers.ts
+++ b/src/agents/tools/media-generation-tool-providers.ts
@@ -1,0 +1,108 @@
+/** Captures a prepared media source through preflight and accepted task work. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { acquirePluginCapabilityProviders } from "../../plugins/capability-provider-acquisition.js";
+import type { CapabilityProviderFor } from "../../plugins/capability-provider-runtime.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.types.js";
+
+type MediaProviderKey = "imageGenerationProviders" | "musicGenerationProviders";
+type MediaProviderOptions = { cfg: OpenClawConfig; prepared?: PreparedModelRuntimeSnapshot };
+
+export function acquireImageGenerationToolProviders(params: MediaProviderOptions) {
+  return acquireMediaGenerationToolProviders("imageGenerationProviders", params);
+}
+
+export function acquireMusicGenerationToolProviders(params: MediaProviderOptions) {
+  return acquireMediaGenerationToolProviders("musicGenerationProviders", params);
+}
+
+async function acquireMediaGenerationToolProviders<K extends MediaProviderKey>(
+  key: K,
+  params: MediaProviderOptions,
+) {
+  const label = key === "imageGenerationProviders" ? "Image" : "Music";
+  const work = new AsyncWorkScope();
+  const prepared = params.prepared;
+  const inGeneration = <T>(run: () => T): T =>
+    prepared
+      ? withPluginRuntimeGenerationScope(
+          { metadataSnapshot: prepared.metadataSnapshot, pluginRegistry: prepared.pluginRegistry },
+          run,
+        )
+      : run();
+  let captured:
+    | ReturnType<NonNullable<PreparedModelRuntimeSnapshot["acquireMediaCapabilityProviders"]>>
+    | undefined;
+  let cold: Awaited<ReturnType<typeof acquirePluginCapabilityProviders<K>>> | undefined;
+  let releaseCompletion: Promise<void> | undefined;
+  const release = () =>
+    (releaseCompletion ??= Promise.resolve().then(async () => {
+      work.beginClose();
+      try {
+        await work.runWhenIdle(async () => {
+          const errors: unknown[] = [];
+          // A copied prepared registry can contribute callbacks without a second physical claim.
+          // Drain the cold view's work before surrendering its original prepared source.
+          for (const owner of [cold, captured]) {
+            try {
+              await owner?.release();
+            } catch (error) {
+              errors.push(error);
+            }
+          }
+          if (errors.length > 0) {
+            throw new AggregateError(errors, `${label} provider resource cleanup failed`);
+          }
+        });
+      } finally {
+        await work.drain();
+      }
+    }));
+  try {
+    const providers = await work.track(async () => {
+      captured = prepared?.acquireMediaCapabilityProviders?.();
+      const knownProviders:
+        | { [P in MediaProviderKey]?: readonly CapabilityProviderFor<P>[] }
+        | undefined = captured ? captured.providers : prepared?.mediaCapabilityProviders;
+      const known = knownProviders?.[key];
+      if (known !== undefined) {
+        return [...known];
+      }
+      cold = await inGeneration(() => acquirePluginCapabilityProviders({ key, cfg: params.cfg }));
+      return cold.providers;
+    });
+    return {
+      providers,
+      assertOpen: () => {
+        if (releaseCompletion) {
+          throw new Error(`${label} provider resources have been released`);
+        }
+        captured?.assertOpen();
+        cold?.assertOpen();
+      },
+      run: <T>(run: () => T | Promise<T>) =>
+        releaseCompletion
+          ? Promise.reject(new Error(`${label} provider resources have been released`))
+          : work.track(() => inGeneration(() => (cold ? cold.run(run) : run()))),
+      release,
+    };
+  } catch (error) {
+    let cleanupFailure: { error: unknown } | undefined;
+    try {
+      await release();
+    } catch (cleanupError) {
+      cleanupFailure = { error: cleanupError };
+    }
+    if (cleanupFailure) {
+      throw new AggregateError(
+        [error, cleanupFailure.error],
+        `${label} provider acquisition and cleanup failed`,
+        {
+          cause: error,
+        },
+      );
+    }
+    throw error;
+  }
+}

--- a/src/agents/tools/music-generate-tool.execution.ts
+++ b/src/agents/tools/music-generate-tool.execution.ts
@@ -1,0 +1,284 @@
+/** Persists complete music buffers and their metadata before task completion. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
+import { saveMediaBuffer } from "../../media/store.js";
+import { generateMusic } from "../../music-generation/runtime.js";
+import type {
+  MusicGenerationOutputFormat,
+  MusicGenerationProvider,
+  MusicGenerationSourceImage,
+} from "../../music-generation/types.js";
+import {
+  formatGeneratedAttachmentLines,
+  sanitizeGeneratedMediaDisplayText,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
+import {
+  musicGenerationTaskLifecycle,
+  type MusicGenerationTaskHandle,
+} from "./media-generate-background.js";
+import {
+  buildMediaReferenceDetails,
+  buildTaskRunDetails,
+  createCapabilityProviderRuntimeDeps,
+} from "./media-tool-shared.js";
+
+const log = createSubsystemLogger("agents/tools/music-generate");
+const GENERATED_MUSIC_MEDIA_SUBDIR = "tool-music-generation";
+const DEFAULT_MUSIC_GENERATION_TIMEOUT_MS = 300_000;
+const MIN_MUSIC_GENERATION_TIMEOUT_MS = 120_000;
+const GENERATED_MUSIC_PROBE_BUDGET_MS = 3000;
+const GENERATED_MUSIC_PROBE_CONCURRENCY = 2;
+const MAX_GENERATED_MUSIC_PROBES = 8;
+
+type MusicGenerationTimeoutNormalization = {
+  requested: number;
+  applied: number;
+  minimum: number;
+};
+
+export function normalizeMusicGenerationTimeoutMs(timeoutMs: number | undefined): {
+  timeoutMs?: number;
+  normalization?: MusicGenerationTimeoutNormalization;
+  message?: string;
+} {
+  if (timeoutMs === undefined) {
+    return { timeoutMs: DEFAULT_MUSIC_GENERATION_TIMEOUT_MS };
+  }
+  if (timeoutMs >= MIN_MUSIC_GENERATION_TIMEOUT_MS) {
+    return { timeoutMs };
+  }
+
+  const normalization = {
+    requested: timeoutMs,
+    applied: MIN_MUSIC_GENERATION_TIMEOUT_MS,
+    minimum: MIN_MUSIC_GENERATION_TIMEOUT_MS,
+  };
+  const message = `Timeout normalized: requested ${timeoutMs}ms; used ${MIN_MUSIC_GENERATION_TIMEOUT_MS}ms.`;
+  log.warn("music_generate timeoutMs is below provider minimum; using minimum", {
+    requestedTimeoutMs: timeoutMs,
+    appliedTimeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
+    minimumTimeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
+  });
+  return {
+    timeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
+    normalization,
+    message,
+  };
+}
+
+type LoadedReferenceImage = {
+  sourceImage: MusicGenerationSourceImage;
+  resolvedInput: string;
+  rewrittenFrom?: string;
+};
+
+type ExecutedMusicGeneration = {
+  provider: string;
+  model: string;
+  count: number;
+  attachments: AgentGeneratedAttachment[];
+  contentText: string;
+  details: Record<string, unknown>;
+  wakeResult: string;
+};
+
+export async function executeMusicGenerationJob(params: {
+  effectiveCfg: OpenClawConfig;
+  prompt: string;
+  agentDir?: string;
+  model?: string;
+  lyrics?: string;
+  instrumental?: boolean;
+  durationSeconds?: number;
+  format?: MusicGenerationOutputFormat;
+  filename?: string;
+  loadedReferenceImages: LoadedReferenceImage[];
+  taskHandle?: MusicGenerationTaskHandle | null;
+  autoProviderFallback?: boolean;
+  timeoutMs?: number;
+  timeoutNormalization?: MusicGenerationTimeoutNormalization;
+  providers?: MusicGenerationProvider[];
+}): Promise<ExecutedMusicGeneration> {
+  if (params.taskHandle) {
+    musicGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Generating music",
+    });
+  }
+  const result = await generateMusic(
+    {
+      cfg: params.effectiveCfg,
+      prompt: params.prompt,
+      agentDir: params.agentDir,
+      modelOverride: params.model,
+      lyrics: params.lyrics,
+      instrumental: params.instrumental,
+      durationSeconds: params.durationSeconds,
+      format: params.format,
+      inputImages: params.loadedReferenceImages.map((entry) => entry.sourceImage),
+      autoProviderFallback: params.autoProviderFallback,
+      timeoutMs: params.timeoutMs,
+    },
+    createCapabilityProviderRuntimeDeps(params.providers),
+  );
+  if (params.taskHandle) {
+    musicGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Saving generated music",
+    });
+  }
+  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "audio");
+  const savedTracks = await persistGeneratedMediaBatch({
+    subdir: GENERATED_MUSIC_MEDIA_SUBDIR,
+    mode: "concurrent",
+    saves: result.tracks.map((track) => async () => {
+      const savedMedia = await saveMediaBuffer(
+        track.buffer,
+        track.mimeType,
+        GENERATED_MUSIC_MEDIA_SUBDIR,
+        mediaMaxBytes,
+        params.filename || track.fileName,
+      );
+      return { value: savedMedia, savedMedia };
+    }),
+  });
+  const ignoredOverrides = result.ignoredOverrides ?? [];
+  const ignoredOverrideKeys = new Set(ignoredOverrides.map((entry) => entry.key));
+  const requestedDurationSeconds =
+    result.normalization?.durationSeconds?.requested ??
+    (typeof result.metadata?.requestedDurationSeconds === "number" &&
+    Number.isFinite(result.metadata.requestedDurationSeconds)
+      ? result.metadata.requestedDurationSeconds
+      : params.durationSeconds);
+  const runtimeNormalizedDurationSeconds =
+    result.normalization?.durationSeconds?.applied ??
+    (typeof result.metadata?.normalizedDurationSeconds === "number" &&
+    Number.isFinite(result.metadata.normalizedDurationSeconds)
+      ? result.metadata.normalizedDurationSeconds
+      : undefined);
+  const appliedDurationSeconds =
+    runtimeNormalizedDurationSeconds ??
+    (!ignoredOverrideKeys.has("durationSeconds") && typeof params.durationSeconds === "number"
+      ? params.durationSeconds
+      : undefined);
+  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
+  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
+  const warning =
+    ignoredOverrides.length > 0
+      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides
+          .map(
+            (entry) =>
+              `${sanitizeGeneratedMediaDisplayText(entry.key)}=${sanitizeGeneratedMediaDisplayText(String(entry.value))}`,
+          )
+          .join(", ")}.`
+      : undefined;
+  const savedTrackMetadata = await probeMediaFilesWithinBudget(
+    savedTracks.map((track) => ({ filePath: track.path, kind: "audio" })),
+    {
+      budgetMs: GENERATED_MUSIC_PROBE_BUDGET_MS,
+      concurrency: GENERATED_MUSIC_PROBE_CONCURRENCY,
+      maxProbes: MAX_GENERATED_MUSIC_PROBES,
+    },
+  );
+  const attachments: AgentGeneratedAttachment[] = savedTracks.map((track, index) => ({
+    type: "audio",
+    path: track.path,
+    mimeType: track.contentType,
+    name: result.tracks[index]?.fileName,
+    sizeBytes: track.size,
+    ...(typeof appliedDurationSeconds === "number"
+      ? { durationMs: appliedDurationSeconds * 1000 }
+      : {}),
+    ...savedTrackMetadata[index],
+  }));
+  const lines = [
+    `Generated ${savedTracks.length} track${savedTracks.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
+    ...(warning ? [`Warning: ${warning}`] : []),
+    ...(params.timeoutNormalization
+      ? [
+          `Timeout normalized: requested ${params.timeoutNormalization.requested}ms; used ${params.timeoutNormalization.applied}ms.`,
+        ]
+      : []),
+    typeof requestedDurationSeconds === "number" &&
+    typeof appliedDurationSeconds === "number" &&
+    requestedDurationSeconds !== appliedDurationSeconds
+      ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${appliedDurationSeconds}s.`
+      : null,
+    ...(result.lyrics?.length
+      ? [
+          "Lyrics returned.",
+          ...result.lyrics.flatMap((lyric) =>
+            lyric
+              .replace(/\r\n?|[\u2028\u2029]/gu, "\n")
+              .split("\n")
+              .map((line) =>
+                sanitizeGeneratedMediaDisplayText(line)
+                  .replace(/^(\s*)(media):/iu, "$1$2：")
+                  // An open provider fence would swallow the trusted attachment lines appended below.
+                  .replace(/^( {0,3})(`{3,}|~{3,})/u, "$1\\$2"),
+              ),
+          ),
+        ]
+      : []),
+    ...formatGeneratedAttachmentLines(attachments),
+  ].filter((entry): entry is string => Boolean(entry));
+  return {
+    provider: result.provider,
+    model: result.model,
+    count: savedTracks.length,
+    attachments,
+    contentText: lines.join("\n"),
+    wakeResult: lines.join("\n"),
+    details: {
+      provider: result.provider,
+      model: result.model,
+      count: savedTracks.length,
+      media: {
+        mediaUrls: savedTracks.map((track) => track.path),
+        attachments,
+      },
+      attachments,
+      paths: savedTracks.map((track) => track.path),
+      ...buildTaskRunDetails(params.taskHandle),
+      ...(!ignoredOverrideKeys.has("lyrics") && params.lyrics
+        ? { requestedLyrics: params.lyrics }
+        : {}),
+      ...(!ignoredOverrideKeys.has("instrumental") && typeof params.instrumental === "boolean"
+        ? { instrumental: params.instrumental }
+        : {}),
+      ...(typeof appliedDurationSeconds === "number"
+        ? { durationSeconds: appliedDurationSeconds }
+        : {}),
+      ...(typeof requestedDurationSeconds === "number" &&
+      typeof appliedDurationSeconds === "number" &&
+      requestedDurationSeconds !== appliedDurationSeconds
+        ? { requestedDurationSeconds }
+        : {}),
+      ...(!ignoredOverrideKeys.has("format") && params.format ? { format: params.format } : {}),
+      ...(params.filename ? { filename: params.filename } : {}),
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      ...(params.timeoutNormalization
+        ? {
+            requestedTimeoutMs: params.timeoutNormalization.requested,
+            timeoutNormalization: params.timeoutNormalization,
+          }
+        : {}),
+      ...buildMediaReferenceDetails({
+        entries: params.loadedReferenceImages,
+        singleKey: "image",
+        pluralKey: "images",
+        getResolvedInput: (entry) => entry.resolvedInput,
+      }),
+      ...(result.lyrics?.length ? { lyrics: result.lyrics } : {}),
+      attempts: result.attempts,
+      ...(result.normalization ? { normalization: result.normalization } : {}),
+      metadata: result.metadata,
+      ...(warning ? { warning } : {}),
+      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
+    },
+  };
+}

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -7,13 +7,8 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseMusicGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
-import { saveMediaBuffer } from "../../media/store.js";
 import { resolveMusicGenerationModeCapabilities } from "../../music-generation/capabilities.js";
-import {
-  generateMusic,
-  listRuntimeMusicGenerationProviders,
-} from "../../music-generation/runtime.js";
+import { listRuntimeMusicGenerationProviders } from "../../music-generation/runtime.js";
 import type {
   MusicGenerationOutputFormat,
   MusicGenerationProvider,
@@ -23,15 +18,9 @@ import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import {
-  formatGeneratedAttachmentLines,
-  sanitizeGeneratedMediaDisplayText,
-  type AgentGeneratedAttachment,
-} from "../generated-attachments.js";
 import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { ToolInputError, readNumberParam, readToolStringParam } from "./common.js";
-import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import {
   createDefaultMediaGenerateBackgroundScheduler,
   type MediaGenerateAsyncStartCallback,
@@ -42,11 +31,10 @@ import {
   runMediaGenerationTask,
   type MusicGenerationTaskHandle,
 } from "./media-generate-background.js";
+import { acquireMusicGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
-  buildTaskRunDetails,
-  createCapabilityProviderRuntimeDeps,
   hasExplicitMediaModel,
   hasGenerationToolAvailability,
   loadMediaToolReferences,
@@ -64,17 +52,15 @@ import {
   createMusicGenerateListActionResult,
   createMusicGenerateStatusActionResult,
 } from "./music-generate-tool.actions.js";
+import {
+  executeMusicGenerationJob,
+  normalizeMusicGenerationTimeoutMs,
+} from "./music-generate-tool.execution.js";
 import type { AnyAgentTool, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const log = createSubsystemLogger("agents/tools/music-generate");
 const MAX_INPUT_IMAGES = 10;
-const GENERATED_MUSIC_MEDIA_SUBDIR = "tool-music-generation";
 const SUPPORTED_OUTPUT_FORMATS = new Set<MusicGenerationOutputFormat>(["mp3", "wav"]);
-const DEFAULT_MUSIC_GENERATION_TIMEOUT_MS = 300_000;
-const MIN_MUSIC_GENERATION_TIMEOUT_MS = 120_000;
-const GENERATED_MUSIC_PROBE_BUDGET_MS = 3000;
-const GENERATED_MUSIC_PROBE_CONCURRENCY = 2;
-const MAX_GENERATED_MUSIC_PROBES = 8;
 
 const MusicGenerateToolSchema = Type.Object({
   action: Type.Optional(
@@ -200,42 +186,6 @@ function validateMusicGenerationCapabilities(params: {
 
 type MusicGenerateSandboxConfig = MediaToolSandbox;
 
-type MusicGenerationTimeoutNormalization = {
-  requested: number;
-  applied: number;
-  minimum: number;
-};
-
-function normalizeMusicGenerationTimeoutMs(timeoutMs: number | undefined): {
-  timeoutMs?: number;
-  normalization?: MusicGenerationTimeoutNormalization;
-  message?: string;
-} {
-  if (timeoutMs === undefined) {
-    return { timeoutMs: DEFAULT_MUSIC_GENERATION_TIMEOUT_MS };
-  }
-  if (timeoutMs >= MIN_MUSIC_GENERATION_TIMEOUT_MS) {
-    return { timeoutMs };
-  }
-
-  const normalization = {
-    requested: timeoutMs,
-    applied: MIN_MUSIC_GENERATION_TIMEOUT_MS,
-    minimum: MIN_MUSIC_GENERATION_TIMEOUT_MS,
-  };
-  const message = `Timeout normalized: requested ${timeoutMs}ms; used ${MIN_MUSIC_GENERATION_TIMEOUT_MS}ms.`;
-  log.warn("music_generate timeoutMs is below provider minimum; using minimum", {
-    requestedTimeoutMs: timeoutMs,
-    appliedTimeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
-    minimumTimeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
-  });
-  return {
-    timeoutMs: MIN_MUSIC_GENERATION_TIMEOUT_MS,
-    normalization,
-    message,
-  };
-}
-
 const defaultScheduleMusicGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
   toolName: "music_generate",
   onCrash: (message, meta) => log.error(message, meta),
@@ -275,215 +225,6 @@ async function loadReferenceImages(params: {
   return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
     Object.assign({ sourceImage: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
   );
-}
-
-type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[number];
-
-type ExecutedMusicGeneration = {
-  provider: string;
-  model: string;
-  count: number;
-  attachments: AgentGeneratedAttachment[];
-  contentText: string;
-  details: Record<string, unknown>;
-  wakeResult: string;
-};
-
-async function executeMusicGenerationJob(params: {
-  effectiveCfg: OpenClawConfig;
-  prompt: string;
-  agentDir?: string;
-  model?: string;
-  lyrics?: string;
-  instrumental?: boolean;
-  durationSeconds?: number;
-  format?: MusicGenerationOutputFormat;
-  filename?: string;
-  loadedReferenceImages: LoadedReferenceImage[];
-  taskHandle?: MusicGenerationTaskHandle | null;
-  autoProviderFallback?: boolean;
-  timeoutMs?: number;
-  timeoutNormalization?: MusicGenerationTimeoutNormalization;
-  providers?: MusicGenerationProvider[];
-}): Promise<ExecutedMusicGeneration> {
-  if (params.taskHandle) {
-    musicGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Generating music",
-    });
-  }
-  const result = await generateMusic(
-    {
-      cfg: params.effectiveCfg,
-      prompt: params.prompt,
-      agentDir: params.agentDir,
-      modelOverride: params.model,
-      lyrics: params.lyrics,
-      instrumental: params.instrumental,
-      durationSeconds: params.durationSeconds,
-      format: params.format,
-      inputImages: params.loadedReferenceImages.map((entry) => entry.sourceImage),
-      autoProviderFallback: params.autoProviderFallback,
-      timeoutMs: params.timeoutMs,
-    },
-    createCapabilityProviderRuntimeDeps(params.providers),
-  );
-  if (params.taskHandle) {
-    musicGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Saving generated music",
-    });
-  }
-  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "audio");
-  const savedTracks = await persistGeneratedMediaBatch({
-    subdir: GENERATED_MUSIC_MEDIA_SUBDIR,
-    mode: "concurrent",
-    saves: result.tracks.map((track) => async () => {
-      const savedMedia = await saveMediaBuffer(
-        track.buffer,
-        track.mimeType,
-        GENERATED_MUSIC_MEDIA_SUBDIR,
-        mediaMaxBytes,
-        params.filename || track.fileName,
-      );
-      return { value: savedMedia, savedMedia };
-    }),
-  });
-  const ignoredOverrides = result.ignoredOverrides ?? [];
-  const ignoredOverrideKeys = new Set(ignoredOverrides.map((entry) => entry.key));
-  const requestedDurationSeconds =
-    result.normalization?.durationSeconds?.requested ??
-    (typeof result.metadata?.requestedDurationSeconds === "number" &&
-    Number.isFinite(result.metadata.requestedDurationSeconds)
-      ? result.metadata.requestedDurationSeconds
-      : params.durationSeconds);
-  const runtimeNormalizedDurationSeconds =
-    result.normalization?.durationSeconds?.applied ??
-    (typeof result.metadata?.normalizedDurationSeconds === "number" &&
-    Number.isFinite(result.metadata.normalizedDurationSeconds)
-      ? result.metadata.normalizedDurationSeconds
-      : undefined);
-  const appliedDurationSeconds =
-    runtimeNormalizedDurationSeconds ??
-    (!ignoredOverrideKeys.has("durationSeconds") && typeof params.durationSeconds === "number"
-      ? params.durationSeconds
-      : undefined);
-  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
-  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
-  const warning =
-    ignoredOverrides.length > 0
-      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides
-          .map(
-            (entry) =>
-              `${sanitizeGeneratedMediaDisplayText(entry.key)}=${sanitizeGeneratedMediaDisplayText(String(entry.value))}`,
-          )
-          .join(", ")}.`
-      : undefined;
-  const savedTrackMetadata = await probeMediaFilesWithinBudget(
-    savedTracks.map((track) => ({ filePath: track.path, kind: "audio" })),
-    {
-      budgetMs: GENERATED_MUSIC_PROBE_BUDGET_MS,
-      concurrency: GENERATED_MUSIC_PROBE_CONCURRENCY,
-      maxProbes: MAX_GENERATED_MUSIC_PROBES,
-    },
-  );
-  const attachments: AgentGeneratedAttachment[] = savedTracks.map((track, index) => ({
-    type: "audio",
-    path: track.path,
-    mimeType: track.contentType,
-    name: result.tracks[index]?.fileName,
-    sizeBytes: track.size,
-    ...(typeof appliedDurationSeconds === "number"
-      ? { durationMs: appliedDurationSeconds * 1000 }
-      : {}),
-    ...savedTrackMetadata[index],
-  }));
-  const lines = [
-    `Generated ${savedTracks.length} track${savedTracks.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
-    ...(warning ? [`Warning: ${warning}`] : []),
-    ...(params.timeoutNormalization
-      ? [
-          `Timeout normalized: requested ${params.timeoutNormalization.requested}ms; used ${params.timeoutNormalization.applied}ms.`,
-        ]
-      : []),
-    typeof requestedDurationSeconds === "number" &&
-    typeof appliedDurationSeconds === "number" &&
-    requestedDurationSeconds !== appliedDurationSeconds
-      ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${appliedDurationSeconds}s.`
-      : null,
-    ...(result.lyrics?.length
-      ? [
-          "Lyrics returned.",
-          ...result.lyrics.flatMap((lyric) =>
-            lyric
-              .replace(/\r\n?|[\u2028\u2029]/gu, "\n")
-              .split("\n")
-              .map((line) =>
-                sanitizeGeneratedMediaDisplayText(line)
-                  .replace(/^(\s*)(media):/iu, "$1$2：")
-                  // An open provider fence would swallow the trusted attachment lines appended below.
-                  .replace(/^( {0,3})(`{3,}|~{3,})/u, "$1\\$2"),
-              ),
-          ),
-        ]
-      : []),
-    ...formatGeneratedAttachmentLines(attachments),
-  ].filter((entry): entry is string => Boolean(entry));
-  return {
-    provider: result.provider,
-    model: result.model,
-    count: savedTracks.length,
-    attachments,
-    contentText: lines.join("\n"),
-    wakeResult: lines.join("\n"),
-    details: {
-      provider: result.provider,
-      model: result.model,
-      count: savedTracks.length,
-      media: {
-        mediaUrls: savedTracks.map((track) => track.path),
-        attachments,
-      },
-      attachments,
-      paths: savedTracks.map((track) => track.path),
-      ...buildTaskRunDetails(params.taskHandle),
-      ...(!ignoredOverrideKeys.has("lyrics") && params.lyrics
-        ? { requestedLyrics: params.lyrics }
-        : {}),
-      ...(!ignoredOverrideKeys.has("instrumental") && typeof params.instrumental === "boolean"
-        ? { instrumental: params.instrumental }
-        : {}),
-      ...(typeof appliedDurationSeconds === "number"
-        ? { durationSeconds: appliedDurationSeconds }
-        : {}),
-      ...(typeof requestedDurationSeconds === "number" &&
-      typeof appliedDurationSeconds === "number" &&
-      requestedDurationSeconds !== appliedDurationSeconds
-        ? { requestedDurationSeconds }
-        : {}),
-      ...(!ignoredOverrideKeys.has("format") && params.format ? { format: params.format } : {}),
-      ...(params.filename ? { filename: params.filename } : {}),
-      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
-      ...(params.timeoutNormalization
-        ? {
-            requestedTimeoutMs: params.timeoutNormalization.requested,
-            timeoutNormalization: params.timeoutNormalization,
-          }
-        : {}),
-      ...buildMediaReferenceDetails({
-        entries: params.loadedReferenceImages,
-        singleKey: "image",
-        pluralKey: "images",
-        getResolvedInput: (entry) => entry.resolvedInput,
-      }),
-      ...(result.lyrics?.length ? { lyrics: result.lyrics } : {}),
-      attempts: result.attempts,
-      ...(result.normalization ? { normalization: result.normalization } : {}),
-      metadata: result.metadata,
-      ...(warning ? { warning } : {}),
-      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
-    },
-  };
 }
 
 export function createMusicGenerateTool(options?: {
@@ -553,163 +294,228 @@ export function createMusicGenerateTool(options?: {
       }
 
       const model = readToolStringParam(args, "model");
-      const musicGenerationModelConfig = resolveCapabilityModelConfigForTool({
-        cfg,
-        workspaceDir: options?.workspaceDir,
-        agentDir: options?.agentDir,
-        authStore: options?.authProfileStore,
-        modelConfig: cfg.agents?.defaults?.mediaModels?.music,
-        modelOverride: model,
-        providers: () => listRuntimeMusicGenerationProviders({ config: cfg }),
-      });
-      if (!musicGenerationModelConfig) {
-        throw new ToolInputError("No music-generation model configured.");
-      }
       const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.music);
-      const effectiveCfg =
-        applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig) ?? cfg;
-      const prompt = readToolStringParam(args, "prompt", { required: true });
-
-      const activeDuplicateGuardResult = createMusicGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, agentId: options?.requesterAgentId },
-      );
-      if (activeDuplicateGuardResult) {
-        return activeDuplicateGuardResult;
+      const configuredModel =
+        model || explicitModelConfig
+          ? resolveCapabilityModelConfigForTool({
+              cfg,
+              modelConfig: cfg.agents?.defaults?.mediaModels?.music,
+              modelOverride: model,
+              providers: [],
+            })
+          : null;
+      const readRequest = () => {
+        const prompt = readToolStringParam(args, "prompt", { required: true });
+        return {
+          prompt,
+          duplicate: createMusicGenerateDuplicateGuardResult(options?.agentSessionKey, {
+            prompt,
+            agentId: options?.requesterAgentId,
+          }),
+        };
+      };
+      const configuredRequest = configuredModel ? readRequest() : undefined;
+      if (configuredRequest?.duplicate) {
+        return configuredRequest.duplicate;
       }
-
-      const lyrics = readToolStringParam(args, "lyrics");
-      const instrumental = readBooleanParam(args, "instrumental");
-      const durationSeconds = readNumberParam(args, "durationSeconds", {
-        positiveInteger: true,
-        strict: true,
-      });
-      if (
-        durationSeconds === undefined &&
-        readSnakeCaseParamRaw(args, "durationSeconds") !== undefined
-      ) {
-        throw new ToolInputError("durationSeconds must be a positive integer");
-      }
-      const format = normalizeOutputFormat(readToolStringParam(args, "format"));
-      const filename = readToolStringParam(args, "filename");
-      const timeout = normalizeMusicGenerationTimeoutMs(musicGenerationModelConfig.timeoutMs);
-      const timeoutMs = timeout.timeoutMs;
-      const imageInputs = normalizeReferenceImageInputs(args);
-      const explicitModelRef = parseMusicGenerationModelRef(model);
-      const primaryModelRef = parseMusicGenerationModelRef(musicGenerationModelConfig.primary);
-      const selectedModelRef = explicitModelRef ?? primaryModelRef;
-      const shouldResolveSelectedProvider =
-        imageInputs.length > 0 ||
-        (model !== undefined && !explicitModelRef) ||
-        (model === undefined && !primaryModelRef);
-      const selectedProvider = shouldResolveSelectedProvider
-        ? resolveSelectedMusicGenerationProvider({
-            config: effectiveCfg,
-            providers: preparedProviders,
-            musicGenerationModelConfig,
-            modelOverride: model,
+      const acquired = options?.preparedModelRuntime?.acquireMediaCapabilityProviders
+        ? await acquireMusicGenerationToolProviders({
+            cfg: configuredModel
+              ? (applyAgentDefaultModelConfig(cfg, "music", configuredModel) ?? cfg)
+              : cfg,
+            prepared: options.preparedModelRuntime,
           })
         : undefined;
-      const selectedProviderId = selectedProvider?.id ?? selectedModelRef?.provider;
-      const requestKey = buildMediaGenerationRequestKey({
-        tool: "music_generate",
-        prompt,
-        provider: selectedProviderId,
-        model:
-          model !== undefined
-            ? (explicitModelRef?.model ?? model)
-            : (primaryModelRef?.model ??
-              musicGenerationModelConfig.primary ??
-              selectedProvider?.defaultModel),
-        lyrics,
-        instrumental,
-        durationSeconds,
-        format,
-        filename,
-        imageInputs,
-      });
-      const duplicateGuardResult = createMusicGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, requestKey, agentId: options?.requesterAgentId },
-      );
-      if (duplicateGuardResult) {
-        return duplicateGuardResult;
-      }
-      const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
-      const loadedReferenceImages = await loadReferenceImages({
-        inputs: imageInputs,
-        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
-        workspaceDir: options?.workspaceDir,
-        sandboxConfig,
-        ssrfPolicy: remoteMediaSsrfPolicy,
-        signal,
-      });
-      validateMusicGenerationCapabilities({
-        provider: selectedProvider,
-        model: selectedModelRef?.model ?? model ?? selectedProvider?.defaultModel,
-        inputImageCount: loadedReferenceImages.length,
-        lyrics,
-        instrumental,
-        durationSeconds,
-        format,
-      });
-      // Accepted tasks own their paid work independently; cancellation applies only before admission.
-      signal?.throwIfAborted();
-      return runMediaGenerationTask({
-        lifecycle: musicGenerationTaskLifecycle,
-        generationLabel: "music",
-        sessionKey: options?.agentSessionKey,
-        requesterAgentId: options?.requesterAgentId,
-        requesterOrigin: options?.requesterOrigin,
-        prompt,
-        requestKey,
-        providerId: selectedProviderId,
-        config: effectiveCfg,
-        scheduleBackgroundWork,
-        onAsyncTaskStarted: options?.onAsyncTaskStarted,
-        onFailure: (message, meta) => log.warn(message, meta),
-        messages: [timeout.message],
-        detailExtras: {
-          ...buildMediaReferenceDetails({
-            entries: loadedReferenceImages,
-            singleKey: "image",
-            pluralKey: "images",
-            getResolvedInput: (entry) => entry.resolvedInput,
-          }),
-          ...(model ? { model } : {}),
-          ...(lyrics ? { requestedLyrics: lyrics } : {}),
-          ...(typeof instrumental === "boolean" ? { instrumental } : {}),
-          ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-          ...(format ? { format } : {}),
-          ...(filename ? { filename } : {}),
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-          ...(timeout.normalization
-            ? {
-                requestedTimeoutMs: timeout.normalization.requested,
-                timeoutNormalization: timeout.normalization,
-                warning: timeout.message,
-              }
-            : {}),
-        },
-        run: (taskHandle) =>
-          executeMusicGenerationJob({
-            effectiveCfg,
-            prompt,
+      const providers = acquired?.providers ?? preparedProviders;
+      const prepare = async () => {
+        const musicGenerationModelConfig =
+          configuredModel ??
+          resolveCapabilityModelConfigForTool({
+            cfg,
+            workspaceDir: options?.workspaceDir,
             agentDir: options?.agentDir,
-            lyrics,
-            instrumental,
-            durationSeconds,
-            model,
-            format,
-            filename,
-            loadedReferenceImages,
-            taskHandle,
-            autoProviderFallback: explicitModelConfig ? false : undefined,
-            timeoutMs,
-            timeoutNormalization: timeout.normalization,
-            providers: preparedProviders,
-          }),
-      });
+            authStore: options?.authProfileStore,
+            modelConfig: cfg.agents?.defaults?.mediaModels?.music,
+            modelOverride: model,
+            providers:
+              acquired?.providers ?? (() => listRuntimeMusicGenerationProviders({ config: cfg })),
+          });
+        if (!musicGenerationModelConfig) {
+          throw new ToolInputError("No music-generation model configured.");
+        }
+        const effectiveCfg =
+          applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig) ?? cfg;
+        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        if (duplicate) {
+          return { kind: "result" as const, result: duplicate };
+        }
+
+        const lyrics = readToolStringParam(args, "lyrics");
+        const instrumental = readBooleanParam(args, "instrumental");
+        const durationSeconds = readNumberParam(args, "durationSeconds", {
+          positiveInteger: true,
+          strict: true,
+        });
+        if (
+          durationSeconds === undefined &&
+          readSnakeCaseParamRaw(args, "durationSeconds") !== undefined
+        ) {
+          throw new ToolInputError("durationSeconds must be a positive integer");
+        }
+        const format = normalizeOutputFormat(readToolStringParam(args, "format"));
+        const filename = readToolStringParam(args, "filename");
+        const timeout = normalizeMusicGenerationTimeoutMs(musicGenerationModelConfig.timeoutMs);
+        const timeoutMs = timeout.timeoutMs;
+        const imageInputs = normalizeReferenceImageInputs(args);
+        const explicitModelRef = parseMusicGenerationModelRef(model);
+        const primaryModelRef = parseMusicGenerationModelRef(musicGenerationModelConfig.primary);
+        const selectedModelRef = explicitModelRef ?? primaryModelRef;
+        const shouldResolveSelectedProvider =
+          imageInputs.length > 0 ||
+          (model !== undefined && !explicitModelRef) ||
+          (model === undefined && !primaryModelRef);
+        const selectedProvider = shouldResolveSelectedProvider
+          ? resolveSelectedMusicGenerationProvider({
+              config: effectiveCfg,
+              providers,
+              musicGenerationModelConfig,
+              modelOverride: model,
+            })
+          : undefined;
+        const selectedProviderId = selectedProvider?.id ?? selectedModelRef?.provider;
+        const requestKey = buildMediaGenerationRequestKey({
+          tool: "music_generate",
+          prompt,
+          provider: selectedProviderId,
+          model:
+            model !== undefined
+              ? (explicitModelRef?.model ?? model)
+              : (primaryModelRef?.model ??
+                musicGenerationModelConfig.primary ??
+                selectedProvider?.defaultModel),
+          lyrics,
+          instrumental,
+          durationSeconds,
+          format,
+          filename,
+          imageInputs,
+        });
+        const duplicateGuardResult = createMusicGenerateDuplicateGuardResult(
+          options?.agentSessionKey,
+          { prompt, requestKey, agentId: options?.requesterAgentId },
+        );
+        if (duplicateGuardResult) {
+          return { kind: "result" as const, result: duplicateGuardResult };
+        }
+        const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+        const loadedReferenceImages = await loadReferenceImages({
+          inputs: imageInputs,
+          maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
+          workspaceDir: options?.workspaceDir,
+          sandboxConfig,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          signal,
+        });
+        validateMusicGenerationCapabilities({
+          provider: selectedProvider,
+          model: selectedModelRef?.model ?? model ?? selectedProvider?.defaultModel,
+          inputImageCount: loadedReferenceImages.length,
+          lyrics,
+          instrumental,
+          durationSeconds,
+          format,
+        });
+        return {
+          kind: "task" as const,
+          params: {
+            lifecycle: musicGenerationTaskLifecycle,
+            generationLabel: "music" as const,
+            sessionKey: options?.agentSessionKey,
+            requesterAgentId: options?.requesterAgentId,
+            requesterOrigin: options?.requesterOrigin,
+            prompt,
+            requestKey,
+            providerId: selectedProviderId,
+            config: effectiveCfg,
+            scheduleBackgroundWork,
+            onAsyncTaskStarted: options?.onAsyncTaskStarted,
+            onFailure: (message: string, meta?: Record<string, unknown>) => log.warn(message, meta),
+            messages: [timeout.message],
+            detailExtras: {
+              ...buildMediaReferenceDetails({
+                entries: loadedReferenceImages,
+                singleKey: "image",
+                pluralKey: "images",
+                getResolvedInput: (entry) => entry.resolvedInput,
+              }),
+              ...(model ? { model } : {}),
+              ...(lyrics ? { requestedLyrics: lyrics } : {}),
+              ...(typeof instrumental === "boolean" ? { instrumental } : {}),
+              ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
+              ...(format ? { format } : {}),
+              ...(filename ? { filename } : {}),
+              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+              ...(timeout.normalization
+                ? {
+                    requestedTimeoutMs: timeout.normalization.requested,
+                    timeoutNormalization: timeout.normalization,
+                    warning: timeout.message,
+                  }
+                : {}),
+            },
+            run: (taskHandle: MusicGenerationTaskHandle | null) =>
+              executeMusicGenerationJob({
+                effectiveCfg,
+                prompt,
+                agentDir: options?.agentDir,
+                lyrics,
+                instrumental,
+                durationSeconds,
+                model,
+                format,
+                filename,
+                loadedReferenceImages,
+                taskHandle,
+                autoProviderFallback: explicitModelConfig ? false : undefined,
+                timeoutMs,
+                timeoutNormalization: timeout.normalization,
+                providers,
+              }),
+          },
+        };
+      };
+      let prepared: Awaited<ReturnType<typeof prepare>>;
+      try {
+        acquired?.assertOpen();
+        prepared = acquired ? await acquired.run(prepare) : await prepare();
+        if (prepared.kind === "task") {
+          // Accepted tasks own paid work independently; cancellation applies before admission.
+          signal?.throwIfAborted();
+          acquired?.assertOpen();
+        }
+      } catch (error) {
+        let cleanupFailure: { error: unknown } | undefined;
+        try {
+          await acquired?.release();
+        } catch (cleanupError) {
+          cleanupFailure = { error: cleanupError };
+        }
+        if (cleanupFailure) {
+          throw new AggregateError(
+            [error, cleanupFailure.error],
+            "Music preflight and cleanup failed",
+            {
+              cause: error,
+            },
+          );
+        }
+        throw error;
+      }
+      if (prepared.kind === "result") {
+        await acquired?.release();
+        return prepared.result;
+      }
+      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
     },
   };
 }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where a prepared `music_generate` tool could lose its plugin resources after acknowledging an accepted job, while generation, saving, or rollback was still pending. It could also admit a new task after its original source retired during reference-image preflight.

## Why This Change Was Made

Reuse the image-job resource transfer for inspected Music providers. Hold the original source through preflight and transfer it to the existing accepted-task owner. Raw prepared hosts and unprepared calls keep their existing behavior.

The image acquisition body moves into a shared image/music helper; the Music execution and normalization bodies move unchanged into their own module. One shared native test suite preserves the four IMAGE cases and adds four Music cases.

## User Impact

Accepted Music jobs can finish saving or rolling back after their originating preparation is released. Retired sources cannot admit new work. Existing duplicate handling, provider selection, timeout normalization, and accepted paid-work cancellation behavior remain intact.

## Evidence

- Original production failed all four Music cases while all four IMAGE controls passed. All eight cases now pass, plus 161 tests across nine sibling files.
- Full changed-file checks, two-pass independent Codex review through P2, ordinary build and docs checks passed. The build took 246 seconds.
- The built public agent-harness SDK acknowledged a real synthetic WAV job in 18.34 ms. After A retired and B was published, A persisted the audio and closed its SQLite connection once; reopening returned the expected row. Retiring B during a real HTTP-reference fetch refused another task.
- The probe combines source-produced prepared facts with the built SDK. With no delivery runtime, it preserves the existing 120-second handoff and ends in blocked delivery with audio retained. It does not prove real channel delivery or fully packaged CLI behavior.
- Rebased production/test bytes match the reviewed candidate. The only changed context file on main extracts an equivalent requester-session expression; it does not alter media ownership.
