### PR TITLE
fix(workers): desktop observe and launch skip stale-build admission

### DIFF
--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -403,6 +403,64 @@ describe("gateway worker environment startup", () => {
           message: STALE_WORKER_BUILD_REASON,
         });
         expect(carrierInvocations).toBe(launchesBeforeStale);
+        // Recovery after redispatch: reconcile refuses the stale delivery and
+        // redelivers the session, which on the durable store creates a fresh
+        // record bootstrapped against the current bundle (the same seed shape the
+        // original current record used). On this same runtime and store, the
+        // redispatched record's desktop launch succeeds while the stale record
+        // keeps refusing.
+        const redispatchIntent = startup.store.createIntent({
+          environmentId: "node-desktop-redispatched-environment",
+          providerId: "fake-provider",
+          profileId: "desktop-profile",
+          profileSnapshot: { settings: { desktop: true } },
+          provisionOperationId: "provision:node-desktop-redispatched-environment",
+        });
+        const redispatchProvisioning = startup.store.transition({
+          environmentId: redispatchIntent.environmentId,
+          from: redispatchIntent.state,
+          to: "provisioning",
+        });
+        const redispatchedRecord = startup.store.transition({
+          environmentId: redispatchProvisioning.environmentId,
+          from: redispatchProvisioning.state,
+          to: "ready",
+          patch: {
+            leaseId: "node-desktop-redispatched-lease",
+            nodeDeviceId: nodeId,
+            sshEndpoint: null,
+            sharedHost: true,
+            desktop: { protocol: "rfb", port: 5900, apps: [app] },
+            bootstrapReceipt: {
+              bundleHash: "a".repeat(64),
+              openclawVersion: "2026.8.14",
+              protocolFeatures: ["worker-heartbeat-v1"],
+              installKind: "bundle",
+            },
+            credential: {
+              credentialHash: hashWorkerCredential("node-desktop-redispatched-credential"),
+              sessionId: null,
+              rpcSetVersion: 1,
+              expiresAtMs: Date.now() + 60_000,
+            },
+          },
+        });
+        await expect(
+          service.launchDesktopApp({
+            environmentId: redispatchedRecord.environmentId,
+            app: "terminal",
+          }),
+        ).resolves.toEqual({ app: "terminal", status: "ready" });
+        expect(carrierInvocations).toBe(launchesBeforeStale + 1);
+        await expect(
+          service.launchDesktopApp({
+            environmentId: staleRecord.environmentId,
+            app: "terminal",
+          }),
+        ).rejects.toMatchObject({
+          code: "invalid_state",
+          message: STALE_WORKER_BUILD_REASON,
+        });
       } finally {
         await service.stop();
       }

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -5,6 +5,9 @@ import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-i
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import { setActiveNodeContext } from "../infra/active-node-context.js";
+import { approveDevicePairing } from "../infra/device-pairing-approval.js";
+import { requestDevicePairing } from "../infra/device-pairing.js";
+import { NODE_WORKER_BUNDLE_INSTALL_COMMAND } from "../infra/node-commands.js";
 import {
   NODE_WORKER_PORTAL_STREAM_VERSION,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
@@ -256,6 +259,17 @@ describe("gateway worker environment startup", () => {
       });
       const nodeId = "node-desktop-device";
       const app = { id: "terminal" as const, executablePath: "/usr/bin/true" };
+      // Pair the node device through the real pairing store so the composed device
+      // worker provider (resolved from durable pairing state) admits the record's
+      // node lease during reconciliation.
+      const pairingRequest = await requestDevicePairing({
+        deviceId: nodeId,
+        publicKey: `pk-${nodeId}`,
+        role: "node",
+        roles: ["node"],
+        scopes: [],
+      });
+      await approveDevicePairing(pairingRequest.request.requestId, { callerScopes: [] });
       const record = startup.store.transition({
         environmentId: provisioning.environmentId,
         from: provisioning.state,
@@ -292,13 +306,28 @@ describe("gateway worker environment startup", () => {
         commands: [],
       };
       let carrierInvocations = 0;
+      let bundleInstallInvocations = 0;
       const transport: NodeWorkerSupervisorTransport = {
         listCurrentNodes: async () => [proof],
         hasCurrentRunner: (candidateNodeId) => candidateNodeId === proof.nodeId,
         isCurrent: () => true,
         invoke: async (request) => {
-          carrierInvocations += 1;
           expect(request.isDispatchAuthorized()).toBe(true);
+          if (request.command === NODE_WORKER_BUNDLE_INSTALL_COMMAND) {
+            // The node host acknowledges installing the exact prepared current bundle.
+            bundleInstallInvocations += 1;
+            const input = request.params as { build: { bundleHash: string } };
+            expect(input.build.bundleHash).toBe("a".repeat(64));
+            return {
+              ok: true,
+              payloadJSON: JSON.stringify({
+                bundleHash: "a".repeat(64),
+                openclawVersion: "2026.8.14",
+                protocolFeatures: ["worker-heartbeat-v1"],
+              }),
+            };
+          }
+          carrierInvocations += 1;
           return { ok: true, payloadJSON: '{"status":"ready"}' };
         },
       };
@@ -359,9 +388,9 @@ describe("gateway worker environment startup", () => {
         // at admission time, before the node carrier's launchApp is reached.
         const staleIntent = startup.store.createIntent({
           environmentId: "node-desktop-stale-environment",
-          providerId: "fake-provider",
-          profileId: "desktop-profile",
-          profileSnapshot: { settings: { desktop: true } },
+          providerId: DEVICE_WORKER_PROVIDER_ID,
+          profileId: `device:${nodeId}`,
+          profileSnapshot: { settings: { device: nodeId, desktop: true } },
           provisionOperationId: "provision:node-desktop-stale-environment",
         });
         const staleProvisioning = startup.store.transition({
@@ -403,55 +432,7 @@ describe("gateway worker environment startup", () => {
           message: STALE_WORKER_BUILD_REASON,
         });
         expect(carrierInvocations).toBe(launchesBeforeStale);
-        // Recovery after redispatch: reconcile refuses the stale delivery and
-        // redelivers the session, which on the durable store creates a fresh
-        // record bootstrapped against the current bundle (the same seed shape the
-        // original current record used). On this same runtime and store, the
-        // redispatched record's desktop launch succeeds while the stale record
-        // keeps refusing.
-        const redispatchIntent = startup.store.createIntent({
-          environmentId: "node-desktop-redispatched-environment",
-          providerId: "fake-provider",
-          profileId: "desktop-profile",
-          profileSnapshot: { settings: { desktop: true } },
-          provisionOperationId: "provision:node-desktop-redispatched-environment",
-        });
-        const redispatchProvisioning = startup.store.transition({
-          environmentId: redispatchIntent.environmentId,
-          from: redispatchIntent.state,
-          to: "provisioning",
-        });
-        const redispatchedRecord = startup.store.transition({
-          environmentId: redispatchProvisioning.environmentId,
-          from: redispatchProvisioning.state,
-          to: "ready",
-          patch: {
-            leaseId: "node-desktop-redispatched-lease",
-            nodeDeviceId: nodeId,
-            sshEndpoint: null,
-            sharedHost: true,
-            desktop: { protocol: "rfb", port: 5900, apps: [app] },
-            bootstrapReceipt: {
-              bundleHash: "a".repeat(64),
-              openclawVersion: "2026.8.14",
-              protocolFeatures: ["worker-heartbeat-v1"],
-              installKind: "bundle",
-            },
-            credential: {
-              credentialHash: hashWorkerCredential("node-desktop-redispatched-credential"),
-              sessionId: null,
-              rpcSetVersion: 1,
-              expiresAtMs: Date.now() + 60_000,
-            },
-          },
-        });
-        await expect(
-          service.launchDesktopApp({
-            environmentId: redispatchedRecord.environmentId,
-            app: "terminal",
-          }),
-        ).resolves.toEqual({ app: "terminal", status: "ready" });
-        expect(carrierInvocations).toBe(launchesBeforeStale + 1);
+        // Repeated attempts keep refusing while the receipt stays stale.
         await expect(
           service.launchDesktopApp({
             environmentId: staleRecord.environmentId,
@@ -461,6 +442,30 @@ describe("gateway worker environment startup", () => {
           code: "invalid_state",
           message: STALE_WORKER_BUILD_REASON,
         });
+        expect(carrierInvocations).toBe(launchesBeforeStale);
+        // Recovery through the real reconciliation path: reconcile drives the provider
+        // lifecycle refresh for the stale node-backed record — stopping the owner,
+        // installing the current bundle on the node through the real gateway bundle
+        // installer and transfer service, and committing the refreshed receipt on the
+        // SAME durable record (the reprovisioning recovery the stale-build error
+        // directs operators to). No replacement record is seeded here.
+        await service.reconcileOnce(staleRecord.environmentId);
+        expect(bundleInstallInvocations).toBe(1);
+        expect(startup.store.get(staleRecord.environmentId)).toMatchObject({
+          state: "ready",
+          bootstrapReceipt: {
+            bundleHash: "a".repeat(64),
+            openclawVersion: "2026.8.14",
+            installKind: "bundle",
+          },
+        });
+        await expect(
+          service.launchDesktopApp({
+            environmentId: staleRecord.environmentId,
+            app: "terminal",
+          }),
+        ).resolves.toEqual({ app: "terminal", status: "ready" });
+        expect(carrierInvocations).toBe(launchesBeforeStale + 1);
       } finally {
         await service.stop();
       }

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -28,6 +28,8 @@ import {
   loadGatewayWorkerEnvironmentStartupState,
 } from "./server-worker-environment-startup.js";
 import { withPreparedNodeAcknowledgement } from "./server-worker-environment-startup.prepared.test-support.js";
+import { STALE_WORKER_BUILD_REASON } from "./worker-environments/admission.js";
+import type { WorkerBundleProducer } from "./worker-environments/bundle.js";
 import { hashWorkerCredential } from "./worker-environments/credential.js";
 import {
   DEVICE_WORKER_PROVIDER_ID,
@@ -289,22 +291,42 @@ describe("gateway worker environment startup", () => {
         workerHost: { enabled: true, capacity: { total: 1, available: 0 } },
         commands: [],
       };
+      let carrierInvocations = 0;
       const transport: NodeWorkerSupervisorTransport = {
         listCurrentNodes: async () => [proof],
         hasCurrentRunner: (candidateNodeId) => candidateNodeId === proof.nodeId,
         isCurrent: () => true,
         invoke: async (request) => {
+          carrierInvocations += 1;
           expect(request.isDispatchAuthorized()).toBe(true);
           return { ok: true, payloadJSON: '{"status":"ready"}' };
         },
       };
       const registry = createEmptyPluginRegistry();
+      // The runtime resolves the current worker build identity through the bundle
+      // producer. Tests run from an unpackaged checkout, so supply a producer that
+      // returns the same identity the seeded record bootstrapped with; admission
+      // otherwise refuses desktop launch with "Current worker build identity is
+      // unavailable" before the node carrier is reached.
+      const workerBundleProducer: WorkerBundleProducer = {
+        prepare: async () => ({
+          install: "bundle",
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.8.14",
+          protocolFeatures: ["worker-heartbeat-v1"],
+          tarballBytes: 1,
+          tarballSha256: "b".repeat(64),
+          tarballPath: "/gateway/cache/worker-bundle.tgz",
+        }),
+        prune: async () => {},
+      };
       const runtime = await createGatewayWorkerEnvironmentRuntime({
         getPluginRegistry: () => registry,
         getPortalRuntime: () => undefined,
         resolveGatewayContext: () => undefined,
         desktopSessionRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
         nodeDesktopStreamBroker: createNodeDesktopStreamBroker(),
+        workerBundleProducer,
         startup,
         log: { child: () => ({ warn: () => {} }) },
       });
@@ -332,6 +354,55 @@ describe("gateway worker environment startup", () => {
         await expect(
           service.launchDesktopApp({ environmentId: record.environmentId, app: "terminal" }),
         ).resolves.toEqual({ app: "terminal", status: "ready" });
+        const launchesBeforeStale = carrierInvocations;
+        // A sibling environment bootstrapped against a superseded bundle is refused
+        // at admission time, before the node carrier's launchApp is reached.
+        const staleIntent = startup.store.createIntent({
+          environmentId: "node-desktop-stale-environment",
+          providerId: "fake-provider",
+          profileId: "desktop-profile",
+          profileSnapshot: { settings: { desktop: true } },
+          provisionOperationId: "provision:node-desktop-stale-environment",
+        });
+        const staleProvisioning = startup.store.transition({
+          environmentId: staleIntent.environmentId,
+          from: staleIntent.state,
+          to: "provisioning",
+        });
+        const staleRecord = startup.store.transition({
+          environmentId: staleProvisioning.environmentId,
+          from: staleProvisioning.state,
+          to: "ready",
+          patch: {
+            leaseId: "node-desktop-stale-lease",
+            nodeDeviceId: nodeId,
+            sshEndpoint: null,
+            sharedHost: true,
+            desktop: { protocol: "rfb", port: 5900, apps: [app] },
+            bootstrapReceipt: {
+              bundleHash: "c".repeat(64),
+              openclawVersion: "2026.8.14",
+              protocolFeatures: ["worker-heartbeat-v1"],
+              installKind: "bundle",
+            },
+            credential: {
+              credentialHash: hashWorkerCredential("node-desktop-stale-credential"),
+              sessionId: null,
+              rpcSetVersion: 1,
+              expiresAtMs: Date.now() + 60_000,
+            },
+          },
+        });
+        await expect(
+          service.launchDesktopApp({
+            environmentId: staleRecord.environmentId,
+            app: "terminal",
+          }),
+        ).rejects.toMatchObject({
+          code: "invalid_state",
+          message: STALE_WORKER_BUILD_REASON,
+        });
+        expect(carrierInvocations).toBe(launchesBeforeStale);
       } finally {
         await service.stop();
       }

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -129,6 +129,14 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   nodeDesktopStreamBroker?: NodeDesktopStreamBroker;
   startup: GatewayWorkerEnvironmentStartupState;
   log: WorkerEnvironmentLogger;
+  /**
+   * Overrides the worker bundle producer used to resolve the current build
+   * identity. Defaults to packaging the running tree on first use. Process
+   * embedders and tests that run from an unpackaged checkout supply a producer
+   * here so admission checks (startTunnel, desktop observe/launch) can resolve
+   * a deterministic current build without a built worker artifact.
+   */
+  workerBundleProducer?: WorkerBundleProducer;
 }): Promise<GatewayWorkerEnvironmentRuntime> {
   const deviceRuntime = createDeviceWorkerRuntime({ getPairedDevice });
   const [
@@ -196,13 +204,15 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
       loadWorkerEnvironmentRuntimeModule(),
       import("../../packages/gateway-protocol/src/schema/worker-admission.js"),
     ]);
-    const producer = (workerBundleProducer ??= workerRuntime.createWorkerBundleProducer({
-      protocolFeatures: WORKER_PROTOCOL_FEATURES,
-      cacheOwnership: "exclusive",
-      onCacheCleanupError: (error) => {
-        workerEnvironmentLog.warn(`Worker bundle cache cleanup failed: ${String(error)}`);
-      },
-    }));
+    const producer = (workerBundleProducer ??= params.workerBundleProducer
+      ? params.workerBundleProducer
+      : workerRuntime.createWorkerBundleProducer({
+          protocolFeatures: WORKER_PROTOCOL_FEATURES,
+          cacheOwnership: "exclusive",
+          onCacheCleanupError: (error) => {
+            workerEnvironmentLog.warn(`Worker bundle cache cleanup failed: ${String(error)}`);
+          },
+        }));
     const bundle = await producer.prepare();
     await producer.prune(listRetainedBundleHashes());
     if (install === "bundle") {

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -664,6 +664,117 @@ describe("worker environment service", () => {
     expect(order).toEqual(["node-desktop-stop", "provider-destroy"]);
   });
 
+  it.each([
+    ["stale receipt", { ...support.BOOTSTRAP_RECEIPT, bundleHash: "c".repeat(64) }, undefined],
+    ["unavailable current bundle", support.BOOTSTRAP_RECEIPT, new Error("bundle unavailable")],
+  ] as const)("rejects desktop observe with %s", async (_name, receipt, prepareError) => {
+    const environmentId = "worker-desktop-observe-stale-build";
+    support.seedReadyDesktop(environmentId, undefined, receipt);
+    if (prepareError) {
+      support.testState.prepareInstallation = vi.fn(async () => {
+        throw prepareError;
+      });
+    }
+    const acquire = vi.fn();
+    const tunnelManager = {
+      desktop: {
+        acquire,
+        attachObserver: vi.fn(),
+        stop: vi.fn(async () => {}),
+        stopAll: vi.fn(async () => {}),
+      },
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = support.createService(support.createProvider(), { tunnelManager });
+
+    await expect(
+      workerService.observeDesktop({ environmentId, control: true }),
+    ).rejects.toMatchObject({
+      code: "invalid_state",
+      message: prepareError
+        ? "Current worker build identity is unavailable"
+        : STALE_WORKER_BUILD_REASON,
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stale receipt", { ...support.BOOTSTRAP_RECEIPT, bundleHash: "c".repeat(64) }, undefined],
+    ["unavailable current bundle", support.BOOTSTRAP_RECEIPT, new Error("bundle unavailable")],
+  ] as const)("rejects desktop app launch with %s", async (_name, receipt, prepareError) => {
+    const environmentId = "worker-desktop-launch-stale-build";
+    support.seedReadyDesktop(environmentId, undefined, receipt);
+    if (prepareError) {
+      support.testState.prepareInstallation = vi.fn(async () => {
+        throw prepareError;
+      });
+    }
+    const launchApp = vi.fn();
+    const tunnelManager = {
+      desktop: {
+        acquire: vi.fn(),
+        attachObserver: vi.fn(),
+        launchApp,
+        stop: vi.fn(async () => {}),
+        stopAll: vi.fn(async () => {}),
+      },
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = support.createService(support.createProvider(), { tunnelManager });
+
+    await expect(
+      workerService.launchDesktopApp({ environmentId, app: "browser" }),
+    ).rejects.toMatchObject({
+      code: "invalid_state",
+      message: prepareError
+        ? "Current worker build identity is unavailable"
+        : STALE_WORKER_BUILD_REASON,
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(launchApp).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale node-backed desktop before reaching the durable carrier", async () => {
+    const environmentId = "worker-node-desktop-stale-build";
+    support.seedReadyNodeDesktop(environmentId, undefined, {
+      ...support.BOOTSTRAP_RECEIPT,
+      bundleHash: "c".repeat(64),
+    });
+    const observe = vi.fn();
+    const launchApp = vi.fn();
+    const nodeDesktopCarrier = {
+      bindRuntime: vi.fn(),
+      observe,
+      launchApp,
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerNodeDesktopCarrier;
+    const workerService = support.createService(support.createProvider(), {
+      nodeDesktopCarrier,
+    });
+
+    await expect(
+      workerService.observeDesktop({ environmentId, control: true }),
+    ).rejects.toMatchObject({
+      code: "invalid_state",
+      message: STALE_WORKER_BUILD_REASON,
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(observe).not.toHaveBeenCalled();
+
+    await expect(
+      workerService.launchDesktopApp({ environmentId, app: "browser" }),
+    ).rejects.toMatchObject({
+      code: "invalid_state",
+      message: STALE_WORKER_BUILD_REASON,
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(launchApp).not.toHaveBeenCalled();
+  });
+
   it("rejects desktop observe for invalid lifecycle gates and a stopped service", async () => {
     const tunnelManager = {
       desktop: {

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -93,6 +93,26 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     return { record, desktop: record.desktop, leaseId: record.leaseId };
   };
 
+  const prepareCurrentBuild = async (): Promise<ExpectedWorkerBuild> => {
+    try {
+      return await options.prepareCurrentBundle();
+    } catch {
+      throw serviceError("invalid_state", "Current worker build identity is unavailable");
+    }
+  };
+
+  const requireAdmittedBuild = (
+    record: WorkerEnvironmentRecord,
+    currentBundle: ExpectedWorkerBuild,
+  ) => {
+    if (
+      !record.bootstrapReceipt ||
+      !verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle)
+    ) {
+      throw new StaleWorkerBuildError();
+    }
+  };
+
   const project = (record: WorkerEnvironmentRecord) => {
     const desktopAvailable =
       inState(record, "ready", "idle", "attached") && record.desktop !== null;
@@ -319,9 +339,15 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     let startup: ReturnType<WorkerTunnelManager["desktop"]["acquire"]> | undefined;
     let nodeStartup: ReturnType<WorkerNodeDesktopCarrier["observe"]> | undefined;
     let ownerEpoch: number | undefined;
+    // Prepare the current bundle outside the lock (process-stable metadata), then
+    // admit the freshly read durable record against it, mirroring startTunnel and
+    // attachSession: a worker bootstrapped against a superseded bundle is refused
+    // before any desktop transport or launcher side effect.
+    const currentBundle = await prepareCurrentBuild();
     await withLock(request.environmentId, async () => {
       const { record, desktop, leaseId } = requireDesktopRecord(request.environmentId);
       ownerEpoch = record.ownerEpoch;
+      requireAdmittedBuild(record, currentBundle);
       if (record.sshEndpoint) {
         if (!tunnels) {
           throw serviceError("invalid_state", "Worker SSH desktop runtime is unavailable");
@@ -403,9 +429,11 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
 
     let startup: Promise<void> | undefined;
     let launchEpoch: number | undefined;
+    const currentBundle = await prepareCurrentBuild();
     await withLock(request.environmentId, async () => {
       const { app, record, leaseId } = requireLaunchable();
       launchEpoch = record.ownerEpoch;
+      requireAdmittedBuild(record, currentBundle);
       if (record.sshEndpoint) {
         if (!tunnels) {
           throw serviceError("invalid_state", "Worker SSH desktop runtime is unavailable");

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -307,7 +307,11 @@ export function seedReady(
   });
 }
 
-export function seedReadyDesktop(environmentId: string, desktop: WorkerDesktopEndpoint = DESKTOP) {
+export function seedReadyDesktop(
+  environmentId: string,
+  desktop: WorkerDesktopEndpoint = DESKTOP,
+  receipt: NonNullable<WorkerEnvironmentTransitionPatch["bootstrapReceipt"]> = BOOTSTRAP_RECEIPT,
+) {
   const intent = testState.store.createIntent({
     environmentId,
     providerId: "fake",
@@ -334,13 +338,14 @@ export function seedReadyDesktop(environmentId: string, desktop: WorkerDesktopEn
     environmentId,
     from: bootstrapping.state,
     to: "ready",
-    patch: readyPatch(environmentId),
+    patch: readyPatch(environmentId, receipt),
   });
 }
 
 export function seedReadyNodeDesktop(
   environmentId: string,
   desktop: WorkerDesktopEndpoint = DESKTOP,
+  receipt: NonNullable<WorkerEnvironmentTransitionPatch["bootstrapReceipt"]> = BOOTSTRAP_RECEIPT,
 ) {
   const intent = testState.store.createIntent({
     environmentId,
@@ -363,7 +368,7 @@ export function seedReadyNodeDesktop(
       nodeDeviceId: `node:${environmentId}`,
       sshEndpoint: null,
       desktop,
-      ...readyPatch(environmentId),
+      ...readyPatch(environmentId, receipt),
     },
   });
 }

--- a/test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts
@@ -401,6 +401,37 @@ async function waitForNodeReady(operator: GatewayClient, nodeId: string): Promis
   );
 }
 
+type EnvironmentSummaryRead = {
+  id?: string;
+  status?: string;
+  desktop?: boolean;
+  worker?: { desktopApps?: string[] };
+};
+
+/**
+ * Waits for the state a Gateway restart produces on the durable record: available
+ * again, and still advertising the attested desktop and its app. E2E readiness
+ * synchronizes on that state instead of on elapsed time or on retrying the
+ * downstream request (test/AGENTS.md).
+ */
+async function waitForDesktopReady(operator: GatewayClient, environmentId: string): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const result = await operator.request<{ environments?: EnvironmentSummaryRead[] }>(
+        "environments.list",
+        {},
+      );
+      const environment = result.environments?.find((entry) => entry.id === environmentId);
+      expect(environment).toMatchObject({
+        status: "available",
+        desktop: true,
+        worker: { desktopApps: ["terminal"] },
+      });
+    },
+    { timeout: 120_000, interval: 500 },
+  );
+}
+
 async function readEnvironmentReceipt(
   gateway: WireGateway,
   environmentId: string,
@@ -606,45 +637,21 @@ describe("paired node worker desktop admission wire", () => {
         );
         await workerNode.connect();
         await waitForNodeReady(operator, workerNode.identity.deviceId);
-        // Let the restarted Gateway's startup reconciliation settle before
-        // driving the desktop paths.
-        await new Promise((resolve) => {
-          setTimeout(resolve, 10_000);
-        });
 
         enterPhase("observing the current worker's real desktop");
-        // The freshly restarted Gateway's startup reconcile and state-database
-        // activity can briefly stall the desktop observe path; retry the RPC
-        // with hard deadlines instead of hanging on a single attempt.
-        let observed: DesktopObserveResult | undefined;
-        for (let attempt = 1; attempt <= 3 && !observed; attempt += 1) {
-          logLine(`observe attempt ${attempt} starting`);
-          if (attempt > 1) {
-            await new Promise((resolve) => {
-              setTimeout(resolve, 15_000);
-            });
-          }
-          observed = await raceWithDiagnostics(
-            operator.request<DesktopObserveResult>("worker.desktop.observe", {
-              environmentId,
-              control: false,
-            }),
-            `worker.desktop.observe attempt ${attempt}`,
-            90_000,
-          ).catch((error: unknown) => {
-            logLine(`observe attempt ${attempt} failed: ${String(error).slice(0, 1500)}`);
-            if (attempt === 3) {
-              throw error;
-            }
-            return undefined;
-          });
-          if (observed) {
-            logLine(`observe attempt ${attempt} resolved wsPath`);
-          }
-        }
-        if (!observed) {
-          throw new Error("worker.desktop.observe did not resolve");
-        }
+        // Readiness is the state the restart produced, not a settled duration: the
+        // record must be available and still advertise the attested desktop before
+        // admission can serve it. One bounded observation request follows.
+        await waitForDesktopReady(operator, environmentId);
+        const observed = await raceWithDiagnostics(
+          operator.request<DesktopObserveResult>("worker.desktop.observe", {
+            environmentId,
+            control: false,
+          }),
+          "worker.desktop.observe",
+          90_000,
+        );
+        logLine("observe resolved wsPath on the first bounded request");
         expect(observed).toMatchObject({ transport: "rfb", control: false });
         expect(observed.wsPath).toMatch(/^\/desktop\/observe\?token=/u);
         const desktop = await observeDesktopFrames({ gateway, wsPath: observed.wsPath });
@@ -855,51 +862,63 @@ describe("paired node worker desktop admission wire", () => {
           ),
         );
       } finally {
-        const withCleanupLog = (
-          step: string,
-          task: Promise<unknown>,
-        ): Promise<"done" | "timeout"> =>
-          Promise.race([
+        // Every teardown step runs even if an earlier one fails or hangs, and each
+        // outcome is reported: a leaked node host, Gateway, provider or Xvnc must
+        // fail the proof instead of passing silently behind a swallowed rejection.
+        type CleanupOutcome =
+          | { step: string; status: "done" }
+          | { step: string; status: "failed"; error: unknown }
+          | { step: string; status: "timeout" };
+        const CLEANUP_TIMEOUT_MS = 60_000;
+        const withCleanupLog = (step: string, task: Promise<unknown>): Promise<CleanupOutcome> =>
+          Promise.race<CleanupOutcome>([
             task.then(
-              () => "done" as const,
-              (error: unknown) => {
-                void fs
-                  .appendFile(
-                    "/tmp/desktop-admission-cleanup.log",
-                    `${step} FAILED: ${String(error)}\n`,
-                  )
-                  .catch(() => undefined);
-                return "done" as const;
-              },
+              () => ({ step, status: "done" as const }),
+              (error: unknown) => ({ step, status: "failed" as const, error }),
             ),
-            new Promise<"timeout">((resolve) => {
-              setTimeout(() => {
-                void fs
-                  .appendFile(progressPath, `${step} TIMED OUT after 60s\n`)
-                  .catch(() => undefined);
-                resolve("timeout");
-              }, 60_000).unref();
+            new Promise<CleanupOutcome>((resolve) => {
+              setTimeout(
+                () => resolve({ step, status: "timeout" as const }),
+                CLEANUP_TIMEOUT_MS,
+              ).unref();
             }),
-          ]);
-        const cleanup = await Promise.allSettled([
-          withCleanupLog("workerNode.stop", workerNode?.stop() ?? Promise.resolve()).then(
-            () => undefined,
-          ),
+          ]).then(async (outcome) => {
+            if (outcome.status !== "done") {
+              logLine(
+                outcome.status === "timeout"
+                  ? `cleanup ${outcome.step} timed out after ${CLEANUP_TIMEOUT_MS}ms`
+                  : `cleanup ${outcome.step} failed: ${String(outcome.error).slice(0, 500)}`,
+              );
+            }
+            return outcome;
+          });
+        const cleanup = await Promise.all([
+          withCleanupLog("workerNode.stop", workerNode?.stop() ?? Promise.resolve()),
           withCleanupLog(
             "operator.stopAndWait",
             operator?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
-          ).then(() => undefined),
-          withCleanupLog("stopQaGatewayFixture", stopQaGatewayFixture(gatewayOwner)).then(
-            () => undefined,
           ),
-          withCleanupLog("provider.stop", provider.stop()).then(() => undefined),
-          withCleanupLog("closeWireServer", closeWireServer(published.server)).then(
-            () => undefined,
-          ),
-          withCleanupLog("vnc.stop", vnc.stop()).then(() => undefined),
+          withCleanupLog("stopQaGatewayFixture", stopQaGatewayFixture(gatewayOwner)),
+          withCleanupLog("provider.stop", provider.stop()),
+          withCleanupLog("closeWireServer", closeWireServer(published.server)),
+          withCleanupLog("vnc.stop", vnc.stop()),
         ]);
         failures.push(
-          ...cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+          ...cleanup.flatMap((outcome) => {
+            if (outcome.status === "timeout") {
+              return [new Error(`cleanup ${outcome.step} timed out after ${CLEANUP_TIMEOUT_MS}ms`)];
+            }
+            if (outcome.status === "failed") {
+              return [
+                outcome.error instanceof Error
+                  ? new Error(`cleanup ${outcome.step} failed: ${outcome.error.message}`, {
+                      cause: outcome.error,
+                    })
+                  : new Error(`cleanup ${outcome.step} failed: ${String(outcome.error)}`),
+              ];
+            }
+            return [];
+          }),
         );
       }
       if (failures.length === 1) {

--- a/test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts
@@ -1,0 +1,913 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import type { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, type RawData } from "ws";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { writeBuildInfo } from "../../../../scripts/write-build-info.js";
+import { STALE_WORKER_BUILD_REASON } from "../../../../src/gateway/worker-environments/admission.js";
+import { hasErrnoCode } from "../../../../src/infra/errno.js";
+import {
+  NODE_WORKER_DESKTOP_LAUNCH_COMMAND,
+  NODE_WORKER_DESKTOP_STREAM_COMMAND,
+} from "../../../../src/infra/node-commands.js";
+import { openNodeSqliteDatabase } from "../../../../src/infra/node-sqlite.js";
+import * as desktopStreamCommand from "../../../../src/node-host/desktop-stream-command.js";
+import { withOpenClawStateDatabaseReadOnly } from "../../../../src/state/openclaw-state-db-readonly.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import { MODEL_REF, PROOF_TIMEOUT_MS } from "./cloud-worker-midturn-loss-fixture.js";
+import { startPairedNodeWorkerLifecycleProvider } from "./paired-node-worker-lifecycle-provider.js";
+import {
+  bundleInstallFrames,
+  closeWireServer,
+  connectWireClient,
+  createPairedNodeWorkerHost,
+  createPublishedWireWorkspace,
+  type PairedNodeWorkerHost,
+  type WireGateway,
+} from "./paired-node-worker-wire-fixture.js";
+
+// A real TigerVNC server provides the worker-side desktop. The proof keeps the
+// desktop boundary real end to end: the packaged Gateway drives the real node
+// host process, which splices a real loopback X server's RFB stream.
+const XVNC_BIN = "/usr/bin/Xvnc";
+const VNCPASSWD_BIN = "/usr/bin/vncpasswd";
+const DESKTOP_VNC_PASSWORD = "e2edesk";
+const DESKTOP_GEOMETRY = "1024x768";
+const DESKTOP_TERMINAL_APP = "/usr/bin/true";
+const RECONCILE_SWEEP_TIMEOUT_MS = 180_000;
+
+const hasDesktopVncServer =
+  existsSync(XVNC_BIN) && existsSync(VNCPASSWD_BIN) && existsSync(DESKTOP_TERMINAL_APP);
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+// The paired worker host runs in this process, so its desktop stream command
+// (RFB probe and Gateway attach) is observable here even when the Gateway
+// masks the observe RPC error. Record its failures for the diagnostics block.
+const nodeDesktopStreamEvents: string[] = [];
+const nodeDesktopStreamErrors: string[] = [];
+// Capture the real implementation before spying; the live export binding is replaced.
+const originalNodeWorkerDesktopStream = desktopStreamCommand.invokeNodeWorkerDesktopStream;
+vi.spyOn(desktopStreamCommand, "invokeNodeWorkerDesktopStream").mockImplementation(
+  async (...args: Parameters<typeof originalNodeWorkerDesktopStream>) => {
+    nodeDesktopStreamEvents.push(`invoked ${new Date().toISOString()}`);
+    try {
+      const result = await originalNodeWorkerDesktopStream(...args);
+      nodeDesktopStreamEvents.push(`settled-ok ${new Date().toISOString()}`);
+      return result;
+    } catch (error) {
+      nodeDesktopStreamEvents.push(`settled-err ${new Date().toISOString()}`);
+      nodeDesktopStreamErrors.push(String(error));
+      throw error;
+    }
+  },
+);
+
+type DesktopObserveResult = {
+  transport: "rfb";
+  wsPath: string;
+  expiresAtMs: number;
+  control: boolean;
+};
+
+type Placement = {
+  environmentId?: string;
+  workerBundleHash?: string;
+};
+
+type WorkerEnvironmentRow = {
+  bootstrap_bundle_hash?: string | null;
+};
+
+function findFreeLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("free-port probe did not bind")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForExitOrTimeout(child: ChildProcess, timeoutMs: number): Promise<void> {
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+  const timer = new Promise<void>((resolve) => {
+    setTimeout(resolve, timeoutMs).unref();
+  });
+  await Promise.race([exited, timer]);
+}
+
+/**
+ * Runs a real headless TigerVNC X server on a private loopback port.
+ *
+ * The VNC password file on disk is plaintext (the format the node host reads);
+ * TigerVNC itself receives the DES-encoded form through -rfbauth.
+ */
+async function startDesktopVncServer(root: string): Promise<{
+  port: number;
+  passwordFilePath: string;
+  stop: () => Promise<void>;
+}> {
+  const encoded = await new Promise<Buffer>((resolve, reject) => {
+    const child = spawn(VNCPASSWD_BIN, ["-f"], { stdio: ["pipe", "pipe", "ignore"] });
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(chunks));
+      } else {
+        reject(new Error(`vncpasswd -f exited with code ${code ?? "unknown"}`));
+      }
+    });
+    child.stdin.write(`${DESKTOP_VNC_PASSWORD}\n`);
+    child.stdin.end();
+  });
+  const encodedPath = path.join(root, "vnc-auth.pw");
+  await fs.writeFile(encodedPath, encoded, { mode: 0o600 });
+  const passwordFilePath = path.join(root, "vnc-password.txt");
+  await fs.writeFile(passwordFilePath, `${DESKTOP_VNC_PASSWORD}\n`, { mode: 0o600 });
+  const port = await findFreeLoopbackPort();
+  const display = 90 + (port % 100);
+  const logPath = path.join(root, "xvnc.log");
+  const child = spawn(
+    XVNC_BIN,
+    [
+      `:${display}`,
+      "-rfbport",
+      String(port),
+      "-rfbauth",
+      encodedPath,
+      "-geometry",
+      DESKTOP_GEOMETRY,
+      "-depth",
+      "24",
+      "-localhost",
+      "-SecurityTypes",
+      "VncAuth",
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  const logChunks: Buffer[] = [];
+  child.stderr?.on("data", (chunk: Buffer) => logChunks.push(chunk));
+  const stopped = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+  if (child.exitCode !== null) {
+    throw new Error(`Xvnc failed to start: ${Buffer.concat(logChunks).toString("utf8")}`);
+  }
+  // Wait until the RFB listener accepts a probe connection.
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    const probe = await new Promise<boolean>((resolve) => {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    if (probe) {
+      break;
+    }
+    if (child.exitCode !== null) {
+      await fs.writeFile(logPath, Buffer.concat(logChunks));
+      throw new Error(`Xvnc exited before listening: ${Buffer.concat(logChunks).toString("utf8")}`);
+    }
+    if (Date.now() > deadline) {
+      child.kill("SIGKILL");
+      throw new Error("Xvnc did not start listening within 15s");
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+  }
+  return {
+    port,
+    passwordFilePath,
+    stop: async () => {
+      child.kill("SIGTERM");
+      await waitForExitOrTimeout(child, 3_000);
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+        await stopped;
+      }
+    },
+  };
+}
+
+function rfbChunkToBuffer(data: RawData): Buffer {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data);
+  }
+  return Buffer.from(data);
+}
+
+class RfbObserverReader {
+  private buffered: Buffer = Buffer.alloc(0);
+  private waiters: Array<{ length: number; resolve: (chunk: Buffer) => void }> = [];
+
+  constructor(private readonly ws: WebSocket) {
+    ws.on("message", (data: RawData, isBinary: boolean) => {
+      if (!isBinary) {
+        return;
+      }
+      this.buffered = Buffer.concat([this.buffered, rfbChunkToBuffer(data)]);
+      this.drain();
+    });
+  }
+
+  private drain(): void {
+    for (;;) {
+      const waiter = this.waiters[0];
+      if (!waiter || this.buffered.length < waiter.length) {
+        return;
+      }
+      this.waiters.shift();
+      waiter.resolve(this.buffered.subarray(0, waiter.length));
+      this.buffered = this.buffered.subarray(waiter.length);
+    }
+  }
+
+  readExactly(length: number, timeoutMs = 15_000): Promise<Buffer> {
+    if (this.buffered.length >= length) {
+      const chunk = this.buffered.subarray(0, length);
+      this.buffered = this.buffered.subarray(length);
+      return Promise.resolve(chunk);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`RFB observer timed out waiting for ${length} bytes`)),
+        timeoutMs,
+      );
+      this.waiters.push({
+        length,
+        resolve: (chunk: Buffer) => {
+          clearTimeout(timer);
+          resolve(chunk);
+        },
+      });
+    });
+  }
+
+  write(buffer: Buffer): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.ws.send(buffer, { binary: true }, (error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+/**
+ * Opens the Gateway's observer WebSocket and completes the RFB session through
+ * ServerInit, proving real RFB frames from the worker-side X server.
+ */
+async function observeDesktopFrames(params: {
+  gateway: WireGateway;
+  wsPath: string;
+}): Promise<{ width: number; height: number; name: string }> {
+  const origin = new URL(params.gateway.wsUrl).origin;
+  const ws = new WebSocket(`${origin}${params.wsPath}`);
+  const failure = new Promise<never>((_, reject) => {
+    ws.once("error", (error) => reject(error));
+    ws.once("close", (code, reason) =>
+      reject(new Error(`observer socket closed (${code}): ${reason}`)),
+    );
+  });
+  try {
+    const opened = await new Promise<void>((resolve, reject) => {
+      const openTimer = setTimeout(
+        () => reject(new Error("observer websocket upgrade timed out after 30s")),
+        30_000,
+      );
+      ws.once("open", () => {
+        clearTimeout(openTimer);
+        resolve();
+      });
+      ws.once("error", (error) => {
+        clearTimeout(openTimer);
+        reject(error);
+      });
+    });
+    void opened;
+    const reader = new RfbObserverReader(ws);
+    // The Gateway preauthenticates against the worker's VNC server and then
+    // synthesizes a no-authentication RFB 3.8 handshake for the observer.
+    const banner = await reader.readExactly(12);
+    if (!banner.toString("latin1").startsWith("RFB 003.")) {
+      throw new Error(`observer did not receive an RFB banner: ${banner.toString("latin1")}`);
+    }
+    await reader.write(Buffer.from("RFB 003.008\n", "latin1"));
+    const securityTypes = await reader.readExactly(2);
+    if (securityTypes[0] !== 1 || securityTypes[1] !== 1) {
+      throw new Error(
+        `observer expected the preauthenticated no-auth offer, received ${[...securityTypes].join(
+          ",",
+        )}`,
+      );
+    }
+    await reader.write(Buffer.from([1]));
+    const securityResult = await reader.readExactly(4);
+    if (!securityResult.equals(Buffer.alloc(4))) {
+      throw new Error("observer security result was not zero");
+    }
+    // ClientInit (shared session), then the server answers with its desktop.
+    await reader.write(Buffer.from([1]));
+    const serverInitHead = await reader.readExactly(24);
+    const width = serverInitHead.readUInt16BE(0);
+    const height = serverInitHead.readUInt16BE(2);
+    const nameLength = serverInitHead.readUInt32BE(20);
+    const name = (await reader.readExactly(nameLength)).toString("utf8");
+    return { width, height, name };
+  } finally {
+    // Close first: awaiting the failure/close promise before initiating the
+    // close would deadlock whenever the handshake succeeds (nothing else owns
+    // this socket, so "error or close" never settles on its own).
+    ws.close(1000, "proof complete");
+    await failure.catch(() => undefined);
+    await new Promise<void>((resolve) => {
+      if (ws.readyState === WebSocket.CLOSED) {
+        resolve();
+        return;
+      }
+      ws.once("close", () => resolve());
+      setTimeout(() => resolve(), 3_000).unref();
+    });
+  }
+}
+
+/**
+ * Races an observe/launch RPC against a deadline; on timeout, dumps live
+ * diagnostics (node stream command state, TCP connections, gateway probe,
+ * gateway log tail) so a silent server-side hang is diagnosable.
+ */
+async function raceWithDiagnostics<T>(
+  operation: Promise<T>,
+  label: string,
+  deadline = 120_000,
+): Promise<T> {
+  const timer = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`${label} timed out after ${deadline}ms`)), deadline).unref();
+  });
+  try {
+    return await Promise.race([operation, timer]);
+  } catch (error) {
+    const probe = await (async () => {
+      try {
+        const { execFileSync } = await import("node:child_process");
+        const ss = execFileSync("ss", ["-tnp"], { encoding: "utf8", timeout: 5_000 }).trim();
+        return [
+          `node desktop stream events: ${JSON.stringify(nodeDesktopStreamEvents)}`,
+          `node desktop stream errors: ${JSON.stringify(nodeDesktopStreamErrors)}`,
+          `established sockets (test process view):\n${ss
+            .split("\n")
+            .filter((line) => line.includes("ESTAB"))
+            .join("\n")}`,
+        ].join("\n");
+      } catch (probeError) {
+        return `diagnostics probe failed: ${String(probeError)}`;
+      }
+    })();
+    throw new Error(`${String(error)}\n[diagnostics]\n${probe}`, { cause: error });
+  }
+}
+
+async function waitForNodeReady(operator: GatewayClient, nodeId: string): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const result = await operator.request<{
+        nodes?: Array<{ connected?: boolean; sessionHost?: boolean }>;
+      }>("node.list", {});
+      const node = result.nodes?.find((entry) => (entry as { nodeId?: string }).nodeId === nodeId);
+      expect(node).toMatchObject({ connected: true, sessionHost: true });
+    },
+    { timeout: 30_000, interval: 200 },
+  );
+}
+
+async function readEnvironmentReceipt(
+  gateway: WireGateway,
+  environmentId: string,
+): Promise<string | null> {
+  return withOpenClawStateDatabaseReadOnly(
+    ({ db }) => {
+      const row = db
+        .prepare("SELECT bootstrap_bundle_hash FROM worker_environments WHERE environment_id = ?")
+        .get(environmentId) as WorkerEnvironmentRow | undefined;
+      return row?.bootstrap_bundle_hash ?? null;
+    },
+    { env: gateway.runtimeEnv },
+  );
+}
+
+async function seedDesktopEndpoint(params: {
+  stateDir: string;
+  environmentId: string;
+  port: number;
+  passwordFilePath: string;
+}): Promise<void> {
+  const database = openNodeSqliteDatabase(path.join(params.stateDir, "state", "openclaw.sqlite"));
+  try {
+    const desktop = {
+      protocol: "rfb" as const,
+      port: params.port,
+      passwordFilePath: params.passwordFilePath,
+      apps: [{ id: "terminal" as const, executablePath: DESKTOP_TERMINAL_APP }],
+    };
+    const result = database
+      .prepare("UPDATE worker_environments SET desktop_json = ? WHERE environment_id = ?")
+      .run(JSON.stringify(desktop), params.environmentId);
+    if (Number(result.changes) !== 1) {
+      throw new Error(
+        `expected to seed exactly one desktop worker environment, updated ${result.changes}`,
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+describe("paired node worker desktop admission wire", () => {
+  it.skipIf(!hasDesktopVncServer)(
+    "serves desktop observe and launch from a real worker, refuses a stale build after a Gateway update, and restores access through real reconciliation",
+    { timeout: 900_000 },
+    async () => {
+      const root = tempDirs.make("openclaw-paired-node-desktop-admission-");
+      const runtimeRoot = path.join(root, "runtime");
+      // Each test owns its deployment bytes; the simulated Gateway rebuild must
+      // never rewrite the shared checkout's dist.
+      await fs.mkdir(runtimeRoot);
+      await fs.cp(path.join(process.cwd(), "dist"), path.join(runtimeRoot, "dist"), {
+        recursive: true,
+        dereference: false,
+      });
+      await fs.cp(
+        path.join(process.cwd(), "docs", "reference", "templates"),
+        path.join(runtimeRoot, "docs", "reference", "templates"),
+        { recursive: true },
+      );
+      const pluginRoot = path.join(runtimeRoot, "dist", "extensions");
+      for (const plugin of await fs.readdir(pluginRoot, { withFileTypes: true })) {
+        if (!plugin.isDirectory()) {
+          continue;
+        }
+        const selfLink = path.join(pluginRoot, plugin.name, "node_modules", "openclaw");
+        const stat = await fs.lstat(selfLink).catch((error: unknown) => {
+          if (!hasErrnoCode(error, "ENOENT")) {
+            throw error;
+          }
+          return undefined;
+        });
+        if (stat?.isSymbolicLink()) {
+          await fs.unlink(selfLink);
+          await fs.symlink(runtimeRoot, selfLink, "junction");
+        }
+      }
+      for (const file of [
+        "package.json",
+        "openclaw.mjs",
+        "node-version.mjs",
+        "node-sqlite.mjs",
+        "node-runtime-update.mjs",
+      ]) {
+        await fs.copyFile(path.join(process.cwd(), file), path.join(runtimeRoot, file));
+      }
+      await fs.symlink(
+        path.join(process.cwd(), "node_modules"),
+        path.join(runtimeRoot, "node_modules"),
+        "junction",
+      );
+
+      const vnc = await startDesktopVncServer(root);
+      const provider = await startPairedNodeWorkerLifecycleProvider([]);
+      const published = await createPublishedWireWorkspace(root);
+      const gatewayOwner = createQaGatewayChild();
+      let gateway: WireGateway | undefined;
+      let operator: GatewayClient | undefined;
+      let workerNode: PairedNodeWorkerHost | undefined;
+      let operatorHelloCount = 0;
+      const failures: unknown[] = [];
+      let phase = "starting the packaged Gateway";
+      const progressPath = path.join(root, "proof-progress.log");
+      // A hard Vitest timeout tears the worker down before the temp-dir trail can
+      // be read, so the same trail is kept in memory and folded into the failure
+      // diagnostics: which phase stalled is the first question every time.
+      const progressTrail: string[] = [];
+      const logLine = (line: string) => {
+        const entry = `[${new Date().toISOString()}] ${line}`;
+        progressTrail.push(entry);
+        void fs.appendFile(progressPath, `${entry}\n`).catch(() => undefined);
+      };
+      const enterPhase = (next: string) => {
+        phase = next;
+        logLine(`phase: ${next}`);
+      };
+      try {
+        gateway = await gatewayOwner.start({
+          repoRoot: runtimeRoot,
+          useRepoCli: true,
+          providerBaseUrl: `${provider.baseUrl}/v1`,
+          providerMode: "mock-openai",
+          primaryModel: MODEL_REF,
+          alternateModel: MODEL_REF,
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          mutateConfig: (config) => ({
+            ...config,
+            agents: {
+              ...config.agents,
+              defaults: {
+                ...config.agents?.defaults,
+                subagents: { ...config.agents?.defaults?.subagents, maxSpawnDepth: 2 },
+              },
+            },
+            cloudWorkers: { ...config.cloudWorkers, desktop: true },
+            nodeHost: { ...config.nodeHost, workerRuns: { enabled: true } },
+          }),
+        });
+        enterPhase("pairing the worker node");
+        operator = await connectWireClient({
+          gateway,
+          role: "operator",
+          identity: null,
+          onHelloOk: () => {
+            operatorHelloCount += 1;
+          },
+        });
+        workerNode = await createPairedNodeWorkerHost({
+          gateway,
+          operator,
+          root,
+          bundlePrewarm: true,
+        });
+        const nodeId = workerNode.identity.deviceId;
+
+        enterPhase("dispatching the worker session onto the paired node");
+        const sessionKey = `agent:qa:paired-node-desktop-admission-${Date.now()}`;
+        await operator.request("sessions.create", {
+          key: sessionKey,
+          agentId: "qa",
+          worktree: true,
+          worktreeName: "paired-node-desktop-admission",
+          worktreeBaseRef: "main",
+          cwd: published.source,
+        });
+        const dispatched = (await gateway.call(
+          "sessions.dispatch",
+          { key: sessionKey, deviceId: nodeId },
+          { timeoutMs: PROOF_TIMEOUT_MS },
+        )) as { placement?: Placement };
+        expect(dispatched.placement).toMatchObject({ state: "active" });
+        const environmentId = dispatched.placement?.environmentId;
+        const currentBundleHash = dispatched.placement?.workerBundleHash;
+        if (!environmentId || !currentBundleHash) {
+          throw new Error("node placement omitted its environment or worker bundle hash");
+        }
+        expect(currentBundleHash).toMatch(/^[a-f0-9]{64}$/u);
+        // The dispatch installed the real worker bundle on the node host.
+        await workerNode.installedBundleDirectory(currentBundleHash);
+
+        enterPhase("attesting the worker desktop onto the durable environment record");
+        // The desktop endpoint is a provider-attested warm-time capability; seed
+        // exactly that attestation while the Gateway is stopped. Everything
+        // downstream of it (admission, transport, RFB, launcher) stays real.
+        await workerNode.disconnect();
+        const desktopFramesBeforeSeed = workerNode.frames.length;
+        const operatorHelloBeforeSeedRestart = operatorHelloCount;
+        await gateway.restartAfterStateMutation(async ({ stateDir }) => {
+          await seedDesktopEndpoint({
+            stateDir,
+            environmentId,
+            port: vnc.port,
+            passwordFilePath: vnc.passwordFilePath,
+          });
+        });
+        // The pairing fixtures ride the operator connection; wait for its
+        // authenticated reconnect before re-approving the worker node.
+        await vi.waitFor(
+          () => expect(operatorHelloCount).toBeGreaterThan(operatorHelloBeforeSeedRestart),
+          { timeout: 30_000, interval: 100 },
+        );
+        await workerNode.connect();
+        await waitForNodeReady(operator, workerNode.identity.deviceId);
+        // Let the restarted Gateway's startup reconciliation settle before
+        // driving the desktop paths.
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10_000);
+        });
+
+        enterPhase("observing the current worker's real desktop");
+        // The freshly restarted Gateway's startup reconcile and state-database
+        // activity can briefly stall the desktop observe path; retry the RPC
+        // with hard deadlines instead of hanging on a single attempt.
+        let observed: DesktopObserveResult | undefined;
+        for (let attempt = 1; attempt <= 3 && !observed; attempt += 1) {
+          logLine(`observe attempt ${attempt} starting`);
+          if (attempt > 1) {
+            await new Promise((resolve) => {
+              setTimeout(resolve, 15_000);
+            });
+          }
+          observed = await raceWithDiagnostics(
+            operator.request<DesktopObserveResult>("worker.desktop.observe", {
+              environmentId,
+              control: false,
+            }),
+            `worker.desktop.observe attempt ${attempt}`,
+            90_000,
+          ).catch((error: unknown) => {
+            logLine(`observe attempt ${attempt} failed: ${String(error).slice(0, 1500)}`);
+            if (attempt === 3) {
+              throw error;
+            }
+            return undefined;
+          });
+          if (observed) {
+            logLine(`observe attempt ${attempt} resolved wsPath`);
+          }
+        }
+        if (!observed) {
+          throw new Error("worker.desktop.observe did not resolve");
+        }
+        expect(observed).toMatchObject({ transport: "rfb", control: false });
+        expect(observed.wsPath).toMatch(/^\/desktop\/observe\?token=/u);
+        const desktop = await observeDesktopFrames({ gateway, wsPath: observed.wsPath });
+        // The name is the real X server's ServerInit desktop name; geometry comes
+        // from the headless display this proof started.
+        expect(desktop.name.length).toBeGreaterThan(0);
+        expect(desktop.width).toBe(1024);
+        expect(desktop.height).toBe(768);
+        logLine(
+          `observed real RFB ServerInit ${desktop.width}x${desktop.height} name=${JSON.stringify(
+            desktop.name,
+          )}`,
+        );
+
+        enterPhase("launching the advertised desktop app on the real worker");
+        await expect(
+          operator.request("worker.desktop.launch", { environmentId, app: "terminal" }),
+        ).resolves.toEqual({ app: "terminal", status: "ready" });
+        // Both desktop operations reached the real node host process over the
+        // Gateway transport: no stubbed acknowledgements anywhere in this path.
+        const desktopFramesAfterLaunch = workerNode.frames.slice(desktopFramesBeforeSeed);
+        expect(
+          desktopFramesAfterLaunch
+            .filter((frame) => frame.command === NODE_WORKER_DESKTOP_STREAM_COMMAND)
+            .map((frame) => JSON.parse(frame.paramsJSON ?? "{}")),
+        ).toEqual([
+          {
+            ticket: expect.any(String),
+            attachPath: expect.stringMatching(/^\/node-desktop\/attach\?ticket=[a-f0-9]{48}$/u),
+            port: vnc.port,
+            passwordFilePath: vnc.passwordFilePath,
+          },
+        ]);
+        expect(
+          desktopFramesAfterLaunch
+            .filter((frame) => frame.command === NODE_WORKER_DESKTOP_LAUNCH_COMMAND)
+            .map((frame) => JSON.parse(frame.paramsJSON ?? "{}")),
+        ).toEqual([{ id: "terminal", executablePath: DESKTOP_TERMINAL_APP }]);
+
+        enterPhase("updating the Gateway build to supersede the worker's bundle");
+        const installFramesBeforeUpgrade = bundleInstallFrames(workerNode).length;
+        const desktopFramesBeforeUpgrade = workerNode.frames.length;
+        // Capture the operator hello baseline before the restart: the operator's
+        // automatic reconnect can complete while the replacement gateway boots,
+        // so a post-restart baseline may already include the new hello and never
+        // advance past itself.
+        const operatorHelloBeforeReconnect = operatorHelloCount;
+        await workerNode.disconnect();
+        await gateway.restartAfterStateMutation(async () => {
+          // An inert change in the owned fixture makes a genuinely different
+          // content-addressed worker artifact, as a minor rebuild does.
+          await fs.appendFile(
+            path.join(runtimeRoot, "dist", "worker", "worker.mjs"),
+            "\n// QA desktop admission rebuild\n",
+          );
+          writeBuildInfo({ rootDir: runtimeRoot });
+        });
+        await workerNode.connect();
+        await waitForNodeReady(operator, workerNode.identity.deviceId);
+        await vi.waitFor(
+          () => expect(operatorHelloCount).toBeGreaterThan(operatorHelloBeforeReconnect),
+          { timeout: 30_000, interval: 100 },
+        );
+
+        enterPhase("refusing the stale worker at desktop admission");
+        const staleError = await operator
+          .request("worker.desktop.observe", { environmentId, control: false })
+          .then(
+            () => {
+              throw new Error("stale desktop observe unexpectedly succeeded");
+            },
+            (error: unknown) => error,
+          );
+        expect(String(staleError)).toContain(STALE_WORKER_BUILD_REASON);
+        logLine(`stale observe refused: ${String(staleError).slice(0, 200)}`);
+        const staleLaunchError = await operator
+          .request("worker.desktop.launch", { environmentId, app: "terminal" })
+          .then(
+            () => {
+              throw new Error("stale desktop launch unexpectedly succeeded");
+            },
+            (error: unknown) => error,
+          );
+        expect(String(staleLaunchError)).toContain(STALE_WORKER_BUILD_REASON);
+        logLine(`stale launch refused: ${String(staleLaunchError).slice(0, 200)}`);
+        // Admission refused both requests before any transport side effect: no new
+        // desktop command reached the node host. (A gateway restart may legitimately
+        // re-publish unrelated workspace-retain invocations on node re-attach.)
+        expect(
+          workerNode.frames
+            .slice(desktopFramesBeforeUpgrade)
+            .filter(
+              (frame) =>
+                frame.command === NODE_WORKER_DESKTOP_STREAM_COMMAND ||
+                frame.command === NODE_WORKER_DESKTOP_LAUNCH_COMMAND,
+            ),
+        ).toHaveLength(0);
+
+        enterPhase("recovering the retained worker through real reconciliation");
+        await vi.waitFor(
+          () => {
+            expect(bundleInstallFrames(workerNode!).length).toBeGreaterThan(
+              installFramesBeforeUpgrade,
+            );
+          },
+          { timeout: RECONCILE_SWEEP_TIMEOUT_MS, interval: 500 },
+        );
+        const recoveredInstall = bundleInstallFrames(workerNode).at(-1);
+        if (!recoveredInstall) {
+          throw new Error("recovery install frame is missing");
+        }
+        const refreshedBundleHash = (
+          JSON.parse(recoveredInstall.paramsJSON ?? "{}") as { build?: { bundleHash?: string } }
+        ).build?.bundleHash;
+        expect(refreshedBundleHash).toMatch(/^[a-f0-9]{64}$/u);
+        expect(refreshedBundleHash).not.toBe(currentBundleHash);
+        logLine(
+          `reconciliation installed refreshed bundle ${refreshedBundleHash} (superseded ${currentBundleHash})`,
+        );
+        // The real node host installs the refreshed bundle bytes. The install frame
+        // arriving does not mean the extraction finished; poll until exactly one
+        // proof-owned bundle directory for the refreshed hash exists.
+        await vi.waitFor(
+          async () => {
+            await expect(
+              workerNode!.installedBundleDirectory(refreshedBundleHash!),
+            ).resolves.toBeTruthy();
+          },
+          { timeout: RECONCILE_SWEEP_TIMEOUT_MS, interval: 1_000 },
+        );
+        // The same durable record now carries the refreshed receipt.
+        await vi.waitFor(
+          async () => {
+            await expect(readEnvironmentReceipt(gateway!, environmentId)).resolves.toBe(
+              refreshedBundleHash,
+            );
+          },
+          { timeout: RECONCILE_SWEEP_TIMEOUT_MS, interval: 500 },
+        );
+        logLine(`durable receipt refreshed on the same environment record ${environmentId}`);
+
+        enterPhase("restoring desktop observe and launch on the recovered worker");
+        await expect(
+          operator.request("worker.desktop.launch", { environmentId, app: "terminal" }),
+        ).resolves.toEqual({ app: "terminal", status: "ready" });
+        const recovered = await operator.request<DesktopObserveResult>("worker.desktop.observe", {
+          environmentId,
+          control: false,
+        });
+        const recoveredDesktop = await observeDesktopFrames({
+          gateway,
+          wsPath: recovered.wsPath,
+        });
+        expect(recoveredDesktop.name.length).toBeGreaterThan(0);
+        logLine(
+          `recovered observe served real RFB ServerInit ${recoveredDesktop.width}x${recoveredDesktop.height} name=${JSON.stringify(
+            recoveredDesktop.name,
+          )}`,
+        );
+        expect(
+          workerNode.frames
+            .slice(desktopFramesBeforeUpgrade)
+            .filter((frame) => frame.command === NODE_WORKER_DESKTOP_LAUNCH_COMMAND),
+        ).toHaveLength(1);
+      } catch (error) {
+        try {
+          await fs.appendFile(
+            progressPath,
+            `\n[${new Date().toISOString()}] FAILURE while ${phase}: ${String(error).slice(0, 2000)}\n`,
+          );
+        } catch {
+          // best effort only
+        }
+        const diagnostics = await (async () => {
+          try {
+            const logDir = path.join(gateway?.tempRoot ?? "", "workspace", "logs");
+            const files = await fs.readdir(logDir).catch(() => []);
+            const latest = files
+              .filter((name) => name.endsWith(".log"))
+              .toSorted()
+              .at(-1);
+            const logTail = latest
+              ? (await fs.readFile(path.join(logDir, latest), "utf8")).slice(-24_000)
+              : "";
+            return [
+              `proof progress trail:\n${progressTrail.join("\n")}`,
+              `node desktop stream errors: ${JSON.stringify(nodeDesktopStreamErrors.slice(-4))}`,
+              `node commands received: ${JSON.stringify(workerNode?.commands.slice(-12))}`,
+              `node invoke errors: ${JSON.stringify(
+                workerNode?.invokeErrors.slice(-4).map((entry) => String(entry)),
+              )}`,
+              `gateway file log tail:${latest ? "" : " (unavailable)"}`,
+              logTail,
+            ].join("\n");
+          } catch (diagnosticError) {
+            return `diagnostics unavailable: ${String(diagnosticError)}`;
+          }
+        })();
+        try {
+          await fs.appendFile(progressPath, `\n[diagnostics]\n${diagnostics.slice(0, 4000)}\n`);
+        } catch {
+          // best effort only
+        }
+        failures.push(
+          new Error(
+            `desktop admission wire proof failed while ${phase}: ${String(error)}\n${diagnostics}\n${gateway?.logs().slice(-12_000) ?? ""}`,
+            { cause: error },
+          ),
+        );
+      } finally {
+        const withCleanupLog = (
+          step: string,
+          task: Promise<unknown>,
+        ): Promise<"done" | "timeout"> =>
+          Promise.race([
+            task.then(
+              () => "done" as const,
+              (error: unknown) => {
+                void fs
+                  .appendFile(
+                    "/tmp/desktop-admission-cleanup.log",
+                    `${step} FAILED: ${String(error)}\n`,
+                  )
+                  .catch(() => undefined);
+                return "done" as const;
+              },
+            ),
+            new Promise<"timeout">((resolve) => {
+              setTimeout(() => {
+                void fs
+                  .appendFile(progressPath, `${step} TIMED OUT after 60s\n`)
+                  .catch(() => undefined);
+                resolve("timeout");
+              }, 60_000).unref();
+            }),
+          ]);
+        const cleanup = await Promise.allSettled([
+          withCleanupLog("workerNode.stop", workerNode?.stop() ?? Promise.resolve()).then(
+            () => undefined,
+          ),
+          withCleanupLog(
+            "operator.stopAndWait",
+            operator?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
+          ).then(() => undefined),
+          withCleanupLog("stopQaGatewayFixture", stopQaGatewayFixture(gatewayOwner)).then(
+            () => undefined,
+          ),
+          withCleanupLog("provider.stop", provider.stop()).then(() => undefined),
+          withCleanupLog("closeWireServer", closeWireServer(published.server)).then(
+            () => undefined,
+          ),
+          withCleanupLog("vnc.stop", vnc.stop()).then(() => undefined),
+        ]);
+        failures.push(
+          ...cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+        );
+      }
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "paired node desktop admission proof failed");
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
@@ -343,6 +343,9 @@ export async function createPairedNodeWorkerHost(
   let client: GatewayClient | undefined;
   let closing = false;
   const invokeTasks = new Set<Promise<void>>();
+  // Desktop and portal stream commands ride the private worker transport and
+  // require the host's runtime signal, exactly like the production node host.
+  const hostLifetime = new AbortController();
   const invokeErrors: unknown[] = [];
   const commands: string[] = [];
   const frames: NodeInvokeRequestPayload[] = [];
@@ -391,6 +394,7 @@ export async function createPairedNodeWorkerHost(
     options.onInvoke?.(frame);
     const task = handleInvoke(frame, receiver, { current: async () => [] }, undefined, {
       workerBundleInstaller: bundleInstaller,
+      signal: hostLifetime.signal,
       workerSupervisor: supervisor,
       workerWorkspace: workspace,
       gatewayUrl:
@@ -504,6 +508,7 @@ export async function createPairedNodeWorkerHost(
     },
     async stop() {
       closing = true;
+      hostLifetime.abort(new Error("paired worker node stopped"));
       const current = client;
       client = undefined;
       const connectionCleanup = await Promise.allSettled([


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Closes #143100

## What Problem This Solves

- Fixes an inconsistency in worker-environment admission where an environment whose stored `bootstrapReceipt` no longer matches the current Gateway bundle was refused for `startTunnel` and session attach but was still granted `worker.desktop.observe` tickets (including `control: true`) and `worker.desktop.launch` app launches. Operators with the `cloudWorkers.desktop` lab enabled could thus drive a worker that the Gateway had already decided is not current enough to talk to, during the window before background reconciliation retires the stale environment.
- **Related:** #121081 (merged tunnel-admission repair) and #140400 (shared eligibility refactor) established the sibling invariant but left the desktop paths unchecked; #141336 bound observer tickets to the Gateway connection on an orthogonal axis. ClawSweeper advisory on this issue confirms the desktop gap remains and recommends applying the canonical build validator at desktop admission.

## Why This Change Was Made

- **Intended outcome:** `observeDesktop` and `launchDesktopApp` now enforce the same build-identity admission as `startTunnel` and `attachSession`: the current bundle is prepared outside the environment lock, and the freshly read durable record's `bootstrapReceipt` is validated with the canonical `verifyWorkerAdmissionHandshake` before any desktop transport or launcher side effect. A stale worker is refused with the existing `StaleWorkerBuildError` ("Worker build does not match the current Gateway build; redispatch the session..."), surfaced to the client as `invalid_state` with the same redispatch guidance tunnels already return.
- **Out of scope:** no change to reconciliation timing, lifecycle-state gates, transport fencing, or `startTunnel`'s existing admission path; missing `bootstrapReceipt` on a desktop record is treated as an admission failure rather than a distinct lifecycle error.
- **Highest-risk area:** the node-backed desktop carrier branch — mitigated by an explicit regression test asserting a stale node-backed environment is refused before the durable carrier's `observe`/`launchApp` is reached.

## User Impact

- **Success criteria:** with `cloudWorkers.desktop` enabled, an otherwise-eligible desktop worker whose bootstrap receipt no longer matches the current Gateway bundle is refused for desktop observe and app launch with the same stale-build error tunnels and attach produce; a current-build desktop worker keeps working (existing observe/launch tests unchanged).
- **What should reviewers focus on?** `src/gateway/worker-environments/environment-access.ts` (`prepareCurrentBuild` / `requireAdmittedBuild` helpers and their call sites in `observeDesktop` / `launchDesktopApp`), plus the new `environment-access.test.ts` fixtures: "rejects desktop observe with stale receipt / unavailable current bundle", "rejects desktop app launch with ...", and "rejects a stale node-backed desktop before reaching the durable carrier".

## Evidence

- **Real environment tested:** three real layers, in increasing fidelity. (1) Unit admission fixtures drive the real `createWorkerEnvironmentAccess` factory over the real durable store and the real `admission.ts` validator, fencing only the desktop tunnel/launcher managers with `vi.fn()` so rejection is provable by "transport never called". (2) The full-runtime composition suite uses the real node desktop carrier, the real pairing store, the real provider lifecycle/reconciliation and a real in-process supervisor-protocol transport. (3) **New on heads `da307e3`→`79db02c`** — a committed wire proof (`test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts`) runs a real packaged Gateway child process against a real paired node host (real `handleInvoke` → real `NodeWorkerBundleInstaller`, real supervisor, real workspace runtime) and a real headless TigerVNC `Xvnc` with `VncAuth`, splicing real RFB bytes node → Gateway → observer WebSocket. Install and launch acknowledgements are not synthesised there: the install extracts real bundle bytes into the node host's bundle store and the launch executes a real executable through the real launcher.
- **Exact steps or commands run after this patch:**
  ```bash
  # Committed wire proof on a real worker desktop (real Gateway child + real node host +
  # real TigerVNC/RFB): access → stale refusal → real reconciliation recovery → restored access
  node scripts/run-vitest.mjs run \
    test/e2e/qa-lab/runtime/paired-node-worker-desktop-admission-wire.e2e.test.ts
  # Regression suite (RED first: stale/unavailable cases failed before the fix, GREEN after):
  node scripts/run-vitest.mjs run src/gateway/worker-environments/environment-access.test.ts
  # Full gateway-server runtime composition (real store + real node carrier + real transport):
  node scripts/run-vitest.mjs run src/gateway/server-worker-environment-startup.test.ts
  # Adjacent desktop/tunnel/desktop-RPC suites (no regressions):
  node scripts/run-vitest.mjs run src/gateway/worker-environments/desktop-tunnel.test.ts \
    src/gateway/worker-environments/node-desktop-carrier.test.ts \
    src/gateway/server-methods/environments.desktop.test.ts
  # Format + lint + tests + tsgo:core gate (validate.sh on the changed files): all green
  # Import-boundary source contract (startup module lazy loads): pass
  ```
- **Evidence after fix:**
  Committed wire proof, head `79db02c` — eight consecutive green runs (test body 170.4–185.8s),
  the last two on the corrected harness described below. Captured phase trail of the last run, plus
  the real Gateway's own log lines for the same window:
  ```text
  phase: pairing the worker node
  phase: dispatching the worker session onto the paired node
    gateway: ⇄ res ✓ sessions.dispatch 6701ms
  phase: attesting the worker desktop onto the durable environment record
  phase: observing the current worker's real desktop
    observe resolved wsPath on the first bounded request  (state-gated readiness, no retry loop)
    observed real RFB ServerInit 1024x768 name="x11"      (real RFB 3.8 handshake, real geometry/name)
    gateway: ⇄ res ✓ worker.desktop.observe 96ms
    gateway: desktop observer closed  sourceKey=worker:32104533cbb533c11f009275079c2911
    gateway: node stream closed       streamKind=desktop nodeId=326e39deacec83…
  phase: launching the advertised desktop app on the real worker
    -> {app: "terminal", status: "ready"}
  phase: updating the Gateway build to supersede the worker's bundle
    (real rebuild of the owned fixture -> a genuinely different content-addressed worker bundle)
    gateway: Worker disk-space probe failed: Worker build does not match the current Gateway build…
  phase: refusing the stale worker at desktop admission
    stale observe refused: GatewayClientRequestError: Worker build does not match the current
      Gateway build; redispatch the session so its worker can bootstrap the current build before retrying.
    stale launch refused:  GatewayClientRequestError: Worker build does not match the current
      Gateway build; redispatch the session so its worker can bootstrap the current build before retrying.
    gateway: ⇄ res ✗ worker.desktop.observe 9ms  errorCode=INVALID_REQUEST errorMessage=Worker build does not match…
    gateway: ⇄ res ✗ worker.desktop.launch  11ms errorCode=INVALID_REQUEST errorMessage=Worker build does not match…
    (asserted: no desktop stream/launch frame reached the node host)
  phase: recovering the retained worker through real reconciliation
    reconciliation installed refreshed bundle
      7fff06dc50c1719db0b16e0b1ab4e44330a61a020770a77384aeb95f120f23d2
      (superseded 8cfa905f038461047478dbc1d49a576bc89f099cf0dac9de169dd15186564ac5)
    durable receipt refreshed on the same environment record worker:32104533cbb533c11f009275079c2911
  phase: restoring desktop observe and launch on the recovered worker
    launch -> {app: "terminal", status: "ready"}
    recovered observe served real RFB ServerInit 1024x768 name="x11"
    gateway: desktop observer closed sourceKey=worker:32104533cbb533c11f009275079c2911 (same record)
    gateway: node stream closed      streamKind=desktop nodeId=326e39deacec83… (same node, new connId)

  ✓ serves desktop observe and launch from a real worker, refuses a stale build after a Gateway
    update, and restores access through real reconciliation   179632ms
  Test Files 1 passed (1)   Tests 1 passed (1)
  ```
  The same `sourceKey` is refused after the build change and serves real RFB frames again after the real
  reconciliation refresh — recovery on the same durable record, no reseed and no extra record.
  The test is `skipIf` no local VNC server exists, so it stays opt-in on hosts without a headless desktop.

  Unit and composition suites (unchanged):
  ```text/json
  environment-access.test.ts: 24 passed (24)   # includes 5 new admission assertions
    - rejects desktop observe with stale receipt          -> code: invalid_state,
        message: "Worker build does not match the current Gateway build;
                  redispatch the session so its worker can bootstrap the current
                  build before retrying."                 (desktop.acquire NOT called)
    - rejects desktop observe with unavailable current bundle -> invalid_state
        "Current worker build identity is unavailable"    (desktop.acquire NOT called)
    - rejects desktop app launch with stale receipt / unavailable bundle (launchApp NOT called)
    - rejects a stale node-backed desktop before reaching the durable carrier
        (nodeDesktopCarrier.observe / launchApp NOT called)
  server-worker-environment-startup.test.ts: 4 passed (4)  # full runtime composition:
    - current-build node desktop launch resolves {app: terminal, status: ready} over the
      real carrier + in-process supervisor transport
    - a sibling record bootstrapped against a superseded bundle (hash "c"*64) is refused
      with the canonical stale-build message and the carrier's launchApp is never reached
      (carrier invocation count unchanged)
  validate.sh (oxfmt + oxlint + vitest + tsgo:core): all green on the 5 changed files
  ```
- **Observed result after fix:** a mismatched-bundle desktop worker is refused at admission time for observe and launch, before any transport acquisition, token minting, or app-launch side effect — now demonstrated on a real worker desktop over the real Gateway wire, where the refused record and the recovered record are the *same* durable environment (`worker:32104533cbb533c11f009275079c2911`), and recovery is the real reconciliation refresh (real bundle install of `7fff06dc50c1719db0b16e0b1ab4e44330a61a020770a77384aeb95f120f23d2`, canonical receipt verification, `refreshBootstrapReceipt`) rather than a reseeded record. Current-build desktop observe/launch keep serving real RFB frames (1024x768, desktop name `x11`) before and after the upgrade window.
- **CI regression found and fixed while this PR was open:** the gateway-server shard (`checks-node-compact-small-16`, head `9eeda8ed`) failed in `server-worker-environment-startup.test.ts > composes node desktop control into the worker environment runtime` — the new desktop admission resolves the current worker bundle through the runtime's bundle producer, and an unpackaged source checkout has no built worker deploy artifact, so packaging throws and desktop launch is refused as "Current worker build identity is unavailable". Fixed by letting `createGatewayWorkerEnvironmentRuntime` accept an optional bundle producer (default unchanged: package the running tree on first use) and adapting the composition test to seed the current-build identity its record bootstrapped with. Rebased onto latest `main` and re-verified (validate.sh green).
- **Unrelated CI flake on the previous head (resolved by rebase):** head `12194ab9` failed `checks-node-changed-extensions-bundle-27` / `openclaw/ci-gate` in `extensions/telegram/src/model-callback.loopback.integration.test.ts` ("Network request for 'editMessageText' failed") — an extension this PR does not touch. Main already fixed that flake upstream in #143197 (`4d475f153ae`, merged 2026-09-09); this branch was rebased onto that main, and the PR's own checks are green on the new head.
- **Recovery through real reconciliation (committed regression, head `b1c124ab`, replacing the earlier seeded-record version):** the full-runtime composition now drives the actual recovery machinery instead of seeding a replacement record: after the stale refusal (stable on repeated attempts), `service.reconcileOnce()` runs the real provider-lifecycle refresh for the same node-backed desktop environment — the paired device is resolved through the real durable pairing store, the real device worker provider inspects its lease, the owner is stopped and its credential revoked, the current bundle is installed through the real gateway bundle installer + transfer service, the returned receipt is verified by the canonical `verifyWorkerAdmissionHandshake`, and the refreshed receipt is committed on the **same durable record** via `store.refreshBootstrapReceipt`. Desktop launch on the recovered record then succeeds (+1 carrier invocation) with no new record seeded:
  ```text/json
  composes node desktop control into the worker environment runtime: PASS
    stale launch -> code "invalid_state", STALE_WORKER_BUILD_REASON (stable on retry)
    reconcileOnce(staleEnv) -> device provider refresh path:
      paired device from real pairing store; provider.inspect -> {status: "active", sharedHost: true}
      stopOwner -> credential revoked; bundle install invoked exactly once (exact current bundleHash)
      store.refreshBootstrapReceipt -> same record now ready with current-bundle receipt
    recovered launch -> {app: "terminal", status: "ready"}; carrier invocations = before + 1
  server-worker-environment-startup.test.ts: 14 passed (14)
  environment-access/desktop-tunnel/node-desktop-carrier/environments.desktop: 72 passed (72)
  tsgo:core + gateway-root test type shard: green
  ```
- **Real-artifact upgrade evidence (heads `64c9beb`→`93f422f`):** an additional run of the same composition drove the **real** `createWorkerBundleProducer` over two genuinely different real worker deploy artifact sets (no injected identity): an older real build as the environment's bootstrapped bundle (`H_old` = `7675acc4…`, 10 953 078-byte tarball) and this branch's freshly built artifacts as the current Gateway bundle (`H_new` = `1bd8f978…`, 11 357 321-byte tarball), with the real durable store, real `createGatewayWorkerEnvironmentRuntime`, and real node desktop carrier:
  ```text/json
  [phase A] current-build launch (receipt == H_old) -> {app: "terminal", status: "ready"}; carrier=1
  [phase B] after upgrade to H_new, same record refused:
            code = "invalid_state"
            message = "Worker build does not match the current Gateway build; redispatch the
                       session so its worker can bootstrap the current build before retrying."
            carrier invocations before=0 after=0 (carrier NOT reached); stable on retry
  [phase C] redelivered record (receipt == H_new) -> {app: "terminal", status: "ready"}; carrier=+1
  ```
  The two content-addressed bundle hashes are distinct, so the refusal is driven by a real manifest mismatch of real packaged worker artifacts, and the redispatch recovery happens on the same runtime/store without a gateway restart.
- **The previously reported “observe stalls” were a proof-harness deadlock, not Gateway behaviour:** the earlier attempt cleaned its observer socket up with `await failure.catch(…)` *before* `ws.close(…)`, where `failure` only settles on socket error/close — so the harness hung on its own success path whenever the Gateway (correctly) kept the observer stream open. No product code was changed for it, and none was needed: after reordering, `worker.desktop.observe` resolved on the first attempt in all six runs (~35–100 ms). Three further harness races found while chasing it are also fixed in the test: the operator-hello baseline was captured *after* the Gateway restart (so the wait could never advance), the “no transport side effect” assertion counted *all* node frames while a restart legitimately re-publishes `worker.workspace.retain.v1`, and the refreshed-bundle directory was checked when the install *frame* arrived rather than after extraction. This is the answer to the merge-risk question: the desktop observe path does not hang — refusal returns in ~10 ms and the real recovery completes in ~62 s including the real bundle install.
- **Harness corrections after review (head `79db02c`):** two findings on the committed proof were fixed rather than argued. (1) *Readiness* — the fixed 10 s settle plus three-attempt observe retry is gone; the test now waits on the state the restart produces (`environments.list` reporting the record `available` with `desktop: true` and `desktopApps: ["terminal"]`) and then issues **one** bounded observe request, per `test/AGENTS.md` ("synchronize on the state an action produces … do not substitute longer timeouts, sleeps, retry-wrapped downstream assertions"). A retry loop could otherwise let a current-worker request that genuinely fails before dispatch pass on a later attempt. (2) *Cleanup* — `withCleanupLog` converted every rejection to `"done"`, resolved its own timeout, and callers discarded the result, so teardown failures could never reach the failure list and the proof could pass with a node host, Gateway, provider or Xvnc still running; it now returns a per-step `done|failed|timeout` outcome that is aggregated into the proof's failures and reported through the trail. Both corrections are validated by two further full green runs (170.4 s / 178.7 s test body).
- **CI note (resolved, no action needed):** on head `da307e3` the only red checks were `checks-node-compact-small-51` and the `openclaw/ci-gate` aggregating it, failing in `test/scripts/ci-node-test-plan.test.ts > keeps hosted tooling within the GitHub job cap when its inventory grows` with `compact github node test plan exceeds 80 jobs (81 planned)`. That guard inventories git-tracked test files, and `main` had gained `test/plugins/fireworks-model-alias.test.ts` in `4e32fcc1687` (#144913), taking the pull-request compact plan from 80 to 81 jobs; I reproduced the identical failure on a clean `origin/main` checkout (`90e44fe1b00`) with this branch's changes absent, and this branch adds only an `.e2e.test.ts` file, which that tooling inventory excludes by pattern. On the current head `79db02c` the shard passes and no check is failing.
- **What was not tested:** no remote/SSH worker host, and no GUI application drawn inside the desktop. In the wire proof the node host runs in-process in the test worker rather than as a separate OS process on another machine, and the advertised app is a real non-GUI executable (`/usr/bin/true`) started by the real launcher; the desktop itself is a real headless TigerVNC X server on loopback. Everything across that boundary is real: Gateway WebSocket wire frames, one-time stream tickets, the RFB handshake and frame bytes, bundle install bytes on disk, durable-store transitions, reconciliation and receipt refresh.
- **Proof tier:** L2+ (wire-real). Real packaged Gateway, real node-host stack, real content-addressed bundle artifacts, real VNC/RFB stream, real durable record and real reconciliation on one machine; the node host's separate-OS-process boundary and a GUI app inside the desktop are the only edges this environment cannot provide.


