### PR TITLE
fix(update): keep bundled plugin aliases bundled in candidate rehearsal

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -43,9 +43,11 @@ boots a canary with copied configuration and verified SQLite snapshots in an
 isolated temporary state directory. The copied database registry points to the
 copied agent databases. Installed plugin payloads and their dependencies are also
 copied; the rehearsal install records point to those copies, and their OpenClaw
-host links target the staged candidate. The live plugin files and host links stay
-unchanged. Channels, cron, automatic updates, and other side services are
-suppressed in this canary.
+host links target the staged candidate. Path aliases that resolve to a running
+package's bundled plugin use the staged bundled plugin with the same ID when
+available, preserving bundled trust. External path installs keep their existing
+classification. The live plugin files and host links stay unchanged. Channels,
+cron, automatic updates, and other side services are suppressed in this canary.
 
 Schema checks also use private SQLite copies so inspection does not create or
 modify WAL sidecars beside live databases. Each schema inspection has a

--- a/src/infra/update-candidate-bundled-provenance.test.ts
+++ b/src/infra/update-candidate-bundled-provenance.test.ts
@@ -1,16 +1,19 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import * as bundledMetadata from "../plugins/bundled-plugin-metadata.js";
 import { loadPluginManifestRegistryCore } from "../plugins/manifest-registry.js";
+import * as pluginCacheFiles from "../plugins/plugin-cache-files.js";
 import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import {
   closeOpenClawStateDatabaseByPath,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { projectUpdateCandidatePlugins } from "./update-candidate-plugins.js";
 import { prepareUpdateCandidateRehearsal } from "./update-candidate-rehearsal.js";
 
 async function writePlugin(directory: string, id: string, generation: string) {
@@ -42,6 +45,9 @@ it.each([
   { kind: "renamed candidate directory", bundled: true },
   { kind: "split candidate runtime", bundled: true },
   { kind: "source checkout alongside built runtime", bundled: true },
+  { kind: "candidate in-package fallback", bundled: true },
+  { kind: "candidate escaping fallback", bundled: false },
+  { kind: "candidate escaping fallback with external install", bundled: false },
   { kind: "external path", bundled: false },
   { kind: "source symlink escapes bundled directory", bundled: false },
   { kind: "candidate symlink escapes bundled directory", bundled: false },
@@ -64,12 +70,15 @@ it.each([
     kind === "split candidate runtime" ? "dist-runtime" : "dist",
     "extensions",
   );
+  const candidateFallback = kind.startsWith("candidate ") && kind.includes("fallback");
+  const escapingFallback = kind.startsWith("candidate escaping fallback");
   const candidatePlugin = path.join(
-    candidateBundled,
+    candidateFallback ? path.join(candidateHost, "extensions") : candidateBundled,
     kind === "renamed candidate directory" ? "renamed-demo" : "demo",
   );
-  const externalSource =
-    kind === "external path" || kind === "source symlink escapes bundled directory";
+  const externalInstall =
+    kind === "external path" || kind === "candidate escaping fallback with external install";
+  const externalSource = externalInstall || kind === "source symlink escapes bundled directory";
   const sourcePlugin = externalSource ? path.join(root, "external", "demo") : livePlugin;
   const shared = path.join(sourceState, "state", "openclaw.sqlite");
   let cleanupRehearsal: (() => Promise<void>) | undefined;
@@ -82,7 +91,20 @@ it.each([
       );
     }
     await fs.mkdir(liveBundled, { recursive: true });
+    await fs.mkdir(path.join(liveHost, "src"));
+    await fs.writeFile(path.join(liveHost, "pnpm-workspace.yaml"), "packages: []\n");
     await fs.mkdir(candidateBundled, { recursive: true });
+    if (candidateFallback) {
+      await fs.mkdir(path.join(candidateHost, "src"));
+      await fs.writeFile(path.join(candidateHost, ".git"), "");
+      await fs.writeFile(path.join(candidateHost, "pnpm-workspace.yaml"), "packages: []\n");
+      await writePlugin(path.join(candidateBundled, "another"), "another", "built candidate");
+      if (escapingFallback) {
+        const externalFallback = path.join(root, "external-fallback");
+        await fs.mkdir(externalFallback);
+        await fs.symlink(externalFallback, path.dirname(candidatePlugin), "junction");
+      }
+    }
     if (kind === "candidate bundled root escapes package") {
       const externalBundled = path.join(root, "external-bundled");
       await fs.mkdir(externalBundled);
@@ -91,14 +113,12 @@ it.each([
     }
     await writePlugin(sourcePlugin, "demo", "live");
     if (kind === "source checkout alongside built runtime") {
-      await fs.mkdir(path.join(liveHost, "src"));
       await fs.writeFile(path.join(liveHost, ".git"), "");
-      await fs.writeFile(path.join(liveHost, "pnpm-workspace.yaml"), "packages: []\n");
       await writePlugin(path.join(sourceBundled, "another"), "another", "built live");
     }
     if (kind === "source symlink escapes bundled directory") {
       await fs.symlink(sourcePlugin, livePlugin, "junction");
-    } else if (kind === "external path") {
+    } else if (externalInstall) {
       await writePlugin(livePlugin, "demo", "bundled live");
     }
     if (kind === "split candidate runtime") {
@@ -115,7 +135,7 @@ it.each([
         "candidate",
       );
     }
-    let locator = kind === "external path" ? sourcePlugin : livePlugin;
+    let locator = externalInstall ? sourcePlugin : livePlugin;
     if (kind === "symlink") {
       locator = path.join(root, "demo-alias");
       await fs.symlink(livePlugin, locator, "junction");
@@ -164,13 +184,11 @@ it.each([
         async (file) => (await fs.stat(file)).mode,
       ),
     );
-    if (kind === "candidate bundled root escapes package" && process.platform !== "win32") {
+    const outsideCandidate = kind === "candidate bundled root escapes package" || escapingFallback;
+    if (outsideCandidate && process.platform !== "win32") {
       await fs.chmod(candidatePlugin, 0o777);
     }
-    const candidateMode =
-      kind === "candidate bundled root escapes package"
-        ? (await fs.stat(candidatePlugin)).mode
-        : undefined;
+    const candidateMode = outsideCandidate ? (await fs.stat(candidatePlugin)).mode : undefined;
     const rehearsal = await prepareUpdateCandidateRehearsal({
       config,
       candidateRoot: candidateHost,
@@ -217,6 +235,49 @@ it.each([
   } finally {
     closeOpenClawStateDatabaseForTest();
     await cleanupRehearsal?.();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+it.each(["source", "candidate"])("does not enumerate an outside %s fallback", async (side) => {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-fallback-")));
+  const sourceHost = path.join(root, "source-host");
+  const candidateHost = path.join(root, "candidate-host");
+  const external = path.join(root, "outside");
+  const fallback = path.join(side === "source" ? sourceHost : candidateHost, "extensions");
+  const installed = path.join(external, "demo");
+  const metadata = vi.spyOn(bundledMetadata, "listBundledPluginMetadata");
+  const directoryReads = vi.spyOn(pluginCacheFiles, "readPluginCacheDirectory");
+  try {
+    for (const host of [sourceHost, candidateHost]) {
+      await fs.mkdir(path.join(host, "src"), { recursive: true });
+      await fs.writeFile(path.join(host, "package.json"), JSON.stringify({ name: "openclaw" }));
+      await fs.writeFile(path.join(host, ".git"), "");
+      await fs.writeFile(path.join(host, "pnpm-workspace.yaml"), "packages: []\n");
+      await writePlugin(path.join(host, "dist", "extensions", "another"), "another", "bundled");
+    }
+    await writePlugin(installed, "demo", "external");
+    await fs.symlink(external, fallback, "junction");
+    const projected = await withPluginCache(createPluginCache(), () =>
+      projectUpdateCandidatePlugins({
+        stateDir: path.join(root, "state"),
+        targetStateDir: path.join(root, "copy"),
+        candidateRoot: candidateHost,
+        config: { plugins: { installs: { demo: { source: "path", installPath: installed } } } },
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(sourceHost, "dist", "extensions"),
+          OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        },
+      }),
+    );
+    expect(directoryReads.mock.calls.map(([directory]) => directory)).not.toContain(fallback);
+    expect(metadata.mock.calls.map(([options]) => options?.scanDir)).not.toContain(fallback);
+    expect(await fs.readFile(path.join(projected[installed]!, "index.js"), "utf8")).toBe(
+      'export default "external";',
+    );
+  } finally {
+    directoryReads.mockRestore();
+    metadata.mockRestore();
     await fs.rm(root, { recursive: true, force: true });
   }
 });

--- a/src/infra/update-candidate-bundled-provenance.test.ts
+++ b/src/infra/update-candidate-bundled-provenance.test.ts
@@ -281,3 +281,133 @@ it.each(["source", "candidate"])("does not enumerate an outside %s fallback", as
     await fs.rm(root, { recursive: true, force: true });
   }
 });
+
+it.each([false, true])(
+  "redirects multi-entry bundles with missing candidate entry=%s",
+  async (missing) => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-entries-")));
+    const sourceHost = path.join(root, "source-host");
+    const candidateHost = path.join(root, "candidate-host");
+    const sourcePlugin = path.join(sourceHost, "extensions", "demo");
+    const candidatePlugin = path.join(candidateHost, "dist", "extensions", "demo");
+    const stateDir = path.join(root, "state");
+    const entries = ["first", "second", "third"];
+    const candidateEntries = missing ? entries.slice(0, 2) : entries;
+    let cleanup: (() => Promise<void>) | undefined;
+    try {
+      for (const host of [sourceHost, candidateHost]) {
+        await fs.mkdir(host, { recursive: true });
+        await fs.writeFile(
+          path.join(host, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2026.9.3" }),
+        );
+      }
+      await fs.mkdir(path.join(sourceHost, "src"));
+      await fs.writeFile(path.join(sourceHost, "pnpm-workspace.yaml"), "packages: []\n");
+      for (const [directory, names, generation] of [
+        [sourcePlugin, entries, "live"],
+        [candidatePlugin, candidateEntries, "candidate"],
+      ] as const) {
+        await writePlugin(directory, "demo", generation);
+        await fs.writeFile(
+          path.join(directory, "package.json"),
+          JSON.stringify({
+            name: "@openclaw/different-package-name",
+            version: "2026.9.3",
+            type: "module",
+            openclaw: { extensions: names.map((name) => `./${name}.js`) },
+          }),
+        );
+        for (const name of names) {
+          await fs.writeFile(
+            path.join(directory, `${name}.js`),
+            `export default ${JSON.stringify(`${generation}-${name}`)};`,
+          );
+        }
+      }
+      const installRecords: Record<string, PluginInstallRecord> = missing
+        ? Object.fromEntries(
+            entries.map((name) => [
+              `demo/${name}`,
+              {
+                source: "path",
+                installPath: path.join(sourcePlugin, `${name}.js`),
+              },
+            ]),
+          )
+        : { demo: { source: "path", installPath: sourcePlugin } };
+      const config: OpenClawConfig = {
+        plugins: {
+          installs: installRecords,
+          ...(!missing
+            ? { load: { paths: entries.map((name) => path.join(sourcePlugin, `${name}.js`)) } }
+            : {}),
+        },
+      };
+      const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } }).db;
+      registry
+        .prepare(
+          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+        )
+        .run(
+          "plugins.installedIndex",
+          JSON.stringify({ revision: 1, index: { installRecords } }),
+          1,
+        );
+      closeOpenClawStateDatabaseByPath(path.join(stateDir, "state", "openclaw.sqlite"));
+      const rehearsal = await prepareUpdateCandidateRehearsal({
+        config,
+        stateDir,
+        candidateRoot: candidateHost,
+        env: {
+          ...process.env,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(sourcePlugin),
+          OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        },
+      });
+      cleanup = rehearsal.cleanup;
+      const copied: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const projectedPaths = entries.map((name, index) =>
+        missing
+          ? copied.plugins?.installs?.[`demo/${name}`]?.installPath
+          : copied.plugins?.load?.paths?.[index],
+      );
+      for (const [index, name] of candidateEntries.entries()) {
+        expect(projectedPaths[index]).toBe(path.join(candidatePlugin, `${name}.js`));
+      }
+      if (!missing) {
+        expect(copied.plugins?.installs?.demo?.installPath).toBe(candidatePlugin);
+      }
+      const discovered = withPluginCache(createPluginCache(), () =>
+        loadPluginManifestRegistryCore({
+          config: copied,
+          env: {
+            OPENCLAW_STATE_DIR: rehearsal.stateDir,
+            OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(candidatePlugin),
+            OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+          },
+        }),
+      ).plugins;
+      for (const name of candidateEntries) {
+        expect(discovered.find((plugin) => plugin.id === `demo/${name}`)).toMatchObject({
+          origin: "bundled",
+          source: path.join(candidatePlugin, `${name}.js`),
+          trust: { reason: "bundled" },
+        });
+      }
+      if (missing) {
+        const retained = projectedPaths[2] ?? "";
+        expect(retained.startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+        expect(await fs.readFile(retained, "utf8")).toBe('export default "live-third";');
+        expect(discovered.find((plugin) => plugin.source === retained)).toMatchObject({
+          origin: "global",
+          trust: { reason: "origin-path" },
+        });
+      }
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await cleanup?.();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/src/infra/update-candidate-bundled-provenance.test.ts
+++ b/src/infra/update-candidate-bundled-provenance.test.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { loadPluginManifestRegistryCore } from "../plugins/manifest-registry.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { prepareUpdateCandidateRehearsal } from "./update-candidate-rehearsal.js";
+
+async function writePlugin(directory: string, id: string, generation: string) {
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(
+    path.join(directory, "package.json"),
+    JSON.stringify({
+      name: `@openclaw/${id}`,
+      version: "2026.9.3",
+      type: "module",
+      openclaw: { extensions: ["./index.js"] },
+    }),
+  );
+  await fs.writeFile(
+    path.join(directory, "openclaw.plugin.json"),
+    JSON.stringify({ id, configSchema: { type: "object" } }),
+  );
+  await fs.writeFile(
+    path.join(directory, "index.js"),
+    `export default ${JSON.stringify(generation)};`,
+  );
+}
+
+it.each([
+  { kind: "directory", bundled: true },
+  { kind: "source permissions", bundled: true },
+  { kind: "symlink", bundled: true },
+  { kind: "entrypoint", bundled: true },
+  { kind: "renamed candidate directory", bundled: true },
+  { kind: "split candidate runtime", bundled: true },
+  { kind: "source checkout alongside built runtime", bundled: true },
+  { kind: "external path", bundled: false },
+  { kind: "source symlink escapes bundled directory", bundled: false },
+  { kind: "candidate symlink escapes bundled directory", bundled: false },
+  { kind: "candidate bundled root escapes package", bundled: false },
+  { kind: "missing candidate ID", bundled: false },
+  { kind: "mismatched candidate ID", bundled: false },
+])("preserves candidate plugin provenance: $kind", async ({ kind, bundled }) => {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-provenance-")));
+  const sourceState = path.join(root, "source-state");
+  const liveHost = path.join(root, "live-host");
+  const candidateHost = path.join(root, "candidate-host");
+  const liveBundled = path.join(liveHost, "extensions");
+  const livePlugin = path.join(liveBundled, "demo");
+  const sourceBundled =
+    kind === "source checkout alongside built runtime"
+      ? path.join(liveHost, "dist", "extensions")
+      : liveBundled;
+  const candidateBundled = path.join(
+    candidateHost,
+    kind === "split candidate runtime" ? "dist-runtime" : "dist",
+    "extensions",
+  );
+  const candidatePlugin = path.join(
+    candidateBundled,
+    kind === "renamed candidate directory" ? "renamed-demo" : "demo",
+  );
+  const externalSource =
+    kind === "external path" || kind === "source symlink escapes bundled directory";
+  const sourcePlugin = externalSource ? path.join(root, "external", "demo") : livePlugin;
+  const shared = path.join(sourceState, "state", "openclaw.sqlite");
+  let cleanupRehearsal: (() => Promise<void>) | undefined;
+  try {
+    for (const host of [liveHost, candidateHost]) {
+      await fs.mkdir(host, { recursive: true });
+      await fs.writeFile(
+        path.join(host, "package.json"),
+        JSON.stringify({ name: "openclaw", version: "2026.9.3", type: "module" }),
+      );
+    }
+    await fs.mkdir(liveBundled, { recursive: true });
+    await fs.mkdir(candidateBundled, { recursive: true });
+    if (kind === "candidate bundled root escapes package") {
+      const externalBundled = path.join(root, "external-bundled");
+      await fs.mkdir(externalBundled);
+      await fs.rmdir(candidateBundled);
+      await fs.symlink(externalBundled, candidateBundled, "junction");
+    }
+    await writePlugin(sourcePlugin, "demo", "live");
+    if (kind === "source checkout alongside built runtime") {
+      await fs.mkdir(path.join(liveHost, "src"));
+      await fs.writeFile(path.join(liveHost, ".git"), "");
+      await fs.writeFile(path.join(liveHost, "pnpm-workspace.yaml"), "packages: []\n");
+      await writePlugin(path.join(sourceBundled, "another"), "another", "built live");
+    }
+    if (kind === "source symlink escapes bundled directory") {
+      await fs.symlink(sourcePlugin, livePlugin, "junction");
+    } else if (kind === "external path") {
+      await writePlugin(livePlugin, "demo", "bundled live");
+    }
+    if (kind === "split candidate runtime") {
+      await writePlugin(path.join(candidateHost, "dist", "extensions", "demo"), "demo", "unused");
+    }
+    if (kind === "candidate symlink escapes bundled directory") {
+      const externalCandidate = path.join(root, "external-candidate", "demo");
+      await writePlugin(externalCandidate, "demo", "candidate");
+      await fs.symlink(externalCandidate, candidatePlugin, "junction");
+    } else if (kind !== "missing candidate ID") {
+      await writePlugin(
+        candidatePlugin,
+        kind === "mismatched candidate ID" ? "other" : "demo",
+        "candidate",
+      );
+    }
+    let locator = kind === "external path" ? sourcePlugin : livePlugin;
+    if (kind === "symlink") {
+      locator = path.join(root, "demo-alias");
+      await fs.symlink(livePlugin, locator, "junction");
+    } else if (kind === "entrypoint") {
+      locator = path.join(livePlugin, "index.js");
+    }
+    const installRecords = {
+      demo: { source: "path", installPath: locator, sourcePath: locator },
+    } satisfies Record<string, PluginInstallRecord>;
+    const config: OpenClawConfig = {
+      plugins: {
+        installs: installRecords,
+        ...(kind === "entrypoint" ? { load: { paths: [locator] } } : {}),
+      },
+    };
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: sourceState } }).db;
+    registry
+      .prepare(
+        "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+      )
+      .run("plugins.installedIndex", JSON.stringify({ revision: 1, index: { installRecords } }), 1);
+    closeOpenClawStateDatabaseByPath(shared);
+    const liveDatabase = await fs.readFile(shared);
+    const liveEntry = await fs.readFile(path.join(sourcePlugin, "index.js"));
+    const inspect = (stateDir: string, bundledRoot: string, inspectedConfig: OpenClawConfig) =>
+      withPluginCache(createPluginCache(), () =>
+        loadPluginManifestRegistryCore({
+          env: {
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+            OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+          },
+          config: inspectedConfig,
+        }).plugins.find((plugin) => plugin.id === "demo"),
+      );
+    expect(inspect(sourceState, sourceBundled, config)).toMatchObject({
+      origin: externalSource ? "global" : "bundled",
+      trust: { reason: externalSource ? "origin-path" : "bundled", installSource: "path" },
+    });
+    if (kind === "source permissions" && process.platform !== "win32") {
+      await fs.chmod(sourcePlugin, 0o777);
+      await fs.chmod(path.join(sourcePlugin, "index.js"), 0o666);
+    }
+    const sourceModes = await Promise.all(
+      [sourcePlugin, path.join(sourcePlugin, "index.js")].map(
+        async (file) => (await fs.stat(file)).mode,
+      ),
+    );
+    if (kind === "candidate bundled root escapes package" && process.platform !== "win32") {
+      await fs.chmod(candidatePlugin, 0o777);
+    }
+    const candidateMode =
+      kind === "candidate bundled root escapes package"
+        ? (await fs.stat(candidatePlugin)).mode
+        : undefined;
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config,
+      candidateRoot: candidateHost,
+      stateDir: sourceState,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: sourceBundled,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      },
+    });
+    cleanupRehearsal = rehearsal.cleanup;
+    if (candidateMode !== undefined) {
+      expect((await fs.stat(candidatePlugin)).mode).toBe(candidateMode);
+    }
+    const copiedConfig: OpenClawConfig = JSON.parse(
+      await fs.readFile(rehearsal.configPath, "utf8"),
+    );
+    const candidate = inspect(rehearsal.stateDir, candidateBundled, {});
+    expect(candidate).toMatchObject({
+      origin: bundled ? "bundled" : "global",
+      trust: { reason: bundled ? "bundled" : "origin-path", installSource: "path" },
+    });
+    const selectedEntry = candidate?.source ?? "";
+    expect(inspect(rehearsal.stateDir, candidateBundled, copiedConfig)?.source).toBe(selectedEntry);
+    expect(await fs.readFile(selectedEntry, "utf8")).toBe(
+      `export default ${JSON.stringify(bundled ? "candidate" : "live")};`,
+    );
+    if (bundled) {
+      expect(selectedEntry).toBe(path.join(candidatePlugin, "index.js"));
+    } else {
+      expect(selectedEntry.startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+    }
+    expect(await fs.readFile(shared)).toEqual(liveDatabase);
+    expect(await fs.readFile(path.join(sourcePlugin, "index.js"))).toEqual(liveEntry);
+    expect(config.plugins?.installs?.demo?.sourcePath).toBe(locator);
+    expect(
+      await Promise.all(
+        [sourcePlugin, path.join(sourcePlugin, "index.js")].map(
+          async (file) => (await fs.stat(file)).mode,
+        ),
+      ),
+    ).toEqual(sourceModes);
+    expect(await rehearsal.changedConfigKeys()).toEqual([]);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await cleanupRehearsal?.();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -10,9 +10,13 @@ import {
   resolveBundledPluginsDir,
 } from "../plugins/bundled-dir.js";
 import { listBundledPluginMetadata } from "../plugins/bundled-plugin-metadata.js";
-import { resolveBundledSourceCheckoutExtensionsDir } from "../plugins/discovery.js";
+import {
+  resolveBundledSourceCheckoutExtensionsDir,
+  resolvePluginPackageEntries,
+} from "../plugins/discovery.js";
 import { INSTALLED_PLUGIN_INDEX_STATE_KEY } from "../plugins/installed-plugin-index-row.js";
 import { loadBundledPluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { resolvePackageExtensionEntries } from "../plugins/manifest.js";
 import { pluginCacheRealpathSync } from "../plugins/plugin-cache-files.js";
 import type { ConfigMachineStateDatabase } from "../state/config-machine-state.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
@@ -67,26 +71,59 @@ function bundledPluginRedirects(
       scanDir: directory,
       includeChannelConfigs: false,
     })) {
-      const candidate = candidates.get(source.manifest.id);
       const sourceRoot = pluginCacheRealpathSync(path.join(directory, source.dirName), true);
-      if (!candidate || !sourceRoot || !isPathInside(sourceReal, sourceRoot)) {
+      if (!sourceRoot || !isPathInside(sourceReal, sourceRoot)) {
         continue;
       }
-      // Only physically bundled aliases with the same staged manifest ID retain bundled identity.
-      for (const [sourcePath, candidatePath] of [
-        [sourceRoot, candidate.rootDir],
-        [path.resolve(sourceRoot, source.source.source), candidate.source],
-      ] as const) {
-        const from = pluginCacheRealpathSync(sourcePath, true);
-        const to = pluginCacheRealpathSync(candidatePath, true);
-        if (
-          from &&
-          to &&
-          isPathInside(sourceRoot, from) &&
-          isPluginInPackageBundledRoots({ rootDir: to, packageRoot: candidateRoot })
-        ) {
-          redirects.set(from, to);
+      const manifest = { name: source.packageName, openclaw: source.packageManifest };
+      const extensions = resolvePackageExtensionEntries(manifest);
+      if (extensions.status !== "ok") {
+        continue;
+      }
+      const entries = resolvePluginPackageEntries({
+        packageDir: sourceRoot,
+        packageRootRealPath: sourceRoot,
+        manifest,
+        manifestId: source.manifest.id,
+        extensions: extensions.entries,
+        origin: "bundled",
+        sourceLabel: sourceRoot,
+        diagnostics: [],
+        rejectHardlinks: false,
+      });
+      let allEntriesMatched = entries.length === extensions.entries.length;
+      const candidateRoots = new Set<string>();
+      for (const entry of entries) {
+        const candidate = candidates.get(entry.idHint);
+        if (!candidate || path.parse(entry.source).name !== path.parse(candidate.source).name) {
+          allEntriesMatched = false;
+          continue;
         }
+        const from = pluginCacheRealpathSync(entry.source, true);
+        const to = pluginCacheRealpathSync(candidate.source, true);
+        const targetRoot = pluginCacheRealpathSync(candidate.rootDir, true);
+        if (
+          !from ||
+          !to ||
+          !targetRoot ||
+          !isPathInside(sourceRoot, from) ||
+          !isPathInside(targetRoot, to) ||
+          !isPluginInPackageBundledRoots({ rootDir: targetRoot, packageRoot: candidateRoot })
+        ) {
+          allEntriesMatched = false;
+          continue;
+        }
+        redirects.set(from, to);
+        const declared = pluginCacheRealpathSync(path.resolve(sourceRoot, entry.entryPath), true);
+        if (declared && isPathInside(sourceRoot, declared)) {
+          redirects.set(declared, to);
+        }
+        candidateRoots.add(targetRoot);
+      }
+      // A package alias moves only when all its entries move together to one candidate package.
+      const [targetRoot] = candidateRoots;
+      if (allEntriesMatched && candidateRoots.size === 1 && targetRoot) {
+        redirects.set(sourceRoot, targetRoot);
       }
     }
   }

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -4,7 +4,16 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parsePluginInstallRecordMap } from "../config/plugin-install-record-map.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import {
+  isPluginInPackageBundledRoots,
+  resolveBundledDirFromPackageRoot,
+  resolveBundledPluginsDir,
+} from "../plugins/bundled-dir.js";
+import { listBundledPluginMetadata } from "../plugins/bundled-plugin-metadata.js";
+import { resolveBundledSourceCheckoutExtensionsDir } from "../plugins/discovery.js";
 import { INSTALLED_PLUGIN_INDEX_STATE_KEY } from "../plugins/installed-plugin-index-row.js";
+import { loadBundledPluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { pluginCacheRealpathSync } from "../plugins/plugin-cache-files.js";
 import type { ConfigMachineStateDatabase } from "../state/config-machine-state.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
@@ -19,6 +28,61 @@ import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
 import { resolveUpdateCandidatePluginPath } from "./update-candidate-paths.js";
 import { copyUpdateCandidatePluginTrees } from "./update-candidate-plugin-tree.js";
+
+function bundledPluginRedirects(
+  candidateRoot: string,
+  env?: NodeJS.ProcessEnv,
+): Map<string, string> {
+  const redirects = new Map<string, string>();
+  const sourceDir = resolveBundledPluginsDir(env);
+  const candidateDir = resolveBundledDirFromPackageRoot(candidateRoot);
+  if (
+    !sourceDir ||
+    !candidateDir ||
+    !isPluginInPackageBundledRoots({ rootDir: candidateDir, packageRoot: candidateRoot })
+  ) {
+    return redirects;
+  }
+  const bundledEnv = { ...env, OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1" };
+  const candidates = new Map(
+    loadBundledPluginManifestRegistry({ env: bundledEnv, bundledRoot: candidateDir }).plugins.map(
+      (plugin) => [plugin.id, plugin],
+    ),
+  );
+  for (const directory of [sourceDir, resolveBundledSourceCheckoutExtensionsDir(sourceDir)]) {
+    const sourceReal = directory && pluginCacheRealpathSync(directory, true);
+    if (!directory || !sourceReal) {
+      continue;
+    }
+    for (const source of listBundledPluginMetadata({
+      scanDir: directory,
+      includeChannelConfigs: false,
+    })) {
+      const candidate = candidates.get(source.manifest.id);
+      const sourceRoot = pluginCacheRealpathSync(path.join(directory, source.dirName), true);
+      if (!candidate || !sourceRoot || !isPathInside(sourceReal, sourceRoot)) {
+        continue;
+      }
+      // Only physically bundled aliases with the same staged manifest ID retain bundled identity.
+      for (const [sourcePath, candidatePath] of [
+        [sourceRoot, candidate.rootDir],
+        [path.resolve(sourceRoot, source.source.source), candidate.source],
+      ] as const) {
+        const from = pluginCacheRealpathSync(sourcePath, true);
+        const to = pluginCacheRealpathSync(candidatePath, true);
+        if (
+          from &&
+          to &&
+          isPathInside(sourceRoot, from) &&
+          isPluginInPackageBundledRoots({ rootDir: to, packageRoot: candidateRoot })
+        ) {
+          redirects.set(from, to);
+        }
+      }
+    }
+  }
+  return redirects;
+}
 
 async function resolvePluginFilePackageRoot(file: string): Promise<string> {
   const directory = path.dirname(file);
@@ -120,6 +184,10 @@ export async function projectUpdateCandidatePlugins(params: {
   for (const source of params.config.plugins?.load?.paths ?? []) {
     sources.add(resolve(source));
   }
+  const bundledRedirects =
+    sources.size > 0
+      ? bundledPluginRedirects(params.candidateRoot, params.env)
+      : new Map<string, string>();
   const pluginPaths: Record<string, string> = {};
   for (const source of sources) {
     const stat = await fs.stat(source).catch((error: unknown) => {
@@ -134,6 +202,11 @@ export async function projectUpdateCandidatePlugins(params: {
       continue;
     }
     const real = await fs.realpath(source);
+    const bundled = bundledRedirects.get(real);
+    if (bundled) {
+      pluginPaths[source] = bundled;
+      continue;
+    }
     const file = stat.isFile();
     locators.push({ source, real, file });
     // Copy the whole managed project so hoisted dependencies remain available.

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -25,6 +25,7 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { resolveOpenClawPackageRootSync } from "./openclaw-root.js";
 import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
 import { resolveUpdateCandidatePluginPath } from "./update-candidate-paths.js";
 import { copyUpdateCandidatePluginTrees } from "./update-candidate-plugin-tree.js";
@@ -35,9 +36,11 @@ function bundledPluginRedirects(
 ): Map<string, string> {
   const redirects = new Map<string, string>();
   const sourceDir = resolveBundledPluginsDir(env);
+  const sourcePackageRoot = sourceDir && resolveOpenClawPackageRootSync({ cwd: sourceDir });
   const candidateDir = resolveBundledDirFromPackageRoot(candidateRoot);
   if (
     !sourceDir ||
+    !sourcePackageRoot ||
     !candidateDir ||
     !isPluginInPackageBundledRoots({ rootDir: candidateDir, packageRoot: candidateRoot })
   ) {
@@ -50,8 +53,14 @@ function bundledPluginRedirects(
     ),
   );
   for (const directory of [sourceDir, resolveBundledSourceCheckoutExtensionsDir(sourceDir)]) {
-    const sourceReal = directory && pluginCacheRealpathSync(directory, true);
-    if (!directory || !sourceReal) {
+    if (
+      !directory ||
+      !isPluginInPackageBundledRoots({ rootDir: directory, packageRoot: sourcePackageRoot })
+    ) {
+      continue;
+    }
+    const sourceReal = pluginCacheRealpathSync(directory, true);
+    if (!sourceReal) {
       continue;
     }
     for (const source of listBundledPluginMetadata({

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -234,6 +234,8 @@ export async function prepareUpdateCandidateRehearsal(params: {
             USERPROFILE: sourceEnv.USERPROFILE,
             OPENCLAW_AGENT_DIR: sourceEnv.OPENCLAW_AGENT_DIR,
             PI_CODING_AGENT_DIR: sourceEnv.PI_CODING_AGENT_DIR,
+            OPENCLAW_BUNDLED_PLUGINS_DIR: sourceEnv.OPENCLAW_BUNDLED_PLUGINS_DIR,
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: sourceEnv.OPENCLAW_DISABLE_BUNDLED_PLUGINS,
           },
         }),
         baseEnv: env,

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -165,7 +165,7 @@ export function isPluginInPackageBundledRoots(params: {
     );
 }
 
-function resolveBundledDirFromPackageRoot(packageRoot: string): string | undefined {
+export function resolveBundledDirFromPackageRoot(packageRoot: string): string | undefined {
   const builtExtensionsDir = path.join(packageRoot, "dist", "extensions");
   // In pnpm source checkouts, prefer the built bundled plugin runtime when it
   // exists so dist gateway runs avoid loading TS plugin entrypoints through jiti.

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -111,7 +111,10 @@ export function resolveSourceCheckoutDependencyDiagnostic(
       continue;
     }
     const extensionsDir = path.join(packageRoot, "extensions");
-    if (!hasUsableBundledPluginTree(extensionsDir)) {
+    if (
+      !isPluginInPackageBundledRoots({ rootDir: extensionsDir, packageRoot }) ||
+      !hasUsableBundledPluginTree(extensionsDir)
+    ) {
       continue;
     }
     if (pluginCacheExistsSync(path.join(packageRoot, "node_modules", ".pnpm"))) {
@@ -173,11 +176,15 @@ export function resolveBundledDirFromPackageRoot(packageRoot: string): string | 
   const runtimeExtensionsDir = path.join(packageRoot, "dist-runtime", "extensions");
   if (isSourceCheckoutRoot(packageRoot)) {
     return [builtExtensionsDir, runtimeExtensionsDir, path.join(packageRoot, "extensions")].find(
-      hasUsableBundledPluginTree,
+      (rootDir) =>
+        isPluginInPackageBundledRoots({ rootDir, packageRoot }) &&
+        hasUsableBundledPluginTree(rootDir),
     );
   }
   return pluginCacheExistsSync(builtExtensionsDir)
-    ? [runtimeExtensionsDir, builtExtensionsDir].find(pluginCacheExistsSync)
+    ? [runtimeExtensionsDir, builtExtensionsDir].find((rootDir) =>
+        isPluginInPackageBundledRoots({ rootDir, packageRoot }),
+      )
     : undefined;
 }
 

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -667,7 +667,9 @@ function isSourceCheckoutExtensionsDir(extensionsDir: string): boolean {
   );
 }
 
-function resolveBundledSourceCheckoutExtensionsDir(bundledRoot?: string): string | undefined {
+export function resolveBundledSourceCheckoutExtensionsDir(
+  bundledRoot?: string,
+): string | undefined {
   if (!bundledRoot) {
     return undefined;
   }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -42,7 +42,7 @@ import {
 } from "./manifest.js";
 import { satisfiesPluginApiRange, resolvePackagePluginApiRange } from "./package-compat.js";
 import {
-  resolvePackageRuntimeExtensionSources,
+  resolvePackageRuntimeExtensions,
   resolvePackageSetupSource,
 } from "./package-entry-resolution.js";
 import { formatPosixMode, isPathInside } from "./path-safety.js";
@@ -560,6 +560,47 @@ function derivePackagePluginIdHint(packageName: unknown): string | undefined {
   return normalizeOptionalString(unscoped);
 }
 
+export function resolvePluginPackageEntries(
+  params: Parameters<typeof resolvePackageRuntimeExtensions>[0] & { manifestId?: string },
+): Array<{ idHint: string; entryPath: string; source: string }> {
+  const entryIdSources = new Map<string, Array<{ entryPath: string; source: string }>>();
+  for (const entry of resolvePackageRuntimeExtensions(params)) {
+    const idHint = deriveIdHint({
+      filePath: entry.source,
+      manifestId: params.manifestId,
+      packageName: params.manifest?.name,
+      fallbackId: path.basename(params.packageDir),
+      hasMultipleExtensions: params.extensions.length > 1,
+    });
+    const sources = entryIdSources.get(idHint);
+    if (sources) {
+      sources.push(entry);
+    } else {
+      entryIdSources.set(idHint, [entry]);
+    }
+  }
+  const entries: Array<{ idHint: string; entryPath: string; source: string }> = [];
+  for (const [idHint, sources] of entryIdSources) {
+    // Entry ids derive from basenames; colliding entries must not silently vanish in the registry.
+    if (params.extensions.length > 1 && sources.length > 1) {
+      params.diagnostics.push({
+        level: "error",
+        pluginId: idHint,
+        source: params.sourceLabel,
+        message:
+          `plugin package entries collide on derived id "${idHint}" ` +
+          `(${sources.map((entry) => path.relative(params.packageDir, entry.source)).join(", ")}); ` +
+          "rename the entry files to unique basenames",
+      });
+      continue;
+    }
+    for (const entry of sources) {
+      entries.push({ ...entry, idHint });
+    }
+  }
+  return entries;
+}
+
 function pushInvalidPackageExtensionDiagnostic(params: {
   resolution: PackageExtensionResolution;
   source: string;
@@ -982,11 +1023,12 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
     };
 
     if (extensions.length > 0) {
-      const resolvedRuntimeSources = resolvePackageRuntimeExtensionSources({
+      const entries = resolvePluginPackageEntries({
         packageDir: dir,
         ...(rootRealPath !== undefined ? { packageRootRealPath: rootRealPath } : {}),
         manifest,
         extensions,
+        manifestId: manifestId ?? normalizeOptionalString(packageMetadata?.plugin?.id),
         origin: params.origin,
         pluginIdHint,
         requireBuiltRuntimeEntry,
@@ -994,41 +1036,12 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
         diagnostics,
         rejectHardlinks,
       });
-      // Entry ids derive from basenames, so ./a/index.js and ./b/index.js would
-      // both become <pack>/index and one entry would silently vanish in the
-      // registry's same-id dedupe. Reject the colliding entries loudly instead.
-      const entryIdSources = new Map<string, string[]>();
-      for (const source of resolvedRuntimeSources) {
-        const idHint = deriveIdHint({
-          filePath: source,
-          manifestId: manifestId ?? normalizeOptionalString(packageMetadata?.plugin?.id),
-          packageName: manifest?.name,
-          fallbackId: path.basename(dir),
-          hasMultipleExtensions: extensions.length > 1,
-        });
-        const sources = entryIdSources.get(idHint);
-        if (sources) {
-          sources.push(source);
-        } else {
-          entryIdSources.set(idHint, [source]);
-        }
-      }
-      for (const [idHint, sources] of entryIdSources) {
-        if (extensions.length > 1 && sources.length > 1) {
-          diagnostics.push({
-            level: "error",
-            pluginId: idHint,
-            source: dir,
-            message:
-              `plugin package entries collide on derived id "${idHint}" ` +
-              `(${sources.map((s) => path.relative(dir, s)).join(", ")}); ` +
-              "rename the entry files to unique basenames",
-          });
-          continue;
-        }
-        for (const source of sources) {
-          addPackageCandidate(source, idHint, extensions.length > 1 ? idHint : undefined);
-        }
+      for (const entry of entries) {
+        addPackageCandidate(
+          entry.source,
+          entry.idHint,
+          extensions.length > 1 ? entry.idHint : undefined,
+        );
       }
       return true;
     }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -14,6 +14,7 @@ import { resolveCompatibilityHostVersion } from "../version.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
 import {
   hasUsableBundledPluginTree,
+  isPluginInPackageBundledRoots,
   resolveBundledPluginsDir,
   resolveSourceCheckoutDependencyDiagnostic,
 } from "./bundled-dir.js";
@@ -674,7 +675,15 @@ export function resolveBundledSourceCheckoutExtensionsDir(
     return undefined;
   }
   const legacyRoot = buildLegacyBundledRootPath(bundledRoot);
-  if (!legacyRoot || !isSourceCheckoutExtensionsDir(legacyRoot)) {
+  // Discovery must not touch a root that containment has not admitted.
+  if (
+    !legacyRoot ||
+    !isPluginInPackageBundledRoots({
+      rootDir: legacyRoot,
+      packageRoot: path.dirname(legacyRoot),
+    }) ||
+    !isSourceCheckoutExtensionsDir(legacyRoot)
+  ) {
     return undefined;
   }
   return legacyRoot;

--- a/src/plugins/package-entry-resolution.ts
+++ b/src/plugins/package-entry-resolution.ts
@@ -548,7 +548,14 @@ export function resolvePackageSetupSource(params: {
 }
 
 /** Resolves runtime extension sources for a plugin package manifest. */
-export function resolvePackageRuntimeExtensionSources(params: {
+export function resolvePackageRuntimeExtensionSources(
+  params: Parameters<typeof resolvePackageRuntimeExtensions>[0],
+): string[] {
+  return resolvePackageRuntimeExtensions(params).map((entry) => entry.source);
+}
+
+/** Keeps declarations paired with their runtime sources when earlier entries cannot resolve. */
+export function resolvePackageRuntimeExtensions(params: {
   packageDir: string;
   packageRootRealPath?: string;
   manifest: PackageManifest | null;
@@ -559,7 +566,7 @@ export function resolvePackageRuntimeExtensionSources(params: {
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
-}): string[] {
+}): Array<{ entryPath: string; source: string }> {
   const runtimeResolution = resolvePackageRuntimeExtensionEntries({
     manifest: params.manifest,
     extensions: params.extensions,
@@ -593,6 +600,6 @@ export function resolvePackageRuntimeExtensionSources(params: {
       diagnostics: params.diagnostics,
       rejectHardlinks: params.rejectHardlinks,
     });
-    return source ? [source] : [];
+    return source ? [{ entryPath, source }] : [];
   });
 }


### PR DESCRIPTION
Refs #142633

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw update` with path-install aliases of bundled plugins can have the candidate Gateway reject a plugin that the serving Gateway loads as bundled. This can prevent candidate readiness and block the update.

## Why This Change Was Made

Copying a bundled alias into independent storage changed discovery to `origin=global` and `trust.reason=origin-path`. Candidate projection now redirects only physically verified bundled plugin roots and entrypoints to the staged bundled plugin with the same manifest ID, using runtime directory selection for source-checkout and split-runtime layouts.

Source metadata inspection stays read-only, and candidate containment is checked before discovery. External paths, escaping aliases, and absent or mismatched staged plugin IDs retain the existing independent-copy path and trust policy. Install-record source values are unchanged.

## User Impact

Candidate rehearsal preserves bundled ownership for these aliases while keeping external path installations subject to their existing trust restrictions. Live plugin files, permissions, install records, and host links remain untouched. The update workflow documentation describes this behavior.

## Evidence

The regression runs the real rehearsal snapshot worker and then real manifest discovery against synthetic plugin packages and SQLite state. With the production fix temporarily reversed against the branch base, the directory-alias regression fails with:

```text
- origin: bundled
+ origin: global
  installSource: path
- trust.reason: bundled
+ trust.reason: origin-path
Test Files 1 failed; Tests 1 failed, 11 skipped
```

The repaired regression matrix covers direct and symlink aliases, entrypoints, renamed staged directories, split runtime and source-checkout layouts, external paths, source/candidate symlink escapes, absent/mismatched IDs, and preservation of live permissions and database bytes. A separate before/after regression proves a candidate bundled-root symlink cannot change permissions outside the staged package during projection.

Focused validation: **205 tests passed across 9 files**, including a real built Gateway reaching started/ready and verified process-group/state cleanup. The test runner rebuilt the final runtime successfully. The final provenance-only rerun passed all **13 cases**; changed-file checks, including production/test typechecks and lint, also passed.

```sh
node scripts/run-vitest.mjs \
  src/infra/update-candidate-bundled-provenance.test.ts \
  src/infra/update-candidate-state.test.ts \
  src/infra/update-candidate-canary.test.ts \
  src/infra/update-candidate-canary.integration.test.ts \
  src/plugins/discovery.test.ts \
  src/plugins/discovery-threading.test.ts \
  src/plugins/discovery-checkout.test.ts \
  src/plugins/bundled-discovery-state.test.ts \
  src/plugins/plugin-discovery-ordering.test.ts
node scripts/run-vitest.mjs src/infra/update-candidate-bundled-provenance.test.ts
node scripts/check-changed.mjs
node scripts/check-docs-mdx.mjs docs/cli/update/how-updates-run.md
git diff --check
```

CI completed on `66b62610dace56cdfa1466523d35285bef0aca88` with 131 checks passed and 50 skipped. CI is not green: [checks-node-changed-extensions-bundle-27](https://github.com/openclaw/openclaw/actions/runs/34365714887/job/102514685679) failed in the unchanged `extensions/telegram/src/model-callback.loopback.integration.test.ts:245`, receiving `HttpError: Network request for 'editMessageText' failed!`; the aggregate `openclaw/ci-gate` consequently failed too. This test exercises the Telegram callback router against a local HTTP server and does not invoke candidate projection. This branch changes no Telegram files; the failure is recorded for separate follow-up.

## Known Gaps

This repairs the reproduced bundled-alias projection defect. The earlier snapshot ENOENT, unexplained npm canary exits, and isolated xAI repair-auth failure reported in #142633 remain unresolved. The synthetic proof does not establish that every reported update failure has this cause, so this PR references the issue rather than closing it.

## Credit

Reported by @DonnieFi in #142633.

## Review notes

Live persisted state and install records remain untouched. There are no persisted-state, install-record, or config schema changes. Candidate projection redirects only aliases whose realpaths belong to the running package's bundled roots and whose discovery identity and entry name match a staged bundled entry. External path installs retain their existing copy and trust behavior.

The accepted fallback-root finding is repaired at the scan owners: source and candidate fallback roots are admitted before enumeration, diagnostics, or permission repair, and source metadata loading also checks package containment. The accepted multi-entry finding is repaired by sharing discovery's runtime entry enumeration, ID derivation, and collision handling. Declared and runtime paths stay paired; unmatched entries keep the existing copy path. A whole-package alias redirects only when every entry matches one candidate package.

The original 13 regression cases are: directory; source permissions; symlink; entrypoint; renamed candidate directory; split candidate runtime; source checkout alongside built runtime; external path; source symlink escaping the bundled directory; candidate symlink escaping the bundled directory; candidate bundled root escaping the package; missing candidate ID; mismatched candidate ID.

Added coverage: valid in-package candidate fallback; escaping candidate fallback; escaping candidate fallback with an external install; no enumeration of an outside source fallback; no enumeration of an outside candidate fallback; complete multi-entry redirect; and a missing candidate entry with matching siblings preserved. The fallback regressions failed before the containment fix, and both multi-entry regressions failed before the entry-mapping fix. All 20 provenance cases now pass. The requested suites plus shared entry-resolver consumer tests passed 262 tests across 12 files; changed-file checks passed before rebase.

The three-commit series was rebased without conflicts onto main containing #143197 and #143213. `git range-diff` reports all three patches unchanged; no hunk changed beyond rebase offsets.

Post-rebase `node scripts/check-changed.mjs` passed on `f02b5484e8ab6f385e6ba98e7268b5e5e74e3fb5`. The earlier CI failure above describes the old head; this head includes the Telegram and Windows fixture fixes from main and received a fresh CI run.

Fresh exact-head CI passed on `f02b5484e8ab6f385e6ba98e7268b5e5e74e3fb5`: [run 34380528777](https://github.com/openclaw/openclaw/actions/runs/34380528777). `node scripts/watch-pr-ci.mjs 143190 f02b5484e8ab6f385e6ba98e7268b5e5e74e3fb5` exited successfully with `STATUS state=SUCCESS pending=0` and `GREEN`; no rerun was needed. ClawSweeper's exact-head review found no actionable findings or remaining Before merge items, and the requested re-review comment has been posted.
