### PR TITLE
fix: node exec on Windows corrupts quoted arguments before the command runs

### DIFF
--- a/src/node-host/invoke.run-command.test.ts
+++ b/src/node-host/invoke.run-command.test.ts
@@ -185,4 +185,33 @@ describe("runCommand", () => {
       expect(testing.clarifyNodeExecCwdSpawnError(enoent(message), "/unreadable")).toBe(message);
     });
   });
+
+  // Runs the real cmd.exe, so it only reports on a Windows host. The
+  // cross-platform wiring assertions live in invoke.windows-cmd-quoting.test.ts.
+  describe.runIf(process.platform === "win32")("Windows cmd payload quoting", () => {
+    it("delivers a quoted argument to the child without added escapes", async () => {
+      const url = "https://tenant.example.com/";
+      const result = await testing.runCommand(
+        ["cmd.exe", "/d", "/s", "/c", `echo "${url}"`],
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.stdout.trim()).toBe(`"${url}"`);
+    });
+
+    it("delivers a payload that itself begins and ends with a quote", async () => {
+      const result = await testing.runCommand(
+        ["cmd.exe", "/d", "/s", "/c", '"C:\\Windows\\System32\\cmd.exe" /c echo "tail"'],
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.stdout.trim()).toBe('"tail"');
+    });
+  });
 });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -341,6 +341,56 @@ function clarifyNodeExecCwdSpawnError(
   return `node exec working directory ${reason} on the node host: ${cwd} (os reported: ${message})`;
 }
 
+const WINDOWS_CMD_SWITCHES = ["/d", "/s", "/c"] as const;
+
+/**
+ * The gateway hands the node host a complete `cmd` command line as a single argv
+ * entry (`["cmd.exe", "/d", "/s", "/c", payload]`). Without
+ * `windowsVerbatimArguments` Node applies its own per-argument quoting to that
+ * payload, which inserts backslashes before every quote it contains, so the
+ * command that runs is not the command that was sent.
+ *
+ * The payload is wrapped in one extra pair of quotes as well: with `/s`, cmd
+ * strips the first and last quote of the whole command line, so a payload that
+ * already begins and ends with a quote loses them when only the verbatim flag
+ * is set. Wrapping gives `/s` a pair to consume and leaves the payload intact.
+ *
+ * Anything that is not the canonical five-element `cmd.exe` invocation keeps its
+ * current behavior: PowerShell, direct executables, other `cmd` paths,
+ * non-canonical argv and non-Windows hosts.
+ */
+function prepareWindowsCmdInvocation(argv: string[]): {
+  argv: string[];
+  windowsVerbatimArguments?: boolean;
+} {
+  if (process.platform !== "win32" || argv.length !== WINDOWS_CMD_SWITCHES.length + 2) {
+    return { argv };
+  }
+  if (!argv.every((entry) => typeof entry === "string")) {
+    return { argv };
+  }
+  const switchesMatch = WINDOWS_CMD_SWITCHES.every(
+    (expected, index) => argv[index + 1]?.toLowerCase() === expected,
+  );
+  if (!switchesMatch) {
+    return { argv };
+  }
+  const executable = argv[0] ?? "";
+  const windowsRoot = process.env.SystemRoot || process.env.WINDIR || "C:\\Windows";
+  const trustedAbsoluteCmd =
+    /^[A-Za-z]:[\\/]/.test(windowsRoot) &&
+    path.win32.normalize(executable).toLowerCase() ===
+      path.win32.join(windowsRoot, "System32", "cmd.exe").toLowerCase();
+  if (executable.toLowerCase() !== "cmd.exe" && !trustedAbsoluteCmd) {
+    return { argv };
+  }
+  const payload = argv[WINDOWS_CMD_SWITCHES.length + 1] ?? "";
+  return {
+    argv: [...argv.slice(0, WINDOWS_CMD_SWITCHES.length + 1), `"${payload}"`],
+    windowsVerbatimArguments: true,
+  };
+}
+
 async function runCommand(
   argv: string[],
   cwd: string | undefined,
@@ -349,7 +399,9 @@ async function runCommand(
   signal?: AbortSignal,
 ): Promise<RunResult> {
   try {
-    const result = await runCommandWithTimeout(argv, {
+    const invocation = prepareWindowsCmdInvocation(argv);
+    const result = await runCommandWithTimeout(invocation.argv, {
+      ...(invocation.windowsVerbatimArguments === true ? { windowsVerbatimArguments: true } : {}),
       baseEnv: env,
       cwd,
       killProcessTree: true,

--- a/src/node-host/invoke.windows-cmd-quoting.test.ts
+++ b/src/node-host/invoke.windows-cmd-quoting.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { runCommandWithTimeoutMock } = vi.hoisted(() => ({
+  runCommandWithTimeoutMock: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runCommandWithTimeout: runCommandWithTimeoutMock,
+}));
+
+const { testing } = await import("./invoke.test-support.js");
+
+const PAYLOAD = 'echo "https://tenant.example.com/"';
+const SWITCHES = ["/d", "/s", "/c"] as const;
+
+const originalPlatform = process.platform;
+const originalSystemRoot = process.env.SystemRoot;
+const originalWindir = process.env.WINDIR;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+/** Drives the real runCommand wiring and returns what reached the shared runner. */
+async function captureRunnerCall(
+  argv: string[],
+): Promise<{ argv: string[]; options: Record<string, unknown> }> {
+  await testing.runCommand(argv, undefined, undefined, undefined);
+  const call = runCommandWithTimeoutMock.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return {
+    argv: call?.[0] as string[],
+    options: call?.[1] as Record<string, unknown>,
+  };
+}
+
+beforeEach(() => {
+  runCommandWithTimeoutMock.mockReset();
+  runCommandWithTimeoutMock.mockResolvedValue({
+    termination: "exit",
+    code: 0,
+    stdout: "",
+    stderr: "",
+  });
+  process.env.SystemRoot = "C:\\Windows";
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  if (originalSystemRoot === undefined) {
+    delete process.env.SystemRoot;
+  } else {
+    process.env.SystemRoot = originalSystemRoot;
+  }
+  if (originalWindir === undefined) {
+    delete process.env.WINDIR;
+  } else {
+    process.env.WINDIR = originalWindir;
+  }
+  vi.restoreAllMocks();
+});
+
+// These assert at the command-runner boundary rather than on a helper, so
+// reverting runCommand's wiring — dropping the wrapped argv or the forwarded
+// windowsVerbatimArguments option — fails them and restores the reported bug.
+describe("runCommand Windows cmd quoting", () => {
+  describe("canonical cmd.exe invocations reach the runner verbatim", () => {
+    it.each([
+      ["bare executable", "cmd.exe", SWITCHES],
+      ["upper-case switches", "cmd.exe", ["/D", "/S", "/C"] as const],
+      ["backslash SystemRoot path", "C:\\Windows\\System32\\cmd.exe", SWITCHES],
+      ["forward-slash SystemRoot path", "C:/Windows/System32/cmd.exe", SWITCHES],
+    ])("%s", async (_name, executable, switches) => {
+      setPlatform("win32");
+      const argv = [executable, ...switches, PAYLOAD];
+
+      const call = await captureRunnerCall(argv);
+
+      // The payload gains exactly one wrapping quote pair for `/s` to consume;
+      // its own content is never rewritten.
+      expect(call.argv).toEqual([executable, ...switches, `"${PAYLOAD}"`]);
+      expect(call.options.windowsVerbatimArguments).toBe(true);
+      // The caller's array must not be mutated.
+      expect(argv[4]).toBe(PAYLOAD);
+    });
+
+    it("falls back to WINDIR when SystemRoot is unset", async () => {
+      setPlatform("win32");
+      delete process.env.SystemRoot;
+      process.env.WINDIR = "D:\\Windows";
+
+      const call = await captureRunnerCall([
+        "D:\\Windows\\System32\\cmd.exe",
+        ...SWITCHES,
+        PAYLOAD,
+      ]);
+
+      expect(call.options.windowsVerbatimArguments).toBe(true);
+    });
+
+    it("still recognises the bare executable when the Windows root is unusable", async () => {
+      setPlatform("win32");
+      process.env.SystemRoot = "not-a-path";
+
+      const call = await captureRunnerCall(["cmd.exe", ...SWITCHES, PAYLOAD]);
+
+      expect(call.options.windowsVerbatimArguments).toBe(true);
+    });
+
+    it("preserves the remaining run options", async () => {
+      setPlatform("win32");
+
+      await testing.runCommand(["cmd.exe", ...SWITCHES, PAYLOAD], "C:\\work", { FOO: "bar" }, 1234);
+      const options = runCommandWithTimeoutMock.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+
+      expect(options).toMatchObject({
+        baseEnv: { FOO: "bar" },
+        cwd: "C:\\work",
+        killProcessTree: true,
+        timeoutMs: 1234,
+        windowsVerbatimArguments: true,
+      });
+    });
+  });
+
+  describe("everything else reaches the runner untouched", () => {
+    it.each([
+      ["a cmd.exe outside the Windows root", ["C:\\Other\\cmd.exe", ...SWITCHES, PAYLOAD]],
+      ["powershell", ["powershell.exe", ...SWITCHES, PAYLOAD]],
+      ["a direct executable", ["node.exe", "-e", "1"]],
+      ["a four-element argv", ["cmd.exe", ...SWITCHES]],
+      ["a six-element argv", ["cmd.exe", ...SWITCHES, PAYLOAD, "extra"]],
+      ["reordered switches", ["cmd.exe", "/s", "/d", "/c", PAYLOAD]],
+      ["a missing switch", ["cmd.exe", "/d", "/c", PAYLOAD, "extra"]],
+    ])("leaves %s untouched", async (_name, argv) => {
+      setPlatform("win32");
+
+      const call = await captureRunnerCall(argv as string[]);
+
+      // The exact same array instance is handed to the runner — no copy, no rewrite.
+      expect(call.argv).toBe(argv);
+      expect(call.options.windowsVerbatimArguments).toBeUndefined();
+    });
+
+    it("rejects an absolute cmd.exe when the Windows root is unusable", async () => {
+      setPlatform("win32");
+      process.env.SystemRoot = "not-a-path";
+      delete process.env.WINDIR;
+      const argv = ["C:\\Windows\\System32\\cmd.exe", ...SWITCHES, PAYLOAD];
+
+      const call = await captureRunnerCall(argv);
+
+      expect(call.argv).toBe(argv);
+      expect(call.options.windowsVerbatimArguments).toBeUndefined();
+    });
+
+    it("ignores a non-string argv entry", async () => {
+      setPlatform("win32");
+      const argv = ["cmd.exe", ...SWITCHES, 123 as unknown as string];
+
+      const call = await captureRunnerCall(argv);
+
+      expect(call.argv).toBe(argv);
+      expect(call.options.windowsVerbatimArguments).toBeUndefined();
+    });
+
+    it.each([["darwin"], ["linux"]])("does nothing on %s", async (platform) => {
+      setPlatform(platform as NodeJS.Platform);
+      const argv = ["cmd.exe", ...SWITCHES, PAYLOAD];
+
+      const call = await captureRunnerCall(argv);
+
+      expect(call.argv).toBe(argv);
+      expect(call.options.windowsVerbatimArguments).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Closes #142847

## What Problem This Solves

Fixes an issue where operators running a native `exec` on a **Windows node host** would have their command silently altered when it contained a double-quoted argument — a quoted URL, a quoted path with spaces, a quoted flag value.

The command still ran, and it ran without error, so the corruption surfaced inside the invoked program instead: a malformed URL, a file that could not be found, a flag with the wrong value. In our case an argument `"https://tenant.example.com/"` arrived with an added leading backslash and a trailing literal quote, the target program built `https://https//…%22`, and the browser reported a DNS failure. We spent a day looking at DNS and endpoint security before looking at the spawn layer.

Running the same command string manually over SSH or in a `cmd` window on the same machine does **not** reproduce it, because those never traverse the node-host spawn path. That divergence is what makes the problem hard to attribute to OpenClaw at all.

## Why This Change Was Made

The gateway hands the node host a complete `cmd` command line as a single argv entry (`["cmd.exe", "/d", "/s", "/c", payload]`). `runCommand()` forwarded that argv to `runCommandWithTimeout()` without `windowsVerbatimArguments`, so Node applied its own per-argument quoting to a payload that is already a full command line.

The core exec path already resolves `windowsVerbatimArguments` through `resolveSafeChildProcessInvocation()`; only this node-host caller was missing it. `runCommandWithTimeout()`'s options already accept and forward the flag, so this is a caller-side change in one file plus its tests.

`prepareWindowsCmdInvocation()` recognises the canonical five-element invocation — `cmd.exe` or the normalized `%SystemRoot%\System32\cmd.exe`, case-insensitive switches — wraps the payload in one extra quote pair, and sets `windowsVerbatimArguments`.

**The wrap is required, not belt-and-braces.** With `/s`, `cmd` strips the first and last quote of the whole command line, so a payload that already begins and ends with a quote loses them when only the verbatim flag is set. That case fails both today and with the flag alone; only wrap-plus-verbatim survives it. The Evidence section shows the measurement.

**Non-goals / boundaries.** Everything that is not the canonical five-element `cmd.exe` invocation keeps its current behavior and gets the caller's argv array back untouched: PowerShell, direct executables, other `cmd` paths, non-canonical argv, and non-Windows hosts. Environment, cwd, cancellation, timeout, process-tree termination, output limits, execution policy and approval handling are unchanged. The payload's own content is never rewritten.

One note for reviewers: `src/node-host/invoke.ts` already carries an `oxlint-disable max-lines` for being a grandfathered oversized file, and this adds roughly 50 lines to it. Happy to move the helper to its own module if you would prefer that.

## User Impact

Operators can run a native `exec` on a Windows node host with quoted arguments and have the command arrive exactly as written. Anything that previously worked keeps working — the change is inert for every invocation shape other than the canonical `cmd.exe /d /s /c` transport, and inert on non-Windows hosts.

## Evidence

**Measured on Windows 11, Node v24.19.0**, spawning `cmd.exe` directly with `child_process.spawnSync` and comparing three configurations of the identical argv. **A** = current behavior, **B** = verbatim flag only, **C** = this change (wrap + verbatim):

| # | payload sent | A — today | B — verbatim only | C — this change |
|---|---|---|---|---|
| 1 | `echo "https://tenant.example.com/"` | `\"https://tenant.example.com/\"` | correct | correct |
| 2 | `echo "https://x.example.com/?a=1&b=2"` | backslashes added | correct | correct |
| 3 | `echo "C:\Program Files\demo\tool.exe" --flag` | backslashes added | correct | correct |
| 4 | `echo "C:\dir\" end` | `\"C:\dir\\\" end` | correct | correct |
| 5 | `"C:\Windows\System32\cmd.exe" /c echo "tail"` | **fails:** `'\"C:\Windows\System32\cmd.exe\"' is not recognized as an internal or external command` | **fails:** `The directory name is invalid.` | `"tail"` |

Row 5 is why the payload is wrapped rather than only flagged.

**Regression tests at the runCommand boundary** — `src/node-host/invoke.windows-cmd-quoting.test.ts`, 18 cases driving the real `testing.runCommand` and asserting what reaches the shared runner: the wrapped argv and `windowsVerbatimArguments: true` for the canonical shapes (bare executable, upper-case switches, backslash and forward-slash `SystemRoot` paths, `WINDIR` fallback, unusable Windows root), the untouched **same array instance** and absent option for everything else (a `cmd.exe` outside the Windows root, PowerShell, a direct executable, four- and six-element argv, reordered switches, a missing switch, a non-string entry, `darwin`, `linux`), plus the surrounding run options (`baseEnv`, `cwd`, `killProcessTree`, `timeoutMs`) surviving unchanged.

**These fail if the wiring is reverted.** Restoring the call site to its previous form (`runCommandWithTimeout(argv, { baseEnv: env, …})`) makes **7 of them fail**, which is the point: a helper-only suite would have stayed green while the reported bug returned.

**Real Windows output** — two cases added to the existing `src/node-host/invoke.run-command.test.ts`, gated with `describe.runIf(process.platform === "win32")` in the same style as the file's existing platform-gated tests. They run real `cmd.exe` and assert the child's stdout for a quoted URL and for a payload that itself begins and ends with a quote. They skip on non-Windows hosts.

No helper-only test API is added — `src/node-host/invoke.test-support.ts` is byte-identical to `main`.

```
node scripts/run-vitest.mjs src/node-host/invoke.windows-cmd-quoting.test.ts src/node-host/invoke.run-command.test.ts
  Test Files  2 passed (2)
       Tests  30 passed | 2 skipped (32)     # the 2 skipped are the Windows-only cases

pnpm tsgo:core        -> exit 0
pnpm tsgo:core:test   -> exit 0
npx oxlint <changed files>  -> clean
oxfmt --write         -> applied
```

**Production soak.** We have been running this change on Windows node hosts since 2026-09-08 (OpenClaw 2026.9.1 and 2026.9.2). End-to-end gateway-to-node native `exec` after a node-host restart: quoted URLs, spaces and ampersands arrive with no characters added or lost, and the browser flow that originally failed now opens the correct page. No regression observed in non-Windows nodes, PowerShell invocations or direct-executable invocations.
