### PR TITLE
refactor: share Memory Wiki session search test inputs

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -180,6 +180,32 @@ function createMemoryManager(overrides?: {
   };
 }
 
+function createSessionSearchInput(
+  sessionPath: string,
+  sessionSnippet: string,
+): NonNullable<Parameters<typeof createMemoryManager>[0]> {
+  return {
+    searchResults: [
+      {
+        path: sessionPath,
+        startLine: 1,
+        endLine: 2,
+        score: 30,
+        snippet: sessionSnippet,
+        source: "sessions",
+      },
+      {
+        path: "MEMORY.md",
+        startLine: 5,
+        endLine: 6,
+        score: 10,
+        snippet: "durable memory",
+        source: "memory",
+      },
+    ],
+  };
+}
+
 describe("getMemoryWikiPage", () => {
   it("enforces visibility for all current session storage layouts", async () => {
     const { config } = await createQueryVault({
@@ -1376,26 +1402,9 @@ describe("searchMemoryWiki", () => {
         },
       },
     });
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/visible-session.jsonl",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "global transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
+    const manager = createMemoryManager(
+      createSessionSearchInput("sessions/visible-session.jsonl", "global transcript"),
+    );
     getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
 
     const results = await searchMemoryWiki({
@@ -1423,26 +1432,12 @@ describe("searchMemoryWiki", () => {
       storePath: "(test)",
       store: {},
     });
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/secondary/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "archived transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
+    const manager = createMemoryManager(
+      createSessionSearchInput(
+        "sessions/secondary/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
+        "archived transcript",
+      ),
+    );
     getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
 
     const results = await searchMemoryWiki({
@@ -1563,26 +1558,9 @@ describe("searchMemoryWiki", () => {
         },
       },
     });
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/other/main.jsonl",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "other transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
+    const manager = createMemoryManager(
+      createSessionSearchInput("sessions/other/main.jsonl", "other transcript"),
+    );
     getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
 
     const results = await searchMemoryWiki({
@@ -1613,26 +1591,9 @@ describe("searchMemoryWiki", () => {
         },
       },
     });
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/visible-session.jsonl",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "other transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
+    const manager = createMemoryManager(
+      createSessionSearchInput("sessions/visible-session.jsonl", "other transcript"),
+    );
     getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
 
     const results = await searchMemoryWiki({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four Memory Wiki query tests duplicate the same session and durable-memory search-result fixtures while exercising distinct ownership rules.

## Why This Change Was Made

Build those inputs with a local constructor that requires the session path and snippet. Preserve both hit scores, line ranges, source tags, property order and fresh per-case values. All four cases remain separate, with their own configurations, store contents and expected results. The one-file change removes 39 net test lines including helper overhead.

## User Impact

No product behavior changes. Global-session access, archived-owner access and both owner-rejection boundaries keep their existing coverage with less fixture boilerplate.

## Evidence

The complete query and query-read suites passed all 74 cases before and after, with no skips and identical per-file case order. Structural expansion verifies all four inputs and fresh nested allocations; every remaining outside-edit token and assertion is unchanged.

The mapped changed gate passed, and fresh P2 review found no actionable issues. No runtime speedup is claimed.
