### PR TITLE
fix(ci): avoid full budgets in stuck SQLite child tests

### DIFF
--- a/src/infra/sqlite-integrity.test.ts
+++ b/src/infra/sqlite-integrity.test.ts
@@ -295,22 +295,53 @@ describe("SQLite integrity child", () => {
     const source = path.join(root, "source.sqlite");
     fs.writeFileSync(source, "retained source");
     const worker = path.join(root, "blocked.mjs");
+    const ready = path.join(root, "ready");
     fs.writeFileSync(
       worker,
-      `process.on('message', () => process.send({ type: 'phase', phase: 'checking' })); process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 35000);`,
+      `import fs from 'node:fs';
+      process.on('SIGTERM', () => {});
+      process.on('message', () => {
+        fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+        process.send({ type: 'phase', phase: 'checking' });
+      });
+      setTimeout(() => process.exit(0), 35000);`,
     );
     vi.spyOn(processUrls, "resolveRuntimeProcessEntrypointUrl").mockReturnValue(
       pathToFileURL(worker),
     );
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    let childClosed: Promise<void> | undefined;
+    let closeSignal: NodeJS.Signals | null | undefined;
+    // Keep native IPC, timeout, and close behavior while shortening only the test wait.
+    vi.mocked(fork).mockImplementationOnce((modulePath, args, options) => {
+      expect(options).toMatchObject({ timeout: 31_000, killSignal: "SIGKILL" });
+      const child = actual.fork(modulePath, args, { ...options, timeout: 2_000 });
+      childClosed = new Promise<void>((resolve) => {
+        child.once("close", (_code, signal) => {
+          closeSignal = signal;
+          resolve();
+        });
+      });
+      return child;
+    });
     const started = performance.now();
-    await expect(
-      assertSqliteIntegrityInWorker(source, 250, new AbortController().signal),
-    ).rejects.toThrow(
-      `SQLite integrity check timed out after 31 seconds (budget for 15 B) for ${source}. Stop the Gateway service and other OpenClaw processes using this database, then retry; if already stopped, check storage performance. (lastObservedPhase=checking)`,
-    );
-    expect(performance.now() - started).toBeLessThan(33_000);
-    expect(fs.readFileSync(source, "utf8")).toBe("retained source");
-  }, 40_000);
+    try {
+      await expect(
+        assertSqliteIntegrityInWorker(source, 250, new AbortController().signal).finally(() => {
+          // Ownership must end after close, not merely after requesting termination.
+          expect(closeSignal).toBe("SIGKILL");
+        }),
+      ).rejects.toThrow(
+        `SQLite integrity check timed out after 31 seconds (budget for 15 B) for ${source}. Stop the Gateway service and other OpenClaw processes using this database, then retry; if already stopped, check storage performance. (lastObservedPhase=checking)`,
+      );
+      expect(performance.now() - started).toBeLessThan(8_000);
+      expect(fs.readFileSync(ready, "utf8")).toBe("ready");
+      expect(fs.readFileSync(source, "utf8")).toBe("retained source");
+    } finally {
+      await childClosed;
+      vi.mocked(fork).mockReset().mockImplementation(actual.fork);
+    }
+  }, 10_000);
 
   it.each([
     { messages: [{ type: "phase", phase: "checking" }], completes: false },

--- a/src/infra/sqlite-readonly-location.cancellation.test.ts
+++ b/src/infra/sqlite-readonly-location.cancellation.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -18,7 +19,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
   processMocks.execFile.mockImplementation(actual.execFile);
   Object.defineProperties(processMocks.execFile, Object.getOwnPropertyDescriptors(actual.execFile));
-  return { ...actual, execFile: processMocks.execFile };
+  return { ...actual, execFile: processMocks.execFile, spawnSync: vi.fn(actual.spawnSync) };
 });
 
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
@@ -31,6 +32,7 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
 let cacheRoot: string;
 beforeEach(() => {
   processMocks.execFile.mockClear();
+  vi.mocked(spawnSync).mockClear();
   cacheRoot = tempDirs.make("openclaw-readonly-cancellation-cache-");
   vi.stubEnv("XDG_CACHE_HOME", cacheRoot);
 });
@@ -139,28 +141,69 @@ describe("read-only snapshot deadline", () => {
       const root = tempDirs.make("openclaw-snapshot-timeout-");
       vi.stubEnv("XDG_CACHE_HOME", root);
       const worker = path.join(root, "blocked.mjs");
+      const ready = path.join(root, "ready");
       fs.writeFileSync(
         worker,
         `import fs from 'node:fs'; import path from 'node:path';
-      if (process.argv[5]) fs.writeFileSync(path.join(process.argv[5], 'partial.sqlite'), 'partial');
       process.on('SIGTERM', () => {});
+      fs.writeFileSync(path.join(process.argv[5], 'partial.sqlite'), 'partial');
+      fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
       setTimeout(() => process.exit(0), 35000);`,
       );
       vi.spyOn(workerUrls, "resolveRuntimeWorkerUrl").mockReturnValue(pathToFileURL(worker));
       const source = path.join(root, "source.sqlite");
       fs.writeFileSync(source, "source must stay unchanged");
+      const actual =
+        await vi.importActual<typeof import("node:child_process")>("node:child_process");
+      let childClosed: Promise<void> | undefined;
+      let closeSignal: NodeJS.Signals | null | undefined;
+      // Exercise native termination and cleanup without waiting out the production budget.
+      if (mode === "sync") {
+        vi.mocked(spawnSync).mockImplementationOnce((command, args, options) => {
+          expect(options).toMatchObject({ timeout: 31_000, killSignal: "SIGKILL" });
+          const result = actual.spawnSync(command, args, { ...options, timeout: 2_000 });
+          expect(result.error).toMatchObject({ code: "ETIMEDOUT" });
+          closeSignal = result.signal;
+          return result;
+        });
+      } else {
+        processMocks.execFile.mockImplementationOnce((file, args, options, callback) => {
+          expect(options).toMatchObject({ timeout: 31_000, killSignal: "SIGKILL" });
+          const child = actual.execFile(file, args, { ...options, timeout: 2_000 }, callback);
+          childClosed = new Promise<void>((resolve) => {
+            child.once("close", (_code, signal) => {
+              closeSignal = signal;
+              resolve();
+            });
+          });
+          return child;
+        });
+      }
       const started = performance.now();
       const run = async () =>
         mode === "sync"
           ? prepareSqliteReadOnlyLocationSync(source)
           : prepareSqliteReadOnlyLocation(source);
-      await expect(run()).rejects.toThrow(
-        /timed out after 31 seconds \(budget for 26 B\).*Stop the Gateway service/,
-      );
-      expect(performance.now() - started).toBeLessThan(33_000);
-      expect(fs.readFileSync(source, "utf8")).toBe("source must stay unchanged");
-      expect(fs.readdirSync(path.join(root, "openclaw"))).toEqual([]);
+      try {
+        await expect(
+          run().finally(() => {
+            // Check at settlement, before the finally block joins for failed-test cleanup.
+            expect(closeSignal).toBe("SIGKILL");
+          }),
+        ).rejects.toThrow(
+          /timed out after 31 seconds \(budget for 26 B\).*Stop the Gateway service/,
+        );
+        expect(performance.now() - started).toBeLessThan(8_000);
+        expect(fs.readFileSync(ready, "utf8")).toBe("ready");
+        expect(fs.readFileSync(source, "utf8")).toBe("source must stay unchanged");
+        expect(fs.readdirSync(path.join(root, "openclaw"))).toEqual([]);
+      } finally {
+        await childClosed;
+        // execFile's copied prototype must not become its own parent during reset.
+        processMocks.execFile.mockReset().mockImplementation(actual.execFile.bind(undefined));
+        vi.mocked(spawnSync).mockReset().mockImplementation(actual.spawnSync);
+      }
     },
-    40_000,
+    10_000,
   );
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CI spends 93 seconds of aggregate test time waiting for deliberately stuck SQLite child processes across three regression cases.

Observed during the [main CI latency audit](https://github.com/openclaw/openclaw/actions/runs/34354161815). This is a maintainer-requested latency improvement, not a workaround for an existing main failure.

## Why This Change Was Made

Use the existing forwarding-spy pattern to shorten only the native child timeout in these tests from 31 seconds to 2 seconds. Each override first verifies the unchanged production budget and `SIGKILL` setting.

The fixtures still launch real SIGTERM-resistant processes. Startup markers survive staging cleanup, asynchronous assertions require actual close before the operation settles, and cleanup joins children and restores the one-shot overrides. Source preservation, unpublished-snapshot cleanup, production-budget diagnostics, and the integrity worker's `lastObservedPhase=checking` assertion remain covered.

## User Impact

Shorter CI test execution without changing production behavior, runner allocation, shard counts, or concurrency. The three deliberate waits drop by about 87 seconds in aggregate; this is not a claim of an equivalent end-to-end CI wall-clock reduction.

## Evidence

- Four owner/sibling test files passed together: 105 tests passed, with one Linux-only POSIX-lock test skipped on macOS.
- The three deadline cases completed in approximately 2.01 seconds each.
- Targeted formatting, targeted oxlint, and `git diff --check` passed.
- Fresh autoreview was scoped-clean through P2.
- The changed-file classifier selected `coreTests`. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34358050503), including the changed-test lanes, `check-test-types`, and `openclaw/ci-gate`. This supplies the typecheck proof that the local borrowed dependency isolation guard could not provide.
- Independent final review cleared the exact head. [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/143130#issuecomment-5602860193) found no actionable findings or pre-merge work.
- No Testbox was allocated: the installed Crabbox version is below the current repository minimum.
- Changed scope: two test files, 92 lines added and 18 removed; production LOC delta is zero.
