### PR TITLE
refactor: share sandbox filesystem parameter contracts

### DIFF
--- a/extensions/mxc/src/fs-bridge.ts
+++ b/extensions/mxc/src/fs-bridge.ts
@@ -81,11 +81,9 @@ class MxcFsBridge implements SandboxFsBridge {
     })) as Buffer;
   }
 
-  async readDirectory(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<DirectoryEntry[]> {
+  async readDirectory(
+    params: Parameters<NonNullable<SandboxFsBridge["readDirectory"]>>[0],
+  ): Promise<DirectoryEntry[]> {
     const target = this.resolveTarget(params);
     const root = await fsRoot(target.mount.hostRoot);
     const entries = await root.list(target.mountRelativePath, { withFileTypes: true });

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -55,12 +55,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     };
   }
 
-  async readFile(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-    maxBytes?: number;
-  }): Promise<Buffer> {
+  async readFile(params: Parameters<SandboxFsBridge["readFile"]>[0]): Promise<Buffer> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     let opened: Awaited<ReturnType<Awaited<ReturnType<typeof fsRoot>>["open"]>>;
@@ -96,11 +91,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
     }
   }
 
-  async readDirectory(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<DirectoryEntry[]> {
+  async readDirectory(
+    params: Parameters<NonNullable<SandboxFsBridge["readDirectory"]>>[0],
+  ): Promise<DirectoryEntry[]> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     await assertLocalPathSafety({
@@ -114,14 +107,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     return entries.map(({ name, isDirectory }) => ({ name, isDirectory }));
   }
 
-  async writeFile(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async writeFile(params: Parameters<SandboxFsBridge["writeFile"]>[0]): Promise<void> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     this.ensureWritable(target, "write files");
@@ -141,14 +127,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
     await this.backend.syncLocalPathToRemote(hostPath, target.containerPath);
   }
 
-  async createFileExclusive(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<"created" | "exists"> {
+  async createFileExclusive(
+    params: Parameters<NonNullable<SandboxFsBridge["createFileExclusive"]>>[0],
+  ): Promise<"created" | "exists"> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     this.ensureWritable(target, "create files");
@@ -192,13 +173,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     await mkdirLocalRootPath({ hostPath, target });
   }
 
-  async remove(params: {
-    filePath: string;
-    cwd?: string;
-    recursive?: boolean;
-    force?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async remove(params: Parameters<SandboxFsBridge["remove"]>[0]): Promise<void> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     this.ensureWritable(target, "remove files", params.recursive);
@@ -221,12 +196,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     });
   }
 
-  async rename(params: {
-    from: string;
-    to: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async rename(params: Parameters<SandboxFsBridge["rename"]>[0]): Promise<void> {
     const { from, to } = this.resolveRenameTargets(params);
     const fromHostPath = this.requireHostPath(from);
     const toHostPath = this.requireHostPath(to);
@@ -255,11 +225,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     await moveLocalRootPath({ from, fromHostPath, to, toHostPath });
   }
 
-  async stat(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<SandboxFsStat | null> {
+  async stat(params: Parameters<SandboxFsBridge["stat"]>[0]): Promise<SandboxFsStat | null> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
     const stats = await fsPromises.lstat(hostPath).catch(() => null);

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -68,21 +68,14 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     };
   }
 
-  async readFile(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-    maxBytes?: number;
-  }): Promise<Buffer> {
+  async readFile(params: Parameters<SandboxFsBridge["readFile"]>[0]): Promise<Buffer> {
     const target = this.resolveResolvedPath(params);
     return this.readPinnedFile(target, params.maxBytes);
   }
 
-  async readDirectory(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<DirectoryEntry[]> {
+  async readDirectory(
+    params: Parameters<NonNullable<SandboxFsBridge["readDirectory"]>>[0],
+  ): Promise<DirectoryEntry[]> {
     const target = this.resolveResolvedPath(params);
     const result = await this.runCheckedCommand({
       ...buildPinnedMutationPlan({
@@ -98,13 +91,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     return parseDirectoryEntries(result.stdout.toString("utf8"));
   }
 
-  async copyFile(params: {
-    sourcePath: string;
-    destinationPath: string;
-    cwd?: string;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async copyFile(params: Parameters<NonNullable<SandboxFsBridge["copyFile"]>>[0]): Promise<void> {
     const source = this.resolveResolvedPath({ filePath: params.sourcePath, cwd: params.cwd });
     const destination = this.resolveResolvedPath({
       filePath: params.destinationPath,
@@ -132,14 +119,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     });
   }
 
-  async writeFile(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async writeFile(params: Parameters<SandboxFsBridge["writeFile"]>[0]): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "write files");
     const writeCheck = {
@@ -166,14 +146,9 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     });
   }
 
-  async createFileExclusive(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<"created" | "exists"> {
+  async createFileExclusive(
+    params: Parameters<NonNullable<SandboxFsBridge["createFileExclusive"]>>[0],
+  ): Promise<"created" | "exists"> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create files");
     const createCheck = {
@@ -231,13 +206,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     });
   }
 
-  async remove(params: {
-    filePath: string;
-    cwd?: string;
-    recursive?: boolean;
-    force?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async remove(params: Parameters<SandboxFsBridge["remove"]>[0]): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "remove files");
     const removeCheck = {
@@ -260,12 +229,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     });
   }
 
-  async rename(params: {
-    from: string;
-    to: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async rename(params: Parameters<SandboxFsBridge["rename"]>[0]): Promise<void> {
     const from = this.resolveResolvedPath({ filePath: params.from, cwd: params.cwd });
     const to = this.resolveResolvedPath({ filePath: params.to, cwd: params.cwd });
     this.ensureWriteAccess(from, "rename files");
@@ -298,11 +262,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     });
   }
 
-  async stat(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<SandboxFsStat | null> {
+  async stat(params: Parameters<SandboxFsBridge["stat"]>[0]): Promise<SandboxFsStat | null> {
     const target = this.resolveResolvedPath(params);
     const anchoredTarget = await this.pathGuard.resolveAnchoredSandboxEntry(target, "stat files");
     const result = await this.runPlannedCommand(

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -85,12 +85,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return canonicalPath;
   }
 
-  async readFile(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-    maxBytes?: number;
-  }): Promise<Buffer> {
+  async readFile(params: Parameters<SandboxFsBridge["readFile"]>[0]): Promise<Buffer> {
     if (
       params.maxBytes !== undefined &&
       (!Number.isSafeInteger(params.maxBytes) || params.maxBytes < 0)
@@ -134,11 +129,9 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return result.stdout;
   }
 
-  async readDirectory(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<DirectoryEntry[]> {
+  async readDirectory(
+    params: Parameters<NonNullable<SandboxFsBridge["readDirectory"]>>[0],
+  ): Promise<DirectoryEntry[]> {
     const target = this.resolveTarget(params);
     const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
@@ -157,13 +150,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return parseDirectoryEntries(result.stdout.toString("utf8"));
   }
 
-  async copyFile(params: {
-    sourcePath: string;
-    destinationPath: string;
-    cwd?: string;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async copyFile(params: Parameters<NonNullable<SandboxFsBridge["copyFile"]>>[0]): Promise<void> {
     const source = this.resolveTarget({ filePath: params.sourcePath, cwd: params.cwd });
     const destination = this.resolveTarget({
       filePath: params.destinationPath,
@@ -199,14 +186,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async writeFile(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async writeFile(params: Parameters<SandboxFsBridge["writeFile"]>[0]): Promise<void> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "write files", params.signal);
     const pinned = await this.resolvePinnedTarget({
@@ -235,14 +215,9 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async createFileExclusive(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<"created" | "exists"> {
+  async createFileExclusive(
+    params: Parameters<NonNullable<SandboxFsBridge["createFileExclusive"]>>[0],
+  ): Promise<"created" | "exists"> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "create files", params.signal);
     const pinned = await this.resolvePinnedTarget({
@@ -305,13 +280,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async remove(params: {
-    filePath: string;
-    cwd?: string;
-    recursive?: boolean;
-    force?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async remove(params: Parameters<SandboxFsBridge["remove"]>[0]): Promise<void> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "remove files", params.signal, params.recursive);
     const exists = await this.remotePathExists(target.containerPath, params.signal);
@@ -342,12 +311,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async rename(params: {
-    from: string;
-    to: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async rename(params: Parameters<SandboxFsBridge["rename"]>[0]): Promise<void> {
     const { from, to } = this.resolveRenameTargets(params);
     await this.ensureRemoteWritable(from, "rename files", params.signal, true);
     await this.ensureRemoteWritable(to, "rename files", params.signal, true);
@@ -378,11 +342,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async stat(params: {
-    filePath: string;
-    cwd?: string;
-    signal?: AbortSignal;
-  }): Promise<SandboxFsStat | null> {
+  async stat(params: Parameters<SandboxFsBridge["stat"]>[0]): Promise<SandboxFsStat | null> {
     const target = this.resolveTarget(params);
     const exists = await this.remotePathExists(target.containerPath, params.signal);
     if (!exists) {


### PR DESCRIPTION
Closes #143186

## What Problem This Solves

Sandbox filesystem implementations repeat parameter records already defined by their shared public contract. Independent copies increase the maintenance cost of keeping implementations aligned. This is part of the maintainer-requested code reduction campaign.

## Why This Change Was Made

Twenty-four exactly matching multiline annotations now derive their parameters from the corresponding `SandboxFsBridge` method. Optional methods use `NonNullable` before extracting parameters; each concrete class retains its required methods and return types. The seven differing mxc signatures remain unchanged. No helpers, aliases, imports, runtime expressions, or SDK exports are added.

## User Impact

No user-visible behavior or public API change. This removes 116 production code/physical lines across four files while keeping the existing filesystem contract as the single owner of those parameter fields.

## Evidence

- The patch is byte-identical after refreshing onto main with the separately landed Telegram fixture repair #143197 and standalone reset repair #143281.
- All four complete files emit byte-identical JavaScript after TypeScript erasure.
- Canonical OpenShell and mxc builds produce identical runtime/static output: three files, 126,518 bytes.
- All 380 regenerated SDK declaration files are byte-identical: 3,504,296 bytes per side.
- Canonical public API rendering is byte-identical across 152 entrypoints, 4,447 exports and 9,504 reachable declaration sections; the complete 14,623,526-byte JSON reports have no changes.
- The full changed-file gate passed, including all four typecheck lanes, six existing doctor cases, formatting, lint, dependency, cycle and boundary guards. SDK export-map verification also passed.
- Independent P2 review has no findings and remains applicable to the identical patch; refreshed source-contract checks retain the differing mxc signatures and OpenShell's concrete method presence.

No live sandbox or Gateway run is claimed for this erased-annotation change. The affected plugin builds and complete SDK/API output were verified; a full root runtime package build was not run. API rendering used the canonical command and its documented memory budget; declaration generation ran after the plugin builds completed.

## Stored-data compatibility and CI

No serialized fields, filesystem operations, storage formats, schemas, migration rules or version markers change. The automated stored-data flag does not apply to these erased annotations, as confirmed by complete runtime and public API equivalence. The [current source review](https://github.com/openclaw/openclaw/pull/143189#issuecomment-5603887596) independently disproves that concern; its remaining generated migration checklist is therefore not applicable.

The earlier CI failures were repaired at their owners in #143197 and #143281. This refreshed head still requires green hosted CI before landing.
