### PR TITLE
test: serialize worker transform fixture layouts

### DIFF
--- a/test/scripts/vitest-worker-artifacts.transforms.test.ts
+++ b/test/scripts/vitest-worker-artifacts.transforms.test.ts
@@ -6,10 +6,8 @@ import { createWorkerArtifactTest, workerProbe } from "./vitest-worker-artifacts
 
 const root = process.cwd();
 const it = createWorkerArtifactTest();
-// Each sequence rebuilds all workers; avoid contention on Windows CI runners.
-const concurrent = process.platform !== "win32";
-
-describe("fresh compiled subprocess invocation", { concurrent }, () => {
+// Each sequence rebuilds all workers; avoid contention on small CI runners.
+describe("fresh compiled subprocess invocation", { concurrent: false }, () => {
   it.for((["single", "projects"] as const).map((layout) => ({ layout })))(
     "preserves filesystem transforms across fresh generations, source mode, and edits ($layout)",
     ({ layout }, { workerArtifacts }) =>


### PR DESCRIPTION
## What Problem This Solves

The two worker-transform fixtures rebuild every worker concurrently while each has its own 120-second deadline. In [CI run 34342640018](https://github.com/openclaw/openclaw/actions/runs/34342640018), both layouts timed out after four of five completed phases on a two-CPU runner. The layouts have independent files, caches, and generations; their overlap does not test shared-worker concurrency.

## Why This Change Was Made

Run these two outer cases serially, extending the existing Windows scheduling choice to every platform. Both layouts, all five phases, every assertion, and the 120-second deadline remain unchanged. The separate real-borrower test continues to exercise concurrent use of one worker generation.

## User Impact

This gives each expensive fixture exclusive use of the test file's resources. It changes test scheduling only, with a deliberate tradeoff in total execution time.

## Evidence

A controlled Linux/Node 24.19 comparison under the same two-CPU affinity passed both layouts before and after; it did not reproduce the CI timeout. Per-case times changed from about 86.1 seconds each to 65.9 and 68.3 seconds. Total invocation time increased from 89.0 to 137.3 seconds. This was one pair on different hardware from the failing CI job, not a timing guarantee.

Both layouts completed all five phases, the existing real-borrower concurrency case passed, and all 15 selected changed-file checks passed. Independent review found no actionable issues. No assertion, timeout, or shared concurrency setting was weakened.
