### PR TITLE
fix(crabbox): validate trusted historical pnpm pins

### DIFF
--- a/scripts/crabbox-untrusted-bootstrap.sh
+++ b/scripts/crabbox-untrusted-bootstrap.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 node_version="24.19.0"
 pnpm_spec="pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457"
+# Trusted main's historical pin is needed to validate older contributor heads.
+historical_pnpm_spec="pnpm@12.1.0+sha512.d9b8276d97f6ec86e49815877f91ee9f63cee61f2063b304e43b6dab8fa07ce8a9afd46d2facd39f921e6a9d06b3c75a81349c7b888c2d22886bae0229901037"
 
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <expected-head-sha> <command> [args...]" >&2
@@ -88,6 +90,38 @@ if ! copy_verified_archive "$archive" "$node_sha256" 256; then
   fi
 fi
 
+sudo /usr/bin/env -i PATH=/usr/bin:/bin /bin/bash -s -- \
+  "$install_root" "$tmp_dir/$archive" <<'INSTALL_NODE'
+set -euo pipefail
+umask 022
+install_root="$1"
+archive_path="$2"
+/bin/rm -rf -- "$install_root"
+/usr/bin/mkdir -p "$install_root"
+/usr/bin/tar -xJf "$archive_path" -C "$install_root" --strip-components=1
+INSTALL_NODE
+
+candidate_package_json="$PWD/package.json"
+pnpm_spec="$(
+  cd "$install_root"
+  "$install_root/bin/node" - "$candidate_package_json" "$pnpm_spec" "$historical_pnpm_spec" <<'PACKAGE_MANAGER'
+const fs = require("node:fs");
+const [file, current, historical] = process.argv.slice(2);
+let pkg;
+try {
+  pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+} catch {
+  console.error("refusing untrusted run: invalid package.json");
+  process.exit(1);
+}
+if (pkg?.packageManager !== current && pkg?.packageManager !== historical) {
+  console.error("refusing untrusted run: packageManager pin differs from trusted main or approved history");
+  process.exit(1);
+}
+process.stdout.write(pkg.packageManager);
+PACKAGE_MANAGER
+)"
+
 pnpm_version="${pnpm_spec#pnpm@}"
 pnpm_version="${pnpm_version%%+*}"
 pnpm_native_sha512=""
@@ -110,18 +144,16 @@ fi
 
 # Only public toolchain artifacts need shared access; keep caller state private.
 sudo /usr/bin/env -i PATH=/usr/bin:/bin /bin/bash -s -- \
-  "$install_root" "$corepack_home" "$tmp_dir/$archive" "$pnpm_spec" "$pnpm_seed" "$node_arch" <<'INSTALL'
+  "$install_root" "$corepack_home" "$pnpm_spec" "$pnpm_seed" "$node_arch" <<'INSTALL'
 set -euo pipefail
 umask 022
 install_root="$1"
 corepack_home="$2"
-archive_path="$3"
-pnpm_spec="$4"
-pnpm_seed="$5"
-node_arch="$6"
-/bin/rm -rf -- "$install_root" "$corepack_home"
-/usr/bin/mkdir -p "$install_root" "$corepack_home"
-/usr/bin/tar -xJf "$archive_path" -C "$install_root" --strip-components=1
+pnpm_spec="$3"
+pnpm_seed="$4"
+node_arch="$5"
+/bin/rm -rf -- "$corepack_home"
+/usr/bin/mkdir -p "$corepack_home"
 if [[ -n "$pnpm_seed" ]]; then
   pnpm_version="${pnpm_spec#pnpm@}"
   pnpm_version="${pnpm_version%%+*}"
@@ -144,6 +176,8 @@ fs.writeFileSync(file, JSON.stringify({
 METADATA
   export COREPACK_ENABLE_NETWORK=0
 fi
+# Corepack must select and warm the approved pin outside the untrusted checkout.
+cd "$install_root"
 /usr/bin/env \
   COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   COREPACK_HOME="$corepack_home" \
@@ -154,8 +188,6 @@ fi
   COREPACK_HOME="$corepack_home" \
   PATH="$install_root/bin:/usr/bin:/bin" \
   "$install_root/bin/corepack" prepare "$pnpm_spec" --activate
-# Warm from the trusted tool directory, never the untrusted checkout.
-cd "$install_root"
 /usr/bin/env \
   COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   COREPACK_HOME="$corepack_home" \
@@ -176,7 +208,7 @@ actual_package_manager="$(
     'const fs = require("node:fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); process.stdout.write(pkg.packageManager || "")'
 )"
 if [[ "$actual_package_manager" != "$pnpm_spec" ]]; then
-  echo "refusing untrusted run: packageManager pin differs from trusted main" >&2
+  echo "refusing untrusted run: packageManager pin changed during bootstrap" >&2
   exit 1
 fi
 

--- a/test/scripts/crabbox-untrusted-bootstrap.test.ts
+++ b/test/scripts/crabbox-untrusted-bootstrap.test.ts
@@ -15,6 +15,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const source = readFileSync("scripts/crabbox-untrusted-bootstrap.sh", "utf8");
+const historicalPnpmSpec =
+  "pnpm@12.1.0+sha512.d9b8276d97f6ec86e49815877f91ee9f63cee61f2063b304e43b6dab8fa07ce8a9afd46d2facd39f921e6a9d06b3c75a81349c7b888c2d22886bae0229901037";
 const roots: string[] = [];
 afterEach(() => {
   for (const root of roots.splice(0)) {
@@ -49,12 +51,14 @@ function fixture(scriptSource = source) {
     join(nodeStage, "bin", "corepack"),
     `#!/bin/bash
 set -eu
+echo "$1" >> ${JSON.stringify(join(root, "corepack-log"))}
 case "$1" in
   enable)
     ln -s corepack "$3/pnpm"
     ln -s corepack "$3/pnpx"
     ;;
   prepare)
+    printf '%s\\n' "$2" "$PWD" > ${JSON.stringify(join(root, "prepared-pin"))}
     version="\${2#pnpm@}"
     version="\${version%%+*}"
     if [[ ! -f "$COREPACK_HOME/v1/pnpm/$version/.corepack" ]]; then
@@ -63,6 +67,9 @@ case "$1" in
     ;;
   install)
     [[ "$2" == "--frozen-lockfile" ]]
+    read -r prepared_pin < ${JSON.stringify(join(root, "prepared-pin"))}
+    candidate_pin="$(${JSON.stringify(process.execPath)} -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).packageManager')"
+    [[ "$prepared_pin" == "$candidate_pin" ]]
     echo frozen >> ${JSON.stringify(join(root, "install-log"))}
     ;;
   *) ;;
@@ -173,9 +180,6 @@ describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
     const pnpmSpec = script.match(/^pnpm_spec="([^"]+)"$/mu)?.[1];
 
     expect(pnpmSpec).toBe(packageJson.packageManager);
-    const warmup = script.indexOf('"$install_root/bin/corepack" "$pnpm_spec" --version');
-    expect(warmup).toBeGreaterThan(script.indexOf('cd "$install_root"'));
-    expect(warmup).toBeLessThan(script.indexOf("actual_package_manager="));
   });
 
   it("bounds both IMDSv2 identity requests", () => {
@@ -206,6 +210,21 @@ describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
     expect(readFileSync(join(f.root, "ran"), "utf8")).toBe("ran\nran\n");
   });
 
+  it.each(["current", "historical"])(
+    "prepares the approved %s pin outside the checkout before frozen installation",
+    (kind) => {
+      const f = fixture();
+      const spec = kind === "historical" ? historicalPnpmSpec : f.spec;
+      writeFileSync(join(f.root, "package.json"), JSON.stringify({ packageManager: spec }));
+      const result = f.run();
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(join(f.root, "prepared-pin"), "utf8")).toBe(`${spec}\n${f.install}\n`);
+      expect(f.downloads()).toBe(kind === "historical" ? "pnpm-download\n" : "");
+      expect(readFileSync(join(f.root, "install-log"), "utf8")).toBe("frozen\n");
+      expect(readFileSync(join(f.root, "ran"), "utf8")).toBe("ran\n");
+    },
+  );
+
   it.each(["node", "wrapper", "native", "wrong-arch"])(
     "rejects a %s cache substitution despite forged adjacent metadata",
     (kind) => {
@@ -234,10 +253,28 @@ describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
     },
   );
 
-  it.each(["candidate-pin", "head", "iam"])("rejects %s before workload execution", (kind) => {
+  it.each([
+    "candidate-pin",
+    "missing-pin",
+    "current-wrong-hash",
+    "historical-wrong-hash",
+    "unsupported-historical-pin",
+    "malformed-json",
+    "head",
+    "iam",
+  ])("rejects %s before Corepack setup, installation, or workload execution", (kind) => {
     const f = fixture();
-    if (kind === "candidate-pin") {
-      writeFileSync(join(f.root, "package.json"), '{"packageManager":"pnpm@99.0.0"}');
+    const manifests: Record<string, string> = {
+      "candidate-pin": '{"packageManager":"pnpm@99.0.0"}',
+      "missing-pin": "{}",
+      "current-wrong-hash": JSON.stringify({ packageManager: `${f.spec}0` }),
+      "historical-wrong-hash": JSON.stringify({ packageManager: `${historicalPnpmSpec}0` }),
+      "unsupported-historical-pin": '{"packageManager":"pnpm@11.22.0"}',
+      "malformed-json": "{",
+    };
+    const manifest = manifests[kind];
+    if (manifest !== undefined) {
+      writeFileSync(join(f.root, "package.json"), manifest);
     }
     const result = f.run(
       kind === "iam" ? { FIXTURE_IAM_STATUS: "200" } : {},
@@ -245,12 +282,15 @@ describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
     );
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      kind === "candidate-pin"
-        ? "packageManager pin differs from trusted main"
-        : kind === "head"
-          ? "expected HEAD"
-          : "IAM credentials endpoint returned 200",
+      kind === "head"
+        ? "expected HEAD"
+        : kind === "iam"
+          ? "IAM credentials endpoint returned 200"
+          : kind === "malformed-json"
+            ? "invalid package.json"
+            : "packageManager pin differs from trusted main",
     );
+    expect(existsSync(join(f.root, "corepack-log"))).toBe(false);
     expect(existsSync(join(f.root, "ran"))).toBe(false);
     expect(existsSync(join(f.root, "install-log"))).toBe(false);
   });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/137892
Related: https://github.com/openclaw/openclaw/pull/138819

## What Problem This Solves

Maintainers cannot run isolated proof for older contributor heads that retain the exact pnpm 12.1.0 pin previously used by trusted main. The bootstrap prepares only the current package manager and then rejects those historical manifests.

## Why This Change Was Made

Use the authenticated Node installation to parse the candidate manifest before Corepack setup. Accept only the current full pnpm pin or the exact historical 12.1.0 pin from trusted main, then prepare and warm that selected version outside the candidate checkout.

The existing authenticated archive cache, IAM check, exact-head check, isolated home, frozen installation, and final manifest reread remain in place. Historical native archives are not reused without trusted digests. There is no arbitrary pin override or dependency-manifest change.

## User Impact

Older reviewed contributor heads can use their existing approved package manager in isolated proof without changing dependencies merely to satisfy the bootstrap.

## Evidence

- The historical-pin case failed against the original bootstrap with the intended package-manager admission error.
- All 56 bootstrap and publisher boundary tests passed. After a test-only strict-type correction, all eight affected rejection cases passed again.
- Direct AWS proof ran the real pnpm 12.1.0 frozen install in a synthetic, empty-dependency repository as a non-root user with a root-owned, non-writable Corepack cache.
- The current pnpm 12.3.4 full workspace install and final test-root typecheck passed on a physical AWS checkout. Remaining selected checks passed locally; the shared local dependency symlink was not bypassed.
- Fresh final autoreview found no actionable P0-P2 issues.
- Exact-head hosted CI passed in https://github.com/openclaw/openclaw/actions/runs/34358113767 (attempt 1, head `597a04c10523b01f2aea3d15d9935f807f914302`).

The synthetic install proves toolchain selection and execution, not either linked PR's dependency compatibility or behavior. Those PRs still require their own isolated proof after this bootstrap change lands. No full local build or full local test-suite result is claimed here.
