### PR TITLE
refactor(tests): remove duplicate xAI stream tests

### DIFF
--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -14,11 +14,6 @@ import { XAI_BASE_URL } from "./model-definitions.js";
 import { resolveFastModeSupport } from "./provider-policy-api.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 import { wrapXaiProviderStream } from "./stream.js";
-import {
-  createXaiPayloadCaptureStream,
-  expectXaiFastToolStreamShaping,
-  runXaiGrok4ResponseStream,
-} from "./test-helpers.js";
 type XaiStreamApi = Extract<Api, "openai-completions" | "openai-responses">;
 type StreamEvent = Record<string, unknown> & { type?: string };
 
@@ -293,11 +288,6 @@ describe("xai stream wrappers", () => {
     );
   });
 
-  it("leaves unsupported or disabled models unchanged", () => {
-    expect(captureWrappedModelId({ modelId: "grok-3-fast", fastMode: true })).toBe("grok-3-fast");
-    expect(captureWrappedModelId({ modelId: "grok-3", fastMode: false })).toBe("grok-3");
-  });
-
   it("resolves dynamic fast mode for each xai stream call", () => {
     const capturedModelIds: string[] = [];
     const baseStreamFn: StreamFn = (model) => {
@@ -323,18 +313,6 @@ describe("xai stream wrappers", () => {
     void wrapped?.(model, { messages: [] } as Context, {});
 
     expect(capturedModelIds).toEqual(["grok-4-fast", "grok-4"]);
-  });
-
-  it("composes the xai provider stream chain from extra params", () => {
-    const capture = createXaiPayloadCaptureStream();
-
-    const wrapped = wrapXaiProviderStream({
-      streamFn: capture.streamFn,
-      extraParams: { fastMode: true },
-    } as never);
-
-    runXaiGrok4ResponseStream(wrapped);
-    expectXaiFastToolStreamShaping(capture);
   });
 
   it("leaves tool-call argument html entities untouched, delegating decode to the core path", async () => {


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

This maintainer-requested test cleanup removes two redundant xAI stream cases.
They repeat Fast-mode mappings already covered by the retained table and stream
shaping already exercised through the actual registered provider.

## Why This Change Was Made

Remove only the unsupported/disabled-model case, the direct composed-stream
case, and their now-unused three-helper import from `stream.test.ts`.

The mapping table still checks enabled and disabled Fast mode, including the
same unsupported model. The retained provider-registration test uses the same
payload helpers to verify the Fast model ID, `tool_stream: true`, reasoning
removal, and `strict: true` preservation. Helpers, registration, and production
code are unchanged.

## User Impact

No runtime or user-visible behavior changes. Two test cases and 22 lines are
removed while the stronger mapping and registered-provider coverage remain.
All other tests, assertions, timeouts, and workflows are unchanged.

## Evidence

- Both complete files passed through the normal Vitest wrapper:
  `extensions/xai/stream.test.ts` had 45 passes and
  `extensions/xai/index.test.ts` had 57 passes, 102 total with zero skips.
- The retained Fast mapping, registered-provider shaping, and strict-flag
  preservation cases all executed and passed.
- Targeted formatting and `git diff --check` passed.
- The actual selected 19-step changed-check gate completed with exit 0, including
  extension-test typechecking and final named-file lint, without a retry.
- Fresh scanned P2 autoreview was scoped-clean with no findings.

This is focused local proof, not a full-suite or live-provider claim. Exact-head
hosted CI remains a separate landing requirement.
