### PR TITLE
refactor(tests): remove duplicate Mistral cache-cost test

### DIFF
--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -39,15 +39,6 @@ describe("mistral model definitions", () => {
     }
   });
 
-  it("charges nonzero cost for cached-token usage on the default model", () => {
-    const model = buildMistralModelDefinition();
-    const cacheReadTokens = 20_000;
-    const cacheReadCost = (model.cost.cacheRead / 1_000_000) * cacheReadTokens;
-
-    expect(cacheReadCost).toBeCloseTo(0.001, 10);
-    expect(cacheReadCost).toBeGreaterThan(0);
-  });
-
   it("publishes a curated set of current Mistral catalog models", () => {
     const models = buildCatalogModels();
     const codestral = catalogModelById(models, "codestral-latest");


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

This maintainer-requested test cleanup removes a redundant Mistral cache-cost
arithmetic case. It repeats pricing already checked through the actual model
builder and arithmetic covered by the shared usage-cost tests.

## Why This Change Was Made

Remove only the cached-token arithmetic case and its separator. Retain the model
builder's full pricing contract, including `cacheRead: 0.05`, the catalog ratio
test, the curated catalog test, and every import and helper.

The shared calculator tests retain ten-decimal cached-token bucket and tier
assertions, including the one-hour cache-write subset. The default-precision
flat-cost case is not the basis for this removal.

## User Impact

No runtime or user-visible behavior changes. One test case and nine lines are
removed; production code, pricing, timeouts, and workflows are unchanged.

## Evidence

- The complete Mistral model-definition and shared usage-cost test files passed
  through the normal Vitest wrapper: 3 Mistral tests plus 24 cost tests, 27 actual
  passes and no skips.
- Targeted formatting and `git diff --check` passed.
- The selected changed-check plan completed across 18 initially passing steps
  and one successful normal retry of the final lint step. The initial aggregate
  command failed when its declaration-input guard detected a changed input; that
  original failure is preserved, not relabeled as a passing command.
- The final lint retry completed declaration sealing and the named-file lint
  command with exit 0. A separate evidence collector's missing-banner assertion
  was reconciled from the wrapper and CLI execution/exit propagation; it was not
  another lint failure. The original input-change cause remains unresolved.
- Fresh scanned P2 autoreview was scoped-clean with no findings.

This is focused local proof, not a full-suite or live-provider claim. Exact-head
hosted CI remains a separate landing requirement.
