### PR TITLE
fix(tests): stop the Windows media file-URL test from stalling

### DIFF
--- a/src/agents/tools/media-tool-file-url.windows.test.ts
+++ b/src/agents/tools/media-tool-file-url.windows.test.ts
@@ -9,6 +9,7 @@ import * as imageGenerationRuntime from "../../image-generation/runtime.js";
 import * as mediaStore from "../../media/store.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
 import { createImageGenerateTool } from "./image-generate-tool.js";
+import * as mediaGenerationToolProviders from "./media-generation-tool-providers.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import {
   createPdfToolInfraStub,
@@ -108,22 +109,31 @@ describe.runIf(process.platform === "win32")("host-local media tool file URLs", 
         expect(pdfResult.content).toEqual([{ type: "text", text: "native summary" }]);
         expect(pdfResult.details).toMatchObject({ pdf: pdfPath, native: true });
 
-        vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
-          {
-            id: "fixture",
-            defaultModel: "edit",
-            models: ["edit"],
-            isConfigured: () => true,
-            capabilities: {
-              generate: { maxCount: 1 },
-              edit: { enabled: true, maxInputImages: 1 },
-              geometry: {},
+        // Provider discovery is outside this local file-URL contract.
+        vi.spyOn(
+          mediaGenerationToolProviders,
+          "acquireImageGenerationToolProviders",
+        ).mockResolvedValue({
+          providers: [
+            {
+              id: "fixture",
+              defaultModel: "edit",
+              models: ["edit"],
+              isConfigured: () => true,
+              capabilities: {
+                generate: { maxCount: 1 },
+                edit: { enabled: true, maxInputImages: 1 },
+                geometry: {},
+              },
+              generateImage: vi.fn(async () => {
+                throw new Error("runtime generateImage spy should own the call");
+              }),
             },
-            generateImage: vi.fn(async () => {
-              throw new Error("runtime generateImage spy should own the call");
-            }),
-          },
-        ]);
+          ],
+          assertOpen() {},
+          run: async (run) => await run(),
+          release: async () => {},
+        });
         const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
           provider: "fixture",
           model: "edit",


### PR DESCRIPTION
Superseded by #143213, merged as `b1db51436d8f623bd24d1ad1e04b29e31eb89740` while this investigation was running. Current main contains the same acquisition-boundary repair. This duplicate is closed without merging; the independent reproduction and CPU-profile findings below are retained as evidence.

## What Problem This Solves

Resolves a problem where the Windows media file-URL integration test times out on unrelated PRs and blocks their CI. Reported examples include #143141, #143153, #143195, and #142522.

Refs #143141, #143153, #143195, #142522.

## Why This Change Was Made

The test supplied a synthetic image-generation provider through the old provider-list function. Execution now acquires providers through `acquireImageGenerationToolProviders`, so that fake was bypassed and the test synchronously discovered and loaded real bundled plugins through Jiti.

Move the existing provider fake to the acquisition boundary used by execution, matching the image-generation unit suite. Real Unicode/space file creation, URL conversion, registered image/PDF execution, image-generation reference loading, and every existing assertion remain intact. No production behavior, timeout, retry, skip, or decoding policy changes.

## User Impact

Unrelated changes can complete this Windows CI check without paying for unrelated provider-plugin initialization. No user-facing runtime behavior changes.

## Evidence

- Full failing Windows logs: [job 102495173113](https://github.com/openclaw/openclaw/actions/runs/34360197443/job/102495173113) measured 179,198 ms; [job 102515437709](https://github.com/openclaw/openclaw/actions/runs/34365990713/job/102515437709) measured 195,006 ms. Both exceeded the unchanged 120,000 ms deadline. The test was alone in its agents-tools invocation.
- An older passing Windows comparison, [job 102338646390](https://github.com/openclaw/openclaw/actions/runs/34311337555/job/102338646390), completed the test body in 526 ms. This is a different head, not a same-head rerun.
- macOS reproduction temporarily enabled the identical test body without its Windows platform gate: `node scripts/run-vitest.mjs src/agents/tools/media-tool-file-url.windows.test.ts` failed before the fix with `Test timed out in 120000ms` at 162,288 ms; after the fix, the test passed in 4,704 ms. The Windows gate was restored after the local experiment.
- A runner CPU profile attributed 142.4 sampled seconds to image-generation provider acquisition, including Jiti loading `extensions/comfy/index.ts` and its SDK/configuration graph. Buffered stdout delayed earlier stage messages; the profile identifies image generation as the expensive call. Native PDF analysis was already stubbed, and no real provider request or PDF rendering was required.

- `node scripts/check-changed.mjs` passed, including the agents-tools test typecheck and targeted lint.
- `node scripts/run-vitest.mjs src/media/web-media.test.ts --testNamePattern='file URLs?'` passed all nine selected URL-handling cases (107 unrelated cases excluded by the filter).

Native Windows proof for the equivalent landed repair was verified directly: [job 102526310237](https://github.com/openclaw/openclaw/actions/runs/34369296327/job/102526310237) succeeded on #143213 head `d1c7fdc814463b192c3347bb075e364e75b8038c`, and its full log records this test passing in 804 ms. That evidence belongs to #143213, not this branch. This branch did not run Windows CI because the overlapping landed fix made it conflicting; no redundant rebase or landing was performed.
