### PR TITLE
fix(ci): budget deferred locale catalogs separately

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 
 function isMetricsRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -27,6 +28,12 @@ const CONTROL_UI_CSS_GZIP_GROWTH_BYTES = KIB;
 // a diagram is viewed. Keep its size visible without relaxing ordinary chunks.
 const MERMAID_RENDERER_ASSET = /^assets\/mermaid\.min-[\w-]+\.js$/u;
 const MERMAID_RENDERER_GZIP_BYTES = 960 * KIB;
+// Locale catalogs are named Vite chunks loaded only after a language selection.
+// Bound them separately so catalog growth cannot relax ordinary application chunks.
+const CONTROL_UI_LOCALE_ASSET_PREFIXES = CONTROL_UI_LOCALE_ENTRIES.map(
+  ({ locale }) => `assets/${locale}-`,
+);
+const CONTROL_UI_LOCALE_GZIP_BYTES = 300 * KIB;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
 // accompany an intentional loading or chunking decision.
@@ -113,6 +120,13 @@ function largestAsset(assets: Array<ReturnType<typeof readAssetMetrics>>) {
   )[0]!;
 }
 
+function isControlUiLocaleAsset(file: string): boolean {
+  return (
+    file.endsWith(".js") &&
+    CONTROL_UI_LOCALE_ASSET_PREFIXES.some((prefix) => file.startsWith(prefix))
+  );
+}
+
 export function collectControlUiPerformanceMetrics(distDir: string) {
   const assetsDir = path.join(distDir, "assets");
   const html = fs.readFileSync(path.join(distDir, "index.html"), "utf8");
@@ -130,7 +144,10 @@ export function collectControlUiPerformanceMetrics(distDir: string) {
   });
   const jsAssets = assets.filter((asset) => asset.type === "js");
   const mermaidRenderer = jsAssets.filter((asset) => MERMAID_RENDERER_ASSET.test(asset.file));
-  const ordinaryJsAssets = jsAssets.filter((asset) => !MERMAID_RENDERER_ASSET.test(asset.file));
+  const localeCatalogs = jsAssets.filter((asset) => isControlUiLocaleAsset(asset.file));
+  const ordinaryJsAssets = jsAssets.filter(
+    (asset) => !MERMAID_RENDERER_ASSET.test(asset.file) && !isControlUiLocaleAsset(asset.file),
+  );
   const cssAssets = assets.filter((asset) => asset.type === "css");
   if (ordinaryJsAssets.length === 0 || cssAssets.length === 0 || startup.length === 0) {
     throw new Error("Control UI performance check found an incomplete production bundle");
@@ -151,6 +168,7 @@ export function collectControlUiPerformanceMetrics(distDir: string) {
       css: largestAsset(cssAssets),
     },
     mermaidRenderer,
+    localeCatalogs,
   };
 }
 
@@ -184,6 +202,24 @@ export function evaluateControlUiPerformanceBudgets(
     [
       "startup Mermaid JS assets",
       metrics.startup.assets.filter((asset) => MERMAID_RENDERER_ASSET.test(asset.file)).length,
+      0,
+      "count",
+    ],
+    [
+      "locale catalog JS assets",
+      metrics.localeCatalogs.length,
+      CONTROL_UI_LOCALE_ENTRIES.length,
+      "count",
+    ],
+    [
+      "largest locale catalog JS gzip",
+      Math.max(0, ...metrics.localeCatalogs.map((asset) => asset.gzipBytes)),
+      CONTROL_UI_LOCALE_GZIP_BYTES,
+      "bytes",
+    ],
+    [
+      "startup locale catalog JS assets",
+      metrics.startup.assets.filter((asset) => isControlUiLocaleAsset(asset.file)).length,
       0,
       "count",
     ],
@@ -338,6 +374,12 @@ export function formatControlUiPerformanceReport(
   if (metrics.mermaidRenderer.length > 0) {
     lines.push(
       `  isolated Mermaid JS: ${formatAssetSummary(summarizeAssets(metrics.mermaidRenderer))} (limits: 1 deferred asset, ${formatControlUiPerformanceBytes(MERMAID_RENDERER_GZIP_BYTES)} gzip; forbidden at startup)`,
+    );
+  }
+  if (metrics.localeCatalogs.length > 0) {
+    const largestLocaleCatalog = largestAsset(metrics.localeCatalogs);
+    lines.push(
+      `  locale catalog JS: ${formatAssetSummary(summarizeAssets(metrics.localeCatalogs))} (largest: ${largestLocaleCatalog.file}, ${formatControlUiPerformanceBytes(largestLocaleCatalog.gzipBytes)} gzip; limits: ${CONTROL_UI_LOCALE_ENTRIES.length} deferred assets, ${formatControlUiPerformanceBytes(CONTROL_UI_LOCALE_GZIP_BYTES)} each; forbidden at startup)`,
     );
   }
   if (

--- a/test/scripts/control-ui-performance-base.test.ts
+++ b/test/scripts/control-ui-performance-base.test.ts
@@ -52,6 +52,8 @@ it("compares real UI builds with canonical compression and keeps artifacts after
       "check-control-ui-performance-base.mts",
       "check-control-ui-performance.mts",
       "check-control-ui-precompressed-assets.mts",
+      "lib/control-ui-i18n-config.json",
+      "lib/control-ui-i18n-config.ts",
       "lib/repo-root.mjs",
       "lib/output-root-guard.mjs",
     ]) {

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -48,14 +48,23 @@ function createCliFixture(startupCssGzipBytes = 15, deferredCssGzipBytes = 15) {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-control-ui-budget-cli-"));
   tempDirs.push(rootDir);
   const scriptsDir = path.join(rootDir, "scripts");
+  const scriptLibDir = path.join(scriptsDir, "lib");
   const configDir = path.join(rootDir, "config");
   const distDir = path.join(rootDir, "dist/control-ui");
   const assetsDir = path.join(distDir, "assets");
-  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.mkdirSync(scriptLibDir, { recursive: true });
   fs.mkdirSync(configDir, { recursive: true });
   fs.mkdirSync(assetsDir, { recursive: true });
   const scriptPath = path.join(scriptsDir, "check-control-ui-performance.mts");
   fs.copyFileSync(path.resolve("scripts/check-control-ui-performance.mts"), scriptPath);
+  fs.copyFileSync(
+    path.resolve("scripts/lib/control-ui-i18n-config.ts"),
+    path.join(scriptLibDir, "control-ui-i18n-config.ts"),
+  );
+  fs.copyFileSync(
+    path.resolve("scripts/lib/control-ui-i18n-config.json"),
+    path.join(scriptLibDir, "control-ui-i18n-config.json"),
+  );
   fs.writeFileSync(
     path.join(scriptsDir, "tsx.mjs"),
     `await import(${JSON.stringify(tsxImport)});\n`,
@@ -111,6 +120,7 @@ function createMetrics(startupJsGzipBytes: number) {
       },
     },
     mermaidRenderer: [],
+    localeCatalogs: [],
   };
 }
 
@@ -269,6 +279,81 @@ describe("Control UI performance budgets", () => {
     }
   });
 
+  it.each([
+    { name: "accepts a capped deferred locale catalog", gzipBytes: 300 * 1024, violations: [] },
+    {
+      name: "rejects locale catalog growth above its cap",
+      gzipBytes: 300 * 1024 + 1,
+      violations: ["largest locale catalog JS gzip"],
+    },
+    {
+      name: "rejects duplicate locale catalog artifacts",
+      gzipBytes: 200_000,
+      duplicateCount: 20,
+      violations: ["locale catalog JS assets"],
+    },
+    {
+      name: "rejects a locale catalog in startup preloads",
+      gzipBytes: 200_000,
+      startup: true,
+      violations: ["startup locale catalog JS assets"],
+    },
+    {
+      name: "retains the ordinary chunk cap beside locale catalogs",
+      gzipBytes: 200_000,
+      ordinaryGzipBytes: 215 * 1024 + 1,
+      violations: ["largest JS gzip"],
+    },
+    {
+      name: "does not exempt unsupported locale chunks",
+      gzipBytes: 300 * 1024,
+      localeName: "en-a.js",
+      violations: ["largest JS gzip"],
+    },
+  ])(
+    "$name",
+    ({ gzipBytes, duplicateCount, startup, ordinaryGzipBytes, localeName, violations }) => {
+      const { distDir, writeAsset } = createDistFixture();
+      fs.writeFileSync(
+        path.join(distDir, "index.html"),
+        '<script type="module" src="./assets/index-a.js"></script>\n' +
+          '<link rel="stylesheet" href="./assets/index-c.css">\n' +
+          (startup ? '<link rel="modulepreload" href="./assets/ru-a.js">\n' : ""),
+      );
+      writeAsset("index-a.js", { rawBytes: 100, gzipBytes: 40, brotliBytes: 30 });
+      writeAsset("lazy-b.js", {
+        rawBytes: 200,
+        gzipBytes: ordinaryGzipBytes ?? 70,
+        brotliBytes: 55,
+      });
+      writeAsset("index-c.css", { rawBytes: 50, gzipBytes: 15, brotliBytes: 12 });
+      writeAsset(localeName ?? "ru-a.js", {
+        rawBytes: 200,
+        gzipBytes,
+        brotliBytes: 100,
+      });
+      for (let index = 0; index < (duplicateCount ?? 0); index += 1) {
+        writeAsset(`ru-duplicate-${index}.js`, {
+          rawBytes: 200,
+          gzipBytes: 100,
+          brotliBytes: 50,
+        });
+      }
+
+      const metrics = collectControlUiPerformanceMetrics(distDir);
+      expect(evaluateControlUiPerformanceBudgets(metrics).map((entry) => entry.metric)).toEqual(
+        violations,
+      );
+      expect(metrics.total.js.gzipBytes).toBe(
+        40 + (ordinaryGzipBytes ?? 70) + gzipBytes + (duplicateCount ?? 0) * 100,
+      );
+      if (!localeName) {
+        expect(metrics.largest.js.file).toBe("assets/lazy-b.js");
+        expect(formatControlUiPerformanceReport(metrics)).toContain("locale catalog JS:");
+      }
+    },
+  );
+
   it("includes exact bytes when rounded violation values collide", () => {
     const metrics = createMetrics(43_009);
     const budgets = {
@@ -378,7 +463,9 @@ describe("Control UI performance budgets", () => {
       const baselinePath = path.join(configDir, "control-ui-startup-budget-baseline.json");
       const before = fs.readFileSync(baselinePath, "utf8");
       const args = ["--update-baseline", option];
-      if (option === "--base-dist") args.push(distDir);
+      if (option === "--base-dist") {
+        args.push(distDir);
+      }
 
       const result = runControlUiPerformanceCli(scriptPath, args, rootDir);
       expect(result.status).toBe(1);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/142699

## What Problem This Solves

Fixes an issue where generated Control UI locale refreshes would fail the performance gate when a deferred locale catalog exceeded the generic ordinary-JavaScript chunk limit, even though locale catalogs never load at startup.

## Why This Change Was Made

Classifies the 20 configured locale catalogs as their own lazy asset family. They remain included in total JavaScript accounting, are forbidden from startup, are limited to one emitted chunk per configured locale, and each retains a 300 KiB gzip ceiling. The existing 215 KiB cap remains unchanged for ordinary application chunks.

## User Impact

Generated translation refreshes can land without weakening startup or ordinary chunk budgets. Oversized, duplicated, or eagerly loaded locale catalogs still fail CI.

## Evidence

- Reproduced the failure against generated PR #142699 exact head `aae0b5a485bc6680fc643e09443b2641fec2e363`: `assets/ru-*.js` was 245,279 B gzip and was incorrectly evaluated against the 215 KiB ordinary chunk limit.
- Ran the repaired checker against those same built artifacts: zero violations; startup JS 347,197 B; largest ordinary JS 200,913 B; 20 locale catalogs; largest locale catalog 245,279 B.
- `node scripts/run-vitest.mjs test/scripts/control-ui-performance.test.ts test/scripts/control-ui-performance-base.test.ts` (49 tests passed)
- Repository formatter and focused oxlint checks passed.
- Exact-head CI exposed an isolated-repository fixture missing the new canonical locale-config dependency; that fixture now copies both config files and passes locally.
- Independent autoreview: scoped clean at P0/P1, 0.93 confidence.
- Local tsgo could not run because this Codex worktree uses the repository-required external `node_modules` symlink and the declaration checker rejects compiler binaries outside the checkout. Exact-head CI provides a physical dependency install.
- ClawSweeper rank-up move skipped as inapplicable: this changes no stored data, schema, config contract, or migration path. The checker only reads the existing static locale list while measuring ephemeral build artifacts.

No release, publish, tag, or registry action is part of this PR.
