### PR TITLE
fix(tests): close skill-upload fixture database handles

### DIFF
--- a/src/gateway/server-methods/skills-upload.test.ts
+++ b/src/gateway/server-methods/skills-upload.test.ts
@@ -10,10 +10,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import {
-  createOpenClawTestState,
-  type OpenClawTestState,
-} from "../../test-utils/openclaw-test-state.js";
+import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 const agentScopeState = vi.hoisted(() => ({
@@ -78,6 +75,9 @@ async function makeHarness(): Promise<{
   stateDir: string;
   workspaceDir: string;
 }> {
+  // Bind fixture cleanup to the same module generation as the handlers.
+  vi.resetModules();
+  const { createOpenClawTestState } = await import("../../test-utils/openclaw-test-state.js");
   const testState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-skill-upload-handler-",
@@ -86,7 +86,6 @@ async function makeHarness(): Promise<{
   const stateDir = testState.stateDir;
   const workspaceDir = testState.workspaceDir;
   agentScopeState.workspaceDir = workspaceDir;
-  vi.resetModules();
   const { skillsHandlers } = await import("./skills.js");
   return { handlers: skillsHandlers, stateDir, workspaceDir };
 }


### PR DESCRIPTION
## What Problem This Solves

The ordinary successful skill-upload test passed while leaving its dynamically loaded shared-state database open after fixture cleanup returned. Its fixture and closer came from the initial module graph, but `makeHarness` reset modules before loading the handlers and their separate database cache.

## Why This Change Was Made

Reset modules before acquiring the fixture, then load the existing fixture helper and handlers from that same generation. Each fixture now owns the cleanup functions for the database its handlers open. Keep the static database opener and closer used by existing SQL assertions, and keep fixture tracking before the awaited handler import.

## User Impact

No production behavior changes. This test-fixture repair closes observed database handles before removing temporary state. All test inputs, assertions and timers remain unchanged; the diff removes one net test line.

## Evidence

- The original ordinary successful-upload diagnostic passed, yet its actual dynamic database handle remained open after normal cleanup returned. The initial-generation handle was already closed.
- The same ordinary case on the repair observed the dynamic handle open before cleanup and closed afterward, before any diagnostic safety-close or unlink. Safety-close changed nothing; WAL/SHM were already absent and the fixture root was removed normally.
- The repaired complete existing owner suite passed all 10 cases. Parser-aware checks verify every case body, assertion, static SQL oracle and original closer is unchanged.
- Mapped changed gate, deslop and fresh P2 review passed. Diagnostics captured only naturally opened, fixture-owned state handles; no proactive database opens or timer changes.

This suite is Gateway-methods. The result does not attribute a historical Gateway-core failure or claim global runtime savings.
