### PR TITLE
fix(update): confirm before automatic triage launches a coding agent

### DIFF
--- a/docs/cli/triage.md
+++ b/docs/cli/triage.md
@@ -15,7 +15,7 @@ Collect sanitized diagnostics and open a coding agent on this machine to diagnos
 openclaw triage
 ```
 
-In an interactive terminal, triage starts the first directly launchable agent on `PATH` in this detection order: Claude Code (`claude`), Codex (`codex`), OpenCode (`opencode`), then Pi (`pi`). It prints the selected agent and passes a bounded repair prompt directly, without a picker. The agent uses its existing authentication, sandbox, and approval settings.
+In an interactive terminal, triage starts the first directly launchable agent on `PATH` in this detection order: Claude Code (`claude`), Codex (`codex`), OpenCode (`opencode`), then Pi (`pi`). An explicit `openclaw triage` invocation prints the selected agent and passes a bounded repair prompt directly, without a picker or launch confirmation. The agent uses its existing authentication, sandbox, and approval settings.
 
 Choose a particular agent with `--agent`, or collect diagnostics without starting one with `--json` or `--non-interactive`:
 
@@ -41,6 +41,8 @@ in the update run report. The updater owns any service restart and decides
 success from validation; triage remains the handoff when recovery cannot finish.
 
 Interactive update recovery uses this same handoff after the updater releases its maintenance state. It starts from the captured update failure and defers fresh Doctor checks and archive collection to the repair agent, so checks against the broken installation do not delay the handoff. The agent starts in the operator's captured working directory, or their OS home if that directory was removed or became inaccessible. Absolute installation selectors still identify the state, config, and default workspace to repair, even when the state directory cannot be accessed or created.
+
+Before an automatic interactive launch, OpenClaw shows the selected binary or the embedded OpenClaw agent using your configured model, the saved prompt path when available, and a notice that it uses your own account/tokens, then asks for confirmation. Enter or `y` proceeds; `n` prints ready-to-run handoffs and the manual `openclaw triage` command while preserving diagnostics and the failed update's exit status; after 30 seconds without an answer, OpenClaw announces that it is continuing and proceeds as Yes.
 
 The prompt preserves the original error, before and after versions, and recorded recovery state ahead of current Doctor findings. It includes up to three failed or interrupted steps, excluding advisory Doctor results, with bounded excerpts from both stderr and stdout. It also retains bounded plugin failures and the terminal Doctor warning. The failure record is limited to 4 KiB and the whole prompt to 8 KiB. A healthy Doctor check does not erase the failed attempt, and an absent restart-safety verdict remains unknown.
 

--- a/docs/install/update-troubleshooting.md
+++ b/docs/install/update-troubleshooting.md
@@ -7,8 +7,11 @@ title: "Update troubleshooting"
 ---
 
 Failed updates enter built-in triage after update recovery settles. In an
-interactive terminal, OpenClaw collects sanitized diagnostics and opens the
-[triage agent picker](/cli/triage). With `--yes`, `--json`, or no interactive
+interactive terminal, OpenClaw shows the selected agent, saved prompt path when
+available, and use of your own account/tokens, then asks before launching
+[triage](/cli/triage). Enter or `y` proceeds, `n` preserves diagnostics and prints
+handoff commands, and no answer within 30 seconds proceeds as Yes with a notice.
+With `--yes`, `--json`, or no interactive
 terminal, it prepares diagnostics and handoff commands without launching an
 agent. The original update failure and exit status remain authoritative;
 diagnostics do not turn a failed update into a successful one.

--- a/docs/install/updating/rollback-and-recovery.md
+++ b/docs/install/updating/rollback-and-recovery.md
@@ -203,9 +203,14 @@ any recorded failed-update outcome so it can repair the installation and verify
 Gateway health, using its normal authentication, sandbox, and approval settings.
 Use `openclaw triage --agent codex` to select a particular agent.
 
-Failed interactive updates open triage automatically after updater cleanup and
+Failed interactive updates offer triage after updater cleanup and
 pass the captured failure to the agent before fresh diagnostics can delay the
-handoff. JSON, `--yes`, and non-interactive update invocations collect diagnostics
+handoff. Before launch, OpenClaw shows the agent, saved prompt path when available,
+and use of your own account/tokens; Enter or `y` proceeds, while `n` prints handoff
+commands and preserves diagnostics and the failed update's exit status.
+After 30 seconds without an answer, it announces that it is continuing and
+proceeds as Yes; explicit `openclaw triage` does not ask for this confirmation.
+JSON, `--yes`, and non-interactive update invocations collect diagnostics
 and print handoff commands without starting an agent. For diagnostic collection
 alone, use `openclaw triage --non-interactive`; add `--update-result <path>` to
 include a saved update-failure artifact. See [Triage](/cli/triage) for command

--- a/src/cli/update-cli/update-command-triage.test.ts
+++ b/src/cli/update-cli/update-command-triage.test.ts
@@ -21,6 +21,10 @@ const runInteractiveUpdateFailureAction = vi.hoisted(() =>
 );
 
 vi.mock("./update-command-report.js", () => ({ runInteractiveUpdateFailureAction }));
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  confirm: async () => true,
+}));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -16,6 +16,11 @@ const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
 }));
 
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  confirm: async () => true,
+}));
+
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
   spawn: mocks.spawn,

--- a/src/commands/triage-run.test.ts
+++ b/src/commands/triage-run.test.ts
@@ -7,12 +7,19 @@ import { triageCommand } from "./triage.js";
 import { createTriageRuntime, withTriageTerminal } from "./triage.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  confirm: mocks.confirm,
+}));
 const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  agentExecCommand: vi.fn(),
   collectDoctorFindings: vi.fn(),
   runUpdateRepairLoop: vi.fn(),
   runUtf8CommandWithTimeout: vi.fn(),
   resolveGatewayInstallEntrypoint: vi.fn(),
 }));
+vi.mock("./agent-exec.js", () => ({ agentExecCommand: mocks.agentExecCommand }));
 vi.mock("./doctor-lint.js", () => ({ collectDoctorFindings: mocks.collectDoctorFindings }));
 vi.mock("../infra/update-repair-agent.js", () => ({
   runUpdateRepairLoop: mocks.runUpdateRepairLoop,
@@ -32,6 +39,7 @@ describe("triage --run", () => {
   let stateDir: string;
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.confirm.mockResolvedValue(true);
     stateDir = tempDirs.make("openclaw-triage-run-");
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.stubEnv("OPENCLAW_CONFIG_PATH", undefined);
@@ -54,6 +62,34 @@ describe("triage --run", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it("confirms an interactive owned update continuation before embedded execution", async () => {
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({ agents: { defaults: { model: "openai/gpt-5.6-luna" } } }),
+    );
+    mocks.confirm.mockResolvedValue(false);
+    mocks.agentExecCommand.mockResolvedValue({ exitCode: 0 });
+    const runtime = createTriageRuntime();
+    await withTriageTerminal(true, () =>
+      triageCommand(
+        runtime,
+        { noExport: true },
+        {
+          signal: new AbortController().signal,
+          assertCurrent: vi.fn(),
+          failure: { kind: "update", phase: "build", error: "install failed", gateway: "preserve" },
+        },
+      ),
+    );
+    expect(mocks.confirm).toHaveBeenCalledOnce();
+    expect(mocks.agentExecCommand).not.toHaveBeenCalled();
+    expect(runtime.log.mock.calls.flat().join("\n")).toContain(
+      "the embedded OpenClaw agent using your configured model",
+    );
+    expect(runtime.log.mock.calls.flat().join("\n")).not.toContain("gpt-5.6-luna");
+    expect(runtime.log).toHaveBeenCalledWith("Ready-to-run agent handoffs:");
   });
 
   it("keeps the onboarding hint when embedded repair has no usable inference", async () => {

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -2,20 +2,35 @@ import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { promisify } from "node:util";
 import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgentCleanupScope } from "../agents/run-cleanup-timeout.js";
+import { UpdateCommandFailure } from "../cli/update-cli/update-command-result.js";
+import { withUpdateFailureTriage } from "../cli/update-cli/update-command-triage.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { resolveInstallationTarget } from "../infra/installation-target-context.js";
+import type { UpdateRunResult } from "../infra/update-runner.js";
+import { defaultRuntime } from "../runtime.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { triageAfterFailure } from "./triage-failure.js";
 import { triageCommand } from "./triage.js";
 import { createTriageRuntime, withTriageTerminal } from "./triage.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const failedUpdate: UpdateRunResult = {
+  status: "error",
+  mode: "npm",
+  reason: "install failed",
+  steps: [],
+  durationMs: 1,
+};
 
 const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  select: vi.fn(),
   collectDoctorFindings: vi.fn(),
   callGatewayFromCliWithTransport: vi.fn(),
   writeDiagnosticSupportExport: vi.fn(),
@@ -24,6 +39,12 @@ const mocks = vi.hoisted(() => ({
   agentExecCommand: vi.fn(),
   resolveExecutablePath: vi.fn(),
   spawn: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  confirm: mocks.confirm,
+  select: mocks.select,
 }));
 
 vi.mock("node:child_process", async (importOriginal) => ({
@@ -63,6 +84,8 @@ describe("triageCommand", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.confirm.mockResolvedValue(true);
+    mocks.select.mockResolvedValue("triage");
     stateDir = tempDirs.make("openclaw-triage-test-");
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.stubEnv("OPENCLAW_SHELL", "");
@@ -85,9 +108,149 @@ describe("triageCommand", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
+
+  it.each([false, true])(
+    "declining automatic update repair preserves diagnostics without launching an agent (embedded=%s)",
+    async (run) => {
+      mocks.confirm.mockResolvedValue(false);
+      mocks.resolveExecutablePath.mockImplementation((agent: string) =>
+        agent === "claude" ? "/usr/local/bin/claude" : undefined,
+      );
+      const runtime = createTriageRuntime();
+      await withTriageTerminal(true, () =>
+        triageCommand(runtime, {
+          run,
+          recovery: {
+            target: resolveInstallationTarget(),
+            updateFailure: { result: failedUpdate },
+          },
+        }),
+      );
+
+      expect(mocks.spawn).not.toHaveBeenCalled();
+      expect(mocks.runUpdateRepairLoop).not.toHaveBeenCalled();
+      expect(mocks.agentExecCommand).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
+      const output = runtime.log.mock.calls.flat().join("\n");
+      expect(output).toContain("Ready-to-run agent handoffs:");
+      expect(output).toContain("claude -p");
+      expect(output).toContain("openclaw triage");
+      const artifacts = await fs.readdir(path.join(stateDir, "logs/support"));
+      const promptFile = artifacts.find((file) => file.endsWith(".md"));
+      expect(await fs.readFile(path.join(stateDir, "logs/support", promptFile!), "utf8")).toContain(
+        "install failed",
+      );
+      const failureFile = artifacts.find((file) => file.endsWith(".json"));
+      expect(
+        JSON.parse(await fs.readFile(path.join(stateDir, "logs/support", failureFile!), "utf8")),
+      ).toMatchObject({ result: { status: "error", reason: "install failed" } });
+    },
+  );
+
+  it("keeps the updater's failure exit code when automatic triage is declined", async () => {
+    mocks.confirm.mockResolvedValue(false);
+    mocks.resolveExecutablePath.mockImplementation((agent: string) =>
+      agent === "claude" ? "/usr/local/bin/claude" : undefined,
+    );
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const failure = new UpdateCommandFailure(failedUpdate, 17);
+    await withTriageTerminal(true, async () => {
+      await expect(
+        withUpdateFailureTriage({}, { env: { ...process.env } }, async () => {
+          throw failure;
+        }),
+      ).rejects.toMatchObject({ code: 17 });
+    });
+    expect(mocks.confirm).toHaveBeenCalledOnce();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.runUpdateRepairLoop).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("Ready-to-run agent handoffs:");
+  });
+
+  it.each([
+    { answer: "y", run: false, launches: true },
+    { answer: "\r", run: true, launches: true },
+    { answer: "timeout", run: false, launches: true },
+    { answer: "timeout", run: true, launches: true },
+    { answer: "n", run: false, launches: false },
+    { answer: "\u0003", run: false, launches: false },
+    { answer: "abort", run: false, launches: false },
+    { answer: "owner-loss", run: false, launches: false },
+  ])(
+    "settles the real update prompt for $answer (embedded=$run)",
+    async ({ answer, run, launches }) => {
+      const clack = await vi.importActual<typeof import("@clack/prompts")>("@clack/prompts");
+      const input = new PassThrough();
+      const output = new PassThrough();
+      const started = createDeferredCore();
+      const controller = new AbortController();
+      let current = true;
+      mocks.confirm.mockImplementation((options: Parameters<typeof clack.confirm>[0]) => {
+        const pending = clack.confirm({ ...options, input, output });
+        started.resolve();
+        return pending;
+      });
+      mocks.resolveExecutablePath.mockImplementation((agent: string) =>
+        agent === "claude" ? "/usr/local/bin/claude" : undefined,
+      );
+      const runtime = createTriageRuntime();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        await withTriageTerminal(true, async () => {
+          const pending = triageCommand(runtime, {
+            run,
+            recovery: {
+              target: resolveInstallationTarget(),
+              updateFailure: { error: "install failed" },
+              signal: controller.signal,
+              isCurrent: () => current && !controller.signal.aborted,
+            },
+          });
+          await started.promise;
+          expect(mocks.spawn).not.toHaveBeenCalled();
+          expect(mocks.runUpdateRepairLoop).not.toHaveBeenCalled();
+          const agent = run ? "the embedded OpenClaw agent using your configured model" : "claude";
+          expect(runtime.log).toHaveBeenCalledWith(
+            `Agent: ${agent}. This will use your own account/tokens.`,
+          );
+          expect(mocks.confirm.mock.calls[0]?.[0].message).toContain(
+            `Open ${agent} to diagnose and repair the installation now? [Y/n]`,
+          );
+          if (answer === "timeout") {
+            await vi.advanceTimersByTimeAsync(29_999);
+            expect(mocks.spawn).not.toHaveBeenCalled();
+            expect(mocks.runUpdateRepairLoop).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(1);
+          } else if (answer === "abort") {
+            controller.abort();
+          } else {
+            if (answer === "owner-loss") {
+              current = false;
+            }
+            input.write(answer === "owner-loss" ? "y" : answer);
+          }
+          await pending;
+          expect(mocks.spawn).toHaveBeenCalledTimes(launches && !run ? 1 : 0);
+          expect(mocks.runUpdateRepairLoop).toHaveBeenCalledTimes(launches && run ? 1 : 0);
+          expect(
+            runtime.log.mock.calls.flat().join("\n").includes("No answer; continuing with"),
+          ).toBe(answer === "timeout");
+          expect(input.listenerCount("keypress")).toBe(0);
+          expect(output.listenerCount("resize")).toBe(0);
+          expect(input.isPaused()).toBe(true);
+          expect(vi.getTimerCount()).toBe(0);
+        });
+      } finally {
+        controller.abort();
+        input.destroy();
+        output.destroy();
+      }
+    },
+  );
 
   it("runs one selected automatic route with the original failure prompt", async () => {
     await fs.writeFile(
@@ -555,6 +718,7 @@ describe("triageCommand", () => {
       expect(JSON.stringify(output)).not.toContain(secret);
       expect(mocks.spawn).not.toHaveBeenCalled();
       expect(mocks.runUpdateRepairLoop).not.toHaveBeenCalled();
+      expect(mocks.confirm).not.toHaveBeenCalled();
     },
   );
 
@@ -830,6 +994,7 @@ describe("triageCommand", () => {
       }
     });
 
+    expect(mocks.confirm).not.toHaveBeenCalled();
     const promptPath = String(runtime.log.mock.calls[0]?.[0]).replace("Debugging prompt: ", "");
     expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
       `/usr/local/bin/${agent}`,

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -2,9 +2,11 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { confirm } from "@clack/prompts";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Result } from "@openclaw/normalization-core/result";
 import { z } from "zod";
+import { stylePromptMessage } from "../../packages/terminal-core/src/prompt-style.js";
 import { tryResolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import {
@@ -56,6 +58,7 @@ type TriageRecoveryContext = {
   target: InstallationTarget;
   cwd?: string;
   updateFailure: TriageUpdateFailure;
+  signal?: AbortSignal;
   isCurrent?: () => boolean;
 };
 
@@ -79,6 +82,33 @@ const triageDoctorReportSchema = z.object({
 function triageCollectionError(error: unknown, redaction: SupportRedactionContext): string {
   const message = error instanceof Error ? error.message : String(error);
   return scrubDoctorErrorMessage(redactSupportString(message, redaction));
+}
+
+async function confirmAutomaticUpdateTriage(
+  runtime: RuntimeEnv,
+  agent: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), 30_000);
+  let answer: boolean | symbol;
+  try {
+    answer = await confirm({
+      message: stylePromptMessage(
+        `Open ${agent} to diagnose and repair the installation now? [Y/n]`,
+      ),
+      initialValue: true,
+      signal: signal ? AbortSignal.any([signal, timeout.signal]) : timeout.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  // Abort settles Clack and restores stdin before handing the terminal to an agent.
+  if (timeout.signal.aborted && !signal?.aborted) {
+    runtime.log(`No answer; continuing with ${agent}`);
+    return true;
+  }
+  return !signal?.aborted && answer === true;
 }
 
 async function collectTriageBundle(
@@ -362,6 +392,17 @@ export async function triageCommand(
     return;
   }
 
+  const needsConfirmation =
+    interactive &&
+    options.nonInteractive !== true &&
+    canStartAgent &&
+    (options.recovery !== undefined || automatic?.failure.kind === "update");
+  const agentLabel = runEmbedded
+    ? "the embedded OpenClaw agent using your configured model"
+    : handoff?.agent;
+  if (needsConfirmation) {
+    runtime.log(`Agent: ${agentLabel}. This will use your own account/tokens.`);
+  }
   if (promptArtifact.ok) {
     runtime.log(`Debugging prompt: ${promptArtifact.value}`);
   } else {
@@ -372,10 +413,35 @@ export async function triageCommand(
   } else if (bundle.kind === "unavailable") {
     runtime.log(`Diagnostics export unavailable: ${bundle.reason}`);
   }
-  if (!allowAgent || runEmbedded || !handoff) {
+  const declined =
+    needsConfirmation &&
+    agentLabel !== undefined &&
+    !(await confirmAutomaticUpdateTriage(
+      runtime,
+      agentLabel,
+      automatic?.signal ?? options.recovery?.signal,
+    ));
+  if (!isCurrent()) {
+    return;
+  }
+  if (declined || !allowAgent || runEmbedded || !handoff) {
     runtime.log("Ready-to-run agent handoffs:");
     for (const command of suggestedCommands) {
       runtime.log(`  ${command}`);
+    }
+    if (declined) {
+      runtime.log(
+        `Run manually: ${formatInstallationTargetCommand(
+          [
+            "openclaw",
+            "triage",
+            ...(updateResultPath ? ["--update-result", updateResultPath] : []),
+          ],
+          target,
+          { env: targetEnv },
+        )}`,
+      );
+      return;
     }
     if (!allowAgent && !runEmbedded) {
       return;

--- a/src/infra/update-triage.ts
+++ b/src/infra/update-triage.ts
@@ -158,6 +158,7 @@ async function runPreparedUpdateFailureTriage(
               target: installationTarget,
               cwd: cwd ?? prepared.operatorHome,
               updateFailure: params.failure,
+              signal: params.signal,
               isCurrent,
             },
           },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw update` or `openclaw update repair` could unexpectedly launch a coding agent after an interactive update failure, spending their own account quota or configured-model tokens. Community feedback after 2026.9.3 described surprise Claude launches, substantial subscription quota usage, and expensive inference, while other users valued the automatic repair.

## Why This Change Was Made

Before an automatic interactive update-failure launch, triage names the selected binary (or the embedded OpenClaw agent using the configured model), prints the saved prompt path when available, explains that it uses the operator's own account/tokens, and asks `Open <agent> to diagnose and repair the installation now? [Y/n]`.

Enter or `y` continues. `n` launches no agent and prints the existing ready-to-run handoffs plus an installation-specific manual `openclaw triage` command. Diagnostics and the updater's original failure exit status remain intact. If this confirmation receives no answer for 30 seconds, it aborts and settles the existing Clack prompt, announces `No answer; continuing with <agent>`, and proceeds as Yes. This default preserves unattended operation at this prompt. Cancellation and current update ownership are checked before launch.

## User Impact

Operators can decline unexpected account/token usage while retaining a usable repair handoff. Explicit `openclaw triage` does not gain a confirmation. Agent selection, JSON/non-interactive behavior, and existing owned managed recovery remain unchanged. The update/triage documentation describes the confirmation and timeout; no configuration, dependencies, or persistent-store changes are added.

## Evidence

Regression command:

```sh
node scripts/run-vitest.mjs src/commands/triage.test.ts -t 'declining automatic update repair'
```

Before the production fix, both external and embedded decline cases failed because their agent execution mock was called once. After the fix, both pass without agent execution and retain saved failure diagnostics and manual commands.

```text
Before: Tests 2 failed | 35 skipped (37)
  expected "vi.fn()" to not be called at all, but actually been called 1 times
After:  Tests 2 passed | 35 skipped (37)
```

The focused suite covers the full updater-to-triage failure exit code, external and embedded decline, actual Clack Yes/Enter/No/Ctrl-C handling, fake-timer timeout at 30 seconds, input listener and timer cleanup, cancellation, ownership loss, explicit invocation, and diagnostic-only paths. Agent execution uses synthetic fixtures/mocks; live account usage and production services were not exercised.

Final focused proof (113 tests passed across five files):

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/l8-triage-consent-vitest node scripts/run-vitest.mjs src/commands/triage.test.ts src/commands/triage-run.test.ts src/commands/triage-target.test.ts src/commands/triage-update.test.ts src/infra/update-triage.test.ts
node scripts/check-docs-mdx.mjs docs/cli/triage.md docs/install/update-troubleshooting.md docs/install/updating/rollback-and-recovery.md
git diff --check
```

The MDX check passed for all three documentation files. The existing embedded-repair test fixture now accepts the newly required launch confirmation; its validation assertions are unchanged.

`node scripts/check-changed.mjs` also passed, including core and test typechecks, changed-file lint, formatting, export scans, and repository guards.

The first CI run also exposed two older recovery fixtures that simulated a terminal without answering the new prompt. They now answer Yes while preserving their real launch, cleanup, and failure-status assertions. Follow-up proof passed all 61 tests:

```sh
node scripts/run-vitest.mjs src/commands/triage-recovery.test.ts src/cli/update-cli/update-command-triage.test.ts
```

That first run separately hit an unrelated [Telegram loopback failure](https://github.com/openclaw/openclaw/actions/runs/34360052291/job/102494724800): `model-callback.loopback.integration.test.ts:245` received `HttpError: Network request for 'editMessageText' failed!`. This PR does not change that fixture or the Telegram callback route.

The fixture follow-up also passed its complete changed-file checks:

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/l8-triage-consent-check node scripts/check-changed.mjs -- src/commands/triage-recovery.test.ts src/cli/update-cli/update-command-triage.test.ts
```

Final CI is green on `05a7ea1ea374ed62323e7e1a06082e6b2ef42c0e`: [successful run 34361183698](https://github.com/openclaw/openclaw/actions/runs/34361183698). The exact-head watcher completed with `GREEN` and zero pending checks.

## Review notes

This change touches no persisted data: no SQLite tables, columns, indexes, or stored records, and no config schema. It only gates the interactive launch of a repair agent with a confirmation prompt. Saved diagnostics and prompt artifacts are written exactly as before. All non-interactive and JSON paths are unchanged, covered by the updated `triage-recovery.test.ts` and `update-command-triage.test.ts` tests.
