### PR TITLE
fix(test): isolate Windows media provider fixture

### DIFF
--- a/src/agents/tools/media-tool-file-url.windows.test.ts
+++ b/src/agents/tools/media-tool-file-url.windows.test.ts
@@ -9,6 +9,7 @@ import * as imageGenerationRuntime from "../../image-generation/runtime.js";
 import * as mediaStore from "../../media/store.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
 import { createImageGenerateTool } from "./image-generate-tool.js";
+import * as mediaGenerationToolProviders from "./media-generation-tool-providers.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import {
   createPdfToolInfraStub,
@@ -108,22 +109,30 @@ describe.runIf(process.platform === "win32")("host-local media tool file URLs", 
         expect(pdfResult.content).toEqual([{ type: "text", text: "native summary" }]);
         expect(pdfResult.details).toMatchObject({ pdf: pdfPath, native: true });
 
-        vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
-          {
-            id: "fixture",
-            defaultModel: "edit",
-            models: ["edit"],
-            isConfigured: () => true,
-            capabilities: {
-              generate: { maxCount: 1 },
-              edit: { enabled: true, maxInputImages: 1 },
-              geometry: {},
+        vi.spyOn(
+          mediaGenerationToolProviders,
+          "acquireImageGenerationToolProviders",
+        ).mockResolvedValue({
+          providers: [
+            {
+              id: "fixture",
+              defaultModel: "edit",
+              models: ["edit"],
+              isConfigured: () => true,
+              capabilities: {
+                generate: { maxCount: 1 },
+                edit: { enabled: true, maxInputImages: 1 },
+                geometry: {},
+              },
+              generateImage: vi.fn(async () => {
+                throw new Error("runtime generateImage spy should own the call");
+              }),
             },
-            generateImage: vi.fn(async () => {
-              throw new Error("runtime generateImage spy should own the call");
-            }),
-          },
-        ]);
+          ],
+          assertOpen() {},
+          run: async (run) => await run(),
+          release: async () => {},
+        });
         const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
           provider: "fixture",
           model: "edit",


### PR DESCRIPTION
Related: #142991

## What Problem This Solves

Resolves a problem where the Windows local-media integration fixture could enter real plugin capability discovery instead of using its synthetic image provider. The fixture still intercepted the old provider-list function after image generation moved to resource-owning provider acquisition.

## Why This Change Was Made

Supply the existing synthetic provider through `acquireImageGenerationToolProviders`, matching the current execution boundary and the regular image-generation test suite. The fixture owns no external provider resources. Its real Unicode/space file-URL reads, registered image and PDF tools, edit-input byte assertion, Windows guard, and timeout remain unchanged.

## User Impact

No runtime behavior changes. Windows CI can exercise the intended local-media contract using its controlled provider fixture.

## Evidence

- A fail-fast diagnostic against the original failing source (`a489e2d1e045081866e00ec604ed84633bdb7f08`) called the real image-generation factory and observed one cold-acquisition call, zero calls to the legacy provider spy, and no generation or media-save calls. This ran on macOS and proves stale fixture interception; it does not establish the cause of the original Windows timeout.
- The complete corrected fixture body passed on macOS in 5.904 seconds in a disposable copy with only the Windows guard removed. It covered image inspection, native-PDF orchestration, and image-edit input bytes.
- `node scripts/check-changed.mjs -- src/agents/tools/media-tool-file-url.windows.test.ts` passed, including agents-tools typechecking, targeted lint, and repository guards.
- Independent review found no actionable P0–P2 issues.
- [Native Windows CI](https://github.com/openclaw/openclaw/actions/runs/34369925456/job/102528504553) on commit `ddaa843ae67fc45713de861c5a49656067f43ccd`: the actual `loads Unicode and space file URLs through registered image and PDF tools` test passed in **679 ms** on Windows x64 / Node 24.21.0 (1 file, 1 test passed). The Windows job completed successfully.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34369925456) is green; the native CI watcher completed with no pending checks.
