### PR TITLE
refactor(tests): remove orphaned WhatsApp snapshot test

### DIFF
--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -1,23 +1,8 @@
 // Whatsapp tests cover web auto reply utils plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeMainKey } from "openclaw/plugin-sdk/routing";
-import {
-  evaluateSessionFreshness,
-  getSessionEntry,
-  normalizeSessionDeliveryState,
-  resolveChannelResetConfig,
-  resolveSessionKey,
-  resolveSessionResetPolicy,
-  resolveSessionResetType,
-  resolveStorePath,
-  resolveThreadFlag,
-  sessionDeliveryChannel,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
 import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { debugMention, resolveOwnerList } from "./mentions.js";
@@ -70,62 +55,6 @@ const makeMsg = (overrides: TestMessageOverrides): AdmittedWebInboundMessage => 
     },
   });
 };
-
-function getSessionSnapshotForTest(
-  cfg: OpenClawConfig,
-  from: string,
-  ctx?: {
-    sessionKey?: string | null;
-    isGroup?: boolean;
-    messageThreadId?: string | number | null;
-    threadLabel?: string | null;
-    threadStarterBody?: string | null;
-    parentSessionKey?: string | null;
-  },
-) {
-  const sessionCfg = cfg.session;
-  const scope = sessionCfg?.scope ?? "per-sender";
-  const key =
-    ctx?.sessionKey?.trim() ??
-    resolveSessionKey(
-      scope,
-      { From: from, To: "", Body: "" },
-      normalizeMainKey(sessionCfg?.mainKey),
-    );
-  const entry = getSessionEntry({
-    sessionKey: key,
-    storePath: resolveStorePath(sessionCfg?.store),
-  });
-  const isThread = resolveThreadFlag({
-    sessionKey: key,
-    messageThreadId: ctx?.messageThreadId ?? null,
-    threadLabel: ctx?.threadLabel ?? null,
-    threadStarterBody: ctx?.threadStarterBody ?? null,
-    parentSessionKey: ctx?.parentSessionKey ?? null,
-  });
-  const resetType = resolveSessionResetType({ sessionKey: key, isGroup: ctx?.isGroup, isThread });
-  const resetPolicy = resolveSessionResetPolicy({
-    sessionCfg,
-    resetType,
-    resetOverride: resolveChannelResetConfig({
-      sessionCfg,
-      channel: sessionDeliveryChannel(entry),
-    }),
-  });
-  const freshness = entry
-    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now: Date.now(), policy: resetPolicy })
-    : { fresh: false };
-
-  return {
-    key,
-    entry,
-    fresh: freshness.fresh,
-    resetPolicy,
-    resetType,
-    dailyResetAt: freshness.dailyResetAt,
-    idleExpiresAt: freshness.idleExpiresAt,
-  };
-}
 
 describe("isBotMentionedFromTargets", () => {
   const mentionCfg = { mentionRegexes: [/\bopenclaw\b/i] };
@@ -304,50 +233,6 @@ describe("resolveMentionTargets with @lid mapping", () => {
         e164: "+1777",
       });
     });
-  });
-});
-
-describe("getSessionSnapshot", () => {
-  it("uses channel reset overrides when configured", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
-    try {
-      await withTempDir("openclaw-snapshot-", async (root) => {
-        const storePath = path.join(root, "sessions.json");
-        const sessionKey = "agent:main:whatsapp:dm:s1";
-
-        await upsertSessionEntry({
-          storePath,
-          sessionKey,
-          entry: {
-            sessionId: "snapshot-session",
-            updatedAt: new Date(2026, 0, 18, 3, 30, 0).getTime(),
-            delivery: normalizeSessionDeliveryState({ context: { channel: "whatsapp" } }),
-          },
-        });
-
-        const cfg = {
-          session: {
-            store: storePath,
-            reset: { mode: "daily", atHour: 4, idleMinutes: 240 },
-            resetByChannel: {
-              whatsapp: { mode: "idle", idleMinutes: 360 },
-            },
-          },
-        } as OpenClawConfig;
-
-        const snapshot = getSessionSnapshotForTest(cfg, "whatsapp:+15550001111", {
-          sessionKey,
-        });
-
-        expect(snapshot.resetPolicy.mode).toBe("idle");
-        expect(snapshot.resetPolicy.idleMinutes).toBe(360);
-        expect(snapshot.fresh).toBe(true);
-        expect(snapshot.dailyResetAt).toBeUndefined();
-      });
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

WhatsApp's utility suite carries an obsolete session-snapshot test that no longer guards runtime behavior.

## Why This Change Was Made

Remove the test-local `getSessionSnapshotForTest` copy, its sole test, and the imports used only by that code. The runtime helper was removed previously; testing the remaining copy does not exercise the actual session initialization path.

Keep the real `initSessionState` channel-reset override coverage and reset-policy tests unchanged. The retained core case checks both `isNewSession === false` and preservation of the existing session ID.

## User Impact

No runtime behavior changes. This removes one obsolete test and its copied helper from one test file, with 1 line added and 116 deleted. All other WhatsApp utility cases and production code remain unchanged.

## Evidence

- Full WhatsApp utility file: **30 passed**.
- Core `initSessionState channel reset overrides` group: **1 passed**, including `uses channel-specific reset policy when configured`; **216 other core cases intentionally filtered**. This is not a full core-file run.
- Full reset-policy file: **21 passed**.
- **52 selected tests passed in total**, using the repository runner and each file's owning configuration:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts --reporter=verbose
node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/session.test.ts -t "initSessionState channel reset overrides" --reporter=verbose
node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/sessions/reset-policy.test.ts --reporter=verbose
```

- Targeted formatting and `git diff --check` passed.
- The complete **19-step selected changed gate passed**, pinned to the validated base:

```text
node scripts/check-changed.mjs --base 49f6843cdd59faca88d5ee47f7b0b3f57e3ecc79 -- extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
```

- Fresh scanned P2 autoreview: **no actionable findings**, with the unchanged production owner, retained tests, test wrapper, and owning configurations supplied as context.
- Hosted PR checks are a separate landing requirement; the results above are local proof.
