### PR TITLE
fix(doctor): preserve ambiguous Workshop migrations for review

### DIFF
--- a/docs/tools/skill-workshop/troubleshooting.md
+++ b/docs/tools/skill-workshop/troubleshooting.md
@@ -18,6 +18,29 @@ read_when:
 | Proposal does not show in list                 | Check the selected agent and `OPENCLAW_STATE_DIR`.                                                                                                                                                          |
 | Agent cannot call `skill_workshop`             | Check the active tool policy and run mode. `coding` includes the tool; restrictive `tools.allow` policies must list it explicitly, and sandboxed runs must use a normal host-side agent session or the CLI. |
 
+### Legacy ownership warnings during an update
+
+Doctor leaves legacy proposal metadata and collection backups in place when
+their workspace has no configured owner or maps to more than one agent. The
+warning names the retained path and candidate agents. These ownership warnings
+do not stop the other migrations or later Doctor repairs.
+
+Review the retained proposal or backup manifest alongside the configured agent
+workspaces. Correct a workspace mapping only when it identifies the actual
+owner; do not assign an arbitrary agent or delete the artifacts to clear the
+warning. Rerun Doctor after resolving ownership. Invalid metadata, failed writes,
+and unfinished recovery remain migration failures.
+
+A retarget count describes proposals changed during that pass. Any remaining
+external targets can belong to different proposals whose migration is blocked.
+Review their identifiers, paths, and migration warnings before retrying the same
+repair.
+
+Package rollback does not reverse the state-schema migration or relocated skill
+files. An older package can therefore be incompatible with the retained state.
+See [Schema bumps and older updaters](/reference/database-schemas#schema-bumps-and-older-updaters)
+and [Downgrade recovery](/reference/database-schemas#downgrade-recovery).
+
 ### Tool-policy diagnostic
 
 In `propose` and `auto` modes, `openclaw doctor` runs the

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -25,14 +25,14 @@ import { resolveSkillProposalTarget } from "../skills/workshop/store.js";
 const LEGACY_COLLECTION_BACKUP_SCHEMA = "openclaw.skill-collection-backup.v1";
 const MAX_BACKUP_MANIFEST_BYTES = 1024 * 1024;
 
-type LegacyCollectionBackupRoot =
+export type LegacyCollectionBackupRoot =
   | {
       legacyRoot: string;
       backups: LegacyCollectionBackup[];
       ownerAgentId: string;
       destinationRoot: string;
     }
-  | { legacyRoot: string; warning: string };
+  | { legacyRoot: string; warning: string; recoverable?: true };
 
 export async function listPendingLegacyCollectionBackupRoots(
   config: OpenClawConfig,
@@ -55,12 +55,24 @@ export async function listPendingLegacyCollectionBackupRoots(
       }
       const workspaceDirs = new Set(backups.map((backup) => backup.workspaceDir));
       const workspaceDir = [...workspaceDirs][0];
+      const candidateAgentIds = [
+        ...new Set(
+          [...workspaceDirs].flatMap((directory) =>
+            listWorkspaceOwnerAgentIds(config, env, directory),
+          ),
+        ),
+      ].toSorted();
       const ownerAgentId =
-        workspaceDirs.size === 1 && workspaceDir
-          ? inferWorkspaceOwnerAgentId(config, env, workspaceDir)
+        workspaceDirs.size === 1 && workspaceDir && candidateAgentIds.length === 1
+          ? candidateAgentIds[0]
           : undefined;
       if (!ownerAgentId) {
-        throw new Error("workspace does not map to exactly one configured agent");
+        roots.push({
+          legacyRoot,
+          warning: `Preserved legacy collection backup root ${legacyRoot} for manual review: workspace ${[...workspaceDirs].join(", ")} does not map to exactly one configured agent (candidate agents: ${candidateAgentIds.join(", ") || "none"}). Review the workspace ownership and retained backup manifests before retrying Doctor.`,
+          recoverable: true,
+        });
+        continue;
       }
       assertWorkspaceStateMigrationReady({
         workspaceDirs: [...workspaceDirs],
@@ -101,12 +113,20 @@ export function inferWorkspaceOwnerAgentId(
   env: NodeJS.ProcessEnv,
   workspaceDir: string,
 ): string | undefined {
-  const workspaceMatches = listAgentIds(config).filter(
+  const workspaceMatches = listWorkspaceOwnerAgentIds(config, env, workspaceDir);
+  return workspaceMatches.length === 1 ? workspaceMatches[0] : undefined;
+}
+
+export function listWorkspaceOwnerAgentIds(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  workspaceDir: string,
+): string[] {
+  return listAgentIds(config).filter(
     (agentId) =>
       resolveCanonicalWorkspacePath(resolveAgentWorkspaceDir(config, agentId, env)) ===
       resolveCanonicalWorkspacePath(workspaceDir),
   );
-  return workspaceMatches.length === 1 ? workspaceMatches[0] : undefined;
 }
 
 function legacyCollectionSkillPath(workspaceDir: string, relativeDir: string): string {
@@ -448,13 +468,17 @@ async function publishLegacyCollectionBackup(
 export async function migrateLegacyCollectionBackups(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
-): Promise<{ migrated: number; warnings: string[] }> {
-  const roots = await listPendingLegacyCollectionBackupRoots(config, env);
+  roots: readonly LegacyCollectionBackupRoot[],
+): Promise<{ migrated: number; warnings: string[]; recoverableWarningCount: number }> {
   let migrated = 0;
+  let recoverableWarningCount = 0;
   const warnings: string[] = [];
   for (const root of roots) {
     if ("warning" in root) {
       warnings.push(root.warning);
+      if (root.recoverable) {
+        recoverableWarningCount += 1;
+      }
       continue;
     }
     const { legacyRoot, backups, ownerAgentId, destinationRoot } = root;
@@ -493,5 +517,5 @@ export async function migrateLegacyCollectionBackups(
       warnings.push(`Preserved legacy collection backup root ${legacyRoot}: ${String(error)}`);
     }
   }
-  return { migrated, warnings };
+  return { migrated, warnings, recoverableWarningCount };
 }

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -11,7 +11,10 @@ import type { SkillProposalRecord } from "../skills/workshop/types.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { inspectLegacySkillWorkshopMigration } from "./doctor-skill-workshop-sqlite.js";
+import {
+  inspectLegacySkillWorkshopMigration,
+  migrateLegacySkillWorkshopProposals,
+} from "./doctor-skill-workshop-sqlite.js";
 import {
   createAppliedLegacyProposal,
   seedLegacyV15ProposalRows,
@@ -39,6 +42,56 @@ async function snapshotDatabase(databasePath: string) {
 }
 
 describe("read-only Skill Workshop migration inspection", () => {
+  it("identifies remaining targets after retargeting without recommending an identical repair", async () => {
+    await withOpenClawTestState({ label: "workshop-remaining-targets" }, async (state) => {
+      const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+      const blockedWorkspace = state.path("old-workspace");
+      await fs.mkdir(path.join(blockedWorkspace, ".openclaw"), { recursive: true });
+      await fs.writeFile(path.join(blockedWorkspace, ".openclaw", "workspace-state.json"), "{}");
+      const records = [
+        { name: "eligible", workspaceDir: state.workspaceDir },
+        { name: "blocked", workspaceDir: blockedWorkspace },
+      ].map(({ name, workspaceDir }) => {
+        const record: SkillProposalRecord = createAppliedLegacyProposal({
+          id: `${name}-20260901-1234567890`,
+          title: name,
+          description: "Saved procedure",
+          content: "# Saved\n",
+          target: { skillKey: name, skillDir: path.join(workspaceDir, "skills", name) },
+        });
+        record.status = "pending";
+        delete record.appliedAt;
+        return record;
+      });
+      for (const record of records) {
+        importLegacySkillProposal({ record, ownerAgentId: "main", store: { env: state.env } });
+      }
+      const [eligible, blocked] = records;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const migration = await migrateLegacySkillWorkshopProposals({ config, env: state.env });
+        if (attempt === 0) {
+          expect(migration.changes.join("\n")).toContain("retargeted 1 proposal");
+        } else {
+          expect(migration.changes).toEqual([]);
+        }
+        expect(migration.warnings.join("\n")).toContain(
+          "Legacy workspace setup state requires migration",
+        );
+        const result = await runDoctorLintChecks(
+          { mode: "doctor", runtime: { log() {}, error() {}, exit() {} }, cfg: config },
+          { checks: createCoreHealthChecks(), onlyIds: ["core/doctor/skill-workshop-relocation"] },
+        );
+        expect(result.findings).toHaveLength(1);
+        const finding = result.findings[0]!;
+        expect(finding.message).toContain(blocked!.id);
+        expect(finding.message).toContain(blocked!.target.skillDir);
+        expect(finding.message).not.toContain(eligible!.id);
+        expect(finding.fixHint).not.toContain("Run `openclaw doctor --fix`");
+        expect(finding.fixHint).toContain("migration warnings");
+      }
+    });
+  });
+
   it.each([
     { roots: [], proposal: false, preserved: 0, automatic: false },
     { roots: ["eligible"], proposal: false, preserved: 0, automatic: true },
@@ -193,6 +246,7 @@ describe("read-only Skill Workshop migration inspection", () => {
           inspectLegacySkillWorkshopMigration({ config, env: state.env }),
         ).resolves.toEqual({
           externalProposalCount: 1,
+          externalProposalDetails: expect.any(Array),
           externalProposalCountsByAgent: { main: 1 },
           legacyBackupRootCount: 0,
           preservedLegacyBackupRootCount: 0,
@@ -288,6 +342,7 @@ describe("read-only Skill Workshop migration inspection", () => {
         inspectLegacySkillWorkshopMigration({ config, env: state.env }),
       ).resolves.toEqual({
         externalProposalCount: 9,
+        externalProposalDetails: expect.any(Array),
         externalProposalCountsByAgent: { main: 5, other: 2, retired: 1, unknown: 1 },
         legacyBackupRootCount: 0,
         preservedLegacyBackupRootCount: 0,

--- a/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
@@ -621,6 +621,7 @@ describe("doctor Skill Workshop SQLite relocation conflicts and recovery", () =>
       inspectLegacySkillWorkshopMigration({ config: {}, env: testState.env }),
     ).resolves.toMatchObject({
       externalProposalCount: 2,
+      externalProposalDetails: expect.any(Array),
       externalProposalCountsByAgent: { main: 2 },
     });
 

--- a/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
@@ -77,6 +77,7 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
       inspectLegacySkillWorkshopMigration({ config: {}, env: testState.env }),
     ).resolves.toEqual({
       externalProposalCount: 1,
+      externalProposalDetails: expect.any(Array),
       externalProposalCountsByAgent: { main: 1 },
       legacyBackupRootCount: 0,
       preservedLegacyBackupRootCount: 0,
@@ -252,6 +253,7 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
       inspectLegacySkillWorkshopMigration({ config, env: testState.env }),
     ).resolves.toEqual({
       externalProposalCount: 1,
+      externalProposalDetails: expect.any(Array),
       externalProposalCountsByAgent: { retired: 1 },
       legacyBackupRootCount: 0,
       preservedLegacyBackupRootCount: 0,

--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -99,6 +99,7 @@ describe("doctor Skill Workshop SQLite migration", () => {
       inspectLegacySkillWorkshopMigration({ config: {}, env: testState.env }),
     ).resolves.toEqual({
       externalProposalCount: 1,
+      externalProposalDetails: [expect.stringContaining(proposalId)],
       externalProposalCountsByAgent: { main: 1 },
       legacyBackupRootCount: 0,
       preservedLegacyBackupRootCount: 0,

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -415,6 +415,32 @@ type PreparedLegacyProposal = {
   ownerAgentId: string;
 };
 
+async function readLegacyProposalArtifacts(
+  stateRoot: Root,
+  record: SkillProposalRecord,
+): Promise<SkillProposalRollback | undefined> {
+  const rollback = await readLegacyRollback(stateRoot, record.id);
+  const draft = await stateRoot
+    .read(`${PROPOSALS_DIR}/${record.id}/PROPOSAL.md`, {
+      hardlinks: "reject",
+      maxBytes: MAX_RECORD_BYTES,
+      symlinks: "reject",
+    })
+    .catch((error: unknown) => {
+      // Missing drafts must not quarantine a bundle that still owns apply recovery.
+      if (rollback && isMissingPathError(error)) {
+        throw new Error(
+          "Legacy bundle has a missing draft and unfinished apply recovery; restore its draft before retrying Doctor.",
+        );
+      }
+      throw error;
+    });
+  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.draftHash) {
+    throw new Error("proposal draft hash does not match proposal metadata");
+  }
+  return rollback;
+}
+
 async function prepareLegacyProposal(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -431,6 +457,7 @@ async function prepareLegacyProposal(params: {
   if (record.value.id !== params.proposalId) {
     throw new Error("invalid proposal metadata");
   }
+  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record.value);
   const workspaceDir = resolveLegacyWorkshopWorkspaceDir(
     record.value.target.skillDir,
     params.config,
@@ -443,6 +470,11 @@ async function prepareLegacyProposal(params: {
     workspaceDir,
   });
   if (!owner.ownerAgentId) {
+    if (rollback) {
+      throw new Error(
+        `Legacy bundle has unfinished apply recovery at ${path.join(resolveStateDir(params.env), proposalDir, "rollback.json")}; resolve its owning agent and recover the retained apply before retrying Doctor.`,
+      );
+    }
     const candidates = workspaceDir
       ? listWorkspaceOwnerAgentIds(params.config, params.env, workspaceDir).toSorted()
       : [];
@@ -464,15 +496,7 @@ async function migrateProposal(params: {
 }): Promise<void> {
   const { record, ownerAgentId } = params.prepared;
   const proposalDir = `${PROPOSALS_DIR}/${record.id}`;
-  const draft = await params.stateRoot.read(`${proposalDir}/PROPOSAL.md`, {
-    hardlinks: "reject",
-    maxBytes: MAX_RECORD_BYTES,
-    symlinks: "reject",
-  });
-  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.draftHash) {
-    throw new Error("proposal draft hash does not match proposal metadata");
-  }
-  const rollback = await readLegacyRollback(params.stateRoot, record.id);
+  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record);
   importLegacySkillProposal({
     record,
     rollback,

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { assertWorkspaceStateMigrationReady } from "../agents/workspace-legacy-state.js";
 import { resolveCanonicalWorkspacePath } from "../agents/workspace-state-identity.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -16,6 +17,7 @@ import {
 import { isPathInside } from "../infra/path-guards.js";
 import { movePathWithCopyFallback } from "../infra/replace-file.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
+import type { MigrationMessages } from "../infra/state-migrations.types.js";
 import { transitionPendingSkillProposalToStale } from "../skills/workshop/apply-transition.js";
 import { reconcileInterruptedSkillProposalApply } from "../skills/workshop/reconcile-transition.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
@@ -46,7 +48,9 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   listPendingLegacyCollectionBackupRoots,
+  listWorkspaceOwnerAgentIds,
   migrateLegacyCollectionBackups,
+  type LegacyCollectionBackupRoot,
 } from "./doctor-skill-workshop-collection-backups.js";
 import {
   classifyWorkshopRelocation,
@@ -75,9 +79,7 @@ const MAX_RECORD_BYTES = 1024 * 1024;
 const MAX_ROLLBACK_BYTES = 128 * 1024 * 1024;
 const PROPOSAL_ID_PATTERN = /^[a-z0-9][a-z0-9-]{5,120}$/;
 
-type MigrationResult = {
-  changes: string[];
-  warnings: string[];
+type MigrationResult = MigrationMessages & {
   detected: number;
   migrated: number;
 };
@@ -88,11 +90,13 @@ type WorkshopRelocationResult = {
   staleProposals: number;
   migratedBackupRoots: number;
   warnings: string[];
+  recoverableWarningCount: number;
 };
 
 export type LegacyWorkshopMigrationInspection = {
   externalProposalCount: number;
   externalProposalCountsByAgent: Record<string, number>;
+  externalProposalDetails?: string[];
   legacyBackupRootCount: number;
   preservedLegacyBackupRootCount: number;
 };
@@ -144,6 +148,20 @@ export async function inspectLegacySkillWorkshopMigration(params: {
       counts[ownerAgentId] = (counts[ownerAgentId] ?? 0) + 1;
       return counts;
     }, {}),
+    ...(external.length > 0
+      ? {
+          externalProposalDetails: external
+            .toSorted((left, right) => left.record.id.localeCompare(right.record.id))
+            .slice(0, 20)
+            .map(({ record, ownerAgentId, unconfiguredOwnerAgentId }) =>
+              truncateWithMarker(
+                `${record.id}: ${record.target.skillDir} (owner: ${ownerAgentId ?? unconfiguredOwnerAgentId ?? "unknown"})`,
+                2000,
+                { marker: "…", reserve: 1, trimEnd: true },
+              ),
+            ),
+        }
+      : {}),
     legacyBackupRootCount: backups.length,
     preservedLegacyBackupRootCount: backups.filter((backup) => "warning" in backup).length,
   };
@@ -153,6 +171,7 @@ async function relocateLegacyWorkshopTargets(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   retireMissingDrafts: boolean,
+  backupRoots: readonly LegacyCollectionBackupRoot[],
 ): Promise<WorkshopRelocationResult> {
   const database = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<
@@ -334,7 +353,7 @@ async function relocateLegacyWorkshopTargets(
   }
   persistUpdates(plan.updates);
   await finishWorkshopWorkspaceRelocations(env);
-  const backupMigration = await migrateLegacyCollectionBackups(config, env);
+  const backupMigration = await migrateLegacyCollectionBackups(config, env, backupRoots);
   const updates = [...plan.updates, ...plan.moves.flatMap((move) => move.updates)];
   const staleProposals = updates.filter((update) => update.record.status === "stale").length;
   return {
@@ -343,6 +362,7 @@ async function relocateLegacyWorkshopTargets(
     staleProposals: staleProposals + missingDraftsRetired,
     migratedBackupRoots: backupMigration.migrated,
     warnings: [...recoveryWarnings, ...plan.warnings, ...backupMigration.warnings],
+    recoverableWarningCount: backupMigration.recoverableWarningCount,
   };
 }
 
@@ -390,12 +410,17 @@ async function verifyImportedProposal(
   }
 }
 
-async function migrateProposal(params: {
+type PreparedLegacyProposal = {
+  record: SkillProposalRecord;
+  ownerAgentId: string;
+};
+
+async function prepareLegacyProposal(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   proposalId: string;
   stateRoot: Root;
-}): Promise<void> {
+}): Promise<PreparedLegacyProposal | { warning: string }> {
   const proposalDir = `${PROPOSALS_DIR}/${params.proposalId}`;
   const record = validateSkillProposalRecord(
     await readJson(params.stateRoot, `${proposalDir}/proposal.json`, MAX_RECORD_BYTES),
@@ -406,39 +431,55 @@ async function migrateProposal(params: {
   if (record.value.id !== params.proposalId) {
     throw new Error("invalid proposal metadata");
   }
+  const workspaceDir = resolveLegacyWorkshopWorkspaceDir(
+    record.value.target.skillDir,
+    params.config,
+    params.env,
+  );
+  const owner = inferOwnerAgentId({
+    config: params.config,
+    env: params.env,
+    record: record.value,
+    workspaceDir,
+  });
+  if (!owner.ownerAgentId) {
+    const candidates = workspaceDir
+      ? listWorkspaceOwnerAgentIds(params.config, params.env, workspaceDir).toSorted()
+      : [];
+    const reason = owner.unconfiguredOwnerAgentId
+      ? `owning agent "${owner.unconfiguredOwnerAgentId}" is not configured`
+      : "owning agent could not be inferred";
+    return {
+      warning: `Preserved Skill Workshop proposal ${path.join(resolveStateDir(params.env), proposalDir)} for manual review: ${reason}; target ${record.value.target.skillDir} (candidate agents: ${candidates.join(", ") || "none"}). Review the retained metadata and configured workspace ownership before retrying Doctor.`,
+    };
+  }
+  return { record: record.value, ownerAgentId: owner.ownerAgentId };
+}
+
+async function migrateProposal(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateRoot: Root;
+  prepared: PreparedLegacyProposal;
+}): Promise<void> {
+  const { record, ownerAgentId } = params.prepared;
+  const proposalDir = `${PROPOSALS_DIR}/${record.id}`;
   const draft = await params.stateRoot.read(`${proposalDir}/PROPOSAL.md`, {
     hardlinks: "reject",
     maxBytes: MAX_RECORD_BYTES,
     symlinks: "reject",
   });
-  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.value.draftHash) {
+  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.draftHash) {
     throw new Error("proposal draft hash does not match proposal metadata");
   }
-  const rollback = await readLegacyRollback(params.stateRoot, params.proposalId);
-  const owner = inferOwnerAgentId({
-    config: params.config,
-    env: params.env,
-    record: record.value,
-    workspaceDir: resolveLegacyWorkshopWorkspaceDir(
-      record.value.target.skillDir,
-      params.config,
-      params.env,
-    ),
-  });
-  if (!owner.ownerAgentId) {
-    throw new Error(
-      owner.unconfiguredOwnerAgentId
-        ? `owning agent "${owner.unconfiguredOwnerAgentId}" is not configured; legacy metadata was retained for manual recovery`
-        : "owning agent could not be inferred; legacy metadata was retained for manual recovery",
-    );
-  }
+  const rollback = await readLegacyRollback(params.stateRoot, record.id);
   importLegacySkillProposal({
-    record: record.value,
+    record,
     rollback,
-    ownerAgentId: owner.ownerAgentId,
+    ownerAgentId,
     store: { env: params.env },
   });
-  await verifyImportedProposal(params.config, params.env, record.value, rollback);
+  await verifyImportedProposal(params.config, params.env, record, rollback);
   if (rollback) {
     await params.stateRoot.remove(`${proposalDir}/rollback.json`);
   }
@@ -509,6 +550,22 @@ async function importLegacySkillProposalSidecars(params: {
     .toSorted((left, right) => left.localeCompare(right));
   const warnings: string[] = [];
   const changes: string[] = [];
+  let recoverableWarningCount = 0;
+  const prepared = new Map<
+    string,
+    PreparedLegacyProposal | { warning: string } | { error: unknown }
+  >();
+  // Resolve every sidecar's ownership before the first import or artifact retirement.
+  for (const proposalId of proposalIds) {
+    try {
+      prepared.set(
+        proposalId,
+        await prepareLegacyProposal({ config: params.config, env, proposalId, stateRoot }),
+      );
+    } catch (error) {
+      prepared.set(proposalId, { error });
+    }
+  }
   const database = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
     database.db,
@@ -516,11 +573,20 @@ async function importLegacySkillProposalSidecars(params: {
   let migrated = 0;
   for (const proposalId of proposalIds) {
     const proposalDir = `${PROPOSALS_DIR}/${proposalId}`;
+    const proposal = prepared.get(proposalId)!;
+    if ("warning" in proposal) {
+      warnings.push(proposal.warning);
+      recoverableWarningCount += 1;
+      continue;
+    }
     try {
+      if ("error" in proposal) {
+        throw proposal.error;
+      }
       await migrateProposal({
         config: params.config,
         env,
-        proposalId,
+        prepared: proposal,
         stateRoot,
       });
       migrated += 1;
@@ -571,6 +637,9 @@ async function importLegacySkillProposalSidecars(params: {
   return {
     changes,
     warnings,
+    ...(warnings.length > 0 && warnings.length === recoverableWarningCount
+      ? { warningDisposition: "recoverable" as const }
+      : {}),
     detected: proposalIds.length,
     migrated,
   };
@@ -588,11 +657,13 @@ export async function migrateLegacySkillWorkshopProposals(params: {
     databasePath: resolveOpenClawStateSqlitePath(env),
   });
   try {
+    const backupRoots = await listPendingLegacyCollectionBackupRoots(params.config, env);
     const sidecars = await importLegacySkillProposalSidecars({ config: params.config, env });
     const relocation = await relocateLegacyWorkshopTargets(
       params.config,
       env,
       params.retireMissingDrafts === true,
+      backupRoots,
     );
     if (
       relocation.movedSkills > 0 ||
@@ -604,9 +675,18 @@ export async function migrateLegacySkillWorkshopProposals(params: {
         `Relocated ${relocation.movedSkills} Skill Workshop skill${relocation.movedSkills === 1 ? "" : "s"}, retargeted ${relocation.retargetedProposals} proposal${relocation.retargetedProposals === 1 ? "" : "s"}, marked ${relocation.staleProposals} stale, and migrated ${relocation.migratedBackupRoots} legacy collection backup root${relocation.migratedBackupRoots === 1 ? "" : "s"}.`,
       );
     }
+    const warnings = [...sidecars.warnings, ...relocation.warnings];
+    const recoverableWarningCount =
+      (sidecars.warningDisposition === "recoverable" ? sidecars.warnings.length : 0) +
+      relocation.recoverableWarningCount;
     return {
-      ...sidecars,
-      warnings: [...sidecars.warnings, ...relocation.warnings],
+      changes: sidecars.changes,
+      detected: sidecars.detected,
+      migrated: sidecars.migrated,
+      warnings,
+      ...(warnings.length > 0 && warnings.length === recoverableWarningCount
+        ? { warningDisposition: "recoverable" as const }
+        : {}),
     };
   } finally {
     coordinator.release();

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -370,7 +370,9 @@ const skillWorkshopRelocationCheck: HealthCheck = {
       inspection.legacyBackupRootCount > inspection.preservedLegacyBackupRootCount
     ) {
       fixHints.push(
-        "Run `openclaw doctor --fix` to process eligible Workshop relocations and legacy collection backups.",
+        ctx.mode === "doctor"
+          ? "Review the remaining targets and migration warnings above. Resolve their ownership or recovery blockers before retrying Doctor; repeating the same repair alone will not resolve them."
+          : "Run `openclaw doctor --fix` to process eligible Workshop relocations and legacy collection backups.",
       );
     }
     if (inspection.preservedLegacyBackupRootCount > 0) {
@@ -388,7 +390,7 @@ const skillWorkshopRelocationCheck: HealthCheck = {
           .map(([agentId, count]) => `${agentId}: ${count}`)
           .join(
             ", ",
-          )}) and ${inspection.legacyBackupRootCount} legacy collection backup root${inspection.legacyBackupRootCount === 1 ? "" : "s"} (${inspection.preservedLegacyBackupRootCount} preserved for review).`,
+          )}) and ${inspection.legacyBackupRootCount} legacy collection backup root${inspection.legacyBackupRootCount === 1 ? "" : "s"} (${inspection.preservedLegacyBackupRootCount} preserved for review).${inspection.externalProposalDetails?.length ? `\nRemaining proposal targets (showing ${inspection.externalProposalDetails.length} of ${inspection.externalProposalCount}):\n${inspection.externalProposalDetails.join("\n")}` : ""}`,
         path: "skills.workshop",
         fixHint: fixHints.join(" "),
       },

--- a/src/infra/state-migrations.skill-workshop.test.ts
+++ b/src/infra/state-migrations.skill-workshop.test.ts
@@ -1,5 +1,11 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  inspectLegacySkillWorkshopMigration,
+  migrateLegacySkillWorkshopProposals,
+} from "../commands/doctor-skill-workshop-sqlite.js";
+import { createAppliedLegacyProposal } from "../commands/doctor-skill-workshop-sqlite.test-support.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
 import {
@@ -18,6 +24,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { autoMigrateLegacyState } from "./state-migrations.doctor.js";
+import { throwIfDoctorStateMigrationRefused } from "./state-migrations.messages.js";
 
 describe("automatic Skill Workshop migration", () => {
   let state: OpenClawTestState;
@@ -28,6 +35,136 @@ describe("automatic Skill Workshop migration", () => {
 
   afterEach(async () => {
     await state.cleanup();
+  });
+
+  async function seedSidecar(name: string, workspaceDir: string) {
+    const content = "---\nname: procedure\ndescription: Saved procedure\n---\n\n# Procedure\n";
+    const record = {
+      ...createAppliedLegacyProposal({
+        id: `${name}-20260901-1234567890`,
+        title: name,
+        description: "Saved procedure",
+        content,
+        target: { skillKey: name, skillDir: path.join(workspaceDir, "skills", name) },
+      }),
+      status: "pending" as const,
+      appliedAt: undefined,
+    };
+    const relativeDir = `skill-workshop/proposals/${record.id}`;
+    const metadata = JSON.stringify(record);
+    const file = await state.writeText(`${relativeDir}/proposal.json`, metadata);
+    await state.writeText(`${relativeDir}/PROPOSAL.md`, content);
+    return { record, file, metadata };
+  }
+
+  it.each([
+    { item: "proposal", candidates: ["alpha", "beta"] },
+    { item: "proposal", candidates: [] },
+    { item: "backup", candidates: ["alpha", "beta"] },
+    { item: "backup", candidates: [] },
+  ])(
+    "continues Doctor with $item ownership candidates $candidates",
+    async ({ item, candidates }) => {
+      const ambiguousWorkspace = state.path("unresolved-workspace");
+      const config: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: { workspace: state.workspaceDir },
+            ...Object.fromEntries(candidates.map((id) => [id, { workspace: ambiguousWorkspace }])),
+          },
+        },
+      };
+      await state.writeConfig(config);
+      const eligible = await seedSidecar("eligible", state.workspaceDir);
+      const preserved =
+        item === "proposal"
+          ? await seedSidecar("unresolved", ambiguousWorkspace)
+          : await (async () => {
+              const metadata = JSON.stringify({
+                schema: "openclaw.skill-collection-backup.v1",
+                id: "legacy-backup",
+                createdAt: "2026-09-01T00:00:00.000Z",
+                workspaceDir: ambiguousWorkspace,
+                skillDirs: [],
+                resultSkillDirs: [],
+                resultSkillHashes: {},
+              });
+              const file = await state.writeText(
+                "skill-workshop/collection-backups/0000000000000000/legacy-backup/manifest.json",
+                metadata,
+              );
+              return { file, metadata };
+            })();
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = await autoMigrateLegacyState({
+          cfg: config,
+          env: state.env,
+          homedir: () => state.home,
+          doctorOnlyStateMigrations: true,
+          legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+        });
+        const workshop = result.stepReceipts.find((receipt) => receipt.id === "skill-workshop");
+        expect(workshop).toMatchObject({ outcome: "warning" });
+        expect(() => throwIfDoctorStateMigrationRefused(result.stepReceipts)).not.toThrow();
+        const warning = workshop?.warnings.join("\n");
+        expect(warning).toContain(
+          item === "proposal"
+            ? path.dirname(preserved.file)
+            : path.dirname(path.dirname(preserved.file)),
+        );
+        expect(warning).toContain(`candidate agents: ${candidates.join(", ") || "none"}`);
+        await expect(fs.readFile(preserved.file, "utf8")).resolves.toBe(preserved.metadata);
+        await expect(
+          inspectLegacySkillWorkshopMigration({ config, env: state.env }),
+        ).resolves.toMatchObject({
+          externalProposalCount: 0,
+        });
+      }
+      await expect(fs.access(eligible.file)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(
+        inspectSkillProposal(eligible.record.id, { config, agentId: "main", env: state.env }),
+      ).resolves.toMatchObject({
+        record: { status: "pending", target: { source: "openclaw-workshop" } },
+      });
+    },
+  );
+
+  it("discovers unreadable backup roots before importing sidecars", async () => {
+    const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+    const eligible = await seedSidecar("eligible", state.workspaceDir);
+    await state.writeText("skill-workshop/collection-backups", "not a directory");
+
+    await expect(
+      migrateLegacySkillWorkshopProposals({ config, env: state.env }),
+    ).rejects.toMatchObject({ code: "ENOTDIR" });
+    await expect(fs.readFile(eligible.file, "utf8")).resolves.toBe(eligible.metadata);
+  });
+
+  it("keeps a corrupt proposal fatal alongside recoverable ownership warnings", async () => {
+    const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+    await state.writeConfig(config);
+    await seedSidecar("unresolved", state.path("unconfigured-workspace"));
+    const corrupt = await seedSidecar("corrupt", state.workspaceDir);
+    await fs.writeFile(path.join(path.dirname(corrupt.file), "PROPOSAL.md"), "corrupt draft");
+
+    const result = await autoMigrateLegacyState({
+      cfg: config,
+      env: state.env,
+      homedir: () => state.home,
+      doctorOnlyStateMigrations: true,
+      legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+    });
+    expect(result.stepReceipts.find((receipt) => receipt.id === "skill-workshop")).toMatchObject({
+      outcome: "refused",
+      warnings: [
+        expect.stringContaining("draft hash does not match"),
+        expect.stringContaining("owning agent could not be inferred"),
+      ],
+    });
+    expect(() => throwIfDoctorStateMigrationRefused(result.stepReceipts)).toThrow("Doctor stopped");
+    await expect(fs.readFile(corrupt.file, "utf8")).resolves.toBe(corrupt.metadata);
   });
 
   it.each([15, 16])(

--- a/src/infra/state-migrations.skill-workshop.test.ts
+++ b/src/infra/state-migrations.skill-workshop.test.ts
@@ -15,6 +15,10 @@ import {
 } from "../skills/workshop/service.js";
 import { updateSkillProposalRecord } from "../skills/workshop/store.js";
 import {
+  SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+  type SkillProposalRollback,
+} from "../skills/workshop/types.js";
+import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
@@ -166,6 +170,76 @@ describe("automatic Skill Workshop migration", () => {
     expect(() => throwIfDoctorStateMigrationRefused(result.stepReceipts)).toThrow("Doctor stopped");
     await expect(fs.readFile(corrupt.file, "utf8")).resolves.toBe(corrupt.metadata);
   });
+
+  it.each([
+    "corrupt draft",
+    "interrupted apply",
+    "corrupt rollback",
+    "missing draft with rollback",
+  ] as const)(
+    "refuses an ownerless bundle with %s before deferring ownership",
+    async (artifact) => {
+      const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+      await state.writeConfig(config);
+      const proposal = await seedSidecar("ownerless", state.path("unconfigured-workspace"));
+      const proposalDir = path.dirname(proposal.file);
+      const draftPath = path.join(proposalDir, "PROPOSAL.md");
+      const rollbackPath = path.join(proposalDir, "rollback.json");
+      const rollback: SkillProposalRollback = {
+        schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+        proposalId: proposal.record.id,
+        writtenAt: "2026-09-01T00:00:00.000Z",
+        targetSkillFile: proposal.record.target.skillFile,
+        action: "create",
+        supportFiles: [],
+      };
+      const rollbackText = artifact === "corrupt rollback" ? "{broken" : JSON.stringify(rollback);
+      const missingDraft = artifact === "missing draft with rollback";
+      if (artifact === "corrupt draft") {
+        await fs.writeFile(draftPath, "corrupt draft");
+      } else {
+        await fs.writeFile(rollbackPath, rollbackText);
+        if (missingDraft) {
+          await fs.unlink(draftPath);
+        }
+      }
+      const draft = missingDraft ? undefined : await fs.readFile(draftPath, "utf8");
+
+      const result = await autoMigrateLegacyState({
+        cfg: config,
+        env: state.env,
+        homedir: () => state.home,
+        doctorOnlyStateMigrations: true,
+        legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+      });
+      const receipt = result.stepReceipts.find((entry) => entry.id === "skill-workshop");
+      expect(receipt).toMatchObject({
+        outcome: "refused",
+        warnings: [
+          expect.stringContaining(
+            `Failed to migrate Skill Workshop proposal ${proposal.record.id}`,
+          ),
+        ],
+      });
+      if (artifact === "corrupt draft") {
+        expect(receipt?.warnings.join("\n")).toContain("draft hash does not match");
+      } else if (artifact === "interrupted apply" || missingDraft) {
+        expect(receipt?.warnings.join("\n")).toContain("unfinished apply recovery");
+      }
+      expect(() => throwIfDoctorStateMigrationRefused(result.stepReceipts)).toThrow(
+        "Doctor stopped",
+      );
+      await expect(fs.readFile(proposal.file, "utf8")).resolves.toBe(proposal.metadata);
+      if (missingDraft) {
+        await expect(fs.access(draftPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        await expect(fs.readFile(draftPath, "utf8")).resolves.toBe(draft);
+      }
+      if (artifact !== "corrupt draft") {
+        await expect(fs.readFile(rollbackPath, "utf8")).resolves.toBe(rollbackText);
+      }
+    },
+  );
 
   it.each([15, 16])(
     "keeps pending proposals readable after migrating legacy targets from schema %i",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating OpenClaw would have Doctor stop when valid, inert legacy Skill Workshop proposals or collection backups could not be assigned to exactly one configured agent. It also makes remaining external proposal targets distinguishable from proposals successfully retargeted during the same pass.

Fixes #143094
Refs #142583
Refs #142770
Refs #142582

## Why This Change Was Made

Workshop already preserved ambiguous artifacts, but its warnings became fatal migration receipts. Classify ownership-only deferrals as recoverable, name the retained path and candidate agents, discover backup roots before Workshop mutations, and preflight all sidecar artifacts and owners before importing proposals.

Read-only diagnostics identify up to 20 remaining proposal IDs, target paths, and owners. After Doctor has attempted migration, explain that ownership/recovery blockers must be resolved before retrying. Successful retargeting uses the existing canonical target resolver.

## User Impact

Doctor can finish eligible work while preserving validated, inert ambiguous proposals and backups for manual review. Corrupt artifacts and unfinished applies still stop Doctor, with their recovery evidence retained. Operators can identify remaining targets without confusing their count with successful retargets.

This does not fix 2026.9.2 package rollback after state migration. The v16 schema transaction commits before later Doctor work; an already-running 9.2 updater can restore old package files without restoring the database or relocated skills. Full recovery needs a separately approved design. Multi-agent config recovery in #142582 is also outside this change.

## Review notes

The accepted P1 is repaired at the legacy bundle validator. Before an ownership deferral, Doctor validates rollback metadata, reads PROPOSAL.md with the existing symlink/hardlink and size guards, and verifies its hash. An ownerless bundle with rollback evidence remains fatal. A missing draft with rollback evidence also stays fatal instead of entering incomplete-bundle quarantine. Owned bundles are checked again immediately before import through the same validator. Valid ownerless bundles without rollback evidence remain advisory.

For #142583, the reporter's original records were not preserved. This PR proves convergence and diagnostic ambiguity, not the exact reported eight-record failure; the issue is referenced rather than marked fixed.

No persisted SQLite tables, columns, indexes, or stored record formats change. The changes are limited to Doctor classification, preflight ordering, validation, and diagnostics; the existing v16 schema migration and package rollback implementation are unchanged.

The mixed-outcome regressions in `src/infra/state-migrations.skill-workshop.test.ts` verify that valid ownership-only deferrals remain advisory while corrupt drafts, malformed rollback metadata, and unfinished applies remain fatal, with retained artifacts unchanged. Its schema 15/16 fixtures verify readable pending proposals after migration; the existing Workshop SQLite and relocation tests cover owned-bundle revision, apply recovery, and quarantine without rollback evidence.

## Evidence

- Against head a19866af06d8cec6a161505f3239c071deec6caf, the three same-bundle regressions (ownerless with corrupt draft, interrupted-apply receipt, or malformed rollback metadata) all failed: expected a refused migration receipt, received an advisory warning.
- The missing-draft-with-rollback regression separately reproduced an incorrect completed receipt through quarantine; it now requires a refusal and retained metadata/rollback files.
- The existing ownership-only regressions verify advisory receipts, unchanged artifacts, and second-pass convergence. Existing owned-bundle tests cover import, revision, apply recovery, and quarantine without rollback evidence.
- `node scripts/run-vitest.mjs src/commands/doctor-skill-workshop*.test.ts src/infra/state-migrations.skill-workshop.test.ts`: 107 tests passed across 10 files before the final missing-draft guard was added.
- Final focused validation passed all 44 tests: `node scripts/run-vitest.mjs src/infra/state-migrations.skill-workshop.test.ts src/commands/doctor-skill-workshop-sqlite.test.ts src/commands/doctor-skill-workshop-sqlite.relocation.test.ts src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts`. This includes schema 15/16 upgrade fixtures, the four ownerless failure cases, valid advisory deferrals, owned apply recovery, and incomplete bundles without rollback evidence.
- `node scripts/check-changed.mjs --base a19866af06d8cec6a161505f3239c071deec6caf` passed. Final core and changed-test type checks, formatting, and `git diff --check` also passed after the missing-draft guard.

No live Gateway or package rollback was exercised. CI for head `2c6c550157515645084392694b1fd522aca7dd98` reported an unrelated [Telegram loopback test failure](https://github.com/openclaw/openclaw/actions/runs/34365347489/job/102513410544): `extensions/telegram/src/model-callback.loopback.integration.test.ts:245` received `HttpError: Network request for 'editMessageText' failed!` instead of the successful model-change message. The Telegram subsystem is unchanged by this PR; this failure is left for separate investigation.

