### PR TITLE
fix(update): avoid false Memory Core migration refusals

### DIFF
--- a/docs/plugins/manifest/surfaces.md
+++ b/docs/plugins/manifest/surfaces.md
@@ -57,6 +57,12 @@ descriptor array. Candidate validation must bind those artifacts separately.
 Until then, Doctor records an explicit planning refusal instead of treating an
 installed manifest as write authority.
 
+A state migration returns `changes` and `warnings`, with optional `notices`. Warnings refuse later
+Doctor repairs by default. A migration may return `warningDisposition: "recoverable"` only when every
+warning is advisory and required state remains safe for later repairs. Doctor preserves those warnings
+in its receipts and continues. Detection errors, thrown failures, and unclassified warnings from another
+migration still refuse the combined step.
+
 The Codex plugin sets `doctorHealthChecks: true` when its public API exports
 health-check registration. Doctor checks the selected plugin's trust before
 loading this surface. Older installed versions without the declaration skip

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -465,7 +465,13 @@ If `openclaw doctor --fix` reports an unsafe Memory Core host-event source, chec
 permissions. Back up the legacy journal before replacing any symlink. To import it, preserve its
 contents at `memory/.dreams/events.jsonl` as a regular file under regular directories inside the intended
 workspace, then rerun `openclaw doctor --fix`. Doctor leaves rejected sources untouched. A symlink to
-the workspace root itself is supported; symlinks below that root are refused by this migration.
+the workspace root itself is supported. Symlinks below that root are refused when a legacy event
+source, import claim, or migrated archive is present; directories without those sources need no repair.
+
+If a checkpointed `events.jsonl.migrated` archive changed other than by append, Doctor warns and
+preserves both the archive and the already imported SQLite events. It defers later event generations
+in that workspace while continuing unrelated repairs. Preserve the archive for inspection; this warning
+does not mean its edited contents were imported. Unsafe source paths and failed imports still stop Doctor.
 
 ---
 

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -663,7 +663,7 @@ describe("memory-core doctor dreaming migration", () => {
     ).resolves.toMatchObject([{ query: "after recovery generation" }]);
   });
 
-  it("fails closed when a checkpointed host event archive changes other than by append", async () => {
+  it("warns without importing when a checkpointed host event archive changes other than by append", async () => {
     const eventPath = path.join(workspaceDir, "memory", ".dreams", "events.jsonl");
     const archivedPath = `${eventPath}.migrated`;
     await fs.writeFile(
@@ -691,14 +691,47 @@ describe("memory-core doctor dreaming migration", () => {
       "utf8",
     );
 
+    const laterSource = `${JSON.stringify({
+      type: "memory.recall.recorded",
+      timestamp: "2026-07-01T00:00:00.000Z",
+      query: "later generation",
+      resultCount: 0,
+      results: [],
+    })}\n`;
+    await fs.writeFile(eventPath, laterSource);
     const result = await migration.migrateLegacyState(migrationParams());
 
     expect(result.changes).toEqual([]);
     expect(result.warnings).toEqual([expect.stringContaining("changed other than by append")]);
+    expect(result).toMatchObject({ warningDisposition: "recoverable" });
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toMatchObject([
       { query: "original archive row" },
     ]);
     await expect(fs.readFile(archivedPath, "utf8")).resolves.toContain("rewritten archive row");
+    await expect(fs.readFile(eventPath, "utf8")).resolves.toBe(laterSource);
+
+    const invalidWorkspace = path.join(rootDir, "invalid-workspace");
+    const invalidPath = path.join(invalidWorkspace, "memory", ".dreams", "events.jsonl");
+    await fs.mkdir(path.dirname(invalidPath), { recursive: true });
+    await fs.writeFile(invalidPath, "invalid JSON\n");
+    const mixed = await migration.migrateLegacyState(
+      migrationParams({
+        agents: {
+          list: [
+            { id: "main", workspace: workspaceDir },
+            { id: "invalid", workspace: invalidWorkspace },
+          ],
+        },
+      }),
+    );
+    expect(mixed).not.toHaveProperty("warningDisposition");
+    expect(mixed.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("changed other than by append"),
+        expect.stringContaining("Skipped malformed Memory Core host event"),
+      ]),
+    );
+    await expect(fs.readFile(invalidPath, "utf8")).resolves.toBe("invalid JSON\n");
   });
 
   it("orders and limits migrated host events by archive generation", async () => {
@@ -949,13 +982,34 @@ describe("memory-core doctor dreaming migration", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
-    "rejects legacy host events beneath symlinked workspace parents",
-    async () => {
+  it.runIf(process.platform !== "win32").each([false, true])(
+    "ignores symlinked memory with no legacy sources (dreams directory: %s)",
+    async (hasDreamsDirectory) => {
+      const sharedMemory = path.join(rootDir, "shared-memory");
+      await fs.mkdir(hasDreamsDirectory ? path.join(sharedMemory, ".dreams") : sharedMemory, {
+        recursive: true,
+      });
+      await fs.rm(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.symlink(sharedMemory, path.join(workspaceDir, "memory"));
+
+      await expect(hostEventsMigration().detectLegacyState(migrationParams())).resolves.toBeNull();
+      await expect(hostEventsMigration().migrateLegacyState(migrationParams())).resolves.toEqual({
+        changes: [],
+        warnings: [],
+      });
+      expect((await fs.lstat(path.join(workspaceDir, "memory"))).isSymbolicLink()).toBe(true);
+    },
+  );
+
+  it
+    .runIf(process.platform !== "win32")
+    .each(["events.jsonl", "events.jsonl.migrated", ".events.jsonl.doctor-importing"])(
+    "rejects legacy host events beneath symlinked workspace parents: %s",
+    async (fileName) => {
       const externalMemoryDir = await fs.mkdtemp(
         path.join(os.tmpdir(), "openclaw-memory-core-external-events-"),
       );
-      const externalEventPath = path.join(externalMemoryDir, ".dreams", "events.jsonl");
+      const externalEventPath = path.join(externalMemoryDir, ".dreams", fileName);
       try {
         await fs.rm(path.join(workspaceDir, "memory"), { recursive: true });
         await fs.mkdir(path.dirname(externalEventPath), { recursive: true });
@@ -979,10 +1033,12 @@ describe("memory-core doctor dreaming migration", () => {
 
         expect(result.changes).toEqual([]);
         expect(result.warnings).toEqual([
-          expect.stringContaining(path.join(workspaceDir, "memory", ".dreams", "events.jsonl")),
+          expect.stringContaining(path.join(workspaceDir, "memory", ".dreams", fileName)),
         ]);
         expect(result.warnings[0]).toContain("memory.search.extraPaths");
         expect(result.warnings[0]).toContain("regular files and directories");
+        expect(result.warnings[0]).toContain("FsSafeError: path alias escape blocked");
+        expect(result).not.toHaveProperty("warningDisposition");
         await expect(hostEventsMigration().detectLegacyState(migrationParams())).resolves.toEqual({
           preview: result.warnings.map((warning) => `- ${warning}`),
         });

--- a/extensions/memory-core/src/migration/doctor-host-event-sources.ts
+++ b/extensions/memory-core/src/migration/doctor-host-event-sources.ts
@@ -68,19 +68,14 @@ export async function collectLegacyMemoryHostEventSources(
       filePath = resolveMemoryHostEventLogPath(canonicalWorkspaceDir);
       const relativePath = path.relative(canonicalWorkspaceDir, filePath);
       const directoryRelativePath = path.dirname(relativePath);
-      if (!(await workspaceRoot.exists(directoryRelativePath))) {
-        continue;
-      }
-      const directoryStat = await workspaceRoot.stat(directoryRelativePath);
-      if (!directoryStat.isDirectory) {
-        continue;
-      }
       const baseName = path.basename(relativePath).replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
       const archivePattern = new RegExp(`^${baseName}\\.migrated(?:\\.([2-9]|[1-9][0-9]+))?$`, "u");
       const claimPattern = new RegExp(
         `^\\.${baseName}\\.doctor-importing(?:\\.([2-9]|[1-9][0-9]+))?$`,
         "u",
       );
+      // Discover names before containment checks: shared notes without legacy
+      // events need no repair. Each actual source still goes through guarded stat/read.
       const entries = await fs.readdir(path.join(workspaceRoot.rootReal, directoryRelativePath));
       const candidates: Array<{
         entry: string;

--- a/extensions/memory-core/src/migration/doctor-host-events.ts
+++ b/extensions/memory-core/src/migration/doctor-host-events.ts
@@ -155,7 +155,7 @@ async function migrateLegacyMemoryHostEventSource(params: {
   context: PluginDoctorStateMigrationContext;
   changes: string[];
   warnings: string[];
-}): Promise<"completed" | "blocked"> {
+}): Promise<"completed" | "blocked" | "warning"> {
   const { normalizeMemoryHostEventRecordForStorage, resolveMemoryHostEventLogPath } =
     await import("openclaw/plugin-sdk/memory-host-events");
   const activeRelativePath = path.relative(
@@ -274,7 +274,7 @@ async function migrateLegacyMemoryHostEventSource(params: {
         params.warnings.push(
           `Skipped Memory Core host event recovery because ${source.filePath} changed other than by append; left the archive in place`,
         );
-        return "blocked";
+        return "warning";
       }
     }
     const firstCandidateOrdinal =
@@ -568,6 +568,7 @@ export const hostEventsStateMigration: PluginDoctorStateMigration = {
   async migrateLegacyState(params) {
     const changes: string[] = [];
     const warnings: string[] = [];
+    let advisoryWarningCount = 0;
     const blockedWorkspaces = new Set<string>();
     for (const source of await collectLegacyMemoryHostEventSources(params.config, params.env)) {
       if (blockedWorkspaces.has(source.workspaceDir)) {
@@ -581,18 +582,28 @@ export const hostEventsStateMigration: PluginDoctorStateMigration = {
       if (!(await memoryHostEventSourceNeedsMigration({ source, context: params.context }))) {
         continue;
       }
+      const warningStart = warnings.length;
       const result = await migrateLegacyMemoryHostEventSource({
         source,
         context: params.context,
         changes,
         warnings,
       });
-      if (result === "blocked") {
+      if (result === "warning") {
+        advisoryWarningCount += warnings.length - warningStart;
+      }
+      if (result !== "completed") {
         // Archive generations encode append order. A later generation cannot
         // overtake an older source that still needs repair or durable import.
         blockedWorkspaces.add(source.workspaceDir);
       }
     }
-    return { changes, warnings };
+    return {
+      changes,
+      warnings,
+      ...(warnings.length > 0 && advisoryWarningCount === warnings.length
+        ? { warningDisposition: "recoverable" as const }
+        : {}),
+    };
   },
 };

--- a/src/infra/state-migrations.plugin-doctor.test.ts
+++ b/src/infra/state-migrations.plugin-doctor.test.ts
@@ -45,7 +45,7 @@ afterEach(async () => {
 });
 
 describe("plugin Doctor migration settlement", () => {
-  it.each(["none", "later-action", "lease-settlement"] as const)(
+  it.each(["none", "later-action", "later-warning", "detector", "lease-settlement"] as const)(
     "preserves completed mutations and replay truth when failure is %s",
     async (failure) => {
       const root = await tempDirs.make("openclaw-plugin-doctor-settlement-");
@@ -65,13 +65,22 @@ describe("plugin Doctor migration settlement", () => {
           id: `action-${index}`,
           label: `Action ${index}`,
           phase: "after-session-repair",
-          detectLegacyState: () => (fs.existsSync(marker) ? null : { preview: ["pending"] }),
+          detectLegacyState: () => {
+            if (failure === "detector" && index === 1) {
+              throw new Error("second detector failed");
+            }
+            return fs.existsSync(marker) ? null : { preview: ["pending"] };
+          },
           migrateLegacyState: () => {
             if (failure === "later-action" && index === 1) {
               throw new Error("second action failed");
             }
             fs.writeFileSync(marker, "committed");
-            return { changes: [`committed action ${index}`], warnings: [] };
+            return {
+              changes: [`committed action ${index}`],
+              warnings: index === 0 ? ["advisory"] : failure === "later-warning" ? ["refusal"] : [],
+              ...(index === 0 ? { warningDisposition: "recoverable" as const } : {}),
+            };
           },
         },
       }));
@@ -88,17 +97,25 @@ describe("plugin Doctor migration settlement", () => {
       const first = await runPostSessionPluginDoctorStateRepairs(params);
 
       expect(fs.readFileSync(markers[0], "utf8")).toBe("committed");
-      expect(fs.existsSync(markers[1])).toBe(failure !== "later-action");
+      expect(fs.existsSync(markers[1])).toBe(!["later-action", "detector"].includes(failure));
       expect(first.changes).toEqual(
-        failure === "later-action"
+        ["later-action", "detector"].includes(failure)
           ? ["committed action 0"]
           : ["committed action 0", "committed action 1"],
       );
       if (failure === "none") {
-        expect(first.warnings).toEqual([]);
+        expect(first.warnings).toEqual(["advisory"]);
+        expect(first.warningDisposition).toBe("recoverable");
       } else {
+        expect(first.warningDisposition).toBeUndefined();
         expect(first.warnings.join("\n")).toContain(
-          failure === "later-action" ? "second action failed" : "lease settlement failed",
+          failure === "later-action"
+            ? "second action failed"
+            : failure === "later-warning"
+              ? "refusal"
+              : failure === "detector"
+                ? "second detector failed"
+                : "lease settlement failed",
         );
       }
 

--- a/src/infra/state-migrations.plugin-doctor.ts
+++ b/src/infra/state-migrations.plugin-doctor.ts
@@ -171,7 +171,11 @@ export async function runPluginDoctorStateMigrationPlans(params: {
       ? refreshedPlans
       : (params.detected.pluginPlans?.plans ?? []);
   const migrated = await migratePluginDoctorStatePlans(input, plans);
-  return { ...migrated, warnings: [...warnings, ...migrated.warnings] };
+  return {
+    ...migrated,
+    warnings: [...warnings, ...migrated.warnings],
+    ...(hasDetectorFailure ? { warningDisposition: undefined } : {}),
+  };
 }
 
 async function migratePluginDoctorStatePlans(
@@ -182,6 +186,7 @@ async function migratePluginDoctorStatePlans(
   const changes: string[] = [];
   const warnings: string[] = [];
   const notices: string[] = [];
+  let hasRefusal = false;
   if (plans.length === 0) {
     return { changes, warnings };
   }
@@ -234,12 +239,21 @@ async function migratePluginDoctorStatePlans(
         repairAuthority?.assertCurrent();
         changes.push(...result.changes);
         warnings.push(...result.warnings);
+        if (result.warnings.length > 0 && result.warningDisposition !== "recoverable") {
+          hasRefusal = true;
+        }
         notices.push(...(result.notices ?? []));
       } catch (err) {
+        hasRefusal = true;
         warnings.push(`Failed migrating ${plan.migration.label}: ${String(err)}`);
       }
     }
-    return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+    return {
+      changes,
+      warnings,
+      ...(notices.length > 0 ? { notices } : {}),
+      ...(warnings.length > 0 && !hasRefusal ? { warningDisposition: "recoverable" as const } : {}),
+    };
   };
   // Session repair already holds the Gateway lock and cross-process database fences.
   if (repairAuthority) {
@@ -318,7 +332,11 @@ export async function runPostSessionPluginDoctorStateRepairs(params: {
       };
     }
     const result = await migratePluginDoctorStatePlans(input, plans, repairAuthority);
-    return { ...result, warnings: [...warnings, ...result.warnings] };
+    return {
+      ...result,
+      warnings: [...warnings, ...result.warnings],
+      ...(warnings.length > 0 ? { warningDisposition: undefined } : {}),
+    };
   };
   const maintenance = params.maintenanceAuthority;
   if (!maintenance) {
@@ -362,6 +380,7 @@ export async function runPostSessionPluginDoctorStateRepairs(params: {
     return {
       ...completed,
       warnings: [...completed.warnings, `Plugin session repair did not settle: ${String(error)}.`],
+      warningDisposition: undefined,
     };
   }
 }

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -65,6 +65,7 @@ import {
   runLegacyStateMigrations as runLegacyStateMigrationsWithSurfaces,
 } from "./state-migrations.doctor.js";
 import * as sessionStore from "./state-migrations.legacy-session-store.js";
+import { throwIfDoctorStateMigrationRefused } from "./state-migrations.messages.js";
 import { autoMigrateLegacyPluginDoctorState } from "./state-migrations.plugin-doctor.js";
 import {
   migrateLegacyCurrentConversationBindings,
@@ -2166,7 +2167,7 @@ describe("state migrations", () => {
               ...params,
               context: params.context as PluginDoctorStateMigrationContext,
             });
-            return { changes: result.changes, warnings: result.warnings };
+            return result;
           },
         },
       },
@@ -2197,6 +2198,25 @@ describe("state migrations", () => {
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toEqual([event]);
     await expectMissingPath(eventPath);
     await expect(fs.stat(`${eventPath}.migrated`)).resolves.toBeDefined();
+
+    const rewritten = `${JSON.stringify({ ...event, query: "rewritten archive" })}\n`;
+    await fs.writeFile(`${eventPath}.migrated`, rewritten);
+    const continued = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(
+      continued.stepReceipts.find((receipt) => receipt.id === "plugin-doctor-state"),
+    ).toMatchObject({
+      outcome: "warning",
+      warnings: [expect.stringContaining("changed other than by append")],
+    });
+    expect(() => throwIfDoctorStateMigrationRefused(continued.stepReceipts)).not.toThrow();
+    expect(continued.stepReceipts.some((receipt) => receipt.outcome === "refused")).toBe(false);
+    await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toEqual([event]);
+    await expect(fs.readFile(`${eventPath}.migrated`, "utf8")).resolves.toBe(rewritten);
   });
 
   it("runs doctor-only repairs after the automatic migration check", async () => {

--- a/src/plugins/doctor-contract-module.ts
+++ b/src/plugins/doctor-contract-module.ts
@@ -105,6 +105,14 @@ type PluginDoctorStateMigrationInput = {
   context: PluginDoctorStateMigrationContext;
 };
 
+type PluginDoctorStateMigrationResult = {
+  changes: string[];
+  warnings: string[];
+  notices?: string[];
+  /** Every warning is advisory; required state remains safe for later repairs. */
+  warningDisposition?: "recoverable";
+};
+
 export type PluginDoctorStateMigration = {
   id: string;
   label: string;
@@ -119,9 +127,7 @@ export type PluginDoctorStateMigration = {
     | null;
   migrateLegacyState: (
     params: PluginDoctorStateMigrationInput,
-  ) =>
-    | Promise<{ changes: string[]; warnings: string[]; notices?: string[] }>
-    | { changes: string[]; warnings: string[]; notices?: string[] };
+  ) => Promise<PluginDoctorStateMigrationResult> | PluginDoctorStateMigrationResult;
 };
 
 export type PluginDoctorContractModule = {


### PR DESCRIPTION
Refs #139166, #139195

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users updating OpenClaw would have Doctor stop when a symlinked memory directory contained no legacy host-event sources, or when a previously migrated host-event archive had been rewritten rather than appended. The latter already reported an intentional skip, but its warning became a refusal receipt and blocked later repairs.

## Why This Change Was Made

Memory Core enumerates candidate filenames before applying containment checks. Actual active logs, import claims, and migrated archives still receive guarded filesystem checks; their contents are never imported through unsafe paths.

The plugin now classifies the checkpointed archive skip as advisory using an optional `warningDisposition: "recoverable"` migration result. The generic plugin runner preserves that classification only when every warning is advisory. Detection errors, thrown failures, unclassified warnings, and lease-settlement failures still refuse. Archive bytes, checkpoints, imported rows, retention, and generation ordering are unchanged; later generations in the affected workspace remain deferred.

## User Impact

Empty shared-memory directory layouts no longer block Doctor. A rewritten checkpointed archive remains available for inspection and emits a warning while unrelated repairs continue. This does not import the edited archive, certify migration completion, or suppress failures in other migrations. Operator and plugin-contract documentation describe the behavior.

## Evidence

Before changing production code:

```text
node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts -t 'symlinked|checkpointed host event archive changes' --reporter=dot
3 failed | 1 passed
  empty symlink: expected null; received FsSafeError: path alias escape blocked
  checkpointed archive: expected warningDisposition: recoverable; received no disposition
  populated symlink: still refused and preserved

node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts src/infra/state-migrations.test.ts -t 'symlinked|checkpointed host event archive changes|retained Memory Core host events'
1 failed (core lane)
  expected Doctor outcome: warning; received outcome: refused

node scripts/run-vitest.mjs src/infra/state-migrations.plugin-doctor.test.ts --reporter=dot
1 failed | 4 passed
  advisory-only result lost its recoverable classification
```

After the fix, the focused run passed all 10 selected tests. The broader migration command passed **227 tests across five files**:

```text
node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts src/infra/state-migrations.test.ts src/infra/state-migrations.plugin-doctor.test.ts src/infra/state-migrations.audit-logs.test.ts src/infra/state-migrations.audit-recovery.test.ts --reporter=dot
infra: 159 passed (4 files)
Memory Core: 68 passed (1 file)
```

`node scripts/check-docs-mdx.mjs docs/reference/memory-config.md docs/plugins/manifest/surfaces.md` and `git diff --check` passed. The changed-file gate passed formatting, six plugin declaration/closure tests, boundaries, all four production/test TypeScript lanes, dead-code scans, and core lint. It stopped at extension lint because declaration preparation observed an ancestor checkout's `node_modules/punycode/package.json`. Its explicit error says reinstalling cannot isolate ancestor lookup and requires a separate physical checkout. The assigned worktree scope prevents that local route; no guard or dependency was changed. This environment limitation also appears in #139195. The isolated CI result below completes extension lint proof.

Tests use synthetic files and isolated SQLite state. Coverage includes populated symlinked active logs, claims, and archives; preserving later generations behind a rewritten archive; mixed malformed-source refusals; and detector/action/lease failures alongside advisory warnings.

All guards after the extension-lint step also passed when run independently: native schema version, database-first legacy stores, media-download helpers, runtime-sidecar loaders, import cycles, webhook body ordering, pairing-store group authorization, and pairing account scope.

Exact-head [CI run 34359801094](https://github.com/openclaw/openclaw/actions/runs/34359801094) passed `check-lint` and `check-additional-extension-package-boundary`, supplying the isolated proof blocked locally. The exact-head watcher completed with `STATUS state=SUCCESS pending=0` and `GREEN`; no CI repair or rerun was needed.

## Known Gaps

No managed Gateway was restarted and no packaged end-to-end update was run. Independent autoreview and landing remain with the campaign lead.

Checkpointless whitespace-only audit `.migrated.raw` files remain refused. A parseable sanitized companion cannot prove matching provenance or completed import. Removing the guard would let an empty projection overwrite the populated companion. Automatic adoption or warning-only deferral requires a separate recovery-semantics decision; this PR does neither.

## Credit

Related diagnostic/recovery guidance shipped in #139195. This change uses the existing migration owners and community-reported symptoms; it does not incorporate contributor PR code.

## Review notes

**Merge risk / advisory contract:** We retain the documented additive `warningDisposition: "recoverable"` contract (ClawSweeper's recommended option 1). The runner keeps refusal as the default; only a plugin that marks every warning advisory can continue later repairs. Detector, action, and lease failures still refuse, and the mixed-disposition regression tests cover this boundary.

**Data-model compatibility:** No persisted SQLite table, column, index, or stored record format changes. This change only classifies an existing migration outcome and propagates it through the existing receipt mechanism; ClawSweeper's technical review likewise states "without changing stored format." Existing databases and archives are read exactly as before. The regression test proves a rewritten archive is preserved byte-for-byte while later repairs continue.
