### PR TITLE
fix(github): point the stuck-FAQ auto-response at a live anchor

### DIFF
--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -26,7 +26,7 @@ const rules = [
     label: "r: support",
     close: true,
     message:
-      "Please use [our support server](https://discord.gg/clawd) and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
+      "Please use [our support server](https://discord.gg/clawd) and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.openclaw.ai/help/faq-first-run#i-am-stuck-fastest-way-to-get-unstuck.",
   },
   {
     label: "r: false-positive",


### PR DESCRIPTION
The `r: support` auto-response in `scripts/github/barnacle-auto-response.mjs` closes issues with a link to:

```
https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck
```

**That anchor does not exist**, and did not before today's FAQ split. `git grep im-stuck-whats-the-fastest-way -- docs/` returns nothing on `main`. The content moved to the first-run FAQ in an earlier split and the id changed spelling at the same time, so every issue closed with this label has been sending people to a page that scrolls nowhere.

The live target is `/help/faq-first-run#i-am-stuck-fastest-way-to-get-unstuck` — `docs/help/faq-first-run.md:33` publishes it as an authored `<a id>` stub, so it resolves and will survive further splits of that page.

Found while splitting `docs/help/faq.md` (#143150). `docs-link-audit` cannot catch this class: the URL lives in a script, not a docs page — worth considering whether the audit should scan `scripts/` for `docs.openclaw.ai` URLs.

`test/scripts/barnacle-auto-response.test.ts`: 47/47 pass.