### PR TITLE
fix(tts): release telephony provider resources after synthesis

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -61,6 +61,14 @@ completed video assets and result metadata. Video assets may contain buffers or
 provider-hosted URLs. Downloads after the call returns belong to the caller;
 registration disposal must not invalidate those completed artifacts.
 
+`api.runtime.tts.textToSpeechTelephony(...)` also owns fresh provider registrations
+through configuration, persona preparation, synthesis, and PCM result metadata.
+It retains managed registrations during the operation and preserves raw host
+ownership. Configured fallback catalogs stay separate from direct preference and
+override lookups. Returned audio buffers outlive registration disposal. The
+separate synchronous speech lookup and request-preparation APIs keep their
+existing caller lifetime; streaming speech is not part of this finite operation.
+
 For `image_generate` and `music_generate` tools prepared from an owned inspection,
 resources remain held through preflight and, once accepted, through generation, media saving, and
 any rollback. A `started` result acknowledges acceptance; it does not mean the

--- a/src/plugins/capability-provider-acquisition.ts
+++ b/src/plugins/capability-provider-acquisition.ts
@@ -2,10 +2,15 @@ import type { Result } from "@openclaw/normalization-core/result";
 import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { acquireBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
 import {
+  preparePluginCapabilityProviderLookup,
   preparePluginCapabilityProviderResolution,
   type CapabilityProviderFor,
 } from "./capability-provider-runtime.js";
-import { acquirePluginRegistryForInspection, isPluginRegistryLoadInFlight } from "./loader.js";
+import {
+  acquirePluginRegistryForInspection,
+  isPluginRegistryLoadInFlight,
+  resolvePluginRegistryLoadCacheKey,
+} from "./loader.js";
 import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import { capturePluginLifecycleAuthority } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
@@ -16,6 +21,7 @@ export async function acquirePluginCapabilityProviders<
 >(params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0]) {
   const work = new AsyncWorkScope();
   const releases: Array<() => Promise<void>> = [];
+  const loads = new Map<string, Promise<PluginRegistry>>();
   const retained = new Set<PluginRegistry>();
   const authorities = new Map<PluginRegistry, (() => boolean) | undefined>();
   const captureAuthority = (registry: PluginRegistry) => {
@@ -59,42 +65,77 @@ export async function acquirePluginCapabilityProviders<
         await work.drain();
       }
     }));
-  try {
-    const providers = await work.track(async () => {
-      const resolution = preparePluginCapabilityProviderResolution(params, retain);
-      let entries: PluginRegistry[K] = [];
-      if (resolution.load) {
-        const load = resolution.prepareLoad();
-        let registry = load.loadedRegistry;
-        if (!registry) {
-          const loadOptions = load.resolveLoadOptions();
-          if (!isPluginRegistryLoadInFlight(loadOptions)) {
-            const acquired = await acquirePluginRegistryForInspection(loadOptions);
-            releases.push(acquired.release);
-            registry = acquired.registry;
-            captureAuthority(registry);
+  const run = <T>(operation: () => T | Promise<T>) =>
+    releaseCompletion
+      ? Promise.reject(new Error("Capability provider acquisition has been released"))
+      : work.track(operation);
+  type LoadResolution = Extract<
+    ReturnType<typeof preparePluginCapabilityProviderResolution<K>>,
+    { prepareLoad: () => unknown }
+  >;
+  const execute = async <T>(
+    resolution: { resolve: (entries: PluginRegistry[K]) => T } & (
+      | { load: undefined }
+      | { load: LoadResolution["load"]; prepareLoad: LoadResolution["prepareLoad"] }
+    ),
+  ): Promise<T> => {
+    let entries: PluginRegistry[K] = [];
+    if (resolution.load) {
+      const load = resolution.prepareLoad();
+      let registry = load.loadedRegistry;
+      if (!registry) {
+        const loadOptions = load.resolveLoadOptions();
+        if (!isPluginRegistryLoadInFlight(loadOptions)) {
+          const key = resolvePluginRegistryLoadCacheKey(loadOptions);
+          let pending = loads.get(key);
+          if (!pending) {
+            pending = acquirePluginRegistryForInspection(loadOptions).then((acquired) => {
+              releases.push(acquired.release);
+              captureAuthority(acquired.registry);
+              return acquired.registry;
+            });
+            loads.set(key, pending);
           }
-        }
-        const fallback = load.fallback(registry);
-        entries = fallback.entries;
-        if (fallback.pluginIds.length > 0) {
-          const captured = await acquireBundledCapabilityRuntimeRegistry({
-            ...resolution.load.loadOptions,
-            pluginIds: fallback.pluginIds,
-          });
-          releases.push(captured.release);
-          captureAuthority(captured.registry);
-          entries = load.merge(entries, captured.registry);
+          registry = await pending;
         }
       }
-      return resolution.resolve(entries);
-    });
+      const fallback = load.fallback(registry);
+      entries = fallback.entries;
+      if (fallback.pluginIds.length > 0) {
+        const captured = await acquireBundledCapabilityRuntimeRegistry({
+          ...resolution.load.loadOptions,
+          pluginIds: fallback.pluginIds,
+        });
+        releases.push(captured.release);
+        captureAuthority(captured.registry);
+        entries = load.merge(entries, captured.registry);
+      }
+    }
+    return resolution.resolve(entries);
+  };
+  const resolveProviders = (
+    query: Omit<Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0], "key">,
+  ) =>
+    run(() =>
+      execute<CapabilityProviderFor<K>[]>(
+        preparePluginCapabilityProviderResolution({ ...query, key: params.key }, retain),
+      ),
+    );
+  const resolveProvider = (
+    query: Omit<Parameters<typeof preparePluginCapabilityProviderLookup<K>>[0], "key">,
+  ) =>
+    run(() =>
+      execute<CapabilityProviderFor<K> | undefined>(
+        preparePluginCapabilityProviderLookup({ ...query, key: params.key }, retain),
+      ),
+    );
+  try {
+    const providers = await resolveProviders(params);
     return {
       providers,
-      run: <T>(run: () => T | Promise<T>) =>
-        releaseCompletion
-          ? Promise.reject(new Error("Capability provider acquisition has been released"))
-          : work.track(run),
+      run,
+      resolveProviders,
+      resolveProvider,
       assertOpen: () => {
         if (releaseCompletion || [...authorities.values()].some((isCurrent) => !isCurrent?.())) {
           throw new Error(
@@ -140,12 +181,18 @@ export async function withAcquiredPluginCapabilityProviders<
   T,
 >(
   params: Parameters<typeof preparePluginCapabilityProviderResolution<K>>[0],
-  run: (providers: CapabilityProviderFor<K>[]) => T | Promise<T>,
+  run: (
+    providers: CapabilityProviderFor<K>[],
+    queries: Pick<
+      Awaited<ReturnType<typeof acquirePluginCapabilityProviders<K>>>,
+      "resolveProvider" | "resolveProviders"
+    >,
+  ) => T | Promise<T>,
 ): Promise<T> {
   const acquired = await acquirePluginCapabilityProviders(params);
   let outcome: Result<T, unknown>;
   try {
-    outcome = { ok: true, value: await acquired.run(() => run(acquired.providers)) };
+    outcome = { ok: true, value: await acquired.run(() => run(acquired.providers, acquired)) };
   } catch (error) {
     outcome = { ok: false, error };
   }

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -487,12 +487,21 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   providerId: string;
   cfg?: OpenClawConfig;
 }): CapabilityProviderFor<K> | undefined {
+  const resolution = preparePluginCapabilityProviderLookup(params);
+  return resolution.resolve(resolution.load ? loadCapabilityProviderEntries(resolution.load) : []);
+}
+
+export function preparePluginCapabilityProviderLookup<K extends CapabilityProviderRegistryKey>(
+  params: { key: K; providerId: string; cfg?: OpenClawConfig },
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
+) {
   if (shouldSkipCapabilityResolution(params)) {
-    return undefined;
+    return { load: undefined, resolve: (_entries: PluginRegistry[K]) => undefined };
   }
 
   const activeRegistry =
     getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getLoadedRuntimePluginRegistry();
+  onSelectedRegistry?.(activeRegistry);
   const activeProviders = filterPolicyAllowedCapabilityProviders({
     entries: activeRegistry?.[params.key] ?? [],
     registry: activeRegistry,
@@ -501,7 +510,7 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   });
   const activeProvider = findProviderById(activeProviders, params.providerId);
   if (activeProvider) {
-    return activeProvider;
+    return { load: undefined, resolve: (_entries: PluginRegistry[K]) => activeProvider };
   }
 
   const loadContext = resolveCapabilityLoadContext(activeRegistry, params.cfg);
@@ -525,7 +534,7 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
       pluginMetadataSnapshot,
     });
     if (pluginIds.runtimePluginIds.length === 0) {
-      return undefined;
+      return { load: undefined, resolve: (_entries: PluginRegistry[K]) => undefined };
     }
   }
 
@@ -534,13 +543,17 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
     resolution: pluginIds,
     loadContext,
   });
-  const loadedProviders = loadCapabilityProviderEntries({
+  const load = {
     key: params.key,
     bundledCompatPluginIds: pluginIds.bundledCompatPluginIds,
     loadOptions,
     requested: new Set([params.providerId.toLowerCase()]),
-  });
-  return findProviderById(loadedProviders, params.providerId);
+  };
+  return {
+    load,
+    prepareLoad: () => prepareCapabilityProviderLoad(load, onSelectedRegistry),
+    resolve: (entries: PluginRegistry[K]) => findProviderById(entries, params.providerId),
+  };
 }
 
 export function preparePluginCapabilityProviderResolution<K extends CapabilityProviderRegistryKey>(

--- a/src/tts/tts-provider-resolution.ts
+++ b/src/tts/tts-provider-resolution.ts
@@ -41,6 +41,26 @@ import {
   type VoiceProviderCandidate,
 } from "./voice-models.js";
 
+export type TtsProviderRegistry = {
+  runtimeConfig?: OpenClawConfig;
+  canonicalizeSpeechProviderId: typeof canonicalizeSpeechProviderId;
+  getSpeechProvider: typeof getSpeechProvider;
+  listSpeechProviders: typeof listSpeechProviders;
+};
+
+const defaultProviderRegistry: TtsProviderRegistry = {
+  canonicalizeSpeechProviderId,
+  getSpeechProvider,
+  listSpeechProviders,
+};
+
+function resolveProviderRuntimeConfig(
+  cfg: OpenClawConfig,
+  registry: TtsProviderRegistry,
+): OpenClawConfig {
+  return registry.runtimeConfig ?? resolveTtsRuntimeConfig(cfg);
+}
+
 function resolvePositiveTimeoutMs(timeoutMs: number | undefined): number | undefined {
   return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
     ? clampTimerTimeoutMs(timeoutMs)
@@ -64,8 +84,9 @@ export function resolveSpeechProviderTimeoutMs(params: {
 function sortSpeechProvidersForAutoSelection(
   cfg?: OpenClawConfig,
   providers?: readonly SpeechProviderPlugin[],
+  registry: TtsProviderRegistry = defaultProviderRegistry,
 ) {
-  return [...(providers ?? listSpeechProviders(cfg))].toSorted(compareSpeechProviderOrder);
+  return [...(providers ?? registry.listSpeechProviders(cfg))].toSorted(compareSpeechProviderOrder);
 }
 
 function canonicalizeSpeechProviderIdFromInventory(
@@ -93,11 +114,12 @@ function canonicalizeSpeechProviderIdFromInventory(
 function resolveConfiguredSpeechVoiceModelRefs(
   cfg: OpenClawConfig | undefined,
   providers?: readonly SpeechProviderPlugin[],
+  registry: TtsProviderRegistry = defaultProviderRegistry,
 ): VoiceModelRef[] {
-  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
+  const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : undefined;
   return resolveSupportedVoiceModelRefs({
     config: effectiveCfg?.agents?.defaults?.voiceModel,
-    providers: sortSpeechProvidersForAutoSelection(effectiveCfg, providers),
+    providers: sortSpeechProvidersForAutoSelection(effectiveCfg, providers, registry),
   });
 }
 
@@ -106,8 +128,10 @@ function resolveConfiguredSpeechVoiceModelForProvider(params: {
   providerId: string;
   provider?: VoiceModelProvider;
   voiceModel?: VoiceModelRef;
+  registry?: TtsProviderRegistry;
 }): VoiceModelRef | undefined {
-  const provider = params.provider ?? getSpeechProvider(params.providerId, params.cfg);
+  const registry = params.registry ?? defaultProviderRegistry;
+  const provider = params.provider ?? registry.getSpeechProvider(params.providerId, params.cfg);
   if (params.voiceModel) {
     return voiceProviderSupportsModel(provider, params.voiceModel.model)
       ? params.voiceModel
@@ -126,12 +150,14 @@ function applyVoiceModelToSpeechProviderConfig(params: {
   providerConfig: SpeechProviderConfig;
   provider?: VoiceModelProvider;
   voiceModel?: VoiceModelRef;
+  registry?: TtsProviderRegistry;
 }): SpeechProviderConfig {
   const voiceModel = resolveConfiguredSpeechVoiceModelForProvider({
     cfg: params.cfg,
     providerId: params.providerId,
     provider: params.provider,
     voiceModel: params.voiceModel,
+    registry: params.registry,
   });
   if (!voiceModel) {
     return params.providerConfig;
@@ -210,18 +236,19 @@ function resolveLazyProviderConfig(
   cfg?: OpenClawConfig,
   voiceModel?: VoiceModelRef,
   provider?: SpeechProviderPlugin,
+  registry: TtsProviderRegistry = defaultProviderRegistry,
 ): SpeechProviderConfig {
   const canonical =
     normalizeConfiguredSpeechProviderId(providerId) ?? normalizeLowercaseStringOrEmpty(providerId);
   const existing = voiceModel ? undefined : config.providerConfigs[canonical];
-  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
+  const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : config.sourceConfig;
   if (existing && !effectiveCfg) {
     return existing;
   }
   const rawConfig = resolveRawProviderConfig(config.rawConfig, canonical);
   const rawBaseConfig = config.rawConfig as Record<string, unknown> | undefined;
   const rawProviders = asProviderConfigMap(config.rawConfig?.providers);
-  const resolvedProvider = provider ?? getSpeechProvider(canonical, effectiveCfg);
+  const resolvedProvider = provider ?? registry.getSpeechProvider(canonical, effectiveCfg);
   let hasRawProviderConfig =
     Object.hasOwn(rawProviders, canonical) ||
     (rawBaseConfig ? Object.hasOwn(rawBaseConfig, canonical) : false);
@@ -250,6 +277,7 @@ function resolveLazyProviderConfig(
     providerConfig: withSpeakerSelectionCompat(asProviderConfig(rawProviderConfig)),
     provider: resolvedProvider,
     voiceModel,
+    registry,
   });
   const shouldInjectCanonicalProviderConfig =
     hasRawProviderConfig || Boolean(voiceModel) || Object.keys(rawProviders).length === 0;
@@ -276,6 +304,7 @@ function resolveLazyProviderConfig(
           providerConfig: rawConfig,
           provider: resolvedProvider,
           voiceModel,
+          registry,
         }),
   );
   if (!voiceModel) {
@@ -289,21 +318,32 @@ export function getResolvedSpeechProviderConfig(
   providerId: string,
   cfg?: OpenClawConfig,
 ): SpeechProviderConfig {
-  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
+  return resolveSpeechProviderConfig(config, providerId, cfg, defaultProviderRegistry);
+}
+
+function resolveSpeechProviderConfig(
+  config: ResolvedTtsConfig,
+  providerId: string,
+  cfg: OpenClawConfig | undefined,
+  registry: TtsProviderRegistry,
+): SpeechProviderConfig {
+  const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : config.sourceConfig;
   const canonical =
-    canonicalizeSpeechProviderId(providerId, effectiveCfg) ??
+    registry.canonicalizeSpeechProviderId(providerId, effectiveCfg) ??
     normalizeConfiguredSpeechProviderId(providerId) ??
     normalizeLowercaseStringOrEmpty(providerId);
-  return resolveLazyProviderConfig(config, canonical, effectiveCfg);
+  return resolveLazyProviderConfig(config, canonical, effectiveCfg, undefined, undefined, registry);
 }
 
 function getResolvedSpeechProviderConfigFromInventory(params: {
   config: ResolvedTtsConfig;
   provider: SpeechProviderPlugin;
   cfg?: OpenClawConfig;
+  registry?: TtsProviderRegistry;
 }): SpeechProviderConfig {
+  const registry = params.registry ?? defaultProviderRegistry;
   const effectiveCfg = params.cfg
-    ? resolveTtsRuntimeConfig(params.cfg)
+    ? resolveProviderRuntimeConfig(params.cfg, registry)
     : params.config.sourceConfig;
   return resolveLazyProviderConfig(
     params.config,
@@ -311,6 +351,7 @@ function getResolvedSpeechProviderConfigFromInventory(params: {
     effectiveCfg,
     undefined,
     params.provider,
+    registry,
   );
 }
 
@@ -319,45 +360,64 @@ export function getResolvedSpeechProviderConfigForVoiceModel(params: {
   providerId: string;
   cfg: OpenClawConfig;
   voiceModel?: VoiceModelRef;
+  registry?: TtsProviderRegistry;
 }): SpeechProviderConfig {
+  const registry = params.registry ?? defaultProviderRegistry;
   if (!params.voiceModel) {
-    return getResolvedSpeechProviderConfig(params.config, params.providerId, params.cfg);
+    return resolveSpeechProviderConfig(params.config, params.providerId, params.cfg, registry);
   }
-  const effectiveCfg = resolveTtsRuntimeConfig(params.cfg);
+  const effectiveCfg = resolveProviderRuntimeConfig(params.cfg, registry);
   const canonical =
-    canonicalizeSpeechProviderId(params.providerId, effectiveCfg) ??
+    registry.canonicalizeSpeechProviderId(params.providerId, effectiveCfg) ??
     normalizeConfiguredSpeechProviderId(params.providerId) ??
     normalizeLowercaseStringOrEmpty(params.providerId);
-  return resolveLazyProviderConfig(params.config, canonical, effectiveCfg, params.voiceModel);
+  return resolveLazyProviderConfig(
+    params.config,
+    canonical,
+    effectiveCfg,
+    params.voiceModel,
+    undefined,
+    registry,
+  );
 }
 
-export function resolveTtsProvider(config: ResolvedTtsConfig, prefsPath: string): TtsProvider {
-  const prefs = readPrefs(prefsPath);
+export function resolveTtsProvider(
+  config: ResolvedTtsConfig,
+  prefsPath: string,
+  registry: TtsProviderRegistry = defaultProviderRegistry,
+  prefs = readPrefs(prefsPath),
+): TtsProvider {
   const prefsProvider =
-    canonicalizeSpeechProviderId(prefs.tts?.provider) ??
+    registry.canonicalizeSpeechProviderId(prefs.tts?.provider) ??
     normalizeConfiguredSpeechProviderId(prefs.tts?.provider);
   if (prefsProvider) {
     return prefsProvider;
   }
   const activePersona = resolveTtsPersonaFromPrefs(config, prefs);
   const personaProvider =
-    canonicalizeSpeechProviderId(activePersona?.provider, config.sourceConfig) ??
+    registry.canonicalizeSpeechProviderId(activePersona?.provider, config.sourceConfig) ??
     normalizeConfiguredSpeechProviderId(activePersona?.provider);
-  if (personaProvider && getSpeechProvider(personaProvider, config.sourceConfig)) {
+  if (personaProvider && registry.getSpeechProvider(personaProvider, config.sourceConfig)) {
     return personaProvider;
   }
   if (config.providerSource === "config") {
     return normalizeConfiguredSpeechProviderId(config.provider) ?? config.provider;
   }
-  const configuredVoiceProvider = resolveConfiguredSpeechVoiceModelRefs(config.sourceConfig)[0]
-    ?.provider;
-  if (configuredVoiceProvider && getSpeechProvider(configuredVoiceProvider, config.sourceConfig)) {
+  const configuredVoiceProvider = resolveConfiguredSpeechVoiceModelRefs(
+    config.sourceConfig,
+    undefined,
+    registry,
+  )[0]?.provider;
+  if (
+    configuredVoiceProvider &&
+    registry.getSpeechProvider(configuredVoiceProvider, config.sourceConfig)
+  ) {
     return configuredVoiceProvider;
   }
 
   const effectiveCfg = config.sourceConfig;
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg)) {
-    if (isTtsProviderConfigured(config, provider.id, effectiveCfg)) {
+  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, undefined, registry)) {
+    if (isSpeechProviderConfigured(config, provider.id, effectiveCfg, registry)) {
       return provider.id;
     }
   }
@@ -444,12 +504,13 @@ export function resolveTtsProviderOrder(
 export function resolveTtsProviderCandidates(
   primary: TtsProvider,
   cfg?: OpenClawConfig,
+  registry: TtsProviderRegistry = defaultProviderRegistry,
 ): VoiceProviderCandidate[] {
-  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
-  const normalizedPrimary = canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
+  const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : undefined;
+  const normalizedPrimary = registry.canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
   return resolveVoiceProviderCandidates({
     primaryProvider: normalizedPrimary,
-    providers: sortSpeechProvidersForAutoSelection(effectiveCfg),
+    providers: sortSpeechProvidersForAutoSelection(effectiveCfg, undefined, registry),
     voiceModelConfig: effectiveCfg?.agents?.defaults?.voiceModel,
   });
 }
@@ -457,11 +518,12 @@ export function resolveTtsProviderCandidates(
 export function resolvePrimaryTtsProviderCandidate(
   primary: TtsProvider,
   cfg?: OpenClawConfig,
+  registry: TtsProviderRegistry = defaultProviderRegistry,
 ): VoiceProviderCandidate {
-  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
+  const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : undefined;
   return resolvePrimaryVoiceProviderCandidate({
-    primaryProvider: canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary,
-    providers: sortSpeechProvidersForAutoSelection(effectiveCfg),
+    primaryProvider: registry.canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary,
+    providers: sortSpeechProvidersForAutoSelection(effectiveCfg, undefined, registry),
     voiceModelConfig: effectiveCfg?.agents?.defaults?.voiceModel,
   });
 }
@@ -471,10 +533,19 @@ export function isTtsProviderConfigured(
   provider: TtsProvider | SpeechProviderPlugin,
   cfg?: OpenClawConfig,
 ): boolean {
+  return isSpeechProviderConfigured(config, provider, cfg, defaultProviderRegistry);
+}
+
+function isSpeechProviderConfigured(
+  config: ResolvedTtsConfig,
+  provider: TtsProvider | SpeechProviderPlugin,
+  cfg: OpenClawConfig | undefined,
+  registry: TtsProviderRegistry,
+): boolean {
   try {
-    const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
+    const effectiveCfg = cfg ? resolveProviderRuntimeConfig(cfg, registry) : config.sourceConfig;
     const resolvedProvider =
-      typeof provider === "string" ? getSpeechProvider(provider, effectiveCfg) : provider;
+      typeof provider === "string" ? registry.getSpeechProvider(provider, effectiveCfg) : provider;
     if (!resolvedProvider) {
       return false;
     }
@@ -483,11 +554,12 @@ export function isTtsProviderConfigured(
         cfg: effectiveCfg,
         providerConfig:
           typeof provider === "string"
-            ? getResolvedSpeechProviderConfig(config, resolvedProvider.id, effectiveCfg)
+            ? resolveSpeechProviderConfig(config, resolvedProvider.id, effectiveCfg, registry)
             : getResolvedSpeechProviderConfigFromInventory({
                 config,
                 provider: resolvedProvider,
                 cfg: effectiveCfg,
+                registry,
               }),
         timeoutMs: resolveSpeechProviderTimeoutMs({ config, provider: resolvedProvider }),
       }) ?? false

--- a/src/tts/tts-runtime.test-support.ts
+++ b/src/tts/tts-runtime.test-support.ts
@@ -35,8 +35,12 @@ const prepareSynthesisMock = vi.hoisted(() =>
   vi.fn(async (_ctx: SpeechProviderPrepareSynthesisContext) => undefined),
 );
 
-const listSpeechProvidersMock = vi.hoisted(() => vi.fn());
-const getSpeechProviderMock = vi.hoisted(() => vi.fn());
+const listSpeechProvidersMock = vi.hoisted(() =>
+  vi.fn<(cfg?: OpenClawConfig) => SpeechProviderPlugin[]>(),
+);
+const getSpeechProviderMock = vi.hoisted(() =>
+  vi.fn<(providerId: string, cfg?: OpenClawConfig) => SpeechProviderPlugin | null | undefined>(),
+);
 const transcodeAudioBufferMock = vi.hoisted(() =>
   // Default off: most tests rely on the synthesized buffer reaching the
   // channel unchanged. Tests that exercise the pre-transcode branch override
@@ -108,6 +112,29 @@ vi.mock("./provider-registry.js", async () => {
       providerId?.trim().toLowerCase() || undefined,
     getSpeechProvider: getSpeechProviderMock,
     listSpeechProviders: listSpeechProvidersMock,
+  };
+});
+
+vi.mock("../plugins/capability-provider-runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/capability-provider-runtime.js")>(
+    "../plugins/capability-provider-runtime.js",
+  );
+  return {
+    ...actual,
+    preparePluginCapabilityProviderResolution: ({ cfg }: { cfg?: OpenClawConfig }) => ({
+      load: undefined,
+      resolve: () => listSpeechProvidersMock(cfg),
+    }),
+    preparePluginCapabilityProviderLookup: ({
+      providerId,
+      cfg,
+    }: {
+      providerId: string;
+      cfg?: OpenClawConfig;
+    }) => ({
+      load: undefined,
+      resolve: () => getSpeechProviderMock(providerId, cfg) ?? undefined,
+    }),
   };
 });
 

--- a/src/tts/tts-synthesis-support.ts
+++ b/src/tts/tts-synthesis-support.ts
@@ -3,6 +3,12 @@ import type { OpenClawConfig, ResolvedTtsPersona, TtsProvider } from "../config/
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { withAcquiredPluginCapabilityProviders } from "../plugins/capability-provider-acquisition.js";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
+import {
+  createSpeechProviderRegistry,
+  normalizeSpeechProviderId,
+} from "./provider-registry-core.js";
 import { canonicalizeSpeechProviderId, getSpeechProvider } from "./provider-registry.js";
 import type { SpeechProviderConfig, SpeechProviderOverrides } from "./provider-types.js";
 import {
@@ -13,10 +19,14 @@ import {
   resolveSpeechProviderTimeoutMs,
   resolveTtsProvider,
   resolveTtsProviderCandidates,
+  type TtsProviderRegistry,
 } from "./tts-provider-resolution.js";
 import type { TtsProviderAttempt } from "./tts-runtime-types.js";
 import {
   getTtsPersona,
+  readTtsPrefs,
+  normalizeConfiguredSpeechProviderId,
+  resolveTtsPersonaFromPrefs,
   resolveTtsConfig,
   resolveTtsPrefsPath,
   resolveTtsRuntimeConfig,
@@ -92,8 +102,12 @@ function resolveReadySpeechProvider(params: {
   persona?: ResolvedTtsPersona;
   voiceModel?: VoiceModelRef;
   requireTelephony?: boolean;
+  providerRegistry?: TtsProviderRegistry;
 }): TtsProviderReadyResolution {
-  const resolvedProvider = getSpeechProvider(params.provider, params.cfg);
+  const resolvedProvider = (params.providerRegistry?.getSpeechProvider ?? getSpeechProvider)(
+    params.provider,
+    params.cfg,
+  );
   if (!resolvedProvider) {
     return {
       kind: "skip",
@@ -106,6 +120,7 @@ function resolveReadySpeechProvider(params: {
     providerId: resolvedProvider.id,
     cfg: params.cfg,
     voiceModel: params.voiceModel,
+    registry: params.providerRegistry,
   });
   const merged = mergeProviderConfigWithPersona({
     providerConfig,
@@ -199,7 +214,7 @@ async function prepareSpeechSynthesis(params: {
   };
 }
 
-export function resolveTtsRequestSetup(params: {
+type TtsRequestSetupParams = {
   text: string;
   cfg: OpenClawConfig;
   prefsPath?: string;
@@ -208,16 +223,11 @@ export function resolveTtsRequestSetup(params: {
   agentId?: string;
   channelId?: string;
   accountId?: string;
-}):
-  | {
-      cfg: OpenClawConfig;
-      config: ResolvedTtsConfig;
-      persona?: ResolvedTtsPersona;
-      providers: VoiceProviderCandidate[];
-    }
-  | {
-      error: string;
-    } {
+};
+
+function resolveTtsRequestConfig(
+  params: TtsRequestSetupParams,
+): { cfg: OpenClawConfig; config: ResolvedTtsConfig; prefsPath: string } | { error: string } {
   const cfg = resolveTtsRuntimeConfig(params.cfg);
   const config = resolveTtsConfig(cfg, {
     agentId: params.agentId,
@@ -231,6 +241,25 @@ export function resolveTtsRequestSetup(params: {
     };
   }
 
+  return { cfg, config, prefsPath };
+}
+
+export function resolveTtsRequestSetup(params: TtsRequestSetupParams):
+  | {
+      cfg: OpenClawConfig;
+      config: ResolvedTtsConfig;
+      persona?: ResolvedTtsPersona;
+      providers: VoiceProviderCandidate[];
+    }
+  | {
+      error: string;
+    } {
+  const facts = resolveTtsRequestConfig(params);
+  if ("error" in facts) {
+    return facts;
+  }
+  const { cfg, config, prefsPath } = facts;
+
   const userProvider = resolveTtsProvider(config, prefsPath);
   const provider = canonicalizeSpeechProviderId(params.providerOverride, cfg) ?? userProvider;
   return {
@@ -241,6 +270,118 @@ export function resolveTtsRequestSetup(params: {
       ? [resolvePrimaryTtsProviderCandidate(provider, cfg)]
       : resolveTtsProviderCandidates(provider, cfg),
   };
+}
+
+type OwnedTtsRequestSetup =
+  | { error: string }
+  | (Exclude<ReturnType<typeof resolveTtsRequestSetup>, { error: string }> & {
+      prepareProviderRegistry: () => Promise<TtsProviderRegistry>;
+    });
+
+/** Keeps catalog and direct lookup selections separate for one finite speech request. */
+export async function withOwnedTtsRequest<T>(
+  params: TtsRequestSetupParams,
+  run: (setup: OwnedTtsRequestSetup) => T | Promise<T>,
+): Promise<T> {
+  const facts = resolveTtsRequestConfig(params);
+  if ("error" in facts) {
+    return await run(facts);
+  }
+  const { cfg, config, prefsPath } = facts;
+  const prefs = readTtsPrefs(prefsPath);
+  const persona = resolveTtsPersonaFromPrefs(config, prefs);
+  return await withAcquiredPluginCapabilityProviders(
+    { key: "speechProviders", cfg },
+    async (catalog, queries) => {
+      const defaultLookups = new Map<string, SpeechProviderPlugin | undefined>();
+      let defaultCatalog: SpeechProviderPlugin[] = [];
+      const preferred = normalizeSpeechProviderId(prefs.tts?.provider);
+      if (preferred) {
+        const provider = await queries.resolveProvider({ providerId: preferred });
+        defaultLookups.set(preferred, provider);
+        if (!provider) {
+          defaultCatalog = await queries.resolveProviders({});
+        }
+      }
+      const defaults = createSpeechProviderRegistry({
+        getProvider: (providerId) => defaultLookups.get(providerId),
+        listProviders: () => defaultCatalog,
+      });
+      const preferredProvider =
+        defaults.canonicalizeSpeechProviderId(prefs.tts?.provider) ??
+        normalizeConfiguredSpeechProviderId(prefs.tts?.provider);
+      const overrideProvider = normalizeSpeechProviderId(params.providerOverride);
+      const requestedInputs = [
+        overrideProvider,
+        !overrideProvider ? preferredProvider : undefined,
+        !preferredProvider ? persona?.provider : undefined,
+        !overrideProvider && !preferredProvider ? config.provider : undefined,
+        ...catalog.map((provider) => provider.id),
+      ];
+      const prepareView = async (
+        queryConfig: OpenClawConfig,
+        providers: SpeechProviderPlugin[],
+      ) => {
+        const lookups = new Map<string, SpeechProviderPlugin | undefined>();
+        const requested = new Set(
+          [...requestedInputs, ...providers.map((provider) => provider.id)].flatMap((id) => {
+            const normalized = normalizeSpeechProviderId(id);
+            return normalized ? [normalized] : [];
+          }),
+        );
+        for (const providerId of requested) {
+          const provider = await queries.resolveProvider({ providerId, cfg: queryConfig });
+          lookups.set(providerId, provider);
+          const canonical = normalizeSpeechProviderId(provider?.id);
+          if (canonical) {
+            requested.add(canonical);
+          }
+        }
+        return createSpeechProviderRegistry({
+          getProvider: (providerId) => lookups.get(providerId),
+          listProviders: () => providers,
+        });
+      };
+      const prepareProviderRegistry = async (): Promise<TtsProviderRegistry> => {
+        const inputView = await prepareView(cfg, await queries.resolveProviders({ cfg }));
+        const runtimeConfig = resolveTtsRuntimeConfig(cfg);
+        const runtimeView =
+          runtimeConfig === cfg
+            ? inputView
+            : await prepareView(
+                runtimeConfig,
+                await queries.resolveProviders({ cfg: runtimeConfig }),
+              );
+        // Policy helpers use the request config or the applicable config prepared for this phase.
+        const selectRegistry = (queryConfig: OpenClawConfig | undefined) => {
+          if (queryConfig === undefined) {
+            return defaults;
+          }
+          return queryConfig === cfg ? inputView : runtimeView;
+        };
+        return {
+          runtimeConfig,
+          getSpeechProvider: (id, queryConfig) => selectRegistry(queryConfig).getSpeechProvider(id),
+          canonicalizeSpeechProviderId: (id, queryConfig) =>
+            selectRegistry(queryConfig).canonicalizeSpeechProviderId(id),
+          listSpeechProviders: (queryConfig) => selectRegistry(queryConfig).listSpeechProviders(),
+        };
+      };
+      const providerRegistry = await prepareProviderRegistry();
+      const userProvider = resolveTtsProvider(config, prefsPath, providerRegistry, prefs);
+      const provider =
+        providerRegistry.canonicalizeSpeechProviderId(params.providerOverride, cfg) ?? userProvider;
+      return await run({
+        cfg,
+        config,
+        persona,
+        providers: params.disableFallback
+          ? [resolvePrimaryTtsProviderCandidate(provider, cfg, providerRegistry)]
+          : resolveTtsProviderCandidates(provider, cfg, providerRegistry),
+        prepareProviderRegistry,
+      });
+    },
+  );
 }
 
 type ReadySpeechProvider = Extract<TtsProviderReadyResolution, { kind: "ready" }>;
@@ -283,6 +424,7 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
   target: "audio-file" | "voice-note" | "telephony";
   logLabel: string;
   requireTelephony?: boolean;
+  prepareProviderRegistry?: () => Promise<TtsProviderRegistry>;
   selectOperation: (params: {
     provider: TtsProvider;
     resolvedProvider: ReadySpeechProvider;
@@ -307,6 +449,9 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
     attemptedProviders.push(provider);
     const providerStart = Date.now();
     try {
+      const providerRegistry = params.prepareProviderRegistry
+        ? await params.prepareProviderRegistry()
+        : undefined;
       const resolvedProvider = resolveReadySpeechProvider({
         provider,
         cfg,
@@ -314,6 +459,7 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
         persona,
         voiceModel,
         requireTelephony: params.requireTelephony,
+        providerRegistry,
       });
       if (resolvedProvider.kind === "skip") {
         errors.push(resolvedProvider.message);

--- a/src/tts/tts-telephony.resources.test.ts
+++ b/src/tts/tts-telephony.resources.test.ts
@@ -1,0 +1,402 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { SpeechTelephonySynthesisRequest } from "./provider-types.js";
+import { textToSpeechTelephony } from "./tts-telephony.js";
+
+const pcm = Buffer.from([0, 0, 32, 0, 224, 255, 0, 0]);
+
+function createNativeTelephonyFixture(id = "native-telephony", reject = false, order = 10) {
+  const dir = makePluginLoaderTempDir();
+  const key = `__openclaw_telephony_resources_${path.basename(dir)}`;
+  const configStarted = createDeferredCore();
+  const prepareStarted = createDeferredCore();
+  const prepareResume = createDeferredCore();
+  const synthesizeStarted = createDeferredCore();
+  const synthesizeResume = createDeferredCore();
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    requests: SpeechTelephonySynthesisRequest[];
+  }> = [];
+  const callbacks: { onResolveConfig?: () => void } = {};
+  const state = {
+    connections,
+    configStarted,
+    prepareStarted,
+    prepareResume,
+    synthesizeStarted,
+    synthesizeResume,
+    pcm,
+    callbacks,
+  };
+  Object.defineProperty(globalThis, key, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const registrationVoice = api.pluginConfig?.voiceId;
+  const database = new DatabaseSync(":memory:");
+  const connection = { database, disposals: 0, requests: [] };
+  state.connections.push(connection);
+  const read = () => database.prepare("SELECT 42 AS value").get().value;
+  api.lifecycle.registerRuntimeLifecycle({ id: "telephony-resource", dispose() {
+    read(); connection.disposals++; database.close();
+  } });
+  api.registerSpeechProvider({
+    id: ${JSON.stringify(id)}, aliases: [${JSON.stringify(`${id}-alias`)}],
+    label: "Native telephony fixture", autoSelectOrder: ${order},
+    defaultModel: "native-model", models: ["native-model"],
+    resolveConfig({ rawConfig }) {
+      state.configStarted.resolve();
+      state.callbacks.onResolveConfig?.();
+      read();
+      return { model: "native-model", voiceId: "native-voice", ...(rawConfig.providers?.[${JSON.stringify(id)}] ?? {}), ...(registrationVoice === undefined ? {} : { voiceId: registrationVoice }) };
+    },
+    isConfigured() { read(); return true; },
+    async prepareSynthesis() {
+      read(); state.prepareStarted.resolve();
+      await state.prepareResume.promise; read();
+      return undefined;
+    },
+    async synthesize() { throw new Error("Unexpected buffered synthesis"); },
+    async synthesizeTelephony(request) {
+      connection.requests.push(request); read(); state.synthesizeStarted.resolve();
+      await state.synthesizeResume.promise; read();
+      if (${reject}) throw new Error("native telephony failure");
+      return { audioBuffer: state.pcm, outputFormat: "pcm", get sampleRate() { read(); return 8000; } };
+    },
+  });
+} };`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { speechProviders: [id] },
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: { voiceId: { type: "string" } },
+      },
+    }),
+  );
+  const cfg: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+    tts: { provider: id, providers: { [id]: {} } },
+  };
+  const prefsPath = path.join(dir, "prefs.json");
+  fs.writeFileSync(prefsPath, "{}");
+  return {
+    id,
+    plugin,
+    cfg,
+    prefsPath,
+    state,
+    run: () =>
+      textToSpeechTelephony({ text: "native telephony", cfg, prefsPath, timeoutMs: 12345 }),
+    withEnvironment: (run: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        run,
+      ),
+    resume() {
+      prepareResume.resolve();
+      synthesizeResume.resolve();
+    },
+    cleanup() {
+      prepareResume.resolve();
+      synthesizeResume.resolve();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+function settle<T>(operation: Promise<T>) {
+  return operation.then(
+    (value) => ({ value, error: undefined }),
+    (error: unknown) => ({ value: undefined, error }),
+  );
+}
+
+async function waitForHook(hook: Promise<void>, operation: Promise<unknown>) {
+  await Promise.race([
+    hook,
+    operation.then((outcome) => {
+      throw new Error(
+        `Telephony settled before the expected provider hook: ${JSON.stringify(outcome)}`,
+      );
+    }),
+  ]);
+}
+
+function combineConfig(
+  primary: ReturnType<typeof createNativeTelephonyFixture>,
+  others: ReturnType<typeof createNativeTelephonyFixture>[],
+): OpenClawConfig {
+  return {
+    ...primary.cfg,
+    plugins: {
+      allow: [primary.id, ...others.map((entry) => entry.id)],
+      load: { paths: [primary.plugin.file, ...others.map((entry) => entry.plugin.file)] },
+      slots: { memory: "none" },
+    },
+  };
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("telephony provider registration resources", () => {
+  it.each([false, true])(
+    "disposes cold telephony resources after settlement (reject=%s)",
+    async (reject) => {
+      const fixture = createNativeTelephonyFixture("native-telephony", reject);
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const result = settle(fixture.run());
+          try {
+            await waitForHook(fixture.state.prepareStarted.promise, result);
+            expect(fixture.state.connections.length).toBeGreaterThan(0);
+            expect(fixture.state.connections.every((entry) => entry.database.isOpen)).toBe(true);
+            fixture.state.prepareResume.resolve();
+            await waitForHook(fixture.state.synthesizeStarted.promise, result);
+            fixture.state.synthesizeResume.resolve();
+            const outcome = await result;
+            expect(outcome.error).toBeUndefined();
+            expect(outcome.value?.success).toBe(!reject);
+            if (reject) {
+              expect(outcome.value?.error).toContain("native telephony failure");
+            } else {
+              expect(outcome.value?.audioBuffer).toEqual(pcm);
+              expect(outcome.value?.sampleRate).toBe(8000);
+              expect(outcome.value?.providerVoice).toBe("native-voice");
+            }
+            const requests = fixture.state.connections.flatMap((entry) => entry.requests);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.timeoutMs).toBe(12345);
+            for (const entry of fixture.state.connections) {
+              expect(entry.database.isOpen).toBe(false);
+              expect(entry.disposals).toBe(1);
+            }
+          } finally {
+            fixture.resume();
+            await result;
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["managed", "managed-config", "raw"] as const)(
+    "retains the %s host through setup and synthesis",
+    async (owner) => {
+      const fixture = createNativeTelephonyFixture();
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const inspection =
+            owner === "raw"
+              ? undefined
+              : await acquirePluginRegistryForInspection({ config: fixture.cfg });
+          const registry =
+            inspection?.registry ?? loadPluginRegistryHandle({ config: fixture.cfg });
+          let parentRelease: Promise<void> | undefined;
+          if (owner === "managed-config") {
+            fixture.state.callbacks.onResolveConfig = () => {
+              parentRelease ??= inspection!.release();
+            };
+          }
+          const result = settle(withPluginRuntimeRegistryScope(registry, fixture.run));
+          try {
+            await waitForHook(
+              owner === "managed-config"
+                ? fixture.state.configStarted.promise
+                : fixture.state.prepareStarted.promise,
+              result,
+            );
+            await (parentRelease ?? inspection?.release());
+            expect(fixture.state.connections.every((entry) => entry.database.isOpen)).toBe(true);
+            fixture.state.prepareResume.resolve();
+            await waitForHook(fixture.state.synthesizeStarted.promise, result);
+            fixture.state.synthesizeResume.resolve();
+            const outcome = await result;
+            expect(outcome.error).toBeUndefined();
+            expect(outcome.value?.success).toBe(true);
+            expect(outcome.value?.audioBuffer).toEqual(pcm);
+            for (const entry of fixture.state.connections) {
+              expect(entry.database.isOpen).toBe(owner === "raw");
+              expect(entry.disposals).toBe(owner === "raw" ? 0 : 1);
+            }
+          } finally {
+            fixture.resume();
+            await result;
+            await inspection?.release();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("keeps preference-only direct providers out of the override fallback catalog", async () => {
+    const catalog = createNativeTelephonyFixture("catalog-voice", false, 20);
+    const override = createNativeTelephonyFixture("override-voice", true, 10);
+    const preferred = createNativeTelephonyFixture("preference-voice", false, 0);
+    const fixtures = [catalog, override, preferred];
+    fixtures.forEach((fixture) => fixture.resume());
+    fs.writeFileSync(
+      catalog.prefsPath,
+      JSON.stringify({ tts: { provider: "preference-voice-alias" } }),
+    );
+    try {
+      await catalog.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const result = await textToSpeechTelephony({
+          text: "override with configured fallback",
+          cfg: combineConfig(catalog, [override, preferred]),
+          prefsPath: catalog.prefsPath,
+          overrides: { provider: "override-voice-alias" },
+        });
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe("catalog-voice");
+        expect(result.attemptedProviders).toEqual(["override-voice", "catalog-voice"]);
+        expect(preferred.state.connections.flatMap((entry) => entry.requests)).toEqual([]);
+        for (const entry of fixtures.flatMap((fixture) => fixture.state.connections)) {
+          expect(entry.database.isOpen).toBe(false);
+          expect(entry.disposals).toBe(1);
+        }
+      });
+    } finally {
+      fixtures.forEach((fixture) => fixture.cleanup());
+    }
+  });
+
+  it("does not turn a prior override-only provider into an automatic fallback", async () => {
+    const catalog = createNativeTelephonyFixture("catalog-voice", true);
+    const override = createNativeTelephonyFixture("override-voice", false);
+    catalog.resume();
+    override.resume();
+    try {
+      await catalog.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const cfg = combineConfig(catalog, [override]);
+        const first = await textToSpeechTelephony({
+          text: "explicit override",
+          cfg,
+          prefsPath: catalog.prefsPath,
+          overrides: { provider: "override-voice-alias" },
+        });
+        expect(first.success).toBe(true);
+        expect(first.provider).toBe("override-voice");
+        const second = await textToSpeechTelephony({
+          text: "configured provider only",
+          cfg,
+          prefsPath: catalog.prefsPath,
+        });
+        expect(second.success).toBe(false);
+        expect(second.attemptedProviders).toEqual(["catalog-voice"]);
+        expect(override.state.connections.flatMap((entry) => entry.requests)).toHaveLength(1);
+        for (const entry of [...catalog.state.connections, ...override.state.connections]) {
+          expect(entry.database.isOpen).toBe(false);
+          expect(entry.disposals).toBe(1);
+        }
+      });
+    } finally {
+      catalog.cleanup();
+      override.cleanup();
+    }
+  });
+  it("resolves fallback config from the refreshed runtime snapshot without a source snapshot", async () => {
+    const primary = createNativeTelephonyFixture("refresh-primary", true);
+    const fallback = createNativeTelephonyFixture("refresh-fallback");
+    primary.state.prepareResume.resolve();
+    fallback.resume();
+    try {
+      await primary.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const base = combineConfig(primary, [fallback]);
+        const cfg: OpenClawConfig = {
+          ...base,
+          plugins: {
+            ...base.plugins,
+            entries: { [fallback.id]: { config: { voiceId: "before-refresh" } } },
+          },
+          tts: { ...base.tts, providers: { [primary.id]: {}, [fallback.id]: {} } },
+        };
+        setRuntimeConfigSnapshot(cfg);
+        const pending = settle(
+          textToSpeechTelephony({
+            text: "refresh during fallback",
+            cfg,
+            prefsPath: primary.prefsPath,
+          }),
+        );
+        try {
+          await waitForHook(primary.state.synthesizeStarted.promise, pending);
+          setRuntimeConfigSnapshot({
+            ...cfg,
+            plugins: {
+              ...cfg.plugins,
+              entries: { [fallback.id]: { config: { voiceId: "after-refresh" } } },
+            },
+          });
+          primary.state.synthesizeResume.resolve();
+          const result = await pending;
+          expect(result.error).toBeUndefined();
+          expect(result.value?.success).toBe(true);
+          expect(result.value?.attemptedProviders).toEqual([primary.id, fallback.id]);
+          expect(result.value?.providerVoice).toBe("after-refresh");
+          expect(result.value?.audioBuffer).toEqual(pcm);
+          for (const entry of [...primary.state.connections, ...fallback.state.connections]) {
+            expect(entry.database.isOpen).toBe(false);
+            expect(entry.disposals).toBe(1);
+          }
+        } finally {
+          primary.resume();
+          await pending;
+          clearRuntimeConfigSnapshot();
+        }
+      });
+    } finally {
+      primary.cleanup();
+      fallback.cleanup();
+    }
+  });
+});

--- a/src/tts/tts-telephony.ts
+++ b/src/tts/tts-telephony.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { TtsDirectiveOverrides } from "./provider-types.js";
 import { assertSpeechRuntimeAvailable } from "./runtime-availability.js";
 import type { TtsTelephonyResult } from "./tts-runtime-types.js";
-import { executeTtsProviderAttempts, resolveTtsRequestSetup } from "./tts-synthesis-support.js";
+import { executeTtsProviderAttempts, withOwnedTtsRequest } from "./tts-synthesis-support.js";
 
 export async function textToSpeechTelephony(params: {
   text: string;
@@ -12,50 +12,55 @@ export async function textToSpeechTelephony(params: {
   timeoutMs?: number;
 }): Promise<TtsTelephonyResult> {
   assertSpeechRuntimeAvailable();
-  const setup = resolveTtsRequestSetup({
-    text: params.text,
-    cfg: params.cfg,
-    prefsPath: params.prefsPath,
-    providerOverride: params.overrides?.provider,
-  });
-  if ("error" in setup) {
-    return { success: false, error: setup.error };
-  }
-
-  const { cfg, config, persona, providers } = setup;
-  return await executeTtsProviderAttempts({
-    cfg,
-    config,
-    persona,
-    providers,
-    synthesisText: params.text,
-    providerOverrides: params.overrides?.providerOverrides,
-    timeoutMs: params.timeoutMs,
-    target: "telephony",
-    logLabel: "TTS telephony",
-    requireTelephony: true,
-    selectOperation: ({ resolvedProvider }) => {
-      const synthesizeTelephony = resolvedProvider.provider.synthesizeTelephony as NonNullable<
-        typeof resolvedProvider.provider.synthesizeTelephony
-      >;
-      return {
-        kind: "ready",
-        synthesize: ({ prepared, cfg: runtimeCfg, timeoutMs }) =>
-          synthesizeTelephony({
-            text: prepared.text,
-            cfg: runtimeCfg,
-            providerConfig: prepared.providerConfig,
-            providerOverrides: prepared.providerOverrides,
-            timeoutMs,
-          }),
-      };
+  return await withOwnedTtsRequest(
+    {
+      text: params.text,
+      cfg: params.cfg,
+      prefsPath: params.prefsPath,
+      providerOverride: params.overrides?.provider,
     },
-    buildSuccess: ({ synthesis, ...metadata }) => ({
-      success: true,
-      ...metadata,
-      audioBuffer: synthesis.audioBuffer,
-      outputFormat: synthesis.outputFormat,
-      sampleRate: synthesis.sampleRate,
-    }),
-  });
+    async (setup) => {
+      if ("error" in setup) {
+        return { success: false, error: setup.error };
+      }
+
+      const { cfg, config, persona, providers } = setup;
+      return await executeTtsProviderAttempts({
+        cfg,
+        config,
+        persona,
+        providers,
+        synthesisText: params.text,
+        providerOverrides: params.overrides?.providerOverrides,
+        timeoutMs: params.timeoutMs,
+        target: "telephony",
+        logLabel: "TTS telephony",
+        requireTelephony: true,
+        prepareProviderRegistry: setup.prepareProviderRegistry,
+        selectOperation: ({ resolvedProvider }) => {
+          const synthesizeTelephony = resolvedProvider.provider.synthesizeTelephony as NonNullable<
+            typeof resolvedProvider.provider.synthesizeTelephony
+          >;
+          return {
+            kind: "ready",
+            synthesize: ({ prepared, cfg: runtimeCfg, timeoutMs }) =>
+              synthesizeTelephony({
+                text: prepared.text,
+                cfg: runtimeCfg,
+                providerConfig: prepared.providerConfig,
+                providerOverrides: prepared.providerOverrides,
+                timeoutMs,
+              }),
+          };
+        },
+        buildSuccess: ({ synthesis, ...metadata }) => ({
+          success: true,
+          ...metadata,
+          audioBuffer: synthesis.audioBuffer,
+          outputFormat: synthesis.outputFormat,
+          sampleRate: synthesis.sampleRate,
+        }),
+      });
+    },
+  );
 }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where telephony speech requests could leave newly loaded plugin resources open, or lose managed provider resources while configuration, preparation, or synthesis was still running.

## Why This Change Was Made

Own speech registrations for the complete finite telephony request, reusing the existing capability acquisition machinery. Share the canonical singular lookup policy while keeping configured catalogs separate from direct preference and override lookups; direct-only providers must not become automatic fallbacks.

Each attempt prepares its applicable configuration view. If runtime configuration refreshes while a primary provider is pending, fallback resolves the updated provider configuration while preserving the initial fallback order. Existing raw hosts, synchronous public SDK signatures, buffered synthesis and streaming retain their current contracts.

## User Impact

Telephony PCM and result metadata remain usable after cleanup. Normal provider failures remain structured results. Persona selection, voice overrides, timeouts, aliases and fallback ordering are preserved.

## Evidence

- Original production failed six native resource cases; the raw-host control passed. Eight final native cases now pass, including a configuration-refresh comparison that first exposed and then repaired stale fallback selection in the intermediate candidate.
- 265 speech, VoiceCall, capability and media siblings passed. Full eight-path checks, independent Codex review through P2 and ordinary build passed; build time was 263 seconds.
- The actual compiled public telephony runtime passed success/failure/success in cold, managed and raw modes. Genuine 8 kHz PCM was saved, decoded and round-tripped after cleanup. SQLite close markers, read-only reopening and every managed process-tree exit were verified.
- Illustrative call timings were cold 34.81/28.98/12.44 ms; managed 7.43/5.05/1.31 ms; raw 7.44/4.10/2.02 ms. These are three synthetic samples per mode, not a statistical speedup claim.
- No carrier/vendor request or real credentials were used. Upstream VoiceCall request preparation and escaping streams are separate ownership boundaries. All eight candidate files are byte-identical after rebasing onto current main.


The branch is refreshed onto the independent Telegram fixture repair in #143197. Post-refresh composition passed 111 tests covering native telephony resources/personas, capability resolution and installed-provider compatibility. The incoming provider-enablement predicate is scoped to each synchronous resolution operation; the ownership change continues to refresh configuration between attempts.
