### PR TITLE
improve(tests): reuse feature artifact fixture builds

### DIFF
--- a/src/cli/plugins-feature-artifact.test.ts
+++ b/src/cli/plugins-feature-artifact.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { build } from "esbuild";
 import { extract } from "tar";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
   validatePackageExtensionEntriesForInstall,
   resolvePackageRuntimeExtensionSources,
@@ -27,6 +27,8 @@ import {
 import { runPluginsPackCommand } from "./plugins-feature-artifact.js";
 
 const directories: string[] = [];
+let pristineParent: string | undefined;
+let pristineFixturePromise: Promise<string> | undefined;
 afterEach(async () => {
   vi.restoreAllMocks();
   await Promise.all(
@@ -34,9 +36,16 @@ afterEach(async () => {
   );
 });
 
-async function fixture() {
-  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feature-pack-"));
-  directories.push(parent);
+afterAll(async () => {
+  await pristineFixturePromise?.catch(() => undefined);
+  if (pristineParent) {
+    await fs.rm(pristineParent, { recursive: true, force: true });
+  }
+});
+
+async function createPristineFixture() {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feature-pack-seed-"));
+  pristineParent = parent;
   const rootDir = path.join(parent, "draft-review");
   await runPluginsInitCommand("draft-review", { directory: rootDir, type: "feature" });
   await fs.symlink(path.resolve("node_modules"), path.join(rootDir, "node_modules"), "dir");
@@ -60,6 +69,17 @@ async function fixture() {
       'const __dirname = "local"; const resourceNames = { __filename: "import.meta.url" }; if (__dirname !== "local" || !resourceNames.__filename) throw new Error("Local resource names failed");\n',
   );
   await runPluginsBuildCommand({ root: rootDir });
+  return rootDir;
+}
+
+async function fixture() {
+  const pristineRoot = await (pristineFixturePromise ??= createPristineFixture());
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feature-pack-"));
+  directories.push(parent);
+  const rootDir = path.join(parent, "draft-review");
+  await fs.cp(pristineRoot, rootDir, { recursive: true, verbatimSymlinks: true });
+  // Preserve the per-path module cache established by the original build before case mutations.
+  await loadToolPlugin({ rootDir, entryPath: path.join(rootDir, "dist/index.js") });
   return { rootDir, parent };
 }
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This is a same-repository branch, editable by maintainers.

</details>

## What Problem This Solves

Developers running the feature-artifact tests pay for repeated, identical fixture
compilation before exercising the actual packing and rejection behavior.

## Why This Change Was Made

Build one lazy, suite-owned pristine feature fixture and copy it into a fresh,
writable directory for each case. Preserve the absolute dependency symlink,
load each copied plugin path before case mutations, and keep seed cleanup separate
from per-case cleanup.

Only `src/cli/plugins-feature-artifact.test.ts` changes. Production behavior,
assertions, case order, extraction paths, cache scopes, concurrency, and timeouts
are unchanged.

## User Impact

No runtime or user-visible behavior changes. Test setup performs 2 compiler calls
instead of 24, while retaining all 16 cases, 17 real pack attempts, 29 other
compiler calls, and four independently constructed tool fixtures.

## Evidence

Matched local Linux runs used Node 24.19.0, unchanged physical dependencies, the
same pass-through compiler observer, and fresh per-invocation Node/Vitest caches.
All five full-file runs passed 16/16 with zero skips. Run order is shown below.

| Run | Whole invocation | Setup compiler wall |
| --- | ---: | ---: |
| Original 1 | 20.225s | 2.058s |
| Original 2 | 19.489s | 1.933s |
| Candidate 1 | 18.598s | 0.237s |
| Candidate 2 | 18.346s | 0.250s |
| Closing original-source control | 19.517s | 1.987s |

The closing control was about 1.045s above the candidate invocation mean.
This supports a modest local improvement, not a precise percentage or a hosted-CI
speedup claim. The host was shared, unrelated compilation/test activity was
observed, and the OS page cache was not flushed.

- All 12 private copies matched the pristine and original fixture hashes before
  mutation. Regular files had independent identities without hardlinks, and the
  absolute `node_modules` symlink target was preserved.
- The seed remained unchanged after all case mutations. All six emitted archives
  and their members matched original-source bytes; emitted files did not depend
  on the seed path.
- The tool-only selection passed 4/4 with zero feature seeds or setup builds.
- Partial seed setup, partial copy, and case-body failure controls failed at their
  intended checkpoints, attempted no pack, and removed every owned directory.
- The browser-build sibling passed 11/11.
- The normal changed-file gate passed, including formatting, lint, typechecking,
  boundary guards, and production/full-tree dead-export checks.
- Fresh P2 autoreview was scoped-clean with no actionable findings.

Full-file command:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/plugins-feature-artifact.test.ts --reporter=verbose
```

Changed-file gate:

```sh
node scripts/check-changed.mjs -- src/cli/plugins-feature-artifact.test.ts
```

This is one bounded test-setup improvement related to the broader audit, not a
claim to complete that issue or meet a global runtime target.
