### PR TITLE
improve(test): avoid full builds for session history HTTP checks

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -3544,8 +3544,7 @@ function classifyTarget(arg: string, cwd: string) {
   }
   if (
     relative === "src/gateway/gateway.test.ts" ||
-    relative === "src/gateway/server.startup-matrix-migration.integration.test.ts" ||
-    relative === "src/gateway/sessions-history-http.test.ts"
+    relative === "src/gateway/server.startup-matrix-migration.integration.test.ts"
   ) {
     return "e2e";
   }

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -22,7 +22,6 @@ describe("e2e vitest config", () => {
       "packages/**/*.e2e.test.ts",
       "src/gateway/gateway.test.ts",
       "src/gateway/server.startup-matrix-migration.integration.test.ts",
-      "src/gateway/sessions-history-http.test.ts",
       BUNDLED_PLUGIN_E2E_TEST_GLOB,
     ]);
     expect(e2eConfig.test?.pool).toBe("threads");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4087,17 +4087,17 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it.each([
-    "src/gateway/gateway.test.ts",
-    "src/gateway/server.startup-matrix-migration.integration.test.ts",
-    "src/gateway/sessions-history-http.test.ts",
-  ])("routes gateway integration fixture %s to the e2e lane", (target) => {
+    ["src/gateway/gateway.test.ts", "e2e"],
+    ["src/gateway/server.startup-matrix-migration.integration.test.ts", "e2e"],
+    ["src/gateway/sessions-history-http.test.ts", "gateway"],
+  ])("routes gateway integration fixture %s to the %s lane", (target, lane) => {
     const plans = buildVitestRunPlans([target], process.cwd());
 
     expect(plans).toEqual([
       {
-        config: "test/vitest/vitest.e2e.config.ts",
-        forwardedArgs: [target],
-        includePatterns: null,
+        config: `test/vitest/vitest.${lane}.config.ts`,
+        forwardedArgs: lane === "e2e" ? [target] : [],
+        includePatterns: lane === "e2e" ? null : [target],
         watchMode: false,
       },
     ]);

--- a/test/vitest-projects-config.test-support.ts
+++ b/test/vitest-projects-config.test-support.ts
@@ -73,7 +73,6 @@ function listNormalFullSuiteTestFiles(): string[] {
   const e2eNamedIntegrationTests = new Set([
     "src/gateway/gateway.test.ts",
     "src/gateway/server.startup-matrix-migration.integration.test.ts",
-    "src/gateway/sessions-history-http.test.ts",
   ]);
   return globSync(["**/*.{test,spec}.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"], {
     cwd: process.cwd(),

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -1017,7 +1017,7 @@ describe("scoped vitest configs", () => {
     expect(testConfig.include).toEqual(["**/*.test.ts"]);
     expect(testConfig.exclude).toContain("gateway.test.ts");
     expect(testConfig.exclude).toContain("server.startup-matrix-migration.integration.test.ts");
-    expect(testConfig.exclude).toContain("sessions-history-http.test.ts");
+    expect(testConfig.exclude).not.toContain("sessions-history-http.test.ts");
   });
 
   it("normalizes infra include patterns relative to the scoped dir", () => {

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -57,7 +57,6 @@ export function createE2EVitestConfig(env: Record<string, string | undefined> = 
         "packages/**/*.e2e.test.ts",
         "src/gateway/gateway.test.ts",
         "src/gateway/server.startup-matrix-migration.integration.test.ts",
-        "src/gateway/sessions-history-http.test.ts",
         BUNDLED_PLUGIN_E2E_TEST_GLOB,
       ],
       exclude,

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -5,6 +5,7 @@ export const gatewayServerBackedHttpTestFiles = [
   "src/gateway/openai-http.test.ts",
   "src/gateway/openresponses-http.test.ts",
   "src/gateway/probe.auth.integration.test.ts",
+  "src/gateway/sessions-history-http.test.ts",
 ];
 
 // Gateway methods needing native process state or a private module graph keep
@@ -26,7 +27,6 @@ export const gatewayServerIsolatedTestFiles = [
 export const gatewayServerExcludedTestFiles = [
   "src/gateway/gateway.test.ts",
   "src/gateway/server.startup-matrix-migration.integration.test.ts",
-  "src/gateway/sessions-history-http.test.ts",
 ];
 
 const gatewayServerBackedHttpTestFileSet = new Set(gatewayServerBackedHttpTestFiles);

--- a/test/vitest/vitest.gateway.config.ts
+++ b/test/vitest/vitest.gateway.config.ts
@@ -22,7 +22,6 @@ export function createGatewayVitestConfig(env?: Record<string, string | undefine
     exclude: [
       "src/gateway/gateway.test.ts",
       "src/gateway/server.startup-matrix-migration.integration.test.ts",
-      "src/gateway/sessions-history-http.test.ts",
       ...gatewayMethodsIsolatedTestFiles,
       ...gatewayServerIsolatedTestFiles,
     ],


### PR DESCRIPTION
Related: #139428 (https://github.com/openclaw/openclaw/issues/139428)

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Focused session-history HTTP checks on a cold checkout enter the E2E lane and
build the full runtime and AI package, although this owner uses the source
Gateway harness and ordinary compiled-worker artifacts. The original
13-case sample spent 435.8s in those cold build prerequisites.

## Why This Change Was Made

Move the existing HTTP owner into the canonical Gateway-server inventory and
update its existing direct, aggregate, E2E, and full-suite routing expectations
across eight files.
Retain Gateway-core exclusion, the other E2E integration owners, ordinary
worker preparation, and every HTTP case and assertion. No production, harness,
dependency, workflow, or build-policy changes.

## User Impact

Developers can run this focused owner without unnecessary full-runtime and AI
builds. There is no user-facing runtime change.

Test and hook defaults remain 120s and 180s. The explicit Gateway-server route
inherits its existing 2,400s project watchdog instead of E2E's 300s; no timeout
override or file-specific exception is added. The complete 107.415s cold proof
fits both windows, so qualification does not rely on that expanded budget.
Whole-CI savings have not been measured.

## Evidence

- Cold normal Gateway-server run: all 91 history cases plus 10 models HTTP
  sibling cases passed, zero skips, in 107.415s. Both owners executed in the same
  non-isolated worker, with fresh module caches.
- Repository `dist` and `packages/ai/dist` were absent. Ordinary worker
  preparation took 6.720s; the real SQLite worker and generation verification
  and disposal were observed. No skip/prebuilt flags or full build.
- Six existing routing/inventory checks passed, including direct and aggregate
  routing, the complete root project graph, and exactly-once full-suite ownership.
- Existing real-consumer missing-SQLite-worker control passed: the next borrower
  fails with ENOENT without rebuilding, and the generation is cleaned up.
- The updated routing expectation fails against the exact original classifier
  because it receives E2E instead of Gateway routing. The saved raw diff confirms
  the intended failure; an auxiliary JSON recorder omitted the rendered diff.
- Exact seven-path `check-changed` passed, including formatting, scripts/root-test
  typechecks, and lint. The eighth-file repair passed all ten newly selected
  checks, including the infra typecheck graph and targeted format/lint; unchanged
  guards reused their prior successful results. Formatting needed no edits.
- Initial hosted CI found one missed strict E2E include-list expectation:
  https://github.com/openclaw/openclaw/actions/runs/34351442378/job/102465663470
  Removing only that stale entry preserves all four cases and their strict
  runtime/setup/worker assertions. The complete four-case file now passes
  through the normal test wrapper, with zero skips.
- Fresh independent P2 review of the full eight-file candidate found no
  actionable findings. The original cold HTTP, routing, and worker proof remains
  unchanged; it was not rerun for the expectation-only repair.

The original baseline selected 13 cases; the candidate cold proof ran 101.
The 435.8s figure is build attribution, not a matched-case wall-time percentage
or a test-execution speedup. Exact-head hosted CI passed:
https://github.com/openclaw/openclaw/actions/runs/34353084079
