### PR TITLE
fix(update): repair young runs after recorded drivers exit

### DIFF
--- a/docs/cli/update/repair-and-recovery.md
+++ b/docs/cli/update/repair-and-recovery.md
@@ -94,9 +94,11 @@ repair records `failed` / `abandoned` and exits successfully without Doctor,
 maintenance, or a service stop. It also acknowledges a Gateway-reconciled row
 once within 30 minutes of reconciliation. Later repair invocations use full
 finalization, so historical recovery cannot suppress plugin convergence.
-Explicit recovery permits identityless historical rows only
-after more than 30 minutes of inactivity; a recorded live or uninspectable driver
-still blocks recovery. JSON output identifies reconciled run IDs in
+Explicit recovery does not wait 30 minutes when every recorded updater process
+is provably dead (its PID is gone or its process-start identity has changed).
+Identityless rows and runs with an unrecorded adopter still require more than
+30 minutes of inactivity; a recorded live or uninspectable driver blocks recovery.
+JSON output identifies reconciled run IDs in
 `reconciledRuns`, with `status: "ok"`, `mode: "repair"`, and `restart: false`.
 
 Explicit channel or capability changes and known incomplete post-core work use

--- a/docs/reference/database-schemas/layout.md
+++ b/docs/reference/database-schemas/layout.md
@@ -199,7 +199,9 @@ Reconciliation writes status `failed`, reason `abandoned`, and a retained
 `operator-reconciled-inactive-run`. All unfinished steps become terminal, and
 history is retained. Explicit `update repair` can reconcile inactive identityless
 rows when the current Gateway generation is healthy and no post-core repair is
-pending. It cannot override a live or inconclusive recorded driver. The
+pending. When every recorded driver is positively dead and no
+`driver:identity-unavailable` marker exists, explicit recovery does not require
+the inactivity window. It cannot override a live or inconclusive recorded driver. The
 [2026.9.2 updater](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command.ts#L465)
 does not record adoption: package-manager and registry preflight can
 leave a live updater at its single `requested/in_progress` step. Older writers

--- a/src/cli/update-cli/update-repair-command.test.ts
+++ b/src/cli/update-cli/update-repair-command.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -63,10 +64,24 @@ const tempDirs = createTempDirTracker();
 const now = Date.now();
 
 function seedRun(
-  params: { phase?: UpdateRunRecord["phase"]; liveDriver?: boolean; ageMs?: number } = {},
+  params: {
+    phase?: UpdateRunRecord["phase"];
+    driver?: "live" | "exited" | "reused";
+    ageMs?: number;
+  } = {},
 ) {
   vi.mocked(Date.now).mockReturnValue(now - (params.ageMs ?? 3_600_000));
-  const driver = params.liveDriver ? readUpdateRunDriver() : undefined;
+  let driver = params.driver ? readUpdateRunDriver() : undefined;
+  if (params.driver && !driver) {
+    throw new Error("Test process identity is unavailable");
+  }
+  if (driver && params.driver === "exited") {
+    const child = spawnSync(process.execPath, ["-e", ""], { timeout: 5_000 });
+    expect(child.status).toBe(0);
+    driver = { ...driver, pid: child.pid };
+  } else if (driver && params.driver === "reused") {
+    driver = { ...driver, startIdentity: String(Number(driver.startIdentity) + 1) };
+  }
   const run = createUpdateRun({
     trigger: "control-ui",
     before: { version: "2026.9.2" },
@@ -132,6 +147,31 @@ describe("update repair ledger recovery", () => {
     },
   );
 
+  it.each(["exited", "reused"] as const)(
+    "repairs a young requested row with a dead driver (%s) without maintenance",
+    async (driver) => {
+      const run = seedRun({ driver, ageMs: 60_000 });
+
+      await runRegisteredCli({ register: registerUpdateCli, argv: ["update", "repair"] });
+
+      expect(getUpdateRun(run.runId)).toMatchObject({
+        status: "failed",
+        phase: "finished",
+        reason: "abandoned",
+        steps: expect.arrayContaining([
+          expect.objectContaining({ step: "reconcile:acknowledged", status: "completed" }),
+        ]),
+      });
+      expect(listUpdateRuns({ active: true })).toEqual([]);
+      expect(listUpdateRuns()).toHaveLength(1);
+      expect(mocks.finalize).not.toHaveBeenCalled();
+      expect(mocks.runtime.log).toHaveBeenCalledWith(
+        "Gateway is healthy. Reconciled 1 abandoned update run. No maintenance or service restart was needed.",
+      );
+      expect(mocks.runtime.exit).not.toHaveBeenCalledWith(1);
+    },
+  );
+
   it("exits successfully when the Gateway already reconciled the abandoned row", async () => {
     const run = seedRun();
     finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
@@ -181,11 +221,14 @@ describe("update repair ledger recovery", () => {
 
   it.each([
     { label: "recent request", ageMs: 60_000 },
-    { label: "live driver", phase: "staging" as const, liveDriver: true },
+    { label: "live driver", phase: "staging" as const, driver: "live" as const },
+    { label: "young live driver", ageMs: 60_000, driver: "live" as const },
   ])("leaves a $label alone without entering maintenance", async (fixture) => {
     const run = seedRun(fixture);
 
-    await expect(updateRepairCommand({})).rejects.toThrow("still in progress");
+    await expect(updateRepairCommand({})).rejects.toThrow(
+      `Update ${run.runId} is still in progress (${run.phase}); its driver is live or abandonment is not established. Wait for that update before running update repair.`,
+    );
 
     expect(getUpdateRun(run.runId)).toEqual(run);
     expect(mocks.finalize).not.toHaveBeenCalled();

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -90,6 +90,8 @@ describe("abandoned update runs", () => {
         options,
       );
     }
+    inspection.mockReturnValue(Number(parent.startIdentity) + 1);
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
     vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 1_000);
     inspection.mockReturnValue(Number(parent.startIdentity));
     expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
@@ -168,14 +170,17 @@ describe("abandoned update runs", () => {
     expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
   });
 
-  it("preserves a recent run even when its driver exited", () => {
+  it("requires explicit recovery for a recent run whose driver exited", () => {
     const options = isolatedOptions();
     const run = createUpdateRun({ trigger: "cli", origin: { driver: exitedDriver() } }, options);
     vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS - 1);
 
-    expect(inspectUpdateRunAbandonment(run, { explicit: true })).toBeUndefined();
-    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+    expect(inspectUpdateRunAbandonment(run)).toBeUndefined();
+    expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
     expect(getUpdateRun(run.runId, options)).toEqual(run);
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toMatchObject([
+      { runId: run.runId, phase: "finished", status: "failed", reason: "abandoned" },
+    ]);
   });
 
   it.each([false, true])("preserves an aged live staging driver with explicit=%s", (explicit) => {
@@ -320,12 +325,13 @@ describe("abandoned update runs", () => {
     },
   );
 
-  it("rechecks current activity when a previously stale run advanced", () => {
+  it("rechecks current ownership when a previously stale run was adopted", () => {
     const options = isolatedOptions();
     const run = createUpdateRun({ trigger: "cli", origin: { driver: exitedDriver() } }, options);
     vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 1);
     expect(inspectUpdateRunAbandonment(run)).toBe("inactive-driver-dead");
 
+    adoptUpdateRun(run.runId, options);
     const advanced = recordUpdateRunStep(
       run.runId,
       { step: "build", status: "completed", endedAtMs: Date.now() },
@@ -463,9 +469,13 @@ describe("abandoned update runs", () => {
     expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
   });
 
-  it.each(["alive", "unknown", "dead"] as const)(
-    "reconciles a dead current driver only when its previous driver is also dead (%s)",
-    (liveness) => {
+  it.each(
+    (["alive", "unknown", "dead"] as const).flatMap((liveness) =>
+      [60_000, ABANDONED_UPDATE_RUN_MS + 10].map((ageMs) => ({ liveness, ageMs })),
+    ),
+  )(
+    "reconciles only when the previous driver is also dead ($liveness, age=$ageMs)",
+    ({ liveness, ageMs }) => {
       const options = isolatedOptions();
       const previous =
         liveness === "alive"
@@ -477,7 +487,7 @@ describe("abandoned update runs", () => {
         { trigger: "cli", origin: { driver: exitedDriver(), previousDrivers: [previous] } },
         options,
       );
-      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+      vi.advanceTimersByTime(ageMs);
       const reconciled = reconcileAbandonedUpdateRuns({ explicit: true }, options);
       expect(reconciled).toHaveLength(liveness === "dead" ? 1 : 0);
       expect(getUpdateRun(run.runId, options)?.status).toBe(

--- a/src/infra/update-run-activity.ts
+++ b/src/infra/update-run-activity.ts
@@ -42,14 +42,21 @@ export function inspectUpdateRunAbandonment(
   record: UpdateRunRecord,
   input: { explicit?: boolean } = {},
 ): string | undefined {
-  const lastActivity = updateRunLastActivity(record);
-  if (record.status !== "running" || Date.now() - lastActivity <= ABANDONED_UPDATE_RUN_MS) {
+  if (record.status !== "running") {
     return undefined;
   }
-  if (!input.explicit && record.steps.some((step) => step.step === "driver:identity-unavailable")) {
+  const identityUnavailable = record.steps.some(
+    (step) => step.step === "driver:identity-unavailable",
+  );
+  if (!input.explicit && identityUnavailable) {
     return undefined;
   }
   const drivers = recordedUpdateRunDrivers(record);
+  // Explicit repair need not wait for dead drivers, but an unrecorded adopter may still be working.
+  const requiresInactivity = !input.explicit || !drivers.length || identityUnavailable;
+  if (requiresInactivity && Date.now() - updateRunLastActivity(record) <= ABANDONED_UPDATE_RUN_MS) {
+    return undefined;
+  }
   if (drivers.length) {
     return drivers.every((driver) => inspectUpdateRunDriver(driver) === "dead")
       ? "inactive-driver-dead"


### PR DESCRIPTION
Fixes #141617
Refs #141562

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw update repair` would be told an update was still in progress for 30 minutes after its recorded updater had exited, even when the Gateway was healthy on the installed version and build. The abandoned `requested/running` row kept the update-in-progress state visible across reconnects.

## Why This Change Was Made

Explicit reconciliation now checks recorded process ownership without requiring inactivity when every recorded driver is provably dead and no adopter is marked `driver:identity-unavailable`. Missing PIDs and changed process-start identities use the existing liveness checks. The ledger rechecks ownership in its terminal write transaction, preserves the original history as `failed/abandoned`, and the existing repair path acknowledges the outcome without entering Doctor, maintenance, or failure triage.

Identityless rows and rows marked `driver:identity-unavailable` retain the inactivity requirement. Live or uninspectable recorded drivers still block repair. Automatic reconciliation, post-core convergence, schema, and retention behavior are unchanged. Documentation explains the explicit-repair rule.

## User Impact

Operators can immediately clear a young abandoned update with `openclaw update repair` when its recorded drivers are dead and the installed Gateway generation is healthy. No service stop, database deletion, or coding-agent launch is needed for ledger-only recovery. Reconnects read the terminal outcome; they cannot recreate the old running row.

## Evidence

Added public-command coverage using real SQLite state and real local process inspection, with controlled Gateway health responses. It covers an exited child PID, a reused PID identity, and a young live driver. Extended existing ledger coverage for young retained parents, an unrecorded adopter, and adoption between inspection and reconciliation.

Before changing production code:

```text
node scripts/run-vitest.mjs src/cli/update-cli/update-repair-command.test.ts
Tests  2 failed | 39 passed (41)
Expected: phase=finished, status=failed, reason=abandoned
Received: phase=requested, status=running, reason=null
```

Both failures were the new young/dead-driver regressions. The young live-driver refusal already passed.

After the repair:

```text
node scripts/run-vitest.mjs src/cli/update-cli/update-repair-command.test.ts src/infra/update-run-abandonment.test.ts src/infra/update-run-driver.test.ts src/infra/update-run-ledger.test.ts src/commands/status.update-ledger.test.ts src/cli/update-cli/status.test.ts
Tests  83 passed + 45 passed + 12 passed (140 total)

node scripts/run-vitest.mjs src/gateway/update-run-watcher.test.ts src/gateway/update-run-notice.test.ts src/gateway/server-restart-update-run.test.ts
Tests  24 passed (24)
```

The command regression verifies the original row becomes terminal and acknowledged, no replacement row is created, no full finalizer is invoked, and the user sees the no-maintenance success message. Existing watcher tests verify terminal broadcasts and polling cessation; ledger tests preserve first-terminal-wins and reject later adoption.

Additional checks passed before a documentation-only rebase: `node scripts/check-changed.mjs` (format, core/test types, lint, ratchets, and architecture guards), `pnpm docs:check-mdx` (1,196 files), and `git diff --check`. The first changed-file run found one formatting issue, corrected with the repository formatter before the successful rerun.

Main moved the database reference into topic pages while CI ran. The explanation now lives in `docs/reference/database-schemas/layout.md`; production and test files are byte-identical across the rebase. Final-head verification reran `node scripts/run-vitest.mjs src/cli/update-cli/update-repair-command.test.ts src/infra/update-run-abandonment.test.ts` (84 passed), checked formatting on the relocated page, and passed `pnpm docs:check-mdx` (1,215 files) and `git diff HEAD^ HEAD --check`.

The final-head changed-file gate also passed:

```text
node scripts/check-changed.mjs -- docs/cli/update/repair-and-recovery.md docs/reference/database-schemas/layout.md src/cli/update-cli/update-repair-command.test.ts src/infra/update-run-abandonment.test.ts src/infra/update-run-activity.ts
Exit code 0
```

Exact-head CI is blocked by [checks-node-changed-extensions-bundle-10](https://github.com/openclaw/openclaw/actions/runs/34363328636/job/102505945003), with the required CI gate failing as a consequence. The failed test is the unchanged `extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts` case `runs and cancels ephemeral side forks without changing the parent`:

```text
CodexAppServerLocalRequestCancellationError: turn/start aborted
code: CODEX_APP_SERVER_LOCAL_REQUEST_CANCELLED
Tests  1 failed | 257 passed (258)
```

Its stack runs through the Codex attempt deadline handler; this native side-fork path does not exercise update repair. The affected test and deadline/client files are unchanged from this branch's original base. The underlying native-test failure still needs separate diagnosis; no timeout, assertion, or CI retry was changed to conceal it. All PR checks have settled.

Validation limitations: Gateway probes are controlled boundary tests, not a live macOS/Homebrew or Raspberry Pi upgrade. Driver metadata has no separate boot ID or executable identity; a coincident PID/start identity after reboot remains conservatively protected. A terminal abandoned outcome may remain as a dismissible history card, but it is no longer an update-in-progress card.
