### PR TITLE
fix(cli): print immutable-config refusals without crash framing

### DIFF
--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,5 +1,6 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
+import { ConfigReadOnlyError, NixModeConfigMutationError } from "../config/config-write-guard.js";
 import {
   GatewayCredentialsRequiredError,
   GatewayExplicitAuthRequiredError,
@@ -219,6 +220,14 @@ describe("formatCliFailureLines", () => {
     {
       label: "gateway URL override without explicit credentials",
       createError: () => new GatewayExplicitAuthRequiredError(EXPLICIT_GATEWAY_AUTH_MESSAGE),
+    },
+    {
+      label: "externally managed config",
+      createError: () => new ConfigReadOnlyError({ configPath: "/tmp/openclaw.json" }),
+    },
+    {
+      label: "Nix-managed config",
+      createError: () => new NixModeConfigMutationError({ configPath: "/tmp/openclaw.json" }),
     },
     {
       label: "unreachable gateway",

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -91,11 +91,22 @@ function isGatewayExplicitAuthCliError(error: unknown): error is Error {
   return error instanceof Error && error.name === "GatewayExplicitAuthRequiredError";
 }
 
+function isImmutableConfigCliError(error: unknown): error is Error {
+  // Config write-guard refusals (src/config/config-write-guard.ts) already carry the
+  // redeploy remedy; crash framing would point operators at a stack trace and
+  // `openclaw doctor`, which cannot lift an externally managed config.
+  return (
+    error instanceof Error &&
+    (error.name === "ConfigReadOnlyError" || error.name === "NixModeConfigMutationError")
+  );
+}
+
 export function isExpectedCliError(error: unknown): error is Error {
   return (
     error instanceof ExpectedCliError ||
     isGatewayCredentialsCliError(error) ||
     isGatewayExplicitAuthCliError(error) ||
+    isImmutableConfigCliError(error) ||
     isGatewayTransportError(error)
   );
 }


### PR DESCRIPTION
## What Problem This Solves

When an operator runs OpenClaw with an externally managed config (`OPENCLAW_CONFIG_READONLY=1`, added in #140719) or under `OPENCLAW_NIX_MODE=1`, the config write guard refuses mutations with a message that already carries the remedy ("Edit the config in your external deployment source, then redeploy or restart OpenClaw as needed."). `openclaw config set` printed that message plainly, but `openclaw plugins enable telegram` on a fresh isolated state (observed live at `71555bcbcb6`) printed:

```
[openclaw] The CLI command failed.
[openclaw] Reason: Config is externally managed (`OPENCLAW_CONFIG_READONLY=1`), so OpenClaw treats openclaw.json as immutable.
Edit the config in your external deployment source, then redeploy or restart OpenClaw as needed.
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
```

Every writer that throws through to the root renderer (`plugins enable|disable|install|uninstall|update`, `openclaw update`, doctor repairs) got the same crash framing. Doctor cannot lift an externally managed config, and there is no stack worth reading; the framing contradicts the guard's own guidance.

## Why This Change Was Made

`isExpectedCliError` in `src/cli/failure-output.ts` is the owner of "this is an operator condition, print the producer message as-is". It already classifies the Gateway credential preflight errors structurally by name (#142112) so the root renderer stays free of the config and transport stacks. This change adds `ConfigReadOnlyError` and `NixModeConfigMutationError` from `src/config/config-write-guard.ts` to that predicate with the same lean name check. The guard messages are already complete, and the `--json` path keeps the canonical `cli_error` envelope through the same predicate. `config set` keeps its own catch; nothing else changes.

## User Impact

Immutable-config refusals now print exactly the guard message on every command, with exit code 1 and no stack-trace or Doctor hint. Non-refusal failures keep their crash framing.

## Evidence

- Before (main `71555bcbcb6`, built dist, isolated state, `OPENCLAW_CONFIG_READONLY=1`): `openclaw plugins enable telegram` printed the six-line crash framing above.
- After (this branch, built dist, same command): prints only the guard message (two lines), exit 1; the same holds for `OPENCLAW_NIX_MODE=1` and for `plugins uninstall`.
- `src/cli/failure-output.test.ts`: two new rows in the existing "routes $label through the shared expected-condition predicate without crash framing" table; both fail on unmodified `main` (`isExpectedCliError` returns false), pass with the fix; the file passes at 24 tests.
- `node scripts/check-changed.mjs`: pass. Autoreview (Codex, P0-P2): scoped-clean.

Production LOC delta: +11 (one predicate with its contract comment, one line in the shared classifier).
