### PR TITLE
test(telegram): avoid stale sockets in the model callback fixture

### DIFF
--- a/extensions/telegram/src/model-callback.loopback.integration.test.ts
+++ b/extensions/telegram/src/model-callback.loopback.integration.test.ts
@@ -33,7 +33,8 @@ async function readJsonBody(request: IncomingMessage): Promise<Record<string, un
 }
 
 function sendJson(response: ServerResponse, result: unknown): void {
-  response.writeHead(200, { "content-type": "application/json" });
+  // Same-process model selection can stall past the loopback socket's idle timeout.
+  response.writeHead(200, { "content-type": "application/json", connection: "close" });
   response.end(JSON.stringify({ ok: true, result }));
 }
 


### PR DESCRIPTION
Related: #142242

## What Problem This Solves

The model callback loopback test can report a failed model change even though persistence succeeds: cold model selection occupies the same process long enough for its fake Bot API server's idle socket timeout to race the next request. The success edit reuses that stale connection and receives `ECONNRESET` before reaching the server handler. This blocked CI for the separately reviewed manifest compression PR.

## Why This Change Was Made

The local JSON response helper declares `Connection: close`, giving each fixture request its own completed connection lifecycle. This test covers callback authorization, opaque model resolution, persistence and response contents; persistent connection reuse is outside that contract.

## User Impact

Production Telegram behavior is unchanged. The test continues to use real grammY and HTTP with the same assertions and deadlines.

## Evidence

The unchanged case failed twice locally with the same visible failure as CI. Passive observation showed the success edit reusing a socket after a 6.83-second gap, then receiving `ECONNRESET` as the server's idle timeout fired; the fallback edit succeeded on a fresh socket.

The repaired case, model-button tests and real HTTP send siblings pass all 57 tests across three files. Independent P2 review reports no findings. Full changed-file checks passed. No retry, longer timeout or relaxed assertion is introduced.
