### PR TITLE
fix: only label scheduled heartbeat alerts

### DIFF
--- a/src/infra/heartbeat-dispatch.ts
+++ b/src/infra/heartbeat-dispatch.ts
@@ -468,8 +468,12 @@ async function prepareHeartbeatDispatchReply(
   }
   policy.deliverySilent = normalized.silent;
   policy.projectTarget = !failed;
+  const isScheduledHeartbeat = wakeSource === undefined || wakeSource === "interval";
   const deliveryText =
-    !failed && delivery.implicitDefaultRoute && stateEntry?.lastHeartbeatSentAt === undefined
+    !failed &&
+    isScheduledHeartbeat &&
+    delivery.implicitDefaultRoute &&
+    stateEntry?.lastHeartbeatSentAt === undefined
       ? `${FIRST_HEARTBEAT_ALERT_PREAMBLE}\n${text}`
       : text;
   const payload = copyReplyPayloadMetadata(selected ?? {}, {
@@ -486,7 +490,7 @@ async function prepareHeartbeatDispatchReply(
       if (!sent) {
         unconfirmed(policy.deliveryError ?? policy.deliveryReason ?? result);
       }
-      if (sent && !failed && deliveryText.trim()) {
+      if (sent && !failed && isScheduledHeartbeat && deliveryText.trim()) {
         await patchSessionEntryCore(
           { agentId, storePath, sessionKey: stateKey },
           (current, context) =>

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1201,6 +1201,61 @@ describe("runHeartbeatOnce", () => {
     expect(store[isolatedSessionKey]?.lastHeartbeatText).toBeUndefined();
   });
 
+  it("does not let an event-driven owner delivery consume the first heartbeat alert", async () => {
+    const tmpDir = await createCaseDir("hb-owner-event-no-preamble");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: tmpDir, heartbeat: { every: "5m" } },
+      },
+      commands: { ownerAllowFrom: ["+15555550166"] },
+      channels: { whatsapp: { allowFrom: ["+15555550166"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await seedWhatsAppSession(storePath, sessionKey);
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+    const replySpy = vi
+      .fn()
+      .mockResolvedValueOnce({ text: "Backup completed" })
+      .mockResolvedValueOnce({ text: "Service needs attention" });
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    await runHeartbeatOnce({
+      cfg,
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      sessionKey,
+      deps: createHeartbeatDeps(sendWhatsApp, { nowMs: 1, getReplyFromConfig: replySpy }),
+    });
+
+    expectWhatsAppSendCall(sendWhatsApp, 0, {
+      to: "+15555550166",
+      text: "Backup completed",
+    });
+    let store = readSessionStoreForTest(storePath);
+    expect(store[sessionKey]?.lastHeartbeatSentAt).toBeUndefined();
+
+    await runHeartbeatOnce({
+      cfg,
+      deps: createHeartbeatDeps(sendWhatsApp, { nowMs: 2, getReplyFromConfig: replySpy }),
+    });
+
+    expectWhatsAppSendCall(sendWhatsApp, 1, {
+      to: "+15555550166",
+      text: 'First heartbeat alert: your bot runs periodic background checks and messages you only when something needs attention. Set agents.defaults.heartbeat.target: "none" to keep these internal.\nService needs attention',
+    });
+    store = readSessionStoreForTest(storePath);
+    expect(store[sessionKey]).toMatchObject({
+      lastHeartbeatText: "Service needs attention",
+      lastHeartbeatSentAt: 2,
+    });
+  });
+
   it("uses per-agent heartbeat overrides and session keys", async () => {
     const tmpDir = await createCaseDir("hb-agent-overrides");
     const storePath = path.join(tmpDir, "sessions.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving an event-driven completion through the heartbeat dispatcher could see it mislabeled as their “First heartbeat alert.” The same event delivery could also consume the state marker, preventing the next genuine scheduled heartbeat alert from receiving the onboarding context.

## Why This Change Was Made

The first-alert preamble and its persisted delivery markers now apply only to scheduled heartbeat runs: explicit `interval` wakes and the existing source-less scheduled compatibility path. Explicit event, manual, hook, and other non-scheduled wakes keep their original text and do not advance scheduled-heartbeat onboarding or dedupe state.

A regression test covers the user-visible sequence: an exec completion is delivered unchanged and leaves heartbeat state unset; the following scheduled heartbeat receives the first-alert preamble and persists its state.

## User Impact

Background task and event completion messages are no longer presented as heartbeat onboarding alerts. Users still receive the onboarding explanation on their first genuine scheduled heartbeat alert.

## Evidence

- Regression demonstrated red on unmodified main: the event-driven delivery included the first-heartbeat preamble.
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.structured-delivery.test.ts src/infra/heartbeat-runner.isolated-session-mirror.test.ts` — 83 passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/heartbeat-dispatch.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — 0 warnings, 0 errors.
- `pnpm exec oxfmt --check src/infra/heartbeat-dispatch.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — passed.
- `git diff --check` — passed.
- Independent P0/P1 targeted review — clean after two identified state-ownership edge cases were fixed.

Full local core/test typecheck did not produce a terminal result: one attempt encountered a stale artifact lock left by an interrupted check, and a subsequent run exceeded the local tool timeout. Exact-head CI remains the source of truth for the complete typecheck lanes.


## Production reproduction (2026-09-10)

A real Telegram DM on the contributor's OpenClaw `2026.9.3` runtime reproduced the reported pre-fix behavior at `2026-09-10 15:16:08 GMT+8`.

A background `openclaw doctor` completion was delivered through the heartbeat path and incorrectly received the scheduled-heartbeat onboarding prefix:

```text
First heartbeat alert: your bot runs periodic background checks and messages you only when something needs attention. Set agents.defaults.heartbeat.target: "none" to keep these internal.
补充检查结果：`openclaw doctor` 未成功跑完（退出码 1）……
```

This is user-visible production evidence for the bug mechanism: a background/event completion can be mislabeled as the first scheduled heartbeat alert. It supplements the red-on-main regression test. It is intentionally not claimed as exact-head after-fix proof; the remaining acceptance proof is the bounded Telegram Test Server sequence on `8bc954f7c103b8fa5512e3449acb09c58e1ed42a`: event delivery without onboarding or marker consumption, followed by the first scheduled alert with onboarding, then a later scheduled alert without repeated onboarding.
