### PR TITLE
fix: non-Latin policy rules are dropped from the AGENTS.md policy digest

### DIFF
--- a/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
@@ -173,6 +173,33 @@ describe("buildBootstrapContextFiles", () => {
     expect(result?.content).toContain(requiredScopedInstruction);
     expect(result?.content).toContain("[...truncated, read AGENTS.md for full content...]");
   });
+  it("keeps non-Latin policy digest lines from oversized AGENTS.md middle content", () => {
+    // CJK codepoints are not \w, so a \b-anchored keyword list can never match a
+    // Chinese policy line: without a CJK alternation these lines are neither
+    // digest candidates nor high priority, and a tight budget drops them first.
+    const mandatoryChineseBullet = "- 🔴 禁止在對話中索取使用者密碼。";
+    const mandatoryChineseProse = "本平台所有 agent 一律不得直接寫入生產資料庫。";
+    const content = [
+      "# Root policy",
+      "A".repeat(900),
+      "## 政策",
+      mandatoryChineseBullet,
+      mandatoryChineseProse,
+      "B".repeat(700),
+      "tail marker",
+    ].join("\n");
+    const [result] = buildBootstrapContextFiles([makeFile({ content })], {
+      maxChars: 700,
+    });
+
+    expect(result?.content.length).toBeLessThanOrEqual(700);
+    expect(result?.content).toContain("[Policy digest from AGENTS.md]");
+    // The bullet is admitted by the structural check even today, but only the CJK
+    // alternation makes it high priority; the prose line is not a candidate at all
+    // without it.
+    expect(result?.content).toContain(mandatoryChineseBullet);
+    expect(result?.content).toContain(mandatoryChineseProse);
+  });
   it("keeps the quoted heartbeat example with its framing", () => {
     const frame = "Example heartbeat prompt:";
     const [result] = buildBootstrapContextFiles(

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -155,13 +155,28 @@ function isUserBootstrapFile(fileName: string | undefined): boolean {
   return fileName?.toLowerCase() === USER_BOOTSTRAP_FILENAME.toLowerCase();
 }
 
+/**
+ * Mandatory-policy vocabulary for the AGENTS.md policy digest.
+ *
+ * The Latin alternation keeps `\b`. The CJK alternation must not have it: CJK
+ * codepoints are not `\w`, so a word boundary can never match beside them, and
+ * adding CJK terms inside the `\b(?:…)\b` group would have no effect at all.
+ *
+ * The high-priority CJK group is deliberately narrower than the candidate group.
+ * Candidate membership only admits a line to the pool; `highPriority` decides
+ * what survives a tight digest budget, so widening it to the softer terms makes
+ * nearly every mandatory line high priority and the ranking stops discriminating.
+ */
+const POLICY_DIGEST_CANDIDATE_PATTERN =
+  /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|owner|security|secret|credential|test|validation|command|commit|push|github|pr)\b|(?:🔴|禁止|嚴禁|不得|絕不|絕對不|切勿|必須|務必|一律|紅線)/iu;
+const POLICY_DIGEST_HIGH_PRIORITY_PATTERN =
+  /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b|(?:🔴|禁止|嚴禁|不得|絕不|絕對不|切勿)/iu;
+
 function isPolicyDigestCandidate(line: string): boolean {
   if (/^(?:#{1,6}|\s*[-*+]|\s*\d+[.)])\s+\S/u.test(line)) {
     return true;
   }
-  return /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|owner|security|secret|credential|test|validation|command|commit|push|github|pr)\b/iu.test(
-    line,
-  );
+  return POLICY_DIGEST_CANDIDATE_PATTERN.test(line);
 }
 
 function normalizePolicyDigestLine(line: string): string {
@@ -218,8 +233,6 @@ function trimAgentsBootstrapContent(trimmed: string, maxChars: number): TrimBoot
   // Budget refinement reselects these distinct source-ordered lines without reparsing them.
   const candidates: PolicyDigestCandidate[] = [];
   if (!(digestBudget <= 0)) {
-    const highPriorityPattern =
-      /\b(?:AGENTS\.md|scoped|required|must|never|do not|before subtree|read scoped|security|secret|credential)\b/iu;
     let lastProseLine: string | null = null;
     for (const sourceLine of trimmed.split(/\r?\n/u)) {
       const line = normalizePolicyDigestLine(sourceLine);
@@ -234,7 +247,7 @@ function trimAgentsBootstrapContent(trimmed: string, maxChars: number): TrimBoot
         candidates.push({
           // Select framing and its candidate as one indivisible text unit.
           text: lastProseLine === null ? line : `${lastProseLine}\n${line}`,
-          highPriority: highPriorityPattern.test(line),
+          highPriority: POLICY_DIGEST_HIGH_PRIORITY_PATTERN.test(line),
         });
         lastProseLine = null;
       } else {


### PR DESCRIPTION
Closes #142848

## What Problem This Solves

Fixes an issue where operators who write their agent instructions in a non-Latin language would have their mandatory rules silently dropped from the model's prompt once `AGENTS.md` grew past `bootstrapMaxChars` (default 20,000).

The policy digest exists precisely to rescue those rules: when `AGENTS.md` is oversized, only a head slice, the digest, and a tail slice reach the model, and the digest is what protects the mandatory lines sitting in the middle of the file. For a Chinese-language `AGENTS.md` it protected the English lines and dropped theirs.

Nothing is logged when this happens. The rule is in the file, the operator believes it is in force, and the model never sees it. The failure is also inverted from what an operator would expect: the more explicitly a rule is marked mandatory in the local language, the more likely it is to be dropped, because the digest cannot see it at all.

## Why This Change Was Made

Both digest matchers were English-only **and** anchored with `\b`. CJK codepoints are not `\w`, so `\b` can never form a boundary beside them — which means adding CJK terms inside the existing `\b(?:…)\b` alternation would have had no effect whatsoever. The boundary has to be absent for that group.

The two patterns move to module constants that join a CJK alternation **without** `\b` to the unchanged Latin alternation (which keeps `\b`).

**The high-priority CJK group is deliberately narrower than the candidate group.** Candidate membership only admits a line to the pool; `highPriority` decides what survives a tight budget. Measured over the same corpus, the strict set (`🔴 禁止 嚴禁 不得 絕不 絕對不 切勿`) matches 10.2% of lines (~41 per file, against a digest budget of roughly 150 lines), while including the softer terms reaches 21.3% — at which point nearly every mandatory line is high priority and the ranking stops discriminating. So the softer terms (`必須 務必 一律 紅線`) admit a line to the pool but do not promote it.

**Non-goals / boundaries.** Latin behavior is unchanged, including that `AGENTS\.md` keeps its literal dot. The term lists were validated against a Traditional-Chinese corpus; Japanese and Korean equivalents are **not** covered here and would be a good follow-up. If you would rather not carry vocabulary in core at all, an alternative shape is a configurable `policyDigestKeywords` with Latin and non-Latin groups kept separate so the `\b` distinction survives — happy to build that instead.

## User Impact

Operators writing agent instructions in Chinese get the same protection English-language operators already had: a mandatory rule in the middle of an oversized `AGENTS.md` reaches the model instead of being silently truncated away. Nothing changes for English-language instruction files.

## Evidence

**Production-resolver measurement** — this runs `buildBootstrapContextFiles` itself (no reimplementation) over 53 real `AGENTS.md` files, once on clean `main` and once on this branch, at the default `bootstrapMaxChars` of 20,000. It counts how many strict-mandatory Chinese lines actually appear in the rendered bootstrap text the model receives. File ids are anonymised and no file content is reproduced.

```
$ node --import ./scripts/tsx.mjs corpus-proof.ts     # on main @ 2cb7337e
resolver: buildBootstrapContextFiles (production, this HEAD)
maxChars=20000  files=53  oversized=45
mandatory lines: 1768
visible in rendered bootstrap: 825 (46.7%)
  a34  chars=50284  mandatory=95  visible=34
  a2   chars=48493  mandatory=63  visible=19
  a3   chars=45358  mandatory=61  visible=21

$ node --import ./scripts/tsx.mjs corpus-proof.ts     # on this branch
resolver: buildBootstrapContextFiles (production, this HEAD)
maxChars=20000  files=53  oversized=45
mandatory lines: 1768
visible in rendered bootstrap: 1684 (95.2%)
  a34  chars=50284  mandatory=95  visible=53
  a2   chars=48493  mandatory=63  visible=54
  a3   chars=45358  mandatory=61  visible=56
```

| | mandatory lines visible | share |
|---|---|---|
| before (clean `main`) | 825 / 1768 | 46.7% |
| after (this branch) | 1684 / 1768 | **95.2%** |

An earlier revision of this PR quoted 812 → 1,661 (46.3% → 94.6%). Those came from a port of the selection logic rather than the shipped resolver; the numbers above replace them and are what the production path actually produces.

For context on why the English-only matcher misses so much: the English `highPriorityPattern` matches 293 lines (1.4%) of that corpus, while 2,185 lines (10.2%) contain a strict Chinese prohibition, and only 5 lines are matched by both.

**Why `\b` is the cause and not the vocabulary list:**

```js
const withB = /\b(?:禁止|嚴禁|不得)\b/u;
const noB   = /(?:禁止|嚴禁|不得)/u;
withB.test("🔴 禁止使用共用登入帳號");  // false
noB.test("🔴 禁止使用共用登入帳號");    // true
```

**Matcher behavior**, running the patterns verbatim:

| line shape | `isPolicyDigestCandidate` before → after | `highPriority` before → after |
|---|---|---|
| Chinese prose line | false → **true** | false → **true** |
| Chinese bullet line | true → true (structural check already admitted it) | false → **true** |
| Chinese heading line | true → true (structural) | false → **true** |
| English bullet line | true → true | true → true |

Note the honest detail: Chinese bullets and headings were already reaching the pool via the structural check; what they could never get is priority. The prose line is the one that was not a candidate at all.

**Regression check** — 11 English lines (including `must never commit secrets`, `read scoped AGENTS.md before subtree`, `push to github`, near-misses like `musty`, `commander`, `scopedly`, and `AGENTSXmd` for the literal dot) produce **identical** results before and after for both patterns.

**Test** — added to the existing `embedded-agent-helpers.buildbootstrapcontextfiles.test.ts` next to the English policy-digest test. It asserts that both a Chinese bullet and a Chinese prose line survive truncation. Verified to **fail before this change and pass after**: at `maxChars: 700` the prose line goes false → true, with the rendered output at 662 characters, leaving headroom under the cap so the test is not brittle.

```
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
  Test Files  1 passed (1)
       Tests  36 passed (36)

pnpm tsgo:core        -> exit 0
pnpm tsgo:core:test   -> exit 0
npx oxlint <changed files>  -> clean
oxfmt --write         -> applied
```
