### PR TITLE
fix(proxy-capture): preserve partial responses and shutdown diagnostics

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3440,7 +3440,7 @@ src/process/windows-command.ts	1
 src/projects/project-registry.ts	1
 src/provider-runtime/operation-retry.ts	3
 src/proxy-capture/env.ts	1
-src/proxy-capture/runtime.ts	10
+src/proxy-capture/runtime.ts	5
 src/proxy-capture/store.sqlite.ts	4
 src/realtime-transcription/websocket-session.ts	2
 src/routing/binding-scope.ts	1

--- a/src/agents/provider-transport-fetch.capture.test.ts
+++ b/src/agents/provider-transport-fetch.capture.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import type { ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { Model } from "@openclaw/llm-core";
+import { Stream } from "openai/core/streaming";
+import { describe, expect, it, vi } from "vitest";
+import { createOpenAIResponsesAssistantOutput } from "../../packages/ai/src/transports/openai-responses-replay-messages-internal.js";
+import { processResponsesStream } from "../../packages/ai/src/transports/openai-responses-stream-internal.js";
+import { buildGuardedModelFetch } from "../plugin-sdk/provider-transport-runtime.js";
+import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
+import { finalizeDebugProxyCapture } from "../proxy-capture/runtime.js";
+import { createDebugProxyCaptureReader } from "../proxy-capture/store-readonly.js";
+import { acquireDebugProxyCaptureStore } from "../proxy-capture/store.sqlite.js";
+import type { CaptureEventRecord } from "../proxy-capture/types.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { closeProviderTransportDispatcherPool } from "./provider-transport-dispatcher-pool.js";
+
+const model: Model<"openai-responses"> = {
+  id: "gpt-5",
+  name: "Loopback fixture",
+  provider: "openai",
+  api: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 1024,
+};
+const usage = {
+  input_tokens: 500,
+  output_tokens: 9,
+  input_tokens_details: { cached_tokens: 300, cache_write_tokens: 100 },
+};
+const frame = (type: string, response: unknown) =>
+  `event: ${type}\ndata: ${JSON.stringify({ type, response })}\n\n`;
+const prefix = frame("response.created", { id: "fixture" });
+const terminal =
+  prefix +
+  frame("response.in_progress", { id: "fixture", fixturePadding: "x".repeat(9000) }) +
+  frame("response.completed", {
+    id: "fixture",
+    model: model.id,
+    status: "completed",
+    usage,
+    output: [
+      {
+        id: "message-fixture",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "ok", annotations: [] }],
+      },
+    ],
+  });
+
+describe("managed provider response capture", () => {
+  it.each([
+    "terminal-eof",
+    "terminal-open",
+    "partial-eof",
+    "partial-idle",
+    "error",
+    "cancel",
+  ] as const)(
+    "keeps raw bytes and caller outcome through %s",
+    async (mode) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "managed-capture-test-"));
+      const sessionId = `managed-${mode}`;
+      vi.stubEnv("OPENCLAW_STATE_DIR", root);
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", sessionId);
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", undefined);
+      const lease = acquireDebugProxyCaptureStore({ env: process.env });
+      const captureDone = createDeferredCore<CaptureEventRecord>();
+      const record = lease.store.recordEvent.bind(lease.store);
+      const recording = vi.spyOn(lease.store, "recordEvent").mockImplementation((event) => {
+        record(event);
+        if (event.kind === "response" || event.kind === "error") {
+          captureDone.resolve(event);
+        }
+      });
+      const controller = new AbortController();
+      const held = createDeferredCore<ServerResponse>();
+      const firstEvent = createDeferredCore();
+      const isTerminal = mode.startsWith("terminal");
+      const body = isTerminal ? terminal : prefix;
+      try {
+        await withServer(
+          (request, response) => {
+            request.resume();
+            response.writeHead(200, { "content-type": "text/event-stream" });
+            response.write(body);
+            held.resolve(response);
+            if (mode.endsWith("eof")) {
+              response.end();
+            }
+          },
+          async (baseUrl) => {
+            const localModel = { ...model, baseUrl: `${baseUrl}/v1` };
+            const response = await buildGuardedModelFetch(localModel, 20_000)(
+              `${baseUrl}/v1/responses`,
+              {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ model: model.id, stream: true, input: "fixture" }),
+                signal: controller.signal,
+              },
+            );
+            try {
+              const sdk = Stream.fromSSEResponse(response, controller);
+              async function* observed() {
+                for await (const event of sdk) {
+                  firstEvent.resolve();
+                  yield event;
+                }
+              }
+              const output = createOpenAIResponsesAssistantOutput(localModel);
+              // The SDK owns its request controller; the runtime's outer run
+              // signal is separate from SDK terminal-iteration cleanup.
+              const caller = new AbortController();
+              const parsed = processResponsesStream(observed(), output, { push() {} }, localModel, {
+                signal: caller.signal,
+              }).then(
+                (value) => ({ value, error: undefined }),
+                (error: unknown) => ({ value: undefined, error }),
+              );
+              await firstEvent.promise;
+              const cancelReason = Object.assign(new Error("fixture caller stopped"), {
+                code: "FIXTURE_CANCEL",
+              });
+              if (mode === "partial-idle") {
+                await captureDone.promise;
+                caller.abort(cancelReason);
+                controller.abort(cancelReason);
+              } else if (mode === "cancel") {
+                caller.abort(cancelReason);
+                controller.abort(cancelReason);
+              } else if (mode === "error") {
+                (await held.promise).destroy();
+              }
+              const outcome = await parsed;
+              const captured = await captureDone.promise;
+              const reader = createDebugProxyCaptureReader({ env: process.env });
+              const rows = reader.getSessionEvents(sessionId, 10);
+              expect(rows.map((row) => row.kind)).toEqual([captured.kind, "request"]);
+              expect(captured.status).toBe(200);
+              expect(typeof captured.dataBlobId).toBe("string");
+              const raw = reader.readBlob(captured.dataBlobId!);
+              expect(raw).toBe(body);
+              const events = [];
+              for await (const event of Stream.fromSSEResponse<{
+                type: string;
+                response: { usage?: typeof usage };
+              }>(new Response(raw), new AbortController())) {
+                events.push(event);
+              }
+              if (isTerminal) {
+                expect(outcome.error).toBeUndefined();
+                expect(output.stopReason).toBe("stop");
+                expect(output.usage).toMatchObject({
+                  input: 100,
+                  output: 9,
+                  cacheRead: 300,
+                  cacheWrite: 100,
+                  totalTokens: 509,
+                });
+                expect(events.at(-1)).toMatchObject({
+                  type: "response.completed",
+                  response: { usage },
+                });
+              } else {
+                expect(outcome.error).toBeInstanceOf(Error);
+                expect(outcome.value).toBeUndefined();
+                expect(events.some((event) => event.type === "response.completed")).toBe(false);
+              }
+              // A parsed terminal closes the SDK iterator. Its managed cleanup
+              // can beat EOF even when the server has already ended the body.
+              if (
+                mode === "error" ||
+                mode === "cancel" ||
+                mode === "terminal-open" ||
+                (mode === "terminal-eof" && captured.kind === "error")
+              ) {
+                expect(captured.kind).toBe("error");
+                expect(captured.errorText).toBeTruthy();
+                expect(JSON.parse(captured.metaJson!)).toMatchObject({
+                  bodyCapture: "failed",
+                  stage: "response-body",
+                });
+              } else if (mode === "partial-idle") {
+                expect(captured.kind).toBe("response");
+                expect(JSON.parse(captured.metaJson!)).toMatchObject({ bodyCapture: "stalled" });
+              } else {
+                expect(captured.kind).toBe("response");
+              }
+              if (mode === "cancel" || mode === "partial-idle") {
+                expect(outcome.error).toBe(cancelReason);
+              }
+            } finally {
+              controller.abort();
+              await response.body?.cancel().catch(() => undefined);
+              await captureDone.promise;
+            }
+          },
+        );
+      } finally {
+        finalizeDebugProxyCapture();
+        recording.mockRestore();
+        lease.release();
+        await closeProviderTransportDispatcherPool();
+        closeOpenClawStateDatabaseByPath(lease.store.dbPath);
+        vi.unstubAllEnvs();
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+});

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -292,42 +292,16 @@ export function retainSafeHeadersForCrossOriginRedirectHeaders(
   return retainSafeRedirectHeaders(headers);
 }
 
-async function captureGuardedFetchExchange(params: {
-  url: string;
-  method: string;
-  requestHeaders?: Headers | Record<string, string> | undefined;
-  requestBody?: BodyInit | Buffer | string | null;
-  response: Response;
-  transport?: "http" | "sse";
-  capture: GuardedFetchOptions["capture"];
-  auditContext?: string;
-  capturedByGlobalFetchPatch?: boolean;
-}): Promise<void> {
+async function prepareGuardedFetchCapture(params: GuardedFetchOptions, fetchImpl: FetchLike) {
   if (params.capture === false || !isTruthyEnvValue(process.env[OPENCLAW_DEBUG_PROXY_ENABLED])) {
-    return;
+    return { fetchImpl };
   }
-  const { captureHttpExchange, isDebugProxyGlobalFetchPatchInstalled } =
+  const { prepareHttpCapture, resolveDebugProxyFetchTransport } =
     await import("../../proxy-capture/runtime.js");
-  if (params.capturedByGlobalFetchPatch && isDebugProxyGlobalFetchPatchInstalled()) {
-    return;
-  }
-  captureHttpExchange({
-    url: params.url,
-    method: params.method,
-    requestHeaders: params.requestHeaders,
-    requestBody: params.requestBody,
-    response: params.response,
-    transport: params.transport,
-    flowId: params.capture?.flowId,
-    meta: {
-      captureOrigin: "guarded-fetch",
-      ...(params.auditContext ? { auditContext: params.auditContext } : {}),
-      ...params.capture?.meta,
-      ...(params.capture?.sensitiveRequestHeaderNames
-        ? { sensitiveRequestHeaderNames: params.capture.sensitiveRequestHeaderNames }
-        : {}),
-    },
-  });
+  return {
+    fetchImpl: resolveDebugProxyFetchTransport(fetchImpl),
+    capture: prepareHttpCapture(),
+  };
 }
 
 function retainSafeHeadersForCrossOriginRedirect(init?: RequestInit): RequestInit | undefined {
@@ -462,11 +436,20 @@ export async function fetchConfiguredLocalOriginWithSsrFGuard({
 async function fetchWithSsrFGuardInternal(
   params: GuardedFetchInternalOptions,
 ): Promise<GuardedFetchResult> {
-  const defaultFetch: FetchLike | undefined = params.fetchImpl ?? globalThis.fetch;
+  const globalFetch = globalThis.fetch;
+  const defaultFetch: FetchLike | undefined = params.fetchImpl ?? globalFetch;
   if (!defaultFetch) {
     throw new Error("fetch is not available");
   }
   const isUsingMockedFetch = isMockedFetch(defaultFetch);
+  const supportsDispatcherInit =
+    (params.fetchImpl !== undefined &&
+      !isAmbientGlobalFetch({ fetchImpl: params.fetchImpl, globalFetch })) ||
+    isUsingMockedFetch;
+  // Admission precedes DNS and transport awaits. Capture must not resolve a new
+  // session after a delayed request outlives its original capture generation.
+  // Bypass only our exact global wrapper so its owner cannot also record.
+  const captureAdmission = await prepareGuardedFetchCapture(params, defaultFetch);
 
   const maxRedirects =
     typeof params.maxRedirects === "number" && Number.isFinite(params.maxRedirects)
@@ -663,13 +646,6 @@ async function fetchWithSsrFGuardInternal(
           : requestController.signal,
       };
 
-      const supportsDispatcherInit =
-        (params.fetchImpl !== undefined &&
-          !isAmbientGlobalFetch({
-            fetchImpl: params.fetchImpl,
-            globalFetch: globalThis.fetch,
-          })) ||
-        isUsingMockedFetch;
       // Explicit caller stubs and test-installed fetch mocks should win.
       // Otherwise, fall back to undici's fetch whenever we attach a dispatcher,
       // because the default global fetch path will not honor per-request
@@ -680,28 +656,33 @@ async function fetchWithSsrFGuardInternal(
         void Promise.resolve(beforeRequestResult).catch(() => undefined);
         throw new TypeError("beforeRequest must be synchronous.");
       }
-      response = shouldUseRuntimeFetch
-        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
-        : await defaultFetch(parsedUrl.toString(), init);
-      const capturedByGlobalFetchPatch =
-        !shouldUseRuntimeFetch &&
-        isAmbientGlobalFetch({
-          fetchImpl: defaultFetch,
-          globalFetch: globalThis.fetch,
-        });
-
-      await captureGuardedFetchExchange({
+      const captureParams = {
         url: parsedUrl.toString(),
         method: currentInit?.method ?? "GET",
         requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
         requestBody:
           (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
-        response,
-        transport: "http",
-        capture: params.capture,
-        auditContext: params.auditContext,
-        capturedByGlobalFetchPatch,
-      });
+        transport: "http" as const,
+        flowId: params.capture === false ? undefined : params.capture?.flowId,
+        meta: {
+          captureOrigin: "guarded-fetch",
+          ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+          ...(params.capture === false ? {} : params.capture?.meta),
+          ...(params.capture && params.capture.sensitiveRequestHeaderNames
+            ? { sensitiveRequestHeaderNames: params.capture.sensitiveRequestHeaderNames }
+            : {}),
+        },
+      };
+      // Only transport rejection belongs here, not policy or capture failures.
+      try {
+        response = shouldUseRuntimeFetch
+          ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
+          : await captureAdmission.fetchImpl(parsedUrl.toString(), init);
+      } catch (error) {
+        captureAdmission.capture?.({ ...captureParams, error });
+        throw error;
+      }
+      captureAdmission.capture?.({ ...captureParams, response });
 
       if (isRedirectStatus(response.status)) {
         redirectCount += 1;

--- a/src/proxy-capture/runtime-owner.ts
+++ b/src/proxy-capture/runtime-owner.ts
@@ -31,6 +31,7 @@ export function resolveRuntimeDeps(deps: DebugProxyCaptureRuntimeDeps = {}) {
     persistEventPayload:
       deps.persistEventPayload ??
       ((store, payload) =>
+        // SAFETY: The default writer receives real stores; lightweight test stores supply their own writer.
         persistEventPayload(store as ReturnType<typeof getDebugProxyCaptureStore>, payload)),
     safeJsonString: deps.safeJsonString ?? safeJsonString,
     fetchTarget: deps.fetchTarget ?? globalThis,
@@ -77,23 +78,21 @@ export function resolveDebugProxyFetchTransport(
 }
 
 export function hasDebugProxyFetchPatch(
-  fetchTarget: typeof globalThis,
+  fetchTarget: GlobalFetchPatchTarget,
   admission: CaptureAdmission,
 ): boolean {
-  return (
-    (fetchTarget as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]?.admission === admission
-  );
+  return fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY]?.admission === admission;
 }
 
 /** Keep wrapper identity and its admission together for matching-owner teardown. */
 export function registerDebugProxyFetchPatch(
-  fetchTarget: typeof globalThis,
+  fetchTarget: GlobalFetchPatchTarget,
   originalFetch: typeof globalThis.fetch,
   patchedFetch: typeof globalThis.fetch,
   admission: CaptureAdmission,
 ): void {
   const patch = { originalFetch, admission };
-  (fetchTarget as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY] = patch;
+  fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY] = patch;
   globalFetchPatches.set(patchedFetch, patch);
   fetchTarget.fetch = patchedFetch;
 }
@@ -102,7 +101,7 @@ export function uninstallDebugProxyGlobalFetchPatch(
   deps: DebugProxyCaptureRuntimeDeps = {},
   admission?: CaptureAdmission,
 ): void {
-  const fetchTarget = resolveRuntimeDeps(deps).fetchTarget as GlobalFetchPatchTarget;
+  const fetchTarget: GlobalFetchPatchTarget = resolveRuntimeDeps(deps).fetchTarget;
   const state = fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
   if (!state || (admission && state.admission !== admission)) {
     return;
@@ -112,7 +111,8 @@ export function uninstallDebugProxyGlobalFetchPatch(
 }
 
 export function isDebugProxyGlobalFetchPatchInstalled(): boolean {
-  return Boolean((globalThis as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]);
+  const fetchTarget: GlobalFetchPatchTarget = globalThis;
+  return Boolean(fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY]);
 }
 
 function captureOwnerKey(settings: DebugProxySettings): string {

--- a/src/proxy-capture/runtime-owner.ts
+++ b/src/proxy-capture/runtime-owner.ts
@@ -1,0 +1,257 @@
+import { writeSync } from "node:fs";
+import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+import { resolveEnabledDebugProxySettings, type DebugProxySettings } from "./env.js";
+import { REDACTED_CAPTURE_HEADER_VALUE } from "./header-redaction.js";
+import { registerCaptureStoreFinalizer } from "./store-lifecycle.js";
+import { getDebugProxyCaptureStore, persistEventPayload, safeJsonString } from "./store.sqlite.js";
+
+const DEBUG_PROXY_FETCH_PATCH_KEY = Symbol.for("openclaw.debugProxy.fetchPatch");
+
+type DebugProxyCaptureStoreLike = Pick<
+  ReturnType<typeof getDebugProxyCaptureStore>,
+  "upsertSession" | "endSession" | "recordEvent"
+> &
+  Partial<Pick<ReturnType<typeof getDebugProxyCaptureStore>, "close" | "isClosed">>;
+
+export type DebugProxyCaptureRuntimeDeps = {
+  getStore?: () => DebugProxyCaptureStoreLike;
+  closeStore?: () => void;
+  persistEventPayload?: (
+    store: DebugProxyCaptureStoreLike,
+    payload: Parameters<typeof persistEventPayload>[1],
+  ) => ReturnType<typeof persistEventPayload>;
+  safeJsonString?: typeof safeJsonString;
+  fetchTarget?: typeof globalThis;
+};
+
+export function resolveRuntimeDeps(deps: DebugProxyCaptureRuntimeDeps = {}) {
+  return {
+    getStore: deps.getStore ?? getDebugProxyCaptureStore,
+    closeStore: deps.closeStore,
+    persistEventPayload:
+      deps.persistEventPayload ??
+      ((store, payload) =>
+        persistEventPayload(store as ReturnType<typeof getDebugProxyCaptureStore>, payload)),
+    safeJsonString: deps.safeJsonString ?? safeJsonString,
+    fetchTarget: deps.fetchTarget ?? globalThis,
+  };
+}
+
+export type CaptureOwner = {
+  settings: DebugProxySettings;
+  runtime: ReturnType<typeof resolveRuntimeDeps>;
+  store: DebugProxyCaptureStoreLike;
+  active: boolean;
+  pending: Set<() => void>;
+  errors: unknown[];
+  unregister: () => void;
+  admission: CaptureAdmission;
+};
+type CaptureAdmission = { current?: CaptureOwner };
+type CaptureRegistry = {
+  owners: Map<string, CaptureOwner>;
+  resolved: WeakMap<DebugProxySettings, CaptureAdmission>;
+  ambient?: { sessionId: string; dbPath: string; admission: CaptureAdmission };
+};
+const captureOwners = new WeakMap<
+  ReturnType<typeof resolveRuntimeDeps>["getStore"],
+  CaptureRegistry
+>();
+
+type GlobalFetchPatchedState = {
+  originalFetch: typeof globalThis.fetch;
+  admission: CaptureAdmission;
+};
+
+type GlobalFetchPatchTarget = typeof globalThis & {
+  [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
+};
+
+const globalFetchPatches = new WeakMap<typeof globalThis.fetch, GlobalFetchPatchedState>();
+
+/** Guarded requests own capture admission, including when given a saved patch. */
+export function resolveDebugProxyFetchTransport(
+  fetchImpl: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return globalFetchPatches.get(fetchImpl)?.originalFetch ?? fetchImpl;
+}
+
+export function hasDebugProxyFetchPatch(
+  fetchTarget: typeof globalThis,
+  admission: CaptureAdmission,
+): boolean {
+  return (
+    (fetchTarget as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]?.admission === admission
+  );
+}
+
+/** Keep wrapper identity and its admission together for matching-owner teardown. */
+export function registerDebugProxyFetchPatch(
+  fetchTarget: typeof globalThis,
+  originalFetch: typeof globalThis.fetch,
+  patchedFetch: typeof globalThis.fetch,
+  admission: CaptureAdmission,
+): void {
+  const patch = { originalFetch, admission };
+  (fetchTarget as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY] = patch;
+  globalFetchPatches.set(patchedFetch, patch);
+  fetchTarget.fetch = patchedFetch;
+}
+
+export function uninstallDebugProxyGlobalFetchPatch(
+  deps: DebugProxyCaptureRuntimeDeps = {},
+  admission?: CaptureAdmission,
+): void {
+  const fetchTarget = resolveRuntimeDeps(deps).fetchTarget as GlobalFetchPatchTarget;
+  const state = fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
+  if (!state || (admission && state.admission !== admission)) {
+    return;
+  }
+  fetchTarget.fetch = state.originalFetch;
+  delete fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
+}
+
+export function isDebugProxyGlobalFetchPatchInstalled(): boolean {
+  return Boolean((globalThis as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]);
+}
+
+function captureOwnerKey(settings: DebugProxySettings): string {
+  // dbPath is the root-derived capture locator, not the shared database route.
+  // Implicit session IDs survive state-root changes, so both identify an owner.
+  return JSON.stringify([settings.dbPath, settings.sessionId]);
+}
+
+export function reportCapturePersistenceFailure(owner: CaptureOwner, error: unknown): void {
+  owner.errors.push(error);
+  // The earlier SQLite exit hook swallows close errors. Report synchronously
+  // here before it closes the store; diagnostics must not interrupt settlement.
+  try {
+    const message = redactRegisteredSecretValues(
+      error instanceof Error ? error.message : String(error),
+      () => REDACTED_CAPTURE_HEADER_VALUE,
+    );
+    writeSync(2, `[proxy-capture] Capture persistence failed: ${message}\n`);
+  } catch {
+    // Preserve the original failure even if the diagnostic sink is unavailable.
+  }
+}
+
+function finishCaptureOwner(owner: CaptureOwner): void {
+  if (!owner.active) {
+    return;
+  }
+  owner.active = false;
+  owner.admission.current = undefined;
+  const registry = captureOwners.get(owner.runtime.getStore)!;
+  registry.owners.delete(captureOwnerKey(owner.settings));
+  uninstallDebugProxyGlobalFetchPatch(owner.runtime, owner.admission);
+  owner.unregister();
+  for (const finish of owner.pending) {
+    finish();
+  }
+  try {
+    if (!owner.store.isClosed) {
+      owner.store.endSession(owner.settings.sessionId);
+    }
+  } catch (error) {
+    reportCapturePersistenceFailure(owner, error);
+  }
+  if (owner.errors.length) {
+    throw new AggregateError(owner.errors.splice(0), "Capture session finalization failed.");
+  }
+}
+
+export function resolveCaptureOwner(
+  settings: DebugProxySettings,
+  runtime: ReturnType<typeof resolveRuntimeDeps>,
+  options: { initialize?: boolean; explicit?: boolean } = {},
+): CaptureOwner | undefined {
+  let registry = captureOwners.get(runtime.getStore);
+  if (!registry) {
+    registry = { owners: new Map(), resolved: new WeakMap() };
+    captureOwners.set(runtime.getStore, registry);
+  }
+  const key = captureOwnerKey(settings);
+  let owner = registry.owners.get(key);
+  if (!owner) {
+    // Explicit settings own their lifetime; ambient capture observes current
+    // configuration. Keep only its current marker, not retired IDs or stores.
+    const prior = options.explicit
+      ? registry.resolved.get(settings)
+      : registry.ambient?.sessionId === settings.sessionId &&
+          registry.ambient.dbPath === settings.dbPath
+        ? registry.ambient.admission
+        : undefined;
+    if (!options.initialize && prior) {
+      return prior.current;
+    }
+    const store = runtime.getStore();
+    if (store.isClosed) {
+      return undefined;
+    }
+    owner = {
+      settings,
+      runtime,
+      store,
+      active: true,
+      pending: new Set(),
+      errors: [],
+      unregister: () => {},
+      admission: {},
+    };
+    owner.admission.current = owner;
+    const retainedOwner = owner;
+    owner.unregister = registerCaptureStoreFinalizer(store, () =>
+      finishCaptureOwner(retainedOwner),
+    );
+    registry.owners.set(key, owner);
+  }
+  if (options.explicit) {
+    registry.resolved.set(settings, owner.admission);
+  } else {
+    registry.ambient = {
+      sessionId: settings.sessionId,
+      dbPath: settings.dbPath,
+      admission: owner.admission,
+    };
+  }
+  return owner;
+}
+
+// Finalization closes the session and restores the fetch patch before closing
+// the cached store, preventing later normal requests from being captured.
+export function finalizeDebugProxyCapture(
+  resolved?: DebugProxySettings,
+  deps: DebugProxyCaptureRuntimeDeps = {},
+): void {
+  const settings = resolveEnabledDebugProxySettings(resolved);
+  if (!settings) {
+    return;
+  }
+  const runtime = resolveRuntimeDeps(deps);
+  const owner = captureOwners.get(runtime.getStore)?.owners.get(captureOwnerKey(settings));
+  if (owner) {
+    uninstallDebugProxyGlobalFetchPatch(deps, owner.admission);
+  }
+  if (!owner?.active) {
+    return;
+  }
+  const errors: unknown[] = [];
+  try {
+    finishCaptureOwner(owner);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    if (owner.runtime.closeStore) {
+      owner.runtime.closeStore();
+    } else {
+      owner.store.close?.();
+    }
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length) {
+    throw new AggregateError(errors, "Capture finalization failed.");
+  }
+}

--- a/src/proxy-capture/runtime.guarded-fetch.test.ts
+++ b/src/proxy-capture/runtime.guarded-fetch.test.ts
@@ -106,7 +106,7 @@ describe("guarded capture ownership", () => {
       // Disabling the guard recorder leaves an installed global recorder in control.
       const expected = mode === "capture-disabled" || mode === "same-owner" ? [2, 0] : [0, 2];
       expect(events.map((rows) => rows.length)).toEqual(expected);
-      for (const rows of events.filter((rows) => rows.length > 0)) {
+      for (const rows of events.filter((captured) => captured.length > 0)) {
         expect(rows[0]).toMatchObject({ kind: "request", dataText: "loopback request" });
         expect(rows[1]).toMatchObject({ status: 200, flowId: rows[0]!.flowId });
         expect(["response", "error"]).toContain(rows[1]!.kind);

--- a/src/proxy-capture/runtime.guarded-fetch.test.ts
+++ b/src/proxy-capture/runtime.guarded-fetch.test.ts
@@ -1,0 +1,238 @@
+import type { ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveDebugProxySettings } from "./env.js";
+import { finalizeDebugProxyCapture, initializeDebugProxyCapture } from "./runtime.js";
+import { acquireDebugProxyCaptureStore, closeDebugProxyCaptureStore } from "./store.sqlite.js";
+
+afterEach(() => {
+  closeDebugProxyCaptureStore();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function captureRoots() {
+  const roots = [tempDirs.make("capture-guard-a-"), tempDirs.make("capture-guard-b-")];
+  const originalFetch = globalThis.fetch;
+  vi.stubGlobal("fetch", originalFetch);
+  vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+  vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", undefined);
+  vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", undefined);
+  vi.stubEnv("OPENCLAW_STATE_DIR", roots[0]);
+  const first = resolveDebugProxySettings();
+  initializeDebugProxyCapture("first", first);
+  const firstLease = acquireDebugProxyCaptureStore();
+  const savedWrapper = globalThis.fetch;
+  vi.stubEnv("OPENCLAW_STATE_DIR", roots[1]);
+  const second = resolveDebugProxySettings();
+  const secondLease = acquireDebugProxyCaptureStore();
+  expect(second.sessionId).toBe(first.sessionId);
+  const settings = [first, second];
+  const leases = [firstLease, secondLease];
+  const recordings = leases.map(({ store }) => vi.spyOn(store, "recordEvent"));
+  return {
+    roots,
+    settings,
+    leases,
+    recordings,
+    originalFetch,
+    savedWrapper,
+    close() {
+      for (const [index, lease] of leases.entries()) {
+        finalizeDebugProxyCapture(settings[index]);
+        lease.release();
+        closeOpenClawStateDatabaseByPath(lease.store.dbPath);
+      }
+    },
+  };
+}
+
+describe("guarded capture ownership", () => {
+  it.each([
+    "same-owner",
+    "other-owner",
+    "saved-wrapper",
+    "caller-wrapper",
+    "capture-disabled",
+  ] as const)("uses one capture owner through %s", async (mode) => {
+    const fixture = captureRoots();
+    if (mode === "same-owner") {
+      vi.stubEnv("OPENCLAW_STATE_DIR", fixture.roots[0]);
+    } else if (mode === "saved-wrapper") {
+      initializeDebugProxyCapture("second", fixture.settings[1]);
+    }
+    const callerFetch = vi.fn<typeof fetch>((input, init) => fixture.originalFetch(input, init));
+    try {
+      await withServer(
+        (request, response) => {
+          request.resume();
+          response.writeHead(200, { "x-fixture": "caller-response" });
+          response.end("loopback response");
+        },
+        async (baseUrl) => {
+          const result = await fetchWithSsrFGuard({
+            url: `${baseUrl}/ownership`,
+            pinDns: false,
+            policy: { allowPrivateNetwork: true },
+            ...(mode === "saved-wrapper"
+              ? { fetchImpl: fixture.savedWrapper }
+              : mode === "caller-wrapper"
+                ? { fetchImpl: callerFetch }
+                : {}),
+            ...(mode === "capture-disabled" ? { capture: false } : {}),
+            init: { method: "POST", body: "loopback request" },
+          });
+          try {
+            expect(result.response.status).toBe(200);
+            expect(result.response.headers.get("x-fixture")).toBe("caller-response");
+            expect(await result.response.text()).toBe("loopback response");
+          } finally {
+            await result.release();
+          }
+        },
+      );
+      // Finalization settles any diagnostic clone before checking all writes.
+      fixture.close();
+      const events = fixture.recordings.map((recording) =>
+        recording.mock.calls.map(([event]) => event),
+      );
+      // Disabling the guard recorder leaves an installed global recorder in control.
+      const expected = mode === "capture-disabled" || mode === "same-owner" ? [2, 0] : [0, 2];
+      expect(events.map((rows) => rows.length)).toEqual(expected);
+      for (const rows of events.filter((rows) => rows.length > 0)) {
+        expect(rows[0]).toMatchObject({ kind: "request", dataText: "loopback request" });
+        expect(rows[1]).toMatchObject({ status: 200, flowId: rows[0]!.flowId });
+        expect(["response", "error"]).toContain(rows[1]!.kind);
+      }
+      expect(callerFetch).toHaveBeenCalledTimes(mode === "caller-wrapper" ? 1 : 0);
+    } finally {
+      fixture.close();
+    }
+  });
+
+  it.each(["guarded", "global"] as const)(
+    "records an active transport rejection once through the %s owner",
+    async (mode) => {
+      const fixture = captureRoots();
+      const arrived = createDeferredCore<ServerResponse>();
+      const controller = new AbortController();
+      const secret = "fixture-transport-secret";
+      registerSecretValueForRedaction(secret);
+      const reason = new Error(`caller abort ${secret}`);
+      try {
+        await withServer(
+          (request, response) => {
+            request.resume();
+            arrived.resolve(response);
+          },
+          async (baseUrl) => {
+            const operation = fetchWithSsrFGuard({
+              url: `${baseUrl}/rejection`,
+              pinDns: false,
+              policy: { allowPrivateNetwork: true },
+              signal: controller.signal,
+              capture: mode === "global" ? false : { flowId: "guarded-rejection-flow" },
+            }).then(
+              (value) => ({ value, error: undefined }),
+              (error: unknown) => ({ value: undefined, error }),
+            );
+            const response = await arrived.promise;
+            controller.abort(reason);
+            response.end();
+            const completed = await operation;
+            expect(completed.error).toBe(reason);
+            expect(completed.value).toBeUndefined();
+          },
+        );
+        fixture.close();
+        const events = fixture.recordings.map((recording) =>
+          recording.mock.calls.map(([event]) => event),
+        );
+        expect(events.map((rows) => rows.length)).toEqual(mode === "global" ? [1, 0] : [0, 1]);
+        const event = events[mode === "global" ? 0 : 1]![0]!;
+        expect(event).toMatchObject({
+          kind: "error",
+          direction: "local",
+          method: "GET",
+          path: "/rejection",
+          errorText: "caller abort [REDACTED]",
+          ...(mode === "guarded" ? { flowId: "guarded-rejection-flow" } : {}),
+        });
+        expect(event.status).toBeUndefined();
+        expect(JSON.parse(event.metaJson!)).toMatchObject({
+          captureOrigin: mode === "global" ? "global-fetch" : "guarded-fetch",
+        });
+      } finally {
+        controller.abort();
+        fixture.close();
+      }
+    },
+  );
+
+  it.each(["response", "abort"] as const)(
+    "keeps a delayed caller %s while retired admissions stay fenced",
+    async (outcome) => {
+      const fixture = captureRoots();
+      const arrived = createDeferredCore<ServerResponse>();
+      const controller = new AbortController();
+      const reason = new Error("fixture caller abort");
+      let replacement: ReturnType<typeof acquireDebugProxyCaptureStore> | undefined;
+      try {
+        await withServer(
+          (request, response) => {
+            request.resume();
+            arrived.resolve(response);
+          },
+          async (baseUrl) => {
+            const operation = fetchWithSsrFGuard({
+              url: `${baseUrl}/delayed`,
+              pinDns: false,
+              policy: { allowPrivateNetwork: true },
+              signal: controller.signal,
+            }).then(
+              (value) => ({ value, error: undefined }),
+              (error: unknown) => ({ value: undefined, error }),
+            );
+            const response = await arrived.promise;
+            fixture.close();
+            initializeDebugProxyCapture("replacement", fixture.settings[1]);
+            replacement = acquireDebugProxyCaptureStore();
+            const recordReplacement = vi.spyOn(replacement.store, "recordEvent");
+            if (outcome === "abort") {
+              controller.abort(reason);
+            }
+            response.writeHead(200, { "x-fixture": "late-response" });
+            response.end("late response");
+            const completed = await operation;
+            if (outcome === "abort") {
+              expect(completed.error).toBe(reason);
+              expect(completed.value).toBeUndefined();
+            } else {
+              expect(completed.error).toBeUndefined();
+              expect(completed.value!.response.headers.get("x-fixture")).toBe("late-response");
+              expect(await completed.value!.response.text()).toBe("late response");
+              await completed.value!.release();
+            }
+            finalizeDebugProxyCapture(fixture.settings[1]);
+            expect(recordReplacement).not.toHaveBeenCalled();
+            expect(fixture.recordings.map((recording) => recording.mock.calls.length)).toEqual([
+              0, 0,
+            ]);
+          },
+        );
+      } finally {
+        controller.abort();
+        finalizeDebugProxyCapture(fixture.settings[1]);
+        replacement?.release();
+        fixture.close();
+      }
+    },
+  );
+});

--- a/src/proxy-capture/runtime.lifecycle.test.ts
+++ b/src/proxy-capture/runtime.lifecycle.test.ts
@@ -1,0 +1,759 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveDebugProxySettings, type DebugProxySettings } from "./env.js";
+import {
+  captureHttpExchange,
+  captureWsEvent,
+  finalizeDebugProxyCapture,
+  initializeDebugProxyCapture,
+  prepareHttpCapture,
+  type DebugProxyCaptureRuntimeDeps,
+} from "./runtime.js";
+import {
+  acquireDebugProxyCaptureStore,
+  closeDebugProxyCaptureStore,
+  DebugProxyCaptureStore,
+  persistEventPayload,
+} from "./store.sqlite.js";
+import type { CaptureEventRecord } from "./types.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  closeDebugProxyCaptureStore();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetSecretRedactionRegistryForTest();
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function stateRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "capture-lifecycle-"));
+  roots.push(root);
+  return root;
+}
+
+function captureSettings(root: string, sessionId = "lifecycle"): DebugProxySettings {
+  return {
+    enabled: true,
+    required: false,
+    dbPath: path.join(root, "capture.sqlite"),
+    blobDir: path.join(root, "blobs"),
+    certDir: path.join(root, "certs"),
+    sessionId,
+    sourceProcess: "fixture",
+  };
+}
+
+function observePendingCapture(response: Response, prefixChunks: number) {
+  const pending = createDeferredCore();
+  const settled = createDeferredCore();
+  const clone = response.clone.bind(response);
+  vi.spyOn(response, "clone").mockImplementation(() => {
+    const captured = clone();
+    const reader = captured.body!.getReader();
+    const read = reader.read.bind(reader);
+    let reads = 0;
+    vi.spyOn(reader, "read").mockImplementation(() => {
+      reads += 1;
+      const last = reads === prefixChunks + 1;
+      if (last) {
+        pending.resolve();
+      }
+      return read().finally(() => {
+        if (last) {
+          settled.resolve();
+        }
+      });
+    });
+    vi.spyOn(captured.body!, "getReader").mockReturnValue(reader);
+    return captured;
+  });
+  return { pending: pending.promise, settled: settled.promise };
+}
+
+function pendingResponse(chunks: Buffer[]) {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(value) {
+        controller = value;
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/plain" } },
+  );
+  return { response, controller: controller!, ...observePendingCapture(response, chunks.length) };
+}
+
+describe("capture store lifecycle", () => {
+  it.each(
+    (["shared", "legacy"] as const).flatMap((storage) =>
+      (["direct", "last-lease"] as const).map((close) => ({ storage, close })),
+    ),
+  )("settles bytes once before $storage $close close", async ({ storage, close }) => {
+    const root = stateRoot();
+    const settings = captureSettings(root);
+    const acquire = () =>
+      storage === "shared"
+        ? acquireDebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } })
+        : acquireDebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+    const lease = acquire();
+    const sibling = acquire();
+    const store = lease.store;
+    const getStore = vi.fn(() => store);
+    const deps: DebugProxyCaptureRuntimeDeps = {
+      getStore,
+      persistEventPayload: (_store, payload) => persistEventPayload(store, payload),
+    };
+    registerSecretValueForRedaction("fixture-secret-value");
+    const bytes = Buffer.from("first fixture-secret-value caf\u00e9");
+    const stream = pendingResponse([
+      bytes.subarray(0, 15),
+      bytes.subarray(15, -1),
+      bytes.subarray(-1),
+    ]);
+    const terminals: CaptureEventRecord[] = [];
+    const record = store.recordEvent.bind(store);
+    const recording = vi.spyOn(store, "recordEvent").mockImplementation((event) => {
+      expect(store.isClosed).toBe(false);
+      record(event);
+      if (event.kind !== "request") {
+        terminals.push(event);
+      }
+    });
+    const end = vi.spyOn(store, "endSession");
+    try {
+      store.upsertSession({
+        id: settings.sessionId,
+        startedAt: Date.now(),
+        mode: "fixture",
+        sourceScope: "openclaw",
+        sourceProcess: "fixture",
+      });
+      captureHttpExchange(
+        { url: "https://example.test/pending", method: "GET", response: stream.response },
+        settings,
+        deps,
+      );
+      await stream.pending;
+      lease.release();
+      expect(store.isClosed).toBe(false);
+      expect(terminals).toHaveLength(0);
+      if (close === "direct") {
+        store.close();
+      } else {
+        sibling.release();
+      }
+      expect(store.isClosed).toBe(true);
+      expect(terminals).toHaveLength(1);
+      expect(terminals[0]).toMatchObject({
+        kind: "response",
+        status: 200,
+        dataText: "first [REDACTED] caf\u00e9",
+      });
+      expect(JSON.parse(terminals[0]!.metaJson!)).toMatchObject({ bodyCapture: "finalized" });
+      expect(end).toHaveBeenCalledExactlyOnceWith(settings.sessionId);
+
+      stream.controller.enqueue(Buffer.from("-later"));
+      stream.controller.close();
+      expect(await stream.response.text()).toBe(`${bytes.toString()}-later`);
+      await stream.settled;
+      finalizeDebugProxyCapture(settings, deps);
+      store.close();
+      sibling.release();
+      expect(terminals).toHaveLength(1);
+      expect(end).toHaveBeenCalledTimes(1);
+      expect(getStore).toHaveBeenCalledTimes(1);
+
+      const reopened = acquire();
+      try {
+        expect(reopened.store.listSessions()[0]?.endedAt).toBeTypeOf("number");
+        expect(reopened.store.getSessionEvents(settings.sessionId)).toHaveLength(2);
+        expect(reopened.store.readBlob(terminals[0]!.dataBlobId!)).toBe(
+          "first [REDACTED] caf\u00e9",
+        );
+      } finally {
+        reopened.release();
+      }
+    } finally {
+      recording.mockRestore();
+      lease.release();
+      sibling.release();
+      store.close();
+      closeOpenClawStateDatabaseByPath(store.dbPath);
+    }
+  });
+
+  it.each(["eof", "error", "finalize"] as const)(
+    "records one terminal through a pending-read %s race",
+    async (mode) => {
+      const root = stateRoot();
+      const settings = captureSettings(root);
+      const store = new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
+      const deps: DebugProxyCaptureRuntimeDeps = { getStore: () => store };
+      const stream = pendingResponse([Buffer.from("prefix")]);
+      const terminals: CaptureEventRecord[] = [];
+      const done = createDeferredCore();
+      const record = store.recordEvent.bind(store);
+      vi.spyOn(store, "recordEvent").mockImplementation((event) => {
+        record(event);
+        if (event.kind !== "request") {
+          terminals.push(event);
+          done.resolve();
+        }
+      });
+      registerSecretValueForRedaction("fixture-error-secret");
+      const reason = new Error("fixture read failure: fixture-error-secret");
+      try {
+        captureHttpExchange(
+          { url: "https://example.test/race", method: "GET", response: stream.response },
+          settings,
+          deps,
+        );
+        await stream.pending;
+        if (mode === "eof") {
+          stream.controller.close();
+        } else if (mode === "error") {
+          stream.controller.error(reason);
+        } else {
+          finalizeDebugProxyCapture(settings, deps);
+          stream.controller.error(reason);
+        }
+        await done.promise;
+        await stream.settled;
+        expect(terminals).toHaveLength(1);
+        expect(terminals[0]).toMatchObject({
+          kind: mode === "error" ? "error" : "response",
+          status: 200,
+          dataText: "prefix",
+        });
+        if (mode === "error") {
+          expect(terminals[0]).toMatchObject({ errorText: "fixture read failure: [REDACTED]" });
+          expect(JSON.parse(terminals[0]!.metaJson!)).toMatchObject({
+            bodyCapture: "failed",
+            stage: "response-body",
+          });
+        }
+        finalizeDebugProxyCapture(settings, deps);
+        expect(terminals).toHaveLength(1);
+      } finally {
+        await stream.response.body?.cancel().catch(() => undefined);
+        store.close();
+        closeOpenClawStateDatabaseByPath(store.dbPath);
+      }
+    },
+  );
+
+  it.each(["blob", "event"] as const)(
+    "settles sibling reads and closes after one terminal %s persistence fails",
+    async (surface) => {
+      const root = stateRoot();
+      const settings = captureSettings(root);
+      const store = new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
+      const deps: DebugProxyCaptureRuntimeDeps = { getStore: () => store };
+      const streams = [
+        pendingResponse([Buffer.from("one")]),
+        pendingResponse([Buffer.from("two")]),
+      ];
+      const failure = new Error("fixture storage failure");
+      const attempted: string[] = [];
+      if (surface === "blob") {
+        const persist = store.persistPayload.bind(store);
+        vi.spyOn(store, "persistPayload").mockImplementation((data, contentType) => {
+          if (data.toString() === "one") {
+            throw failure;
+          }
+          return persist(data, contentType);
+        });
+      }
+      const record = store.recordEvent.bind(store);
+      vi.spyOn(store, "recordEvent").mockImplementation((event) => {
+        if (event.kind !== "request") {
+          attempted.push(event.flowId);
+          if (surface === "event" && event.flowId === "one") {
+            throw failure;
+          }
+        }
+        record(event);
+      });
+      try {
+        for (const [index, stream] of streams.entries()) {
+          captureHttpExchange(
+            {
+              url: "https://example.test/sibling",
+              method: "GET",
+              response: stream.response,
+              flowId: index === 0 ? "one" : "two",
+            },
+            settings,
+            deps,
+          );
+        }
+        await Promise.all(streams.map((stream) => stream.pending));
+        let error: unknown;
+        try {
+          finalizeDebugProxyCapture(settings, deps);
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error).toBeInstanceOf(AggregateError);
+        expect((error as AggregateError).errors[0].errors).toContain(failure);
+        expect(store.isClosed).toBe(true);
+        expect(attempted).toEqual(surface === "blob" ? ["two"] : ["one", "two"]);
+        finalizeDebugProxyCapture(settings, deps);
+        expect(attempted).toEqual(surface === "blob" ? ["two"] : ["one", "two"]);
+      } finally {
+        for (const stream of streams) {
+          stream.controller.close();
+          await stream.response.body?.cancel();
+          await stream.settled;
+        }
+        store.close();
+        closeOpenClawStateDatabaseByPath(store.dbPath);
+      }
+    },
+  );
+
+  it("does not revive a retired database while finalizing its retained owner", async () => {
+    const root = stateRoot();
+    const settings = captureSettings(root);
+    const store = new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
+    const getStore = vi.fn(() => store);
+    const deps: DebugProxyCaptureRuntimeDeps = { getStore };
+    const stream = pendingResponse([Buffer.from("prefix")]);
+    try {
+      captureHttpExchange(
+        { url: "https://example.test/retired", method: "GET", response: stream.response },
+        settings,
+        deps,
+      );
+      await stream.pending;
+      closeOpenClawStateDatabaseByPath(store.dbPath);
+      expect(store.isClosed).toBe(true);
+      expect(() => finalizeDebugProxyCapture(settings, deps)).toThrow(AggregateError);
+      expect(() => finalizeDebugProxyCapture(settings, deps)).not.toThrow();
+      expect(getStore).toHaveBeenCalledTimes(1);
+      expect(store.db.isOpen).toBe(false);
+    } finally {
+      stream.controller.close();
+      await stream.response.body?.cancel();
+      await stream.settled;
+      store.close();
+    }
+  });
+
+  it.each(
+    (["shared", "legacy"] as const).flatMap((storage) =>
+      (["none", "blob", "event"] as const).map((failure) => ({ storage, failure })),
+    ),
+  )(
+    "ends the $storage session and reports $failure failure before CLI exit finalization",
+    ({ storage, failure }) => {
+      const root = stateRoot();
+      const settings = captureSettings(root);
+      const runtimeUrl = new URL("./runtime.ts", import.meta.url).href;
+      const storeUrl = new URL("./store.sqlite.ts", import.meta.url).href;
+      const redactionUrl = new URL("../logging/secret-redaction-registry.ts", import.meta.url).href;
+      const script = `
+        import assert from "node:assert/strict";
+        import { captureHttpExchange, initializeDebugProxyCapture, finalizeDebugProxyCapture } from ${JSON.stringify(runtimeUrl)};
+        import { getDebugProxyCaptureStore } from ${JSON.stringify(storeUrl)};
+        import { registerSecretValueForRedaction } from ${JSON.stringify(redactionUrl)};
+        const settings = ${JSON.stringify(settings)};
+        const store = ${storage === "shared" ? "getDebugProxyCaptureStore()" : "getDebugProxyCaptureStore(settings.dbPath, settings.blobDir)"};
+        const failure = ${JSON.stringify(failure)};
+        registerSecretValueForRedaction("fixture-storage-secret");
+        const error = new Error("fixture " + failure + " persistence failure: fixture-storage-secret");
+        let acquired = 0, terminals = 0, ended = 0, failures = 0;
+        const persist = store.persistPayload.bind(store);
+        store.persistPayload = (data, contentType) => {
+          if (failure === "blob" && data?.toString() === "prefix-one") {
+            failures++;
+            throw error;
+          }
+          return persist(data, contentType);
+        };
+        const record = store.recordEvent.bind(store);
+        store.recordEvent = event => {
+          assert.equal(store.isClosed, false);
+          if (failure === "event" && event.kind !== "request" && event.flowId === "one") {
+            failures++;
+            throw error;
+          }
+          record(event);
+          if (event.kind !== "request") terminals++;
+        };
+        const end = store.endSession.bind(store);
+        store.endSession = id => { ended++; end(id); };
+        const deps = { getStore: () => { acquired++; return store; } };
+        initializeDebugProxyCapture("fixture", settings, deps);
+        for (const flowId of ["one", "two"]) {
+          const response = new Response(new ReadableStream({
+            start(controller) { controller.enqueue(new TextEncoder().encode("prefix-" + flowId)); }
+          }));
+          const clone = response.clone.bind(response);
+          let pending, reads = 0;
+          const ready = new Promise(resolve => pending = resolve);
+          response.clone = () => {
+            const cloned = clone();
+            const reader = cloned.body.getReader();
+            const read = reader.read.bind(reader);
+            reader.read = () => { if (++reads === 2) pending(); return read(); };
+            cloned.body.getReader = () => reader;
+            return cloned;
+          };
+          captureHttpExchange({ url: "https://example.test/exit", method: "GET", response, flowId }, settings, deps);
+          await ready;
+        }
+        process.once("exit", () => {
+          assert.equal(store.isClosed, true);
+          finalizeDebugProxyCapture(settings, deps);
+          finalizeDebugProxyCapture(settings, deps);
+          assert.equal(acquired, 1);
+          assert.equal(terminals, failure === "none" ? 2 : 1);
+          assert.equal(ended, 1);
+          assert.equal(failures, failure === "none" ? 0 : 1);
+          process.stdout.write(JSON.stringify({ acquired, terminals, ended, failures }));
+        });
+        process.exit(0);
+      `;
+      const child = spawnSync(
+        process.execPath,
+        [
+          "--disable-warning=ExperimentalWarning",
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "-e",
+          script,
+        ],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, OPENCLAW_STATE_DIR: root },
+          encoding: "utf8",
+          timeout: 20_000,
+        },
+      );
+      expect(child.stderr).toBe(
+        failure === "none"
+          ? ""
+          : `[proxy-capture] Capture persistence failed: fixture ${failure} persistence failure: [REDACTED]\n`,
+      );
+      expect(child.status).toBe(0);
+      expect(JSON.parse(child.stdout)).toEqual({
+        acquired: 1,
+        terminals: failure === "none" ? 2 : 1,
+        ended: 1,
+        failures: failure === "none" ? 0 : 1,
+      });
+      const reopened =
+        storage === "shared"
+          ? new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } })
+          : new DebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+      try {
+        expect(reopened.listSessions()[0]?.endedAt).toBeTypeOf("number");
+        const events = reopened.getSessionEvents(settings.sessionId);
+        expect(events).toHaveLength(failure === "none" ? 4 : 3);
+        expect(events[0]).toMatchObject({ kind: "response", dataText: "prefix-two" });
+      } finally {
+        reopened.close();
+        closeOpenClawStateDatabaseByPath(reopened.dbPath);
+      }
+    },
+  );
+});
+
+describe("capture admission generation", () => {
+  it.each([
+    [0, 1],
+    [1, 0],
+  ] as const)(
+    "isolates same-session databases when finalizing %s before %s",
+    async (first, second) => {
+      const envs = [stateRoot(), stateRoot()].map((root) => ({
+        OPENCLAW_STATE_DIR: root,
+        OPENCLAW_DEBUG_PROXY_ENABLED: "1",
+      }));
+      const settings = envs.map((env) => resolveDebugProxySettings(env));
+      expect(settings[0]!.sessionId).toBe(settings[1]!.sessionId);
+      expect(settings[0]!.dbPath).not.toBe(settings[1]!.dbPath);
+      const stores = envs.map((env) => new DebugProxyCaptureStore({ env }));
+      let selected = stores[0]!;
+      const getStore = vi.fn(() => selected);
+      const deps = { getStore };
+      const recordings = stores.map((store) => vi.spyOn(store, "recordEvent"));
+      const streams = stores.map((_, index) => pendingResponse([Buffer.from(`database-${index}`)]));
+      const admissions = settings.map((value, index) => {
+        selected = stores[index]!;
+        return prepareHttpCapture(value, deps)!;
+      });
+      try {
+        for (const [index, capture] of admissions.entries()) {
+          capture({
+            url: "https://example.test/identity",
+            method: "POST",
+            flowId: `database-${index}`,
+            requestBody: `request-${index}`,
+            response: streams[index]!.response,
+          });
+        }
+        await Promise.all(streams.map((stream) => stream.pending));
+        expect(
+          stores.map((store, index) =>
+            store.getSessionEvents(settings[index]!.sessionId).map((event) => event.flowId),
+          ),
+        ).toEqual([["database-0"], ["database-1"]]);
+        expect(getStore).toHaveBeenCalledTimes(2);
+        getStore.mockImplementation(() => {
+          throw new Error("Existing-owner lookup or finalization acquired a store.");
+        });
+        for (const index of [first, second]) {
+          const fresh = resolveDebugProxySettings(envs[index]);
+          captureWsEvent(
+            {
+              url: "wss://example.test/identity",
+              direction: "inbound",
+              kind: "ws-frame",
+              flowId: `database-${index}`,
+              payload: "before-close",
+            },
+            fresh,
+            deps,
+          );
+          expect(recordings[index]!.mock.lastCall?.[0].kind).toBe("ws-frame");
+          finalizeDebugProxyCapture(fresh, deps);
+          expect(stores[index]!.isClosed).toBe(true);
+          const terminals = recordings[index]!.mock.calls.map(([event]) => event).filter(
+            (event) => event.kind === "response",
+          );
+          expect(terminals).toHaveLength(1);
+          expect(terminals[0]).toMatchObject({
+            flowId: `database-${index}`,
+            dataText: `database-${index}`,
+          });
+          const recorded = recordings[index]!.mock.calls.length;
+          admissions[index]!({
+            url: "https://example.test/delayed",
+            method: "GET",
+            response: new Response("late"),
+          });
+          expect(recordings[index]).toHaveBeenCalledTimes(recorded);
+          if (index === first) {
+            expect(stores[second]!.isClosed).toBe(false);
+            expect(
+              recordings[second]!.mock.calls.some(([event]) => event.kind === "response"),
+            ).toBe(false);
+          }
+          finalizeDebugProxyCapture(resolveDebugProxySettings(envs[index]), deps);
+        }
+        expect(getStore).toHaveBeenCalledTimes(2);
+      } finally {
+        for (const [index, stream] of streams.entries()) {
+          finalizeDebugProxyCapture(settings[index], deps);
+          stream.controller.close();
+          await stream.response.body?.cancel();
+          await stream.settled;
+          stores[index]!.close();
+          closeOpenClawStateDatabaseByPath(stores[index]!.dbPath);
+        }
+      }
+    },
+  );
+
+  it.each(["explicit", "ambient"] as const)(
+    "preserves fresh %s lazy sessions without reopening retired admission",
+    (mode) => {
+      const root = stateRoot();
+      let settings = captureSettings(root, "first");
+      vi.stubEnv("OPENCLAW_STATE_DIR", root);
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", settings.sessionId);
+      const record = vi.fn();
+      const getStore = vi.fn(() => ({
+        upsertSession() {},
+        endSession() {},
+        recordEvent: record,
+        close() {},
+      }));
+      const deps = {
+        getStore,
+        persistEventPayload: () => ({}),
+        fetchTarget: { fetch: vi.fn() } as unknown as typeof globalThis,
+      };
+      const resolved = () => (mode === "explicit" ? settings : undefined);
+      const frame = {
+        url: "wss://example.test/stream",
+        direction: "inbound" as const,
+        kind: "ws-frame" as const,
+        flowId: "fixture",
+        payload: "frame",
+      };
+      const delayed = prepareHttpCapture(resolved(), deps)!;
+      captureWsEvent(frame, resolved(), deps);
+      finalizeDebugProxyCapture(resolved(), deps);
+      captureWsEvent(frame, resolved(), deps);
+      expect(getStore).toHaveBeenCalledTimes(1);
+      expect(record).toHaveBeenCalledTimes(1);
+
+      settings = captureSettings(root, "second");
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", settings.sessionId);
+      captureWsEvent(frame, resolved(), deps);
+      expect(getStore).toHaveBeenCalledTimes(2);
+      expect(record).toHaveBeenCalledTimes(2);
+      delayed({
+        url: "https://example.test/delayed",
+        method: "GET",
+        response: new Response("late"),
+      });
+      expect(record).toHaveBeenCalledTimes(2);
+      finalizeDebugProxyCapture(resolved(), deps);
+
+      initializeDebugProxyCapture("replacement", resolved(), deps);
+      captureWsEvent(frame, resolved(), deps);
+      expect(getStore).toHaveBeenCalledTimes(3);
+      expect(record).toHaveBeenCalledTimes(3);
+      finalizeDebugProxyCapture(resolved(), deps);
+    },
+  );
+
+  it("releases retired settings, store, and runtime closures while delayed admission stays fenced", () => {
+    const root = stateRoot();
+    const runtimeUrl = new URL("./runtime.ts", import.meta.url).href;
+    const script = `
+      import assert from "node:assert/strict";
+      import { initializeDebugProxyCapture, finalizeDebugProxyCapture, prepareHttpCapture } from ${JSON.stringify(runtimeUrl)};
+      let store, acquired = 0, recorded = 0, complete;
+      const getStore = () => { acquired++; return store; };
+      const target = { fetch: () => new Promise(resolve => complete = resolve) };
+      const control = new WeakRef({});
+      function retire() {
+        const settings = ${JSON.stringify(captureSettings(root))};
+        store = { upsertSession() {}, endSession() {}, recordEvent() { recorded++; }, close() {} };
+        const payload = { retained: Buffer.alloc(1024) };
+        const persist = () => { assert.ok(payload.retained); return {}; };
+        const refs = [new WeakRef(settings), new WeakRef(store), new WeakRef(persist)];
+        const deps = { getStore, persistEventPayload: persist, fetchTarget: target };
+        initializeDebugProxyCapture("fixture", settings, deps);
+        const capture = prepareHttpCapture(settings, deps);
+        const late = target.fetch("https://example.test/delayed");
+        finalizeDebugProxyCapture(settings, deps);
+        store = undefined;
+        return { refs, capture, late };
+      }
+      const retired = retire();
+      for (let i = 0; i < 30; i++) {
+        await new Promise(setImmediate);
+        globalThis.gc();
+      }
+      assert.equal(control.deref(), undefined, "GC control must be collected");
+      const released = retired.refs.map(ref => ref.deref() === undefined);
+      const response = new Response("late");
+      complete(response);
+      assert.equal(await retired.late, response);
+      retired.capture({ url: "https://example.test/delayed", method: "GET", response });
+      assert.equal(acquired, 1);
+      assert.equal(recorded, 0);
+      process.stdout.write(JSON.stringify(released));
+    `;
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--disable-warning=ExperimentalWarning",
+        "--expose-gc",
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "-e",
+        script,
+      ],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, OPENCLAW_STATE_DIR: root },
+        encoding: "utf8",
+        timeout: 20_000,
+      },
+    );
+    expect(child.stderr).toBe("");
+    expect(child.status).toBe(0);
+    expect(JSON.parse(child.stdout)).toEqual([true, true, true]);
+  });
+
+  it.each(
+    (["patched", "guarded"] as const).flatMap((route) =>
+      (["success", "rejection"] as const).map((outcome) => ({ route, outcome })),
+    ),
+  )(
+    "does not attach a delayed $route $outcome to a replacement owner",
+    async ({ route, outcome }) => {
+      const root = stateRoot();
+      const settings = captureSettings(root, `generation-${route}-${outcome}`);
+      vi.stubEnv("OPENCLAW_STATE_DIR", root);
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+      vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", settings.sessionId);
+      const admitted = createDeferredCore();
+      const transport = createDeferredCore<Response>();
+      const fetchImpl = vi.fn(async () => {
+        admitted.resolve();
+        return await transport.promise;
+      });
+      const target = { ...globalThis, fetch: fetchImpl } as typeof globalThis;
+      const deps = { fetchTarget: target };
+      initializeDebugProxyCapture("first", settings, deps);
+      const firstStore = acquireDebugProxyCaptureStore();
+      const operation =
+        route === "patched"
+          ? target.fetch("https://example.test/delayed").then((response) => ({
+              response,
+              release: async () => {},
+            }))
+          : fetchWithSsrFGuard({ url: "https://example.test/delayed", fetchImpl });
+      const result = operation.then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error }),
+      );
+      await admitted.promise;
+      finalizeDebugProxyCapture(settings, deps);
+      expect(firstStore.store.isClosed).toBe(true);
+      initializeDebugProxyCapture("replacement", settings, deps);
+      const replacement = acquireDebugProxyCaptureStore();
+      const record = vi.spyOn(replacement.store, "recordEvent");
+      const response = new Response("late");
+      const error = new Error("fixture late transport failure");
+      try {
+        if (outcome === "success") {
+          transport.resolve(response);
+        } else {
+          transport.reject(error);
+        }
+        const completed = await result;
+        if (outcome === "success") {
+          expect(completed.error).toBeUndefined();
+          expect(completed.value?.response).toBe(response);
+          expect(await completed.value!.response.text()).toBe("late");
+          await completed.value!.release();
+        } else {
+          expect(completed.error).toBe(error);
+        }
+        expect(record).not.toHaveBeenCalled();
+        expect(replacement.store.getSessionEvents(settings.sessionId)).toEqual([]);
+      } finally {
+        finalizeDebugProxyCapture(settings, deps);
+        firstStore.release();
+        replacement.release();
+        closeOpenClawStateDatabaseByPath(replacement.store.dbPath);
+      }
+    },
+  );
+});

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,9 +1,13 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Headers as UndiciHeaders } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
 import type { DebugProxySettings } from "./env.js";
 import {
   captureHttpExchange,
@@ -12,6 +16,7 @@ import {
   initializeDebugProxyCapture,
   type DebugProxyCaptureRuntimeDeps,
 } from "./runtime.js";
+import { DebugProxyCaptureStore, persistEventPayload } from "./store.sqlite.js";
 
 type StoreCall = { name: string; args: unknown[] };
 
@@ -101,6 +106,8 @@ async function waitForResponseSettled(): Promise<void> {
 describe("debug proxy runtime", () => {
   beforeEach(() => {
     finalizeDebugProxyCapture(settings, deps);
+    // Each test owns a fresh injected store binding, including its admission.
+    deps.getStore = () => store;
     events.length = 0;
     calls.length = 0;
     resetSecretRedactionRegistryForTest();
@@ -110,6 +117,64 @@ describe("debug proxy runtime", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it("settles a pending response capture before finalization closes its store", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "capture-finalize-test-"));
+    const realStore = new DebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
+    const readStarted = createDeferredCore();
+    const terminalRecorded = createDeferredCore();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let lateWrites = 0;
+    const record = realStore.recordEvent.bind(realStore);
+    const recording = vi.spyOn(realStore, "recordEvent").mockImplementation((event) => {
+      if (realStore.isClosed) {
+        lateWrites += 1;
+      }
+      record(event);
+      if (event.kind === "response" || event.kind === "error") {
+        terminalRecorded.resolve();
+      }
+    });
+    const realDeps: DebugProxyCaptureRuntimeDeps = {
+      fetchTarget,
+      getStore: () => realStore,
+      closeStore: () => realStore.close(),
+      persistEventPayload: (_store, payload) => persistEventPayload(realStore, payload),
+    };
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(value) {
+          controller = value;
+        },
+        pull() {
+          readStarted.resolve();
+        },
+      }),
+      { headers: { "content-type": "text/plain" } },
+    );
+    try {
+      captureHttpExchange(
+        { url: "https://example.test/pending", method: "GET", response },
+        settings,
+        realDeps,
+      );
+      await readStarted.promise;
+      expect(realStore.getSessionEvents(settings.sessionId)).toHaveLength(1);
+      const finalizing = Promise.resolve(finalizeDebugProxyCapture(settings, realDeps));
+      controller!.enqueue(new TextEncoder().encode("complete"));
+      controller!.close();
+      expect(await response.text()).toBe("complete");
+      await terminalRecorded.promise;
+      await finalizing;
+      expect(realStore.isClosed).toBe(true);
+      expect(lateWrites).toBe(0);
+    } finally {
+      recording.mockRestore();
+      realStore.close();
+      closeOpenClawStateDatabaseByPath(realStore.dbPath);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it.each([
@@ -538,7 +603,7 @@ describe("debug proxy runtime", () => {
       const response = events.find((event) => event.kind === "response");
       expect(response?.status).toBe(200);
       expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "stalled" });
-      expect(response).not.toHaveProperty("dataText");
+      expect(response?.dataText).toBe("partial");
       expect(events.some((event) => event.kind === "error")).toBe(false);
     } finally {
       vi.useRealTimers();

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -1,7 +1,6 @@
 // Proxy capture runtime coordinates capture sessions, proxy startup, and storage.
 import { isUtf8 } from "node:buffer";
 import { randomUUID } from "node:crypto";
-import { writeSync } from "node:fs";
 import { URL } from "node:url";
 import {
   isHeadersLike,
@@ -15,8 +14,18 @@ import {
 } from "../logging/secret-redaction-registry.js";
 import { resolveEnabledDebugProxySettings, type DebugProxySettings } from "./env.js";
 import { redactedCaptureHeaders, REDACTED_CAPTURE_HEADER_VALUE } from "./header-redaction.js";
-import { registerCaptureStoreFinalizer } from "./store-lifecycle.js";
-import { getDebugProxyCaptureStore, persistEventPayload, safeJsonString } from "./store.sqlite.js";
+import {
+  hasDebugProxyFetchPatch,
+  registerDebugProxyFetchPatch,
+  reportCapturePersistenceFailure,
+  resolveCaptureOwner,
+  resolveDebugProxyFetchTransport,
+  resolveRuntimeDeps,
+  uninstallDebugProxyGlobalFetchPatch,
+  type CaptureOwner,
+  type DebugProxyCaptureRuntimeDeps,
+} from "./runtime-owner.js";
+import { safeJsonString } from "./store.sqlite.js";
 import type {
   CaptureDirection,
   CaptureEventKind,
@@ -24,7 +33,13 @@ import type {
   CaptureProtocol,
 } from "./types.js";
 
-const DEBUG_PROXY_FETCH_PATCH_KEY = Symbol.for("openclaw.debugProxy.fetchPatch");
+export {
+  finalizeDebugProxyCapture,
+  isDebugProxyGlobalFetchPatchInstalled,
+  resolveDebugProxyFetchTransport,
+  type DebugProxyCaptureRuntimeDeps,
+} from "./runtime-owner.js";
+
 const REDACTED_CAPTURE_BINARY_PAYLOAD = Buffer.from("[REDACTED BINARY PAYLOAD]", "utf8");
 // Cap captured response bodies so debug proxy capture cannot be turned into an
 // out-of-memory vector. The patched global fetch tees every outbound response
@@ -124,7 +139,10 @@ function readCapturedResponseBodyBounded(
         return;
       }
       reader = body.getReader();
-      while (!finished && owner.active) {
+      for (;;) {
+        if (finished || !owner.active) {
+          return;
+        }
         const { done, value } = await withResponseBodyTimeout({
           timeoutMs: CAPTURED_RESPONSE_BODY_IDLE_TIMEOUT_MS,
           onTimeout: ({ timeoutMs }) =>
@@ -173,179 +191,6 @@ function parseDeclaredCaptureContentLength(raw: string | null | undefined): bigi
     return undefined;
   }
   return BigInt(trimmed);
-}
-
-// Runtime capture records HTTP/fetch and websocket events into the SQLite store,
-// redacting sensitive headers and persisting bodies in capture_blobs.
-type GlobalFetchPatchedState = {
-  originalFetch: typeof globalThis.fetch;
-  admission: CaptureAdmission;
-};
-
-type GlobalFetchPatchTarget = typeof globalThis & {
-  [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
-};
-
-const globalFetchPatches = new WeakMap<typeof globalThis.fetch, GlobalFetchPatchedState>();
-
-/** Guarded requests own capture admission, including when given a saved patch. */
-export function resolveDebugProxyFetchTransport(
-  fetchImpl: typeof globalThis.fetch,
-): typeof globalThis.fetch {
-  return globalFetchPatches.get(fetchImpl)?.originalFetch ?? fetchImpl;
-}
-
-type DebugProxyCaptureStoreLike = Pick<
-  ReturnType<typeof getDebugProxyCaptureStore>,
-  "upsertSession" | "endSession" | "recordEvent"
-> &
-  Partial<Pick<ReturnType<typeof getDebugProxyCaptureStore>, "close" | "isClosed">>;
-
-export type DebugProxyCaptureRuntimeDeps = {
-  getStore?: () => DebugProxyCaptureStoreLike;
-  closeStore?: () => void;
-  persistEventPayload?: (
-    store: DebugProxyCaptureStoreLike,
-    payload: Parameters<typeof persistEventPayload>[1],
-  ) => ReturnType<typeof persistEventPayload>;
-  safeJsonString?: typeof safeJsonString;
-  fetchTarget?: typeof globalThis;
-};
-
-function resolveRuntimeDeps(deps: DebugProxyCaptureRuntimeDeps = {}) {
-  return {
-    getStore: deps.getStore ?? getDebugProxyCaptureStore,
-    closeStore: deps.closeStore,
-    persistEventPayload:
-      deps.persistEventPayload ??
-      ((store, payload) =>
-        persistEventPayload(store as ReturnType<typeof getDebugProxyCaptureStore>, payload)),
-    safeJsonString: deps.safeJsonString ?? safeJsonString,
-    fetchTarget: deps.fetchTarget ?? globalThis,
-  };
-}
-
-type CaptureOwner = {
-  settings: DebugProxySettings;
-  runtime: ReturnType<typeof resolveRuntimeDeps>;
-  store: DebugProxyCaptureStoreLike;
-  active: boolean;
-  pending: Set<() => void>;
-  errors: unknown[];
-  unregister: () => void;
-  admission: CaptureAdmission;
-};
-type CaptureAdmission = { current?: CaptureOwner };
-type CaptureRegistry = {
-  owners: Map<string, CaptureOwner>;
-  resolved: WeakMap<DebugProxySettings, CaptureAdmission>;
-  ambient?: { sessionId: string; dbPath: string; admission: CaptureAdmission };
-};
-const captureOwners = new WeakMap<
-  ReturnType<typeof resolveRuntimeDeps>["getStore"],
-  CaptureRegistry
->();
-
-function captureOwnerKey(settings: DebugProxySettings): string {
-  // dbPath is the root-derived capture locator, not the shared database route.
-  // Implicit session IDs survive state-root changes, so both identify an owner.
-  return JSON.stringify([settings.dbPath, settings.sessionId]);
-}
-
-function reportCapturePersistenceFailure(owner: CaptureOwner, error: unknown): void {
-  owner.errors.push(error);
-  // The earlier SQLite exit hook swallows close errors. Report synchronously
-  // here before it closes the store; diagnostics must not interrupt settlement.
-  try {
-    writeSync(
-      2,
-      `[proxy-capture] Capture persistence failed: ${redactCaptureText(error instanceof Error ? error.message : String(error))}\n`,
-    );
-  } catch {
-    // Preserve the original failure even if the diagnostic sink is unavailable.
-  }
-}
-
-function finishCaptureOwner(owner: CaptureOwner): void {
-  if (!owner.active) {
-    return;
-  }
-  owner.active = false;
-  owner.admission.current = undefined;
-  const registry = captureOwners.get(owner.runtime.getStore)!;
-  registry.owners.delete(captureOwnerKey(owner.settings));
-  uninstallDebugProxyGlobalFetchPatch(owner.runtime, owner.admission);
-  owner.unregister();
-  for (const finish of owner.pending) {
-    finish();
-  }
-  try {
-    if (!owner.store.isClosed) {
-      owner.store.endSession(owner.settings.sessionId);
-    }
-  } catch (error) {
-    reportCapturePersistenceFailure(owner, error);
-  }
-  if (owner.errors.length) {
-    throw new AggregateError(owner.errors.splice(0), "Capture session finalization failed.");
-  }
-}
-
-function resolveCaptureOwner(
-  settings: DebugProxySettings,
-  runtime: ReturnType<typeof resolveRuntimeDeps>,
-  options: { initialize?: boolean; explicit?: boolean } = {},
-): CaptureOwner | undefined {
-  let registry = captureOwners.get(runtime.getStore);
-  if (!registry) {
-    registry = { owners: new Map(), resolved: new WeakMap() };
-    captureOwners.set(runtime.getStore, registry);
-  }
-  const key = captureOwnerKey(settings);
-  let owner = registry.owners.get(key);
-  if (!owner) {
-    // Explicit settings own their lifetime; ambient capture observes current
-    // configuration. Keep only its current marker, not retired IDs or stores.
-    const prior = options.explicit
-      ? registry.resolved.get(settings)
-      : registry.ambient?.sessionId === settings.sessionId &&
-          registry.ambient.dbPath === settings.dbPath
-        ? registry.ambient.admission
-        : undefined;
-    if (!options.initialize && prior) {
-      return prior.current;
-    }
-    const store = runtime.getStore();
-    if (store.isClosed) {
-      return undefined;
-    }
-    owner = {
-      settings,
-      runtime,
-      store,
-      active: true,
-      pending: new Set(),
-      errors: [],
-      unregister: () => {},
-      admission: {},
-    };
-    owner.admission.current = owner;
-    const retainedOwner = owner;
-    owner.unregister = registerCaptureStoreFinalizer(store, () =>
-      finishCaptureOwner(retainedOwner),
-    );
-    registry.owners.set(key, owner);
-  }
-  if (options.explicit) {
-    registry.resolved.set(settings, owner.admission);
-  } else {
-    registry.ambient = {
-      sessionId: settings.sessionId,
-      dbPath: settings.dbPath,
-      admission: owner.admission,
-    };
-  }
-  return owner;
 }
 
 function protocolFromUrl(rawUrl: string): CaptureProtocol {
@@ -501,11 +346,11 @@ function installDebugProxyGlobalFetchPatch(
 ): void {
   const runtime = resolveRuntimeDeps(deps);
   const admission = owner.admission;
-  const fetchTarget = runtime.fetchTarget as GlobalFetchPatchTarget;
+  const fetchTarget = runtime.fetchTarget;
   if (typeof fetchTarget.fetch !== "function") {
     return;
   }
-  if (fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY]?.admission === admission) {
+  if (hasDebugProxyFetchPatch(fetchTarget, admission)) {
     return;
   }
   uninstallDebugProxyGlobalFetchPatch(deps);
@@ -513,8 +358,6 @@ function installDebugProxyGlobalFetchPatch(
   // teardown in tests and nested capture sessions.
   const fetchImpl = fetchTarget.fetch;
   const originalFetch = resolveDebugProxyFetchTransport(fetchImpl).bind(fetchTarget);
-  const patch = { originalFetch, admission };
-  fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY] = patch;
   const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = resolveUrlString(input);
     const normalizedInit = normalizeRequestInitHeadersForFetch(init);
@@ -583,25 +426,7 @@ function installDebugProxyGlobalFetchPatch(
     // Preserve Vitest mock metadata when patching mocked fetch targets.
     (patchedFetch as typeof globalThis.fetch & { mock?: unknown }).mock = mockState;
   }
-  globalFetchPatches.set(patchedFetch, patch);
-  fetchTarget.fetch = patchedFetch as typeof globalThis.fetch;
-}
-
-function uninstallDebugProxyGlobalFetchPatch(
-  deps: DebugProxyCaptureRuntimeDeps = {},
-  admission?: CaptureAdmission,
-): void {
-  const fetchTarget = resolveRuntimeDeps(deps).fetchTarget as GlobalFetchPatchTarget;
-  const state = fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
-  if (!state || (admission && state.admission !== admission)) {
-    return;
-  }
-  fetchTarget.fetch = state.originalFetch;
-  delete fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
-}
-
-export function isDebugProxyGlobalFetchPatchInstalled(): boolean {
-  return Boolean((globalThis as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]);
+  registerDebugProxyFetchPatch(fetchTarget, originalFetch, patchedFetch, admission);
 }
 
 export function initializeDebugProxyCapture(
@@ -631,44 +456,6 @@ export function initializeDebugProxyCapture(
   installDebugProxyGlobalFetchPatch(owner, deps);
 }
 
-// Finalization closes the session and restores the fetch patch before closing
-// the cached store, preventing later normal requests from being captured.
-export function finalizeDebugProxyCapture(
-  resolved?: DebugProxySettings,
-  deps: DebugProxyCaptureRuntimeDeps = {},
-): void {
-  const settings = resolveEnabledDebugProxySettings(resolved);
-  if (!settings) {
-    return;
-  }
-  const runtime = resolveRuntimeDeps(deps);
-  const owner = captureOwners.get(runtime.getStore)?.owners.get(captureOwnerKey(settings));
-  if (owner) {
-    uninstallDebugProxyGlobalFetchPatch(deps, owner.admission);
-  }
-  if (!owner?.active) {
-    return;
-  }
-  const errors: unknown[] = [];
-  try {
-    finishCaptureOwner(owner);
-  } catch (error) {
-    errors.push(error);
-  }
-  try {
-    if (owner.runtime.closeStore) {
-      owner.runtime.closeStore();
-    } else {
-      owner.store.close?.();
-    }
-  } catch (error) {
-    errors.push(error);
-  }
-  if (errors.length) {
-    throw new AggregateError(errors, "Capture finalization failed.");
-  }
-}
-
 type HttpCaptureParams = {
   url: string;
   method: string;
@@ -689,7 +476,7 @@ export function prepareHttpCapture(
 ) {
   const settings = resolveEnabledDebugProxySettings(resolved);
   if (!settings) {
-    return;
+    return undefined;
   }
   const admission = resolveCaptureOwner(settings, resolveRuntimeDeps(deps), {
     explicit: resolved !== undefined,

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -1,25 +1,22 @@
 // Proxy capture runtime coordinates capture sessions, proxy startup, and storage.
 import { isUtf8 } from "node:buffer";
 import { randomUUID } from "node:crypto";
+import { writeSync } from "node:fs";
 import { URL } from "node:url";
 import {
   isHeadersLike,
   normalizeRequestInitHeadersForFetch,
   type HeadersLike,
 } from "../infra/fetch-headers.js";
-import { readChunkWithIdleTimeout } from "../infra/http-body.js";
+import { withResponseBodyTimeout } from "../infra/http-response-body-timeout.js";
 import {
   hasRegisteredSecretValuesForRedaction,
   redactRegisteredSecretValues,
 } from "../logging/secret-redaction-registry.js";
 import { resolveEnabledDebugProxySettings, type DebugProxySettings } from "./env.js";
 import { redactedCaptureHeaders, REDACTED_CAPTURE_HEADER_VALUE } from "./header-redaction.js";
-import {
-  closeDebugProxyCaptureStore,
-  getDebugProxyCaptureStore,
-  persistEventPayload,
-  safeJsonString,
-} from "./store.sqlite.js";
+import { registerCaptureStoreFinalizer } from "./store-lifecycle.js";
+import { getDebugProxyCaptureStore, persistEventPayload, safeJsonString } from "./store.sqlite.js";
 import type {
   CaptureDirection,
   CaptureEventKind,
@@ -48,7 +45,9 @@ class CaptureReadIdleTimeoutError extends Error {}
 
 type CapturedResponseBodyResult =
   | { status: "captured"; buffer: Buffer }
-  | { status: "too-large" | "unavailable" | "stalled" };
+  | { status: "stalled" | "finalized"; buffer: Buffer }
+  | { status: "failed"; buffer: Buffer; error: unknown }
+  | { status: "too-large" | "unavailable" };
 
 // Reads a cloned capture response body under a byte cap. Oversized or
 // non-streaming Response-like bodies return a metadata-only status instead of
@@ -60,80 +59,109 @@ type CapturedResponseBodyResult =
 // settles (it only resolves once BOTH branches cancel). Awaiting it would hang
 // the capture pipeline and retain the buffered prefix forever, so we cancel
 // fire-and-forget, mirroring src/agents/tools/web-shared.ts#readResponseText.
-async function readCapturedResponseBodyBounded(
+function readCapturedResponseBodyBounded(
   response: Response,
   maxBytes: number,
-): Promise<CapturedResponseBodyResult> {
-  const clone = response.clone();
-  const body = clone.body;
-  if (!body || typeof body.getReader !== "function") {
-    // A real null-body Response consumes as empty. Response-like objects without
-    // a stream cannot be read under a byte cap, so never call arrayBuffer().
-    return clone instanceof Response && clone.body === null
-      ? { status: "captured", buffer: Buffer.alloc(0) }
-      : { status: "unavailable" };
-  }
-  const reader = body.getReader();
-  const chunks: Buffer[] = [];
+  owner: CaptureOwner,
+  record: (result: CapturedResponseBodyResult) => void,
+): void {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let chunks: Buffer[] = [];
   let total = 0;
-  let truncated = false;
-  let stalled = false;
-  try {
-    while (true) {
-      let next: Awaited<ReturnType<typeof readChunkWithIdleTimeout>>;
-      try {
-        next = await readChunkWithIdleTimeout(
-          reader,
-          CAPTURED_RESPONSE_BODY_IDLE_TIMEOUT_MS,
-          ({ chunkTimeoutMs }) =>
-            new CaptureReadIdleTimeoutError(
-              `capture read stalled: no data for ${chunkTimeoutMs}ms`,
-            ),
-        );
-      } catch (error) {
-        // The helper rejects for a failed read as well as for the deadline, and
-        // only the deadline is a capture decision: a reset or aborted stream is
-        // the exchange failing, and has to keep reaching the error handler.
-        if (!(error instanceof CaptureReadIdleTimeoutError)) {
-          throw error;
-        }
-        // The helper has already issued the branch cancel fire-and-forget, which
-        // is what lets the tee settle. Capture keeps what it has and records the
-        // exchange as metadata: a stalled remote must not turn a diagnostic read
-        // into a failure of the request being observed.
-        stalled = true;
-        break;
-      }
-      const { done, value } = next;
-      if (done) {
-        break;
-      }
-      if (!value?.length) {
-        continue;
-      }
-      if (total + value.length > maxBytes) {
-        truncated = true;
-        break;
-      }
-      chunks.push(Buffer.from(value));
-      total += value.length;
+  let finished = false;
+  let canceled = false;
+  const cancel = (reason?: unknown) => {
+    if (!reader || canceled) {
+      return;
     }
-  } finally {
-    if (truncated) {
-      void reader.cancel().catch(() => undefined);
-    }
+    canceled = true;
+    // A clone is one tee branch: awaiting cancel can wait for the live caller.
     try {
-      reader.releaseLock();
-    } catch {
-      // Some non-compliant/mocked streams reject releaseLock; ignore.
+      void reader.cancel(reason).catch(() => undefined);
+    } catch (error) {
+      owner.errors.push(error);
     }
-  }
-  if (stalled) {
-    return { status: "stalled" };
-  }
-  return truncated
-    ? { status: "too-large" }
-    : { status: "captured", buffer: Buffer.concat(chunks, total) };
+  };
+  const release = () => {
+    try {
+      reader?.releaseLock();
+    } catch {
+      // A pending read releases its lock when the canceled read settles.
+    }
+  };
+  const finish = (result: CapturedResponseBodyResult) => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    owner.pending.delete(finalize);
+    try {
+      if (owner.store.isClosed) {
+        throw new Error("Capture store closed before its response could be finalized.");
+      }
+      record(result);
+    } catch (error) {
+      // Persistence failure is not a second stream error. Preserve it for close.
+      reportCapturePersistenceFailure(owner, error);
+    } finally {
+      chunks = [];
+      cancel();
+      release();
+    }
+  };
+  const finalize = () => finish({ status: "finalized", buffer: Buffer.concat(chunks, total) });
+  owner.pending.add(finalize);
+  void (async () => {
+    try {
+      const clone = response.clone();
+      const body = clone.body;
+      if (!body || typeof body.getReader !== "function") {
+        finish(
+          clone instanceof Response && clone.body === null
+            ? { status: "captured", buffer: Buffer.alloc(0) }
+            : { status: "unavailable" },
+        );
+        return;
+      }
+      reader = body.getReader();
+      while (!finished && owner.active) {
+        const { done, value } = await withResponseBodyTimeout({
+          timeoutMs: CAPTURED_RESPONSE_BODY_IDLE_TIMEOUT_MS,
+          onTimeout: ({ timeoutMs }) =>
+            new CaptureReadIdleTimeoutError(`capture read stalled: no data for ${timeoutMs}ms`),
+          cancel: async (error) => cancel(error),
+          read: () => reader!.read(),
+        });
+        // Finalize may have synchronously recorded and closed this exact store.
+        if (finished || !owner.active) {
+          return;
+        }
+        if (done) {
+          finish({ status: "captured", buffer: Buffer.concat(chunks, total) });
+          return;
+        }
+        if (!value?.length) {
+          continue;
+        }
+        if (total + value.length > maxBytes) {
+          finish({ status: "too-large" });
+          return;
+        }
+        chunks.push(Buffer.from(value));
+        total += value.length;
+      }
+    } catch (error) {
+      if (!finished && owner.active) {
+        finish(
+          error instanceof CaptureReadIdleTimeoutError
+            ? { status: "stalled", buffer: Buffer.concat(chunks, total) }
+            : { status: "failed", buffer: Buffer.concat(chunks, total), error },
+        );
+      }
+    } finally {
+      release();
+    }
+  })();
 }
 
 function parseDeclaredCaptureContentLength(raw: string | null | undefined): bigint | undefined {
@@ -151,20 +179,31 @@ function parseDeclaredCaptureContentLength(raw: string | null | undefined): bigi
 // redacting sensitive headers and persisting bodies in capture_blobs.
 type GlobalFetchPatchedState = {
   originalFetch: typeof globalThis.fetch;
+  admission: CaptureAdmission;
 };
 
 type GlobalFetchPatchTarget = typeof globalThis & {
   [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
 };
 
+const globalFetchPatches = new WeakMap<typeof globalThis.fetch, GlobalFetchPatchedState>();
+
+/** Guarded requests own capture admission, including when given a saved patch. */
+export function resolveDebugProxyFetchTransport(
+  fetchImpl: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return globalFetchPatches.get(fetchImpl)?.originalFetch ?? fetchImpl;
+}
+
 type DebugProxyCaptureStoreLike = Pick<
   ReturnType<typeof getDebugProxyCaptureStore>,
   "upsertSession" | "endSession" | "recordEvent"
->;
+> &
+  Partial<Pick<ReturnType<typeof getDebugProxyCaptureStore>, "close" | "isClosed">>;
 
 export type DebugProxyCaptureRuntimeDeps = {
   getStore?: () => DebugProxyCaptureStoreLike;
-  closeStore?: typeof closeDebugProxyCaptureStore;
+  closeStore?: () => void;
   persistEventPayload?: (
     store: DebugProxyCaptureStoreLike,
     payload: Parameters<typeof persistEventPayload>[1],
@@ -176,7 +215,7 @@ export type DebugProxyCaptureRuntimeDeps = {
 function resolveRuntimeDeps(deps: DebugProxyCaptureRuntimeDeps = {}) {
   return {
     getStore: deps.getStore ?? getDebugProxyCaptureStore,
-    closeStore: deps.closeStore ?? closeDebugProxyCaptureStore,
+    closeStore: deps.closeStore,
     persistEventPayload:
       deps.persistEventPayload ??
       ((store, payload) =>
@@ -184,6 +223,129 @@ function resolveRuntimeDeps(deps: DebugProxyCaptureRuntimeDeps = {}) {
     safeJsonString: deps.safeJsonString ?? safeJsonString,
     fetchTarget: deps.fetchTarget ?? globalThis,
   };
+}
+
+type CaptureOwner = {
+  settings: DebugProxySettings;
+  runtime: ReturnType<typeof resolveRuntimeDeps>;
+  store: DebugProxyCaptureStoreLike;
+  active: boolean;
+  pending: Set<() => void>;
+  errors: unknown[];
+  unregister: () => void;
+  admission: CaptureAdmission;
+};
+type CaptureAdmission = { current?: CaptureOwner };
+type CaptureRegistry = {
+  owners: Map<string, CaptureOwner>;
+  resolved: WeakMap<DebugProxySettings, CaptureAdmission>;
+  ambient?: { sessionId: string; dbPath: string; admission: CaptureAdmission };
+};
+const captureOwners = new WeakMap<
+  ReturnType<typeof resolveRuntimeDeps>["getStore"],
+  CaptureRegistry
+>();
+
+function captureOwnerKey(settings: DebugProxySettings): string {
+  // dbPath is the root-derived capture locator, not the shared database route.
+  // Implicit session IDs survive state-root changes, so both identify an owner.
+  return JSON.stringify([settings.dbPath, settings.sessionId]);
+}
+
+function reportCapturePersistenceFailure(owner: CaptureOwner, error: unknown): void {
+  owner.errors.push(error);
+  // The earlier SQLite exit hook swallows close errors. Report synchronously
+  // here before it closes the store; diagnostics must not interrupt settlement.
+  try {
+    writeSync(
+      2,
+      `[proxy-capture] Capture persistence failed: ${redactCaptureText(error instanceof Error ? error.message : String(error))}\n`,
+    );
+  } catch {
+    // Preserve the original failure even if the diagnostic sink is unavailable.
+  }
+}
+
+function finishCaptureOwner(owner: CaptureOwner): void {
+  if (!owner.active) {
+    return;
+  }
+  owner.active = false;
+  owner.admission.current = undefined;
+  const registry = captureOwners.get(owner.runtime.getStore)!;
+  registry.owners.delete(captureOwnerKey(owner.settings));
+  uninstallDebugProxyGlobalFetchPatch(owner.runtime, owner.admission);
+  owner.unregister();
+  for (const finish of owner.pending) {
+    finish();
+  }
+  try {
+    if (!owner.store.isClosed) {
+      owner.store.endSession(owner.settings.sessionId);
+    }
+  } catch (error) {
+    reportCapturePersistenceFailure(owner, error);
+  }
+  if (owner.errors.length) {
+    throw new AggregateError(owner.errors.splice(0), "Capture session finalization failed.");
+  }
+}
+
+function resolveCaptureOwner(
+  settings: DebugProxySettings,
+  runtime: ReturnType<typeof resolveRuntimeDeps>,
+  options: { initialize?: boolean; explicit?: boolean } = {},
+): CaptureOwner | undefined {
+  let registry = captureOwners.get(runtime.getStore);
+  if (!registry) {
+    registry = { owners: new Map(), resolved: new WeakMap() };
+    captureOwners.set(runtime.getStore, registry);
+  }
+  const key = captureOwnerKey(settings);
+  let owner = registry.owners.get(key);
+  if (!owner) {
+    // Explicit settings own their lifetime; ambient capture observes current
+    // configuration. Keep only its current marker, not retired IDs or stores.
+    const prior = options.explicit
+      ? registry.resolved.get(settings)
+      : registry.ambient?.sessionId === settings.sessionId &&
+          registry.ambient.dbPath === settings.dbPath
+        ? registry.ambient.admission
+        : undefined;
+    if (!options.initialize && prior) {
+      return prior.current;
+    }
+    const store = runtime.getStore();
+    if (store.isClosed) {
+      return undefined;
+    }
+    owner = {
+      settings,
+      runtime,
+      store,
+      active: true,
+      pending: new Set(),
+      errors: [],
+      unregister: () => {},
+      admission: {},
+    };
+    owner.admission.current = owner;
+    const retainedOwner = owner;
+    owner.unregister = registerCaptureStoreFinalizer(store, () =>
+      finishCaptureOwner(retainedOwner),
+    );
+    registry.owners.set(key, owner);
+  }
+  if (options.explicit) {
+    registry.resolved.set(settings, owner.admission);
+  } else {
+    registry.ambient = {
+      sessionId: settings.sessionId,
+      dbPath: settings.dbPath,
+      admission: owner.admission,
+    };
+  }
+  return owner;
 }
 
 function protocolFromUrl(rawUrl: string): CaptureProtocol {
@@ -334,29 +496,38 @@ function createHttpCaptureEventBase(params: {
 }
 
 function installDebugProxyGlobalFetchPatch(
-  settings: DebugProxySettings,
+  owner: CaptureOwner,
   deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
   const runtime = resolveRuntimeDeps(deps);
+  const admission = owner.admission;
   const fetchTarget = runtime.fetchTarget as GlobalFetchPatchTarget;
   if (typeof fetchTarget.fetch !== "function") {
     return;
   }
-  if (fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY]) {
+  if (fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY]?.admission === admission) {
     return;
   }
+  uninstallDebugProxyGlobalFetchPatch(deps);
   // Patch only once per target and keep the original fetch for deterministic
   // teardown in tests and nested capture sessions.
   const fetchImpl = fetchTarget.fetch;
-  const originalFetch = fetchImpl.bind(fetchTarget);
-  fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY] = { originalFetch };
+  const originalFetch = resolveDebugProxyFetchTransport(fetchImpl).bind(fetchTarget);
+  const patch = { originalFetch, admission };
+  fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY] = patch;
   const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = resolveUrlString(input);
     const normalizedInit = normalizeRequestInitHeadersForFetch(init);
+    // Retain admission before awaiting transport; a late result cannot join a
+    // replacement capture session or reopen a store closed during shutdown.
+    const admitted = Boolean(admission.current);
+    let response: Response;
     try {
-      const response = await originalFetch(input, normalizedInit);
-      if (url && /^https?:/i.test(url)) {
-        captureHttpExchange(
+      response = await originalFetch(input, normalizedInit);
+    } catch (error) {
+      const current = admission.current;
+      if (admitted && current && url && /^https?:/i.test(url)) {
+        captureOwnedHttpError(
           {
             url,
             method:
@@ -365,70 +536,64 @@ function installDebugProxyGlobalFetchPatch(
                 : undefined) ??
               normalizedInit?.method ??
               "GET",
-            requestHeaders:
-              (typeof Request !== "undefined" && input instanceof Request
-                ? input.headers
-                : undefined) ??
-              (normalizedInit?.headers as Headers | Record<string, string> | undefined),
-            requestBody:
-              (typeof Request !== "undefined" && input instanceof Request
-                ? (input as Request & { body?: BodyInit | null }).body
-                : undefined) ??
-              (normalizedInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ??
-              null,
-            response,
-            transport: "http",
-            meta: {
-              captureOrigin: "global-fetch",
-              source: settings.sourceProcess,
-            },
+            error,
+            meta: { captureOrigin: "global-fetch" },
           },
-          settings,
-          deps,
+          current,
         );
       }
-      return response;
-    } catch (error) {
-      if (url && /^https?:/i.test(url)) {
-        const store = runtime.getStore();
-        const captureUrl = redactCaptureUrl(url);
-        const parsed = new URL(captureUrl);
-        store.recordEvent({
-          sessionId: settings.sessionId,
-          ts: Date.now(),
-          sourceScope: "openclaw",
-          sourceProcess: settings.sourceProcess,
-          protocol: protocolFromUrl(captureUrl),
-          direction: "local",
-          kind: "error",
-          flowId: randomUUID(),
+      throw error;
+    }
+    const current = admission.current;
+    if (admitted && current && url && /^https?:/i.test(url)) {
+      captureOwnedHttpExchange(
+        {
+          url,
           method:
             (typeof Request !== "undefined" && input instanceof Request
               ? input.method
               : undefined) ??
             normalizedInit?.method ??
             "GET",
-          host: parsed.host,
-          path: `${parsed.pathname}${parsed.search}`,
-          errorText: redactCaptureText(error instanceof Error ? error.message : String(error)),
-          metaJson: redactedCaptureJson({ captureOrigin: "global-fetch" }, runtime.safeJsonString),
-        });
-      }
-      throw error;
+          requestHeaders:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? input.headers
+              : undefined) ??
+            (normalizedInit?.headers as Headers | Record<string, string> | undefined),
+          requestBody:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? (input as Request & { body?: BodyInit | null }).body
+              : undefined) ??
+            (normalizedInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ??
+            null,
+          response,
+          transport: "http",
+          meta: {
+            captureOrigin: "global-fetch",
+            source: current.settings.sourceProcess,
+          },
+        },
+        current,
+      );
     }
+    return response;
   };
   const mockState = (fetchImpl as typeof globalThis.fetch & { mock?: unknown }).mock;
   if (typeof mockState === "object" && mockState !== null) {
     // Preserve Vitest mock metadata when patching mocked fetch targets.
     (patchedFetch as typeof globalThis.fetch & { mock?: unknown }).mock = mockState;
   }
+  globalFetchPatches.set(patchedFetch, patch);
   fetchTarget.fetch = patchedFetch as typeof globalThis.fetch;
 }
 
-function uninstallDebugProxyGlobalFetchPatch(deps: DebugProxyCaptureRuntimeDeps = {}): void {
+function uninstallDebugProxyGlobalFetchPatch(
+  deps: DebugProxyCaptureRuntimeDeps = {},
+  admission?: CaptureAdmission,
+): void {
   const fetchTarget = resolveRuntimeDeps(deps).fetchTarget as GlobalFetchPatchTarget;
   const state = fetchTarget[DEBUG_PROXY_FETCH_PATCH_KEY];
-  if (!state) {
+  if (!state || (admission && state.admission !== admission)) {
     return;
   }
   fetchTarget.fetch = state.originalFetch;
@@ -448,7 +613,14 @@ export function initializeDebugProxyCapture(
   if (!settings) {
     return;
   }
-  resolveRuntimeDeps(deps).getStore().upsertSession({
+  const owner = resolveCaptureOwner(settings, resolveRuntimeDeps(deps), {
+    initialize: true,
+    explicit: resolved !== undefined,
+  });
+  if (!owner) {
+    return;
+  }
+  owner.store.upsertSession({
     id: settings.sessionId,
     startedAt: Date.now(),
     mode,
@@ -456,7 +628,7 @@ export function initializeDebugProxyCapture(
     sourceProcess: settings.sourceProcess,
     proxyUrl: settings.proxyUrl,
   });
-  installDebugProxyGlobalFetchPatch(settings, deps);
+  installDebugProxyGlobalFetchPatch(owner, deps);
 }
 
 // Finalization closes the session and restores the fetch patch before closing
@@ -470,31 +642,106 @@ export function finalizeDebugProxyCapture(
     return;
   }
   const runtime = resolveRuntimeDeps(deps);
-  runtime.getStore().endSession(settings.sessionId);
-  uninstallDebugProxyGlobalFetchPatch(deps);
-  runtime.closeStore();
+  const owner = captureOwners.get(runtime.getStore)?.owners.get(captureOwnerKey(settings));
+  if (owner) {
+    uninstallDebugProxyGlobalFetchPatch(deps, owner.admission);
+  }
+  if (!owner?.active) {
+    return;
+  }
+  const errors: unknown[] = [];
+  try {
+    finishCaptureOwner(owner);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    if (owner.runtime.closeStore) {
+      owner.runtime.closeStore();
+    } else {
+      owner.store.close?.();
+    }
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length) {
+    throw new AggregateError(errors, "Capture finalization failed.");
+  }
 }
 
-export function captureHttpExchange(
-  params: {
-    url: string;
-    method: string;
-    requestHeaders?: HeadersLike | Record<string, string> | undefined;
-    requestBody?: BodyInit | Buffer | string | null;
-    response: Response;
-    transport?: "http" | "sse";
-    flowId?: string;
-    meta?: Record<string, unknown>;
-  },
+type HttpCaptureParams = {
+  url: string;
+  method: string;
+  requestHeaders?: HeadersLike | Record<string, string> | undefined;
+  requestBody?: BodyInit | Buffer | string | null;
+  response: Response;
+  transport?: "http" | "sse";
+  flowId?: string;
+  meta?: Record<string, unknown>;
+};
+
+type HttpCaptureErrorParams = Omit<HttpCaptureParams, "response"> & { error: unknown };
+
+/** Internal fetch seams retain this admission before awaiting network work. */
+export function prepareHttpCapture(
   resolved?: DebugProxySettings,
   deps: DebugProxyCaptureRuntimeDeps = {},
-): void {
+) {
   const settings = resolveEnabledDebugProxySettings(resolved);
   if (!settings) {
     return;
   }
-  const runtime = resolveRuntimeDeps(deps);
-  const store = runtime.getStore();
+  const admission = resolveCaptureOwner(settings, resolveRuntimeDeps(deps), {
+    explicit: resolved !== undefined,
+  })?.admission;
+  return admission
+    ? (params: HttpCaptureParams | HttpCaptureErrorParams) => {
+        if (admission.current) {
+          if ("response" in params) {
+            captureOwnedHttpExchange(params, admission.current);
+          } else {
+            captureOwnedHttpError(params, admission.current);
+          }
+        }
+      }
+    : undefined;
+}
+
+export function captureHttpExchange(
+  params: HttpCaptureParams,
+  resolved?: DebugProxySettings,
+  deps: DebugProxyCaptureRuntimeDeps = {},
+): void {
+  prepareHttpCapture(resolved, deps)?.(params);
+}
+
+function captureOwnedHttpError(params: HttpCaptureErrorParams, owner: CaptureOwner): void {
+  try {
+    const captureUrl = redactCaptureUrl(params.url);
+    owner.store.recordEvent({
+      ...createHttpCaptureEventBase({
+        settings: owner.settings,
+        rawUrl: captureUrl,
+        url: new URL(captureUrl),
+        transport: params.transport,
+        direction: "local",
+        kind: "error",
+        flowId: params.flowId ?? randomUUID(),
+        method: params.method,
+      }),
+      errorText: redactCaptureText(
+        params.error instanceof Error ? params.error.message : String(params.error),
+      ),
+      metaJson: redactedCaptureJson(params.meta, owner.runtime.safeJsonString),
+    });
+  } catch (error) {
+    // Diagnostic persistence cannot replace the caller's transport rejection.
+    reportCapturePersistenceFailure(owner, error);
+  }
+}
+
+function captureOwnedHttpExchange(params: HttpCaptureParams, owner: CaptureOwner): void {
+  const { settings, runtime, store } = owner;
   const flowId = params.flowId ?? randomUUID();
   const captureUrl = redactCaptureUrl(params.url);
   const url = new URL(captureUrl);
@@ -515,47 +762,58 @@ export function captureHttpExchange(
       : undefined;
   const responseContentType =
     rawResponseContentType === undefined ? undefined : redactCaptureText(rawResponseContentType);
-  const requestPayload = runtime.persistEventPayload(store, {
-    data: redactCapturePayload(requestBody),
-    contentType: requestContentType,
-  });
-  store.recordEvent({
-    ...createHttpCaptureEventBase({
-      settings,
-      rawUrl: captureUrl,
-      url,
-      transport: params.transport,
-      direction: "outbound",
-      kind: "request",
-      flowId,
-      method: params.method,
-    }),
-    contentType: requestContentType,
-    headersJson: runtime.safeJsonString(
-      redactedCaptureHeaders(
-        params.requestHeaders,
-        Array.isArray(params.meta?.sensitiveRequestHeaderNames)
-          ? params.meta.sensitiveRequestHeaderNames.filter(
-              (name): name is string => typeof name === "string",
-            )
-          : undefined,
-      ),
-    ),
-    metaJson: redactedCaptureJson(params.meta, runtime.safeJsonString),
-    ...requestPayload,
-  });
-  // Records the response status/headers without a body. Used both when a
-  // Response-like object cannot be cloned and when capturing the body would be
-  // unsafe (over the cap), so the exchange is still observable without OOM risk.
-  const recordResponseMetadataOnly = (bodyCapture: "unavailable" | "too-large" | "stalled") => {
+  try {
+    const requestPayload = runtime.persistEventPayload(store, {
+      data: redactCapturePayload(requestBody),
+      contentType: requestContentType,
+    });
     store.recordEvent({
       ...createHttpCaptureEventBase({
         settings,
         rawUrl: captureUrl,
         url,
         transport: params.transport,
-        direction: "inbound",
-        kind: "response",
+        direction: "outbound",
+        kind: "request",
+        flowId,
+        method: params.method,
+      }),
+      contentType: requestContentType,
+      headersJson: runtime.safeJsonString(
+        redactedCaptureHeaders(
+          params.requestHeaders,
+          Array.isArray(params.meta?.sensitiveRequestHeaderNames)
+            ? params.meta.sensitiveRequestHeaderNames.filter(
+                (name): name is string => typeof name === "string",
+              )
+            : undefined,
+        ),
+      ),
+      metaJson: redactedCaptureJson(params.meta, runtime.safeJsonString),
+      ...requestPayload,
+    });
+  } catch (error) {
+    reportCapturePersistenceFailure(owner, error);
+    return;
+  }
+  const recordTerminal = (result: CapturedResponseBodyResult) => {
+    const failed = result.status === "failed";
+    // Join first, then redact: secrets and UTF-8 code points can cross chunks.
+    const payload =
+      "buffer" in result
+        ? runtime.persistEventPayload(store, {
+            data: redactCapturePayload(result.buffer),
+            contentType: responseContentType,
+          })
+        : {};
+    store.recordEvent({
+      ...createHttpCaptureEventBase({
+        settings,
+        rawUrl: captureUrl,
+        url,
+        transport: params.transport,
+        direction: failed ? "local" : "inbound",
+        kind: failed ? "error" : "response",
         flowId,
         method: params.method,
       }),
@@ -565,13 +823,35 @@ export function captureHttpExchange(
         params.response.headers && typeof params.response.headers.entries === "function"
           ? runtime.safeJsonString(redactedCaptureHeaders(params.response.headers))
           : undefined,
-      metaJson: redactedCaptureJson({ ...params.meta, bodyCapture }, runtime.safeJsonString),
+      errorText: failed
+        ? redactCaptureText(
+            result.error instanceof Error ? result.error.message : String(result.error),
+          )
+        : undefined,
+      metaJson: redactedCaptureJson(
+        result.status === "captured"
+          ? params.meta
+          : {
+              ...params.meta,
+              bodyCapture: result.status,
+              ...(failed ? { stage: "response-body" } : {}),
+            },
+        runtime.safeJsonString,
+      ),
+      ...payload,
     });
+  };
+  const recordMetadata = (status: "unavailable" | "too-large") => {
+    try {
+      recordTerminal({ status });
+    } catch (error) {
+      reportCapturePersistenceFailure(owner, error);
+    }
   };
   if (typeof params.response.clone !== "function") {
     // Some Response-like objects cannot be cloned. Still record status/headers
     // rather than forcing capture to consume or mutate the original response.
-    recordResponseMetadataOnly("unavailable");
+    recordMetadata("unavailable");
     return;
   }
   // Fast path: when the provider declares an oversized Content-Length, skip the
@@ -583,54 +863,15 @@ export function captureHttpExchange(
       : undefined,
   );
   if (declaredLength !== undefined && declaredLength > BigInt(MAX_CAPTURED_RESPONSE_BODY_BYTES)) {
-    recordResponseMetadataOnly("too-large");
+    recordMetadata("too-large");
     return;
   }
-  void readCapturedResponseBodyBounded(params.response, MAX_CAPTURED_RESPONSE_BODY_BYTES)
-    .then((result) => {
-      if (result.status !== "captured") {
-        // The body either exceeded the cap or offered no bounded streaming path.
-        // Preserve the exchange as metadata instead of allocating the whole body.
-        recordResponseMetadataOnly(result.status);
-        return;
-      }
-      const responsePayload = runtime.persistEventPayload(store, {
-        data: redactCapturePayload(result.buffer),
-        contentType: responseContentType,
-      });
-      store.recordEvent({
-        ...createHttpCaptureEventBase({
-          settings,
-          rawUrl: captureUrl,
-          url,
-          transport: params.transport,
-          direction: "inbound",
-          kind: "response",
-          flowId,
-          method: params.method,
-        }),
-        status: params.response.status,
-        contentType: responseContentType,
-        headersJson: runtime.safeJsonString(redactedCaptureHeaders(params.response.headers)),
-        metaJson: redactedCaptureJson(params.meta, runtime.safeJsonString),
-        ...responsePayload,
-      });
-    })
-    .catch((error: unknown) => {
-      store.recordEvent({
-        ...createHttpCaptureEventBase({
-          settings,
-          rawUrl: captureUrl,
-          url,
-          transport: params.transport,
-          direction: "local",
-          kind: "error",
-          flowId,
-          method: params.method,
-        }),
-        errorText: redactCaptureText(error instanceof Error ? error.message : String(error)),
-      });
-    });
+  readCapturedResponseBodyBounded(
+    params.response,
+    MAX_CAPTURED_RESPONSE_BODY_BYTES,
+    owner,
+    recordTerminal,
+  );
 }
 
 // Websocket seams call this directly because Node fetch patching cannot observe
@@ -653,8 +894,13 @@ export function captureWsEvent(
   if (!settings) {
     return;
   }
-  const runtime = resolveRuntimeDeps(deps);
-  const store = runtime.getStore();
+  const owner = resolveCaptureOwner(settings, resolveRuntimeDeps(deps), {
+    explicit: resolved !== undefined,
+  });
+  if (!owner) {
+    return;
+  }
+  const { runtime, store } = owner;
   const captureUrl = redactCaptureUrl(params.url);
   const url = new URL(captureUrl);
   const payload = runtime.persistEventPayload(store, {

--- a/src/proxy-capture/store-lifecycle.ts
+++ b/src/proxy-capture/store-lifecycle.ts
@@ -1,0 +1,37 @@
+// Capture sessions must settle while their exact store is still writable.
+// This registry avoids a runtime/store import cycle and never acquires a store.
+const finalizers = new WeakMap<object, Set<() => void>>();
+const closed = new WeakSet<object>();
+
+export function registerCaptureStoreFinalizer(store: object, finalize: () => void): () => void {
+  if (closed.has(store)) {
+    throw new Error("Capture store is already finalized.");
+  }
+  let callbacks = finalizers.get(store);
+  if (!callbacks) {
+    callbacks = new Set();
+    finalizers.set(store, callbacks);
+  }
+  callbacks.add(finalize);
+  return () => callbacks.delete(finalize);
+}
+
+export function finalizeCaptureStore(store: object): void {
+  if (closed.has(store)) {
+    return;
+  }
+  closed.add(store);
+  const callbacks = finalizers.get(store);
+  finalizers.delete(store);
+  const errors: unknown[] = [];
+  for (const finalize of callbacks ?? []) {
+    try {
+      finalize();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length) {
+    throw new AggregateError(errors, "Capture store finalization failed.");
+  }
+}

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -169,8 +169,8 @@ describe("DebugProxyCaptureStore", () => {
       sourceProcess: "cli",
     });
 
-    // Exit-time hook closes the shared handle out from under the cached store;
-    // finalizeDebugProxyCapture then re-fetches and must not get a dead handle.
+    // Explicit acquisition after shared-handle retirement must rebind; retained
+    // capture finalizers instead keep their exact owner and must not reopen it.
     closeOpenClawStateDatabaseForTest();
     expect(stale.isClosed).toBe(true);
 

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -24,6 +24,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { finalizeCaptureStore } from "./store-lifecycle.js";
 import {
   findDebugProxyCaptureBlobReference,
   listDebugProxyCaptureSessions,
@@ -225,6 +226,7 @@ class DebugProxyCaptureStoreImpl {
   readonly blobDir: string;
   private readonly pathBased?: PathBasedDebugProxyCaptureStore;
   private closed = false;
+  private closing = false;
 
   constructor(
     optionsOrDbPath: DebugProxyCaptureStoreOptions | string = {},
@@ -250,14 +252,31 @@ class DebugProxyCaptureStoreImpl {
   }
 
   close(): void {
-    if (this.closed) {
+    if (this.closed || this.closing) {
       return;
     }
-    if (this.pathBased) {
-      this.pathBased.walMaintenance.close();
-      this.db.close();
+    this.closing = true;
+    const errors: unknown[] = [];
+    for (const close of [
+      () => finalizeCaptureStore(this),
+      () => this.pathBased?.walMaintenance.close(),
+      () => {
+        if (this.pathBased && this.db.isOpen) {
+          this.db.close();
+        }
+      },
+    ]) {
+      try {
+        close();
+      } catch (error) {
+        errors.push(error);
+      }
     }
     this.closed = true;
+    this.closing = false;
+    if (errors.length) {
+      throw new AggregateError(errors, "Capture store close failed.");
+    }
   }
 
   get isClosed(): boolean {
@@ -738,10 +757,19 @@ export function getDebugProxyCaptureStore(
 export function closeDebugProxyCaptureStore(): void {
   unregisterExitClose?.();
   unregisterExitClose = null;
-  for (const cached of cachedStores.values()) {
-    cached.store.close();
-  }
+  const stores = [...cachedStores.values()];
   cachedStores.clear();
+  const errors: unknown[] = [];
+  for (const cached of stores) {
+    try {
+      cached.store.close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length) {
+    throw new AggregateError(errors, "Capture stores failed to close.");
+  }
 }
 
 // Lease API keeps one cached capture-store wrapper alive across related
@@ -785,8 +813,8 @@ export function acquireDebugProxyCaptureStore(
       }
       current.leases = Math.max(0, current.leases - 1);
       if (current.leases === 0) {
-        current.store.close();
         cachedStores.delete(key);
+        current.store.close();
       }
     },
   };


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/143010
Related: https://github.com/openclaw/openclaw/pull/143012
Related: https://github.com/openclaw/openclaw/pull/140621

## What Problem This Solves

Resolves a problem where operators inspecting debug proxy captures could lose response bytes already received when a stream failed or capture shutdown interrupted the read. Pending readers could also write after their store closed, persistence failures could disappear during process exit, and a guarded request could be recorded in the wrong capture session after the state root changed.

This is a capture prerequisite discovered while validating the runtime prompt-cache test stack. It does not fix the prompt-cache behavior discussed in the related PR, and the completed live runs have not reproduced that original defect. The secretless stream tests do not establish the cause of a particular live transport failure.

## Why This Change Was Made

Capture now owns one bounded response read and one terminal record, preserving observed bytes and explicit incomplete/error outcomes while settling pending reads before the exact owning store closes. Admission remains tied to its original store generation; guarded and globally patched fetch paths share error recording without duplicate or replacement-session writes.

Retired owners release their heavy state, state-root/session identity stays isolated, and persistence failures emit synchronous redacted diagnostics. Caller streams, error identity, cancellation, existing byte/idle limits, and the `capture: false` global-delegation contract remain intact. No schema, configuration, dependency, provider parser, cache accounting, or cache-threshold changes.

The final scope is capture-only: five production files, five capture test files, and one shrink-only assertion-baseline change. Earlier Windows and Telegram fixture amendments were dropped entirely after main independently landed the fixes by @steipete in https://github.com/openclaw/openclaw/pull/143213 and https://github.com/openclaw/openclaw/pull/143197. Both fixture files match the frozen main base exactly. No retained fixture, temporary observer, or workflow delta.

## User Impact

Debug captures retain the response prefix actually observed, distinguish stream/read failures from storage failures, and close without late writes or silently moving requests into another capture session. A transport rejection remains visible as one error event, not a fabricated HTTP response.

Release-note context: preserve partial debug capture responses and finalize capture sessions safely without losing failure diagnostics.

## Evidence

- Reviewed head: `f240de23583a42902c13298881276baa5652ba28`; tree `12247570b625e5be1cb7e4e8838a454c625efacf`; frozen source base `895bdee99ed94c0f4d1014faecc2c0bf79b0db1f`. All three capture commits are signed and patch-identical to the previous reviewed series. All ten capture implementation/test blobs match prior head `f24c277659b495309300a06bd1d40921031a75c2`; both superseded fixtures match frozen main.
- **Exact-head CI passed:** https://github.com/openclaw/openclaw/actions/runs/34374251977, attempt 1. The primary-job audit counted **110 passed, 16 skipped, 0 failed jobs**; these are job counts, not test-case counts. Required gate: https://github.com/openclaw/openclaw/actions/runs/34374251977/job/102551111983.
- CI executed merge `1b27dc36dba7e327f0f008e7e29589bbb9720e9c`, combining this head with main `73b4086ff658973fb9ae07fa208c49ca8de82a67`. Both Windows jobs passed; the media file-URL case executed in 800 ms. Core/test types and artifact runtime SDK entry declarations, exports, and UI checks passed. This is not a full release-DTS or release-package qualification claim.
- Fresh exact-candidate autoreview is **scoped-clean at P0-P2**, with final source verification. Independent reconciliation review confirmed all 11 files, blob identities, signatures, and baseline preservation. Exact-head ClawSweeper revision 7 reports no findings, no security issue, and no before-merge item: https://github.com/openclaw/openclaw/pull/143107#issuecomment-5602254071.
- Prior focused proof remains explicitly prior-head: **87 tests passed, zero skipped**, at `cc3ed5b3e48420a847020833814a0bb1417e15a3` on Node 26.7 in 35.59 seconds, covering runtime/injected-store behavior, lifecycle, nine real-loopback ownership/rejection cases, and 22 existing OpenAI TTS cases. The broader **133 tests passed, zero skipped**, at `59d4f3fc28b3f7d7b8e9f917d279299af9ef35d1` in 162.37 seconds, additionally covering store, managed-fetch, pooled-release, and guarded-body tests. These counts are not described as new runs on the final head.
- Fail-before proof covered late writes after finalization, missing exit-time persistence diagnostics, retained owner state, same-session stores under different roots, wrong-owner recording, saved-wrapper duplication, and an active rejection with zero error records. Existing TTS proves `capture: false` global delegation remains exact-once; an initial zero-record test expectation was rejected rather than counted as a product defect.
- Managed-fetch coverage includes terminal responses with an open body, partial EOF, idle timeout, read error, and caller cancellation. A successful terminal can coexist with a captured response-body read failure; this PR preserves the evidence without inferring its cause. Lifecycle coverage includes direct/last-lease shared and legacy closure, sibling settlement, delayed success/rejection across retirement, both finalization orders, and subprocess exit ordering with injected blob/event persistence failures.
- Earlier independent findings were repaired at these owners. A proposed pre-reader-finalization finding was independently dismissed because native clone/reader acquisition is synchronous before the first await; no speculative guard was added.
- Production: **+689/-353, net +336** across five files. Tests: **+1,286/-3** across five files. The baseline is separately **+1/-1**: main's full baseline remains intact except the existing runtime allowance reduction from 10 to 5. Production growth implements observed-byte, exact-store lifecycle, and admission-ownership invariants; the module extraction keeps retirement and matching patch cleanup together without a second registry or new public entrypoints.
- Earlier Testbox proof at https://github.com/openclaw/openclaw/actions/runs/34354040282 admitted prior head `fead06567d0697765c90eea0466ca5859baaa56e`. Core production types and all 17 core test-type graphs passed, then four lint findings stopped that payload before build. Its lease was stopped and its Actions result was not an aggregate pass. Later reviewed corrections addressed those findings; the final exact-head hosted CI above is the current qualification.
- Earlier local typed lint was blocked before analysis by shared-install declaration admission, without bypass or retry. Earlier fixture diagnostics remain historical only: the temporary Telegram idle-expiry trace was globally incomplete, so historical CI failures are not assigned that cause. No fixture workaround remains in this PR.
- Native review artifacts now record the exact-head green evidence and maintainer-ready recommendation. No additional provider inference, duplicate release build, or new Testbox lease was used for closeout.

Named separate follow-up: Telegram model-selection reporting can say selection failed after persistence succeeded if confirmation delivery fails. That production reporting issue is outside this capture repair.
