### PR TITLE
refactor: skip redundant CLI JSON-mode parsing

### DIFF
--- a/src/cli/json-output-mode.ts
+++ b/src/cli/json-output-mode.ts
@@ -1,7 +1,7 @@
 // Early JSON-output detection and console-log routing for parseable CLI stdout.
 import { loggingState } from "../logging/state.js";
-import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { isConfigSetJsonParseOnly } from "./config-output-mode.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 let resolvedJsonOutputMode: boolean | null = null;
 
@@ -20,10 +20,13 @@ export function hasJsonOutputFlag(argv: readonly string[]): boolean {
 
 /** Uses Commander-resolved output ownership when available, then falls back to argv. */
 export function isJsonOutputModeActive(argv: readonly string[]): boolean {
-  const commandPath = resolveCliArgvInvocation([...argv]).commandPath;
-  const parseOnlyJson =
-    commandPath[0] === "config" && commandPath[1] === "set" && isConfigSetJsonParseOnly(argv);
-  return resolvedJsonOutputMode ?? (hasJsonOutputFlag(argv) && !parseOnlyJson);
+  return (
+    resolvedJsonOutputMode ??
+    (hasJsonOutputFlag(argv) &&
+      !(
+        resolveCliParentCommandPath(argv, "config")?.[1] === "set" && isConfigSetJsonParseOnly(argv)
+      ))
+  );
 }
 
 /** Keeps structured JSON stdout clean by routing incidental console logs to stderr. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

CLI JSON-output detection parses the command invocation even when Commander has already resolved the output mode or the arguments contain no JSON-output flag. That repeats work on a path used to keep machine-readable stdout separate from incidental console logs.

## Why This Change Was Made

Honor the resolved output mode first, then check for a JSON flag, and inspect the config parent command only when the parser-only `config set --json` exception matters, reusing the existing parent-command helper. The one-file change removes the eager invocation parse and argv copy; its net three production lines (8 added, 5 removed) express that short-circuit order explicitly without adding another parser, cache, dependency or test seam.

## User Impact

No intended output or command behavior changes. Command aliases and root/parent options retain their existing parsing behavior; `config set --json` remains a value-parser alias, while its `--dry-run` JSON-report behavior is preserved. The argv sentinel, resolved true/false output ownership and nested console-routing restoration are unchanged.

The cleanup reduces measured work within JSON-mode detection. Full CLI results are mixed: all 12 paired helper batch medians improved, but 9 of 12 built-CLI wall-time pairs regressed. This does not establish an overall CLI startup, Gateway or memory improvement.

## Evidence

All 161 existing tests passed across five files; no tests were added or changed. All seven local supplemental package guards passed, Codex review completed cleanly, and normal baseline/candidate builds both succeeded. These checks do not replace exact-head CI. [Earlier CI run 34351621347](https://github.com/openclaw/openclaw/actions/runs/34351621347) failed an unchanged Telegram model-callback loopback test twice. Main now contains the independently reproduced fixture repair [#143197](https://github.com/openclaw/openclaw/pull/143197). This PR was rebased onto that repair with an identical patch (verified by range-diff); [CI run 34373360608](https://github.com/openclaw/openclaw/actions/runs/34373360608) passed the Telegram job but failed the first Discord native `/new` reset case, including one exact-job diagnostic replay. Main now contains the owning catalog repair [#143254](https://github.com/openclaw/openclaw/pull/143254). The same JSON patch was rebased again without changes onto that repair; [CI run 34382634733](https://github.com/openclaw/openclaw/actions/runs/34382634733) passed on head `168b342e5fe74da57b7079979b846b554380778d`, including both previously failing shards and the required gate. This PR merged as `fd490cf304fea7d4fd83c3a8643078ebe2884ff7`. All original failures remain retained; no timeout was changed.

The completed fixed R3 cohort passed independent saved-data audit: all 16,190 helper booleans (16,152 workload calls plus 38 untimed correctness calls), 24 actual built-CLI outcomes and 24 setup validations matched their complete literal contracts. Helper argv inputs were unchanged. All CLI stdout/stderr bytes matched; each CLI child normally exited 1 as required by its parse-error oracle. This expected exit status was not an acquisition failure. Source/build pins, native closures and candidate restoration were verified. No target was rerun for the audit.

<details>
<summary>All six helper rows, both orders</summary>

Values are nanoseconds: medians of five 128-call batch means. Forward compares B0 → C0; reverse compares B1 → C1. Lower is better.

| Helper row | Forward ns | Δ | Reverse ns | Δ |
|---|---:|---:|---:|---:|
| plain | 2525.453→491.148 | -80.55% | 3205.766→252.938 | -92.11% |
| unresolved-json | 1855.188→1759.125 | -5.18% | 2133.141→763.648 | -64.20% |
| config-parser-alias | 1615.594→1270.148 | -21.38% | 2012.367→1290.055 | -35.89% |
| config-dry-json | 1489.547→701.172 | -52.93% | 1885.422→623.023 | -66.96% |
| resolved-true-no-literal | 956.055→30.875 | -96.77% | 1184.242→34.156 | -97.12% |
| resolved-false-literal | 1049.453→31.859 | -96.96% | 1213.797→33.141 | -97.27% |

The resolved fast paths at approximately 31–34 ns are near clock overhead, not a universal production latency. First/warmup and maximum observations remain separate: reverse unresolved-JSON first call rose 3.084 → 76.333 µs (+2375.13%); forward config-parser-alias first call rose 4.292 → 15.250 µs (+255.31%). Config-dry-JSON maximum rose 8.167 → 223.708 µs forward and 32.625 → 200.291 µs reverse.

Across retained helper statistics, 32/192 cells, 6/60 batch comparisons and 433/8,076 ordinal comparisons were adverse. These overlapping counts are not independent experiments; all adverse and tied observations are retained.

</details>

<details>
<summary>All six built-CLI cases, both orders — 9/12 adverse wall-time pairs</summary>

Values are whole-process milliseconds. Each case has only one observation per image/order, not a latency distribution or significance estimate. Positive changes are regressions.

| Actual CLI case | Forward ms | Δ | Reverse ms | Δ |
|---|---:|---:|---:|---:|
| plain-parse-failure | 560.629→423.460 | -24.47% | 572.523→447.794 | -21.79% |
| json-parse-failure | 427.607→430.049 | +0.57% | 446.232→547.234 | +22.63% |
| config-parser-alias | 446.250→448.795 | +0.57% | 460.034→498.288 | +8.32% |
| config-dry-json | 444.609→452.945 | +1.87% | 462.866→476.004 | +2.84% |
| config-parent-section | 462.443→444.023 | -3.98% | 468.739→485.296 | +3.53% |
| config-parent-consumed-json | 447.196→449.379 | +0.49% | 478.823→485.839 | +1.47% |

Plain parse failure improved by 137.168 ms forward and 124.729 ms reverse. Reverse JSON parse failure regressed by 101.002 ms, with system CPU rising 88.133 → 119.154 ms (+35.20%). Despite faster plain-error wall times, its sampled-tree RSS increased by 39,550,976 bytes (+21.68%) forward and 30,801,920 bytes (+16.63%) reverse. Of all 60 CLI wall/user/system/kernel-RSS/tree-RSS comparisons, 33 were adverse; every resource pair remains retained.

</details>

Helper whole-process wall was also mixed: 453.772 → 537.870 ms forward (+18.53%) and 541.944 → 435.619 ms reverse (−19.62%). Forward helper system CPU rose 30.35%; both helper kernel RSS peaks fell roughly 12%. Five of 20 helper/setup resource comparisons were adverse. Whole-process costs include source-loader imports, journal append/stat work and proof overhead; they are neither the narrow helper stopwatch nor isolated import measurements. Untimed schema setup is kept separate from helper and CLI results. RSS measures footprint, not allocations, and no general memory benefit is attributed to this change.

Measurements use the frozen `38f9a69d` source/build context. The helper exercise and one-off built CLI processes do not measure live Gateway traffic or establish a general startup gain. Full results, literal outputs, timings, resource pairs and adverse observations remain in the retained audit dataset.

Earlier R1/R2 failed prefixes remain separate and unpooled: R1 stopped at a platform-specific proof-preflight observation; R2 stopped during untimed source-loader setup, with its separate pre-admission capacity refusal also retained. Neither produced a CLI outcome. R3 corrected only the accepted setup working directory; actual built CLI arguments, output oracles and empty fixture working directories remained unchanged.
