### PR TITLE
refactor: share Memory Wiki visibility test callbacks

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1075,111 +1075,66 @@ describe("searchMemoryWiki", () => {
     expect(manager.search).toHaveBeenCalledWith("alpha", { maxResults: 5 });
   });
 
-  it("filters session memory hits outside the caller visibility policy", async () => {
-    const { config } = await createQueryVault({
-      initialize: true,
-      config: {
-        search: { backend: "shared", corpus: "memory" },
-      },
-    });
-    mockSessionTranscriptStore();
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/child-session.jsonl",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "caller transcript",
-          source: "sessions",
-        },
-        {
-          path: "sessions/main/sibling-session.jsonl",
-          startLine: 3,
-          endLine: 4,
-          score: 20,
-          snippet: "sibling transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
-    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
-
-    const results = await searchMemoryWiki({
-      config,
-      appConfig: createSessionVisibilityAppConfig(),
-      agentSessionKey: "agent:main:child-session",
-      sandboxed: true,
-      query: "transcript",
-      maxResults: 10,
-    });
-
-    expect(results.map((result) => result.path)).toEqual([
-      "sessions/child-session.jsonl",
-      "MEMORY.md",
-    ]);
-  });
-
-  it("filters session memory hits for session-bound non-sandboxed callers", async () => {
-    const { config } = await createQueryVault({
-      initialize: true,
-      config: {
-        search: { backend: "shared", corpus: "memory" },
-      },
-    });
-    mockSessionTranscriptStore();
-    const manager = createMemoryManager({
-      searchResults: [
-        {
-          path: "sessions/child-session.jsonl",
-          startLine: 1,
-          endLine: 2,
-          score: 30,
-          snippet: "caller transcript",
-          source: "sessions",
-        },
-        {
-          path: "sessions/main/sibling-session.jsonl",
-          startLine: 3,
-          endLine: 4,
-          score: 20,
-          snippet: "sibling transcript",
-          source: "sessions",
-        },
-        {
-          path: "MEMORY.md",
-          startLine: 5,
-          endLine: 6,
-          score: 10,
-          snippet: "durable memory",
-          source: "memory",
-        },
-      ],
-    });
-    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
-
-    const results = await searchMemoryWiki({
-      config,
-      appConfig: createSessionVisibilityAppConfig(),
-      agentSessionKey: "agent:main:child-session",
+  for (const { name, sandboxed } of [
+    { name: "filters session memory hits outside the caller visibility policy", sandboxed: true },
+    {
+      name: "filters session memory hits for session-bound non-sandboxed callers",
       sandboxed: false,
-      query: "transcript",
-      maxResults: 10,
-    });
+    },
+  ] satisfies ReadonlyArray<{ name: string; sandboxed: boolean }>) {
+    it(name, async () => {
+      const { config } = await createQueryVault({
+        initialize: true,
+        config: {
+          search: { backend: "shared", corpus: "memory" },
+        },
+      });
+      mockSessionTranscriptStore();
+      const manager = createMemoryManager({
+        searchResults: [
+          {
+            path: "sessions/child-session.jsonl",
+            startLine: 1,
+            endLine: 2,
+            score: 30,
+            snippet: "caller transcript",
+            source: "sessions",
+          },
+          {
+            path: "sessions/main/sibling-session.jsonl",
+            startLine: 3,
+            endLine: 4,
+            score: 20,
+            snippet: "sibling transcript",
+            source: "sessions",
+          },
+          {
+            path: "MEMORY.md",
+            startLine: 5,
+            endLine: 6,
+            score: 10,
+            snippet: "durable memory",
+            source: "memory",
+          },
+        ],
+      });
+      getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
 
-    expect(results.map((result) => result.path)).toEqual([
-      "sessions/child-session.jsonl",
-      "MEMORY.md",
-    ]);
-  });
+      const results = await searchMemoryWiki({
+        config,
+        appConfig: createSessionVisibilityAppConfig(),
+        agentSessionKey: "agent:main:child-session",
+        sandboxed,
+        query: "transcript",
+        maxResults: 10,
+      });
+
+      expect(results.map((result) => result.path)).toEqual([
+        "sessions/child-session.jsonl",
+        "MEMORY.md",
+      ]);
+    });
+  }
 
   it.each([
     { configuredCorpus: "wiki" as const, requestedCorpus: undefined },


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Two adjacent Memory Wiki visibility tests repeat the same full callback while differing only in whether the caller is sandboxed.

## Why This Change Was Made

Register the two original named cases from a typed table of primitive names and sandbox flags. Keep all vault, manager, search-hit, expected-result and nested callback allocations inside each test. The independent expected paths, assertions, cleanup and registration order remain unchanged. This removes 45 net test lines; the earlier session-input cleanup is not part of this change.

## User Impact

No product behavior changes. Both sandboxed and session-bound non-sandboxed visibility paths retain their existing coverage with less duplicated test code.

## Evidence

The full query and query-read suites passed all 74 cases before and after, with no skips and identical ordered names within each file. Substituting each row into the shared callback reproduces its original body; all outside-table tokens and per-test mutable allocations are preserved.

The mapped changed gate passed, and fresh P2 review found no actionable issues. No runtime speedup is claimed.
