### PR TITLE
refactor(build): simplify package import path resolution

### DIFF
--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -19,17 +19,6 @@ function hasJavaScriptFileExtension(value) {
   return /\.(?:cjs|js|mjs)$/u.test(path.posix.basename(stripSpecifierSuffix(value)));
 }
 
-function resolveDistImportPath(importerPath, specifier) {
-  if (!specifier.startsWith(".")) {
-    return null;
-  }
-  const stripped = stripSpecifierSuffix(specifier);
-  if (!stripped) {
-    return null;
-  }
-  return path.posix.normalize(path.posix.join(path.posix.dirname(importerPath), stripped));
-}
-
 function appendImportEdges(source, importerPath, imports) {
   const sourceFile = ts.createSourceFile(
     importerPath,
@@ -48,8 +37,10 @@ function appendImportEdges(source, importerPath, imports) {
       ) {
         return;
       }
-      const importedPath = resolveDistImportPath(importerPath, specifier);
-      if (importedPath && (kind !== "import-meta-url" || importedPath.startsWith("dist/"))) {
+      const importedPath = path.posix.normalize(
+        path.posix.join(path.posix.dirname(importerPath), stripSpecifierSuffix(specifier)),
+      );
+      if (kind !== "import-meta-url" || importedPath.startsWith("dist/")) {
         imports.push({ importerPath, importedPath });
       }
     },


### PR DESCRIPTION
## What Problem This Solves

Package import scanning repeats relative-path validation inside a private helper whose only caller has already rejected nonrelative imports. This leaves unreachable branches in the package closure check.

## Why This Change Was Made

Inline the existing path calculation at that caller and remove the redundant guards. Ordinary imports and CommonJS references keep their existing behavior; `import.meta.url` dependencies still require JavaScript files inside `dist`. The change removes nine tooling lines and adds no API or helper.

## User Impact

Package validation produces the same import edges and missing-file errors with a simpler implementation. There is no intended user-visible behavior change.

## Evidence

The same 18 existing import, CLI, and package-inventory contract cases passed before and after the change. All 14 selected changed-file checks passed, formatting and diff checks passed, and independent review found no actionable findings. No tests or check limits changed.
