### PR TITLE
refactor: share Doctor routing-warning agent fixtures

### DIFF
--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -43,6 +43,26 @@ async function collectChannelBoundMessageToolPolicyWarningsThroughDoctor(
   return warnings.filter((warning) => warning.includes("is routed from channel"));
 }
 
+function createMessagePolicyAgents(routedAgentId: string): NonNullable<OpenClawConfig["agents"]> {
+  return {
+    list: [
+      {
+        id: "main",
+        default: true,
+        tools: {
+          allow: ["read"],
+        },
+      },
+      {
+        id: routedAgentId,
+        tools: {
+          profile: "messaging",
+        },
+      },
+    ],
+  };
+}
+
 type TestManifestRecord = {
   id: string;
   channels: string[];
@@ -1469,23 +1489,7 @@ describe("doctor preview warnings", () => {
         discord: {},
         telegram: {},
       },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            tools: {
-              allow: ["read"],
-            },
-          },
-          {
-            id: "commander",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
+      agents: createMessagePolicyAgents("commander"),
       bindings: [
         {
           agentId: "commander",
@@ -1508,23 +1512,7 @@ describe("doctor preview warnings", () => {
       channels: {
         discord: {},
       },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            tools: {
-              allow: ["read"],
-            },
-          },
-          {
-            id: "commander",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
+      agents: createMessagePolicyAgents("commander"),
       bindings: [
         {
           agentId: "commander",
@@ -1547,23 +1535,7 @@ describe("doctor preview warnings", () => {
       channels: {
         discord: {},
       },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            tools: {
-              allow: ["read"],
-            },
-          },
-          {
-            id: "commander",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
+      agents: createMessagePolicyAgents("commander"),
       bindings: [
         {
           agentId: "commander",
@@ -1637,23 +1609,7 @@ describe("doctor preview warnings", () => {
       channels: {
         imessage: {},
       },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            tools: {
-              allow: ["read"],
-            },
-          },
-          {
-            id: "ios-agent",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
+      agents: createMessagePolicyAgents("ios-agent"),
       bindings: [
         {
           agentId: "ios-agent",
@@ -1681,23 +1637,7 @@ describe("doctor preview warnings", () => {
           },
         },
       },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            tools: {
-              allow: ["read"],
-            },
-          },
-          {
-            id: "personal-agent",
-            tools: {
-              profile: "messaging",
-            },
-          },
-        ],
-      },
+      agents: createMessagePolicyAgents("personal-agent"),
       bindings: [
         {
           agentId: "personal-agent",


### PR DESCRIPTION
## What Problem This Solves

Five Doctor routing-warning tests repeat the same pair of agent tool policies, obscuring the channel and account bindings that distinguish their scenarios.

## Why This Change Was Made

A file-local constructor accepts the routed agent ID and creates the same fresh agent configuration. Each test keeps its channels, bindings, exact warning text, and exclusions explicit. All five distinct routing cases remain, including scoped-account fallback, wildcard coverage, aliases, and incomplete account coverage.

## User Impact

No user-visible behavior change. The test-only refactor removes 60 net lines while retaining Doctor’s routing and tool-policy warning coverage. No runtime improvement is claimed.

## Evidence

All 47 preview-warning tests and three routing tests passed before and after, with identical per-file case order. Parser-aware expansion reproduced the original test AST; checks confirmed five input-only uses, exact field order and absence, and fresh seven-node object graphs. Mapped changed checks passed, and independent review found no actionable issues. Production code and the adjacent three-agent coverage case are unchanged.
