### PR TITLE
refactor(tests): reuse remaining xAI SecretRef fixtures

### DIFF
--- a/extensions/xai/src/tool-auth-shared.test.ts
+++ b/extensions/xai/src/tool-auth-shared.test.ts
@@ -51,17 +51,7 @@ describe("xai tool auth helpers", () => {
   it("returns source metadata and managed markers for fallback auth", () => {
     expect(
       resolveFallbackXaiAuth({
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: { source: "file", provider: "vault", id: "/xai/tool-key" },
-                },
-              },
-            },
-          },
-        },
+        plugins: xaiWebSearchSecretRefPlugins("file", "vault", "/xai/tool-key"),
       }),
     ).toEqual({
       apiKey: NON_ENV_SECRETREF_MARKER,
@@ -180,17 +170,7 @@ describe("xai tool auth helpers", () => {
           defaults: { env: "selected" },
           providers: declaration ? { selected: declaration } : undefined,
         },
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: { source: "env", provider: "selected", id: "XAI_API_KEY" },
-                },
-              },
-            },
-          },
-        },
+        plugins: xaiWebSearchSecretRefPlugins("env", "selected", "XAI_API_KEY"),
       };
 
       expect(isXaiToolEnabled({ sourceConfig, auth })).toBe(false);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Two xAI tool-auth cases still repeat the SecretRef configuration already covered by the local fixture.

## Why This Change Was Made

Reuse the existing helper for fallback metadata and the missing-reference table. All input values, assertions, ten table invocations, and shared configuration references remain unchanged. This removes 20 net test lines without changing the helper.

## User Impact

No runtime or authentication behavior changes. The tests retain managed-marker metadata and the rule that a missing configured reference must not borrow profile credentials.

## Evidence

- Complete xAI tool-auth and shared SecretRef suites before and after: the same 53 ordered cases passed, including all ten missing-reference rows.
- Expanding both calls reproduces the original source bytes; object-graph checks preserve fresh nested objects, key order, field absence, descriptors, and mutation independence.
- Mapped changed-file gate and fresh independent P2 review passed.
