### PR TITLE
refactor(tests): consolidate xAI SecretRef configuration fixtures

### DIFF
--- a/extensions/xai/src/tool-auth-shared.test.ts
+++ b/extensions/xai/src/tool-auth-shared.test.ts
@@ -8,6 +8,20 @@ import {
   resolveXaiToolApiKeyWithAuth,
 } from "./tool-auth-shared.js";
 
+function xaiWebSearchSecretRefPlugins(source: "env" | "file", provider: string, id: string) {
+  return {
+    entries: {
+      xai: {
+        config: {
+          webSearch: {
+            apiKey: { source, provider, id },
+          },
+        },
+      },
+    },
+  };
+}
+
 describe("xai tool auth helpers", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -133,21 +147,7 @@ describe("xai tool auth helpers", () => {
     await expect(
       resolveXaiToolApiKeyWithAuth({
         sourceConfig: {
-          plugins: {
-            entries: {
-              xai: {
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "file",
-                      provider: "vault",
-                      id: "/xai/tool-key",
-                    },
-                  },
-                },
-              },
-            },
-          },
+          plugins: xaiWebSearchSecretRefPlugins("file", "vault", "/xai/tool-key"),
         },
       }),
     ).resolves.toBeUndefined();
@@ -207,21 +207,7 @@ describe("xai tool auth helpers", () => {
     };
 
     const sourceConfig = {
-      plugins: {
-        entries: {
-          xai: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "file",
-                  provider: "vault",
-                  id: "/xai/tool-key",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: xaiWebSearchSecretRefPlugins("file", "vault", "/xai/tool-key"),
     };
 
     expect(isXaiToolEnabled({ sourceConfig, auth })).toBe(false);
@@ -234,21 +220,7 @@ describe("xai tool auth helpers", () => {
     await expect(
       resolveXaiToolApiKeyWithAuth({
         sourceConfig: {
-          plugins: {
-            entries: {
-              xai: {
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "env",
-                      provider: "default",
-                      id: "XAI_API_KEY",
-                    },
-                  },
-                },
-              },
-            },
-          },
+          plugins: xaiWebSearchSecretRefPlugins("env", "default", "XAI_API_KEY"),
         },
       }),
     ).resolves.toBe("xai-secretref-key");
@@ -260,21 +232,7 @@ describe("xai tool auth helpers", () => {
     await expect(
       resolveXaiToolApiKeyWithAuth({
         sourceConfig: {
-          plugins: {
-            entries: {
-              xai: {
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "env",
-                      provider: "default",
-                      id: "UNRELATED_SECRET",
-                    },
-                  },
-                },
-              },
-            },
-          },
+          plugins: xaiWebSearchSecretRefPlugins("env", "default", "UNRELATED_SECRET"),
         },
       }),
     ).resolves.toBeUndefined();
@@ -294,21 +252,7 @@ describe("xai tool auth helpers", () => {
               },
             },
           },
-          plugins: {
-            entries: {
-              xai: {
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "env",
-                      provider: "xai-env",
-                      id: "XAI_API_KEY",
-                    },
-                  },
-                },
-              },
-            },
-          },
+          plugins: xaiWebSearchSecretRefPlugins("env", "xai-env", "XAI_API_KEY"),
         },
       }),
     ).resolves.toBeUndefined();
@@ -328,21 +272,7 @@ describe("xai tool auth helpers", () => {
               },
             },
           },
-          plugins: {
-            entries: {
-              xai: {
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "env",
-                      provider: "xai-env",
-                      id: "XAI_API_KEY",
-                    },
-                  },
-                },
-              },
-            },
-          },
+          plugins: xaiWebSearchSecretRefPlugins("env", "xai-env", "XAI_API_KEY"),
         },
       }),
     ).resolves.toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Six xAI tool-auth cases repeat the same nested plugin configuration, obscuring the credential-policy values each case exercises.

## Why This Change Was Made

Use one local fixture with required source, provider, and ID arguments. Each call creates the original fresh object graph; all six policy cases, resolver invocations, explicit inputs, and independent assertions remain intact. This removes 70 net test lines.

## User Impact

No runtime or authentication behavior changes. The tests continue to protect credential precedence, blocked fallback, permitted environment IDs, and provider source/allowlist rules.

## Evidence

- Complete xAI tool-auth and shared SecretRef suites before and after: the same 53 ordered cases passed, with no skipped cases.
- Expanding all six fixture calls reproduces the original source bytes. Structural and object-graph checks confirm field order, absence, descriptors, fresh nested objects, and mutation independence.
- Mapped changed-file gate and fresh independent P2 review passed.
