### PR TITLE
fix(test): wait for compaction entry before racing session changes

### DIFF
--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { closeGatewayTestWebSocket } from "../../test/helpers/gateway-websocket.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { QueuedCompactionHostOptions } from "../agents/embedded-agent-runner/compact.queued-execution.js";
 import { acceptCompactionSuccessor } from "../agents/embedded-agent-runner/compaction-successor.js";
@@ -66,6 +67,42 @@ const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
   setupGatewaySessionsTestHarness();
 
 type CheckpointFixture = Awaited<ReturnType<typeof createCheckpointFixture>>;
+
+type HeldCompactionResult = {
+  ok: true;
+  compacted: true;
+  result: {
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    tokensAfter: number;
+    sessionId?: string;
+  };
+};
+
+function holdCompaction(result: HeldCompactionResult) {
+  const entered = createDeferred();
+  const terminal = createDeferred<HeldCompactionResult>();
+  embeddedRunMock.compactEmbeddedAgentSession.mockImplementationOnce(() => {
+    entered.resolve();
+    return terminal.promise;
+  });
+  return {
+    release: () => terminal.resolve(result),
+    waitForEntry: async (compactResult: Promise<unknown>) => {
+      // Admission can outlast waitFor's default; only backend entry makes the held result ready.
+      await Promise.race([
+        entered.promise,
+        compactResult.then((response) => {
+          throw new Error(
+            `Compaction RPC completed before backend entry: ${JSON.stringify(response)}`,
+          );
+        }),
+      ]);
+      expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
+    },
+  };
+}
 
 function buildSessionTranscriptLines(sessionId: string, totalLines: number): string[] {
   const header = JSON.stringify({
@@ -1290,30 +1327,7 @@ test("sessions.compact rejects stale terminal persistence after the session chan
     storePath,
     totalLines: 3,
   });
-  const compaction = createDeferred<{
-    ok: true;
-    compacted: true;
-    result: {
-      summary: string;
-      firstKeptEntryId: string;
-      tokensBefore: number;
-      tokensAfter: number;
-      sessionId: string;
-    };
-  }>();
-  embeddedRunMock.compactEmbeddedAgentSession.mockReturnValueOnce(compaction.promise);
-
-  const { ws } = await openClient();
-  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
-  await vi.waitFor(() => {
-    expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
-  });
-  await seedSessionEntry({
-    entry: sessionStoreEntry("sess-replacement"),
-    sessionKey: "agent:main:main",
-    storePath,
-  });
-  compaction.resolve({
+  const compaction = holdCompaction({
     ok: true,
     compacted: true,
     result: {
@@ -1325,15 +1339,30 @@ test("sessions.compact rejects stale terminal persistence after the session chan
     },
   });
 
-  const response = await compactResult;
-  expect(response.ok).toBe(false);
-  expect(response.error).toMatchObject({
-    details: { reason: "session-changed" },
-  });
-  const replacedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
-  expect(replacedEntry?.sessionId).toBe("sess-replacement");
-  expect(replacedEntry?.compactionCount).toBeUndefined();
-  ws.close();
+  const { ws } = await openClient();
+  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
+  try {
+    await compaction.waitForEntry(compactResult);
+    await seedSessionEntry({
+      entry: sessionStoreEntry("sess-replacement"),
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+    compaction.release();
+
+    const response = await compactResult;
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatchObject({
+      details: { reason: "session-changed" },
+    });
+    const replacedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+    expect(replacedEntry?.sessionId).toBe("sess-replacement");
+    expect(replacedEntry?.compactionCount).toBeUndefined();
+  } finally {
+    compaction.release();
+    await Promise.allSettled([compactResult]);
+    await closeGatewayTestWebSocket(ws);
+  }
 });
 
 test("sessions.reset waits for terminal compaction before replacing the session", async () => {
@@ -1349,35 +1378,7 @@ test("sessions.reset waits for terminal compaction before replacing the session"
     storePath,
     totalLines: 3,
   });
-  const compaction = createDeferred<{
-    ok: true;
-    compacted: true;
-    result: {
-      summary: string;
-      firstKeptEntryId: string;
-      tokensBefore: number;
-      tokensAfter: number;
-    };
-  }>();
-  embeddedRunMock.compactEmbeddedAgentSession.mockReturnValueOnce(compaction.promise);
-
-  const { ws } = await openClient();
-  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
-  await vi.waitFor(() => {
-    expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
-  });
-  let resetSettled = false;
-  const resetResult = rpcReq<{ entry: { sessionId: string } }>(ws, "sessions.reset", {
-    key: "main",
-  }).finally(() => {
-    resetSettled = true;
-  });
-  await new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-  expect(resetSettled).toBe(false);
-
-  compaction.resolve({
+  const compaction = holdCompaction({
     ok: true,
     compacted: true,
     result: {
@@ -1387,14 +1388,36 @@ test("sessions.reset waits for terminal compaction before replacing the session"
       tokensAfter: 80,
     },
   });
-  expect((await compactResult).ok).toBe(true);
-  const reset = await resetResult;
-  expect(reset.ok).toBe(true);
-  const resetSessionId = reset.payload?.entry.sessionId;
-  expect(resetSessionId).toBe("sess-compact-reset");
-  const resetEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
-  expect(resetEntry?.sessionId).toBe(resetSessionId);
-  ws.close();
+
+  const { ws } = await openClient();
+  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
+  let resetResult: ReturnType<typeof rpcReq<{ entry: { sessionId: string } }>> | undefined;
+  try {
+    await compaction.waitForEntry(compactResult);
+    let resetSettled = false;
+    resetResult = rpcReq<{ entry: { sessionId: string } }>(ws, "sessions.reset", {
+      key: "main",
+    }).finally(() => {
+      resetSettled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(resetSettled).toBe(false);
+
+    compaction.release();
+    expect((await compactResult).ok).toBe(true);
+    const reset = await resetResult;
+    expect(reset.ok).toBe(true);
+    const resetSessionId = reset.payload?.entry.sessionId;
+    expect(resetSessionId).toBe("sess-compact-reset");
+    const resetEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+    expect(resetEntry?.sessionId).toBe(resetSessionId);
+  } finally {
+    compaction.release();
+    await Promise.allSettled([compactResult, resetResult]);
+    await closeGatewayTestWebSocket(ws);
+  }
 });
 
 test("sessions.compaction.restore waits for terminal compaction before replacing the session", async () => {
@@ -1428,36 +1451,7 @@ test("sessions.compaction.restore waits for terminal compaction before replacing
     sessionKey: "agent:main:main",
     storePath,
   });
-  const compaction = createDeferred<{
-    ok: true;
-    compacted: true;
-    result: {
-      summary: string;
-      firstKeptEntryId: string;
-      tokensBefore: number;
-      tokensAfter: number;
-    };
-  }>();
-  embeddedRunMock.compactEmbeddedAgentSession.mockReturnValueOnce(compaction.promise);
-
-  const { ws } = await openClient();
-  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
-  await vi.waitFor(() => {
-    expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
-  });
-  let restoreSettled = false;
-  const restoreResult = rpcReq<{ sessionId: string }>(ws, "sessions.compaction.restore", {
-    key: "main",
-    checkpointId: "checkpoint-race",
-  }).finally(() => {
-    restoreSettled = true;
-  });
-  await new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-  expect(restoreSettled).toBe(false);
-
-  compaction.resolve({
+  const compaction = holdCompaction({
     ok: true,
     compacted: true,
     result: {
@@ -1467,12 +1461,35 @@ test("sessions.compaction.restore waits for terminal compaction before replacing
       tokensAfter: 45,
     },
   });
-  expect((await compactResult).ok).toBe(true);
-  const restored = await restoreResult;
-  expect(restored.ok, JSON.stringify(restored)).toBe(true);
-  expect(restored.payload?.sessionId).toBeTruthy();
-  expect(restored.payload?.sessionId).not.toBe(fixture.sessionId);
-  ws.close();
+
+  const { ws } = await openClient();
+  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
+  let restoreResult: ReturnType<typeof rpcReq<{ sessionId: string }>> | undefined;
+  try {
+    await compaction.waitForEntry(compactResult);
+    let restoreSettled = false;
+    restoreResult = rpcReq<{ sessionId: string }>(ws, "sessions.compaction.restore", {
+      key: "main",
+      checkpointId: "checkpoint-race",
+    }).finally(() => {
+      restoreSettled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(restoreSettled).toBe(false);
+
+    compaction.release();
+    expect((await compactResult).ok).toBe(true);
+    const restored = await restoreResult;
+    expect(restored.ok, JSON.stringify(restored)).toBe(true);
+    expect(restored.payload?.sessionId).toBeTruthy();
+    expect(restored.payload?.sessionId).not.toBe(fixture.sessionId);
+  } finally {
+    compaction.release();
+    await Promise.allSettled([compactResult, restoreResult]);
+    await closeGatewayTestWebSocket(ws);
+  }
 });
 
 test("sessions.compaction.restore leaves replacement-session work untouched when queued state is stale", async () => {
@@ -1560,39 +1577,7 @@ test("sessions.compact blocks new work admission through terminal persistence", 
     storePath,
     totalLines: 3,
   });
-  const compaction = createDeferred<{
-    ok: true;
-    compacted: true;
-    result: {
-      summary: string;
-      firstKeptEntryId: string;
-      tokensBefore: number;
-      tokensAfter: number;
-    };
-  }>();
-  embeddedRunMock.compactEmbeddedAgentSession.mockReturnValueOnce(compaction.promise);
-
-  const { ws } = await openClient();
-  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
-  await vi.waitFor(() => {
-    expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
-  });
-
-  let admitted = false;
-  const pendingAdmission = beginSessionWorkAdmission({
-    scope: storePath,
-    identities: ["agent:main:main", sessionId],
-    assertAllowed: () => {},
-  }).then((lease) => {
-    admitted = true;
-    return lease;
-  });
-  await new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-  expect(admitted).toBe(false);
-
-  compaction.resolve({
+  const compaction = holdCompaction({
     ok: true,
     compacted: true,
     result: {
@@ -1602,14 +1587,39 @@ test("sessions.compact blocks new work admission through terminal persistence", 
       tokensAfter: 80,
     },
   });
-  expect((await compactResult).ok).toBe(true);
-  const admission = await pendingAdmission;
+
+  const { ws } = await openClient();
+  const compactResult = rpcReq(ws, "sessions.compact", { key: "main" });
+  let pendingAdmission: ReturnType<typeof beginSessionWorkAdmission> | undefined;
   try {
+    await compaction.waitForEntry(compactResult);
+
+    let admitted = false;
+    pendingAdmission = beginSessionWorkAdmission({
+      scope: storePath,
+      identities: ["agent:main:main", sessionId],
+      assertAllowed: () => {},
+    }).then((lease) => {
+      admitted = true;
+      return lease;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(admitted).toBe(false);
+
+    compaction.release();
+    expect((await compactResult).ok).toBe(true);
+    await pendingAdmission;
     expect(admitted).toBe(true);
   } finally {
-    admission.release();
+    compaction.release();
+    await Promise.allSettled([
+      compactResult,
+      pendingAdmission?.then((admission) => admission.release()),
+    ]);
+    await closeGatewayTestWebSocket(ws);
   }
-  ws.close();
 });
 
 test("sessions.compact returns a no-op without interrupting an active admission", async () => {
@@ -1932,36 +1942,7 @@ test("sessions.patch waits for terminal compaction before archiving the session"
     storePath,
     totalLines: 3,
   });
-  const compaction = createDeferred<{
-    ok: true;
-    compacted: true;
-    result: {
-      summary: string;
-      firstKeptEntryId: string;
-      tokensBefore: number;
-      tokensAfter: number;
-    };
-  }>();
-  embeddedRunMock.compactEmbeddedAgentSession.mockReturnValueOnce(compaction.promise);
-
-  const { ws } = await openClient();
-  const compactResult = rpcReq(ws, "sessions.compact", { key: sessionKey });
-  await vi.waitFor(() => {
-    expect(embeddedRunMock.compactEmbeddedAgentSession).toHaveBeenCalledTimes(1);
-  });
-  let archiveSettled = false;
-  const archiveResult = rpcReq(ws, "sessions.patch", {
-    key: sessionKey,
-    archived: true,
-    expectedSessionId: "sess-compact-archive",
-  }).then((result) => {
-    archiveSettled = true;
-    return result;
-  });
-  await Promise.resolve();
-  expect(archiveSettled).toBe(false);
-
-  compaction.resolve({
+  const compaction = holdCompaction({
     ok: true,
     compacted: true,
     result: {
@@ -1971,9 +1952,32 @@ test("sessions.patch waits for terminal compaction before archiving the session"
       tokensAfter: 80,
     },
   });
-  expect((await compactResult).ok).toBe(true);
-  expect((await archiveResult).ok).toBe(true);
-  ws.close();
+
+  const { ws } = await openClient();
+  const compactResult = rpcReq(ws, "sessions.compact", { key: sessionKey });
+  let archiveResult: ReturnType<typeof rpcReq> | undefined;
+  try {
+    await compaction.waitForEntry(compactResult);
+    let archiveSettled = false;
+    archiveResult = rpcReq(ws, "sessions.patch", {
+      key: sessionKey,
+      archived: true,
+      expectedSessionId: "sess-compact-archive",
+    }).then((result) => {
+      archiveSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(archiveSettled).toBe(false);
+
+    compaction.release();
+    expect((await compactResult).ok).toBe(true);
+    expect((await archiveResult).ok).toBe(true);
+  } finally {
+    compaction.release();
+    await Promise.allSettled([compactResult, archiveResult]);
+    await closeGatewayTestWebSocket(ws);
+  }
 });
 
 test("sessions.compact maxLines trims SQLite transcript rows without creating a transcript archive", async () => {


### PR DESCRIPTION
## What Problem This Solves

Gateway compaction race tests can fail before reaching their session-ownership assertions because they give backend admission only one second. [Main CI](https://github.com/openclaw/openclaw/actions/runs/34340643015/job/102431987005) hit the zero-call assertion in the stale-terminal-persistence case.

## Why This Change Was Made

A shared local fixture now signals entry from the existing held compaction mock. The five related race tests wait for that signal, while an early RPC response or rejection fails promptly. This preserves the intended order: backend entry, competing session action, terminal completion, then assertions.

Each fixture also releases its held result, joins the compact RPC and any secondary operation or admission lease, and closes the WebSocket in `finally`. The original terminal payloads, exact one-call checks, stale-persistence checks, and reset/restore/admission/archive assertions remain.

## User Impact

More reliable CI without an arbitrary one-second readiness poll or leaked fixture work after an assertion failure. Production code, mock scope, RPC/test deadlines, and shard settings are unchanged. Test delta is +180/-176 (net +4), mostly moving existing payloads and adding cleanup blocks.

## Evidence

- A temporary existing session-lifecycle blocker scheduled release 1,250ms after the real RPC started. The original poll failed with the CI symptom (`expected 1 call, got 0`) in 1,439ms. The candidate passed under the same scheduled delay in 1,628ms, including every stale-session assertion. Both runs released and joined their controlled work.
- The delay was removed before final proof. All 37 original file cases passed on Node 24.19.0 / pnpm 12.3.4 in 35.86s. The five changed cases took 148/330/205/147/312ms.
- Required changed checks passed, including core-test types, lint, guards, and dead-export scans. Independent managed P2 review found no actionable findings.
- The controlled reproduction establishes the readiness defect; the historical CI log does not distinguish delayed admission from an early RPC response. The new fixture handles both explicitly.
- [Exact-head PR CI](https://github.com/openclaw/openclaw/actions/runs/34345213430) passed in 6m58s. The Linux changed-test job passed all 37 cases, with the previously failing case at 203ms; changed boundary checks also passed. No CI retry was needed.
- No production or native Codex implementation change is claimed.
