### PR TITLE
fix: reduce memory spikes when checking long sessions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2063,7 +2063,7 @@ src/auto-reply/reply/agent-lifecycle-terminal.ts	2
 src/auto-reply/reply/agent-runner-event-handler.ts	1
 src/auto-reply/reply/agent-runner-execution.ts	1
 src/auto-reply/reply/agent-runner-fallback-candidate.ts	1
-src/auto-reply/reply/agent-runner-memory.ts	6
+src/auto-reply/reply/agent-runner-memory.ts	5
 src/auto-reply/reply/agent-runner-run.ts	1
 src/auto-reply/reply/agent-runner-session-reset.ts	1
 src/auto-reply/reply/agent-runner-trace.ts	1

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -23,11 +23,13 @@ import { makeAssistantMessageFixture } from "../../agents/test-helpers/assistant
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import { isInternalSessionEffectsKey } from "../../config/sessions/internal-session-key.js";
 import {
+  appendTranscriptEvent,
   loadSessionEntry,
   readSessionTranscriptMessageEvents,
   readSessionTranscriptActiveStats,
   readTranscriptStatsSync,
   upsertSessionEntryCore,
+  waitForSessionTranscriptProjection,
 } from "../../config/sessions/session-accessor.js";
 import { replaceTranscriptEvents } from "../../config/sessions/session-accessor.sqlite-transcript-write.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
@@ -227,6 +229,7 @@ async function writeTestSessionTranscript(params: {
   };
   await upsertSessionEntryCore(scope, { sessionId, updatedAt: 10 });
   await replaceTranscriptEvents(scope, params.events);
+  await waitForSessionTranscriptProjection(scope);
 }
 
 type ModelFallbackParams = {
@@ -809,70 +812,90 @@ describe("runMemoryFlushIfNeeded", () => {
     );
   });
 
-  it("downgrades an owner-directed flush after a network-tainted embedded turn", async () => {
-    const storePath = path.join(rootDir, "tainted-owner-session.json");
-    const sessionKey = "agent:main:main";
-    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
-    await upsertSessionEntryCore(scope, { sessionId: "session", updatedAt: 10 });
-    const transcript = SessionManager.open(scope, rootDir);
-    const user = {
-      role: "user" as const,
-      content: "Research this",
-      timestamp: 1,
-      __openclaw: { senderIsOwner: true },
-    };
-    transcript.appendMessage(user);
-    const networkResult = {
-      role: "toolResult" as const,
-      toolCallId: "network-read",
-      toolName: "read",
-      isError: false,
-      content: [{ type: "text" as const, text: "untrusted page" }],
-      timestamp: 2,
-      __openclaw: { resultContentSource: "network" as const },
-    };
-    transcript.appendMessage(networkResult);
-    const answer = {
-      ...makeAssistantMessageFixture({
-        content: [{ type: "text", text: "network-derived answer" }],
-        stopReason: "stop",
-        errorMessage: undefined,
-      }),
-      __openclaw: { turnTainted: true },
-    };
-    transcript.appendMessage(answer);
-    // The bounded taint reader loses the original turn marker across this tail.
-    for (let index = 0; index < 512; index += 1) {
-      transcript.appendCustomEntry("fixture-tail", { index });
-    }
-    const targetPath = path.join(rootDir, "memory", "2023-11-14.md");
-    await fs.mkdir(path.dirname(targetPath), { recursive: true });
-    runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await fs.writeFile(targetPath, "network-derived memory\n", "utf8");
-      params.onAgentEvent?.({
-        stream: "tool",
-        data: { name: "write", phase: "result", isError: false },
+  it.each([
+    { label: "bounded tail", customTail: 512, newUser: false, tainted: true },
+    { label: "latest usage", customTail: 0, newUser: false, tainted: true },
+    { label: "new user boundary", customTail: 0, newUser: true, tainted: false },
+  ])(
+    "accounts for usage and owner-turn taint independently across $label",
+    async ({ customTail, newUser, tainted }) => {
+      const storePath = path.join(rootDir, "tainted-owner-session.json");
+      const sessionKey = "agent:main:main";
+      const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+      await upsertSessionEntryCore(scope, { sessionId: "session", updatedAt: 10 });
+      const transcript = SessionManager.open(scope, rootDir);
+      const user = {
+        role: "user" as const,
+        content: "Research this",
+        timestamp: 1,
+        __openclaw: { senderIsOwner: true },
+      };
+      transcript.appendMessage(user);
+      const networkResult = {
+        role: "toolResult" as const,
+        toolCallId: "network-read",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "text" as const, text: "untrusted page" }],
+        timestamp: 2,
+        __openclaw: { resultContentSource: "network" as const },
+      };
+      transcript.appendMessage(networkResult);
+      const answer = {
+        ...makeAssistantMessageFixture({
+          content: [{ type: "text", text: "network-derived answer" }],
+          stopReason: "stop",
+          errorMessage: undefined,
+        }),
+        usage: {
+          ...makeAssistantMessageFixture().usage,
+          input: 78_000,
+          output: 100,
+          totalTokens: 78_100,
+        },
+      };
+      transcript.appendMessage(answer);
+      if (newUser) {
+        transcript.appendMessage({ ...user, content: "Save my own notes", timestamp: 3 });
+      }
+      // The bounded case loses the original turn marker across this tail.
+      for (let index = 0; index < customTail; index += 1) {
+        transcript.appendCustomEntry("fixture-tail", { index });
+      }
+      const targetPath = path.join(rootDir, "memory", "2023-11-14.md");
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        await fs.writeFile(targetPath, "network-derived memory\n", "utf8");
+        params.onAgentEvent?.({
+          stream: "tool",
+          data: { name: "write", phase: "result", isError: false },
+        });
+        return { payloads: [], meta: {} };
       });
-      return { payloads: [], meta: {} };
-    });
-    const sessionEntry = createFlushSessionEntry();
+      const sessionEntry = createFlushSessionEntry({ totalTokensFresh: customTail > 0 });
 
-    await runDefaultMemoryFlush(sessionEntry, {
-      followupRun: createTestFollowupRun({
-        workspaceDir: rootDir,
-        sessionId: "session",
+      await runDefaultMemoryFlush(sessionEntry, {
+        followupRun: createTestFollowupRun({
+          workspaceDir: rootDir,
+          sessionId: "session",
+          sessionKey,
+          senderIsOwner: true,
+        }),
+        sessionStore: { [sessionKey]: sessionEntry },
         sessionKey,
-        senderIsOwner: true,
-      }),
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-    });
+        storePath,
+      });
 
-    expect(runEmbeddedAgentMock).toHaveBeenCalledWith(
-      expect.objectContaining({ initialTurnTainted: true }),
-    );
-  });
+      expect(runEmbeddedAgentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ initialTurnTainted: tainted }),
+      );
+      if (customTail === 0) {
+        expect(loadSessionEntry({ sessionKey, storePath })?.totalTokens).toBeGreaterThanOrEqual(
+          78_000,
+        );
+      }
+    },
+  );
 
   it.each([undefined, "default", "ultra"] as const)(
     "revalidates original thinking for memory-flush fallback with turn request=%s",
@@ -4592,6 +4615,34 @@ describe("runMemoryFlushIfNeeded", () => {
       expect.objectContaining({ agentId: "main", sessionKey, storePath: expectedStorePath }),
     );
   });
+
+  it.each([
+    { targetId: null, shouldCompact: false },
+    { targetId: "missing", shouldCompact: true },
+  ])(
+    "preserves accounting for an initial leaf control targeting $targetId",
+    async ({ targetId, shouldCompact }) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "session",
+        sessionKey: "main",
+        storePath: path.join(rootDir, "sessions.json"),
+      };
+      await appendTranscriptEvent(scope, { type: "leaf", id: "leaf", parentId: null, targetId });
+      await appendTranscriptEvent(scope, {
+        message: {
+          role: "assistant",
+          content: "flat continuation",
+          usage: { input: 90_000, output: 100 },
+        },
+      });
+      await runDefaultPreflight(
+        { sessionId: "session", updatedAt: Date.now(), totalTokensFresh: false },
+        { agentHarnessId: "openclaw" },
+      );
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(shouldCompact ? 1 : 0);
+    },
+  );
 
   it("resolves usage from an active branch whose leaf target predates the bounded tail", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -47,12 +47,15 @@ import {
 } from "../../config/sessions.js";
 import {
   persistCompactionBoundaryWithSessionEntrySync,
-  readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   updateSessionEntry,
+  withRecentSessionTranscriptActiveEvents,
 } from "../../config/sessions/session-accessor.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
-import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
+import {
+  isSessionTranscriptLeafControl,
+  selectSessionTranscriptLeafControlledPath,
+} from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
 import { logVerbose } from "../../globals.js";
@@ -384,73 +387,85 @@ function deriveTranscriptUsageSnapshot(
   };
 }
 
-function readLatestNonzeroUsageSnapshotFromTranscriptEvents(events: readonly unknown[]):
-  | {
-      usage: NonNullable<ReturnType<typeof normalizeUsage>>;
-      trailingMessages: AgentMessage[];
-    }
-  | undefined {
-  const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
+function readTranscriptAccountingSnapshot(
+  visit: (visitor: (event: unknown) => void) => void,
+  options: { includeUsage: boolean; includeTurnTaint?: boolean },
+): {
+  boundaryFound: boolean;
+  eventCount: number;
+  hasLeafControl: boolean;
+  tainted: boolean;
+  usage?: SessionTranscriptUsageSnapshot;
+} {
+  let scanUsage = options.includeUsage;
+  let scanTaint = options.includeTurnTaint === true;
+  let latestUsage: ReturnType<typeof normalizeUsage>;
   const trailingMessages: AgentMessage[] = [];
-  for (const event of activeEvents.toReversed()) {
+  let boundaryFound = false;
+  let tainted = false;
+  let eventCount = 0;
+  let hasLeafControl = false;
+  visit((event) => {
+    eventCount += 1;
+    hasLeafControl ||= isSessionTranscriptLeafControl(event);
     if (!event || typeof event !== "object" || Array.isArray(event)) {
-      continue;
+      return;
     }
     const record = event as { message?: unknown; type?: unknown; usage?: UsageLike };
-    if (record.type === "compaction" || record.type === "reset") {
-      return undefined;
-    }
     const message =
       record.message && typeof record.message === "object" && !Array.isArray(record.message)
         ? (record.message as AgentMessage & { api?: unknown; usage?: UsageLike })
         : undefined;
-    const rawUsage = message?.usage ?? record.usage;
-    if (message?.api === "cli" && rawUsage && rawUsage.contextUsage === undefined) {
-      return undefined;
+    if (scanUsage) {
+      const rawUsage = message?.usage ?? record.usage;
+      if (
+        record.type === "compaction" ||
+        record.type === "reset" ||
+        (message?.api === "cli" && rawUsage && rawUsage.contextUsage === undefined)
+      ) {
+        scanUsage = false;
+        trailingMessages.length = 0;
+      } else {
+        const usage = normalizeUsage(rawUsage);
+        if (usage && isUnavailableContextBarrier(usage)) {
+          scanUsage = false;
+          trailingMessages.length = 0;
+        } else if (usage && hasNonzeroUsage(usage)) {
+          latestUsage = usage;
+          scanUsage = false;
+        } else if (message) {
+          trailingMessages.push(message);
+        }
+      }
     }
-    const usage = normalizeUsage(rawUsage);
-    if (usage && isUnavailableContextBarrier(usage)) {
-      // This turn supersedes older context facts without supplying a replacement.
-      // Stop the reverse scan so pre-fix cumulative records cannot become fresh again.
-      return undefined;
+    if (scanTaint && message) {
+      if (message.role === "user") {
+        boundaryFound = true;
+        scanTaint = false;
+      } else {
+        const metadata = (message as { __openclaw?: unknown })["__openclaw"];
+        if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+          const openClaw = metadata as { resultContentSource?: unknown; turnTainted?: unknown };
+          if (openClaw.turnTainted === true || openClaw.resultContentSource === "network") {
+            tainted = true;
+            scanTaint = false;
+          }
+        }
+      }
     }
-    if (usage && hasNonzeroUsage(usage)) {
-      return { usage, trailingMessages: trailingMessages.toReversed() };
-    }
-    if (message) {
-      trailingMessages.push(message);
-    }
-  }
-  return undefined;
-}
-
-function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): {
-  boundaryFound: boolean;
-  tainted: boolean;
-} {
-  const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
-  for (const event of activeEvents.toReversed()) {
-    if (!event || typeof event !== "object" || Array.isArray(event)) {
-      continue;
-    }
-    const message = (event as { message?: unknown }).message;
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    if (record.role === "user") {
-      return { boundaryFound: true, tainted: false };
-    }
-    const metadata = record["__openclaw"];
-    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-      continue;
-    }
-    const openClaw = metadata as { resultContentSource?: unknown; turnTainted?: unknown };
-    if (openClaw.turnTainted === true || openClaw.resultContentSource === "network") {
-      return { boundaryFound: false, tainted: true };
-    }
-  }
-  return { boundaryFound: false, tainted: false };
+  });
+  return {
+    boundaryFound,
+    eventCount,
+    hasLeafControl,
+    tainted,
+    usage: latestUsage
+      ? deriveTranscriptUsageSnapshot({
+          usage: latestUsage,
+          trailingMessages: trailingMessages.toReversed(),
+        })
+      : undefined,
+  };
 }
 
 function readSqliteSessionLogSnapshot(
@@ -470,19 +485,37 @@ function readSqliteSessionLogSnapshot(
       snapshot.eventCount = stats.eventCount;
     }
     if (options.includeUsage || options.includeTurnTaint) {
-      const events = readRecentSessionTranscriptActiveEvents(
+      const accounting = withRecentSessionTranscriptActiveEvents(
         scope,
         options.usageEventLimit ?? SQLITE_USAGE_TAIL_MAX_EVENTS,
+        (visit) => {
+          const result = readTranscriptAccountingSnapshot(visit, options);
+          if (!result.hasLeafControl) {
+            return result;
+          }
+          // First-row and legacy flat projections can still contain leaf controls.
+          // Preserve their serialized navigation contract in this same snapshot.
+          const events: unknown[] = [];
+          visit((event) => events.push(event));
+          events.reverse();
+          const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
+          return {
+            ...readTranscriptAccountingSnapshot((visitor) => {
+              for (let index = activeEvents.length - 1; index >= 0; index -= 1) {
+                visitor(activeEvents[index]);
+              }
+            }, options),
+            eventCount: result.eventCount,
+          };
+        },
       );
       if (options.includeUsage) {
-        snapshot.usage = deriveTranscriptUsageSnapshot(
-          readLatestNonzeroUsageSnapshotFromTranscriptEvents(events),
-        );
+        snapshot.usage = accounting.usage;
       }
       if (options.includeTurnTaint) {
-        const scan = readActiveTurnTaintFromTranscriptEvents(events);
         snapshot.turnTainted =
-          scan.tainted || (!scan.boundaryFound && events.length >= SQLITE_USAGE_TAIL_MAX_EVENTS);
+          accounting.tainted ||
+          (!accounting.boundaryFound && accounting.eventCount >= SQLITE_USAGE_TAIL_MAX_EVENTS);
       }
     }
   } catch {

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -1,7 +1,9 @@
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { sql } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import {
   getActiveTranscriptKysely,
@@ -131,29 +133,63 @@ export function readRecentSessionTranscriptActiveEvents(
   scope: SessionTranscriptReadScope,
   maxEvents: number,
 ): TranscriptEvent[] {
+  return withRecentSessionTranscriptActiveEvents(scope, maxEvents, (visit) => {
+    const events: TranscriptEvent[] = [];
+    visit((event) => events.push(event));
+    return events.toReversed();
+  });
+}
+
+/** Runs repeatable newest-first visits synchronously inside one context-tail snapshot. */
+export function withRecentSessionTranscriptActiveEvents<T>(
+  scope: SessionTranscriptReadScope,
+  maxEvents: number,
+  read: (visit: (visitor: (event: TranscriptEvent) => void) => void) => T,
+): T {
   return withCurrentProjectionSnapshot(scope, (projection) => {
     const limit = Math.max(0, Math.floor(Number.isFinite(maxEvents) ? maxEvents : 0));
-    if (limit === 0) {
-      return [];
-    }
     const db = getActiveTranscriptKysely(projection.database);
-    return executeSqliteQuerySync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select("event.event_json")
-        .where("active.session_id", "=", projection.resolved.sessionId)
-        .where("active.context_eligible", "=", 1)
-        .orderBy("active.active_position", "desc")
-        .limit(limit),
-    )
-      .rows.toReversed()
-      .map((row) => JSON.parse(row.event_json) as TranscriptEvent);
+    const query = db
+      .selectFrom("session_transcript_active_events as active")
+      .innerJoin("transcript_events as event", (join) =>
+        join
+          .onRef("event.session_id", "=", "active.session_id")
+          .onRef("event.seq", "=", "active.event_seq"),
+      )
+      .select("event.event_json")
+      .where("active.session_id", "=", projection.resolved.sessionId)
+      .where("active.context_eligible", "=", 1)
+      .orderBy("active.active_position", "desc")
+      .limit(limit);
+    let active = true;
+    try {
+      return read((visitor) => {
+        if (!active) {
+          throw new Error("Transcript visitor used outside its read snapshot");
+        }
+        if (limit === 0) {
+          return;
+        }
+        let parseError: Error | undefined;
+        // Finish stepping before reporting JSON errors: SQL failures take precedence,
+        // followed by the oldest malformed row in the selected tail.
+        for (const row of iterateSqliteQuerySync(projection.database.db, query)) {
+          let event: TranscriptEvent;
+          try {
+            event = JSON.parse(row.event_json) as TranscriptEvent;
+          } catch (error) {
+            parseError = toErrorObject(error, "Transcript event JSON parsing failed");
+            continue;
+          }
+          visitor(event);
+        }
+        if (parseError !== undefined) {
+          throw parseError;
+        }
+      });
+    } finally {
+      active = false;
+    }
   });
 }
 

--- a/src/config/sessions/session-accessor.sqlite-context-accounting.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-context-accounting.test.ts
@@ -1,6 +1,7 @@
 // Context accounting excludes display-only activity without changing durable history.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -16,6 +17,7 @@ import {
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptMessageEventPage,
+  withRecentSessionTranscriptActiveEvents,
 } from "./session-accessor.sqlite-active-events.js";
 import { reconcileSessionTranscriptIndexes } from "./session-transcript-reconcile.js";
 
@@ -95,7 +97,118 @@ describe("SQLite transcript context accounting", () => {
       const tail = readRecentSessionTranscriptActiveEvents(scope, 2);
       expect(tail.map((event) => (event as { id: string }).id)).toEqual(["bootstrap", "usage"]);
       expect(tail[1]).toMatchObject({ message: { usage: { input: 86_000, output: 2_000 } } });
+      const visited: unknown[] = [];
+      withRecentSessionTranscriptActiveEvents(scope, 2, (visit) => {
+        visit((event) => visited.push(event));
+      });
+      expect(visited).toEqual(tail.toReversed());
       expect(readTranscriptStatsSync(scope).eventCount).toBeGreaterThan(513);
+    },
+  );
+
+  it("keeps repeated visits on one snapshot and expires their reader on return", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "seed", parentId: null, message: { role: "user", content: "before" } }],
+      touchSessionEntry: false,
+    });
+    const database = openOpenClawAgentDatabase(scope);
+    const { DatabaseSync } = requireNodeSqlite();
+    const writer = new DatabaseSync(database.path);
+    let savedVisit: ((visitor: (event: unknown) => void) => void) | undefined;
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    try {
+      withRecentSessionTranscriptActiveEvents(scope, 1, (visit) => {
+        savedVisit = visit;
+        visit((event) => first.push(event));
+        writer.prepare("UPDATE transcript_events SET event_json = ? WHERE session_id = ?").run(
+          JSON.stringify({
+            type: "message",
+            id: "seed",
+            parentId: null,
+            message: { role: "user", content: "after" },
+          }),
+          scope.sessionId,
+        );
+        visit((event) => second.push(event));
+      });
+    } finally {
+      writer.close();
+    }
+    expect(first).toMatchObject([{ message: { content: "before" } }]);
+    expect(second).toEqual(first);
+    expect(readRecentSessionTranscriptActiveEvents(scope, 1)).toMatchObject([
+      { message: { content: "after" } },
+    ]);
+    expect(() => savedVisit?.(() => {})).toThrow("outside its read snapshot");
+  });
+
+  it.each(["json", "sql", "consumer"] as const)(
+    "preserves %s failure precedence and releases the read cursor",
+    async (failureKind) => {
+      await persistSessionTranscriptTurn(scope, {
+        messages: [
+          { eventId: "oldest", parentId: null, message: { role: "user", content: "oldest" } },
+          {
+            eventId: "middle",
+            parentId: "oldest",
+            message: { role: "assistant", content: "middle" },
+          },
+          { eventId: "newest", parentId: "middle", message: { role: "user", content: "newest" } },
+        ],
+        touchSessionEntry: false,
+      });
+      const database = openOpenClawAgentDatabase(scope);
+      const failure = new Error("consumer stopped");
+      const malformed = '{"old":}';
+      let parseFailure: Error | undefined;
+      try {
+        JSON.parse(malformed);
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error;
+        }
+        parseFailure = error;
+      }
+      if (failureKind !== "consumer") {
+        // The connection-local view corrupts reads without changing canonical rows or projections.
+        database.db.exec(`CREATE TEMP VIEW transcript_events AS
+          SELECT event.session_id, event.seq, event.created_at,
+            CASE identity.event_id
+              WHEN 'oldest' THEN ${failureKind === "sql" ? "json_extract('{broken', '$')" : "'{\"old\":}'"}
+              WHEN 'middle' THEN '{"newer":}'
+              ELSE event.event_json
+            END AS event_json
+          FROM main.transcript_events AS event
+          JOIN transcript_event_identities AS identity
+            ON identity.session_id = event.session_id AND identity.seq = event.seq`);
+      }
+      try {
+        if (failureKind === "consumer") {
+          expect(() =>
+            withRecentSessionTranscriptActiveEvents(scope, 3, (visit) => {
+              visit(() => {
+                throw failure;
+              });
+            }),
+          ).toThrow(failure);
+        } else {
+          expect(() => readRecentSessionTranscriptActiveEvents(scope, 3)).toThrow(
+            failureKind === "sql" ? "malformed JSON" : parseFailure,
+          );
+        }
+      } finally {
+        if (failureKind !== "consumer") {
+          database.db.exec("DROP VIEW temp.transcript_events");
+        }
+      }
+      expect(database.db.isTransaction).toBe(false);
+      expect(database.db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get()).toMatchObject({
+        busy: 0,
+      });
+      expect(readRecentSessionTranscriptActiveEvents(scope, 3)).toHaveLength(3);
+      await appendTranscriptEvent(scope, { type: "custom", id: "after", parentId: "newest" });
+      expect(readRecentSessionTranscriptActiveEvents(scope, 1)).toMatchObject([{ id: "after" }]);
     },
   );
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -300,6 +300,7 @@ export {
   readSessionTranscriptVisibleMessageDeltaCore,
   SessionTranscriptProjectionUnavailableError,
   waitForSessionTranscriptProjection,
+  withRecentSessionTranscriptActiveEvents,
 } from "./session-accessor.sqlite-active-events.js";
 export {
   readSessionTranscriptTitleProbeBatch,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where checking long conversations for preflight compaction or memory flushing causes excessive temporary memory use while looking for an older provider-usage anchor. The reader retained both the selected raw JSON window and all parsed events, including historical message content that accounting had already discarded.

## Why This Change Was Made

Account for usage and current-turn taint during synchronous newest-first visits inside one SQLite snapshot. Retain the usage facts and every later message needed for prompt projection, while releasing older message bodies. The existing 512-event scan, full-context retry, usage barriers, taint rules, and SQL/JSON failure precedence remain intact.

First-row and legacy flat projections can still contain leaf controls. Those exceptional tails retain the existing selector through a second traversal of the same snapshot. The ordinary full-event reader shares the streaming parser, and the assertion baseline shrinks to match a removed assertion.

## User Impact

Long conversations need less temporary heap for transcript accounting without changing compaction decisions or truncating context. Required trailing messages still determine memory use; exceptional leaf-controlled tails still materialize their selected output.

## Evidence

- 150 focused tests passed across memory-runner accounting, context eligibility, reset races, and SQLite context accounting. Added coverage includes repeatable snapshot reads, expired visitors, cursor cleanup, oldest-malformed/SQL error precedence, independent usage and taint boundaries, and exceptional leaf controls.
- A matched synthetic run through the real preflight owner used 640 active events totaling 16,861,580 serialized bytes, with 512 complete trailing messages. Both versions parsed 1,152 events and made the same below-threshold decision. Sampled peak live-heap growth fell from 76,474,344 to 43,138,920 bytes (31.8 MiB less). This forced-GC experiment includes cold runtime work; it is not a throughput benchmark or attribution of a production OOM.
- Final validation passed `node scripts/check-changed.mjs`, a 77-test focused accounting/storage/bootstrap pass after lint cleanup, and independent review with no actionable P0–P2 findings.
- [Blacksmith Testbox CLI proof](https://github.com/openclaw/openclaw/actions/runs/34361532126) built the candidate and ran real local CLI turns against an isolated mock provider. It charged all 637 trailing messages: 105,494 tokens stayed below the 108,000 threshold, while 109,494 committed compaction and carried the saved summary into the foreground request. Both raw JSON outputs contained the expected successful reply payload. Captured source hashes matched the local candidate, native process trees and ports closed, and the Testbox was stopped.

Exact-head hosted CI on the original commit failed in the Telegram loopback and Windows media tests, and both failures repeated on one unchanged retry. Investigation reproduced stale loopback socket reuse and outdated Windows provider-fixture wiring; the original Windows timeout did not expose its internal stage. Existing repairs #143197 and #143213 landed for those boundaries while our separate investigations were in progress. The redundant fixture PRs #143217 and #143218 were closed unmerged with their evidence retained. No assertions or timeouts were weakened.

This PR is refreshed onto main containing both existing repairs. The accounting patch is identical (`git range-diff`), and all five accounting source/test files are byte-for-byte unchanged. The allocation and CLI receipts above remain bound to original commit `a489e2d1e045081866e00ec604ed84633bdb7f08`; [Fresh exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34374037878) for rebased commit `bbf8977f43aae5f98da44851ea69e7adbbc03687`, including both Windows jobs. The completed ClawSweeper review for that exact head has no actionable findings.
