### PR TITLE
fix(sessions): CJK transcript searches return zero results

### DIFF
--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -213,6 +213,32 @@ describe("searchSessionTranscripts", () => {
     expect(search("alpha").hits).toHaveLength(1);
   });
 
+  it("reaches CJK prose through the LIKE fallback when unicode61 cannot address it (#140736)", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "明天下午三点开项目评审会议讨论排期");
+
+    const result = search("会议");
+    expect(result.indexing).toBe(false);
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]).toMatchObject({ sessionId: "session-1", role: "user" });
+    expect(result.hits[0]?.snippet).toContain("会议");
+    expect(search("会议 排期").hits).toHaveLength(1);
+  });
+
+  it("scopes the CJK LIKE fallback to the requested session keys", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "记录配置变更的会议纪要");
+    await appendUserMessage("session-2", "agent:main:other", "另一条配置相关的会议记录");
+
+    const result = search("配置", { sessionKeys: ["agent:main:other"] });
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]?.sessionId).toBe("session-2");
+  });
+
+  it("keeps non-CJK zero-hit queries off the fallback scan", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "明天下午三点开项目评审会议讨论排期");
+
+    expect(search("zzz")).toEqual({ hits: [], indexing: false, truncated: false });
+  });
+
   it("filters hits to the requested session keys", async () => {
     await appendUserMessage("session-1", "agent:main:main", "shared keyword payload");
     await appendUserMessage("session-2", "agent:main:other", "shared keyword payload");

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -239,6 +239,30 @@ describe("searchSessionTranscripts", () => {
     expect(search("zzz")).toEqual({ hits: [], indexing: false, truncated: false });
   });
 
+  it("anchors fallback excerpts on the matched CJK term in late messages (#140736)", async () => {
+    const filler = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+    await appendUserMessage("session-1", "agent:main:main", `${filler} 明天开会议讨论排期`);
+
+    const result = search("会议");
+    expect(result.hits).toHaveLength(1);
+    const snippet = result.hits[0]?.snippet ?? "";
+    expect(snippet).toContain("会议");
+    expect(snippet.startsWith("… ")).toBe(true);
+  });
+
+  it("keeps non-CJK fallback terms on exact-word MATCH semantics", async () => {
+    // "scattered" contains the substring "cat" but is not the word "cat";
+    // substring-widening it would resurrect the false positive.
+    await appendUserMessage("session-1", "agent:main:main", "明天开会议讨论 scattered plans");
+
+    expect(search("会议 cat").hits).toHaveLength(0);
+
+    await appendUserMessage("session-2", "agent:main:other", "cat 会议纪要已归档");
+    const result = search("会议 cat");
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]?.sessionId).toBe("session-2");
+  });
+
   it("filters hits to the requested session keys", async () => {
     await appendUserMessage("session-1", "agent:main:main", "shared keyword payload");
     await appendUserMessage("session-2", "agent:main:other", "shared keyword payload");

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -15,6 +15,11 @@ import {
 const SEARCH_SNIPPET_MAX_CHARS = 500;
 const SEARCH_LIMIT_MAX = 25;
 const SEARCH_QUERY_MAX_CHARS = 4096;
+// Runs of Han/Kana/Hangul have no spaces for the unicode61 tokenizer to split
+// on, so any exact-phrase term overlapping such a run is unaddressable by the
+// FTS index and needs the LIKE retry below.
+const CJK_RUN_PATTERN =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]{2,}/u;
 
 type SessionTranscriptSearchHit = {
   sessionKey: string;
@@ -38,6 +43,10 @@ function toFtsQuery(query: string): string {
     .split(/\s+/u)
     .map((token) => `"${token.replaceAll('"', '""')}"`)
     .join(" AND ");
+}
+
+function toLikePattern(term: string): string {
+  return `%${term.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`;
 }
 
 /** Search the per-agent FTS index; kicks off one background reconcile when the index lags. */
@@ -99,7 +108,7 @@ export function searchSessionTranscripts(params: {
     LIMIT ?
     `);
       const values = [toFtsQuery(query), ...sessionFilterValues, limit + 1];
-      const rows = statement.all(...values) as Array<{
+      type TranscriptSearchRow = {
         message_id: unknown;
         rank: unknown;
         role: unknown;
@@ -107,7 +116,34 @@ export function searchSessionTranscripts(params: {
         session_key: unknown;
         snippet: unknown;
         timestamp: unknown;
-      }>;
+      };
+      let rows = statement.all(...values) as TranscriptSearchRow[];
+      if (rows.length === 0 && CJK_RUN_PATTERN.test(query)) {
+        const likeValues = query.split(/\s+/u).filter(Boolean).map(toLikePattern);
+        if (likeValues.length > 0) {
+          // The zero-hit gate keeps this full scan off every served query; the
+          // LIKE terms reuse the FTS row text so snippet()/filters behave the
+          // same as the MATCH path.
+          const fallbackStatement = database.db.prepare(/* sqlite-allow-raw: FTS5 snippet/LIKE */ `
+      SELECT session_windows.session_key AS session_key, session_transcript_fts.session_id AS session_id,
+        message_id, role, timestamp,
+        snippet(session_transcript_fts, 0, '', '', ' … ', 48) AS snippet
+      FROM session_transcript_fts
+      JOIN session_windows ON session_windows.session_id = session_transcript_fts.session_id
+      WHERE ${likeValues.map(() => "text LIKE ? ESCAPE '\\'").join(" AND ")}${whereSession}
+        AND session_transcript_fts.session_id NOT IN (
+          SELECT session_id FROM session_transcript_index_state WHERE needs_rebuild != 0
+        )
+      ORDER BY timestamp DESC, message_id ASC
+      LIMIT ?
+    `);
+          rows = fallbackStatement.all(
+            ...likeValues,
+            ...sessionFilterValues,
+            limit + 1,
+          ) as TranscriptSearchRow[];
+        }
+      }
       const hits = rows.flatMap((row): SessionTranscriptSearchHit[] => {
         if (
           typeof row.session_key !== "string" ||

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -13,6 +13,9 @@ import {
 } from "./session-transcript-reconcile.js";
 
 const SEARCH_SNIPPET_MAX_CHARS = 500;
+// Roughly matches the MATCH path's 48-token snippet radius for the fallback's
+// char-based excerpt window.
+const SEARCH_EXCERPT_MARGIN_CHARS = 160;
 const SEARCH_LIMIT_MAX = 25;
 const SEARCH_QUERY_MAX_CHARS = 4096;
 // Runs of Han/Kana/Hangul have no spaces for the unicode61 tokenizer to split
@@ -47,6 +50,28 @@ function toFtsQuery(query: string): string {
 
 function toLikePattern(term: string): string {
   return `%${term.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`;
+}
+
+// snippet() needs MATCH phrase locations, which the LIKE retry does not have;
+// cut a bounded window around the first term hit instead so excerpts stay
+// anchored to the match rather than the start of the message.
+function toMatchExcerpt(text: string, terms: string[]): string {
+  const haystack = text.toLowerCase();
+  let index = -1;
+  let matchedLength = 0;
+  for (const term of terms) {
+    const at = haystack.indexOf(term.toLowerCase());
+    if (at !== -1 && (index === -1 || at < index)) {
+      index = at;
+      matchedLength = term.length;
+    }
+  }
+  if (index === -1) {
+    return `${truncateUtf16Safe(text, SEARCH_EXCERPT_MARGIN_CHARS)} …`;
+  }
+  const start = Math.max(0, index - SEARCH_EXCERPT_MARGIN_CHARS);
+  const end = Math.min(text.length, index + matchedLength + SEARCH_EXCERPT_MARGIN_CHARS);
+  return `${start > 0 ? "… " : ""}${text.slice(start, end)}${end < text.length ? " …" : ""}`;
 }
 
 /** Search the per-agent FTS index; kicks off one background reconcile when the index lags. */
@@ -114,34 +139,49 @@ export function searchSessionTranscripts(params: {
         role: unknown;
         session_id: unknown;
         session_key: unknown;
+        raw_text: unknown;
         snippet: unknown;
         timestamp: unknown;
       };
       let rows = statement.all(...values) as TranscriptSearchRow[];
       if (rows.length === 0 && CJK_RUN_PATTERN.test(query)) {
-        const likeValues = query.split(/\s+/u).filter(Boolean).map(toLikePattern);
-        if (likeValues.length > 0) {
-          // The zero-hit gate keeps this full scan off every served query; the
-          // LIKE terms reuse the FTS row text so snippet()/filters behave the
-          // same as the MATCH path.
-          const fallbackStatement = database.db.prepare(/* sqlite-allow-raw: FTS5 snippet/LIKE */ `
+        const terms = query.split(/\s+/u).filter(Boolean);
+        // Only CJK-run terms are unaddressable by the unicode61 tokenizer; the
+        // rest keep their exact-word MATCH semantics so a mixed query like
+        // "会议 cat" cannot widen into a substring match on any term.
+        const cjkTerms = terms.filter((term) => CJK_RUN_PATTERN.test(term));
+        const ftsTerms = terms.filter((term) => !CJK_RUN_PATTERN.test(term));
+        if (cjkTerms.length > 0) {
+          const matchClause = ftsTerms.length > 0 ? "session_transcript_fts MATCH ? AND " : "";
+          // The zero-hit gate keeps this scan off every served query; the LIKE
+          // terms reuse the FTS row text so filters behave like the MATCH path,
+          // and the excerpt is rebuilt around the matched substring.
+          const fallbackStatement = database.db.prepare(/* sqlite-allow-raw: FTS5 MATCH/LIKE */ `
       SELECT session_windows.session_key AS session_key, session_transcript_fts.session_id AS session_id,
         message_id, role, timestamp,
-        snippet(session_transcript_fts, 0, '', '', ' … ', 48) AS snippet
+        session_transcript_fts.text AS raw_text
       FROM session_transcript_fts
       JOIN session_windows ON session_windows.session_id = session_transcript_fts.session_id
-      WHERE ${likeValues.map(() => "text LIKE ? ESCAPE '\\'").join(" AND ")}${whereSession}
+      WHERE ${matchClause}${cjkTerms.map(() => "text LIKE ? ESCAPE '\\'").join(" AND ")}${whereSession}
         AND session_transcript_fts.session_id NOT IN (
           SELECT session_id FROM session_transcript_index_state WHERE needs_rebuild != 0
         )
       ORDER BY timestamp DESC, message_id ASC
       LIMIT ?
     `);
-          rows = fallbackStatement.all(
-            ...likeValues,
+          const fallbackValues = [
+            ...(ftsTerms.length > 0 ? [toFtsQuery(ftsTerms.join(" "))] : []),
+            ...cjkTerms.map(toLikePattern),
             ...sessionFilterValues,
             limit + 1,
-          ) as TranscriptSearchRow[];
+          ];
+          // SAFETY: FTS rows are the fixed column projection selected above, owned by the schema.
+          rows = (fallbackStatement.all(...fallbackValues) as TranscriptSearchRow[]).map((row) =>
+            Object.assign({}, row, {
+              snippet:
+                typeof row.raw_text === "string" ? toMatchExcerpt(row.raw_text, cjkTerms) : "",
+            }),
+          );
         }
       }
       const hits = rows.flatMap((row): SessionTranscriptSearchHit[] => {


### PR DESCRIPTION
Refs #140736 — the issue stays open as the tracking item for the broader CJK recall half, so this PR should not auto-close it.

## What Problem This Solves

Fixes an issue where users searching session transcripts in Chinese, Japanese, or Korean got zero results even for text that is clearly in the history. A query like `会议` matches nothing while English queries over the same sessions work.

## Why This Change Was Made

`session_transcript_fts` is created with `unicode61 remove_diacritics 2`, which keeps a whole run of Han/Kana/Hangul as a single token (nothing to split on), so no exact-phrase term can address text inside such a run. Migrating the index schema would force a full rebuild for every existing agent, so this takes the query-side path instead: when `MATCH` returns zero rows and the query contains a CJK run, only the CJK-run terms are retried with `LIKE` (escaped, AND-combined); non-CJK terms stay on the exact-word `MATCH` path so a mixed query like `会议 cat` cannot widen into a substring match. Same session filter, `needs_rebuild` exclusion, ordering and `LIMIT + 1` as before.

The fallback only fires on a zero-hit query, so it stays off every normally served path.

Scope note: this is the zero-hit mitigation only. The issue's partial-recall half (CJK runs that the tokenizer *did* index but rank poorly) is untouched and the issue stays the tracking item for it.

## User Impact

CJK transcript searches return hits, with excerpts anchored on the matched term instead of the start of the message, and mixed-language queries keep their word-matching semantics.

## Evidence

- New cases in `session-transcript-search.test.ts`: CJK fallback hit with multi-term AND, session-scoped filtering, a non-CJK zero-hit query staying on the MATCH path, a late-message excerpt regression (60 filler words + CJK at the end — fails on the previous head), and a mixed-language false-positive regression (`scattered` must not satisfy `cat` — fails on the previous head).
- Focused runs: session-transcript-search 20/20, embedded-gateway-stub 22/22; oxfmt/oxlint clean; assertion-safety ratchet passes locally (`check-assertion-safety-ratchet --base origin/main`).

### Real-behavior proof (gateway `sessions.search`, no mocks)

Driven against a real agent SQLite store in an isolated state dir through the real gateway handler body (validation → scoping → visibility → `searchSessionTranscripts` → respond). Seeded via the production `appendTranscriptMessage` write path. Before = previous head `c3d52ffc`, after = this head.

After fix, query `会议` (late message: 60 filler words then `明天开会议讨论排期，重点是预算评审`):

```json
{
  "sessionKey": "agent:main:main",
  "sessionId": "proof-late",
  "role": "user",
  "snippet": "… word37 word38 … word59 明天开会议讨论排期，重点是预算评审",
  "score": 0
}
```

Before fix, same query: the excerpt started at token zero and lost the match entirely — `"snippet": "word0 word1 … word47 … "` with no `会议` visible.

Mixed-language check, query `会议 cat` against a transcript `明天开会议讨论 scattered plans`:

- after fix: `{"results": []}` (no substring false positive on "scattered")
- before fix: returned that transcript (`%cat%` matched the substring)

Cost note on the zero-hit scan: the measured ~2ms was on a 2,000-row store seeded through the real write path, worst case (all-CJK query misses everything). The scan is linear in scanned rows, so latency scales with store size; whether that tradeoff is acceptable as an interim mitigation on much larger stores is exactly the owner decision tracked in the review.
