### PR TITLE
fix(tests): isolate prewarm repository fixture

### DIFF
--- a/src/gateway/server.context-prewarm.remote-proof.test.ts
+++ b/src/gateway/server.context-prewarm.remote-proof.test.ts
@@ -5,10 +5,12 @@ import {
   type PerformanceEntry,
 } from "node:perf_hooks";
 import { afterEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { prepareContextWindowCaches } from "../agents/context-cache-projection.js";
 import { getContextWindowCaches, replaceContextWindowCaches } from "../agents/context-cache.js";
 import { resetContextWindowCacheForTest } from "../agents/context-runtime-state.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "../agents/prepared-model-runtime.test-support.js";
+import { initializeManagedWorktreeTestRepository } from "../agents/worktrees/service.test-support.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
 import {
@@ -18,10 +20,12 @@ import {
 } from "./test-helpers.js";
 
 installGatewayTestHooks();
+const repositories = createTempDirTracker();
 
 afterEach(async () => {
   resetContextWindowCacheForTest();
   await resetPreparedModelRuntimeSnapshotsForTest();
+  repositories.cleanup();
 });
 
 describe("Gateway context cache remote proof", () => {
@@ -53,10 +57,13 @@ describe("Gateway context cache remote proof", () => {
       scopes: ["operator.read", "operator.write", "operator.admin"],
     });
     try {
+      const workspaceDir = await initializeManagedWorktreeTestRepository(
+        repositories.make("openclaw-context-prewarm-"),
+      );
       const warmConfig = {
         agents: {
           defaults: {
-            workspace: process.cwd(),
+            workspace: workspaceDir,
             model: { primary: "synthetic-a/shared-model" },
             models: {
               "synthetic-a/shared-model": { agentRuntime: { id: "openclaw" } },
@@ -84,7 +91,7 @@ describe("Gateway context cache remote proof", () => {
       await refreshPreparedModelRuntimeSnapshots(warmConfig, {
         gatewayLifecycle: true,
         catalogMode: "static",
-        defaultWorkspaceDir: process.cwd(),
+        defaultWorkspaceDir: workspaceDir,
         allowGatewaySubagentBinding: true,
       });
       const { getPublishedPreparedModelCatalogOwnerSnapshot } =
@@ -99,7 +106,7 @@ describe("Gateway context cache remote proof", () => {
       await Promise.all([
         client.request("health", { probe: true }),
         client.request("chat.metadata", {}),
-        client.request("worktrees.branches", { repoRoot: process.cwd() }),
+        client.request("worktrees.branches", { repoRoot: workspaceDir }),
       ]);
 
       const contextModule = await import("../agents/context.js");
@@ -175,7 +182,7 @@ describe("Gateway context cache remote proof", () => {
             }),
             probeRpc("healthRpc", "health", { probe: true }),
             probeRpc("metadataRpc", "chat.metadata", {}),
-            probeRpc("branchesRpc", "worktrees.branches", { repoRoot: process.cwd() }),
+            probeRpc("branchesRpc", "worktrees.branches", { repoRoot: workspaceDir }),
           ]);
           if (!probing) {
             break;


### PR DESCRIPTION
Related: #139428.

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Resolves a problem where the Gateway context-prewarm proof fails before measurement when its checkout has enough repository references to exceed the existing branch-output limit.

## Why This Change Was Made

Give the proof a fresh, fixture-owned repository using the existing managed-worktree test helper. Use that same repository for cache preparation and branch probes, and clean it up after the case. Existing metrics, models, assertions, and deadlines remain unchanged.

## User Impact

No production behavior changes. Developers can run the existing proof independently of their checkout reference inventory.

## Evidence

- Original case reproduced the repository branch-output cap failure before measurement.
- Repaired case passed with all original assertions; reversing only the fixture change restores the original source exactly.
- Mapped changed checks and independent review passed.

This repair adds seven net test lines. No runtime acceptance or speedup is claimed.
