### PR TITLE
fix(test): keep Telegram callback loopback requests reliable

### DIFF
--- a/extensions/telegram/src/model-callback.loopback.integration.test.ts
+++ b/extensions/telegram/src/model-callback.loopback.integration.test.ts
@@ -1,6 +1,6 @@
 // A real grammY bot and HTTP Bot API prove model callbacks across the active router.
 import { mkdtemp, rm } from "node:fs/promises";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Agent, createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -99,6 +99,8 @@ describe("Telegram model callback loopback", () => {
     await new Promise<void>((resolve) => {
       server.listen(0, "127.0.0.1", resolve);
     });
+    // Cold model persistence can outlast the loopback server's idle timeout.
+    const callbackAgent = new Agent({ keepAlive: false });
 
     try {
       const apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
@@ -139,7 +141,10 @@ describe("Telegram model callback loopback", () => {
       expect(Buffer.byteLength(callbackData ?? "", "utf8")).toBeLessThanOrEqual(64);
 
       const callbackSteps: string[] = [];
-      const bot = new Bot(TOKEN, { botInfo: telegramBotInfoForTest, client: { apiRoot } });
+      const bot = new Bot(TOKEN, {
+        botInfo: telegramBotInfoForTest,
+        client: { apiRoot, baseFetchConfig: { agent: callbackAgent } },
+      });
       const telegramDeps = {
         ...defaultTelegramBotDeps,
         buildModelsProviderData: async (): ReturnType<
@@ -246,6 +251,7 @@ describe("Telegram model callback loopback", () => {
         `Model changed to <b>${PROVIDER}/${MODEL}</b>`,
       );
     } finally {
+      callbackAgent.destroy();
       server.close();
       server.closeAllConnections();
       server.unref();


### PR DESCRIPTION
Related: #143175

## What Problem This Solves

Resolves a problem where the Telegram model callback loopback test reports a failed model change after the selection was successfully persisted. Cold session setup can hold the event loop past the loopback server's idle connection deadline, so the confirmation edit fails on a stale pooled socket.

## Why This Change Was Made

Give the fixture's callback client its own HTTP agent with keepalive disabled and destroy it during cleanup. The test still uses a real grammY bot and real HTTP requests, with its original request-order, authorization, persistence, confirmation-text assertions, and timing budgets.

## User Impact

No production behavior changes. Developers get reliable callback integration evidence when cold local or CI setup takes longer than the loopback server's idle deadline.

## Evidence

- Two runs of the unchanged test failed at the confirmation-text assertion: [first attempt](https://github.com/openclaw/openclaw/actions/runs/34364316951/job/102509312071), [second attempt](https://github.com/openclaw/openclaw/actions/runs/34364316951/job/102520915500).
- An instrumented original full test reproduced naturally: acknowledgement completed at 58 ms, confirmation edit started at 6,382 ms, the socket timed out, and node-fetch reported `ECONNRESET`. The error edit opened a new socket and succeeded, reproducing the same three recorded requests and assertion failure.
- The corrected full test passed all existing assertions with an additional 6,200 ms synchronous pause after acknowledgement; no server or request timeout was increased.
- Final uninstrumented focused test passed: `node scripts/run-vitest.mjs extensions/telegram/src/model-callback.loopback.integration.test.ts`.
- Managed independent review accepted the patch. `node scripts/check-changed.mjs -- extensions/telegram/src/model-callback.loopback.integration.test.ts` passed, including extension test typechecking, formatting, lint and repository guards. An initial borrowed-dependency admission failure was resolved by using a task-owned physical install.
