### PR TITLE
refactor(test): reuse shared budget flag parsing

### DIFF
--- a/scripts/lib/budget-number-args.mts
+++ b/scripts/lib/budget-number-args.mts
@@ -32,7 +32,7 @@ export function budgetFloatFlag<Key extends string>(flag: string, key: Key) {
         flag,
         nextIndex: index + 1,
         repeatable: false,
-        apply(target: Record<Key, number>) {
+        apply(target: Record<Key, number | null>) {
           const parsed = parseBudgetNumber(value, flag);
           if (parsed === null) {
             throw new Error(`${flag} requires a value`);

--- a/scripts/lib/budget-number-args.mts
+++ b/scripts/lib/budget-number-args.mts
@@ -1,6 +1,6 @@
 // Numeric budget flag/env helpers shared by benchmark and performance scripts.
 /** Parse an optional non-negative budget number from CLI or env text. */
-export function parseBudgetNumber(raw: string | undefined, label: string): number | null {
+function parseBudgetNumber(raw: string | undefined, label: string): number | null {
   const value = raw?.trim();
   if (!value) {
     return null;

--- a/scripts/test-perf-budget.mts
+++ b/scripts/test-perf-budget.mts
@@ -6,53 +6,11 @@ import {
   isStrictAffirmativeValue,
   parseFlagArgs,
   stringFlag,
-  type FlagSpec,
 } from "./lib/arg-utils.mts";
-import {
-  budgetFloatFlag,
-  parseBudgetNumber,
-  readBudgetEnvNumber,
-} from "./lib/budget-number-args.mts";
+import { budgetFloatFlag, readBudgetEnvNumber } from "./lib/budget-number-args.mts";
 import { coerceErrorMessage } from "./lib/error-format.mts";
 import { formatMs } from "./lib/vitest-report-cli-utils.mts";
 import { readJsonFile, runVitestJsonReport } from "./test-report-utils.mts";
-
-type PerfBudgetOptions = {
-  baselineWallMs: number | null;
-  config: string;
-  maxRegressionPct: number;
-  maxWallMs: number | null;
-  reportOnly: boolean;
-};
-
-function nullableBudgetFloatFlag(
-  flag: string,
-  key: "baselineWallMs" | "maxWallMs",
-): FlagSpec<PerfBudgetOptions> {
-  return {
-    consume(argv, index) {
-      if (argv[index] !== flag) {
-        return null;
-      }
-      const value = argv[index + 1];
-      if (!value || value.startsWith("-")) {
-        throw new Error(`${flag} requires a value`);
-      }
-      return {
-        flag,
-        nextIndex: index + 1,
-        repeatable: false,
-        apply(target) {
-          const parsed = parseBudgetNumber(value, flag);
-          if (parsed === null) {
-            throw new Error(`${flag} requires a value`);
-          }
-          target[key] = parsed;
-        },
-      };
-    },
-  };
-}
 
 function parseArgs(argv: readonly string[], env = process.env) {
   const opts = parseFlagArgs(
@@ -66,8 +24,8 @@ function parseArgs(argv: readonly string[], env = process.env) {
     },
     [
       stringFlag("--config", "config"),
-      nullableBudgetFloatFlag("--max-wall-ms", "maxWallMs"),
-      nullableBudgetFloatFlag("--baseline-wall-ms", "baselineWallMs"),
+      budgetFloatFlag("--max-wall-ms", "maxWallMs"),
+      budgetFloatFlag("--baseline-wall-ms", "baselineWallMs"),
       budgetFloatFlag("--max-regression-pct", "maxRegressionPct"),
       booleanFlag("--report-only", "reportOnly", true),
     ],


### PR DESCRIPTION
## What Problem This Solves

The performance-budget script copied the shared numeric flag parser during its TypeScript migration because two destination fields start as `null`. The copy had identical parsing and assignment behavior, leaving two implementations of the same validation rules.

## Why This Change Was Made

Let the shared helper accept that existing nullable initial state. It still assigns only a validated number. Reuse it for both wall-time flags and remove the private copy, its sole-use option type and unused imports: 42 tooling lines removed. Keep the numeric parser private now that only the shared helpers call it.

## User Impact

Flags, defaults, error messages, budget enforcement and runner behavior are preserved.

## Evidence

- The same six existing cases passed before and after: four performance-parser cases and two startup CLI/environment argument controls. Thirteen unrelated cases were filtered; tests were unchanged.
- All 16 selected changed-file checks passed, including full scripts typechecking.
- Independent review of the consolidation and the subsequent export-only cleanup found no actionable issues through P2.
- Initial CI caught the numeric parser’s now-unused export. After removing that export, both `deadcode:full` and the canonical dead-export check passed, followed by the same six cases and all 16 changed-file checks. The original failure is retained; [final-head CI](https://github.com/openclaw/openclaw/actions/runs/34376265694) is green.
- No benchmark speedup or changed budget is claimed; this consolidates identical parsing behavior.
