### PR TITLE
docs: fix one-way and absolute links across cli, tools, gateway, and channels

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -8,8 +8,16 @@
     "target": "macOS 平台说明"
   },
   {
+    "source": "Gateway on macOS",
+    "target": "macOS 上的 Gateway"
+  },
+  {
     "source": "Logging",
     "target": "日志"
+  },
+  {
+    "source": "Prometheus metrics",
+    "target": "Prometheus 指标"
   },
   {
     "source": "iMessage",
@@ -42,6 +50,18 @@
   {
     "source": "Secrets management",
     "target": "密钥管理"
+  },
+  {
+    "source": "1Password",
+    "target": "1Password"
+  },
+  {
+    "source": "Ask user",
+    "target": "询问用户"
+  },
+  {
+    "source": "Audit history",
+    "target": "审计历史"
   },
   {
     "source": "Channel troubleshooting",
@@ -102,6 +122,26 @@
   {
     "source": "OpenAI provider",
     "target": "OpenAI provider"
+  },
+  {
+    "source": "xAI provider",
+    "target": "xAI provider"
+  },
+  {
+    "source": "MiniMax provider",
+    "target": "MiniMax provider"
+  },
+  {
+    "source": "Inworld provider",
+    "target": "Inworld provider"
+  },
+  {
+    "source": "ElevenLabs provider",
+    "target": "ElevenLabs provider"
+  },
+  {
+    "source": "CLI backends",
+    "target": "CLI 后端"
   },
   {
     "source": "Mantis",
@@ -176,6 +216,14 @@
     "target": "Gateway 网关"
   },
   {
+    "source": "Gateway integrations for external apps",
+    "target": "面向外部应用的 Gateway 集成"
+  },
+  {
+    "source": "Gateway protocol",
+    "target": "Gateway 协议"
+  },
+  {
     "source": "Gateway health",
     "target": "Gateway 健康"
   },
@@ -200,6 +248,10 @@
     "target": "会话"
   },
   {
+    "source": "Cloud Workers",
+    "target": "Cloud Workers"
+  },
+  {
     "source": "Session permission modes",
     "target": "会话权限模式"
   },
@@ -217,6 +269,10 @@
   },
   {
     "source": "Code mode",
+    "target": "代码模式"
+  },
+  {
+    "source": "Code Mode",
     "target": "代码模式"
   },
   {
@@ -288,6 +344,14 @@
     "target": "Steer"
   },
   {
+    "source": "Slash commands",
+    "target": "斜杠命令"
+  },
+  {
+    "source": "Goal",
+    "target": "目标"
+  },
+  {
     "source": "Models",
     "target": "Models"
   },
@@ -346,6 +410,10 @@
   {
     "source": "Tailscale",
     "target": "Tailscale"
+  },
+  {
+    "source": "Stable HTTPS URL",
+    "target": "稳定的 HTTPS URL"
   },
   {
     "source": "Getting Started",
@@ -546,6 +614,14 @@
   {
     "source": "Diffs",
     "target": "Diffs"
+  },
+  {
+    "source": "Browser login",
+    "target": "浏览器登录"
+  },
+  {
+    "source": "Web fetch",
+    "target": "网页抓取"
   },
   {
     "source": "Dreaming",
@@ -754,6 +830,10 @@
   {
     "source": "Tokenjuice",
     "target": "Tokenjuice"
+  },
+  {
+    "source": "Kimi search",
+    "target": "Kimi 搜索"
   },
   {
     "source": "WhatsApp",
@@ -1232,6 +1312,14 @@
     "target": "插件参考"
   },
   {
+    "source": "Lobster plugin reference",
+    "target": "Lobster 插件参考"
+  },
+  {
+    "source": "A2A plugin reference",
+    "target": "A2A 插件参考"
+  },
+  {
     "source": "Community plugins",
     "target": "社区插件"
   },
@@ -1572,8 +1660,16 @@
     "target": "子智能体"
   },
   {
+    "source": "Thinking levels",
+    "target": "思考级别"
+  },
+  {
     "source": "ACP agents",
     "target": "ACP 智能体"
+  },
+  {
+    "source": "ACP agents — setup",
+    "target": "ACP 智能体 — 设置"
   },
   {
     "source": "Tools and custom providers",
@@ -1724,6 +1820,14 @@
     "target": "Control UI"
   },
   {
+    "source": "Control UI URLs",
+    "target": "Control UI 地址"
+  },
+  {
+    "source": "Tools invoke API",
+    "target": "工具调用 API"
+  },
+  {
     "source": "Models CLI",
     "target": "模型 CLI"
   },
@@ -1793,6 +1897,10 @@
   },
   {
     "source": "Channels Overview",
+    "target": "渠道概览"
+  },
+  {
+    "source": "Channels overview",
     "target": "渠道概览"
   },
   {
@@ -1882,6 +1990,10 @@
   {
     "source": "Media overview",
     "target": "媒体概览"
+  },
+  {
+    "source": "Music generation",
+    "target": "音乐生成"
   },
   {
     "source": "Text to speech",

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -224,6 +224,10 @@
     "target": "Gateway 协议"
   },
   {
+    "source": "Gateway RPC methods",
+    "target": "Gateway RPC 方法"
+  },
+  {
     "source": "Gateway health",
     "target": "Gateway 健康"
   },

--- a/docs/automation/standing-orders.md
+++ b/docs/automation/standing-orders.md
@@ -238,3 +238,4 @@ Each program should have:
 - [Hooks](/automation/hooks): event-driven scripts for agent lifecycle events.
 - [Webhooks](/automation/cron-jobs#webhooks): inbound HTTP event triggers.
 - [Agent workspace](/concepts/agent-workspace): where standing orders live, including the full list of auto-injected bootstrap files (`AGENTS.md`, `SOUL.md`, etc.).
+- [Goal](/tools/goal) — the session goal standing orders run against

--- a/docs/automation/standing-orders.md
+++ b/docs/automation/standing-orders.md
@@ -238,4 +238,4 @@ Each program should have:
 - [Hooks](/automation/hooks): event-driven scripts for agent lifecycle events.
 - [Webhooks](/automation/cron-jobs#webhooks): inbound HTTP event triggers.
 - [Agent workspace](/concepts/agent-workspace): where standing orders live, including the full list of auto-injected bootstrap files (`AGENTS.md`, `SOUL.md`, etc.).
-- [Goal](/tools/goal) — the session goal standing orders run against
+- [Goal](/tools/goal) — durable per-session objectives and the `/goal` controls

--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -184,3 +184,4 @@ Flows coordinate tasks, not replace them. A single flow may drive multiple backg
 - [CLI: tasks](/cli/tasks) - CLI command reference for `openclaw tasks flow`
 - [Automation Overview](/automation) - all automation mechanisms at a glance
 - [Automations](/automation/cron-jobs) - scheduled jobs that may feed into flows
+- [Goal](/tools/goal) — setting the objective a flow works toward

--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -184,4 +184,4 @@ Flows coordinate tasks, not replace them. A single flow may drive multiple backg
 - [CLI: tasks](/cli/tasks) - CLI command reference for `openclaw tasks flow`
 - [Automation Overview](/automation) - all automation mechanisms at a glance
 - [Automations](/automation/cron-jobs) - scheduled jobs that may feed into flows
-- [Goal](/tools/goal) - setting the objective a flow works toward
+- [Goal](/tools/goal) - durable per-session objectives and the `/goal` controls

--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -184,4 +184,4 @@ Flows coordinate tasks, not replace them. A single flow may drive multiple backg
 - [CLI: tasks](/cli/tasks) - CLI command reference for `openclaw tasks flow`
 - [Automation Overview](/automation) - all automation mechanisms at a glance
 - [Automations](/automation/cron-jobs) - scheduled jobs that may feed into flows
-- [Goal](/tools/goal) — setting the objective a flow works toward
+- [Goal](/tools/goal) - setting the objective a flow works toward

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -447,5 +447,5 @@ flow content into the generic decision-fact table.
 - [Heartbeat](/gateway/heartbeat) - periodic main-session turns
 - [Automations](/automation/cron-jobs) - scheduling background work
 - [Task Flow](/automation/taskflow) - flow orchestration above tasks
-- [Sub-agents](/tools/subagents) — running a task on a spawned child agent
-- [Music generation](/tools/music-generation) — a long-running generation a task can drive
+- [Sub-agents](/tools/subagents) - running a task on a spawned child agent
+- [Music generation](/tools/music-generation) - a long-running generation a task can drive

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -447,5 +447,5 @@ flow content into the generic decision-fact table.
 - [Heartbeat](/gateway/heartbeat) - periodic main-session turns
 - [Automations](/automation/cron-jobs) - scheduling background work
 - [Task Flow](/automation/taskflow) - flow orchestration above tasks
-- [Sub-agents](/tools/subagents) - running a task on a spawned child agent
-- [Music generation](/tools/music-generation) - a long-running generation a task can drive
+- [Sub-agents](/tools/subagents) - child agents spawned from a session
+- [Music generation](/tools/music-generation) - generate music via `music_generate` across the supported provider workflows

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -447,3 +447,5 @@ flow content into the generic decision-fact table.
 - [Heartbeat](/gateway/heartbeat) - periodic main-session turns
 - [Automations](/automation/cron-jobs) - scheduling background work
 - [Task Flow](/automation/taskflow) - flow orchestration above tasks
+- [Sub-agents](/tools/subagents) — running a task on a spawned child agent
+- [Music generation](/tools/music-generation) — a long-running generation a task can drive

--- a/docs/channels/a2a.md
+++ b/docs/channels/a2a.md
@@ -193,3 +193,4 @@ Tasks remain in memory only. Completed and other terminal tasks are retained for
 - [Channel routing](/channels/channel-routing)
 - [Gateway security](/gateway/security)
 - [Channel plugin SDK](/plugins/sdk-channel-plugins)
+- [A2A plugin reference](/plugins/reference/a2a) — manifest, config, and tool reference for the plugin

--- a/docs/channels/access-groups.md
+++ b/docs/channels/access-groups.md
@@ -195,3 +195,8 @@ If a sender should match but is blocked:
 5. For Discord channel audiences, confirm the bot can see the guild channel and has Server Members Intent enabled.
 
 Run `openclaw doctor` after editing access-control config. It catches many invalid allowlist and policy combinations before runtime.
+
+## Related
+
+- [Pairing](/channels/pairing) — how a channel account is bound to an operator before access groups apply
+- [Channels overview](/channels) — the channels these groups apply to

--- a/docs/channels/access-groups.md
+++ b/docs/channels/access-groups.md
@@ -198,5 +198,5 @@ Run `openclaw doctor` after editing access-control config. It catches many inval
 
 ## Related
 
-- [Pairing](/channels/pairing) — how a channel account is bound to an operator before access groups apply
+- [Pairing](/channels/pairing) — the separate DM pairing flow for channel senders
 - [Channels overview](/channels) — the channels these groups apply to

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -291,7 +291,7 @@ Default account supports:
 - `IRC_NICKSERV_PASSWORD`
 - `IRC_NICKSERV_REGISTER_EMAIL`
 
-`IRC_HOST` cannot be set from a workspace `.env`; see [Workspace `.env` files](/gateway/security).
+`IRC_HOST` cannot be set from a workspace `.env`; see [Workspace `.env` files](/gateway/security#workspace-env-files).
 
 ## Troubleshooting
 

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -297,3 +297,4 @@ imported into SQLite at gateway startup and archived with a `.migrated` suffix.
   - iMessage: [iMessage](/channels/imessage)
   - Discord: [Discord](/channels/discord)
   - Slack: [Slack](/channels/slack)
+- [`openclaw pairing`](/cli/pairing) — drive pairing from the CLI

--- a/docs/channels/sms.md
+++ b/docs/channels/sms.md
@@ -218,7 +218,7 @@ Then enable the channel in config:
 
 ### SecretRef auth token
 
-`authToken` can be a SecretRef (`source: "env" | "file" | "exec" | "store"`). Use this when the Gateway should resolve the Twilio Auth Token from the OpenClaw secrets runtime instead of storing plaintext config:
+`authToken` can be a [SecretRef](/gateway/secrets) (`source: "env" | "file" | "exec" | "store"`). Use this when the Gateway should resolve the Twilio Auth Token from the OpenClaw secrets runtime instead of storing plaintext config:
 
 ```json5
 {
@@ -403,7 +403,7 @@ The webhook route also enforces, independent of signature validation:
 - Signed delivery callbacks are classified before inbound sender quotas and commit to bounded, plugin-scoped SQLite state before HTTP 200. They do not consume inbound dispatch quotas: those quotas protect raw inbound message admission and downstream agent dispatch. Delivery persistence instead has a separate 3,000-callback-per-minute safety fuse per SMS account route and returns HTTP 503 without the durable-acceptance marker above that limit. This is fail-closed overload protection, not lossless backpressure. With signature validation disabled, delivery callbacks first use the stricter 30/minute resolved-client-address cap before persistence.
 - Dispatchable callback rate limit of 30 accepted callbacks per minute per SMS account, webhook route, and validated sender after body parsing and signature validation pass (HTTP 429 above that). The sender key is the canonicalized, signature-covered `From` value, so equivalent SMS/RCS address forms share one budget, one flooding sender exhausts only its own budget, and callbacks from other senders behind Twilio's shared egress addresses remain dispatchable. Invalid or missing sender values share a separate empty-sender budget.
 - Aggregate validated-callback ceiling of 300 accepted callbacks per minute per SMS account and webhook route. This bounds durable-ingress pressure from many distinct signed senders without recreating shared-egress cross-throttling. If signature validation is disabled, nothing authenticates `From`; the stricter 30/min resolved-client-address dispatch cap applies instead of the validated sender and aggregate policy.
-- Client addresses are resolved through the shared Gateway trusted-proxy rules. If `gateway.trustedProxies` contains the reverse proxy that forwards Twilio callbacks, OpenClaw keys the address-based limits from the forwarded client address; otherwise it falls back to the direct socket address.
+- Client addresses are resolved through the shared Gateway trusted-proxy rules. If [`gateway.trustedProxies`](/gateway/config-gateway) contains the reverse proxy that forwards Twilio callbacks, OpenClaw keys the address-based limits from the forwarded client address; otherwise it falls back to the direct socket address.
 - Inbound payloads must carry a nonempty `AccountSid` that exactly matches the configured `accountSid`. Direct-number callbacks must target the configured `fromNumber`; Messaging Service callbacks must carry the configured `MessagingServiceSid`. The raw callback is first committed to the durable ingress queue and acknowledged; an identity mismatch is then marked as a permanent invalid-payload failure during drain and is never dispatched or allowed to download media.
 - Delivery callbacks with a missing or different `AccountSid` are acknowledged, logged, and intentionally not stored.
 - Replayed `MessageSid` values are deduplicated by the durable ingress queue. Completed-message tombstones are retained for 24 hours (up to 20,000 entries per account); permanent-failure tombstones are retained for 30 days (up to 1,000 entries).
@@ -493,3 +493,9 @@ If the recent outbound status is `failed` or `undelivered`, use its `messageSid`
 ### Messages arrive but the agent does not answer
 
 Check `dmPolicy` and `allowFrom`. With the default `pairing` policy, the sender must be approved before normal agent turns are processed.
+
+## Related
+
+- [Channels overview](/channels)
+- [Secrets management](/gateway/secrets) — resolving the Twilio auth token from a SecretRef
+- [Configuration — gateway](/gateway/config-gateway) — `gateway.trustedProxies` and the other Gateway settings used above

--- a/docs/channels/zaloclawbot.md
+++ b/docs/channels/zaloclawbot.md
@@ -17,7 +17,7 @@ OpenClaw connects to Zalo ClawBot through the catalog-listed external `@zalo-pla
 ## Prerequisites
 
 - Node.js >= 22
-- [OpenClaw](https://docs.openclaw.ai/install) installed (`openclaw` CLI available)
+- [OpenClaw](/install) installed (`openclaw` CLI available)
 - A Zalo account on a mobile device to scan the login QR code
 
 ## Install with onboard (recommended)

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -618,3 +618,4 @@ Inside the TUI, a leading `!` runs a literal local shell command (after a one-ti
 
 - [CLI reference](/cli)
 - [Configuration](/gateway/configuration)
+- [`openclaw configure`](/cli/configure) — guided editor for the same settings

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -236,4 +236,4 @@ If approval keeps failing, run `openclaw devices list` first to confirm a pendin
 
 - [CLI reference](/cli)
 - [Nodes](/nodes)
-- [`openclaw qr`](/cli/qr) — render a pairing code as a QR image
+- [`openclaw qr`](/cli/qr) — generate the mobile-node bootstrap QR and setup code

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -236,3 +236,4 @@ If approval keeps failing, run `openclaw devices list` first to confirm a pendin
 
 - [CLI reference](/cli)
 - [Nodes](/nodes)
+- [`openclaw qr`](/cli/qr) — render a pairing code as a QR image

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -75,3 +75,4 @@ Each entry points at the page that now holds the content.
 
 - [CLI reference](/cli)
 - [Gateway doctor](/gateway/doctor)
+- [`openclaw policy`](/cli/policy) — the policy rules `doctor --lint` reports on

--- a/docs/cli/doctor/lint.md
+++ b/docs/cli/doctor/lint.md
@@ -13,7 +13,7 @@ This page covers lint output, check selection, and post-upgrade probes.
 
 Bare `openclaw doctor --json` is read-only and non-interactive: no prompts, repairs, or config/state rewrites. It emits the same default findings as lint mode, but exits `0` after a report is produced so output formatting does not change ordinary Doctor's advisory success contract. Read the payload's `ok` and `findings` fields to determine health.
 
-Explicit `openclaw doctor --lint` is the deployment-preflight posture. Add `--json` for machine-readable output without changing lint's threshold-based exit code.
+Explicit `openclaw doctor --lint` is the deployment-preflight posture. Add `--json` for machine-readable output without changing lint's threshold-based exit code. Policy findings reported here are documented in [`openclaw policy`](/cli/policy).
 
 ```bash
 openclaw doctor --json

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -11,6 +11,8 @@ sidebarTitle: "Gateway"
 
 The Gateway is OpenClaw's WebSocket server (channels, nodes, sessions, hooks). All subcommands on the pages listed here live under `openclaw gateway ...`.
 
+`openclaw daemon ...` is a legacy alias for the service-control subcommands; see [`openclaw daemon`](/cli/daemon).
+
 <CardGroup cols={3}>
   <Card title="Bonjour discovery" href="/gateway/bonjour">
     Local mDNS + wide-area DNS-SD setup.

--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -154,14 +154,14 @@ openclaw infer model run --local --model ollama/qwen2.5vl:7b --prompt "Describe 
 Notes:
 
 - Local `model run` is the narrowest CLI smoke for provider/model/auth health: for non-ChatGPT-Codex providers it sends only the supplied prompt.
-- Local `model run --model <provider/model>` can resolve exact bundled static-catalog rows (the same rows `openclaw models list --all` shows) before that provider is written to config. Provider auth is still required; missing credentials fail as auth errors, not `Unknown model`.
+- Local `model run --model <provider/model>` can resolve exact bundled static-catalog rows (the same rows [`openclaw models list --all`](/cli/models) shows) before that provider is written to config. Provider auth is still required; missing credentials fail as auth errors, not `Unknown model`.
 - For Mistral Medium 3.5 reasoning probes, leave temperature unset/default. Mistral rejects `reasoning_effort="high"` with `temperature: 0`; use default temperature or a non-zero value such as `0.7`.
 - OpenAI ChatGPT/Codex OAuth (`openai-chatgpt-responses` API) local probes add a minimal system instruction so the transport can populate its required `instructions` field — no full agent context, tools, memory, or session transcript.
 - `model run --file` attaches image content directly to the single user message. Common formats (PNG, JPEG, WebP) work when MIME type is detected as `image/*`; unsupported or unrecognized files fail before the provider is called. Use `infer image describe` instead when you want OpenClaw's image-model routing and fallbacks rather than a direct multimodal-model probe.
 - The selected model must support image input; text-only models may reject the request at the provider layer.
 - `model run --prompt` must contain non-whitespace text; empty prompts are rejected before any provider or Gateway call.
 - Local `model run` exits non-zero when the provider returns no text output, so unreachable providers and empty completions do not look like successful probes.
-- Use `model run --gateway` to test Gateway routing or agent-runtime setup while keeping the model input raw. Use `openclaw agent` or a chat surface for full agent context, tools, memory, and session transcript.
+- Use `model run --gateway` to test Gateway routing or agent-runtime setup while keeping the model input raw. Use [`openclaw agent`](/cli/agent) or a chat surface for full agent context, tools, memory, and session transcript.
 - `--thinking adaptive` maps to the completion-runtime level `medium`; `--thinking max` maps to `max` for OpenAI models that support the native max effort, otherwise `xhigh`.
 - `model auth login`, `model auth logout`, and `model auth status` manage saved provider auth state.
 

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -138,3 +138,4 @@ the page that now holds the content.
 - [Connect MCP servers](/tools/mcp)
 - [CLI reference](/cli)
 - [Plugins](/cli/plugins)
+- [`openclaw attach`](/cli/attach) — attach a terminal to a running session

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -138,4 +138,4 @@ the page that now holds the content.
 - [Connect MCP servers](/tools/mcp)
 - [CLI reference](/cli)
 - [Plugins](/cli/plugins)
-- [`openclaw attach`](/cli/attach) — attach a terminal to a running session
+- [`openclaw attach`](/cli/attach) — launch Claude Code with a temporary session-scoped Gateway MCP grant

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -365,4 +365,4 @@ Notes:
 - [CLI reference](/cli)
 - [Model selection](/concepts/model-providers)
 - [Model failover](/concepts/model-failover)
-- [`openclaw promos`](/cli/promos) — provider promotions that affect model pricing
+- [`openclaw promos`](/cli/promos) — list and claim promotional model offers

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -365,3 +365,4 @@ Notes:
 - [CLI reference](/cli)
 - [Model selection](/concepts/model-providers)
 - [Model failover](/concepts/model-failover)
+- [`openclaw promos`](/cli/promos) — provider promotions that affect model pricing

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -466,3 +466,8 @@ openclaw channels add
 openclaw configure
 openclaw agents add <name>
 ```
+
+## Related
+
+- [CLI reference](/cli)
+- [`openclaw setup`](/cli/setup) — the non-interactive setup command

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -470,4 +470,4 @@ openclaw agents add <name>
 ## Related
 
 - [CLI reference](/cli)
-- [`openclaw setup`](/cli/setup) — the non-interactive setup command
+- [`openclaw setup`](/cli/setup) — the system-agent entry point; bare `setup` is interactive, and falls through to guided onboarding on a fresh system

--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -71,3 +71,4 @@ If you approved a sender before the first-owner bootstrap shipped in 2026.4.29, 
 
 - [CLI reference](/cli)
 - [Channel pairing](/channels/pairing)
+- [`openclaw qr`](/cli/qr) — render a pairing code as a QR image

--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -7,7 +7,7 @@ title: "Pairing CLI"
 
 # `openclaw pairing`
 
-Approve or inspect DM pairing requests for channels that support pairing (chat DMs only - node/device pairing uses `openclaw devices`).
+Approve or inspect DM pairing requests for channels that support pairing (chat DMs only - node/device pairing uses [`openclaw devices`](/cli/devices)).
 
 Related: [Pairing flow](/channels/pairing)
 
@@ -65,7 +65,7 @@ If `commands.ownerAllowFrom` is empty when you approve a pairing code, the CLI a
 
 The command owner is the human operator account allowed to run owner-only commands and approve dangerous actions such as `/diagnostics`, `/export-session`, `/export-trajectory`, `/config`, and exec approvals. Pairing only lets a sender talk to the agent; it does not by itself grant owner privileges beyond this one-time bootstrap.
 
-If you approved a sender before the first-owner bootstrap shipped in 2026.4.29, run `openclaw doctor`; it warns when no command owner is configured and shows the exact `openclaw config set commands.ownerAllowFrom ...` command to fix it.
+If you approved a sender before the first-owner bootstrap shipped in 2026.4.29, run [`openclaw doctor`](/cli/doctor); it warns when no command owner is configured and shows the exact `openclaw config set commands.ownerAllowFrom ...` command to fix it.
 
 ## Related
 

--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -71,4 +71,4 @@ If you approved a sender before the first-owner bootstrap shipped in 2026.4.29, 
 
 - [CLI reference](/cli)
 - [Channel pairing](/channels/pairing)
-- [`openclaw qr`](/cli/qr) — render a pairing code as a QR image
+- [`openclaw qr`](/cli/qr) — mobile/device bootstrap QR and setup code, not a channel DM pairing code

--- a/docs/cli/promos.md
+++ b/docs/cli/promos.md
@@ -69,3 +69,8 @@ Existing claimed-model configuration and credentials remain available.
 
 Claiming revalidates the offer against the live ClawHub API, so a withdrawn offer
 is refused even when an older cached copy still shows it.
+
+## Related
+
+- [CLI reference](/cli)
+- [`openclaw models`](/cli/models) — the models these promotions apply to

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -10,6 +10,8 @@ title: "QR"
 
 Generate a mobile pairing QR and setup code from your current Gateway configuration.
 
+The legacy [`openclaw clawbot qr`](/cli/clawbot) alias accepts every flag below.
+
 ```bash
 openclaw qr
 openclaw qr --setup-code-only

--- a/docs/cli/reset.md
+++ b/docs/cli/reset.md
@@ -47,3 +47,6 @@ openclaw reset --scope full --yes --non-interactive
 ## Related
 
 - [CLI reference](/cli)
+- [`openclaw backup`](/cli/backup) — archive state before resetting it
+- [`openclaw onboard`](/cli/onboard) — set the install up again after a reset
+- [`openclaw uninstall`](/cli/uninstall) — remove the install instead of resetting it

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -130,3 +130,4 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
 - [Sandboxing](/gateway/sandboxing)
 - [Agent workspace](/concepts/agent-workspace)
 - [Doctor](/gateway/doctor): checks sandbox setup.
+- [OpenShell](/gateway/openshell) — the shell surface the sandbox bounds

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -130,4 +130,4 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
 - [Sandboxing](/gateway/sandboxing)
 - [Agent workspace](/concepts/agent-workspace)
 - [Doctor](/gateway/doctor): checks sandbox setup.
-- [OpenShell](/gateway/openshell) — the shell surface the sandbox bounds
+- [OpenShell](/gateway/openshell) — a managed sandbox backend driven through the `openshell` CLI

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -415,3 +415,5 @@ Example truncate response (`--max-lines 200`):
 - [Session management](/concepts/session)
 - [Compaction](/concepts/compaction)
 - [CLI reference](/cli)
+- [`openclaw resume`](/cli/resume) — reopen a previous session
+- [Cloud Workers](/gateway/cloud-workers) — sessions hosted on remote workers

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -415,5 +415,5 @@ Example truncate response (`--max-lines 200`):
 - [Session management](/concepts/session)
 - [Compaction](/concepts/compaction)
 - [CLI reference](/cli)
-- [`openclaw resume`](/cli/resume) — reopen a previous session
+- [`openclaw resume`](/cli/resume) — attach the TUI to a recent Gateway session
 - [Cloud Workers](/gateway/cloud-workers) — sessions hosted on remote workers

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -159,3 +159,4 @@ their own files, chunks, vector, and FTS state.
 
 - [CLI reference](/cli)
 - [Doctor](/gateway/doctor)
+- [`openclaw health`](/cli/health) — full health snapshot across channels and nodes

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -159,4 +159,4 @@ their own files, chunks, vector, and FTS state.
 
 - [CLI reference](/cli)
 - [Doctor](/gateway/doctor)
-- [`openclaw health`](/cli/health) — full health snapshot across channels and nodes
+- [`openclaw health`](/cli/health) — Gateway health snapshot over RPC

--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -11,8 +11,9 @@ title: "Transcripts CLI"
 
 # `openclaw transcripts`
 
-Inspector and export command for durable meeting transcripts. Google Meet,
-Microsoft Teams, and Zoom browser participants capture notes automatically;
+Inspector and export command for durable meeting transcripts.
+[Google Meet](/plugins/google-meet), [Microsoft Teams](/plugins/teams-meetings),
+and [Zoom](/plugins/zoom-meetings) browser participants capture notes automatically;
 the `transcripts` agent tool also supports provider capture and manual import.
 
 Canonical transcript state lives in the shared SQLite database at
@@ -479,3 +480,8 @@ The meeting provider ids are `google-meet`, `teams`, and `zoom`. Their aliases
 are `googlemeet`/`meet`, `teams-meetings`/`microsoft-teams`/`msteams`, and
 `zoom-meetings`, respectively. Meeting providers attach to an already-active
 meeting bot session; normal meeting joins do not need an `autoStart` entry.
+
+## Related
+
+- [CLI reference](/cli)
+- [Meeting plugins](/plugins/meeting-plugins) — the plugins that capture these transcripts

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -153,4 +153,4 @@ rerun `openclaw config validate`. See [TUI](/web/tui) and
 - [Control UI URLs](/web/urls)
 - [Devices](/cli/devices)
 - [Goal](/tools/goal)
-- [`openclaw attach`](/cli/attach) — attach a terminal to a running session
+- [`openclaw attach`](/cli/attach) — launch Claude Code with a temporary session-scoped Gateway MCP grant

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -153,3 +153,4 @@ rerun `openclaw config validate`. See [TUI](/web/tui) and
 - [Control UI URLs](/web/urls)
 - [Devices](/cli/devices)
 - [Goal](/tools/goal)
+- [`openclaw attach`](/cli/attach) — attach a terminal to a running session

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -25,7 +25,8 @@ Remove any remaining CLI through the [installation-specific steps](/install/unin
 | `--dry-run`         | `false` | Print planned actions without removing files.        |
 
 With no scope flags, an interactive multiselect prompts for which components
-to remove (defaults to the Gateway service only).
+to remove (defaults to the Gateway service only). Take an archive with
+[`openclaw backup`](/cli/backup) first if you may want the state back.
 
 ## Examples
 

--- a/docs/cli/webhooks.md
+++ b/docs/cli/webhooks.md
@@ -147,3 +147,4 @@ untrusted inbox.
 - [CLI reference](/cli)
 - [Webhook automation](/automation/cron-jobs#webhooks)
 - [Gmail Pub/Sub integration](/automation/cron-jobs#gmail-pubsub-integration)
+- [Configuration reference](/gateway/configuration-reference) — where each webhook setting is documented

--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -313,4 +313,4 @@ reject the turn. The completed result records the runtime that actually ran.
 - [Agent loop](/concepts/agent-loop)
 - [Models](/concepts/models)
 - [Status](/cli/status)
-- [Code Mode](/tools/code-mode) — running tool calls as code inside a runtime
+- [Code Mode](/tools/code-mode) — an experimental, opt-in agent-runtime feature

--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -313,3 +313,4 @@ reject the turn. The completed result records the runtime that actually ran.
 - [Agent loop](/concepts/agent-loop)
 - [Models](/concepts/models)
 - [Status](/cli/status)
+- [Code Mode](/tools/code-mode) — running tool calls as code inside a runtime

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -268,4 +268,4 @@ For advanced configuration (reserve tokens, identifier preservation, custom cont
 - [Context engines](/concepts/context-engine): pluggable context assembly.
 - [Hooks](/automation/hooks/event-types): internal compaction events (`session:compact:before`, `session:compact:after`).
 - [Plugin hooks](/plugins/hooks/reference#hook-catalog): typed compaction hooks (`before_compaction`, `after_compaction`).
-- [Goal](/tools/goal) — the goal preserved across a compaction
+- [Goal](/tools/goal) — durable per-session objectives and the `/goal` controls

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -268,3 +268,4 @@ For advanced configuration (reserve tokens, identifier preservation, custom cont
 - [Context engines](/concepts/context-engine): pluggable context assembly.
 - [Hooks](/automation/hooks/event-types): internal compaction events (`session:compact:before`, `session:compact:after`).
 - [Plugin hooks](/plugins/hooks/reference#hook-catalog): typed compaction hooks (`before_compaction`, `after_compaction`).
+- [Goal](/tools/goal) — the goal preserved across a compaction

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -334,3 +334,7 @@ openclaw memory index --force   # Rebuild the index
 - [Active memory](/concepts/active-memory): sub-agent memory for interactive chat sessions.
 - [User model](/concepts/user-model): directive-based durable preferences and profile facts.
 - [Standing intents](/concepts/standing-intents): event-conditioned prospective memory.
+
+## Related
+
+- [`openclaw memory`](/cli/memory) — command reference for inspecting and editing memory

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -404,6 +404,7 @@ See [Gateway configuration](/gateway/configuration) for:
 - `auth.profiles` / `auth.order`
 - `agents.defaults.model.primary` / `agents.defaults.model.fallbacks`
 - `agents.defaults.imageModel` routing
+- [`openclaw models`](/cli/models) — inspect resolved defaults and fallbacks
 
 See [Models](/concepts/models) for the broader model selection and fallback overview.
 

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -89,3 +89,4 @@ See also: [Configuration](/gateway/configuration) for full configuration example
 - [Models](/concepts/models) - model configuration and aliases
 - [Providers](/providers) - per-provider setup guides
 - [Agent harness plugins](/plugins/sdk-agent-harness) - SDK surface for plugins that replace the embedded agent executor
+- [`openclaw models`](/cli/models) — list, select, and authenticate providers from the CLI

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -89,4 +89,4 @@ See also: [Configuration](/gateway/configuration) for full configuration example
 - [Models](/concepts/models) - model configuration and aliases
 - [Providers](/providers) - per-provider setup guides
 - [Agent harness plugins](/plugins/sdk-agent-harness) - SDK surface for plugins that replace the embedded agent executor
-- [`openclaw models`](/cli/models) — list, select, and authenticate providers from the CLI
+- [`openclaw models`](/cli/models) - list, select, and authenticate providers from the CLI

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -416,3 +416,4 @@ Marker persistence is source-authoritative: OpenClaw writes markers from the act
 - [Models CLI reference](/cli/models) — full command and flag reference
 - [Music generation](/tools/music-generation) — music model configuration
 - [Video generation](/tools/video-generation) — video model configuration
+- [`openclaw infer`](/cli/infer) — run a one-shot inference against a selected model

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -416,4 +416,4 @@ Marker persistence is source-authoritative: OpenClaw writes markers from the act
 - [Models CLI reference](/cli/models) — full command and flag reference
 - [Music generation](/tools/music-generation) — music model configuration
 - [Video generation](/tools/video-generation) — video model configuration
-- [`openclaw infer`](/cli/infer) — run a one-shot inference against a selected model
+- [`openclaw infer`](/cli/infer) — infer-first CLI for provider-backed model, media, and embedding workflows

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -612,3 +612,4 @@ See [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) for detail
 - [Presence](/concepts/presence) — agent presence and availability
 - [Session](/concepts/session) — session isolation and routing
 - [Sub-agents](/tools/subagents) — spawning background agent runs
+- [`openclaw agents`](/cli/agents) — create and inspect agents from the CLI

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -244,4 +244,4 @@ and prompt hints; they do not grant access.
 
 - [Session management](/concepts/session)
 - [Session pruning](/concepts/session-pruning)
-- [Goal](/tools/goal) — the session goal these tools read and update
+- [Goal](/tools/goal) — durable per-session objectives, read and updated through the dedicated `get_goal`, `create_goal`, and `update_goal` tools

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -244,3 +244,4 @@ and prompt hints; they do not grant access.
 
 - [Session management](/concepts/session)
 - [Session pruning](/concepts/session-pruning)
+- [Goal](/tools/goal) — the session goal these tools read and update

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -343,4 +343,4 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 - [Session pruning](/concepts/session-pruning)
 - [Session tools](/concepts/session-tool)
 - [Command queue](/concepts/queue)
-- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) — how session visibility is limited per agent
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - how session visibility is limited per agent

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -343,3 +343,4 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 - [Session pruning](/concepts/session-pruning)
 - [Session tools](/concepts/session-tool)
 - [Command queue](/concepts/queue)
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) — how session visibility is limited per agent

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -343,4 +343,4 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 - [Session pruning](/concepts/session-pruning)
 - [Session tools](/concepts/session-tool)
 - [Command queue](/concepts/queue)
-- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - how session visibility is limited per agent
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - per-agent sandbox and tool restrictions, including session visibility

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -500,3 +500,4 @@ retry, authentication, timeout, or fallback classification.
 
 - [Gateway runbook](/gateway)
 - [Local models](/gateway/local-models)
+- [Thinking levels](/tools/thinking) — how the reasoning budget maps onto a CLI backend

--- a/docs/gateway/clients.md
+++ b/docs/gateway/clients.md
@@ -14,7 +14,7 @@ the wire contract: authentication, capabilities, reconnect recovery, history,
 subscriptions, and version upgrades.
 
 For frame shapes, the handshake, errors, and the complete method surface, read the
-[Gateway protocol specification](https://docs.openclaw.ai/gateway/protocol).
+[Gateway protocol specification](/gateway/protocol).
 
 ## Install the packages
 
@@ -66,7 +66,7 @@ A full interactive chat client that also renders approval prompts should request
 Add `operator.questions` only if the client handles interactive questions,
 `operator.pairing` only if it manages paired devices or nodes, and
 `operator.admin` only for administrative operations such as `config.patch`.
-The [operator scopes reference](https://docs.openclaw.ai/gateway/operator-scopes)
+The [operator scopes reference](/gateway/operator-scopes)
 defines the complete method and approval-time rules.
 
 Do not create a per-client bearer token by hand-editing `openclaw.json`. Configure
@@ -90,7 +90,7 @@ pairing mint the client token:
 
 Scope or role upgrades create a new pending pairing request. Token rotation cannot
 expand the approved pairing contract. See the
-[Devices CLI](https://docs.openclaw.ai/cli/devices) for approval, rotation, and
+[Devices CLI](/cli/devices) for approval, rotation, and
 revocation commands.
 
 ## Advertise client capabilities
@@ -307,7 +307,7 @@ before each upgrade.
 
 ## Related
 
-- [Gateway protocol](https://docs.openclaw.ai/gateway/protocol)
-- [Embedding OpenClaw](https://docs.openclaw.ai/gateway/embedding)
-- [Gateway RPC reference](https://docs.openclaw.ai/reference/rpc)
-- [Gateway integrations for external apps](https://docs.openclaw.ai/gateway/external-apps)
+- [Gateway protocol](/gateway/protocol)
+- [Embedding OpenClaw](/gateway/embedding)
+- [Gateway RPC reference](/reference/rpc)
+- [Gateway integrations for external apps](/gateway/external-apps)

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -158,3 +158,6 @@ the page that now holds the content.
 - [Sandboxing](/gateway/sandboxing) — reducing blast radius for local tool execution
 - [Sessions CLI](/cli/sessions) — inspecting stored sessions
 - [Configuration reference](/gateway/configuration-reference)
+- [`openclaw worker`](/cli/worker) — run and inspect a worker from the CLI
+- [Gateway RPC reference](/reference/rpc) — full shape of the worker RPC methods named above
+- [Operator scopes](/gateway/operator-scopes) — the scopes these worker calls are authorized against

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -158,6 +158,6 @@ the page that now holds the content.
 - [Sandboxing](/gateway/sandboxing) — reducing blast radius for local tool execution
 - [Sessions CLI](/cli/sessions) — inspecting stored sessions
 - [Configuration reference](/gateway/configuration-reference)
-- [`openclaw worker`](/cli/worker) — run and inspect a worker from the CLI
-- [Gateway RPC reference](/reference/rpc) — full shape of the worker RPC methods named above
+- [`openclaw worker`](/cli/worker) — the restricted runtime entry point a Gateway-owned launcher starts inside a prepared worker environment
+- [Gateway RPC methods](/gateway/protocol/rpc-methods) — RPC method families, discovery, and event families
 - [Operator scopes](/gateway/operator-scopes) — the scopes these worker calls are authorized against

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -107,3 +107,4 @@ entry points at the page that now holds the content.
 - [Configuration examples](/gateway/configuration-examples)
 - [Model providers](/concepts/model-providers) — provider setup and model catalogs
 - [Agent bindings](/concepts/agent-bindings) — how channel accounts and users select an agent
+- [Configuration — channels](/gateway/config-channels) — the matching `channels.*` reference

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -224,3 +224,4 @@ Moved to [Configuration — environment, secrets, and includes](/gateway/config-
 - [Configuration](/gateway/configuration)
 - [Configuration examples](/gateway/configuration-examples)
 - [Doctor](/gateway/doctor)
+- [Cloud Workers](/gateway/cloud-workers) — the feature these worker settings configure

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -966,3 +966,7 @@ _Related: [Configuration Examples](/gateway/configuration-examples) · [Configur
 - [Configuration reference](/gateway/configuration-reference)
 - [Configuration examples](/gateway/configuration-examples)
 - [Gateway runbook](/gateway)
+- [`openclaw config`](/cli/config) — read and write these settings from the CLI
+- [`openclaw configure`](/cli/configure) — guided editor for these settings
+- [Security audit checks](/gateway/security/audit-checks) — what the audit flags in this configuration
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) — configuring the Gateway behind a reverse proxy

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -97,4 +97,4 @@ still resolves. Each entry points at the page that now holds the content.
 - [Gateway runbook](/gateway)
 - [Gateway troubleshooting](/gateway/troubleshooting)
 - [`openclaw status`](/cli/status) — local diagnosis and channel probes
-- [Configuration reference](/gateway/configuration-reference) — every setting doctor validates
+- [Configuration reference](/gateway/configuration-reference) — core config keys, defaults, and links to subsystem references

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -96,3 +96,5 @@ still resolves. Each entry points at the page that now holds the content.
 
 - [Gateway runbook](/gateway)
 - [Gateway troubleshooting](/gateway/troubleshooting)
+- [`openclaw status`](/cli/status) — local diagnosis and channel probes
+- [Configuration reference](/gateway/configuration-reference) — every setting doctor validates

--- a/docs/gateway/embedding.md
+++ b/docs/gateway/embedding.md
@@ -13,7 +13,7 @@ replaceable runtime. This keeps process ownership, readiness, failure recovery,
 and upgrades explicit without depending on OpenClaw's private state layout.
 
 For client authentication and reconnect state, read
-[Building a Gateway client](https://docs.openclaw.ai/gateway/clients).
+[Building a Gateway client](/gateway/clients).
 
 ## Start the child with an embedding preset
 
@@ -161,7 +161,7 @@ bundle, or vendor selected extension files.
 
 ## Related
 
-- [Building a Gateway client](https://docs.openclaw.ai/gateway/clients)
-- [Gateway protocol](https://docs.openclaw.ai/gateway/protocol)
-- [Gateway CLI](https://docs.openclaw.ai/cli/gateway)
-- [Gateway integrations for external apps](https://docs.openclaw.ai/gateway/external-apps)
+- [Building a Gateway client](/gateway/clients)
+- [Gateway protocol](/gateway/protocol)
+- [Gateway CLI](/cli/gateway)
+- [Gateway integrations for external apps](/gateway/external-apps)

--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -22,7 +22,7 @@ for results, cancel work, or inspect Gateway resources.
   guide pins the verified stable `2026.8.1` packages and explains how package and
   wire versions affect compatibility. If your
   app supervises the Gateway as a child process, also read
-  [Embedding OpenClaw](https://docs.openclaw.ai/gateway/embedding).
+  [Embedding OpenClaw](/gateway/embedding).
 </Note>
 
 <Note>
@@ -35,7 +35,7 @@ for results, cancel work, or inspect Gateway resources.
 | Surface                                                       | Status          | Use it for                                                                                    |
 | ------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------- |
 | [Gateway client guide](/gateway/clients#install-the-packages) | Stable packages | npm packages, auth, reconnect, history, events, approvals, and version policy.                |
-| [Embedding guide](https://docs.openclaw.ai/gateway/embedding) | Release train   | Child-process environment, readiness, lifecycle, recovery, RPC ownership, and packaging.      |
+| [Embedding guide](/gateway/embedding)                         | Release train   | Child-process environment, readiness, lifecycle, recovery, RPC ownership, and packaging.      |
 | [Gateway protocol](/gateway/protocol)                         | Ready           | WebSocket transport, connect handshake, auth scopes, protocol versioning, and events.         |
 | [Gateway RPC reference](/reference/rpc)                       | Ready           | Current Gateway methods for agents, sessions, tasks, models, tools, artifacts, and approvals. |
 | [`openclaw agent`](/cli/agent)                                | Ready           | One-shot script integration when shelling out to the CLI is enough.                           |
@@ -315,8 +315,8 @@ plugins loaded by OpenClaw.
 
 ## Related
 
-- [Building a Gateway client](https://docs.openclaw.ai/gateway/clients)
-- [Embedding OpenClaw](https://docs.openclaw.ai/gateway/embedding)
+- [Building a Gateway client](/gateway/clients)
+- [Embedding OpenClaw](/gateway/embedding)
 - [Gateway protocol](/gateway/protocol)
 - [Gateway RPC reference](/reference/rpc)
 - [CLI agent command](/cli/agent)

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -158,4 +158,4 @@ The health snapshot includes: `ok` (boolean), `ts` (timestamp), `durationMs` (pr
 - [Gateway runbook](/gateway)
 - [Diagnostics export](/gateway/diagnostics)
 - [Gateway troubleshooting](/gateway/troubleshooting)
-- [`openclaw health`](/cli/health) — request the same snapshot from the CLI
+- [`openclaw health`](/cli/health) — request this snapshot over RPC from the CLI

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -158,3 +158,4 @@ The health snapshot includes: `ok` (boolean), `ts` (timestamp), `durationMs` (pr
 - [Gateway runbook](/gateway)
 - [Diagnostics export](/gateway/diagnostics)
 - [Gateway troubleshooting](/gateway/troubleshooting)
+- [`openclaw health`](/cli/health) — request the same snapshot from the CLI

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -69,7 +69,7 @@ Gateway config reload watches the active config file path (resolved from profile
 - One always-on process for routing, control plane, and channel connections.
 - Single multiplexed port for:
   - WebSocket control/RPC
-  - HTTP APIs (`/v1/models`, `/v1/embeddings`, `/v1/chat/completions`, `/v1/responses`, `/tools/invoke`)
+  - HTTP APIs (`/v1/models`, `/v1/embeddings`, `/v1/chat/completions`, `/v1/responses`, [`/tools/invoke`](/gateway/tools-invoke-http-api))
   - Plugin HTTP routes, such as optional `/api/v1/admin/rpc`
   - Control UI and hooks
 - Default bind mode: `loopback`. Inside a detected container environment the effective default is `auto` (resolves to `0.0.0.0` for port-forwarding), unless Tailscale serve/funnel is active, which always forces `loopback`.
@@ -402,3 +402,4 @@ For full diagnosis ladders, use [Gateway Troubleshooting](/gateway/troubleshooti
 - [Authentication](/gateway/authentication)
 - [Remote access](/gateway/remote)
 - [Secrets management](/gateway/secrets)
+- [CLI backends](/gateway/cli-backends) — running an external CLI agent as a Gateway backend

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -293,3 +293,4 @@ If the model loads cleanly but full agent turns misbehave, confirm transport fir
 
 - [Configuration reference](/gateway/configuration-reference)
 - [Model failover](/concepts/model-failover)
+- [CLI backends](/gateway/cli-backends) — driving a local CLI agent instead of an API model

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -210,3 +210,4 @@ This keeps file logs stable while making interactive output scannable.
 - [Logging](/logging)
 - [OpenTelemetry export](/gateway/opentelemetry)
 - [Diagnostics export](/gateway/diagnostics)
+- [`openclaw logs`](/cli/logs) — tail and filter logs from the CLI

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -210,4 +210,4 @@ This keeps file logs stable while making interactive output scannable.
 - [Logging](/logging)
 - [OpenTelemetry export](/gateway/opentelemetry)
 - [Diagnostics export](/gateway/diagnostics)
-- [`openclaw logs`](/cli/logs) — tail and filter logs from the CLI
+- [`openclaw logs`](/cli/logs) — tail Gateway logs over RPC from the CLI

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -79,5 +79,5 @@ points at the page that now holds the content.
 - [Diagnostics flags](/diagnostics/flags) - targeted debug-log flags
 - [Diagnostics export](/gateway/diagnostics) - operator support-bundle tool (separate from OTEL export)
 - [Configuration reference](/gateway/config-observability#diagnostics) - full `diagnostics.*` field reference
-- [Prometheus metrics](/gateway/prometheus) — the Prometheus surface these metrics are exported through
-- [Audit history](/gateway/audit) — the audit ledger alongside these traces
+- [Prometheus metrics](/gateway/prometheus) - the Prometheus surface these metrics are exported through
+- [Audit history](/gateway/audit) - the audit ledger alongside these traces

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -79,3 +79,5 @@ points at the page that now holds the content.
 - [Diagnostics flags](/diagnostics/flags) - targeted debug-log flags
 - [Diagnostics export](/gateway/diagnostics) - operator support-bundle tool (separate from OTEL export)
 - [Configuration reference](/gateway/config-observability#diagnostics) - full `diagnostics.*` field reference
+- [Prometheus metrics](/gateway/prometheus) — the Prometheus surface these metrics are exported through
+- [Audit history](/gateway/audit) — the audit ledger alongside these traces

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -79,5 +79,5 @@ points at the page that now holds the content.
 - [Diagnostics flags](/diagnostics/flags) - targeted debug-log flags
 - [Diagnostics export](/gateway/diagnostics) - operator support-bundle tool (separate from OTEL export)
 - [Configuration reference](/gateway/config-observability#diagnostics) - full `diagnostics.*` field reference
-- [Prometheus metrics](/gateway/prometheus) - the Prometheus surface these metrics are exported through
+- [Prometheus metrics](/gateway/prometheus) - expose diagnostics as Prometheus text metrics through the diagnostics-prometheus plugin
 - [Audit history](/gateway/audit) - the audit ledger alongside these traces

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -408,3 +408,8 @@ shared-secret bearer auth, even if a caller sends narrower declared scopes.
 Identity-bearing modes, such as trusted proxy auth or private-ingress `none`,
 can still honor explicit declared scopes. Use separate Gateways for real trust
 boundary separation.
+
+## Related
+
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) — how a trusted proxy supplies the operator identity these scopes attach to
+- [Gateway protocol](/gateway/protocol) — the methods these scopes authorize

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -84,6 +84,11 @@ Every section heading from the previous single-page version keeps its anchor her
 
 ## Related
 
-- [Building a Gateway client](https://docs.openclaw.ai/gateway/clients)
-- [Embedding OpenClaw](https://docs.openclaw.ai/gateway/embedding)
+- [Building a Gateway client](/gateway/clients)
+- [Embedding OpenClaw](/gateway/embedding)
 - [Gateway runbook](/gateway)
+- [Operator scopes](/gateway/operator-scopes) — the scopes protocol methods are authorized against
+- [Audit history](/gateway/audit) — the ledger the audit RPCs read
+- [Pairing](/channels/pairing) — how a client is paired before it can call the protocol
+- [Cloud Workers](/gateway/cloud-workers) — worker sessions driven over this protocol
+- [Tools invoke API](/gateway/tools-invoke-http-api) — the HTTP endpoint that mirrors tool invocation

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -88,7 +88,7 @@ Every section heading from the previous single-page version keeps its anchor her
 - [Embedding OpenClaw](/gateway/embedding)
 - [Gateway runbook](/gateway)
 - [Operator scopes](/gateway/operator-scopes) — the scopes protocol methods are authorized against
-- [Audit history](/gateway/audit) — the ledger the audit RPCs read
-- [Pairing](/channels/pairing) — how a client is paired before it can call the protocol
+- [Audit history](/gateway/audit) — metadata-only activity history and decision receipts
+- [Pairing](/channels/pairing) — approve who can DM you and which nodes can join
 - [Cloud Workers](/gateway/cloud-workers) — worker sessions driven over this protocol
-- [Tools invoke API](/gateway/tools-invoke-http-api) — the HTTP endpoint that mirrors tool invocation
+- [Tools invoke API](/gateway/tools-invoke-http-api) — invoke a single tool directly via the Gateway HTTP endpoint

--- a/docs/gateway/protocol/handshake.md
+++ b/docs/gateway/protocol/handshake.md
@@ -214,7 +214,8 @@ existing token's role and scopes before any local-backend pairing exception.
 
 ### Worker role and closed protocol
 
-Workers are started and inspected with [`openclaw worker`](/cli/worker).
+A Gateway-owned launcher starts the worker process through
+[`openclaw worker`](/cli/worker); it is not a manual registration command.
 Workers use a closed protocol through either the public
 `/__openclaw__/worker` WebSocket path on the main TLS endpoint or the dedicated
 loopback ingress reached through the gateway-owned, host-key-pinned SSH tunnel.

--- a/docs/gateway/protocol/handshake.md
+++ b/docs/gateway/protocol/handshake.md
@@ -214,6 +214,7 @@ existing token's role and scopes before any local-backend pairing exception.
 
 ### Worker role and closed protocol
 
+Workers are started and inspected with [`openclaw worker`](/cli/worker).
 Workers use a closed protocol through either the public
 `/__openclaw__/worker` WebSocket path on the main TLS endpoint or the dedicated
 loopback ingress reached through the gateway-owned, host-key-pinned SSH tunnel.

--- a/docs/gateway/protocol/transport.md
+++ b/docs/gateway/protocol/transport.md
@@ -28,9 +28,9 @@ the wire protocol version and the root `openclaw` CLI release.
   `@openclaw/gateway-client/browser`.
 
 For application lifecycle guidance, see
-[Building a Gateway client](https://docs.openclaw.ai/gateway/clients). For apps
+[Building a Gateway client](/gateway/clients). For apps
 that supervise the Gateway as a child process, see
-[Embedding OpenClaw](https://docs.openclaw.ai/gateway/embedding).
+[Embedding OpenClaw](/gateway/embedding).
 
 ## Transport and framing
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -346,3 +346,4 @@ launchctl bootout gui/$UID/ai.openclaw.ssh-tunnel
 
 - [Tailscale](/gateway/tailscale)
 - [Authentication](/gateway/authentication)
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) — authenticating remote access through a reverse proxy

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -158,3 +158,4 @@ In `"non-main"` mode, group/channel keys are _not_ main. Use the main session ke
 - [Sandboxing](/gateway/sandboxing) -- full sandbox reference (modes, scopes, backends, images)
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides and precedence
 - [Elevated Mode](/tools/elevated)
+- [OpenShell](/gateway/openshell) — the shell surface these three layers bound

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -158,4 +158,4 @@ In `"non-main"` mode, group/channel keys are _not_ main. Use the main session ke
 - [Sandboxing](/gateway/sandboxing) -- full sandbox reference (modes, scopes, backends, images)
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides and precedence
 - [Elevated Mode](/tools/elevated)
-- [OpenShell](/gateway/openshell) — the shell surface these three layers bound
+- [OpenShell](/gateway/openshell) — a managed sandbox backend that runs the sandbox layer over SSH

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -637,3 +637,5 @@ Each agent can override sandbox + tools: `agents.entries.*.sandbox` and `agents.
 - [Sandbox configuration](/gateway/config-agents/sandbox#agentsdefaultssandbox)
 - [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) -- debugging "why is this blocked?"
 - [Security](/gateway/security)
+- [`openclaw sandbox`](/cli/sandbox) — inspect and exercise the sandbox from the CLI
+- [Cloud Workers](/gateway/cloud-workers) — remote worker sessions that use these sandbox settings

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -637,5 +637,5 @@ Each agent can override sandbox + tools: `agents.entries.*.sandbox` and `agents.
 - [Sandbox configuration](/gateway/config-agents/sandbox#agentsdefaultssandbox)
 - [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) -- debugging "why is this blocked?"
 - [Security](/gateway/security)
-- [`openclaw sandbox`](/cli/sandbox) — inspect and exercise the sandbox from the CLI
+- [`openclaw sandbox`](/cli/sandbox) — manage sandbox runtimes and inspect the effective sandbox policy
 - [Cloud Workers](/gateway/cloud-workers) — dispatching session work to throwaway cloud machines; its managed workspace is not an OS sandbox

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -638,4 +638,4 @@ Each agent can override sandbox + tools: `agents.entries.*.sandbox` and `agents.
 - [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) -- debugging "why is this blocked?"
 - [Security](/gateway/security)
 - [`openclaw sandbox`](/cli/sandbox) — inspect and exercise the sandbox from the CLI
-- [Cloud Workers](/gateway/cloud-workers) — remote worker sessions that use these sandbox settings
+- [Cloud Workers](/gateway/cloud-workers) — dispatching session work to throwaway cloud machines; its managed workspace is not an OS sandbox

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -941,3 +941,5 @@ This store page manages values only. Configure the corresponding `store` SecretR
 - [SecretRef Credential Surface](/reference/secretref-credential-surface) - credential surface
 - [Secrets Apply Plan Contract](/gateway/secrets-plan-contract) - plan contract details
 - [Security](/gateway/security) - security posture
+- [Configuration reference](/gateway/configuration-reference) — where each secrets and env setting is documented
+- [Ask user](/tools/ask-user) — prompting the operator for a value instead of storing it

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -942,4 +942,4 @@ This store page manages values only. Configure the corresponding `store` SecretR
 - [Secrets Apply Plan Contract](/gateway/secrets-plan-contract) - plan contract details
 - [Security](/gateway/security) - security posture
 - [Configuration reference](/gateway/configuration-reference) - where each secrets and env setting is documented
-- [Ask user](/tools/ask-user) - prompting the operator for a value instead of storing it
+- [Ask user](/tools/ask-user) - asking the operator a non-secret question; never answer it with a credential, use the masked `secrets` tool for those

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -941,5 +941,5 @@ This store page manages values only. Configure the corresponding `store` SecretR
 - [SecretRef Credential Surface](/reference/secretref-credential-surface) - credential surface
 - [Secrets Apply Plan Contract](/gateway/secrets-plan-contract) - plan contract details
 - [Security](/gateway/security) - security posture
-- [Configuration reference](/gateway/configuration-reference) — where each secrets and env setting is documented
-- [Ask user](/tools/ask-user) — prompting the operator for a value instead of storing it
+- [Configuration reference](/gateway/configuration-reference) - where each secrets and env setting is documented
+- [Ask user](/tools/ask-user) - prompting the operator for a value instead of storing it

--- a/docs/gateway/security/audit-checks.md
+++ b/docs/gateway/security/audit-checks.md
@@ -162,3 +162,4 @@ instead have unproven ownership. Ingress diagnostics distinguish
 - [Security](/gateway/security)
 - [Configuration](/gateway/configuration)
 - [Trusted proxy auth](/gateway/trusted-proxy-auth)
+- [Gateway exposure runbook](/gateway/security/exposure-runbook) — the pre-flight checklist for the exposure findings above

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -51,6 +51,11 @@ Expose and operate:
 - [Rate limiting](/gateway/security/rate-limiting) - Every Gateway rate limit: lockouts, throttles, caps, and cooldowns.
 - [Operator incident response](/gateway/security/operator-incident-response) - Contain, rotate, audit, and collect evidence after a suspected compromise.
 
+Run it from the CLI:
+
+- [`openclaw security`](/cli/security) - Run the audit, read findings, and apply the supported auto-fixes.
+- [`openclaw policy`](/cli/policy) - Inspect and test the tool policy the guidance above configures.
+
 ## Where each section moved
 
 Every anchor this page used to publish still resolves here. Each entry below carries the original anchor and links to its new home.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -48,6 +48,7 @@ Harden a deployment:
 Expose and operate:
 
 - [Gateway exposure runbook](/gateway/security/exposure-runbook) - Pre-flight and rollback checklist before exposing the Gateway beyond loopback.
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) - Running the Gateway behind a reverse proxy that supplies the operator identity.
 - [Rate limiting](/gateway/security/rate-limiting) - Every Gateway rate limit: lockouts, throttles, caps, and cooldowns.
 - [Operator incident response](/gateway/security/operator-incident-response) - Contain, rotate, audit, and collect evidence after a suspected compromise.
 

--- a/docs/gateway/troubleshooting/gateway-service-and-process.md
+++ b/docs/gateway/troubleshooting/gateway-service-and-process.md
@@ -190,7 +190,7 @@ What to do:
 
 Related:
 
-- [macOS platform notes](/platforms/mac/bundled-gateway)
+- [Gateway on macOS](/platforms/mac/bundled-gateway)
 - [Doctor](/gateway/doctor)
 - [Gateway CLI](/cli/gateway)
 

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -637,3 +637,4 @@ A Gateway token cannot replace proxy authentication. Do not send identity header
 - [Remote access](/gateway/remote) — other remote access patterns
 - [Security](/gateway/security) — full security guide
 - [Tailscale](/gateway/tailscale) — simpler alternative for tailnet-only access
+- [Security audit checks](/gateway/security/audit-checks) — the catalog entry for the trusted-proxy findings

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -149,3 +149,4 @@ In-place plugin upgrades preserve the same plugin id and config keys but may mov
 - [Install overview](/install): all installation methods.
 - [Doctor](/gateway/doctor): post-migration health check.
 - [Uninstall](/install/uninstall): removing OpenClaw cleanly.
+- [`openclaw backup`](/cli/backup) — create the archive this migration restores

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -161,3 +161,4 @@ Open a new shell and check `command -v openclaw` (PowerShell: `Get-Command openc
 
 - [Install overview](/install)
 - [Migration guide](/install/migrating)
+- [`openclaw uninstall`](/cli/uninstall) — command reference and flags

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -466,4 +466,4 @@ For OTLP export to a collector, see [OpenTelemetry export](/gateway/opentelemetr
 - [Diagnostics flags](/diagnostics/flags) — targeted debug-log flags
 - [Gateway logging internals](/gateway/logging) — WS log styles, subsystem prefixes, and console capture
 - [Configuration reference](/gateway/config-observability#diagnostics) — full `diagnostics.*` field reference
-- [`openclaw logs`](/cli/logs) — tail and filter logs from the CLI
+- [`openclaw logs`](/cli/logs) — tail Gateway logs over RPC from the CLI

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -466,3 +466,4 @@ For OTLP export to a collector, see [OpenTelemetry export](/gateway/opentelemetr
 - [Diagnostics flags](/diagnostics/flags) — targeted debug-log flags
 - [Gateway logging internals](/gateway/logging) — WS log styles, subsystem prefixes, and console capture
 - [Configuration reference](/gateway/config-observability#diagnostics) — full `diagnostics.*` field reference
+- [`openclaw logs`](/cli/logs) — tail and filter logs from the CLI

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -314,3 +314,4 @@ On channels that support audio preflight, OpenClaw transcribes audio **before** 
 - [Media understanding](/nodes/media-understanding)
 - [Talk mode](/nodes/talk)
 - [Voice wake](/nodes/voicewake)
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -56,6 +56,7 @@ Node capabilities in depth:
 - [Image and media support](/nodes/images) - Image formats and attachment handling.
 - [Audio and voice notes](/nodes/audio) - Audio capture and voice-note handling.
 - [Node troubleshooting](/nodes/troubleshooting) - Pairing, foreground, permission, and tool failures.
+- [`openclaw nodes`](/cli/nodes) - CLI reference for listing, inspecting, and managing nodes.
 
 ## Where each section moved
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -436,3 +436,4 @@ openclaw doctor --lint --only core/doctor/local-audio-acceleration --severity-mi
 - [Media playback](/nodes/media-playback)
 - [Talk mode](/nodes/talk)
 - [Voice wake](/nodes/voicewake)
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -211,3 +211,4 @@ and unlisted GPT-Live routes remain Platform-key-only.
 - [Audio and voice notes](/nodes/audio)
 - [Media understanding](/nodes/media-understanding)
 - [Google Meet plugin](/plugins/google-meet)
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -456,4 +456,4 @@ WhatsApp, WhatsApp Business, Telegram, Telegram X, Discord, and Signal notificat
 - [iOS app](/platforms/ios)
 - [Nodes](/nodes)
 - [Android node troubleshooting](/nodes/troubleshooting)
-- [Stable HTTPS URL](/gateway/stable-https-url) — give the Gateway a durable address this app can keep
+- [Stable HTTPS URL](/gateway/stable-https-url) — give a loopback-only Gateway a stable, tailnet-only HTTPS URL with Tailscale Serve

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -456,3 +456,4 @@ WhatsApp, WhatsApp Business, Telegram, Telegram X, Discord, and Signal notificat
 - [iOS app](/platforms/ios)
 - [Nodes](/nodes)
 - [Android node troubleshooting](/nodes/troubleshooting)
+- [Stable HTTPS URL](/gateway/stable-https-url) — give the Gateway a durable address this app can keep

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -636,4 +636,4 @@ same iOS limits as Talk started inside the app.
 - [Pairing](/channels/pairing)
 - [Discovery](/gateway/discovery)
 - [Bonjour](/gateway/bonjour)
-- [Stable HTTPS URL](/gateway/stable-https-url) — give the Gateway a durable address this app can keep
+- [Stable HTTPS URL](/gateway/stable-https-url) — give a loopback-only Gateway a stable, tailnet-only HTTPS URL with Tailscale Serve

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -636,3 +636,4 @@ same iOS limits as Talk started inside the app.
 - [Pairing](/channels/pairing)
 - [Discovery](/gateway/discovery)
 - [Bonjour](/gateway/bonjour)
+- [Stable HTTPS URL](/gateway/stable-https-url) — give the Gateway a durable address this app can keep

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -634,3 +634,4 @@ path even if the Codex turn has no assistant text.
 - [Agent runtimes](/concepts/agent-runtimes)
 - [Diagnostics export](/gateway/diagnostics)
 - [Trajectory export](/tools/trajectory)
+- [ACP agents](/tools/acp-agents) — how ACP agents are configured and bound

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -309,3 +309,5 @@ nine child pages below. The anchors from the single-page version still resolve h
 - [Diagnostics export](/gateway/diagnostics)
 - [Status](/cli/status)
 - [Testing](/help/testing-live#live-codex-app-server-harness-smoke)
+- [ACP agents](/tools/acp-agents) — how ACP agents are configured and bound
+- [ACP agents — setup](/tools/acp-agents-setup) — configuring this harness as an ACP agent

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -331,4 +331,4 @@ Policy and validation errors:
 ## Related
 
 - [Secrets management](/gateway/secrets)
-- [1Password](/gateway/1password) — the built-in `op://` secret source this plugin extends
+- [1Password](/gateway/1password) — the built-in `op://` secret source, and how the plugin, skill, and MCP options compare

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -331,3 +331,4 @@ Policy and validation errors:
 ## Related
 
 - [Secrets management](/gateway/secrets)
+- [1Password](/gateway/1password) — the built-in `op://` secret source this plugin extends

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -174,3 +174,4 @@ still resolves. Each entry points at the page that now holds the content.
 - [Multi-agent sandbox tools](/tools/multi-agent-sandbox-tools)
 - [`openclaw acp` (bridge mode)](/cli/acp)
 - [Sub-agents](/tools/subagents)
+- [Steer](/tools/steer) — redirect a running agent mid-task

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -157,4 +157,7 @@ openclaw agent --agent ops --message "Alert" --deliver --reply-channel telegram 
   <Card title="Slash commands" href="/tools/slash-commands" icon="slash">
     Native command catalog used inside agent sessions.
   </Card>
+  <Card title="ACP agents" href="/tools/acp-agents" icon="robot">
+    External agents reachable over ACP.
+  </Card>
 </CardGroup>

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -93,6 +93,6 @@ still resolves. Each entry points at the page that now holds the content.
 - [Tools Overview](/tools) - all available agent tools
 - [Sandboxing](/gateway/sandboxing) - browser control in sandboxed environments
 - [Security](/gateway/security) - browser control risks and hardening
-- [Web fetch](/tools/web-fetch) — retrieve a page without driving a browser
-- [Diffs](/tools/diffs) — reviewing changes the agent proposes
-- [Browser login](/tools/browser-login) — signing a profile into a site before automating it
+- [Web fetch](/tools/web-fetch) - retrieve a page without driving a browser
+- [Diffs](/tools/diffs) - reviewing changes the agent proposes
+- [Browser login](/tools/browser-login) - signing a profile into a site before automating it

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -94,5 +94,5 @@ still resolves. Each entry points at the page that now holds the content.
 - [Sandboxing](/gateway/sandboxing) - browser control in sandboxed environments
 - [Security](/gateway/security) - browser control risks and hardening
 - [Web fetch](/tools/web-fetch) - retrieve a page without driving a browser
-- [Diffs](/tools/diffs) - reviewing changes the agent proposes
+- [Diffs](/tools/diffs) - read-only diff viewer and file renderer for agents
 - [Browser login](/tools/browser-login) - signing a profile into a site before automating it

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -93,3 +93,6 @@ still resolves. Each entry points at the page that now holds the content.
 - [Tools Overview](/tools) - all available agent tools
 - [Sandboxing](/gateway/sandboxing) - browser control in sandboxed environments
 - [Security](/gateway/security) - browser control risks and hardening
+- [Web fetch](/tools/web-fetch) — retrieve a page without driving a browser
+- [Diffs](/tools/diffs) — reviewing changes the agent proposes
+- [Browser login](/tools/browser-login) — signing a profile into a site before automating it

--- a/docs/tools/code-execution.md
+++ b/docs/tools/code-execution.md
@@ -173,6 +173,7 @@ exception), so the agent can self-correct:
     Grok models, web/x search, and code execution config.
   </Card>
   <Card title="Code Mode" href="/tools/code-mode" icon="code">
-    The agent-facing mode built on this execution surface.
+    A separate surface: JavaScript/TypeScript orchestration of enabled tools in
+    OpenClaw's own worker, not this remote Python tool.
   </Card>
 </CardGroup>

--- a/docs/tools/code-execution.md
+++ b/docs/tools/code-execution.md
@@ -172,4 +172,7 @@ exception), so the agent can self-correct:
   <Card title="xAI provider" href="/providers/xai" icon="microchip">
     Grok models, web/x search, and code execution config.
   </Card>
+  <Card title="Code Mode" href="/tools/code-mode" icon="code">
+    The agent-facing mode built on this execution surface.
+  </Card>
 </CardGroup>

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -291,4 +291,7 @@ personal owner or an organization where you have publisher access.
   <Card title="Building plugins" href="/plugins/building-plugins" icon="plug">
     Plugins can ship skills alongside the tools they document.
   </Card>
+  <Card title="Slash commands" href="/tools/slash-commands" icon="terminal">
+    How the command a skill registers is invoked and gated.
+  </Card>
 </CardGroup>

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -408,3 +408,4 @@ Diff rendering engine powered by [Diffs](https://diffs.com).
 - [Browser](/tools/browser)
 - [Plugins](/tools/plugin)
 - [Tools overview](/tools)
+- [`apply_patch`](/tools/apply-patch) — the tool that produces these edits

--- a/docs/tools/elevated.md
+++ b/docs/tools/elevated.md
@@ -125,4 +125,10 @@ Allowlist entry formats:
   <Card title="Sandbox vs Tool Policy vs Elevated" href="/gateway/sandbox-vs-tool-policy-vs-elevated" icon="scale-balanced">
     How the three gates compose during a tool call.
   </Card>
+  <Card title="Multi-agent sandbox and tools" href="/tools/multi-agent-sandbox-tools" icon="shield">
+    Per-agent sandbox and tool limits.
+  </Card>
+  <Card title="Thinking levels" href="/tools/thinking" icon="brain">
+    The reasoning budget an elevated run uses.
+  </Card>
 </CardGroup>

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -320,6 +320,6 @@ Notes:
 - [Sandboxing](/gateway/sandboxing) — running commands in sandboxed environments
 - [Background Process](/gateway/background-process) — long-running exec and process tool
 - [Security](/gateway/security) — tool policy and elevated access
-- [Code Mode](/tools/code-mode) — running tool calls as code instead of one exec at a time
+- [Code Mode](/tools/code-mode) — an opt-in runtime where the model writes a program that calls the hidden tool catalog
 - [`apply_patch`](/tools/apply-patch) — apply a structured edit instead of shelling out
 - [Tokenjuice](/tools/tokenjuice) — compacting large command output

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -320,3 +320,6 @@ Notes:
 - [Sandboxing](/gateway/sandboxing) — running commands in sandboxed environments
 - [Background Process](/gateway/background-process) — long-running exec and process tool
 - [Security](/gateway/security) — tool policy and elevated access
+- [Code Mode](/tools/code-mode) — running tool calls as code instead of one exec at a time
+- [`apply_patch`](/tools/apply-patch) — apply a structured edit instead of shelling out
+- [Tokenjuice](/tools/tokenjuice) — compacting large command output

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -145,3 +145,4 @@ as provided after trimming trailing slashes.
 - [Web Search overview](/tools/web) -- all providers and auto-detection
 - [Brave Search](/tools/brave-search) -- structured results with snippets
 - [Perplexity Search](/tools/perplexity-search) -- structured results with domain filtering
+- [Kimi search](/tools/kimi-search) -- Kimi web search via Moonshot

--- a/docs/tools/grok-search.md
+++ b/docs/tools/grok-search.md
@@ -121,3 +121,4 @@ falls back to the same `webSearch.baseUrl` unless
 - [Web Search overview](/tools/web) -- all providers and auto-detection
 - [x_search in Web Search](/tools/web#x_search) -- first-class X search via xAI
 - [Gemini Search](/tools/gemini-search) -- AI-synthesized answers via Google grounding
+- [Kimi search](/tools/kimi-search) — the Moonshot-backed search tool

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -602,3 +602,4 @@ as ignored for them.
 - [xAI](/providers/xai) - Grok image, video, search, code execution, and TTS setup
 - [Configuration reference](/gateway/config-agents#agent-defaults) - `agents.defaults.mediaModels.image` config
 - [Models](/concepts/models) - model configuration and failover
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -602,4 +602,4 @@ as ignored for them.
 - [xAI](/providers/xai) - Grok image, video, search, code execution, and TTS setup
 - [Configuration reference](/gateway/config-agents#agent-defaults) - `agents.defaults.mediaModels.image` config
 - [Models](/concepts/models) - model configuration and failover
-- [Media overview](/tools/media-overview) — how the media tools fit together
+- [Media overview](/tools/media-overview) - how the media tools fit together

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -217,3 +217,4 @@ the current turn:
 - [Code Mode](/tools/code-mode) for compact JavaScript or TypeScript workflows
   over a hidden OpenClaw tool catalog
 - [Swarm](/tools/swarm) for structured fan-out and collection from Code Mode
+- [Tools invoke API](/gateway/tools-invoke-http-api) — call these tools over HTTP

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -410,4 +410,4 @@ not.
 
 - [Automation](/automation) - all automation mechanisms
 - [Tools Overview](/tools) - all available agent tools
-- [Lobster plugin reference](/plugins/reference/lobster) — manifest, config, and tool reference for the plugin
+- [Lobster plugin reference](/plugins/reference/lobster) - manifest, config, and tool reference for the plugin

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -410,3 +410,4 @@ not.
 
 - [Automation](/automation) - all automation mechanisms
 - [Tools Overview](/tools) - all available agent tools
+- [Lobster plugin reference](/plugins/reference/lobster) — manifest, config, and tool reference for the plugin

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -442,6 +442,6 @@ After configuring multi-agent sandbox and tools:
 - [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) — debugging "why is this blocked?"
 - [Sandboxing](/gateway/sandboxing) — full sandbox reference (modes, scopes, backends, images)
 - [Session management](/concepts/session)
-- [OpenShell](/gateway/openshell) — the shell surface these per-agent limits apply to
-- [ACP agents](/tools/acp-agents) — external agents these per-agent limits also cover
+- [OpenShell](/gateway/openshell) — a managed sandbox backend a per-agent sandbox can delegate to
+- [ACP agents](/tools/acp-agents) — a separate boundary: OpenClaw sandbox policy does not wrap ACP harness execution
 - [Sub-agents](/tools/subagents) — the spawned sessions these limits clamp

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -442,3 +442,6 @@ After configuring multi-agent sandbox and tools:
 - [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) — debugging "why is this blocked?"
 - [Sandboxing](/gateway/sandboxing) — full sandbox reference (modes, scopes, backends, images)
 - [Session management](/concepts/session)
+- [OpenShell](/gateway/openshell) — the shell surface these per-agent limits apply to
+- [ACP agents](/tools/acp-agents) — external agents these per-agent limits also cover
+- [Sub-agents](/tools/subagents) — the spawned sessions these limits clamp

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -392,3 +392,4 @@ sections are configured.
 - [MiniMax](/providers/minimax)
 - [Models](/concepts/models) — model configuration and failover
 - [Tools overview](/tools)
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -463,5 +463,5 @@ reload behavior, and legacy cleanup, see
 - [Plugin SDK overview](/plugins/sdk-overview) - runtime registration, hooks, and API fields
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata
 - [Context engines](/concepts/context-engine) - pluggable context assembly plugins
-- [Diffs](/tools/diffs) — reviewing changes a plugin tool proposes
-- [ACP agents — setup](/tools/acp-agents-setup) — configuring a plugin-provided ACP agent
+- [Diffs](/tools/diffs) - reviewing changes a plugin tool proposes
+- [ACP agents — setup](/tools/acp-agents-setup) - configuring a plugin-provided ACP agent

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -463,3 +463,5 @@ reload behavior, and legacy cleanup, see
 - [Plugin SDK overview](/plugins/sdk-overview) - runtime registration, hooks, and API fields
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata
 - [Context engines](/concepts/context-engine) - pluggable context assembly plugins
+- [Diffs](/tools/diffs) — reviewing changes a plugin tool proposes
+- [ACP agents — setup](/tools/acp-agents-setup) — configuring a plugin-provided ACP agent

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -463,5 +463,5 @@ reload behavior, and legacy cleanup, see
 - [Plugin SDK overview](/plugins/sdk-overview) - runtime registration, hooks, and API fields
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata
 - [Context engines](/concepts/context-engine) - pluggable context assembly plugins
-- [Diffs](/tools/diffs) - reviewing changes a plugin tool proposes
+- [Diffs](/tools/diffs) - read-only diff viewer and file renderer (optional plugin tool)
 - [ACP agents — setup](/tools/acp-agents-setup) - configuring a plugin-provided ACP agent

--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -122,3 +122,9 @@ Use the `dashboard` tool to keep the live card on the current session's dashboar
 ```
 
 Omit `props.sessionKey` to follow the dashboard's session. To show another session's card, add `"props": { "sessionKey": "agent:main:release" }`. The current connection must participate in that session; otherwise select an accessible session or change its sharing.
+
+## Related
+
+- [Tools overview](/tools)
+- [`openclaw dashboard`](/cli/dashboard) — where progress cards are rendered
+- [Control UI URLs](/web/urls) — reaching the dashboard in a browser

--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -126,5 +126,5 @@ Omit `props.sessionKey` to follow the dashboard's session. To show another sessi
 ## Related
 
 - [Tools overview](/tools)
-- [`openclaw dashboard`](/cli/dashboard) — where progress cards are rendered
-- [Control UI URLs](/web/urls) — reaching the dashboard in a browser
+- [`openclaw dashboard`](/cli/dashboard) — open the Control UI from the CLI
+- [Control UI URLs](/web/urls) — reaching the Control UI in a browser

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -627,6 +627,9 @@ See [BTW side questions](/tools/btw) for the full behavior.
   <Card title="Steer" href="/tools/steer" icon="compass">
     Guide the agent mid-run with `/steer`.
   </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="sliders">
+    Settings that change how slash commands are resolved and gated.
+  </Card>
   <Card title="OpenProse migration" href="/prose" icon="pen-nib">
     Where the removed `/prose` command went.
   </Card>

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -139,3 +139,4 @@ the page that now holds the content.
 - [Agent send](/tools/agent-send)
 - [Background tasks](/automation/tasks)
 - [Multi-agent sandbox tools](/tools/multi-agent-sandbox-tools)
+- [Steer](/tools/steer) — redirect a running agent mid-task

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -125,6 +125,8 @@ Malformed local-model reasoning tags are handled conservatively. Closed `<think>
 ## Related
 
 - Elevated mode docs live in [Elevated mode](/tools/elevated).
+- [Slash commands](/tools/slash-commands) — changing the thinking level mid-session
+- [Configuration reference](/gateway/configuration-reference) — where the thinking defaults are configured
 
 ## Heartbeats
 

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -12,7 +12,7 @@ OpenClaw converts outbound replies into native voice messages on Feishu, Matrix,
 Telegram, and WhatsApp; audio attachments everywhere else; and PCM/Ulaw streams
 for telephony and Talk.
 
-TTS is the speech-output half of Talk's `stt-tts` mode (`talk.speak` calls this
+TTS is the speech-output half of [Talk](/nodes/talk)'s `stt-tts` mode (`talk.speak` calls this
 same synthesis path). Provider-native `realtime` Talk sessions synthesize
 speech inside the realtime provider instead; `transcription` sessions never
 synthesize an assistant voice reply.
@@ -212,18 +212,23 @@ keeps the old id and points at the new one.
 
 - [Azure Speech provider](/providers/azure-speech)
 - [Azure Speech REST text-to-speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech)
+- [ElevenLabs provider](/providers/elevenlabs)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [Gradium](/providers/gradium)
+- [Inworld provider](/providers/inworld)
 - [Inworld TTS API](https://docs.inworld.ai/tts/tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
+- [MiniMax provider](/providers/minimax)
 - [MiniMax T2A v2 API](https://platform.minimaxi.com/document/T2A%20V2)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
+- [OpenAI provider](/providers/openai)
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [OpenAI text-to-speech guide](https://platform.openai.com/docs/guides/text-to-speech)
 - [speech-core](https://github.com/soniqo/speech-core)
 - [Speech Swift](https://github.com/soniqo/speech-swift)
 - [Volcengine TTS HTTP API](/providers/volcengine#text-to-speech)
+- [xAI provider](/providers/xai)
 - [xAI text to speech](https://docs.x.ai/developers/rest-api-reference/inference/voice#text-to-speech-rest)
 - [Xiaomi MiMo speech synthesis](/providers/xiaomi#text-to-speech)
 

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -562,4 +562,4 @@ openclaw config set agents.defaults.mediaModels.video.primary "qwen/wan2.6-t2v"
 - [Tools overview](/tools)
 - [Vydra](/providers/vydra)
 - [xAI](/providers/xai)
-- [Media overview](/tools/media-overview) — how the media tools fit together
+- [Media overview](/tools/media-overview) - how the media tools fit together

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -562,3 +562,4 @@ openclaw config set agents.defaults.mediaModels.video.primary "qwen/wan2.6-t2v"
 - [Tools overview](/tools)
 - [Vydra](/providers/vydra)
 - [xAI](/providers/xai)
+- [Media overview](/tools/media-overview) — how the media tools fit together

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -129,4 +129,4 @@ Non-goals for v1:
 
 - [Control UI](/web/control-ui)
 - [WebChat](/web/webchat)
-- [`openclaw dashboard`](/cli/dashboard) — open the dashboard from the CLI
+- [`openclaw dashboard`](/cli/dashboard) — securely open the Control UI from the CLI

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -129,3 +129,4 @@ Non-goals for v1:
 
 - [Control UI](/web/control-ui)
 - [WebChat](/web/webchat)
+- [`openclaw dashboard`](/cli/dashboard) — open the dashboard from the CLI

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -286,5 +286,5 @@ No output after sending a message:
 - [Config](/cli/config) — inspect, validate, and edit `openclaw.json`
 - [Doctor](/cli/doctor) — guided repair and migration checks
 - [CLI Reference](/cli) — full CLI command reference
-- [`openclaw resume`](/cli/resume) — reopen a previous session
+- [`openclaw resume`](/cli/resume) — attach the TUI to a recent Gateway session
 - [`openclaw tui`](/cli/tui) — command reference and flags for the terminal UI

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -286,3 +286,5 @@ No output after sending a message:
 - [Config](/cli/config) — inspect, validate, and edit `openclaw.json`
 - [Doctor](/cli/doctor) — guided repair and migration checks
 - [CLI Reference](/cli) — full CLI command reference
+- [`openclaw resume`](/cli/resume) — reopen a previous session
+- [`openclaw tui`](/cli/tui) — command reference and flags for the terminal UI


### PR DESCRIPTION
## What

Closes the open `link`-kind audit findings filed against `docs/cli/`, `docs/tools/`, `docs/gateway/` and `docs/channels/` (88 rows). 101 files, all under `docs/`. No anchor target changes, no prose rewrites beyond the linked phrases themselves.

**⚠️ CODEOWNERS: 6 of the changed files are owned by `@openclaw/openclaw-secops`** — `docs/gateway/sandboxing.md`, `docs/gateway/sandbox-vs-tool-policy-vs-elevated.md`, `docs/gateway/secrets.md`, `docs/gateway/security/index.md`, `docs/gateway/security/audit-checks.md`, `docs/cli/sandbox.md`. Each change there is a single added Related bullet. This needs secops review; please do not merge around it.

## Changes

1. **Absolute → root-relative links (21).** `https://docs.openclaw.ai/...` → `/...` on `gateway/protocol.md`, `gateway/protocol/transport.md`, `gateway/clients.md`, `gateway/external-apps.md`, `gateway/embedding.md`, `channels/zaloclawbot.md`. Every target was verified to resolve to a real route first. (`r3-1136`, `r3-1512`, `r3-1612`, `r3-1631`, `r3-1668`)
2. **Reverse links for one-way Related entries.** Added the missing backlink using whatever shape the target page already uses — a `-` bullet, or a `<Card>` inside its `<CardGroup>`. CLI targets are labelled with the command itself (`` [`openclaw status`](/cli/status) ``), matching the style already on `docs/cli/health.md`.
3. **Named-but-unlinked terms.** SecretRef and `gateway.trustedProxies` on `channels/sms.md`; Google Meet / Teams / Zoom on `cli/transcripts.md`; `openclaw models` and `openclaw agent` on `cli/infer.md`; Talk on `tools/tts.md`; five local provider pages in the tts Service links; `/tools/invoke` on `gateway/index.md`; the `openclaw daemon` and `openclaw clawbot qr` legacy aliases on their modern pages.
4. **Ambiguous link text.** `gateway/troubleshooting.md` had two links reading "macOS platform notes" pointing at different pages; the second is now "Gateway on macOS", which is that page's title. (`r3-1561`)
5. **Anchor fix (1).** `channels/irc.md` linked the Security index for workspace `.env` files; it now targets `/gateway/security#workspace-env-files`, an id the index publishes. (`r5-0007`)
6. **New Related sections** on pages that had none: `channels/sms.md`, `cli/transcripts.md`, `cli/promos.md`, `cli/onboard.md`, `tools/progress-card.md`, `channels/access-groups.md`, `concepts/memory.md`, `gateway/operator-scopes.md`.
7. **Glossary.** 28 new zh-CN sources for the newly introduced list-item link labels, as `check-docs-i18n-glossary.mts` requires. All are page titles or established product terms — none coined to satisfy the checker. Each is inserted **beside a related existing term**, not appended, so this does not collide on the last line with every other concurrent PR. Diff is +112/-0.

## Findings refuted

13 rows were refuted against the current tree rather than fixed. Most of these directories were split into child pages recently, and the ledger's line numbers and premises predate that.

**Three rows whose suggested fix is itself the breaking change.** The ledger reads percent-encoded anchors as suspect and proposes de-encoding them. That inverts reality: the encoded form is what `parseDocsDocument` emits. I proved it by applying each suggested fix and running the checker:

```
channels/qqbot.md      #group-channel-tool-restrictions-optional   :: fragment not found
cli/connect.md:133     #openclaw-devices-remove-deviceid           :: fragment not found
gateway/stable-https-url.md:14  #public-internet-funnel-shared-password :: fragment not found
```

All three currently resolve; applying `r3-1084`, `r3-1305` or `r5-0023` as written would break them. Reverted, and `broken_links=3` (the known pre-existing `#windows-app-node` rows) was restored.

That same break-test also establishes the checker's coverage — `<Card href>`, table-cell links and inline links are all checked — so the remaining refutations rest on a measured green, not an assumption:

- **`r3-1053`** — the Remote Mac card's `#remote-mac-over-ssh` is a Tab title, as the row says, but Tab titles mint resolvable ids. Breaking it to `#remote-mac-over-ssh-XX` produces `channels/imessage/setup.md:28 :: fragment not found`; unbroken, it resolves.
- **`r5-0268`, `r3-2464`** — both ask for explicit `tools-sessions` / `tools-agenttoagent` anchors on `config-tools.md`. Those already exist: `docs/gateway/config-tools.md:44-45` authors both the dotted and the hyphenated id. The `security/index.md:34` line the row cites also no longer exists there; that content moved to `security/trust-model.md`.
- **`r3-1519`** — `config-agents.md:44` is not a link. It is prose explaining that the pre-split dotted anchors still resolve, and the page publishes both id forms for every moved anchor.
- **`r5-0264`, `r5-0265`, `r5-0267`** — the cited anchors resolve today; the splits repointed them at the child pages that now own the headings.
- **`r5-0090`, `r5-0106`** — `channels/slack.md` is now a 153-line index and `gateway/protocol.md` an 89-line index. The cited lines (1051, 635/733/749) are past EOF, and no `/channels/slack#` self-links remain.
- **`r5-0091`** — `channels/troubleshooting.md:105` already links Slack (`/channels/slack/troubleshooting`); my scan missed it by matching only the bare route. The other Related-card targets (`/channels/groups`, `/channels/channel-routing`, `/gateway/config-channels`, `/gateway/security`, `/tools/slash-commands`) are channel-agnostic hub pages that deliberately link no specific channel — `channel-routing.md` links none at all, `groups.md` one. Adding a Slack-only backlink there would break that shape, and the row's alternative (drop them from Slack's Related cards) would cost real navigation.

## Findings partially stale

- **`r5-0071`** claims four pages don't link back to `/gateway/configuration-reference`. Two now do; the split closed them. Fixed the two that remain (`gateway/doctor.md`, `tools/slash-commands.md`).
- **`r3-1545`** — the "names Prometheus twice but never links it" half is already fixed: `gateway/opentelemetry/model-calls-and-metrics.md:257,282` link `/gateway/prometheus`. Added the Related entry the row also asks for.
- **`r3-2367`, `r3-2468`** — one target in each already had the backlink as a `<Card href>`. No change made there.
- **`r3-2343`** asks for backlinks from "seven referenced pages". Four are genuine one-way Related entries and are fixed. The rest are `/tools/acp-agents/*` split children, which do not backlink their own parent index in body prose; treating those as defects would balloon the diff without improving navigation.

## Validators

Run on the staged tree, in a worktree with `node_modules` symlinked in.

```
pnpm check:docs                                    exit 0   (the CI job's own aggregate)
node scripts/check-docs-mdx.mjs                    passed (1195 files)
node scripts/docs-link-audit.mjs                   broken_links=0  (12323 checked)
node scripts/docs-link-audit.mjs --anchors         broken_links=3  (pre-existing #windows-app-node)
npx tsx scripts/format-docs.mts --check            clean (1183 files)
npx tsx scripts/check-docs-i18n-glossary.mts       exit 0
npx markdownlint-cli2 --config config/...jsonc     0 issues in 0 files (1182 linted)
vitest full-core-unit-src.config.ts src/docs/      8 files, 16 tests passed
vitest tooling.config.ts docs-link-audit.test.ts   32 passed, 1 failed  (pre-existing)
```

The one failure is `preserves Mint component targets for raw component apostrophes...` — `expected ['ass-guide','param-ass-guide'] to deeply equal ['as-s-guide','param-as-s-guide']`. It is a slug-normalization unit test on inline fixtures, unrelated to any docs file. Reproduced identically at the merge base `2c191557f38` in a detached worktree, where `--anchors` also reports `broken_links=3`. No stash was used.

`.github/labeler.yml` needs no change: this PR adds no docs directory, and every file it touches is already matched.
