### PR TITLE
test(gateway): wait for stream diagnostics before ending each fixture

### DIFF
--- a/src/gateway/desktop/node-stream-broker.test.ts
+++ b/src/gateway/desktop/node-stream-broker.test.ts
@@ -47,7 +47,13 @@ async function startBrokerServer(params: {
       connId === params.session.connId && (await (params.pairingCurrent?.() ?? true)),
   };
   const server = http.createServer();
+  const upgradedSocketsClosed: Promise<void>[] = [];
   server.on("upgrade", (req, socket, head) => {
+    upgradedSocketsClosed.push(
+      new Promise<void>((resolve) => {
+        socket.once("close", () => resolve());
+      }),
+    );
     void params.broker.handleUpgrade(req, socket, head, registry as never);
   });
   await new Promise<void>((resolve) => {
@@ -57,12 +63,13 @@ async function startBrokerServer(params: {
   if (!address || typeof address === "string") {
     throw new Error("expected broker test address");
   }
-  cleanups.push(
-    async () =>
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      }),
-  );
+  cleanups.push(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    // HTTP close excludes upgraded sockets; their late diagnostics belong to this test.
+    await Promise.all(upgradedSocketsClosed);
+  });
   return `ws://127.0.0.1:${address.port}`;
 }
 


### PR DESCRIPTION
Related: #142242, #134931

## What Problem This Solves

Fixes a desktop stream test fixture that can attribute a previous connection's close diagnostic to the next test. This blocked CI for the separately reviewed workspace-manifest compression fix in #142242: the actual cancelled client closed with 1008, but the next test captured an earlier connection's 1006 diagnostic.

## Why This Change Was Made

HTTP server shutdown does not wait for upgraded sockets, and client termination returns before the server observes closure. The fixture now records each upgraded socket's close promise before broker handoff and joins those promises during cleanup, before diagnostic capture is flushed and reset.

## User Impact

No production behavior changes. Existing stream cancellation, idle connection, backpressure and diagnostic assertions remain unchanged; this makes their execution order reliable.

## Evidence

A real loopback probe in the original test order, without scheduler mocks or inserted delays, reproduced previous-connection diagnostic leakage in 25/25 runs with the old cleanup and 0/25 with this fix. Current-connection close codes remained 1008. The complete existing test file passes all 19 cases. Full changed checks and independent P2 review pass with no findings, including review of the installed WebSocket receiver completion order.

This is a one-file fixture repair required to validate #142242, split from that production PR. The PR does not increase timeouts, relax assertions, suppress diagnostics or change runtime code.
