### PR TITLE
fix(sessions): preserve spawning agent attribution

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/acp-spawn-gateway.ts
@@ -38,6 +38,10 @@ export async function launchAcpChildThroughGateway(params: {
           deliver: params.deliveryPlan.useInlineDelivery,
           lane: AGENT_LANE_SUBAGENT,
           acpTurnSource: "manual_spawn",
+          inputProvenance: {
+            kind: "internal_system",
+            sourceTool: "sessions_spawn",
+          },
           timeout: params.runTimeoutSeconds,
           label: params.label || undefined,
           ...(params.attachments ? { attachments: params.attachments } : {}),

--- a/src/agents/subagents/spawn/subagent-spawn-launch-request.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-launch-request.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildSubagentLaunchRequest } from "./subagent-spawn-launch-request.js";
+
+describe("buildSubagentLaunchRequest", () => {
+  it("marks sessions_spawn instructions as internal agent-authored input", () => {
+    const result = buildSubagentLaunchRequest({
+      completionMode: "announce",
+      spawnMode: "run",
+      message: "[Subagent Task]\nFix it",
+      spawnedByKey: "agent:coordinator:dashboard:parent",
+      toolSpawnMetadata: {},
+      childSessionKey: "agent:worker:subagent:child",
+      childIdem: "idem-1",
+      childSystemPrompt: "system",
+      runTimeoutSeconds: 60,
+      lightContext: false,
+      swarmMaxConcurrent: 1,
+    });
+
+    expect(result.childLaunch.request.inputProvenance).toEqual({
+      kind: "internal_system",
+      sourceSessionKey: "agent:coordinator:dashboard:parent",
+      sourceTool: "sessions_spawn",
+    });
+  });
+});

--- a/src/agents/subagents/spawn/subagent-spawn-launch-request.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-launch-request.ts
@@ -100,6 +100,11 @@ export function buildSubagentLaunchRequest(params: {
     extraSystemPrompt: params.childSystemPrompt,
     thinking: params.thinkingOverride,
     timeout: params.runTimeoutSeconds,
+    inputProvenance: {
+      kind: "internal_system",
+      sourceSessionKey: params.spawnedByKey,
+      sourceTool: "sessions_spawn",
+    },
     // Creation owns the label; delayed launches must preserve operator renames.
     ...(bootstrapContextMode
       ? {

--- a/src/chat/sender-identity.ts
+++ b/src/chat/sender-identity.ts
@@ -6,7 +6,7 @@ import {
 
 export type TranscriptSenderIdentity = Extract<
   SessionParticipantIdentity,
-  { type: "profile" | "remote" | "observation" }
+  { type: "profile" | "agent" | "remote" | "observation" }
 >;
 
 /** Transcript attribution uses the closed product vocabulary, never raw-id inference. */
@@ -15,7 +15,10 @@ export function readTranscriptSenderIdentity(value: unknown): TranscriptSenderId
     typeof value !== "object" ||
     value === null ||
     !Value.Check(SessionParticipantIdentitySchema, value) ||
-    (value.type !== "profile" && value.type !== "remote" && value.type !== "observation") ||
+    (value.type !== "profile" &&
+      value.type !== "agent" &&
+      value.type !== "remote" &&
+      value.type !== "observation") ||
     Object.values(value).some((part) => part !== null && (!part.trim() || part.length > 512))
   ) {
     return undefined;

--- a/src/gateway/agent-turn/agent-run-user-turn.test.ts
+++ b/src/gateway/agent-turn/agent-run-user-turn.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSubagentLaunchRequest } from "../../agents/subagents/spawn/subagent-spawn-launch-request.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import { prepareAgentRunUserTurn } from "./agent-run-user-turn.js";
@@ -7,6 +8,7 @@ import type { AgentTurnContext } from "./types.js";
 const mocks = vi.hoisted(() => ({
   loadSessionEntry: vi.fn(),
   persistSessionTranscriptTurn: vi.fn(),
+  stageSessionPendingInput: vi.fn(),
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -18,7 +20,11 @@ vi.mock("../../config/sessions/session-accessor.js", async () => {
   const actual = await vi.importActual<typeof import("../../config/sessions/session-accessor.js")>(
     "../../config/sessions/session-accessor.js",
   );
-  return { ...actual, persistSessionTranscriptTurn: mocks.persistSessionTranscriptTurn };
+  return {
+    ...actual,
+    persistSessionTranscriptTurn: mocks.persistSessionTranscriptTurn,
+    stageSessionPendingInput: mocks.stageSessionPendingInput,
+  };
 });
 
 describe("prepareAgentRunUserTurn", () => {
@@ -47,6 +53,15 @@ describe("prepareAgentRunUserTurn", () => {
           },
         ],
         sessionEntry: scope.sessionEntry,
+      };
+    });
+    mocks.stageSessionPendingInput.mockReset().mockImplementation(async (_target, options) => {
+      const message = await options.prepareMessageAfterIdempotencyCheck(options.message);
+      return {
+        state: "staged",
+        message,
+        run: async (run: () => unknown) => await run(),
+        finish: vi.fn(),
       };
     });
   });
@@ -92,6 +107,123 @@ describe("prepareAgentRunUserTurn", () => {
         } as unknown as AgentTurnContext,
       }),
     ).rejects.toThrow("agent turn was not durably admitted");
-    expect(mocks.persistSessionTranscriptTurn).not.toHaveBeenCalled();
+    expect(mocks.stageSessionPendingInput).not.toHaveBeenCalled();
+  });
+
+  it("propagates sessions_spawn runtime authorship through admission and durable persistence", async () => {
+    const sessionKey = "agent:worker:subagent:child";
+    const admittedSessionId = "child-session";
+    const sessionEntry: SessionEntry = { sessionId: admittedSessionId, updatedAt: 1 };
+    const launch = buildSubagentLaunchRequest({
+      completionMode: "announce",
+      spawnMode: "run",
+      message: "[Subagent Task]\nFix it",
+      spawnedByKey: "agent:coordinator:dashboard:parent",
+      toolSpawnMetadata: {},
+      childSessionKey: sessionKey,
+      childIdem: "spawn-agent-attribution",
+      childSystemPrompt: "system",
+      runTimeoutSeconds: 60,
+      lightContext: false,
+      swarmMaxConcurrent: 1,
+    });
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: sessionKey,
+      entry: sessionEntry,
+      store: { [sessionKey]: sessionEntry },
+    });
+
+    const prepared = await prepareAgentRunUserTurn({
+      assertCurrent: () => {},
+      request: launch.childLaunch.request as AgentRunRequest,
+      cfg: { agents: { list: [{ id: "coordinator", identity: { name: "Coordinator" } }] } },
+      sessionEntry,
+      resolvedSessionKey: sessionKey,
+      admittedSessionId,
+      activeSessionAgentId: "worker",
+      suppressVisibleSessionEffects: false,
+      requestedPromptPersistenceSuppression: false,
+      canUseInternalRuntimeHandoff: false,
+      message: launch.childLaunch.request.message,
+      effectiveTranscriptInputText: launch.childLaunch.request.message,
+      images: [],
+      offloadedRefs: [],
+      inputProvenance: launch.childLaunch.request.inputProvenance,
+      runId: "spawn-agent-attribution",
+      client: {
+        connect: { scopes: ["operator.admin"] },
+        authenticatedUserProfile: { profileId: "owner", displayName: "Example User" },
+        internal: {
+          syntheticClient: true,
+          agentRuntimeIdentity: {
+            kind: "agentRuntime",
+            agentId: "coordinator",
+            sessionKey: "agent:coordinator:dashboard:parent",
+          },
+        },
+      } as never,
+      context: { logGateway: { warn: vi.fn() } } as unknown as AgentTurnContext,
+    });
+
+    expect(prepared.senderIsOwner).toBe(true);
+    expect(mocks.stageSessionPendingInput).toHaveBeenCalledOnce();
+    const persisted = prepared.recorder?.getPendingInputMessage();
+    expect(persisted).toMatchObject({
+      role: "user",
+      content: "[Subagent Task]\nFix it",
+      provenance: {
+        kind: "internal_system",
+        sourceSessionKey: "agent:coordinator:dashboard:parent",
+        sourceTool: "sessions_spawn",
+      },
+      __openclaw: {
+        senderId: "coordinator",
+        senderName: "Coordinator",
+        senderIdentity: { type: "agent", id: "coordinator" },
+        senderIsOwner: false,
+      },
+    });
+    expect(persisted?.__openclaw).not.toMatchObject({
+      senderId: "owner",
+      senderName: "Example User",
+    });
+  });
+
+  it("keeps hidden synthetic spawn turns out of persistence", async () => {
+    const prepared = await prepareAgentRunUserTurn({
+      assertCurrent: () => {},
+      request: { message: "hidden", idempotencyKey: "hidden-spawn" } as AgentRunRequest,
+      cfg: {},
+      admittedSessionId: "hidden-session",
+      activeSessionAgentId: "worker",
+      resolvedSessionKey: "agent:worker:subagent:hidden",
+      suppressVisibleSessionEffects: true,
+      requestedPromptPersistenceSuppression: false,
+      canUseInternalRuntimeHandoff: false,
+      message: "hidden",
+      effectiveTranscriptInputText: "hidden",
+      images: [],
+      offloadedRefs: [],
+      inputProvenance: { kind: "internal_system", sourceTool: "sessions_spawn" },
+      runId: "hidden-spawn",
+      client: {
+        connect: { scopes: ["operator.admin"] },
+        internal: {
+          syntheticClient: true,
+          agentRuntimeIdentity: {
+            kind: "agentRuntime",
+            agentId: "coordinator",
+            sessionKey: "agent:coordinator:dashboard:parent",
+          },
+        },
+      } as never,
+      context: { logGateway: { warn: vi.fn() } } as unknown as AgentTurnContext,
+    });
+
+    expect(prepared.senderIsOwner).toBe(true);
+    expect(prepared.recorder).toBeUndefined();
+    expect(mocks.stageSessionPendingInput).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/agent-turn/agent-run-user-turn.ts
+++ b/src/gateway/agent-turn/agent-run-user-turn.ts
@@ -11,6 +11,7 @@ import {
 } from "../../agents/bash-tools.exec-approval-output.js";
 import type { ExecElevatedDefaults } from "../../agents/bash-tools.exec-types.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
+import { resolveAgentIdentity } from "../../agents/identity.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { deleteMediaBuffer } from "../../media/store.js";
@@ -153,6 +154,12 @@ export async function prepareAgentRunUserTurn(params: {
       const slots = persistedMedia.entries.flatMap((entry, factIndex) =>
         entry.imageKind ? [{ kind: entry.imageKind, factIndex }] : [],
       );
+      const senderFields = gatewayClientSenderFields(params.client);
+      const sender = senderFields.sender;
+      const runtimeAgentName =
+        sender?.identity?.type === "agent"
+          ? resolveAgentIdentity(params.cfg, sender.identity.id)?.name?.trim()
+          : undefined;
       const input: UserTurnInput = {
         text:
           persistedMedia.omission === "inline-image-save-failed"
@@ -162,7 +169,9 @@ export async function prepareAgentRunUserTurn(params: {
             : effectiveTranscriptInputText,
         timestamp: Date.now(),
         idempotencyKey: buildRunUserTurnIdempotencyKey(params.runId),
-        ...gatewayClientSenderFields(params.client),
+        ...(sender
+          ? { sender: { ...sender, ...(runtimeAgentName ? { name: runtimeAgentName } : {}) } }
+          : {}),
         senderIsOwner,
         ...(params.inputProvenance ? { provenance: params.inputProvenance } : {}),
         ...(media.length > 0 ? { media } : {}),

--- a/src/gateway/server-methods/gateway-client-identity.test.ts
+++ b/src/gateway/server-methods/gateway-client-identity.test.ts
@@ -70,4 +70,18 @@ describe("gateway client identity", () => {
     expect(gatewayClientSenderFields(client)).toEqual({});
     expect(gatewayClientSessionCreator(client)).toBeUndefined();
   });
+
+  it("attributes a trusted agent runtime without replacing its operator authority", () => {
+    const client = {
+      connect: { scopes: ["operator.admin"] },
+      internal: {
+        syntheticClient: true,
+        agentRuntimeIdentity: { agentId: "coordinator" },
+      },
+    } as GatewayClient;
+
+    expect(gatewayClientSenderFields(client)).toEqual({
+      sender: { id: "coordinator", identity: { type: "agent", id: "coordinator" } },
+    });
+  });
 });

--- a/src/gateway/server-methods/gateway-client-identity.ts
+++ b/src/gateway/server-methods/gateway-client-identity.ts
@@ -32,6 +32,15 @@ export function gatewayClientSenderFields(client: GatewayClient | null): {
   if (client?.internal?.senderAttribution) {
     return { sender: client.internal.senderAttribution };
   }
+  const runtimeAgentId = normalizeOptionalString(client?.internal?.agentRuntimeIdentity?.agentId);
+  if (runtimeAgentId) {
+    return {
+      sender: {
+        id: runtimeAgentId,
+        identity: { type: "agent", id: runtimeAgentId },
+      },
+    };
+  }
   const profile = client?.authenticatedUserProfile;
   if (profile) {
     return {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -241,6 +241,57 @@ describe("gateway server chat", () => {
     expect(res.payload?.startedAt).toBe(startedAt);
   };
 
+  test("chat.history preserves visible agent-authored spawn attribution and filters hidden turns", async () => {
+    const history = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: "visible delegated task",
+        timestamp: 1,
+        provenance: {
+          kind: "internal_system",
+          sourceSessionKey: "agent:coordinator:dashboard:parent",
+          sourceTool: "sessions_spawn",
+        },
+        __openclaw: {
+          senderId: "coordinator",
+          senderName: "Coordinator",
+          senderIdentity: { type: "agent", id: "coordinator" },
+          senderIsOwner: false,
+        },
+      },
+      {
+        role: "user",
+        content: "hidden delegated task",
+        timestamp: 2,
+        display: false,
+        provenance: { kind: "internal_system", sourceTool: "sessions_spawn" },
+        __openclaw: {
+          senderId: "coordinator",
+          senderName: "Coordinator",
+          senderIdentity: { type: "agent", id: "coordinator" },
+          senderIsOwner: false,
+        },
+      },
+    ]);
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      role: "user",
+      content: "visible delegated task",
+      provenance: {
+        kind: "internal_system",
+        sourceSessionKey: "agent:coordinator:dashboard:parent",
+        sourceTool: "sessions_spawn",
+      },
+      __openclaw: {
+        senderId: "coordinator",
+        senderName: "Coordinator",
+        senderIdentity: { type: "agent", id: "coordinator" },
+        senderIsOwner: false,
+      },
+    });
+  });
+
   const sendChatAndExpectStarted = async (runId: string, message = "/context list") => {
     const res = await rpcReq(ws, "chat.send", {
       sessionKey: "main",

--- a/src/sessions/user-turn-transcript.metadata.ts
+++ b/src/sessions/user-turn-transcript.metadata.ts
@@ -50,9 +50,13 @@ export function buildPersistedUserTurnMetadata(
   const senderId = normalizeOptionalString(input.sender?.id);
   const senderName = normalizeOptionalString(input.sender?.name);
   const senderUsername = normalizeOptionalString(input.sender?.username);
+  const candidateSenderIdentity = readTranscriptSenderIdentity(input.sender?.identity);
   const senderIdentity =
-    input.display !== false && (!input.provenance || input.provenance.kind === "external_user")
-      ? readTranscriptSenderIdentity(input.sender?.identity)
+    input.display !== false &&
+    (!input.provenance ||
+      input.provenance.kind === "external_user" ||
+      (input.provenance.kind === "internal_system" && candidateSenderIdentity?.type === "agent"))
+      ? candidateSenderIdentity
       : undefined;
   const replyToId = normalizeOptionalString(input.replyToId);
   const replyPreviewText = normalizeOptionalString(input.replyToPreview?.text);

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -129,6 +129,32 @@ describe("user turn transcript persistence", () => {
         __openclaw: { senderIsOwner: false },
       });
     });
+
+    it("persists internal agent authorship separately from owner authority", () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "delegated task",
+          senderIsOwner: true,
+          sender: {
+            id: "coordinator",
+            name: "Coordinator",
+            identity: { type: "agent", id: "coordinator" },
+          },
+          provenance: { kind: "internal_system", sourceTool: "sessions_spawn" },
+        },
+        target: unusedRecorderTarget,
+      });
+
+      expect(recorder.message).toMatchObject({
+        provenance: { kind: "internal_system", sourceTool: "sessions_spawn" },
+        __openclaw: {
+          senderIsOwner: false,
+          senderId: "coordinator",
+          senderName: "Coordinator",
+          senderIdentity: { type: "agent", id: "coordinator" },
+        },
+      });
+    });
   });
 
   describe("mergePreparedUserTurnMessageForRuntime", () => {

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -268,7 +268,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     const provenance = asRecord(raw.provenance);
-    if (role === "user" && provenance?.kind === "internal_system") {
+    const senderIdentity = asRecord(asRecord(raw.__openclaw)?.senderIdentity);
+    const isAgentAuthoredInternalTurn =
+      senderIdentity?.type === "agent" && typeof senderIdentity.id === "string";
+    if (role === "user" && provenance?.kind === "internal_system" && !isAgentAuthoredInternalTurn) {
       const noticeKind = resolveSystemNoticeKind(
         typeof provenance.sourceTool === "string" ? provenance.sourceTool : undefined,
       );

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2310,6 +2310,40 @@ describe("buildCachedChatItems", () => {
     expect(items[2]).toMatchObject({ kind: "group", role: "assistant" });
   });
 
+  it("keeps agent-authored sessions_spawn turns as attributed user groups", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        messages: [
+          userMessage("Visible delegated task", 1000, {
+            provenance: {
+              kind: "internal_system",
+              sourceSessionKey: "agent:coordinator:dashboard:parent",
+              sourceTool: "sessions_spawn",
+            },
+            __openclaw: {
+              senderId: "coordinator",
+              senderName: "Coordinator",
+              senderIdentity: { type: "agent", id: "coordinator" },
+              senderIsOwner: false,
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "group",
+      role: "user",
+      senderLabel: "Coordinator",
+      sender: {
+        id: "coordinator",
+        name: "Coordinator",
+        identity: { type: "agent", id: "coordinator" },
+      },
+    });
+  });
+
   it("attributes assistant groups to the latest user in multi-sender threads", () => {
     const groups = messageGroups({
       messages: [


### PR DESCRIPTION
Related: #22774
Related PR: #139371

## What Problem This Solves

Prompts that start a spawned agent session can lose the spawning agent's identity while they move through Gateway client metadata and transcript persistence. The Control UI then classifies the user-role prompt as a generic internal-system notice, so the spawning agent's visible name and provenance are lost.

## Why This Change Was Made

This change carries the authenticated spawning agent identity through the existing private launch context and transcript sender metadata. The Control UI keeps an internal agent-authored prompt as an attributed user group, allowing the persisted agent name to remain visible.

This is a narrow complement to #139371, not a reversal of it. Subagent transcripts continue to use `avatarPlacement: "none"`; this PR does not change avatar rendering or avatar tests. It also does not change admission, authorization, sender ownership, proxy behavior, or the attribution of real human-authored messages.

Issue #22774 describes a broader multi-role UI feature, including distinct avatars and colors. This PR addresses only the existing name/provenance defect and does not close or implement that full feature request.

## User Impact

Spawned agent sessions retain the spawning agent's visible name and diagnostic provenance for their initial prompt. Author avatars remain hidden in subagent transcripts, matching the current maintainer decision. Human messages keep their existing identity and authority semantics.

## Evidence

- Added focused coverage for native and ACP spawn launch requests, Gateway client identity projection, transcript persistence, chat history, and Control UI transcript classification.
- Verified that the final diff does not modify avatar rendering, avatar placement, message-group rendering, or avatar tests.
- `git diff --check` passes.
- Targeted formatting passes for all changed TypeScript files.
- The focused Vitest run could not be completed in the isolated worktree because its reused dependency graph does not match the current checkout configuration (`defineCacheKeyGenerator is not a function`). No dependency installation or trust workaround was attempted.
- Browser-level loopback proof is not claimed: the integrated proxy rejects the available HTTP probe because it is not an HTTPS request.
- The repository's autoreview command was attempted but could not run because its required TruffleHog scanner is unavailable. A manual code and privacy review was performed; this is not a substitute for the pending independent review.
- Full CI and maintainer review are still required. This PR is intentionally opened as a draft, not as a validated fix ready to merge.

## AI assistance

This AI-assisted draft has not yet received a human code review. Human review and the outstanding validation are required before it is marked ready or merged.
