### PR TITLE
feat(openai): support GPT Image 2.5 variants

### DIFF
--- a/docs/providers/openai/image-and-video.md
+++ b/docs/providers/openai/image-and-video.md
@@ -46,6 +46,55 @@ as explicit model overrides. Use `openai/gpt-image-1.5` for
 transparent-background PNG/WebP output; the current `gpt-image-2` API rejects
 `background: "transparent"`.
 
+### GPT Image 2.5
+
+Select `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst` explicitly.
+Both support generation and edits through the direct Images API.
+The default remains `openai/gpt-image-2`.
+
+Export `OPENAI_API_KEY` and select API-key authentication:
+
+```json5
+{
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        auth: "api-key",
+        models: [],
+      },
+    },
+  },
+}
+```
+
+This explicit selection matters when an OpenAI OAuth profile also exists.
+Exporting the environment variable alone does not override that profile.
+GPT Image 2.5 subscription access is not established by this API-key setup.
+
+Both variants accept `low`, `medium`, `high`, `xhigh`, `max`, or `auto` quality.
+Use PNG or WebP for transparent backgrounds. Edits accept up to 5 reference
+images through OpenClaw.
+
+```bash
+openclaw infer image generate \
+  --model openai/gpt-image-2.5-flare \
+  --prompt "A simple red circle sticker on a transparent background" \
+  --quality low --output-format webp --background transparent --json
+
+openclaw infer image edit \
+  --model openai/gpt-image-2.5-sunburst \
+  --file /path/to/reference.png \
+  --prompt "Keep the shape and change the color to blue" \
+  --quality low --size auto --json
+```
+
+`size` accepts `auto` or `WIDTHxHEIGHT`. Dimensions must be divisible by 16,
+with no edge above 3840 pixels and total pixels between 655,360 and 8,294,400.
+The aspect ratio must be between 1:3 and 3:1.
+
+### Other Image Models
+
 For a transparent-background request, call `image_generate` with
 `model: "openai/gpt-image-1.5"`, `outputFormat: "png"` or `"webp"`, and
 `background: "transparent"`; the older `openai.background` provider option is

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -299,7 +299,7 @@ and ComfyUI support 1.
     PNG/JPEG/WebP output, and transparent backgrounds with PNG or WebP.
     OpenAI accepts up to 5 reference images through OpenClaw.
 
-    Use the [explicit OpenAI API-key route](/providers/openai/image-and-video#gpt-image-25)
+    Use the [explicit OpenAI API-key route](/providers/openai/image-and-video#gpt-image-2.5)
     for direct GPT Image 2.5 requests. Exporting `OPENAI_API_KEY` alone does not
     override an existing OAuth profile. These examples do not establish
     GPT Image 2.5 subscription access.

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -75,17 +75,18 @@ internal image endpoints remain blocked by default.
 
 ## Common routes
 
-| Goal                                                 | Model ref                                          | Auth                                   |
-| ---------------------------------------------------- | -------------------------------------------------- | -------------------------------------- |
-| OpenAI image generation with API billing             | `openai/gpt-image-2`                               | `OPENAI_API_KEY`                       |
-| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                               | OpenAI ChatGPT/Codex OAuth             |
-| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                             | `OPENAI_API_KEY` or OpenAI Codex OAuth |
-| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`       | `DEEPINFRA_API_KEY`                    |
-| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                 | `FAL_KEY`                              |
-| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview` | `OPENROUTER_API_KEY`                   |
-| LiteLLM image generation                             | `litellm/gpt-image-2`                              | `LITELLM_API_KEY`                      |
-| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`              | `AZURE_OPENAI_API_KEY` or Entra ID     |
-| Google Gemini image generation                       | `google/gemini-3.1-flash-image`                    | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
+| Goal                                                 | Model ref                                                       | Auth                                   |
+| ---------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------- |
+| OpenAI image generation with API billing             | `openai/gpt-image-2`                                            | `OPENAI_API_KEY`                       |
+| OpenAI GPT Image 2.5                                 | `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst` | Explicit OpenAI API-key route          |
+| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                                            | OpenAI ChatGPT/Codex OAuth             |
+| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                                          | `OPENAI_API_KEY` or OpenAI Codex OAuth |
+| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`                    | `DEEPINFRA_API_KEY`                    |
+| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                              | `FAL_KEY`                              |
+| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview`              | `OPENROUTER_API_KEY`                   |
+| LiteLLM image generation                             | `litellm/gpt-image-2`                                           | `LITELLM_API_KEY`                      |
+| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`                           | `AZURE_OPENAI_API_KEY` or Entra ID     |
+| Google Gemini image generation                       | `google/gemini-3.1-flash-image`                                 | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
 
 The same tool handles text-to-image and reference-image editing. Use `image`
 for one reference or `images` for multiple. For Krea 2 models on fal, those
@@ -169,8 +170,9 @@ current session:
   `1:4`, `8:1`, `1:8`. Providers validate their model-specific subset.
 </ParamField>
 <ParamField path="resolution" type='"1K" | "2K" | "4K"'>Resolution hint.</ParamField>
-<ParamField path="quality" type='"low" | "medium" | "high" | "auto"'>
-  Quality hint when the provider supports it.
+<ParamField path="quality" type='"low" | "medium" | "high" | "xhigh" | "max" | "auto"'>
+  Quality hint when the model supports it. GPT Image 2.5 supports `xhigh`
+  and `max` through OpenAI.
 </ParamField>
 <ParamField path="outputFormat" type='"png" | "jpeg" | "webp"'>
   Output format hint when the provider supports it.
@@ -289,6 +291,24 @@ and ComfyUI support 1.
 ## Provider deep dives
 
 <AccordionGroup>
+  <Accordion title="GPT Image 2.5 through OpenAI">
+    Select `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst`
+    explicitly. The default remains `openai/gpt-image-2`.
+
+    Both variants support generation, edits, `xhigh` and `max` quality,
+    PNG/JPEG/WebP output, and transparent backgrounds with PNG or WebP.
+    OpenAI accepts up to 5 reference images through OpenClaw.
+
+    Use the [explicit OpenAI API-key route](/providers/openai/image-and-video#gpt-image-25)
+    for direct GPT Image 2.5 requests. Exporting `OPENAI_API_KEY` alone does not
+    override an existing OAuth profile. These examples do not establish
+    GPT Image 2.5 subscription access.
+
+    Use `size: "auto"` or valid `WIDTHxHEIGHT` dimensions. Both dimensions
+    must be divisible by 16, with no edge above 3840 pixels.
+    Total pixels must be 655,360-8,294,400, with an aspect ratio from 1:3 to 3:1.
+
+  </Accordion>
   <Accordion title="OpenAI gpt-image-2 (and gpt-image-1.5)">
     OpenAI image generation defaults to `openai/gpt-image-2`. If an
     `openai` OAuth profile is configured, OpenClaw reuses the same

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -364,6 +364,8 @@ describe("openai image generation provider", () => {
     expect(provider.defaultModel).toBe("gpt-image-2");
     expect(provider.models).toEqual([
       "gpt-image-2",
+      "gpt-image-2.5-flare",
+      "gpt-image-2.5-sunburst",
       "gpt-image-1.5",
       "gpt-image-1",
       "gpt-image-1-mini",
@@ -373,11 +375,17 @@ describe("openai image generation provider", () => {
     expect(provider.capabilities.geometry?.sizes).toContain("2160x3840");
     expect(provider.capabilities.geometry?.sizesByModel).toEqual({
       "gpt-image-2": [],
+      "gpt-image-2.5-flare": [],
+      "gpt-image-2.5-sunburst": [],
       "gpt-image-2-2026-04-21": [],
     });
     expect(provider.capabilities.output).toEqual({
       formats: ["png", "jpeg", "webp"],
       qualities: ["low", "medium", "high", "auto"],
+      qualitiesByModel: {
+        "gpt-image-2.5-flare": ["low", "medium", "high", "xhigh", "max", "auto"],
+        "gpt-image-2.5-sunburst": ["low", "medium", "high", "xhigh", "max", "auto"],
+      },
       backgrounds: ["transparent", "opaque", "auto"],
     });
   });
@@ -669,6 +677,10 @@ describe("openai image generation provider", () => {
     { model: "gpt-image-2", size: "2880x2880" },
     { model: "gpt-image-2", size: "3072x2176" },
     { model: "gpt-image-2-2026-04-21", size: "864x1536" },
+    { model: "gpt-image-2.5-flare", size: "1536x864" },
+    { model: "gpt-image-2.5-sunburst", size: "1024x640" },
+    { model: "gpt-image-2.5-flare", size: "auto" },
+    { model: "gpt-image-2.5-sunburst", size: "auto" },
   ])("preserves flexible $model generation dimensions $size", async ({ model, size }) => {
     mockGeneratedPngResponse();
 
@@ -684,6 +696,54 @@ describe("openai image generation provider", () => {
       size,
     });
     expect(result.metadata).toBeUndefined();
+  });
+
+  it.each([
+    { model: "gpt-image-2.5-flare", quality: "xhigh" as const },
+    { model: "gpt-image-2.5-sunburst", quality: "max" as const },
+  ])("uses the direct generation and edit contracts for $model", async ({ model, quality }) => {
+    mockGeneratedPngResponse();
+    const request = {
+      model,
+      quality,
+      size: "1536x864",
+      outputFormat: "webp" as const,
+      background: "transparent" as const,
+      authStore: createMixedOpenAIAuthStore(),
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              auth: "api-key" as const,
+              models: [],
+            },
+          },
+        },
+      },
+    };
+    await generateOpenAIImage("A transparent sticker", request);
+    expect(jsonRequestCall().url).toBe("https://api.openai.com/v1/images/generations");
+    expect(jsonRequestCall().body).toMatchObject({
+      model,
+      quality,
+      size: "1536x864",
+      output_format: "webp",
+      background: "transparent",
+    });
+
+    await generateOpenAIImage("Change the sticker color", {
+      ...request,
+      inputImages: [{ buffer: Buffer.from("reference"), mimeType: "image/png" }],
+    });
+    const edit = postMultipartRequestMock.mock.calls[0]?.[0];
+    expect(edit.url).toBe("https://api.openai.com/v1/images/edits");
+    expect(edit.body.get("model")).toBe(model);
+    expect(edit.body.get("quality")).toBe(quality);
+    expect(edit.body.get("size")).toBe("1536x864");
+    expect(edit.body.get("background")).toBe("transparent");
+    expect(edit.body.get("output_format")).toBe("webp");
+    expect(edit.body.getAll("image[]")).toHaveLength(1);
   });
 
   it.each(["16x16", "1024x624", "1025x1024", "3088x1024", "4096x2048", "2896x2896"])(

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -55,14 +55,18 @@ const MOCK_OPENAI_PROVIDER_ID = "mock-openai";
 const OPENAI_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const OPENAI_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const OPENAI_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const OPENAI_IMAGE_25_MODELS = ["gpt-image-2.5-flare", "gpt-image-2.5-sunburst"] as const;
+const OPENAI_IMAGE_25_QUALITIES = ["low", "medium", "high", "xhigh", "max", "auto"] as const;
 const OPENAI_IMAGE_MODELS = [
   DEFAULT_OPENAI_IMAGE_MODEL,
+  ...OPENAI_IMAGE_25_MODELS,
   OPENAI_TRANSPARENT_BACKGROUND_IMAGE_MODEL,
   "gpt-image-1",
   "gpt-image-1-mini",
 ] as const;
 const OPENAI_FLEXIBLE_IMAGE_MODELS = [
   DEFAULT_OPENAI_IMAGE_MODEL,
+  ...OPENAI_IMAGE_25_MODELS,
   "gpt-image-2-2026-04-21",
 ] as const;
 
@@ -248,6 +252,9 @@ function isValidFlexibleOpenAIImageSize(model: string, size: string | undefined)
     !OPENAI_FLEXIBLE_IMAGE_MODELS.includes(model as (typeof OPENAI_FLEXIBLE_IMAGE_MODELS)[number])
   ) {
     return false;
+  }
+  if (size === "auto") {
+    return OPENAI_IMAGE_25_MODELS.some((candidate) => candidate === model);
   }
   const dimensions = /^(\d+)x(\d+)$/.exec(size ?? "");
   if (!dimensions) {
@@ -695,6 +702,9 @@ function createOpenAIImageGenerationProviderBase(params: {
       output: {
         formats: [...OPENAI_OUTPUT_FORMATS],
         qualities: [...OPENAI_QUALITIES],
+        qualitiesByModel: Object.fromEntries(
+          OPENAI_IMAGE_25_MODELS.map((model) => [model, [...OPENAI_IMAGE_25_QUALITIES]]),
+        ),
         backgrounds: [...OPENAI_BACKGROUNDS],
       },
     },

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1611,55 +1611,58 @@ describe("createImageGenerateTool", () => {
     expect(resultDetails(overrideResult).timeoutMs).toBe(12_345);
   });
 
-  it("forwards output hints and OpenAI provider options", async () => {
-    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
-      provider: "openai",
-      model: "gpt-image-2",
-      attempts: [],
-      ignoredOverrides: [],
-      images: [
-        {
-          buffer: Buffer.from("jpg-out"),
-          mimeType: "image/jpeg",
-          fileName: "preview.jpg",
+  it.each(["low", "xhigh", "max"])(
+    "forwards %s quality and OpenAI provider options",
+    async (quality) => {
+      const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+        provider: "openai",
+        model: "gpt-image-2",
+        attempts: [],
+        ignoredOverrides: [],
+        images: [
+          {
+            buffer: Buffer.from("jpg-out"),
+            mimeType: "image/jpeg",
+            fileName: "preview.jpg",
+          },
+        ],
+      });
+      vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+        path: "/tmp/generated.jpg",
+        id: "generated.jpg",
+        size: 5,
+        contentType: "image/jpeg",
+      });
+
+      const tool = createToolWithPrimaryImageModel("openai/gpt-image-2");
+      const result = await tool.execute("call-openai-hints", {
+        prompt: "Cheap preview",
+        quality,
+        outputFormat: "jpeg",
+        openai: {
+          background: "opaque",
+          moderation: "low",
+          outputCompression: 60,
+          user: "end-user-42",
         },
-      ],
-    });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
-      path: "/tmp/generated.jpg",
-      id: "generated.jpg",
-      size: 5,
-      contentType: "image/jpeg",
-    });
+      });
 
-    const tool = createToolWithPrimaryImageModel("openai/gpt-image-2");
-    const result = await tool.execute("call-openai-hints", {
-      prompt: "Cheap preview",
-      quality: "low",
-      outputFormat: "jpeg",
-      openai: {
-        background: "opaque",
-        moderation: "low",
-        outputCompression: 60,
-        user: "end-user-42",
-      },
-    });
-
-    const generateArgs = mockCallArg(generateImage, 0, "generateImage");
-    expect(generateArgs.quality).toBe("low");
-    expect(generateArgs.outputFormat).toBe("jpeg");
-    expect(generateArgs.providerOptions).toEqual({
-      openai: {
-        background: "opaque",
-        moderation: "low",
-        outputCompression: 60,
-        user: "end-user-42",
-      },
-    });
-    const details = resultDetails(result);
-    expect(details.quality).toBe("low");
-    expect(details.outputFormat).toBe("jpeg");
-  });
+      const generateArgs = mockCallArg(generateImage, 0, "generateImage");
+      expect(generateArgs.quality).toBe(quality);
+      expect(generateArgs.outputFormat).toBe("jpeg");
+      expect(generateArgs.providerOptions).toEqual({
+        openai: {
+          background: "opaque",
+          moderation: "low",
+          outputCompression: 60,
+          user: "end-user-42",
+        },
+      });
+      const details = resultDetails(result);
+      expect(details.quality).toBe(quality);
+      expect(details.outputFormat).toBe("jpeg");
+    },
+  );
 
   it("forwards generic fal provider options", async () => {
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -73,7 +73,7 @@ const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
 const DEFAULT_MAX_INPUT_IMAGES = 10;
 const MAX_REFERENCE_IMAGE_INPUTS = 14;
-const SUPPORTED_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const SUPPORTED_QUALITIES = ["low", "medium", "high", "xhigh", "max", "auto"] as const;
 const SUPPORTED_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const SUPPORTED_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const SUPPORTED_OPENAI_MODERATIONS = ["low", "auto"] as const;
@@ -126,7 +126,7 @@ const ImageGenerateToolSchema = Type.Object({
     }),
   ),
   quality: optionalStringEnum(SUPPORTED_QUALITIES, {
-    description: "Quality: low, medium, high, auto.",
+    description: "Quality: low, medium, high, xhigh, max, auto; model-specific.",
   }),
   outputFormat: optionalStringEnum(SUPPORTED_OUTPUT_FORMATS, {
     description: "Output format: png, jpeg, webp.",

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2493,30 +2493,33 @@ describe("capability cli", () => {
     expect(generationCall?.providerOptions).toBeUndefined();
   });
 
-  it("passes image quality and OpenAI moderation hints through to generation runtime", async () => {
-    primeGeneratedImage("gpt-image-2", "draft.png");
+  it.each(["low", "xhigh", "max"])(
+    "passes %s image quality and OpenAI moderation through to runtime",
+    async (quality) => {
+      primeGeneratedImage("gpt-image-2", "draft.png");
 
-    await runCapability(
-      "image",
-      "generate",
-      "--prompt",
-      "low-cost draft",
-      "--quality",
-      "low",
-      "--openai-moderation",
-      "low",
-      "--json",
-    );
+      await runCapability(
+        "image",
+        "generate",
+        "--prompt",
+        "low-cost draft",
+        "--quality",
+        quality,
+        "--openai-moderation",
+        "low",
+        "--json",
+      );
 
-    const generationCall = firstImageGenerationCall();
-    expect(generationCall?.prompt).toBe("low-cost draft");
-    expect(generationCall?.quality).toBe("low");
-    expect(generationCall?.providerOptions).toEqual({
-      openai: {
-        moderation: "low",
-      },
-    });
-  });
+      const generationCall = firstImageGenerationCall();
+      expect(generationCall?.prompt).toBe("low-cost draft");
+      expect(generationCall?.quality).toBe(quality);
+      expect(generationCall?.providerOptions).toEqual({
+        openai: {
+          moderation: "low",
+        },
+      });
+    },
+  );
 
   it("passes image output format, quality, and OpenAI hints through to edit runtime", async () => {
     primeGeneratedImage("gpt-image-1.5", "transparent-edit.png");
@@ -2644,7 +2647,7 @@ describe("capability cli", () => {
       ),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--quality must be one of low, medium, high, or auto",
+      "--quality must be one of low, medium, high, xhigh, max, or auto",
     );
 
     mocks.runtime.error.mockClear();

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -44,7 +44,7 @@ import {
 
 const IMAGE_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const IMAGE_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
-const IMAGE_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const IMAGE_QUALITIES = ["low", "medium", "high", "xhigh", "max", "auto"] as const;
 const IMAGE_MODERATIONS = ["low", "auto"] as const;
 const parseImageOption = createEnumOptionParser();
 
@@ -247,7 +247,7 @@ function addImageGenerationOptions(command: Command): Command {
     .option("--background <value>", "Background hint: transparent, opaque, or auto")
     .option("--openai-background <value>", "OpenAI background hint: transparent, opaque, or auto")
     .option("--openai-moderation <value>", "OpenAI moderation hint: low or auto")
-    .option("--quality <value>", "Quality hint: low, medium, high, or auto")
+    .option("--quality <value>", "Quality hint: low, medium, high, xhigh, max, or auto")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
     .option("--output <path>", "Output path")
     .option(

--- a/src/image-generation/normalization.ts
+++ b/src/image-generation/normalization.ts
@@ -60,8 +60,11 @@ export function resolveImageGenerationOverrides(params: {
   });
   const ignoredOverrides: ImageGenerationIgnoredOverride[] = sanitized.ignoredOverrides;
   let { quality, outputFormat, background } = params;
+  const output = params.provider.capabilities.output;
+  const qualities =
+    (params.model ? output?.qualitiesByModel?.[params.model] : undefined) ?? output?.qualities;
 
-  if (quality && !(params.provider.capabilities.output?.qualities ?? []).includes(quality)) {
+  if (quality && !(qualities ?? []).includes(quality)) {
     ignoredOverrides.push({ key: "quality", value: quality });
     quality = undefined;
   }

--- a/src/image-generation/runtime.output-capabilities.test.ts
+++ b/src/image-generation/runtime.output-capabilities.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { generateImage } from "./runtime.js";
+import type { ImageGenerationProvider } from "./types.js";
+
+describe("image-generation output capabilities", () => {
+  it.each([
+    { model: "extended", accepted: true },
+    { model: "legacy", accepted: false },
+    { model: "restricted", accepted: false },
+  ])("filters quality against $model model capabilities", async ({ model, accepted }) => {
+    let seenQuality: string | undefined;
+    const provider: ImageGenerationProvider = {
+      id: "test",
+      capabilities: {
+        generate: {},
+        edit: { enabled: true },
+        output: {
+          qualities: ["low"],
+          qualitiesByModel: { extended: ["xhigh", "max"], restricted: [] },
+        },
+      },
+      async generateImage(req) {
+        seenQuality = req.quality;
+        return { images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }] };
+      },
+    };
+    const result = await generateImage(
+      {
+        cfg: {},
+        modelOverride: `test/${model}`,
+        prompt: "A sticker",
+        quality: "max",
+      },
+      {
+        getProvider: (id) => (id === provider.id ? provider : undefined),
+        listProviders: () => [provider],
+      },
+    );
+    expect(seenQuality).toBe(accepted ? "max" : undefined);
+    expect(result.ignoredOverrides).toEqual(accepted ? [] : [{ key: "quality", value: "max" }]);
+  });
+});

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -15,7 +15,7 @@ export type GeneratedImageAsset = {
 
 export type ImageGenerationResolution = "1K" | "2K" | "4K";
 
-export type ImageGenerationQuality = "low" | "medium" | "high" | "auto";
+export type ImageGenerationQuality = "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 
 export type ImageGenerationOutputFormat = "png" | "jpeg" | "webp";
 
@@ -113,6 +113,7 @@ type ImageGenerationGeometryCapabilities = {
 
 type ImageGenerationOutputCapabilities = {
   qualities?: ImageGenerationQuality[];
+  qualitiesByModel?: Record<string, ImageGenerationQuality[]>;
   formats?: ImageGenerationOutputFormat[];
   backgrounds?: ImageGenerationBackground[];
 };


### PR DESCRIPTION
Related: #143007

<details>
<summary>Additional instructions</summary>

Same-repository branch; maintainers with repository write access can update it.

</details>

## What Problem This Solves

Operators cannot select GPT Image 2.5 Flare or Sunburst with the full supported quality and flexible-size controls through the OpenAI plugin, CLI, and image-generation tool.

## Why This Change Was Made

Adds the two canonical OpenAI model IDs through the existing direct Images API generation and edit paths. A narrow model-specific quality capability enables `xhigh` and `max` only for the new models. Their valid custom dimensions and `auto` sizing use the existing geometry normalization flow.

The `gpt-image-2` default, five-reference cap, four-output cap, and existing authentication routing remain unchanged. No Fal, configuration, dependency, mask, or input-fidelity changes. Fal support is a separate stacked draft, [#143069](https://github.com/openclaw/openclaw/pull/143069), with authenticated live validation pending; this PR intentionally does not close the shared issue.

## User Impact

Operators can select `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst` through the existing CLI and `image_generate` tool. Documentation covers explicit API-key selection when an OAuth profile also exists. This does not claim GPT Image 2.5 subscription entitlement.

Release-note context: support GPT Image 2.5 Flare and Sunburst through the direct OpenAI Images API, including generation, edits, flexible sizes, `xhigh`/`max` quality, and transparent PNG/WebP output.

## Evidence

- Contract: [OpenAI image-generation guide](https://developers.openai.com/api/docs/guides/image-generation).
- Current head `600abdea67c64eecaad77ba81f66891a6b96d0a2`, tree `d88b96bbf35443a413f9a074cf226a0671732da2`, fixed base `e11c7a657334de9bac47908cc28677b6fdd59a94`. The rebase preserves main's provider acquisition and execution-helper extraction; the tool differs from that base only in its quality enum and description.
- Final-head Blacksmith Testbox focused proof passed all five routed Vitest shards: `pnpm test extensions/openai/image-generation-provider.test.ts extensions/fal/image-generation-provider.test.ts src/image-generation/runtime.test.ts src/image-generation/runtime.output-capabilities.test.ts src/image-generation/capabilities.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/image-generate-tool.resources.test.ts src/cli/capability-cli.test.ts`. Linux, Node 24.19.0, pnpm 12.3.4. Source, tree, and all changed-file hashes were verified before execution.
- Exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34345023248) and `openclaw/ci-gate` passed, covering the required checks and published build. `node scripts/watch-pr-ci.mjs 143068 600abdea67c64eecaad77ba81f66891a6b96d0a2` returned `GREEN`, exit 0; superseded nonrequired cancellations are not failed current checks.
- The additional Testbox `node scripts/check-changed.mjs --base origin/main` invocation was stopped during core test-type checking after exact-head hosted CI became green. Its completed formatting/core-type checks are useful supplemental proof, but the partial invocation is not claimed as a complete gate or build pass. The lease is completed; hosted CI supplies the complete required gate/build evidence.
- `git diff --check` and all 11 changed files' `oxfmt` checks pass. Docs config-fence validation passed; documentation lint has no increase over the existing baseline. Fresh exact-head direct-only autoreview reports no actionable P0-P2 findings.
- The publisher parser verifies the corrected `gpt-image-2.5` heading and cross-link. The full anchor audit remains non-green on 42 unrelated findings: external ClawHub mirror routes and the existing `windows-app-node` maturity anchor. None are in the changed pages; these are separate docs follow-ups.
- Exact-head authenticated live refresh passed all four cells through the real `generateImage` runtime and OpenAI provider, using the explicit API-key route, isolated configuration, one image per request, and a synthetic edit reference. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34345012034): source `600abdea67c64eecaad77ba81f66891a6b96d0a2`, tree `d88b96bbf35443a413f9a074cf226a0671732da2`, carrier `9f9006a4f9cf86a91c74bdfc688589bb93fd0a81`. Before calls, all 11 source files matched the ordered SHA-256 list digest `b369a3438a8cb67bc18a3966435a26555c36514c7822194cbcb05c9c0b0eacbe`; wrapper exit 0. All outputs decoded as 1024x1024 with nonempty bytes and a blue center; both edits changed the synthetic red square to blue. No generated media is committed.
- The single rebase conflict is resolved without restoring removed execution code. `src/agents/tools/image-generate-tool.resources.test.ts` passed, covering main's admission, persistence, rollback, and release invariants. Independent exact-head delta review is clean. [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/143068#issuecomment-5601130720) has no findings or before-merge actions.
- Production delta: +14 net lines; tests: +108; docs: +69. The production growth adds the model catalog entries and the generic model-quality capability without adding unused Fal-specific seams.

| Live cell | Quality | Verified format | Bytes |
| --- | --- | --- | ---: |
| Flare generation | low | PNG | 740828 |
| Flare edit | low | PNG | 706139 |
| Sunburst generation | xhigh | WebP, alpha and transparent corner verified | 128312 |
| Sunburst edit | low | PNG | 706681 |
