### PR TITLE
fix(doctor): explain hard-linked session migration refusals

### DIFF
--- a/docs/cli/doctor/sqlite-maintenance.md
+++ b/docs/cli/doctor/sqlite-maintenance.md
@@ -241,6 +241,28 @@ them, so interrupted cleanup can be resumed. Restore distinguishes intentional
 disposal, pending cleanup, and unexpected missing files. See
 [Update cleanup](/cli/update#update-cleanup).
 
+### Hard-linked legacy artifacts
+
+Doctor refuses a legacy `sessions.json` or transcript artifact when another hard
+link references its inode. The diagnostic names the artifact path, device, inode,
+and observed link count (`nlink`). Doctor does not scan for other linked paths.
+The refusal protects snapshot copies from changes through a shared inode.
+
+For a legacy source rejected before its identity was recorded for archival, stop
+the Gateway and create a verified backup. Copy the contents to a **new** temporary
+regular file in the same directory, preserving permissions. Verify that the copy
+has identical contents and a link count of one, then rename it over the reported
+source path and rerun the same Doctor command. Do not overwrite the source in
+place or create another hard link: replacing its directory entry with the fresh
+copy preserves the snapshot's contents without needing to find its other paths.
+
+If an earlier migration was interrupted or the reported path is an archived
+recovery artifact, preserve the files and manifests. Run
+`openclaw doctor --session-sqlite recover` with the same profile and legacy-source
+selectors first. Recorded artifacts depend on their original identities;
+replacing them with copies can prevent restoration. If recovery still refuses
+the artifact, retain that evidence for support instead of replacing it.
+
 ### Downgrading After Session SQLite Migration
 
 Follow [Downgrade](/install/updating#downgrade) before starting an older release.

--- a/src/commands/doctor-session-sqlite-artifact.ts
+++ b/src/commands/doctor-session-sqlite-artifact.ts
@@ -67,6 +67,19 @@ export function isPendingMigrationArtifactClaim(
   );
 }
 
+function formatMigrationArtifactRefusal(filePath: string, stat: fs.BigIntStats): string {
+  if (!stat.isFile() || stat.nlink <= 1n) {
+    return "artifact is not an unaliased regular file";
+  }
+  return (
+    `Artifact ${filePath} is not an unaliased regular file ` +
+    `(nlink=${stat.nlink}, dev=${stat.dev}, inode=${stat.ino}): ` +
+    "another hard link references this inode; the migration refuses aliased inputs so a snapshot copy cannot be rewritten in place. " +
+    "Stop the Gateway and make a verified backup, then follow the recovery guidance: " +
+    "https://docs.openclaw.ai/cli/doctor/sqlite-maintenance#hard-linked-legacy-artifacts"
+  );
+}
+
 /** Descriptor reads are bounded; identity and content are checked before and after hashing. */
 export function readMigrationArtifactIdentity(
   filePath: string,
@@ -75,7 +88,7 @@ export function readMigrationArtifactIdentity(
 ): MigrationArtifactIdentity {
   const before = fs.lstatSync(filePath, { bigint: true });
   if (!before.isFile() || before.nlink !== expectedLinks) {
-    throw new Error("artifact is not an unaliased regular file");
+    throw new Error(formatMigrationArtifactRefusal(filePath, before));
   }
   if (
     importedFingerprint &&

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -5319,6 +5319,54 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(store.transcriptPath)).toBe(true);
   });
 
+  it("explains hard-linked legacy index refusal and supports an independent copy before retry", async () => {
+    const store = createLegacyStore();
+    const snapshotPath = path.join(store.tempDir, "snapshot-sessions.json");
+    const originalBytes = fs.readFileSync(store.storePath);
+    fs.linkSync(store.storePath, snapshotPath);
+
+    const refused = importLegacyStore(store);
+    await expect(refused).rejects.toThrow(store.storePath);
+    await expect(refused).rejects.toThrow("nlink=2");
+    await expect(refused).rejects.toThrow("another hard link references this inode");
+    await expect(refused).rejects.toThrow("backup");
+    await expect(refused).rejects.toThrow("#hard-linked-legacy-artifacts");
+    expect(fs.lstatSync(store.storePath).nlink).toBe(2);
+    expect(fs.readFileSync(store.storePath)).toEqual(originalBytes);
+    expect(fs.readFileSync(snapshotPath)).toEqual(originalBytes);
+    expect(fs.existsSync(store.transcriptPath)).toBe(true);
+
+    const copyPath = path.join(store.sessionDir, "sessions-copy.tmp");
+    fs.copyFileSync(store.storePath, copyPath, fs.constants.COPYFILE_EXCL);
+    expect(fs.readFileSync(copyPath)).toEqual(originalBytes);
+    fs.renameSync(copyPath, store.storePath);
+    expect(fs.lstatSync(store.storePath).nlink).toBe(1);
+    expect((await importLegacyStore(store)).totals.issues).toBe(0);
+    expect(fs.readFileSync(snapshotPath)).toEqual(originalBytes);
+  });
+
+  it("explains hard-linked transcript archive refusal without changing either link", async () => {
+    const store = createLegacyStore();
+    const snapshotPath = path.join(store.tempDir, "snapshot-transcript.jsonl");
+    const originalBytes = fs.readFileSync(store.transcriptPath);
+    fs.linkSync(store.transcriptPath, snapshotPath);
+
+    const report = await importLegacyStore(store);
+    const issue = expectDefined(
+      report.targets[0]?.issues.find((entry) => entry.code === "transcript_archive_failed"),
+      "hard-linked transcript archive refusal",
+    );
+    expect(issue.message).toContain(store.transcriptPath);
+    expect(issue.message).toContain("nlink=2");
+    expect(issue.message).toContain("another hard link references this inode");
+    expect(issue.message).toContain("backup");
+    expect(issue.message).toContain("#hard-linked-legacy-artifacts");
+    expect(fs.lstatSync(store.transcriptPath).nlink).toBe(2);
+    expect(fs.readFileSync(store.transcriptPath)).toEqual(originalBytes);
+    expect(fs.readFileSync(snapshotPath)).toEqual(originalBytes);
+    expect(fs.existsSync(store.storePath)).toBe(true);
+  });
+
   it.skipIf(process.platform === "win32")(
     "rejects symlink-backed legacy stores before migration",
     async () => {


### PR DESCRIPTION
Fixes #142584

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users upgrading legacy session history would receive an opaque refusal when a snapshot retained another hard link to a session artifact. Legacy-index admission omitted the affected path; archive failures omitted link metadata and recovery guidance.

## Why This Change Was Made

The shared artifact identity reader now formats hard-link refusals using its existing guarded stat: artifact path, observed link count, device, inode, the snapshot safety reason, and a link to recovery instructions. All admission, alias, hashing, publication, and recovery identity checks remain unchanged.

The recovery subsection explains verified backup and independent-copy replacement for sources rejected before archival identity capture, and directs interrupted or recorded artifacts through existing recovery. Doctor does not scan for other aliases or automatically replace files.

## User Impact

Operators can identify the blocked artifact and follow a documented recovery procedure without locating every hard link. Symlink refusals and successful imports retain their existing behavior.

Thanks to @GitHoubi for reporting the upgrade blocker.

## Evidence

The new real-filesystem regressions exercise legacy-index admission and transcript archival. Before the production fix:

```text
legacy index: Expected: <fixture>/sessions.json
              Received: artifact is not an unaliased regular file
transcript:   Expected: nlink=2
              Received: <fixture>/session-1.jsonl: artifact is not an unaliased regular file
Tests 2 failed | 231 skipped (233)
```

After the fix:

```text
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -t 'explains hard-linked' --reporter=dot
Tests 2 passed | 231 skipped (233)
```

The index fixture also verifies that copying to a fresh file and renaming over the active source permits migration while preserving the snapshot bytes. The transcript fixture verifies refusal leaves both links intact.

Full focused validation: **7 files, 282 tests passed**:

```sh
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts src/commands/doctor-session-sqlite.shared-store.test.ts src/commands/doctor-session-sqlite-readers.test.ts src/commands/doctor-session-sqlite-transcript-readers.test.ts src/commands/doctor-session-transcripts.sqlite.test.ts src/infra/state-migrations.legacy-session-store.test.ts src/commands/doctor-config-preflight.refusal-receipts.process.test.ts --reporter=dot
```

Changed-file checks passed locally, including production/test typechecks, lint, ratchets, and all selected guards:

```sh
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs --base 5cc68a7a345bf0a3bacf62cf8e4f4b359048f27d
```

The changed page passes MDX validation, formatting, and `git diff --check`. The shared publishing parser confirms the new recovery anchor.

Known validation gap: the repository-wide docs anchor audit reports three existing `windows-app-node` fragment failures in `docs/maturity/scorecard.md` and `docs/maturity/taxonomy.md`; the touched page has no reported link failures. ClawHub fragments were not verified because that separately owned docs source is absent.

This is diagnostics and guidance only. Files whose identities were already recorded still require existing recovery; no automatic de-aliasing or manifest identity changes are included.

Hosted CI for `0f988fc77f2c78bbe1522cdcc8a615aacdf5fbc5` completed with an unrelated failure: [Windows shard 1](https://github.com/openclaw/openclaw/actions/runs/34365990713/job/102515437709) reports `src/agents/tools/media-tool-file-url.windows.test.ts:61` timing out after 120000 ms in “loads Unicode and space file URLs through registered image and PDF tools.” That test is unchanged by this branch and exercises media tools, not the migration artifact reader. The aggregate `openclaw/ci-gate` failed with it; no other job failed. This unrelated timeout is left for separate triage.
