### PR TITLE
fix(cli): reject blank account selectors before command startup

### DIFF
--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -227,6 +227,36 @@ describe("runMessageAction", () => {
   );
 
   it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("rejects a %s account before plugin preload", async (_name, account) => {
+    const program = new Command();
+    const message = program.command("message");
+    registerMessageSendCommand(message, createMessageCliHelpers("discord"));
+
+    await expect(
+      program.parseAsync(
+        [
+          "message",
+          "send",
+          "--channel",
+          "discord",
+          "--target",
+          "channel:123",
+          "--message",
+          "hi",
+          "--account",
+          account,
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(loadPluginRegistryHandleMock).not.toHaveBeenCalled();
+    expect(messageCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["disabled reaction", "react", { ok: false, hint: "Reactions are disabled." }, 1],
     ["rejected added reaction", "react", { ok: false, warning: "Unavailable", added: "✅" }, 1],
     ["rejected delete", "delete", { ok: false, deleted: false, warning: "Not deleted" }, 1],

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -9,6 +9,7 @@ import {
   type ChannelMessageActionName,
 } from "../../../channels/plugins/types.public.js";
 import { resolveMessageSecretScope } from "../../../cli/message-secret-scope.js";
+import { parseAccountSelector } from "../../../commands/channels/account-selector.js";
 import { messageCommand } from "../../../commands/message.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { danger, setVerbose } from "../../../globals.js";
@@ -150,7 +151,7 @@ export function createMessageCliHelpers(messageChannelOptions: string): MessageC
     withMessageBase: (command) =>
       command
         .option("--channel <channel>", `Channel: ${messageChannelOptions}`)
-        .option("--account <id>", "Channel account id (accountId)")
+        .option("--account <id>", "Channel account id (accountId)", parseAccountSelector)
         .option("--json", "Output result as JSON", false)
         .option("--dry-run", "Print payload and skip sending", false)
         .option("--verbose", "Verbose logging", false),

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -76,16 +76,19 @@ describe("channelsResolveCommand", () => {
     });
   });
 
-  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
-    await expect(
-      channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
-    ).rejects.toThrow("--account must not be blank");
+  it.each(["", " \t\n "])(
+    "rejects a blank account selector before startup: %j",
+    async (account) => {
+      await expect(
+        channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
+      ).rejects.toThrow("--account must not be blank");
 
-    expect(mocks.loadConfig).not.toHaveBeenCalled();
-    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
-    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
-    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
-  });
+      expect(mocks.loadConfig).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses installed channel plugins for explicit target resolution without installing", async () => {
     mocks.loadConfig.mockReturnValue({

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -76,6 +76,17 @@ describe("channelsResolveCommand", () => {
     });
   });
 
+  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
+    await expect(
+      channelsResolveCommand({ account, channel: "telegram", entries: ["friends"] }, runtime),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+  });
+
   it("uses installed channel plugins for explicit target resolution without installing", async () => {
     mocks.loadConfig.mockReturnValue({
       agents: { list: [{ id: "main" }, { id: "ops" }] },

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -137,6 +137,17 @@ describe("channelsCapabilitiesCommand", () => {
     });
   });
 
+  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
+    await expect(
+      channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+  });
+
   it.each([undefined, "all"])("keeps %s capabilities listing read-only", async (channel) => {
     await channelsCapabilitiesCommand({ channel }, runtime);
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledOnce();

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -137,16 +137,19 @@ describe("channelsCapabilitiesCommand", () => {
     });
   });
 
-  it.each(["", " \t\n "])("rejects a blank account selector before startup: %j", async (account) => {
-    await expect(
-      channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
-    ).rejects.toThrow("--account must not be blank");
+  it.each(["", " \t\n "])(
+    "rejects a blank account selector before startup: %j",
+    async (account) => {
+      await expect(
+        channelsCapabilitiesCommand({ channel: "slack", account }, runtime),
+      ).rejects.toThrow("--account must not be blank");
 
-    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
-    expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
-    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
-    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
-  });
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([undefined, "all"])("keeps %s capabilities listing read-only", async (channel) => {
     await channelsCapabilitiesCommand({ channel }, runtime);

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -32,6 +32,7 @@ import {
   requireValidConfigFileSnapshot,
   requireValidConfigForWrite,
 } from "../config-validation.js";
+import { parseAccountSelector } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { formatChannelAccountLabel } from "./shared.js";
 
@@ -279,6 +280,7 @@ export async function channelsCapabilitiesCommand(
   opts: ChannelsCapabilitiesOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  parseAccountSelector(opts.account);
   const rawChannel = normalizeLowercaseStringOrEmpty(opts.channel);
   const canInstall = Boolean(rawChannel && rawChannel !== "all");
   const writeSnapshot = canInstall ? await requireValidConfigForWrite(runtime) : null;

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -18,6 +18,7 @@ import { danger } from "../../globals.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
+import { parseAccountSelector } from "./account-selector.js";
 
 export type ChannelsResolveOptions = {
   agent?: string;
@@ -124,6 +125,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
       `At least one entry is required. Example: ${formatCliCommand("openclaw channels resolve --channel discord <name-or-id>")}.`,
     );
   }
+  parseAccountSelector(opts.account);
 
   const loadedRaw = getRuntimeConfig();
   const requestedAgent = opts.agent?.trim();


### PR DESCRIPTION
Related: #143083, #143066. Combines the shared account-selector repair from #143067 into this PR, preserving @ly85206559's three original commits and credit.

## What Problem This Solves

Fixes an issue where operators passing an empty shell variable to `--account` could select a default message account, inspect a broader set of channel accounts, or forward a blank selector to target resolution.

## Why This Change Was Made

The existing account parser now validates the shared message option and the `channels capabilities` and `channels resolve` options before command startup. The two channel checks move from command bodies to option parsing so configuration readiness cannot hide the input error. Nonblank values retain their exact input bytes and each command's existing selection rules.

## User Impact

Explicit empty or whitespace-only values fail with `--account must not be blank`. Scripts requesting default or broader scope must omit `--account`; passing an empty variable is now rejected. Omitted, named, padded nonblank, unknown, and disabled inputs retain their existing command-specific behavior. Generic bootstrap configuration reads are outside this option-validation boundary.

## Evidence

- A real built CLI with an isolated offline channel fixture distinguishes default and named account selection. All message controls use dry-run; the fixture has no delivery transport.
- The baseline accepts explicit blank selectors. The repaired CLI rejects them before account-dependent command work while preserving valid controls in JSON and human output.
- The complete matrix covers separate and joined empty input, spaces, mixed tab/newline whitespace, omission, named and padded accounts, unknown and disabled accounts, missing values, nested thread creation, broadcast, and missing resolve entries.
- Startup-sentinel controls distinguish selector rejection from configuration-readiness failure. A registration suite covers all 32 shared message actions and both channel commands.
- Native formatting, lint, signed build, commit hook, and 257 focused tests passed. Independent behavior acceptance is retained with the repair evidence; hosted CI and final review must pass before merge.

The contributor's original narrower command-line demonstrations remain available in the linked PR histories. This combined repair adds valid-account controls and startup-order coverage; it does not claim live channel delivery.
