### PR TITLE
fix(agents): Code Mode deadline expiry during a tool call is reported as an internal failure

### DIFF
--- a/src/agents/code-mode-headless.cancellation.test.ts
+++ b/src/agents/code-mode-headless.cancellation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { CodeModeHeadlessAbortError, CodeModeHeadlessTimeoutError } from "./code-mode-worker.js";
 import { runCodeModeScriptHeadless } from "./code-mode.js";
 import {
   createHeadlessCodeModeHarness,
@@ -78,4 +79,50 @@ describe("headless Code Mode cancellation", () => {
       error: "code mode execution aborted",
     });
   });
+
+  it.each([
+    {
+      name: "deadline",
+      createError: () => new CodeModeHeadlessTimeoutError(),
+      code: "timeout",
+      error: "code mode timeout exceeded",
+    },
+    {
+      name: "abort",
+      createError: () => new CodeModeHeadlessAbortError(),
+      code: "aborted",
+      error: "code mode execution aborted",
+    },
+  ])(
+    "classifies a host exchange that rejects with the scope $name error before its signal settles",
+    async ({ createError, code, error }) => {
+      const ctx = createHeadlessCodeModeHarness();
+      const config = testing.resolveCodeModeHeadlessConfig(ctx);
+      // The scope observes its own deadline inside the host exchange, so the run
+      // can reject before the abort controller that shares that deadline settles.
+      const scopeSignal = new AbortController().signal;
+
+      const result = await testing.runCodeModeWorker(
+        {
+          kind: "exec",
+          source: "await new Promise((resolve) => setTimeout(resolve, 0)); return 1;",
+          config,
+          catalog: [],
+          apiFiles: [],
+          namespaces: [],
+        },
+        config.timeoutMs + 2000,
+        undefined,
+        scopeSignal,
+        {
+          onBoundary: async () => {
+            throw createError();
+          },
+        },
+      );
+
+      expect(scopeSignal.aborted).toBe(false);
+      expect(result, JSON.stringify(result)).toMatchObject({ status: "failed", code, error });
+    },
+  );
 });

--- a/src/agents/code-mode-headless.cancellation.test.ts
+++ b/src/agents/code-mode-headless.cancellation.test.ts
@@ -8,6 +8,7 @@ import {
   resetCodeModeTestState,
   testing,
 } from "./code-mode.test-support.js";
+import { jsonResult } from "./tools/common.js";
 
 describe("headless Code Mode cancellation", () => {
   afterEach(() => {
@@ -21,12 +22,22 @@ describe("headless Code Mode cancellation", () => {
 
   it("classifies a wall-clock expiry observed during a real tool leg as timeout", async () => {
     // Only the timer clock is virtual here: the production headless entry, its deadline
-    // scope, a real worker and a real tool all run unchanged. performance.now() keeps
-    // advancing, so the scope observes its own deadline inside the host exchange before
-    // the abort timer this advance would reach - the ordering the classification lost.
+    // scope, a real worker and real tools all run unchanged. The first leg parks the run
+    // for a known span of real time, and the scope measures its remaining budget with an
+    // unfaked performance clock, so the second leg's deadline observation is always armed
+    // at least that far ahead of the scope's abort timer - the ordering the classification
+    // lost - no matter how fast this run starts.
+    const realSetTimeout = globalThis.setTimeout;
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const wallClockMs = 15_000;
-    const toolStarted = createDeferred<void>();
+    const separationMs = 200;
+    const toolStarted = createDeferred();
+    const warmUp = pluginToolWithExecute("warm_up", "Parks for a fixed real span", async () => {
+      await new Promise<void>((resolve) => {
+        realSetTimeout(resolve, separationMs);
+      });
+      return jsonResult({ ok: true });
+    });
     const slowLeg = pluginToolWithExecute("slow_leg", "Never settles on its own", async () => {
       toolStarted.resolve();
       return await new Promise<never>(() => {});
@@ -34,20 +45,23 @@ describe("headless Code Mode cancellation", () => {
     const startedAt = performance.now();
 
     const resultPromise = runCodeModeScriptHeadless({
-      ctx: createHeadlessCodeModeHarness([slowLeg]),
-      code: "await slow_leg({}); return true;",
+      ctx: createHeadlessCodeModeHarness([warmUp, slowLeg]),
+      code: "await warm_up({}); await slow_leg({}); return true;",
       wallClockMs,
     });
     await toolStarted.promise;
-    const realElapsedMs = performance.now() - startedAt;
-    await vi.advanceTimersByTimeAsync(wallClockMs - 50);
+    // Assert the separation before advancing: the second leg's deadline is armed no later
+    // than wallClockMs - separationMs, which this advance reaches while the abort timer at
+    // wallClockMs stays pending.
+    expect(performance.now() - startedAt).toBeGreaterThanOrEqual(separationMs);
+
+    await vi.advanceTimersByTimeAsync(wallClockMs - separationMs / 2);
     const result = await resultPromise;
 
-    expect(realElapsedMs).toBeGreaterThan(50);
     expect(result, JSON.stringify(result)).toMatchObject({
       status: "failed",
       code: "timeout",
-      toolCallCount: 1,
+      toolCallCount: 2,
     });
   });
 

--- a/src/agents/code-mode-headless.cancellation.test.ts
+++ b/src/agents/code-mode-headless.cancellation.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { CodeModeHeadlessAbortError, CodeModeHeadlessTimeoutError } from "./code-mode-worker.js";
 import { runCodeModeScriptHeadless } from "./code-mode.js";
 import {
   createHeadlessCodeModeHarness,
+  pluginToolWithExecute,
   resetCodeModeTestState,
   testing,
 } from "./code-mode.test-support.js";
@@ -12,8 +14,41 @@ describe("headless Code Mode cancellation", () => {
     try {
       expect(testing.activeRuns.size).toBe(0);
     } finally {
+      vi.useRealTimers();
       resetCodeModeTestState();
     }
+  });
+
+  it("classifies a wall-clock expiry observed during a real tool leg as timeout", async () => {
+    // Only the timer clock is virtual here: the production headless entry, its deadline
+    // scope, a real worker and a real tool all run unchanged. performance.now() keeps
+    // advancing, so the scope observes its own deadline inside the host exchange before
+    // the abort timer this advance would reach - the ordering the classification lost.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const wallClockMs = 15_000;
+    const toolStarted = createDeferred<void>();
+    const slowLeg = pluginToolWithExecute("slow_leg", "Never settles on its own", async () => {
+      toolStarted.resolve();
+      return await new Promise<never>(() => {});
+    });
+    const startedAt = performance.now();
+
+    const resultPromise = runCodeModeScriptHeadless({
+      ctx: createHeadlessCodeModeHarness([slowLeg]),
+      code: "await slow_leg({}); return true;",
+      wallClockMs,
+    });
+    await toolStarted.promise;
+    const realElapsedMs = performance.now() - startedAt;
+    await vi.advanceTimersByTimeAsync(wallClockMs - 50);
+    const result = await resultPromise;
+
+    expect(realElapsedMs).toBeGreaterThan(50);
+    expect(result, JSON.stringify(result)).toMatchObject({
+      status: "failed",
+      code: "timeout",
+      toolCallCount: 1,
+    });
   });
 
   it("completes after canceling a guest timer across two resumes", async () => {

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -182,6 +182,15 @@ export async function runCodeModeWorker(
         signal.reason instanceof CodeModeHeadlessTimeoutError ? "timeout" : "aborted",
       );
     }
+    // A host exchange observes the same deadline as the scope that owns this run, so it
+    // can reject with the scope's own error before that scope's signal settles. Classify
+    // by the typed error too; otherwise an expired deadline reports an internal failure.
+    if (error instanceof CodeModeHeadlessTimeoutError) {
+      return failedCodeModeWorkerResult("code mode timeout exceeded", "timeout");
+    }
+    if (error instanceof CodeModeHeadlessAbortError) {
+      return failedCodeModeWorkerResult("code mode execution aborted", "aborted");
+    }
     return error instanceof WorkerTaskError && error.code === "timeout"
       ? failedCodeModeWorkerResult("code mode worker timeout exceeded", "timeout")
       : failedCodeModeWorkerResult(


### PR DESCRIPTION
Related: #141265

## What Problem This Solves

Resolves a problem where a Code Mode script that runs out of its wall-clock allowance while a tool call is in flight is reported as an internal failure instead of a timeout.

The failure code is the closed value cron automations classify with, so the misreport is not cosmetic. `classifyCronScriptFailure` (`src/cron/script-failure.ts:7-15`) maps `timeout` to a retryable reason and everything else to `{ kind: "permanent" }`. A permanent classification resolves to no error reason at all (`src/cron/run-error-reason.ts:11-13`), so the automation's failure notification says the script "failed internally" instead of "timed out" (`src/cron/failure-notification-text.ts:6-15`) and drops its `Cause:` line, and `job.state.lastErrorReason` stays empty.

## Why This Change Was Made

A headless run and the host exchange it drives share one deadline. `createHeadlessDeadlineScope` arms a `setTimeout` that aborts the run's controller, and `awaitCodeModeDeadline` arms a second timer for the remaining time each time the host exchange waits for bridge settlement. Both target the same instant, so either can observe the expiry first.

When the host exchange observes it first, it rejects with that scope's own `CodeModeHeadlessTimeoutError`. The worker task pool preserves the error instance through host-exchange failure and worker retirement, so the typed error reaches `runCodeModeWorker`'s catch — but at that moment the scope's controller has not aborted yet. That catch classified timeouts only from `signal.reason`, so the typed error fell through to `codeModeFailureCode`, which has no knowledge of the headless error classes and returns its default `internal_error`. The headless caller returns a failed worker leg verbatim, so the outer handler that already classifies these two error types never sees it.

The fix classifies the two typed errors in that catch as well. It is additive: the `signal.aborted` branch and the `WorkerTaskError` branch are unchanged, so only failures that previously reached the `codeModeFailureCode` default are affected, and the returned messages match the ones the `signal.aborted` branch already produces. `CodeModeHeadlessAbortError` had the same gap and is covered by the same change.

Scope is limited to the two callers that build this scope: the headless runner (`src/agents/code-mode-headless.ts:241`) and the cron script runner (`src/cron/trigger-script.ts:354`). No configuration, schema, or protocol change.

## User Impact

A Code Mode script that exceeds its wall clock during a tool call now reports `timeout`. Cron automations that hit their configured `timeoutSeconds` are classified as timed out rather than permanently failed, and their failure notification names the cause instead of reporting a generic internal failure. Scripts that fail for any other reason keep the code they had.

## Evidence

### Real behavior: the production headless path, end to end

`classifies a wall-clock expiry observed during a real tool leg as timeout` runs the production entry `runCodeModeScriptHeadless` with a real QuickJS worker, real registered tools and the real `createHeadlessDeadlineScope`. Nothing on the host side is substituted. Only the timer clock is virtual.

The ordering is forced, not assumed. The run parks on a first tool leg for a fixed real span (200 ms) before reaching the leg under test. The scope measures its remaining budget with an unfaked `performance` clock while `setTimeout` is virtual, so the second leg's deadline observation is always armed at least that span ahead of the scope's abort timer, on warm runs as well as cold ones. The advance sits between the two, and the separation is asserted before the advance rather than after an await on a tool that never settles.

Measured on this branch with the source change reverted, on Node 24.21.0:

```
x headless Code Mode cancellation > classifies a wall-clock expiry observed during a real tool leg as timeout

AssertionError: {"status":"failed","code":"internal_error","toolCallCount":2,"output":[],
"error":"code mode headless wall-clock timeout exceeded"}

- Expected
+ Received
-   "code": "timeout",
+   "code": "internal_error",
```

The returned result carries the wall-clock timeout message and an `internal_error` code at the same time: the run knows the deadline expired and still classifies the failure as internal. That is the defect, observed through the production path.

With the change applied, the same case returns `{ status: "failed", code: "timeout", toolCallCount: 2 }`.

### Supported Node and repeatability

Validated on Node 24.21.0, inside the declared `>=24.16.0 <25` range. Five consecutive runs of the file, no retries:

```
run 1:       Tests  6 passed (6)
run 2:       Tests  6 passed (6)
run 3:       Tests  6 passed (6)
run 4:       Tests  6 passed (6)
run 5:       Tests  6 passed (6)
```

The reverted-source measurement above was taken on the same Node version.

### Classification cells

Two further cells drive `runCodeModeWorker` with a real worker and assert the scope signal is still un-aborted, pinning the exact state the defect needs for each typed error. Reverted, both report `internal_error`:

```
- "code": "timeout",   + "code": "internal_error"   (CodeModeHeadlessTimeoutError)
- "code": "aborted",   + "code": "internal_error"   (CodeModeHeadlessAbortError)
```

### Neighbouring suites and gates

`code-mode-headless.test.ts`, `code-mode-headless.budget.test.ts`, `code-mode-headless.validation.test.ts` and `code-mode-worker-lifecycle.test.ts` pass together, 94 tests across 4 files, including the existing wall-clock deadline and cancellation coverage. `oxfmt --check`, the changed-scope check, the core typecheck lane and the `src` test typecheck lane are clean. The earlier `check-lint-core-2` red was reproduced locally with `--only=core --split-core --core-stripe=2/5`, traced to a redundant type argument this branch had introduced, and that stripe now passes.

### Independent observation

This classification was reported on main by a maintainer while landing an unrelated PR: a CI run failed in `code-mode-headless.test.ts` because the wall-clock deadline case returned `internal_error` instead of `timeout`, and a controlled reproduction on main attributed it to an inner deadline firing before the outer abort and losing its timeout type during worker retirement (https://github.com/openclaw/openclaw/pull/137376#issuecomment-5596003091). That report also identified the inline deadline path as introduced by #141265 and recorded the repair as separate work; this PR is that repair.

### Not claimed

No live provider run. Which of the two timers wins in a deployed run depends on scheduling, so the wrong classification is not claimed to be deterministic there; the evidence above pins the state that ordering produces, through the production path, rather than the race that produces it.


### Maintainer current-source qualification — September 15

The unchanged repair was independently qualified after the same classification failure blocked [PR #125027 CI](https://github.com/openclaw/openclaw/actions/runs/34927605266/job/104249052866). On Code Mode/worker source matching inspected main `52b49bb95df`, applying only this PR's canonical regression reproduced `internal_error` with the wall-clock-timeout message. Applying the unchanged nine-line production repair then passed **100 tests across five affected headless/worker suites**. Temporary proof changes were removed afterward; no competing implementation or relaxed assertion was introduced.

Fresh isolated P0–P2 autoreview is **scoped-clean**. The native exact-head CI watcher accepted [CI34378374418](https://github.com/openclaw/openclaw/actions/runs/34378374418) for unchanged head `ff365359b30dfaebb3ee0d92593ec296c327b98d`. That full run remains historical September 9 synthetic-merge evidence; it is not relabeled as current-main execution. The new 100-test proof covers current worker-pool surroundings with real QuickJS/host tools and controlled timers, not a live provider.

Native preparation rejected the historical full-CI run as too old. The existing branch was therefore updated through GitHub's expected-head merge to signed `f00c86fcc50ba2f2b7087a5ca42c5782c3a2ab11`, preserving Yigtwxx's ancestry. Both changed files exactly match the current-source 100-test proof. Fresh [CI34929224873](https://github.com/openclaw/openclaw/actions/runs/34929224873) passed with 151 successful jobs. Native preparation and merge completed at `4c7cabb58b4a1712d583a8e9edec6b628962fe72`; the landed source matches the independently qualified patch and was verified on main. Original implementation and credit remain Yigtwxx's; no CI waiver or duplicated implementation.
