### PR TITLE
fix(test): keep Windows media file URL coverage isolated

### DIFF
--- a/src/agents/tools/media-tool-file-url.windows.test.ts
+++ b/src/agents/tools/media-tool-file-url.windows.test.ts
@@ -9,6 +9,7 @@ import * as imageGenerationRuntime from "../../image-generation/runtime.js";
 import * as mediaStore from "../../media/store.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
 import { createImageGenerateTool } from "./image-generate-tool.js";
+import * as mediaGenerationToolProviders from "./media-generation-tool-providers.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import {
   createPdfToolInfraStub,
@@ -108,7 +109,7 @@ describe.runIf(process.platform === "win32")("host-local media tool file URLs", 
         expect(pdfResult.content).toEqual([{ type: "text", text: "native summary" }]);
         expect(pdfResult.details).toMatchObject({ pdf: pdfPath, native: true });
 
-        vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+        const providers = [
           {
             id: "fixture",
             defaultModel: "edit",
@@ -123,7 +124,16 @@ describe.runIf(process.platform === "win32")("host-local media tool file URLs", 
               throw new Error("runtime generateImage spy should own the call");
             }),
           },
-        ]);
+        ];
+        vi.spyOn(
+          mediaGenerationToolProviders,
+          "acquireImageGenerationToolProviders",
+        ).mockResolvedValue({
+          providers,
+          assertOpen() {},
+          run: async (run) => await run(),
+          release: async () => {},
+        });
         const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
           provider: "fixture",
           model: "edit",


### PR DESCRIPTION
Related: #142991

## What Problem This Solves

Resolves a problem where Windows media file-URL coverage could enter real plugin discovery despite configuring a synthetic image generator. The fixture still mocked the old provider-list function after image generation moved to provider acquisition.

## Why This Change Was Made

Supply the same synthetic provider through `acquireImageGenerationToolProviders`, with the fixture's resource callbacks, following the current image-generation test boundary. Real Unicode and space paths, registered image/PDF tools, reference-image bytes, existing assertions, and the Windows guard remain unchanged.

## User Impact

No product behavior changes. Windows CI exercises media file handling without unrelated plugin-registry acquisition.

## Evidence

- Local macOS sibling proof: 68 image-generation and PDF-provider tests passed. The Windows-only case was skipped and is not counted as Windows proof.
- The exact-base changed gate, formatting, and `git diff --check` passed.
- Independent P2 review is clean with no actionable findings.
- The earlier Windows case timed out in [run 34362692276](https://github.com/openclaw/openclaw/actions/runs/34362692276/job/102503681660). That log has no phase-level timing, so it does not establish the precise stalled step.

Native Windows proof passed on the exact PR head: the original Unicode/space file-URL case executed with all existing assertions in **804 ms** in [Windows test part 1](https://github.com/openclaw/openclaw/actions/runs/34369296327/job/102526310237). The job passed. The complete exact-head CI run also passed.
