### PR TITLE
perf(plugins): batch installed capability eligibility

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -541,6 +541,47 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.loadPluginManifestRegistryCore).not.toHaveBeenCalled();
   });
 
+  it("shares installed policy across external owners and refreshes it on the next selection", () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `external-${index}`);
+    const registry = createEmptyPluginRegistry();
+    for (const id of ids) {
+      registry.plugins.push(createPluginRecord({ id, origin: "global" }));
+      addCapabilityProvider(registry, "imageGenerationProviders", { id });
+    }
+    const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: ids.map((id) => ({
+        id,
+        origin: "global",
+        contracts: { imageGenerationProviders: [id] },
+      })),
+    });
+    const firstEntry = { enabled: false };
+    let enumerations = 0;
+    const entries = new Proxy(
+      Object.fromEntries(
+        ids.map((id, index) => [id, index === 0 ? firstEntry : { enabled: true }]),
+      ),
+      {
+        ownKeys(target) {
+          enumerations += 1;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const cfg: OpenClawConfig = { plugins: { entries } };
+    for (const enabled of [false, true]) {
+      firstEntry.enabled = enabled;
+      enumerations = 0;
+      const prepared = prepareMediaCapabilityProviders({ cfg, pluginMetadataSnapshot, registry });
+
+      expect(prepared.imageGenerationProviders?.map((provider) => provider.id)).toEqual(
+        enabled ? ids : ids.slice(1),
+      );
+      // Manifest, installed, and loaded-provider filters each prepare policy at most once.
+      expect(enumerations).toBeLessThanOrEqual(3);
+    }
+  });
+
   it.each([
     {
       name: "explicitly disabled",

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -13,6 +13,7 @@ import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
 import type { PluginCapabilityCatalog } from "./capability-catalog.types.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { createInstalledPluginEnabledPredicate } from "./installed-plugin-index.js";
 import { resolvePluginCapabilityCatalogContext } from "./loader-runtime-load.js";
 import { resolveRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
 import {
@@ -89,6 +90,7 @@ function resolveCapabilityPluginIds(params: {
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "plugins">;
 }): CapabilityPluginResolution {
   const snapshot = loadCapabilityManifestSnapshot(params);
+  const isEnabled = createInstalledPluginEnabledPredicate(snapshot.index.plugins, params.cfg);
   let normalizedConfig: NormalizedPluginsConfig | undefined;
   const providerIds = params.providerIds;
   const matchedProviderIds = providerIds ? new Set<string>() : undefined;
@@ -104,6 +106,7 @@ function resolveCapabilityPluginIds(params: {
         snapshot,
         plugin,
         config: params.cfg,
+        isInstalledPluginEnabled: isEnabled,
         normalizedConfig:
           params.cfg?.plugins && (normalizedConfig ??= normalizePluginsConfig(params.cfg.plugins)),
         // Legacy TTS remains available when the operator disables plugins globally.


### PR DESCRIPTION
## What Problem This Solves

Capability selection repeats installed-plugin policy preparation for each matching external provider owner, even though every owner is evaluated against the same metadata snapshot and configuration.

## Why This Change Was Made

Prepare the existing lazy enablement predicate once per selection and pass it through the existing eligibility callback. Each later selection prepares fresh policy. The change adds three production lines and preserves installed membership, bundled-provider handling, speech compatibility, and provider-alias resolution.

## User Impact

Selecting capabilities with multiple external plugin owners performs less repeated configuration work while returning the same eligible providers.

## Evidence

The regression first returned the correct providers but failed because it enumerated configuration entries nine times. With the change, it stays within three enumerations and observes an enablement change on the same configuration during the next selection. This measures operation count, not elapsed performance.

All 115 owner and sibling cases passed, the final regression passed again, and all 29 selected changed-file checks passed. Independent review found no actionable issues. No acquisition lifecycle, persistent cache, configuration option, dependency, or runtime import fanout changed.
