### PR TITLE
fix(cli): reject blank accounts in read-only channel commands

### DIFF
--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -76,16 +76,19 @@ describe("channelsResolveCommand", () => {
     });
   });
 
-  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
-    await expect(
-      channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
-    ).rejects.toThrow("--account must not be blank");
+  it.each(["", " \t\n "])(
+    "rejects a blank account selector before startup: %j",
+    async (account) => {
+      await expect(
+        channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
+      ).rejects.toThrow("--account must not be blank");
 
-    expect(mocks.loadConfig).not.toHaveBeenCalled();
-    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
-    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
-    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
-  });
+      expect(mocks.loadConfig).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses installed channel plugins for explicit target resolution without installing", async () => {
     mocks.loadConfig.mockReturnValue({

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -76,6 +76,17 @@ describe("channelsResolveCommand", () => {
     });
   });
 
+  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
+    await expect(
+      channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+  });
+
   it("uses installed channel plugins for explicit target resolution without installing", async () => {
     mocks.loadConfig.mockReturnValue({
       agents: { list: [{ id: "main" }, { id: "ops" }] },

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -137,6 +137,17 @@ describe("channelsCapabilitiesCommand", () => {
     });
   });
 
+  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
+    await expect(
+      channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+  });
+
   it.each([undefined, "all"])("keeps %s capabilities listing read-only", async (channel) => {
     await channelsCapabilitiesCommand({ channel }, runtime);
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledOnce();

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -137,16 +137,19 @@ describe("channelsCapabilitiesCommand", () => {
     });
   });
 
-  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
-    await expect(
-      channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
-    ).rejects.toThrow("--account must not be blank");
+  it.each(["", " \t\n "])(
+    "rejects a blank account selector before startup: %j",
+    async (account) => {
+      await expect(
+        channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
+      ).rejects.toThrow("--account must not be blank");
 
-    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
-    expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
-    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
-    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
-  });
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([undefined, "all"])("keeps %s capabilities listing read-only", async (channel) => {
     await channelsCapabilitiesCommand({ channel }, runtime);

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -32,6 +32,7 @@ import {
   requireValidConfigFileSnapshot,
   requireValidConfigForWrite,
 } from "../config-validation.js";
+import { parseAccountSelector } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { formatChannelAccountLabel } from "./shared.js";
 
@@ -279,6 +280,7 @@ export async function channelsCapabilitiesCommand(
   opts: ChannelsCapabilitiesOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  parseAccountSelector(opts.account);
   const rawChannel = normalizeLowercaseStringOrEmpty(opts.channel);
   const canInstall = Boolean(rawChannel && rawChannel !== "all");
   const writeSnapshot = canInstall ? await requireValidConfigForWrite(runtime) : null;

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -18,6 +18,7 @@ import { danger } from "../../globals.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
+import { parseAccountSelector } from "./account-selector.js";
 
 export type ChannelsResolveOptions = {
   agent?: string;
@@ -124,6 +125,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
       `At least one entry is required. Example: ${formatCliCommand("openclaw channels resolve --channel discord <name-or-id>")}.`,
     );
   }
+  parseAccountSelector(opts.account);
 
   const loadedRaw = getRuntimeConfig();
   const requestedAgent = opts.agent?.trim();


### PR DESCRIPTION
Closes #143066

## What Problem This Solves

Fixes an issue where operators passing an empty or whitespace-only `--account` value to `openclaw channels capabilities` or `openclaw channels resolve` would enter config/plugin lookup with an unintended account scope instead of receiving the shared validation error.

## Why This Change Was Made

Both read-only channel command boundaries now reuse the existing `parseAccountSelector` owner before configuration, SecretRef, plugin, resolver, or probe work begins. Omitted and nonblank selectors retain their existing behavior; no channel plugin, config, protocol, or dependency contract changes.

## User Impact

Shell scripts with an unset account variable fail immediately with `--account must not be blank` instead of broadening capability inspection or forwarding an invalid selector. Omitting `--account` still selects the existing default/all-account behavior.

## Evidence

- Test-only baseline `8272ad3871567586f81d352c36a4c945bb38ba9a`: [secretless fork lane](https://github.com/ly85206559/openclaw/actions/runs/34339741244/job/102428720921) reproduced all four empty/whitespace failures; the other 801 tests in the lane passed.
- Exact source `eb436db578ad08b75d1f11dc89e4cced71234fc3`: [secretless fork lane](https://github.com/ly85206559/openclaw/actions/runs/34342032166/job/102435033128) passed after both command boundaries adopted the shared selector validation.
- Exact source `eb436db578ad08b75d1f11dc89e4cced71234fc3`: [upstream CI](https://github.com/openclaw/openclaw/actions/runs/34344453749) completed successfully.
- [Secretless Ubuntu CLI proof](https://github.com/ly85206559/openclaw/actions/runs/34345562564/job/102446211818) ran the real `pnpm openclaw channels capabilities` and `channels resolve` entry points. Empty and whitespace-only selectors failed with `--account must not be blank`; omitted and nonblank selectors advanced to their existing command behavior. The proof commit `5330e601515ae2f04cb59a145b0cb694d96ecb76` differs from the PR head only by the fork-only workflow.
- Targeted oxfmt with the trusted main config and `git diff --check` pass.
- Exact pending-range autoreview:

  ```sh
  python .agents/skills/autoreview/scripts/autoreview --mode branch --base a48a9f4cb98402ebc580b34aa74c32021a055876 --max-priority P3
  ```

  Result: scoped clean, no accepted/actionable P0-P3 findings; patch correct, confidence 0.95.
- No live channel, credentials, or user configuration was accessed or modified.
