### PR TITLE
fix(update): preserve post-core handoff across pnpm generations

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -151,6 +151,11 @@ chained after the update. After a handoff result, use the printed follow-up comm
 for the final outcome. Plain terminal updates remain synchronous, and `--no-restart`
 does not authorize stopping the agent's Gateway.
 
+Post-core steps follow the verified replacement package, including pnpm updates
+that change the target of the global package link. The helper retains the
+original installation identity for recovery; a child running from a different
+installation is still rejected.
+
 The Gateway core auto-updater requires a managed service restart path. It hands
 the CLI update to a detached helper before activation. A foreground
 Gateway keeps update hints but leaves installation and activation to the

--- a/src/cli/update-cli/update-command-post-core-root.test.ts
+++ b/src/cli/update-cli/update-command-post-core-root.test.ts
@@ -1,0 +1,120 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writePackageRoot } from "../../infra/package-update-steps.test-support.js";
+import {
+  CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
+  readControlPlaneUpdateSentinelMeta,
+} from "../../infra/update-control-plane-sentinel.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), root: vi.fn<() => Promise<string>>() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: (command: string, args: string[], options: import("node:child_process").SpawnOptions) =>
+      args[1] === "update"
+        ? mocks.spawn(command, args, options)
+        : original.spawn(command, args, options),
+  };
+});
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
+  resolveUpdateRoot: mocks.root,
+}));
+// This boundary test never inspects or changes an operator's service.
+vi.mock("./update-command-service-plan.js", () => ({
+  resolveManagedServicePackageUpdatePlan: async () => ({ rootRedirect: null }),
+}));
+
+import { continuePostCoreUpdateInFreshProcess } from "./update-command-post-core.js";
+import { prepareUpdateCommand } from "./update-command-run.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("managed post-core root handoff", () => {
+  it.each([false, true])(
+    "binds pnpm replacement to the activated generation (foreign child=%s)",
+    async (foreignChild) => {
+      const state = await createOpenClawTestState({ label: "post-core-root" });
+      try {
+        await state.writeConfig({});
+        const globalRoot = state.path("pnpm", "global", "5", "node_modules");
+        const previous = path.join(
+          globalRoot,
+          ".pnpm",
+          "openclaw@1.0.0",
+          "node_modules",
+          "openclaw",
+        );
+        const next = path.join(globalRoot, ".pnpm", "openclaw@2.0.0", "node_modules", "openclaw");
+        const root = path.join(globalRoot, "openclaw");
+        await writePackageRoot(previous, "1.0.0");
+        await writePackageRoot(next, "2.0.0");
+        await fs.symlink(previous, root, process.platform === "win32" ? "junction" : "dir");
+        const meta = {
+          root: await fs.realpath(root),
+          handoffId: "fixture-handoff",
+          runId: "fixture-run",
+          serviceStoppedAtMs: 123,
+          note: "Fixture update",
+        };
+        const metaPath = await state.writeJson("sentinel-meta.json", { version: 1, meta });
+        await withEnvAsync({ [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath }, async () => {
+          mocks.root.mockResolvedValue(root);
+          await prepareUpdateCommand({ json: true });
+          // pnpm keeps the global link name while replacing its versioned target.
+          await fs.unlink(root);
+          await fs.symlink(next, root, process.platform === "win32" ? "junction" : "dir");
+          const foreign = state.path("different-install");
+          await writePackageRoot(foreign, "2.0.0");
+          mocks.root.mockResolvedValue(foreignChild ? foreign : root);
+          let childError: unknown;
+          let childMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>> = null;
+          mocks.spawn.mockImplementation(
+            (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+              const child = new EventEmitter();
+              void withEnvAsync(options.env, async () => {
+                childMeta = await readControlPlaneUpdateSentinelMeta();
+                await prepareUpdateCommand({ json: true });
+              }).then(
+                () => child.emit("exit", 0, null),
+                (error: unknown) => {
+                  childError = error;
+                  child.emit("exit", 1, null);
+                },
+              );
+              return child;
+            },
+          );
+          const result = await continuePostCoreUpdateInFreshProcess({
+            root,
+            channel: "stable",
+            requestedChannel: null,
+            opts: { json: true },
+            pluginInstallRecords: {},
+            updateStartedAtMs: 123,
+            timeoutMs: 15_000,
+          });
+          if (foreignChild) {
+            expect(String(childError)).toContain("Managed update handoff root mismatch");
+            expect(result).toEqual({ resumed: false, exitCode: 1 });
+          } else {
+            expect(childError).toBeUndefined();
+            expect(result).toEqual({ resumed: true });
+          }
+          expect(childMeta).toMatchObject({ ...meta, root: await fs.realpath(next) });
+          expect(await readControlPlaneUpdateSentinelMeta()).toMatchObject(meta);
+          expect(JSON.parse(await fs.readFile(metaPath, "utf8"))).toEqual({ version: 1, meta });
+        });
+      } finally {
+        await state.cleanup();
+      }
+    },
+  );
+});

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -19,7 +19,13 @@ import { formatErrorMessage, hasErrnoCode } from "../../infra/errors.js";
 import { readJsonIfExists, writeJson } from "../../infra/json-files.js";
 import type { UpdateChannel } from "../../infra/update-channels.js";
 import { compareSemverStrings } from "../../infra/update-check.js";
-import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
+import {
+  CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
+  readControlPlaneUpdateSentinelMeta,
+  UPDATE_RUN_ID_ENV,
+  type ControlPlaneUpdateSentinelMetaFile,
+} from "../../infra/update-control-plane-sentinel.js";
+import { resolveUpdateInstallRoot } from "../../infra/update-install-root.js";
 import {
   buildPostCoreHandoffEnv,
   POST_CORE_UPDATE_ENV,
@@ -365,6 +371,18 @@ export async function continuePostCoreUpdateInFreshProcess(params: {
       requestedChannel: params.requestedChannel,
       sourceConfigPath: params.preUpdateConfig ? sourceConfigPath : undefined,
     });
+    const sentinelMeta = await readControlPlaneUpdateSentinelMeta(baseEnv);
+    if (sentinelMeta?.root) {
+      // Activation can replace a pnpm generation. Bind only this child to the
+      // activated root; the helper retains its original recovery/lease identity.
+      const sentinelPath = path.join(resultDir, "sentinel-meta.json");
+      const sentinel: ControlPlaneUpdateSentinelMetaFile = {
+        version: 1,
+        meta: { ...sentinelMeta, root: resolveUpdateInstallRoot(params.root) },
+      };
+      await fs.writeFile(sentinelPath, JSON.stringify(sentinel), { mode: 0o600 });
+      handoffEnv[CONTROL_PLANE_UPDATE_SENTINEL_META_ENV] = sentinelPath;
+    }
     const child = spawn(nodeRunner, argv, {
       stdio: childStdio,
       env: {


### PR DESCRIPTION
Refs #142715

## What Problem This Solves

Fixes an issue where managed pnpm updates can reject the post-core CLI after successfully replacing the package. The global `openclaw` link can retain its path while its canonical version directory changes; the next CLI then reports `Managed update handoff root mismatch` against the previous generation.

## Why This Change Was Made

The post-core launcher now gives its child a private copy of the existing handoff metadata bound to the activated package root. The helper's original metadata and recovery/lease identity remain unchanged, and the child still rejects a different installation. No recovery guard, state schema, configuration option, or protocol changes.

## User Impact

Post-core plugin convergence can continue across a legitimate pnpm generation replacement instead of failing the root check. The existing verified-recovery requirements remain in force.

## Evidence

The regression uses real package directories and replaces a global symlink, then runs the actual post-core producer and CLI admission consumer through a substituted spawn boundary. It verifies both acceptance of the replacement and rejection of a foreign installation, plus preservation of the original helper metadata.

With the production fix reversed, the regression fails with `Managed update handoff root mismatch`: the expected root ends in `.pnpm/openclaw@1.0.0/node_modules/openclaw`, while the unchanged global link resolves to the 2.0.0 generation. With the fix restored:

```text
node scripts/run-vitest.mjs src/cli/update-cli/update-command-post-core-root.test.ts src/cli/update-cli/update-command-post-core.test.ts
Test Files 2 passed (2)
Tests 19 passed (19)
```

`node scripts/check-changed.mjs` passed, including core/test typechecking, formatting, lint, and guards. The repository wrapper's required helper runtime build passed.

The broader native-transaction and handoff-lifecycle run produced 186 passes and one failure in the unchanged `preserves update failure after unavailable triage (0, timeout=true, missing=false)` case: its service-restore step returned exit 1 instead of 0. The fixture sets `recoveryTimeoutMs: 1000` when `triageHang` is enabled (`update-managed-service-handoff-boundary.test-support.ts:332`), also constraining the preceding service recovery. This run was under concurrent host load. The native transaction cases and verified previous-generation recovery/unsafe-refusal cases passed. No timeout, assertion, or recovery change was made to conceal this failure. `node scripts/run-vitest.mjs src/cli/update-cli/update-command-lease.test.ts` passed all 31 CLI lifecycle/lease tests.

Known gap: the historical pnpm 10.28.2 pre/post canonical paths from #142715 are unavailable. This proves and fixes the generation-transition failure shape, not a full reproduction of that user's release upgrade. No live Gateway or real package-manager upgrade was exercised. The fix is owned by the launching updater: installing a target containing it cannot retroactively change an already-running older updater during that first hop. The issue is referenced rather than automatically closed. The independent canary and unsafe-recovery reports remain outside this patch. Lead-owned autoreview and landing are pending.


Exact-head CI: [job 102493298024](https://github.com/openclaw/openclaw/actions/runs/34359621941/job/102493298024) failed in `checks-node-changed-extensions-bundle-15`. The failure is `extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts:176`, “lets configured steer mode reach queue policy while the prior Matrix turn is active”: expected the queue-policy spy once, received zero calls. That Matrix shard had 780 passes and one failure. This patch changes no Matrix or inbound-message implementation; the failure is recorded for a separate repair, without retrying or weakening its timeout/assertion. CI is not green.
