### PR TITLE
fix(test): Telegram model-callback loopback test fails with editMessageText ECONNRESET on unrelated PRs

### DIFF
--- a/extensions/telegram/src/model-callback.loopback.integration.test.ts
+++ b/extensions/telegram/src/model-callback.loopback.integration.test.ts
@@ -96,6 +96,14 @@ describe("Telegram model callback loopback", () => {
         response.destroy(error instanceof Error ? error : new Error(String(error)));
       });
     });
+    // grammY reuses one keep-alive socket for answerCallbackQuery and
+    // editMessageText. Between them applySessionModelSelection loads the
+    // provider model-policy surface synchronously (several seconds through
+    // jiti in build-less checkouts such as CI), so neither side's idle timer
+    // can run until the edit is already on the wire. Node's default 5 s idle
+    // close would then reset that in-flight request; connections are retired
+    // by closeAllConnections() in the finally block instead.
+    server.keepAliveTimeout = 0;
     await new Promise<void>((resolve) => {
       server.listen(0, "127.0.0.1", resolve);
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes a main-side flake where `extensions/telegram/src/model-callback.loopback.integration.test.ts` failed on PRs that did not touch Telegram, then passed on rerun. On 2026-09-09 it hit at least #143139, #143159, #143174, #143190, and #143141 (for example [bundle-27](https://github.com/openclaw/openclaw/actions/runs/34362151740/job/102501745976) and [bundle-10](https://github.com/openclaw/openclaw/actions/runs/34365714887/job/102514685679)) with:

```
AssertionError: expected '❌ Failed to change model: HttpError: …' to contain 'Model changed to <b>ollama/…'
Received: "❌ Failed to change model: HttpError: Network request for 'editMessageText' failed!"
```

## Why This Change Was Made

The test's loopback Bot API stub is a plain `node:http` server, whose default `keepAliveTimeout` is 5 s. grammY's Node client (node-fetch with a keep-alive `http.Agent`) answers the callback query and then edits the message over the same idle socket. Between those two requests the router awaits `applySessionModelSelection`, which loads the provider model-policy surface synchronously (`addAllowedCatalogRef` → `resolveProviderModelPolicySurface` → jiti source transform). In a build-less checkout such as CI that blocks the worker event loop for 6–9 s, so neither the client's 4 s free-socket timer (Node subtracts a 1 s buffer from the server's `Keep-Alive: timeout=5` hint) nor the server's 5 s idle timer can run first. When the stall ends, the continuation writes the edit onto the idle socket before the timers phase, then the server's keep-alive timer destroys that socket under the in-flight POST → `read ECONNRESET` → the router's error path edits the message with "Failed to change model". Whether a run fails depends only on whether the stall crosses 5 s, which is why it flaked per runner speed.

The stub now sets `server.keepAliveTimeout = 0`, so it never idle-closes a connection on its own timer; connections are retired by the existing `server.closeAllConnections()` in the `finally` block. The client's own free-socket handling is unchanged, and the test still drives both API calls over one persistent connection as with the real Bot API. No test timeout, retry, or assertion was changed.

The synchronous jiti load itself is the known build-less-checkout cost of plugin public-surface loading (production installs load the built artifact); it is not changed here.

## User Impact

No user-facing change. Contributors stop seeing this unrelated Telegram test fail on their PRs.

## Evidence

Reproduction (fresh worktree from `origin/main`, `node scripts/run-vitest.mjs extensions/telegram/src/model-callback.loopback.integration.test.ts`): failed 2/2 plain runs before the fix (test 9.5 s, same `HttpError`).

Instrumented timeline from a scratch copy (socket events, grammY API transformer, event-loop stall monitor):

```
[+    65ms] client: answerCallbackQuery done          (idle keep-alive socket :56918)
[+    67ms] mock: catalog
[+  6161ms] client: editMessageText start             (written to :56918)
[+  6165ms] EVENT LOOP STALL 6108ms
[+  6165ms] server: socket :56918 TIMEOUT (keepAliveTimeout=5000)
[+  6166ms] client: editMessageText ERROR HttpError: Network request for 'editMessageText' failed!
            cause=FetchError: … reason: read ECONNRESET
[+  6167ms] server: request editMessageText on socket :56973   (error-path edit, new connection)
```

Worker CPU profile (`NODE_OPTIONS=--cpu-prof`) for the stall, inclusive time:

```
7842ms  applySessionModelSelection        src/model-picker/apply-session-model-selection.ts
7254ms  addAllowedCatalogRef              src/agents/model-selection-shared.ts
7550ms  resolveProviderModelPolicySurface src/plugins/provider-model-routes.ts
7549ms  loadPluginPublicSurfaceModuleSync src/plugins/plugin-module-loader-cache.ts
7436ms  jitiRequire                       jiti/dist/jiti.cjs
```

Deterministic check with an injected synchronous stall in the catalog mock:

| Variant | Result |
| --- | --- |
| 5.5 s sync stall, default `keepAliveTimeout` | fails, same `ECONNRESET` on `editMessageText` |
| 5.5 s sync stall, `keepAliveTimeout = 0` | passes (11.4 s total stall) |

After the fix, five consecutive runs of the real test in the same build-less worktree (stall still present, test 6–9 s each):

| Run | Result | Test time |
| --- | --- | --- |
| 1 | pass | 6.7 s |
| 2 | pass | 7.2 s |
| 3 | pass | 7.0 s |
| 4 | pass | 6.5 s |
| 5 | pass | 5.7 s |

`node scripts/check-changed.mjs -- extensions/telegram/src/model-callback.loopback.integration.test.ts`: all lanes pass except `lint extension changed file`, which fails before linting in this nested worktree (the tsdown declaration-boundary guard refuses ancestor `node_modules`); direct `oxlint --tsconfig extensions/tsconfig.json` on the file passes, and CI runs the real lane.

Codex autoreview (`--mode local`, P2): scoped-clean, no P0–P2 findings.

Note: this file runs under `vitest.extension-telegram.config.ts` with `isolate: true` and `fileParallelism: false`, so the shared-worker (`isolate: false`) mode does not apply to it; the single-file shard in CI matches the local invocation above.
