### PR TITLE
fix(ci): reject stale and empty timing sample cohorts

### DIFF
--- a/docs/ci/capacity.md
+++ b/docs/ci/capacity.md
@@ -116,16 +116,36 @@ never download timing artifacts or consult restored timing caches. Missing or
 invalid timing files, or `OPENCLAW_CI_TEST_TIMINGS=0`, use the cold-start estimates
 for the entire file; stale keys cannot change the discovered test inventory.
 
-With an authenticated `gh` CLI, run `pnpm ci:timings:refit` to regenerate the file
-from all attempts of the last five successful `ci.yml` push runs on `main`, plus
-the last five successful manual runs of each release-check workflow that owns
-Gateway E2E. The refit validates run metadata before reading job logs; ordinary
-manual CI dispatches are rejected because their measured target can differ from
-the workflow head. Release workflows validate their selected target before tests,
-and their temporary branch identifies tooling rather than the measured source.
-Use `--runs <n>` to change
-the sample window, `--repo <owner/repo>` to select a repository, `--out <path>` to
-write elsewhere, or `--dry-run` to print changed entries without writing.
+With an authenticated `gh` CLI, run `pnpm ci:timings:refit` to regenerate the file.
+Each invocation freezes one UTC upper bound and a lower bound seven days earlier.
+Every run-list page uses both bounds. Returned run timestamps and successful job
+timestamps outside that window fail validation.
+
+The refit seeks up to five successful `ci.yml` push runs on `main` with parsed
+compact measurements. Docs-only runs and unparseable logs do not fill that quota.
+It also samples up to five successful manual runs of each release-check workflow
+that owns Gateway E2E. Run searches remain bounded by 25 pages and GitHub's
+1,000-result filtered-query limit. Incomplete pagination fails without writing.
+
+For each selected run, the refit captures `run_attempt` and enumerates attempts
+one through that value. It verifies each job's run ID, attempt and workflow SHA
+before reading successful, completed jobs. This retains original successful jobs
+when a partial retry runs only failed jobs. Duplicate run and job IDs do not add
+samples. Ordinary manual CI dispatches remain excluded because their measured
+target can differ from the workflow head. Release workflows validate their
+selected target before tests. Their workflow SHA identifies tooling, not the
+measured source.
+
+Use `--runs <n>` to change the run quota, not the seven-day window.
+Use `--repo <owner/repo>` to select a repository, `--out <path>` to write elsewhere,
+or `--dry-run` to report changes without writing. The report separates main and
+release observations, including run IDs, attempts, workflow SHAs, creation dates,
+parsed profiles and timing-job counts.
+
+Fewer than two independent main compact contributors fails the invocation.
+It also fails if no compact key meets the existing independent-run sampling rules.
+Retained baseline weights and release measurements cannot satisfy these checks.
+Both failures leave the timing file unchanged.
 Measurements come only from successful UI E2E, Gateway E2E, and compact jobs; compact groups
 also require an `exit 0` marker. Each entry needs at least two run samples;
 multiple attempts within one run still contribute only one sample per key and

--- a/scripts/ci-refit-test-timings.mts
+++ b/scripts/ci-refit-test-timings.mts
@@ -16,8 +16,14 @@ const jobPageSchema = z.object({
   jobs: z.array(
     z.object({
       id: z.number().int().positive(),
+      run_id: z.number().int().positive(),
+      run_attempt: z.number().int().positive(),
+      head_sha: z.string().regex(/^[a-f0-9]{40}$/u),
       name: z.string(),
+      status: z.string(),
       conclusion: z.string().nullable(),
+      started_at: z.iso.datetime(),
+      completed_at: z.iso.datetime().nullable(),
       labels: z.array(z.string()),
     }),
   ),
@@ -62,133 +68,218 @@ async function main() {
     .string()
     .regex(/^[\w.-]+\/[\w.-]+$/u)
     .parse(values.repo);
-  const runPageSchema = z.array(
-    z.object({
-      id: z.number().int().positive(),
-      created_at: z.iso.datetime(),
-      status: z.literal("completed"),
-      conclusion: z.literal("success"),
-      // A dispatch from main can check out target_ref; only push runs prove the measured ref.
-      event: z.literal("push"),
-      head_branch: z.literal("main"),
-      head_sha: z.string().regex(/^[a-f0-9]{40}$/u),
-    }),
+  // Freeze both bounds once. Pagination and retries must not move the cohort.
+  const upper = new Date().toISOString();
+  const lower = new Date(Date.parse(upper) - 7 * 86_400_000).toISOString();
+  const inWindow = (timestamp: string) =>
+    Date.parse(timestamp) >= Date.parse(lower) && Date.parse(timestamp) <= Date.parse(upper);
+  const runSchema = z.object({
+    id: z.number().int().positive(),
+    run_attempt: z.number().int().positive(),
+    created_at: z.iso.datetime().refine(inWindow, "created_at is outside the frozen UTC window"),
+    status: z.literal("completed"),
+    conclusion: z.literal("success"),
+    event: z.string(),
+    head_branch: z.string().min(1),
+    head_sha: z.string().regex(/^[a-f0-9]{40}$/u),
+  });
+  console.log(`Frozen UTC window: ${lower} through ${upper} (7 days).\n`);
+  console.log("Release workflow SHAs identify tooling, not the measured target.\n");
+  console.log(
+    "| Source | Run | Attempt | Workflow SHA | Created (UTC) | Parsed profiles | Timing jobs |\n| --- | ---: | ---: | --- | --- | --- | ---: |",
   );
-  const listed: z.infer<typeof runPageSchema> = [];
-  const pageSize = Math.min(count, 100);
-  for (let page = 1; listed.length < count; page += 1) {
-    if (page > 25) {
-      throw new Error("Run pagination limit exceeded; reduce --runs");
-    }
-    const runs = runPageSchema.parse(
-      JSON.parse(
-        await readGh([
-          "api",
-          `repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=${pageSize}&page=${page}`,
-          "--jq",
-          "[.workflow_runs[] | {id, created_at, status, conclusion, event, head_branch, head_sha}]",
-        ]),
-      ),
-    );
-    listed.push(...runs);
-    if (runs.length < pageSize) {
-      break;
-    }
-  }
-  if (listed.length === 0) {
-    throw new Error("No successful main CI runs found");
-  }
-  const releaseRunPageSchema = z.array(
-    runPageSchema.element.extend({
-      event: z.literal("workflow_dispatch"),
-      head_branch: z.string().min(1),
-    }),
-  );
-  const releaseRuns: z.infer<typeof releaseRunPageSchema> = [];
-  // Full Release Validation freezes tooling on release-ci branches. These
-  // workflows validate the canonical target before any Gateway test executes;
-  // workflow head_sha is tooling identity, not the measured source identity.
-  for (const workflow of [
-    "openclaw-release-checks.yml",
-    "openclaw-live-and-e2e-checks-reusable.yml",
-  ]) {
-    let sampled = 0;
-    for (let page = 1; sampled < count; page += 1) {
-      if (page > 25) {
-        throw new Error("Release run pagination limit exceeded; reduce --runs");
-      }
-      const pageRuns = releaseRunPageSchema.parse(
-        JSON.parse(
-          await readGh([
-            "api",
-            `repos/${repo}/actions/workflows/${workflow}/runs?event=workflow_dispatch&status=success&per_page=${pageSize}&page=${page}`,
-            "--jq",
-            "[.workflow_runs[] | {id, created_at, status, conclusion, event, head_branch, head_sha}]",
-          ]),
-        ),
-      );
-      releaseRuns.push(...pageRuns.slice(0, count - sampled));
-      sampled += pageRuns.length;
-      if (pageRuns.length < pageSize) {
-        break;
-      }
-    }
-  }
   // New gh versions reject reporter ANSI unless opted in; logs are parsed, never printed.
   const logFlags = (await readGh(["api", "--help"])).includes("--allow-escape-sequences")
     ? ["--allow-escape-sequences"]
     : [];
   const runs: CiTimingRun[] = [];
-  const sampledRuns = [
-    ...listed.slice(0, count).map((run) => ({ run, source: "ci" as const })),
-    ...releaseRuns.map((run) => ({ run, source: "release" as const })),
-  ];
-  for (const { run, source } of sampledRuns) {
+  const seenRuns = new Map<number, string>();
+  const seenJobs = new Map<number, string>();
+  async function readRun(run: z.infer<typeof runSchema>, source: "main" | "release") {
     const logs: CiTimingRun["logs"] = [];
-    let seenJobs = 0;
-    for (let page = 1; page <= 25; page += 1) {
-      const payload = jobPageSchema.parse(
+    let pages = 0;
+    // A partial retry omits successful original jobs. Read every captured attempt,
+    // then give the refit one run so retries cannot become independent samples.
+    for (let attempt = 1; attempt <= run.run_attempt; attempt += 1) {
+      const attemptLogs: CiTimingRun["logs"] = [];
+      const jobIds = new Set<number>();
+      let total: number | undefined;
+      for (let page = 1; page <= 25; page += 1) {
+        if (++pages > 25) {
+          throw new Error(`Job pagination limit reached for run ${run.id}`);
+        }
+        const payload = jobPageSchema.parse(
+          JSON.parse(
+            await readGh([
+              "api",
+              `repos/${repo}/actions/runs/${run.id}/attempts/${attempt}/jobs?per_page=100&page=${page}`,
+            ]),
+          ),
+        );
+        if (total !== undefined && total !== payload.total_count) {
+          throw new Error(`Job pagination changed for run ${run.id} attempt ${attempt}`);
+        }
+        total = payload.total_count;
+        for (const job of payload.jobs) {
+          if (
+            job.run_id !== run.id ||
+            job.run_attempt !== attempt ||
+            job.head_sha !== run.head_sha
+          ) {
+            throw new Error(`Job ${job.id} run_id/run_attempt/head_sha does not match its cohort`);
+          }
+          const identity = JSON.stringify(job);
+          if (seenJobs.has(job.id) && seenJobs.get(job.id) !== identity) {
+            throw new Error(`Job ${job.id} changed during pagination`);
+          }
+          jobIds.add(job.id);
+          if (seenJobs.has(job.id)) {
+            continue;
+          }
+          seenJobs.set(job.id, identity);
+          if (job.conclusion !== "success") {
+            continue;
+          }
+          if (
+            job.status !== "completed" ||
+            !job.completed_at ||
+            !inWindow(job.started_at) ||
+            !inWindow(job.completed_at) ||
+            Date.parse(job.completed_at) < Date.parse(job.started_at)
+          ) {
+            throw new Error(
+              `Successful job ${job.id} is not completed inside the frozen UTC window`,
+            );
+          }
+          const kind =
+            source === "release"
+              ? /(?:^| \/ )Repo E2E \(Gateway \d+\/\d+\)$/u.test(job.name)
+                ? "repoE2e"
+                : undefined
+              : job.name.startsWith("checks-ui-e2e (")
+                ? "uiE2e"
+                : job.name.startsWith("checks-node-compact-")
+                  ? "compact"
+                  : undefined;
+          if (kind) {
+            console.error(`[ci-timings] ${run.id} attempt ${attempt}: ${job.name}`);
+            attemptLogs.push({
+              kind,
+              labels: job.labels,
+              text: await readGh(["api", `repos/${repo}/actions/jobs/${job.id}/logs`, ...logFlags]),
+            });
+          }
+        }
+        if (jobIds.size === total) {
+          break;
+        }
+        if (jobIds.size > total || payload.jobs.length === 0 || page === 25) {
+          throw new Error(`Job pagination incomplete for run ${run.id} attempt ${attempt}`);
+        }
+      }
+      const { contributingRunIds } = refitTestTimings([
+        { id: run.id, createdAt: run.created_at, logs: attemptLogs },
+      ]);
+      const profiles = Object.entries(contributingRunIds)
+        .filter(([, ids]) => ids.length > 0)
+        .map(([profile]) => profile);
+      console.log(
+        `| ${source} | ${run.id} | ${attempt} | ${run.head_sha} | ${run.created_at} | ${profiles.join(", ") || "none"} | ${attemptLogs.length} |`,
+      );
+      logs.push(...attemptLogs);
+    }
+    return { id: run.id, createdAt: run.created_at, logs };
+  }
+  async function sampleWorkflow(workflow: string, source: "main" | "release") {
+    const pageSchema = z.object({
+      total_count: z.number().int().nonnegative(),
+      workflow_runs: z.array(
+        runSchema.extend({
+          // A dispatch from main can check out target_ref; only push runs prove the measured ref.
+          event: z.literal(source === "main" ? "push" : "workflow_dispatch"),
+          head_branch: source === "main" ? z.literal("main") : z.string().min(1),
+        }),
+      ),
+    });
+    const pageSize = Math.min(count, 100);
+    const query = new URLSearchParams({
+      ...(source === "main" ? { branch: "main" } : {}),
+      event: source === "main" ? "push" : "workflow_dispatch",
+      status: "success",
+      created: `${lower}..${upper}`,
+      per_page: String(pageSize),
+    });
+    const listed = new Set<number>();
+    let listedRows = 0;
+    let sampled = 0;
+    // GitHub caps filtered searches at 1,000 results, even when total_count is larger.
+    const maxPages = Math.min(25, Math.ceil(1000 / pageSize));
+    for (let page = 1; page <= maxPages; page += 1) {
+      const payload = pageSchema.parse(
         JSON.parse(
           await readGh([
             "api",
-            `repos/${repo}/actions/runs/${run.id}/jobs?filter=all&per_page=100&page=${page}`,
-            "--jq",
-            "{total_count, jobs: [.jobs[] | {id, name, conclusion, labels}]}",
+            `repos/${repo}/actions/workflows/${workflow}/runs?${query}&page=${page}`,
           ]),
         ),
       );
-      for (const job of payload.jobs) {
-        if (job.conclusion !== "success") {
+      listedRows += payload.workflow_runs.length;
+      if (listedRows > 1000) {
+        throw new Error(`Run pagination limit reached for ${workflow}; reduce --runs`);
+      }
+      for (const run of payload.workflow_runs) {
+        listed.add(run.id);
+        const identity = JSON.stringify(run);
+        if (seenRuns.has(run.id) && seenRuns.get(run.id) !== identity) {
+          throw new Error(`Run ${run.id} changed during pagination`);
+        }
+        if (seenRuns.has(run.id)) {
           continue;
         }
-        const kind =
-          source === "release"
-            ? /(?:^| \/ )Repo E2E \(Gateway \d+\/\d+\)$/u.test(job.name)
-              ? "repoE2e"
-              : undefined
-            : job.name.startsWith("checks-ui-e2e (")
-              ? "uiE2e"
-              : job.name.startsWith("checks-node-compact-")
-                ? "compact"
-                : undefined;
-        if (kind) {
-          console.error(`[ci-timings] ${run.id}: ${job.name}`);
-          logs.push({
-            kind,
-            labels: job.labels,
-            text: await readGh(["api", `repos/${repo}/actions/jobs/${job.id}/logs`, ...logFlags]),
-          });
+        seenRuns.set(run.id, identity);
+        const timingRun = await readRun(run, source);
+        const { contributingRunIds } = refitTestTimings([timingRun]);
+        const compact = contributingRunIds.blacksmith.length + contributingRunIds.github.length > 0;
+        if (source === "main" ? compact : contributingRunIds.repoE2e.length > 0) {
+          runs.push(timingRun);
+        }
+        if (source === "release" || compact) {
+          sampled += 1;
+        }
+        if (sampled === count) {
+          return;
         }
       }
-      seenJobs += payload.jobs.length;
-      if (seenJobs >= payload.total_count) {
-        break;
+      if (listed.size === payload.total_count) {
+        return;
       }
-      if (payload.jobs.length === 0 || page === 25) {
-        throw new Error(`Job pagination incomplete for CI run ${run.id}`);
+      if (listed.size > payload.total_count || payload.workflow_runs.length === 0) {
+        throw new Error(`Run pagination incomplete for ${workflow}`);
       }
     }
-    runs.push({ id: run.id, createdAt: run.created_at, logs });
+    throw new Error(`Run pagination limit reached for ${workflow}; reduce --runs`);
+  }
+  await sampleWorkflow("ci.yml", "main");
+  const fresh = refitTestTimings(runs);
+  const { blacksmith, github } = fresh.contributingRunIds;
+  const mainContributors = new Set([...blacksmith, ...github]);
+  if (
+    mainContributors.size < 2 ||
+    Object.values(fresh.timings.compactGroupSeconds).every(
+      (profile) => Object.keys(profile).length === 0,
+    )
+  ) {
+    throw new Error(
+      `Found ${mainContributors.size} independent main compact contributors. Need at least two and a newly eligible compact measurement in the frozen UTC window; retry after successful main CI. No timing file written.`,
+    );
+  }
+  // Release workflows validate their target before Gateway tests. Their head SHA
+  // binds jobs to tooling, never substitutes for the measured source identity.
+  for (const workflow of [
+    "openclaw-release-checks.yml",
+    "openclaw-live-and-e2e-checks-reusable.yml",
+  ]) {
+    await sampleWorkflow(workflow, "release");
   }
   let previous;
   try {
@@ -196,16 +287,10 @@ async function main() {
   } catch {
     // A missing or invalid baseline has no measurements worth preserving.
   }
-  const { timings, changes, runIds } = refitTestTimings(runs, previous);
-  if (
-    Object.keys(timings.uiE2e.fileSeconds).length +
-      Object.keys(timings.repoE2eFileSeconds).length +
-      Object.keys(timings.compactGroupSeconds.blacksmith).length +
-      Object.keys(timings.compactGroupSeconds.github).length ===
-    0
-  ) {
-    throw new Error("No test timings have at least two successful run samples");
-  }
+  const { timings, changes, runIds, contributingRunIds } = refitTestTimings(runs, previous);
+  console.log(
+    `\nIndependent main compact contributors: ${mainContributors.size} (Blacksmith: ${blacksmith.length}; GitHub: ${github.length}). Release Gateway contributors: ${contributingRunIds.repoE2e.length}.\n`,
+  );
   ciTestTimingsSchema.parse(timings);
   console.log(`Sampled successful CI and release-check runs: ${runIds.join(", ")}\n`);
   console.log("| Key | Old seconds | New seconds | Delta |\n| --- | ---: | ---: | ---: |");

--- a/scripts/lib/ci-test-timings-refit.mts
+++ b/scripts/lib/ci-test-timings-refit.mts
@@ -292,5 +292,11 @@ export function refitTestTimings(runs: CiTimingRun[], previous?: CiTestTimings) 
     timings,
     changes: changes.toSorted((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)),
     runIds,
+    contributingRunIds: {
+      blacksmith: [...contributingRuns.blacksmith].toSorted((a, b) => a - b),
+      github: [...contributingRuns.github].toSorted((a, b) => a - b),
+      repoE2e: [...contributingRuns.repoE2e].toSorted((a, b) => a - b),
+      uiE2e: [...contributingRuns.uiE2e].toSorted((a, b) => a - b),
+    },
   };
 }

--- a/test/scripts/ci-test-timings.test.ts
+++ b/test/scripts/ci-test-timings.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs, {
   chmodSync,
   mkdtempSync,
@@ -56,6 +56,159 @@ const baseline: CiTestTimings = {
   updatedAt: "2026-08-22",
   version: 1,
 };
+
+const sampleNow = "2026-08-28T12:00:00.000Z";
+
+function samplerRun(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    run_attempt: 1,
+    created_at: "2026-08-27T22:00:00Z",
+    status: "completed",
+    conclusion: "success",
+    event: "push",
+    head_branch: "main",
+    head_sha: "a".repeat(40),
+    ...overrides,
+  };
+}
+
+function samplerJob(id: number, runId: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    run_id: runId,
+    run_attempt: 1,
+    head_sha: "a".repeat(40),
+    name: "checks-node-compact-small (1)",
+    status: "completed",
+    conclusion: "success",
+    labels: ["blacksmith-4vcpu-ubuntu-2404"],
+    started_at: "2026-08-27T23:00:00Z",
+    completed_at: "2026-08-27T23:10:00Z",
+    log: compactLog(20),
+    ...overrides,
+  };
+}
+
+type SamplerFixture = {
+  runs: ReturnType<typeof samplerRun>[];
+  jobs: ReturnType<typeof samplerJob>[];
+  releaseRuns?: ReturnType<typeof samplerRun>[];
+  runPages?: ReturnType<typeof samplerRun>[][];
+  jobPages?: Record<string, ReturnType<typeof samplerJob>[][]>;
+  jobTotals?: Record<string, number>;
+  baseline?: CiTestTimings;
+};
+
+function withSamplerFixture(
+  fixture: SamplerFixture,
+  check: (context: {
+    invoke: (dryRun?: boolean, count?: number) => SpawnSyncReturns<string>;
+    contents: () => string;
+    requests: () => string[][];
+    original: string;
+  }) => void,
+) {
+  const directory = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-ci-refit-")));
+  const fakeGh = path.join(directory, "gh");
+  const output = path.join(directory, "timings.json");
+  const requests = path.join(directory, "requests.jsonl");
+  const clock = path.join(directory, "clock.cjs");
+  const original = `${JSON.stringify(fixture.baseline ?? baseline, null, 2)}\n`;
+  try {
+    writeFileSync(output, original);
+    writeFileSync(requests, "");
+    writeFileSync(
+      clock,
+      `const OriginalDate = Date;
+global.Date = class extends OriginalDate {
+  constructor(...args) { super(...(args.length ? args : [${JSON.stringify(sampleNow)}])); }
+  static now() { return OriginalDate.parse(${JSON.stringify(sampleNow)}); }
+};\n`,
+    );
+    writeFileSync(
+      fakeGh,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(requests)}, JSON.stringify(args) + "\\n");
+const fixture = ${JSON.stringify(fixture)};
+const endpoint = new URL(args[1], "https://api.github.com/");
+const page = Number(endpoint.searchParams.get("page") || 1);
+const size = Number(endpoint.searchParams.get("per_page") || 100);
+const slice = rows => rows.slice((page - 1) * size, page * size);
+if (args[1] === "--help") {
+  console.log("--allow-escape-sequences");
+} else if (endpoint.pathname.includes("/workflows/")) {
+  const main = endpoint.pathname.includes("/ci.yml/");
+  const rows = main ? fixture.runs : endpoint.pathname.includes("/openclaw-release-checks.yml/") ? fixture.releaseRuns || [] : [];
+  const selected = main && fixture.runPages ? fixture.runPages[page - 1] || [] : slice(rows);
+  console.log(JSON.stringify(args.at(-1).startsWith("[.workflow_runs") ? selected : {total_count: rows.length, workflow_runs: selected}));
+} else if (endpoint.pathname.endsWith("/jobs")) {
+  const match = endpoint.pathname.match(/\\/runs\\/(\\d+)(?:\\/attempts\\/(\\d+))?\\/jobs$/);
+  if (!match) process.exit(2);
+  const key = match[1] + ":" + (match[2] || "all");
+  const rows = fixture.jobs.filter(job => job.run_id === Number(match[1]) && (!match[2] || job.run_attempt === Number(match[2])));
+  const pages = fixture.jobPages?.[key];
+  console.log(JSON.stringify({total_count: fixture.jobTotals?.[key] ?? rows.length, jobs: pages ? pages[page - 1] || [] : slice(rows)}));
+} else if (endpoint.pathname.endsWith("/logs")) {
+  const id = Number(endpoint.pathname.split("/").at(-2));
+  const job = fixture.jobs.find(job => job.id === id);
+  if (!job) process.exit(2);
+  console.log(job.log);
+} else {
+  console.error("Unexpected gh request", args);
+  process.exit(2);
+}\n`,
+    );
+    chmodSync(fakeGh, 0o755);
+    check({
+      original,
+      contents: () => readFileSync(output, "utf8"),
+      requests: () =>
+        readFileSync(requests, "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as string[]),
+      invoke: (dryRun = false, count = 2) =>
+        spawnSync(
+          process.execPath,
+          [
+            "--require",
+            clock,
+            "--import",
+            "tsx",
+            "scripts/ci-refit-test-timings.mts",
+            "--runs",
+            String(count),
+            "--repo",
+            "fixture/repo",
+            "--out",
+            output,
+            ...(dryRun ? ["--dry-run"] : []),
+          ],
+          {
+            cwd: fileURLToPath(new URL("../../", import.meta.url)),
+            encoding: "utf8",
+            timeout: 30_000,
+            env: { ...process.env, OPENCLAW_GH_BIN: fakeGh, GH_TOKEN: "fixture-token" },
+          },
+        ),
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+it("rejects a populated baseline without fresh compact contributors before writing", () => {
+  withSamplerFixture({ runs: [samplerRun(1), samplerRun(2)], jobs: [] }, (fixture) => {
+    const result = fixture.invoke();
+    expect(result.status, result.stderr || result.stdout).toBe(1);
+    expect(result.stderr).toContain("compact");
+    expect(fixture.contents()).toBe(fixture.original);
+  });
+});
 
 it("rejects non-plain timing objects even when their fields are valid", () => {
   expect(() =>
@@ -631,135 +784,141 @@ it.todo("retains todo coverage");
       ).timings,
     ).toEqual(first.timings);
   });
+});
+
+describe("CI timing sampler provenance", () => {
+  it.each([
+    ["manual main dispatch", { event: "workflow_dispatch" }, "event"],
+    ["pull request", { event: "pull_request" }, "event"],
+    ["another branch", { head_branch: "feature" }, "head_branch"],
+    ["missing SHA", { head_sha: null }, "head_sha"],
+    ["missing attempt", { run_attempt: undefined }, "run_attempt"],
+    ["zero attempt", { run_attempt: 0 }, "run_attempt"],
+    ["incomplete run", { status: "in_progress" }, "status"],
+    ["failed run", { conclusion: "failure" }, "conclusion"],
+    ["stale run", { created_at: "2026-08-21T11:59:59.999Z" }, "created_at"],
+    ["future run", { created_at: "2026-08-28T12:00:00.001Z" }, "created_at"],
+  ] satisfies [string, Record<string, unknown>, string][])(
+    "rejects %s before reading logs or changing the baseline",
+    (_name, metadata, field) => {
+      withSamplerFixture(
+        {
+          runs: [samplerRun(1, metadata), samplerRun(2)],
+          jobs: [samplerJob(11, 1), samplerJob(21, 2)],
+        },
+        (fixture) => {
+          const result = fixture.invoke();
+          expect(result.status, result.stderr).toBe(1);
+          expect(result.stderr).toContain(field);
+          expect(fixture.requests().some((args) => args[1]?.endsWith("/logs"))).toBe(false);
+          expect(fixture.contents()).toBe(fixture.original);
+        },
+      );
+    },
+  );
 
   it.each([
-    { label: "main push retries", metadata: {}, invalidField: undefined },
-    {
-      label: "manual dispatch from main",
-      metadata: { event: "workflow_dispatch" },
-      invalidField: "event",
-    },
-    {
-      label: "push to another branch",
-      metadata: { head_branch: "feature" },
-      invalidField: "head_branch",
-    },
-    { label: "missing head commit", metadata: { head_sha: null }, invalidField: "head_sha" },
-  ])(
-    "validates $label before fetching samples and preserves dry-run/unchanged bytes",
-    ({ metadata, invalidField }) => {
-      const directory = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-ci-refit-")));
-      const fakeGh = path.join(directory, "gh");
-      const output = path.join(directory, "timings.json");
-      const requests = path.join(directory, "requests.json");
-      const root = fileURLToPath(new URL("../../", import.meta.url));
-      const log = uiLog({ [measuredFile]: 130 });
-      writeFileSync(
-        fakeGh,
-        `#!/usr/bin/env node
-const args = process.argv.slice(2);
-const endpoint = args[1];
-if (args[0] === "api" && args[1] === "--help") {
-  console.log("--allow-escape-sequences");
-} else if (endpoint.replace("&event=push", "") === "repos/fixture/repo/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=3&page=1") {
-  if (!args.includes("--jq")) process.exit(2);
-  require("node:fs").writeFileSync(${JSON.stringify(requests)}, JSON.stringify(args));
-  console.log(JSON.stringify([1, 2, 3].map(id => ({id, created_at: "2026-08-27T23:00:00Z", status: "completed", conclusion: "success", event: "push", head_branch: "main", head_sha: "a".repeat(40), run_attempt: 2, ...${JSON.stringify(metadata)}}))));
-} else if (endpoint.includes("actions/workflows/openclaw-") && endpoint.includes("/runs?event=workflow_dispatch&")) {
-  console.log(JSON.stringify(endpoint.includes("openclaw-release-checks.yml") ? [4, 5, 6].map(id => ({id, created_at: "2026-08-27T23:00:00Z", status: "completed", conclusion: "success", event: "workflow_dispatch", head_branch: "release-ci/frozen", head_sha: "b".repeat(40)})) : []));
-} else if (endpoint.includes("actions/runs/") && endpoint.includes("/jobs?filter=all&")) {
-  if (!args.at(-1).includes("labels")) process.exit(2);
-  if (Number(endpoint.split("/actions/runs/")[1].split("/")[0]) >= 4) {
-    console.log(JSON.stringify({total_count: 2, jobs: [
-      {id: 7, name: "Run repo/live E2E validation / Gateway E2E / Repo E2E (Gateway 1/4)", conclusion: "success", labels: ["ubuntu-24.04"]},
-      {id: 8, name: "UI and plugin E2E / Repo E2E (UI 1/4)", conclusion: "success", labels: ["ubuntu-24.04"]},
-    ]}));
-    process.exit(0);
-  }
-  const jobs = endpoint.endsWith("page=1")
-    ? [{id: 1, name: "unrelated", conclusion: "success"}, {id: 2, name: "checks-ui-e2e (2/11)", conclusion: "failure"}]
-    : [{id: 3, name: "checks-ui-e2e (1/11)", conclusion: "success"},
-       {id: 4, name: "checks-node-compact-small (1)", conclusion: "success", labels: ["blacksmith-4vcpu-ubuntu-2404"]},
-       {id: 5, name: "checks-node-compact-small (1)", conclusion: "success", labels: ["ubuntu-24.04"]},
-       {id: 6, name: "checks-node-compact-small (1)", conclusion: "success", labels: ["ubuntu-24.04"]}];
-  console.log(JSON.stringify({ total_count: 6, jobs: jobs.map(job => ({labels: ["ubuntu-24.04"], ...job})) }));
-} else if (endpoint.endsWith("actions/jobs/3/logs")) {
-  if (!args.includes("--allow-escape-sequences")) process.exit(2);
-  console.log(${JSON.stringify(log)});
-} else if (endpoint.endsWith("actions/jobs/4/logs")) {
-  console.log(${JSON.stringify(compactLog(20))});
-} else if (endpoint.endsWith("actions/jobs/5/logs")) {
-  console.log(${JSON.stringify(compactLog(40))});
-} else if (endpoint.endsWith("actions/jobs/6/logs")) {
-  console.log(${JSON.stringify(compactLog(60))});
-} else if (endpoint.endsWith("actions/jobs/7/logs")) {
-  console.log("✓ test/release.e2e.test.ts (1 test) 4500ms\\nDuration 5s (tests 4.5s)");
-} else {
-  console.error("Unexpected gh request", args);
-  process.exit(2);
-}
-`,
-      );
-      chmodSync(fakeGh, 0o755);
-      const original = `${JSON.stringify(
+    ["wrong run", { run_id: 9 }],
+    ["wrong attempt", { run_attempt: 2 }],
+    ["wrong SHA", { head_sha: "b".repeat(40) }],
+    ["unfinished success", { status: "in_progress" }],
+    ["missing completion", { completed_at: null }],
+    ["stale start", { started_at: "2026-08-21T11:59:59.999Z" }],
+    ["future completion", { completed_at: "2026-08-28T12:00:00.001Z" }],
+    ["reversed timestamps", { completed_at: "2026-08-27T22:59:59Z" }],
+  ] satisfies [string, Record<string, unknown>][])(
+    "rejects a job with %s without reading its log",
+    (_name, metadata) => {
+      const job = samplerJob(11, 1, metadata);
+      withSamplerFixture(
         {
-          ...baseline,
-          compactGroupSeconds: { blacksmith: { deleted: 30 }, github: {} },
+          runs: [samplerRun(1), samplerRun(2)],
+          jobs: [job, samplerJob(21, 2)],
+          jobPages: { "1:1": [[job]] },
+          jobTotals: { "1:1": 1 },
         },
-        null,
-        2,
-      )}\n`;
-      writeFileSync(output, original);
-      const invoke = (dryRun: boolean) =>
-        spawnSync(
-          process.execPath,
-          [
-            "--import",
-            "tsx",
-            "scripts/ci-refit-test-timings.mts",
-            "--runs",
-            "3",
-            "--repo",
-            "fixture/repo",
-            "--out",
-            output,
-            ...(dryRun ? ["--dry-run"] : []),
-          ],
-          {
-            cwd: root,
-            encoding: "utf8",
-            env: { ...process.env, OPENCLAW_GH_BIN: fakeGh, GH_TOKEN: "fixture-token" },
-          },
-        );
-      try {
-        const dryRun = invoke(true);
-        if (invalidField) {
-          expect(dryRun.status, dryRun.stderr).toBe(1);
-          expect(dryRun.stderr).toContain(invalidField);
-          expect(dryRun.stdout).not.toContain("Sampled successful CI and release-check runs");
-          expect(readFileSync(output, "utf8")).toBe(original);
-          return;
-        }
+        (fixture) => {
+          const result = fixture.invoke();
+          expect(result.status, result.stderr).toBe(1);
+          expect(result.stderr).toMatch(/cohort|frozen UTC window/u);
+          expect(fixture.requests().some((args) => args[1]?.endsWith("/logs"))).toBe(false);
+          expect(fixture.contents()).toBe(fixture.original);
+        },
+      );
+    },
+  );
+
+  it("seeks compact contributors past docs-only and unparseable runs, preserving all attempts and unchanged bytes", () => {
+    const releaseRuns = [10, 11].map((id) =>
+      samplerRun(id, {
+        event: "workflow_dispatch",
+        head_branch: "release-ci/frozen",
+        head_sha: "b".repeat(40),
+      }),
+    );
+    withSamplerFixture(
+      {
+        runs: [
+          samplerRun(1),
+          samplerRun(2),
+          samplerRun(3, { run_attempt: 2 }),
+          samplerRun(4, { run_attempt: 2 }),
+        ],
+        releaseRuns,
+        jobs: [
+          samplerJob(11, 1, { name: "docs", log: "No test results" }),
+          samplerJob(21, 2, { log: "No complete compact spans" }),
+          ...[3, 4].flatMap((id) => [
+            samplerJob(id * 10 + 1, id),
+            samplerJob(id * 10 + 2, id, {
+              name: "checks-ui-e2e (1/6)",
+              log: uiLog({ [measuredFile]: 130 }),
+            }),
+            samplerJob(id * 10 + 3, id, {
+              run_attempt: 2,
+              labels: ["ubuntu-24.04"],
+              log: compactLog(id === 3 ? 40 : 60),
+            }),
+            samplerJob(id * 10 + 4, id, {
+              run_attempt: 2,
+              conclusion: "failure",
+              log: compactLog(900),
+            }),
+          ]),
+          ...releaseRuns.map((run) =>
+            samplerJob(run.id * 10, run.id, {
+              head_sha: "b".repeat(40),
+              name: "Run repo/live E2E validation / Gateway E2E / Repo E2E (Gateway 1/4)",
+              log: "✓ test/release.e2e.test.ts (1 test) 4500ms\nDuration 5s (tests 4.5s)",
+            }),
+          ),
+        ],
+      },
+      (fixture) => {
+        const dryRun = fixture.invoke(true);
         expect(dryRun.status, dryRun.stderr).toBe(0);
-        expect(JSON.parse(readFileSync(requests, "utf8"))).toEqual([
-          "api",
-          "repos/fixture/repo/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=3&page=1",
-          "--jq",
-          "[.workflow_runs[] | {id, created_at, status, conclusion, event, head_branch, head_sha}]",
-        ]);
+        expect(fixture.contents()).toBe(fixture.original);
         expect(dryRun.stdout).toContain(
-          `| uiE2e.fileSeconds.${measuredFile} | 100 | 130 | 30.0% |`,
+          "Independent main compact contributors: 2 (Blacksmith: 2; GitHub: 2). Release Gateway contributors: 2.",
         );
+        expect(dryRun.stdout).toContain(`| release | 10 | 1 | ${"b".repeat(40)} |`);
         expect(dryRun.stdout).toContain(
-          "| compactGroupSeconds.blacksmith.deleted | 30 | — | removed |",
+          "Release workflow SHAs identify tooling, not the measured target.",
         );
-        expect(dryRun.stdout).toContain(
-          "Sampled successful CI and release-check runs: 1, 2, 3, 4, 5, 6",
-        );
-        expect(readFileSync(output, "utf8")).toBe(original);
-        const write = invoke(false);
+        const requests = fixture.requests();
+        const runRequests = requests.filter((args) => args[1]?.includes("/workflows/"));
+        expect(runRequests).toHaveLength(4);
+        for (const args of runRequests) {
+          const params = new URL(args[1]!, "https://api.github.com").searchParams;
+          expect(params.get("created")).toBe(`2026-08-21T12:00:00.000Z..${sampleNow}`);
+        }
+        expect(requests.some((args) => args[1]?.includes("/runs/3/attempts/1/jobs?"))).toBe(true);
+        expect(requests.some((args) => args[1]?.includes("/runs/3/attempts/2/jobs?"))).toBe(true);
+        expect(requests.some((args) => args[1]?.includes("filter=all"))).toBe(false);
+        expect(requests.some((args) => args[1]?.endsWith("/jobs/34/logs"))).toBe(false);
+        const write = fixture.invoke();
         expect(write.status, write.stderr).toBe(0);
-        const updated = readFileSync(output, "utf8");
+        const updated = fixture.contents();
         const timings = ciTestTimingsSchema.parse(JSON.parse(updated));
         expect(timings.uiE2e.fileSeconds[measuredFile]).toBe(130);
         expect(timings.repoE2eFileSeconds).toEqual({ "test/release.e2e.test.ts": 5 });
@@ -767,16 +926,138 @@ if (args[0] === "api" && args[1] === "--help") {
           blacksmith: { "core-unit-src-security-2": 20 },
           github: { "core-unit-src-security-2": 50 },
         });
-        expect(updated.endsWith("\n")).toBe(true);
-        const unchanged = invoke(false);
+        const unchanged = fixture.invoke();
         expect(unchanged.status, unchanged.stderr).toBe(0);
         expect(unchanged.stdout).toContain("No timing changes");
-        expect(readFileSync(output, "utf8")).toBe(updated);
-      } finally {
-        rmSync(directory, { recursive: true, force: true });
-      }
+        expect(fixture.contents()).toBe(updated);
+      },
+    );
+  });
+
+  it("accepts both date boundaries without changing an unobserved profile", () => {
+    const lower = "2026-08-21T12:00:00.000Z";
+    withSamplerFixture(
+      {
+        runs: [samplerRun(1, { created_at: lower }), samplerRun(2, { created_at: sampleNow })],
+        jobs: [
+          samplerJob(11, 1, { started_at: lower, completed_at: lower }),
+          samplerJob(21, 2, { started_at: sampleNow, completed_at: sampleNow }),
+        ],
+        baseline: {
+          ...baseline,
+          compactGroupSeconds: { blacksmith: {}, github: { retained: 90 } },
+        },
+      },
+      (fixture) => {
+        const result = fixture.invoke();
+        expect(result.status, result.stderr).toBe(0);
+        expect(JSON.parse(fixture.contents()).compactGroupSeconds.github).toEqual({ retained: 90 });
+      },
+    );
+  });
+
+  it.each(["different keys", "one run with retries", "release only"])(
+    "rejects %s as evidence for a new compact measurement",
+    (condition) => {
+      const first = samplerRun(1, { run_attempt: condition === "one run with retries" ? 2 : 1 });
+      withSamplerFixture(
+        {
+          runs:
+            condition === "release only"
+              ? []
+              : condition === "one run with retries"
+                ? [first]
+                : [first, samplerRun(2)],
+          jobs:
+            condition === "release only"
+              ? [10, 11].map((id) =>
+                  samplerJob(id * 10, id, {
+                    name: "Repo E2E (Gateway 1/4)",
+                    log: "✓ test/release.e2e.test.ts (1 test) 4000ms\nDuration 5s",
+                  }),
+                )
+              : [
+                  samplerJob(11, 1),
+                  samplerJob(21, condition === "one run with retries" ? 1 : 2, {
+                    run_attempt: condition === "one run with retries" ? 2 : 1,
+                    log: compactLog(20, condition === "different keys" ? "different" : undefined),
+                  }),
+                ],
+          releaseRuns:
+            condition === "release only"
+              ? [10, 11].map((id) => samplerRun(id, { event: "workflow_dispatch" }))
+              : [],
+        },
+        (fixture) => {
+          const result = fixture.invoke();
+          expect(result.status, result.stderr).toBe(1);
+          expect(result.stderr).toContain("newly eligible compact measurement");
+          expect(fixture.contents()).toBe(fixture.original);
+          expect(fixture.requests().some((args) => args[1]?.includes("/workflows/openclaw-"))).toBe(
+            false,
+          );
+        },
+      );
     },
   );
+
+  it("deduplicates overlapping run and job pages without treating retries as extra runs", () => {
+    const first = samplerRun(1);
+    const second = samplerRun(2);
+    const compact = samplerJob(11, 1);
+    const ui = samplerJob(12, 1, {
+      name: "checks-ui-e2e (1/6)",
+      log: uiLog({ [measuredFile]: 130 }),
+    });
+    withSamplerFixture(
+      {
+        runs: [first, second],
+        runPages: [[first, first], [second]],
+        jobs: [compact, ui, samplerJob(21, 2)],
+        jobPages: { "1:1": [[compact, compact], [ui]] },
+      },
+      (fixture) => {
+        const result = fixture.invoke();
+        expect(result.status, result.stderr).toBe(0);
+        expect(
+          fixture.requests().filter((args) => args[1]?.endsWith("/jobs/11/logs")),
+        ).toHaveLength(1);
+        expect(result.stdout).toContain("Independent main compact contributors: 2");
+      },
+    );
+  });
+
+  it.each(["run", "job"])("refuses incomplete %s pagination without writing", (kind) => {
+    const first = samplerRun(1);
+    const job = samplerJob(11, 1);
+    withSamplerFixture(
+      {
+        runs: [first, samplerRun(2)],
+        jobs: [job, samplerJob(21, 2)],
+        ...(kind === "run"
+          ? { runPages: [[first], []] }
+          : { jobPages: { "1:1": [[job], []] }, jobTotals: { "1:1": 2 } }),
+      },
+      (fixture) => {
+        const result = fixture.invoke();
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stderr).toContain("pagination incomplete");
+        expect(fixture.contents()).toBe(fixture.original);
+      },
+    );
+  });
+
+  it("keeps the 25-page job budget across all captured attempts", () => {
+    withSamplerFixture({ runs: [samplerRun(1, { run_attempt: 26 })], jobs: [] }, (fixture) => {
+      const result = fixture.invoke();
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("Job pagination limit reached");
+      const jobRequests = fixture.requests().filter((args) => args[1]?.includes("/jobs?"));
+      expect(jobRequests).toHaveLength(25);
+      expect(jobRequests.at(-1)?.[1]).toContain("/attempts/25/jobs?");
+      expect(fixture.contents()).toBe(fixture.original);
+    });
+  });
 });
 
 describe("CI timing schema", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/142719

## What Problem This Solves

Resolves a problem where maintainers refitting CI timings could select stale runs or count successful runs with no usable compact measurements, then report success because the existing timing baseline was populated.

## Why This Change Was Made

The sampler now freezes one inclusive seven-day UTC window, applies both bounds to every run-list page, and validates returned run and job provenance. It enumerates attempts 1 through each captured `run_attempt`, preserving successful original jobs when only failed jobs are retried, while counting retries as one independent run/profile sample.

Run selection seeks actual compact contributors using the canonical parser's existing contributor sets. Fewer than two independent main contributors, or no newly eligible compact key, fails visibly without writing. Existing aggregation, pruning, unchanged-output behavior, and untouched profiles are preserved.

## User Impact

Maintainers get a bounded, auditable fresh timing cohort instead of a successful no-op based on old weights. Reports distinguish main and release observations and show run, attempt, workflow SHA, creation date, parsed profiles, and job count. Release workflow SHAs identify tooling, not the measured target.

No runtime, generated timing weights, workflow, runner class, shard count, or concurrency changes are included. This repair claims no immediate CI speedup. Any later weight refresh remains a separate change and must validate the same or fewer runner allocations to avoid oversharding.

## Evidence

- Regression reproduced before repair: a populated baseline with no fresh compact contributors returned success. The new boundary test failed on the original behavior.
- `node scripts/run-vitest.mjs test/scripts/ci-test-timings.test.ts --reporter=dot`: 126/126 passed, 30.84 seconds.
- Coverage includes frozen-clock boundaries, stale/future timestamps, event/branch/SHA/attempt identity, incomplete and duplicate pagination, docs-only/unparseable logs, original successful jobs plus partial retries, retry independence, release-only rejection, unchanged bytes, untouched profiles, and the existing 25-page job budget.
- Targeted formatting and `git diff --check` passed.
- GitHub's official [workflow-run contract](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow) and [attempt-specific job contract](https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt) were checked directly.
- Bounded live metadata queries used the identical `2026-09-02T14:18:52.381Z..2026-09-09T14:18:52.381Z` range on two run-list pages. An attempt-specific job query verified `run_id`, `run_attempt`, `head_sha`, completion, and runner-label fields. No bulk logs or timing artifacts were downloaded; partial-retry behavior is covered by the CLI fixture, not claimed as a live retry observation.
- Independent source review found no blocking findings. Fresh autoreview was scoped-clean through P2 with no accepted/actionable findings. Exact-head hosted CI and the native landing gates remain required before merge.

Tooling delta: +91 net lines for cohort/provenance validation and reporting; tests: +281; docs: +20. The producer repair in the related PR remains unchanged.
