### PR TITLE
refactor(docs): require caller-owned route indexes

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,9 +5,9 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 ## Source Ownership
 
 - Maintainers author `/clawhub/**` pages in [openclaw/clawhub](https://github.com/openclaw/clawhub/tree/main/docs). `scripts/docs-sync-publish.mjs` replaces the entire publish `docs/clawhub/` tree from that source. Do not keep authored copies here.
-- This repo therefore holds no `/clawhub/**` page sources, even though `docs/docs.json` lists them in the navigation. A local docs preview and `pnpm docs:check-links` report those routes as missing until you point `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` at a ClawHub checkout.
+- This repo therefore holds no `/clawhub/**` page sources, even though `docs/docs.json` lists them in the navigation. Both link-audit modes accept those declared routes without a ClawHub checkout; undeclared routes still fail.
 - Keep OpenClaw-specific skill and plugin guidance in the owning OpenClaw docs, such as `docs/cli/skills.md` and `docs/cli/plugins.md`. That guidance covers installation, update, verification, removal, and release trust. Standalone ClawHub CLI and publishing reference belongs upstream.
-- For links into `/clawhub/**`, run `pnpm docs:check-links:anchors` with `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` pointing to the actual ClawHub source checkout. Local-only pages cannot prove published ClawHub routes or anchors.
+- For links into `/clawhub/**`, plain `pnpm docs:check-links` does not check fragments. To verify anchors, run `pnpm docs:check-links:anchors` with `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` pointing to the actual ClawHub source checkout. Without that source, fragments into declared mirrored routes are reported as unverified.
 
 ## Published Link Rules
 

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -373,33 +373,24 @@ function buildAuditIndex(
   };
 }
 
-let defaultAuditIndex: ReturnType<typeof buildAuditIndex> | undefined;
-
-function getDefaultAuditIndex() {
-  defaultAuditIndex ??= buildAuditIndex(DOCS_DIR);
-  return defaultAuditIndex;
-}
-
 export function resolveRoute(
   route: string,
-  options: { redirects?: Map<string, string>; routes?: Set<string> } = {},
+  { redirects, routes }: { redirects: Map<string, string>; routes: Set<string> },
 ) {
-  const redirectMap = options.redirects ?? getDefaultAuditIndex().redirects;
-  const publishedRoutes = options.routes ?? getDefaultAuditIndex().routes;
   let current = normalizeRoute(route);
   if (current === "/") {
     return { ok: true, terminal: "/" };
   }
 
   const seen = new Set([current]);
-  while (redirectMap.has(current)) {
-    current = normalizeRoute(redirectMap.get(current) ?? "");
+  while (redirects.has(current)) {
+    current = normalizeRoute(redirects.get(current) ?? "");
     if (seen.has(current)) {
       return { ok: false, terminal: current, loop: true };
     }
     seen.add(current);
   }
-  return { ok: publishedRoutes.has(current), terminal: current };
+  return { ok: routes.has(current), terminal: current };
 }
 
 /** Prepares a docs directory, mirroring ClawHub docs when available. */


### PR DESCRIPTION
## What Problem This Solves

The docs-link auditor retained a process-global index fallback after every caller moved to indexes owned by an individual audit. That unused path could build a different filesystem index from the one the caller was checking.

## Why This Change Was Made

Require both redirect and route indexes at `resolveRoute` and remove the global cache and fallback loader. All existing callers already supply both indexes. This removes nine tooling lines and keeps one owner for each audit's route inventory.

The docs guide also now matches the existing auditor: declared ClawHub routes resolve without a local checkout, while anchor checks report their fragments as unverified until the ClawHub sources are available.

## User Impact

CLI defaults, redirect handling and link-validation behavior are preserved. Contributor instructions accurately distinguish route checks from anchor verification.

## Evidence

- The same 33 existing owner tests passed before and after; no tests changed.
- All 16 selected changed-file checks passed, including full scripts typechecking. The first attempt exposed missing dependencies in a partial worktree installation; one complete private frozen install resolved all diagnostics before the successful run.
- Formatting and diff checks passed. Independent review found no actionable issues through P2.
