### PR TITLE
fix(state): rebuild Skill Workshop reviews when the content marker outruns the table

### DIFF
--- a/docs/reference/database-schemas/state-schema-history.md
+++ b/docs/reference/database-schemas/state-schema-history.md
@@ -45,6 +45,13 @@ stale proposals and leave the legacy directories unchanged. Review history rows
 map to a unique owner agent when possible; otherwise the schema migration discards them as
 cache-class state.
 
+If a database reports schema 16 but still has recognized schema-15 Workshop
+columns, update preflight identifies the pending migration and Doctor runs it
+before rebuilding canonical indexes. Proposal-only legacy columns are handled
+the same way. The repair preserves attributable review rows and unrelated
+indexes; unrecognized column sets or dependencies on retired columns still
+refuse and roll back the transaction.
+
 Skill-only workspace relocation uses the existing `migration_runs` and
 `migration_sources` tables to save pre-move directory identity, file hashes,
 and the workspace attestation timestamp. After relocation, only matching

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -43,7 +43,10 @@ import {
   openClawStateMigrationAssertions,
 } from "./openclaw-state-db-maintenance.js";
 import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
-import { readStateSchemaContentVersion } from "./openclaw-state-db-schema-version.js";
+import {
+  readStateSchemaContentVersion,
+  readStateSchemaMigrationVersion,
+} from "./openclaw-state-db-schema-version.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   resolveOpenClawRegisteredAgentDatabasePath,
@@ -381,7 +384,7 @@ export async function preflightOpenClawStateDatabasePath(
       return result("incompatible");
     }
     ownership = inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
-    if (contentVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
+    if (readStateSchemaMigrationVersion(database) < OPENCLAW_STATE_SCHEMA_VERSION) {
       return result("migration-required", { requiresWrite: true });
     }
     if (foundVersion < contentVersion) {
@@ -467,7 +470,11 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         stateVersion > options.supportedVersions.state
           ? stateVersion
           : readStateSchemaContentVersion(stateDatabase);
-      if (contentVersion < options.supportedVersions.state) {
+      const migrationVersion =
+        contentVersion > options.supportedVersions.state
+          ? contentVersion
+          : readStateSchemaMigrationVersion(stateDatabase);
+      if (migrationVersion < options.supportedVersions.state) {
         (result.pendingMigrations ??= []).push({
           kind: "state",
           path: statePath,
@@ -485,7 +492,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
           ...(writerAppVersion ? { writerAppVersion } : {}),
         });
       }
-      if (stateVersion < contentVersion) {
+      if (stateVersion < contentVersion && migrationVersion === contentVersion) {
         (result.deferredSchemaPublications ??= []).push(
           describeDeferredStateSchemaPublication(
             stateDatabase,
@@ -501,7 +508,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       ) {
         assertSqliteIntegrity(stateDatabase, statePath);
         assertCanonicalStateSchemaShape(stateDatabase, statePath);
-        if (contentVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
+        if (migrationVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           const { blockingIssues } = inspectCurrentStateStartupSchema(
             stateDatabase,
             statePath,
@@ -513,13 +520,13 @@ export async function preflightOpenClawDatabaseSchemas(options: {
             );
           }
         } else {
-          openClawStateMigrationAssertions.get(contentVersion)?.(stateDatabase, {
+          openClawStateMigrationAssertions.get(migrationVersion)?.(stateDatabase, {
             pathname: statePath,
           });
         }
       } else if (
         options.verifyCurrentSchemaShape === true &&
-        contentVersion === OPENCLAW_STATE_SCHEMA_VERSION
+        migrationVersion === OPENCLAW_STATE_SCHEMA_VERSION
       ) {
         try {
           assertOpenClawStateDatabaseForMaintenance(stateDatabase, { pathname: statePath });

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -17,7 +17,7 @@ import {
 } from "./openclaw-state-db-schema-repair.js";
 import {
   assertSupportedStateSchemaVersion,
-  readStateSchemaContentVersion,
+  readStateSchemaMigrationVersion,
 } from "./openclaw-state-db-schema-version.js";
 import {
   getOpenClawStateRuntimeSchema,
@@ -31,7 +31,7 @@ export function needsOpenClawStateDatabaseSchemaRepair(pathname: string): boolea
     database = openNodeSqliteDatabase(pathname, { readOnly: true });
     assertSupportedStateSchemaVersion(database, pathname);
     const needsRepair =
-      readStateSchemaContentVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION ||
+      readStateSchemaMigrationVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION ||
       detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0;
     if (!needsRepair) {
       assertCurrentStateRuntimeSchema(database, pathname);
@@ -60,7 +60,7 @@ export function isOpenClawStateSchemaFastPathEligible(
 ): boolean {
   return runSqliteDeferredTransactionSync(database, () => {
     assertSupportedStateSchemaVersion(database, pathname);
-    if (readStateSchemaContentVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
+    if (readStateSchemaMigrationVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
       return false;
     }
     assertSqliteIntegrity(database, pathname);

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -22,6 +22,7 @@ import { migrateJsonCanonicalWideRowsV13 } from "./openclaw-state-db-schema-v13-
 import {
   assertSupportedStateSchemaVersion,
   readStateSchemaContentVersion,
+  readStateSchemaMigrationVersion,
 } from "./openclaw-state-db-schema-version.js";
 import type { DB } from "./openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
@@ -137,7 +138,7 @@ function assertOpenClawStateDatabaseVersionForMigration(
   options: { pathname: string; version: OpenClawStateMigrationVersion },
 ): void {
   const userVersion = readSqliteUserVersion(database);
-  if (userVersion !== options.version) {
+  if (readStateSchemaMigrationVersion(database) !== options.version) {
     throw new Error(
       `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; expected ${options.version} before migrating it.`,
     );
@@ -146,11 +147,11 @@ function assertOpenClawStateDatabaseVersionForMigration(
   const metadata = database
     .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
     .get() as { schema_version?: unknown } | undefined;
-  if (metadata?.schema_version !== options.version) {
+  if (metadata?.schema_version !== userVersion) {
     const schemaVersion =
       typeof metadata?.schema_version === "number" ? metadata.schema_version : "invalid";
     throw new Error(
-      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${options.version}; repair the ownership metadata before migrating it.`,
+      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${userVersion}; repair the ownership metadata before migrating it.`,
     );
   }
   assertSqliteSchemaTablesPresent(database, options.pathname, OPENCLAW_STATE_SCHEMA_SQL, {
@@ -332,25 +333,16 @@ const RELEASED_WORKSHOP_CLAIM_REASON =
   "Skill Workshop released this skill in a collection review; the path stays user-owned.";
 
 function migrateSkillWorkshopCollectionReviewOwnership(db: DatabaseSync): void {
-  if (!tableExists(db, "skill_workshop_proposals")) {
-    db.exec(`
-      CREATE TABLE skill_workshop_collection_reviews_v16 (
-        review_id TEXT NOT NULL PRIMARY KEY,
-        owner_agent_id TEXT NOT NULL,
-        backup_id TEXT NOT NULL,
-        create_time INTEGER NOT NULL,
-        kept_names_json TEXT NOT NULL,
-        written_names_json TEXT NOT NULL,
-        dropped_json TEXT NOT NULL
-      ) STRICT;
-      DROP TABLE skill_workshop_collection_reviews;
-      ALTER TABLE skill_workshop_collection_reviews_v16
-        RENAME TO skill_workshop_collection_reviews;
-      CREATE INDEX idx_skill_workshop_collection_reviews_owner_time
-        ON skill_workshop_collection_reviews(owner_agent_id, create_time DESC, review_id);
-    `);
-    return;
-  }
+  const retainedObjects = db
+    .prepare(`
+    SELECT sql FROM sqlite_schema
+    WHERE tbl_name = 'skill_workshop_collection_reviews'
+      AND type IN ('index', 'trigger') AND sql IS NOT NULL
+      AND name NOT IN ('idx_skill_workshop_collection_reviews_workspace_time',
+                       'idx_skill_workshop_collection_reviews_owner_time')
+    ORDER BY type, name
+  `)
+    .all();
   db.exec(`
     CREATE TABLE skill_workshop_collection_reviews_v16 (
       review_id TEXT NOT NULL PRIMARY KEY,
@@ -361,6 +353,9 @@ function migrateSkillWorkshopCollectionReviewOwnership(db: DatabaseSync): void {
       written_names_json TEXT NOT NULL,
       dropped_json TEXT NOT NULL
     ) STRICT;
+  `);
+  if (tableExists(db, "skill_workshop_proposals")) {
+    db.exec(`
     INSERT INTO skill_workshop_collection_reviews_v16 (
       review_id, owner_agent_id, backup_id, create_time,
       kept_names_json, written_names_json, dropped_json
@@ -390,12 +385,20 @@ function migrateSkillWorkshopCollectionReviewOwnership(db: DatabaseSync): void {
       WHERE proposal.workspace_dir = review.workspace_dir
         AND proposal.owner_agent_id IS NOT NULL
     ) = 1;
+    `);
+  }
+  db.exec(`
     DROP TABLE skill_workshop_collection_reviews;
     ALTER TABLE skill_workshop_collection_reviews_v16
       RENAME TO skill_workshop_collection_reviews;
     CREATE INDEX idx_skill_workshop_collection_reviews_owner_time
       ON skill_workshop_collection_reviews(owner_agent_id, create_time DESC, review_id);
   `);
+  for (const object of retainedObjects) {
+    if (typeof object.sql === "string") {
+      db.exec(object.sql);
+    }
+  }
 }
 
 /** Remove row provenance after the Workshop directory becomes the ownership boundary. */

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -24,7 +24,7 @@ import {
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 import {
   assertSupportedStateSchemaVersion,
-  readStateSchemaContentVersion,
+  readStateSchemaMigrationVersion,
 } from "./openclaw-state-db-schema-version.js";
 
 const stateDbLog = createSubsystemLogger("state/db");
@@ -33,7 +33,7 @@ function assertStateDatabaseIntegrityBeforeMutation(
   database: DatabaseSync,
   pathname: string,
 ): void {
-  const contentVersion = readStateSchemaContentVersion(database);
+  const contentVersion = readStateSchemaMigrationVersion(database);
   const hasApplicationSchema = database // sqlite-allow-raw -- Cold-open schema presence probe before Kysely exposure.
     .prepare("SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' LIMIT 1")
     .get();

--- a/src/state/openclaw-state-db-schema-migration-required.test.ts
+++ b/src/state/openclaw-state-db-schema-migration-required.test.ts
@@ -1,7 +1,12 @@
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { guardUpdateDoctorSchemaUpgrade } from "../commands/doctor-update-schema-guard.js";
 import { createUpdateRun } from "../infra/update-run-ledger.js";
+import {
+  preflightOpenClawDatabaseSchemas,
+  preflightOpenClawStateDatabasePath,
+} from "./openclaw-database-preflight.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -23,6 +28,7 @@ beforeEach(() => {
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 function seedRun(db: DatabaseSync, version = "2026.9.2", id = runId) {
@@ -95,6 +101,198 @@ function reopen(options: Parameters<typeof openOpenClawStateDatabase>[0]) {
 }
 
 describe("shared state schema publication", () => {
+  it.each(["content-v16", "published-v16"] as const)(
+    "repairs legacy Workshop columns with a %s marker atomically",
+    async (marker) => {
+      const { options, databasePath } = createV15Database();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec(`
+        CREATE INDEX fixture_review_backup ON skill_workshop_collection_reviews(backup_id);
+        INSERT INTO config_machine_state VALUES ('state.schema.contentVersion', '16', 1);
+      `);
+      if (marker === "published-v16") {
+        legacy.exec("PRAGMA user_version = 16; UPDATE schema_meta SET schema_version = 16;");
+      }
+      legacy.close();
+
+      const preflight = await preflightOpenClawStateDatabasePath(databasePath);
+      expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      expect(preflight).toMatchObject({ status: "migration-required", requiresWrite: true });
+      const repaired = openOpenClawStateDatabase(options).db;
+      expect(
+        repaired
+          .prepare("SELECT owner_agent_id, backup_id FROM skill_workshop_collection_reviews")
+          .all(),
+      ).toEqual([{ owner_agent_id: "main", backup_id: "backup" }]);
+      expect(
+        repaired.prepare("SELECT proposal_id, status FROM skill_workshop_proposals").all(),
+      ).toEqual([{ proposal_id: "released", status: "stale" }]);
+      expect(
+        repaired
+          .prepare("SELECT sql FROM sqlite_schema WHERE name = 'fixture_review_backup'")
+          .get(),
+      ).toEqual({
+        sql: "CREATE INDEX fixture_review_backup ON skill_workshop_collection_reviews(backup_id)",
+      });
+      expect(
+        repaired
+          .prepare(
+            "SELECT 1 FROM sqlite_schema WHERE name = 'idx_skill_workshop_collection_reviews_workspace_time'",
+          )
+          .get(),
+      ).toBeUndefined();
+      const rows = repaired.prepare("SELECT * FROM skill_workshop_proposals").all();
+      closeOpenClawStateDatabaseForTest();
+      expect(repairOpenClawStateDatabaseSchema(options)).toEqual({ changes: [], warnings: [] });
+      expect(
+        openOpenClawStateDatabase(options)
+          .db.prepare("SELECT * FROM skill_workshop_proposals")
+          .all(),
+      ).toEqual(rows);
+      closeOpenClawStateDatabaseForTest();
+      await expect(preflightOpenClawStateDatabasePath(databasePath)).resolves.toMatchObject({
+        status: "exact",
+        issues: [],
+      });
+    },
+  );
+
+  it.each(["content-v16", "published-v16"] as const)(
+    "routes a %s Workshop split through update preflight to Doctor",
+    async (marker) => {
+      const { options, databasePath } = createV15Database();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec(
+        "INSERT INTO config_machine_state VALUES ('state.schema.contentVersion', '16', 1);",
+      );
+      if (marker === "published-v16") {
+        legacy.exec("PRAGMA user_version = 16; UPDATE schema_meta SET schema_version = 16;");
+      }
+      legacy.close();
+      const preflight = await preflightOpenClawDatabaseSchemas({
+        env: options.env,
+        scope: "state",
+        supportedVersions: { state: 16, agent: 19 },
+        requireStartupMigrationReadiness: true,
+      });
+      expect(preflight).toMatchObject({
+        incompatible: [],
+        indeterminate: [],
+        pendingMigrations: [
+          {
+            kind: "state",
+            path: databasePath,
+            foundVersion: marker === "published-v16" ? 16 : 15,
+            supportedVersion: 16,
+          },
+        ],
+      });
+      expect(preflight.deferredSchemaPublications).toBeUndefined();
+      vi.stubEnv("OPENCLAW_STATE_DIR", options.env.OPENCLAW_STATE_DIR);
+      vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", "1");
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      await expect(
+        guardUpdateDoctorSchemaUpgrade({ schemas: preflight, runtime }),
+      ).resolves.toBeUndefined();
+      expect(runtime.exit).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["workspace_dir", "claim_released_time"] as const)(
+    "repairs a published v16 proposal-only leftover %s on cold open",
+    async (column) => {
+      const { options, databasePath } = createV15Database();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec(`
+        DROP TABLE skill_workshop_collection_reviews;
+        CREATE TABLE skill_workshop_collection_reviews (
+          review_id TEXT NOT NULL PRIMARY KEY, owner_agent_id TEXT NOT NULL,
+          backup_id TEXT NOT NULL, create_time INTEGER NOT NULL,
+          kept_names_json TEXT NOT NULL, written_names_json TEXT NOT NULL, dropped_json TEXT NOT NULL
+        ) STRICT;
+        INSERT INTO skill_workshop_collection_reviews VALUES ('review', 'main', 'backup', 1, '[]', '[]', '[]');
+        CREATE INDEX idx_skill_workshop_collection_reviews_owner_time
+          ON skill_workshop_collection_reviews(owner_agent_id, create_time DESC, review_id);
+        ALTER TABLE skill_workshop_proposals DROP COLUMN ${column === "workspace_dir" ? "claim_released_time" : "workspace_dir"};
+        PRAGMA user_version = 16;
+        UPDATE schema_meta SET schema_version = 16;
+      `);
+      legacy.close();
+      await expect(preflightOpenClawStateDatabasePath(databasePath)).resolves.toMatchObject({
+        status: "migration-required",
+      });
+      const repaired = openOpenClawStateDatabase(options).db;
+      expect(repaired.prepare("PRAGMA table_info(skill_workshop_proposals)").all()).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: column })]),
+      );
+      expect(
+        repaired.prepare("SELECT proposal_id, status FROM skill_workshop_proposals").all(),
+      ).toEqual([
+        { proposal_id: "released", status: column === "claim_released_time" ? "stale" : "applied" },
+      ]);
+      expect(
+        repaired
+          .prepare("SELECT owner_agent_id, backup_id FROM skill_workshop_collection_reviews")
+          .all(),
+      ).toEqual([{ owner_agent_id: "main", backup_id: "backup" }]);
+    },
+  );
+
+  it.each([
+    "missing review column",
+    "missing attribution mapping",
+    "retired-column index",
+    "review constraint",
+    "future version",
+  ] as const)("preserves Workshop state when marker repair refuses %s", (damage) => {
+    const { options, databasePath } = createV15Database(null);
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec("PRAGMA user_version = 16; UPDATE schema_meta SET schema_version = 16;");
+    if (damage === "missing review column") {
+      legacy.exec("ALTER TABLE skill_workshop_collection_reviews DROP COLUMN backup_id;");
+    } else if (damage === "missing attribution mapping") {
+      legacy.exec("ALTER TABLE skill_workshop_proposals DROP COLUMN workspace_dir;");
+    } else if (damage === "retired-column index") {
+      legacy.exec(
+        "CREATE INDEX fixture_workspace ON skill_workshop_collection_reviews(workspace_dir);",
+      );
+    } else if (damage === "review constraint") {
+      legacy.exec(`
+          DROP TABLE skill_workshop_collection_reviews;
+          CREATE TABLE skill_workshop_collection_reviews (
+            review_id TEXT NOT NULL PRIMARY KEY, workspace_dir TEXT NOT NULL,
+            backup_id TEXT NOT NULL UNIQUE, create_time INTEGER NOT NULL,
+            kept_names_json TEXT NOT NULL, written_names_json TEXT NOT NULL, dropped_json TEXT NOT NULL
+          ) STRICT;
+          INSERT INTO skill_workshop_collection_reviews VALUES ('review', '/fixture/workspace', 'backup', 1, '[]', '[]', '[]');
+        `);
+    } else {
+      legacy.exec(
+        "INSERT INTO config_machine_state VALUES ('state.schema.contentVersion', '17', 1);",
+      );
+    }
+    const schema = legacy.prepare("SELECT name, sql FROM sqlite_schema ORDER BY name").all();
+    const proposals = legacy.prepare("SELECT * FROM skill_workshop_proposals").all();
+    const reviews = legacy.prepare("SELECT * FROM skill_workshop_collection_reviews").all();
+    legacy.close();
+    const result = repairOpenClawStateDatabaseSchema(options);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(after.prepare("SELECT name, sql FROM sqlite_schema ORDER BY name").all()).toEqual(
+        schema,
+      );
+      expect(after.prepare("SELECT * FROM skill_workshop_proposals").all()).toEqual(proposals);
+      expect(after.prepare("SELECT * FROM skill_workshop_collection_reviews").all()).toEqual(
+        reviews,
+      );
+      expectVersion(after, 16);
+    } finally {
+      after.close();
+    }
+  });
+
   it.each(["runtime open", "doctor repair"] as const)(
     "%s applies v16 content while preserving the unfenced updater's v15 floor",
     (entry) => {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -22,7 +22,7 @@ import {
 } from "./openclaw-state-db-schema-helpers.js";
 import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import { FOLDED_SINGLETON_STATE_TABLES_V12 } from "./openclaw-state-db-schema-v12-foldin.js";
-import { readStateSchemaContentVersion } from "./openclaw-state-db-schema-version.js";
+import { readStateSchemaMigrationVersion } from "./openclaw-state-db-schema-version.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
 import {
   hasRecognizedRetiredCommitmentsSchema,
@@ -367,7 +367,7 @@ export function detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
   pathname: string,
 ): OpenClawStateDatabaseSchemaMigration[] {
   const migrations: OpenClawStateDatabaseSchemaMigration[] = [];
-  const userVersion = readStateSchemaContentVersion(db);
+  const userVersion = readStateSchemaMigrationVersion(db);
   if (
     userVersion < RETIRED_COMMITMENTS_SCHEMA_VERSION &&
     tableExists(db, "commitments") &&

--- a/src/state/openclaw-state-db-schema-version.ts
+++ b/src/state/openclaw-state-db-schema-version.ts
@@ -6,7 +6,7 @@ import {
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
-import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import type { DB } from "./openclaw-state-db.generated.js";
 
 // Read-only clients need schema admission without loading updater publication policy.
@@ -55,21 +55,9 @@ export function readStateSchemaMigrationVersion(db: DatabaseSync): number {
   if (version !== 16) {
     return version;
   }
-  const reviews = new Set(
-    db
-      .prepare("PRAGMA table_xinfo(skill_workshop_collection_reviews)")
-      .all()
-      .map((row) => row.name),
-  );
-  const proposals = new Set(
-    db
-      .prepare("PRAGMA table_xinfo(skill_workshop_proposals)")
-      .all()
-      .map((row) => row.name),
-  );
-  const reviewWorkspace = reviews.has("workspace_dir");
-  const proposalWorkspace = proposals.has("workspace_dir");
-  const releasedClaim = proposals.has("claim_released_time");
+  const reviewWorkspace = tableHasColumn(db, "skill_workshop_collection_reviews", "workspace_dir");
+  const proposalWorkspace = tableHasColumn(db, "skill_workshop_proposals", "workspace_dir");
+  const releasedClaim = tableHasColumn(db, "skill_workshop_proposals", "claim_released_time");
   if (!reviewWorkspace && !proposalWorkspace && !releasedClaim) {
     return version;
   }

--- a/src/state/openclaw-state-db-schema-version.ts
+++ b/src/state/openclaw-state-db-schema-version.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { getNodeSqliteKysely, prepareSqliteQuerySync } from "../infra/kysely-sync.js";
+import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
 import {
   createNewerSqliteSchemaVersionError,
   readSqliteUserVersion,
@@ -46,6 +47,79 @@ export function readStateSchemaContentVersion(db: DatabaseSync): number {
     throw new Error(`Invalid shared state schema content version in ${CONTENT_VERSION_KEY}.`);
   }
   return Math.max(published, contentVersion);
+}
+
+/** Cold migration planning checks physical content; admission still uses the recorded version. */
+export function readStateSchemaMigrationVersion(db: DatabaseSync): number {
+  const version = readStateSchemaContentVersion(db);
+  if (version !== 16) {
+    return version;
+  }
+  const reviews = new Set(
+    db
+      .prepare("PRAGMA table_xinfo(skill_workshop_collection_reviews)")
+      .all()
+      .map((row) => row.name),
+  );
+  const proposals = new Set(
+    db
+      .prepare("PRAGMA table_xinfo(skill_workshop_proposals)")
+      .all()
+      .map((row) => row.name),
+  );
+  const reviewWorkspace = reviews.has("workspace_dir");
+  const proposalWorkspace = proposals.has("workspace_dir");
+  const releasedClaim = proposals.has("claim_released_time");
+  if (!reviewWorkspace && !proposalWorkspace && !releasedClaim) {
+    return version;
+  }
+  // Review attribution needs the old proposal workspace mapping. Never guess it from a mixed pair.
+  const missingAttribution = reviewWorkspace && !proposalWorkspace;
+  const schema = `
+    CREATE TABLE skill_workshop_collection_reviews (
+      review_id TEXT NOT NULL PRIMARY KEY,
+      ${reviewWorkspace ? "workspace_dir" : "owner_agent_id"} TEXT NOT NULL,
+      backup_id TEXT NOT NULL,
+      create_time INTEGER NOT NULL,
+      kept_names_json TEXT NOT NULL,
+      written_names_json TEXT NOT NULL,
+      dropped_json TEXT NOT NULL
+    ) STRICT;
+    CREATE TABLE skill_workshop_proposals (
+      proposal_id TEXT NOT NULL PRIMARY KEY,
+      record_json TEXT NOT NULL,
+      owner_agent_id TEXT,
+      ${proposalWorkspace ? "workspace_dir TEXT NOT NULL," : ""}
+      kind TEXT NOT NULL CHECK (kind IN ('create', 'update')),
+      status TEXT NOT NULL CHECK (status IN ('pending', 'applied', 'rejected', 'quarantined', 'stale')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      draft_hash TEXT NOT NULL,
+      origin_agent_id TEXT,
+      origin_session_key TEXT,
+      origin_run_id TEXT,
+      origin_message_id TEXT,
+      applied_at TEXT,
+      rejected_at TEXT,
+      quarantined_at TEXT,
+      stale_at TEXT,
+      status_reason TEXT
+      ${releasedClaim ? ", claim_released_time INTEGER" : ""}
+    ) STRICT;
+  `;
+  const issues = collectSqliteSchemaIssues(db, schema, {
+    allowedMissingTables: ["skill_workshop_collection_reviews"],
+    allowedColumnDefinitions: {
+      "skill_workshop_collection_reviews.workspace_dir": ["workspace_dir TEXT NOT NULL DEFAULT ''"],
+      "skill_workshop_proposals.workspace_dir": ["workspace_dir TEXT NOT NULL DEFAULT ''"],
+    },
+  });
+  if (!missingAttribution && issues.length === 0) {
+    return 15;
+  }
+  throw new Error(
+    "Unrecognized Skill Workshop ownership schema; cannot apply the schema 16 migration.",
+  );
 }
 
 export function assertSupportedStateSchemaVersion(db: DatabaseSync, pathname: string): number {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -90,6 +90,7 @@ import { migrateSingletonStateFoldInV12 } from "./openclaw-state-db-schema-v12-f
 import {
   assertSupportedStateSchemaVersion,
   readStateSchemaContentVersion,
+  readStateSchemaMigrationVersion,
 } from "./openclaw-state-db-schema-version.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
 import {
@@ -165,7 +166,7 @@ function repairStateSchema(
       () => {
         assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
         const applied: string[] = [];
-        const previousVersion = readStateSchemaContentVersion(db);
+        const previousVersion = readStateSchemaMigrationVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of verifyAndRepairCanonicalSqliteIndexes(
             db,
@@ -374,7 +375,7 @@ function ensureSchema(
           if (initializeNativeOnly && !isUninitializedNativeStartupDatabase(db)) {
             return [];
           }
-          const previousVersion = readStateSchemaContentVersion(db);
+          const previousVersion = readStateSchemaMigrationVersion(db);
           if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
             verifyAndRepairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
               allowMissingColumns: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running update-time Doctor would hit `Deferral failed: SQLite canonical index idx_skill_workshop_collection_reviews_owner_time ... no such column: owner_agent_id` when the shared-state version or content marker reports schema 16 while the Workshop tables still have recognized schema-15 columns. Update preflight could also reject those tables before Doctor could repair them.

Fixes #143001
Refs #142331 #142370 #142522 #142770

## Why This Change Was Made

Migration selection trusted the recorded content version and skipped the Workshop migration, then attempted to create an index for a column that was still absent. Cold migration planning now checks the historical Workshop table contract separately from recorded-version admission. Recognized splits rerun the existing attribution migration before canonical DDL and index repair, including proposal-only leftovers. Newer versions and unrecognized schemas still refuse. Database-local review indexes survive the rebuild; dependencies on retired columns roll the transaction back.

The publication audit found no early marker writer in #141109 or current source. Doctor repair and writable open already run the table migration, canonical DDL/index work, marker publication, and final validation inside one synchronous transaction. Publication reconciliation validates the current schema before writing metadata; the update Doctor guard only reads a snapshot. This change repairs consumption of the inconsistent state; its original producer remains unestablished.

PR #142522 investigates cleanup of a dangling legacy index. The shipped migration drops the original review table, which removes that index, and these regressions reproduce the refusal with an ordinary SQLite catalog. The mismatch here is between the version marker and physical columns, so selecting the existing migration addresses this failure. No code or test fixtures from #142522 were reused.

## User Impact

Doctor and writable startup can complete the existing Workshop migration when its marker outruns its tables. Preflight identifies the pending repair instead of claiming content has already been applied. Attributable review rows and proposal records retain the existing migration semantics, and repeated repair is idempotent. No configuration, schema version, ownership-admission, or publication-policy changes are introduced.

## Evidence

The two repair regressions failed on the original code with `no such column: owner_agent_id`; both preflight regressions also failed before the repair. Tests additionally cover proposal-only leftovers, unrelated index preservation, repeated repair, future-version refusal, unknown table constraints, and transaction rollback for an index depending on a retired column.

Validation:

- `node scripts/run-vitest.mjs src/state/openclaw-state-db-schema-migration-required.test.ts src/state/openclaw-state-db.test.ts src/infra/state-migrations.skill-workshop.test.ts src/state/openclaw-database-preflight.test.ts src/commands/doctor-config-preflight.refusal.process.test.ts src/commands/doctor-config-preflight.state-migration.test.ts --reporter=dot`: 292 passed, one existing skip.
- The four fail-before regressions pass on Node 24.20.0 as well as Node 26.8.1. The real update Doctor guard is exercised in the preflight regression cases.
- `node scripts/check-changed.mjs`: passed. The final schema-contract and test refinements also passed a fresh scoped `check-changed` run.
- Docs formatting and `git diff --check`: passed.

The first CI head failed `check-additional-runtime-topology-architecture` because the Kysely guard rejected two direct SQLite schema probes. The follow-up uses the existing `tableHasColumn` owner helper instead. The Kysely guard, all 61 migration/preflight tests, and the four original regressions on Node 24.20.0 passed after that change; no allowlist or suppression was added.

The earlier unchanged-base failure at `src/infra/state-migrations.test.ts:1157` expected populated Workshop receipt source/target arrays and received empty arrays. Both an isolated rerun and a full unchanged-base rerun passed (125 tests in the full file); it remains an unmodified intermittent baseline finding. Lead autoreview and landing remain separate.

## CI Status

Final head: `9300ae7efa4bd4b98a39e54ed038f872820a0211`.

The [CI run](https://github.com/openclaw/openclaw/actions/runs/34364266207) completed with a failure outside this diff: `checks-windows-node-test-1` timed out after 120000ms in `src/agents/tools/media-tool-file-url.windows.test.ts:61`, “loads Unicode and space file URLs through registered image and PDF tools.” The test is unchanged from the original base and does not set up legacy Workshop state. Its timeout was not increased. The aggregate `openclaw/ci-gate` consequently failed; the architecture/Kysely job passed.

The [labeler job](https://github.com/openclaw/openclaw/actions/runs/34364264955/job/102508813452) separately failed during “Apply PR size label” with `UND_ERR_SOCKET` / “other side closed.” Neither unrelated failure was patched or manually rerun in this lane.

Main's documentation split was incorporated without changing the tested `src/state` files; the recovery paragraph now lives in `docs/reference/database-schemas/state-schema-history.md`. The PR remains ready for review and unmerged.


## Review notes

Maintainer review confirms that this PR introduces no schema-version, table, column, or index definition changes. It makes migration planning validate the physical Workshop table contract before selecting the already-existing attribution migration. Regression fixtures cover `content-v16` and `published-v16` marker splits, proposal-only leftovers, repeated repair, transaction rollback, and future-version refusal.

The documented rollback for custom indexes that depend on retired columns is intentional and accepted: preserving those dependencies and refusing the transaction is preferable to silently discarding them. The original producer of the inconsistent marker/table state remains unestablished; this bounded repair of recognized instances is accepted without changing publication or ownership admission.
