### PR TITLE
improve(test): reduce repeated Testbox base fixture setup

### DIFF
--- a/test/scripts/testbox-base.test.ts
+++ b/test/scripts/testbox-base.test.ts
@@ -2,11 +2,16 @@ import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { devNull } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+const seedDirs = createTempDirTracker();
+let source: string;
+let eventBase: string;
+let mainBase: string;
 const workflows = [
   ".github/workflows/ci-check-testbox.yml",
   ".github/workflows/ci-check-arm-testbox.yml",
@@ -25,6 +30,37 @@ type Step = {
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
+
+beforeAll(() => {
+  source = seedDirs.make("openclaw-testbox-source-");
+  git(source, "init", "-q", "--initial-branch=main");
+  git(source, "config", "user.name", "Test User");
+  git(source, "config", "user.email", "test@example.com");
+  for (const action of ["git-owner", "ensure-base-commit", "prepare-testbox-shell"]) {
+    fs.cpSync(`.github/actions/${action}`, path.join(source, ".github/actions", action), {
+      recursive: true,
+    });
+  }
+  fs.mkdirSync(path.join(source, "scripts/lib"), { recursive: true });
+  for (const helper of ["merge-head-diff-base.mjs", "arg-utils.runtime.mjs"]) {
+    fs.copyFileSync(`scripts/lib/${helper}`, path.join(source, "scripts/lib", helper));
+  }
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "base");
+  eventBase = git(source, "rev-parse", "HEAD");
+  git(source, "switch", "-q", "-c", "feature");
+  fs.writeFileSync(path.join(source, "feature.txt"), "feature\n");
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "feature");
+  git(source, "switch", "-q", "main");
+  fs.writeFileSync(path.join(source, "main.txt"), "main\n");
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "main advanced");
+  mainBase = git(source, "rev-parse", "HEAD");
+  git(source, "merge", "--no-ff", "feature", "-m", "synthetic merge");
+});
+
+afterAll(() => seedDirs.cleanup());
 
 function runBasePreparation(
   repo: string,
@@ -114,32 +150,6 @@ describe.each(workflows)("%s Testbox base preparation", (workflowName) => {
       eventName: "workflow_dispatch",
     },
   ])("pins the correct base in a $shape checkout", ({ branch, depth, passes, eventName }) => {
-    const source = createTempDir("openclaw-testbox-source-");
-    git(source, "init", "-q", "--initial-branch=main");
-    git(source, "config", "user.name", "Test User");
-    git(source, "config", "user.email", "test@example.com");
-    for (const action of ["git-owner", "ensure-base-commit", "prepare-testbox-shell"]) {
-      fs.cpSync(`.github/actions/${action}`, path.join(source, ".github/actions", action), {
-        recursive: true,
-      });
-    }
-    fs.mkdirSync(path.join(source, "scripts/lib"), { recursive: true });
-    for (const helper of ["merge-head-diff-base.mjs", "arg-utils.runtime.mjs"]) {
-      fs.copyFileSync(`scripts/lib/${helper}`, path.join(source, "scripts/lib", helper));
-    }
-    git(source, "add", ".");
-    git(source, "commit", "-qm", "base");
-    const eventBase = git(source, "rev-parse", "HEAD");
-    git(source, "switch", "-q", "-c", "feature");
-    fs.writeFileSync(path.join(source, "feature.txt"), "feature\n");
-    git(source, "add", ".");
-    git(source, "commit", "-qm", "feature");
-    git(source, "switch", "-q", "main");
-    fs.writeFileSync(path.join(source, "main.txt"), "main\n");
-    git(source, "add", ".");
-    git(source, "commit", "-qm", "main advanced");
-    const mainBase = git(source, "rev-parse", "HEAD");
-    git(source, "merge", "--no-ff", "feature", "-m", "synthetic merge");
     const repo = createTempDir("openclaw-testbox-shallow-");
     git(
       source,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The Testbox base-preparation tests repeatedly construct the same Git history for
all twelve workflow cases, adding avoidable setup time to this tooling test file.

## Why This Change Was Made

Construct the unchanged four-commit seed once in `beforeAll`, with a separate
temporary-directory tracker cleaned by `afterAll`. Each case still creates its
own real `git clone --no-local`; the existing per-case harness continues to own
clone, tool and trace cleanup.

Only `test/scripts/testbox-base.test.ts` changes. The workflows, actions, matrix,
assertions, Git settings and fetch behavior are unchanged.

## User Impact

No product behavior changes. The complete test-file invocation was consistently
faster in three matched local Linux pairs. These measurements do not establish
Windows, full CI or end-to-end savings.

## Evidence

All three pairs ran the whole file through the repository Vitest wrapper, with
fresh private per-run caches and identical twelve-case inventories. Pair 2 ran
candidate first. Instrumentation was excluded from the timed runs.

| Pair | Original Wall | Candidate Wall | Reduction |
| --- | ---: | ---: | ---: |
| 1 | 11.291s | 9.238s | 18.18% |
| 2 | 10.724s | 8.256s | 23.01% |
| 3 | 11.135s | 8.680s | 22.05% |

Median paired reduction: **2.455s / 22.05%**. Wall time includes wrapper startup,
seed construction, all cases and hooks, cleanup, and child-process exit. Every
sample passed 12/12; the initial diagnostic was excluded from comparison.

Untimed controls verified:

- Seed construction falls from 168 Git calls and 48 commits to 14 calls and
  four commits. All twelve real clones remain.
- All clones have private physical Git directories, no alternates or shared
  common directory, and no hardlinked files.
- Seed refs, config, index, objects and tracked bytes remain unchanged across
  the cases. The seed survives per-case cleanup and is removed by `afterAll`.
- Nine cases still perform zero fetches; three retain exactly five failed
  fetch attempts and their original failure/base assertions.
- An injected partial seed-construction failure removes its allocated root.
  A separate injected first-case failure leaves the other eleven cases passing
  and removes all case and seed roots. Both controls exit nonzero as intended;
  no tracked source was modified for either probe.

Focused proof, targeted formatting, `git diff --check`, and the full required
`check:changed` gate passed. Fresh complete P2 review was scoped-clean with no
findings.
