### PR TITLE
docs: split help/faq into 13 topic pages

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1032,12 +1032,56 @@
     "target": "常见问题"
   },
   {
-    "source": "FAQ: quick start and first-run setup",
-    "target": "常见问题：快速开始与首次运行设置"
+    "source": "What is OpenClaw?",
+    "target": "什么是 OpenClaw？"
   },
   {
-    "source": "FAQ: providers, hardware, and hosting",
-    "target": "常见问题：服务商、硬件与托管"
+    "source": "Skills and automation",
+    "target": "Skills 与自动化"
+  },
+  {
+    "source": "Sandboxing and memory",
+    "target": "沙箱与记忆"
+  },
+  {
+    "source": "Where things live on disk",
+    "target": "磁盘上的文件位置"
+  },
+  {
+    "source": "Config basics",
+    "target": "配置基础"
+  },
+  {
+    "source": "Remote gateways and nodes",
+    "target": "远程 Gateway 与节点"
+  },
+  {
+    "source": "Env vars and .env loading",
+    "target": "环境变量与 .env 加载"
+  },
+  {
+    "source": "Sessions and multiple chats",
+    "target": "会话与多个聊天"
+  },
+  {
+    "source": "Gateway ports, already running, and remote mode",
+    "target": "Gateway 端口、已在运行与远程模式"
+  },
+  {
+    "source": "Logging and debugging",
+    "target": "日志与调试"
+  },
+  {
+    "source": "Media and attachments",
+    "target": "媒体与附件"
+  },
+  {
+    "source": "Security and access control",
+    "target": "安全与访问控制"
+  },
+  {
+    "source": "Chat commands, aborting tasks, and stopping a run",
+    "target": "聊天命令、中止任务与停止运行"
   },
   {
     "source": "Ollama Web Search",
@@ -4190,5 +4234,13 @@
   {
     "source": "Docker",
     "target": "Docker"
+  },
+  {
+    "source": "FAQ: quick start and first-run setup",
+    "target": "常见问题：快速开始与首次运行设置"
+  },
+  {
+    "source": "FAQ: providers, hardware, and hosting",
+    "target": "常见问题：服务商、硬件与托管"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3213,6 +3213,24 @@
                 "group": "FAQ",
                 "pages": [
                   "help/faq",
+                  {
+                    "group": "FAQ topics",
+                    "pages": [
+                      "help/faq/what-is-openclaw",
+                      "help/faq/skills-and-automation",
+                      "help/faq/sandboxing-and-memory",
+                      "help/faq/where-things-live-on-disk",
+                      "help/faq/config-basics",
+                      "help/faq/remote-gateways-and-nodes",
+                      "help/faq/env-vars",
+                      "help/faq/sessions-and-chats",
+                      "help/faq/gateway-ports-and-remote-mode",
+                      "help/faq/logging-and-debugging",
+                      "help/faq/media-and-attachments",
+                      "help/faq/security-and-access-control",
+                      "help/faq/chat-commands-and-stopping"
+                    ]
+                  },
                   "help/faq-first-run",
                   {
                     "group": "First-run FAQ",

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -8,6 +8,25 @@ title: "FAQ"
 
 Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS, multi-agent, OAuth/API keys, model failover). For runtime diagnostics, see [Troubleshooting](/gateway/troubleshooting). For the full config reference, see [Configuration](/gateway/configuration).
 
+This page is an index. The day-to-day FAQ is split across thirteen pages, one per
+topic. The triage ladder stays on this page; open the page that matches your question.
+
+| Page                                                                                       | Read it when                                                                    |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| [What is OpenClaw?](/help/faq/what-is-openclaw)                                            | You are evaluating OpenClaw, or explaining what it is and who funds it.         |
+| [Skills and automation](/help/faq/skills-and-automation)                                   | You are customizing skills, or a cron job, reminder, or subagent misbehaved.    |
+| [Sandboxing and memory](/help/faq/sandboxing-and-memory)                                   | You are tuning the sandbox, or memory is not persisting.                        |
+| [Where things live on disk](/help/faq/where-things-live-on-disk)                           | You need to find, back up, move, or remove OpenClaw data.                       |
+| [Config basics](/help/faq/config-basics)                                                   | You are editing config, enabling web search, or recovering from `config.apply`. |
+| [Remote gateways and nodes](/help/faq/remote-gateways-and-nodes)                           | You run the Gateway on a VPS or another machine, or you are adding a node.      |
+| [Env vars and .env loading](/help/faq/env-vars)                                            | You are setting keys through env or `.env`, or the service lost them.           |
+| [Sessions and multiple chats](/help/faq/sessions-and-chats)                                | You are managing sessions, resets, context limits, groups, or several bots.     |
+| [Gateway ports, already running, and remote mode](/help/faq/gateway-ports-and-remote-mode) | The Gateway will not bind, says it is already running, or you want remote mode. |
+| [Logging and debugging](/help/faq/logging-and-debugging)                                   | You need logs or a service restart, or replies never arrive.                    |
+| [Media and attachments](/help/faq/media-and-attachments)                                   | A skill produced an image or PDF but nothing was sent.                          |
+| [Security and access control](/help/faq/security-and-access-control)                       | You are exposing OpenClaw to inbound messages or judging plugin risk.           |
+| [Chat commands, aborting tasks, and stopping a run](/help/faq/chat-commands-and-stopping)  | A task will not stop, or you are tuning slash commands and the queue.           |
+
 ## First 60 seconds if something is broken
 
 <Steps>
@@ -66,1532 +85,9 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
 First-run Q&A - install, onboard, auth routes, subscriptions, initial failures - lives on the [First-run FAQ](/help/faq-first-run).
 
-## What is OpenClaw?
-
-<AccordionGroup>
-  <Accordion title="What is OpenClaw, in one paragraph?">
-    OpenClaw is an AI assistant you run on your own infrastructure - for yourself, or shared with your team. It replies on the messaging surfaces you already use (Discord, Google Chat, iMessage, Mattermost, Signal, Slack, Telegram, WebChat, WhatsApp, and bundled channel plugins such as QQ Bot) and can also do voice plus hosted widgets in chat, on session dashboards, and in the macOS panel. The **Gateway** is the always-on control plane; the assistant is the product. The same gateway scales from one person's WhatsApp to a shared workspace bot with [multi-user sessions](/concepts/multi-user).
-  </Accordion>
-
-  <Accordion title="Can my team share one OpenClaw?">
-    Yes. A shared gateway is a supported, first-class deployment: sessions carry an immutable creator, an assignable owner, and the people who prompted them; the Control UI shows who is viewing and typing in real time; and commits from shared sessions can carry `Co-authored-by` trailers for the people who steered them. [Named operator roles](/gateway/operator-scopes#named-operator-roles) bound what each teammate can do.
-
-    One boundary to respect: a gateway is one trust domain. Share it with people who trust each other; mutually adversarial users need separate gateways. See [Team setup](/start/teams), [Multi-user mode](/concepts/multi-user), and [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Value proposition">
-    OpenClaw is not "just a Claude wrapper." It is a **local-first control plane** that runs a capable assistant on **your own hardware**, reachable from the chat apps you already use, with stateful sessions, memory, and tools - without handing your workflows to a hosted SaaS.
-
-    - **Your devices, your data**: run the Gateway wherever you want (Mac, Linux, VPS) and keep the workspace and session history local.
-    - **Real channels, not a web sandbox**: Discord/iMessage/Signal/Slack/Telegram/WhatsApp/etc, plus mobile voice and hosted widgets.
-    - **Model-agnostic**: use Anthropic, MiniMax, OpenAI, OpenRouter, etc., with per-agent routing and failover.
-    - **Local-only option**: run local models so all data can stay on your device.
-    - **Multi-agent routing**: separate agents per channel, account, or task, each with its own workspace and defaults.
-    - **Open source and hackable**: inspect, extend, and self-host without vendor lock-in.
-
-    Docs: [Gateway](/gateway), [Channels](/channels), [Multi-agent](/concepts/multi-agent), [Memory](/concepts/memory).
-
-  </Accordion>
-
-  <Accordion title="I just set it up - what should I do first?">
-    Good first projects: build a website (WordPress, Shopify, or a static site); prototype a mobile app (outline, screens, API plan); organize files and folders; connect Gmail and automate summaries or follow-ups.
-
-    It can handle large tasks, but works best split into phases with sub-agents for parallel work.
-
-  </Accordion>
-
-  <Accordion title="What are the top five everyday use cases for OpenClaw?">
-    - **Personal briefings**: summaries of inbox, calendar, and news you care about.
-    - **Research and drafting**: quick research, summaries, and first drafts for emails or docs.
-    - **Reminders and follow-ups**: cron- or heartbeat-driven nudges and checklists.
-    - **Browser automation**: filling forms, collecting data, repeating web tasks.
-    - **Cross-device coordination**: send a task from your phone, let the Gateway run it on a server, get the result back in chat.
-
-  </Accordion>
-
-  <Accordion title="Can OpenClaw help with lead gen, outreach, ads, and blogs for a SaaS?">
-    Yes, for **research, qualification, and drafting**: scanning sites, building shortlists, summarizing prospects, writing outreach or ad copy drafts.
-
-    For **outreach or ad runs**, keep a human in the loop. Avoid spam, follow local laws and platform policies, and review anything before it sends. Let OpenClaw draft; you approve.
-
-    Docs: [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Is OpenClaw owned by OpenAI?">
-    No. OpenClaw is stewarded by the [OpenClaw Foundation](https://openclaw.org), an independent 501(c)(3). OpenAI is one of several donors, and its creator works there. Donors do not own, control, or direct the project. Codex is one [agent harness](/concepts/agent-runtimes) plugin among several, and no lab's model is privileged in the code.
-
-  </Accordion>
-
-  <Accordion title="What does OpenClaw send to the Foundation?">
-    By default, a daily update check carrying the OpenClaw version, OS, Node version, and CPU architecture: the same information any package registry sees. Optional anonymous feature statistics are off by default and carry no identifier. No prompts, messages, model names, keys, paths, or machine identifiers are ever sent to the Foundation. Set `update.checkOnStart: false` to send nothing at all. Traffic to the model providers and chat platforms you configure is separate and goes to them, as always; see "Is all data used with OpenClaw saved locally?" below. Details: [Usage telemetry and update checks](/gateway/telemetry).
-
-  </Accordion>
-
-  <Accordion title="How is OpenClaw funded, and how does that compare?">
-    The Foundation is funded by donations and has no product to sell: no paid tier, no hosted service, no token. It is not venture-backed. Some other self-hosted agents are built by venture-funded companies that sell a subscription their agent offers during setup. That is a difference in incentives, not a judgment of their engineering; see the [governance comparison](/start/why-openclaw#governance).
-
-  </Accordion>
-
-  <Accordion title="What are the advantages vs Claude Code for web development?">
-    OpenClaw is an **assistant and coordination layer**, not an IDE replacement. Use Claude Code or Codex for the fastest direct coding loop inside a repo. Use OpenClaw for durable memory, cross-device access, and tool orchestration.
-
-    - Persistent memory and workspace across sessions.
-    - Multi-platform access (Telegram, WhatsApp, TUI, WebChat).
-    - Tool orchestration (browser, files, scheduling, hooks).
-    - Always-on Gateway (run on a VPS, interact from anywhere).
-    - Nodes for local browser/screen/camera/exec.
-
-    Showcase: [https://openclaw.ai/showcase](https://openclaw.ai/showcase).
-
-  </Accordion>
-</AccordionGroup>
-
-## Skills and automation
-
-<AccordionGroup>
-  <Accordion title="How do I customize skills without keeping the repo dirty?">
-    Use managed overrides instead of editing the repo copy. Put changes in `~/.openclaw/skills/<name>/SKILL.md` (or add a folder via `skills.load.extraDirs` in `~/.openclaw/openclaw.json`). Precedence: `<workspace>/skills` -> `<workspace>/.agents/skills` -> `~/.agents/skills` -> `~/.openclaw/skills` -> bundled -> `skills.load.extraDirs`, so managed overrides win over bundled skills without touching git. To install globally but limit visibility to some agents, keep the shared copy in `~/.openclaw/skills` and control visibility with `agents.defaults.skills` / `agents.entries.*.skills`. Only upstream-worthy edits should go out as PRs against the repo copy.
-  </Accordion>
-
-  <Accordion title="Can I load skills from a custom folder?">
-    Yes: add directories via `skills.load.extraDirs` in `~/.openclaw/openclaw.json` (lowest precedence in the order above). `clawhub` installs into `./skills` by default, which OpenClaw treats as `<workspace>/skills` on the next session. To limit visibility to certain agents, pair with `agents.defaults.skills` or `agents.entries.*.skills`.
-  </Accordion>
-
-  <Accordion title="How can I use different models or settings for different tasks?">
-    Supported patterns:
-
-    - **Cron jobs**: isolated jobs can set a `model` override per job.
-    - **Agents**: route tasks to separate agents with different default models, thinking levels, and stream params.
-    - **Current session only**: `/model <model> -s` (or `--session`) leaves configured defaults unchanged.
-    - **Agent default + current session**: Owner/admin `/model <model> -a` (or `--agent`) updates the selected agent.
-    - **Global default + current session**: Owner/admin `/model <model> -g` (or `--global`) updates `agents.defaults.model`.
-
-    Bare `/model <model>` keeps owner/admin configured-default persistence unless
-    you set the optional [model selection scope](/gateway/config-agents/models#agentsdefaultsmodelselectionscope).
-
-    Example - same model, different per-agent settings:
-
-    ```json5
-    {
-      agents: {
-        ownership: "explicit",
-        entries: {
-          coder: {
-            model: "xiaomi/mimo-v2.5-pro",
-            thinkingDefault: "high",
-            params: { temperature: 0.1 },
-          },
-          chat: {
-            model: "xiaomi/mimo-v2.5-pro",
-            thinkingDefault: "off",
-            params: { temperature: 0.8 },
-          },
-        },
-      },
-    }
-    ```
-
-    Put shared per-model defaults in `agents.defaults.models["provider/model"].params`. Use `agents.entries.*.models["provider/model"].params` when one agent needs different settings for that model. Flat `agents.entries.*.params` applies across that agent's models and wins over both per-model layers.
-
-    See [Cron jobs](/automation/cron-jobs), [Multi-Agent Routing](/concepts/multi-agent), [Configuration](/gateway/config-agents), [Slash commands](/tools/slash-commands).
-
-  </Accordion>
-
-  <Accordion title="The bot freezes while doing heavy work. How do I offload that?">
-    Use **sub-agents** for long or parallel tasks: they run in their own session, return a summary, and keep your main chat responsive. Ask the bot to "spawn a sub-agent for this task," or use `/subagents`. Use `/status` to see whether the Gateway is currently busy.
-
-    Long tasks and sub-agents both consume tokens; set a cheaper model for sub-agents via `agents.defaults.subagents.model` if cost matters.
-
-    Docs: [Sub-agents](/tools/subagents), [Background Tasks](/automation/tasks).
-
-  </Accordion>
-
-  <Accordion title="How do thread-bound subagent sessions work on Discord?">
-    Bind a Discord thread to a subagent or session target so follow-up messages there stay on that bound session.
-
-    - Spawn with `sessions_spawn` using `thread: true` (optionally `mode: "session"` for persistent follow-up).
-    - `/agents` inspects binding state.
-    - `/session idle <duration|off>` and `/session max-age <duration|off>` control automatic expiry.
-    - `/session unbind` detaches the thread without closing the agent session.
-
-    Config: `session.threadBindings.enabled` (global switch), `session.threadBindings.idleHours` (default `24`, `0` disables), `session.threadBindings.maxAgeHours` (default `0` = no hard cap), and `session.threadBindings.spawnSessions` for auto-bind on spawn (default `true`).
-
-    Docs: [Sub-agents](/tools/subagents), [Discord](/channels/discord), [Configuration Reference](/gateway/configuration-reference), [Slash commands](/tools/slash-commands).
-
-  </Accordion>
-
-  <Accordion title="A subagent finished, but the completion update went to the wrong place or never posted. What should I check?">
-    Check the resolved requester route:
-
-    - Completion-mode subagent delivery prefers a bound thread or conversation route when one exists.
-    - If the completion origin only carries a channel, OpenClaw falls back to the requester session's stored route (`lastChannel` / `lastTo` / `lastAccountId`) so direct delivery can still succeed.
-    - No bound route and no usable stored route: direct delivery can fail and the result falls back to queued session delivery instead of posting immediately.
-    - Invalid or stale targets can also force queue fallback or final delivery failure.
-    - If the child's last visible assistant reply is exactly `NO_REPLY` / `no_reply` or `ANNOUNCE_SKIP`, OpenClaw intentionally suppresses the announce instead of posting stale earlier progress.
-
-    Debug: `openclaw tasks show <lookup>` where `<lookup>` is a task id, run id, or session key.
-
-    Docs: [Sub-agents](/tools/subagents), [Background Tasks](/automation/tasks), [Session Tools](/concepts/session-tool).
-
-  </Accordion>
-
-  <Accordion title="Cron or reminders do not fire. What should I check?">
-    Cron runs inside the Gateway process; it does not fire if the Gateway is not running continuously.
-
-    - Confirm cron is enabled (`cron.enabled`) and `OPENCLAW_SKIP_CRON` is not set.
-    - Confirm the Gateway is running 24/7 (no sleep/restarts).
-    - Verify job timezone (`--tz` vs host timezone).
-
-    Debug:
-    ```bash
-    openclaw automations run <jobId>
-    openclaw automations runs <jobId> --limit 50
-    ```
-
-    Docs: [Cron jobs](/automation/cron-jobs), [Automation](/automation).
-
-  </Accordion>
-
-  <Accordion title="Cron fired, but nothing was sent to the channel. Why?">
-    Check the delivery mode:
-
-    - `--no-deliver` / `delivery.mode: "none"`: no runner fallback send is expected.
-    - Missing or invalid announce target (`channel` / `to`): the runner skipped outbound delivery.
-    - Channel auth failures (`unauthorized`, `Forbidden`): the runner tried to deliver but credentials blocked it.
-    - A silent isolated result (`NO_REPLY` / `no_reply` only) is treated as intentionally non-deliverable, so queued fallback delivery is also suppressed.
-
-    For isolated cron jobs, the agent can still send directly with the `message` tool when a chat route is available. `--announce` only controls runner fallback delivery for final text the agent did not already send itself.
-
-    Debug:
-    ```bash
-    openclaw automations runs <jobId> --limit 50
-    openclaw tasks show <lookup>
-    ```
-
-    Docs: [Cron jobs](/automation/cron-jobs), [Background Tasks](/automation/tasks).
-
-  </Accordion>
-
-  <Accordion title="Why did an isolated cron run switch models or retry once?">
-    That is the live model-switch path, not duplicate scheduling. Isolated cron persists a runtime model handoff and retries when the active run throws `LiveSessionModelSwitchError`, keeping the switched provider/model (and any switched auth-profile override) before retrying.
-
-    Model-selection precedence: Gmail hook model override (`hooks.gmail.model`) first, then per-job `model`, then any stored cron-session model override, then normal agent/default model selection.
-
-    The retry loop is bounded to the initial attempt plus 2 switch retries; cron then aborts instead of looping forever.
-
-    Debug:
-    ```bash
-    openclaw automations runs <jobId> --limit 50
-    ```
-
-    Docs: [Cron jobs](/automation/cron-jobs), [cron CLI](/cli/cron).
-
-  </Accordion>
-
-  <Accordion title="How do I install skills on Linux?">
-    Use native `openclaw skills` commands or drop skills into your workspace; the macOS Skills UI is not available on Linux. Browse skills at [https://clawhub.ai](https://clawhub.ai).
-
-    ```bash
-    openclaw skills search "calendar"
-    openclaw skills search --limit 20
-    openclaw skills install @owner/<skill-slug>
-    openclaw skills install @owner/<skill-slug> --version <version>
-    openclaw skills install @owner/<skill-slug> --force
-    openclaw skills install @owner/<skill-slug> --global
-    openclaw skills update --all
-    openclaw skills update --all --global
-    openclaw skills list --eligible
-    openclaw skills check
-    ```
-
-    Native `openclaw skills install` writes into the active workspace `skills/` directory by default. Add `--global` to install into the shared managed skills directory for all local agents. Install the separate `clawhub` CLI only to publish or sync your own skills. Use `agents.defaults.skills` or `agents.entries.*.skills` to narrow which agents see shared skills.
-
-  </Accordion>
-
-  <Accordion title="Can OpenClaw run tasks on a schedule or continuously in the background?">
-    Yes, via the Gateway scheduler:
-
-    - **Cron jobs** for scheduled or recurring tasks (persist across restarts).
-    - **Heartbeat** for main-session periodic checks.
-    - **Isolated jobs** for autonomous agents that post summaries or deliver to chats.
-
-    Docs: [Cron jobs](/automation/cron-jobs), [Automation](/automation), [Heartbeat](/gateway/heartbeat).
-
-  </Accordion>
-
-  <Accordion title="Can I run Apple macOS-only skills from Linux?">
-    Not directly. macOS skills are gated by `metadata.openclaw.os` plus required binaries, and only load when eligible on the **Gateway host**. On Linux, `darwin`-only skills (`apple-notes`, `apple-reminders`, `things-mac`) will not load unless you override the gating.
-
-    Three supported patterns:
-
-    **Option A - run the Gateway on a Mac (simplest)**. Run the Gateway where the macOS binaries exist, then connect from Linux in [remote mode](#gateway-ports-already-running-and-remote-mode) or over Tailscale. Skills load normally because the Gateway host is macOS.
-
-    **Option B - use a macOS node (no SSH)**. Run the Gateway on Linux, pair a macOS node (menubar app), and set **Node Run Commands** to "Always Ask" or "Always Allow" on the Mac. OpenClaw treats macOS-only skills as eligible when required binaries exist on the node; the agent runs them via the `nodes` tool. With "Always Ask," approving "Always Allow" in the prompt adds that command to the allowlist.
-
-    **Option C - proxy macOS binaries over SSH (advanced)**. Keep the Gateway on Linux, but make the required CLI binaries resolve to SSH wrappers that run on a Mac, then override the skill to allow Linux so it stays eligible.
-
-    1. Create an SSH wrapper for the binary (example: `memo` for Apple Notes):
-       ```bash
-       #!/usr/bin/env bash
-       set -euo pipefail
-       exec ssh -T user@mac-host /opt/homebrew/bin/memo "$@"
-       ```
-    2. Put the wrapper on `PATH` on the Linux host (for example `~/bin/memo`).
-    3. Override the skill metadata (workspace or `~/.openclaw/skills`) to allow Linux:
-       ```markdown
-       ---
-       name: apple-notes
-       description: Manage Apple Notes via the memo CLI on macOS.
-       metadata: { "openclaw": { "os": ["darwin", "linux"], "requires": { "bins": ["memo"] } } }
-       ---
-       ```
-    4. Start a new session so the skills snapshot refreshes.
-
-  </Accordion>
-
-  <Accordion title="Do you have a Notion or HeyGen integration?">
-    Not built in today. Options:
-
-    - **Custom skill / plugin**: best for reliable API access (both have APIs).
-    - **Browser automation**: works without code but is slower and more fragile.
-
-    For agency-style per-client context: keep one Notion page per client (context + preferences + active work) and ask the agent to fetch that page at the start of a session.
-
-    For a native integration, open a feature request or build a skill against those APIs.
-
-    ```bash
-    openclaw skills install @owner/<skill-slug>
-    openclaw skills update --all
-    ```
-
-    Native installs land in the active workspace `skills/` directory; use `--global` for all local agents, or configure `agents.defaults.skills` / `agents.entries.*.skills` to limit visibility. Some skills expect Homebrew-installed binaries; on Linux that means Linuxbrew.
-
-    See [Skills](/tools/skills), [Skills config](/tools/skills-config), [ClawHub](/clawhub).
-
-  </Accordion>
-
-  <Accordion title="How do I use my existing signed-in Chrome with OpenClaw?">
-    Use the built-in `user` browser profile, which attaches through Chrome DevTools MCP:
-
-    ```bash
-    openclaw browser --browser-profile user tabs
-    openclaw browser --browser-profile user snapshot
-    ```
-
-    For a custom name, create an explicit MCP profile:
-
-    ```bash
-    openclaw browser create-profile --name chrome-live --driver existing-session
-    openclaw browser --browser-profile chrome-live tabs
-    ```
-
-    This can use the local host browser or a connected browser node. If the Gateway runs elsewhere, run a node host on the browser machine, or use remote CDP instead.
-
-    Current limits on `existing-session` / `user` profiles versus the managed `openclaw` profile:
-
-    - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs, not CSS selectors.
-    - Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`.
-    - `responsebody`, PDF export, download interception, and batch actions still require the managed browser path.
-
-    See [Browser](/tools/browser/existing-session#existing-session-via-chrome-devtools-mcp) for the full comparison.
-
-  </Accordion>
-</AccordionGroup>
-
-## Sandboxing and memory
-
-<AccordionGroup>
-  <Accordion title="Is there a dedicated sandboxing doc?">
-    Yes: [Sandboxing](/gateway/sandboxing). For Docker-specific setup (full gateway in Docker or sandbox images), see [Docker](/install/docker).
-  </Accordion>
-
-  <Accordion title="Docker feels limited - how do I enable full features?">
-    The default image is security-first and runs as the `node` user, so it excludes system packages, Homebrew, and bundled browsers. For a fuller setup:
-
-    - Persist `/home/node` with `OPENCLAW_HOME_VOLUME` so caches survive.
-    - Bake system deps into the image with `OPENCLAW_IMAGE_APT_PACKAGES`.
-    - Bake Playwright Chromium and its system dependencies into the image with `OPENCLAW_INSTALL_BROWSER=1`.
-
-    Docs: [Docker](/install/docker), [Browser](/tools/browser).
-
-  </Accordion>
-
-  <Accordion title="Can I keep DMs personal but make groups public/sandboxed with one agent?">
-    Yes, if private traffic is **DMs** and public traffic is **groups**. Set `agents.defaults.sandbox.mode: "non-main"` so group/channel sessions (non-main keys) run in the configured sandbox backend while the main DM session stays on-host. Select `backend: "docker"` for Docker or `backend: "podman"` for Podman. Restrict tools available in sandboxed sessions via `tools.sandbox.tools`.
-
-    Setup walkthrough: [Groups: personal DMs + public groups](/channels/groups#pattern-personal-dms-public-groups-single-agent). Key reference: [Gateway configuration](/gateway/config-agents/sandbox#agentsdefaultssandbox).
-
-  </Accordion>
-
-  <Accordion title="How do I bind a host folder into the sandbox?">
-    Set `agents.defaults.sandbox.docker.binds` to `["host:container:mode"]` (for example `"/home/user/src:/src:ro"`). Global and per-agent binds merge; per-agent binds are ignored when `scope: "shared"`. Use `:ro` for anything sensitive; binds bypass the sandbox filesystem walls.
-
-    OpenClaw validates bind sources against both the normalized path and the canonical path resolved through the deepest existing ancestor, so symlink-parent escapes fail closed even when the final path segment does not exist yet.
-
-    See [Sandboxing](/gateway/sandboxing#multiple-folders-for-one-agent) and [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated#bind-mounts-security-quick-check).
-
-  </Accordion>
-
-  <Accordion title="How does memory work?">
-    OpenClaw memory is Markdown files in the agent workspace: daily notes in `memory/YYYY-MM-DD.md`, curated long-term notes in `MEMORY.md` (main/private sessions only).
-
-    OpenClaw also runs a silent **pre-compaction memory flush** before compaction summarizes the conversation, reminding the model to write durable notes first. It only runs when the workspace is writable (read-only sandboxes skip it); disable with `agents.defaults.compaction.memoryFlush.enabled: false`. See [Memory](/concepts/memory).
-
-  </Accordion>
-
-  <Accordion title="Memory keeps forgetting things. How do I make it stick?">
-    Ask the bot to **write the fact to memory**: long-term notes go in `MEMORY.md`, short-term context in `memory/YYYY-MM-DD.md`. Reminding the model to store memories usually resolves it. If it keeps forgetting, verify the Gateway uses the same workspace on every run.
-
-    Docs: [Memory](/concepts/memory), [Agent workspace](/concepts/agent-workspace).
-
-  </Accordion>
-
-  <Accordion title="Does memory persist forever? What are the limits?">
-    Memory files live on disk and persist until deleted; the limit is your storage, not the model. **Session context** is still limited by the model context window, so long conversations can compact or truncate - that is why memory search exists, pulling only the relevant parts back into context.
-
-    Docs: [Memory](/concepts/memory), [Context](/concepts/context).
-
-  </Accordion>
-
-  <Accordion title="Does semantic memory search require an OpenAI API key?">
-    Only if you use **OpenAI embeddings**, which is the default provider. Codex OAuth covers chat/completions and does **not** grant embeddings access, so signing in with Codex (OAuth or the Codex CLI login) does not enable semantic memory search. OpenAI embeddings still need a real API key (`OPENAI_API_KEY` or `models.providers.openai.apiKey`).
-
-    To stay local, set `memory.search.provider: "local"` (GGUF/llama.cpp). Other supported providers: Bedrock, DeepInfra, Gemini (`GEMINI_API_KEY` or `memory.search.remote.apiKey`), GitHub Copilot, LM Studio, Mistral, Ollama, OpenAI-compatible, and Voyage. See [Memory](/concepts/memory) and [Memory search](/concepts/memory-search) for setup details.
-
-  </Accordion>
-</AccordionGroup>
-
-## Where things live on disk
-
-<AccordionGroup>
-  <Accordion title="Is all data used with OpenClaw saved locally?">
-    No: **OpenClaw's own state is local**, but **external services still see what you send them**.
-
-    - **Local by default**: sessions, memory files, config, and workspace live on the Gateway host (`~/.openclaw` plus your workspace directory).
-    - **Remote by necessity**: messages sent to model providers (Anthropic/OpenAI/etc.) go to their APIs, and chat platforms (Slack/Telegram/WhatsApp/etc.) store message data on their servers.
-    - **You control the footprint**: local models keep prompts on your machine, but channel traffic still goes through the channel's servers.
-
-    Related: [Agent workspace](/concepts/agent-workspace), [Memory](/concepts/memory).
-
-  </Accordion>
-
-  <Accordion title="Where does OpenClaw store its data?">
-    Everything lives under `$OPENCLAW_STATE_DIR` (default: `~/.openclaw`):
-
-    | Path                                                               | Purpose                                                            |
-    | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
-    | `$OPENCLAW_STATE_DIR/openclaw.json`                                 | Main config (JSON5)                                                 |
-    | `$OPENCLAW_STATE_DIR/credentials/oauth.json`                        | Legacy OAuth migration source for `openclaw doctor --fix`           |
-    | `$OPENCLAW_STATE_DIR/state/openclaw.sqlite`                         | Shared SQLite state, including shared auth profiles                 |
-    | `$OPENCLAW_STATE_DIR/secrets.json`                                  | Optional file-backed secret payload for `file` SecretRef providers   |
-    | `$OPENCLAW_STATE_DIR/agents/<agentId>/agent/auth.json`              | Legacy auth migration source for `openclaw doctor --fix`             |
-    | `$OPENCLAW_STATE_DIR/credentials/`                                  | Provider state (for example `whatsapp/<accountId>/creds.json`)      |
-    | `$OPENCLAW_STATE_DIR/agents/`                                       | Per-agent state (agentDir + legacy/archive session artifacts)        |
-    | `$OPENCLAW_STATE_DIR/agents/<agentId>/agent/openclaw-agent.sqlite`  | Per-agent SQLite state, including local auth profiles, sessions, and transcripts |
-    | `$OPENCLAW_STATE_DIR/agents/<agentId>/sessions/`                    | Legacy session migration sources and archive/support artifacts      |
-
-    Legacy single-agent path `~/.openclaw/agent/*` is migrated by `openclaw doctor`.
-
-    Legacy `auth-profiles.json` files are imported by `openclaw doctor --fix`;
-    new logins write SQLite. Agent-local profiles override the shared read-through
-    base. Older installs keep that shared store in the main agent's database until
-    doctor relocates it; see [Auth credential semantics](/auth-credential-semantics#agent-copy-portability).
-
-    Your **workspace** (AGENTS.md, memory files, skills, etc.) is separate, configured via `agents.defaults.workspace` (default: `~/.openclaw/workspace`).
-
-  </Accordion>
-
-  <Accordion title="Where should AGENTS.md / SOUL.md / USER.md / MEMORY.md live?">
-    These live in the **agent workspace**, not `~/.openclaw`.
-
-    - **Workspace (per agent)**: `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`, `memory/YYYY-MM-DD.md`. Lowercase root `memory.md` is legacy repair input only; `openclaw doctor --fix` can merge it into `MEMORY.md` when both exist.
-    - **State dir (`~/.openclaw`)**: config, channel/provider state, auth profiles, sessions, logs, shared skills (`~/.openclaw/skills`).
-
-    Default workspace is `~/.openclaw/workspace`, configurable:
-
-    ```json5
-    {
-      agents: { defaults: { workspace: "~/.openclaw/workspace" } },
-    }
-    ```
-
-    If the bot "forgets" after a restart, confirm the Gateway uses the same workspace on every launch (remote mode uses the **gateway host's** workspace, not your local laptop).
-
-    Tip: for durable behavior or preference, ask the bot to **write it into AGENTS.md or MEMORY.md** rather than relying on chat history.
-
-    See [Agent workspace](/concepts/agent-workspace) and [Memory](/concepts/memory).
-
-  </Accordion>
-
-  <Accordion title="Can I make SOUL.md bigger?">
-    Yes. `SOUL.md` is one of the workspace bootstrap files injected into agent context. Default per-file injection limit is `20000` characters; total bootstrap budget across files is `60000` characters.
-
-    Change shared defaults:
-
-    ```json5
-    {
-      agents: {
-        defaults: {
-          bootstrapMaxChars: 50000,
-          bootstrapTotalMaxChars: 300000,
-        },
-      },
-    }
-    ```
-
-    Or override one agent under `agents.entries.*.bootstrapMaxChars` / `bootstrapTotalMaxChars`.
-
-    Use `/context` to check raw vs injected sizes and whether truncation happened. Keep `SOUL.md` focused on voice, stance, and personality; put operating rules in `AGENTS.md` and durable facts in memory.
-
-    See [Context](/concepts/context) and [Agent config](/gateway/config-agents).
-
-  </Accordion>
-
-  <Accordion title="Recommended backup strategy">
-    Put your **agent workspace** in a **private** git repo and back it up somewhere private (for example GitHub private). This captures memory plus AGENTS/SOUL/USER files and lets you restore the assistant's "mind" later.
-
-    Do **not** commit anything under `~/.openclaw` (credentials, sessions, tokens, encrypted secrets payloads). For a full restore, back up the workspace and state directory separately.
-
-    Docs: [Agent workspace](/concepts/agent-workspace).
-
-  </Accordion>
-
-  <Accordion title="How do I completely uninstall OpenClaw?">
-    See [Uninstall](/install/uninstall).
-  </Accordion>
-
-  <Accordion title="Can agents work outside the workspace?">
-    Yes. The workspace is the **default cwd** and memory anchor, not a hard sandbox. Relative paths resolve inside the workspace; absolute paths can access other host locations unless sandboxing is enabled. For isolation, use [`agents.defaults.sandbox`](/gateway/sandboxing) or per-agent sandbox settings. To make a repo the default working directory, point that agent's `workspace` at the repo root - the OpenClaw repo itself is just source code, so keep the workspace separate unless you intentionally want the agent to work inside it.
-
-    ```json5
-    {
-      agents: {
-        defaults: {
-          workspace: "~/path/to/my-repo",
-        },
-      },
-    }
-    ```
-
-  </Accordion>
-
-  <Accordion title="Remote mode: where is the session store?">
-    Session state is owned by the **gateway host**. In remote mode, the session store you care about is on the remote machine, not your local laptop. See [Session management](/concepts/session).
-  </Accordion>
-</AccordionGroup>
-
-## Config basics
-
-<AccordionGroup>
-  <Accordion title="What format is the config? Where is it?">
-    OpenClaw reads an optional **JSON5** config from `$OPENCLAW_CONFIG_PATH` (default: `~/.openclaw/openclaw.json`). If the file is missing, it uses safe-ish defaults, including a default workspace of `~/.openclaw/workspace`.
-  </Accordion>
-
-  <Accordion title='I set gateway.bind: "lan" (or "tailnet") and now nothing listens / the UI says unauthorized'>
-    Non-loopback binds **require a valid gateway auth path**: shared-secret auth (token or password), or `gateway.auth.mode: "trusted-proxy"` behind a correctly configured identity-aware reverse proxy.
-
-    ```json5
-    {
-      gateway: {
-        bind: "lan",
-        auth: {
-          mode: "token",
-          token: "replace-me",
-        },
-      },
-    }
-    ```
-
-    - `gateway.remote.token` / `.password` do **not** enable local gateway auth by themselves; local call paths can use `gateway.remote.*` as fallback only when `gateway.auth.*` is unset.
-    - For password auth, set `gateway.auth.mode: "password"` plus `gateway.auth.password` (or `OPENCLAW_GATEWAY_PASSWORD`).
-    - If `gateway.auth.token` / `.password` is explicitly configured via SecretRef and unresolved, resolution fails closed (no remote fallback masking).
-    - Shared-secret Control UI setups authenticate via `connect.params.auth.token` or `connect.params.auth.password` (stored in app/UI settings). Identity-bearing modes such as Tailscale Serve or `trusted-proxy` use request headers instead - avoid putting shared secrets in URLs.
-    - With `gateway.auth.mode: "trusted-proxy"`, same-host loopback reverse proxies require explicit `gateway.auth.trustedProxy.allowLoopback = true` and a loopback entry in `gateway.trustedProxies`.
-
-  </Accordion>
-
-  <Accordion title="Why do I need a token on localhost now?">
-    OpenClaw enforces gateway auth by default, including loopback. If no explicit auth path is configured, startup resolves to token mode and generates a runtime-only token for that startup, so local WS clients must authenticate. This blocks other local processes from calling the Gateway.
-
-    On a fresh loopback start, the Gateway prepares the canonical same-user CLI device credential before `/readyz`, so normal `openclaw` CLI calls can authenticate without persisting the generated token. Other clients still need an explicit shared secret or an approved device pairing.
-
-    Configure `gateway.auth.token`, `gateway.auth.password`, `OPENCLAW_GATEWAY_TOKEN`, or `OPENCLAW_GATEWAY_PASSWORD` explicitly when clients need a stable secret across restarts. You can also choose password mode, or `trusted-proxy` for identity-aware reverse proxies. For open loopback, set `gateway.auth.mode: "none"` explicitly. `openclaw doctor --generate-gateway-token` generates a token any time.
-
-  </Accordion>
-
-  <Accordion title="Do I have to restart after changing config?">
-    The Gateway watches the config and supports hot-reload: `gateway.reload.mode: "hybrid"` (default) hot-applies safe changes and restarts for critical ones. `off` disables config reload; the earlier `hot` and `restart` modes are retired. Most `tools.*`, `agents.*` policy, `session.*`, and `messages.*` changes apply immediately with no reload action at all; `gateway.*` binding/port changes require a restart.
-  </Accordion>
-
-  <Accordion title="How do I enable web search (and web fetch)?">
-    `web_fetch` works without an API key. `web_search` depends on your selected provider:
-
-    | Provider | Key-free | Env var(s) |
-    | --- | --- | --- |
-    | Brave | No | `BRAVE_API_KEY` |
-    | DuckDuckGo | Yes (unofficial HTML-based) | - |
-    | Exa | No | `EXA_API_KEY` |
-    | Firecrawl | No | `FIRECRAWL_API_KEY` |
-    | Gemini | No | `GEMINI_API_KEY` |
-    | Grok | No (xAI OAuth or key) | `XAI_API_KEY` |
-    | Kimi | No | `KIMI_API_KEY` or `MOONSHOT_API_KEY` |
-    | MiniMax Search | No | `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, or `MINIMAX_API_KEY` |
-    | Ollama Web Search | Local: yes (needs `ollama signin`); hosted: no | Hosted: `OLLAMA_API_KEY` |
-    | Perplexity | No | `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` |
-    | SearXNG | Yes (self-hosted) | `SEARXNG_BASE_URL` |
-    | Tavily | No | `TAVILY_API_KEY` |
-
-    Grok can also reuse xAI OAuth from model auth (`openclaw onboard --auth-choice xai-oauth`).
-
-    **Recommended**: `openclaw configure --section web` and pick a provider.
-
-    ```json5
-    {
-      plugins: {
-        entries: {
-          brave: {
-            config: {
-              webSearch: {
-                apiKey: "BRAVE_API_KEY_HERE",
-              },
-            },
-          },
-        },
-      },
-      tools: {
-        web: {
-          search: {
-            enabled: true,
-            provider: "brave",
-            maxResults: 5,
-          },
-          fetch: {
-            enabled: true,
-            provider: "firecrawl", // optional; omit for auto-detect
-          },
-        },
-      },
-    }
-    ```
-
-    Provider-specific web-search config lives under `plugins.entries.<plugin>.config.webSearch.*`. Legacy `tools.web.search.*` provider paths still load for compatibility but should not be used in new configs. Firecrawl web-fetch fallback config lives under `plugins.entries.firecrawl.config.webFetch.*`.
-
-    - Allowlists: add `web_search`/`web_fetch`/`x_search`, or `group:web` for all three.
-    - `web_fetch` is enabled by default.
-    - If `tools.web.fetch.provider` is omitted, OpenClaw auto-detects the first ready fetch fallback provider from available credentials; the official Firecrawl plugin provides that fallback.
-    - Daemons read env vars from `~/.openclaw/.env` (or the service environment).
-
-    Docs: [Web tools](/tools/web).
-
-  </Accordion>
-
-  <Accordion title="config.apply wiped my config. How do I recover and avoid this?">
-    `config.apply` replaces the **entire config**; a partial object removes everything else.
-
-    Current OpenClaw protects most accidental clobbers:
-
-    - OpenClaw-owned config writes validate the full post-change config before writing.
-    - Invalid or destructive OpenClaw-owned writes are rejected and saved as `openclaw.json.rejected.*`.
-    - Startup can migrate deterministic legacy keys in eligible single-file configs when the whole result validates, keeping the previous config in the `.bak` ring. Other invalid edits make startup fail closed; hot reload skips invalid edits without rewriting `openclaw.json`.
-    - `openclaw doctor --fix` owns repairs beyond that startup migration, can restore last-known-good, and saves the rejected file as `openclaw.json.clobbered.*`.
-
-    Recover:
-
-    - Check `openclaw logs --follow` for `Invalid config at`, `Config write rejected:`, or `config reload skipped (invalid config)`.
-    - Inspect the newest `openclaw.json.clobbered.*` or `openclaw.json.rejected.*` beside the active config.
-    - Run `openclaw config validate` and `openclaw doctor --fix`.
-    - Copy only the intended keys back with `openclaw config set` or `config.patch`.
-    - No last-known-good or rejected payload: restore from backup, or re-run `openclaw doctor` and reconfigure channels/models.
-    - Unexpected loss: file a bug with your last known config or a backup. A local coding agent can often reconstruct a working config from logs or history.
-
-    Avoid it: use `openclaw config set` for small changes, `openclaw configure` for interactive edits, `config.schema.lookup` to inspect an unfamiliar path (returns a shallow schema node plus immediate child summaries), and `config.patch` for partial RPC edits - reserve `config.apply` for full-config replacement. The agent-facing `gateway` runtime tool refuses to rewrite `tools.exec.ask` / `tools.exec.security` even via legacy `tools.bash.*` aliases.
-
-    Docs: [Config](/cli/config), [Configure](/cli/configure), [Gateway troubleshooting](/gateway/troubleshooting#gateway-rejected-invalid-config), [Doctor](/gateway/doctor).
-
-  </Accordion>
-
-  <Accordion title="How do I run a central Gateway with specialized workers across devices?">
-    Common pattern: **one Gateway** (for example a Raspberry Pi) plus **nodes** and **agents**.
-
-    - **Gateway (central)**: owns channels (Signal/WhatsApp), routing, sessions.
-    - **Nodes (devices)**: Macs/iOS/Android connect as peripherals and expose local tools such as `system.run` and `camera`; Macs can also present hosted widgets in the native panel.
-    - **Agents (workers)**: separate brains/workspaces for special roles (for example ops vs personal data).
-    - **Sub-agents**: spawn background work from a main agent for parallelism.
-    - **TUI**: connect to the Gateway and switch agents/sessions.
-
-    Docs: [Nodes](/nodes), [Remote access](/gateway/remote), [Multi-Agent Routing](/concepts/multi-agent), [Sub-agents](/tools/subagents), [TUI](/web/tui).
-
-  </Accordion>
-
-  <Accordion title="Can the OpenClaw browser run headless?">
-    Yes:
-
-    ```json5
-    {
-      browser: { headless: true },
-      agents: {
-        defaults: {
-          sandbox: { browser: { headless: true } },
-        },
-      },
-    }
-    ```
-
-    Default is `false` (headful). Headless is more likely to trigger anti-bot checks on some sites (X/Twitter often blocks headless sessions). It uses the same Chromium engine and works for most automation; the main difference is no visible browser window (use screenshots for visuals). See [Browser](/tools/browser).
-
-  </Accordion>
-
-  <Accordion title="How do I use Brave for browser control?">
-    Set `browser.executablePath` to your Brave binary (or any Chromium-based browser) and restart the Gateway. See [Browser](/tools/browser/configuration#use-brave-or-another-chromium-based-browser).
-  </Accordion>
-</AccordionGroup>
-
-## Remote gateways and nodes
-
-<AccordionGroup>
-  <Accordion title="How do commands propagate between Telegram, the gateway, and nodes?">
-    Telegram messages are handled by the **gateway**, which runs the agent and only then calls nodes over the **Gateway WebSocket** when a node tool is needed:
-
-    Telegram -> Gateway -> Agent -> `node.*` -> Node -> Gateway -> Telegram
-
-    Nodes do not see inbound provider traffic; they only receive node RPC calls.
-
-  </Accordion>
-
-  <Accordion title="How can my agent access my computer if the Gateway is hosted remotely?">
-    Pair your computer as a **node**. The Gateway runs elsewhere but can call `node.*` tools (screen, camera, system) on your local machine over the Gateway WebSocket.
-
-    1. Run the Gateway on the always-on host (VPS/home server).
-    2. Put the Gateway host and your computer on the same tailnet.
-    3. Ensure the Gateway WS is reachable (tailnet bind or SSH tunnel).
-    4. Open the macOS app locally and connect in **Remote over SSH** mode (or direct tailnet) so it registers as a node.
-    5. Approve the node:
-       ```bash
-       openclaw devices list
-       openclaw devices approve <requestId>
-       ```
-
-    No separate TCP bridge is required; nodes connect over the Gateway WebSocket.
-
-    Security reminder: pairing a macOS node allows `system.run` on that machine. Only pair devices you trust; review [Security](/gateway/security).
-
-    Docs: [Nodes](/nodes), [Gateway protocol](/gateway/protocol), [macOS remote mode](/platforms/mac/remote), [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Tailscale is connected but I get no replies. What now?">
-    Check the basics:
-
-    ```bash
-    openclaw gateway status
-    openclaw status
-    openclaw channels status
-    ```
-
-    Then verify auth and routing: if you use Tailscale Serve, confirm `gateway.auth.allowTailscale` is set correctly; if you connect via SSH tunnel, confirm the tunnel is up and points at the right port; confirm your DM/group allowlists include your account.
-
-    Docs: [Tailscale](/gateway/tailscale), [Remote access](/gateway/remote), [Channels](/channels).
-
-  </Accordion>
-
-  <Accordion title="Can two OpenClaw instances talk to each other (local + VPS)?">
-    Yes, though there is no built-in bot-to-bot bridge.
-
-    **Simplest**: use a normal chat channel both bots can access (Slack/Telegram/WhatsApp). Have Bot A message Bot B, then let Bot B reply as usual.
-
-    **CLI bridge (generic)**: run a script that calls the other Gateway with `openclaw agent --message ... --deliver`, targeting a chat where the other bot listens. If one bot is on a remote VPS, point your CLI at that remote Gateway via SSH/Tailscale (see [Remote access](/gateway/remote)):
-
-    ```bash
-    openclaw agent --message "Hello from local bot" --deliver --channel telegram --reply-to <chat-id>
-    ```
-
-    Add a guardrail so the two bots do not loop endlessly (mention-only, channel allowlists, or a "do not reply to bot messages" rule).
-
-    Docs: [Remote access](/gateway/remote), [Agent CLI](/cli/agent), [Agent send](/tools/agent-send).
-
-  </Accordion>
-
-  <Accordion title="Do I need separate VPSes for multiple agents?">
-    No. One Gateway hosts multiple agents, each with its own workspace, model defaults, and routing - this is the normal setup and much cheaper/simpler than one VPS per agent. Use separate VPSes only for hard isolation (security boundaries) or very different configs you do not want to share.
-  </Accordion>
-
-  <Accordion title="Is there a benefit to using a node on my personal laptop instead of SSH from a VPS?">
-    Yes: nodes are the first-class way to reach your laptop from a remote Gateway and unlock more than shell access. The Gateway runs on macOS, Linux, and Windows (native or WSL2) and is lightweight (a small VPS or Raspberry Pi-class box is fine; 4 GB RAM is plenty), so a common setup is an always-on host plus your laptop as a node.
-
-    - **No inbound SSH required** - nodes connect out to the Gateway WebSocket via device pairing.
-    - **Safer execution controls** - `system.run` is gated by node allowlists/approvals on that laptop.
-    - **More device tools** - nodes expose `camera` and `screen` in addition to `system.run`; Macs also expose the widget panel.
-    - **Local browser automation** - keep the Gateway on a VPS but run Chrome locally through a node host, or attach to local Chrome via Chrome MCP.
-
-    SSH is fine for ad-hoc shell access; nodes are simpler for ongoing agent workflows and device automation.
-
-    Docs: [Nodes](/nodes), [Nodes CLI](/cli/nodes), [Browser](/tools/browser).
-
-  </Accordion>
-
-  <Accordion title="Do nodes run a gateway service?">
-    No. Only **one gateway** should run per host unless you intentionally run isolated profiles (see [Multiple gateways](/gateway/multiple-gateways)). Nodes are peripherals that connect to the gateway (iOS/Android nodes, or macOS "node mode" in the menubar app). For headless node hosts and CLI control, see [Node host CLI](/cli/node).
-
-    A full restart is required for `gateway`, `discovery`, and hosted plugin surface changes.
-
-  </Accordion>
-
-  <Accordion title="Is there an API / RPC way to apply config?">
-    Yes:
-
-    - `config.schema.lookup`: inspect one config subtree with its shallow schema node, matched UI hint, and immediate child summaries before writing.
-    - `config.get`: fetch the current snapshot plus hash.
-    - `config.patch`: safe partial update (preferred for most RPC edits); hot-reloads when possible, restarts when required.
-    - `config.apply`: validate and replace the full config; hot-reloads when possible, restarts when required.
-    - The agent-facing `gateway` runtime tool still refuses to rewrite `tools.exec.ask` / `tools.exec.security`; legacy `tools.bash.*` aliases normalize to the same protected paths.
-
-  </Accordion>
-
-  <Accordion title="Minimal sane config for a first install">
-    ```json5
-    {
-      agents: { defaults: { workspace: "~/.openclaw/workspace" } },
-      channels: { whatsapp: { allowFrom: ["+15555550123"] } },
-    }
-    ```
-
-    Sets your workspace and restricts who can trigger the bot.
-
-  </Accordion>
-
-  <Accordion title="How do I set up Tailscale on a VPS and connect from my Mac?">
-    1. **Install + login on the VPS**:
-       ```bash
-       curl -fsSL https://tailscale.com/install.sh | sh
-       sudo tailscale up
-       ```
-    2. **Install + login on your Mac** using the Tailscale app, same tailnet.
-    3. **Enable MagicDNS** in the Tailscale admin console so the VPS has a stable name.
-    4. **Use the tailnet hostname**: SSH `ssh user@your-vps.tailnet-xxxx.ts.net`; Gateway WS `ws://your-vps.tailnet-xxxx.ts.net:18789`.
-
-    For the Control UI without SSH, use Tailscale Serve on the VPS:
-
-    ```bash
-    openclaw gateway --tailscale serve
-    ```
-
-    This keeps the gateway bound to loopback and exposes HTTPS via Tailscale. See [Tailscale](/gateway/tailscale).
-
-  </Accordion>
-
-  <Accordion title="How do I connect a Mac node to a remote Gateway (Tailscale Serve)?">
-    Serve exposes the **Gateway Control UI + WS**; nodes connect over the same Gateway WS endpoint.
-
-    1. Make sure the VPS and Mac are on the same tailnet.
-    2. Use the macOS app in Remote mode (SSH target can be the tailnet hostname) - it tunnels the Gateway port and connects as a node.
-    3. Approve the node:
-       ```bash
-       openclaw devices list
-       openclaw devices approve <requestId>
-       ```
-
-    Docs: [Gateway protocol](/gateway/protocol), [Discovery](/gateway/discovery), [macOS remote mode](/platforms/mac/remote).
-
-  </Accordion>
-
-  <Accordion title="Should I install on a second laptop or just add a node?">
-    For **local tools only** (screen/camera/exec) on the second laptop, add it as a **node** - one Gateway, no duplicated config. The local tools a node exposes depend on its platform. See [Nodes](/nodes) for the per-platform defaults. Install a second Gateway only for **hard isolation** or two fully separate bots.
-
-    Docs: [Nodes](/nodes), [Nodes CLI](/cli/nodes), [Multiple gateways](/gateway/multiple-gateways).
-
-  </Accordion>
-</AccordionGroup>
-
-## Env vars and .env loading
-
-<AccordionGroup>
-  <Accordion title="How does OpenClaw load environment variables?">
-    OpenClaw reads env vars from the parent process (shell, launchd/systemd, CI, etc.) and additionally loads:
-
-    - `.env` from the current working directory.
-    - a global fallback `.env` from `~/.openclaw/.env` (`$OPENCLAW_STATE_DIR/.env`).
-
-    Normally, neither `.env` file overrides existing env vars. For an OpenClaw-installed systemd service, the global `.env` may replace only service values that OpenClaw recorded as managed; operator-owned service values still take precedence. Provider credential and endpoint-routing keys are an exception for workspace `.env`: keys such as `GEMINI_API_KEY`, `XAI_API_KEY`, `MISTRAL_API_KEY`, or any key ending in `_ENDPOINT` (and other bundled-provider auth or endpoint env vars) are ignored from workspace `.env` and should live in the process environment, `~/.openclaw/.env`, or config `env.vars`.
-
-    Inline env vars in config apply only if missing from the process env:
-
-    ```json5
-    {
-      env: {
-        vars: {
-          OPENROUTER_API_KEY: "sk-or-...",
-          GROQ_API_KEY: "gsk-...",
-        },
-      },
-    }
-    ```
-
-    See [/environment](/help/environment) for full precedence and sources.
-
-  </Accordion>
-
-  <Accordion title="I started the Gateway via the service and my env vars disappeared. What now?">
-    Two fixes:
-
-    1. Put the missing keys in `~/.openclaw/.env` so they load even when the service does not inherit your shell env.
-    2. Enable shell import (opt-in convenience):
-       ```json5
-       {
-         env: {
-           shellEnv: {
-             enabled: true,
-             timeoutMs: 15000,
-           },
-         },
-       }
-       ```
-       This runs your login shell and imports only missing expected keys (never overrides). Env var equivalents: `OPENCLAW_LOAD_SHELL_ENV=1`, `OPENCLAW_SHELL_ENV_TIMEOUT_MS=15000`.
-
-  </Accordion>
-
-  <Accordion title='I set COPILOT_GITHUB_TOKEN, but models status shows "Shell env: off." Why?'>
-    `openclaw models status` reports whether **shell env import** is enabled. "Shell env: off" does **not** mean your env vars are missing - it just means OpenClaw will not load your login shell automatically.
-
-    If the Gateway runs as a service (launchd/systemd), it will not inherit your shell environment. Fix by putting the token in `~/.openclaw/.env`, enabling `env.shellEnv.enabled: true`, or adding it to config `env` (applies only if missing), then restarting the gateway and rechecking:
-
-    ```bash
-    openclaw models status
-    ```
-
-    Copilot tokens resolve in this order: `OPENCLAW_GITHUB_TOKEN`, then `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`.
-
-    See [/concepts/model-providers](/concepts/model-providers) and [/environment](/help/environment).
-
-  </Accordion>
-</AccordionGroup>
-
-## Sessions and multiple chats
-
-<AccordionGroup>
-  <Accordion title="How do I start a fresh conversation?">
-    Send `/new` or `/reset` as a standalone message. See [Session management](/concepts/session).
-  </Accordion>
-
-  <Accordion title="Do sessions reset automatically if I never send /new?">
-    No, not by default. Sessions keep the same `sessionId`, and compaction bounds the active model context as conversations grow. `/new` and `/reset` remain available, or you can opt into automatic resets with `mode: "daily"` or `mode: "idle"`. Daily mode rolls over at `session.reset.atHour` (default `4`, 0-23) on the gateway host; idle mode uses `session.reset.idleMinutes` since the last real interaction, not heartbeat/cron/exec system events.
-
-    ```json5
-    {
-      session: {
-        reset: { mode: "daily", atHour: 4 },
-        resetByType: {
-          group: { mode: "idle", idleMinutes: 120 },
-          thread: { mode: "daily", atHour: 6 },
-        },
-        resetByChannel: {
-          discord: { mode: "idle", idleMinutes: 10080 },
-        },
-      },
-    }
-    ```
-
-    `resetByType` supports `direct`, `group`, and `thread`. Doctor migrates legacy `dm` entries to `direct`; the schema rejects `dm`. Legacy top-level `session.idleMinutes` still works as a compatibility alias for an idle-mode default when no `session.reset`/`resetByType` block is set. See [Session management](/concepts/session) for the full lifecycle.
-
-  </Accordion>
-
-  <Accordion title="Is there a way to make a team of OpenClaw instances (one CEO and many agents)?">
-    Yes, via **multi-agent routing** and **sub-agents**: one coordinator agent plus several worker agents with their own workspaces and models.
-
-    This is best seen as a fun experiment - it is token-heavy and often less efficient than one bot with separate sessions. The typical model is one bot you talk to, with different sessions for parallel work, spawning sub-agents when needed.
-
-    Docs: [Multi-agent routing](/concepts/multi-agent), [Sub-agents](/tools/subagents), [Agents CLI](/cli/agents).
-
-  </Accordion>
-
-  <Accordion title="Why did context get truncated mid-task? How do I prevent it?">
-    Session context is limited by the model window. Long chats, large tool outputs, or many files can trigger compaction or truncation.
-
-    - Ask the bot to summarize current state and write it to a file.
-    - Use `/compact` before long tasks, `/new` when switching topics.
-    - Keep important context in the workspace and ask the bot to read it back.
-    - Use sub-agents for long or parallel work so the main chat stays smaller.
-    - Pick a model with a larger context window if this happens often.
-
-  </Accordion>
-
-  <Accordion title="How do I completely reset OpenClaw but keep it installed?">
-    ```bash
-    openclaw reset
-    ```
-
-    Non-interactive full reset:
-
-    ```bash
-    openclaw reset --scope full --yes --non-interactive
-    ```
-
-    Then re-run setup:
-
-    ```bash
-    openclaw onboard --install-daemon
-    ```
-
-    To reset and immediately re-run onboarding, pass `openclaw onboard --reset`; reset is a command flag, not a **Setup mode** menu choice. See [Onboarding (CLI)](/start/wizard). If you used profiles (`--profile` / `OPENCLAW_PROFILE`), reset each state dir (default `~/.openclaw-<profile>`). Dev-only reset: `openclaw gateway --dev --reset` wipes dev config, credentials, sessions, and workspace.
-
-  </Accordion>
-
-  <Accordion title='I am getting "context too large" errors - how do I reset or compact?'>
-    - **Compact** (keeps the conversation, summarizes older turns): `/compact` or `/compact <instructions>` to guide the summary.
-    - **Reset** (fresh session ID for the same chat key): `/new` or `/reset`.
-
-    If it keeps happening, tune **session pruning** (`agents.defaults.contextPruning`) to trim old tool output, or use a model with a larger context window.
-
-    Docs: [Compaction](/concepts/compaction), [Session pruning](/concepts/session-pruning), [Session management](/concepts/session).
-
-  </Accordion>
-
-  <Accordion title='Why am I seeing "LLM request rejected: messages.content.tool_use.input field required"?'>
-    Provider validation error: the model emitted a `tool_use` block without the required `input`. Usually means the session history is stale or corrupted (often after long threads or a tool/schema change).
-
-    Fix: start a fresh session with `/new` (standalone message).
-
-  </Accordion>
-
-  <Accordion title="Why am I getting heartbeat messages every 30 minutes?">
-    Heartbeats run every **30m** by default, or **1h** when the resolved auth mode is Anthropic OAuth/token auth (including Claude CLI reuse) and `heartbeat.every` is unset. Tune or disable:
-
-    ```json5
-    {
-      agents: {
-        defaults: {
-          heartbeat: {
-            every: "2h", // or "0m" to disable recurring cadence
-          },
-        },
-      },
-    }
-    ```
-
-    Heartbeat instructions live in the monitor's cron scratch. Effectively empty scratch skips the heartbeat run to save API calls; without scratch, the heartbeat still runs and the model decides what to do. `0m` does not block targeted event-driven wakes, such as a background exec completion follow-up; those can still run one agent turn without enabling recurring cadence.
-
-    Per-agent overrides use `agents.entries.*.heartbeat`. Docs: [Heartbeat](/gateway/heartbeat).
-
-  </Accordion>
-
-  <Accordion title='Do I need to add a "bot account" to a WhatsApp group?'>
-    No. OpenClaw runs on **your own account** - if you are in the group, OpenClaw can see it. By default, group replies are blocked until you allow senders (`groupPolicy: "allowlist"`).
-
-    To restrict group replies to only you:
-
-    ```json5
-    {
-      channels: {
-        whatsapp: {
-          groupPolicy: "allowlist",
-          groupAllowFrom: ["+15551234567"],
-        },
-      },
-    }
-    ```
-
-  </Accordion>
-
-  <Accordion title="How do I get the JID of a WhatsApp group?">
-    Fastest: tail logs and send a test message in the group.
-
-    ```bash
-    openclaw logs --follow --json
-    ```
-
-    Look for `chatId` (or `from`) ending in `@g.us`, like `1234567890-1234567890@g.us`.
-
-    If already configured/allowlisted, list groups from config:
-
-    ```bash
-    openclaw directory groups list --channel whatsapp
-    ```
-
-    Docs: [WhatsApp](/channels/whatsapp), [Directory](/cli/directory), [Logs](/cli/logs).
-
-  </Accordion>
-
-  <Accordion title="Why does OpenClaw not reply in a group?">
-    Two common causes: mention gating is on by default (you must @mention the bot, or match `mentionPatterns`), or you configured `channels.whatsapp.groups` without `"*"` and the group is not allowlisted.
-
-    See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
-
-  </Accordion>
-
-  <Accordion title="Do groups/threads share context with DMs?">
-    Direct chats collapse to the main session by default. Groups/channels get their own session keys unless a route binding sets `session.groupScope: "main"` to merge that room into the main session; Telegram topics / Discord threads are separate sessions. See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
-  </Accordion>
-
-  <Accordion title="How many workspaces and agents can I create?">
-    No hard limits - dozens or even hundreds are fine, but watch:
-
-    - **Disk growth**: active sessions and transcripts live in the per-agent SQLite database; legacy/archive artifacts can still accumulate under `~/.openclaw/agents/<agentId>/sessions/`.
-    - **Token cost**: more agents means more concurrent model usage.
-    - **Ops overhead**: per-agent auth profiles, workspaces, and channel routing.
-
-    Keep one **active** workspace per agent (`agents.defaults.workspace`), prune old sessions with `openclaw sessions cleanup` if disk grows (do not edit active SQLite state by hand), and use `openclaw doctor` to spot stray workspaces and profile mismatches.
-
-  </Accordion>
-
-  <Accordion title="Can I run multiple bots or chats at the same time (Slack), and how should I set that up?">
-    Yes, via **Multi-Agent Routing**: run multiple isolated agents and route inbound messages by channel/account/peer. Slack is supported as a channel and can be bound to specific agents.
-
-    Browser access is powerful but not "do anything a human can" - anti-bot, CAPTCHAs, and MFA can still block automation. For the most reliable control, use local Chrome MCP on the host, or CDP on the machine that actually runs the browser.
-
-    Best-practice setup: always-on Gateway host (VPS/Mac mini), one agent per role (bindings), Slack channel(s) bound to those agents, and local browser via Chrome MCP or a node when needed.
-
-    Docs: [Multi-Agent Routing](/concepts/multi-agent), [Slack](/channels/slack), [Browser](/tools/browser), [Nodes](/nodes).
-
-  </Accordion>
-</AccordionGroup>
-
 ## Models, failover, and auth profiles
 
 Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - lives on the [Models FAQ](/help/faq-models).
-
-## Gateway: ports, "already running", and remote mode
-
-<AccordionGroup>
-  <Accordion title="What port does the Gateway use?">
-    `gateway.port` controls the single multiplexed port for WebSocket + HTTP (Control UI, hooks, etc.). Precedence:
-
-    ```text
-    --port > OPENCLAW_GATEWAY_PORT > gateway.port > default 18789
-    ```
-
-  </Accordion>
-
-  <Accordion title='Why does openclaw gateway status say "Runtime: running" but "Connectivity probe: failed"?'>
-    "Running" is the **supervisor's** view (launchd/systemd/schtasks); the connectivity probe is the CLI actually connecting to the gateway WebSocket. Trust these lines from `openclaw gateway status`: `Probe target:` (the URL the probe used), `Listening:` (what is actually bound on the port), `Last gateway error:` (common root cause when the process is alive but the port is not listening).
-  </Accordion>
-
-  <Accordion title='Why does openclaw gateway status show "Config (cli)" and "Config (service)" different?'>
-    You are editing one config file while the service runs another (often a `--profile` / `OPENCLAW_STATE_DIR` mismatch).
-
-    Fix, run from the same `--profile` / environment you want the service to use:
-
-    ```bash
-    openclaw gateway install --force
-    ```
-
-  </Accordion>
-
-  <Accordion title='What does "another gateway instance is already listening" mean?'>
-    OpenClaw enforces a runtime lock by binding the WebSocket listener immediately on startup (default `ws://127.0.0.1:18789`). If the bind fails with `EADDRINUSE`, it throws `GatewayLockError` ("another gateway instance is already listening").
-
-    Fix: stop the other instance, free the port, or run with `openclaw gateway --port <port>`.
-
-  </Accordion>
-
-  <Accordion title="How do I run OpenClaw in remote mode (client connects to a Gateway elsewhere)?">
-    Set `gateway.mode: "remote"` and point to a remote WebSocket URL, optionally with shared-secret remote credentials:
-
-    ```json5
-    {
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "ws://gateway.tailnet:18789",
-          token: "your-token",
-          password: "your-password",
-        },
-      },
-    }
-    ```
-
-    - `openclaw gateway` only starts when `gateway.mode` is `local` (or you pass an override flag).
-    - The macOS app watches the config file and switches modes live when these values change.
-    - `gateway.remote.token` / `.password` are client-side remote credentials only; they do not enable local gateway auth by themselves.
-
-  </Accordion>
-
-  <Accordion title='The Control UI says "unauthorized" (or keeps reconnecting). What now?'>
-    Your gateway auth path and the UI's auth method do not match.
-
-    Facts (from code):
-
-    - The Control UI keeps the token in `sessionStorage`, scoped to the current browser tab and selected gateway URL, so same-tab refreshes keep working without long-lived localStorage token persistence.
-    - On `AUTH_TOKEN_MISMATCH`, trusted clients can attempt one bounded retry with a cached device token when the gateway returns retry hints (`canRetryWithDeviceToken=true`, `recommendedNextStep=retry_with_device_token`).
-    - That cached-token retry reuses the cached approved scopes stored with the device token; explicit `deviceToken` / explicit `scopes` callers keep their requested scope set instead of inheriting cached scopes.
-    - Outside that retry path, connect auth precedence is explicit shared token/password first, then explicit `deviceToken`, then stored device token, then bootstrap token.
-    - Built-in setup-code bootstrap returns a node device token with `scopes: []` plus a bounded operator handoff token for trusted mobile onboarding. The operator handoff can read setup-time native configuration but does not grant pairing mutation scopes or `operator.admin`.
-
-    Fix:
-
-    - Fastest: `openclaw dashboard` (prints + copies the dashboard URL, tries to open; shows an SSH hint if headless).
-    - No token yet: `openclaw doctor --generate-gateway-token`.
-    - Remote: tunnel first with `ssh -N -L 18789:127.0.0.1:18789 user@host`, then open `http://127.0.0.1:18789/`.
-    - Shared-secret mode: set `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`, then paste the matching secret in Control UI settings.
-    - Tailscale Serve mode: confirm `gateway.auth.allowTailscale` is enabled and you are opening the Serve URL, not a raw loopback/tailnet URL that bypasses Tailscale identity headers.
-    - Trusted-proxy mode: confirm you are coming through the configured identity-aware proxy. Same-host loopback proxies also need `gateway.auth.trustedProxy.allowLoopback = true`.
-    - Mismatch persists after the one retry: rotate/re-approve the paired device token:
-      ```bash
-      openclaw devices list
-      openclaw devices rotate --device <id> --role operator
-      ```
-    - Rotate denied: paired-device sessions can rotate only their **own** device unless they also have `operator.admin`, and explicit `--scope` values cannot exceed the caller's current operator scopes.
-    - Still stuck: `openclaw status --all` plus [Troubleshooting](/gateway/troubleshooting). See [Dashboard](/web/dashboard) for auth details.
-
-  </Accordion>
-
-  <Accordion title="I set gateway.bind tailnet but it listens only on loopback">
-    `tailnet` bind picks a Tailscale IP from your network interfaces (100.64.0.0/10). If the machine is not on Tailscale (or the interface is down), the Gateway falls back to loopback instead of exposing another network interface.
-
-    Fix: start Tailscale on that host and restart the Gateway, or switch explicitly to `gateway.bind: "loopback"` / `"lan"`.
-
-    `tailnet` is explicit; `auto` prefers loopback. Use `gateway.bind: "tailnet"` to limit non-loopback exposure to the Tailnet while retaining the required same-host `127.0.0.1` listener.
-
-  </Accordion>
-
-  <Accordion title="Can I run multiple Gateways on the same host?">
-    Usually no - one Gateway can run multiple messaging channels and agents. Use multiple Gateways only for redundancy (for example a rescue bot) or hard isolation, and isolate each with its own `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `agents.defaults.workspace`, and unique `gateway.port`.
-
-    Recommended: `openclaw --profile <name> ...` per instance (auto-creates `~/.openclaw-<name>`), a unique `gateway.port` per profile config (or `--port` for manual runs), and a per-profile service with `openclaw --profile <name> gateway install`.
-
-    Profiles also suffix service names: launchd `ai.openclaw.<profile>`, systemd `openclaw-gateway-<profile>.service`, Windows `OpenClaw Gateway (<profile>)`. The unqualified `openclaw-gateway` systemd unit only exists for the default profile; the legacy pre-rename systemd unit name `clawdbot-gateway` is migrated automatically.
-
-    Full guide: [Multiple gateways](/gateway/multiple-gateways).
-
-  </Accordion>
-
-  <Accordion title='What does "invalid handshake" / code 1008 mean?'>
-    The Gateway is a **WebSocket server** and expects the first message to be a `connect` frame. Anything else closes the connection with **code 1008** (policy violation).
-
-    Common causes: you opened the **HTTP** URL in a browser instead of a WS client, used the wrong port/path, or a proxy/tunnel stripped auth headers or sent a non-Gateway request.
-
-    Fix: use the WS URL (`ws://<host>:18789`, or `wss://...` over HTTPS), do not open the WS port in a normal browser tab, and include the token/password in the `connect` frame when auth is on. CLI/TUI example:
-
-    ```bash
-    openclaw tui --url ws://<host>:18789 --token <token>
-    ```
-
-    Protocol details: [Gateway protocol](/gateway/protocol).
-
-  </Accordion>
-</AccordionGroup>
-
-## Logging and debugging
-
-<AccordionGroup>
-  <Accordion title="Where are logs?">
-    File logs (structured): `/tmp/openclaw/openclaw-YYYY-MM-DD.log` for the default profile, or `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log` for a named profile. Set a stable path via `logging.file`; file log level via `logging.level`; console verbosity via `--verbose` and `logging.consoleLevel`.
-
-    Fastest tail:
-
-    ```bash
-    openclaw logs --follow
-    ```
-
-    Service/supervisor logs (when the gateway runs via launchd/systemd):
-
-    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`; stderr is suppressed).
-    - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
-    - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
-
-    See [Troubleshooting](/gateway/troubleshooting) for more.
-
-  </Accordion>
-
-  <Accordion title="How do I start/stop/restart the Gateway service?">
-    ```bash
-    openclaw gateway status
-    openclaw gateway restart
-    ```
-
-    If you run the gateway manually, `openclaw gateway --force` can reclaim the port. See [Gateway](/gateway).
-
-  </Accordion>
-
-  <Accordion title="I closed my terminal on Windows - how do I restart OpenClaw?">
-    Three Windows install modes:
-
-    **1) Windows Hub local setup**: the native app manages a local app-owned WSL Gateway. Open **OpenClaw Companion** from the Start menu or tray, then use **Gateway Setup** or the Connections tab.
-
-    **2) Manual WSL2 Gateway**: the Gateway runs inside Linux.
-    ```powershell
-    wsl
-    openclaw gateway status
-    openclaw gateway restart
-    ```
-    If you never installed the service, start it in the foreground: `openclaw gateway run`.
-
-    **3) Native Windows CLI/Gateway**: runs directly in Windows.
-    ```powershell
-    openclaw gateway status
-    openclaw gateway restart
-    ```
-    If you run it manually (no service): `openclaw gateway run`.
-
-    Docs: [Windows](/platforms/windows), [Gateway service runbook](/gateway).
-
-  </Accordion>
-
-  <Accordion title="The Gateway is up but replies never arrive. What should I check?">
-    Quick health sweep:
-
-    ```bash
-    openclaw status
-    openclaw models status
-    openclaw channels status
-    openclaw logs --follow
-    ```
-
-    Common causes: model auth not loaded on the **gateway host** (check `models status`), channel pairing/allowlist blocking replies (check channel config and logs), or WebChat/Dashboard open without the right token. If remote, confirm the tunnel/Tailscale connection is up and the Gateway WebSocket is reachable.
-
-    Docs: [Channels](/channels), [Troubleshooting](/gateway/troubleshooting), [Remote access](/gateway/remote).
-
-  </Accordion>
-
-  <Accordion title='"Disconnected from gateway: no reason" - what now?'>
-    Usually means the UI lost the WebSocket connection. Check: is the Gateway running (`openclaw gateway status`)? Is it healthy (`openclaw status`)? Does the UI have the right token (`openclaw dashboard`)? If remote, is the tunnel/Tailscale link up?
-
-    Then tail logs:
-
-    ```bash
-    openclaw logs --follow
-    ```
-
-    Docs: [Dashboard](/web/dashboard), [Remote access](/gateway/remote), [Troubleshooting](/gateway/troubleshooting).
-
-  </Accordion>
-
-  <Accordion title="Telegram setMyCommands fails. What should I check?">
-    ```bash
-    openclaw channels status
-    openclaw channels logs --channel telegram
-    ```
-
-    Then match the error:
-
-    - `BOT_COMMANDS_TOO_MUCH`: the Telegram menu has too many entries. OpenClaw already trims to the Telegram limit and retries with fewer commands, but some menu entries may still be dropped. Reduce plugin/skill/custom commands, or disable `channels.telegram.commands.native` if you do not need the menu.
-    - `TypeError: fetch failed`, `Network request for 'setMyCommands' failed!`, or similar network errors: on a VPS or behind a proxy, confirm outbound HTTPS is allowed and DNS works for `api.telegram.org`.
-
-    If the Gateway is remote, check logs on the Gateway host.
-
-    Docs: [Telegram](/channels/telegram), [Channel troubleshooting](/channels/troubleshooting).
-
-  </Accordion>
-
-  <Accordion title="TUI shows no output. What should I check?">
-    ```bash
-    openclaw status
-    openclaw models status
-    openclaw logs --follow
-    ```
-
-    In the TUI, use `/status` to see the current state. If you expect replies in a chat channel, confirm delivery is enabled (`/deliver on`).
-
-    Docs: [TUI](/web/tui), [Slash commands](/tools/slash-commands).
-
-  </Accordion>
-
-  <Accordion title="How do I completely stop then start the Gateway?">
-    If you installed the service (launchd on macOS, systemd on Linux):
-
-    ```bash
-    openclaw gateway stop
-    openclaw gateway start
-    ```
-
-    In the foreground, stop with Ctrl-C, then `openclaw gateway run`.
-
-    Docs: [Gateway service runbook](/gateway).
-
-  </Accordion>
-
-  <Accordion title="ELI5: openclaw gateway restart vs openclaw gateway">
-    `openclaw gateway restart` restarts the **background service** (launchd/systemd). `openclaw gateway` runs the gateway **in the foreground** for this terminal session. Use the gateway subcommands if you installed the service; use the bare foreground run for a one-off.
-  </Accordion>
-
-  <Accordion title="Fastest way to get more details when something fails">
-    Start the Gateway with `--verbose` for more console detail, then inspect the log file for channel auth, model routing, and RPC errors.
-  </Accordion>
-</AccordionGroup>
-
-## Media and attachments
-
-<AccordionGroup>
-  <Accordion title="My skill generated an image/PDF, but nothing was sent">
-    Outbound attachments from the agent must use structured media fields such as `media`, `mediaUrl`, `path`, or `filePath`. See [OpenClaw assistant setup](/start/openclaw) and [Agent send](/tools/agent-send).
-
-    ```bash
-    openclaw message send --target +15555550123 --message "Here you go" --media /path/to/file.png
-    ```
-
-    Also check: the target channel supports outbound media and is not blocked by allowlists; the file is within the provider's size limits (images resize to a max side of 2048px); `tools.fs.workspaceOnly=true` limits local-path sends to workspace, temp/media-store, and sandbox-validated files; `tools.fs.workspaceOnly=false` (default) lets structured local media sends use host-local files the agent can already read, for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as Markdown/MD, TXT, JSON, YAML/YML). This is not a secret scanner - an agent-readable `secret.txt` or `config.json` can be attached when the extension and content validation match. Keep sensitive files outside agent-readable paths, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
-
-    See [Images](/nodes/images).
-
-  </Accordion>
-</AccordionGroup>
-
-## Security and access control
-
-<AccordionGroup>
-  <Accordion title="Is it safe to expose OpenClaw to inbound DMs?">
-    Yes - on channels that default to **pairing** (most DM-capable channels), a stranger who DMs your bot never reaches the model:
-
-    - With the pairing default, unknown senders receive a pairing code and their message is not processed. Approve with `openclaw pairing approve --channel <channel> [--account <id>] <code>`. Pending requests are capped at **3 per channel**; check `openclaw pairing list --channel <channel> [--account <id>]` if a code did not arrive.
-    - Opening DMs publicly requires explicit opt-in (`dmPolicy: "open"` and allowlist `"*"`).
-
-    A few workspace channels ship different defaults - ClickClack, for example, allows workspace members by default. Check your channel's page, and run `openclaw doctor` to confirm your DM policies look the way you expect.
-
-  </Accordion>
-
-  <Accordion title="Is prompt injection only a concern for public bots?">
-    No. Prompt injection is about **untrusted content**, not just who can DM the bot. If your assistant reads external content (web search/fetch, browser pages, emails, docs, attachments, pasted logs), that content can carry instructions that try to hijack the model - even if you are the only sender.
-
-    The biggest risk is when tools are enabled: the model can be tricked into exfiltrating context or calling tools on your behalf. Reduce the blast radius:
-
-    - use a read-only or tool-disabled "reader" agent to summarize untrusted content
-    - keep `web_search` / `web_fetch` / `browser` off for tool-enabled agents
-    - treat decoded file/document text as untrusted too: OpenResponses `input_file` and media-attachment extraction both wrap extracted text in explicit external-content boundary markers instead of passing raw file text
-    - sandbox and use strict tool allowlists
-
-    Details: [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Is OpenClaw less safe because it uses TypeScript/Node instead of Rust/WASM?">
-    Language and runtime matter, but are not the main risk for a personal agent. The practical risks are gateway exposure, who can message the bot, prompt injection, tool scope, credential handling, browser access, exec access, and third-party skill/plugin trust.
-
-    Rust and WASM can provide stronger isolation for some code classes, but do not solve prompt injection, bad allowlists, public gateway exposure, overbroad tools, or a browser profile already logged in to sensitive accounts. Treat these as the primary controls: keep the Gateway private or authenticated, use pairing and allowlists for DMs/groups, deny or sandbox risky tools for untrusted inputs, install only trusted plugins and skills, and run `openclaw security audit --deep` after config changes.
-
-    Details: [Security](/gateway/security), [Sandboxing](/gateway/sandboxing).
-
-  </Accordion>
-
-  <Accordion title="I saw reports about exposed OpenClaw instances. What should I check?">
-    ```bash
-    openclaw security audit --deep
-    openclaw gateway status
-    ```
-
-    A safer baseline: Gateway bound to `loopback`, or exposed only through authenticated private access (tailnet, SSH tunnel, token/password auth, or a correctly configured trusted proxy); DMs in `pairing` or `allowlist` mode; group access limited to rooms you chose (group allowlists), with mention gating or sender allowlists where membership is broad or public; high-risk tools (`exec`, `browser`, `gateway`, `cron`) denied or tightly scoped for agents that read untrusted content; sandboxing enabled where tool execution needs a smaller blast radius.
-
-    Public binds without auth, open DMs/groups with tools, and exposed browser control are the findings to fix first. Details: [openclaw security audit](/gateway/security/running-the-audit#openclaw-security-audit).
-
-  </Accordion>
-
-  <Accordion title="Are ClawHub skills and third-party plugins safe to install?">
-    Treat third-party skills and plugins as code you are choosing to trust. ClawHub skill pages expose scan state before install, but scans are not a complete security boundary. OpenClaw does not run built-in local dangerous-code blocking during plugin/skill install or update; use operator-owned `security.installPolicy` for local allow/warn/block decisions.
-
-    Safer pattern: prefer trusted authors and pinned versions, read the skill/plugin before enabling it, keep plugin/skill allowlists narrow, run untrusted-input workflows in a sandbox with minimal tools, and avoid giving third-party code broad filesystem, exec, browser, or secret access.
-
-    Details: [Skills](/tools/skills), [Plugins](/tools/plugin), [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Should my bot have its own email, GitHub account, or phone number?">
-    Yes, for most setups. Isolating the bot with separate accounts and phone numbers reduces the blast radius if something goes wrong, and makes it easier to rotate credentials or revoke access without impacting your personal accounts.
-
-    Start small: give access only to the tools and accounts you actually need, and expand later if required.
-
-    Docs: [Security](/gateway/security), [Pairing](/channels/pairing).
-
-  </Accordion>
-
-  <Accordion title="Can I give it autonomy over my text messages and is that safe?">
-    We do **not** recommend full autonomy over your personal messages. Safest pattern: keep DMs in **pairing mode** or a tight allowlist, use a **separate number or account** if it should message on your behalf, and let it draft while you **approve before sending**.
-
-    To experiment, do it on a dedicated, isolated account. See [Security](/gateway/security).
-
-  </Accordion>
-
-  <Accordion title="Can I use cheaper models for personal assistant tasks?">
-    Yes, **if** the agent is chat-only and the input is trusted. Smaller tiers are more susceptible to instruction hijacking, so avoid them for tool-enabled agents or when reading untrusted content. If you must use a smaller model, lock down tools and run inside a sandbox. See [Security](/gateway/security).
-  </Accordion>
-
-  <Accordion title="I ran /start in Telegram but did not get a pairing code">
-    Pairing codes are sent **only** when an unknown sender messages the bot and `dmPolicy: "pairing"` is enabled; `/start` by itself does not generate a code.
-
-    Check pending requests:
-
-    ```bash
-    openclaw pairing list telegram
-    ```
-
-    For immediate access, allowlist your sender id or set `dmPolicy: "open"` for that account.
-
-  </Accordion>
-
-  <Accordion title="WhatsApp: will it message my contacts? How does pairing work?">
-    No. Default WhatsApp DM policy is **pairing**. Unknown senders only get a pairing code; their message is **not processed**. OpenClaw only replies to chats it receives or to explicit sends you trigger.
-
-    ```bash
-    openclaw pairing approve whatsapp <code>
-    openclaw pairing list whatsapp
-    ```
-
-    The wizard's phone number prompt sets your **allowlist/owner** so your own DMs are permitted - it is not used for auto-sending. On your personal WhatsApp number, use that number and enable `channels.whatsapp.selfChatMode`.
-
-  </Accordion>
-</AccordionGroup>
-
-## Chat commands, aborting tasks, and "it will not stop"
-
-<AccordionGroup>
-  <Accordion title="How do I stop internal system messages from showing in chat?">
-    Most internal/tool messages only appear when **verbose**, **trace**, or **reasoning** is enabled for that session.
-
-    Fix in the chat where you see it:
-
-    ```text
-    /verbose off
-    /trace off
-    /reasoning off
-    ```
-
-    Still noisy: check session settings in the Control UI and set verbose to **inherit**; confirm you are not using a bot profile with `verboseDefault: "on"` in config.
-
-    Docs: [Thinking and verbose](/tools/thinking), [Security](/gateway/security/index#reasoning-and-verbose-output-in-groups).
-
-  </Accordion>
-
-  <Accordion title="How do I stop/cancel a running task?">
-    Send any of these **as a standalone message** (no slash) to trigger an abort: `stop`, `stop action`, `stop current action`, `stop run`, `stop current run`, `stop agent`, `stop the agent`, `stop openclaw`, `openclaw stop`, `stop don't do anything`, `stop do not do anything`, `stop doing anything`, `do not do that`, `please stop`, `stop please`, `abort`, `esc`, `exit`, `interrupt`, `halt`. Common non-English triggers (French, German, Spanish, Chinese, Japanese, Hindi, Arabic, Russian) also work.
-
-    For background processes started by the exec tool, ask the agent to run:
-
-    ```text
-    process action:kill sessionId:XXX
-    ```
-
-    Most slash commands must be sent as a **standalone** message starting with `/`, but a few shortcuts (like `/status`) also work inline for allowlisted senders. See [Slash commands](/tools/slash-commands).
-
-  </Accordion>
-
-  <Accordion title='How do I send a Discord message from Telegram? ("Cross-context messaging denied")'>
-    OpenClaw blocks **cross-provider** messaging by default. If a tool call is bound to Telegram, it will not send to Discord unless you explicitly allow it - and this takes effect immediately, no gateway restart needed:
-
-    ```json5
-    {
-      tools: {
-        message: {
-          crossContext: {
-            allowAcrossProviders: true,
-            marker: { enabled: true, prefix: "[from {channel}] " },
-          },
-        },
-      },
-    }
-    ```
-
-  </Accordion>
-
-  <Accordion title='Why does it feel like the bot "ignores" rapid-fire messages?'>
-    Mid-run prompts are steered into the active run by default. Use `/queue` to choose active-run behavior:
-
-    - `steer` (default) - guide the active run at the next model boundary.
-    - `followup` - queue messages and run them one at a time after the current run ends.
-    - `collect` - queue compatible messages and reply once after the current run ends.
-    - `interrupt` - abort the current run and start fresh.
-
-    Add options to queued modes like `debounce:0.5s cap:25 drop:summarize`. See [Command queue](/concepts/queue) and [Steering queue](/concepts/queue-steering).
-
-  </Accordion>
-</AccordionGroup>
 
 ## Miscellaneous
 
@@ -1604,6 +100,138 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 ---
 
 Still stuck? Ask in [Discord](https://discord.com/invite/clawd) or use the [GitHub issue chooser](https://github.com/openclaw/openclaw/issues/new/choose).
+
+## Where each section moved
+
+Every question heading from the previous single-page version keeps its anchor
+here, so an existing link such as `/help/faq#where-things-live-on-disk` still
+resolves. Each entry points at the page that now holds the answer.
+
+- <a id="what-is-openclaw%3F" /><a id="what-is-openclaw" />[What is OpenClaw?](/help/faq/what-is-openclaw#what-is-openclaw)
+- <a id="what-is-openclaw-in-one-paragraph" />[What is OpenClaw, in one paragraph?](/help/faq/what-is-openclaw#what-is-openclaw-in-one-paragraph)
+- <a id="can-my-team-share-one-openclaw" />[Can my team share one OpenClaw?](/help/faq/what-is-openclaw#can-my-team-share-one-openclaw)
+- <a id="value-proposition" />[Value proposition](/help/faq/what-is-openclaw#value-proposition)
+- <a id="i-just-set-it-up-what-should-i-do-first" />[I just set it up - what should I do first?](/help/faq/what-is-openclaw#i-just-set-it-up-what-should-i-do-first)
+- <a id="what-are-the-top-five-everyday-use-cases-for-openclaw" />[What are the top five everyday use cases for OpenClaw?](/help/faq/what-is-openclaw#what-are-the-top-five-everyday-use-cases-for-openclaw)
+- <a id="can-openclaw-help-with-lead-gen-outreach-ads-and-blogs-for-a-saas" />[Can OpenClaw help with lead gen, outreach, ads, and blogs for a SaaS?](/help/faq/what-is-openclaw#can-openclaw-help-with-lead-gen-outreach-ads-and-blogs-for-a-saas)
+- <a id="is-openclaw-owned-by-openai" />[Is OpenClaw owned by OpenAI?](/help/faq/what-is-openclaw#is-openclaw-owned-by-openai)
+- <a id="what-does-openclaw-send-to-the-foundation" />[What does OpenClaw send to the Foundation?](/help/faq/what-is-openclaw#what-does-openclaw-send-to-the-foundation)
+- <a id="how-is-openclaw-funded-and-how-does-that-compare" />[How is OpenClaw funded, and how does that compare?](/help/faq/what-is-openclaw#how-is-openclaw-funded-and-how-does-that-compare)
+- <a id="what-are-the-advantages-vs-claude-code-for-web-development" />[What are the advantages vs Claude Code for web development?](/help/faq/what-is-openclaw#what-are-the-advantages-vs-claude-code-for-web-development)
+- <a id="skills-and-automation" />[Skills and automation](/help/faq/skills-and-automation#skills-and-automation)
+- <a id="how-do-i-customize-skills-without-keeping-the-repo-dirty" />[How do I customize skills without keeping the repo dirty?](/help/faq/skills-and-automation#how-do-i-customize-skills-without-keeping-the-repo-dirty)
+- <a id="can-i-load-skills-from-a-custom-folder" />[Can I load skills from a custom folder?](/help/faq/skills-and-automation#can-i-load-skills-from-a-custom-folder)
+- <a id="how-can-i-use-different-models-or-settings-for-different-tasks" />[How can I use different models or settings for different tasks?](/help/faq/skills-and-automation#how-can-i-use-different-models-or-settings-for-different-tasks)
+- <a id="the-bot-freezes-while-doing-heavy-work-how-do-i-offload-that" />[The bot freezes while doing heavy work. How do I offload that?](/help/faq/skills-and-automation#the-bot-freezes-while-doing-heavy-work-how-do-i-offload-that)
+- <a id="how-do-thread-bound-subagent-sessions-work-on-discord" />[How do thread-bound subagent sessions work on Discord?](/help/faq/skills-and-automation#how-do-thread-bound-subagent-sessions-work-on-discord)
+- <a id="a-subagent-finished-but-the-completion-update-went-to-the-wrong-place-or-never-posted-what-should-i-check" />[A subagent finished, but the completion update went to the wrong place or never posted. What should I check?](/help/faq/skills-and-automation#a-subagent-finished-but-the-completion-update-went-to-the-wrong-place-or-never-posted-what-should-i-check)
+- <a id="cron-or-reminders-do-not-fire-what-should-i-check" />[Cron or reminders do not fire. What should I check?](/help/faq/skills-and-automation#cron-or-reminders-do-not-fire-what-should-i-check)
+- <a id="cron-fired-but-nothing-was-sent-to-the-channel-why" />[Cron fired, but nothing was sent to the channel. Why?](/help/faq/skills-and-automation#cron-fired-but-nothing-was-sent-to-the-channel-why)
+- <a id="why-did-an-isolated-cron-run-switch-models-or-retry-once" />[Why did an isolated cron run switch models or retry once?](/help/faq/skills-and-automation#why-did-an-isolated-cron-run-switch-models-or-retry-once)
+- <a id="how-do-i-install-skills-on-linux" />[How do I install skills on Linux?](/help/faq/skills-and-automation#how-do-i-install-skills-on-linux)
+- <a id="can-openclaw-run-tasks-on-a-schedule-or-continuously-in-the-background" />[Can OpenClaw run tasks on a schedule or continuously in the background?](/help/faq/skills-and-automation#can-openclaw-run-tasks-on-a-schedule-or-continuously-in-the-background)
+- <a id="can-i-run-apple-macos-only-skills-from-linux" />[Can I run Apple macOS-only skills from Linux?](/help/faq/skills-and-automation#can-i-run-apple-macos-only-skills-from-linux)
+- <a id="do-you-have-a-notion-or-heygen-integration" />[Do you have a Notion or HeyGen integration?](/help/faq/skills-and-automation#do-you-have-a-notion-or-heygen-integration)
+- <a id="how-do-i-use-my-existing-signed-in-chrome-with-openclaw" />[How do I use my existing signed-in Chrome with OpenClaw?](/help/faq/skills-and-automation#how-do-i-use-my-existing-signed-in-chrome-with-openclaw)
+- <a id="sandboxing-and-memory" />[Sandboxing and memory](/help/faq/sandboxing-and-memory#sandboxing-and-memory)
+- <a id="is-there-a-dedicated-sandboxing-doc" />[Is there a dedicated sandboxing doc?](/help/faq/sandboxing-and-memory#is-there-a-dedicated-sandboxing-doc)
+- <a id="docker-feels-limited-how-do-i-enable-full-features" />[Docker feels limited - how do I enable full features?](/help/faq/sandboxing-and-memory#docker-feels-limited-how-do-i-enable-full-features)
+- <a id="can-i-keep-dms-personal-but-make-groups-public-sandboxed-with-one-agent" />[Can I keep DMs personal but make groups public/sandboxed with one agent?](/help/faq/sandboxing-and-memory#can-i-keep-dms-personal-but-make-groups-public-sandboxed-with-one-agent)
+- <a id="how-do-i-bind-a-host-folder-into-the-sandbox" />[How do I bind a host folder into the sandbox?](/help/faq/sandboxing-and-memory#how-do-i-bind-a-host-folder-into-the-sandbox)
+- <a id="how-does-memory-work" />[How does memory work?](/help/faq/sandboxing-and-memory#how-does-memory-work)
+- <a id="memory-keeps-forgetting-things-how-do-i-make-it-stick" />[Memory keeps forgetting things. How do I make it stick?](/help/faq/sandboxing-and-memory#memory-keeps-forgetting-things-how-do-i-make-it-stick)
+- <a id="does-memory-persist-forever-what-are-the-limits" />[Does memory persist forever? What are the limits?](/help/faq/sandboxing-and-memory#does-memory-persist-forever-what-are-the-limits)
+- <a id="does-semantic-memory-search-require-an-openai-api-key" />[Does semantic memory search require an OpenAI API key?](/help/faq/sandboxing-and-memory#does-semantic-memory-search-require-an-openai-api-key)
+- <a id="where-things-live-on-disk" />[Where things live on disk](/help/faq/where-things-live-on-disk#where-things-live-on-disk)
+- <a id="is-all-data-used-with-openclaw-saved-locally" />[Is all data used with OpenClaw saved locally?](/help/faq/where-things-live-on-disk#is-all-data-used-with-openclaw-saved-locally)
+- <a id="where-does-openclaw-store-its-data" />[Where does OpenClaw store its data?](/help/faq/where-things-live-on-disk#where-does-openclaw-store-its-data)
+- <a id="where-should-agents-md-soul-md-user-md-memory-md-live" />[Where should AGENTS.md / SOUL.md / USER.md / MEMORY.md live?](/help/faq/where-things-live-on-disk#where-should-agents-md-soul-md-user-md-memory-md-live)
+- <a id="can-i-make-soul-md-bigger" />[Can I make SOUL.md bigger?](/help/faq/where-things-live-on-disk#can-i-make-soul-md-bigger)
+- <a id="recommended-backup-strategy" />[Recommended backup strategy](/help/faq/where-things-live-on-disk#recommended-backup-strategy)
+- <a id="how-do-i-completely-uninstall-openclaw" />[How do I completely uninstall OpenClaw?](/help/faq/where-things-live-on-disk#how-do-i-completely-uninstall-openclaw)
+- <a id="can-agents-work-outside-the-workspace" />[Can agents work outside the workspace?](/help/faq/where-things-live-on-disk#can-agents-work-outside-the-workspace)
+- <a id="remote-mode-where-is-the-session-store" />[Remote mode: where is the session store?](/help/faq/where-things-live-on-disk#remote-mode-where-is-the-session-store)
+- <a id="config-basics" />[Config basics](/help/faq/config-basics#config-basics)
+- <a id="what-format-is-the-config-where-is-it" />[What format is the config? Where is it?](/help/faq/config-basics#what-format-is-the-config-where-is-it)
+- <a id="i-set-gateway-bind-lan-or-tailnet-and-now-nothing-listens-the-ui-says-unauthorized" />[I set gateway.bind: "lan" (or "tailnet") and now nothing listens / the UI says unauthorized](/help/faq/config-basics#i-set-gateway-bind-lan-or-tailnet-and-now-nothing-listens-the-ui-says-unauthorized)
+- <a id="why-do-i-need-a-token-on-localhost-now" />[Why do I need a token on localhost now?](/help/faq/config-basics#why-do-i-need-a-token-on-localhost-now)
+- <a id="do-i-have-to-restart-after-changing-config" />[Do I have to restart after changing config?](/help/faq/config-basics#do-i-have-to-restart-after-changing-config)
+- <a id="how-do-i-enable-web-search-and-web-fetch" />[How do I enable web search (and web fetch)?](/help/faq/config-basics#how-do-i-enable-web-search-and-web-fetch)
+- <a id="config-apply-wiped-my-config-how-do-i-recover-and-avoid-this" />[config.apply wiped my config. How do I recover and avoid this?](/help/faq/config-basics#config-apply-wiped-my-config-how-do-i-recover-and-avoid-this)
+- <a id="how-do-i-run-a-central-gateway-with-specialized-workers-across-devices" />[How do I run a central Gateway with specialized workers across devices?](/help/faq/config-basics#how-do-i-run-a-central-gateway-with-specialized-workers-across-devices)
+- <a id="can-the-openclaw-browser-run-headless" />[Can the OpenClaw browser run headless?](/help/faq/config-basics#can-the-openclaw-browser-run-headless)
+- <a id="how-do-i-use-brave-for-browser-control" />[How do I use Brave for browser control?](/help/faq/config-basics#how-do-i-use-brave-for-browser-control)
+- <a id="remote-gateways-and-nodes" />[Remote gateways and nodes](/help/faq/remote-gateways-and-nodes#remote-gateways-and-nodes)
+- <a id="how-do-commands-propagate-between-telegram-the-gateway-and-nodes" />[How do commands propagate between Telegram, the gateway, and nodes?](/help/faq/remote-gateways-and-nodes#how-do-commands-propagate-between-telegram-the-gateway-and-nodes)
+- <a id="how-can-my-agent-access-my-computer-if-the-gateway-is-hosted-remotely" />[How can my agent access my computer if the Gateway is hosted remotely?](/help/faq/remote-gateways-and-nodes#how-can-my-agent-access-my-computer-if-the-gateway-is-hosted-remotely)
+- <a id="tailscale-is-connected-but-i-get-no-replies-what-now" />[Tailscale is connected but I get no replies. What now?](/help/faq/remote-gateways-and-nodes#tailscale-is-connected-but-i-get-no-replies-what-now)
+- <a id="can-two-openclaw-instances-talk-to-each-other-local-vps" />[Can two OpenClaw instances talk to each other (local + VPS)?](/help/faq/remote-gateways-and-nodes#can-two-openclaw-instances-talk-to-each-other-local-vps)
+- <a id="do-i-need-separate-vpses-for-multiple-agents" />[Do I need separate VPSes for multiple agents?](/help/faq/remote-gateways-and-nodes#do-i-need-separate-vpses-for-multiple-agents)
+- <a id="is-there-a-benefit-to-using-a-node-on-my-personal-laptop-instead-of-ssh-from-a-vps" />[Is there a benefit to using a node on my personal laptop instead of SSH from a VPS?](/help/faq/remote-gateways-and-nodes#is-there-a-benefit-to-using-a-node-on-my-personal-laptop-instead-of-ssh-from-a-vps)
+- <a id="do-nodes-run-a-gateway-service" />[Do nodes run a gateway service?](/help/faq/remote-gateways-and-nodes#do-nodes-run-a-gateway-service)
+- <a id="is-there-an-api-rpc-way-to-apply-config" />[Is there an API / RPC way to apply config?](/help/faq/remote-gateways-and-nodes#is-there-an-api-rpc-way-to-apply-config)
+- <a id="minimal-sane-config-for-a-first-install" />[Minimal sane config for a first install](/help/faq/remote-gateways-and-nodes#minimal-sane-config-for-a-first-install)
+- <a id="how-do-i-set-up-tailscale-on-a-vps-and-connect-from-my-mac" />[How do I set up Tailscale on a VPS and connect from my Mac?](/help/faq/remote-gateways-and-nodes#how-do-i-set-up-tailscale-on-a-vps-and-connect-from-my-mac)
+- <a id="how-do-i-connect-a-mac-node-to-a-remote-gateway-tailscale-serve" />[How do I connect a Mac node to a remote Gateway (Tailscale Serve)?](/help/faq/remote-gateways-and-nodes#how-do-i-connect-a-mac-node-to-a-remote-gateway-tailscale-serve)
+- <a id="should-i-install-on-a-second-laptop-or-just-add-a-node" />[Should I install on a second laptop or just add a node?](/help/faq/remote-gateways-and-nodes#should-i-install-on-a-second-laptop-or-just-add-a-node)
+- <a id="env-vars-and-.env-loading" /><a id="env-vars-and-env-loading" />[Env vars and .env loading](/help/faq/env-vars#env-vars-and-env-loading)
+- <a id="how-does-openclaw-load-environment-variables" />[How does OpenClaw load environment variables?](/help/faq/env-vars#how-does-openclaw-load-environment-variables)
+- <a id="i-started-the-gateway-via-the-service-and-my-env-vars-disappeared-what-now" />[I started the Gateway via the service and my env vars disappeared. What now?](/help/faq/env-vars#i-started-the-gateway-via-the-service-and-my-env-vars-disappeared-what-now)
+- <a id="i-set-copilot-github-token-but-models-status-shows-shell-env-off-why" />[I set COPILOT_GITHUB_TOKEN, but models status shows "Shell env: off." Why?](/help/faq/env-vars#i-set-copilot-github-token-but-models-status-shows-shell-env-off-why)
+- <a id="sessions-and-multiple-chats" />[Sessions and multiple chats](/help/faq/sessions-and-chats#sessions-and-multiple-chats)
+- <a id="how-do-i-start-a-fresh-conversation" />[How do I start a fresh conversation?](/help/faq/sessions-and-chats#how-do-i-start-a-fresh-conversation)
+- <a id="do-sessions-reset-automatically-if-i-never-send-new" />[Do sessions reset automatically if I never send /new?](/help/faq/sessions-and-chats#do-sessions-reset-automatically-if-i-never-send-new)
+- <a id="is-there-a-way-to-make-a-team-of-openclaw-instances-one-ceo-and-many-agents" />[Is there a way to make a team of OpenClaw instances (one CEO and many agents)?](/help/faq/sessions-and-chats#is-there-a-way-to-make-a-team-of-openclaw-instances-one-ceo-and-many-agents)
+- <a id="why-did-context-get-truncated-mid-task-how-do-i-prevent-it" />[Why did context get truncated mid-task? How do I prevent it?](/help/faq/sessions-and-chats#why-did-context-get-truncated-mid-task-how-do-i-prevent-it)
+- <a id="how-do-i-completely-reset-openclaw-but-keep-it-installed" />[How do I completely reset OpenClaw but keep it installed?](/help/faq/sessions-and-chats#how-do-i-completely-reset-openclaw-but-keep-it-installed)
+- <a id="i-am-getting-context-too-large-errors-how-do-i-reset-or-compact" />[I am getting "context too large" errors - how do I reset or compact?](/help/faq/sessions-and-chats#i-am-getting-context-too-large-errors-how-do-i-reset-or-compact)
+- <a id="why-am-i-seeing-llm-request-rejected-messages-content-tool-use-input-field-required" />[Why am I seeing "LLM request rejected: messages.content.tool_use.input field required"?](/help/faq/sessions-and-chats#why-am-i-seeing-llm-request-rejected-messages-content-tool-use-input-field-required)
+- <a id="why-am-i-getting-heartbeat-messages-every-30-minutes" />[Why am I getting heartbeat messages every 30 minutes?](/help/faq/sessions-and-chats#why-am-i-getting-heartbeat-messages-every-30-minutes)
+- <a id="do-i-need-to-add-a-bot-account-to-a-whatsapp-group" />[Do I need to add a "bot account" to a WhatsApp group?](/help/faq/sessions-and-chats#do-i-need-to-add-a-bot-account-to-a-whatsapp-group)
+- <a id="how-do-i-get-the-jid-of-a-whatsapp-group" />[How do I get the JID of a WhatsApp group?](/help/faq/sessions-and-chats#how-do-i-get-the-jid-of-a-whatsapp-group)
+- <a id="why-does-openclaw-not-reply-in-a-group" />[Why does OpenClaw not reply in a group?](/help/faq/sessions-and-chats#why-does-openclaw-not-reply-in-a-group)
+- <a id="do-groups-threads-share-context-with-dms" />[Do groups/threads share context with DMs?](/help/faq/sessions-and-chats#do-groups-threads-share-context-with-dms)
+- <a id="how-many-workspaces-and-agents-can-i-create" />[How many workspaces and agents can I create?](/help/faq/sessions-and-chats#how-many-workspaces-and-agents-can-i-create)
+- <a id="can-i-run-multiple-bots-or-chats-at-the-same-time-slack-and-how-should-i-set-that-up" />[Can I run multiple bots or chats at the same time (Slack), and how should I set that up?](/help/faq/sessions-and-chats#can-i-run-multiple-bots-or-chats-at-the-same-time-slack-and-how-should-i-set-that-up)
+- <a id="gateway%3A-ports%2C-%22already-running%22%2C-and-remote-mode" /><a id="gateway-ports-already-running-and-remote-mode" />[Gateway: ports, "already running", and remote mode](/help/faq/gateway-ports-and-remote-mode#gateway-ports-already-running-and-remote-mode)
+- <a id="what-port-does-the-gateway-use" />[What port does the Gateway use?](/help/faq/gateway-ports-and-remote-mode#what-port-does-the-gateway-use)
+- <a id="why-does-openclaw-gateway-status-say-runtime-running-but-connectivity-probe-failed" />[Why does openclaw gateway status say "Runtime: running" but "Connectivity probe: failed"?](/help/faq/gateway-ports-and-remote-mode#why-does-openclaw-gateway-status-say-runtime-running-but-connectivity-probe-failed)
+- <a id="why-does-openclaw-gateway-status-show-config-cli-and-config-service-different" />[Why does openclaw gateway status show "Config (cli)" and "Config (service)" different?](/help/faq/gateway-ports-and-remote-mode#why-does-openclaw-gateway-status-show-config-cli-and-config-service-different)
+- <a id="what-does-another-gateway-instance-is-already-listening-mean" />[What does "another gateway instance is already listening" mean?](/help/faq/gateway-ports-and-remote-mode#what-does-another-gateway-instance-is-already-listening-mean)
+- <a id="how-do-i-run-openclaw-in-remote-mode-client-connects-to-a-gateway-elsewhere" />[How do I run OpenClaw in remote mode (client connects to a Gateway elsewhere)?](/help/faq/gateway-ports-and-remote-mode#how-do-i-run-openclaw-in-remote-mode-client-connects-to-a-gateway-elsewhere)
+- <a id="the-control-ui-says-unauthorized-or-keeps-reconnecting-what-now" />[The Control UI says "unauthorized" (or keeps reconnecting). What now?](/help/faq/gateway-ports-and-remote-mode#the-control-ui-says-unauthorized-or-keeps-reconnecting-what-now)
+- <a id="i-set-gateway-bind-tailnet-but-it-listens-only-on-loopback" />[I set gateway.bind tailnet but it listens only on loopback](/help/faq/gateway-ports-and-remote-mode#i-set-gateway-bind-tailnet-but-it-listens-only-on-loopback)
+- <a id="can-i-run-multiple-gateways-on-the-same-host" />[Can I run multiple Gateways on the same host?](/help/faq/gateway-ports-and-remote-mode#can-i-run-multiple-gateways-on-the-same-host)
+- <a id="what-does-invalid-handshake-code-1008-mean" />[What does "invalid handshake" / code 1008 mean?](/help/faq/gateway-ports-and-remote-mode#what-does-invalid-handshake-code-1008-mean)
+- <a id="logging-and-debugging" />[Logging and debugging](/help/faq/logging-and-debugging#logging-and-debugging)
+- <a id="where-are-logs" />[Where are logs?](/help/faq/logging-and-debugging#where-are-logs)
+- <a id="how-do-i-start-stop-restart-the-gateway-service" />[How do I start/stop/restart the Gateway service?](/help/faq/logging-and-debugging#how-do-i-start-stop-restart-the-gateway-service)
+- <a id="i-closed-my-terminal-on-windows-how-do-i-restart-openclaw" />[I closed my terminal on Windows - how do I restart OpenClaw?](/help/faq/logging-and-debugging#i-closed-my-terminal-on-windows-how-do-i-restart-openclaw)
+- <a id="the-gateway-is-up-but-replies-never-arrive-what-should-i-check" />[The Gateway is up but replies never arrive. What should I check?](/help/faq/logging-and-debugging#the-gateway-is-up-but-replies-never-arrive-what-should-i-check)
+- <a id="disconnected-from-gateway-no-reason-what-now" />["Disconnected from gateway: no reason" - what now?](/help/faq/logging-and-debugging#disconnected-from-gateway-no-reason-what-now)
+- <a id="telegram-setmycommands-fails-what-should-i-check" />[Telegram setMyCommands fails. What should I check?](/help/faq/logging-and-debugging#telegram-setmycommands-fails-what-should-i-check)
+- <a id="tui-shows-no-output-what-should-i-check" />[TUI shows no output. What should I check?](/help/faq/logging-and-debugging#tui-shows-no-output-what-should-i-check)
+- <a id="how-do-i-completely-stop-then-start-the-gateway" />[How do I completely stop then start the Gateway?](/help/faq/logging-and-debugging#how-do-i-completely-stop-then-start-the-gateway)
+- <a id="eli5-openclaw-gateway-restart-vs-openclaw-gateway" />[ELI5: openclaw gateway restart vs openclaw gateway](/help/faq/logging-and-debugging#eli5-openclaw-gateway-restart-vs-openclaw-gateway)
+- <a id="fastest-way-to-get-more-details-when-something-fails" />[Fastest way to get more details when something fails](/help/faq/logging-and-debugging#fastest-way-to-get-more-details-when-something-fails)
+- <a id="media-and-attachments" />[Media and attachments](/help/faq/media-and-attachments#media-and-attachments)
+- <a id="my-skill-generated-an-image-pdf-but-nothing-was-sent" />[My skill generated an image/PDF, but nothing was sent](/help/faq/media-and-attachments#my-skill-generated-an-image-pdf-but-nothing-was-sent)
+- <a id="security-and-access-control" />[Security and access control](/help/faq/security-and-access-control#security-and-access-control)
+- <a id="is-it-safe-to-expose-openclaw-to-inbound-dms" />[Is it safe to expose OpenClaw to inbound DMs?](/help/faq/security-and-access-control#is-it-safe-to-expose-openclaw-to-inbound-dms)
+- <a id="is-prompt-injection-only-a-concern-for-public-bots" />[Is prompt injection only a concern for public bots?](/help/faq/security-and-access-control#is-prompt-injection-only-a-concern-for-public-bots)
+- <a id="is-openclaw-less-safe-because-it-uses-typescript-node-instead-of-rust-wasm" />[Is OpenClaw less safe because it uses TypeScript/Node instead of Rust/WASM?](/help/faq/security-and-access-control#is-openclaw-less-safe-because-it-uses-typescript-node-instead-of-rust-wasm)
+- <a id="i-saw-reports-about-exposed-openclaw-instances-what-should-i-check" />[I saw reports about exposed OpenClaw instances. What should I check?](/help/faq/security-and-access-control#i-saw-reports-about-exposed-openclaw-instances-what-should-i-check)
+- <a id="are-clawhub-skills-and-third-party-plugins-safe-to-install" />[Are ClawHub skills and third-party plugins safe to install?](/help/faq/security-and-access-control#are-clawhub-skills-and-third-party-plugins-safe-to-install)
+- <a id="should-my-bot-have-its-own-email-github-account-or-phone-number" />[Should my bot have its own email, GitHub account, or phone number?](/help/faq/security-and-access-control#should-my-bot-have-its-own-email-github-account-or-phone-number)
+- <a id="can-i-give-it-autonomy-over-my-text-messages-and-is-that-safe" />[Can I give it autonomy over my text messages and is that safe?](/help/faq/security-and-access-control#can-i-give-it-autonomy-over-my-text-messages-and-is-that-safe)
+- <a id="can-i-use-cheaper-models-for-personal-assistant-tasks" />[Can I use cheaper models for personal assistant tasks?](/help/faq/security-and-access-control#can-i-use-cheaper-models-for-personal-assistant-tasks)
+- <a id="i-ran-start-in-telegram-but-did-not-get-a-pairing-code" />[I ran /start in Telegram but did not get a pairing code](/help/faq/security-and-access-control#i-ran-start-in-telegram-but-did-not-get-a-pairing-code)
+- <a id="whatsapp-will-it-message-my-contacts-how-does-pairing-work" />[WhatsApp: will it message my contacts? How does pairing work?](/help/faq/security-and-access-control#whatsapp-will-it-message-my-contacts-how-does-pairing-work)
+- <a id="chat-commands%2C-aborting-tasks%2C-and-%22it-will-not-stop%22" /><a id="chat-commands-aborting-tasks-and-it-will-not-stop" />[Chat commands, aborting tasks, and "it will not stop"](/help/faq/chat-commands-and-stopping#chat-commands-aborting-tasks-and-it-will-not-stop)
+- <a id="how-do-i-stop-internal-system-messages-from-showing-in-chat" />[How do I stop internal system messages from showing in chat?](/help/faq/chat-commands-and-stopping#how-do-i-stop-internal-system-messages-from-showing-in-chat)
+- <a id="how-do-i-stop-cancel-a-running-task" />[How do I stop/cancel a running task?](/help/faq/chat-commands-and-stopping#how-do-i-stop-cancel-a-running-task)
+- <a id="how-do-i-send-a-discord-message-from-telegram-cross-context-messaging-denied" />[How do I send a Discord message from Telegram? ("Cross-context messaging denied")](/help/faq/chat-commands-and-stopping#how-do-i-send-a-discord-message-from-telegram-cross-context-messaging-denied)
+- <a id="why-does-it-feel-like-the-bot-ignores-rapid-fire-messages" />[Why does it feel like the bot "ignores" rapid-fire messages?](/help/faq/chat-commands-and-stopping#why-does-it-feel-like-the-bot-ignores-rapid-fire-messages)
 
 ## Related
 

--- a/docs/help/faq/chat-commands-and-stopping.md
+++ b/docs/help/faq/chat-commands-and-stopping.md
@@ -1,0 +1,71 @@
+---
+summary: "Hiding system messages, cancelling runs, cross-context messaging, and the steering queue"
+title: "Chat commands, aborting tasks, and stopping a run"
+read_when:
+  - A task will not stop, or the bot ignores rapid messages
+  - You are tuning slash commands or the queue
+---
+
+## Chat commands, aborting tasks, and "it will not stop"
+
+<AccordionGroup>
+  <Accordion title="How do I stop internal system messages from showing in chat?">
+    Most internal/tool messages only appear when **verbose**, **trace**, or **reasoning** is enabled for that session.
+
+    Fix in the chat where you see it:
+
+    ```text
+    /verbose off
+    /trace off
+    /reasoning off
+    ```
+
+    Still noisy: check session settings in the Control UI and set verbose to **inherit**; confirm you are not using a bot profile with `verboseDefault: "on"` in config.
+
+    Docs: [Thinking and verbose](/tools/thinking), [Security](/gateway/security/index#reasoning-and-verbose-output-in-groups).
+
+  </Accordion>
+
+  <Accordion title="How do I stop/cancel a running task?">
+    Send any of these **as a standalone message** (no slash) to trigger an abort: `stop`, `stop action`, `stop current action`, `stop run`, `stop current run`, `stop agent`, `stop the agent`, `stop openclaw`, `openclaw stop`, `stop don't do anything`, `stop do not do anything`, `stop doing anything`, `do not do that`, `please stop`, `stop please`, `abort`, `esc`, `exit`, `interrupt`, `halt`. Common non-English triggers (French, German, Spanish, Chinese, Japanese, Hindi, Arabic, Russian) also work.
+
+    For background processes started by the exec tool, ask the agent to run:
+
+    ```text
+    process action:kill sessionId:XXX
+    ```
+
+    Most slash commands must be sent as a **standalone** message starting with `/`, but a few shortcuts (like `/status`) also work inline for allowlisted senders. See [Slash commands](/tools/slash-commands).
+
+  </Accordion>
+
+  <Accordion title='How do I send a Discord message from Telegram? ("Cross-context messaging denied")'>
+    OpenClaw blocks **cross-provider** messaging by default. If a tool call is bound to Telegram, it will not send to Discord unless you explicitly allow it - and this takes effect immediately, no gateway restart needed:
+
+    ```json5
+    {
+      tools: {
+        message: {
+          crossContext: {
+            allowAcrossProviders: true,
+            marker: { enabled: true, prefix: "[from {channel}] " },
+          },
+        },
+      },
+    }
+    ```
+
+  </Accordion>
+
+  <Accordion title='Why does it feel like the bot "ignores" rapid-fire messages?'>
+    Mid-run prompts are steered into the active run by default. Use `/queue` to choose active-run behavior:
+
+    - `steer` (default) - guide the active run at the next model boundary.
+    - `followup` - queue messages and run them one at a time after the current run ends.
+    - `collect` - queue compatible messages and reply once after the current run ends.
+    - `interrupt` - abort the current run and start fresh.
+
+    Add options to queued modes like `debounce:0.5s cap:25 drop:summarize`. See [Command queue](/concepts/queue) and [Steering queue](/concepts/queue-steering).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/config-basics.md
+++ b/docs/help/faq/config-basics.md
@@ -1,0 +1,173 @@
+---
+summary: "Config format and location, restarts, web search, config.apply recovery, and browser control"
+title: "Config basics"
+read_when:
+  - You are editing the config for the first time
+  - You need web search, browser control, or config recovery
+---
+
+## Config basics
+
+<AccordionGroup>
+  <Accordion title="What format is the config? Where is it?">
+    OpenClaw reads an optional **JSON5** config from `$OPENCLAW_CONFIG_PATH` (default: `~/.openclaw/openclaw.json`). If the file is missing, it uses safe-ish defaults, including a default workspace of `~/.openclaw/workspace`.
+  </Accordion>
+
+  <Accordion title='I set gateway.bind: "lan" (or "tailnet") and now nothing listens / the UI says unauthorized'>
+    Non-loopback binds **require a valid gateway auth path**: shared-secret auth (token or password), or `gateway.auth.mode: "trusted-proxy"` behind a correctly configured identity-aware reverse proxy.
+
+    ```json5
+    {
+      gateway: {
+        bind: "lan",
+        auth: {
+          mode: "token",
+          token: "replace-me",
+        },
+      },
+    }
+    ```
+
+    - `gateway.remote.token` / `.password` do **not** enable local gateway auth by themselves; local call paths can use `gateway.remote.*` as fallback only when `gateway.auth.*` is unset.
+    - For password auth, set `gateway.auth.mode: "password"` plus `gateway.auth.password` (or `OPENCLAW_GATEWAY_PASSWORD`).
+    - If `gateway.auth.token` / `.password` is explicitly configured via SecretRef and unresolved, resolution fails closed (no remote fallback masking).
+    - Shared-secret Control UI setups authenticate via `connect.params.auth.token` or `connect.params.auth.password` (stored in app/UI settings). Identity-bearing modes such as Tailscale Serve or `trusted-proxy` use request headers instead - avoid putting shared secrets in URLs.
+    - With `gateway.auth.mode: "trusted-proxy"`, same-host loopback reverse proxies require explicit `gateway.auth.trustedProxy.allowLoopback = true` and a loopback entry in `gateway.trustedProxies`.
+
+  </Accordion>
+
+  <Accordion title="Why do I need a token on localhost now?">
+    OpenClaw enforces gateway auth by default, including loopback. If no explicit auth path is configured, startup resolves to token mode and generates a runtime-only token for that startup, so local WS clients must authenticate. This blocks other local processes from calling the Gateway.
+
+    On a fresh loopback start, the Gateway prepares the canonical same-user CLI device credential before `/readyz`, so normal `openclaw` CLI calls can authenticate without persisting the generated token. Other clients still need an explicit shared secret or an approved device pairing.
+
+    Configure `gateway.auth.token`, `gateway.auth.password`, `OPENCLAW_GATEWAY_TOKEN`, or `OPENCLAW_GATEWAY_PASSWORD` explicitly when clients need a stable secret across restarts. You can also choose password mode, or `trusted-proxy` for identity-aware reverse proxies. For open loopback, set `gateway.auth.mode: "none"` explicitly. `openclaw doctor --generate-gateway-token` generates a token any time.
+
+  </Accordion>
+
+  <Accordion title="Do I have to restart after changing config?">
+    The Gateway watches the config and supports hot-reload: `gateway.reload.mode: "hybrid"` (default) hot-applies safe changes and restarts for critical ones. `off` disables config reload; the earlier `hot` and `restart` modes are retired. Most `tools.*`, `agents.*` policy, `session.*`, and `messages.*` changes apply immediately with no reload action at all; `gateway.*` binding/port changes require a restart.
+  </Accordion>
+
+  <Accordion title="How do I enable web search (and web fetch)?">
+    `web_fetch` works without an API key. `web_search` depends on your selected provider:
+
+    | Provider | Key-free | Env var(s) |
+    | --- | --- | --- |
+    | Brave | No | `BRAVE_API_KEY` |
+    | DuckDuckGo | Yes (unofficial HTML-based) | - |
+    | Exa | No | `EXA_API_KEY` |
+    | Firecrawl | No | `FIRECRAWL_API_KEY` |
+    | Gemini | No | `GEMINI_API_KEY` |
+    | Grok | No (xAI OAuth or key) | `XAI_API_KEY` |
+    | Kimi | No | `KIMI_API_KEY` or `MOONSHOT_API_KEY` |
+    | MiniMax Search | No | `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, or `MINIMAX_API_KEY` |
+    | Ollama Web Search | Local: yes (needs `ollama signin`); hosted: no | Hosted: `OLLAMA_API_KEY` |
+    | Perplexity | No | `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` |
+    | SearXNG | Yes (self-hosted) | `SEARXNG_BASE_URL` |
+    | Tavily | No | `TAVILY_API_KEY` |
+
+    Grok can also reuse xAI OAuth from model auth (`openclaw onboard --auth-choice xai-oauth`).
+
+    **Recommended**: `openclaw configure --section web` and pick a provider.
+
+    ```json5
+    {
+      plugins: {
+        entries: {
+          brave: {
+            config: {
+              webSearch: {
+                apiKey: "BRAVE_API_KEY_HERE",
+              },
+            },
+          },
+        },
+      },
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "brave",
+            maxResults: 5,
+          },
+          fetch: {
+            enabled: true,
+            provider: "firecrawl", // optional; omit for auto-detect
+          },
+        },
+      },
+    }
+    ```
+
+    Provider-specific web-search config lives under `plugins.entries.<plugin>.config.webSearch.*`. Legacy `tools.web.search.*` provider paths still load for compatibility but should not be used in new configs. Firecrawl web-fetch fallback config lives under `plugins.entries.firecrawl.config.webFetch.*`.
+
+    - Allowlists: add `web_search`/`web_fetch`/`x_search`, or `group:web` for all three.
+    - `web_fetch` is enabled by default.
+    - If `tools.web.fetch.provider` is omitted, OpenClaw auto-detects the first ready fetch fallback provider from available credentials; the official Firecrawl plugin provides that fallback.
+    - Daemons read env vars from `~/.openclaw/.env` (or the service environment).
+
+    Docs: [Web tools](/tools/web).
+
+  </Accordion>
+
+  <Accordion title="config.apply wiped my config. How do I recover and avoid this?">
+    `config.apply` replaces the **entire config**; a partial object removes everything else.
+
+    Current OpenClaw protects most accidental clobbers:
+
+    - OpenClaw-owned config writes validate the full post-change config before writing.
+    - Invalid or destructive OpenClaw-owned writes are rejected and saved as `openclaw.json.rejected.*`.
+    - Startup can migrate deterministic legacy keys in eligible single-file configs when the whole result validates, keeping the previous config in the `.bak` ring. Other invalid edits make startup fail closed; hot reload skips invalid edits without rewriting `openclaw.json`.
+    - `openclaw doctor --fix` owns repairs beyond that startup migration, can restore last-known-good, and saves the rejected file as `openclaw.json.clobbered.*`.
+
+    Recover:
+
+    - Check `openclaw logs --follow` for `Invalid config at`, `Config write rejected:`, or `config reload skipped (invalid config)`.
+    - Inspect the newest `openclaw.json.clobbered.*` or `openclaw.json.rejected.*` beside the active config.
+    - Run `openclaw config validate` and `openclaw doctor --fix`.
+    - Copy only the intended keys back with `openclaw config set` or `config.patch`.
+    - No last-known-good or rejected payload: restore from backup, or re-run `openclaw doctor` and reconfigure channels/models.
+    - Unexpected loss: file a bug with your last known config or a backup. A local coding agent can often reconstruct a working config from logs or history.
+
+    Avoid it: use `openclaw config set` for small changes, `openclaw configure` for interactive edits, `config.schema.lookup` to inspect an unfamiliar path (returns a shallow schema node plus immediate child summaries), and `config.patch` for partial RPC edits - reserve `config.apply` for full-config replacement. The agent-facing `gateway` runtime tool refuses to rewrite `tools.exec.ask` / `tools.exec.security` even via legacy `tools.bash.*` aliases.
+
+    Docs: [Config](/cli/config), [Configure](/cli/configure), [Gateway troubleshooting](/gateway/troubleshooting#gateway-rejected-invalid-config), [Doctor](/gateway/doctor).
+
+  </Accordion>
+
+  <Accordion title="How do I run a central Gateway with specialized workers across devices?">
+    Common pattern: **one Gateway** (for example a Raspberry Pi) plus **nodes** and **agents**.
+
+    - **Gateway (central)**: owns channels (Signal/WhatsApp), routing, sessions.
+    - **Nodes (devices)**: Macs/iOS/Android connect as peripherals and expose local tools such as `system.run` and `camera`; Macs can also present hosted widgets in the native panel.
+    - **Agents (workers)**: separate brains/workspaces for special roles (for example ops vs personal data).
+    - **Sub-agents**: spawn background work from a main agent for parallelism.
+    - **TUI**: connect to the Gateway and switch agents/sessions.
+
+    Docs: [Nodes](/nodes), [Remote access](/gateway/remote), [Multi-Agent Routing](/concepts/multi-agent), [Sub-agents](/tools/subagents), [TUI](/web/tui).
+
+  </Accordion>
+
+  <Accordion title="Can the OpenClaw browser run headless?">
+    Yes:
+
+    ```json5
+    {
+      browser: { headless: true },
+      agents: {
+        defaults: {
+          sandbox: { browser: { headless: true } },
+        },
+      },
+    }
+    ```
+
+    Default is `false` (headful). Headless is more likely to trigger anti-bot checks on some sites (X/Twitter often blocks headless sessions). It uses the same Chromium engine and works for most automation; the main difference is no visible browser window (use screenshots for visuals). See [Browser](/tools/browser).
+
+  </Accordion>
+
+  <Accordion title="How do I use Brave for browser control?">
+    Set `browser.executablePath` to your Brave binary (or any Chromium-based browser) and restart the Gateway. See [Browser](/tools/browser/configuration#use-brave-or-another-chromium-based-browser).
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/env-vars.md
+++ b/docs/help/faq/env-vars.md
@@ -1,0 +1,70 @@
+---
+summary: "How OpenClaw loads environment variables and why service starts lose them"
+title: "Env vars and .env loading"
+read_when:
+  - You are setting API keys through env or .env
+  - Your env vars disappeared after starting the Gateway as a service
+---
+
+## Env vars and .env loading
+
+<AccordionGroup>
+  <Accordion title="How does OpenClaw load environment variables?">
+    OpenClaw reads env vars from the parent process (shell, launchd/systemd, CI, etc.) and additionally loads:
+
+    - `.env` from the current working directory.
+    - a global fallback `.env` from `~/.openclaw/.env` (`$OPENCLAW_STATE_DIR/.env`).
+
+    Normally, neither `.env` file overrides existing env vars. For an OpenClaw-installed systemd service, the global `.env` may replace only service values that OpenClaw recorded as managed; operator-owned service values still take precedence. Provider credential and endpoint-routing keys are an exception for workspace `.env`: keys such as `GEMINI_API_KEY`, `XAI_API_KEY`, `MISTRAL_API_KEY`, or any key ending in `_ENDPOINT` (and other bundled-provider auth or endpoint env vars) are ignored from workspace `.env` and should live in the process environment, `~/.openclaw/.env`, or config `env.vars`.
+
+    Inline env vars in config apply only if missing from the process env:
+
+    ```json5
+    {
+      env: {
+        vars: {
+          OPENROUTER_API_KEY: "sk-or-...",
+          GROQ_API_KEY: "gsk-...",
+        },
+      },
+    }
+    ```
+
+    See [/environment](/help/environment) for full precedence and sources.
+
+  </Accordion>
+
+  <Accordion title="I started the Gateway via the service and my env vars disappeared. What now?">
+    Two fixes:
+
+    1. Put the missing keys in `~/.openclaw/.env` so they load even when the service does not inherit your shell env.
+    2. Enable shell import (opt-in convenience):
+       ```json5
+       {
+         env: {
+           shellEnv: {
+             enabled: true,
+             timeoutMs: 15000,
+           },
+         },
+       }
+       ```
+       This runs your login shell and imports only missing expected keys (never overrides). Env var equivalents: `OPENCLAW_LOAD_SHELL_ENV=1`, `OPENCLAW_SHELL_ENV_TIMEOUT_MS=15000`.
+
+  </Accordion>
+
+  <Accordion title='I set COPILOT_GITHUB_TOKEN, but models status shows "Shell env: off." Why?'>
+    `openclaw models status` reports whether **shell env import** is enabled. "Shell env: off" does **not** mean your env vars are missing - it just means OpenClaw will not load your login shell automatically.
+
+    If the Gateway runs as a service (launchd/systemd), it will not inherit your shell environment. Fix by putting the token in `~/.openclaw/.env`, enabling `env.shellEnv.enabled: true`, or adding it to config `env` (applies only if missing), then restarting the gateway and rechecking:
+
+    ```bash
+    openclaw models status
+    ```
+
+    Copilot tokens resolve in this order: `OPENCLAW_GITHUB_TOKEN`, then `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`.
+
+    See [/concepts/model-providers](/concepts/model-providers) and [/environment](/help/environment).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/gateway-ports-and-remote-mode.md
+++ b/docs/help/faq/gateway-ports-and-remote-mode.md
@@ -1,0 +1,128 @@
+---
+summary: "Gateway ports, remote-mode clients, bind addresses, and running more than one Gateway"
+title: "Gateway ports, already running, and remote mode"
+read_when:
+  - The Gateway will not bind or reports it is already running
+  - You are connecting a client to a Gateway elsewhere
+---
+
+## Gateway: ports, "already running", and remote mode
+
+<AccordionGroup>
+  <Accordion title="What port does the Gateway use?">
+    `gateway.port` controls the single multiplexed port for WebSocket + HTTP (Control UI, hooks, etc.). Precedence:
+
+    ```text
+    --port > OPENCLAW_GATEWAY_PORT > gateway.port > default 18789
+    ```
+
+  </Accordion>
+
+  <Accordion title='Why does openclaw gateway status say "Runtime: running" but "Connectivity probe: failed"?'>
+    "Running" is the **supervisor's** view (launchd/systemd/schtasks); the connectivity probe is the CLI actually connecting to the gateway WebSocket. Trust these lines from `openclaw gateway status`: `Probe target:` (the URL the probe used), `Listening:` (what is actually bound on the port), `Last gateway error:` (common root cause when the process is alive but the port is not listening).
+  </Accordion>
+
+  <Accordion title='Why does openclaw gateway status show "Config (cli)" and "Config (service)" different?'>
+    You are editing one config file while the service runs another (often a `--profile` / `OPENCLAW_STATE_DIR` mismatch).
+
+    Fix, run from the same `--profile` / environment you want the service to use:
+
+    ```bash
+    openclaw gateway install --force
+    ```
+
+  </Accordion>
+
+  <Accordion title='What does "another gateway instance is already listening" mean?'>
+    OpenClaw enforces a runtime lock by binding the WebSocket listener immediately on startup (default `ws://127.0.0.1:18789`). If the bind fails with `EADDRINUSE`, it throws `GatewayLockError` ("another gateway instance is already listening").
+
+    Fix: stop the other instance, free the port, or run with `openclaw gateway --port <port>`.
+
+  </Accordion>
+
+  <Accordion title="How do I run OpenClaw in remote mode (client connects to a Gateway elsewhere)?">
+    Set `gateway.mode: "remote"` and point to a remote WebSocket URL, optionally with shared-secret remote credentials:
+
+    ```json5
+    {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "ws://gateway.tailnet:18789",
+          token: "your-token",
+          password: "your-password",
+        },
+      },
+    }
+    ```
+
+    - `openclaw gateway` only starts when `gateway.mode` is `local` (or you pass an override flag).
+    - The macOS app watches the config file and switches modes live when these values change.
+    - `gateway.remote.token` / `.password` are client-side remote credentials only; they do not enable local gateway auth by themselves.
+
+  </Accordion>
+
+  <Accordion title='The Control UI says "unauthorized" (or keeps reconnecting). What now?'>
+    Your gateway auth path and the UI's auth method do not match.
+
+    Facts (from code):
+
+    - The Control UI keeps the token in `sessionStorage`, scoped to the current browser tab and selected gateway URL, so same-tab refreshes keep working without long-lived localStorage token persistence.
+    - On `AUTH_TOKEN_MISMATCH`, trusted clients can attempt one bounded retry with a cached device token when the gateway returns retry hints (`canRetryWithDeviceToken=true`, `recommendedNextStep=retry_with_device_token`).
+    - That cached-token retry reuses the cached approved scopes stored with the device token; explicit `deviceToken` / explicit `scopes` callers keep their requested scope set instead of inheriting cached scopes.
+    - Outside that retry path, connect auth precedence is explicit shared token/password first, then explicit `deviceToken`, then stored device token, then bootstrap token.
+    - Built-in setup-code bootstrap returns a node device token with `scopes: []` plus a bounded operator handoff token for trusted mobile onboarding. The operator handoff can read setup-time native configuration but does not grant pairing mutation scopes or `operator.admin`.
+
+    Fix:
+
+    - Fastest: `openclaw dashboard` (prints + copies the dashboard URL, tries to open; shows an SSH hint if headless).
+    - No token yet: `openclaw doctor --generate-gateway-token`.
+    - Remote: tunnel first with `ssh -N -L 18789:127.0.0.1:18789 user@host`, then open `http://127.0.0.1:18789/`.
+    - Shared-secret mode: set `gateway.auth.token` / `OPENCLAW_GATEWAY_TOKEN` or `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`, then paste the matching secret in Control UI settings.
+    - Tailscale Serve mode: confirm `gateway.auth.allowTailscale` is enabled and you are opening the Serve URL, not a raw loopback/tailnet URL that bypasses Tailscale identity headers.
+    - Trusted-proxy mode: confirm you are coming through the configured identity-aware proxy. Same-host loopback proxies also need `gateway.auth.trustedProxy.allowLoopback = true`.
+    - Mismatch persists after the one retry: rotate/re-approve the paired device token:
+      ```bash
+      openclaw devices list
+      openclaw devices rotate --device <id> --role operator
+      ```
+    - Rotate denied: paired-device sessions can rotate only their **own** device unless they also have `operator.admin`, and explicit `--scope` values cannot exceed the caller's current operator scopes.
+    - Still stuck: `openclaw status --all` plus [Troubleshooting](/gateway/troubleshooting). See [Dashboard](/web/dashboard) for auth details.
+
+  </Accordion>
+
+  <Accordion title="I set gateway.bind tailnet but it listens only on loopback">
+    `tailnet` bind picks a Tailscale IP from your network interfaces (100.64.0.0/10). If the machine is not on Tailscale (or the interface is down), the Gateway falls back to loopback instead of exposing another network interface.
+
+    Fix: start Tailscale on that host and restart the Gateway, or switch explicitly to `gateway.bind: "loopback"` / `"lan"`.
+
+    `tailnet` is explicit; `auto` prefers loopback. Use `gateway.bind: "tailnet"` to limit non-loopback exposure to the Tailnet while retaining the required same-host `127.0.0.1` listener.
+
+  </Accordion>
+
+  <Accordion title="Can I run multiple Gateways on the same host?">
+    Usually no - one Gateway can run multiple messaging channels and agents. Use multiple Gateways only for redundancy (for example a rescue bot) or hard isolation, and isolate each with its own `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `agents.defaults.workspace`, and unique `gateway.port`.
+
+    Recommended: `openclaw --profile <name> ...` per instance (auto-creates `~/.openclaw-<name>`), a unique `gateway.port` per profile config (or `--port` for manual runs), and a per-profile service with `openclaw --profile <name> gateway install`.
+
+    Profiles also suffix service names: launchd `ai.openclaw.<profile>`, systemd `openclaw-gateway-<profile>.service`, Windows `OpenClaw Gateway (<profile>)`. The unqualified `openclaw-gateway` systemd unit only exists for the default profile; the legacy pre-rename systemd unit name `clawdbot-gateway` is migrated automatically.
+
+    Full guide: [Multiple gateways](/gateway/multiple-gateways).
+
+  </Accordion>
+
+  <Accordion title='What does "invalid handshake" / code 1008 mean?'>
+    The Gateway is a **WebSocket server** and expects the first message to be a `connect` frame. Anything else closes the connection with **code 1008** (policy violation).
+
+    Common causes: you opened the **HTTP** URL in a browser instead of a WS client, used the wrong port/path, or a proxy/tunnel stripped auth headers or sent a non-Gateway request.
+
+    Fix: use the WS URL (`ws://<host>:18789`, or `wss://...` over HTTPS), do not open the WS port in a normal browser tab, and include the token/password in the `connect` frame when auth is on. CLI/TUI example:
+
+    ```bash
+    openclaw tui --url ws://<host>:18789 --token <token>
+    ```
+
+    Protocol details: [Gateway protocol](/gateway/protocol).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/logging-and-debugging.md
+++ b/docs/help/faq/logging-and-debugging.md
@@ -1,0 +1,145 @@
+---
+summary: "Where logs are, service start and restart, and what to check when replies never arrive"
+title: "Logging and debugging"
+read_when:
+  - You need logs or a Gateway service restart
+  - The Gateway is up but replies never arrive
+---
+
+## Logging and debugging
+
+<AccordionGroup>
+  <Accordion title="Where are logs?">
+    File logs (structured): `/tmp/openclaw/openclaw-YYYY-MM-DD.log` for the default profile, or `/tmp/openclaw/openclaw-<profile>-YYYY-MM-DD.log` for a named profile. Set a stable path via `logging.file`; file log level via `logging.level`; console verbosity via `--verbose` and `logging.consoleLevel`.
+
+    Fastest tail:
+
+    ```bash
+    openclaw logs --follow
+    ```
+
+    Service/supervisor logs (when the gateway runs via launchd/systemd):
+
+    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`; stderr is suppressed).
+    - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
+    - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
+
+    See [Troubleshooting](/gateway/troubleshooting) for more.
+
+  </Accordion>
+
+  <Accordion title="How do I start/stop/restart the Gateway service?">
+    ```bash
+    openclaw gateway status
+    openclaw gateway restart
+    ```
+
+    If you run the gateway manually, `openclaw gateway --force` can reclaim the port. See [Gateway](/gateway).
+
+  </Accordion>
+
+  <Accordion title="I closed my terminal on Windows - how do I restart OpenClaw?">
+    Three Windows install modes:
+
+    **1) Windows Hub local setup**: the native app manages a local app-owned WSL Gateway. Open **OpenClaw Companion** from the Start menu or tray, then use **Gateway Setup** or the Connections tab.
+
+    **2) Manual WSL2 Gateway**: the Gateway runs inside Linux.
+    ```powershell
+    wsl
+    openclaw gateway status
+    openclaw gateway restart
+    ```
+    If you never installed the service, start it in the foreground: `openclaw gateway run`.
+
+    **3) Native Windows CLI/Gateway**: runs directly in Windows.
+    ```powershell
+    openclaw gateway status
+    openclaw gateway restart
+    ```
+    If you run it manually (no service): `openclaw gateway run`.
+
+    Docs: [Windows](/platforms/windows), [Gateway service runbook](/gateway).
+
+  </Accordion>
+
+  <Accordion title="The Gateway is up but replies never arrive. What should I check?">
+    Quick health sweep:
+
+    ```bash
+    openclaw status
+    openclaw models status
+    openclaw channels status
+    openclaw logs --follow
+    ```
+
+    Common causes: model auth not loaded on the **gateway host** (check `models status`), channel pairing/allowlist blocking replies (check channel config and logs), or WebChat/Dashboard open without the right token. If remote, confirm the tunnel/Tailscale connection is up and the Gateway WebSocket is reachable.
+
+    Docs: [Channels](/channels), [Troubleshooting](/gateway/troubleshooting), [Remote access](/gateway/remote).
+
+  </Accordion>
+
+  <Accordion title='"Disconnected from gateway: no reason" - what now?'>
+    Usually means the UI lost the WebSocket connection. Check: is the Gateway running (`openclaw gateway status`)? Is it healthy (`openclaw status`)? Does the UI have the right token (`openclaw dashboard`)? If remote, is the tunnel/Tailscale link up?
+
+    Then tail logs:
+
+    ```bash
+    openclaw logs --follow
+    ```
+
+    Docs: [Dashboard](/web/dashboard), [Remote access](/gateway/remote), [Troubleshooting](/gateway/troubleshooting).
+
+  </Accordion>
+
+  <Accordion title="Telegram setMyCommands fails. What should I check?">
+    ```bash
+    openclaw channels status
+    openclaw channels logs --channel telegram
+    ```
+
+    Then match the error:
+
+    - `BOT_COMMANDS_TOO_MUCH`: the Telegram menu has too many entries. OpenClaw already trims to the Telegram limit and retries with fewer commands, but some menu entries may still be dropped. Reduce plugin/skill/custom commands, or disable `channels.telegram.commands.native` if you do not need the menu.
+    - `TypeError: fetch failed`, `Network request for 'setMyCommands' failed!`, or similar network errors: on a VPS or behind a proxy, confirm outbound HTTPS is allowed and DNS works for `api.telegram.org`.
+
+    If the Gateway is remote, check logs on the Gateway host.
+
+    Docs: [Telegram](/channels/telegram), [Channel troubleshooting](/channels/troubleshooting).
+
+  </Accordion>
+
+  <Accordion title="TUI shows no output. What should I check?">
+    ```bash
+    openclaw status
+    openclaw models status
+    openclaw logs --follow
+    ```
+
+    In the TUI, use `/status` to see the current state. If you expect replies in a chat channel, confirm delivery is enabled (`/deliver on`).
+
+    Docs: [TUI](/web/tui), [Slash commands](/tools/slash-commands).
+
+  </Accordion>
+
+  <Accordion title="How do I completely stop then start the Gateway?">
+    If you installed the service (launchd on macOS, systemd on Linux):
+
+    ```bash
+    openclaw gateway stop
+    openclaw gateway start
+    ```
+
+    In the foreground, stop with Ctrl-C, then `openclaw gateway run`.
+
+    Docs: [Gateway service runbook](/gateway).
+
+  </Accordion>
+
+  <Accordion title="ELI5: openclaw gateway restart vs openclaw gateway">
+    `openclaw gateway restart` restarts the **background service** (launchd/systemd). `openclaw gateway` runs the gateway **in the foreground** for this terminal session. Use the gateway subcommands if you installed the service; use the bare foreground run for a one-off.
+  </Accordion>
+
+  <Accordion title="Fastest way to get more details when something fails">
+    Start the Gateway with `--verbose` for more console detail, then inspect the log file for channel auth, model routing, and RPC errors.
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/media-and-attachments.md
+++ b/docs/help/faq/media-and-attachments.md
@@ -1,0 +1,23 @@
+---
+summary: "Why a generated image or PDF was not delivered to chat"
+title: "Media and attachments"
+read_when:
+  - A skill produced a file but nothing was sent
+---
+
+## Media and attachments
+
+<AccordionGroup>
+  <Accordion title="My skill generated an image/PDF, but nothing was sent">
+    Outbound attachments from the agent must use structured media fields such as `media`, `mediaUrl`, `path`, or `filePath`. See [OpenClaw assistant setup](/start/openclaw) and [Agent send](/tools/agent-send).
+
+    ```bash
+    openclaw message send --target +15555550123 --message "Here you go" --media /path/to/file.png
+    ```
+
+    Also check: the target channel supports outbound media and is not blocked by allowlists; the file is within the provider's size limits (images resize to a max side of 2048px); `tools.fs.workspaceOnly=true` limits local-path sends to workspace, temp/media-store, and sandbox-validated files; `tools.fs.workspaceOnly=false` (default) lets structured local media sends use host-local files the agent can already read, for media plus safe document types (images, audio, video, PDF, Office docs, and validated text documents such as Markdown/MD, TXT, JSON, YAML/YML). This is not a secret scanner - an agent-readable `secret.txt` or `config.json` can be attached when the extension and content validation match. Keep sensitive files outside agent-readable paths, or keep `tools.fs.workspaceOnly=true` for stricter local-path sends.
+
+    See [Images](/nodes/images).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/remote-gateways-and-nodes.md
+++ b/docs/help/faq/remote-gateways-and-nodes.md
@@ -1,0 +1,163 @@
+---
+summary: "Command propagation, Tailscale setups, multi-device nodes, and applying config remotely"
+title: "Remote gateways and nodes"
+read_when:
+  - You run the Gateway on a VPS or another machine
+  - You are adding a node or wiring Tailscale
+---
+
+## Remote gateways and nodes
+
+<AccordionGroup>
+  <Accordion title="How do commands propagate between Telegram, the gateway, and nodes?">
+    Telegram messages are handled by the **gateway**, which runs the agent and only then calls nodes over the **Gateway WebSocket** when a node tool is needed:
+
+    Telegram -> Gateway -> Agent -> `node.*` -> Node -> Gateway -> Telegram
+
+    Nodes do not see inbound provider traffic; they only receive node RPC calls.
+
+  </Accordion>
+
+  <Accordion title="How can my agent access my computer if the Gateway is hosted remotely?">
+    Pair your computer as a **node**. The Gateway runs elsewhere but can call `node.*` tools (screen, camera, system) on your local machine over the Gateway WebSocket.
+
+    1. Run the Gateway on the always-on host (VPS/home server).
+    2. Put the Gateway host and your computer on the same tailnet.
+    3. Ensure the Gateway WS is reachable (tailnet bind or SSH tunnel).
+    4. Open the macOS app locally and connect in **Remote over SSH** mode (or direct tailnet) so it registers as a node.
+    5. Approve the node:
+       ```bash
+       openclaw devices list
+       openclaw devices approve <requestId>
+       ```
+
+    No separate TCP bridge is required; nodes connect over the Gateway WebSocket.
+
+    Security reminder: pairing a macOS node allows `system.run` on that machine. Only pair devices you trust; review [Security](/gateway/security).
+
+    Docs: [Nodes](/nodes), [Gateway protocol](/gateway/protocol), [macOS remote mode](/platforms/mac/remote), [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Tailscale is connected but I get no replies. What now?">
+    Check the basics:
+
+    ```bash
+    openclaw gateway status
+    openclaw status
+    openclaw channels status
+    ```
+
+    Then verify auth and routing: if you use Tailscale Serve, confirm `gateway.auth.allowTailscale` is set correctly; if you connect via SSH tunnel, confirm the tunnel is up and points at the right port; confirm your DM/group allowlists include your account.
+
+    Docs: [Tailscale](/gateway/tailscale), [Remote access](/gateway/remote), [Channels](/channels).
+
+  </Accordion>
+
+  <Accordion title="Can two OpenClaw instances talk to each other (local + VPS)?">
+    Yes, though there is no built-in bot-to-bot bridge.
+
+    **Simplest**: use a normal chat channel both bots can access (Slack/Telegram/WhatsApp). Have Bot A message Bot B, then let Bot B reply as usual.
+
+    **CLI bridge (generic)**: run a script that calls the other Gateway with `openclaw agent --message ... --deliver`, targeting a chat where the other bot listens. If one bot is on a remote VPS, point your CLI at that remote Gateway via SSH/Tailscale (see [Remote access](/gateway/remote)):
+
+    ```bash
+    openclaw agent --message "Hello from local bot" --deliver --channel telegram --reply-to <chat-id>
+    ```
+
+    Add a guardrail so the two bots do not loop endlessly (mention-only, channel allowlists, or a "do not reply to bot messages" rule).
+
+    Docs: [Remote access](/gateway/remote), [Agent CLI](/cli/agent), [Agent send](/tools/agent-send).
+
+  </Accordion>
+
+  <Accordion title="Do I need separate VPSes for multiple agents?">
+    No. One Gateway hosts multiple agents, each with its own workspace, model defaults, and routing - this is the normal setup and much cheaper/simpler than one VPS per agent. Use separate VPSes only for hard isolation (security boundaries) or very different configs you do not want to share.
+  </Accordion>
+
+  <Accordion title="Is there a benefit to using a node on my personal laptop instead of SSH from a VPS?">
+    Yes: nodes are the first-class way to reach your laptop from a remote Gateway and unlock more than shell access. The Gateway runs on macOS, Linux, and Windows (native or WSL2) and is lightweight (a small VPS or Raspberry Pi-class box is fine; 4 GB RAM is plenty), so a common setup is an always-on host plus your laptop as a node.
+
+    - **No inbound SSH required** - nodes connect out to the Gateway WebSocket via device pairing.
+    - **Safer execution controls** - `system.run` is gated by node allowlists/approvals on that laptop.
+    - **More device tools** - nodes expose `camera` and `screen` in addition to `system.run`; Macs also expose the widget panel.
+    - **Local browser automation** - keep the Gateway on a VPS but run Chrome locally through a node host, or attach to local Chrome via Chrome MCP.
+
+    SSH is fine for ad-hoc shell access; nodes are simpler for ongoing agent workflows and device automation.
+
+    Docs: [Nodes](/nodes), [Nodes CLI](/cli/nodes), [Browser](/tools/browser).
+
+  </Accordion>
+
+  <Accordion title="Do nodes run a gateway service?">
+    No. Only **one gateway** should run per host unless you intentionally run isolated profiles (see [Multiple gateways](/gateway/multiple-gateways)). Nodes are peripherals that connect to the gateway (iOS/Android nodes, or macOS "node mode" in the menubar app). For headless node hosts and CLI control, see [Node host CLI](/cli/node).
+
+    A full restart is required for `gateway`, `discovery`, and hosted plugin surface changes.
+
+  </Accordion>
+
+  <Accordion title="Is there an API / RPC way to apply config?">
+    Yes:
+
+    - `config.schema.lookup`: inspect one config subtree with its shallow schema node, matched UI hint, and immediate child summaries before writing.
+    - `config.get`: fetch the current snapshot plus hash.
+    - `config.patch`: safe partial update (preferred for most RPC edits); hot-reloads when possible, restarts when required.
+    - `config.apply`: validate and replace the full config; hot-reloads when possible, restarts when required.
+    - The agent-facing `gateway` runtime tool still refuses to rewrite `tools.exec.ask` / `tools.exec.security`; legacy `tools.bash.*` aliases normalize to the same protected paths.
+
+  </Accordion>
+
+  <Accordion title="Minimal sane config for a first install">
+    ```json5
+    {
+      agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+      channels: { whatsapp: { allowFrom: ["+15555550123"] } },
+    }
+    ```
+
+    Sets your workspace and restricts who can trigger the bot.
+
+  </Accordion>
+
+  <Accordion title="How do I set up Tailscale on a VPS and connect from my Mac?">
+    1. **Install + login on the VPS**:
+       ```bash
+       curl -fsSL https://tailscale.com/install.sh | sh
+       sudo tailscale up
+       ```
+    2. **Install + login on your Mac** using the Tailscale app, same tailnet.
+    3. **Enable MagicDNS** in the Tailscale admin console so the VPS has a stable name.
+    4. **Use the tailnet hostname**: SSH `ssh user@your-vps.tailnet-xxxx.ts.net`; Gateway WS `ws://your-vps.tailnet-xxxx.ts.net:18789`.
+
+    For the Control UI without SSH, use Tailscale Serve on the VPS:
+
+    ```bash
+    openclaw gateway --tailscale serve
+    ```
+
+    This keeps the gateway bound to loopback and exposes HTTPS via Tailscale. See [Tailscale](/gateway/tailscale).
+
+  </Accordion>
+
+  <Accordion title="How do I connect a Mac node to a remote Gateway (Tailscale Serve)?">
+    Serve exposes the **Gateway Control UI + WS**; nodes connect over the same Gateway WS endpoint.
+
+    1. Make sure the VPS and Mac are on the same tailnet.
+    2. Use the macOS app in Remote mode (SSH target can be the tailnet hostname) - it tunnels the Gateway port and connects as a node.
+    3. Approve the node:
+       ```bash
+       openclaw devices list
+       openclaw devices approve <requestId>
+       ```
+
+    Docs: [Gateway protocol](/gateway/protocol), [Discovery](/gateway/discovery), [macOS remote mode](/platforms/mac/remote).
+
+  </Accordion>
+
+  <Accordion title="Should I install on a second laptop or just add a node?">
+    For **local tools only** (screen/camera/exec) on the second laptop, add it as a **node** - one Gateway, no duplicated config. The local tools a node exposes depend on its platform. See [Nodes](/nodes) for the per-platform defaults. Install a second Gateway only for **hard isolation** or two fully separate bots.
+
+    Docs: [Nodes](/nodes), [Nodes CLI](/cli/nodes), [Multiple gateways](/gateway/multiple-gateways).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/sandboxing-and-memory.md
+++ b/docs/help/faq/sandboxing-and-memory.md
@@ -1,0 +1,70 @@
+---
+summary: "Sandbox modes, host folder binds, and how agent memory persists"
+title: "Sandboxing and memory"
+read_when:
+  - You are enabling or loosening the sandbox
+  - Memory is not persisting the way you expect
+---
+
+## Sandboxing and memory
+
+<AccordionGroup>
+  <Accordion title="Is there a dedicated sandboxing doc?">
+    Yes: [Sandboxing](/gateway/sandboxing). For Docker-specific setup (full gateway in Docker or sandbox images), see [Docker](/install/docker).
+  </Accordion>
+
+  <Accordion title="Docker feels limited - how do I enable full features?">
+    The default image is security-first and runs as the `node` user, so it excludes system packages, Homebrew, and bundled browsers. For a fuller setup:
+
+    - Persist `/home/node` with `OPENCLAW_HOME_VOLUME` so caches survive.
+    - Bake system deps into the image with `OPENCLAW_IMAGE_APT_PACKAGES`.
+    - Bake Playwright Chromium and its system dependencies into the image with `OPENCLAW_INSTALL_BROWSER=1`.
+
+    Docs: [Docker](/install/docker), [Browser](/tools/browser).
+
+  </Accordion>
+
+  <Accordion title="Can I keep DMs personal but make groups public/sandboxed with one agent?">
+    Yes, if private traffic is **DMs** and public traffic is **groups**. Set `agents.defaults.sandbox.mode: "non-main"` so group/channel sessions (non-main keys) run in the configured sandbox backend while the main DM session stays on-host. Select `backend: "docker"` for Docker or `backend: "podman"` for Podman. Restrict tools available in sandboxed sessions via `tools.sandbox.tools`.
+
+    Setup walkthrough: [Groups: personal DMs + public groups](/channels/groups#pattern-personal-dms-public-groups-single-agent). Key reference: [Gateway configuration](/gateway/config-agents/sandbox#agentsdefaultssandbox).
+
+  </Accordion>
+
+  <Accordion title="How do I bind a host folder into the sandbox?">
+    Set `agents.defaults.sandbox.docker.binds` to `["host:container:mode"]` (for example `"/home/user/src:/src:ro"`). Global and per-agent binds merge; per-agent binds are ignored when `scope: "shared"`. Use `:ro` for anything sensitive; binds bypass the sandbox filesystem walls.
+
+    OpenClaw validates bind sources against both the normalized path and the canonical path resolved through the deepest existing ancestor, so symlink-parent escapes fail closed even when the final path segment does not exist yet.
+
+    See [Sandboxing](/gateway/sandboxing#multiple-folders-for-one-agent) and [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated#bind-mounts-security-quick-check).
+
+  </Accordion>
+
+  <Accordion title="How does memory work?">
+    OpenClaw memory is Markdown files in the agent workspace: daily notes in `memory/YYYY-MM-DD.md`, curated long-term notes in `MEMORY.md` (main/private sessions only).
+
+    OpenClaw also runs a silent **pre-compaction memory flush** before compaction summarizes the conversation, reminding the model to write durable notes first. It only runs when the workspace is writable (read-only sandboxes skip it); disable with `agents.defaults.compaction.memoryFlush.enabled: false`. See [Memory](/concepts/memory).
+
+  </Accordion>
+
+  <Accordion title="Memory keeps forgetting things. How do I make it stick?">
+    Ask the bot to **write the fact to memory**: long-term notes go in `MEMORY.md`, short-term context in `memory/YYYY-MM-DD.md`. Reminding the model to store memories usually resolves it. If it keeps forgetting, verify the Gateway uses the same workspace on every run.
+
+    Docs: [Memory](/concepts/memory), [Agent workspace](/concepts/agent-workspace).
+
+  </Accordion>
+
+  <Accordion title="Does memory persist forever? What are the limits?">
+    Memory files live on disk and persist until deleted; the limit is your storage, not the model. **Session context** is still limited by the model context window, so long conversations can compact or truncate - that is why memory search exists, pulling only the relevant parts back into context.
+
+    Docs: [Memory](/concepts/memory), [Context](/concepts/context).
+
+  </Accordion>
+
+  <Accordion title="Does semantic memory search require an OpenAI API key?">
+    Only if you use **OpenAI embeddings**, which is the default provider. Codex OAuth covers chat/completions and does **not** grant embeddings access, so signing in with Codex (OAuth or the Codex CLI login) does not enable semantic memory search. OpenAI embeddings still need a real API key (`OPENAI_API_KEY` or `models.providers.openai.apiKey`).
+
+    To stay local, set `memory.search.provider: "local"` (GGUF/llama.cpp). Other supported providers: Bedrock, DeepInfra, Gemini (`GEMINI_API_KEY` or `memory.search.remote.apiKey`), GitHub Copilot, LM Studio, Mistral, Ollama, OpenAI-compatible, and Voyage. See [Memory](/concepts/memory) and [Memory search](/concepts/memory-search) for setup details.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/security-and-access-control.md
+++ b/docs/help/faq/security-and-access-control.md
@@ -1,0 +1,110 @@
+---
+summary: "Exposure, prompt injection, third-party skills, pairing, and how much autonomy to grant"
+title: "Security and access control"
+read_when:
+  - You are exposing OpenClaw to inbound messages
+  - You are judging plugin, skill, or autonomy risk
+---
+
+## Security and access control
+
+<AccordionGroup>
+  <Accordion title="Is it safe to expose OpenClaw to inbound DMs?">
+    Yes - on channels that default to **pairing** (most DM-capable channels), a stranger who DMs your bot never reaches the model:
+
+    - With the pairing default, unknown senders receive a pairing code and their message is not processed. Approve with `openclaw pairing approve --channel <channel> [--account <id>] <code>`. Pending requests are capped at **3 per channel**; check `openclaw pairing list --channel <channel> [--account <id>]` if a code did not arrive.
+    - Opening DMs publicly requires explicit opt-in (`dmPolicy: "open"` and allowlist `"*"`).
+
+    A few workspace channels ship different defaults - ClickClack, for example, allows workspace members by default. Check your channel's page, and run `openclaw doctor` to confirm your DM policies look the way you expect.
+
+  </Accordion>
+
+  <Accordion title="Is prompt injection only a concern for public bots?">
+    No. Prompt injection is about **untrusted content**, not just who can DM the bot. If your assistant reads external content (web search/fetch, browser pages, emails, docs, attachments, pasted logs), that content can carry instructions that try to hijack the model - even if you are the only sender.
+
+    The biggest risk is when tools are enabled: the model can be tricked into exfiltrating context or calling tools on your behalf. Reduce the blast radius:
+
+    - use a read-only or tool-disabled "reader" agent to summarize untrusted content
+    - keep `web_search` / `web_fetch` / `browser` off for tool-enabled agents
+    - treat decoded file/document text as untrusted too: OpenResponses `input_file` and media-attachment extraction both wrap extracted text in explicit external-content boundary markers instead of passing raw file text
+    - sandbox and use strict tool allowlists
+
+    Details: [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Is OpenClaw less safe because it uses TypeScript/Node instead of Rust/WASM?">
+    Language and runtime matter, but are not the main risk for a personal agent. The practical risks are gateway exposure, who can message the bot, prompt injection, tool scope, credential handling, browser access, exec access, and third-party skill/plugin trust.
+
+    Rust and WASM can provide stronger isolation for some code classes, but do not solve prompt injection, bad allowlists, public gateway exposure, overbroad tools, or a browser profile already logged in to sensitive accounts. Treat these as the primary controls: keep the Gateway private or authenticated, use pairing and allowlists for DMs/groups, deny or sandbox risky tools for untrusted inputs, install only trusted plugins and skills, and run `openclaw security audit --deep` after config changes.
+
+    Details: [Security](/gateway/security), [Sandboxing](/gateway/sandboxing).
+
+  </Accordion>
+
+  <Accordion title="I saw reports about exposed OpenClaw instances. What should I check?">
+    ```bash
+    openclaw security audit --deep
+    openclaw gateway status
+    ```
+
+    A safer baseline: Gateway bound to `loopback`, or exposed only through authenticated private access (tailnet, SSH tunnel, token/password auth, or a correctly configured trusted proxy); DMs in `pairing` or `allowlist` mode; group access limited to rooms you chose (group allowlists), with mention gating or sender allowlists where membership is broad or public; high-risk tools (`exec`, `browser`, `gateway`, `cron`) denied or tightly scoped for agents that read untrusted content; sandboxing enabled where tool execution needs a smaller blast radius.
+
+    Public binds without auth, open DMs/groups with tools, and exposed browser control are the findings to fix first. Details: [openclaw security audit](/gateway/security/running-the-audit#openclaw-security-audit).
+
+  </Accordion>
+
+  <Accordion title="Are ClawHub skills and third-party plugins safe to install?">
+    Treat third-party skills and plugins as code you are choosing to trust. ClawHub skill pages expose scan state before install, but scans are not a complete security boundary. OpenClaw does not run built-in local dangerous-code blocking during plugin/skill install or update; use operator-owned `security.installPolicy` for local allow/warn/block decisions.
+
+    Safer pattern: prefer trusted authors and pinned versions, read the skill/plugin before enabling it, keep plugin/skill allowlists narrow, run untrusted-input workflows in a sandbox with minimal tools, and avoid giving third-party code broad filesystem, exec, browser, or secret access.
+
+    Details: [Skills](/tools/skills), [Plugins](/tools/plugin), [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Should my bot have its own email, GitHub account, or phone number?">
+    Yes, for most setups. Isolating the bot with separate accounts and phone numbers reduces the blast radius if something goes wrong, and makes it easier to rotate credentials or revoke access without impacting your personal accounts.
+
+    Start small: give access only to the tools and accounts you actually need, and expand later if required.
+
+    Docs: [Security](/gateway/security), [Pairing](/channels/pairing).
+
+  </Accordion>
+
+  <Accordion title="Can I give it autonomy over my text messages and is that safe?">
+    We do **not** recommend full autonomy over your personal messages. Safest pattern: keep DMs in **pairing mode** or a tight allowlist, use a **separate number or account** if it should message on your behalf, and let it draft while you **approve before sending**.
+
+    To experiment, do it on a dedicated, isolated account. See [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Can I use cheaper models for personal assistant tasks?">
+    Yes, **if** the agent is chat-only and the input is trusted. Smaller tiers are more susceptible to instruction hijacking, so avoid them for tool-enabled agents or when reading untrusted content. If you must use a smaller model, lock down tools and run inside a sandbox. See [Security](/gateway/security).
+  </Accordion>
+
+  <Accordion title="I ran /start in Telegram but did not get a pairing code">
+    Pairing codes are sent **only** when an unknown sender messages the bot and `dmPolicy: "pairing"` is enabled; `/start` by itself does not generate a code.
+
+    Check pending requests:
+
+    ```bash
+    openclaw pairing list telegram
+    ```
+
+    For immediate access, allowlist your sender id or set `dmPolicy: "open"` for that account.
+
+  </Accordion>
+
+  <Accordion title="WhatsApp: will it message my contacts? How does pairing work?">
+    No. Default WhatsApp DM policy is **pairing**. Unknown senders only get a pairing code; their message is **not processed**. OpenClaw only replies to chats it receives or to explicit sends you trigger.
+
+    ```bash
+    openclaw pairing approve whatsapp <code>
+    openclaw pairing list whatsapp
+    ```
+
+    The wizard's phone number prompt sets your **allowlist/owner** so your own DMs are permitted - it is not used for auto-sending. On your personal WhatsApp number, use that number and enable `channels.whatsapp.selfChatMode`.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/sessions-and-chats.md
+++ b/docs/help/faq/sessions-and-chats.md
@@ -1,0 +1,186 @@
+---
+summary: "Fresh sessions, context truncation, full resets, groups, and multi-agent setups"
+title: "Sessions and multiple chats"
+read_when:
+  - You are managing sessions, resets, or context limits
+  - You run multiple chats, groups, or bots
+---
+
+## Sessions and multiple chats
+
+<AccordionGroup>
+  <Accordion title="How do I start a fresh conversation?">
+    Send `/new` or `/reset` as a standalone message. See [Session management](/concepts/session).
+  </Accordion>
+
+  <Accordion title="Do sessions reset automatically if I never send /new?">
+    No, not by default. Sessions keep the same `sessionId`, and compaction bounds the active model context as conversations grow. `/new` and `/reset` remain available, or you can opt into automatic resets with `mode: "daily"` or `mode: "idle"`. Daily mode rolls over at `session.reset.atHour` (default `4`, 0-23) on the gateway host; idle mode uses `session.reset.idleMinutes` since the last real interaction, not heartbeat/cron/exec system events.
+
+    ```json5
+    {
+      session: {
+        reset: { mode: "daily", atHour: 4 },
+        resetByType: {
+          group: { mode: "idle", idleMinutes: 120 },
+          thread: { mode: "daily", atHour: 6 },
+        },
+        resetByChannel: {
+          discord: { mode: "idle", idleMinutes: 10080 },
+        },
+      },
+    }
+    ```
+
+    `resetByType` supports `direct`, `group`, and `thread`. Doctor migrates legacy `dm` entries to `direct`; the schema rejects `dm`. Legacy top-level `session.idleMinutes` still works as a compatibility alias for an idle-mode default when no `session.reset`/`resetByType` block is set. See [Session management](/concepts/session) for the full lifecycle.
+
+  </Accordion>
+
+  <Accordion title="Is there a way to make a team of OpenClaw instances (one CEO and many agents)?">
+    Yes, via **multi-agent routing** and **sub-agents**: one coordinator agent plus several worker agents with their own workspaces and models.
+
+    This is best seen as a fun experiment - it is token-heavy and often less efficient than one bot with separate sessions. The typical model is one bot you talk to, with different sessions for parallel work, spawning sub-agents when needed.
+
+    Docs: [Multi-agent routing](/concepts/multi-agent), [Sub-agents](/tools/subagents), [Agents CLI](/cli/agents).
+
+  </Accordion>
+
+  <Accordion title="Why did context get truncated mid-task? How do I prevent it?">
+    Session context is limited by the model window. Long chats, large tool outputs, or many files can trigger compaction or truncation.
+
+    - Ask the bot to summarize current state and write it to a file.
+    - Use `/compact` before long tasks, `/new` when switching topics.
+    - Keep important context in the workspace and ask the bot to read it back.
+    - Use sub-agents for long or parallel work so the main chat stays smaller.
+    - Pick a model with a larger context window if this happens often.
+
+  </Accordion>
+
+  <Accordion title="How do I completely reset OpenClaw but keep it installed?">
+    ```bash
+    openclaw reset
+    ```
+
+    Non-interactive full reset:
+
+    ```bash
+    openclaw reset --scope full --yes --non-interactive
+    ```
+
+    Then re-run setup:
+
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+
+    To reset and immediately re-run onboarding, pass `openclaw onboard --reset`; reset is a command flag, not a **Setup mode** menu choice. See [Onboarding (CLI)](/start/wizard). If you used profiles (`--profile` / `OPENCLAW_PROFILE`), reset each state dir (default `~/.openclaw-<profile>`). Dev-only reset: `openclaw gateway --dev --reset` wipes dev config, credentials, sessions, and workspace.
+
+  </Accordion>
+
+  <Accordion title='I am getting "context too large" errors - how do I reset or compact?'>
+    - **Compact** (keeps the conversation, summarizes older turns): `/compact` or `/compact <instructions>` to guide the summary.
+    - **Reset** (fresh session ID for the same chat key): `/new` or `/reset`.
+
+    If it keeps happening, tune **session pruning** (`agents.defaults.contextPruning`) to trim old tool output, or use a model with a larger context window.
+
+    Docs: [Compaction](/concepts/compaction), [Session pruning](/concepts/session-pruning), [Session management](/concepts/session).
+
+  </Accordion>
+
+  <Accordion title='Why am I seeing "LLM request rejected: messages.content.tool_use.input field required"?'>
+    Provider validation error: the model emitted a `tool_use` block without the required `input`. Usually means the session history is stale or corrupted (often after long threads or a tool/schema change).
+
+    Fix: start a fresh session with `/new` (standalone message).
+
+  </Accordion>
+
+  <Accordion title="Why am I getting heartbeat messages every 30 minutes?">
+    Heartbeats run every **30m** by default, or **1h** when the resolved auth mode is Anthropic OAuth/token auth (including Claude CLI reuse) and `heartbeat.every` is unset. Tune or disable:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "2h", // or "0m" to disable recurring cadence
+          },
+        },
+      },
+    }
+    ```
+
+    Heartbeat instructions live in the monitor's cron scratch. Effectively empty scratch skips the heartbeat run to save API calls; without scratch, the heartbeat still runs and the model decides what to do. `0m` does not block targeted event-driven wakes, such as a background exec completion follow-up; those can still run one agent turn without enabling recurring cadence.
+
+    Per-agent overrides use `agents.entries.*.heartbeat`. Docs: [Heartbeat](/gateway/heartbeat).
+
+  </Accordion>
+
+  <Accordion title='Do I need to add a "bot account" to a WhatsApp group?'>
+    No. OpenClaw runs on **your own account** - if you are in the group, OpenClaw can see it. By default, group replies are blocked until you allow senders (`groupPolicy: "allowlist"`).
+
+    To restrict group replies to only you:
+
+    ```json5
+    {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551234567"],
+        },
+      },
+    }
+    ```
+
+  </Accordion>
+
+  <Accordion title="How do I get the JID of a WhatsApp group?">
+    Fastest: tail logs and send a test message in the group.
+
+    ```bash
+    openclaw logs --follow --json
+    ```
+
+    Look for `chatId` (or `from`) ending in `@g.us`, like `1234567890-1234567890@g.us`.
+
+    If already configured/allowlisted, list groups from config:
+
+    ```bash
+    openclaw directory groups list --channel whatsapp
+    ```
+
+    Docs: [WhatsApp](/channels/whatsapp), [Directory](/cli/directory), [Logs](/cli/logs).
+
+  </Accordion>
+
+  <Accordion title="Why does OpenClaw not reply in a group?">
+    Two common causes: mention gating is on by default (you must @mention the bot, or match `mentionPatterns`), or you configured `channels.whatsapp.groups` without `"*"` and the group is not allowlisted.
+
+    See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
+
+  </Accordion>
+
+  <Accordion title="Do groups/threads share context with DMs?">
+    Direct chats collapse to the main session by default. Groups/channels get their own session keys unless a route binding sets `session.groupScope: "main"` to merge that room into the main session; Telegram topics / Discord threads are separate sessions. See [Groups](/channels/groups) and [Group messages](/channels/group-messages).
+  </Accordion>
+
+  <Accordion title="How many workspaces and agents can I create?">
+    No hard limits - dozens or even hundreds are fine, but watch:
+
+    - **Disk growth**: active sessions and transcripts live in the per-agent SQLite database; legacy/archive artifacts can still accumulate under `~/.openclaw/agents/<agentId>/sessions/`.
+    - **Token cost**: more agents means more concurrent model usage.
+    - **Ops overhead**: per-agent auth profiles, workspaces, and channel routing.
+
+    Keep one **active** workspace per agent (`agents.defaults.workspace`), prune old sessions with `openclaw sessions cleanup` if disk grows (do not edit active SQLite state by hand), and use `openclaw doctor` to spot stray workspaces and profile mismatches.
+
+  </Accordion>
+
+  <Accordion title="Can I run multiple bots or chats at the same time (Slack), and how should I set that up?">
+    Yes, via **Multi-Agent Routing**: run multiple isolated agents and route inbound messages by channel/account/peer. Slack is supported as a channel and can be bound to specific agents.
+
+    Browser access is powerful but not "do anything a human can" - anti-bot, CAPTCHAs, and MFA can still block automation. For the most reliable control, use local Chrome MCP on the host, or CDP on the machine that actually runs the browser.
+
+    Best-practice setup: always-on Gateway host (VPS/Mac mini), one agent per role (bindings), Slack channel(s) bound to those agents, and local browser via Chrome MCP or a node when needed.
+
+    Docs: [Multi-Agent Routing](/concepts/multi-agent), [Slack](/channels/slack), [Browser](/tools/browser), [Nodes](/nodes).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/skills-and-automation.md
+++ b/docs/help/faq/skills-and-automation.md
@@ -1,0 +1,259 @@
+---
+summary: "Customizing skills, per-task models, subagents, cron jobs, and background runs"
+title: "Skills and automation"
+read_when:
+  - You are customizing, loading, or installing skills
+  - A cron job, reminder, or subagent did not behave
+---
+
+## Skills and automation
+
+<AccordionGroup>
+  <Accordion title="How do I customize skills without keeping the repo dirty?">
+    Use managed overrides instead of editing the repo copy. Put changes in `~/.openclaw/skills/<name>/SKILL.md` (or add a folder via `skills.load.extraDirs` in `~/.openclaw/openclaw.json`). Precedence: `<workspace>/skills` -> `<workspace>/.agents/skills` -> `~/.agents/skills` -> `~/.openclaw/skills` -> bundled -> `skills.load.extraDirs`, so managed overrides win over bundled skills without touching git. To install globally but limit visibility to some agents, keep the shared copy in `~/.openclaw/skills` and control visibility with `agents.defaults.skills` / `agents.entries.*.skills`. Only upstream-worthy edits should go out as PRs against the repo copy.
+  </Accordion>
+
+  <Accordion title="Can I load skills from a custom folder?">
+    Yes: add directories via `skills.load.extraDirs` in `~/.openclaw/openclaw.json` (lowest precedence in the order above). `clawhub` installs into `./skills` by default, which OpenClaw treats as `<workspace>/skills` on the next session. To limit visibility to certain agents, pair with `agents.defaults.skills` or `agents.entries.*.skills`.
+  </Accordion>
+
+  <Accordion title="How can I use different models or settings for different tasks?">
+    Supported patterns:
+
+    - **Cron jobs**: isolated jobs can set a `model` override per job.
+    - **Agents**: route tasks to separate agents with different default models, thinking levels, and stream params.
+    - **Current session only**: `/model <model> -s` (or `--session`) leaves configured defaults unchanged.
+    - **Agent default + current session**: Owner/admin `/model <model> -a` (or `--agent`) updates the selected agent.
+    - **Global default + current session**: Owner/admin `/model <model> -g` (or `--global`) updates `agents.defaults.model`.
+
+    Bare `/model <model>` keeps owner/admin configured-default persistence unless
+    you set the optional [model selection scope](/gateway/config-agents/models#agentsdefaultsmodelselectionscope).
+
+    Example - same model, different per-agent settings:
+
+    ```json5
+    {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          coder: {
+            model: "xiaomi/mimo-v2.5-pro",
+            thinkingDefault: "high",
+            params: { temperature: 0.1 },
+          },
+          chat: {
+            model: "xiaomi/mimo-v2.5-pro",
+            thinkingDefault: "off",
+            params: { temperature: 0.8 },
+          },
+        },
+      },
+    }
+    ```
+
+    Put shared per-model defaults in `agents.defaults.models["provider/model"].params`. Use `agents.entries.*.models["provider/model"].params` when one agent needs different settings for that model. Flat `agents.entries.*.params` applies across that agent's models and wins over both per-model layers.
+
+    See [Cron jobs](/automation/cron-jobs), [Multi-Agent Routing](/concepts/multi-agent), [Configuration](/gateway/config-agents), [Slash commands](/tools/slash-commands).
+
+  </Accordion>
+
+  <Accordion title="The bot freezes while doing heavy work. How do I offload that?">
+    Use **sub-agents** for long or parallel tasks: they run in their own session, return a summary, and keep your main chat responsive. Ask the bot to "spawn a sub-agent for this task," or use `/subagents`. Use `/status` to see whether the Gateway is currently busy.
+
+    Long tasks and sub-agents both consume tokens; set a cheaper model for sub-agents via `agents.defaults.subagents.model` if cost matters.
+
+    Docs: [Sub-agents](/tools/subagents), [Background Tasks](/automation/tasks).
+
+  </Accordion>
+
+  <Accordion title="How do thread-bound subagent sessions work on Discord?">
+    Bind a Discord thread to a subagent or session target so follow-up messages there stay on that bound session.
+
+    - Spawn with `sessions_spawn` using `thread: true` (optionally `mode: "session"` for persistent follow-up).
+    - `/agents` inspects binding state.
+    - `/session idle <duration|off>` and `/session max-age <duration|off>` control automatic expiry.
+    - `/session unbind` detaches the thread without closing the agent session.
+
+    Config: `session.threadBindings.enabled` (global switch), `session.threadBindings.idleHours` (default `24`, `0` disables), `session.threadBindings.maxAgeHours` (default `0` = no hard cap), and `session.threadBindings.spawnSessions` for auto-bind on spawn (default `true`).
+
+    Docs: [Sub-agents](/tools/subagents), [Discord](/channels/discord), [Configuration Reference](/gateway/configuration-reference), [Slash commands](/tools/slash-commands).
+
+  </Accordion>
+
+  <Accordion title="A subagent finished, but the completion update went to the wrong place or never posted. What should I check?">
+    Check the resolved requester route:
+
+    - Completion-mode subagent delivery prefers a bound thread or conversation route when one exists.
+    - If the completion origin only carries a channel, OpenClaw falls back to the requester session's stored route (`lastChannel` / `lastTo` / `lastAccountId`) so direct delivery can still succeed.
+    - No bound route and no usable stored route: direct delivery can fail and the result falls back to queued session delivery instead of posting immediately.
+    - Invalid or stale targets can also force queue fallback or final delivery failure.
+    - If the child's last visible assistant reply is exactly `NO_REPLY` / `no_reply` or `ANNOUNCE_SKIP`, OpenClaw intentionally suppresses the announce instead of posting stale earlier progress.
+
+    Debug: `openclaw tasks show <lookup>` where `<lookup>` is a task id, run id, or session key.
+
+    Docs: [Sub-agents](/tools/subagents), [Background Tasks](/automation/tasks), [Session Tools](/concepts/session-tool).
+
+  </Accordion>
+
+  <Accordion title="Cron or reminders do not fire. What should I check?">
+    Cron runs inside the Gateway process; it does not fire if the Gateway is not running continuously.
+
+    - Confirm cron is enabled (`cron.enabled`) and `OPENCLAW_SKIP_CRON` is not set.
+    - Confirm the Gateway is running 24/7 (no sleep/restarts).
+    - Verify job timezone (`--tz` vs host timezone).
+
+    Debug:
+    ```bash
+    openclaw automations run <jobId>
+    openclaw automations runs <jobId> --limit 50
+    ```
+
+    Docs: [Cron jobs](/automation/cron-jobs), [Automation](/automation).
+
+  </Accordion>
+
+  <Accordion title="Cron fired, but nothing was sent to the channel. Why?">
+    Check the delivery mode:
+
+    - `--no-deliver` / `delivery.mode: "none"`: no runner fallback send is expected.
+    - Missing or invalid announce target (`channel` / `to`): the runner skipped outbound delivery.
+    - Channel auth failures (`unauthorized`, `Forbidden`): the runner tried to deliver but credentials blocked it.
+    - A silent isolated result (`NO_REPLY` / `no_reply` only) is treated as intentionally non-deliverable, so queued fallback delivery is also suppressed.
+
+    For isolated cron jobs, the agent can still send directly with the `message` tool when a chat route is available. `--announce` only controls runner fallback delivery for final text the agent did not already send itself.
+
+    Debug:
+    ```bash
+    openclaw automations runs <jobId> --limit 50
+    openclaw tasks show <lookup>
+    ```
+
+    Docs: [Cron jobs](/automation/cron-jobs), [Background Tasks](/automation/tasks).
+
+  </Accordion>
+
+  <Accordion title="Why did an isolated cron run switch models or retry once?">
+    That is the live model-switch path, not duplicate scheduling. Isolated cron persists a runtime model handoff and retries when the active run throws `LiveSessionModelSwitchError`, keeping the switched provider/model (and any switched auth-profile override) before retrying.
+
+    Model-selection precedence: Gmail hook model override (`hooks.gmail.model`) first, then per-job `model`, then any stored cron-session model override, then normal agent/default model selection.
+
+    The retry loop is bounded to the initial attempt plus 2 switch retries; cron then aborts instead of looping forever.
+
+    Debug:
+    ```bash
+    openclaw automations runs <jobId> --limit 50
+    ```
+
+    Docs: [Cron jobs](/automation/cron-jobs), [cron CLI](/cli/cron).
+
+  </Accordion>
+
+  <Accordion title="How do I install skills on Linux?">
+    Use native `openclaw skills` commands or drop skills into your workspace; the macOS Skills UI is not available on Linux. Browse skills at [https://clawhub.ai](https://clawhub.ai).
+
+    ```bash
+    openclaw skills search "calendar"
+    openclaw skills search --limit 20
+    openclaw skills install @owner/<skill-slug>
+    openclaw skills install @owner/<skill-slug> --version <version>
+    openclaw skills install @owner/<skill-slug> --force
+    openclaw skills install @owner/<skill-slug> --global
+    openclaw skills update --all
+    openclaw skills update --all --global
+    openclaw skills list --eligible
+    openclaw skills check
+    ```
+
+    Native `openclaw skills install` writes into the active workspace `skills/` directory by default. Add `--global` to install into the shared managed skills directory for all local agents. Install the separate `clawhub` CLI only to publish or sync your own skills. Use `agents.defaults.skills` or `agents.entries.*.skills` to narrow which agents see shared skills.
+
+  </Accordion>
+
+  <Accordion title="Can OpenClaw run tasks on a schedule or continuously in the background?">
+    Yes, via the Gateway scheduler:
+
+    - **Cron jobs** for scheduled or recurring tasks (persist across restarts).
+    - **Heartbeat** for main-session periodic checks.
+    - **Isolated jobs** for autonomous agents that post summaries or deliver to chats.
+
+    Docs: [Cron jobs](/automation/cron-jobs), [Automation](/automation), [Heartbeat](/gateway/heartbeat).
+
+  </Accordion>
+
+  <Accordion title="Can I run Apple macOS-only skills from Linux?">
+    Not directly. macOS skills are gated by `metadata.openclaw.os` plus required binaries, and only load when eligible on the **Gateway host**. On Linux, `darwin`-only skills (`apple-notes`, `apple-reminders`, `things-mac`) will not load unless you override the gating.
+
+    Three supported patterns:
+
+    **Option A - run the Gateway on a Mac (simplest)**. Run the Gateway where the macOS binaries exist, then connect from Linux in [remote mode](/help/faq/gateway-ports-and-remote-mode#gateway-ports-already-running-and-remote-mode) or over Tailscale. Skills load normally because the Gateway host is macOS.
+
+    **Option B - use a macOS node (no SSH)**. Run the Gateway on Linux, pair a macOS node (menubar app), and set **Node Run Commands** to "Always Ask" or "Always Allow" on the Mac. OpenClaw treats macOS-only skills as eligible when required binaries exist on the node; the agent runs them via the `nodes` tool. With "Always Ask," approving "Always Allow" in the prompt adds that command to the allowlist.
+
+    **Option C - proxy macOS binaries over SSH (advanced)**. Keep the Gateway on Linux, but make the required CLI binaries resolve to SSH wrappers that run on a Mac, then override the skill to allow Linux so it stays eligible.
+
+    1. Create an SSH wrapper for the binary (example: `memo` for Apple Notes):
+       ```bash
+       #!/usr/bin/env bash
+       set -euo pipefail
+       exec ssh -T user@mac-host /opt/homebrew/bin/memo "$@"
+       ```
+    2. Put the wrapper on `PATH` on the Linux host (for example `~/bin/memo`).
+    3. Override the skill metadata (workspace or `~/.openclaw/skills`) to allow Linux:
+       ```markdown
+       ---
+       name: apple-notes
+       description: Manage Apple Notes via the memo CLI on macOS.
+       metadata: { "openclaw": { "os": ["darwin", "linux"], "requires": { "bins": ["memo"] } } }
+       ---
+       ```
+    4. Start a new session so the skills snapshot refreshes.
+
+  </Accordion>
+
+  <Accordion title="Do you have a Notion or HeyGen integration?">
+    Not built in today. Options:
+
+    - **Custom skill / plugin**: best for reliable API access (both have APIs).
+    - **Browser automation**: works without code but is slower and more fragile.
+
+    For agency-style per-client context: keep one Notion page per client (context + preferences + active work) and ask the agent to fetch that page at the start of a session.
+
+    For a native integration, open a feature request or build a skill against those APIs.
+
+    ```bash
+    openclaw skills install @owner/<skill-slug>
+    openclaw skills update --all
+    ```
+
+    Native installs land in the active workspace `skills/` directory; use `--global` for all local agents, or configure `agents.defaults.skills` / `agents.entries.*.skills` to limit visibility. Some skills expect Homebrew-installed binaries; on Linux that means Linuxbrew.
+
+    See [Skills](/tools/skills), [Skills config](/tools/skills-config), [ClawHub](/clawhub).
+
+  </Accordion>
+
+  <Accordion title="How do I use my existing signed-in Chrome with OpenClaw?">
+    Use the built-in `user` browser profile, which attaches through Chrome DevTools MCP:
+
+    ```bash
+    openclaw browser --browser-profile user tabs
+    openclaw browser --browser-profile user snapshot
+    ```
+
+    For a custom name, create an explicit MCP profile:
+
+    ```bash
+    openclaw browser create-profile --name chrome-live --driver existing-session
+    openclaw browser --browser-profile chrome-live tabs
+    ```
+
+    This can use the local host browser or a connected browser node. If the Gateway runs elsewhere, run a node host on the browser machine, or use remote CDP instead.
+
+    Current limits on `existing-session` / `user` profiles versus the managed `openclaw` profile:
+
+    - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs, not CSS selectors.
+    - Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`.
+    - `responsebody`, PDF export, download interception, and batch actions still require the managed browser path.
+
+    See [Browser](/tools/browser/existing-session#existing-session-via-chrome-devtools-mcp) for the full comparison.
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/what-is-openclaw.md
+++ b/docs/help/faq/what-is-openclaw.md
@@ -65,7 +65,7 @@ read_when:
   </Accordion>
 
   <Accordion title="What does OpenClaw send to the Foundation?">
-    By default, a daily update check carrying the OpenClaw version, OS, Node version, and CPU architecture: the same information any package registry sees. Optional anonymous feature statistics are off by default and carry no identifier. No prompts, messages, model names, keys, paths, or machine identifiers are ever sent to the Foundation. Set `update.checkOnStart: false` to send nothing at all. Traffic to the model providers and chat platforms you configure is separate and goes to them, as always; see "Is all data used with OpenClaw saved locally?" below. Details: [Usage telemetry and update checks](/gateway/telemetry).
+    By default, a daily update check carrying the OpenClaw version, OS, Node version, and CPU architecture: the same information any package registry sees. Optional anonymous feature statistics are off by default and carry no identifier. No prompts, messages, model names, keys, paths, or machine identifiers are ever sent to the Foundation. Set `update.checkOnStart: false` to send nothing at all. Traffic to the model providers and chat platforms you configure is separate and goes to them, as always; see [Is all data used with OpenClaw saved locally?](/help/faq/where-things-live-on-disk#is-all-data-used-with-openclaw-saved-locally). Details: [Usage telemetry and update checks](/gateway/telemetry).
 
   </Accordion>
 

--- a/docs/help/faq/what-is-openclaw.md
+++ b/docs/help/faq/what-is-openclaw.md
@@ -1,0 +1,89 @@
+---
+summary: "What OpenClaw is, who it is for, how it is funded, and how it compares"
+title: "What is OpenClaw?"
+read_when:
+  - You are evaluating OpenClaw or explaining it to someone
+  - You want the ownership, funding, or comparison answers
+---
+
+## What is OpenClaw?
+
+<AccordionGroup>
+  <Accordion title="What is OpenClaw, in one paragraph?">
+    OpenClaw is an AI assistant you run on your own infrastructure - for yourself, or shared with your team. It replies on the messaging surfaces you already use (Discord, Google Chat, iMessage, Mattermost, Signal, Slack, Telegram, WebChat, WhatsApp, and bundled channel plugins such as QQ Bot) and can also do voice plus hosted widgets in chat, on session dashboards, and in the macOS panel. The **Gateway** is the always-on control plane; the assistant is the product. The same gateway scales from one person's WhatsApp to a shared workspace bot with [multi-user sessions](/concepts/multi-user).
+  </Accordion>
+
+  <Accordion title="Can my team share one OpenClaw?">
+    Yes. A shared gateway is a supported, first-class deployment: sessions carry an immutable creator, an assignable owner, and the people who prompted them; the Control UI shows who is viewing and typing in real time; and commits from shared sessions can carry `Co-authored-by` trailers for the people who steered them. [Named operator roles](/gateway/operator-scopes#named-operator-roles) bound what each teammate can do.
+
+    One boundary to respect: a gateway is one trust domain. Share it with people who trust each other; mutually adversarial users need separate gateways. See [Team setup](/start/teams), [Multi-user mode](/concepts/multi-user), and [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Value proposition">
+    OpenClaw is not "just a Claude wrapper." It is a **local-first control plane** that runs a capable assistant on **your own hardware**, reachable from the chat apps you already use, with stateful sessions, memory, and tools - without handing your workflows to a hosted SaaS.
+
+    - **Your devices, your data**: run the Gateway wherever you want (Mac, Linux, VPS) and keep the workspace and session history local.
+    - **Real channels, not a web sandbox**: Discord/iMessage/Signal/Slack/Telegram/WhatsApp/etc, plus mobile voice and hosted widgets.
+    - **Model-agnostic**: use Anthropic, MiniMax, OpenAI, OpenRouter, etc., with per-agent routing and failover.
+    - **Local-only option**: run local models so all data can stay on your device.
+    - **Multi-agent routing**: separate agents per channel, account, or task, each with its own workspace and defaults.
+    - **Open source and hackable**: inspect, extend, and self-host without vendor lock-in.
+
+    Docs: [Gateway](/gateway), [Channels](/channels), [Multi-agent](/concepts/multi-agent), [Memory](/concepts/memory).
+
+  </Accordion>
+
+  <Accordion title="I just set it up - what should I do first?">
+    Good first projects: build a website (WordPress, Shopify, or a static site); prototype a mobile app (outline, screens, API plan); organize files and folders; connect Gmail and automate summaries or follow-ups.
+
+    It can handle large tasks, but works best split into phases with sub-agents for parallel work.
+
+  </Accordion>
+
+  <Accordion title="What are the top five everyday use cases for OpenClaw?">
+    - **Personal briefings**: summaries of inbox, calendar, and news you care about.
+    - **Research and drafting**: quick research, summaries, and first drafts for emails or docs.
+    - **Reminders and follow-ups**: cron- or heartbeat-driven nudges and checklists.
+    - **Browser automation**: filling forms, collecting data, repeating web tasks.
+    - **Cross-device coordination**: send a task from your phone, let the Gateway run it on a server, get the result back in chat.
+
+  </Accordion>
+
+  <Accordion title="Can OpenClaw help with lead gen, outreach, ads, and blogs for a SaaS?">
+    Yes, for **research, qualification, and drafting**: scanning sites, building shortlists, summarizing prospects, writing outreach or ad copy drafts.
+
+    For **outreach or ad runs**, keep a human in the loop. Avoid spam, follow local laws and platform policies, and review anything before it sends. Let OpenClaw draft; you approve.
+
+    Docs: [Security](/gateway/security).
+
+  </Accordion>
+
+  <Accordion title="Is OpenClaw owned by OpenAI?">
+    No. OpenClaw is stewarded by the [OpenClaw Foundation](https://openclaw.org), an independent 501(c)(3). OpenAI is one of several donors, and its creator works there. Donors do not own, control, or direct the project. Codex is one [agent harness](/concepts/agent-runtimes) plugin among several, and no lab's model is privileged in the code.
+
+  </Accordion>
+
+  <Accordion title="What does OpenClaw send to the Foundation?">
+    By default, a daily update check carrying the OpenClaw version, OS, Node version, and CPU architecture: the same information any package registry sees. Optional anonymous feature statistics are off by default and carry no identifier. No prompts, messages, model names, keys, paths, or machine identifiers are ever sent to the Foundation. Set `update.checkOnStart: false` to send nothing at all. Traffic to the model providers and chat platforms you configure is separate and goes to them, as always; see "Is all data used with OpenClaw saved locally?" below. Details: [Usage telemetry and update checks](/gateway/telemetry).
+
+  </Accordion>
+
+  <Accordion title="How is OpenClaw funded, and how does that compare?">
+    The Foundation is funded by donations and has no product to sell: no paid tier, no hosted service, no token. It is not venture-backed. Some other self-hosted agents are built by venture-funded companies that sell a subscription their agent offers during setup. That is a difference in incentives, not a judgment of their engineering; see the [governance comparison](/start/why-openclaw#governance).
+
+  </Accordion>
+
+  <Accordion title="What are the advantages vs Claude Code for web development?">
+    OpenClaw is an **assistant and coordination layer**, not an IDE replacement. Use Claude Code or Codex for the fastest direct coding loop inside a repo. Use OpenClaw for durable memory, cross-device access, and tool orchestration.
+
+    - Persistent memory and workspace across sessions.
+    - Multi-platform access (Telegram, WhatsApp, TUI, WebChat).
+    - Tool orchestration (browser, files, scheduling, hooks).
+    - Always-on Gateway (run on a VPS, interact from anywhere).
+    - Nodes for local browser/screen/camera/exec.
+
+    Showcase: [https://openclaw.ai/showcase](https://openclaw.ai/showcase).
+
+  </Accordion>
+</AccordionGroup>

--- a/docs/help/faq/where-things-live-on-disk.md
+++ b/docs/help/faq/where-things-live-on-disk.md
@@ -1,0 +1,126 @@
+---
+summary: "Data locations, AGENTS.md and SOUL.md placement, backups, and uninstalling"
+title: "Where things live on disk"
+read_when:
+  - You need to find, back up, or move OpenClaw data
+  - You are deciding where agent instruction files belong
+---
+
+## Where things live on disk
+
+<AccordionGroup>
+  <Accordion title="Is all data used with OpenClaw saved locally?">
+    No: **OpenClaw's own state is local**, but **external services still see what you send them**.
+
+    - **Local by default**: sessions, memory files, config, and workspace live on the Gateway host (`~/.openclaw` plus your workspace directory).
+    - **Remote by necessity**: messages sent to model providers (Anthropic/OpenAI/etc.) go to their APIs, and chat platforms (Slack/Telegram/WhatsApp/etc.) store message data on their servers.
+    - **You control the footprint**: local models keep prompts on your machine, but channel traffic still goes through the channel's servers.
+
+    Related: [Agent workspace](/concepts/agent-workspace), [Memory](/concepts/memory).
+
+  </Accordion>
+
+  <Accordion title="Where does OpenClaw store its data?">
+    Everything lives under `$OPENCLAW_STATE_DIR` (default: `~/.openclaw`):
+
+    | Path                                                               | Purpose                                                            |
+    | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+    | `$OPENCLAW_STATE_DIR/openclaw.json`                                 | Main config (JSON5)                                                 |
+    | `$OPENCLAW_STATE_DIR/credentials/oauth.json`                        | Legacy OAuth migration source for `openclaw doctor --fix`           |
+    | `$OPENCLAW_STATE_DIR/state/openclaw.sqlite`                         | Shared SQLite state, including shared auth profiles                 |
+    | `$OPENCLAW_STATE_DIR/secrets.json`                                  | Optional file-backed secret payload for `file` SecretRef providers   |
+    | `$OPENCLAW_STATE_DIR/agents/<agentId>/agent/auth.json`              | Legacy auth migration source for `openclaw doctor --fix`             |
+    | `$OPENCLAW_STATE_DIR/credentials/`                                  | Provider state (for example `whatsapp/<accountId>/creds.json`)      |
+    | `$OPENCLAW_STATE_DIR/agents/`                                       | Per-agent state (agentDir + legacy/archive session artifacts)        |
+    | `$OPENCLAW_STATE_DIR/agents/<agentId>/agent/openclaw-agent.sqlite`  | Per-agent SQLite state, including local auth profiles, sessions, and transcripts |
+    | `$OPENCLAW_STATE_DIR/agents/<agentId>/sessions/`                    | Legacy session migration sources and archive/support artifacts      |
+
+    Legacy single-agent path `~/.openclaw/agent/*` is migrated by `openclaw doctor`.
+
+    Legacy `auth-profiles.json` files are imported by `openclaw doctor --fix`;
+    new logins write SQLite. Agent-local profiles override the shared read-through
+    base. Older installs keep that shared store in the main agent's database until
+    doctor relocates it; see [Auth credential semantics](/auth-credential-semantics#agent-copy-portability).
+
+    Your **workspace** (AGENTS.md, memory files, skills, etc.) is separate, configured via `agents.defaults.workspace` (default: `~/.openclaw/workspace`).
+
+  </Accordion>
+
+  <Accordion title="Where should AGENTS.md / SOUL.md / USER.md / MEMORY.md live?">
+    These live in the **agent workspace**, not `~/.openclaw`.
+
+    - **Workspace (per agent)**: `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`, `memory/YYYY-MM-DD.md`. Lowercase root `memory.md` is legacy repair input only; `openclaw doctor --fix` can merge it into `MEMORY.md` when both exist.
+    - **State dir (`~/.openclaw`)**: config, channel/provider state, auth profiles, sessions, logs, shared skills (`~/.openclaw/skills`).
+
+    Default workspace is `~/.openclaw/workspace`, configurable:
+
+    ```json5
+    {
+      agents: { defaults: { workspace: "~/.openclaw/workspace" } },
+    }
+    ```
+
+    If the bot "forgets" after a restart, confirm the Gateway uses the same workspace on every launch (remote mode uses the **gateway host's** workspace, not your local laptop).
+
+    Tip: for durable behavior or preference, ask the bot to **write it into AGENTS.md or MEMORY.md** rather than relying on chat history.
+
+    See [Agent workspace](/concepts/agent-workspace) and [Memory](/concepts/memory).
+
+  </Accordion>
+
+  <Accordion title="Can I make SOUL.md bigger?">
+    Yes. `SOUL.md` is one of the workspace bootstrap files injected into agent context. Default per-file injection limit is `20000` characters; total bootstrap budget across files is `60000` characters.
+
+    Change shared defaults:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          bootstrapMaxChars: 50000,
+          bootstrapTotalMaxChars: 300000,
+        },
+      },
+    }
+    ```
+
+    Or override one agent under `agents.entries.*.bootstrapMaxChars` / `bootstrapTotalMaxChars`.
+
+    Use `/context` to check raw vs injected sizes and whether truncation happened. Keep `SOUL.md` focused on voice, stance, and personality; put operating rules in `AGENTS.md` and durable facts in memory.
+
+    See [Context](/concepts/context) and [Agent config](/gateway/config-agents).
+
+  </Accordion>
+
+  <Accordion title="Recommended backup strategy">
+    Put your **agent workspace** in a **private** git repo and back it up somewhere private (for example GitHub private). This captures memory plus AGENTS/SOUL/USER files and lets you restore the assistant's "mind" later.
+
+    Do **not** commit anything under `~/.openclaw` (credentials, sessions, tokens, encrypted secrets payloads). For a full restore, back up the workspace and state directory separately.
+
+    Docs: [Agent workspace](/concepts/agent-workspace).
+
+  </Accordion>
+
+  <Accordion title="How do I completely uninstall OpenClaw?">
+    See [Uninstall](/install/uninstall).
+  </Accordion>
+
+  <Accordion title="Can agents work outside the workspace?">
+    Yes. The workspace is the **default cwd** and memory anchor, not a hard sandbox. Relative paths resolve inside the workspace; absolute paths can access other host locations unless sandboxing is enabled. For isolation, use [`agents.defaults.sandbox`](/gateway/sandboxing) or per-agent sandbox settings. To make a repo the default working directory, point that agent's `workspace` at the repo root - the OpenClaw repo itself is just source code, so keep the workspace separate unless you intentionally want the agent to work inside it.
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          workspace: "~/path/to/my-repo",
+        },
+      },
+    }
+    ```
+
+  </Accordion>
+
+  <Accordion title="Remote mode: where is the session store?">
+    Session state is owned by the **gateway host**. In remote mode, the session store you care about is on the remote machine, not your local laptop. See [Session management](/concepts/session).
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## What this does

`docs/help/faq.md` was **89,648 characters / 1,613 lines** — the largest hand-written page left in the tree, and the subject of ledger findings `r3-0388` (128 heading-equivalents vs a 40-heading split signal), `r3-0389` (no scannable index), and `r3-0390` (four Diataxis types in one document).

It is now a **31,704-character index** plus **13 topic children** under `docs/help/faq/`.

| | before | after |
| --- | --- | --- |
| `docs/help/faq.md` | 89,648 ch / 1,613 lines | 31,704 ch / 240 lines |
| children | — | 13 pages, 1,513–14,257 ch |

The index keeps, at their original heading level and in their original order: the `First 60 seconds if something is broken` triage ladder, the two pointer sections to the already-split `/help/faq-first-run` and `/help/faq-models`, the one-question `Miscellaneous` section with its "Still stuck?" closer, and `Related`. Added on top: a 13-row child table and a `Where each section moved` anchor list.

### Children

Cut on `##` boundaries only, so **no `<AccordionGroup>` is split across files** — the page has 14 H2 sections and each owns exactly one group, so the boundaries line up with no wrapper invented anywhere.

`what-is-openclaw`, `skills-and-automation`, `sandboxing-and-memory`, `where-things-live-on-disk`, `config-basics`, `remote-gateways-and-nodes`, `env-vars`, `sessions-and-chats`, `gateway-ports-and-remote-mode`, `logging-and-debugging`, `media-and-attachments`, `security-and-access-control`, `chat-commands-and-stopping`.

## Anchors: all 143 pre-split ids still resolve

Enumerated with the repo's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`), never a slug approximation.

- **143** ids on the pre-split page → **143** resolve on `/help/faq` after the split. Asserted, not assumed.
- **14** are still published by the index itself (the retained sections and their `<Step>` / `<Accordion>` titles) and therefore carry no stub — a stub there would be a duplicate authored/canonical id.
- **129** are authored `<a id="…" />` stubs in `Where each section moved`, as **125** bullets: 4 H2 titles carry punctuation that mints an encoded *and* a cleaned id, and both variants are stubbed on one line, matching the `docs/help/testing.md` precedent.
- **0** collisions on the parent and on each of the 13 children.
- All **125** stub targets were resolved against the destination child with `resolveDocsFragment`.

Every child id is byte-identical to its pre-split id: no accordion title on this page contains inline code, so no id carries a verbatim-marker occurrence index, and the per-section id decomposition reproduces the whole-document id set exactly (143 in, 143 out, no counter suffixes).

Inbound links that use these anchors and keep working: `/help/faq#env-vars-and-env-loading` (from `docs/help/environment.md`, `docs/tools/exa-search.md`, `docs/tools/perplexity-search.md`, `docs/tools/web.md`), `/help/faq#where-things-live-on-disk` (from `docs/help/faq-first-run.md` ×2, `docs/install/migrating.md`), and `/help/faq#first-60-seconds-if-something-is-broken` (from `docs/help/faq-first-run.md`).

## Losslessness, proven

Concatenating the 13 children (frontmatter stripped) with the 5 index-retained sections, in original document order, reproduces the original file **byte for byte**:

```
original sha256   : fe2dd3d60761c790a6fd2ebaea52a62e45b98aa2ea4d71fc4cf986cdc5e3f7e5
reassembled sha256: fe2dd3d60761c790a6fd2ebaea52a62e45b98aa2ea4d71fc4cf986cdc5e3f7e5
BYTE-IDENTICAL    : True
```

`fe2dd3d6…` is the blob of `docs/help/faq.md` at `origin/main`, re-derived after the rebase — `main` did not touch this page while the split was in flight.

Supporting counts: **63/63** fenced blocks match one-for-one on info string + body sha256; **25** table rows preserved (the new tree has 40 — the 15 extra are the index's own child table); word count 11,233 → 13,577, growth only.

### The two exceptions, listed separately

The proof above is run against the raw extraction. Exactly **two** cross-page rewrites were then applied, and they are the entire link-and-prose diff inside the moved content:

1. `docs/help/faq/skills-and-automation.md` — `](#gateway-ports-already-running-and-remote-mode)` → `](/help/faq/gateway-ports-and-remote-mode#gateway-ports-already-running-and-remote-mode)`. It was the page's only intra-page `](#…)` link, and its target moved to a different child.
2. `docs/help/faq/what-is-openclaw.md:68` — `see "Is all data used with OpenClaw saved locally?" below.` → `see [Is all data used with OpenClaw saved locally?](/help/faq/where-things-live-on-disk#is-all-data-used-with-openclaw-saved-locally).` **Added in response to the ClawSweeper P3 finding**; that answer moved to a different child, so "below" was orphaned.

Both are verified to resolve, and with both reversed the reassembly is still byte-identical.

### Prose diff

Apart from rewrite 2 above, the **entire** prose diff is the index scaffolding: the two-sentence "This page is an index" lede, the child table, and the `Where each section moved` heading and its lede. No FAQ answer was rewritten, reordered, or reworded.

`python3 .audit/check-orphan-refs.py` on the index and all 13 children reports **1** directional reference, in `skills-and-automation.md` ("lowest precedence in the order above") — its target is the immediately preceding accordion in the same section, so it lands on the same child and is intact.

That script did **not** flag the `what-is-openclaw.md` orphan that ClawSweeper caught — its heuristic misses `see "…" below` where the quoted string is the heading. After fixing it I swept all 14 files for `below|above|earlier|further down|next section|previous section|later on this page`: 4 hits, 3 of them temporal rather than spatial (`the earlier hot and restart modes are retired`, `stale earlier progress`) or same-page (`in the order above`). Only the one ClawSweeper found was a real orphan, and it is fixed.

`python3 .audit/stranded-stubs.py docs` → **0 suspects**. The pre-split page contained no authored `<a id>` stubs at all, so the stranded-stub failure mode could not arise.

## Pins, CI, ownership

- `python3 .audit/docs-test-pins.py docs/help/faq.md` reports 2 "tests"; both are mislabelled by that script and neither is a contract test. `scripts/github/barnacle-auto-response.mjs` holds a support-reply URL (see below); `taxonomy.yaml` lists `docs/help/faq.md` in three `docs:` coverage lists whose `search_anchors` are free-text phrases, not doc fragments. The file still exists, so the lists still resolve. `docs/help/testing/**` is not listed in `taxonomy.yaml` either, so this matches how the sibling split was handled.
- Independent `git grep -n "help/faq" origin/main` with no path filter: every hit classified. The two Go files (`scripts/docs-i18n/doc_mode_test.go`, `localized_links_test.go`) use `"help/faq.md"` as a synthetic fixture name with inline content, not as a read of this file.
- `RELEASE_METADATA_PATHS` in `scripts/changed-lanes.mts` contains only `docs/install/updating*` docs paths. This page is not in it.
- `.github/labeler.yml`: **no CI gap is created**. No glob names `docs/help/faq.md`; the `"docs"` label matches `docs/**`, which already covers `docs/help/faq/**`. `labeler-extension-coverage` and `labeler-label-cap` tests pass.
- **CODEOWNERS: no rule matches `docs/help/faq.md` or `docs/help/faq/**`.** Simulated last-match-wins over all 71 rules. The secops docs rules are scoped to `/docs/security/`, `/docs/gateway/security/`, `/docs/gateway/*.md` file-exact entries and `/docs/cli/*.md` — none reach `docs/help/faq/`, including the new `security-and-access-control.md`. No maintainer team owns this page.
- `docs/docs.json`: the 13 children are nested under a `FAQ topics` group directly after `help/faq`, matching the `Testing guide` / `Live testing guide` shape.
- `docs/.i18n/glossary.zh-CN.json`: 13 source entries added, one per new child title — `check-docs-i18n-glossary.mts` hard-fails without them. They are inserted **beside the existing `FAQ` entry at index 250**, not appended at the end (index 1002), so this does not collide with other concurrent split PRs. No existing entry was rewritten or reordered; 0 duplicate sources; the JSON round-trips byte-identically apart from the insertion.

## Validators

Run on the staged tree, after the rebase onto `origin/main`.

Re-run after the P3 fix, on the staged tree.

- `pnpm check:docs` — **exit 0** (format:docs:check, lint:docs incl. `docs/**/*.mdx`, lint:templates, check-mdx, check-i18n-glossary, check-links, check-config-examples; markdownlint "0 issues in 0 files" over 1,195 files).
- `node scripts/docs-link-audit.mjs --anchors` — **identical to baseline**: the same 3 pre-existing `#windows-app-node` errors, no additions. Internal links checked rose 12,456 → 12,607. Baseline measured in a detached worktree at `git merge-base HEAD origin/main` (`7e1c957`) with `node_modules` symlinked, not by stashing.
- `npx vitest --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files, 16 tests, all pass.**
- `npx vitest --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — 32 pass, **1 pre-existing failure**, reproduced unchanged at `7e1c957`: `preserves Mint component targets for raw component apostrophes…` expects `as-s-guide`, gets `ass-guide`. A synthetic in-test fixture; no docs file involved.

## Pre-existing defect found, not fixed here

`scripts/github/barnacle-auto-response.mjs:29` sends users to `https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck`. That id **does not exist on `/help/faq` today and did not before this PR** — the content moved to `/help/faq-first-run` in an earlier split, where it is `#i-am-stuck-fastest-way-to-get-unstuck`. The link audit does not check that file because it is a script, not a doc. Out of scope for a content-preserving split; flagging it for a follow-up.

## Precedent

`docs/help/testing/` and `docs/help/testing-live/` are both on `main` (`test -d` verified, not cited from an open PR). This PR matches the nearer of the two: parent as index, child table, `Where each section moved` stub list, children with `summary`/`title`/`read_when` frontmatter and no synthetic lede, nested nav group.
