### PR TITLE
fix(ci): prevent systemd shim timing flakes

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7789,9 +7789,11 @@ done
     const { readSystemdServiceExecStart } =
       await import("../../src/daemon/systemd-service-files.js");
     expect(
+      // The production 5s deadline budgets for native busctl; the Node shim's cold
+      // spawn can exceed its per-call slice under load, so widen it here.
       await readSystemdServiceExecStart(
         { HOME: home, PATH: `${binDir}:${process.env.PATH}`, OPENCLAW_SYSTEMD_UNIT: serviceName },
-        { requireEffective: true },
+        { requireEffective: true, timeoutMs: 30_000 },
       ),
     ).toMatchObject({
       programArguments,
@@ -7833,7 +7835,9 @@ done
     };
     const { readSystemdServiceExecStart } =
       await import("../../src/daemon/systemd-service-files.js");
-    expect(await readSystemdServiceExecStart(env, { requireEffective: true })).toBeNull();
+    expect(
+      await readSystemdServiceExecStart(env, { requireEffective: true, timeoutMs: 30_000 }),
+    ).toBeNull();
     const loadArgs = [
       "--user",
       "--json=short",
@@ -7865,7 +7869,10 @@ done
       unitPath,
       "[Service]\nExecStart=/usr/bin/node /opt/profile/openclaw.mjs gateway\nEnvironment=OLD=stale\nEnvironment=\nEnvironment=KEEP=current REMOVE=value\nUnsetEnvironment=KEEP\nUnsetEnvironment=\nUnsetEnvironment=REMOVE\nEnvironmentFile=/missing/required.env\nEnvironmentFile=\n",
     );
-    const command = await readSystemdServiceExecStart(env, { requireEffective: true });
+    const command = await readSystemdServiceExecStart(env, {
+      requireEffective: true,
+      timeoutMs: 30_000,
+    });
     expect(command?.sourcePath).toBe(unitPath);
     expect(command?.environment).toEqual({ KEEP: "current" });
     rmSync(unitPath);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the tooling Docker test shard could fail while inspecting a
missing systemd unit when host load made the Node-based `busctl` fixture exceed
the production deadline's first per-call slice.

## Why This Change Was Made

The affected integration tests now pass an explicit 30-second manager-read
budget to their Node-shim-backed calls. Production systemd deadlines, fixture
behavior, and all result assertions remain unchanged.

## User Impact

CI no longer reports a false systemd inspection failure when the test fixture's
Node process starts slowly. There is no runtime product behavior change.

## Evidence

- Pre-fix focused reproduction failed twice after about 1.7-1.9 seconds with
  `Effective systemd service command could not be inspected`.
- Both affected focused tests pass after the change.
- The full 297-test file completed cleanly twice after one unrelated,
  non-reproducing first-run failure elsewhere in the file.
- Changed-gate lanes passed except the worktree test-root typecheck wrapper,
  which rejected the shared `node_modules` symlink before compilation.
- Direct test-root `tsgo` reported no errors in the edited file.
- `git diff --check` is clean.
- Independent final autoreview is scoped-clean at P0-P2.
