### PR TITLE
fix(agents): make skill workflow gates override generic execution bias

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1446,6 +1446,55 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("read exact <location> with `read`");
   });
 
+  it("allows loading another applicable skill when the active workflow requires it", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).toContain(
+      "Up-front max one; read another applicable skill when the active workflow requires it. Never invent paths.",
+    );
+    expect(prompt).toContain("Never invent paths.");
+    expect(prompt).toContain("Several: most specific");
+    // The old wording closed the door on later skill reads after up-front selection.
+    expect(prompt).not.toContain("Up-front max one. Never invent paths.");
+  });
+
+  it("lets execution bias pause for workflow-required decisions, not only safety blockers", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).toContain("## Execution Bias");
+    expect(prompt).toContain(
+      "- Non-final turn: advance with tools, or ask one decision the applicable workflow requires (a safety-blocking decision always qualifies).",
+    );
+    // The old wording permitted asking only a safety-blocking decision.
+    expect(prompt).not.toContain("ask one safety-blocking decision");
+  });
+
+  it("makes applicable skill workflow gates override generic execution bias", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).toContain(
+      "- Applicable skill workflow gates (prerequisites, required decisions, ordering) override generic Execution Bias; safety rules and tool policy stay authoritative.",
+    );
+    expect(prompt).toContain(
+      "- Continue to done/real blocker; no plan-only finish when tools can act.",
+    );
+  });
+
   it("omits code-mode skill guidance when the actual exec tool is unavailable", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -267,7 +267,7 @@ function buildSkillsSection(params: {
       ? 'Scan <available_skills>. Clear match: use `skills.read("<name>")` inside `exec`; obey.'
       : `Scan <available_skills>. Clear match: read exact <location> with \`${params.readToolName}\`; obey.`,
     "Several: most specific. None: read none.",
-    "Up-front max one. Never invent paths.",
+    "Up-front max one; read another applicable skill when the active workflow requires it. Never invent paths.",
     "External writes: batch safely; no tight loops; honor 429/Retry-After.",
     trimmed,
     "",
@@ -504,7 +504,8 @@ function buildExecutionBiasSection(params: { isMinimal: boolean }) {
   return [
     "## Execution Bias",
     "- Actionable request: act now.",
-    "- Non-final turn: advance with tools, or ask one safety-blocking decision.",
+    "- Non-final turn: advance with tools, or ask one decision the applicable workflow requires (a safety-blocking decision always qualifies).",
+    "- Applicable skill workflow gates (prerequisites, required decisions, ordering) override generic Execution Bias; safety rules and tool policy stay authoritative.",
     "- Continue to done/real blocker; no plan-only finish when tools can act.",
     "- Weak/empty result: vary query/path/command/source, then conclude.",
     "- Mutable facts: live-check files/git/time/versions/services/processes/packages.",


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #143155

## What Problem This Solves

Fixes a prompt-consistency defect where the built system prompt tells the model to read and obey an applicable skill while generic Execution Bias guidance only permits a **safety-blocking** decision as a valid non-final-turn stop and pushes `act now` / "no plan-only finish when tools can act". In an observed 2026.9.3 session the agent read the required multi-stage workflow skills and then skipped their explicit prerequisite/decision gates, proceeding with fork sync, branch deletion, and PR creation. The conflicting clauses are still on `main` in `buildSkillsSection` (`Up-front max one. Never invent paths.`) and `buildExecutionBiasSection` (`advance with tools, or ask one safety-blocking decision`).

- Users relying on ordered, multi-stage skills (e.g. development/debug/Git/PR workflows with mandatory human-decision gates) can see premature repository/external actions even after the required skills are successfully read.
- **Related:** #63940 (earlier, broader skill-discovery PR closed unmerged; it did not cover this narrower workflow-consistency repair). No open fixing PR exists.

## Why This Change Was Made

The bounded repair rewrites the two prompt clauses so execution guidance advances through applicable workflow prerequisites and decisions instead of reading as permission to skip them. Targeted initial skill selection, `Never invent paths.`, user authority, safety rules, and tool policy are all preserved; no new config, dependency, hook, or enforcement layer is added.

- **Intended outcome:** the Skills section explicitly allows reading another applicable skill when the active workflow requires it, and Execution Bias (a) treats a workflow-required decision as a valid non-final-turn ask, not only a safety-blocking one, and (b) states that an applicable skill's explicit workflow gates override generic Execution Bias while safety and tool policy stay authoritative.
- **Out of scope:** removing targeted initial skill selection, mechanical/security enforcement of skill text, docs, CHANGELOG, and any behavior change for sessions without applicable skills.
- **Highest-risk area:** rewording shared prompt guidance that also applies to non-skill requests.
- **How is that risk mitigated?** the generic act-now / continue-to-done bullets are unchanged; only the decision-ask permission and an explicit precedence statement are added, so non-skill behavior is unaffected; negative regression tests pin the old contradictory wording out.

## User Impact

Multi-skill workflow sessions now receive internally consistent guidance: a workflow's explicit prerequisite steps and required decisions count as valid execution progress, and the agent may load another applicable skill mid-workflow without contradicting up-front selection wording.

- **Success criteria:** rendered prompt (production `buildAgentSystemPrompt`) contains the workflow-consistent wording and no longer contains `Up-front max one. Never invent paths.` or `ask one safety-blocking decision`; focused prompt tests pass on `src/agents/system-prompt.test.ts` and `src/agents/system-prompt-stability.test.ts`.
- **What should reviewers focus on?** `src/agents/system-prompt.ts` (`buildSkillsSection`, `buildExecutionBiasSection`) and the three new regression tests in `src/agents/system-prompt.test.ts` guarding the new wording and the old contradictory strings.

## Evidence

- **Real environment tested:** local checkout on branch `feat/issue-143155-bug-system-prompt-execution-bias` (rebased on `origin/main` @ fe79d36c0dd), Node v26.7.0.
- **Exact steps or commands run after this patch:**
  ```bash
  # RED: new regression tests against unpatched source (3 failed)
  node scripts/run-vitest.mjs run src/agents/system-prompt.test.ts -t "workflow"
  # GREEN: patched source
  node scripts/run-vitest.mjs run src/agents/system-prompt.test.ts src/agents/system-prompt-stability.test.ts
  # full targeted validation (format + lint + same-dir tests + tsgo:core)
  skills/fix-pr/scripts/validate.sh src/agents/system-prompt.ts src/agents/system-prompt.test.ts
  # test-file type check (agents-root shard, full rebuild)
  node scripts/run-tsgo.mts -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1
  # before/after renderer evidence (production buildAgentSystemPrompt on base vs patched source)
  node --import ./scripts/tsx.mjs render-evidence.mts
  ```
- **Evidence after fix:**
  ```json
  {
    "skills_lines": [
      "Scan <available_skills>. Clear match: read exact <location> with `read`; obey.",
      "Several: most specific. None: read none.",
      "Up-front max one; read another applicable skill when the active workflow requires it. Never invent paths.",
      "External writes: batch safely; no tight loops; honor 429/Retry-After."
    ],
    "execution_bias_lines": [
      "- Actionable request: act now.",
      "- Non-final turn: advance with tools, or ask one decision the applicable workflow requires (a safety-blocking decision always qualifies).",
      "- Applicable skill workflow gates (prerequisites, required decisions, ordering) override generic Execution Bias; safety rules and tool policy stay authoritative.",
      "- Continue to done/real blocker; no plan-only finish when tools can act."
    ]
  }
  ```
- **Observed result after fix:** `validate.sh` green (format/lint/158 system-prompt tests + tsgo:core); both acceptance test files pass (2 Vitest shards); agents-root test-file type check passes on full rebuild; renderer output shows the workflow-consistent clauses.
- **Before evidence:** same renderer on unpatched `origin/main` produced the contradictory wording:
  ```json
  {
    "skills_lines": ["Up-front max one. Never invent paths."],
    "execution_bias_lines": ["- Non-final turn: advance with tools, or ask one safety-blocking decision."]
  }
  ```
  RED run against unpatched source: `Tests 3 failed | 1 passed | 154 skipped`.
- **What was not tested:** live model session A/B (the reporter's `opencode/muse-spark-1.3-contributor-free` runtime is not available here); end-to-end proof that a real model honors workflow gates is outside a prompt-renderer fix. No UI/gateway changes.
- **Proof tier:** L2 (deterministic before/after output of the production prompt renderer on real sources).
- **Proof limitations:** none at the renderer layer — the defect is deterministic prompt text, so renderer-level before/after is the authoritative proof; model-level compliance remains a follow-up observation.
- **Review state:** Awaiting CI + maintainer review. CI lanes (check-lint / test / check:test-types) pending on Actions.
