### PR TITLE
fix(update): converge plugin cohort when core is already current

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -29,11 +29,9 @@ aligned:
 
 If the resolved package version equals the installed version without changing
 the selected channel or installation method, or the Git target SHA equals
-`HEAD`, the run finishes `skipped` with reason `already-current`. A same-version
+`HEAD`, plugin convergence still runs; if plugins remain unchanged, the run finishes `skipped` with reason `already-current`. A same-version
 explicit `--channel` or installation-method change finishes successfully.
-Neither path stops or restarts the Gateway unless the installation method
-changes. Read-only plugin convergence checks can still report repair needs; use
-`openclaw update repair` to apply them.
+Changed plugins restart a running managed Gateway unless `--no-restart` is set; retained exact pins produce the same advisories as a core update without requiring a restart.
 
 For targets that support candidate validation, the old Gateway keeps serving through `staging` and
 `validating`. The updater uses the candidate entrypoint for Doctor lint
@@ -397,7 +395,7 @@ reclaim these stages. If an interrupted update leaves one behind, confirm that
 no updater is still using it before removing that exact directory. This separation
 does not make simultaneous package swaps safe.
 
-A matching installed version is an `already-current` no-op. Real updates also
+A matching installed version skips core replacement but still converges plugins. Core updates also
 refresh core-command completion; full plugin-command completion rebuilds remain explicit
 `openclaw completion --write-state` runs.
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -26,8 +26,7 @@ the old Gateway serves, then activates and verifies the update.
 openclaw update
 ```
 
-An already-installed package version or Git target SHA finishes as
-`skipped` / `already-current` without stopping or restarting the Gateway.
+An already-installed package version or Git target SHA still runs plugin convergence, preserves exact pins with retained-pin advisories, and restarts a running managed Gateway only when plugins change and `--no-restart` is not set; unchanged runs finish as `skipped` / `already-current`.
 An explicit `--channel` choice still becomes the saved update channel.
 For targets that support candidate validation, Doctor lint, config and plugin planning, and a
 canary boot on copied state finish before the service stops. The first activation
@@ -162,7 +161,7 @@ starting the Gateway.
 
 The OpenClaw owner can say "update" (the agent uses the `gateway` action
 `update.run`) or send `/update`. The candidate validates while the old Gateway
-serves, and an already-current update does not restart it. Update runs can send
+serves, and an already-current update restarts it only when plugins change. Update runs can send
 these notices in that chat as the Gateway observes the recorded milestones:
 
 1. An acknowledgement when the update is accepted.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6366,8 +6366,262 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { restart: true, running: true, failure: undefined },
+    { restart: false, running: true, failure: undefined },
+    { restart: true, running: false, failure: undefined },
+    { restart: true, running: true, failure: "doctor" },
+    { restart: true, running: true, failure: "stop" },
+  ])(
+    "converges plugins on an already-current core (restart=$restart, running=$running, failure=$failure)",
+    async ({ restart, running, failure }) => {
+      const root = await mockPackageInstallAtCaseDir();
+      await writeOpenClawPackageFixture(root, "2026.9.3");
+      mockFileBackedPathExists();
+      vi.mocked(resolveGatewayInstallEntrypoint).mockReset();
+      readPackageVersion.mockResolvedValue("2026.9.3");
+      primeNpmChannelTag("latest", "2026.9.3");
+      if (running) {
+        mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
+      }
+      const installPath = createCaseDir("current-core-plugin");
+      await fs.mkdir(installPath, { recursive: true });
+      await writeJsonFixture(path.join(installPath, "package.json"), {
+        name: "@openclaw/brave-plugin",
+        version: "2026.9.2",
+      });
+      const record: PluginInstallRecord = {
+        source: "npm",
+        spec: "@openclaw/brave-plugin",
+        installPath,
+        version: "2026.9.2",
+      };
+      loadInstalledPluginIndexInstallRecords.mockResolvedValue({ brave: record });
+      const updatedRecord = { ...record, version: "2026.9.3" };
+      mockNpmPluginOutcomes(
+        [
+          {
+            pluginId: "brave",
+            status: "updated",
+            currentVersion: "2026.9.2",
+            nextVersion: "2026.9.3",
+            message: "Updated brave: 2026.9.2 -> 2026.9.3.",
+          },
+        ],
+        true,
+        { ...baseConfig, plugins: { ...baseConfig.plugins, installs: { brave: updatedRecord } } },
+      );
+      runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+        ...postCoreConvergenceResult(),
+        installRecords: { brave: updatedRecord },
+      });
+
+      if (failure === "doctor") {
+        const runFixtureExec = requireValue(
+          vi.mocked(runExec).getMockImplementation(),
+          "fixture exec",
+        );
+        vi.mocked(runExec).mockImplementation(async (file, args, options) => {
+          if (args[1] === "doctor" && args.includes("--repair")) {
+            throw new Error("plugin Doctor failed");
+          }
+          return runFixtureExec(file, args, options);
+        });
+      } else if (failure === "stop") {
+        serviceStop.mockImplementationOnce(async (params: { onMutation?: () => void }) => {
+          serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+          params.onMutation?.();
+          throw new Error("listener check failed after stop");
+        });
+      }
+      if (failure) {
+        await expect(updateCommand({ yes: true, restart, json: true })).rejects.toEqual(
+          new ExitError(1),
+        );
+        expect(serviceStop).toHaveBeenCalledOnce();
+        expect(freshRestartCalls()).toHaveLength(0);
+        expect(lastWriteJsonCall()).toMatchObject({
+          status: "error",
+          reason: "post-update-plugins",
+          run: { verification: { serviceRunning: false } },
+        });
+        return;
+      }
+      await updateCommand({ yes: true, restart, json: true });
+
+      expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
+      expect(updateNpmInstalledPlugins).toHaveBeenCalledWith(
+        expect.objectContaining({ coreVersion: "2026.9.3", syncOfficialPluginInstalls: true }),
+      );
+      expect(lastWriteJsonCall()).toMatchObject({
+        status: "ok",
+        postUpdate: {
+          plugins: {
+            changed: true,
+            warnings: [],
+            npm: { outcomes: [expect.objectContaining({ pluginId: "brave", status: "updated" })] },
+          },
+        },
+      });
+      expect(serviceStop).toHaveBeenCalledTimes(restart && running ? 1 : 0);
+      expect(freshRestartCalls()).toHaveLength(restart && running ? 1 : 0);
+      expect(packageInstallCommandCall()).toBeUndefined();
+      expect(candidateValidation).not.toHaveBeenCalled();
+      if (!restart) {
+        expect(lastWriteJsonCall()).toMatchObject({
+          run: {
+            origin: {
+              nextAction: expect.stringContaining("Gateway restart skipped (--no-restart)"),
+            },
+          },
+        });
+      }
+      if (restart && running) {
+        expect(updateNpmInstalledPlugins.mock.invocationCallOrder[0]).toBeLessThan(
+          serviceStop.mock.invocationCallOrder[0]!,
+        );
+      }
+    },
+  );
+
+  it.each(["unavailable plugin", "changed service owner"])(
+    "refuses %s before already-current convergence",
+    async (failure) => {
+      const root = await mockPackageInstallAtCaseDir();
+      readPackageVersion.mockResolvedValue("2026.9.3");
+      primeNpmChannelTag("latest", "2026.9.3");
+      mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
+      if (failure === "unavailable plugin") {
+        pluginAvailabilityPreflight.mockRejectedValueOnce(
+          new updateCliShared.UpdatePreMutationError(
+            "plugin-target-unavailable",
+            "Plugin target unavailable",
+          ),
+        );
+      } else {
+        pluginAvailabilityPreflight.mockImplementationOnce(async () => {
+          primeServiceCommand(["node", "/foreign/openclaw/dist/index.js", "gateway", "run"]);
+        });
+      }
+      await expect(updateCommand({ yes: true, json: true })).rejects.toEqual(new ExitError(1));
+      expect(lastWriteJsonCall()).toMatchObject({
+        status: "error",
+        reason:
+          failure === "unavailable plugin"
+            ? "plugin-target-unavailable"
+            : "managed-service-preflight",
+      });
+      expectNoSideEffects(
+        updateNpmInstalledPlugins,
+        syncPluginsForUpdateChannel,
+        serviceStop,
+        serviceRestart,
+      );
+      expect(packageInstallCommandCall()).toBeUndefined();
+    },
+  );
+
+  it("converges a current Git core using its before-only version receipt", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValueOnce({
+      status: "skipped",
+      mode: "git",
+      root: process.cwd(),
+      reason: "already-current",
+      before: { version: "2026.9.3", sha: "abc123" },
+      steps: [],
+      durationMs: 1,
+    });
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(FRESH_POST_UPDATE_ENTRYPOINT);
+    await updateCommand({ yes: true, restart: false, json: true });
+    expect(pluginAvailabilityPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({ targetVersion: "2026.9.3" }),
+    );
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
+    expect(lastWriteJsonCall()).toMatchObject({
+      status: "skipped",
+      reason: "already-current",
+      after: { version: "2026.9.3", sha: "abc123" },
+      postUpdate: { plugins: { changed: false } },
+    });
+    expectNoSideEffects(serviceStop, serviceRestart, runDaemonRestart);
+  });
+
+  it.each([false, true])(
+    "reports retained pins on an already-current core (json=%s)",
+    async (json) => {
+      const root = await mockPackageInstallAtCaseDir();
+      await writeOpenClawPackageFixture(root, "2026.9.3");
+      readPackageVersion.mockResolvedValue("2026.9.3");
+      primeNpmChannelTag("latest", "2026.9.3");
+      mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
+      const installPath = createCaseDir("current-core-pin");
+      await fs.mkdir(installPath, { recursive: true });
+      await writeJsonFixture(path.join(installPath, "package.json"), {
+        name: "@openclaw/discord",
+        version: "2026.9.2",
+      });
+      const records: Record<string, PluginInstallRecord> = {
+        discord: {
+          source: "npm",
+          spec: "@openclaw/discord@2026.9.2",
+          installPath,
+          version: "2026.9.2",
+        },
+      };
+      loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      const message =
+        "discord is pinned to @openclaw/discord@2026.9.2 (installed 2026.9.2); registry latest resolves to 2026.9.3. Pass `openclaw plugins update @openclaw/discord@latest` to replace this version pin.";
+      mockNpmPluginOutcomes(
+        [
+          {
+            pluginId: "discord",
+            status: "unchanged",
+            currentVersion: "2026.9.2",
+            nextVersion: "2026.9.3",
+            message,
+          },
+        ],
+        false,
+        { ...baseConfig, plugins: { ...baseConfig.plugins, installs: records } },
+      );
+      runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+        ...postCoreConvergenceResult(),
+        installRecords: records,
+      });
+
+      await updateCommand({ yes: true, json });
+
+      expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
+      expectNoSideEffects(serviceStop, serviceRestart, runDaemonRestart);
+      expect(freshRestartCalls()).toHaveLength(0);
+      if (json) {
+        expect(lastWriteJsonCall()).toMatchObject({
+          status: "skipped",
+          reason: "already-current",
+          postUpdate: {
+            plugins: {
+              status: "warning",
+              changed: false,
+              warnings: [
+                expect.objectContaining({
+                  pluginId: "discord",
+                  reason: "retained-plugin-pin",
+                  message: expect.stringContaining(message),
+                }),
+              ],
+            },
+          },
+        });
+      } else {
+        expect(stripAnsi(getLogOutput())).toContain(message);
+      }
+      expect(writePersistedInstalledPluginIndexInstallRecordsWithLease).not.toHaveBeenCalled();
+      expect(records.discord?.spec).toBe("@openclaw/discord@2026.9.2");
+    },
+  );
+
   it.each([true, false])(
-    "never stops a same-version managed gateway (restart=%s)",
+    "never stops an unchanged same-version managed gateway (restart=%s)",
     async (restart) => {
       const root = await mockPackageInstallAtCaseDir();
       readPackageVersion.mockResolvedValue("2026.4.22");
@@ -6376,13 +6630,8 @@ describe("update-cli", () => {
 
       await updateCommand({ yes: true, restart, json: true });
 
-      expectNoSideEffects(
-        serviceStop,
-        serviceRestart,
-        runDaemonRestart,
-        candidateValidation,
-        updateNpmInstalledPlugins,
-      );
+      expectNoSideEffects(serviceStop, serviceRestart, runDaemonRestart, candidateValidation);
+      expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
       expect(packageInstallCommandCall()?.[0]).toBeUndefined();
       expect(replaceConfigFile).not.toHaveBeenCalled();
       expect(lastWriteJsonCall()).toMatchObject({ status: "skipped", reason: "already-current" });
@@ -6413,14 +6662,8 @@ describe("update-cli", () => {
     });
 
     expect(lastReplaceConfigCall()?.nextConfig?.update?.channel).toBe("beta");
-    expectNoSideEffects(
-      serviceStop,
-      serviceRestart,
-      runDaemonRestart,
-      candidateValidation,
-      syncPluginsForUpdateChannel,
-      updateNpmInstalledPlugins,
-    );
+    expectNoSideEffects(serviceStop, serviceRestart, runDaemonRestart, candidateValidation);
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
     expect(packageInstallCommandCall()?.[0]).toBeUndefined();
     expect(doctorCommandCall()).toBeUndefined();
     expect(lastWriteJsonCall()).toMatchObject({ status: "ok" });
@@ -6451,14 +6694,8 @@ describe("update-cli", () => {
     });
 
     expect(replaceConfigFile).not.toHaveBeenCalled();
-    expectNoSideEffects(
-      serviceStop,
-      serviceRestart,
-      runDaemonRestart,
-      candidateValidation,
-      syncPluginsForUpdateChannel,
-      updateNpmInstalledPlugins,
-    );
+    expectNoSideEffects(serviceStop, serviceRestart, runDaemonRestart, candidateValidation);
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
     expect(packageInstallCommandCall()?.[0]).toBeUndefined();
     expect(doctorCommandCall()).toBeUndefined();
     expect(lastWriteJsonCall()).toMatchObject({ status: "skipped", reason: "already-current" });
@@ -10145,7 +10382,7 @@ describe("update-cli", () => {
     expect(packageInstallCommandCall()?.[0]).toBeUndefined();
     expect(doctorCommandCall()).toBeUndefined();
     expect(spawnCall()).toBeUndefined();
-    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
     expect(getLogOutput()).toContain("already-current");
   });
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -10761,6 +10761,136 @@ describe("update-cli", () => {
     },
   );
 
+  it.each([
+    { fallback: false, restart: true, writable: true, refreshFails: false },
+    { fallback: true, restart: true, writable: true, refreshFails: false },
+    { fallback: true, restart: false, writable: true, refreshFails: false },
+    { fallback: true, restart: true, writable: false, refreshFails: false },
+    { fallback: true, restart: true, writable: true, refreshFails: true },
+  ])(
+    "admits managed Node before already-current plugin maintenance ($fallback, restart=$restart, writable=$writable, refreshFails=$refreshFails)",
+    async ({ fallback, restart, writable, refreshFails }) => {
+      const servicePrefix = tempDirs.make("openclaw-current-runtime-");
+      const { nodeModules, root, serviceNode, serviceNpm, serviceNpmReal, entrypoint } =
+        await setupServicePackageAtPrefix({ prefix: servicePrefix, version: "2026.9.3" });
+      mockPackageInstallStatus(root);
+      readPackageVersion.mockResolvedValue("2026.9.3");
+      primeServiceCommand([serviceNode, entrypoint, "gateway"]);
+      serviceLoaded.mockResolvedValue(true);
+      if (!writable) {
+        serviceDefinitionMutationCapability.mockResolvedValue({
+          kind: "sealed",
+          detail: "test service owner",
+        });
+      }
+      serviceReadRuntime.mockResolvedValue({
+        status: "running",
+        pid: gatewayFixturePid,
+        state: "running",
+      });
+      primeNpmChannelTag("latest", "2026.9.3");
+      vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+        packageTargetStatus({ version: "2026.9.3", nodeEngine: ">=24.16.0 <25 || >=26.1.0" }),
+      );
+      nodeVersionSatisfiesEngine.mockImplementation(
+        (version) => fallback && version === process.versions.node,
+      );
+      mockFileBackedPathExists();
+      vi.mocked(resolveGatewayInstallEntrypoint).mockReset();
+      mockServicePackageCommands({
+        nodeModules,
+        packageRoot: root,
+        targetVersion: "2026.9.3",
+        npmCommands: [serviceNpm, serviceNpmReal!],
+        nodeVersions: {
+          [serviceNode]: "v22.23.1",
+          [process.execPath]: `v${process.versions.node}`,
+        },
+      });
+      const fixtureCommand = requireValue(
+        vi.mocked(runCommandWithTimeout).getMockImplementation(),
+        "runtime fixture command",
+      );
+      vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+        if (argv[2] === "gateway" && argv[3] === "install") {
+          if (refreshFails) {
+            return commandResult({ code: 1, stderr: "runtime refresh failed" });
+          }
+          primeServiceCommand([argv[0], entrypoint, "gateway"]);
+        }
+        return fixtureCommand(argv, options);
+      });
+      const installPath = createCaseDir("current-runtime-plugin");
+      await fs.mkdir(installPath, { recursive: true });
+      await writeJsonFixture(path.join(installPath, "package.json"), {
+        name: "@openclaw/brave-plugin",
+        version: "2026.9.2",
+      });
+      const record: PluginInstallRecord = {
+        source: "npm",
+        spec: "@openclaw/brave-plugin",
+        installPath,
+        version: "2026.9.2",
+      };
+      loadInstalledPluginIndexInstallRecords.mockResolvedValue({ brave: record });
+      const updated = { ...record, version: "2026.9.3" };
+      mockNpmPluginOutcomes(
+        [
+          {
+            pluginId: "brave",
+            status: "updated",
+            currentVersion: "2026.9.2",
+            nextVersion: "2026.9.3",
+            message: "Updated brave.",
+          },
+        ],
+        true,
+        { ...baseConfig, plugins: { ...baseConfig.plugins, installs: { brave: updated } } },
+      );
+      runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+        ...postCoreConvergenceResult(),
+        installRecords: { brave: updated },
+      });
+
+      if (!fallback || !restart || !writable) {
+        await expect(updateCommand({ yes: true, restart, json: true })).rejects.toEqual(
+          new ExitError(1),
+        );
+        expect(lastWriteJsonCall()).toMatchObject({
+          status: "error",
+          reason: "node-runtime-preflight",
+        });
+        expect(getErrorOutput()).toContain(
+          "Use a compatible version of the Node runtime that owns the managed Gateway service",
+        );
+        expectNoSideEffects(
+          updateNpmInstalledPlugins,
+          syncPluginsForUpdateChannel,
+          serviceStop,
+          serviceRestart,
+        );
+      } else if (refreshFails) {
+        await expect(updateCommand({ yes: true, json: true })).rejects.toEqual(new ExitError(1));
+        expect(unattendedRepair).not.toHaveBeenCalled();
+        expect(freshRestartCalls()).toHaveLength(0);
+        expect(serviceRestart).not.toHaveBeenCalled();
+        expect((await serviceReadCommand(process.env))?.programArguments[0]).toBe(serviceNode);
+      } else {
+        await updateCommand({ yes: true, json: true });
+        expect(lastWriteJsonCall()).toMatchObject({
+          status: "ok",
+          postUpdate: { plugins: { changed: true } },
+        });
+        const install = gatewayCommandCall(entrypoint, "install");
+        expect(install?.[0][0]).toBe(process.execPath);
+        expect((await serviceReadCommand(process.env))?.programArguments[0]).toBe(process.execPath);
+        expect(serviceStop).toHaveBeenCalledOnce();
+        expect(freshRestartCalls()).toHaveLength(0);
+      }
+      expect(packageInstallCommandCall()).toBeUndefined();
+    },
+  );
+
   it("refreshes the managed service to current Node when its baked Node cannot run the target", async () => {
     const servicePrefix = tempDirs.make("openclaw-service-prefix-");
     const { nodeModules, root, serviceNode, serviceNpm, serviceNpmReal, entrypoint } =

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -5,19 +5,13 @@ import path from "node:path";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
-import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { hasErrnoCode } from "../../infra/errors.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
 import { normalizePackageTagInput } from "../../infra/package-tag.js";
-import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
 import { parseSemver } from "../../infra/runtime-guard.js";
-import type { UpdateStateSchemaVersion } from "../../infra/update-candidate-state.js";
-import type { UpdateChannel } from "../../infra/update-channels.js";
 import { fetchNpmTagVersion } from "../../infra/update-check.js";
-import type { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-plane-sentinel.js";
 import {
   canResolveRegistryVersionForPackageTarget,
   createGlobalInstallEnv,
@@ -30,12 +24,9 @@ import { runStep } from "../../infra/update-runner-command.js";
 import type { UpdateStepProgress, UpdateStepResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
-import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { pathExists } from "../../utils.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../completion-runtime.js";
 import { isJsonOutputModeActive } from "../json-output-mode.js";
-import type { UpdateConfigSnapshot } from "./update-command-config-snapshot.js";
-import type { UpdateRestartParams } from "./update-command-restart-context.js";
 
 export type UpdateCommandOptions = {
   /** Internal orchestration context, shared across update phases and child processes. */
@@ -53,32 +44,6 @@ export type UpdateCommandOptions = {
   tag?: string;
   timeout?: string;
   yes?: boolean;
-};
-
-export type FinishUpdateParams = UpdateRestartParams & {
-  coreAlreadyCurrent?: boolean;
-  failure?: { cause: unknown; detail: string };
-  mutationStarted: boolean;
-  expectedVersion?: string;
-  previousInstallRoot?: string;
-  installKindChanged: boolean;
-  configSnapshot: ConfigFileSnapshot;
-  requestedChannel: UpdateChannel | null;
-  storedChannel: UpdateChannel | null;
-  channel: UpdateChannel;
-  downgradeRisk: boolean;
-  opts: UpdateCommandOptions;
-  controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
-  preUpdatePluginInstallRecords: Record<string, PluginInstallRecord>;
-  startedAt: number;
-  packageUpdateNodeRunner?: string;
-  packageTransaction?: PackageUpdateTransaction;
-  schemaVersions?: UpdateStateSchemaVersion[];
-  candidateSchemaVersions?: OpenClawSchemaVersions;
-  previousSchemaVersions?: OpenClawSchemaVersions;
-  previousVerified?: boolean;
-  activationConfig?: UpdateConfigSnapshot;
-  rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
 };
 
 export type UpdateStatusOptions = {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -5,13 +5,19 @@ import path from "node:path";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { hasErrnoCode } from "../../infra/errors.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
 import { normalizePackageTagInput } from "../../infra/package-tag.js";
+import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
 import { parseSemver } from "../../infra/runtime-guard.js";
+import type { UpdateStateSchemaVersion } from "../../infra/update-candidate-state.js";
+import type { UpdateChannel } from "../../infra/update-channels.js";
 import { fetchNpmTagVersion } from "../../infra/update-check.js";
+import type { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-plane-sentinel.js";
 import {
   canResolveRegistryVersionForPackageTarget,
   createGlobalInstallEnv,
@@ -24,9 +30,12 @@ import { runStep } from "../../infra/update-runner-command.js";
 import type { UpdateStepProgress, UpdateStepResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { pathExists } from "../../utils.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../completion-runtime.js";
 import { isJsonOutputModeActive } from "../json-output-mode.js";
+import type { UpdateConfigSnapshot } from "./update-command-config-snapshot.js";
+import type { UpdateRestartParams } from "./update-command-restart-context.js";
 
 export type UpdateCommandOptions = {
   /** Internal orchestration context, shared across update phases and child processes. */
@@ -44,6 +53,32 @@ export type UpdateCommandOptions = {
   tag?: string;
   timeout?: string;
   yes?: boolean;
+};
+
+export type FinishUpdateParams = UpdateRestartParams & {
+  coreAlreadyCurrent?: boolean;
+  failure?: { cause: unknown; detail: string };
+  mutationStarted: boolean;
+  expectedVersion?: string;
+  previousInstallRoot?: string;
+  installKindChanged: boolean;
+  configSnapshot: ConfigFileSnapshot;
+  requestedChannel: UpdateChannel | null;
+  storedChannel: UpdateChannel | null;
+  channel: UpdateChannel;
+  downgradeRisk: boolean;
+  opts: UpdateCommandOptions;
+  controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
+  preUpdatePluginInstallRecords: Record<string, PluginInstallRecord>;
+  startedAt: number;
+  packageUpdateNodeRunner?: string;
+  packageTransaction?: PackageUpdateTransaction;
+  schemaVersions?: UpdateStateSchemaVersion[];
+  candidateSchemaVersions?: OpenClawSchemaVersions;
+  previousSchemaVersions?: OpenClawSchemaVersions;
+  previousVerified?: boolean;
+  activationConfig?: UpdateConfigSnapshot;
+  rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
 };
 
 export type UpdateStatusOptions = {
@@ -481,4 +516,47 @@ export async function tryWriteCompletionCache(
     );
   }
   return "failed";
+}
+
+export async function confirmUpdateDowngrade(params: {
+  opts: UpdateCommandOptions;
+  currentVersion: string | null;
+  targetVersion: string | null;
+  tag: string;
+}): Promise<boolean> {
+  const { confirm, isCancel } = await import("@clack/prompts");
+  const { finishUpdateRun } = await import("../../infra/update-run-ledger.js");
+  const { stylePromptMessage } =
+    await import("../../../packages/terminal-core/src/prompt-style.js");
+  const { opts, currentVersion, targetVersion, tag } = params;
+  const run = opts.run!;
+  if (!process.stdin.isTTY || opts.json) {
+    finishUpdateRun(
+      run.runId,
+      { status: "skipped", reason: "downgrade-confirmation-required" },
+      { env: run.env },
+    );
+    defaultRuntime.error(
+      "Downgrade confirmation required.\nDowngrading can break configuration. Re-run in a TTY to confirm.",
+    );
+    defaultRuntime.exit(1);
+    return false;
+  }
+
+  const targetLabel = targetVersion ?? `${tag} (unknown)`;
+  const message = `Downgrading from ${currentVersion} to ${targetLabel} can break configuration. Continue?`;
+  const ok = await confirm({
+    message: stylePromptMessage(message),
+    initialValue: false,
+  });
+  if (isCancel(ok) || !ok) {
+    finishUpdateRun(run.runId, { status: "skipped", reason: "cancelled" }, { env: run.env });
+    if (!opts.json) {
+      defaultRuntime.log(theme.muted("Update cancelled."));
+    }
+    defaultRuntime.exit(0);
+    return false;
+  }
+
+  return true;
 }

--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -21,6 +21,7 @@ import {
 } from "./update-command-post-core.js";
 
 export async function convergeUpdatePlugins(params: {
+  coreAlreadyCurrent?: boolean;
   result: UpdateRunResult;
   root: string;
   installKindChanged: boolean;
@@ -168,7 +169,7 @@ export async function convergeUpdatePlugins(params: {
         postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
       }
 
-      const resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
+      let resultWithPostUpdate: UpdateRunResult = postCorePluginUpdate
         ? {
             ...params.result,
             status: postCorePluginUpdate.status === "error" ? "error" : params.result.status,
@@ -179,6 +180,15 @@ export async function convergeUpdatePlugins(params: {
             },
           }
         : params.result;
+      if (
+        params.coreAlreadyCurrent &&
+        resultWithPostUpdate.status !== "error" &&
+        (postCorePluginUpdate?.changed ||
+          (params.requestedChannel !== null && params.requestedChannel !== params.storedChannel))
+      ) {
+        resultWithPostUpdate = { ...resultWithPostUpdate, status: "ok" };
+        delete resultWithPostUpdate.reason;
+      }
       if (params.opts.run) {
         recordUpdateRunStep(
           params.opts.run.runId,

--- a/src/cli/update-cli/update-command-migrated.ts
+++ b/src/cli/update-cli/update-command-migrated.ts
@@ -20,7 +20,7 @@ import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-version
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { CLI_NAME } from "../cli-name.js";
 import { resolveNodeRunner } from "./shared.js";
-import type { FinishUpdateParams } from "./update-command-post-update.js";
+import type { FinishUpdateParams } from "./update-command-post-update-types.js";
 import { UpdateCommandFailure } from "./update-command-result.js";
 import {
   resolveUpdatedInstallCommandEnv,

--- a/src/cli/update-cli/update-command-noop.ts
+++ b/src/cli/update-cli/update-command-noop.ts
@@ -12,7 +12,8 @@ import {
   withOwnedManagedUpdateEnv,
 } from "./update-command-managed-context.js";
 import { preflightConfiguredNpmPluginTargets } from "./update-command-plugin-preflight.js";
-import { finishUpdate, type FinishUpdateParams } from "./update-command-post-update.js";
+import type { FinishUpdateParams } from "./update-command-post-update-types.js";
+import { finishUpdate } from "./update-command-post-update.js";
 import {
   GatewayServiceUpdateOwnershipError,
   type ManagedServiceRootRedirect,

--- a/src/cli/update-cli/update-command-noop.ts
+++ b/src/cli/update-cli/update-command-noop.ts
@@ -1,6 +1,6 @@
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-state-ownership.js";
-import { readPackageVersion, UpdatePreMutationError } from "./shared.js";
+import { readPackageVersion, resolveNodeRunner, UpdatePreMutationError } from "./shared.js";
 import { inspectUpdateDatabaseContexts } from "./update-command-database-context.js";
 import {
   formatUpdateAncestryBlockMessage,
@@ -16,6 +16,7 @@ import type { FinishUpdateParams } from "./update-command-post-update-types.js";
 import { finishUpdate } from "./update-command-post-update.js";
 import {
   GatewayServiceUpdateOwnershipError,
+  resolvePackageRuntimePreflight,
   type ManagedServiceRootRedirect,
 } from "./update-command-service-plan.js";
 import {
@@ -43,6 +44,7 @@ export async function finishAlreadyCurrentUpdate(
     | "ownedManagedUpdateEnv"
   > & {
     managedServiceRootRedirect: ManagedServiceRootRedirect | null;
+    runtimeTarget?: { version: string; nodeEngine: string | null };
     stop: () => void;
     refuseUpdate: (reason: string, message?: string) => Promise<void>;
   },
@@ -68,6 +70,24 @@ export async function finishAlreadyCurrentUpdate(
       managedServiceRootRedirect: params.managedServiceRootRedirect,
     };
     const admission = await inspectUpdateDatabaseContexts(inspection);
+    const service = admission.service;
+    const runtime = await resolvePackageRuntimePreflight({
+      target: params.runtimeTarget,
+      installedRoot: params.root,
+      nodeRunner: service?.serviceNodeRunner ?? params.packageUpdateNodeRunner,
+      fallbackNodeRunner:
+        params.shouldRestart &&
+        service?.running &&
+        service.serviceUpdateVerdict?.kind === "owned" &&
+        service.serviceUpdateVerdict.refreshDefinition
+          ? resolveNodeRunner()
+          : undefined,
+      timeoutMs: params.updateStepTimeoutMs,
+    });
+    if (!runtime.ok) {
+      throw new UpdatePreMutationError("node-runtime-preflight", runtime.error);
+    }
+    const packageUpdateNodeRunner = runtime.value.nodeRunner;
     const context = admission.contexts.at(-1)!;
     await preflightConfiguredNpmPluginTargets({
       config: context.configSnapshot.sourceConfig,
@@ -97,7 +117,7 @@ export async function finishAlreadyCurrentUpdate(
                 ? undefined
                 : (result.after.version ?? undefined),
             timeoutMs: params.updateStepTimeoutMs,
-            nodeRunner: params.packageUpdateNodeRunner,
+            nodeRunner: packageUpdateNodeRunner,
             invocationCwd: params.invocationCwd,
             stopProgress: params.stop,
           }),
@@ -132,6 +152,8 @@ export async function finishAlreadyCurrentUpdate(
     params.stop();
     await finishUpdate({
       ...params,
+      packageUpdateNodeRunner,
+      serviceRuntimeRefreshRequired: runtime.value.replacedNodeRunner !== undefined,
       result: { ...result, status: "skipped", reason: "already-current" },
       coreAlreadyCurrent: true,
       mutationStarted: false,

--- a/src/cli/update-cli/update-command-noop.ts
+++ b/src/cli/update-cli/update-command-noop.ts
@@ -1,64 +1,157 @@
-import { createConfigIO } from "../../config/io.js";
-import { normalizeUpdateChannel } from "../../infra/update-channels.js";
-import { recordUpdateRunStep } from "../../infra/update-run-ledger.js";
-import type { UpdateRunResult } from "../../infra/update-runner.js";
-import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
-import { collectMissingPluginInstallPayloads } from "../../plugins/payload-verification.js";
-import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
-import { printResult } from "./progress.js";
-import type { UpdateCommandOptions } from "./shared.js";
-import { persistRequestedUpdateChannel } from "./update-command-config.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
-import { completeUpdateCommandRun } from "./update-command-run.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-state-ownership.js";
+import { readPackageVersion, UpdatePreMutationError } from "./shared.js";
+import { inspectUpdateDatabaseContexts } from "./update-command-database-context.js";
+import {
+  formatUpdateAncestryBlockMessage,
+  handoffUpdateFromGateway,
+} from "./update-command-handoff.js";
+import {
+  captureOwnedManagedUpdateContext,
+  revalidateUpdateDatabaseContext,
+  withOwnedManagedUpdateEnv,
+} from "./update-command-managed-context.js";
+import { preflightConfiguredNpmPluginTargets } from "./update-command-plugin-preflight.js";
+import { finishUpdate, type FinishUpdateParams } from "./update-command-post-update.js";
+import {
+  GatewayServiceUpdateOwnershipError,
+  type ManagedServiceRootRedirect,
+} from "./update-command-service-plan.js";
+import {
+  maybeStopManagedServiceBeforeMutableUpdate,
+  shouldBlockMutableUpdateFromGatewayServiceEnv,
+  UpdateCommandAbort,
+} from "./update-command-service.js";
 
-/** A same-version request inspects payloads without running repair or touching the service. */
-export async function finishAlreadyCurrentUpdate(params: {
-  opts: UpdateCommandOptions;
-  result: UpdateRunResult;
-  env?: NodeJS.ProcessEnv;
-}): Promise<void> {
-  const run = params.opts.run!;
-  const env = params.env ?? run.env;
-  const startedAtMs = Date.now();
-  const snapshot = await createConfigIO({
-    env,
-    observe: false,
-    pluginValidation: "skip",
-  }).readConfigFileSnapshot();
-  if (params.opts.channel) {
-    await withOwnedManagedUpdateEnv(env, () =>
-      withPluginLifecycleLease({}, async () => {
-        await persistRequestedUpdateChannel({
-          configSnapshot: snapshot,
-          requestedChannel: normalizeUpdateChannel(params.opts.channel),
-        });
-      }),
-    );
-  }
-  const records = await loadInstalledPluginIndexInstallRecords({ env });
-  const missing = await collectMissingPluginInstallPayloads({
-    records,
-    config: snapshot.config,
-    skipDisabledPlugins: true,
-    env,
+/** A current core still owns plugin convergence, but only changed plugins need activation. */
+export async function finishAlreadyCurrentUpdate(
+  params: Pick<
+    FinishUpdateParams,
+    | "opts"
+    | "result"
+    | "root"
+    | "requestedChannel"
+    | "storedChannel"
+    | "channel"
+    | "shouldRestart"
+    | "updateStepTimeoutMs"
+    | "invocationCwd"
+    | "startedAt"
+    | "controlPlaneUpdateSentinelMeta"
+    | "packageUpdateNodeRunner"
+    | "ownedManagedUpdateEnv"
+  > & {
+    managedServiceRootRedirect: ManagedServiceRootRedirect | null;
+    stop: () => void;
+    refuseUpdate: (reason: string, message?: string) => Promise<void>;
+  },
+): Promise<void> {
+  await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () => {
+    const result = {
+      ...params.result,
+      after: {
+        ...(params.result.after ?? params.result.before),
+        version:
+          params.result.after?.version ??
+          params.result.before?.version ??
+          (await readPackageVersion(params.root)),
+      },
+    };
+    const inspection = {
+      roots: [params.root],
+      updateInstallKind: params.result.mode === "git" ? ("git" as const) : ("package" as const),
+      shouldRestart: params.shouldRestart,
+      jsonMode: Boolean(params.opts.json),
+      timeoutMs: params.updateStepTimeoutMs,
+      invocationCwd: params.invocationCwd,
+      managedServiceRootRedirect: params.managedServiceRootRedirect,
+    };
+    const admission = await inspectUpdateDatabaseContexts(inspection);
+    const context = admission.contexts.at(-1)!;
+    await preflightConfiguredNpmPluginTargets({
+      config: context.configSnapshot.sourceConfig,
+      env: context.env,
+      targetVersion: result.after.version,
+      channel: params.channel,
+      timeoutMs: params.updateStepTimeoutMs,
+    });
+    await inspectUpdateDatabaseContexts({ ...inspection, expectedServices: admission.services });
+    await Promise.all(admission.contexts.map(revalidateUpdateDatabaseContext));
+    let stopState;
+    try {
+      stopState = await maybeStopManagedServiceBeforeMutableUpdate({
+        ...inspection,
+        root: params.root,
+        phase: "inspect",
+        expectedService: admission.services.get(params.root),
+        updateRun: params.opts.run,
+        handoffFromGateway: (state) =>
+          handoffUpdateFromGateway({
+            state,
+            root: params.root,
+            mode: params.result.mode,
+            opts: params.opts,
+            tag:
+              params.channel === "extended-stable"
+                ? undefined
+                : (result.after.version ?? undefined),
+            timeoutMs: params.updateStepTimeoutMs,
+            nodeRunner: params.packageUpdateNodeRunner,
+            invocationCwd: params.invocationCwd,
+            stopProgress: params.stop,
+          }),
+      });
+    } catch (error) {
+      if (error instanceof UpdateCommandAbort) {
+        return;
+      }
+      throw error;
+    }
+    if (
+      stopState.blockMessage ||
+      shouldBlockMutableUpdateFromGatewayServiceEnv({ preManagedServiceStop: stopState })
+    ) {
+      throw new UpdatePreMutationError(
+        "managed-service-preflight",
+        formatUpdateAncestryBlockMessage(
+          stopState.blockMessage ??
+            "Run openclaw update from a terminal outside the Gateway service before changing installed plugins.",
+        ),
+      );
+    }
+    await assertOpenClawStateWriteAllowedAtPath({
+      databasePath: resolveOpenClawStateSqlitePath(context.env),
+      env: context.env,
+    });
+    const owned = await captureOwnedManagedUpdateContext({
+      stopState,
+      invocationCwd: params.invocationCwd,
+    });
+    const env = owned?.env ?? context.env;
+    params.stop();
+    await finishUpdate({
+      ...params,
+      result: { ...result, status: "skipped", reason: "already-current" },
+      coreAlreadyCurrent: true,
+      mutationStarted: false,
+      installKindChanged: false,
+      downgradeRisk: false,
+      preManagedServiceStop: stopState,
+      ownedManagedUpdateEnv: env,
+      configSnapshot: owned?.configSnapshot ?? context.configSnapshot,
+      preUpdatePluginInstallRecords: owned?.pluginInstallRecords ?? {},
+    });
+  }).catch(async (error: unknown) => {
+    if (
+      error instanceof UpdatePreMutationError ||
+      error instanceof GatewayServiceUpdateOwnershipError
+    ) {
+      await params.refuseUpdate(
+        error instanceof UpdatePreMutationError ? error.reason : "managed-service-preflight",
+        error.message,
+      );
+      return;
+    }
+    throw error;
   });
-  recordUpdateRunStep(
-    run.runId,
-    {
-      step: "plugin convergence check",
-      status: "completed",
-      startedAtMs,
-      endedAtMs: Date.now(),
-      detail: missing.length
-        ? `${missing.length} plugin payload(s) need repair; run openclaw update repair.`
-        : "Installed plugin payloads are present.",
-    },
-    { env: run.env },
-  );
-  const result = completeUpdateCommandRun(params.result, run, 0);
-  printResult(
-    result,
-    params.opts,
-    missing.length ? { nextAction: "Run openclaw update repair to repair plugin payloads." } : {},
-  );
 }

--- a/src/cli/update-cli/update-command-post-update-repair.test.ts
+++ b/src/cli/update-cli/update-command-post-update-repair.test.ts
@@ -102,7 +102,8 @@ vi.mock("./update-command-result.js", async (importOriginal) => ({
   writeControlPlaneUpdateRestartSentinelBestEffort: async () => {},
   markControlPlaneUpdateRestartSentinelFailureBestEffort: async () => {},
 }));
-import { finishUpdate, type FinishUpdateParams } from "./update-command-post-update.js";
+import type { FinishUpdateParams } from "./update-command-post-update-types.js";
+import { finishUpdate } from "./update-command-post-update.js";
 import { repairUpdateService } from "./update-command-repair-service.js";
 import { revalidateManagedGatewayServiceAfterUpdate } from "./update-command-service-maintenance.js";
 import { verifyUpdatedGateway } from "./update-command-verification.js";

--- a/src/cli/update-cli/update-command-post-update-types.ts
+++ b/src/cli/update-cli/update-command-post-update-types.ts
@@ -1,0 +1,36 @@
+import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
+import type { UpdateStateSchemaVersion } from "../../infra/update-candidate-state.js";
+import type { UpdateChannel } from "../../infra/update-channels.js";
+import type { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-plane-sentinel.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import type { UpdateCommandOptions } from "./shared.js";
+import type { UpdateConfigSnapshot } from "./update-command-config-snapshot.js";
+import type { UpdateRestartParams } from "./update-command-restart-context.js";
+
+export type FinishUpdateParams = UpdateRestartParams & {
+  coreAlreadyCurrent?: boolean;
+  failure?: { cause: unknown; detail: string };
+  mutationStarted: boolean;
+  expectedVersion?: string;
+  previousInstallRoot?: string;
+  installKindChanged: boolean;
+  configSnapshot: ConfigFileSnapshot;
+  requestedChannel: UpdateChannel | null;
+  storedChannel: UpdateChannel | null;
+  channel: UpdateChannel;
+  downgradeRisk: boolean;
+  opts: UpdateCommandOptions;
+  controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
+  preUpdatePluginInstallRecords: Record<string, PluginInstallRecord>;
+  startedAt: number;
+  packageUpdateNodeRunner?: string;
+  packageTransaction?: PackageUpdateTransaction;
+  schemaVersions?: UpdateStateSchemaVersion[];
+  candidateSchemaVersions?: OpenClawSchemaVersions;
+  previousSchemaVersions?: OpenClawSchemaVersions;
+  previousVerified?: boolean;
+  activationConfig?: UpdateConfigSnapshot;
+  rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
+};

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -18,10 +18,11 @@ import { defaultRuntime } from "../../runtime.js";
 import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
 import { formatCliCommand } from "../command-format.js";
 import { printResult } from "./progress.js";
-import { tryWriteCompletionCache, type FinishUpdateParams } from "./shared.js";
+import { tryWriteCompletionCache } from "./shared.js";
 import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import { retireStandaloneGitWrapper } from "./update-command-git.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+import type { FinishUpdateParams } from "./update-command-post-update-types.js";
 import { repairUpdateService } from "./update-command-repair-service.js";
 import { prepareUpdateRestart } from "./update-command-restart-context.js";
 import {
@@ -49,8 +50,6 @@ import {
   type PreManagedServiceStop,
 } from "./update-command-service.js";
 import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
-
-export type { FinishUpdateParams } from "./shared.js";
 
 export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRunResult> {
   const shouldRestart =

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -503,6 +503,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           result: resultWithPostUpdate,
           opts: params.opts,
           refreshServiceEnv: refreshGatewayServiceEnv,
+          serviceRuntimeRefreshRequired: params.serviceRuntimeRefreshRequired,
           serviceUpdateVerdict,
           serviceEnv: gatewayServiceEnv,
           serviceInstallEnv: gatewayServiceInstallEnv,
@@ -539,10 +540,12 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         reason: verificationFailure,
         recovery: { serviceRestartSafe: false, reason: "runtime-verification-failed" },
       };
+      const canRepairService =
+        serviceMutationAllowed && !skipLegacyServiceRestart && !postVerificationRepairAttempted;
       const recovered = await recoverFailedResult(
         failure,
         false,
-        serviceMutationAllowed && !skipLegacyServiceRestart && !postVerificationRepairAttempted
+        verificationFailure !== "service-runtime-refresh-failed" && canRepairService
           ? (result) =>
               repairUpdateService({
                 result,
@@ -640,7 +643,9 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         });
         pendingRestartAtMs ??= Date.now();
         restartScriptPath = null;
-        refreshGatewayServiceEnv = false;
+        if (!params.serviceRuntimeRefreshRequired) {
+          refreshGatewayServiceEnv = false;
+        }
         if (params.coreAlreadyCurrent) {
           await notifyRestart();
         }

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -3,12 +3,8 @@ import type { TriageFailureContext } from "../../commands/triage-prompt.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
-import type { UpdateStateSchemaVersion } from "../../infra/update-candidate-state.js";
-import type { UpdateChannel } from "../../infra/update-channels.js";
 import {
   buildControlPlaneUpdateRestartHealthPendingResult,
-  readControlPlaneUpdateSentinelMeta,
   resolveManagedServiceUpdateFailureExitCode,
 } from "../../infra/update-control-plane-sentinel.js";
 import {
@@ -18,21 +14,16 @@ import {
   recordUpdateRunStep,
 } from "../../infra/update-run-ledger.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
-import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { defaultRuntime } from "../../runtime.js";
 import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
-import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { formatCliCommand } from "../command-format.js";
 import { printResult } from "./progress.js";
-import { tryWriteCompletionCache, type UpdateCommandOptions } from "./shared.js";
+import { tryWriteCompletionCache, type FinishUpdateParams } from "./shared.js";
 import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import { retireStandaloneGitWrapper } from "./update-command-git.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { repairUpdateService } from "./update-command-repair-service.js";
-import {
-  prepareUpdateRestart,
-  type UpdateRestartParams,
-} from "./update-command-restart-context.js";
+import { prepareUpdateRestart } from "./update-command-restart-context.js";
 import {
   markControlPlaneUpdateRestartSentinelFailureBestEffort,
   UpdateCommandFailure,
@@ -59,32 +50,12 @@ import {
 } from "./update-command-service.js";
 import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
 
-export type FinishUpdateParams = UpdateRestartParams & {
-  failure?: { cause: unknown; detail: string };
-  mutationStarted: boolean;
-  expectedVersion?: string;
-  previousInstallRoot?: string;
-  installKindChanged: boolean;
-  configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
-  requestedChannel: UpdateChannel | null;
-  storedChannel: UpdateChannel | null;
-  channel: UpdateChannel;
-  downgradeRisk: boolean;
-  opts: UpdateCommandOptions;
-  controlPlaneUpdateSentinelMeta: Awaited<ReturnType<typeof readControlPlaneUpdateSentinelMeta>>;
-  preUpdatePluginInstallRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>;
-  startedAt: number;
-  packageUpdateNodeRunner?: string;
-  packageTransaction?: PackageUpdateTransaction;
-  schemaVersions?: UpdateStateSchemaVersion[];
-  candidateSchemaVersions?: OpenClawSchemaVersions;
-  previousSchemaVersions?: OpenClawSchemaVersions;
-  previousVerified?: boolean;
-  activationConfig?: import("./update-command-config-snapshot.js").UpdateConfigSnapshot;
-  rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
-};
+export type { FinishUpdateParams } from "./shared.js";
 
 export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRunResult> {
+  const shouldRestart =
+    params.shouldRestart &&
+    (!params.coreAlreadyCurrent || params.preManagedServiceStop?.running === true);
   let gateway: TriageFailureContext["gateway"] = "preserve";
   let triageAllowed = true;
   const createFailure = (
@@ -119,7 +90,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
     );
   };
   let rolledBack = false;
-  let completedDowntimeMs: number | undefined;
+  let completedDowntimeMs: number | undefined = params.coreAlreadyCurrent ? 0 : undefined;
   let pendingRestartAtMs =
     params.preManagedServiceStop?.stoppedAtMs ??
     params.controlPlaneUpdateSentinelMeta?.serviceStoppedAtMs;
@@ -145,6 +116,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
     const active = run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
     const nextAction = resolveUpdateResultNextAction({
       result,
+      restart: params.coreAlreadyCurrent ? params.opts.restart : undefined,
       serviceRunning: active?.verification.serviceRunning,
       runningVersion: active?.verification.runningVersion,
       verificationFailure: active?.steps.findLast(
@@ -331,7 +303,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         finalResult.steps = [...finalResult.steps, retained];
       }
     }
-    if (finalResult.status === "error" && !rolledBack && params.preManagedServiceStop?.stopped) {
+    if (finalResult.status === "error" && !rolledBack && currentServiceStop()?.stopped) {
       await recordFailedUpdateGatewayState(
         params.opts.run,
         currentServiceStop()?.serviceEnv ?? process.env,
@@ -432,7 +404,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
       );
     }
 
-    if (params.result.status === "skipped") {
+    if (params.result.status === "skipped" && !params.coreAlreadyCurrent) {
       const reported = await reportResult(
         params.result,
         params.result.recovery?.serviceRestartSafe === true,
@@ -462,11 +434,17 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
     // Plugin install/sync changes shared payloads, config, and the installed index.
     // Start the rehearsed core first; a changed plugin snapshot gets one later restart.
     const deferPluginConvergence =
-      params.shouldRestart && params.preManagedServiceStop?.stopped === true;
+      shouldRestart &&
+      (params.preManagedServiceStop?.stopped === true ||
+        (params.coreAlreadyCurrent === true &&
+          params.preManagedServiceStop?.serviceUpdateVerdict?.kind === "owned"));
     let resultWithPostUpdate = params.result;
     let postUpdateConfigSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | undefined;
     if (!deferPluginConvergence) {
       ({ resultWithPostUpdate, postUpdateConfigSnapshot } = await convergePlugins());
+      if (params.coreAlreadyCurrent) {
+        return await reportResult(resultWithPostUpdate);
+      }
     }
     const restartConfigSnapshot =
       postUpdateConfigSnapshot ??
@@ -479,7 +457,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
     let restartContext;
     try {
       restartContext = await prepareUpdateRestart(
-        { ...params, result: resultWithPostUpdate },
+        { ...params, shouldRestart, result: resultWithPostUpdate },
         restartConfigSnapshot,
       );
     } catch (error) {
@@ -508,18 +486,21 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
     } = restartContext;
     let { gatewayPort } = restartContext;
 
-    await writeControlPlaneUpdateRestartSentinelBestEffort({
-      meta: params.controlPlaneUpdateSentinelMeta,
-      result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
-      jsonMode: Boolean(params.opts.json),
-    });
-
-    await restoreWindowsAutoStart(resultWithPostUpdate);
+    const notifyRestart = () =>
+      writeControlPlaneUpdateRestartSentinelBestEffort({
+        meta: params.controlPlaneUpdateSentinelMeta,
+        result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
+        jsonMode: Boolean(params.opts.json),
+      });
+    if (!params.coreAlreadyCurrent) {
+      await notifyRestart();
+      await restoreWindowsAutoStart(resultWithPostUpdate);
+    }
     let verificationFailure = "restart-unhealthy";
     const restart = async () => {
       const restarted = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
         maybeRestartService({
-          shouldRestart: params.shouldRestart && serviceMutationAllowed,
+          shouldRestart: shouldRestart && serviceMutationAllowed,
           result: resultWithPostUpdate,
           opts: params.opts,
           refreshServiceEnv: refreshGatewayServiceEnv,
@@ -531,7 +512,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           invocationCwd: params.invocationCwd,
           nodeRunner: params.packageUpdateNodeRunner,
           skipLegacyServiceRestart,
-          requireRunningServiceAfterRestart: params.preManagedServiceStop?.stopped === true,
+          requireRunningServiceAfterRestart: currentServiceStop()?.stopped === true,
           serviceMutationSkipMessage,
           timeoutMs: params.updateStepTimeoutMs,
           onVerificationFailure: (reason) => {
@@ -600,7 +581,9 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         throw createFailure(reported, resolveManagedServiceUpdateFailureExitCode(reported));
       }
     };
-    await restart();
+    if (!params.coreAlreadyCurrent) {
+      await restart();
+    }
     if (deferPluginConvergence) {
       ({ resultWithPostUpdate, postUpdateConfigSnapshot } = await convergePlugins(async () => {
         const before = currentServiceStop();
@@ -617,9 +600,14 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           shouldRestart: true,
           jsonMode: Boolean(params.opts.json),
           expectedService: { serviceEnv: gatewayServiceEnv, serviceUpdateVerdict },
-          activatedInstall: params,
+          activatedInstall: params.coreAlreadyCurrent ? undefined : params,
           timeoutMs: params.updateStepTimeoutMs,
+          onStopped: (state) => {
+            rollbackStopState = state;
+            pendingRestartAtMs ??= state.stoppedAtMs;
+          },
         });
+        rollbackStopState = stopped;
         before.windowsTaskAutoStartRecovery = stopped.windowsTaskAutoStartRecovery;
         if (stopped.blockMessage || !stopped.stopped) {
           throw new Error(
@@ -654,9 +642,15 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         pendingRestartAtMs ??= Date.now();
         restartScriptPath = null;
         refreshGatewayServiceEnv = false;
+        if (params.coreAlreadyCurrent) {
+          await notifyRestart();
+        }
         await restoreWindowsAutoStart(resultWithPostUpdate);
         await restart();
       }
+    }
+    if (params.coreAlreadyCurrent) {
+      return await reportResult(resultWithPostUpdate);
     }
     // Restart and health verification own recovery of the service stopped for this update.
     // Optional completion refresh must run only after that lifecycle boundary settles.

--- a/src/cli/update-cli/update-command-restart-context.ts
+++ b/src/cli/update-cli/update-command-restart-context.ts
@@ -30,6 +30,7 @@ export type UpdateRestartParams = {
   invocationCwd?: string;
   shouldRestart: boolean;
   updateStepTimeoutMs: number;
+  serviceRuntimeRefreshRequired?: boolean;
 };
 
 export async function prepareUpdateRestart(
@@ -144,6 +145,15 @@ export async function prepareUpdateRestart(
         "Code update completed; gateway service management skipped because its current ownership could not be inspected. " +
         "Run `openclaw gateway status --deep` before restarting it manually.";
     }
+  }
+  if (
+    params.serviceRuntimeRefreshRequired &&
+    (!serviceMutationAllowed || !refreshGatewayServiceEnv || gatewayServiceInstallEnv === null)
+  ) {
+    throw new GatewayServiceUpdateOwnershipError(
+      "Replacing the unsupported Gateway Node requires a writable service definition and a reproducible service environment. Ask its deployment owner to refresh the service before retrying.",
+      undefined,
+    );
   }
   return {
     restartScriptPath,

--- a/src/cli/update-cli/update-command-service-plan.test.ts
+++ b/src/cli/update-cli/update-command-service-plan.test.ts
@@ -1,9 +1,60 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as processExec from "../../process/exec.js";
+import { withTempDir } from "../../test-utils/temp-dir.js";
 import { resolvePackageRuntimePreflight } from "./update-command-service-plan.js";
 
 describe("package runtime compatibility guidance", () => {
   afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.restoreAllMocks());
 
+  it.each([false, true])(
+    "admits only a compatible explicit replacement (fallback=%s)",
+    async (fallback) => {
+      vi.spyOn(processExec, "runCommandWithTimeout").mockImplementation(async (argv) => ({
+        stdout: argv[0] === "/old/node" ? "v22.23.1" : "v26.8.1",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      }));
+      const result = await resolvePackageRuntimePreflight({
+        target: { version: "2027.1.0", nodeEngine: ">=24.16.0 <25 || >=26.1.0" },
+        nodeRunner: "/old/node",
+        fallbackNodeRunner: fallback ? "/new/node" : undefined,
+      });
+      if (fallback) {
+        expect(result).toEqual({
+          ok: true,
+          value: {
+            nodeRunner: "/new/node",
+            replacedNodeRunner: "/old/node",
+            targetVersion: "2027.1.0",
+          },
+        });
+      } else {
+        expect(result).toMatchObject({
+          ok: false,
+          error: expect.stringContaining("Node 22.23.1 at /old/node is incompatible"),
+        });
+      }
+    },
+  );
+
+  it("checks installed package engines when registry target metadata is absent", async () => {
+    await withTempDir("openclaw-runtime-target-", async (root) => {
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ version: "2027.1.0", engines: { node: ">=90.0.0" } }),
+      );
+      expect(await resolvePackageRuntimePreflight({ installedRoot: root })).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("The requested package requires >=90.0.0."),
+      });
+    });
+  });
   it.each(["22.23.2", "24.15.0", "25.9.0", "26.0.0"])(
     "renders the target engine range for unsupported Node %s",
     async (node) => {

--- a/src/cli/update-cli/update-command-service-plan.ts
+++ b/src/cli/update-cli/update-command-service-plan.ts
@@ -1,6 +1,7 @@
 // Read-only managed Gateway ownership and Node selection for update planning.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { createConfigIO } from "../../config/io.js";
@@ -10,6 +11,7 @@ import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { assertGatewayServiceMutationAllowed } from "../../infra/gateway-supervision.js";
+import { tryReadJson } from "../../infra/json-files.js";
 import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
 import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
@@ -100,13 +102,31 @@ type PackageRuntimePreflight = {
 
 export async function resolvePackageRuntimePreflight(params: {
   target?: { version: string; nodeEngine: string | null };
+  installedRoot?: string;
   timeoutMs?: number;
   nodeRunner?: string;
   fallbackNodeRunner?: string;
 }): Promise<Result<PackageRuntimePreflight, string>> {
   const nodeRunner = normalizeOptionalString(params.nodeRunner);
   const unchanged = (): PackageRuntimePreflight => (nodeRunner ? { nodeRunner } : {});
-  const target = params.target;
+  let target = params.target;
+  if (!target && params.installedRoot) {
+    const manifest = asNullableRecord(
+      await tryReadJson<unknown>(path.join(params.installedRoot, "package.json"), {
+        maxBytes: 1024 * 1024,
+      }),
+    );
+    const version = normalizeOptionalString(manifest?.version);
+    if (!version) {
+      return resultError(
+        "Cannot inspect the installed OpenClaw runtime requirement; repair its package.json before retrying openclaw update.",
+      );
+    }
+    target = {
+      version,
+      nodeEngine: normalizeOptionalString(asNullableRecord(manifest?.engines)?.node) ?? null,
+    };
+  }
   if (!target) {
     return ok(unchanged());
   }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -195,6 +195,7 @@ export async function maybeRestartService(params: {
   result: UpdateRunResult;
   opts: UpdateCommandOptions;
   refreshServiceEnv: boolean;
+  serviceRuntimeRefreshRequired?: boolean;
   serviceEnv?: NodeJS.ProcessEnv;
   serviceInstallEnv?: NodeJS.ProcessEnv | null;
   serviceUpdateVerdict?: ManagedGatewayUpdateVerdict;
@@ -317,7 +318,7 @@ export async function maybeRestartService(params: {
 
   if (activation.shouldRestart) {
     if (
-      requiresInstallRootRefresh &&
+      (requiresInstallRootRefresh || activation.serviceRuntimeRefreshRequired) &&
       (!activation.refreshServiceEnv || activation.serviceInstallEnv === null)
     ) {
       defaultRuntime.error(
@@ -367,6 +368,10 @@ export async function maybeRestartService(params: {
           defaultRuntime.error(
             `Failed to refresh gateway service environment from updated install: ${String(err)}`,
           );
+          if (activation.serviceRuntimeRefreshRequired) {
+            params.onVerificationFailure?.("service-runtime-refresh-failed");
+            throw err;
+          }
           if (DEFINITION_DENIAL.test(String(err))) {
             // A writer denial is not a lifecycle grant: revalidate the retained
             // command and manager before using native activation without repair.

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,6 +1,4 @@
 // Main update orchestration for source checkouts and package installs.
-import { confirm, isCancel } from "@clack/prompts";
-import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { createConfigIO } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
@@ -40,6 +38,7 @@ import { CLI_NAME } from "../cli-name.js";
 import { createUpdateProgress } from "./progress.js";
 import {
   DEFAULT_PACKAGE_NAME,
+  confirmUpdateDowngrade,
   normalizeTag,
   readPackageName,
   readPackageVersion,
@@ -520,10 +519,26 @@ async function updateCommandInternal(
     return;
   }
 
+  const currentCoreFinalization = {
+    root,
+    requestedChannel,
+    storedChannel,
+    channel,
+    shouldRestart,
+    updateStepTimeoutMs,
+    invocationCwd,
+    startedAt,
+    controlPlaneUpdateSentinelMeta,
+    packageUpdateNodeRunner: packageUpdateNodeRunner ?? managedServiceNodeRunner,
+    managedServiceRootRedirect,
+    stop: presentation.stop,
+    refuseUpdate,
+  };
   if (packageAlreadyCurrent) {
     const { finishAlreadyCurrentUpdate } = await import("./update-execution.runtime.js");
     const channelChanged = requestedChannel !== null && requestedChannel !== storedChannel;
     await finishAlreadyCurrentUpdate({
+      ...currentCoreFinalization,
       opts,
       result: {
         status: channelChanged ? "ok" : "skipped",
@@ -539,34 +554,12 @@ async function updateCommandInternal(
     return;
   }
 
-  if (downgradeRisk && !opts.yes) {
-    if (!process.stdin.isTTY || opts.json) {
-      finishUpdateRun(
-        run.runId,
-        { status: "skipped", reason: "downgrade-confirmation-required" },
-        { env: run.env },
-      );
-      defaultRuntime.error(
-        "Downgrade confirmation required.\nDowngrading can break configuration. Re-run in a TTY to confirm.",
-      );
-      defaultRuntime.exit(1);
-      return;
-    }
-
-    const targetLabel = targetVersion ?? `${tag} (unknown)`;
-    const message = `Downgrading from ${currentVersion} to ${targetLabel} can break configuration. Continue?`;
-    const ok = await confirm({
-      message: stylePromptMessage(message),
-      initialValue: false,
-    });
-    if (isCancel(ok) || !ok) {
-      finishUpdateRun(run.runId, { status: "skipped", reason: "cancelled" }, { env: run.env });
-      if (!opts.json) {
-        defaultRuntime.log(theme.muted("Update cancelled."));
-      }
-      defaultRuntime.exit(0);
-      return;
-    }
+  if (
+    downgradeRisk &&
+    !opts.yes &&
+    !(await confirmUpdateDowngrade({ opts, currentVersion, targetVersion, tag }))
+  ) {
+    return;
   }
 
   if (updateInstallKind === "git" && opts.tag && !opts.json) {
@@ -679,7 +672,14 @@ async function updateCommandInternal(
   result.runId = run.runId;
   if (result.status === "skipped" && result.reason === "already-current") {
     stop();
-    await finishAlreadyCurrentUpdate({ opts, result, env: ownedManagedUpdateContext?.env });
+    await finishAlreadyCurrentUpdate({
+      ...currentCoreFinalization,
+      root: result.root ?? root,
+      opts,
+      result,
+      ownedManagedUpdateEnv: ownedManagedUpdateContext?.env,
+      packageUpdateNodeRunner: packageUpdateNodeRunner ?? managedServiceNodeRunner,
+    });
     return;
   }
   recoveryState.triageTarget.root = result.root ?? root;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -530,6 +530,7 @@ async function updateCommandInternal(
     startedAt,
     controlPlaneUpdateSentinelMeta,
     packageUpdateNodeRunner: packageUpdateNodeRunner ?? managedServiceNodeRunner,
+    runtimeTarget: packageRuntimeTarget,
     managedServiceRootRedirect,
     stop: presentation.stop,
     refuseUpdate,

--- a/src/cli/update-cli/update-recovery-guidance.ts
+++ b/src/cli/update-cli/update-recovery-guidance.ts
@@ -22,6 +22,7 @@ export function resolveUnsafeUpdateRecoveryGuidance(
 
 export function resolveUpdateResultNextAction(params: {
   result: UpdateRunResult;
+  restart?: boolean;
   serviceRunning?: boolean;
   runningVersion?: string;
   verificationFailure?: string;
@@ -57,6 +58,9 @@ export function resolveUpdateResultNextAction(params: {
     return `This OpenClaw install isn't a git checkout, and the package manager couldn't be detected. Update via your package manager, then run \`${command("openclaw doctor")}\` and \`${command("openclaw gateway restart")}\`. Examples: \`npm i -g openclaw@latest\` or \`pnpm add -g openclaw@latest\`.`;
   }
   if (result.status === "ok") {
+    if (params.restart === false && result.postUpdate?.plugins?.changed) {
+      return `Plugins updated; Gateway restart skipped (--no-restart). Run \`${command("openclaw gateway restart")}\` to activate them in the running Gateway.`;
+    }
     return `After verifying your history, preview recovery rollback retirement with ${command("openclaw update cleanup --dry-run")} for state ${resolveStateDir(env)}. Keep the same state/config overrides.`;
   }
   return undefined;


### PR DESCRIPTION
Refs #135776 #133884

## What Problem This Solves

Fixes an issue where users who upgraded core with `npm i -g openclaw@latest` and then ran `openclaw update` got an `already-current` result without the normal plugin update pass. Official plugins could remain on the previous release, and retained exact pins did not receive the existing aggregate advisories.

## Why This Change Was Made

Run the existing post-update convergence/finalization flow when core is already current. Reuse plugin target admission, managed-service ownership and handoff checks, the managed environment, capability/integrity policy, and the existing retained-pin warnings. A changed plugin result parks an owned running Gateway only for fresh Doctor validation, then uses the existing restart and health verification; unchanged plugins do not restart it. `--no-restart` retains manual activation with explicit guidance.

Core files are not replaced. Git no-ops retain their current version from the before-only receipt. Exact-pin intent and plugin cohort-selection policy are unchanged; this does not infer whether a legacy pin was intentional. Finalization parameter types live in a separate contract, and existing downgrade-confirmation code moves into shared update primitives to keep the orchestration files within the existing line limits without dependency cycles.

## User Impact

One `openclaw update` invocation now performs the normal plugin maintenance even after a manual core upgrade. JSON uses the existing `postUpdate.plugins` fields. Retained pins are reported, unchanged runs retain `skipped` / `already-current`, and stopped or absent services are not started by this plugin-only path.

## Evidence

The final regression tests ran against the original production source and then the restored fix using the same command:

```sh
node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t 'converges plugins on an already-current core.*failure=undefined' --reporter=dot
```

Before: **3 failed**, each with `expected "vi.fn()" to be called once, but got 0 times` at the plugin-update assertion. After: **3 passed**. Cases cover a running Gateway, `--no-restart`, and an absent service.

The full update CLI, finalization/recovery, execution, and shared-command suites passed **569 tests**. Subsequent focused checks passed **15 tests**, including retained-pin text/JSON advisories, unchanged/channel-only results, plugin-target refusal, service ownership changes, Git receipts, and Doctor/partial-stop failures. The final result-builder relocation was followed by the three-case regression rerun above. The test harness also completed its required runtime build and bootstrap/plugin-loading guards.

`node scripts/check-changed.mjs` passed. After the type-only contract extraction, all 15 focused cases passed again, as did core and config/CLI test typechecks, targeted lint, and the Madge cycle check (0 cycles). CI validates the final pushed head.

Proof uses the existing isolated update harness with mocked package/service boundaries. No live Gateway or registry upgrade was performed. No code was reused from #133884.

CI limitation on the final head: [the changed-extension bundle job](https://github.com/openclaw/openclaw/actions/runs/34365312113/job/102513224313) failed in `extensions/telegram/src/model-callback.loopback.integration.test.ts:245`: the expected model-change confirmation was replaced by `HttpError: Network request for 'editMessageText' failed!`. The unchanged test exercises the Telegram callback router and its loopback HTTP server, not the update command; the Telegram test/router/send paths are unchanged by this PR. This separate failure is recorded without broadening the repair. The CI run on `38fce4305c7edbdf230352c48d7c6b47aad5301c` completed with failure. The final bounded poll showed 130 passed checks and this Telegram failure; only the aggregate `openclaw/ci-gate` remained pending. The architecture check passed on this head.


## Review notes

This PR introduces no persisted SQLite tables, columns, or indexes, no install-record format changes, and no config-schema changes. The already-current path reuses the same plugin convergence and finalization flow as a real core update: retained pins stay selected, advisories are emitted, and a running managed Gateway restarts only when plugins changed and `--no-restart` is not set. Stopped or absent services are not started.

The accepted runtime-admission finding is repaired. `finishAlreadyCurrentUpdate` now calls the existing `resolvePackageRuntimePreflight` before plugin mutation or shutdown. An unsupported service Node without a permitted compatible fallback is refused with `node-runtime-preflight`. The admitted runner and explicit replacement requirement reach Doctor and service activation; required refresh failure cannot replay the unsupported definition through generic recovery.

Regression coverage includes `admits managed Node before already-current plugin maintenance`, `checks installed package engines when registry target metadata is absent`, `reports retained pins on an already-current core`, and `never stops an unchanged same-version managed gateway`. Both requested runtime cases failed before repair and passed afterward. The seven requested test files passed 581 tests; after rebase, 28 focused tests and `node scripts/check-changed.mjs` passed. Independent P0/P1 reviews were scoped-clean before and after the rebase. Production hunks are unchanged by rebase; the service-plan test hunk retains both main's global cleanup/version cases and the repair's mock cleanup/runtime cases.

This validation applies to `4cbabb9e04e88b66261781c54eb0bf3c39e82697`, rebased onto main containing #143159, #143197, and #143213. The older CI limitation above describes the previous head; [fresh CI](https://github.com/openclaw/openclaw/actions/runs/34378085192) is running for this revision.
