### PR TITLE
refactor: skip unused install details in all-plugin tables

### DIFF
--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -187,12 +187,11 @@ export async function runPluginsInspectCommand(
         ...loggerParams,
         report,
       });
-      const inspectAllWithInstall = inspectAll.map((inspect) => ({
-        ...inspect,
-        install: resolveInstallRecord(inspect.plugin.id),
-      }));
-
       if (opts.json) {
+        const inspectAllWithInstall = inspectAll.map((inspect) => ({
+          ...inspect,
+          install: resolveInstallRecord(inspect.plugin.id),
+        }));
         return JSON.stringify(inspectAllWithInstall, null, 2);
       }
       const tableWidth = getTerminalTableWidth();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

`openclaw plugins inspect --all` prepares per-plugin install details even for the human-readable table, which never displays them. That adds ownership lookups and intermediate objects while rendering larger plugin lists.

## Why This Change Was Made

Move the unchanged install-enrichment map inside the `--json` branch, where its fields are consumed, while leaving the existing ownership resolver at the same creation point. This removes unused work from the human table without changing JSON provenance resolution, ambiguous-owner handling, table contents/order, diagnostics or single-plugin inspection; the one-file change is 4 added/5 removed production lines, with no test changes, new dependency or cache.

## User Impact

The human-readable all-plugin table retains the same output with less preparation work. In the fixed 24-plugin fixture, warm-call wall medians were 79.31% and 76.23% lower in the two measurement orders. Empty-human and JSON cases regressed in both orders, so this is a targeted cleanup rather than a general command-speed or memory improvement.

## Evidence

All 39 existing whole-file tests and seven local supplemental guards passed. Codex review completed cleanly with 0.99 confidence. [Exact-head CI34352929942](https://github.com/openclaw/openclaw/actions/runs/34352929942) passed; the independent CI audit covers all21 ordinary obligations plus the seven local supplements. Finalized review had no actionable findings. Merged through the native workflow as `f2a629ea05ce3f46c3d89a6d45866c50ad2c04cf`, then verified against clean updated main.

Independent saved-data audit verified all 132 actual awaited Commander/plugin-inspect outcomes against literal fixtures, complete supplied inputs, selected public Commander return properties and identity assertions. All 408 journal records matched their final reports in order, with no missing sample, failed call, failed verification or mismatched output. Source/input/proof bindings and native closure records matched; the candidate was restored and controls disabled. The audit did not rerun product code.

<details>
<summary>All warm-call wall medians, including empty and JSON regressions</summary>

Nine warm calls per case; values are microseconds. Forward compares B0 → C0 and reverse B1 → C1. Positive changes are regressions.

| Case | Order | Baseline µs | Candidate µs | Change |
|---|---|---:|---:|---:|
| empty-human | forward | 224.209 | 255.917 | +14.1422% |
| fleet-human | forward | 1459.042 | 301.916 | -79.3072% |
| json-ownership | forward | 168.333 | 202.750 | +20.4458% |
| empty-human | reverse | 200.375 | 201.667 | +0.6448% |
| fleet-human | reverse | 1447.625 | 344.125 | -76.2283% |
| json-ownership | reverse | 170.041 | 212.167 | +24.7740% |

JSON warm mean/maximum also worsened: +43.70%/+102.49% forward and +3.94%/+2.97% reverse. No adverse observations were trimmed or pooled away. This small fixed sample describes these fixtures; it is not statistical significance or population-tail evidence.

</details>

First calls and warmups remain separate. Wall-time regressions occurred in 3/6 first calls, 4/6 warmups, 24/54 indexed warm comparisons and 14/24 warm min/median/mean/max comparisons. JSON first calls worsened 16.64% forward and 138.89% reverse; JSON warmups worsened 6.40% and 41.35%. The 24-plugin human case improved at first call and warmup in both orders. The first empty-human call includes lazy command imports and is not a process-startup measurement.

Warm user-CPU medians for the 24-plugin human table improved 79.53%/78.28%, and system-CPU medians improved 58.04%/62.77%. JSON warm CPU medians regressed in both orders: user CPU +76.19%/+28.04% and system CPU +38.71%/+77.78%.

Whole-native-child wall time improved 14.29%/1.06%, but 5/10 native resource comparisons were adverse: all four RSS comparisons and reverse system CPU. Kernel child peak RSS rose by 1,785,856 bytes (+0.40%) forward and 3,080,192 bytes (+0.70%) reverse; sampled-tree peak RSS rose by 46,563,328 bytes (+11.75%) and 1,654,784 bytes (+0.38%). Reverse system CPU increased 0.13%. These whole-child measures include Vitest, imports, setup and capture and cannot isolate the production change's cost. RSS is footprint, not allocation, and no memory-saving claim is made.

Across all retained metrics, 183/396 indexed comparisons and 75/144 warm-statistic comparisons were adverse, alongside the 5/10 native-resource regressions. These views overlap and are not independent trials. All signed RSS deltas, raw operands and zero-baseline percentages remain retained; neither order was rerun selectively.

The measured boundary uses the real awaited Commander/plugin-inspect/ownership/table path with fixture-backed config, metadata/status producers and runtime output sinks from the existing test harness. It checks public return projections and identity assertions, not Command's full internal graph. It does not measure live plugin discovery/execution, a full process launch or a Gateway, and does not establish a general startup improvement.
