### PR TITLE
refactor(tests): remove duplicate MiniMax input test

### DIFF
--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -89,11 +89,6 @@ describe("minimax model definitions", () => {
     expect(model.contextWindow).toBe(EXPECTED_DEFAULT_CONTEXT_WINDOW);
   });
 
-  it("keeps M2.7 text-only on the Anthropic-compatible chat path", () => {
-    const model = buildMinimaxApiModelDefinition("MiniMax-M2.7");
-    expect(model.input).toEqual(["text"]);
-  });
-
   it("keeps M2.7-highspeed text-only on the Anthropic-compatible chat path", () => {
     const model = buildMinimaxApiModelDefinition("MiniMax-M2.7-highspeed");
     expect(model.input).toEqual(["text"]);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

This maintainer-requested test cleanup removes a duplicate MiniMax M2.7 input assertion that adds maintenance without protecting a distinct regression.

## Why This Change Was Made

Remove only the standalone text-only input case. The preceding `keeps M2.7 on its existing price and text-only metadata` case builds the same model and retains the identical `["text"]` assertion, plus its cost and context-window checks.

## User Impact

No runtime behavior changes. One test and five test-file lines are removed; every other case, import, and production file is unchanged.

## Evidence

- Full `extensions/minimax/model-definitions.test.ts` through the repository Vitest wrapper: all 10 tests passed, none skipped, including the retained M2.7 metadata case.
- Targeted formatting and `git diff --check` passed.
- The actual selected `check:changed` plan completed all 19 steps against base `8f99051283621332b4e9e2a2041c9a2cb3c6038d`.
- Fresh scanned P2 autoreview with the unchanged owner and caller context completed with no findings.

Exact-head hosted checks are a separate landing requirement; the results above are local proof.
