### PR TITLE
fix(update): replace unsupported Gateway service Node runtimes

### DIFF
--- a/docs/cli/gateway/service.md
+++ b/docs/cli/gateway/service.md
@@ -137,6 +137,7 @@ openclaw gateway restart
   </Accordion>
   <Accordion title="Service runtime">
     - Node is the primary, default, and recommended managed Gateway runtime.
+    - `gateway install` checks the Node executable recorded in the managed service. If it is unsupported, installation refreshes the service without requiring `--force` and reports the replacement path. This also applies when an installer or update refreshes the service. Repair prefers the current CLI's supported Node, retaining stable Homebrew paths, then checks supported system installations. Custom wrappers keep control of their runtime; protected service definitions still require their deployment owner to repair them.
     - Bun 1.4+ with WAL-reset-safe `node:sqlite` is available as an explicit opt-in with `gateway install --runtime bun`.
 
   </Accordion>

--- a/docs/cli/gateway/service.md
+++ b/docs/cli/gateway/service.md
@@ -137,7 +137,7 @@ openclaw gateway restart
   </Accordion>
   <Accordion title="Service runtime">
     - Node is the primary, default, and recommended managed Gateway runtime.
-    - `gateway install` checks the Node executable recorded in the managed service. If it is unsupported, installation refreshes the service without requiring `--force` and reports the replacement path. This also applies when an installer or update refreshes the service. Repair prefers the current CLI's supported Node, retaining stable Homebrew paths, then checks supported system installations. Custom wrappers keep control of their runtime; protected service definitions still require their deployment owner to repair them.
+    - `gateway install` checks the Node executable recorded in the managed service. If it is missing, non-executable, or unsupported, installation refreshes the service without requiring `--force` and reports the replacement path. This also applies when an installer or update refreshes the service. Repair prefers the current CLI's supported Node, retaining stable Homebrew paths, then checks supported system installations. Custom wrappers keep control of their runtime; protected service definitions still require their deployment owner to repair them.
     - Bun 1.4+ with WAL-reset-safe `node:sqlite` is available as an explicit opt-in with `gateway install --runtime bun`.
 
   </Accordion>

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1764,7 +1764,8 @@ refresh_gateway_service_if_loaded() {
   emit_json step name gateway-service status start
   log "Refreshing loaded gateway service..."
 
-  if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+  if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+    refresh_output="$(printf '%s\n' "$refresh_output" | sed '/^node-runtime-replaced$/d')"
     if [[ -n "$refresh_output" ]]; then
       emit_json step name gateway-service status warn reason definition-mutation-denied
       printf '%s\n' "Code installed; gateway service definition left unchanged; ${refresh_output}." >&2
@@ -1774,6 +1775,9 @@ refresh_gateway_service_if_loaded() {
     emit_json step name gateway-service status warn reason install-failed
     log "Warning: gateway service refresh failed; continuing."
     return 0
+  fi
+  if [[ "$refresh_output" == *node-runtime-replaced* ]]; then
+    printf '%s\n' "Gateway service Node runtime replaced." >&2
   fi
 
   # `gateway install --force` activates the replacement service. A second

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1764,7 +1764,7 @@ refresh_gateway_service_if_loaded() {
   emit_json step name gateway-service status start
   log "Refreshing loaded gateway service..."
 
-  if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+  if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/^Replacing missing Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
     refresh_output="$(printf '%s\n' "$refresh_output" | sed '/^node-runtime-replaced$/d')"
     if [[ -n "$refresh_output" ]]; then
       emit_json step name gateway-service status warn reason definition-mutation-denied

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3679,7 +3679,8 @@ refresh_gateway_service_if_loaded() {
     fi
 
     ui_info "Refreshing loaded gateway service"
-    if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+    if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+        refresh_output="$(printf '%s\n' "$refresh_output" | sed '/^node-runtime-replaced$/d')"
         if [[ -n "$refresh_output" ]]; then
             ui_warn "Code installed; gateway service definition left unchanged; ${refresh_output}"
             ui_info "Run openclaw gateway status --deep, verify the installation owner, and restart it manually if needed."
@@ -3689,6 +3690,9 @@ refresh_gateway_service_if_loaded() {
             return 0
         fi
     else
+        if [[ "$refresh_output" == *node-runtime-replaced* ]]; then
+            ui_success "Gateway service Node runtime replaced"
+        fi
         ui_success "Gateway service metadata refreshed"
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3679,7 +3679,7 @@ refresh_gateway_service_if_loaded() {
     fi
 
     ui_info "Refreshing loaded gateway service"
-    if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
+    if ! refresh_output="$({ set +x; "$claw" gateway install --force; } 2>&1 | sed -n -e 's/^Replacing unsupported Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/^Replacing missing Gateway service Node .*; refreshing the install\.$/node-runtime-replaced/p' -e 's/.*SERVICE_DEFINITION_SEALED:.*/ask the privileged deployment owner to manually repair it/p' -e 's/.*SERVICE_DEFINITION_UNKNOWN:.*/inspect service-definition access and manually repair it/p')"; then
         refresh_output="$(printf '%s\n' "$refresh_output" | sed '/^node-runtime-replaced$/d')"
         if [[ -n "$refresh_output" ]]; then
             ui_warn "Code installed; gateway service definition left unchanged; ${refresh_output}"

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -158,20 +158,40 @@ describe("runDaemonInstall integration", () => {
     clearConfigCache();
   });
 
-  it.each([
-    { platform: "darwin", force: false },
-    { platform: "linux", force: false },
-    { platform: "darwin", force: true },
-    { platform: "linux", force: true },
-  ] as const)(
-    "repairs unsupported Node in the $platform definition (force=$force)",
-    async ({ platform, force }) => {
+  it.each(
+    (
+      [
+        { platform: "darwin", force: false },
+        { platform: "linux", force: false },
+        { platform: "darwin", force: true },
+        { platform: "linux", force: true },
+      ] as const
+    ).flatMap(({ platform, force }) =>
+      ["unsupported", "missing", "non-executable"].map((condition) => ({
+        platform,
+        force,
+        condition,
+      })),
+    ),
+  )(
+    "repairs $condition Node in the $platform definition (force=$force)",
+    async ({ platform, force, condition }) => {
       vi.spyOn(process, "platform", "get").mockReturnValue(platform);
       const entry = path.join(tempHome, "dist", "index.js");
       await fs.mkdir(path.dirname(entry), { recursive: true });
       await fs.writeFile(entry, "");
       const originalArgv = process.argv;
-      const oldNode = path.join(accountHome, ".hermes", "node", "bin", "node");
+      const oldNode = path.join(
+        accountHome,
+        `.hermes-${condition}-${platform}-${force}`,
+        "node",
+        "bin",
+        "node",
+      );
+      if (condition === "non-executable") {
+        await fs.mkdir(path.dirname(oldNode), { recursive: true });
+        await fs.writeFile(oldNode, "not executable\n", { mode: 0o600 });
+      }
       const definitionPath = path.join(
         tempHome,
         platform === "darwin" ? "gateway.plist" : "gateway.service",
@@ -187,7 +207,7 @@ describe("runDaemonInstall integration", () => {
           : buildSystemdUnit({ programArguments });
       const runExec = processExec.runExec;
       vi.spyOn(processExec, "runExec").mockImplementation(async (file, args, options) => {
-        if (file === oldNode) {
+        if (file === oldNode && condition === "unsupported") {
           return {
             stdout: JSON.stringify({ nodeVersion: "22.23.1", sqliteVersion: "3.53.4" }),
             stderr: "",
@@ -239,7 +259,9 @@ describe("runDaemonInstall integration", () => {
         expect(repaired?.programArguments).toContain(entry);
         expect(await fs.readFile(definitionPath, "utf8")).not.toContain(oldNode);
         expect(runtimeLogs.join("\n")).toContain(
-          "Replacing unsupported Gateway service Node 22.23.1",
+          condition === "unsupported"
+            ? "Replacing unsupported Gateway service Node 22.23.1"
+            : `Replacing missing Gateway service Node (${oldNode})`,
         );
       } finally {
         process.argv = originalArgv;

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -14,6 +14,7 @@ import {
   buildSystemdUnitPropertyOutput,
   mockSystemAccountHome,
 } from "../../daemon/service.test-helpers.js";
+import { buildSystemdUnit, parseSystemdExecStart } from "../../daemon/systemd-unit.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { captureEnv, withEnvAsync } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
@@ -65,6 +66,11 @@ vi.mock("../../runtime.js", () => ({
 }));
 
 const { mergeInstallInvocationEnv, runDaemonInstall } = await import("./install.js");
+const { buildLaunchAgentPlist, readLaunchAgentProgramArgumentsFromFile } =
+  await import("../../daemon/launchd-plist.js");
+const { decodeLaunchAgentPlistFixture } =
+  await import("../../daemon/launchd-plist.test-support.js");
+const processExec = await import("../../process/exec.js");
 const { clearConfigCache, clearRuntimeConfigSnapshot, readConfigFileSnapshot } =
   await import("../../config/config.js");
 const { readSystemdDefinitionMutationCapability } =
@@ -143,12 +149,103 @@ describe("runDaemonInstall integration", () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "";
     process.env.OPENCLAW_GATEWAY_PASSWORD = "";
     serviceMock.isLoaded.mockResolvedValue(false);
+    serviceMock.install.mockReset();
+    serviceMock.install.mockResolvedValue(undefined);
     serviceMock.readDefinitionMutationCapability.mockResolvedValue({ kind: "writable" });
     serviceMock.readCommand.mockReset();
     serviceMock.readCommand.mockResolvedValue(null);
     await fs.writeFile(configPath, JSON.stringify({}, null, 2));
     clearConfigCache();
   });
+
+  it.each([
+    { platform: "darwin", force: false },
+    { platform: "linux", force: false },
+    { platform: "darwin", force: true },
+    { platform: "linux", force: true },
+  ] as const)(
+    "repairs unsupported Node in the $platform definition (force=$force)",
+    async ({ platform, force }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const entry = path.join(tempHome, "dist", "index.js");
+      await fs.mkdir(path.dirname(entry), { recursive: true });
+      await fs.writeFile(entry, "");
+      const originalArgv = process.argv;
+      const oldNode = path.join(accountHome, ".hermes", "node", "bin", "node");
+      const definitionPath = path.join(
+        tempHome,
+        platform === "darwin" ? "gateway.plist" : "gateway.service",
+      );
+      const render = (programArguments: string[]) =>
+        platform === "darwin"
+          ? buildLaunchAgentPlist({
+              label: "ai.openclaw.gateway",
+              programArguments,
+              stdoutPath: path.join(tempHome, "stdout.log"),
+              stderrPath: path.join(tempHome, "stderr.log"),
+            })
+          : buildSystemdUnit({ programArguments });
+      const runExec = processExec.runExec;
+      vi.spyOn(processExec, "runExec").mockImplementation(async (file, args, options) => {
+        if (file === oldNode) {
+          return {
+            stdout: JSON.stringify({ nodeVersion: "22.23.1", sqliteVersion: "3.53.4" }),
+            stderr: "",
+          };
+        }
+        if (file === "/usr/bin/plutil") {
+          if (typeof options === "number" || !options?.input) {
+            throw new Error("Missing plist fixture input");
+          }
+          return decodeLaunchAgentPlistFixture(options.input);
+        }
+        return runExec(file, args, options);
+      });
+      const readDefinition = async (): Promise<GatewayServiceCommandConfig | null> => {
+        if (platform === "darwin") {
+          return readLaunchAgentProgramArgumentsFromFile(definitionPath, {
+            requireEffective: true,
+          });
+        }
+        const unit = await fs.readFile(definitionPath, "utf8");
+        const execStart = unit.split("\n").find((line) => line.startsWith("ExecStart="));
+        if (!execStart) {
+          throw new Error("Missing systemd command");
+        }
+        return {
+          programArguments: parseSystemdExecStart(execStart.slice("ExecStart=".length)),
+          sourcePath: definitionPath,
+        };
+      };
+      await fs.writeFile(definitionPath, render([oldNode, entry, "gateway"]));
+      serviceMock.isLoaded.mockResolvedValue(true);
+      serviceMock.readCommand.mockImplementation(readDefinition);
+      serviceMock.install.mockImplementationOnce(async (plan) => {
+        if (!plan) {
+          throw new Error("Missing install plan");
+        }
+        await fs.writeFile(definitionPath, render(plan.programArguments));
+      });
+      try {
+        process.argv = [process.execPath, entry];
+        await runDaemonInstall({ json: true, force });
+        expect(serviceMock.install).toHaveBeenCalledOnce();
+        const repaired = await readDefinition();
+        const nodePath = repaired?.programArguments[0];
+        if (!nodePath) {
+          throw new Error("Missing repaired runtime");
+        }
+        expect(await fs.realpath(nodePath)).toBe(await fs.realpath(process.execPath));
+        expect(repaired?.programArguments).toContain(entry);
+        expect(await fs.readFile(definitionPath, "utf8")).not.toContain(oldNode);
+        expect(runtimeLogs.join("\n")).toContain(
+          "Replacing unsupported Gateway service Node 22.23.1",
+        );
+      } finally {
+        process.argv = originalArgv;
+      }
+    },
+  );
 
   it.each([
     { mode: "Nix before external supervision", reason: "Nix mode detected" },

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -777,20 +777,20 @@ describe("runDaemonInstall", () => {
   );
 
   it.each([
-    { failure: "probe", message: "Node runtime probe failed" },
+    { failure: "probe", message: "openclaw gateway install --force" },
     { failure: "no-replacement", message: "No supported Node runtime is available" },
     { failure: "sealed-definition", message: "SERVICE_DEFINITION_UNKNOWN" },
   ])(
     "refuses runtime repair on $failure without claiming success",
     async ({ failure, message }) => {
       service.isLoaded.mockResolvedValue(true);
-      const oldNode = "/opt/old/bin/node";
+      const oldNode = failure === "probe" ? process.execPath : "/opt/old/bin/node";
       service.readCommand.mockResolvedValue({
         programArguments: [oldNode, "/opt/openclaw/dist/index.js", "gateway"],
       });
       runExecMock.mockImplementation(async (file: string) => {
         if (failure === "probe") {
-          throw new Error("EACCES");
+          throw new Error("runtime probe timed out");
         }
         return nodeProbeOutput(
           failure === "sealed-definition" && file !== oldNode ? "26.8.1" : "22.23.1",

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,5 +1,6 @@
 // Daemon install tests cover service install command behavior and plan handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { mockSystemAccountHome } from "../../daemon/service.test-helpers.js";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
@@ -11,6 +12,7 @@ type DaemonActionResponse = Parameters<
 >[0];
 
 const resolveNodeStartupTlsEnvironmentMock = vi.hoisted(() => vi.fn());
+const runExecMock = vi.hoisted(() => vi.fn());
 const loadConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn(() => 18789));
@@ -82,12 +84,17 @@ const service = vi.hoisted(() => ({
   restart: vi.fn(async () => {}),
   stop: vi.fn(async () => {}),
   readDefinitionMutationCapability: vi.fn(async () => ({ kind: "writable" as const })),
-  readCommand: vi.fn(async () => null),
+  readCommand: vi.fn<() => Promise<GatewayServiceCommandConfig | null>>(async () => null),
   readRuntime: vi.fn(async () => ({ status: "stopped" as const })),
 }));
 
 vi.mock("../../bootstrap/node-startup-env.js", () => ({
   resolveNodeStartupTlsEnvironment: resolveNodeStartupTlsEnvironmentMock,
+}));
+
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
+  runExec: runExecMock,
 }));
 
 vi.mock("../../config/io.js", () => ({
@@ -241,9 +248,15 @@ function mockResolvedGatewayTokenSecretRef() {
 const { runDaemonInstall } = await import("./install.js");
 const envSnapshot = captureFullEnv();
 
+function nodeProbeOutput(nodeVersion: string, sqliteVersion = "3.53.4") {
+  return { stdout: JSON.stringify({ nodeVersion, sqliteVersion }), stderr: "" };
+}
+
 describe("runDaemonInstall", () => {
   beforeEach(() => {
     loadConfigMock.mockReset();
+    runExecMock.mockReset();
+    runExecMock.mockResolvedValue(nodeProbeOutput("26.8.1"));
     resolveNodeStartupTlsEnvironmentMock.mockReset();
     readConfigFileSnapshotMock.mockReset();
     resolveGatewayPortMock.mockClear();
@@ -748,6 +761,50 @@ describe("runDaemonInstall", () => {
     expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
     expectLastEmittedResult("already-installed");
   });
+
+  it.each(["3.53.4", "3.51.0"])(
+    "preserves a supported Node version with SQLite %s without force",
+    async (sqliteVersion) => {
+      service.isLoaded.mockResolvedValue(true);
+      service.readCommand.mockResolvedValue({
+        programArguments: ["/opt/supported/bin/node", "/opt/openclaw/dist/index.js", "gateway"],
+      });
+      runExecMock.mockResolvedValue(nodeProbeOutput("26.8.1", sqliteVersion));
+      await runDaemonInstall({ json: true });
+      expectLastEmittedResult("already-installed");
+      expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { failure: "probe", message: "Node runtime probe failed" },
+    { failure: "no-replacement", message: "No supported Node runtime is available" },
+    { failure: "sealed-definition", message: "SERVICE_DEFINITION_UNKNOWN" },
+  ])(
+    "refuses runtime repair on $failure without claiming success",
+    async ({ failure, message }) => {
+      service.isLoaded.mockResolvedValue(true);
+      const oldNode = "/opt/old/bin/node";
+      service.readCommand.mockResolvedValue({
+        programArguments: [oldNode, "/opt/openclaw/dist/index.js", "gateway"],
+      });
+      runExecMock.mockImplementation(async (file: string) => {
+        if (failure === "probe") {
+          throw new Error("EACCES");
+        }
+        return nodeProbeOutput(
+          failure === "sealed-definition" && file !== oldNode ? "26.8.1" : "22.23.1",
+        );
+      });
+      if (failure === "sealed-definition") {
+        service.readDefinitionMutationCapability.mockRejectedValue(new Error("sealed"));
+      }
+      await runDaemonInstall({ json: true });
+      expect(actionState.failed[0]?.message).toContain(message);
+      expect(actionState.emitted).toEqual([]);
+      expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("reinstalls when the loaded service still embeds OPENCLAW_GATEWAY_TOKEN", async () => {
     const programArguments = [

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -1,4 +1,6 @@
 // Gateway service installer: writes config defaults, resolves credentials, and installs service definitions.
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isSupportedOpenClawNodeVersion, SUPPORTED_NODE_VERSIONS } from "../../../node-version.mjs";
 import { resolveNodeStartupTlsEnvironment } from "../../bootstrap/node-startup-env.js";
@@ -32,6 +34,7 @@ import {
   isLoopbackHost,
   resolveGatewayBindHost,
 } from "../../gateway/net.js";
+import { hasErrnoCode, isMissingPathError } from "../../infra/errno.js";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -276,10 +279,19 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
   const recordedNode = existingManagedCommand?.programArguments[0];
   if (runtimeRaw === "node" && !wrapperPath && recordedNode && isNodeRuntime(recordedNode)) {
     const recordedRuntime = await resolveNodeRuntimeInfo(recordedNode, installEnv);
-    if (
-      recordedRuntime.status === "unsupported" &&
-      !isSupportedOpenClawNodeVersion(recordedRuntime.version)
-    ) {
+    const missingRuntime =
+      recordedRuntime.status === "probe-failed" &&
+      (await fs.access(recordedNode, fsConstants.X_OK).then(
+        () => false,
+        (error: unknown) => isMissingPathError(error) || hasErrnoCode(error, "EACCES"),
+      ));
+    const replacement = missingRuntime
+      ? `missing Gateway service Node (${recordedNode})`
+      : recordedRuntime.status === "unsupported" &&
+          !isSupportedOpenClawNodeVersion(recordedRuntime.version)
+        ? `unsupported Gateway service Node ${recordedRuntime.version} (${recordedNode})`
+        : undefined;
+    if (replacement) {
       try {
         runtimePath = await resolvePreferredNodePath({
           env: installEnv,
@@ -296,9 +308,11 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         fail(`Gateway runtime selection failed: ${String(error)}`);
         return;
       }
-      autoRefreshMessage = `Replacing unsupported Gateway service Node ${recordedRuntime.version} (${recordedNode}) with ${runtimePath}; refreshing the install.`;
+      autoRefreshMessage = `Replacing ${replacement} with ${runtimePath}; refreshing the install.`;
     } else if (recordedRuntime.status === "probe-failed" && !opts.force) {
-      fail(recordedRuntime.error.message);
+      fail(
+        `${recordedRuntime.error.message} Reinstall with: ${formatCliCommand("openclaw gateway install --force")}.`,
+      );
       return;
     }
   }

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -1,5 +1,6 @@
 // Gateway service installer: writes config defaults, resolves credentials, and installs service definitions.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isSupportedOpenClawNodeVersion, SUPPORTED_NODE_VERSIONS } from "../../../node-version.mjs";
 import { resolveNodeStartupTlsEnvironment } from "../../bootstrap/node-startup-env.js";
 import { buildGatewayInstallPlan } from "../../commands/daemon-install-helpers.js";
 import {
@@ -15,6 +16,8 @@ import { resolveGatewayPort } from "../../config/paths.js";
 import type { GatewayBindMode } from "../../config/types.gateway.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { OPENCLAW_WRAPPER_ENV_KEY, resolveOpenClawWrapperPath } from "../../daemon/program-args.js";
+import { isNodeRuntime } from "../../daemon/runtime-binary.js";
+import { resolveNodeRuntimeInfo, resolvePreferredNodePath } from "../../daemon/runtime-paths.js";
 import { readEmbeddedGatewayToken } from "../../daemon/service-audit.js";
 import { mergeGatewayServiceEnv } from "../../daemon/service-env-merge.js";
 import {
@@ -269,8 +272,38 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     return;
   }
   let autoRefreshMessage: string | undefined;
+  let runtimePath: string | undefined;
+  const recordedNode = existingManagedCommand?.programArguments[0];
+  if (runtimeRaw === "node" && !wrapperPath && recordedNode && isNodeRuntime(recordedNode)) {
+    const recordedRuntime = await resolveNodeRuntimeInfo(recordedNode, installEnv);
+    if (
+      recordedRuntime.status === "unsupported" &&
+      !isSupportedOpenClawNodeVersion(recordedRuntime.version)
+    ) {
+      try {
+        runtimePath = await resolvePreferredNodePath({
+          env: installEnv,
+          runtime: "node",
+          preferCurrentExecPath: true,
+        });
+        if (!runtimePath) {
+          fail(
+            `No supported Node runtime is available. Install Node ${SUPPORTED_NODE_VERSIONS}, then rerun openclaw gateway install.`,
+          );
+          return;
+        }
+      } catch (error) {
+        fail(`Gateway runtime selection failed: ${String(error)}`);
+        return;
+      }
+      autoRefreshMessage = `Replacing unsupported Gateway service Node ${recordedRuntime.version} (${recordedNode}) with ${runtimePath}; refreshing the install.`;
+    } else if (recordedRuntime.status === "probe-failed" && !opts.force) {
+      fail(recordedRuntime.error.message);
+      return;
+    }
+  }
   if (loaded && !opts.force) {
-    autoRefreshMessage = await getGatewayServiceAutoRefreshMessage({
+    autoRefreshMessage ??= await getGatewayServiceAutoRefreshMessage({
       currentCommand: existingServiceCommand,
       env: process.env,
       installEnv,
@@ -285,8 +318,10 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       if (!(await assertWritable())) {
         return;
       }
-      warn(autoRefreshMessage);
     }
+  }
+  if (autoRefreshMessage) {
+    warn(autoRefreshMessage);
   }
 
   if (configSnapshot.valid && cfg.gateway?.mode === undefined) {
@@ -341,6 +376,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       env: installEnv,
       port,
       runtime: runtimeRaw,
+      runtimePath,
       wrapperPath,
       existingCommand: existingServiceCommand,
       existingEnvironment: existingServiceEnv,

--- a/src/cli/update-cli/update-command-service-plan.test.ts
+++ b/src/cli/update-cli/update-command-service-plan.test.ts
@@ -1,7 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolvePackageRuntimePreflight } from "./update-command-service-plan.js";
 
 describe("package runtime compatibility guidance", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each(["22.23.2", "24.15.0", "25.9.0", "26.0.0"])(
+    "renders the target engine range for unsupported Node %s",
+    async (node) => {
+      vi.stubGlobal("process", { ...process, versions: { ...process.versions, node } });
+      const engine = ">=24.16.0 <25 || >=26.1.0";
+      const result = await resolvePackageRuntimePreflight({
+        target: { version: "2026.9.3", nodeEngine: engine },
+      });
+      expect(result).toEqual({
+        ok: false,
+        error: [
+          `Node ${node} is incompatible with openclaw@2026.9.3.`,
+          `The requested package requires ${engine}.`,
+          "Use a Node runtime that satisfies the engine range above, then rerun `openclaw update`.",
+          "Bare `npm i -g openclaw` can silently install an older compatible release.",
+          "After switching Node versions, use `npm i -g openclaw@latest`.",
+        ].join("\n"),
+      });
+    },
+  );
+
   for (const { name, engine } of [
     {
       name: "reports the full target range when Node is below its minimum",

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -142,6 +142,16 @@ describe.each(["node", "bun"] as const)("%s probe failures", (runtime) => {
   });
 });
 
+it("treats an unparseable Node version as a probe failure", async () => {
+  mockNodePathPresent("/usr/bin/node");
+  const result = await resolveSystemNodeInfo({
+    env: {},
+    platform: "linux",
+    execFile: async () => nodeRuntime("unparseable"),
+  });
+  expect(result?.status).toBe("probe-failed");
+});
+
 describe("resolvePreferredNodePath", () => {
   const darwinNode = "/opt/homebrew/bin/node";
   const fnmNode = "/Users/test/.fnm/node-versions/v24.16.0/installation/bin/node";

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -191,6 +191,21 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledTimes(2);
   });
 
+  it("prefers the supported CLI runtime when repairing an unsupported service runtime", async () => {
+    mockNodePathPresent(darwinNode);
+    const execFile = vi.fn().mockResolvedValue(nodeRuntime("26.8.1"));
+    expect(
+      await resolvePreferredNodePath({
+        env: {},
+        runtime: "node",
+        platform: "darwin",
+        execFile,
+        execPath: fnmNode,
+        preferCurrentExecPath: true,
+      }),
+    ).toBe(fnmNode);
+  });
+
   it.each([
     [nvmNode, true],
     ["/home/test/.local/share/fnm/aliases/default/bin/node", true],

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -6,7 +6,11 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { SUPPORTED_NODE_VERSIONS } from "../../node-version.mjs";
 import { isMissingPathError } from "../infra/errno.js";
-import { isSupportedBunVersion, isSupportedNodeVersion } from "../infra/runtime-guard.js";
+import {
+  isSupportedBunVersion,
+  isSupportedNodeVersion,
+  parseSemver,
+} from "../infra/runtime-guard.js";
 import { resolveRuntimeProcessEntrypointUrl } from "../infra/runtime-process-url.js";
 import { isSqliteWalResetSafeVersion } from "../infra/sqlite-runtime-version.js";
 import { resolveStableNodePath } from "../infra/stable-node-path.js";
@@ -226,6 +230,7 @@ async function resolveRuntimeInfo(
     const sqliteSelectionError = parsed.sqliteSelectionError;
     if (
       !(typeof version === "string" || (runtime === "bun" && version === null)) ||
+      (runtime === "node" && typeof version === "string" && !parseSemver(version)) ||
       !(typeof sqliteVersion === "string" || sqliteVersion === null) ||
       !(typeof sqliteSelectionError === "string" || sqliteSelectionError == null)
     ) {

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -265,6 +265,14 @@ export function resolveBunRuntimeInfo(
   return resolveRuntimeInfo(bunPath, "bun", execFileImpl, env);
 }
 
+/** Probes a recorded Node executable without inheriting service preloads or secrets. */
+export function resolveNodeRuntimeInfo(
+  nodePath: string,
+  env: Record<string, string | undefined> = process.env,
+) {
+  return resolveRuntimeInfo(nodePath, "node", execFileAsync, env);
+}
+
 async function isVersionManagedRealNodePath(
   nodePath: string,
   platform: NodeJS.Platform,
@@ -383,7 +391,7 @@ type RuntimePathOptions = {
 
 /** Resolves the Node binary the daemon should use for a node runtime. */
 export async function resolvePreferredNodePath(
-  params: RuntimePathOptions,
+  params: RuntimePathOptions & { preferCurrentExecPath?: boolean },
 ): Promise<string | undefined> {
   if (params.runtime !== "node") {
     return undefined;
@@ -396,7 +404,10 @@ export async function resolvePreferredNodePath(
   const currentNode = isNodeExecPath(currentExecPath, platform)
     ? await resolveRuntimeInfo(currentExecPath, "node", execFileImpl, env)
     : null;
-  if (currentNode?.status === "supported" && !isVersionManagedNodePath(currentExecPath, platform)) {
+  if (
+    currentNode?.status === "supported" &&
+    (params.preferCurrentExecPath || !isVersionManagedNodePath(currentExecPath, platform))
+  ) {
     return resolveStableNodePath(currentExecPath);
   }
 

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -679,7 +679,7 @@ describe("install-cli.sh", () => {
     expect(wrapperIndex).toBeGreaterThan(compatibilityIndex);
   });
 
-  it.each([false, true])(
+  it.each(["none", "unsupported", "missing"])(
     "reports a successful runtime replacement (%s) without restarting again",
     (replaced) => {
       const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-gateway-refresh-"));
@@ -695,7 +695,8 @@ describe("install-cli.sh", () => {
           'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
           'if [[ "$*" == "gateway install --force" ]]; then',
           '  printf "%s\\n" "incidental-output-canary"',
-          '  if [[ "$REPLACED" == 1 ]]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          '  if [[ "$REPLACED" == unsupported ]]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          '  if [[ "$REPLACED" == missing ]]; then printf "%s\\n" "Replacing missing Gateway service Node (/old/node) with /new/node; refreshing the install."; fi',
           "fi",
         ].join("\n"),
       );
@@ -711,11 +712,13 @@ describe("install-cli.sh", () => {
             "is_gateway_daemon_loaded() { return 0; }",
             "refresh_gateway_service_if_loaded",
           ].join("\n"),
-          { COMMAND_LOG: commandLog, REPLACED: replaced ? "1" : "0" },
+          { COMMAND_LOG: commandLog, REPLACED: replaced },
         );
 
         expect(result.status).toBe(0);
-        expect(result.stderr.includes("Gateway service Node runtime replaced.")).toBe(replaced);
+        expect(result.stderr.includes("Gateway service Node runtime replaced.")).toBe(
+          replaced !== "none",
+        );
         expect(result.stdout + result.stderr).not.toContain("incidental-output-canary");
         expect(result.stdout + result.stderr).not.toContain("/old/node");
         expect(result.stdout + result.stderr).not.toContain("/new/node");

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -679,38 +679,55 @@ describe("install-cli.sh", () => {
     expect(wrapperIndex).toBeGreaterThan(compatibilityIndex);
   });
 
-  it("does not restart a gateway again after force-install activates it", () => {
-    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-gateway-refresh-"));
-    const prefix = join(tmp, "prefix");
-    const bin = join(prefix, "bin");
-    const commandLog = join(tmp, "commands.log");
-    const openclaw = join(bin, "openclaw");
-    mkdirSync(bin, { recursive: true });
-    writeFileSync(openclaw, '#!/bin/bash\nprintf "%s\\n" "$*" >> "$COMMAND_LOG"\n');
-    chmodSync(openclaw, 0o755);
-
-    try {
-      const result = runInstallCliShell(
+  it.each([false, true])(
+    "reports a successful runtime replacement (%s) without restarting again",
+    (replaced) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-gateway-refresh-"));
+      const prefix = join(tmp, "prefix");
+      const bin = join(prefix, "bin");
+      const commandLog = join(tmp, "commands.log");
+      const openclaw = join(bin, "openclaw");
+      mkdirSync(bin, { recursive: true });
+      writeFileSync(
+        openclaw,
         [
-          "set -euo pipefail",
-          `cd ${JSON.stringify(process.cwd())}`,
-          `source ${JSON.stringify(SCRIPT_PATH)}`,
-          `PREFIX=${JSON.stringify(prefix)}`,
-          "is_gateway_daemon_loaded() { return 0; }",
-          "refresh_gateway_service_if_loaded",
+          "#!/bin/bash",
+          'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
+          'if [[ "$*" == "gateway install --force" ]]; then',
+          '  printf "%s\\n" "incidental-output-canary"',
+          '  if [[ "$REPLACED" == 1 ]]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          "fi",
         ].join("\n"),
-        { COMMAND_LOG: commandLog },
       );
+      chmodSync(openclaw, 0o755);
 
-      expect(result.status).toBe(0);
-      expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
-        "gateway install --force",
-        "gateway status --probe --json",
-      ]);
-    } finally {
-      rmSync(tmp, { force: true, recursive: true });
-    }
-  });
+      try {
+        const result = runInstallCliShell(
+          [
+            "set -euo pipefail",
+            `cd ${JSON.stringify(process.cwd())}`,
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            `PREFIX=${JSON.stringify(prefix)}`,
+            "is_gateway_daemon_loaded() { return 0; }",
+            "refresh_gateway_service_if_loaded",
+          ].join("\n"),
+          { COMMAND_LOG: commandLog, REPLACED: replaced ? "1" : "0" },
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stderr.includes("Gateway service Node runtime replaced.")).toBe(replaced);
+        expect(result.stdout + result.stderr).not.toContain("incidental-output-canary");
+        expect(result.stdout + result.stderr).not.toContain("/old/node");
+        expect(result.stdout + result.stderr).not.toContain("/new/node");
+        expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+          "gateway install --force",
+          "gateway status --probe --json",
+        ]);
+      } finally {
+        rmSync(tmp, { force: true, recursive: true });
+      }
+    },
+  );
 
   it.each([
     { error: "SERVICE_DEFINITION_SEALED: protected", args: "", stream: "stderr" },
@@ -731,6 +748,7 @@ describe("install-cli.sh", () => {
         'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
         'if [[ "$1" == "--version" ]]; then printf "OpenClaw 2026.8.25\\n"; exit 0; fi',
         'if [[ "$*" == "gateway install --force" ]]; then',
+        '  printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."',
         '  if [[ "$SERVICE_STREAM" == stdout ]]; then printf "%s\\n" "$SERVICE_ERROR"; else printf "%s\\n" "$SERVICE_ERROR" >&2; fi',
         '  printf "%s\\n" "$SECRET_CANARY" >&2; exit 1',
         "fi",
@@ -760,6 +778,7 @@ describe("install-cli.sh", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("+ main");
     expect(result.stdout + result.stderr).not.toContain(secretCanary);
+    expect(result.stdout + result.stderr).not.toContain("Gateway service Node runtime replaced");
     if (denied) {
       expect(result.stderr).toContain("gateway service definition left unchanged");
       expect(result.stderr).toContain(

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3918,16 +3918,28 @@ EOF
     expect(result?.stdout).toContain(`Run: ${quotedBin} gateway status --deep`);
   });
 
-  it("does not explicitly restart after force-installing a loaded gateway", () => {
-    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-gateway-transition-"));
-    const openclawBin = join(tmp, "openclaw");
-    const commandLog = join(tmp, "commands.log");
-    writeFileSync(openclawBin, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$COMMAND_LOG"\n');
-    chmodSync(openclawBin, 0o755);
+  it.each([false, true])(
+    "reports a successful runtime replacement (%s) without restarting again",
+    (replaced) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-gateway-transition-"));
+      const openclawBin = join(tmp, "openclaw");
+      const commandLog = join(tmp, "commands.log");
+      writeFileSync(
+        openclawBin,
+        [
+          "#!/bin/sh",
+          'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
+          'if [ "$*" = "gateway install --force" ]; then',
+          '  printf "%s\\n" "incidental-output-canary"',
+          '  if [ "$REPLACED" = 1 ]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          "fi",
+        ].join("\n"),
+      );
+      chmodSync(openclawBin, 0o755);
 
-    try {
-      const result = runInstallShell(
-        `
+      try {
+        const result = runInstallShell(
+          `
           set -euo pipefail
           source "${SCRIPT_PATH}"
           OPENCLAW_BIN=${JSON.stringify(openclawBin)}
@@ -3939,18 +3951,23 @@ EOF
           }
           refresh_gateway_service_if_loaded
         `,
-        { COMMAND_LOG: commandLog },
-      );
+          { COMMAND_LOG: commandLog, REPLACED: replaced ? "1" : "0" },
+        );
 
-      expect(result.status, result.stderr || result.stdout).toBe(0);
-      expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
-        "gateway install --force",
-        "gateway status --deep",
-      ]);
-    } finally {
-      rmSync(tmp, { force: true, recursive: true });
-    }
-  });
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(result.stdout.includes("Gateway service Node runtime replaced")).toBe(replaced);
+        expect(result.stdout + result.stderr).not.toContain("incidental-output-canary");
+        expect(result.stdout + result.stderr).not.toContain("/old/node");
+        expect(result.stdout + result.stderr).not.toContain("/new/node");
+        expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+          "gateway install --force",
+          "gateway status --deep",
+        ]);
+      } finally {
+        rmSync(tmp, { force: true, recursive: true });
+      }
+    },
+  );
 
   it.each([
     { error: "SERVICE_DEFINITION_SEALED: protected", stream: "stderr" },
@@ -3968,6 +3985,7 @@ EOF
         "#!/bin/bash",
         'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
         'if [[ "$*" == "gateway install --force" ]]; then',
+        '  printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."',
         '  if [[ "$SERVICE_STREAM" == stdout ]]; then printf "%s\\n" "$SERVICE_ERROR"; else printf "%s\\n" "$SERVICE_ERROR" >&2; fi',
         '  printf "%s\\n" "$SECRET_CANARY" >&2; exit 1',
         "fi",
@@ -4000,6 +4018,7 @@ EOF
       expect(result.status).toBe(0);
       expect(result.stderr).toContain("+ refresh_gateway_service_if_loaded");
       expect(result.stdout + result.stderr).not.toContain(secretCanary);
+      expect(result.stdout + result.stderr).not.toContain("Gateway service Node runtime replaced");
       if (denied) {
         expect(result.stdout).toContain("gateway service definition left unchanged");
         expect(result.stdout).toContain(

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3918,7 +3918,7 @@ EOF
     expect(result?.stdout).toContain(`Run: ${quotedBin} gateway status --deep`);
   });
 
-  it.each([false, true])(
+  it.each(["none", "unsupported", "missing"])(
     "reports a successful runtime replacement (%s) without restarting again",
     (replaced) => {
       const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-gateway-transition-"));
@@ -3931,7 +3931,8 @@ EOF
           'printf "%s\\n" "$*" >> "$COMMAND_LOG"',
           'if [ "$*" = "gateway install --force" ]; then',
           '  printf "%s\\n" "incidental-output-canary"',
-          '  if [ "$REPLACED" = 1 ]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          '  if [ "$REPLACED" = unsupported ]; then printf "%s\\n" "Replacing unsupported Gateway service Node 22.23.1 (/old/node) with /new/node; refreshing the install."; fi',
+          '  if [ "$REPLACED" = missing ]; then printf "%s\\n" "Replacing missing Gateway service Node (/old/node) with /new/node; refreshing the install."; fi',
           "fi",
         ].join("\n"),
       );
@@ -3951,11 +3952,13 @@ EOF
           }
           refresh_gateway_service_if_loaded
         `,
-          { COMMAND_LOG: commandLog, REPLACED: replaced ? "1" : "0" },
+          { COMMAND_LOG: commandLog, REPLACED: replaced },
         );
 
         expect(result.status, result.stderr || result.stdout).toBe(0);
-        expect(result.stdout.includes("Gateway service Node runtime replaced")).toBe(replaced);
+        expect(result.stdout.includes("Gateway service Node runtime replaced")).toBe(
+          replaced !== "none",
+        );
         expect(result.stdout + result.stderr).not.toContain("incidental-output-canary");
         expect(result.stdout + result.stderr).not.toContain("/old/node");
         expect(result.stdout + result.stderr).not.toContain("/new/node");


### PR DESCRIPTION
Refs #107930

## What Problem This Solves

Fixes an issue where users running `openclaw gateway install` after upgrading Node could be told the service was already installed while its recorded Node executable was unsupported. A macOS field report described Homebrew Node 26.8.1 and OpenClaw 2026.9.3 installed successfully while the LaunchAgent still referenced another tool's Node 22.23.1; forcing a reinstall recovered the Gateway.

The contradictory update-preflight guidance is already repaired on this base by #142322 (thanks @SunnyShu0925). This change adds explicit coverage for Node 22.23.2, 24.15.0, 25.9.0, and 26.0.0 against the target package's engine range.

## Why This Change Was Made

The shared Gateway install command now probes the recorded Node with the existing runtime classifier and treats an unsupported executable as a required refresh. Repair prefers the supported running CLI Node, retaining stable Homebrew paths, then uses the existing supported-system-node selection. The chosen runtime goes through the normal service install plan. Supported services, explicit wrappers, Bun selection, and service-definition ownership rules retain their existing behavior.

POSIX installer refreshes retain a fixed confirmation that Node was replaced after installation succeeds, while continuing to suppress incidental child output and runtime paths. Failed refreshes cannot report a successful runtime replacement.

## User Impact

Missing or non-executable recorded Node binaries now trigger the same supported-runtime replacement, while genuine probe failures on an existing executable retain an actionable `openclaw gateway install --force` hint.

Users can repair a stale unsupported service Node by running `openclaw gateway install` from a supported Node without adding `--force`. Installer and update refreshes share that repair. Genuine probe failures and missing supported replacements produce actionable errors instead of an already-installed result.

## Evidence

- Regressions fail against the original code: both non-force platform cases skip installation; forced cases omit the replacement notice; the resolver selects system Node instead of the requested supported CLI; both POSIX installers suppress the confirmation. The four version-guidance cases also fail with the diagnostic hunk from #142322 reverted.
- Source owner suites pass: 71 runtime-selector tests, 94 install/unit/integration tests on the final repair, and 8 target-package preflight tests.
- POSIX installer suites pass: 192 `install.sh` tests and 106 `install-cli.sh` tests, including success, failed refresh, output filtering, and no duplicate restart.
- `node scripts/check-changed.mjs`: passed, including production/test typechecks, lint, ratchets, unused-export scans, and runtime/security boundary guards. `git diff --check` and Bash syntax checks pass.

The definition fixtures use the real install plan and serializers, temporary files, a simulated obsolete Node, and the real supported CLI Node. Native service managers were not started. Windows-specific installer forwarding is outside this patch; PowerShell execution was unavailable locally. The broader preference question for an already-supported private Node in #107930 remains open. Maintainer review and landing are pending.

Compatibility evidence: this PR changes no SQLite schema, persisted user-data format, or store retention/recovery rules and introduces no service-definition format. Existing readers decode the recorded launchd/systemd definitions and the normal install plan writes their replacements. Upgrade fixtures cover unsupported, missing, and non-executable recorded Node paths with and without force, verify the Gateway entrypoint is retained, and keep supported-runtime, explicit-wrapper, genuine-probe-error, and definition-ownership controls covered. No database migration or backfill is needed.

Follow-up validation: eight missing/non-executable definition cases failed before repair and pass afterward; malformed-version and missing-notice regressions also fail before/pass after. All 173 requested owner tests, six focused installer-notice cases, and `node scripts/check-changed.mjs` pass. Independent follow-up autoreview is clean at P0/P1. Hosted CI is green for `f8066edee26fd9208464b8863ed0e956c187ca88`: https://github.com/openclaw/openclaw/actions/runs/34366200361. No rerun was needed on this head.
