### PR TITLE
fix(ui): prevent animation races in attachment layout checks

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4338,27 +4338,49 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page.locator(".agent-chat__input").evaluate((node) => {
           node.scrollTop = 0;
         });
-        const input = await getBoundingBox(
-          page,
-          ".agent-chat__composer-shell > .agent-chat__input",
+        // Ancestor entrance animations move these boxes together; compare one frame.
+        const { input, preview, attachment, remove, topHits, textStart } = await page.evaluate(
+          () => {
+            const elementFor = (selector: string) => {
+              const [element, ...others] = document.querySelectorAll(selector);
+              if (!element || others.length > 0) {
+                throw new Error(`Expected one layout element: ${selector}`);
+              }
+              return element;
+            };
+            const rectFor = (selector: string) => {
+              const {
+                x,
+                y,
+                width: rectWidth,
+                height: rectHeight,
+              } = elementFor(selector).getBoundingClientRect();
+              return { x, y, width: rectWidth, height: rectHeight };
+            };
+            const removeNode = elementFor(".chat-attachment-remove");
+            const removeRect = rectFor(".chat-attachment-remove");
+            const textarea = elementFor(".agent-chat__composer-combobox > textarea");
+            return {
+              input: rectFor(".agent-chat__composer-shell > .agent-chat__input"),
+              preview: rectFor(".chat-attachments-preview"),
+              attachment: rectFor(".chat-attachment-thumb"),
+              remove: removeRect,
+              topHits: [1, 3].map(
+                (offset) =>
+                  document.elementFromPoint(
+                    removeRect.x + removeRect.width / 2,
+                    removeRect.y + offset,
+                  ) === removeNode,
+              ),
+              textStart:
+                textarea.getBoundingClientRect().x +
+                Number.parseFloat(getComputedStyle(textarea).paddingLeft),
+            };
+          },
         );
-        const preview = await getBoundingBox(page, ".chat-attachments-preview");
-        const attachment = await getBoundingBox(page, ".chat-attachment-thumb");
-        const remove = await getBoundingBox(page, ".chat-attachment-remove");
-        const topHits = await page.locator(".chat-attachment-remove").evaluate((node) => {
-          const bounds = node.getBoundingClientRect();
-          return [1, 3].map(
-            (offset) =>
-              document.elementFromPoint(bounds.x + bounds.width / 2, bounds.y + offset) === node,
-          );
-        });
-        const textStart = await page
-          .locator(".agent-chat__composer-combobox > textarea")
-          .evaluate(
-            (node) =>
-              node.getBoundingClientRect().x +
-              Number.parseFloat(getComputedStyle(node).paddingLeft),
-          );
+        for (const rect of [input, preview, attachment, remove]) {
+          expectFiniteRect(rect);
+        }
 
         expect(attachment.x - input.x).toBeGreaterThanOrEqual(9.5);
         expect(Math.abs(attachment.x - textStart)).toBeLessThanOrEqual(0.5);


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent CI failure in the mobile attachment layout test. Main run [34348886307](https://github.com/openclaw/openclaw/actions/runs/34348886307/job/102457720621) compared the preview and its remove button at different moments, reporting a 0.134px clipping failure at 393×852.

## Why This Change Was Made

Read the related rectangles, text origin, and top-edge hit targets in one synchronous browser evaluation, following the neighboring composer tests. The shell and card entrance animations move all descendants together; separate browser calls could compare different animation frames. This reduces six measurement calls to one while retaining the original assertions, selector uniqueness, finite rectangles, focus behavior, and scrolled right-edge hit tests.

## User Impact

More reliable layout CI with fewer browser round trips. Product rendering, animation behavior, shard counts, timeouts, and geometry tolerances are unchanged. Production delta is zero; only the existing test changes.

## Evidence

- Controlled Chromium reproduction: pause the existing ancestor animations at 0ms, read the preview, then advance them to 250ms before the later measurements. The original assertion fails with remove y=666.007385 versus earlier preview y=679. At either individual frame the remove button remains 7px inside the preview; ancestor/input/rail scroll positions remain zero. This proves the frame-crossing failure mode, not the precise animation phase of the CI failure.
- Original focused four cases and full 127-case browser file pass locally; the failure is intermittent. The candidate also passes all 127 cases, covering all four original attachment viewports and neighboring composer interactions. Temporary diagnostics were removed before candidate validation.
- Whole-file local durations varied from 28.10s to 38.91s, so no wall-time speedup is claimed from this pair.
- Managed independent review through P2: no actionable findings. Required changed-file checks passed after correcting local variable shadowing.

Command: `node scripts/run-vitest.mjs run ui/src/pages/chat/chat-responsive.browser.test.ts` (Node 24, pnpm 12).

Exact-head CI [34352752812](https://github.com/openclaw/openclaw/actions/runs/34352752812) passed, including all 127 changed-file cases in Linux (31.98s; attachment cases 278–305ms). One failed-job rerun was needed for an unchanged catalog-reopen E2E test. Its retained failure showed the picker closed and only two catalog requests; an unchanged local 11-case run and one instrumented replay passed without establishing the cause. The same-head retry passed all 70 files/322 tests in that shard (707.82s; catalog case 2.064s). That separate toggle race remains a follow-up; this PR does not claim to fix it.
