### PR TITLE
fix(ui): ask for the Gateway token when a remembered device token is stale

### DIFF
--- a/ui/src/lib/connection-hints.node.test.ts
+++ b/ui/src/lib/connection-hints.node.test.ts
@@ -135,9 +135,22 @@ describe("resolveAuthHintKind", () => {
     ).toBe("required");
   });
 
+  it("returns required when only a remembered device token was rejected", () => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "disconnected (4008): connect failed",
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
+        hasToken: false,
+        hasPassword: false,
+      }),
+    ).toBe("required");
+  });
+
   it.each([
     { lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH, hasToken: true },
     { lastErrorCode: ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID, hasToken: false },
+    { lastErrorCode: ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH, hasToken: true },
   ])("returns failed for structured auth code $lastErrorCode", ({ lastErrorCode, hasToken }) => {
     expect(
       resolveAuthHintKind({

--- a/ui/src/lib/connection-hints.ts
+++ b/ui/src/lib/connection-hints.ts
@@ -126,7 +126,16 @@ export function resolveAuthHintKind(params: {
     if (!AUTH_FAILURE_CODES.has(params.lastErrorCode)) {
       return null;
     }
-    return AUTH_REQUIRED_CODES.has(params.lastErrorCode) ? "required" : "failed";
+    // A remembered device token the Gateway no longer knows is not an operator-supplied
+    // secret; without a typed token or password the Gateway is asking for its token,
+    // not rejecting one (the client already dropped the stale device token).
+    const staleDeviceTokenOnly =
+      params.lastErrorCode === ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH &&
+      !params.hasToken &&
+      !params.hasPassword;
+    return staleDeviceTokenOnly || AUTH_REQUIRED_CODES.has(params.lastErrorCode)
+      ? "required"
+      : "failed";
   }
 
   const lower = normalizeLowercaseStringOrEmpty(params.lastError);


### PR DESCRIPTION
## What Problem This Solves

Open the Control UI in a browser that previously paired with a Gateway on the same origin, against a Gateway whose state was recreated (or any Gateway that no longer knows that device). Before the operator types anything, the login card reads (observed live at `71555bcbcb6`, in-app browser against an isolated dev Gateway on `127.0.0.1:18918`):

> **Gateway secret rejected**
> 127.0.0.1:18918 rejected the supplied Gateway secret. Check that it belongs to this Gateway and try again.
> Raw error: unauthorized: device token mismatch (rotate/reissue device token)

No Gateway secret was supplied. The client auto-connected with its remembered device token, the Gateway answered `AUTH_DEVICE_TOKEN_MISMATCH`, and `ui/src/api/gateway.ts` already cleared the stale stored token. The card then tells the operator their secret was wrong, which contradicts what happened.

## Why This Change Was Made

`resolveAuthHintKind` in `ui/src/lib/connection-hints.ts` owns the "required vs failed" decision for the login card. Its structured-code path returned `failed` for `AUTH_DEVICE_TOKEN_MISMATCH` whether or not a token or password was typed, while its own text fallback already applied "no typed credential means required". The fix makes the structured path follow the same rule for a rejected remembered device token: with nothing typed it returns `required`, so the card becomes "This Gateway expects its token" with the paste-token steps; with a typed secret it stays `failed`. `hasToken` is the login form field (`ui/src/app/app-root.ts`), so a stored shared token that mismatches still arrives as `AUTH_TOKEN_MISMATCH` and keeps its rejection card; the bootstrap-token precedent (`failed` with nothing typed) is unchanged because a setup code is an operator-supplied credential.

## User Impact

After a Gateway state reset, re-pair, or device revocation, the first login card says the Gateway expects its token and tells the operator to paste it, instead of claiming a secret was rejected. Typed-secret mismatches keep their current card.

## Evidence

- Before (main, built dist, same browser profile): the "Gateway secret rejected" card with the device-token raw error, screenshot and accessibility tree captured.
- After: the exact browser state that produced the card (a stored device token the Gateway no longer accepts, no stored shared secret) could not be reconstructed on demand; replaying it with a Gateway state reset or a tampered stored token made the client drop the token and re-pair silently over loopback, which never reaches the login card. The classification change is proven at its owner by the unit case below; the rendered "required" card is the existing auth-required path covered by `ui/src/e2e/login-gate.e2e.test.ts`.
- `ui/src/lib/connection-hints.node.test.ts`: new case "returns required when only a remembered device token was rejected" fails on unmodified `main` (`failed`), passes with the fix; the structured-failure table gains the typed-token row for the same code. File passes at 43 tests.
- `node scripts/check-changed.mjs`: pass. Autoreview (Codex, P0-P2): scoped-clean.

Production LOC delta: +9 (one named condition with its contract comment; the return reshaped).
