### PR TITLE
fix: prevent leaked chat preview Escape listeners in tests

### DIFF
--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -259,6 +259,7 @@ describe("conversation position rail", () => {
       expect(preview.querySelector("script")).toBeNull();
       expect(preview.closest("[inert]")).not.toBeNull();
     } finally {
+      render(nothing, container);
       transcript.hostDisconnected();
     }
   });


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>
The branch is hosted in this repository and remains editable by repository maintainers.
</details>

## What Problem This Solves

Resolves a problem where shared UI test runs lose Escape events after the chat position rail Markdown preview tests, causing two otherwise passing picker tests to fail.

## Why This Change Was Made

Clear the table's Lit-rendered fixture before disconnecting its transcript controller. This invokes the existing directive teardown and removes the preview's window listener. Removing the DOM alone does not notify a Lit AsyncDirective that its root part was disconnected.

## User Impact

No product behavior changes. Developers get isolated test fixtures while retaining both Markdown preview cases and all existing picker assertions.

## Evidence

- The unchanged rail → picker sequence reproduced exactly two failures among 20 cases. Escape traces identified the detached chat preview's capture listener; the one-line cleanup makes all 20 pass with normal picker handling.
- Replayed the recorded 277-file historical UI prefix: before, 7,568 passed and the same two failed; after, all 7,570 passed with no skips. The candidate run had no Escape instrumentation and retained the exact file order and case identities.
- The historical replay uses frozen source `78e9b1432867356d47682de04ec68b6f840bbe45` on macOS/Node 26.8.1; the original failure was recorded on Linux/Node 24.19. This is not a full-suite performance acceptance result.
- Mapped changed checks and independent review passed. The only source change is one test teardown line.
