### PR TITLE
fix(sessions): move cold cleanup integrity checks off the main thread

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -38,6 +38,14 @@ admission. Publish live session changes and other dependent effects only after
 the durable write succeeds. A future network-backed owner must preserve that
 ordering while awaiting its driver.
 
+Explicit session deletion and lifecycle-artifact cleanup prepare their plans
+inside the session writer queue. When the parent database handle is cold, its
+existing asynchronous admission owner runs the full integrity and foreign-key
+checks in a read-only child, moving those full checks off the main thread while
+retaining that queue position. A supplied caller guard is rechecked before the open
+resumes into index repair, schema work, or registration, and before that caller
+uses the admitted handle. Coalesced callers retain their own guards.
+
 Session reclamation keeps its deletion transaction on a worker connection.
 The worker opens its database under the session writer, then releases that writer
 while full integrity and foreign-key checks run on the same connection. Unrelated

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-admission.test.ts
@@ -1,0 +1,319 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as sqlite from "../../infra/node-sqlite.js";
+import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config.js";
+import {
+  appendTranscriptMessage,
+  cleanupSessionLifecycleArtifactsCore,
+  deleteSessionEntryLifecycle,
+  loadSessionEntryReadOnly,
+  replaceSessionEntrySync,
+  resetSessionEntryLifecycle,
+} from "./session-accessor.js";
+import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
+
+const archiveHook = vi.hoisted(() => ({ afterMaterialize: undefined as (() => void) | undefined }));
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    materializeSessionStateDeletePlans: async (
+      ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
+    ) => {
+      const result = await actual.materializeSessionStateDeletePlans(...args);
+      archiveHook.afterMaterialize?.();
+      return result;
+    },
+  };
+});
+
+const roots = createTempDirTracker();
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realOpen = sqlite.openNodeSqliteDatabase;
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+
+beforeEach(() => {
+  resetConfigRuntimeState();
+  const config = { session: { maintenance: { mode: "warn" as const } } };
+  setRuntimeConfigSnapshot(config, config);
+});
+
+afterEach(async () => {
+  for (const release of releases.splice(0)) {
+    release();
+  }
+  await Promise.allSettled(pending.splice(0));
+  archiveHook.afterMaterialize = undefined;
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetConfigRuntimeState();
+  roots.cleanup();
+});
+
+function own<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  void promise.catch(() => {});
+  return promise;
+}
+
+function fixture() {
+  const root = roots.make("session-lifecycle-admission-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  const storePath = path.join(root, "agents", "main", "sessions", "sessions.json");
+  const scope = { storePath, sessionKey: "agent:main:cleanup-admission-target" };
+  replaceSessionEntrySync(scope, { sessionId: "retained", updatedAt: 1 });
+  const database = openOpenClawAgentDatabase({ agentId: "main" });
+  const databaseOptions = {
+    agentId: "main",
+    path: database.path,
+    env: { OPENCLAW_STATE_DIR: root },
+  };
+  closeOpenClawAgentDatabaseByPath(database.path);
+  return { scope, databaseOptions };
+}
+
+function observeColdAdmission(databasePath: string) {
+  const entered = createDeferred();
+  const release = createDeferred();
+  releases.push(() => release.resolve());
+  let parentChecks = 0;
+  vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, options) => {
+    const database = realOpen(pathname, options);
+    if (pathname === databasePath && !options?.readOnly) {
+      const prepare = database.prepare.bind(database);
+      database.prepare = (sql) => {
+        const statement = prepare(sql);
+        if (sql === "PRAGMA integrity_check;") {
+          const all = statement.all.bind(statement);
+          statement.all = () => {
+            parentChecks += 1;
+            return all();
+          };
+        }
+        return statement;
+      };
+    }
+    return database;
+  });
+  vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation((...args) => {
+    const work = realIntegrity(...args);
+    if (args[0] !== databasePath) {
+      return work;
+    }
+    entered.resolve();
+    return Promise.all([work, release.promise]).then(() => undefined);
+  });
+  return { entered, release, parentChecks: () => parentChecks };
+}
+
+it.each(["delete", "artifact cleanup"] as const)(
+  "keeps cold %s preparation asynchronous inside its writer FIFO",
+  async (operation) => {
+    const f = fixture();
+    const admission = observeColdAdmission(f.databaseOptions.path);
+    const work =
+      operation === "delete"
+        ? own(
+            deleteSessionEntryLifecycle({
+              storePath: f.scope.storePath,
+              target: { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] },
+              archiveTranscript: false,
+            }),
+          )
+        : own(
+            cleanupSessionLifecycleArtifactsCore({
+              storePath: f.scope.storePath,
+              sessionKeySegmentPrefix: "cleanup-admission-",
+              transcriptContentMarker: "unused-marker",
+              archiveRemovedEntryTranscripts: false,
+              orphanTranscriptMinAgeMs: 0,
+            }),
+          );
+    await yieldToEventLoop();
+    expect(admission.parentChecks()).toBe(0);
+    expect(
+      await Promise.race([
+        admission.entered.promise.then(() => true),
+        work.then(
+          () => false,
+          () => false,
+        ),
+      ]),
+    ).toBe(true);
+    let followingWriterEntered = false;
+    const following = own(
+      runExclusiveSqliteSessionWrite(f.databaseOptions, async () => {
+        followingWriterEntered = true;
+      }),
+    );
+    await yieldToEventLoop();
+    expect(followingWriterEntered).toBe(false);
+    expect(loadSessionEntryReadOnly(f.scope)).toMatchObject({ sessionId: "retained" });
+    admission.release.resolve();
+    await expect(work).resolves.toMatchObject(
+      operation === "delete" ? { deleted: true } : { removedEntries: 1 },
+    );
+    await following;
+    expect(followingWriterEntered).toBe(true);
+    expect(loadSessionEntryReadOnly(f.scope)).toBeUndefined();
+  },
+);
+
+it("rejects retired authority before evaluating a stale deletion target", async () => {
+  const f = fixture();
+  const admission = observeColdAdmission(f.databaseOptions.path);
+  let allowed = true;
+  const revoked = new Error("deletion authority retired during validation");
+  const work = own(
+    deleteSessionEntryLifecycle({
+      storePath: f.scope.storePath,
+      target: { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] },
+      archiveTranscript: false,
+      expectedSessionId: "stale-generation",
+      commitGuard: () => {
+        if (!allowed) {
+          throw revoked;
+        }
+      },
+    }),
+  );
+  expect(
+    await Promise.race([
+      admission.entered.promise.then(() => true),
+      work.then(
+        () => false,
+        () => false,
+      ),
+    ]),
+  ).toBe(true);
+  allowed = false;
+  admission.release.resolve();
+  await expect(work).rejects.toBe(revoked);
+  expect(loadSessionEntryReadOnly(f.scope)).toMatchObject({ sessionId: "retained" });
+});
+
+it("keeps a warm lifecycle owner synchronous without another integrity child", async () => {
+  const f = fixture();
+  openOpenClawAgentDatabase(f.databaseOptions);
+  const admission = observeColdAdmission(f.databaseOptions.path);
+  const work = own(
+    deleteSessionEntryLifecycle({
+      storePath: f.scope.storePath,
+      target: { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] },
+      archiveTranscript: false,
+    }),
+  );
+  expect(
+    await Promise.race([admission.entered.promise.then(() => false), work.then(() => true)]),
+  ).toBe(true);
+  await expect(work).resolves.toMatchObject({ deleted: true });
+  expect(admission.parentChecks()).toBe(0);
+});
+
+it("retains the selected state owner while cold deletion waits in the FIFO", async () => {
+  const f = fixture();
+  const blockerEntered = createDeferred();
+  const releaseBlocker = createDeferred();
+  releases.push(() => releaseBlocker.resolve());
+  const blocker = own(
+    runExclusiveSqliteSessionWrite(f.databaseOptions, async () => {
+      blockerEntered.resolve();
+      await releaseBlocker.promise;
+    }),
+  );
+  await blockerEntered.promise;
+  const admission = observeColdAdmission(f.databaseOptions.path);
+  const work = own(
+    deleteSessionEntryLifecycle({
+      storePath: f.scope.storePath,
+      target: { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] },
+      archiveTranscript: false,
+    }),
+  );
+  const otherRoot = roots.make("session-lifecycle-other-state-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", otherRoot);
+  releaseBlocker.resolve();
+  await blocker;
+  expect(
+    await Promise.race([
+      admission.entered.promise.then(() => true),
+      work.then(
+        () => false,
+        () => false,
+      ),
+    ]),
+  ).toBe(true);
+  admission.release.resolve();
+  await expect(work).resolves.toMatchObject({ deleted: true });
+  expect(fs.existsSync(path.join(otherRoot, "state", "openclaw.sqlite"))).toBe(false);
+  expect(loadSessionEntryReadOnly(f.scope)).toBeUndefined();
+});
+
+it("keeps historical preparation asynchronous after materialization evicts its parent handle", async () => {
+  const f = fixture();
+  const target = { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] };
+  await appendTranscriptMessage(
+    { ...f.scope, sessionId: "retained" },
+    {
+      message: { role: "user", content: "historical content" },
+    },
+  );
+  await resetSessionEntryLifecycle({
+    storePath: f.scope.storePath,
+    target,
+    buildNextEntry: () => ({ sessionId: "current", updatedAt: 2 }),
+  });
+  await appendTranscriptMessage(
+    { ...f.scope, sessionId: "current" },
+    {
+      message: { role: "user", content: "current content" },
+    },
+  );
+  const admission = observeColdAdmission(f.databaseOptions.path);
+  archiveHook.afterMaterialize = () => {
+    archiveHook.afterMaterialize = undefined;
+    closeOpenClawAgentDatabaseByPath(f.databaseOptions.path);
+  };
+  const work = own(
+    deleteSessionEntryLifecycle({
+      storePath: f.scope.storePath,
+      target,
+      archiveTranscript: true,
+    }),
+  );
+  expect(
+    await Promise.race([
+      admission.entered.promise.then(() => true),
+      work.then(
+        () => false,
+        () => false,
+      ),
+    ]),
+  ).toBe(true);
+  expect(admission.parentChecks()).toBe(0);
+  expect(loadSessionEntryReadOnly(f.scope)).toMatchObject({ sessionId: "current" });
+  admission.release.resolve();
+  const result = await work;
+  expect(result.deleted).toBe(true);
+  expect(result.archivedTranscripts.map((archive) => archive.sessionId).toSorted()).toEqual([
+    "current",
+    "retained",
+  ]);
+  expect(loadSessionEntryReadOnly(f.scope)).toBeUndefined();
+});

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -11,9 +11,14 @@ import { deletePersonalGitHubSessionReceipts } from "../../state/github-personal
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   deferOpenClawAgentPostCommitPublication,
+  getOpenClawAgentDatabaseIfOpen,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+  withOpenClawAgentDatabaseAsync,
   type OpenClawAgentDatabase,
+  type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
+import { resolveStateDir } from "../paths.js";
 import type { ResetSessionEntryLifecycleMutation } from "./session-accessor.lifecycle-types.js";
 import { publishSessionStateArchives } from "./session-accessor.sqlite-archive-store.js";
 import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
@@ -67,6 +72,7 @@ import {
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  type ResolvedSqliteReadScope,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
 import {
@@ -77,8 +83,31 @@ import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.
 
+function captureLifecycleDatabaseScope<T extends ResolvedSqliteReadScope>(scope: T): T {
+  const env = { ...(scope.env ?? process.env) };
+  env.OPENCLAW_STATE_DIR = resolveStateDir(env);
+  return {
+    ...scope,
+    env,
+    path: resolveOpenClawAgentSqlitePath(toDatabaseOptions({ ...scope, env })),
+  };
+}
+
+function withLifecycleDatabase<T>(
+  options: OpenClawAgentDatabaseOptions,
+  operation: (database: OpenClawAgentDatabase) => T,
+  assertCurrent?: () => void,
+): T | Promise<T> {
+  assertCurrent?.();
+  if (getOpenClawAgentDatabaseIfOpen(options)) {
+    return operation(openOpenClawAgentDatabase(options));
+  }
+  // The caller keeps its FIFO section while the existing owner joins the integrity child.
+  return withOpenClawAgentDatabaseAsync(options, operation, assertCurrent);
+}
+
 async function withCommittedHistoryMaintenance<T>(
-  { agentId, storePath }: { agentId?: string; storePath: string },
+  { agentId, env, storePath }: { agentId?: string; env?: NodeJS.ProcessEnv; storePath: string },
   run: (
     recordCommit: (database: OpenClawAgentDatabase) => void,
     markCommitted: () => void,
@@ -101,7 +130,7 @@ async function withCommittedHistoryMaintenance<T>(
     // A partial commit still needs maintenance, but only after archive publication and
     // lifecycle-owner cleanup finish. Rejected preparation or rollback creates no pressure.
     if (committed && options.scheduleNext !== false) {
-      kickSessionHistoryDiskBudgetMaintenance({ agentId, storePath, force: true });
+      kickSessionHistoryDiskBudgetMaintenance({ agentId, env, storePath, force: true });
     }
   }
 }
@@ -116,28 +145,31 @@ export async function cleanupSessionLifecycleArtifactsCore(
     return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
   }
 
-  const resolved = resolveSqliteReadScope({
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    storePath: params.storePath,
-  });
+  const resolved = captureLifecycleDatabaseScope(
+    resolveSqliteReadScope({
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      storePath: params.storePath,
+    }),
+  );
   const databaseOptions = toDatabaseOptions(resolved);
   // Maintenance must not turn a read-only startup probe into a newly materialized agent store.
   if (!withOpenClawAgentDatabaseReadOnly(() => true, databaseOptions).found) {
     return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
   }
-  const cleanupPlan = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const database = openOpenClawAgentDatabase(databaseOptions);
-    return planSessionLifecycleArtifactCleanup(database, {
-      ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
-      archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
-      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-      ...(pluginOwnerId ? { pluginOwnerId } : {}),
-      sessionKeySegmentPrefix,
-      transcriptContentMarker,
-      orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
-      nowMs: params.nowMs ?? Date.now(),
-    });
-  });
+  const cleanupPlan = await runExclusiveSqliteSessionWrite(resolved, async () =>
+    withLifecycleDatabase(databaseOptions, (database) =>
+      planSessionLifecycleArtifactCleanup(database, {
+        ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
+        archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
+        archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+        ...(pluginOwnerId ? { pluginOwnerId } : {}),
+        sessionKeySegmentPrefix,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs: params.nowMs ?? Date.now(),
+      }),
+    ),
+  );
   if (cleanupPlan.entries.length === 0 && cleanupPlan.deletePlans.length === 0) {
     // Startup probes need no reclamation Worker, but previously committed archives
     // still need their publication retry even when this pass has no deletions.
@@ -278,16 +310,20 @@ async function deleteSqliteSessionEntryLifecycleInternal(
   expectedPluginOwnerId?: string,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const agentId = params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId;
-  const resolved = resolveSqliteStoreScope(params.storePath, { agentId });
-  return await withCommittedHistoryMaintenance(params, async (recordCommit, markCommitted) =>
-    deleteSqliteSessionEntryLifecycleLocked(
-      resolved,
-      params,
-      allowLockedEntryRemoval,
-      expectedPluginOwnerId,
-      recordCommit,
-      markCommitted,
-    ),
+  const resolved = captureLifecycleDatabaseScope(
+    resolveSqliteStoreScope(params.storePath, { agentId }),
+  );
+  return await withCommittedHistoryMaintenance(
+    { ...params, env: resolved.env },
+    async (recordCommit, markCommitted) =>
+      deleteSqliteSessionEntryLifecycleLocked(
+        resolved,
+        params,
+        allowLockedEntryRemoval,
+        expectedPluginOwnerId,
+        recordCommit,
+        markCommitted,
+      ),
   );
 }
 
@@ -301,85 +337,89 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   recordCommit: (database: OpenClawAgentDatabase) => void,
   markCommitted: () => void,
 ): Promise<DeleteSessionEntryLifecycleResult> {
-  const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    // Opening a store can register durable ownership, even before the deletion transaction.
-    params.commitGuard?.();
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-    const current = targetSnapshot[0];
-    if (!current) {
-      return null;
-    }
-    if (!shouldDeleteSqliteSessionEntryLifecycle(database, current.entry, params)) {
-      return DELETE_EXPECTED_ENTRY_MISMATCH;
-    }
-    if (current.entry.modelSelectionLocked === true && !allowLockedEntryRemoval) {
-      throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
-    }
-    if (
-      expectedPluginOwnerId &&
-      targetSnapshot.some(
-        ({ entry, sessionKey }) =>
-          isAgentHarnessSessionKey(sessionKey) ||
-          entry.agentHarnessId !== undefined ||
-          entry.modelSelectionLocked !== true ||
-          normalizeOptionalString(entry.pluginOwnerId) !== expectedPluginOwnerId,
-      )
-    ) {
-      throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
-    }
-    const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
-      database,
-      params.target,
-    );
-    const deleteTranscriptState =
-      params.archiveTranscript || params.deleteTranscriptWithoutArchive === true;
-    // SQLite transcript state is keyed by session id; sessionFile is only its
-    // marker. Materialization dedupes aliases that share the same state owner.
-    const archiveDirectory = resolveSqliteTranscriptArchiveDirectory(resolved);
-    const entryPlans = deleteTranscriptState
-      ? targetSnapshot.flatMap(({ entry }) =>
-          planSessionStateAfterEntryRemoval({
-            archiveDirectory,
-            archiveTranscript: params.archiveTranscript,
-            database,
-            entry,
-            reason: "deleted",
-            referencedSessionIds: referencedAfterDelete,
-          }),
-        )
-      : [];
-    const entryPlanIds = new Set(entryPlans.map((plan) => plan.sessionId));
-    // Ids only — archive extraction happens lazily one generation at a time
-    // outside the SQLite write transaction.
-    const historicalGenerationIds = deleteTranscriptState
-      ? readSessionGenerationIdsForKeys(database, [
-          params.target.canonicalKey,
-          ...params.target.storeKeys,
-          ...targetSnapshot.map((row) => row.sessionKey),
-        ]).filter((sessionId) => !entryPlanIds.has(sessionId))
-      : [];
-    // Historical generations are reclaimed BEFORE the entry-removing
-    // transaction, one generation per transaction: an archive or delete
-    // failure aborts the whole deletion while the live entry still exists,
-    // so a retry rediscovers the remaining history. Acknowledging deletion
-    // first would let surviving generations become unreachable via delete.
-    // Preflight the admission fence over every generation BEFORE deleting
-    // anything, so an in-flight run rejects the whole deletion instead of
-    // aborting it midway through committed removals.
-    const preflightFence = collectAdmissionProtectedSessionIds({
-      database,
-      storePath: params.storePath,
-    });
-    for (const sessionId of historicalGenerationIds) {
-      if (preflightFence.has(sessionId) && !referencedAfterDelete.has(sessionId)) {
-        throw new Error(
-          `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+  const databaseOptions = toDatabaseOptions(resolved);
+  const prepared = await runExclusiveSqliteSessionWrite(resolved, async () =>
+    withLifecycleDatabase(
+      databaseOptions,
+      (database) => {
+        const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+        const current = targetSnapshot[0];
+        if (!current) {
+          return null;
+        }
+        if (!shouldDeleteSqliteSessionEntryLifecycle(database, current.entry, params)) {
+          return DELETE_EXPECTED_ENTRY_MISMATCH;
+        }
+        if (current.entry.modelSelectionLocked === true && !allowLockedEntryRemoval) {
+          throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
+        }
+        if (
+          expectedPluginOwnerId &&
+          targetSnapshot.some(
+            ({ entry, sessionKey }) =>
+              isAgentHarnessSessionKey(sessionKey) ||
+              entry.agentHarnessId !== undefined ||
+              entry.modelSelectionLocked !== true ||
+              normalizeOptionalString(entry.pluginOwnerId) !== expectedPluginOwnerId,
+          )
+        ) {
+          throw new Error(MODEL_SELECTION_LOCK_REMOVAL_MESSAGE);
+        }
+        const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
+          database,
+          params.target,
         );
-      }
-    }
-    return { archiveDirectory, current, entryPlans, historicalGenerationIds, targetSnapshot };
-  });
+        const deleteTranscriptState =
+          params.archiveTranscript || params.deleteTranscriptWithoutArchive === true;
+        // SQLite transcript state is keyed by session id; sessionFile is only its
+        // marker. Materialization dedupes aliases that share the same state owner.
+        const archiveDirectory = resolveSqliteTranscriptArchiveDirectory(resolved);
+        const entryPlans = deleteTranscriptState
+          ? targetSnapshot.flatMap(({ entry }) =>
+              planSessionStateAfterEntryRemoval({
+                archiveDirectory,
+                archiveTranscript: params.archiveTranscript,
+                database,
+                entry,
+                reason: "deleted",
+                referencedSessionIds: referencedAfterDelete,
+              }),
+            )
+          : [];
+        const entryPlanIds = new Set(entryPlans.map((plan) => plan.sessionId));
+        // Ids only — archive extraction happens lazily one generation at a time
+        // outside the SQLite write transaction.
+        const historicalGenerationIds = deleteTranscriptState
+          ? readSessionGenerationIdsForKeys(database, [
+              params.target.canonicalKey,
+              ...params.target.storeKeys,
+              ...targetSnapshot.map((row) => row.sessionKey),
+            ]).filter((sessionId) => !entryPlanIds.has(sessionId))
+          : [];
+        // Historical generations are reclaimed BEFORE the entry-removing
+        // transaction, one generation per transaction: an archive or delete
+        // failure aborts the whole deletion while the live entry still exists,
+        // so a retry rediscovers the remaining history. Acknowledging deletion
+        // first would let surviving generations become unreachable via delete.
+        // Preflight the admission fence over every generation BEFORE deleting
+        // anything, so an in-flight run rejects the whole deletion instead of
+        // aborting it midway through committed removals.
+        const preflightFence = collectAdmissionProtectedSessionIds({
+          database,
+          storePath: params.storePath,
+        });
+        for (const sessionId of historicalGenerationIds) {
+          if (preflightFence.has(sessionId) && !referencedAfterDelete.has(sessionId)) {
+            throw new Error(
+              `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+            );
+          }
+        }
+        return { archiveDirectory, current, entryPlans, historicalGenerationIds, targetSnapshot };
+      },
+      () => params.commitGuard?.(),
+    ),
+  );
   if (!prepared) {
     await publishSessionStateArchives(resolved, []);
     return { archivedTranscripts: [], deleted: false };
@@ -393,43 +433,51 @@ async function deleteSqliteSessionEntryLifecycleLocked(
     resolved,
     prepared.targetSnapshot,
     async (assertCurrent) => {
+      const assertDeletionCurrent = () => {
+        params.commitGuard?.();
+        assertCurrent();
+      };
       const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
       for (const sessionId of prepared.historicalGenerationIds) {
-        const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
-          params.commitGuard?.();
-          const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-          const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-          if (
-            !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-            !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
-          ) {
-            return DELETE_EXPECTED_ENTRY_MISMATCH;
-          }
-          const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
-            database,
-            params.target,
-          );
-          if (referencedAfterDelete.has(sessionId)) {
-            return null;
-          }
-          const admissionProtected = collectAdmissionProtectedSessionIds({
-            database,
-            storePath: params.storePath,
-          });
-          if (admissionProtected.has(sessionId)) {
-            throw new Error(
-              `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
-            );
-          }
-          return planSessionStateDeleteIfUnreferenced({
-            archiveDirectory: prepared.archiveDirectory,
-            archiveTranscript: params.archiveTranscript,
-            database,
-            reason: "deleted",
-            referencedSessionIds: referencedAfterDelete,
-            sessionId,
-          });
-        });
+        const plan = await runExclusiveSqliteSessionWrite(resolved, async () =>
+          withLifecycleDatabase(
+            databaseOptions,
+            (database) => {
+              const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+              if (
+                !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+                !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
+              ) {
+                return DELETE_EXPECTED_ENTRY_MISMATCH;
+              }
+              const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
+                database,
+                params.target,
+              );
+              if (referencedAfterDelete.has(sessionId)) {
+                return null;
+              }
+              const admissionProtected = collectAdmissionProtectedSessionIds({
+                database,
+                storePath: params.storePath,
+              });
+              if (admissionProtected.has(sessionId)) {
+                throw new Error(
+                  `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+                );
+              }
+              return planSessionStateDeleteIfUnreferenced({
+                archiveDirectory: prepared.archiveDirectory,
+                archiveTranscript: params.archiveTranscript,
+                database,
+                reason: "deleted",
+                referencedSessionIds: referencedAfterDelete,
+                sessionId,
+              });
+            },
+            assertDeletionCurrent,
+          ),
+        );
         if (plan === DELETE_EXPECTED_ENTRY_MISMATCH) {
           return expectedEntryMismatchResult(historicalArchivedTranscripts);
         }
@@ -441,35 +489,41 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           const diagnostics: SqliteSessionReclamationDiagnostics = {};
           const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
-            async () => {
-              params.commitGuard?.();
-              assertCurrent();
-              const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-              const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-              if (
-                !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-                !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
-              ) {
-                return DELETE_EXPECTED_ENTRY_MISMATCH;
-              }
-              const protectedSessionIds = collectAdmissionProtectedSessionIds({
-                database,
-                storePath: params.storePath,
-              });
-              if (protectedSessionIds.has(sessionId)) {
-                throw new Error(
-                  `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
-                );
-              }
-              return createHistoricalGenerationReclamationPlan({
-                databaseOptions: toDatabaseOptions(resolved),
-                deleteParams: params,
-                materializedPlans: materializedGeneration,
-                preparedTargetSnapshot: prepared.targetSnapshot,
-                protectedSessionIds,
-                sessionId,
-              });
-            },
+            async () =>
+              withLifecycleDatabase(
+                databaseOptions,
+                (database) => {
+                  const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+                  if (
+                    !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+                    !shouldDeleteSqliteSessionEntryLifecycle(
+                      database,
+                      targetSnapshot[0]?.entry,
+                      params,
+                    )
+                  ) {
+                    return DELETE_EXPECTED_ENTRY_MISMATCH;
+                  }
+                  const protectedSessionIds = collectAdmissionProtectedSessionIds({
+                    database,
+                    storePath: params.storePath,
+                  });
+                  if (protectedSessionIds.has(sessionId)) {
+                    throw new Error(
+                      `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+                    );
+                  }
+                  return createHistoricalGenerationReclamationPlan({
+                    databaseOptions,
+                    deleteParams: params,
+                    materializedPlans: materializedGeneration,
+                    preparedTargetSnapshot: prepared.targetSnapshot,
+                    protectedSessionIds,
+                    sessionId,
+                  });
+                },
+                assertDeletionCurrent,
+              ),
             diagnostics,
           );
           if (reclamationPlan === DELETE_EXPECTED_ENTRY_MISMATCH) {
@@ -477,10 +531,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           }
           const reclaimed = await runSqliteSessionReclamation({
             diagnostics,
-            assertCommitAllowed: () => {
-              params.commitGuard?.();
-              assertCurrent();
-            },
+            assertCommitAllowed: assertDeletionCurrent,
             forceInProcess: hasPreparedNativeSessionDeletion(),
             onInProcessCommit: recordCommit,
             plan: reclamationPlan,
@@ -525,10 +576,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         });
         const reclaimed = await runSqliteSessionReclamation({
           diagnostics,
-          assertCommitAllowed: () => {
-            params.commitGuard?.();
-            assertCurrent();
-          },
+          assertCommitAllowed: assertDeletionCurrent,
           forceInProcess: hasPreparedNativeSessionDeletion(),
           onInProcessCommit: recordCommit,
           plan: reclamationPlan,
@@ -599,16 +647,16 @@ export async function deleteDiskBudgetSessionEntryLifecycle(
 ): Promise<DeleteSessionEntryLifecycleResult> {
   // A shared store lends its physical owner, not the victim's logical identity.
   // Validate against captured ownership so a custom selector cannot retarget cleanup.
-  const targetScope = {
+  const targetScope = captureLifecycleDatabaseScope({
     ...resolved,
     agentId: resolveSqliteAgentId({
       scopedAgentId: params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId,
       storeAgentId: resolved.databaseAgentId ?? resolved.agentId,
       storeShared: resolved.databaseAgentId !== undefined,
     }),
-  };
+  });
   return await withCommittedHistoryMaintenance(
-    params,
+    { ...params, env: targetScope.env },
     async (recordCommit, markCommitted) =>
       await deleteSqliteSessionEntryLifecycleLocked(
         targetScope,

--- a/src/state/openclaw-agent-db-admission.ts
+++ b/src/state/openclaw-agent-db-admission.ts
@@ -29,6 +29,32 @@ export type OpenClawAgentDatabaseWriteAdmission = <T>(
   run: (assertCurrent: () => void) => T | Promise<T>,
 ) => Promise<T>;
 
+/** Refusal must unwind ownership without entering corruption repair or changing its caller error. */
+function assertAgentDatabaseOpenAuthority(
+  operation: SqliteIntegrityOperation<OpenClawAgentDatabase>,
+  assertCurrent?: () => void,
+): void {
+  try {
+    assertCurrent?.();
+  } catch (error) {
+    const refusal = new Error("Agent database open authority was refused", { cause: error });
+    try {
+      operation.throw(refusal);
+    } catch (cleanupError) {
+      if (cleanupError !== refusal) {
+        throw new AggregateError(
+          [error, cleanupError],
+          `Agent database authority and cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+          {
+            cause: cleanupError,
+          },
+        );
+      }
+    }
+    throw error;
+  }
+}
+
 /** Bind both admission drivers to the canonical private database-open generator. */
 export function createOpenClawAgentDatabaseAdmissionOwner(
   openSteps: (
@@ -36,11 +62,19 @@ export function createOpenClawAgentDatabaseAdmissionOwner(
     pending: PendingAgentDatabaseOpen,
   ) => SqliteIntegrityOperation<OpenClawAgentDatabase>,
 ) {
-  /** Retain the verified connection through an async caller's operation; disposal still revokes it. */
+  /** The initiating caller guards its physical open; each coalesced caller guards its own operation. */
   function withOpenClawAgentDatabaseAsync<T>(
     inputOptions: OpenClawAgentDatabaseOptions,
     operation: (database: OpenClawAgentDatabase) => T | Promise<T>,
+    /** Synchronous live authority for the initiating open and this caller's operation. */
+    assertCurrent?: () => void,
   ): Promise<T> {
+    try {
+      assertCurrent?.();
+    } catch (error) {
+      // oxlint-disable-next-line typescript/prefer-promise-reject-errors -- Caller assertions retain their original thrown value.
+      return Promise.reject(error);
+    }
     // Admission retains its original path, registration, and permission inputs across awaits.
     const options = { ...inputOptions, env: { ...(inputOptions.env ?? process.env) } };
     const agentId = normalizeAgentId(options.agentId);
@@ -53,11 +87,12 @@ export function createOpenClawAgentDatabaseAdmissionOwner(
     }
     if (existing?.controller.signal.aborted) {
       return existing.promise.then(
-        () => withOpenClawAgentDatabaseAsync(options, operation),
-        () => withOpenClawAgentDatabaseAsync(options, operation),
+        () => withOpenClawAgentDatabaseAsync(options, operation, assertCurrent),
+        () => withOpenClawAgentDatabaseAsync(options, operation, assertCurrent),
       );
     }
-    const pending = existing ?? startOpenClawAgentDatabaseAdmission(options, agentId, pathname);
+    const pending =
+      existing ?? startOpenClawAgentDatabaseAdmission(options, agentId, pathname, assertCurrent);
     pending.operations += 1;
     return pending.promise
       .then((database) => {
@@ -67,6 +102,7 @@ export function createOpenClawAgentDatabaseAdmissionOwner(
         }
         // Coalesced callers keep their own scope; admission cannot lend its cleanup authority.
         assertAgentDeletionDatabaseCleanupAccess(database, options);
+        assertCurrent?.();
         return operation(database);
       })
       .finally(() => {
@@ -248,13 +284,16 @@ export function createOpenClawAgentDatabaseAdmissionOwner(
     options: OpenClawAgentDatabaseOptions,
     agentId: string,
     pathname: string,
+    assertCurrent?: () => void,
   ): PendingAgentDatabaseOpen {
     const admission = createOpenClawAgentDatabaseAdmission(agentId, pathname);
     const { pending } = admission;
     const operation = openSteps(options, pending);
     void (async () => {
+      assertAgentDatabaseOpenAuthority(operation, assertCurrent);
       let step = operation.next();
       while (!step.done) {
+        const database = step.value.database;
         let failure: unknown;
         let failed = false;
         try {
@@ -267,12 +306,11 @@ export function createOpenClawAgentDatabaseAdmissionOwner(
           failure = error;
           failed = true;
         }
-        try {
-          assertOpenClawAgentDatabaseAdmissionCurrent(options, pending, step.value.database);
-        } catch (error) {
-          failure = error;
-          failed = true;
-        }
+        // Throwing an integrity verdict into the generator can repair indexes too.
+        assertAgentDatabaseOpenAuthority(operation, () => {
+          assertOpenClawAgentDatabaseAdmissionCurrent(options, pending, database);
+          assertCurrent?.();
+        });
         // Resuming, or throwing into, the same owner preserves repair and unwind policy.
         step = failed ? operation.throw(failure) : operation.next();
       }

--- a/src/state/openclaw-agent-db-open-authority.test.ts
+++ b/src/state/openclaw-agent-db-open-authority.test.ts
@@ -1,0 +1,420 @@
+import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
+import fs from "node:fs";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import * as integrity from "../infra/sqlite-integrity-worker.js";
+import * as agentLeases from "./openclaw-agent-db-lease.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+  resolveIncognitoOpenClawAgentSqlitePath,
+  withOpenClawAgentDatabaseAsync,
+} from "./openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+
+const roots = createTempDirTracker();
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+const wrongIndex = "CREATE INDEX idx_agent_cache_expiry ON cache_entries(key)";
+
+afterEach(async () => {
+  releases.splice(0).forEach((release) => release());
+  await Promise.allSettled(pending.splice(0));
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  roots.cleanup();
+});
+
+function own<T>(work: Promise<T>): Promise<T> {
+  pending.push(work);
+  void work.catch(() => {});
+  return work;
+}
+
+function fixture(repair = false) {
+  const root = roots.make("agent-open-authority-");
+  const options = { agentId: "synthetic", env: { OPENCLAW_STATE_DIR: root } };
+  const database = openOpenClawAgentDatabase(options);
+  if (repair) {
+    database.db.exec(`DROP INDEX idx_agent_cache_expiry; ${wrongIndex};`);
+  }
+  const pathname = database.path;
+  closeOpenClawAgentDatabaseByPath(pathname);
+  const state = openOpenClawStateDatabase({ env: options.env });
+  const leases = () => state.db.prepare("SELECT lease_id FROM agent_database_leases").all();
+  return { options, pathname, state, leases };
+}
+
+function indexSql(pathname: string) {
+  const database = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    return database
+      .prepare("SELECT sql FROM sqlite_schema WHERE name='idx_agent_cache_expiry'")
+      .get()?.sql;
+  } finally {
+    database.close();
+  }
+}
+
+function holdIntegrity(pathname: string) {
+  const entered = createDeferred();
+  const release = createDeferred();
+  releases.push(() => release.resolve());
+  let joined = false;
+  let calls = 0;
+  vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation(async (...args) => {
+    if (args[0] !== pathname) {
+      return await realIntegrity(...args);
+    }
+    calls += 1;
+    const result = realIntegrity(...args)
+      .then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error }),
+      )
+      .finally(() => {
+        joined = true;
+      });
+    entered.resolve();
+    const outcome = await result;
+    await release.promise;
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+  });
+  return { entered, release, joined: () => joined, calls: () => calls };
+}
+
+it("rejects already-retired authority without creating database state", async () => {
+  const root = roots.make("agent-open-refused-");
+  const options = { agentId: "refused", env: { OPENCLAW_STATE_DIR: root } };
+  const refused = new Error("authority already retired");
+  const operation = vi.fn();
+  let work: Promise<unknown> | undefined;
+  expect(() => {
+    work = own(
+      withOpenClawAgentDatabaseAsync(options, operation, () => {
+        throw refused;
+      }),
+    );
+  }).not.toThrow();
+  await expect(work).rejects.toBe(refused);
+  expect(operation).not.toHaveBeenCalled();
+  expect(fs.existsSync(resolveOpenClawAgentSqlitePath(options))).toBe(false);
+  expect(fs.readdirSync(root)).toEqual([]);
+});
+
+it.each(["ordinary", "integrity-shaped", "falsy", "native-failure"] as const)(
+  "unwinds %s initiating refusal before repairing indexes for coalesced callers",
+  async (kind) => {
+    const f = fixture(true);
+    if (kind === "native-failure") {
+      const writer = openNodeSqliteDatabase(f.pathname);
+      try {
+        writer.exec(
+          "PRAGMA foreign_keys=OFF; INSERT INTO memory_index_chunk_recall_metadata (chunk_id,importance) VALUES ('missing',1)",
+        );
+      } finally {
+        writer.close();
+      }
+    }
+    const gate = holdIntegrity(f.pathname);
+    const refused = kind === "falsy" ? 0 : new Error("initiating authority retired");
+    if (kind === "integrity-shaped" && refused instanceof Error) {
+      refused.name = "SqliteIntegrityError";
+    }
+    let allowed = true;
+    const operation = vi.fn();
+    const first = own(
+      withOpenClawAgentDatabaseAsync(f.options, operation, () => {
+        if (!allowed) {
+          // oxlint-disable-next-line typescript/only-throw-error -- This fixture deliberately verifies a falsy non-Error refusal.
+          throw refused;
+        }
+      }),
+    );
+    await gate.entered.promise;
+    const peer = own(withOpenClawAgentDatabaseAsync(f.options, operation, () => {}));
+    allowed = false;
+    gate.release.resolve();
+    await expect(first).rejects.toBe(refused);
+    await expect(peer).rejects.toBe(refused);
+    expect(gate.calls()).toBe(1);
+    expect(gate.joined()).toBe(true);
+    expect(operation).not.toHaveBeenCalled();
+    expect(indexSql(f.pathname)).toBe(wrongIndex);
+    expect(f.leases()).toEqual([]);
+    expect(getOpenClawAgentDatabaseIfOpen(f.options)).toBeUndefined();
+    if (kind === "native-failure") {
+      const writer = openNodeSqliteDatabase(f.pathname);
+      try {
+        writer.exec("DELETE FROM memory_index_chunk_recall_metadata WHERE chunk_id='missing'");
+      } finally {
+        writer.close();
+      }
+    }
+    // Refusal neither quarantines the file nor lends stale authority to a fresh caller.
+    await expect(
+      own(
+        withOpenClawAgentDatabaseAsync(
+          f.options,
+          () => "fresh",
+          () => {},
+        ),
+      ),
+    ).resolves.toBe("fresh");
+    expect(indexSql(f.pathname)).not.toBe(wrongIndex);
+  },
+);
+
+it("keeps a coalesced peer's authority and async context separate", async () => {
+  const f = fixture();
+  const gate = holdIntegrity(f.pathname);
+  const context = new AsyncLocalStorage<string>();
+  const observations: Array<{ caller: string; context: string | undefined }> = [];
+  const refused = new Error("peer retired");
+  let peerAllowed = true;
+  const first = own(
+    context.run("initiator", () =>
+      withOpenClawAgentDatabaseAsync(
+        f.options,
+        () => context.getStore(),
+        () => {
+          observations.push({ caller: "initiator", context: context.getStore() });
+        },
+      ),
+    ),
+  );
+  await gate.entered.promise;
+  const deniedOperation = vi.fn();
+  const initiallyDenied = own(
+    withOpenClawAgentDatabaseAsync(f.options, deniedOperation, () => {
+      throw refused;
+    }),
+  );
+  await expect(initiallyDenied).rejects.toBe(refused);
+  expect(deniedOperation).not.toHaveBeenCalled();
+  const peerOperation = vi.fn();
+  const peer = own(
+    context.run("peer", () =>
+      withOpenClawAgentDatabaseAsync(f.options, peerOperation, () => {
+        observations.push({ caller: "peer", context: context.getStore() });
+        if (!peerAllowed) {
+          throw refused;
+        }
+      }),
+    ),
+  );
+  peerAllowed = false;
+  gate.release.resolve();
+  await expect(first).resolves.toBe("initiator");
+  await expect(peer).rejects.toBe(refused);
+  expect(peerOperation).not.toHaveBeenCalled();
+  expect(gate.calls()).toBe(1);
+  expect(observations.some((row) => row.caller === "peer")).toBe(true);
+  expect(observations.every((row) => row.caller === row.context)).toBe(true);
+  expect(getOpenClawAgentDatabaseIfOpen(f.options)?.db.isOpen).toBe(true);
+});
+
+it("denies an initiating operation after publication without retiring its valid peer or handle", async () => {
+  const f = fixture();
+  const gate = holdIntegrity(f.pathname);
+  const refused = new Error("caller retired at publication");
+  const firstOperation = vi.fn();
+  const first = own(
+    withOpenClawAgentDatabaseAsync(f.options, firstOperation, () => {
+      if (getOpenClawAgentDatabaseIfOpen(f.options)) {
+        throw refused;
+      }
+    }),
+  );
+  await gate.entered.promise;
+  const peer = own(
+    withOpenClawAgentDatabaseAsync(
+      f.options,
+      (database) => database,
+      () => {},
+    ),
+  );
+  gate.release.resolve();
+  await expect(first).rejects.toBe(refused);
+  const database = await peer;
+  expect(firstOperation).not.toHaveBeenCalled();
+  expect(database).toBe(getOpenClawAgentDatabaseIfOpen(f.options));
+  expect(database.db.isOpen).toBe(true);
+  expect(gate.calls()).toBe(1);
+});
+
+it("keeps the joining caller's guard across an aborted predecessor retry", async () => {
+  const f = fixture();
+  const gate = holdIntegrity(f.pathname);
+  const first = own(withOpenClawAgentDatabaseAsync(f.options, () => "old"));
+  await gate.entered.promise;
+  closeOpenClawAgentDatabaseByPath(f.pathname);
+  const context = new AsyncLocalStorage<string>();
+  const seen: Array<string | undefined> = [];
+  const refused = new Error("joining caller retired");
+  let allowed = true;
+  const operation = vi.fn();
+  const joining = own(
+    context.run("joining", () =>
+      withOpenClawAgentDatabaseAsync(f.options, operation, () => {
+        seen.push(context.getStore());
+        if (!allowed) {
+          throw refused;
+        }
+      }),
+    ),
+  );
+  allowed = false;
+  gate.release.resolve();
+  await expect(first).rejects.toThrow(/revoked/);
+  await expect(joining).rejects.toBe(refused);
+  expect(gate.calls()).toBe(1);
+  expect(operation).not.toHaveBeenCalled();
+  expect(seen.length).toBeGreaterThan(1);
+  expect(seen.every((value) => value === "joining")).toBe(true);
+  expect(f.leases()).toEqual([]);
+});
+
+it("retains both authority refusal and recoverable lease cleanup failure", async () => {
+  const f = fixture(true);
+  const gate = holdIntegrity(f.pathname);
+  const refused = new Error("authority retired before cleanup");
+  let allowed = true;
+  const work = own(
+    withOpenClawAgentDatabaseAsync(
+      f.options,
+      () => "forbidden",
+      () => {
+        if (!allowed) {
+          throw refused;
+        }
+      },
+    ),
+  );
+  await gate.entered.promise;
+  f.state.db.exec(
+    "CREATE TEMP TRIGGER fail_authority_release BEFORE DELETE ON agent_database_leases BEGIN SELECT RAISE(ABORT, 'retained cleanup failure'); END",
+  );
+  try {
+    allowed = false;
+    gate.release.resolve();
+    const failure = await work.catch((error: unknown) => error);
+    assert(failure instanceof AggregateError);
+    expect(failure.errors).toContain(refused);
+    expect(failure.errors.some((error) => String(error).includes("retained cleanup failure"))).toBe(
+      true,
+    );
+    expect(gate.joined()).toBe(true);
+    expect(indexSql(f.pathname)).toBe(wrongIndex);
+    expect(f.leases()).toHaveLength(1);
+  } finally {
+    f.state.db.exec("DROP TRIGGER fail_authority_release");
+  }
+  await closeOpenClawAgentDatabasesAsync();
+  expect(f.leases()).toEqual([]);
+});
+
+it("checks lost database ownership before consulting the initiating caller again", async () => {
+  const f = fixture();
+  const gate = holdIntegrity(f.pathname);
+  let ownerRetired = false;
+  const forbiddenRead = vi.fn();
+  const work = own(
+    withOpenClawAgentDatabaseAsync(
+      f.options,
+      () => "forbidden",
+      () => {
+        if (ownerRetired) {
+          forbiddenRead();
+          throw new Error("caller consulted after owner retirement");
+        }
+      },
+    ),
+  );
+  await gate.entered.promise;
+  ownerRetired = true;
+  closeOpenClawAgentDatabaseByPath(f.pathname);
+  gate.release.resolve();
+  await expect(work).rejects.toThrow(/revoked/);
+  expect(forbiddenRead).not.toHaveBeenCalled();
+  expect(gate.joined()).toBe(true);
+  expect(f.leases()).toEqual([]);
+});
+
+it.each([false, true])(
+  "keeps warm operation denial local without another native check (incognito=%s)",
+  async (incognito) => {
+    const f = fixture();
+    const options = incognito
+      ? {
+          ...f.options,
+          path: resolveIncognitoOpenClawAgentSqlitePath(f.options),
+        }
+      : f.options;
+    const database = openOpenClawAgentDatabase(options);
+    const check = vi.spyOn(integrity, "assertSqliteIntegrityInWorker");
+    const refused = new Error("warm caller retired");
+    let allowed = true;
+    const work = own(
+      withOpenClawAgentDatabaseAsync(
+        options,
+        () => "forbidden",
+        () => {
+          if (!allowed) {
+            throw refused;
+          }
+        },
+      ),
+    );
+    allowed = false;
+    await expect(work).rejects.toBe(refused);
+    expect(getOpenClawAgentDatabaseIfOpen(options)).toBe(database);
+    expect(database.db.isOpen).toBe(true);
+    expect(check).not.toHaveBeenCalled();
+  },
+);
+
+it("does not treat a database-owner failure as a repairable integrity verdict", async () => {
+  const f = fixture(true);
+  const gate = holdIntegrity(f.pathname);
+  const failedOwner = new Error("shared database owner could not be checked");
+  failedOwner.name = "SqliteIntegrityError";
+  let ownerFailed = false;
+  const callerRead = vi.fn();
+  const work = own(
+    withOpenClawAgentDatabaseAsync(
+      f.options,
+      () => "forbidden",
+      () => {
+        if (ownerFailed) {
+          callerRead();
+        }
+      },
+    ),
+  );
+  await gate.entered.promise;
+  ownerFailed = true;
+  vi.spyOn(agentLeases, "assertOpenClawAgentDatabaseLease").mockImplementation(() => {
+    throw failedOwner;
+  });
+  gate.release.resolve();
+  await expect(work).rejects.toBe(failedOwner);
+  expect(callerRead).not.toHaveBeenCalled();
+  expect(indexSql(f.pathname)).toBe(wrongIndex);
+  expect(f.leases()).toEqual([]);
+});

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -264,6 +264,8 @@ describe("production lint suppressions", () => {
         // Raw PowerShell errors carry the -EncodedCommand argv; only the sanitized cause may escape.
         "src/secrets/private-plan-file.ts|preserve-caught-error|1",
         "src/state/config-machine-state.ts|typescript/no-unnecessary-type-parameters|2",
+        // Caller assertions retain their original thrown value, including non-Error values.
+        "src/state/openclaw-agent-db-admission.ts|typescript/prefer-promise-reject-errors|1",
         "src/system-agent/setup-inference-activate.ts|no-unsafe-finally|1",
         "src/system-agent/setup-inference-activate.ts|preserve-caught-error|1",
         // Cleanup stays in AggregateError.errors; the initiating failure remains cause for classification and remediation.


### PR DESCRIPTION
## What Problem This Solves

Deleting sessions or cleaning lifecycle artifacts could temporarily block other Gateway work when the parent database connection was cold.

## Why This Change Was Made

Cold preparation now uses the existing asynchronous database owner inside the same writer queue. The initiating caller's live guard is checked before native-open work resumes, including index repair, schema work and registration; coalesced callers retain their own operation guards. Refusal preserves the original thrown value while joining owned cleanup, and distinct cleanup failures remain visible.

## User Impact

Full integrity and foreign-key checks for these cold preparation paths run off the main thread. Writer ordering, all required checks, archive/deletion order, and reclamation Worker settlement remain intact.

## Evidence

- The focused and surrounding SQLite owner/lifecycle suites passed (85 tests). The final inventory and owner follow-up passed 23 tests, required changed-file checks, and independent review through P2. Source-preserving rebases retain the reviewed production and regression-test bytes. ClawSweeper also reviewed the current head without actionable findings.
- A retained 35 MB synthetic cold-deletion fixture preserved all four full agent checks: one standalone integrity child and three identified reclamation Workers, with zero parent-main-thread full checks. All three archives and the unrelated filler payload were preserved. The integrity child and identified reclamation Workers closed, and managed process-group extinction was verified.
- A source-bound Linux Testbox run completed a fresh build in 352 seconds and the built-CLI Gateway flow in 19 seconds: health, create without a model turn, reset, delete, repeat missing delete, and health. Reset preserved the session ID and changed its lifecycle revision; delete returned true, the repeat returned false, and final session count was zero. All seven Gateway/CLI owners exited cleanly and proved descendant extinction and release. The downloaded evidence, complete selected source tree, fresh build, dist fingerprint, and transport carrier were independently audited.
- Linux proof selected source: `9d6e72d6c1112e500585205b469dbe5f0d679853`. [Testbox lifecycle workflow](https://github.com/openclaw/openclaw/actions/runs/34377128924): the native proof command exited zero; the workflow is canceled during lease cleanup. A nonfatal portal-sync warning and subsequent cleanup API timeout are retained separately from the successful workload.
- [CI for the reviewed head](https://github.com/openclaw/openclaw/actions/runs/34375441556) is green.

The Linux lane proves the ordinary API workflow and its returned archive path; the separate local cold fixture proves check placement and archive contents. These runs do not establish a latency ratio or reduced total host CPU. No model turn, external channel, or live operator state was used.
