### PR TITLE
fix: worktree option disappears in repositories with many branches

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4341,17 +4341,20 @@ public struct WorktreesBranchesResult: Codable, Sendable {
     public let defaultbranch: String?
     public let headbranch: String?
     public let repositorystatus: WorktreeRepositoryStatus?
+    public let branchesunavailable: Bool?
 
     public init(
         branches: [WorktreeBranch],
         defaultbranch: String? = nil,
         headbranch: String? = nil,
-        repositorystatus: WorktreeRepositoryStatus? = nil)
+        repositorystatus: WorktreeRepositoryStatus? = nil,
+        branchesunavailable: Bool? = nil)
     {
         self.branches = branches
         self.defaultbranch = defaultbranch
         self.headbranch = headbranch
         self.repositorystatus = repositorystatus
+        self.branchesunavailable = branchesunavailable
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4359,6 +4362,7 @@ public struct WorktreesBranchesResult: Codable, Sendable {
         case defaultbranch = "defaultBranch"
         case headbranch = "headBranch"
         case repositorystatus = "repositoryStatus"
+        case branchesunavailable = "branchesUnavailable"
     }
 }
 

--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -90,6 +90,8 @@ Remote sessions started from a Gateway folder retain a durable managed-worktree 
 
 The Control UI offers **Worktree** only after confirming a usable Git checkout with at least one commit, or when a selected remote Git repository is awaiting cloning. Plain folders and newly initialized repositories without commits can run directly on the Gateway. A failed Git check also leaves direct execution available if the folder is accessible; a `.git` entry or saved project alone does not enable isolation. If you already selected **Worktree** and a later check fails, that selection stays visible and starting is blocked. Clear **Worktree** to run directly, or reselect the folder to check it again.
 
+The base-ref field suggests up to 100 local and 100 remote refs, plus the default and current branches. You can enter any branch or commit even when it is not suggested. If branch suggestions cannot be loaded, the Control UI explains that you can enter a ref manually; a verified Git checkout remains available for worktrees. The selected ref must still resolve to a commit before session creation.
+
 Group **New session defaults** checks the agent workspace the same way as a custom folder. If verification fails, retry before saving the group defaults. A remembered cloud destination cannot block a new local draft in a plain folder; a transient Git-check failure leaves the saved destination intact for the next visit.
 
 The Place picker's **Projects** section can start the same worktree flow from a registered project ID. The Gateway resolves the recorded checkout path, so this path remains available at `operator.write`; selecting an arbitrary host folder still requires `operator.admin`.

--- a/packages/gateway-protocol/src/schema/worktrees.test.ts
+++ b/packages/gateway-protocol/src/schema/worktrees.test.ts
@@ -70,6 +70,7 @@ describe("managed worktree protocol schemas", () => {
         defaultBranch: "main",
         headBranch: "feature",
         repositoryStatus: "git",
+        branchesUnavailable: true,
       }),
     ).toBe(true);
     expect(

--- a/packages/gateway-protocol/src/schema/worktrees.ts
+++ b/packages/gateway-protocol/src/schema/worktrees.ts
@@ -83,6 +83,7 @@ export const WorktreesBranchesResultSchema = closedObject({
   defaultBranch: Type.Optional(NonEmptyString),
   headBranch: Type.Optional(NonEmptyString),
   repositoryStatus: Type.Optional(WorktreeRepositoryStatusSchema),
+  branchesUnavailable: Type.Optional(Type.Boolean()),
 });
 
 export const WorktreesRestoreParamsSchema = closedObject({ id: NonEmptyString });

--- a/src/agents/worktrees/service-branches.test.ts
+++ b/src/agents/worktrees/service-branches.test.ts
@@ -90,7 +90,7 @@ describe("ManagedWorktreeService branch discovery", () => {
         ),
       ),
       "refs/remotes/origin/z-default",
-    ].sort();
+    ].toSorted();
     await fs.writeFile(
       path.join(repo, ".git", "packed-refs"),
       "# pack-refs with: peeled fully-peeled sorted\n" +

--- a/src/agents/worktrees/service-branches.test.ts
+++ b/src/agents/worktrees/service-branches.test.ts
@@ -79,13 +79,18 @@ describe("ManagedWorktreeService branch discovery", () => {
     },
   );
 
-  it("rejects a truncated branch inventory instead of returning a partial picker", async () => {
+  it("keeps large repositories usable with bounded suggestions and an explicit unlisted base", async () => {
     const { stdout } = await execFileAsync("git", ["-C", repo, "rev-parse", "HEAD"]);
     const commit = stdout.trim();
-    const refs = Array.from(
-      { length: 3_000 },
-      (_, index) => `refs/heads/overflow-${String(index).padStart(80, "0")}`,
-    );
+    const refs = [
+      ...["refs/heads", "refs/remotes/origin"].flatMap((prefix) =>
+        Array.from(
+          { length: 3_000 },
+          (_, index) => `${prefix}/overflow-${String(index).padStart(80, "0")}`,
+        ),
+      ),
+      "refs/remotes/origin/z-default",
+    ].sort();
     await fs.writeFile(
       path.join(repo, ".git", "packed-refs"),
       "# pack-refs with: peeled fully-peeled sorted\n" +
@@ -93,8 +98,53 @@ describe("ManagedWorktreeService branch discovery", () => {
         "\n",
     );
 
-    await expect(service.listRepositoryBranches(repo)).rejects.toThrow(
-      "too many branches to list safely",
+    await git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/z-default");
+    await git(repo, "switch", "-c", "z-current");
+    const inventory = await execFileAsync("git", [
+      "-C",
+      repo,
+      "for-each-ref",
+      "--format=%(refname)",
+      "refs/remotes",
+    ]);
+    expect(Buffer.byteLength(inventory.stdout)).toBeGreaterThan(256 * 1024);
+
+    const result = await service.listRepositoryBranches(repo, { includeRepositoryStatus: true });
+    expect(result.repositoryStatus).toBe("git");
+    expect(result.branches.length).toBeLessThanOrEqual(202);
+    expect(result.defaultBranch).toBe("origin/z-default");
+    expect(result.headBranch).toBe("z-current");
+    expect(result.branches.slice(0, 2)).toEqual([
+      { name: "origin/z-default", kind: "remote" },
+      { name: "z-current", kind: "local" },
+    ]);
+    const baseRef = `origin/overflow-${String(2_999).padStart(80, "0")}`;
+    expect(result.branches.some((branch) => branch.name === baseRef)).toBe(false);
+    const worktree = await service.create({ repoRoot: repo, name: "unlisted-base", baseRef });
+    const createdHead = await execFileAsync("git", ["-C", worktree.path, "rev-parse", "HEAD"]);
+    expect(createdHead.stdout.trim()).toBe(commit);
+    await expect(
+      service.create({ repoRoot: repo, name: "invalid-base", baseRef: "missing-branch" }),
+    ).rejects.toThrow(/base ref|resolve|revision/i);
+  });
+
+  it("retains Git availability without parsing suggestions that exceed the byte guard", async () => {
+    const { stdout } = await execFileAsync("git", ["-C", repo, "rev-parse", "HEAD"]);
+    const prefix = "segment/".repeat(400);
+    const refs = Array.from(
+      { length: 100 },
+      (_, index) =>
+        `${stdout.trim()} refs/remotes/origin/${prefix}${String(index).padStart(3, "0")}`,
     );
+    await fs.writeFile(path.join(repo, ".git", "packed-refs"), `${refs.join("\n")}\n`);
+
+    await expect(
+      service.listRepositoryBranches(repo, { includeRepositoryStatus: true }),
+    ).resolves.toEqual({
+      repositoryStatus: "git",
+      branchesUnavailable: true,
+      branches: [{ name: "main", kind: "local" }],
+      headBranch: "main",
+    });
   });
 });

--- a/src/agents/worktrees/service-branches.test.ts
+++ b/src/agents/worktrees/service-branches.test.ts
@@ -147,4 +147,67 @@ describe("ManagedWorktreeService branch discovery", () => {
       headBranch: "main",
     });
   });
+
+  it.each(["local", "current", "default", "remote"] as const)(
+    "keeps ambiguous %s branch suggestions usable even when Git warnings are disabled",
+    async (selection) => {
+      const initial = await execFileAsync("git", ["-C", repo, "rev-parse", "HEAD"]);
+      const branchCommit = await execFileAsync("git", [
+        "-C",
+        repo,
+        "commit-tree",
+        "HEAD^{tree}",
+        "-p",
+        initial.stdout.trim(),
+        "-m",
+        "branch target",
+      ]);
+      const commit = branchCommit.stdout.trim();
+      const remote = selection === "remote";
+      const ref = remote ? "refs/remotes/origin/z-selected" : "refs/heads/z-selected";
+      await git(repo, "config", "core.warnAmbiguousRefs", "false");
+      await git(repo, "tag", remote ? "origin/z-selected" : "z-selected");
+      await git(repo, "update-ref", ref, commit);
+      if (selection !== "local") {
+        const fillers = ["refs/heads", "refs/remotes/origin"].flatMap((prefix) =>
+          Array.from(
+            { length: 150 },
+            (_, index) =>
+              `${initial.stdout.trim()} ${prefix}/filler-${String(index).padStart(3, "0")}`,
+          ),
+        );
+        await fs.writeFile(path.join(repo, ".git", "packed-refs"), `${fillers.join("\n")}\n`);
+      }
+      if (selection === "current") {
+        await git(repo, "symbolic-ref", "HEAD", ref);
+      }
+      if (selection === "default" || remote) {
+        await git(repo, "update-ref", "refs/remotes/origin/z-selected", commit);
+        await git(
+          repo,
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/z-selected",
+        );
+      }
+
+      const result = await service.listRepositoryBranches(repo, { includeRepositoryStatus: true });
+      const expected = remote ? "remotes/origin/z-selected" : "heads/z-selected";
+      expect(result.branches).toContainEqual({ name: expected, kind: remote ? "remote" : "local" });
+      expect(result.branches.length).toBeLessThanOrEqual(202);
+      if (selection === "current") {
+        expect(result.headBranch).toBe(expected);
+      }
+      if (selection === "default" || remote) {
+        expect(result.defaultBranch).toBe(expected);
+      }
+      const created = await service.create({
+        repoRoot: repo,
+        name: "disambiguated",
+        baseRef: expected,
+      });
+      const head = await execFileAsync("git", ["-C", created.path, "rev-parse", "HEAD"]);
+      expect(head.stdout.trim()).toBe(commit);
+    },
+  );
 });

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -294,6 +294,55 @@ async function resolveRepository(repoRoot: string): Promise<ResolvedRepository> 
   return await resolveRepositoryFromRealPath(requested, repoRoot);
 }
 
+type RepositoryBranchRef = {
+  ref: string;
+  branchName: string;
+  branch: ManagedWorktreeBranch;
+};
+
+async function listRepositoryBranchRefs(
+  repoRoot: string,
+  pattern: string,
+  count: number,
+): Promise<RepositoryBranchRef[]> {
+  const result = await runGit(
+    repoRoot,
+    [
+      "-c",
+      "core.warnAmbiguousRefs=true",
+      "for-each-ref",
+      `--count=${count}`,
+      "--sort=refname",
+      "--format=%(refname)%00%(refname:short)",
+      pattern,
+    ],
+    { maxOutputBytes: BRANCH_INVENTORY_MAX_OUTPUT_BYTES },
+  );
+  const output = requireGitCommandOutput("git for-each-ref", result);
+  const branches: RepositoryBranchRef[] = [];
+  for (const line of output.trim().split("\n")) {
+    const [ref, name] = line.split("\0");
+    if (!ref || !name) {
+      continue;
+    }
+    if (ref.startsWith("refs/heads/")) {
+      branches.push({
+        ref,
+        branchName: ref.slice("refs/heads/".length),
+        branch: { name, kind: "local" },
+      });
+    } else if (ref.startsWith("refs/remotes/")) {
+      const remoteRef = ref.slice("refs/remotes/".length);
+      const slash = remoteRef.indexOf("/");
+      const branchName = remoteRef.slice(slash + 1);
+      if (slash > 0 && branchName && branchName !== "HEAD") {
+        branches.push({ ref, branchName, branch: { name, kind: "remote" } });
+      }
+    }
+  }
+  return branches;
+}
+
 async function canonicalPathKey(target: string): Promise<string> {
   const canonical = await fs.realpath(target);
   return process.platform === "win32" ? canonical.toLowerCase() : canonical;
@@ -1092,89 +1141,71 @@ export class ManagedWorktreeService {
     } else {
       repository = await resolveRepository(repoRoot);
     }
-    // Suggestions are bounded at Git; their availability cannot invalidate the
-    // checkout already verified above. Never parse output rejected by the byte guard.
-    const branches = new Map<string, ManagedWorktreeBranch>();
+    // Keep canonical refs for identity and Git's strict short names for selection.
+    // A branch named like a tag may need heads/ or remotes/ to remain unambiguous.
+    const branches = new Map<string, RepositoryBranchRef>();
     let branchesUnavailable = false;
-    for (const [prefix, kind] of [
-      ["refs/remotes/", "remote"],
-      ["refs/heads/", "local"],
-    ] as const) {
+    for (const prefix of ["refs/remotes/", "refs/heads/"]) {
       try {
-        const result = await runGit(
+        for (const entry of await listRepositoryBranchRefs(
           repository.repoRoot,
-          [
-            "for-each-ref",
-            `--count=${BRANCH_SUGGESTIONS_PER_KIND}`,
-            "--sort=refname",
-            "--format=%(refname)",
-            prefix,
-          ],
-          { maxOutputBytes: BRANCH_INVENTORY_MAX_OUTPUT_BYTES },
-        );
-        const output = requireGitCommandOutput("git for-each-ref", result);
-        for (const ref of output.trim().split("\n")) {
-          if (!ref.startsWith(prefix)) {
-            continue;
-          }
-          const name = ref.slice(prefix.length);
-          const slash = name.indexOf("/");
-          const shortName = kind === "remote" ? name.slice(slash + 1) : name;
-          if (!shortName || (kind === "remote" && (slash <= 0 || shortName === "HEAD"))) {
-            continue;
-          }
-          // Local branches win collisions; remote-only refs retain their remote qualifier.
-          branches.set(shortName, { name, kind });
+          prefix,
+          BRANCH_SUGGESTIONS_PER_KIND,
+        )) {
+          // Local branches win collisions with the same logical remote branch name.
+          branches.set(entry.branchName, entry);
         }
       } catch {
+        // Never parse partial output or invalidate the already verified checkout.
         branchesUnavailable = true;
       }
     }
     const remoteHead = await runGit(repository.repoRoot, [
       "symbolic-ref",
       "--quiet",
-      "--short",
       "refs/remotes/origin/HEAD",
     ]);
-    const defaultShort =
-      remoteHead.code === 0
-        ? remoteHead.stdout.trim().replace(/^origin\//, "") || undefined
-        : undefined;
-    const head = await runGit(repository.repoRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
-    const headBranch = head.code === 0 ? head.stdout.trim() || undefined : undefined;
-    // Resolve priority refs independently: alphabetical suggestion limits may omit both.
-    if (defaultShort) {
-      const localDefault = await runGit(repository.repoRoot, [
-        "show-ref",
-        "--verify",
-        "--quiet",
-        `refs/heads/${defaultShort}`,
-      ]);
-      branches.set(
-        defaultShort,
-        localDefault.code === 0
-          ? { name: defaultShort, kind: "local" }
-          : { name: remoteHead.stdout.trim(), kind: "remote" },
-      );
-    }
-    if (headBranch) {
-      branches.set(headBranch, { name: headBranch, kind: "local" });
-    }
-    const defaultBranch = defaultShort
-      ? (branches.get(defaultShort)?.name ?? defaultShort)
+    const defaultRef = remoteHead.code === 0 ? remoteHead.stdout.trim() : undefined;
+    const head = await runGit(repository.repoRoot, ["symbolic-ref", "--quiet", "HEAD"]);
+    const headRef = head.code === 0 ? head.stdout.trim() : undefined;
+    const resolveBranch = async (ref: string | undefined) => {
+      if (!ref) {
+        return undefined;
+      }
+      const known = [...branches.values()].find((entry) => entry.ref === ref);
+      if (known) {
+        return known;
+      }
+      try {
+        // Patterns can match descendants; only the exact priority ref is eligible.
+        return (await listRepositoryBranchRefs(repository.repoRoot, ref, 1)).find(
+          (entry) => entry.ref === ref,
+        );
+      } catch {
+        branchesUnavailable = true;
+        return undefined;
+      }
+    };
+    const localDefaultRef = defaultRef?.startsWith("refs/remotes/origin/")
+      ? `refs/heads/${defaultRef.slice("refs/remotes/origin/".length)}`
       : undefined;
-    // Deterministic picker ordering: default base first, current checkout next, rest alphabetical.
-    const rank = (shortName: string) =>
-      shortName === defaultShort ? 0 : shortName === headBranch ? 1 : 2;
-    const sorted = [...branches.entries()]
-      .toSorted(
-        ([aShort, a], [bShort, b]) => rank(aShort) - rank(bShort) || a.name.localeCompare(b.name),
-      )
-      .map(([, branch]) => branch);
+    // Priority refs must survive the inventory bound and use the same disambiguation.
+    const defaultEntry =
+      (await resolveBranch(localDefaultRef)) ?? (await resolveBranch(defaultRef));
+    const headEntry = await resolveBranch(headRef);
+    for (const entry of [defaultEntry, headEntry]) {
+      if (entry) {
+        branches.set(entry.branchName, entry);
+      }
+    }
+    const rank = (entry: RepositoryBranchRef) =>
+      entry.ref === defaultEntry?.ref ? 0 : entry.ref === headEntry?.ref ? 1 : 2;
     return {
-      branches: sorted,
-      ...(defaultBranch ? { defaultBranch } : {}),
-      ...(headBranch ? { headBranch } : {}),
+      branches: [...branches.values()]
+        .toSorted((a, b) => rank(a) - rank(b) || a.branch.name.localeCompare(b.branch.name))
+        .map((entry) => entry.branch),
+      ...(defaultEntry ? { defaultBranch: defaultEntry.branch.name } : {}),
+      ...(headEntry ? { headBranch: headEntry.branch.name } : {}),
       ...(options.includeRepositoryStatus ? { repositoryStatus: "git" as const } : {}),
       ...(branchesUnavailable ? { branchesUnavailable: true } : {}),
     };

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -82,6 +82,7 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const BRANCH_INVENTORY_MAX_OUTPUT_BYTES = 256 * 1024;
+const BRANCH_SUGGESTIONS_PER_KIND = 100;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const WORKTREE_CREATE_LEASE_SCOPE = "core:managed-worktrees:create";
@@ -95,18 +96,6 @@ export class WorktreeSnapshotError extends Error {
     super(`worktree snapshot failed; removal aborted: ${snapshotError}`, options);
     this.snapshotError = snapshotError;
   }
-}
-
-function branchInventoryError(command: string, result: GitResult): Error {
-  if (result.outputLimitExceeded) {
-    return new Error(
-      "Repository has too many branches to list safely. Remove obsolete branches and retry.",
-      { cause: commandError(command, result) },
-    );
-  }
-  return new Error("Git could not list repository branches. Check the repository and retry.", {
-    cause: commandError(command, result),
-  });
 }
 
 export type WorktreeRemovalFailureReason =
@@ -1103,51 +1092,42 @@ export class ManagedWorktreeService {
     } else {
       repository = await resolveRepository(repoRoot);
     }
-    // Keyed by short branch name; the stored name is always a resolvable base
-    // ref, so remote-only branches keep their remote-qualified form
-    // (origin/feature-a) instead of a bare name git cannot resolve.
+    // Suggestions are bounded at Git; their availability cannot invalidate the
+    // checkout already verified above. Never parse output rejected by the byte guard.
     const branches = new Map<string, ManagedWorktreeBranch>();
-    const remoteRaw = await runGit(
-      repository.repoRoot,
-      ["for-each-ref", "--format=%(refname)", "refs/remotes"],
-      { maxOutputBytes: BRANCH_INVENTORY_MAX_OUTPUT_BYTES },
-    );
-    const remoteOutput = requireGitCommandOutput(
-      "git for-each-ref refs/remotes",
-      remoteRaw,
-      branchInventoryError,
-    );
-    for (const refname of remoteOutput.split("\n")) {
-      const trimmed = refname.trim();
-      if (!trimmed.startsWith("refs/remotes/")) {
-        continue;
-      }
-      const withoutPrefix = trimmed.slice("refs/remotes/".length);
-      const slash = withoutPrefix.indexOf("/");
-      if (slash <= 0) {
-        continue;
-      }
-      const shortName = withoutPrefix.slice(slash + 1);
-      // remote HEAD symrefs are pointers, not selectable branches.
-      if (!shortName || shortName === "HEAD") {
-        continue;
-      }
-      branches.set(shortName, { name: withoutPrefix, kind: "remote" });
-    }
-    const localRaw = await runGit(
-      repository.repoRoot,
-      ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
-      { maxOutputBytes: BRANCH_INVENTORY_MAX_OUTPUT_BYTES },
-    );
-    const localOutput = requireGitCommandOutput(
-      "git for-each-ref refs/heads",
-      localRaw,
-      branchInventoryError,
-    );
-    for (const line of localOutput.split("\n")) {
-      const name = line.trim();
-      if (name) {
-        branches.set(name, { name, kind: "local" });
+    let branchesUnavailable = false;
+    for (const [prefix, kind] of [
+      ["refs/remotes/", "remote"],
+      ["refs/heads/", "local"],
+    ] as const) {
+      try {
+        const result = await runGit(
+          repository.repoRoot,
+          [
+            "for-each-ref",
+            `--count=${BRANCH_SUGGESTIONS_PER_KIND}`,
+            "--sort=refname",
+            "--format=%(refname)",
+            prefix,
+          ],
+          { maxOutputBytes: BRANCH_INVENTORY_MAX_OUTPUT_BYTES },
+        );
+        const output = requireGitCommandOutput("git for-each-ref", result);
+        for (const ref of output.trim().split("\n")) {
+          if (!ref.startsWith(prefix)) {
+            continue;
+          }
+          const name = ref.slice(prefix.length);
+          const slash = name.indexOf("/");
+          const shortName = kind === "remote" ? name.slice(slash + 1) : name;
+          if (!shortName || (kind === "remote" && (slash <= 0 || shortName === "HEAD"))) {
+            continue;
+          }
+          // Local branches win collisions; remote-only refs retain their remote qualifier.
+          branches.set(shortName, { name, kind });
+        }
+      } catch {
+        branchesUnavailable = true;
       }
     }
     const remoteHead = await runGit(repository.repoRoot, [
@@ -1162,6 +1142,24 @@ export class ManagedWorktreeService {
         : undefined;
     const head = await runGit(repository.repoRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
     const headBranch = head.code === 0 ? head.stdout.trim() || undefined : undefined;
+    // Resolve priority refs independently: alphabetical suggestion limits may omit both.
+    if (defaultShort) {
+      const localDefault = await runGit(repository.repoRoot, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        `refs/heads/${defaultShort}`,
+      ]);
+      branches.set(
+        defaultShort,
+        localDefault.code === 0
+          ? { name: defaultShort, kind: "local" }
+          : { name: remoteHead.stdout.trim(), kind: "remote" },
+      );
+    }
+    if (headBranch) {
+      branches.set(headBranch, { name: headBranch, kind: "local" });
+    }
     const defaultBranch = defaultShort
       ? (branches.get(defaultShort)?.name ?? defaultShort)
       : undefined;
@@ -1178,6 +1176,7 @@ export class ManagedWorktreeService {
       ...(defaultBranch ? { defaultBranch } : {}),
       ...(headBranch ? { headBranch } : {}),
       ...(options.includeRepositoryStatus ? { repositoryStatus: "git" as const } : {}),
+      ...(branchesUnavailable ? { branchesUnavailable: true } : {}),
     };
   }
 

--- a/src/agents/worktrees/types.ts
+++ b/src/agents/worktrees/types.ts
@@ -73,6 +73,7 @@ export type ManagedWorktreeBranchesResult = {
   defaultBranch?: string;
   headBranch?: string;
   repositoryStatus?: ManagedWorktreeRepositoryStatus;
+  branchesUnavailable?: boolean;
 };
 
 export type ManagedWorktreeGcResult = {

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -778,6 +778,63 @@ suite.define(() => {
     });
   });
 
+  it.each([false, true])(
+    "starts a worktree from an unsuggested ref when branch suggestions are unavailable=%s",
+    async (branchesUnavailable) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        const gateway = await installMockGateway(page, {
+          workspaceGit: true,
+          models: NEW_SESSION_MODEL_CATALOG,
+          methodResponses: {
+            "agents.list": mainAgentList(),
+            "worktrees.branches": {
+              ...GIT_BRANCHES,
+              branches: branchesUnavailable ? [] : GIT_BRANCHES.branches,
+              ...(branchesUnavailable ? { branchesUnavailable: true } : {}),
+            },
+            "sessions.create": { key: "agent:main:unsuggested-ref", runStarted: true },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        const checkout = page.locator("#new-session-checkout-trigger");
+        await checkout.click();
+        await page
+          .getByRole("button", { name: "New worktree Isolated copy of the repo", exact: true })
+          .click();
+        await expect.poll(() => checkout.getAttribute("data-worktree")).toBe("true");
+        const baseRef = page.locator('input[list="new-session-branches"]');
+        await baseRef.fill("origin/release-outside-suggestions");
+        expect(
+          await page
+            .locator('#new-session-branches option[value="origin/release-outside-suggestions"]')
+            .count(),
+        ).toBe(0);
+        await captureUiProof(
+          suite,
+          page,
+          `worktree-branches-${branchesUnavailable ? "unavailable" : "limited"}.png`,
+        );
+        await page
+          .getByText(
+            branchesUnavailable
+              ? "Branch suggestions are unavailable. Enter a branch or commit."
+              : "Suggestions are limited. Enter any branch or commit.",
+            { exact: true },
+          )
+          .waitFor({ state: "visible" });
+        await page.keyboard.press("Escape");
+        await page.locator(".new-session-page__message").fill("start from the selected release");
+        await page.getByRole("button", { name: "Start session" }).click();
+        expect((await gateway.waitForRequest("sessions.create")).params).toMatchObject({
+          agentId: "main",
+          message: "start from the selected release",
+          worktree: true,
+          worktreeBaseRef: "origin/release-outside-suggestions",
+        });
+      });
+    },
+  );
+
   it("reuses ready model metadata while a remembered worktree choice validates", async () => {
     await withNewSessionPage(BASE_CONTEXT, async (page) => {
       const models = NEW_SESSION_MODEL_CATALOG;

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -778,63 +778,6 @@ suite.define(() => {
     });
   });
 
-  it.each([false, true])(
-    "starts a worktree from an unsuggested ref when branch suggestions are unavailable=%s",
-    async (branchesUnavailable) => {
-      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
-        const gateway = await installMockGateway(page, {
-          workspaceGit: true,
-          models: NEW_SESSION_MODEL_CATALOG,
-          methodResponses: {
-            "agents.list": mainAgentList(),
-            "worktrees.branches": {
-              ...GIT_BRANCHES,
-              branches: branchesUnavailable ? [] : GIT_BRANCHES.branches,
-              ...(branchesUnavailable ? { branchesUnavailable: true } : {}),
-            },
-            "sessions.create": { key: "agent:main:unsuggested-ref", runStarted: true },
-          },
-        });
-        await page.goto(`${suite.server.baseUrl}new`);
-        const checkout = page.locator("#new-session-checkout-trigger");
-        await checkout.click();
-        await page
-          .getByRole("button", { name: "New worktree Isolated copy of the repo", exact: true })
-          .click();
-        await expect.poll(() => checkout.getAttribute("data-worktree")).toBe("true");
-        const baseRef = page.locator('input[list="new-session-branches"]');
-        await baseRef.fill("origin/release-outside-suggestions");
-        expect(
-          await page
-            .locator('#new-session-branches option[value="origin/release-outside-suggestions"]')
-            .count(),
-        ).toBe(0);
-        await captureUiProof(
-          suite,
-          page,
-          `worktree-branches-${branchesUnavailable ? "unavailable" : "limited"}.png`,
-        );
-        await page
-          .getByText(
-            branchesUnavailable
-              ? "Branch suggestions are unavailable. Enter a branch or commit."
-              : "Suggestions are limited. Enter any branch or commit.",
-            { exact: true },
-          )
-          .waitFor({ state: "visible" });
-        await page.keyboard.press("Escape");
-        await page.locator(".new-session-page__message").fill("start from the selected release");
-        await page.getByRole("button", { name: "Start session" }).click();
-        expect((await gateway.waitForRequest("sessions.create")).params).toMatchObject({
-          agentId: "main",
-          message: "start from the selected release",
-          worktree: true,
-          worktreeBaseRef: "origin/release-outside-suggestions",
-        });
-      });
-    },
-  );
-
   it("reuses ready model metadata while a remembered worktree choice validates", async () => {
     await withNewSessionPage(BASE_CONTEXT, async (page) => {
       const models = NEW_SESSION_MODEL_CATALOG;

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -7,9 +7,11 @@ import {
 } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { holdModuleResponse, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
+  NEW_SESSION_MODEL_CATALOG,
   SOURCE_REPO,
   TARGET_REPO,
   WORKSPACE,
+  captureUiProof,
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
   installMockGateway,
@@ -113,6 +115,64 @@ async function expectPendingNewSession(page: Page, message: string) {
 }
 
 suite.define(() => {
+  it.each([false, true])(
+    "starts a worktree from an unsuggested ref when branch suggestions are unavailable=%s",
+    async (branchesUnavailable) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        const branches = branchList();
+        const gateway = await installMockGateway(page, {
+          workspaceGit: true,
+          models: NEW_SESSION_MODEL_CATALOG,
+          methodResponses: {
+            "agents.list": mainAgentList(),
+            "worktrees.branches": {
+              ...branches,
+              branches: branchesUnavailable ? [] : branches.branches,
+              ...(branchesUnavailable ? { branchesUnavailable: true } : {}),
+            },
+            "sessions.create": { key: "agent:main:unsuggested-ref", runStarted: true },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        const checkout = page.locator("#new-session-checkout-trigger");
+        await checkout.click();
+        await page
+          .getByRole("button", { name: "New worktree Isolated copy of the repo", exact: true })
+          .click();
+        await expect.poll(() => checkout.getAttribute("data-worktree")).toBe("true");
+        const baseRef = page.locator('input[list="new-session-branches"]');
+        await baseRef.fill("origin/release-outside-suggestions");
+        expect(
+          await page
+            .locator('#new-session-branches option[value="origin/release-outside-suggestions"]')
+            .count(),
+        ).toBe(0);
+        await captureUiProof(
+          suite,
+          page,
+          `worktree-branches-${branchesUnavailable ? "unavailable" : "limited"}.png`,
+        );
+        await page
+          .getByText(
+            branchesUnavailable
+              ? "Branch suggestions are unavailable. Enter a branch or commit."
+              : "Suggestions are limited. Enter any branch or commit.",
+            { exact: true },
+          )
+          .waitFor({ state: "visible" });
+        await page.keyboard.press("Escape");
+        await page.locator(".new-session-page__message").fill("start from the selected release");
+        await page.getByRole("button", { name: "Start session" }).click();
+        expect((await gateway.waitForRequest("sessions.create")).params).toMatchObject({
+          agentId: "main",
+          message: "start from the selected release",
+          worktree: true,
+          worktreeBaseRef: "origin/release-outside-suggestions",
+        });
+      });
+    },
+  );
+
   it("blocks a selected workspace worktree when branch rediscovery is unavailable until cleared", async () => {
     await withNewSessionPage(BASE_CONTEXT, async (page) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1017,6 +1017,8 @@ export const en: TranslationMap & {
     gitCheckUnavailable: "Couldn't verify Git for this folder. Choose it again to retry.",
     worktreeUnavailable: "Selected folder is not a Git checkout",
     worktreeBaseRef: "From",
+    worktreeBranchesLimited: "Suggestions are limited. Enter any branch or commit.",
+    worktreeBranchesUnavailable: "Branch suggestions are unavailable. Enter a branch or commit.",
     worktreeName: "Name",
     worktreeNamePlaceholder: "Named from the session title",
     worktreeBranchNote: "Creates branch openclaw/<name> in a separate checkout.",

--- a/ui/src/pages/new-session/checkout-chip.ts
+++ b/ui/src/pages/new-session/checkout-chip.ts
@@ -72,6 +72,13 @@ function renderWorktreeFields(params: {
         )}
       </datalist>
     </label>
+    <div class="new-session-page__menu-note">
+      ${t(
+        params.branches?.branchesUnavailable
+          ? "newSession.worktreeBranchesUnavailable"
+          : "newSession.worktreeBranchesLimited",
+      )}
+    </div>
     ${
       params.repository
         ? nothing

--- a/ui/src/pages/new-session/discovery.ts
+++ b/ui/src/pages/new-session/discovery.ts
@@ -17,6 +17,7 @@ export type DraftBranches = {
   branches: Array<{ name: string; kind: "local" | "remote" }>;
   defaultBranch?: string;
   headBranch?: string;
+  branchesUnavailable?: boolean;
 };
 
 export type DraftRepositoryState =

--- a/ui/src/pages/new-session/draft-repository-state.ts
+++ b/ui/src/pages/new-session/draft-repository-state.ts
@@ -222,6 +222,7 @@ export class DraftRepositoryController {
                 branches: result.branches,
                 ...(result.defaultBranch ? { defaultBranch: result.defaultBranch } : {}),
                 ...(result.headBranch ? { headBranch: result.headBranch } : {}),
+                ...(result.branchesUnavailable ? { branchesUnavailable: true } : {}),
               }
             : { kind: result?.repositoryStatus === "not_git" ? "direct" : "unavailable", repoRoot },
         );


### PR DESCRIPTION
Related: #135917

## What Problem This Solves

Fixes an issue where users starting a session in a Git repository with many branches would lose the Worktree option from New Session. Branch enumeration exceeded the 256 KiB output guard, and its failure was treated as an unavailable repository.

## Why This Change Was Made

Bound Git's branch suggestions to 100 local and 100 remote refs, with the default and current branches resolved independently. Preserve verified repository status when suggestions fail, discard incomplete output, and show guidance for entering a branch or commit manually. Git provides strict, unambiguous selectable names for both sampled and priority refs, including branch/tag collisions. The existing byte guard and explicit-base validation remain enforced.

## User Impact

Large repositories remain usable for worktree sessions. Users can select the default/current branch or type any valid ref outside the suggestions. Invalid refs still fail before session creation. No configuration, dependency, or database changes.

## Evidence

- Real Git overflow regressions failed with the original output-limit error and passed after the repair, including preservation of the byte guard. Branch/tag collision regressions reproduced the review finding and now pass for ordinary, current, local-default and remote-default refs with repository ambiguity warnings disabled.
- 58 focused Gateway/worktree tests passed; the Windows-specific branch case was skipped on macOS. Five protocol schema tests passed.
- All 13 existing cases in the scoped UI file passed; both new limited/unavailable-suggestion cases passed after correcting their fixture catalog reference.
- `pnpm build` and targeted typed lint passed. The first CI run exposed test lint issues (`toSorted` and file length); both are fixed and the moved UI cases passed again. Final [exact-head PR CI passed](https://github.com/openclaw/openclaw/actions/runs/34373148605) for `1e7ae1f66b32`; native prepare/merge completed as `7d568cabed59`.
- The unrelated Telegram loopback CI failure was independently reproduced with a controlled 6.1-second stall. Upstream #143197 landed the same connection-close fixture fix, so this branch was rebased to include it and the duplicate commit was dropped. Stressed/normal tests, independent review, and the [extension-only changed gate](https://github.com/openclaw/openclaw/actions/runs/34369703663) passed; its Testbox lease was cleaned up.
- Isolated real Gateway + Chromium: a 6,007-ref repository produced 414,073 bytes of unbounded inventory. Before the repair, the RPC failed and the selector disappeared. Afterward, discovery returned 101 suggestions and the browser accepted an unlisted ref. Real `sessions.create` created the worktree at that ref's distinct commit without a model call. A second creation from `heads/release` selected the branch commit rather than the conflicting tag; an invalid ref returned `INVALID_REQUEST` and created neither a session nor a worktree. The fixture Gateway and state were cleaned up.
- Attached before image is a synthetic UI reproduction of the original RPC failure. The after image is from the isolated real-Gateway proof. All published captures contain synthetic data.

![Before: synthetic reproduction of the original branch-list failure](https://github.com/user-attachments/assets/c7279bc7-a8d9-4166-a053-4dd96bc2c0da)

![After: real Gateway with bounded and disambiguated branch suggestions](https://github.com/user-attachments/assets/3b42219b-2c43-49f2-b536-69897b6ec886)
