### PR TITLE
fix(macos): stop push-to-talk capture when its hold ends

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState+Talk.swift
+++ b/apps/macos/Sources/OpenClaw/AppState+Talk.swift
@@ -2,9 +2,11 @@ import Foundation
 
 extension AppState {
     func persistTalkRealtimeRelayPreference(previousValue: Bool) {
-        guard !self.isPreview else { return }
-        AppDefaults.standard.set(self.talkRealtimeRelayEnabled, forKey: talkRealtimeRelayEnabledKey)
-        guard self.talkEnabled, self.talkRealtimeRelayEnabled != previousValue else { return }
-        Task { await TalkModeRuntime.shared.realtimeRelayPreferenceDidChange() }
+        if !self.isPreview {
+            AppDefaults.standard.set(self.talkRealtimeRelayEnabled, forKey: talkRealtimeRelayEnabledKey)
+        }
+        guard self.voiceRuntime.isActive, self.talkEnabled,
+              self.talkRealtimeRelayEnabled != previousValue else { return }
+        Task { [runtime = self.voiceRuntime.talkRuntime] in await runtime.realtimeRelayPreferenceDidChange() }
     }
 }

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -86,6 +86,8 @@ final class AppState {
     private var conflictedGatewayConfigFields: Set<GatewayConfigField> = []
     private var suppressVoiceWakeGlobalSync = false
     @ObservationIgnored private var voiceWakeEnableGeneration: UInt64 = 0
+    @ObservationIgnored private var talkEnableGeneration: UInt64 = 0
+    @ObservationIgnored private var talkTransitionTask: Task<Void, Never>?
     @ObservationIgnored private var locationModeGeneration: UInt64 = 0
     @ObservationIgnored private let voiceWakeGlobalSyncScheduler = VoiceWakeGlobalSyncScheduler()
     @ObservationIgnored private var activeComputerPresenceTask: Task<Void, Never>?
@@ -224,7 +226,7 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.talkEnabled, forKey: talkEnabledKey)
-                Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }
+                self.applyTalkEnabled()
             }
         }
     }
@@ -600,7 +602,7 @@ final class AppState {
 
         if !self.isPreview {
             Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-            Task { await TalkModeController.shared.setEnabled(self.talkEnabled) }
+            self.applyTalkEnabled()
         }
 
         if !self.isPreview {
@@ -1091,23 +1093,31 @@ extension AppState {
         AppDefaults.standard.set(mode.rawValue, forKey: locationModeKey)
     }
 
+    private func applyTalkEnabled() {
+        let enabled = self.talkEnabled
+        self.talkTransitionTask = Task { await TalkModeController.shared.setEnabled(enabled) }
+    }
+
     func setTalkEnabled(_ enabled: Bool) async {
+        self.talkEnableGeneration &+= 1
+        let generation = self.talkEnableGeneration
         self.talkEnabled = enabled && voiceWakeSupported
         guard !self.isPreview else { return }
-
-        if !self.talkEnabled {
-            await GatewayConnection.shared.talkMode(enabled: false, phase: "disabled")
-            return
+        var transition = self.talkTransitionTask
+        var phase = self.talkEnabled ? "enabled" : "disabled"
+        if self.talkEnabled, !PermissionManager.voiceWakePermissionsGranted() {
+            let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
+            if generation == self.talkEnableGeneration {
+                self.talkEnabled = granted
+                transition = self.talkTransitionTask
+                phase = granted ? "enabled" : "denied"
+            }
         }
-
-        if PermissionManager.voiceWakePermissionsGranted() {
-            await GatewayConnection.shared.talkMode(enabled: true, phase: "enabled")
-            return
-        }
-
-        let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
-        self.talkEnabled = granted
-        await GatewayConnection.shared.talkMode(enabled: granted, phase: granted ? "enabled" : "denied")
+        // Even a replaced wake handoff waits for its Talk pause acknowledgement.
+        // Only the latest request may project completion or restore permission-gated intent.
+        await transition?.value
+        guard generation == self.talkEnableGeneration else { return }
+        await GatewayConnection.shared.talkMode(enabled: self.talkEnabled, phase: phase)
     }
 
     // MARK: - Global wake words sync (Gateway-owned)

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -63,6 +63,9 @@ final class AppState {
 
     let isPreview: Bool
     @ObservationIgnored private let gatewayConfigSaver: ([String: Any], Bool) -> Bool
+    @ObservationIgnored private let voiceEnvironment: AppVoiceRuntime.Environment
+    @ObservationIgnored private(set) lazy var voiceRuntime = AppVoiceRuntime(
+        state: self, environment: self.voiceEnvironment)
     @ObservationIgnored let bundleLocationAllowsPersistentIntegration: Bool
     @ObservationIgnored private var isHydratingLaunchAtLogin = false
     private var isInitializing = true
@@ -127,8 +130,8 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.swabbleEnabled, forKey: swabbleEnabledKey)
-                Task { await VoiceWakeRuntime.shared.refresh(state: self) }
             }
+            self.refreshVoiceWake()
         }
     }
 
@@ -137,11 +140,9 @@ final class AppState {
             // Preserve the raw editing state; sanitization happens when we actually use the triggers.
             self.ifNotPreview {
                 AppDefaults.standard.set(self.swabbleTriggerWords, forKey: swabbleTriggersKey)
-                if self.swabbleEnabled {
-                    Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-                }
                 self.scheduleVoiceWakeGlobalSyncIfNeeded()
             }
+            if self.swabbleEnabled { self.refreshVoiceWake() }
         }
     }
 
@@ -172,12 +173,10 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.voiceWakeMicID, forKey: voiceWakeMicKey)
-                if self.swabbleEnabled, !self.talkEnabled {
-                    Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-                }
-                if self.talkEnabled {
-                    Task { await TalkModeRuntime.shared.inputDeviceSelectionDidChange() }
-                }
+            }
+            if self.swabbleEnabled, !self.talkEnabled { self.refreshVoiceWake() }
+            if self.voiceRuntime.isActive, self.talkEnabled {
+                Task { [runtime = self.voiceRuntime.talkRuntime] in await runtime.inputDeviceSelectionDidChange() }
             }
         }
     }
@@ -190,10 +189,8 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.voiceWakeLocaleID, forKey: voiceWakeLocaleKey)
-                if self.swabbleEnabled {
-                    Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-                }
             }
+            if self.swabbleEnabled { self.refreshVoiceWake() }
         }
     }
 
@@ -213,10 +210,8 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.voiceWakeTriggersTalkMode, forKey: voiceWakeTriggersTalkModeKey)
-                if self.swabbleEnabled {
-                    Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-                }
             }
+            if self.swabbleEnabled { self.refreshVoiceWake() }
         }
     }
 
@@ -226,8 +221,8 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.talkEnabled, forKey: talkEnabledKey)
-                self.applyTalkEnabled()
             }
+            self.applyTalkEnabled()
         }
     }
 
@@ -247,7 +242,9 @@ final class AppState {
         didSet {
             self.ifNotPreview {
                 AppDefaults.standard.set(self.talkShiftToStopEnabled, forKey: talkShiftToStopEnabledKey)
-                Task { TalkSpeechInterruptMonitor.shared.setEnabled(self.talkShiftToStopEnabled && self.talkEnabled) }
+            }
+            if self.voiceRuntime.isActive {
+                self.voiceRuntime.interruptMonitor.setEnabled(self.talkShiftToStopEnabled && self.talkEnabled)
             }
         }
     }
@@ -462,7 +459,8 @@ final class AppState {
         preview: Bool = false,
         gatewayConfigSaver: @escaping ([String: Any], Bool) -> Bool = {
             OpenClawConfigFile.saveDict($0, allowGatewayModeRemoval: $1)
-        })
+        },
+        voiceEnvironment: AppVoiceRuntime.Environment = .live)
     {
         let isPreview = preview || ProcessInfo.processInfo.isRunningTests
         self.isPreview = isPreview
@@ -470,13 +468,14 @@ final class AppState {
             !AppProfile.current.isActive &&
             (isPreview || ApplicationRelocator.currentBundleAllowsPersistentIntegration())
         self.gatewayConfigSaver = gatewayConfigSaver
+        self.voiceEnvironment = voiceEnvironment
         let onboardingSeen = AppDefaults.standard.bool(forKey: onboardingSeenKey)
         self.isPaused = AppLaunchRuntimePlan.current.resolvePaused(AppDefaults.standard.bool(forKey: pauseDefaultsKey))
         self.launchAtLogin = false
         self.onboardingSeen = onboardingSeen
         self.debugPaneEnabled = AppDefaults.standard.bool(forKey: debugPaneEnabledKey)
         let savedVoiceWake = AppDefaults.standard.bool(forKey: swabbleEnabledKey)
-        self.swabbleEnabled = voiceWakeSupported ? savedVoiceWake : false
+        self.swabbleEnabled = voiceEnvironment.appStatePermissions.supported() ? savedVoiceWake : false
         self.swabbleTriggerWords = AppDefaults.standard
             .stringArray(forKey: swabbleTriggersKey) ?? defaultVoiceWakeTriggers
         self.voiceWakeTriggerChime = Self.loadChime(
@@ -593,16 +592,15 @@ final class AppState {
             Self.logger.info("login-agent status skipped (unavailable under app profile)")
         }
 
-        if self.swabbleEnabled, !PermissionManager.voiceWakePermissionsGranted() {
+        if self.swabbleEnabled, !voiceEnvironment.appStatePermissions.granted() {
             self.swabbleEnabled = false
         }
-        if self.talkEnabled, !PermissionManager.voiceWakePermissionsGranted() {
+        if self.talkEnabled, !voiceEnvironment.appStatePermissions.granted() {
             self.talkEnabled = false
         }
 
         if !self.isPreview {
-            Task { await VoiceWakeRuntime.shared.refresh(state: self) }
-            self.applyTalkEnabled()
+            self.activateVoice()
         }
 
         if !self.isPreview {
@@ -1063,10 +1061,11 @@ extension AppState {
         guard !Task.isCancelled, requestIsCurrent() else { return }
         self.voiceWakeEnableGeneration &+= 1
         let generation = self.voiceWakeEnableGeneration
-        var authorized = enabled && voiceWakeSupported && SpeechRecognitionRequestPolicy.supportsPassiveVoiceWake(
-            localeID: self.voiceWakeLocaleID)
-        if authorized, !self.isPreview, !PermissionManager.voiceWakePermissionsGranted() {
-            authorized = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
+        var authorized = enabled && self.voiceEnvironment.appStatePermissions.supported() &&
+            SpeechRecognitionRequestPolicy.supportsPassiveVoiceWake(
+                localeID: self.voiceWakeLocaleID)
+        if authorized, self.voiceRuntime.isActive, !self.voiceEnvironment.appStatePermissions.granted() {
+            authorized = await self.voiceEnvironment.appStatePermissions.ensure(true)
         }
         // OS authorization outlives task cancellation. Only the current intent and
         // requesting document may commit; didSet owns persistence and runtime refresh.
@@ -1093,20 +1092,37 @@ extension AppState {
         AppDefaults.standard.set(mode.rawValue, forKey: locationModeKey)
     }
 
+    func activateVoice() {
+        guard !self.voiceRuntime.isActive else { return }
+        // Normal startup calls this at the original voice activation point; preview
+        // construction remains inert and does not enable persistence or other services.
+        self.voiceRuntime.activate()
+        self.refreshVoiceWake()
+        self.applyTalkEnabled()
+    }
+
+    private func refreshVoiceWake() {
+        guard self.voiceRuntime.isActive else { return }
+        Task { [wake = self.voiceRuntime.wake] in await wake.refresh(state: self) }
+    }
+
     private func applyTalkEnabled() {
+        guard self.voiceRuntime.isActive else { return }
         let enabled = self.talkEnabled
-        self.talkTransitionTask = Task { await TalkModeController.shared.setEnabled(enabled) }
+        self.talkTransitionTask = Task { [controller = self.voiceRuntime.talkController] in
+            await controller.setEnabled(enabled)
+        }
     }
 
     func setTalkEnabled(_ enabled: Bool) async {
         self.talkEnableGeneration &+= 1
         let generation = self.talkEnableGeneration
-        self.talkEnabled = enabled && voiceWakeSupported
-        guard !self.isPreview else { return }
+        self.talkEnabled = enabled && self.voiceEnvironment.appStatePermissions.supported()
+        guard self.voiceRuntime.isActive else { return }
         var transition = self.talkTransitionTask
         var phase = self.talkEnabled ? "enabled" : "disabled"
-        if self.talkEnabled, !PermissionManager.voiceWakePermissionsGranted() {
-            let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
+        if self.talkEnabled, !self.voiceEnvironment.appStatePermissions.granted() {
+            let granted = await self.voiceEnvironment.appStatePermissions.ensure(true)
             if generation == self.talkEnableGeneration {
                 self.talkEnabled = granted
                 transition = self.talkTransitionTask
@@ -1117,7 +1133,7 @@ extension AppState {
         // Only the latest request may project completion or restore permission-gated intent.
         await transition?.value
         guard generation == self.talkEnableGeneration else { return }
-        await GatewayConnection.shared.talkMode(enabled: self.talkEnabled, phase: phase)
+        await self.voiceEnvironment.publishTalk(self.talkEnabled, phase)
     }
 
     // MARK: - Global wake words sync (Gateway-owned)

--- a/apps/macos/Sources/OpenClaw/AppVoiceRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/AppVoiceRuntime.swift
@@ -1,0 +1,177 @@
+import Foundation
+import OpenClawKit
+
+struct VoicePermissions: Sendable {
+    let supported: @Sendable () -> Bool
+    let granted: @Sendable () -> Bool
+    let ensure: @Sendable (Bool) async -> Bool
+
+    static let live = Self(
+        supported: { voiceWakeSupported },
+        granted: { PermissionManager.voiceWakePermissionsGranted() },
+        ensure: { await PermissionManager.ensureVoiceWakePermissions(interactive: $0) })
+}
+
+@MainActor
+final class AppVoiceRuntime {
+    typealias State = @MainActor @Sendable () -> AppState?
+    typealias Controller = @MainActor @Sendable () -> TalkModeController?
+    typealias UIAction = @MainActor @Sendable () -> Void
+    typealias Forward = @Sendable (String, String?) async -> Result<Void, VoiceWakeForwarder.VoiceWakeForwardError>
+    typealias PublishTalk = @Sendable (Bool, String) async -> Void
+    typealias Bootstrap = @Sendable () async throws -> GatewayConnection.RealtimeTalkBootstrap
+
+    struct Environment: Sendable {
+        let appStatePermissions: VoicePermissions
+        let pttPermissions: VoicePermissions
+        let wakePermissions: VoicePermissions
+        let talkPermissions: VoicePermissions
+        let talkAudioCapture: @MainActor @Sendable (@escaping State) -> any RealtimeTalkAudioCapturing
+        let talkPCMPlayer: @MainActor @Sendable () -> any PCMStreamingAudioPlaying
+        let talkSelectedSession: @MainActor @Sendable () -> String?
+        let stopPCM: @MainActor @Sendable () async -> Double?
+        let stopMP3: @MainActor @Sendable () async -> Double?
+        let stopBuffered: @MainActor @Sendable () async -> Double?
+        let stopSystem: @Sendable () async -> Void
+        let stopMLX: @Sendable () async -> Void
+        let talkBootstrap: Bootstrap
+        let publishTalk: PublishTalk
+        let forward: Forward
+        let wakePresentation: VoiceWakeOverlayController.Presentation
+        let talkPresentation: TalkOverlayController.Presentation
+        let interruptRegistration: TalkSpeechInterruptMonitor.Registration
+
+        static let live = Self(
+            appStatePermissions: .live,
+            pttPermissions: .live,
+            wakePermissions: .live,
+            talkPermissions: .live,
+            talkAudioCapture: { state in
+                MacRealtimeTalkAudioCapture(selectedInputUID: { state()?.voiceWakeMicID })
+            },
+            talkPCMPlayer: { RealtimePCMStreamingAudioPlayer() },
+            talkSelectedSession: { WebChatManager.shared.activeSessionKey },
+            stopPCM: { PCMStreamingAudioPlayer.shared.stop() },
+            stopMP3: { StreamingAudioPlayer.shared.stop() },
+            stopBuffered: { TalkBufferedAudioPlayer.shared.stop() },
+            stopSystem: { await TalkSystemSpeechSynthesizer.shared.stop() },
+            stopMLX: { await TalkMLXSpeechSynthesizer.shared.cancelCurrent() },
+            talkBootstrap: AppVoiceRuntime.liveBootstrap,
+            publishTalk: AppVoiceRuntime.livePublishTalk,
+            forward: {
+                await VoiceWakeForwarder.forwardToSelectedSession(transcript: $0, voiceWakeTrigger: $1)
+            },
+            wakePresentation: .live,
+            talkPresentation: .live,
+            interruptRegistration: .live)
+    }
+
+    private weak var state: AppState?
+    let overlay: VoiceWakeOverlayController
+    let sessions: VoiceSessionCoordinator
+    let wake: VoiceWakeRuntime
+    let ptt: VoicePushToTalk
+    let hotkey: VoicePushToTalkHotkey
+    let talkRuntime: TalkModeRuntime
+    let talkOverlay: TalkOverlayController
+    let interruptMonitor: TalkSpeechInterruptMonitor
+    let talkController: TalkModeController
+    private(set) var isActive = false
+
+    init(state: AppState, environment: Environment) {
+        self.state = state
+        // Back-references are not evaluated until AppState has stored the complete graph.
+        // Operation-local action values then retain their concrete cleanup owners.
+        let stateProvider: State = { [weak state] in state }
+        let controllerProvider: Controller = { [weak state] in state?.voiceRuntime.talkController }
+        let overlay = VoiceWakeOverlayController(
+            presentation: environment.wakePresentation,
+            actions: { [weak state] in
+                guard let state else { return nil }
+                let sessions = state.voiceRuntime.sessions
+                return .init(
+                    send: { sessions.sendNow(token: $0, reason: $1) },
+                    didPresent: { state.startVoiceEars() },
+                    didDismiss: { token, outcome in
+                        if outcome == .empty { state.blinkOnce() }
+                        if outcome == .sent { state.celebrateSend() }
+                        state.stopVoiceEars()
+                        sessions.overlayDidDismiss(token: token)
+                    })
+            })
+        let sessions = VoiceSessionCoordinator(
+            overlay: overlay,
+            forward: environment.forward,
+            didDismiss: { [weak state] _ in
+                guard let state else { return }
+                let wake = state.voiceRuntime.wake
+                Task { await wake.refresh(state: state) }
+            })
+        let wake = VoiceWakeRuntime(
+            state: stateProvider,
+            sessions: sessions,
+            overlay: overlay,
+            permissions: environment.wakePermissions,
+            forward: environment.forward)
+        let ptt = VoicePushToTalk(
+            state: stateProvider, wake: wake, sessions: sessions, permissions: environment.pttPermissions)
+        let hotkey = VoicePushToTalkHotkey(
+            beginAction: { ptt.begin() }, endAction: { ptt.end(cancelled: $0) })
+        let talkRuntime = TalkModeRuntime(
+            realtimeTalkBootstrapProvider: environment.talkBootstrap,
+            state: stateProvider,
+            controller: controllerProvider,
+            dependencies: .init(
+                permissions: environment.talkPermissions,
+                audioCapture: { environment.talkAudioCapture(stateProvider) },
+                pcmPlayer: environment.talkPCMPlayer,
+                selectedSession: environment.talkSelectedSession,
+                stopPCM: environment.stopPCM,
+                stopMP3: environment.stopMP3,
+                stopBuffered: environment.stopBuffered,
+                stopSystem: environment.stopSystem,
+                stopMLX: environment.stopMLX))
+        let talkOverlay = TalkOverlayController(
+            state: stateProvider,
+            presentation: environment.talkPresentation,
+            actions: {
+                guard let controller = controllerProvider() else { return nil }
+                return .init(
+                    togglePaused: { controller.togglePaused() },
+                    stopSpeaking: { controller.stopSpeaking(reason: .userTap) },
+                    pauseForDrag: { controller.setPaused(true) },
+                    exit: { controller.exitTalkMode() })
+            })
+        let interruptMonitor = TalkSpeechInterruptMonitor(
+            registration: environment.interruptRegistration, controller: controllerProvider)
+        let owners = TalkModeController.Owners(
+            runtime: talkRuntime,
+            wake: wake,
+            hotkey: hotkey,
+            overlay: talkOverlay,
+            interruptMonitor: interruptMonitor)
+        self.overlay = overlay
+        self.sessions = sessions
+        self.wake = wake
+        self.ptt = ptt
+        self.hotkey = hotkey
+        self.talkRuntime = talkRuntime
+        self.talkOverlay = talkOverlay
+        self.interruptMonitor = interruptMonitor
+        self.talkController = TalkModeController(
+            state: stateProvider, owners: { owners }, publishTalk: environment.publishTalk)
+    }
+
+    func activate() {
+        guard self.state != nil else { return }
+        self.isActive = true
+    }
+
+    nonisolated static func liveBootstrap() async throws -> GatewayConnection.RealtimeTalkBootstrap {
+        try await GatewayConnection.shared.acquireRealtimeTalkBootstrap()
+    }
+
+    nonisolated static func livePublishTalk(_ enabled: Bool, _ phase: String) async {
+        await GatewayConnection.shared.talkMode(enabled: enabled, phase: phase)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/StatusMenuController.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuController.swift
@@ -7,16 +7,17 @@ import SwiftUI
 final class StatusMenuController: NSObject, NSMenuDelegate {
     private let state: AppState
     private let updater: UpdaterProviding
-    private let menu = NSMenu()
-    private let gatewayManager = GatewayProcessManager.shared
-    private let controlChannel = ControlChannel.shared
-    private let activityStore = WorkActivityStore.shared
-    private let sessions = StatusMenuSessions.shared
-    private let approvals = ExecApprovalQueueStore.shared
-    private let summaries = StatusMenuSummaries.shared
-    private let nodes = NodesStore.shared
-    private let cron = CronJobsStore.shared
-    private let dashboard = DashboardManager.shared
+    private let hotkey: VoicePushToTalkHotkey
+    private lazy var menu = NSMenu()
+    private lazy var gatewayManager = GatewayProcessManager.shared
+    private lazy var controlChannel = ControlChannel.shared
+    private lazy var activityStore = WorkActivityStore.shared
+    private lazy var sessions = StatusMenuSessions.shared
+    private lazy var approvals = ExecApprovalQueueStore.shared
+    private lazy var summaries = StatusMenuSummaries.shared
+    private lazy var nodes = NodesStore.shared
+    private lazy var cron = CronJobsStore.shared
+    private lazy var dashboard = DashboardManager.shared
 
     private var statusItem: NSStatusItem?
     private var clickMonitor: Any?
@@ -27,14 +28,15 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private var isChatWindowVisible = false
     private var observedPaused: Bool
     private var observedConnectionMode: AppState.ConnectionMode
-    private var observedPushToTalk: Bool
+    private var voiceObservationGeneration: UInt64 = 0
+    private var observingVoice = false
 
     init(state: AppState, updater: UpdaterProviding) {
         self.state = state
         self.updater = updater
+        self.hotkey = state.voiceRuntime.hotkey
         self.observedPaused = state.isPaused
         self.observedConnectionMode = state.connectionMode
-        self.observedPushToTalk = state.voicePushToTalkEnabled
         super.init()
     }
 
@@ -56,7 +58,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         self.installButton(in: item)
         self.installWindowCallbacks()
         self.approvals.start()
-        VoicePushToTalkHotkey.shared.setEnabled(voiceWakeSupported && self.state.voicePushToTalkEnabled)
+        self.startVoiceObservation()
 
         self.renderCachedMenu()
         self.updateStatusAppearance()
@@ -65,8 +67,9 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     func stop() {
-        VoicePushToTalkHotkey.shared.setEnabled(false)
+        self.stopVoiceObservation()
         self.observationGeneration &+= 1
+        guard let statusItem else { return }
         self.refreshTask?.cancel()
         self.refreshTask = nil
         self.sessions.cancelPreviewTasks()
@@ -76,9 +79,33 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             NSEvent.removeMonitor(clickMonitor)
             self.clickMonitor = nil
         }
-        guard let statusItem else { return }
         self.statusItem = nil
         NSStatusBar.system.removeStatusItem(statusItem)
+    }
+
+    func startVoiceObservation() {
+        guard !self.observingVoice else { return }
+        self.observingVoice = true
+        self.observeVoiceChanges()
+    }
+
+    func stopVoiceObservation() {
+        self.observingVoice = false
+        self.voiceObservationGeneration &+= 1
+        self.hotkey.setEnabled(false)
+    }
+
+    private func observeVoiceChanges() {
+        let generation = self.voiceObservationGeneration
+        let enabled = withObservationTracking {
+            self.state.voicePushToTalkEnabled
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.observingVoice, self.voiceObservationGeneration == generation else { return }
+                self.observeVoiceChanges()
+            }
+        }
+        self.hotkey.setEnabled(voiceWakeSupported && enabled)
     }
 
     func menuWillOpen(_ menu: NSMenu) {
@@ -233,7 +260,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             _ = self.gatewayManager.status
             _ = self.controlChannel.state
             _ = self.state.voiceWakeMeterActive
-            _ = self.state.voicePushToTalkEnabled
             _ = self.state.quickChatEnabled
             _ = self.state.canvasEnabled
             _ = self.state.canvasPanelVisible
@@ -290,12 +316,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
                 }
             }
             BrowserProfileImportModel.shared.handleConnectionModeChange()
-        }
-
-        let pushToTalk = self.state.voicePushToTalkEnabled
-        if pushToTalk != self.observedPushToTalk {
-            self.observedPushToTalk = pushToTalk
-            VoicePushToTalkHotkey.shared.setEnabled(voiceWakeSupported && pushToTalk)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/StatusMenuController.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuController.swift
@@ -65,6 +65,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     func stop() {
+        VoicePushToTalkHotkey.shared.setEnabled(false)
         self.observationGeneration &+= 1
         self.refreshTask?.cancel()
         self.refreshTask = nil

--- a/apps/macos/Sources/OpenClaw/TalkModeController.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeController.swift
@@ -5,7 +5,42 @@ import OpenClawKit
 @MainActor
 @Observable
 final class TalkModeController {
-    static let shared = TalkModeController()
+    static var shared: TalkModeController {
+        AppStateStore.shared.voiceRuntime.talkController
+    }
+
+    struct Owners: Sendable {
+        let runtime: TalkModeRuntime
+        let wake: VoiceWakeRuntime
+        let hotkey: VoicePushToTalkHotkey
+        let overlay: TalkOverlayController
+        let interruptMonitor: TalkSpeechInterruptMonitor
+    }
+
+    typealias OwnersProvider = @MainActor @Sendable () -> Owners
+    @ObservationIgnored private let state: AppVoiceRuntime.State
+    @ObservationIgnored private let owners: OwnersProvider
+    @ObservationIgnored private let publishTalk: AppVoiceRuntime.PublishTalk
+
+    static func liveOwners() -> Owners {
+        let voice = AppStateStore.shared.voiceRuntime
+        return Owners(
+            runtime: voice.talkRuntime,
+            wake: voice.wake,
+            hotkey: voice.hotkey,
+            overlay: voice.talkOverlay,
+            interruptMonitor: voice.interruptMonitor)
+    }
+
+    init(
+        state: @escaping AppVoiceRuntime.State = { AppStateStore.shared },
+        owners: @escaping OwnersProvider = TalkModeController.liveOwners,
+        publishTalk: @escaping AppVoiceRuntime.PublishTalk = AppVoiceRuntime.livePublishTalk)
+    {
+        self.state = state
+        self.owners = owners
+        self.publishTalk = publishTalk
+    }
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "talk.controller")
     private static let transcriptLimit = 20
@@ -27,25 +62,27 @@ final class TalkModeController {
     }
 
     func setEnabled(_ enabled: Bool) async {
+        guard !enabled || self.state() != nil else { return }
+        let owners = self.owners()
         let transitionID = UUID()
         self.transitionID = transitionID
         // Preference updates must not reopen PTT during Talk admission or audio teardown.
-        VoicePushToTalkHotkey.shared.setTalkSuppressed(true)
+        owners.hotkey.setTalkSuppressed(true)
         self.logger.info("talk enabled=\(enabled)")
         if enabled {
             self.partialTranscript = ""
             self.recentTranscripts = []
-            TalkOverlayController.shared.present()
+            owners.overlay.present()
         } else {
-            TalkOverlayController.shared.dismiss()
+            owners.overlay.dismiss()
         }
-        TalkSpeechInterruptMonitor.shared.setEnabled(enabled && AppStateStore.shared.talkShiftToStopEnabled)
+        owners.interruptMonitor.setEnabled(enabled && self.state()?.talkShiftToStopEnabled == true)
         if !enabled {
             let previousShutdown = self.shutdownTask
             self.shutdownTask = Task {
                 // Disable invalidates a suspended startup immediately. A repeated disable still
                 // joins the original shutdown before PTT or another Talk start can acquire audio.
-                await TalkModeRuntime.shared.setEnabled(false)
+                await owners.runtime.setEnabled(false)
                 await previousShutdown?.value
             }
         }
@@ -53,7 +90,7 @@ final class TalkModeController {
         if enabled, self.wakePauseLease == nil {
             let lease = UUID()
             self.wakePauseLease = lease
-            self.wakePauseTask = Task { await VoiceWakeRuntime.shared.pauseForPushToTalk(lease: lease) }
+            self.wakePauseTask = Task { await owners.wake.pauseForPushToTalk(lease: lease) }
         }
         // Overlapping transitions share the acquisition until the latest Off has shut down.
         // A replaced caller may release its wake handoff only after this insertion is acknowledged.
@@ -61,7 +98,7 @@ final class TalkModeController {
         guard self.transitionID == transitionID else { return }
         await shutdown?.value
         if enabled, self.transitionID == transitionID {
-            await TalkModeRuntime.shared.setEnabled(true)
+            await owners.runtime.setEnabled(true)
         }
 
         guard self.transitionID == transitionID else { return }
@@ -70,9 +107,9 @@ final class TalkModeController {
         let lease = self.wakePauseLease
         self.wakePauseLease = nil
         self.wakePauseTask = nil
-        VoicePushToTalkHotkey.shared.setTalkSuppressed(false)
+        owners.hotkey.setTalkSuppressed(false)
         if let lease {
-            await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: lease)
+            await owners.wake.resumeAfterPushToTalk(lease: lease)
         }
     }
 
@@ -82,24 +119,23 @@ final class TalkModeController {
         if phase == .idle || phase == .thinking {
             self.updateLevel(0)
         }
-        TalkOverlayController.shared.updatePhase(phase)
+        self.owners().overlay.updatePhase(phase)
 
         if phase != previousPhase {
-            Self.playPhaseSound(phase, previousPhase: previousPhase)
+            self.playPhaseSound(phase, previousPhase: previousPhase)
         }
         self.publishPhase()
     }
 
     private func publishPhase() {
-        let state = AppStateStore.shared
-        // Preview projections stay local, including shutdown's idle phase.
-        guard !state.isPreview else { return }
+        guard let state = self.state(), state.voiceRuntime.isActive else { return }
         let effectivePhase = self.isPaused ? "paused" : self.phase.rawValue
-        Task { await GatewayConnection.shared.talkMode(enabled: state.talkEnabled, phase: effectivePhase) }
+        let enabled = state.talkEnabled
+        Task { [publishTalk] in await publishTalk(enabled, effectivePhase) }
     }
 
-    private static func playPhaseSound(_ phase: TalkModePhase, previousPhase: TalkModePhase) {
-        let state = AppStateStore.shared
+    private func playPhaseSound(_ phase: TalkModePhase, previousPhase: TalkModePhase) {
+        guard let state = self.state() else { return }
         guard !state.isPreview, state.talkPhaseSoundsEnabled else { return }
         let soundName: String? = switch phase {
         case .thinking:
@@ -126,7 +162,7 @@ final class TalkModeController {
             let response = clamped > self.level ? 0.45 : 0.18
             self.level += (clamped - self.level) * response
         }
-        TalkOverlayController.shared.updateLevel(self.level)
+        self.owners().overlay.updateLevel(self.level)
     }
 
     /// Playback level published while agent speech plays; nil (path without
@@ -167,10 +203,11 @@ final class TalkModeController {
         guard self.isPaused != paused else { return }
         self.logger.info("talk paused=\(paused)")
         self.isPaused = paused
-        TalkOverlayController.shared.updatePaused(paused)
-        guard !AppStateStore.shared.isPreview else { return }
+        let owners = self.owners()
+        owners.overlay.updatePaused(paused)
+        guard self.state()?.voiceRuntime.isActive == true else { return }
         self.publishPhase()
-        Task { await TalkModeRuntime.shared.setPaused(paused) }
+        Task { await owners.runtime.setPaused(paused) }
     }
 
     func togglePaused() {
@@ -178,11 +215,13 @@ final class TalkModeController {
     }
 
     func stopSpeaking(reason: TalkStopReason = .userTap) {
-        Task { await TalkModeRuntime.shared.stopSpeaking(reason: reason) }
+        let runtime = self.owners().runtime
+        Task { await runtime.stopSpeaking(reason: reason) }
     }
 
     func exitTalkMode() {
-        Task { await AppStateStore.shared.setTalkEnabled(false) }
+        guard let state = self.state() else { return }
+        Task { await state.setTalkEnabled(false) }
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/TalkModeController.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeController.swift
@@ -15,6 +15,10 @@ final class TalkModeController {
     private(set) var level: Double = 0
     private(set) var partialTranscript: String = ""
     private(set) var recentTranscripts: [String] = []
+    @ObservationIgnored private var transitionID = UUID()
+    @ObservationIgnored private var wakePauseLease: UUID?
+    @ObservationIgnored private var wakePauseTask: Task<Void, Never>?
+    @ObservationIgnored private var shutdownTask: Task<Void, Never>?
 
     /// Meters streamed PCM speech so the orb waveform follows the audible
     /// envelope instead of a synthetic pulse.
@@ -23,25 +27,52 @@ final class TalkModeController {
     }
 
     func setEnabled(_ enabled: Bool) async {
+        let transitionID = UUID()
+        self.transitionID = transitionID
+        // Preference updates must not reopen PTT during Talk admission or audio teardown.
+        VoicePushToTalkHotkey.shared.setTalkSuppressed(true)
         self.logger.info("talk enabled=\(enabled)")
         if enabled {
             self.partialTranscript = ""
             self.recentTranscripts = []
             TalkOverlayController.shared.present()
-            await VoiceWakeRuntime.shared.pauseForPushToTalk()
         } else {
             TalkOverlayController.shared.dismiss()
         }
         TalkSpeechInterruptMonitor.shared.setEnabled(enabled && AppStateStore.shared.talkShiftToStopEnabled)
-        // Talk Mode and Push-to-Talk share the right Option key — disable PTT while Talk Mode is active.
-        let pttEnabled = !enabled && AppStateStore.shared.voicePushToTalkEnabled
-        VoicePushToTalkHotkey.shared.setEnabled(pttEnabled)
-        await TalkModeRuntime.shared.setEnabled(enabled)
-        // Resume voice wake listener *after* TalkMode audio is fully torn down.
-        // Check swabbleEnabled (not voiceWakeTriggersTalkMode) so the paused wake listener
-        // resumes even if the user toggled "Trigger Talk Mode" off during the session.
-        if !enabled, AppStateStore.shared.swabbleEnabled {
-            Task { await VoiceWakeRuntime.shared.refresh(state: AppStateStore.shared) }
+        if !enabled {
+            let previousShutdown = self.shutdownTask
+            self.shutdownTask = Task {
+                // Disable invalidates a suspended startup immediately. A repeated disable still
+                // joins the original shutdown before PTT or another Talk start can acquire audio.
+                await TalkModeRuntime.shared.setEnabled(false)
+                await previousShutdown?.value
+            }
+        }
+        let shutdown = self.shutdownTask
+        if enabled, self.wakePauseLease == nil {
+            let lease = UUID()
+            self.wakePauseLease = lease
+            self.wakePauseTask = Task { await VoiceWakeRuntime.shared.pauseForPushToTalk(lease: lease) }
+        }
+        // Overlapping transitions share the acquisition until the latest Off has shut down.
+        // A replaced caller may release its wake handoff only after this insertion is acknowledged.
+        await self.wakePauseTask?.value
+        guard self.transitionID == transitionID else { return }
+        await shutdown?.value
+        if enabled, self.transitionID == transitionID {
+            await TalkModeRuntime.shared.setEnabled(true)
+        }
+
+        guard self.transitionID == transitionID else { return }
+        self.shutdownTask = nil
+        guard !enabled else { return }
+        let lease = self.wakePauseLease
+        self.wakePauseLease = nil
+        self.wakePauseTask = nil
+        VoicePushToTalkHotkey.shared.setTalkSuppressed(false)
+        if let lease {
+            await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: lease)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime+Realtime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime+Realtime.swift
@@ -12,12 +12,6 @@ private enum RealtimeRelayConfigurationError: LocalizedError {
 }
 
 extension TalkModeRuntime {
-    #if DEBUG
-    typealias VoiceWakePermissionProvider = @Sendable () async -> Bool
-    typealias RealtimeAudioCaptureProvider =
-        @MainActor @Sendable () -> any RealtimeTalkAudioCapturing
-    #endif
-
     private enum ScheduledRealtimeRecoveryState: Equatable {
         case cancelled
         case waitingForStartToFinish
@@ -71,9 +65,9 @@ extension TalkModeRuntime {
         let projectionGeneration = self.realtimeRelayGeneration
         _ = await MainActor.run {
             self.realtimeRelayDeliveryGate.deliver(ifActive: projectionGeneration) {
-                TalkModeController.shared.updateLevel(0)
-                TalkModeController.shared.updatePartialTranscript("")
-                TalkModeController.shared.updatePhase(.idle)
+                self.controller()?.updateLevel(0)
+                self.controller()?.updatePartialTranscript("")
+                self.controller()?.updatePhase(.idle)
             }
         }
     }
@@ -104,20 +98,14 @@ extension TalkModeRuntime {
 
     func start() async {
         let gen = lifecycleGeneration
-        #if DEBUG
-        guard self.voiceWakeSupportedProvider() else { return }
-        let hasVoiceWakePermission = await self.voiceWakePermissionProvider()
-        #else
-        guard voiceWakeSupported else { return }
-        let hasVoiceWakePermission = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
-        #endif
+        guard self.dependencies.permissions.supported() else { return }
+        let hasVoiceWakePermission = await self.dependencies.permissions.ensure(true)
         guard hasVoiceWakePermission else {
             logger.error("talk runtime not starting: permissions missing")
             return
         }
-        macOSRealtimeRelayOptIn = await MainActor.run {
-            AppStateStore.shared.talkRealtimeRelayEnabled
-        }
+        guard let optIn = await MainActor.run(body: { self.state()?.talkRealtimeRelayEnabled }) else { return }
+        macOSRealtimeRelayOptIn = optIn
         let bypassRealtime = bypassRealtimeOnNextStart
         bypassRealtimeOnNextStart = false
         if !macOSRealtimeRelayOptIn || bypassRealtime {
@@ -127,8 +115,8 @@ extension TalkModeRuntime {
         if isPaused {
             phase = .idle
             await MainActor.run {
-                TalkModeController.shared.updateLevel(0)
-                TalkModeController.shared.updatePhase(.idle)
+                self.controller()?.updateLevel(0)
+                self.controller()?.updatePhase(.idle)
             }
             return
         }
@@ -209,12 +197,12 @@ extension TalkModeRuntime {
         phase = recognitionStarted ? .listening : .idle
         return await self.projectRealtimeRelay(relayGeneration, nil) {
             if recognitionStarted, let status {
-                TalkModeController.shared.updatePartialTranscript(status)
+                self.controller()?.updatePartialTranscript(status)
             } else if !recognitionStarted {
-                TalkModeController.shared.updatePartialTranscript(
+                self.controller()?.updatePartialTranscript(
                     String(localized: "Realtime unavailable — native speech could not start"))
             }
-            TalkModeController.shared.updatePhase(recognitionStarted ? .listening : .idle)
+            self.controller()?.updatePhase(recognitionStarted ? .listening : .idle)
         }
     }
 
@@ -307,8 +295,8 @@ extension TalkModeRuntime {
         realtimeSessionReadyAt = Date()
         phase = .listening
         _ = await self.projectRealtimeRelay(relayGeneration, session) {
-            TalkModeController.shared.updatePartialTranscript("")
-            TalkModeController.shared.updatePhase(.listening)
+            self.controller()?.updatePartialTranscript("")
+            self.controller()?.updatePhase(.listening)
         }
         logger.info(
             "talk realtime ready provider=\(realtimeProvider ?? "default", privacy: .public) " +
@@ -321,10 +309,11 @@ extension TalkModeRuntime {
         relayGeneration: UInt64) async throws
     {
         let locale = await MainActor.run { () -> String? in
+            guard let state = self.state() else { return nil }
             guard self.realtimeRelayDeliveryGate.deliver(ifActive: relayGeneration, {
-                AppStateStore.shared.seamColorHex = config.seamColorHex
+                state.seamColorHex = config.seamColorHex
             }) else { return nil }
-            return AppStateStore.shared.voiceWakeLocaleID
+            return state.voiceWakeLocaleID
         }
         #if DEBUG
         if let checkpoint = self.realtimeConfigApplicationCheckpoint {
@@ -346,13 +335,13 @@ extension TalkModeRuntime {
         recognitionGeneration: Int,
         relayGeneration: UInt64) async -> Bool
     {
-        let locale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
+        let locale = await MainActor.run { self.state()?.voiceWakeLocaleID }
         #if DEBUG
         if let checkpoint = self.realtimeConfigApplicationCheckpoint {
             await checkpoint()
         }
         #endif
-        guard self.isCurrent(lifecycleGeneration),
+        guard let locale, self.isCurrent(lifecycleGeneration),
               !self.isPaused,
               self.recognitionGeneration == recognitionGeneration,
               self.realtimeRelayGeneration == relayGeneration,
@@ -391,9 +380,7 @@ extension TalkModeRuntime {
         guard isCurrent(lifecycleGeneration), !isPaused,
               realtimeRelayGeneration == relayGeneration
         else { throw CancellationError() }
-        let activeSessionKey = await MainActor.run {
-            WebChatManager.shared.activeSessionKey
-        }
+        let activeSessionKey = await self.dependencies.selectedSession()
         let sessionKey: String = if let activeSessionKey {
             activeSessionKey
         } else {
@@ -404,20 +391,14 @@ extension TalkModeRuntime {
             provider: realtimeProvider,
             model: realtimeModelId,
             voice: realtimeSpeakerVoice)
-        #if DEBUG
-        let audioCaptureProvider = self.realtimeAudioCaptureProvider
-        #endif
+        let dependencies = self.dependencies
         return await MainActor.run {
-            #if DEBUG
-            let audioCapture = audioCaptureProvider()
-            #else
-            let audioCapture = MacRealtimeTalkAudioCapture()
-            #endif
+            let audioCapture = dependencies.audioCapture()
             return RealtimeTalkRelaySession(
                 transport: bootstrap.transport,
                 options: options,
                 audioCapture: audioCapture,
-                pcmPlayer: RealtimePCMStreamingAudioPlayer(),
+                pcmPlayer: dependencies.pcmPlayer(),
                 onStatus: { [weak self] status in
                     Task { await self?.handleRealtimeStatus(status, relayGeneration: relayGeneration) }
                 },
@@ -512,7 +493,7 @@ extension TalkModeRuntime {
         logger.error(
             "talk realtime issue code=\(issue.code, privacy: .public) " +
                 "message=\(issue.message, privacy: .public)")
-        _ = await self.projectRealtimeRelay(relayGeneration, session) { TalkModeController.shared
+        _ = await self.projectRealtimeRelay(relayGeneration, session) { self.controller()?
             .updatePartialTranscript(issue.message)
         }
     }
@@ -580,11 +561,11 @@ extension TalkModeRuntime {
             activeDuration: activeDuration)
         let delay = Self.realtimeRestartDelayNanoseconds(attempt: attempt)
         guard await self.projectRealtimeRelay(terminalGeneration, nil, {
-            TalkModeController.shared.updateLevel(0)
-            TalkModeController.shared.updateSpeakingLevel(nil)
-            TalkModeController.shared.updatePhase(.idle)
+            self.controller()?.updateLevel(0)
+            self.controller()?.updateSpeakingLevel(nil)
+            self.controller()?.updatePhase(.idle)
             if shouldRecover {
-                TalkModeController.shared.updatePartialTranscript(delay == nil
+                self.controller()?.updatePartialTranscript(delay == nil
                     ? String(localized: "Realtime disconnected repeatedly — using native speech")
                     : String(localized: "Realtime disconnected — reconnecting…"))
             }
@@ -612,12 +593,12 @@ extension TalkModeRuntime {
         if speaking {
             phase = .speaking
             _ = await self.projectRealtimeRelay(relayGeneration, session) {
-                TalkModeController.shared.updatePhase(.speaking)
+                self.controller()?.updatePhase(.speaking)
             }
         } else if !isPaused {
             phase = .listening
             _ = await self.projectRealtimeRelay(relayGeneration, session) {
-                TalkModeController.shared.updatePhase(.listening)
+                self.controller()?.updatePhase(.listening)
             }
         }
     }
@@ -629,7 +610,7 @@ extension TalkModeRuntime {
               !self.isPaused
         else { return }
         _ = await self.projectRealtimeRelay(relayGeneration, session) {
-            TalkModeController.shared.updateLevel(level)
+            self.controller()?.updateLevel(level)
         }
     }
 
@@ -640,7 +621,7 @@ extension TalkModeRuntime {
               !self.isPaused
         else { return }
         _ = await self.projectRealtimeRelay(relayGeneration, session) {
-            TalkModeController.shared.updateSpeakingLevel(level)
+            self.controller()?.updateSpeakingLevel(level)
         }
     }
 
@@ -659,12 +640,12 @@ extension TalkModeRuntime {
         if transcript.isFinal {
             phase = .thinking
             _ = await self.projectRealtimeRelay(relayGeneration, session) {
-                TalkModeController.shared.commitTranscript(text)
-                TalkModeController.shared.updatePhase(.thinking)
+                self.controller()?.commitTranscript(text)
+                self.controller()?.updatePhase(.thinking)
             }
         } else {
             _ = await self.projectRealtimeRelay(relayGeneration, session) {
-                TalkModeController.shared.updatePartialTranscript(text)
+                self.controller()?.updatePartialTranscript(text)
             }
         }
     }
@@ -768,17 +749,6 @@ extension TalkModeRuntime {
 
     func _test_setRecognitionCleanupProbe(_ probe: (@Sendable () -> Void)?) {
         self.recognitionCleanupProbe = probe
-    }
-
-    func _test_setVoiceWakeReadiness(supported: Bool, permissionGranted: Bool) {
-        self.voiceWakeSupportedProvider = { supported }
-        self.voiceWakePermissionProvider = { permissionGranted }
-    }
-
-    func _test_setRealtimeAudioCaptureProvider(
-        _ provider: @escaping RealtimeAudioCaptureProvider)
-    {
-        self.realtimeAudioCaptureProvider = provider
     }
 
     func _test_setRealtimeConfigApplicationCheckpoint(

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -8,9 +8,35 @@ import OSLog
 import Speech
 
 actor TalkModeRuntime {
-    static let shared = TalkModeRuntime()
     typealias RealtimeTalkBootstrapProvider =
         @Sendable () async throws -> GatewayConnection.RealtimeTalkBootstrap
+
+    struct Dependencies: Sendable {
+        let permissions: VoicePermissions
+        let audioCapture: @MainActor @Sendable () -> any RealtimeTalkAudioCapturing
+        let pcmPlayer: @MainActor @Sendable () -> any PCMStreamingAudioPlaying
+        let selectedSession: @MainActor @Sendable () -> String?
+        let stopPCM: @MainActor @Sendable () async -> Double?
+        let stopMP3: @MainActor @Sendable () async -> Double?
+        let stopBuffered: @MainActor @Sendable () async -> Double?
+        let stopSystem: @Sendable () async -> Void
+        let stopMLX: @Sendable () async -> Void
+
+        static let live = Self(
+            permissions: .live,
+            audioCapture: { MacRealtimeTalkAudioCapture() },
+            pcmPlayer: { RealtimePCMStreamingAudioPlayer() },
+            selectedSession: { WebChatManager.shared.activeSessionKey },
+            stopPCM: { PCMStreamingAudioPlayer.shared.stop() },
+            stopMP3: { StreamingAudioPlayer.shared.stop() },
+            stopBuffered: { TalkBufferedAudioPlayer.shared.stop() },
+            stopSystem: { await TalkSystemSpeechSynthesizer.shared.stop() },
+            stopMLX: { await TalkMLXSpeechSynthesizer.shared.cancelCurrent() })
+    }
+
+    let state: AppVoiceRuntime.State
+    let controller: AppVoiceRuntime.Controller
+    let dependencies: Dependencies
 
     enum PlaybackPlan: Equatable {
         case elevenLabsThenSystemVoice(apiKey: String, voiceId: String)
@@ -105,15 +131,6 @@ actor TalkModeRuntime {
     var realtimeReconfigurationGeneration: UInt64 = 0
     let realtimeTalkBootstrapProvider: RealtimeTalkBootstrapProvider
     #if DEBUG
-    var voiceWakeSupportedProvider: @Sendable () -> Bool = { voiceWakeSupported }
-    var voiceWakePermissionProvider: VoiceWakePermissionProvider = {
-        await PermissionManager.ensureVoiceWakePermissions(interactive: true)
-    }
-
-    var realtimeAudioCaptureProvider: RealtimeAudioCaptureProvider = {
-        MacRealtimeTalkAudioCapture()
-    }
-
     var realtimeConfigApplicationCheckpoint: (@Sendable () async -> Void)?
     var recognitionCleanupProbe: (@Sendable () -> Void)?
     #endif
@@ -131,10 +148,16 @@ actor TalkModeRuntime {
     private let minSpeechRMS: Double = 1e-3
     private let speechBoostFactor: Double = 6.0
 
-    init(realtimeTalkBootstrapProvider: @escaping RealtimeTalkBootstrapProvider = {
-        try await GatewayConnection.shared.acquireRealtimeTalkBootstrap()
-    }) {
+    init(
+        realtimeTalkBootstrapProvider: @escaping RealtimeTalkBootstrapProvider = AppVoiceRuntime.liveBootstrap,
+        state: @escaping AppVoiceRuntime.State = { AppStateStore.shared },
+        controller: @escaping AppVoiceRuntime.Controller = { TalkModeController.shared },
+        dependencies: Dependencies = .live)
+    {
         self.realtimeTalkBootstrapProvider = realtimeTalkBootstrapProvider
+        self.state = state
+        self.controller = controller
+        self.dependencies = dependencies
     }
 
     // MARK: - Lifecycle
@@ -154,7 +177,7 @@ actor TalkModeRuntime {
     func setPaused(_ paused: Bool) async {
         guard paused != self.isPaused else { return }
         self.isPaused = paused
-        await MainActor.run { TalkModeController.shared.updateLevel(0) }
+        await MainActor.run { self.controller()?.updateLevel(0) }
 
         guard self.isEnabled else { return }
 
@@ -189,10 +212,10 @@ actor TalkModeRuntime {
                 self.lastSpeechEnergyAt = nil
                 self.phase = .idle
                 _ = await projectRealtimeRelay(relayGeneration, realtimeSession) {
-                    TalkModeController.shared.updateLevel(0)
-                    TalkModeController.shared.updateSpeakingLevel(nil)
-                    TalkModeController.shared.updatePartialTranscript("")
-                    TalkModeController.shared.updatePhase(.idle)
+                    self.controller()?.updateLevel(0)
+                    self.controller()?.updateSpeakingLevel(nil)
+                    self.controller()?.updatePartialTranscript("")
+                    self.controller()?.updatePhase(.idle)
                 }
             } else {
                 guard await setRealtimeInputPaused(
@@ -213,7 +236,7 @@ actor TalkModeRuntime {
                 }
                 self.phase = .listening
                 _ = await projectRealtimeRelay(relayGeneration, realtimeSession) {
-                    TalkModeController.shared.updatePhase(.listening)
+                    self.controller()?.updatePhase(.listening)
                 }
             }
             return
@@ -228,7 +251,7 @@ actor TalkModeRuntime {
             self.lastTranscript = ""
             self.lastHeard = nil
             self.lastSpeechEnergyAt = nil
-            await MainActor.run { TalkModeController.shared.updatePartialTranscript("") }
+            await MainActor.run { self.controller()?.updatePartialTranscript("") }
             self.stopRecognition()
             return
         }
@@ -238,7 +261,7 @@ actor TalkModeRuntime {
             guard await self.startRecognition(lifecycleGeneration: lifecycleGeneration),
                   self.isCurrent(lifecycleGeneration), !self.isPaused else { return }
             self.phase = .listening
-            await MainActor.run { TalkModeController.shared.updatePhase(.listening) }
+            await MainActor.run { self.controller()?.updatePhase(.listening) }
             self.startSilenceMonitor()
         }
     }
@@ -271,8 +294,8 @@ actor TalkModeRuntime {
     func startAudioInputObserver() {
         guard self.audioInputObserver == nil else { return }
         let observer = AudioInputDeviceObserver()
-        observer.start {
-            Task { await TalkModeRuntime.shared.audioInputDevicesDidChange() }
+        observer.start { [weak self] in
+            Task { await self?.audioInputDevicesDidChange() }
         }
         self.audioInputObserver = observer
     }
@@ -309,8 +332,9 @@ actor TalkModeRuntime {
             lifecycleGeneration: lifecycleGeneration)
         else { return false }
 
-        let voiceWakeLocale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
-        let selectedInputUID = await MainActor.run { AppStateStore.shared.voiceWakeMicID }
+        guard let voiceWakeLocale = await MainActor.run(body: { self.state()?.voiceWakeLocaleID }),
+              let selectedInputUID = await MainActor.run(body: { self.state()?.voiceWakeMicID })
+        else { return false }
         let supportedLocaleIDs = Set(SFSpeechRecognizer.supportedLocales().map(\.identifier))
         let localeID = TalkConfigParsing.resolvedSpeechRecognitionLocaleID(
             preferredLocaleIDs: [
@@ -458,7 +482,7 @@ actor TalkModeRuntime {
             self.lastHeard = Date()
         }
 
-        await MainActor.run { TalkModeController.shared.updatePartialTranscript(trimmed) }
+        await MainActor.run { self.controller()?.updatePartialTranscript(trimmed) }
 
         if update.isFinal {
             self.lastTranscript = trimmed
@@ -496,9 +520,9 @@ actor TalkModeRuntime {
         self.lastTranscript = ""
         self.lastHeard = nil
         await MainActor.run {
-            TalkModeController.shared.updatePhase(.listening)
-            TalkModeController.shared.updateLevel(0)
-            TalkModeController.shared.updatePartialTranscript("")
+            self.controller()?.updatePhase(.listening)
+            self.controller()?.updateLevel(0)
+            self.controller()?.updatePartialTranscript("")
         }
     }
 
@@ -507,11 +531,11 @@ actor TalkModeRuntime {
         self.lastHeard = nil
         self.phase = .thinking
         await MainActor.run {
-            TalkModeController.shared.commitTranscript(text)
-            TalkModeController.shared.updatePhase(.thinking)
+            self.controller()?.commitTranscript(text)
+            self.controller()?.updatePhase(.thinking)
         }
         // Play "send" chime when the user's speech is finalized and about to be sent
-        let sendChime = await MainActor.run { AppStateStore.shared.voiceWakeSendChime }
+        let sendChime = await MainActor.run { self.state()?.voiceWakeSendChime ?? .none }
         if sendChime != .none {
             await MainActor.run { VoiceWakeChimePlayer.play(sendChime, reason: "talk.send") }
         }
@@ -700,7 +724,7 @@ extension TalkModeRuntime {
             self.lastHeard = nil
             self.lastSpeechEnergyAt = nil
             await MainActor.run {
-                TalkModeController.shared.updateLevel(0)
+                self.controller()?.updateLevel(0)
             }
             return
         }
@@ -889,7 +913,7 @@ extension TalkModeRuntime {
 
         if self.phase == .speaking {
             self.phase = .thinking
-            await MainActor.run { TalkModeController.shared.updatePhase(.thinking) }
+            await MainActor.run { self.controller()?.updatePhase(.thinking) }
         }
     }
 
@@ -1051,7 +1075,7 @@ extension TalkModeRuntime {
             guard await self.prepareForPlayback(generation: input.generation) else { return }
         }
 
-        await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
+        await MainActor.run { self.controller()?.updatePhase(.speaking) }
         self.phase = .speaking
 
         let result = await playRemoteStream(
@@ -1123,7 +1147,7 @@ extension TalkModeRuntime {
         if self.interruptOnSpeech {
             guard await self.prepareForPlayback(generation: input.generation) else { return }
         }
-        await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
+        await MainActor.run { self.controller()?.updatePhase(.speaking) }
         self.phase = .speaking
         let playback = await playTalkAudio(data: audioData)
         self.ttsLogger
@@ -1143,11 +1167,11 @@ extension TalkModeRuntime {
         if self.interruptOnSpeech {
             guard await self.prepareForPlayback(generation: input.generation) else { return }
         }
-        await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
+        await MainActor.run { self.controller()?.updatePhase(.speaking) }
         self.phase = .speaking
-        await TalkSystemSpeechSynthesizer.shared.stop()
+        await self.dependencies.stopSystem()
         // Use app locale as fallback when no explicit language is set (e.g. system voice without ElevenLabs directive).
-        let appLocale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
+        guard let appLocale = await MainActor.run(body: { self.state()?.voiceWakeLocaleID }) else { return }
         let ttsLanguage = input.language ?? appLocale
         try await TalkSystemSpeechSynthesizer.shared.speak(
             text: input.cleanedText,
@@ -1160,7 +1184,7 @@ extension TalkModeRuntime {
         if self.interruptOnSpeech {
             guard await self.prepareForPlayback(generation: input.generation) else { return }
         }
-        await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
+        await MainActor.run { self.controller()?.updatePhase(.speaking) }
         self.phase = .speaking
         let modelRepo = input.directive?.modelId ?? self.currentModelId
         self.lastPlaybackWasPCM = true
@@ -1260,7 +1284,7 @@ extension TalkModeRuntime {
             else { return }
             if cancelled, reason != .manual, !self.isPaused {
                 self.phase = .listening
-                await MainActor.run { TalkModeController.shared.updatePhase(.listening) }
+                await MainActor.run { self.controller()?.updatePhase(.listening) }
             }
             return
         }
@@ -1280,7 +1304,7 @@ extension TalkModeRuntime {
             expectedReconfigurationGeneration,
             lifecycleGeneration: expectedLifecycleGeneration)
         else { return }
-        await TalkSystemSpeechSynthesizer.shared.stop()
+        await self.dependencies.stopSystem()
         guard self.ownsReconfiguration(
             expectedReconfigurationGeneration,
             lifecycleGeneration: expectedLifecycleGeneration)
@@ -1303,7 +1327,7 @@ extension TalkModeRuntime {
             return
         }
         self.phase = .thinking
-        await MainActor.run { TalkModeController.shared.updatePhase(.thinking) }
+        await MainActor.run { self.controller()?.updatePhase(.thinking) }
     }
 }
 
@@ -1363,9 +1387,12 @@ extension TalkModeRuntime {
         stream: AsyncThrowingStream<Data, Error>,
         sampleRate: Double) async -> StreamingPlaybackResult
     {
-        let metered = TalkModeController.shared.meteredSpeechStream(stream, sampleRate: sampleRate)
+        guard let controller = self.controller() else {
+            return StreamingPlaybackResult(finished: false, interruptedAt: nil)
+        }
+        let metered = controller.meteredSpeechStream(stream, sampleRate: sampleRate)
         let result = await PCMStreamingAudioPlayer.shared.play(stream: metered, sampleRate: sampleRate)
-        TalkModeController.shared.endSpeechMetering()
+        controller.endSpeechMetering()
         return result
     }
 
@@ -1376,26 +1403,27 @@ extension TalkModeRuntime {
     }
 
     @MainActor
-    private func stopPCM() -> Double? {
-        PCMStreamingAudioPlayer.shared.stop()
+    private func stopPCM() async -> Double? {
+        await self.dependencies.stopPCM()
     }
 
     @MainActor
-    private func stopMP3() -> Double? {
-        StreamingAudioPlayer.shared.stop()
+    private func stopMP3() async -> Double? {
+        await self.dependencies.stopMP3()
     }
 
     @MainActor
     private func playTalkAudio(data: Data) async -> StreamingPlaybackResult {
-        TalkBufferedAudioPlayer.shared.setLevelHandler { level in
-            TalkModeController.shared.updateSpeakingLevel(level)
+        let controller = self.controller()
+        TalkBufferedAudioPlayer.shared.setLevelHandler { [weak controller] level in
+            controller?.updateSpeakingLevel(level)
         }
         return await TalkBufferedAudioPlayer.shared.play(data: data)
     }
 
     @MainActor
-    private func stopTalkAudio() -> Double? {
-        TalkBufferedAudioPlayer.shared.stop()
+    private func stopTalkAudio() async -> Double? {
+        await self.dependencies.stopBuffered()
     }
 
     private func streamMLXVoice(
@@ -1418,7 +1446,7 @@ extension TalkModeRuntime {
     }
 
     private func stopMLXVoice() async {
-        await TalkMLXSpeechSynthesizer.shared.cancelCurrent()
+        await self.dependencies.stopMLX()
     }
 
     func parseTalkConfig(_ snap: ConfigSnapshot) -> TalkModeGatewayConfigState {
@@ -1474,15 +1502,16 @@ extension TalkModeRuntime {
         let cfg = await fetchTalkConfig()
         await self.applyTalkConfig(cfg)
         self.macOSRealtimeRelayOptIn = await MainActor.run {
-            AppStateStore.shared.talkRealtimeRelayEnabled
+            self.state()?.talkRealtimeRelayEnabled ?? false
         }
     }
 
     func applyTalkConfig(_ cfg: TalkModeGatewayConfigState) async {
-        let locale = await MainActor.run {
-            AppStateStore.shared.seamColorHex = cfg.seamColorHex
-            return AppStateStore.shared.voiceWakeLocaleID
-        }
+        guard let locale = await MainActor.run(body: { () -> String? in
+            guard let state = self.state() else { return nil }
+            state.seamColorHex = cfg.seamColorHex
+            return state.voiceWakeLocaleID
+        }) else { return }
         self.commitTalkConfig(cfg, locale: locale)
     }
 
@@ -1567,7 +1596,7 @@ extension TalkModeRuntime {
 
         if self.phase == .listening {
             let clamped = min(1.0, max(0.0, rms / max(self.minSpeechRMS, threshold)))
-            await MainActor.run { TalkModeController.shared.updateLevel(clamped) }
+            await MainActor.run { self.controller()?.updateLevel(clamped) }
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -6,7 +6,6 @@ import SwiftUI
 @MainActor
 @Observable
 final class TalkOverlayController {
-    static let shared = TalkOverlayController()
     static let overlaySize: CGFloat = 440
     static let orbSize: CGFloat = 96
     static let orbPadding: CGFloat = 12
@@ -25,14 +24,63 @@ final class TalkOverlayController {
     private var hostingView: NSHostingView<TalkOverlayView>?
     private let screenInset: CGFloat = 0
     @ObservationIgnored private var transitionID = UUID()
+    @ObservationIgnored let state: AppVoiceRuntime.State
+    @ObservationIgnored private let presentation: Presentation
+    @ObservationIgnored let actions: ActionsProvider
+
+    struct Presentation: Sendable {
+        let present: @MainActor @Sendable (TalkOverlayController, Bool) -> Void
+        let animateDismiss: @MainActor @Sendable (
+            TalkOverlayController, @escaping @MainActor @Sendable (AppVoiceRuntime.UIAction) -> Void) -> Void
+
+        static let live = Self(
+            present: { $0.presentWindow(isFirst: $1) },
+            animateDismiss: { owner, completion in
+                guard let window = owner.window else { return }
+                OverlayPanelFactory.animateDismiss(window: window) {
+                    completion { window.orderOut(nil) }
+                }
+            })
+    }
+
+    struct Actions: Sendable {
+        let togglePaused: AppVoiceRuntime.UIAction
+        let stopSpeaking: AppVoiceRuntime.UIAction
+        let pauseForDrag: AppVoiceRuntime.UIAction
+        let exit: AppVoiceRuntime.UIAction
+    }
+
+    typealias ActionsProvider = @MainActor @Sendable () -> Actions?
+
+    static func liveActions() -> Actions? {
+        Actions(
+            togglePaused: { TalkModeController.shared.togglePaused() },
+            stopSpeaking: { TalkModeController.shared.stopSpeaking(reason: .userTap) },
+            pauseForDrag: { TalkModeController.shared.setPaused(true) },
+            exit: { TalkModeController.shared.exitTalkMode() })
+    }
+
+    init(
+        state: @escaping AppVoiceRuntime.State = { AppStateStore.shared },
+        presentation: Presentation = .live,
+        actions: @escaping ActionsProvider = TalkOverlayController.liveActions)
+    {
+        self.state = state
+        self.presentation = presentation
+        self.actions = actions
+    }
 
     func present() {
         self.transitionID = UUID()
+        let isFirst = !self.model.isVisible
+        if isFirst { self.model.isVisible = true }
+        self.presentation.present(self, isFirst)
+    }
+
+    private func presentWindow(isFirst: Bool) {
         self.ensureWindow()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
-        let isFirst = !self.model.isVisible
-        if isFirst { self.model.isVisible = true }
         OverlayPanelFactory.present(
             window: self.window,
             isFirstPresent: isFirst,
@@ -47,12 +95,10 @@ final class TalkOverlayController {
         let dismissalID = UUID()
         self.transitionID = dismissalID
         self.model.isVisible = false
-        guard let window else { return }
-
-        OverlayPanelFactory.animateDismiss(window: window) { [weak self] in
+        self.presentation.animateDismiss(self) { [weak self] finishWindow in
             // A later present or dismiss owns the panel, even while this fade is completing.
             guard self?.transitionID == dismissalID else { return }
-            window.orderOut(nil)
+            finishWindow()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 struct TalkOverlayView: View {
     var controller: TalkOverlayController
-    @State private var appState = AppStateStore.shared
     @State private var hoveringWindow = false
 
     var body: some View {
@@ -23,12 +22,12 @@ struct TalkOverlayView: View {
                 .opacity(isPaused ? 0.55 : 1)
                 .background(
                     TalkOrbInteractionView(
-                        onSingleClick: { TalkModeController.shared.togglePaused() },
-                        onDoubleClick: { TalkModeController.shared.stopSpeaking(reason: .userTap) },
-                        onDragStart: { TalkModeController.shared.setPaused(true) }))
+                        onSingleClick: { self.controller.actions()?.togglePaused() },
+                        onDoubleClick: { self.controller.actions()?.stopSpeaking() },
+                        onDragStart: { self.controller.actions()?.pauseForDrag() }))
                 .overlay(alignment: .topLeading) {
                     Button {
-                        TalkModeController.shared.exitTalkMode()
+                        self.controller.actions()?.exit()
                     } label: {
                         Image(systemName: "xmark")
                             .font(.system(size: 10, weight: .bold))
@@ -54,7 +53,7 @@ struct TalkOverlayView: View {
     private static let defaultSeamColor = Color(red: 79 / 255.0, green: 122 / 255.0, blue: 154 / 255.0)
 
     private var seamColor: Color {
-        ColorHexSupport.color(fromHex: self.appState.effectiveAccentHex) ?? Self.defaultSeamColor
+        ColorHexSupport.color(fromHex: self.controller.state()?.effectiveAccentHex) ?? Self.defaultSeamColor
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/TalkSpeechInterruptMonitor.swift
+++ b/apps/macos/Sources/OpenClaw/TalkSpeechInterruptMonitor.swift
@@ -4,11 +4,31 @@ import OSLog
 /// Monitors right Option key (keyCode 61) to interrupt Talk Mode speech.
 /// Independent of Push-to-Talk — active whenever Talk Mode is enabled.
 final class TalkSpeechInterruptMonitor: @unchecked Sendable {
-    static let shared = TalkSpeechInterruptMonitor()
+    struct Registration: Sendable {
+        let addGlobal: @MainActor @Sendable (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any?
+        let addLocal: @MainActor @Sendable (NSEvent.EventTypeMask, @escaping (NSEvent) -> NSEvent?) -> Any?
+        let remove: @MainActor @Sendable (Any) -> Void
+
+        static let live = Self(
+            addGlobal: { NSEvent.addGlobalMonitorForEvents(matching: $0, handler: $1) },
+            addLocal: { NSEvent.addLocalMonitorForEvents(matching: $0, handler: $1) },
+            remove: { NSEvent.removeMonitor($0) })
+    }
+
+    private let registration: Registration
+    private let controller: AppVoiceRuntime.Controller
+
+    init(
+        registration: Registration = .live,
+        controller: @escaping AppVoiceRuntime.Controller = { TalkModeController.shared })
+    {
+        self.registration = registration
+        self.controller = controller
+    }
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "talk.interrupt")
-    private var globalMonitor: Any?
-    private var localMonitor: Any?
+    @MainActor private var globalMonitor: Any?
+    @MainActor private var localMonitor: Any?
 
     func setEnabled(_ enabled: Bool) {
         DispatchQueue.main.async { [weak self] in
@@ -21,25 +41,25 @@ final class TalkSpeechInterruptMonitor: @unchecked Sendable {
         }
     }
 
-    private func startMonitoring() {
+    @MainActor private func startMonitoring() {
         guard self.globalMonitor == nil, self.localMonitor == nil else { return }
-        self.globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+        self.globalMonitor = self.registration.addGlobal(.flagsChanged) { [weak self] event in
             self?.handleFlags(keyCode: event.keyCode, modifierFlags: event.modifierFlags)
         }
-        self.localMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+        self.localMonitor = self.registration.addLocal(.flagsChanged) { [weak self] event in
             self?.handleFlags(keyCode: event.keyCode, modifierFlags: event.modifierFlags)
             return event
         }
         self.logger.info("talk interrupt monitor started")
     }
 
-    private func stopMonitoring() {
+    @MainActor private func stopMonitoring() {
         if let globalMonitor {
-            NSEvent.removeMonitor(globalMonitor)
+            self.registration.remove(globalMonitor)
             self.globalMonitor = nil
         }
         if let localMonitor {
-            NSEvent.removeMonitor(localMonitor)
+            self.registration.remove(localMonitor)
             self.localMonitor = nil
         }
         self.logger.info("talk interrupt monitor stopped")
@@ -49,9 +69,9 @@ final class TalkSpeechInterruptMonitor: @unchecked Sendable {
         // Right Option key down (keyCode 61).
         guard keyCode == 61, modifierFlags.contains(.option) else { return }
         Task { @MainActor in
-            guard TalkModeController.shared.phase == .speaking else { return }
+            guard let controller = self.controller(), controller.phase == .speaking else { return }
             self.logger.info("right option — interrupting talk mode speech")
-            TalkModeController.shared.stopSpeaking(reason: .userTap)
+            controller.stopSpeaking(reason: .userTap)
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -49,18 +49,16 @@ final class VoicePushToTalkHotkey {
         guard self.globalMonitor == nil, self.localMonitor == nil else { return }
         // Listen-only global monitor; we rely on Input Monitoring permission to receive events.
         self.globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            let keyCode = event.keyCode
             let flags = event.modifierFlags
             MainActor.assumeIsolated {
-                self?.updateModifierState(keyCode: keyCode, modifierFlags: flags)
+                self?.updateModifierState(modifierFlags: flags)
             }
         }
         // Also listen locally so we still catch events when the app is active/focused.
         self.localMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            let keyCode = event.keyCode
             let flags = event.modifierFlags
             MainActor.assumeIsolated {
-                self?.updateModifierState(keyCode: keyCode, modifierFlags: flags)
+                self?.updateModifierState(modifierFlags: flags)
             }
             return event
         }
@@ -80,7 +78,7 @@ final class VoicePushToTalkHotkey {
         self.endAction(true)
     }
 
-    private func updateModifierState(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) {
+    private func updateModifierState(modifierFlags: NSEvent.ModifierFlags) {
         guard self.enabled, !self.talkSuppressed else { return }
         // Aggregate Option stays set when the other Option key remains held.
         let chordActive = modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
@@ -93,8 +91,8 @@ final class VoicePushToTalkHotkey {
         }
     }
 
-    func _testUpdateModifierState(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) {
-        self.updateModifierState(keyCode: keyCode, modifierFlags: modifierFlags)
+    func _testUpdateModifierState(modifierFlags: NSEvent.ModifierFlags) {
+        self.updateModifierState(modifierFlags: modifierFlags)
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -1,61 +1,72 @@
 import AppKit
 import AVFoundation
-import Dispatch
+import IOKit.hidsystem
 import OSLog
 import Speech
 
 /// Observes right Option and starts a push-to-talk capture while it is held.
-final class VoicePushToTalkHotkey: @unchecked Sendable {
+@MainActor
+final class VoicePushToTalkHotkey {
     static let shared = VoicePushToTalkHotkey()
 
     private var globalMonitor: Any?
     private var localMonitor: Any?
-    private var optionDown = false // right option only
     private var active = false
+    private var enabled = false
+    private var talkSuppressed = false
 
-    private let beginAction: @Sendable () async -> Void
-    private let endAction: @Sendable () async -> Void
+    private let beginAction: @MainActor () -> Void
+    private let endAction: @MainActor (_ cancelled: Bool) -> Void
 
     init(
-        beginAction: @escaping @Sendable () async -> Void = { await VoicePushToTalk.shared.begin() },
-        endAction: @escaping @Sendable () async -> Void = { await VoicePushToTalk.shared.end() })
+        beginAction: @escaping @MainActor () -> Void = { VoicePushToTalk.shared.begin() },
+        endAction: @escaping @MainActor (Bool) -> Void = { VoicePushToTalk.shared.end(cancelled: $0) })
     {
         self.beginAction = beginAction
         self.endAction = endAction
     }
 
     func setEnabled(_ enabled: Bool) {
-        if ProcessInfo.processInfo.isRunningTests { return }
-        self.withMainThread { [weak self] in
-            guard let self else { return }
-            if enabled {
-                self.startMonitoring()
-            } else {
-                self.stopMonitoring()
-            }
+        self.enabled = enabled
+        self.reconcile()
+    }
+
+    func setTalkSuppressed(_ suppressed: Bool) {
+        self.talkSuppressed = suppressed
+        self.reconcile()
+    }
+
+    private func reconcile() {
+        if self.enabled, !self.talkSuppressed, voiceWakeSupported {
+            self.startMonitoring()
+        } else {
+            self.stopMonitoring()
         }
     }
 
     private func startMonitoring() {
-        // assert(Thread.isMainThread) - Removed for Swift 6
+        if ProcessInfo.processInfo.isRunningTests { return }
         guard self.globalMonitor == nil, self.localMonitor == nil else { return }
         // Listen-only global monitor; we rely on Input Monitoring permission to receive events.
         self.globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             let keyCode = event.keyCode
             let flags = event.modifierFlags
-            self?.handleFlagsChanged(keyCode: keyCode, modifierFlags: flags)
+            MainActor.assumeIsolated {
+                self?.updateModifierState(keyCode: keyCode, modifierFlags: flags)
+            }
         }
         // Also listen locally so we still catch events when the app is active/focused.
         self.localMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             let keyCode = event.keyCode
             let flags = event.modifierFlags
-            self?.handleFlagsChanged(keyCode: keyCode, modifierFlags: flags)
+            MainActor.assumeIsolated {
+                self?.updateModifierState(keyCode: keyCode, modifierFlags: flags)
+            }
             return event
         }
     }
 
     private func stopMonitoring() {
-        // assert(Thread.isMainThread) - Removed for Swift 6
         if let globalMonitor {
             NSEvent.removeMonitor(globalMonitor)
             self.globalMonitor = nil
@@ -64,43 +75,21 @@ final class VoicePushToTalkHotkey: @unchecked Sendable {
             NSEvent.removeMonitor(localMonitor)
             self.localMonitor = nil
         }
-        self.optionDown = false
         self.active = false
-    }
-
-    private func handleFlagsChanged(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) {
-        self.withMainThread { [weak self] in
-            self?.updateModifierState(keyCode: keyCode, modifierFlags: modifierFlags)
-        }
-    }
-
-    private func withMainThread(_ block: @escaping @Sendable () -> Void) {
-        DispatchQueue.main.async(execute: block)
+        // Teardown also cancels a pending start or a released session still draining Speech.
+        self.endAction(true)
     }
 
     private func updateModifierState(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) {
-        // assert(Thread.isMainThread)  - Removed for Swift 6
-
-        // Right Option (keyCode 61) acts as a hold-to-talk modifier.
-        if keyCode == 61 {
-            self.optionDown = modifierFlags.contains(.option)
-        }
-
-        let chordActive = self.optionDown
+        guard self.enabled, !self.talkSuppressed else { return }
+        // Aggregate Option stays set when the other Option key remains held.
+        let chordActive = modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
         if chordActive, !self.active {
             self.active = true
-            Task {
-                Logger(subsystem: "ai.openclaw", category: "voicewake.ptt")
-                    .info("ptt hotkey down")
-                await self.beginAction()
-            }
+            self.beginAction()
         } else if !chordActive, self.active {
             self.active = false
-            Task {
-                Logger(subsystem: "ai.openclaw", category: "voicewake.ptt")
-                    .info("ptt hotkey up")
-                await self.endAction()
-            }
+            self.endAction(false)
         }
     }
 
@@ -110,7 +99,8 @@ final class VoicePushToTalkHotkey: @unchecked Sendable {
 }
 
 /// Records speech while the hotkey is held.
-actor VoicePushToTalk {
+@MainActor
+final class VoicePushToTalk {
     static let shared = VoicePushToTalk()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.ptt")
@@ -122,6 +112,9 @@ actor VoicePushToTalk {
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var tapInstalled = false
+    private var holdID: UUID?
+    private var startupTask: Task<Void, Never>?
+    private var pauseLease: UUID?
 
     /// Session token used to drop stale callbacks when a new capture starts.
     private var sessionID = UUID()
@@ -130,8 +123,7 @@ actor VoicePushToTalk {
     private var volatile: String = ""
     private var activeConfig: Config?
     private var isCapturing = false
-    private var triggerChimePlayed = false
-    private var finalized = false
+    private var finalized = true
     private var timeoutTask: Task<Void, Never>?
     private var overlayToken: UUID?
     private var adoptedPrefix: String = ""
@@ -143,62 +135,87 @@ actor VoicePushToTalk {
         let sendChime: VoiceWakeChime
     }
 
-    func begin() async {
-        guard voiceWakeSupported else { return }
-        guard !self.isCapturing else { return }
-
-        // Start a fresh session and invalidate any in-flight callbacks tied to an older one.
+    func begin() {
+        guard voiceWakeSupported, self.holdID == nil else { return }
+        let snapshot = VoiceSessionCoordinator.shared.snapshot()
+        // Retire the old capture, but retain its overlay and wake lease until admission
+        // commits or cancels. Dismissing here would animate out the replacement overlay.
+        self.retireCapture()
         let sessionID = UUID()
+        self.holdID = sessionID
         self.sessionID = sessionID
+        self.finalized = false
+        self.adoptedPrefix = snapshot.visible ? snapshot.text.trimmingCharacters(in: .whitespacesAndNewlines) : ""
+        self.startupTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if self.holdID == sessionID { self.startupTask = nil }
+            }
+            let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
+            guard !Task.isCancelled, self.holdID == sessionID else { return }
+            guard granted, VoiceSessionCoordinator.shared.snapshot().token == snapshot.token else {
+                self.end(cancelled: true)
+                return
+            }
 
-        // Ensure permissions up front.
-        let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
-        guard granted else { return }
+            // The startup task owns acquisition until its acknowledgement; end must not remove
+            // a lease before the wake actor has inserted it.
+            await VoiceWakeRuntime.shared.pauseForPushToTalk(lease: sessionID)
+            guard !Task.isCancelled, self.holdID == sessionID else {
+                await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: sessionID)
+                return
+            }
+            let previousLease = self.pauseLease
+            self.pauseLease = sessionID
+            if let previousLease {
+                // Acquisition precedes release so wake cannot restart between held sessions.
+                Task { await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: previousLease) }
+            }
+            guard VoiceSessionCoordinator.shared.snapshot().token == snapshot.token else {
+                self.end(cancelled: true)
+                return
+            }
+            self.startCapture(sessionID: sessionID)
+        }
+    }
 
-        let config = await MainActor.run { self.makeConfig() }
+    private func startCapture(sessionID: UUID) {
+        let config = self.makeConfig()
         self.activeConfig = config
         self.isCapturing = true
-        self.triggerChimePlayed = false
-        self.finalized = false
-        self.timeoutTask?.cancel()
-        self.timeoutTask = nil
-        let snapshot = await MainActor.run { VoiceSessionCoordinator.shared.snapshot() }
-        self.adoptedPrefix = snapshot.visible ? snapshot.text.trimmingCharacters(in: .whitespacesAndNewlines) : ""
         self.logger.info("ptt begin adopted_prefix_len=\(self.adoptedPrefix.count, privacy: .public)")
         if config.triggerChime != .none {
-            self.triggerChimePlayed = true
-            await MainActor.run { VoiceWakeChimePlayer.play(config.triggerChime, reason: "ptt.trigger") }
+            VoiceWakeChimePlayer.play(config.triggerChime, reason: "ptt.trigger")
         }
-        // Pause the always-on wake word recognizer so both pipelines don't fight over the mic tap.
-        await VoiceWakeRuntime.shared.pauseForPushToTalk()
         let adoptedPrefix = self.adoptedPrefix
         let adoptedAttributed: NSAttributedString? = adoptedPrefix.isEmpty ? nil : VoiceOverlayTextFormatting
             .makeAttributed(
                 committed: adoptedPrefix,
                 volatile: "",
                 isFinal: false)
-        self.overlayToken = await MainActor.run {
-            VoiceSessionCoordinator.shared.startSession(
-                source: .pushToTalk,
-                text: adoptedPrefix,
-                attributed: adoptedAttributed,
-                forwardEnabled: true)
-        }
+        self.overlayToken = VoiceSessionCoordinator.shared.startSession(
+            source: .pushToTalk,
+            text: adoptedPrefix,
+            attributed: adoptedAttributed,
+            forwardEnabled: true)
 
         do {
-            try await self.startRecognition(localeID: config.localeID, sessionID: sessionID)
+            try self.startRecognition(localeID: config.localeID, sessionID: sessionID)
         } catch {
-            await MainActor.run {
-                VoiceWakeOverlayController.shared.dismiss()
-            }
-            self.isCapturing = false
-            // If push-to-talk fails to start after pausing wake-word, ensure we resume listening.
-            await VoiceWakeRuntime.shared.applyPushToTalkCooldown()
-            await VoiceWakeRuntime.shared.refresh(state: AppStateStore.shared)
+            self.logger.debug("push-to-talk failed to start: \(error.localizedDescription, privacy: .public)")
+            self.finalize(transcriptOverride: nil, reason: "startFailed", forward: false)
         }
     }
 
-    func end() async {
+    func end(cancelled: Bool = false) {
+        let wasStarting = self.startupTask != nil
+        self.holdID = nil
+        self.startupTask?.cancel()
+        self.startupTask = nil
+        if cancelled || wasStarting {
+            self.finalize(transcriptOverride: nil, reason: "cancelled", forward: false)
+            return
+        }
         guard self.isCapturing else { return }
         self.isCapturing = false
         let sessionID = self.sessionID
@@ -213,21 +230,26 @@ actor VoicePushToTalk {
 
         // If we captured nothing, dismiss immediately when the user lets go.
         if self.committed.isEmpty, self.volatile.isEmpty, self.adoptedPrefix.isEmpty {
-            await self.finalize(transcriptOverride: "", reason: "emptyOnRelease", sessionID: sessionID)
+            self.finalize(transcriptOverride: "", reason: "emptyOnRelease")
             return
         }
 
         // Otherwise, give Speech a brief window to deliver the final result; then fall back.
         self.timeoutTask?.cancel()
         self.timeoutTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5s grace period to await final result
-            await self?.finalize(transcriptOverride: nil, reason: "timeout", sessionID: sessionID)
+            do {
+                try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5s grace period to await final result
+            } catch {
+                return
+            }
+            guard let self, self.sessionID == sessionID else { return }
+            self.finalize(transcriptOverride: nil, reason: "timeout")
         }
     }
 
     // MARK: - Private
 
-    private func startRecognition(localeID: String?, sessionID: UUID) async throws {
+    private func startRecognition(localeID: String?, sessionID: UUID) throws {
         let recognizer = self.recognizerCache.recognizer(localeID: localeID ?? Locale.current.identifier)
         guard let recognizer, recognizer.isAvailable else {
             throw NSError(
@@ -254,38 +276,47 @@ actor VoicePushToTalk {
                 userInfo: [NSLocalizedDescriptionKey: "No usable audio input device available"])
         }
 
-        let input = audioEngine.inputNode
-        let format = input.outputFormat(forBus: 0)
-        if self.tapInstalled {
-            input.removeTap(onBus: 0)
-            self.tapInstalled = false
-        }
-        // Pipe Speech-compatible mic buffers into the request while the chord is held.
-        input.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak request] buffer, _ in
-            request?.append(SpeechAudioBufferNormalizer.speechCompatibleBuffer(from: buffer))
-        }
+        Self.installTap(input: audioEngine.inputNode, request: request)
         self.tapInstalled = true
 
         audioEngine.prepare()
         try audioEngine.start()
 
-        self.recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
-            guard let self else { return }
-            if let error {
-                self.logger.debug("push-to-talk error: \(error.localizedDescription, privacy: .public)")
+        self.recognitionTask = Self.recognize(recognizer, request: request, owner: self, sessionID: sessionID)
+    }
+
+    private nonisolated static func installTap(
+        input: AVAudioInputNode,
+        request: SFSpeechAudioBufferRecognitionRequest)
+    {
+        // Construct the callback outside MainActor; PCM delivery must stay on the audio thread.
+        input
+            .installTap(onBus: 0, bufferSize: 2048, format: input.outputFormat(forBus: 0)) { [weak request] buffer, _ in
+                request?.append(SpeechAudioBufferNormalizer.speechCompatibleBuffer(from: buffer))
             }
+    }
+
+    private nonisolated static func recognize(
+        _ recognizer: SFSpeechRecognizer,
+        request: SFSpeechAudioBufferRecognitionRequest,
+        owner: VoicePushToTalk,
+        sessionID: UUID) -> SFSpeechRecognitionTask
+    {
+        recognizer.recognitionTask(with: request) { [weak owner] result, error in
             let transcript = result?.bestTranscription.formattedString
             let isFinal = result?.isFinal ?? false
-            // Hop to a Task so UI updates stay off the Speech callback thread.
-            Task.detached { [weak self, transcript, isFinal, sessionID] in
-                guard let self else { return }
-                await self.handle(transcript: transcript, isFinal: isFinal, sessionID: sessionID)
+            let message = error?.localizedDescription
+            Task { @MainActor [weak owner] in
+                if let message {
+                    owner?.logger.debug("push-to-talk error: \(message, privacy: .public)")
+                }
+                owner?.handle(transcript: transcript, isFinal: isFinal, sessionID: sessionID)
             }
         }
     }
 
-    private func handle(transcript: String?, isFinal: Bool, sessionID: UUID) async {
-        guard sessionID == self.sessionID else {
+    private func handle(transcript: String?, isFinal: Bool, sessionID: UUID) {
+        guard !self.finalized, sessionID == self.sessionID else {
             self.logger.debug("push-to-talk drop transcript for stale session")
             return
         }
@@ -304,25 +335,17 @@ actor VoicePushToTalk {
             volatile: self.volatile,
             isFinal: isFinal)
         if let token = self.overlayToken {
-            await MainActor.run {
-                VoiceSessionCoordinator.shared.updatePartial(
-                    token: token,
-                    text: snapshot,
-                    attributed: attributed)
-            }
+            VoiceSessionCoordinator.shared.updatePartial(token: token, text: snapshot, attributed: attributed)
         }
     }
 
-    private func finalize(transcriptOverride: String?, reason: String, sessionID: UUID?) async {
+    private func finalize(
+        transcriptOverride: String?,
+        reason: String,
+        forward: Bool = true)
+    {
         if self.finalized { return }
-        if let sessionID, sessionID != self.sessionID {
-            self.logger.debug("push-to-talk drop finalize for stale session")
-            return
-        }
         self.finalized = true
-        self.isCapturing = false
-        self.timeoutTask?.cancel()
-        self.timeoutTask = nil
 
         let finalRecognized: String = {
             if let override = transcriptOverride?.trimmingCharacters(in: .whitespacesAndNewlines) {
@@ -334,26 +357,32 @@ actor VoicePushToTalk {
         let chime = finalText.isEmpty ? .none : (self.activeConfig?.sendChime ?? .none)
 
         let token = self.overlayToken
-        let logger = self.logger
-        await MainActor.run {
-            logger.info("ptt finalize reason=\(reason, privacy: .public) len=\(finalText.count, privacy: .public)")
-            if let token {
+        let lease = self.pauseLease
+        self.pauseLease = nil
+        self.retireCapture()
+        self.overlayToken = nil
+        self.adoptedPrefix = ""
+
+        // All old audio and mutable session state are retired before UI callbacks or awaited cleanup.
+        self.logger.info("ptt finalize reason=\(reason, privacy: .public) len=\(finalText.count, privacy: .public)")
+        if let token {
+            if forward {
                 VoiceSessionCoordinator.shared.finalize(
-                    token: token,
-                    text: finalText,
-                    sendChime: chime,
-                    autoSendAfter: nil)
+                    token: token, text: finalText, sendChime: chime, autoSendAfter: nil)
                 VoiceSessionCoordinator.shared.sendNow(token: token, reason: reason)
-            } else if !finalText.isEmpty {
-                if chime != .none {
-                    VoiceWakeChimePlayer.play(chime, reason: "ptt.fallback_send")
-                }
-                Task.detached {
-                    await VoiceWakeForwarder.forwardToSelectedSession(transcript: finalText)
-                }
+            } else {
+                VoiceSessionCoordinator.shared.dismiss(token: token, reason: .explicit, outcome: .empty)
             }
         }
+        if let lease {
+            Task { await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: lease) }
+        }
+    }
 
+    private func retireCapture() {
+        self.isCapturing = false
+        self.timeoutTask?.cancel()
+        self.timeoutTask = nil
         self.recognitionTask?.cancel()
         self.recognitionRequest = nil
         self.recognitionTask = nil
@@ -365,19 +394,11 @@ actor VoicePushToTalk {
             self.audioEngine?.stop()
             self.audioEngine?.reset()
         }
-        // Release the engine so we also release any audio session/resources when push-to-talk ends.
+        // Release the engine so we also release its audio session/resources.
         self.audioEngine = nil
-
         self.committed = ""
         self.volatile = ""
         self.activeConfig = nil
-        self.triggerChimePlayed = false
-        self.overlayToken = nil
-        self.adoptedPrefix = ""
-
-        // Resume the wake-word runtime after push-to-talk finishes.
-        await VoiceWakeRuntime.shared.applyPushToTalkCooldown()
-        _ = await MainActor.run { Task { await VoiceWakeRuntime.shared.refresh(state: AppStateStore.shared) } }
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -7,8 +7,6 @@ import Speech
 /// Observes right Option and starts a push-to-talk capture while it is held.
 @MainActor
 final class VoicePushToTalkHotkey {
-    static let shared = VoicePushToTalkHotkey()
-
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private var active = false
@@ -99,7 +97,26 @@ final class VoicePushToTalkHotkey {
 /// Records speech while the hotkey is held.
 @MainActor
 final class VoicePushToTalk {
-    static let shared = VoicePushToTalk()
+    static var shared: VoicePushToTalk {
+        AppStateStore.shared.voiceRuntime.ptt
+    }
+
+    private let state: AppVoiceRuntime.State
+    private let wake: VoiceWakeRuntime
+    private let sessions: VoiceSessionCoordinator
+    private let permissions: VoicePermissions
+
+    init(
+        state: @escaping AppVoiceRuntime.State,
+        wake: VoiceWakeRuntime,
+        sessions: VoiceSessionCoordinator,
+        permissions: VoicePermissions)
+    {
+        self.state = state
+        self.wake = wake
+        self.sessions = sessions
+        self.permissions = permissions
+    }
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.ptt")
 
@@ -134,8 +151,8 @@ final class VoicePushToTalk {
     }
 
     func begin() {
-        guard voiceWakeSupported, self.holdID == nil else { return }
-        let snapshot = VoiceSessionCoordinator.shared.snapshot()
+        guard self.permissions.supported(), self.state() != nil, self.holdID == nil else { return }
+        let snapshot = self.sessions.snapshot()
         // Retire the old capture, but retain its overlay and wake lease until admission
         // commits or cancels. Dismissing here would animate out the replacement overlay.
         self.retireCapture()
@@ -149,27 +166,27 @@ final class VoicePushToTalk {
             defer {
                 if self.holdID == sessionID { self.startupTask = nil }
             }
-            let granted = await PermissionManager.ensureVoiceWakePermissions(interactive: true)
+            let granted = await self.permissions.ensure(true)
             guard !Task.isCancelled, self.holdID == sessionID else { return }
-            guard granted, VoiceSessionCoordinator.shared.snapshot().token == snapshot.token else {
+            guard granted, self.sessions.snapshot().token == snapshot.token else {
                 self.end(cancelled: true)
                 return
             }
 
             // The startup task owns acquisition until its acknowledgement; end must not remove
             // a lease before the wake actor has inserted it.
-            await VoiceWakeRuntime.shared.pauseForPushToTalk(lease: sessionID)
+            await self.wake.pauseForPushToTalk(lease: sessionID)
             guard !Task.isCancelled, self.holdID == sessionID else {
-                await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: sessionID)
+                await self.wake.resumeAfterPushToTalk(lease: sessionID)
                 return
             }
             let previousLease = self.pauseLease
             self.pauseLease = sessionID
             if let previousLease {
                 // Acquisition precedes release so wake cannot restart between held sessions.
-                Task { await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: previousLease) }
+                Task { [wake] in await wake.resumeAfterPushToTalk(lease: previousLease) }
             }
-            guard VoiceSessionCoordinator.shared.snapshot().token == snapshot.token else {
+            guard self.sessions.snapshot().token == snapshot.token else {
                 self.end(cancelled: true)
                 return
             }
@@ -178,7 +195,10 @@ final class VoicePushToTalk {
     }
 
     private func startCapture(sessionID: UUID) {
-        let config = self.makeConfig()
+        guard let config = self.makeConfig() else {
+            self.end(cancelled: true)
+            return
+        }
         self.activeConfig = config
         self.isCapturing = true
         self.logger.info("ptt begin adopted_prefix_len=\(self.adoptedPrefix.count, privacy: .public)")
@@ -191,7 +211,7 @@ final class VoicePushToTalk {
                 committed: adoptedPrefix,
                 volatile: "",
                 isFinal: false)
-        self.overlayToken = VoiceSessionCoordinator.shared.startSession(
+        self.overlayToken = self.sessions.startSession(
             source: .pushToTalk,
             text: adoptedPrefix,
             attributed: adoptedAttributed,
@@ -333,7 +353,7 @@ final class VoicePushToTalk {
             volatile: self.volatile,
             isFinal: isFinal)
         if let token = self.overlayToken {
-            VoiceSessionCoordinator.shared.updatePartial(token: token, text: snapshot, attributed: attributed)
+            self.sessions.updatePartial(token: token, text: snapshot, attributed: attributed)
         }
     }
 
@@ -365,15 +385,15 @@ final class VoicePushToTalk {
         self.logger.info("ptt finalize reason=\(reason, privacy: .public) len=\(finalText.count, privacy: .public)")
         if let token {
             if forward {
-                VoiceSessionCoordinator.shared.finalize(
+                self.sessions.finalize(
                     token: token, text: finalText, sendChime: chime, autoSendAfter: nil)
-                VoiceSessionCoordinator.shared.sendNow(token: token, reason: reason)
+                self.sessions.sendNow(token: token, reason: reason)
             } else {
-                VoiceSessionCoordinator.shared.dismiss(token: token, reason: .explicit, outcome: .empty)
+                self.sessions.dismiss(token: token, reason: .explicit, outcome: .empty)
             }
         }
         if let lease {
-            Task { await VoiceWakeRuntime.shared.resumeAfterPushToTalk(lease: lease) }
+            Task { [wake] in await wake.resumeAfterPushToTalk(lease: lease) }
         }
     }
 
@@ -400,8 +420,8 @@ final class VoicePushToTalk {
     }
 
     @MainActor
-    private func makeConfig() -> Config {
-        let state = AppStateStore.shared
+    private func makeConfig() -> Config? {
+        guard let state = self.state() else { return nil }
         return Config(
             micID: state.voiceWakeMicID.isEmpty ? nil : state.voiceWakeMicID,
             localeID: state.voiceWakeLocaleID,

--- a/apps/macos/Sources/OpenClaw/VoiceSessionCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceSessionCoordinator.swift
@@ -5,7 +5,23 @@ import Observation
 @MainActor
 @Observable
 final class VoiceSessionCoordinator {
-    static let shared = VoiceSessionCoordinator()
+    static var shared: VoiceSessionCoordinator {
+        AppStateStore.shared.voiceRuntime.sessions
+    }
+
+    private let overlay: VoiceWakeOverlayController
+    private let forward: AppVoiceRuntime.Forward
+    private let didDismiss: @MainActor @Sendable (UUID) -> Void
+
+    init(
+        overlay: VoiceWakeOverlayController,
+        forward: @escaping AppVoiceRuntime.Forward,
+        didDismiss: @escaping @MainActor @Sendable (UUID) -> Void)
+    {
+        self.overlay = overlay
+        self.forward = forward
+        self.didDismiss = didDismiss
+    }
 
     enum Source: String { case wakeWord, pushToTalk }
 
@@ -34,7 +50,7 @@ final class VoiceSessionCoordinator {
     {
         let token = UUID()
         self.logger.info("coordinator start token=\(token.uuidString) source=\(source.rawValue) len=\(text.count)")
-        let attributedText = attributed ?? VoiceWakeOverlayController.shared.makeAttributed(from: text)
+        let attributedText = attributed ?? self.overlay.makeAttributed(from: text)
         let session = Session(
             token: token,
             source: source,
@@ -45,7 +61,7 @@ final class VoiceSessionCoordinator {
             autoSendDelay: nil,
             voiceWakeTrigger: voiceWakeTrigger)
         self.session = session
-        VoiceWakeOverlayController.shared.startSession(
+        self.overlay.startSession(
             token: token,
             source: VoiceWakeOverlayController.Source(rawValue: source.rawValue) ?? .wakeWord,
             transcript: text,
@@ -59,7 +75,7 @@ final class VoiceSessionCoordinator {
         guard let session, session.token == token else { return }
         self.session?.text = text
         self.session?.attributed = attributed
-        VoiceWakeOverlayController.shared.updatePartial(token: token, transcript: text, attributed: attributed)
+        self.overlay.updatePartial(token: token, transcript: text, attributed: attributed)
     }
 
     func finalize(
@@ -81,8 +97,8 @@ final class VoiceSessionCoordinator {
             self.session?.voiceWakeTrigger = voiceWakeTrigger
         }
 
-        let attributed = VoiceWakeOverlayController.shared.makeAttributed(from: text)
-        VoiceWakeOverlayController.shared.presentFinal(
+        let attributed = self.overlay.makeAttributed(from: text)
+        self.overlay.presentFinal(
             token: token,
             transcript: text,
             autoSendAfter: autoSendAfter,
@@ -96,15 +112,13 @@ final class VoiceSessionCoordinator {
         let sendChime = session.sendChime
         guard !text.isEmpty else {
             self.logger.info("coordinator sendNow \(reason) empty -> dismiss")
-            VoiceWakeOverlayController.shared.dismiss(token: token, reason: .empty, outcome: .empty)
+            self.overlay.dismiss(token: token, reason: .empty, outcome: .empty)
             self.clearSession()
             return
         }
-        VoiceWakeOverlayController.shared.beginSendUI(token: token, sendChime: sendChime)
-        Task.detached {
-            _ = await VoiceWakeForwarder.forwardToSelectedSession(
-                transcript: text,
-                voiceWakeTrigger: voiceWakeTrigger)
+        self.overlay.beginSendUI(token: token, sendChime: sendChime)
+        Task.detached { [forward] in
+            _ = await forward(text, voiceWakeTrigger)
         }
     }
 
@@ -114,17 +128,17 @@ final class VoiceSessionCoordinator {
         outcome: VoiceWakeOverlayController.SendOutcome)
     {
         guard let session, session.token == token else { return }
-        VoiceWakeOverlayController.shared.dismiss(token: token, reason: reason, outcome: outcome)
+        self.overlay.dismiss(token: token, reason: reason, outcome: outcome)
         self.clearSession()
     }
 
     func updateLevel(token: UUID, _ level: Double) {
         guard let session, session.token == token else { return }
-        VoiceWakeOverlayController.shared.updateLevel(token: token, level)
+        self.overlay.updateLevel(token: token, level)
     }
 
     func snapshot() -> (token: UUID?, text: String, visible: Bool) {
-        (self.session?.token, self.session?.text ?? "", VoiceWakeOverlayController.shared.isVisible)
+        (self.session?.token, self.session?.text ?? "", self.overlay.isVisible)
     }
 
     // MARK: - Private
@@ -139,6 +153,6 @@ final class VoiceSessionCoordinator {
         if self.session?.token == token {
             self.clearSession()
         }
-        Task { await VoiceWakeRuntime.shared.refresh(state: AppStateStore.shared) }
+        self.didDismiss(token)
     }
 }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlay.swift
@@ -6,7 +6,52 @@ import SwiftUI
 @MainActor
 @Observable
 final class VoiceWakeOverlayController {
-    static let shared = VoiceWakeOverlayController()
+    static var shared: VoiceWakeOverlayController {
+        AppStateStore.shared.voiceRuntime.overlay
+    }
+
+    enum DismissalCompletion: Sendable {
+        case disabledUI
+        case missingWindow
+        case animated(finishWindow: AppVoiceRuntime.UIAction)
+    }
+
+    struct Presentation: Sendable {
+        let present: @MainActor @Sendable (VoiceWakeOverlayController, Bool) -> Void
+        let updateFrame: @MainActor @Sendable (VoiceWakeOverlayController, Bool) -> Void
+        let bringToFront: @MainActor @Sendable (VoiceWakeOverlayController) -> Void
+        let animateDismiss: @MainActor @Sendable (
+            VoiceWakeOverlayController, DismissReason, SendOutcome,
+            @escaping @MainActor @Sendable (DismissalCompletion) -> Void) -> Void
+
+        static let live = Self(
+            present: { $0.presentWindow(isFirst: $1) },
+            updateFrame: { $0.updateNativeWindowFrame(animate: $1) },
+            bringToFront: { $0.bringNativeWindowToFront() },
+            animateDismiss: { $0.animateWindowDismissal(reason: $1, outcome: $2, completion: $3) })
+    }
+
+    struct Actions: Sendable {
+        let send: @MainActor @Sendable (UUID, String) -> Void
+        let didPresent: AppVoiceRuntime.UIAction
+        let didDismiss: @MainActor @Sendable (UUID, SendOutcome) -> Void
+    }
+
+    typealias ActionsProvider = @MainActor @Sendable () -> Actions?
+    let presentation: Presentation
+    let actions: ActionsProvider
+
+    static func liveActions() -> Actions? {
+        Actions(
+            send: { VoiceSessionCoordinator.shared.sendNow(token: $0, reason: $1) },
+            didPresent: { AppStateStore.shared.startVoiceEars() },
+            didDismiss: { token, outcome in
+                if outcome == .empty { AppStateStore.shared.blinkOnce() }
+                if outcome == .sent { AppStateStore.shared.celebrateSend() }
+                AppStateStore.shared.stopVoiceEars()
+                VoiceSessionCoordinator.shared.overlayDidDismiss(token: token)
+            })
+    }
 
     let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.overlay")
     let enableUI: Bool
@@ -52,11 +97,17 @@ final class VoiceWakeOverlayController {
     let closeOverflow: CGFloat = 10
     let levelUpdateInterval: TimeInterval = 1.0 / 12.0
 
-    enum DismissReason { case explicit, empty }
-    enum SendOutcome { case sent, empty }
+    enum DismissReason: Sendable { case explicit, empty }
+    enum SendOutcome: Sendable { case sent, empty }
     enum GuardOutcome { case accept, dropMismatch, dropNoActive }
 
-    init(enableUI: Bool = true) {
+    init(
+        enableUI: Bool = true,
+        presentation: Presentation = .live,
+        actions: @escaping ActionsProvider = VoiceWakeOverlayController.liveActions)
+    {
         self.enableUI = enableUI
+        self.presentation = presentation
+        self.actions = actions
     }
 }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Session.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Session.swift
@@ -87,7 +87,7 @@ extension VoiceWakeOverlayController {
         if let delay {
             if delay <= 0 {
                 self.logger.log(level: .info, "overlay autoSend immediate token=\(token.uuidString)")
-                VoiceSessionCoordinator.shared.sendNow(token: token, reason: "autoSendImmediate")
+                self.actions()?.send(token, "autoSendImmediate")
             } else {
                 self.scheduleAutoSend(token: token, after: delay)
             }
@@ -151,7 +151,7 @@ extension VoiceWakeOverlayController {
     func requestSend(token: UUID? = nil, reason: String = "overlay_request") {
         guard self.guardToken(token, context: "requestSend") else { return }
         guard let active = token ?? self.activeToken else { return }
-        VoiceSessionCoordinator.shared.sendNow(token: active, reason: reason)
+        self.actions()?.send(active, reason)
     }
 
     func dismiss(token: UUID? = nil, reason: DismissReason = .explicit, outcome: SendOutcome = .empty) {
@@ -170,47 +170,33 @@ extension VoiceWakeOverlayController {
         self.model.isSending = false
         self.model.isEditing = false
 
-        if !self.enableUI {
-            self.model.isVisible = false
-            self.model.level = 0
-            self.lastLevelUpdate = 0
-            self.activeToken = nil
-            self.activeSource = nil
-            return
-        }
-        guard let window else {
-            if ProcessInfo.processInfo.isRunningTests {
-                self.model.isVisible = false
-                self.model.level = 0
-                self.activeToken = nil
-                self.activeSource = nil
-            }
-            return
-        }
-        let target = self.dismissTargetFrame(for: window.frame, reason: reason, outcome: outcome)
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.18
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            if let target {
-                window.animator().setFrame(target, display: true)
-            }
-            window.animator().alphaValue = 0
-        } completionHandler: {
-            Task { @MainActor in
-                guard self.guardToken(dismissedToken, context: "dismissCompletion") else { return }
-                window.orderOut(nil)
+        // Retain the admitted notification owner through the animation. Resolving it
+        // later could lose cleanup when the graph is no longer available.
+        let actions = self.actions()
+        self.presentation.animateDismiss(self, reason, outcome) { completion in
+            switch completion {
+            case .disabledUI:
                 self.model.isVisible = false
                 self.model.level = 0
                 self.lastLevelUpdate = 0
                 self.activeToken = nil
                 self.activeSource = nil
-                if outcome == .empty {
-                    AppStateStore.shared.blinkOnce()
-                } else if outcome == .sent {
-                    AppStateStore.shared.celebrateSend()
+            case .missingWindow:
+                if ProcessInfo.processInfo.isRunningTests {
+                    self.model.isVisible = false
+                    self.model.level = 0
+                    self.activeToken = nil
+                    self.activeSource = nil
                 }
-                AppStateStore.shared.stopVoiceEars()
-                VoiceSessionCoordinator.shared.overlayDidDismiss(token: dismissedToken)
+            case let .animated(finishWindow):
+                guard self.guardToken(dismissedToken, context: "dismissCompletion") else { return }
+                finishWindow()
+                self.model.isVisible = false
+                self.model.level = 0
+                self.lastLevelUpdate = 0
+                self.activeToken = nil
+                self.activeSource = nil
+                actions?.didDismiss(dismissedToken, outcome)
             }
         }
     }
@@ -270,7 +256,7 @@ extension VoiceWakeOverlayController {
                 self.logger.log(
                     level: .info,
                     "overlay autoSend firing token=\(token.uuidString, privacy: .public)")
-                VoiceSessionCoordinator.shared.sendNow(token: token, reason: "autoSendDelay")
+                self.actions()?.send(token, "autoSendDelay")
                 self.autoSendTask = nil
             }
         }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -4,17 +4,17 @@ import SwiftUI
 
 extension VoiceWakeOverlayController {
     func present() {
-        if !self.enableUI || ProcessInfo.processInfo.isRunningTests {
-            if !self.model.isVisible {
-                self.model.isVisible = true
-            }
-            return
-        }
+        let isFirst = !self.model.isVisible
+        if isFirst { self.model.isVisible = true }
+        self.presentation.present(self, isFirst)
+    }
+
+    func presentWindow(isFirst: Bool) {
+        if !self.enableUI || ProcessInfo.processInfo.isRunningTests { return }
         self.ensureWindow()
         self.hostingView?.rootView = VoiceWakeOverlayView(controller: self)
         let target = self.targetFrame()
-        let isFirst = !self.model.isVisible
-        if isFirst { self.model.isVisible = true }
+        let actions = self.actions()
         OverlayPanelFactory.present(
             window: self.window,
             isFirstPresent: isFirst,
@@ -24,7 +24,7 @@ extension VoiceWakeOverlayController {
                     level: .info,
                     "overlay present windowShown textLen=\(self.model.text.count, privacy: .public)")
                 // Keep the status item in “listening” mode until we explicitly dismiss the overlay.
-                AppStateStore.shared.startVoiceEars()
+                actions?.didPresent()
             },
             onAlreadyVisible: { window in
                 self.updateWindowFrame(animate: true)
@@ -49,6 +49,10 @@ extension VoiceWakeOverlayController {
 
     /// Reassert window ordering when other panels are shown.
     func bringToFrontIfVisible() {
+        self.presentation.bringToFront(self)
+    }
+
+    func bringNativeWindowToFront() {
         guard self.model.isVisible, let window = self.window else { return }
         window.level = Self.preferredWindowLevel
         window.orderFrontRegardless()
@@ -66,7 +70,39 @@ extension VoiceWakeOverlayController {
     }
 
     func updateWindowFrame(animate: Bool = false) {
+        self.presentation.updateFrame(self, animate)
+    }
+
+    func updateNativeWindowFrame(animate: Bool) {
         OverlayPanelFactory.applyFrame(window: self.window, target: self.targetFrame(), animate: animate)
+    }
+
+    func animateWindowDismissal(
+        reason: DismissReason,
+        outcome: SendOutcome,
+        completion: @escaping @MainActor @Sendable (DismissalCompletion) -> Void)
+    {
+        guard self.enableUI else {
+            completion(.disabledUI)
+            return
+        }
+        guard let window else {
+            completion(.missingWindow)
+            return
+        }
+        let target = self.dismissTargetFrame(for: window.frame, reason: reason, outcome: outcome)
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            if let target {
+                window.animator().setFrame(target, display: true)
+            }
+            window.animator().alphaValue = 0
+        } completionHandler: {
+            Task { @MainActor in
+                completion(.animated(finishWindow: { window.orderOut(nil) }))
+            }
+        }
     }
 
     func measuredHeight() -> CGFloat {

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -22,7 +22,25 @@ enum VoiceWakeRuntimeTaskSupport {
 
 /// Background listener that keeps the voice-wake pipeline alive outside the settings test view.
 actor VoiceWakeRuntime {
-    static let shared = VoiceWakeRuntime()
+    private let state: AppVoiceRuntime.State
+    private let sessions: VoiceSessionCoordinator
+    private let overlay: VoiceWakeOverlayController
+    private let permissions: VoicePermissions
+    private let forward: AppVoiceRuntime.Forward
+
+    init(
+        state: @escaping AppVoiceRuntime.State,
+        sessions: VoiceSessionCoordinator,
+        overlay: VoiceWakeOverlayController,
+        permissions: VoicePermissions,
+        forward: @escaping AppVoiceRuntime.Forward)
+    {
+        self.state = state
+        self.sessions = sessions
+        self.overlay = overlay
+        self.permissions = permissions
+        self.forward = forward
+    }
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.runtime")
 
@@ -122,12 +140,12 @@ actor VoiceWakeRuntime {
         }
         guard generation == self.refreshGeneration, self.pauseLeases.isEmpty else { return }
 
-        guard voiceWakeSupported, snapshot.0 else {
+        guard self.permissions.supported(), snapshot.0 else {
             self.stop()
             return
         }
 
-        guard PermissionManager.voiceWakePermissionsGranted() else {
+        guard self.permissions.granted() else {
             self.logger.debug("voicewake runtime not starting: permissions missing")
             self.stop()
             return
@@ -275,11 +293,11 @@ actor VoiceWakeRuntime {
         let token = self.overlayToken
         self.overlayToken = nil
         guard dismissOverlay else { return }
-        Task { @MainActor in
+        Task { @MainActor [sessions, overlay] in
             if let token {
-                VoiceSessionCoordinator.shared.dismiss(token: token, reason: .explicit, outcome: .empty)
+                sessions.dismiss(token: token, reason: .explicit, outcome: .empty)
             } else {
-                VoiceWakeOverlayController.shared.dismiss()
+                overlay.dismiss()
             }
         }
     }
@@ -333,7 +351,7 @@ actor VoiceWakeRuntime {
                 let snapshot = self.committedTranscript + self.volatileTranscript
                 if let token = self.overlayToken {
                     await MainActor.run {
-                        VoiceSessionCoordinator.shared.updatePartial(
+                        self.sessions.updatePartial(
                             token: token,
                             text: snapshot,
                             attributed: attributed)
@@ -574,7 +592,7 @@ actor VoiceWakeRuntime {
             if config.triggerChime != .none {
                 await MainActor.run { VoiceWakeChimePlayer.play(config.triggerChime, reason: "voicewake.trigger") }
             }
-            await AppStateStore.shared.setTalkEnabled(true)
+            await self.state()?.setTalkEnabled(true)
             await self.resumeAfterPushToTalk(lease: lease)
             return
         }
@@ -605,7 +623,8 @@ actor VoiceWakeRuntime {
             volatile: self.volatileTranscript,
             isFinal: false)
         self.overlayToken = await MainActor.run {
-            VoiceSessionCoordinator.shared.startSession(
+            guard self.state() != nil else { return nil as UUID? }
+            return self.sessions.startSession(
                 source: .wakeWord,
                 text: snapshot,
                 attributed: attributed,
@@ -614,7 +633,7 @@ actor VoiceWakeRuntime {
         }
 
         // Keep the "ears" boosted for the capture window so the status icon animates while recording.
-        await MainActor.run { AppStateStore.shared.startVoiceEars() }
+        await MainActor.run { self.state()?.startVoiceEars() }
 
         self.captureTask?.cancel()
         self.captureTask = Task { [weak self] in
@@ -675,16 +694,16 @@ actor VoiceWakeRuntime {
         self.triggerOnlyTask?.cancel()
         self.triggerOnlyTask = nil
 
-        await MainActor.run { AppStateStore.shared.stopVoiceEars() }
+        await MainActor.run { self.state()?.stopVoiceEars() }
         if let token = self.overlayToken {
-            await MainActor.run { VoiceSessionCoordinator.shared.updateLevel(token: token, 0) }
+            await MainActor.run { self.sessions.updateLevel(token: token, 0) }
         }
 
         let delay: TimeInterval = 0.0
         let sendChime = finalTranscript.isEmpty ? .none : config.sendChime
         if let token = self.overlayToken {
             await MainActor.run {
-                VoiceSessionCoordinator.shared.finalize(
+                self.sessions.finalize(
                     token: token,
                     text: finalTranscript,
                     sendChime: sendChime,
@@ -695,10 +714,8 @@ actor VoiceWakeRuntime {
             if sendChime != .none {
                 await MainActor.run { VoiceWakeChimePlayer.play(sendChime, reason: "voicewake.send") }
             }
-            Task.detached {
-                await VoiceWakeForwarder.forwardToSelectedSession(
-                    transcript: finalTranscript,
-                    voiceWakeTrigger: triggerWord)
+            Task.detached { [forward] in
+                await forward(finalTranscript, triggerWord)
             }
         }
         self.overlayToken = nil
@@ -722,8 +739,8 @@ actor VoiceWakeRuntime {
         // Normalize against the adaptive threshold so the UI meter stays roughly 0...1 across devices.
         let clamped = min(1.0, max(0.0, rms / max(self.minSpeechRMS, threshold)))
         if let token = self.overlayToken {
-            Task { @MainActor in
-                VoiceSessionCoordinator.shared.updateLevel(token: token, clamped)
+            Task { @MainActor [sessions] in
+                sessions.updateLevel(token: token, clamped)
             }
         }
     }
@@ -764,7 +781,9 @@ actor VoiceWakeRuntime {
         self.refreshGeneration &+= 1
         guard self.pauseLeases.isEmpty else { return }
         self.cooldownUntil = Date().addingTimeInterval(self.debounceAfterSend)
-        await self.refresh(state: AppStateStore.shared)
+        if let state = await self.state() {
+            await self.refresh(state: state)
+        }
     }
 
     private func updateHeardBeyondTrigger(withTrimmed trimmed: String) {

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -58,6 +58,8 @@ actor VoiceWakeRuntime {
     private var preDetectTask: Task<Void, Never>?
     private var isStarting: Bool = false
     private var triggerOnlyTask: Task<Void, Never>?
+    private var pauseLeases: Set<UUID> = []
+    private var refreshGeneration: UInt64 = 0
 
     /// Tunables
     /// Silence threshold once we've captured user speech (post-trigger).
@@ -105,6 +107,8 @@ actor VoiceWakeRuntime {
     }
 
     func refresh(state: AppState) async {
+        self.refreshGeneration &+= 1
+        let generation = self.refreshGeneration
         let snapshot = await MainActor.run { () -> (Bool, RuntimeConfig) in
             let enabled = state.swabbleEnabled
             let config = RuntimeConfig(
@@ -116,6 +120,7 @@ actor VoiceWakeRuntime {
                 triggersTalkMode: state.voiceWakeTriggersTalkMode)
             return (enabled, config)
         }
+        guard generation == self.refreshGeneration, self.pauseLeases.isEmpty else { return }
 
         guard voiceWakeSupported, snapshot.0 else {
             self.stop()
@@ -146,11 +151,12 @@ actor VoiceWakeRuntime {
         }
 
         self.stop()
-        await self.start(with: config)
+        self.start(with: config)
     }
 
-    private func start(with config: RuntimeConfig) async {
-        if self.isStarting { return }
+    private func start(with config: RuntimeConfig) {
+        // Scheduled restarts also enter here, without passing through refresh.
+        guard self.pauseLeases.isEmpty, !self.isStarting else { return }
         self.isStarting = true
         defer { self.isStarting = false }
         do {
@@ -563,11 +569,13 @@ actor VoiceWakeRuntime {
         if config.triggersTalkMode {
             self.logger.info("voicewake trigger -> activating Talk Mode (skipping capture)")
             DiagnosticsFileLog.shared.log(category: "voicewake.runtime", event: "triggerTalkMode")
+            let lease = UUID()
+            self.pauseForPushToTalk(lease: lease)
             if config.triggerChime != .none {
                 await MainActor.run { VoiceWakeChimePlayer.play(config.triggerChime, reason: "voicewake.trigger") }
             }
-            self.pauseForPushToTalk()
             await AppStateStore.shared.setTalkEnabled(true)
+            await self.resumeAfterPushToTalk(lease: lease)
             return
         }
         self.isCapturing = true
@@ -725,12 +733,13 @@ actor VoiceWakeRuntime {
         let current = self.currentConfig
         self.stop(dismissOverlay: false, cancelScheduledRestart: false)
         if let current {
-            Task { await self.start(with: current) }
+            self.start(with: current)
         }
     }
 
-    private func restartRecognizerIfIdleAndOverlayHidden() async {
-        if self.isCapturing { return }
+    private func restartRecognizerIfIdleAndOverlayHidden() {
+        guard !Task.isCancelled, self.pauseLeases.isEmpty, !self.isCapturing else { return }
+        self.scheduledRestartTask = nil
         self.restartRecognizer()
     }
 
@@ -740,21 +749,22 @@ actor VoiceWakeRuntime {
             let nanos = UInt64(max(0, delay) * 1_000_000_000)
             guard await VoiceWakeRuntimeTaskSupport.wait(nanoseconds: nanos) else { return }
             guard let self else { return }
-            await self.consumeScheduledRestart()
             await self.restartRecognizerIfIdleAndOverlayHidden()
         }
     }
 
-    private func consumeScheduledRestart() {
-        self.scheduledRestartTask = nil
-    }
-
-    func applyPushToTalkCooldown() {
-        self.cooldownUntil = Date().addingTimeInterval(self.debounceAfterSend)
-    }
-
-    func pauseForPushToTalk() {
+    func pauseForPushToTalk(lease: UUID) {
+        guard self.pauseLeases.insert(lease).inserted else { return }
+        self.refreshGeneration &+= 1
         self.stop(dismissOverlay: false)
+    }
+
+    func resumeAfterPushToTalk(lease: UUID) async {
+        guard self.pauseLeases.remove(lease) != nil else { return }
+        self.refreshGeneration &+= 1
+        guard self.pauseLeases.isEmpty else { return }
+        self.cooldownUntil = Date().addingTimeInterval(self.debounceAfterSend)
+        await self.refresh(state: AppStateStore.shared)
     }
 
     private func updateHeardBeyondTrigger(withTrimmed trimmed: String) {

--- a/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
@@ -425,6 +425,23 @@ private actor RuntimeTestBootstrapSequence {
     }
 }
 
+private func runtimeTestDependencies(
+    audioCapture: @escaping @MainActor @Sendable () -> any RealtimeTalkAudioCapturing)
+    -> TalkModeRuntime.Dependencies
+{
+    let live = TalkModeRuntime.Dependencies.live
+    return .init(
+        permissions: .init(supported: { true }, granted: { true }, ensure: { _ in true }),
+        audioCapture: audioCapture,
+        pcmPlayer: { RuntimeTestPCMPlayer() },
+        selectedSession: live.selectedSession,
+        stopPCM: live.stopPCM,
+        stopMP3: live.stopMP3,
+        stopBuffered: live.stopBuffered,
+        stopSystem: live.stopSystem,
+        stopMLX: live.stopMLX)
+}
+
 @Suite(.serialized)
 struct TalkModeRuntimeSpeechTests {
     @Test func `macOS realtime relay requires local opt in and exact Gateway tuple`() {
@@ -525,12 +542,12 @@ struct TalkModeRuntimeSpeechTests {
             let requests = RuntimeTestRelayRequestLog()
             let recoveryRequests = RuntimeTestRelayRequestLog()
             let bootstrap = try makeRuntimeTestBootstrap(requests: recoveryRequests)
-            let runtime = TalkModeRuntime(realtimeTalkBootstrapProvider: { bootstrap })
             let recoveryStarted = RuntimeTestSignal<Void>()
             let recoveryCapture = RuntimeTestAudioCapture()
             recoveryCapture.onStart = { recoveryStarted.send(()) }
-            await runtime._test_setRealtimeAudioCaptureProvider { recoveryCapture }
-            await runtime._test_setVoiceWakeReadiness(supported: true, permissionGranted: true)
+            let runtime = TalkModeRuntime(
+                realtimeTalkBootstrapProvider: { bootstrap },
+                dependencies: runtimeTestDependencies(audioCapture: { recoveryCapture }))
             let audioCapture = RuntimeTestAudioCapture()
             let session = makeRecordingRelaySession(requests: requests, audioCapture: audioCapture)
             defer { session.stop() }
@@ -715,9 +732,9 @@ struct TalkModeRuntimeSpeechTests {
             let bootstrap = try makeRuntimeTestBootstrap(
                 requests: requests,
                 realtimeModel: "fresh-model")
-            let runtime = TalkModeRuntime(realtimeTalkBootstrapProvider: { bootstrap })
-            await runtime._test_setRealtimeAudioCaptureProvider { RuntimeTestAudioCapture() }
-            await runtime._test_setVoiceWakeReadiness(supported: true, permissionGranted: true)
+            let runtime = TalkModeRuntime(
+                realtimeTalkBootstrapProvider: { bootstrap },
+                dependencies: runtimeTestDependencies(audioCapture: { RuntimeTestAudioCapture() }))
             _ = await runtime._test_prepareEnabledLifecycle()
             await runtime.setPaused(true)
             await runtime.setEnabled(false)
@@ -996,9 +1013,9 @@ struct TalkModeRuntimeSpeechTests {
             let sequence = RuntimeTestBootstrapSequence(
                 bootstraps: [firstBootstrap, retryBootstrap],
                 firstBarrier: barrier)
-            let runtime = TalkModeRuntime(realtimeTalkBootstrapProvider: { try await sequence.next() })
-            await runtime._test_setRealtimeAudioCaptureProvider { RuntimeTestAudioCapture() }
-            await runtime._test_setVoiceWakeReadiness(supported: true, permissionGranted: true)
+            let runtime = TalkModeRuntime(
+                realtimeTalkBootstrapProvider: { try await sequence.next() },
+                dependencies: runtimeTestDependencies(audioCapture: { RuntimeTestAudioCapture() }))
             let attempt = Task {
                 await runtime.setEnabled(true)
                 return true
@@ -1086,10 +1103,9 @@ struct TalkModeRuntimeSpeechTests {
         let sequence = RuntimeTestBootstrapSequence(
             bootstraps: [bootstrapA, bootstrapB],
             firstBarrier: barrier)
-        let runtime = TalkModeRuntime(realtimeTalkBootstrapProvider: {
-            try await sequence.next()
-        })
-        await runtime._test_setRealtimeAudioCaptureProvider { RuntimeTestAudioCapture() }
+        let runtime = TalkModeRuntime(
+            realtimeTalkBootstrapProvider: { try await sequence.next() },
+            dependencies: runtimeTestDependencies(audioCapture: { RuntimeTestAudioCapture() }))
         let lifecycleA = await runtime._test_prepareEnabledLifecycle()
         await runtime._test_enableRealtimeRelaySelection()
         let attemptA = Task {

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceOwnerLifecycleTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceOwnerLifecycleTests.swift
@@ -1,0 +1,232 @@
+import AppKit
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct VoiceOwnerLifecycleTests {
+    enum PendingAdmission: CaseIterable, Sendable {
+        case permission
+        case bootstrap
+    }
+
+    @Test func `preview graph construction does not activate voice`() async throws {
+        try await withVoiceOwnerFixture(activate: false) { fixture, state, _ in
+            #expect(state.isPreview)
+            #expect(!state.voiceRuntime.isActive)
+            #expect(fixture.log.snapshot().isEmpty)
+            state.activateVoice()
+            await fixture.requestTalk(false, state: state).value
+            #expect(state.voiceRuntime.isActive)
+            #expect(state.isPreview)
+            #expect(fixture.log.count("publish:false:disabled") == 1)
+        }
+    }
+
+    @Test func `preference observation admits fresh denied holds`() async throws {
+        try await withVoiceOwnerFixture { fixture, state, menu in
+            let hotkey = state.voiceRuntime.hotkey
+            menu.startVoiceObservation()
+            state.voicePushToTalkEnabled = true
+            // A positive permission receipt establishes the scheduled Observation
+            // route. Repeated down flags do not manufacture a fresh hold.
+            try await waitForVoiceOwner("observed preference enables PTT") { [log = fixture.log] in
+                await MainActor.run { hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040)) }
+                return log.count("ptt.permission.request") == 1
+            }
+            hotkey._testUpdateModifierState(modifierFlags: [])
+            state.voicePushToTalkEnabled = false
+            menu.stopVoiceObservation()
+            state.voicePushToTalkEnabled = true
+            menu.startVoiceObservation()
+            hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
+            try await waitForVoiceOwner("fresh denied hold") { [log = fixture.log] in
+                log.count("ptt.permission.request") == 2
+            }
+            hotkey._testUpdateModifierState(modifierFlags: [])
+            #expect(fixture.log.count("app.permission.request") == 0)
+            #expect(fixture.log.count("talk.permission.request") == 0)
+            // Permission receipts do not join PTT's private startup task.
+        }
+    }
+
+    @Test func `wake refresh waits for last acknowledged lease`() async throws {
+        try await withVoiceOwnerFixture(activate: false) { fixture, state, _ in
+            let wake = state.voiceRuntime.wake
+            state.swabbleEnabled = true
+            let first = UUID()
+            let second = UUID()
+            await wake.pauseForPushToTalk(lease: first)
+            await wake.pauseForPushToTalk(lease: second)
+            await wake.refresh(state: state)
+            await wake.resumeAfterPushToTalk(lease: first)
+            await wake.resumeAfterPushToTalk(lease: UUID())
+            #expect(fixture.log.count("wake.permission") == 0)
+            await wake.resumeAfterPushToTalk(lease: second)
+            #expect(fixture.log.count("wake.permission") == 1)
+            await wake.resumeAfterPushToTalk(lease: second)
+            #expect(fixture.log.count("wake.permission") == 1)
+        }
+    }
+
+    @Test(arguments: PendingAdmission.allCases)
+    func `off invalidates pending runtime before joining shutdown`(pending: PendingAdmission) async throws {
+        try await withVoiceOwnerFixture { fixture, state, menu in
+            state.voicePushToTalkEnabled = true
+            menu.startVoiceObservation()
+            switch pending {
+            case .permission: await fixture.talkPermission.hold()
+            case .bootstrap: await fixture.bootstrap.hold()
+            }
+            let on = fixture.requestTalk(true, state: state)
+            let request = pending == .permission ? "talk.permission.request" : "bootstrap.request"
+            try await waitForVoiceOwner("runtime admission pending") { [log = fixture.log] in
+                log.count(request) == 1
+            }
+            await fixture.shutdown.hold()
+            let hidden = fixture.log.count("talk.hidden")
+            let off = fixture.requestTalk(false, state: state)
+            try await waitForVoiceOwner("shutdown entered before admission resolves") { [log = fixture.log] in
+                log.count("shutdown.buffered.request") == 1
+            }
+            #expect(await state.voiceRuntime.talkRuntime.isEnabled == false)
+            let repeatedOff = fixture.requestTalk(false, state: state)
+            try await waitForVoiceOwner("repeated Off entered its controller") { [log = fixture.log] in
+                log.count("talk.hidden") == hidden + 2
+            }
+            state.voiceRuntime.hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
+            await fixture.talkPermission.releaseAll()
+            await fixture.bootstrap.releaseAll()
+            await on.value
+            #expect(fixture.log.count("capture.make") == 0)
+            await fixture.shutdown.releaseAll()
+            await off.value
+            await repeatedOff.value
+            state.voiceRuntime.hotkey._testUpdateModifierState(modifierFlags: [])
+            state.voiceRuntime.hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
+            try await waitForVoiceOwner("PTT available after joined shutdown") { [log = fixture.log] in
+                log.count("ptt.permission.request") == 1
+            }
+            state.voiceRuntime.hotkey._testUpdateModifierState(modifierFlags: [])
+            #expect(fixture.log.count("shutdown.buffered.request") == 1)
+            #expect(!state.talkEnabled)
+        }
+    }
+
+    @Test func `replacement talk starts after old audio shutdown`() async throws {
+        try await withVoiceOwnerFixture { fixture, state, _ in
+            await fixture.requestTalk(true, state: state).value
+            #expect(fixture.log.count("capture.start:1") == 1)
+            await fixture.shutdown.hold()
+            let off = fixture.requestTalk(false, state: state)
+            try await waitForVoiceOwner("old shutdown suspended") { [log = fixture.log] in
+                log.count("shutdown.buffered.request") == 1
+            }
+            let replacement = fixture.requestTalk(true, state: state)
+            try await waitForVoiceOwner("replacement entered its controller") { [log = fixture.log] in
+                log.count("talk.present") == 2
+            }
+            #expect(await state.voiceRuntime.talkRuntime.isEnabled == false)
+            await fixture.shutdown.releaseAll()
+            await off.value
+            await replacement.value
+            #expect(state.talkEnabled)
+            #expect(fixture.log.count("capture.start:2") == 1)
+            #expect(fixture.log.count("capture.stop:1") == 1)
+            #expect(fixture.log.count("capture.stop:2") == 0)
+            let events = fixture.log.snapshot()
+            let stopped = try #require(events.firstIndex(of: "capture.stop:1"))
+            let started = try #require(events.firstIndex(of: "capture.start:2"))
+            #expect(stopped < started)
+            let buffered = try #require(events.firstIndex(of: "shutdown.buffered.request"))
+            let system = try #require(events.firstIndex(of: "shutdown.system"))
+            let mlx = try #require(events.firstIndex(of: "shutdown.mlx"))
+            #expect(buffered < system && system < mlx && mlx < started)
+            await fixture.requestTalk(false, state: state).value
+            #expect(fixture.log.count("capture.stop:2") == 1)
+            #expect(fixture.log.count("player.stop:1") >= 1)
+            #expect(fixture.log.count("player.stop:2") >= 1)
+        }
+    }
+
+    @Test func `late relay create is closed without capture`() async throws {
+        try await withVoiceOwnerFixture { fixture, state, _ in
+            await fixture.create.hold()
+            let on = fixture.requestTalk(true, state: state)
+            try await waitForVoiceOwner("relay create pending") { [log = fixture.log] in
+                log.count("relay.created:relay-1") == 1
+            }
+            await fixture.requestTalk(false, state: state).value
+            await fixture.create.releaseAll()
+            await on.value
+            try await waitForVoiceOwner("late relay close") { [log = fixture.log] in
+                log.count("relay.closed:relay-1") == 1
+            }
+            #expect(fixture.log.count("capture.start:1") == 0)
+            #expect(await state.voiceRuntime.talkRuntime.isEnabled == false)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `superseded app permission cannot restore talk`(granted: Bool) async throws {
+        try await withVoiceOwnerFixture(appPermissionGranted: false) { fixture, state, _ in
+            await fixture.appPermission.hold()
+            await fixture.talkPermission.hold()
+            let on = fixture.requestTalk(true, state: state)
+            try await waitForVoiceOwner("distinct owner permission requests") { [log = fixture.log] in
+                log.count("app.permission.request") == 1 && log.count("talk.permission.request") == 1
+            }
+            await fixture.requestTalk(false, state: state).value
+            await fixture.appPermission.resolve(1, returning: granted)
+            await fixture.talkPermission.releaseAll()
+            await on.value
+            #expect(!state.talkEnabled)
+            #expect(await state.voiceRuntime.talkRuntime.isEnabled == false)
+            #expect(fixture.log.count("publish:true:enabled") == 0)
+            #expect(fixture.log.count("capture.make") == 0)
+            #expect(fixture.log.count("ptt.permission.request") == 0)
+        }
+    }
+
+    @Test func `stale originating dismissal cannot hide replacement`() async throws {
+        try await withVoiceOwnerFixture { fixture, state, _ in
+            let voice = state.voiceRuntime
+            let first = voice.sessions.startSession(source: .pushToTalk, text: "first draft")
+            let blink = state.blinkTick
+            voice.overlay.dismiss(token: first)
+            #expect(fixture.log.count("overlay.request:\(first)") == 1)
+            let second = voice.sessions.startSession(source: .pushToTalk, text: "second draft")
+            fixture.completeDismissal(first)
+            #expect(voice.sessions.snapshot().token == second)
+            #expect(voice.overlay.snapshot().text == "second draft")
+            #expect(voice.overlay.isVisible)
+            #expect(state.earBoostActive)
+            #expect(state.blinkTick == blink)
+            #expect(fixture.log.count("overlay.finished:\(first)") == 0)
+            voice.overlay.dismiss(token: second)
+            fixture.completeDismissal(second)
+            #expect(voice.sessions.snapshot().token == nil)
+            #expect(!voice.overlay.isVisible)
+            #expect(!state.earBoostActive)
+            #expect(state.blinkTick == blink + 1)
+            #expect(fixture.log.count("overlay.finished:\(second)") == 1)
+        }
+    }
+
+    @Test func `overlay send uses owned coordinator and originating completion`() async throws {
+        try await withVoiceOwnerFixture(activate: false) { fixture, state, _ in
+            let voice = state.voiceRuntime
+            let celebration = state.sendCelebrationTick
+            let token = voice.sessions.startSession(source: .pushToTalk, text: "owned transcript")
+            voice.overlay.requestSend(token: token)
+            try await waitForVoiceOwner("owned forward and send dismissal") { [log = fixture.log] in
+                log.count("forward:owned transcript") == 1 && log.count("overlay.request:\(token)") == 1
+            }
+            #expect(voice.sessions.snapshot().token == token)
+            fixture.completeDismissal(token)
+            #expect(voice.sessions.snapshot().token == nil)
+            #expect(!voice.overlay.isVisible)
+            #expect(state.sendCelebrationTick == celebration + 1)
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceOwnerTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceOwnerTestSupport.swift
@@ -1,0 +1,355 @@
+import AppKit
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+final class VoiceOwnerLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String] = []
+    private var sequences: [String: Int] = [:]
+
+    @discardableResult
+    func record(_ event: String) -> Int {
+        self.lock.withLock {
+            self.entries.append(event)
+            self.sequences[event, default: 0] += 1
+            return self.sequences[event, default: 0]
+        }
+    }
+
+    func count(_ event: String) -> Int {
+        self.lock.withLock { self.sequences[event, default: 0] }
+    }
+
+    func snapshot() -> [String] {
+        self.lock.withLock { self.entries }
+    }
+}
+
+/// Each instance belongs to one external boundary. Cancellation deliberately does
+/// not acknowledge permission completion; no test treats this as a PTT task join.
+actor VoiceOwnerGate<Value: Sendable> {
+    private let value: Value
+    private let name: String
+    private let log: VoiceOwnerLog
+    private var held = false
+    private var pending: [Int: CheckedContinuation<Value, Never>] = [:]
+
+    init(_ name: String, value: Value, log: VoiceOwnerLog) {
+        self.name = name
+        self.value = value
+        self.log = log
+    }
+
+    func hold() {
+        self.held = true
+    }
+
+    func request() async -> Value {
+        let id = self.log.record("\(self.name).request")
+        guard self.held else { return self.value }
+        return await withCheckedContinuation { self.pending[id] = $0 }
+    }
+
+    func resolve(_ id: Int, returning value: Value) {
+        self.pending.removeValue(forKey: id)?.resume(returning: value)
+    }
+
+    func releaseAll() {
+        self.held = false
+        let pending = self.pending
+        self.pending.removeAll()
+        for continuation in pending.values {
+            continuation.resume(returning: self.value)
+        }
+    }
+}
+
+struct VoiceOwnerTimeout: Error {
+    let operation: String
+}
+
+func waitForVoiceOwner(
+    _ operation: String,
+    until condition: @escaping @Sendable () async -> Bool) async throws
+{
+    try await AsyncTimeout.withTimeout(
+        seconds: 2,
+        onTimeout: { VoiceOwnerTimeout(operation: operation) },
+        operation: {
+            while await !condition() {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+        })
+}
+
+@MainActor
+final class VoiceOwnerCapture: RealtimeTalkAudioCapturing {
+    let suppressesInputDuringOutput = false
+    private let id: Int
+    private let log: VoiceOwnerLog
+    private var running = false
+
+    init(log: VoiceOwnerLog) {
+        self.log = log
+        self.id = log.record("capture.make")
+    }
+
+    func start(
+        targetSampleRate: Double,
+        onAudio: @escaping @Sendable (RealtimeTalkAudioFrame) -> Void,
+        onFailure: @escaping @MainActor (String) -> Void) throws
+    {
+        self.running = true
+        self.log.record("capture.start:\(self.id)")
+    }
+
+    func stop() {
+        guard self.running else { return }
+        self.running = false
+        self.log.record("capture.stop:\(self.id)")
+    }
+}
+
+@MainActor
+final class VoiceOwnerPlayer: PCMStreamingAudioPlaying {
+    private let id: Int
+    private let log: VoiceOwnerLog
+
+    init(log: VoiceOwnerLog) {
+        self.log = log
+        self.id = log.record("player.make")
+    }
+
+    func play(
+        stream: AsyncThrowingStream<Data, Error>,
+        sampleRate: Double) async -> StreamingPlaybackResult
+    {
+        Issue.record("Voice owner fixture unexpectedly requested PCM playback")
+        return StreamingPlaybackResult(finished: false, interruptedAt: nil)
+    }
+
+    func stop() -> Double? {
+        self.log.record("player.stop:\(self.id)")
+        return nil
+    }
+}
+
+@MainActor
+final class VoiceOwnerFixture {
+    let log: VoiceOwnerLog
+    let appPermission: VoiceOwnerGate<Bool>
+    let talkPermission: VoiceOwnerGate<Bool>
+    let pttPermission: VoiceOwnerGate<Bool>
+    let bootstrap: VoiceOwnerGate<Void>
+    let create: VoiceOwnerGate<Void>
+    let shutdown: VoiceOwnerGate<Void>
+    private var streams: [AsyncStream<EventFrame>.Continuation] = []
+    private var dismissals: [UUID: @MainActor @Sendable (VoiceWakeOverlayController.DismissalCompletion) -> Void] = [:]
+    var operations: [Task<Void, Never>] = []
+
+    init() {
+        let log = VoiceOwnerLog()
+        self.log = log
+        self.appPermission = VoiceOwnerGate("app.permission", value: true, log: log)
+        self.talkPermission = VoiceOwnerGate("talk.permission", value: true, log: log)
+        self.pttPermission = VoiceOwnerGate("ptt.permission", value: false, log: log)
+        self.bootstrap = VoiceOwnerGate("bootstrap", value: (), log: log)
+        self.create = VoiceOwnerGate("create", value: (), log: log)
+        self.shutdown = VoiceOwnerGate("shutdown.buffered", value: (), log: log)
+    }
+
+    func environment(appPermissionGranted: Bool = true) -> AppVoiceRuntime.Environment {
+        let log = self.log
+        return .init(
+            appStatePermissions: .init(
+                supported: { true },
+                granted: { appPermissionGranted },
+                ensure: { [appPermission] _ in await appPermission.request() }),
+            pttPermissions: .init(
+                supported: { true },
+                granted: { false },
+                ensure: { [pttPermission] _ in await pttPermission.request() }),
+            wakePermissions: .init(
+                supported: { true },
+                granted: { log.record("wake.permission")
+                    return false
+                },
+                ensure: { _ in false }),
+            talkPermissions: .init(
+                supported: { true },
+                granted: { true },
+                ensure: { [talkPermission] _ in await talkPermission.request() }),
+            talkAudioCapture: { _ in VoiceOwnerCapture(log: log) },
+            talkPCMPlayer: { VoiceOwnerPlayer(log: log) },
+            talkSelectedSession: { nil },
+            stopPCM: { log.record("shutdown.pcm")
+                return nil
+            },
+            stopMP3: { log.record("shutdown.mp3")
+                return nil
+            },
+            stopBuffered: { [shutdown] in await shutdown.request()
+                return nil
+            },
+            stopSystem: { log.record("shutdown.system") },
+            stopMLX: { log.record("shutdown.mlx") },
+            talkBootstrap: { [self] in await self.bootstrap.request()
+                return try await self.makeBootstrap()
+            },
+            publishTalk: { log.record("publish:\($0):\($1)") },
+            forward: { text, _ in log.record("forward:\(text)")
+                return .success(())
+            },
+            wakePresentation: .init(
+                present: { owner, first in if first { owner.actions()?.didPresent() } },
+                updateFrame: { _, _ in },
+                bringToFront: { _ in },
+                animateDismiss: { [self] owner, _, _, completion in
+                    guard let token = owner.activeToken else {
+                        Issue.record("Dismissal without an overlay token")
+                        return
+                    }
+                    log.record("overlay.request:\(token)")
+                    self.dismissals[token] = completion
+                }),
+            talkPresentation: .init(
+                present: { _, _ in log.record("talk.present") },
+                animateDismiss: { _, completion in completion { log.record("talk.hidden") } }),
+            interruptRegistration: .init(
+                addGlobal: { _, _ in NSNumber(value: log.record("monitor.global")) },
+                addLocal: { _, _ in NSNumber(value: -log.record("monitor.local")) },
+                remove: { log.record("monitor.remove:\($0)") }))
+    }
+
+    private func makeBootstrap() throws -> GatewayConnection.RealtimeTalkBootstrap {
+        let events = AsyncStream<EventFrame>.makeStream(bufferingPolicy: .bufferingNewest(8))
+        self.streams.append(events.continuation)
+        let log = self.log
+        let create = self.create
+        let transport = RealtimeTalkRelayTransport(
+            subscribeServerEvents: { _ in events.stream },
+            request: { method, params, _ in
+                if method == "talk.session.create" {
+                    let id = "relay-\(log.record("relay.create"))"
+                    log.record("relay.created:\(id)")
+                    await create.request()
+                    events.continuation.yield(EventFrame(
+                        type: "event",
+                        event: "talk.event",
+                        payload: AnyCodable(["relaySessionId": id, "type": "ready"]),
+                        seq: nil,
+                        stateversion: nil))
+                    return try JSONEncoder().encode(TalkSessionCreateResult(
+                        sessionid: "talk-session",
+                        mode: AnyCodable("realtime"),
+                        transport: AnyCodable("gateway-relay"),
+                        brain: AnyCodable("agent-consult"),
+                        relaysessionid: id))
+                }
+                if method == "talk.session.close" {
+                    guard let id = params?["sessionId"]?.value as? String else {
+                        throw VoiceOwnerTimeout(operation: "close missing relay identity")
+                    }
+                    log.record("relay.closed:\(id)")
+                }
+                return Data("{\"ok\":true}".utf8)
+            },
+            isCurrent: { true })
+        let snapshot = ConfigSnapshot(
+            path: nil,
+            exists: true,
+            raw: nil,
+            hash: nil,
+            parsed: nil,
+            valid: true,
+            config: [
+                "session": AnyCodable(["mainKey": AnyCodable("main")]),
+                "talk": AnyCodable(["realtime": AnyCodable([
+                    "provider": AnyCodable("openai"),
+                    "providers": AnyCodable(["openai": AnyCodable(["model": AnyCodable("gpt-realtime-2")])]),
+                    "mode": AnyCodable("realtime"),
+                    "transport": AnyCodable("gateway-relay"),
+                    "brain": AnyCodable("agent-consult"),
+                ])]),
+            ], issues: nil)
+        return .init(transport: transport, configSnapshot: snapshot, sessionKey: "main")
+    }
+
+    func completeDismissal(_ token: UUID) {
+        self.dismissals.removeValue(forKey: token)?(.animated(finishWindow: { [log] in
+            log.record("overlay.finished:\(token)")
+        }))
+    }
+
+    @discardableResult
+    func requestTalk(_ enabled: Bool, state: AppState) -> Task<Void, Never> {
+        let task = Task { await state.setTalkEnabled(enabled) }
+        self.operations.append(task)
+        return task
+    }
+
+    func cleanup(state: AppState, menu: StatusMenuController) async throws {
+        menu.stopVoiceObservation()
+        self.requestTalk(false, state: state)
+        await self.appPermission.releaseAll()
+        await self.talkPermission.releaseAll()
+        await self.bootstrap.releaseAll()
+        await self.create.releaseAll()
+        await self.shutdown.releaseAll()
+        for task in self.operations {
+            await task.value
+        }
+        state.swabbleEnabled = false
+        await state.voiceRuntime.wake.refresh(state: state)
+        for token in Array(self.dismissals.keys) {
+            self.completeDismissal(token)
+        }
+        defer {
+            for stream in self.streams {
+                stream.finish()
+            }
+            self.streams.removeAll()
+            self.operations.removeAll()
+        }
+        try await waitForVoiceOwner("all created relays closed") { [log] in
+            let created = log.snapshot().filter { $0.hasPrefix("relay.created:") }
+            return created
+                .allSatisfy { log.count($0.replacingOccurrences(of: "relay.created:", with: "relay.closed:")) == 1 }
+        }
+    }
+}
+
+@MainActor
+func withVoiceOwnerFixture(
+    activate: Bool = true,
+    appPermissionGranted: Bool = true,
+    _ body: (VoiceOwnerFixture, AppState, StatusMenuController) async throws -> Void) async throws
+{
+    try await TestIsolation.withIsolatedState(
+        env: ["OPENCLAW_CONFIG_PATH": TestIsolation.tempConfigPath()],
+        defaults: [swabbleEnabledKey: false, talkEnabledKey: false, voicePushToTalkEnabledKey: false])
+    {
+        let fixture = VoiceOwnerFixture()
+        let state = AppState(preview: true, voiceEnvironment: fixture.environment(
+            appPermissionGranted: appPermissionGranted))
+        state.voiceWakeLocaleID = "en-US"
+        state.voiceWakeTriggerChime = .none
+        state.voiceWakeSendChime = .none
+        state.talkRealtimeRelayEnabled = true
+        let menu = StatusMenuController(state: state, updater: DisabledUpdaterController())
+        if activate {
+            state.activateVoice()
+            await fixture.requestTalk(false, state: state).value
+        }
+        do {
+            try await body(fixture, state, menu)
+        } catch {
+            try await fixture.cleanup(state: state, menu: menu)
+            throw error
+        }
+        try await fixture.cleanup(state: state, menu: menu)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkHotkeyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkHotkeyTests.swift
@@ -6,9 +6,9 @@ import Testing
 @MainActor
 struct VoicePushToTalkHotkeyTests {
     @Test func `either Option release order ends the right hold`() {
-        let releaseOrders: [[(UInt16, UInt)]] = [
-            [(61, 0x80020), (58, 0)],
-            [(58, 0x80040), (61, 0)],
+        let releaseOrders: [[UInt]] = [
+            [0x80020, 0],
+            [0x80040, 0],
         ]
         for releases in releaseOrders {
             var began = 0
@@ -19,18 +19,18 @@ struct VoicePushToTalkHotkeyTests {
                     if !cancelled { ended += 1 }
                 })
             hotkey.setEnabled(true)
-            hotkey._testUpdateModifierState(keyCode: 58, modifierFlags: .init(rawValue: 0x80020))
+            hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80020))
             #expect(began == 0)
             for flags in [UInt(0x80040), 0x80040, 0x80060] {
-                hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: flags))
+                hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: flags))
             }
             #expect(began == 1)
-            for (keyCode, flags) in releases {
-                hotkey._testUpdateModifierState(keyCode: keyCode, modifierFlags: .init(rawValue: flags))
+            for flags in releases {
+                hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: flags))
             }
             #expect(ended == 1)
-            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
-            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: [])
+            hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
+            hotkey._testUpdateModifierState(modifierFlags: [])
             #expect(began == 2)
             #expect(ended == 2)
         }
@@ -45,15 +45,15 @@ struct VoicePushToTalkHotkeyTests {
                 if forced { cancelled += 1 }
             })
         hotkey.setEnabled(true)
-        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
         hotkey.setTalkSuppressed(true)
         #expect(cancelled == 1)
         hotkey.setEnabled(false)
         hotkey.setEnabled(true)
-        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
         #expect(began == 1)
         hotkey.setTalkSuppressed(false)
-        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        hotkey._testUpdateModifierState(modifierFlags: .init(rawValue: 0x80040))
         #expect(began == 2)
         hotkey.setEnabled(false)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkHotkeyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkHotkeyTests.swift
@@ -2,44 +2,59 @@ import AppKit
 import Testing
 @testable import OpenClaw
 
-@Suite(.serialized) struct VoicePushToTalkHotkeyTests {
-    actor Counter {
-        private(set) var began = 0
-        private(set) var ended = 0
-
-        func incBegin() {
-            self.began += 1
-        }
-
-        func incEnd() {
-            self.ended += 1
-        }
-
-        func snapshot() -> (began: Int, ended: Int) {
-            (self.began, self.ended)
+@Suite(.serialized)
+@MainActor
+struct VoicePushToTalkHotkeyTests {
+    @Test func `either Option release order ends the right hold`() {
+        let releaseOrders: [[(UInt16, UInt)]] = [
+            [(61, 0x80020), (58, 0)],
+            [(58, 0x80040), (61, 0)],
+        ]
+        for releases in releaseOrders {
+            var began = 0
+            var ended = 0
+            let hotkey = VoicePushToTalkHotkey(
+                beginAction: { began += 1 },
+                endAction: { cancelled in
+                    if !cancelled { ended += 1 }
+                })
+            hotkey.setEnabled(true)
+            hotkey._testUpdateModifierState(keyCode: 58, modifierFlags: .init(rawValue: 0x80020))
+            #expect(began == 0)
+            for flags in [UInt(0x80040), 0x80040, 0x80060] {
+                hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: flags))
+            }
+            #expect(began == 1)
+            for (keyCode, flags) in releases {
+                hotkey._testUpdateModifierState(keyCode: keyCode, modifierFlags: .init(rawValue: flags))
+            }
+            #expect(ended == 1)
+            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: [])
+            #expect(began == 2)
+            #expect(ended == 2)
         }
     }
 
-    @Test func `begin end fires once per hold`() async {
-        let counter = Counter()
+    @Test func `Talk suppression survives preference changes until shutdown completes`() {
+        var began = 0
+        var cancelled = 0
         let hotkey = VoicePushToTalkHotkey(
-            beginAction: { await counter.incBegin() },
-            endAction: { await counter.incEnd() })
-
-        await MainActor.run {
-            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: [.option])
-            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: [.option])
-            hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: [])
-        }
-
-        for _ in 0..<50 {
-            let snap = await counter.snapshot()
-            if snap.began == 1, snap.ended == 1 { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-
-        let snap = await counter.snapshot()
-        #expect(snap.began == 1)
-        #expect(snap.ended == 1)
+            beginAction: { began += 1 },
+            endAction: { forced in
+                if forced { cancelled += 1 }
+            })
+        hotkey.setEnabled(true)
+        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        hotkey.setTalkSuppressed(true)
+        #expect(cancelled == 1)
+        hotkey.setEnabled(false)
+        hotkey.setEnabled(true)
+        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        #expect(began == 1)
+        hotkey.setTalkSuppressed(false)
+        hotkey._testUpdateModifierState(keyCode: 61, modifierFlags: .init(rawValue: 0x80040))
+        #expect(began == 2)
+        hotkey.setEnabled(false)
     }
 }

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -32,14 +32,16 @@ Voice Wake requires Apple Speech to support on-device recognition for the select
 
 ## Lifecycle invariants
 
-- If Voice Wake is enabled and permissions are granted, the wake-word recognizer stays listening, except during an active push-to-talk capture.
-- Overlay dismissal, including manual dismiss via the X button, always resumes the recognizer: `VoiceSessionCoordinator.overlayDidDismiss` calls `VoiceWakeRuntime.refresh(state:)` on every dismiss path. See [Voice overlay](/platforms/mac/voice-overlay) for the session/token model.
+- If Voice Wake is enabled and permissions are granted, the wake-word recognizer stays listening, except while push-to-talk or Talk Mode owns the microphone.
+- Overlay dismissal, including manual dismiss via the X button, requests a recognizer refresh. Listening resumes only after all active voice owners have released their pauses; dismissing an overlay cannot restart it during capture or Talk shutdown. See [Voice overlay](/platforms/mac/voice-overlay) for the session/token model.
 
 ## Push-to-talk specifics
 
-- Hotkey detection uses a global `.flagsChanged` monitor for right Option (`keyCode 61` + `.option`). It only observes events, never swallows them.
-- Capture lives in `VoicePushToTalk`: starts Speech immediately, streams partials to the overlay, and calls `VoiceWakeForwarder` on release.
-- Starting push-to-talk pauses the wake-word runtime to avoid dueling audio taps; it restarts automatically after release.
+- Hotkey detection observes `.flagsChanged` and the physical right-Option flag. Releasing right Option ends the hold even while left Option remains down. Events are never swallowed.
+- Capture lives in `VoicePushToTalk`: after permissions resolve, Speech starts only if the same hold remains active. Release allows up to 1.5 seconds for final Speech results before forwarding; an empty capture dismisses immediately.
+- Disabling push-to-talk or entering Talk Mode cancels pending or active capture without forwarding. Push-to-talk stays unavailable until Talk shutdown finishes, even if its preference changes meanwhile.
+- Starting push-to-talk pauses the wake-word runtime to avoid competing audio taps. The pause remains through the final Speech drain and is released after audio teardown.
+- A fresh hold adopts visible overlay text, including a previous capture still awaiting final Speech results, without forwarding the replaced capture twice.
 - Permissions: requires Microphone + Speech; receiving key events needs Accessibility/Input Monitoring approval.
 - External keyboards: some do not expose right Option as expected. Offer a fallback shortcut if users report misses.
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users releasing right Option or disabling push-to-talk could
still start microphone capture after pending permission or startup work completed.
Releasing right Option while left Option remained down could also leave the hold
active. Overlapping push-to-talk, Talk Mode, and wake-listener transitions could
let stale work acquire or release resources belonging to a newer session.

## Why This Change Was Made

Make hotkey delivery, hold admission, and invalidation synchronous on MainActor,
bind asynchronous startup and cleanup to the current session, and separate audio
retirement from terminal transcript cleanup. Replacement admission retains its
exact overlay and acknowledged wake pause until it commits or terminates.
One hotkey-availability owner, an awaited canonical Talk transition with eager
disable and shutdown ordering, and token-bound wake pauses coordinate capture;
AppState rejects stale permission and completion projections.

The current candidate also binds the real PTT, Wake, Talk controller/runtime,
session coordinator, and overlay owners into one constructor-bound graph owned
by AppState. It routes status-menu observation, overlay actions and originating
dismissal completion through that graph, retains acquired cleanup collaborators,
and removes disconnected singleton paths and mutable test-only dependency
setters. Remaining shared accessors project the production graph. Normal AppState
voice activation timing, preview/test safeguards, persistence, and unrelated
startup remain intact; focused fixtures replace external effects, not the
transition owners.

## User Impact

- Releasing physical right Option ends the hold even while left Option remains
  down; monitor teardown also cancels pending or active capture.
- Ordinary release preserves the existing 1.5-second Speech drain and send.
  Forced teardown cancels without forwarding. A fresh hold can adopt a visible
  draft without sending the replaced capture twice.
- Talk suppresses push-to-talk before asynchronous admission and through audio
  shutdown, including overlapping enable/disable requests and preference changes.
- Successful replacement does not request overlay dismissal. Aborted replacement
  resolves only its owned transcript; lost coordinator ownership prevents stale
  admission from restoring a saved draft over a newer overlay.

No configuration, defaults, persistence, schema, protocol, or dependency changes.
Microphone-selection semantics are outside this repair. The audio tap callback
remains constructed outside MainActor; PCM append is not moved onto MainActor.
The new owner composition has static validation plus recorded merge-checkout native CI, as detailed below; signed interactive behavior remains unqualified.

## Evidence

### Current candidate

- SwiftFormat 0.63.0 lint passed all 19 changed Swift files under
  `config/swiftformat`: 0/19 required formatting.
- Strict SwiftLint 0.65.1 completed all 19 files, including tests and test support,
  under `config/swiftlint.yml`: zero violations. The successful invocation used
  the existing Command Line Tools SourceKit through a process-local toolchain
  selection; no system configuration changed.
- One fresh local autoreview covered the complete dirty 19-file delta, including
  all three new files, against `443e69d332b980a816a302c8de656acab6243695`.
  Its two complete helper-managed passes returned no P0 findings and
  `scoped-clean`, exit 0. Input, evidence, and final source checks completed.
  This is P0-scoped static review, not an all-severity clearance, compilation
  result, or native behavioral proof.
- Source/mode/freeze checks remained unchanged after those checks and review.
  Earlier failed formatting/lint attempts remain failures; only the completed
  all-file runs above establish the current static results.

**Recorded native CI:** [CI run 34389511457, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34389511457/attempts/1)
ran on September 9, 2026 for PR head
`f383129f85d9c8e6a289cb11731ee163629eb802`. The logged checkout was
`c10d6578c98c2870957c02d7550b207436f5abe3`, with actual ordered parents
`10af9baebe45b2e123857e512ed186714ad6d1f8` then
`f383129f85d9c8e6a289cb11731ee163629eb802`.
The [macos-swift (tests) job 102594272037](https://github.com/openclaw/openclaw/actions/runs/34389511457/job/102594272037)
and `ci-gate` succeeded. All 15 expected named tests passed, representing
19 coverage cases: 11 lifecycle, six speech, and two hotkey cases. This is
aggregate completion plus parameter admissions, not 19 individual finish records.
The default suite completed 2140 tests in 237 suites; the separate
AppStateIsolation suite completed two tests in one suite. The release build was
SKIPPED. These are dated merge-checkout observations, not a standalone full-HEAD
observation or signed-interactive/readiness qualification.
The fixtures retain actual owner instances, separate permission ledgers, relay
identities, and originating presentation completions. PTT fixture admissions
always deny; these tests do not establish successful native PTT capture.

### Historical synthetic proof

These completed results belong to earlier source snapshots, before the current
constructor-bound graph. They are not execution proof for the new composition.
The original baseline is `20e0ed521c00fd38b1d4d003636fa4ddd3bf2066`.

| Historical proof stage | Scenarios | Behavioral result |
| --- | ---: | --- |
| Original-commit PTT baseline | 12 | 21 passed, 13 failed |
| First PTT candidate | 12 | All 34 shared assertions passed, plus one candidate-only lease assertion |
| Replacement-admission pre-repair candidate | 22 | 77 passed, 19 failed |
| Repaired PTT + real coordinator candidate | 22 | 96 passed, 0 failed |
| Then-current whole Talk controller with synthetic runtime | 4 | 15 passed, 0 failed |

The final 22-scenario pre/post pair used identical final fixture bytes. It compiled
whole `VoicePushToTalk.swift` and whole actual `VoiceSessionCoordinator.swift`,
including `@Observable`, with synthetic native edges and narrowly documented
application stand-ins, not copies of the algorithms. The fixture SHA-256 was
`8373782b0368b427862f55747497529b5f5650826d398634244cea851c6080de`.
There was no original-commit Talk execution result.

That pair covers suspended permissions followed by release or disable, both
modifier-bit overlap orders, failed engine startup, reordered permission
completion, pending pause acknowledgement, draining replacement, admission
cancellation, coordinator takeover, exact engine/request/session identities,
and lease retention with acquire-before-release ordering. Stranded-overlay
assertions wait beyond the original 1.5-second drain; successful replacement
asserts no dismissal request and one combined forward.

Autoreview had identified the stranded transcript on aborted replacement
admission (P2). The finding was reproduced and repaired under an independently
reviewed owner-repair plan, retaining overlay and acknowledged lease ownership
until owned replacement or terminal cancellation. That earlier review reported
the defect; it was not a clean review of the repaired snapshot.

Both final paired runs separately passed 20 isolation checks. Their runtime
sandbox denied helper spawning, operator files/state, network access, preferences,
Keychain, and native service lookup. Audio, physical events, permissions,
rendering, wake behavior, and forwarding remained synthetic. The temporary
harness is not part of the repository changes.

Independent real-native-SDK typechecking passed for the historical whole PTT
source with SHA-256
`a028739f1bf07034113baed46b72215139e5670b1ae4b413d942253d6372fd4d`,
using actual AppKit, AVFoundation, Speech, and IOKit with application dependencies
stubbed. This was compile-only evidence, not an app launch, and did not typecheck
the new owner graph. The historical documentation change also passed pinned
oxfmt 0.65.0 and whitespace checks; that is not native proof.

### Historical CI

- At PR head `38bdcaa52d40b278bc60f855e398e3f750722b9a`, ordinary
  [CI run 34345983026](https://github.com/openclaw/openclaw/actions/runs/34345983026)
  passed on actual workflow/checkout merge
  `81de8d20db03577521131171427bd1f170f72e98`, incorporating base
  `f4491789290079c3027bf20622c47ef1cf608e15`. Native debug compilation and
  the existing suites passed. The separate Periphery scan failed on unused
  key-code plumbing; that failure was subsequently repaired, not ignored.
- At PR head `443e69d332b980a816a302c8de656acab6243695`, ordinary
  [CI run 34350899352](https://github.com/openclaw/openclaw/actions/runs/34350899352)
  and [Periphery run 34350899558](https://github.com/openclaw/openclaw/actions/runs/34350899558)
  passed on checkout merge `77758863b021967d5b63007a1ed7246ac8ab03f5`,
  incorporating base `329c12d11475589ac06c4bc0c9bc8d197a47489f`.
  The native log confirms compilation and both hotkey cases; the enforced
  Periphery report had zero findings. Ordinary CI logged that merge as both
  workflow and checkout SHA; Periphery did not separately log its workflow
  definition SHA.

These were merge-ref runs on earlier heads, not candidate-only runs or new-graph
qualification. Release builds and health-render/screenshot steps were skipped.
They do not prove signed-app microphone/Speech/TCC, physical modifiers, native
overlay rendering, or the new causal owner schedules.

### Change size and remaining limits

The new 19-file delta against `443e69d332b980a816a302c8de656acab6243695`
is production **+780/-336 (net +444)** and tests/support
**+616/-13 (net +603)**. The complete PR against original base
`20e0ed521c00fd38b1d4d003636fa4ddd3bf2066` is 21 files: production
**+1015/-500 (net +515)**, tests/support **+666/-48 (net +618)**, and docs
**+7/-5 (net +2)**. Production growth establishes concrete instance ownership
across the cyclic voice graph and binds external effects at construction,
replacing global escape paths without a parallel Talk-start route.

**Still unproven:** paired pre-fix execution with identical composition wiring; signed microphone
and Speech permission flows; physical modifier delivery; rendered overlay
animation; and arbitrary native Speech/Wake internal suspension schedules.
There is no isolated signed interactive fixture, and no app or full native suite
was run on an operator desktop. No screenshots or recordings are claimed.

The new fixture does not prove complete quiescence or cross-suite isolation:
private PTT startup/late completions, initial or dismissal-triggered Wake tasks,
queued monitor registrations, and phase publications remain unjoined.

**Known follow-ups:** the pre-existing Wake stop path can dismiss an overlay
without a token after the last pause is released. Historical newer/unrelated
overlay preservation is proven only at PTT + real coordinator, not through that
real Wake path. Manual-send versus PTT draft adoption remains an existing source
risk. Microphone-selection semantics, including unused PTT `micID`, are not
changed or certified here.
