### PR TITLE
improve(test): reuse diagnostics-otel install package fixture

### DIFF
--- a/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
@@ -1,13 +1,23 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  copyFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, test } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import {
   createQaGatewayChild,
   startQaMockOpenAiServer,
@@ -348,6 +358,33 @@ async function installAndConfigure(params: {
 }
 
 describe("managed diagnostics-otel install runtime", () => {
+  let seedDir: string | undefined;
+  let packedPlugin: ReturnType<typeof packPlugin> | undefined;
+
+  afterAll(async () => {
+    await runQaGatewayFixture(
+      async () => await packedPlugin,
+      async () => {
+        if (seedDir) {
+          await rm(seedDir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
+  async function copyPackedPlugin(repoRoot: string, scratch: string) {
+    packedPlugin ??= (async () => {
+      seedDir = await mkdtemp(path.join(tmpdir(), "openclaw-otel-install-seed-"));
+      return await packPlugin(repoRoot, seedDir);
+    })();
+    const packed = await packedPlugin;
+    const outputDir = path.join(scratch, "pack");
+    await mkdir(outputDir, { recursive: true });
+    const tarball = path.join(outputDir, path.basename(packed.tarball));
+    await copyFile(packed.tarball, tarball);
+    return { tarball, version: packed.version };
+  }
+
   test("installs the exact package and exports with config precedence, sampling, and flush", async () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../../..");
     const scratch = await mkdtemp(path.join(tmpdir(), "openclaw-otel-install-"));
@@ -358,7 +395,7 @@ describe("managed diagnostics-otel install runtime", () => {
     const gatewayOwner = createQaGatewayChild();
     let gateway: QaGatewayChild | undefined;
     const runProof = async () => {
-      const packed = await packPlugin(repoRoot, scratch);
+      const packed = await copyPackedPlugin(repoRoot, scratch);
       registry = await startRegistry(repoRoot, scratch, packed.tarball, packed.version);
       mock = await startQaMockOpenAiServer();
       gateway = await startInstallGateway({
@@ -450,7 +487,7 @@ describe("managed diagnostics-otel install runtime", () => {
     const gatewayOwner = createQaGatewayChild();
     let gateway: QaGatewayChild | undefined;
     const runProof = async () => {
-      const packed = await packPlugin(repoRoot, scratch);
+      const packed = await copyPackedPlugin(repoRoot, scratch);
       registry = await startRegistry(repoRoot, scratch, packed.tarball, packed.version);
       mock = await startQaMockOpenAiServer();
       const preloadRoot = path.join(scratch, `otel-preload-${randomUUID()}`);

--- a/test/helpers/qa-gateway-cleanup.test.ts
+++ b/test/helpers/qa-gateway-cleanup.test.ts
@@ -461,6 +461,7 @@ describe("QA gateway fixture error composition", () => {
       const finalizationError = new Error("fixture finalization failed");
       const cleaned: string[] = [];
       const bodies: Array<() => Promise<void>> = [];
+      const cleanups: Array<() => Promise<void>> = [];
       const registry = {
         exitCode: null as number | null,
         kill() {
@@ -471,6 +472,7 @@ describe("QA gateway fixture error composition", () => {
       };
       let receiverCount = 0;
       vi.doMock("vitest", () => ({
+        afterAll: (cleanup: () => Promise<void>) => cleanups.push(cleanup),
         describe: (_name: string, body: () => void) => body(),
         test: (_name: string, body: () => Promise<void>) => bodies.push(body),
         expect,
@@ -485,14 +487,18 @@ describe("QA gateway fixture error composition", () => {
         spawn: () => registry,
       }));
       vi.doMock("node:fs/promises", () => ({
+        copyFile: async () => {},
         cp: async () => {},
         mkdir: async () => {},
-        mkdtemp: async () => "/qa-fixture/scratch",
+        mkdtemp: vi
+          .fn()
+          .mockResolvedValueOnce("/qa-fixture/scratch")
+          .mockResolvedValueOnce("/qa-fixture/seed"),
         readdir: async () => ["diagnostics-otel.tgz"],
         readFile: async (file: string) =>
           file.endsWith("registry-port") ? "43210" : JSON.stringify({ version: "1.0.0" }),
-        rm: async () => {
-          cleaned.push("scratch");
+        rm: async (target: string) => {
+          cleaned.push(target);
         },
         symlink: async () => {},
         writeFile: async () => {},
@@ -531,14 +537,23 @@ describe("QA gateway fixture error composition", () => {
 
       await import("../e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.js");
       expect(bodies).toHaveLength(2);
-      const failure: unknown = await bodies[0]!().catch((error: unknown) => error);
+      expect(cleanups).toHaveLength(1);
+      let failure: unknown;
+      try {
+        failure = await bodies[0]!().catch((error: unknown) => error);
+      } finally {
+        for (const cleanup of cleanups) {
+          await cleanup();
+        }
+      }
       expect(cleaned).toEqual([
         "gateway",
         "provider",
         "registry",
         "receiver-0",
         "receiver-1",
-        "scratch",
+        "/qa-fixture/scratch",
+        "/qa-fixture/seed",
       ]);
       expect(errorTree(failure)).toContain(startupError);
       expect(errorTree(failure)).toContain(finalizationError);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The two diagnostics-otel installation E2E cases build and pack the same plugin
independently. This repeats expensive fixture preparation while both cases still
need to exercise their own real installation and Gateway lifecycle.

## Why This Change Was Made

Lazily build and pack one describe-owned seed, then copy its tarball into each
case's private scratch directory. The existing builder is unchanged. The promise
retains construction failures without retrying, and suite cleanup awaits its
settlement before removing the separately owned seed directory.

Both case bodies retain their assertions, deadlines, real CLI/Gateway/registry
processes, receivers, state directories, and preloaded-SDK isolation. No production
code, dependencies, concurrency settings, or coverage changes.

The second changed file is the existing cleanup regression harness. It now
captures and executes the fixture's suite cleanup, supports the added file-copy
operation, and distinguishes scratch and seed roots while retaining the original
startup/finalization error-identity and cleanup-order assertions.

## User Impact

No shipped behavior changes. The full file performs one real plugin runtime build
and one manifest/npm-pack operation instead of two of each, while retaining both
installation cases and independent physical tarball copies.

## Evidence

### Local measurement and limits

Linux, Node 24.19.0, frozen source and prebuilt runtime at
`bc847251aab255bbe46115bf398ae4544b17d4c5`, using the existing
`OPENCLAW_E2E_USE_PREBUILT_DIST=1` contract. These are local diagnostic measurements,
not fresh-main compiled proof or a CI speedup estimate.

| Run, in execution order | Full invocation | Fixture build/package subprocesses | Cases |
| --- | ---: | ---: | --- |
| Original | 201.334 s | 29.132 s | 2/2 passed |
| Candidate | 184.401 s | 15.062 s | 2/2 passed |
| Closing original | 199.077 s | 28.738 s | 2/2 passed |

Candidate and closing-original runs used the same archive observer and fresh
per-run cache layout; capture overhead is included. The first original had only
process observation. Shared-host noise limits timing precision. The deterministic
result is two build/pack preparations becoming one, with roughly 14 seconds less
observed package preparation.

Underlying full-file command, with external observation and per-run caches:

```sh
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts --reporter=verbose
```

Read-only source comparison against main
`7fdf62ec4b394821d0bab341c19ee5ae3d500f4d` found the original test, cleanup and OTLP
helpers, checked build/package helpers, diagnostics-otel source tree, root package
manifest, and lockfile unchanged. This does not upgrade the pinned runtime evidence
to current-main execution.

### Isolation, package contents, and failure behavior

- Both candidate cases passed with one seed and two regular physical copies.
  Copy hashes matched the seed, file identities were independent, and the seed
  remained unchanged. Owned roots and recorded child processes were cleaned up.
- Raw archive equality is **false**, including between the two original builds.
  Of 6,298 entries, 6,295 were exact. The remaining three JavaScript files differed
  only in generated source-region path prefixes and the resulting hashed chunk
  filename/static imports.
- An independently reviewed, Acorn-based comparison passed all three pairs:
  original A versus original B, and each original versus the candidate. It
  normalized only 20 actual region-comment prefix spans and two AST-identified
  static-import hash spans per archive, with a unique matching chunk mapping.
  Allowed roots came from hash-bound source and independently observed fixture
  roots; build cwd/staging were source-reconstructed, not directly sampled.
  Inventory, types, modes, links, and all other bytes remained exact. Region tails,
  executable code, quotes, bindings, directives, licenses, and source-map comments
  were preserved. No archives were rewritten.
- Six in-memory negative controls rejected executable-literal, wrong-import,
  region-suffix, license, source-map, and directive changes. The initial raw
  comparison failure remains retained separately from normalized success.
- The preloaded-SDK case passed alone as the first seed consumer, with one real
  build/pack and complete cleanup.
- A construction fault after seed creation produced one real failed build,
  zero packs, zero registry starts, and no partial publication or retry. Both
  cases retained the same original compiler failure. Cleanup waited for the
  builder, then removed all owned roots; no recorded child remained.
- Initial hosted CI found that the existing cleanup harness's Vitest mock did
  not expose `afterAll`:
  https://github.com/openclaw/openclaw/actions/runs/34355284028/job/102478510762.
  After adapting that existing case, the full harness passed 11/11 tests.
  A selected negative control retained the suite hook but suppressed the
  producer's seed removal; it failed specifically because `/qa-fixture/seed`
  was absent from the disposal sequence. Restoring the exact fixture bytes
  made the selected case pass. This mock proves disposal/error-composition
  coverage, not a held-construction race; the real fault proof above is separate.
- Proof-tool preflight corrections were limited to the pinned Acorn dependency
  lookup and ANSI-aware reconciliation of the saved compiler marker. Neither
  relaxed provenance nor reran a test; historical failed receipts were retained.
- Changed-file dry-run and actual `check:changed` passed, including root-test
  typechecking, tooling checks, targeted formatting and lint. `git diff --check`
  passed. Fresh independent P2 review of the complete candidate against `bc847`
  returned scoped-clean with no findings.

Exact-head hosted CI is required before merge. This PR addresses
only this fixture's repeated preparation; it does not close or claim a global
performance target for the related issue.
