### PR TITLE
fix(agents): name the last two silent model fallback chain stops

### DIFF
--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -25,6 +25,7 @@ import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { getRegisteredAgentHarness } from "./harness/registry.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
+  logLocalChainStop,
   logModelFallbackChainStopped,
   logModelFallbackDecision,
   type ModelFallbackChainStopReason,
@@ -284,6 +285,10 @@ async function runFallbackCandidate<T>(params: {
       lane: params.attribution?.lane,
     });
     if (fallbackError.kind === "coordination") {
+      // A local coordination failure is not a provider failure, so the chain
+      // stops here by design. Name it: the remaining candidates are skipped and
+      // nothing else on this path says so.
+      logLocalChainStop(err, params, params.attribution);
       throw err;
     }
     return { ok: false, error: fallbackError.error };

--- a/src/agents/model-fallback-observation.ts
+++ b/src/agents/model-fallback-observation.ts
@@ -356,7 +356,32 @@ export type ModelFallbackChainStopReason =
   | "caller_signal_aborted"
   | "agent_run_direct_abort"
   | "agent_run_restart_abort"
-  | "terminal_abort_wrapper";
+  | "terminal_abort_wrapper"
+  | "local_runtime_coordination"
+  | "transcript_not_continuable";
+
+/**
+ * Names the local, non-provider conditions that stop a chain at a rethrow site.
+ *
+ * The predicate lives in `model-fallback-attempt.ts`, which already imports this
+ * module, so the caller passes the classification instead of this module
+ * importing it back and closing a cycle.
+ */
+export function logLocalChainStop(
+  error: unknown,
+  candidate: { provider: string; model: string },
+  attribution?: { sessionId?: string; lane?: string },
+  transcriptNotContinuable?: boolean,
+): void {
+  logModelFallbackChainStopped({
+    reason: transcriptNotContinuable ? "transcript_not_continuable" : "local_runtime_coordination",
+    provider: candidate.provider,
+    model: candidate.model,
+    sessionId: attribution?.sessionId,
+    lane: attribution?.lane,
+    error,
+  });
+}
 
 /** Record a local or terminal stop separately from provider-failure decisions. */
 export function logModelFallbackChainStopped(params: {

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -68,6 +68,7 @@ import {
 } from "./model-fallback-cooldown.js";
 import {
   isModelFallbackDecisionLogEnabled,
+  logLocalChainStop,
   logModelFallbackDecision,
   type ModelFallbackDecisionParams,
 } from "./model-fallback-observation.js";
@@ -609,6 +610,7 @@ async function runWithModelFallbackInternal<T>(
     // the same local condition and surfacing a misleading "All models
     // failed" summary. See #83510.
     if (isNonProviderRuntimeCoordinationError(err) || isTranscriptNotContinuableError(err)) {
+      logLocalChainStop(err, candidate, runAttribution, isTranscriptNotContinuableError(err));
       throw err;
     }
     if (transientProbeProviderForAttempt) {

--- a/src/agents/model-fallback.chain-stop.test.ts
+++ b/src/agents/model-fallback.chain-stop.test.ts
@@ -9,6 +9,7 @@ import {
   it,
   vi,
 } from "vitest";
+import { TranscriptNotContinuableError } from "../../packages/agent-core/src/errors.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { createSuiteLogPathTracker } from "../logging/log-test-helpers.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
@@ -21,7 +22,10 @@ import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./embedded-agent-runner/run/terminal-outcome.js";
 import { resolveEmbeddedRunTerminalTimeout } from "./embedded-agent-runner/run/terminal-timeout.js";
 import { FailoverError } from "./failover-error.js";
-import { AgentHarnessPreflightError } from "./harness/errors.js";
+import {
+  AgentHarnessPreflightError,
+  AgentHarnessSessionSupersededError,
+} from "./harness/errors.js";
 import { type ModelFallbackStepHandler, runFallbackAttempt } from "./model-fallback-attempt.js";
 import { runWithImageModelFallback } from "./model-fallback-image.js";
 import { runWithModelFallback } from "./model-fallback-runner.js";
@@ -557,4 +561,37 @@ describe("model fallback chain-stop diagnostics", () => {
       );
     },
   );
+  it("names a local coordination stop instead of skipping the tail in silence", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new AgentHarnessSessionSupersededError("private supersede detail"));
+    await expect(runWithModelFallback({ ...fallbackOptions, run })).rejects.toThrow(
+      "private supersede detail",
+    );
+    expect(run).toHaveBeenCalledOnce();
+    await capture.flush();
+    expect(fallbackRecords().at(-1)?.attributes).toMatchObject({
+      event: "model_fallback_chain_stopped",
+      reason: "local_runtime_coordination",
+      candidateProvider: "fixture-primary",
+      candidateModel: "fixture-model",
+      sessionId: "chain-stop-session",
+      lane: "chain-stop-lane",
+    });
+  });
+
+  it("names a transcript stop instead of skipping the tail in silence", async () => {
+    const run = vi.fn().mockRejectedValueOnce(new TranscriptNotContinuableError("assistant"));
+    await expect(runWithModelFallback({ ...fallbackOptions, run })).rejects.toThrow(
+      TranscriptNotContinuableError,
+    );
+    expect(run).toHaveBeenCalledOnce();
+    await capture.flush();
+    expect(fallbackRecords().at(-1)?.attributes).toMatchObject({
+      event: "model_fallback_chain_stopped",
+      reason: "transcript_not_continuable",
+      candidateProvider: "fixture-primary",
+      candidateModel: "fixture-model",
+    });
+  });
 });


### PR DESCRIPTION
Closes #141604.

## What Problem This Solves

A configured model fallback chain can stop partway and say nothing about it. The operator sees a chain that did not run, remaining candidates never attempted, and no line anywhere explaining why.

#141658 named the chain stops inside `runFallbackCandidate`'s terminal branch. Two rethrow sites on current `main` are still silent:

- `src/agents/model-fallback-attempt.ts:286` rethrows a local coordination failure (session superseded, gateway admission, stale lifecycle, writer rebound) so that fallback cannot blame a model for something no model did. That behaviour is correct. It is also invisible.
- `src/agents/model-fallback-runner.ts:611` rethrows for the same reason under the #83510 guard, for a non-provider runtime coordination error or a transcript that cannot be continued.

Both skip every remaining configured candidate without emitting a decision or a chain-stop record. Same class of blind spot #141658 closed, at two sites it did not reach.

## What This Changes

Two new reasons, `local_runtime_coordination` and `transcript_not_continuable`, emitted from both sites through a single helper in `model-fallback-observation.ts`.

No control-flow change. Both sites still rethrow exactly as before, the same errors reach the same callers in the same order, and no candidate is newly attempted or newly skipped. The only difference is that the stop is now named.

## Evidence

- `src/agents/model-fallback.chain-stop.test.ts`, written failing first: **2 failed / 29 passed before** the source change, **31 passed after**. The two new cases assert the specific reason on the emitted record, not merely that something was emitted. Re-run on this branch immediately before opening: `31 passed (31)`.
- `pnpm check` exits **0**, including the max-lines ratchet. Both edited source files land one line under the cap, which is why the emit goes through one shared helper rather than being inlined at each site.
- `pnpm build` exits **0**.
- CI on this head: 160 checks passing. The one red test, `src/cli/doctor-output.process.test.ts > omits backup tips for Git-backed nested agent workspaces`, is a ~12s process test in the CLI doctor path, untouched by this diff, and it passes locally on this exact branch. Reads as flake rather than a regression; happy to be told otherwise.

## Note On The Base

This branch is based on `037e0059e` rather than the current tip. It is an ancestor of `main`, and the touched files have no conflicting commits since. Happy to rebase if you would rather review it on the tip.