### PR TITLE
improve(test): reduce Telegram policy fixture startup overhead

### DIFF
--- a/test/e2e/qa-lab/runtime/telegram-inherited-policy-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-inherited-policy-gateway.e2e.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { expect, test } from "vitest";
 import {
@@ -141,7 +142,15 @@ test.each(["allowlist", "open"] as const)(
               repoRoot,
               command: {
                 executablePath: process.execPath,
-                argsPrefix: [path.join(repoRoot, "scripts/run-node.mjs")],
+                argsPrefix: [
+                  "--import",
+                  pathToFileURL(path.join(repoRoot, "scripts/tsx.mjs")).href,
+                  path.join(repoRoot, "scripts/run-with-env.mts"),
+                  `OPENCLAW_DEV_SOURCE_ROOT=${repoRoot}`,
+                  "--",
+                  process.execPath,
+                  path.join(repoRoot, "openclaw.mjs"),
+                ],
                 argsSuffix: ["--verbose"],
                 cwd: repoRoot,
                 usePackagedPlugins: true,


### PR DESCRIPTION
Related: #139428 (https://github.com/openclaw/openclaw/issues/139428)

## What Problem This Solves

The Telegram inherited-policy E2E fixture repeats development-runner freshness checks for each CLI operation even though E2E setup already prepares the runtime. Those checks add overhead to both policy cases.

## Why This Change Was Made

Launch the prepared CLI through the existing signal-forwarding `run-with-env` wrapper and explicitly preserve `OPENCLAW_DEV_SOURCE_ROOT`. Use a file URL for the preload so Windows paths and special characters are handled correctly. The change is confined to one test file.

Both cases retain fresh state, all ten auth/help/repair/Gateway operations, packaged plugins, the working directory, verbose output, timeouts, HTTP assertions and cleanup. No production, helper, dependency, configuration or workflow changes.

## User Impact

No product behavior changes. Developers get lower startup overhead in this focused E2E test without removing its policy-inheritance or real-dispatch coverage.

## Evidence

- Original, initial candidate and closing-original full-file runs each passed **2/2**, with zero skipped and all ten fixture operations.
- Case totals were **127.310s / 100.887s / 108.136s**. Candidate was **7.249s lower than closing original**, with **6.242s** attributable to the measured auth/help operations. This is one bounded comparison, not a whole-CI estimate; repair warm-up, worker preparation and outer invocation variance are not claimed as runner savings.
- After making the preload a portable file URL, one additional final-source full-file run passed **2/2**, zero skipped, with all ten operations and verified recorded cleanup. Loader probes covered the Windows drive-letter rejection and an actual filename containing spaces, `#` and `%`.
- Separate diagnostic runs verified selected inner CLI environments, actual compiled core/Telegram module bytes, and observed process-group/port release before and after owned-root deletion. These instrumented runs are correctness evidence, not performance measurements.
- Opposite account policies failed both original policy assertions with the intended downstream effects. Original and candidate startup-failure controls rejected at the existing `onListening` boundary and released their observed processes, ports and roots with unchanged deadlines.
- Required one-file `check-changed` passed, including formatting, root test typechecking, script guards and targeted lint. Affected formatting, root types and file lint passed again after the preload URL correction. Fresh full local P2 review of the final diff was scoped-clean.

Proof used the existing prebuilt E2E contract with matching complete private-QA, AI and runtime-overlay artifacts. Normal worker preparation remained enabled. Transport/provider endpoints were fixture-owned mocks, not a live Telegram account.

All local measurements and loader probes ran on Linux; no native Windows E2E execution was performed.
