### PR TITLE
fix(process): prevent false cleanup failures after successful commands

### DIFF
--- a/src/infra/update-managed-service-handoff-boundary.test-support.ts
+++ b/src/infra/update-managed-service-handoff-boundary.test-support.ts
@@ -329,7 +329,8 @@ export function createManagedServiceManagerBoundary({
             ? {}
             : { parentExitDeadlineAt: Date.now() + options.systemdHandoffDeadlineMs }),
           ...commandFixture,
-          ...(options?.recoveryHang || options?.triageHang ? { recoveryTimeoutMs: 1000 } : {}),
+          // Triage hangs must reach the diagnostic cap without timing out healthy recovery.
+          ...(options?.recoveryHang ? { recoveryTimeoutMs: 1000 } : {}),
           recovery: { serviceRestartSafe: true, version: "1.0.0" },
           recoveryModulePath,
           commandArgv: [process.execPath, "-e", updaterScript],

--- a/src/process/supervisor/service-child-group-anchor.retirement.test.ts
+++ b/src/process/supervisor/service-child-group-anchor.retirement.test.ts
@@ -1,0 +1,164 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { Duplex } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
+import {
+  resolveRuntimeWorkerArgv,
+  resolveRuntimeWorkerUrl,
+} from "../../infra/runtime-worker-url.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { ServiceChildAnchorMessage } from "./service-child-protocol.js";
+
+describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
+  it.each([
+    "matching",
+    "missing",
+    "stale-generation",
+    "wrong-receipt",
+    "malformed-receipt",
+    "non-monotonic",
+    "pre-armed",
+    "control-lost",
+    "relay-lost",
+    "startup-error",
+    "legacy-host",
+    "unsupported-capability",
+  ] as const)(
+    "retires gracefully only after the closing receipt is acknowledged (%s)",
+    async (acknowledgement) => {
+      const generation = randomUUID();
+      const child = spawn(
+        process.execPath,
+        resolveRuntimeWorkerArgv(
+          resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.serviceChildGroupAnchor),
+        ),
+        { detached: true, stdio: ["ignore", "pipe", "pipe", "pipe", "ipc"] },
+      );
+      const exited = createDeferredCore<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }>();
+      child.once("exit", (code, signal) => exited.resolve({ code, signal }));
+      child.once("error", exited.reject);
+      const control = child.stdio[3];
+      if (!(control instanceof Duplex)) {
+        child.kill("SIGKILL");
+        throw new Error("Expected the anchor's private control pipe");
+      }
+      const messages: ServiceChildAnchorMessage[] = [];
+      let prearmedSequence: number | undefined;
+      let outboundSequence = 0;
+      const startupFailure = acknowledgement === "pre-armed" || acknowledgement === "startup-error";
+      let pending = "";
+      let stderr = "";
+      child.stdout?.resume();
+      child.stderr?.setEncoding("utf8").on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      // A failed reply is observed through the anchor's terminal result, not an unhandled stream error.
+      control.on("error", () => {});
+      const reply = (closingSequence: unknown, replyGeneration: string, sequence: number) =>
+        control.write(
+          `${JSON.stringify({ type: "closing-ack", generation: replyGeneration, sequence, closingSequence })}\n`,
+        );
+      control.setEncoding("utf8").on("data", (chunk: string) => {
+        pending += chunk;
+        for (;;) {
+          const newline = pending.indexOf("\n");
+          if (newline < 0) {
+            return;
+          }
+          // SAFETY: this exact spawned anchor is the sole writer on its private control channel.
+          const message = JSON.parse(pending.slice(0, newline)) as ServiceChildAnchorMessage;
+          pending = pending.slice(newline + 1);
+          messages.push(message);
+          if (message.type === "startup-error") {
+            if (acknowledgement === "pre-armed") {
+              // Both frames share the ordered control channel: the early ACK must
+              // be consumed before startup acknowledgement can begin retirement.
+              prearmedSequence = message.sequence + 1;
+              reply(prearmedSequence, generation, ++outboundSequence);
+            }
+            control.write(
+              `${JSON.stringify({ type: "startup-error-ack", generation, sequence: ++outboundSequence })}\n`,
+            );
+          }
+          if (message.type !== "closing") {
+            continue;
+          }
+          if (acknowledgement === "control-lost") {
+            control.destroy();
+          } else if (acknowledgement === "relay-lost") {
+            child.disconnect();
+          } else if (
+            acknowledgement !== "missing" &&
+            acknowledgement !== "pre-armed" &&
+            acknowledgement !== "legacy-host"
+          ) {
+            reply(
+              acknowledgement === "malformed-receipt"
+                ? String(message.sequence)
+                : acknowledgement === "wrong-receipt"
+                  ? message.sequence - 1
+                  : message.sequence,
+              acknowledgement === "stale-generation" ? `${generation}-stale` : generation,
+              acknowledgement === "non-monotonic" ? 0 : ++outboundSequence,
+            );
+          }
+        }
+      });
+      try {
+        child.send({
+          type: "start",
+          generation,
+          command: startupFailure ? `/openclaw-missing-command-${generation}` : process.execPath,
+          args: ["-e", ""],
+          env: {},
+          stdinMode: "pipe-closed",
+          controlFd: 3,
+          ...(acknowledgement === "legacy-host"
+            ? {}
+            : { acknowledgeClosing: acknowledgement !== "unsupported-capability" }),
+        });
+        const result = await exited.promise;
+        if (acknowledgement === "unsupported-capability") {
+          expect(result, stderr).toEqual({ code: 1, signal: null });
+          expect(messages).toEqual([]);
+          return;
+        }
+        expect(messages, stderr).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining(
+              startupFailure
+                ? { type: "startup-error", generation }
+                : { type: "root-result", generation, code: 0, signal: null },
+            ),
+            expect.objectContaining({ type: "closing", generation }),
+          ]),
+        );
+        if (acknowledgement === "pre-armed") {
+          expect(messages.find((message) => message.type === "closing")?.sequence).toBe(
+            prearmedSequence,
+          );
+        }
+        if (
+          acknowledgement === "matching" ||
+          acknowledgement === "startup-error" ||
+          acknowledgement === "legacy-host"
+        ) {
+          expect(result, stderr).toEqual({ code: 0, signal: null });
+        } else {
+          expect(
+            result.code,
+            "An unacknowledged closing receipt must not retire gracefully",
+          ).not.toBe(0);
+        }
+      } finally {
+        child.kill("SIGKILL");
+        await exited.promise;
+        control.destroy();
+      }
+    },
+  );
+});

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
 import { Socket } from "node:net";
 import { pipeline, type Readable } from "node:stream";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import { hasLiveOwnedProcessGroupMembers } from "./service-child-group-ownership.js";
@@ -65,6 +66,8 @@ export function runServiceChildGroupAnchor(): void {
   const rootExited = createDeferredCore();
   const rootSettledDone = createDeferredCore();
   const startupErrorAcknowledged = createDeferredCore();
+  const retirementReady = createDeferredCore<boolean>();
+  let closingSequence: number | undefined;
 
   const send = async (message: ServiceChildAnchorPayload) => {
     if (!start || !control || control.destroyed) {
@@ -87,6 +90,7 @@ export function runServiceChildGroupAnchor(): void {
   const closeAuthority = async (
     reason: Extract<ServiceChildAnchorMessage, { type: "closing" }>["reason"],
     hardKill: boolean,
+    deadline = Date.now() + GRACEFUL_CANCEL_TIMEOUT_MS,
   ) => {
     if (!start || state === "closed") {
       return;
@@ -98,7 +102,31 @@ export function runServiceChildGroupAnchor(): void {
       process.kill(0, "SIGKILL");
       return;
     }
-    await send({ type: "closing", reason });
+    // Kernel acceptance is not host consumption. Keep the read side alive so a
+    // crossing cancellation cannot destroy the host's unread closing receipt.
+    const requiresAcknowledgement = start.acknowledgeClosing === true;
+    closingSequence = requiresAcknowledgement ? sequence + 1 : undefined;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs > 0) {
+      void send({ type: "closing", reason }).then(
+        () => {
+          // --no-restart can retain an old host across replacement of these workers.
+          // Preserve its prior protocol until restart; new hosts always request ACKs.
+          if (!requiresAcknowledgement) {
+            retirementReady.resolve(true);
+          }
+        },
+        () => retirementReady.resolve(false),
+      );
+    }
+    if (
+      remainingMs <= 0 ||
+      !(await Promise.race([retirementReady.promise, delay(remainingMs).then(() => false)])) ||
+      Date.now() >= deadline
+    ) {
+      process.kill(0, "SIGKILL");
+      return;
+    }
     control?.end(() => process.exit(0));
   };
 
@@ -164,7 +192,7 @@ export function runServiceChildGroupAnchor(): void {
       // This census only schedules retirement or escalation; it cannot certify closure.
       // The outside-group host must observe kernel group disappearance after we exit.
       if (hasLiveOwnedProcessGroupMembers(remainingMs) === false) {
-        await closeAuthority(reason, false);
+        await closeAuthority(reason, false, cleanupDeadline);
         return;
       }
       const nextObservationMs = Math.min(100, cleanupDeadline - Date.now());
@@ -173,16 +201,30 @@ export function runServiceChildGroupAnchor(): void {
       }
       await Promise.race([delay(nextObservationMs), forceCleanupRequested.promise]);
     }
-    await closeAuthority(reason, true);
+    await closeAuthority(reason, true, cleanupDeadline);
   };
 
   const onControlMessage = (message: ServiceChildControlMessage) => {
     if (
       !start ||
       message.generation !== start.generation ||
-      message.sequence <= lastHostSequence ||
-      state === "closed"
+      !Number.isSafeInteger(message.sequence) ||
+      message.sequence <= lastHostSequence
     ) {
+      return;
+    }
+    if (message.type === "closing-ack") {
+      if (
+        state === "closed" &&
+        closingSequence !== undefined &&
+        message.closingSequence === closingSequence
+      ) {
+        lastHostSequence = message.sequence;
+        retirementReady.resolve(true);
+      }
+      return;
+    }
+    if (state === "closed") {
       return;
     }
     lastHostSequence = message.sequence;
@@ -231,7 +273,9 @@ export function runServiceChildGroupAnchor(): void {
       }
     });
     const onControlLoss = () => {
-      if (state !== "closed") {
+      if (state === "closed") {
+        retirementReady.resolve(false);
+      } else {
         void requestCleanup("parent-lost");
       }
     };
@@ -368,6 +412,7 @@ export function runServiceChildGroupAnchor(): void {
     }
   });
   process.once("disconnect", () => {
+    retirementReady.resolve(false);
     if (state !== "closed") {
       void requestCleanup("parent-lost");
     }
@@ -376,6 +421,13 @@ export function runServiceChildGroupAnchor(): void {
     // SAFETY: the spawned relay is the sole sender on this private IPC channel.
     const message = raw as ServiceChildStart | { type: "parent-loss"; generation?: string };
     if (message.type === "start" && state === "starting") {
+      if (
+        isRecord(raw) &&
+        raw.acknowledgeClosing !== undefined &&
+        raw.acknowledgeClosing !== true
+      ) {
+        process.exit(1);
+      }
       void startCommand(message);
     } else if (message.type === "parent-loss" && message.generation === start?.generation) {
       void requestCleanup("parent-lost");

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -9,13 +9,19 @@ export type ServiceChildStart = {
   stdinMode: "inherit" | "pipe-open" | "pipe-closed";
   secretFd?: number;
   controlFd?: number;
+  /** Absent only for older Gateway hosts retained by update --no-restart. */
+  acknowledgeClosing?: true;
   windowsShellCommand?: string;
 };
 
 export type ServiceChildControlMessage = {
   generation: string;
   sequence: number;
-} & ({ type: "cancel"; signal: "SIGTERM" | "SIGKILL" } | { type: "startup-error-ack" });
+} & (
+  | { type: "cancel"; signal: "SIGTERM" | "SIGKILL" }
+  | { type: "startup-error-ack" }
+  | { type: "closing-ack"; closingSequence: number }
+);
 
 export type ServiceChildAnchorPayload =
   | {

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -9,6 +9,7 @@ import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorPayload,
+  type ServiceChildControlMessage,
 } from "./service-child-protocol.js";
 import { createServiceChildRelayAdapter } from "./service-child-relay-host.js";
 import { createProcessSupervisor } from "./supervisor.js";
@@ -43,12 +44,20 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
   });
   const stub = createStubChild();
   const cancellations: Array<(error: Error) => void> = [];
+  const acknowledgements: ServiceChildControlMessage[] = [];
   // Keep channel closure independently controlled from cancellation write completion.
   const control = new Duplex({
     autoDestroy: false,
     read() {},
-    write(_chunk, _encoding, callback) {
-      cancellations.push(callback);
+    write(chunk: Buffer, _encoding, callback) {
+      // SAFETY: this exact adapter is the sole writer on its private control channel.
+      const message = JSON.parse(chunk.toString()) as ServiceChildControlMessage;
+      if (message.type === "cancel") {
+        cancellations.push(callback);
+      } else {
+        acknowledgements.push(message);
+        callback();
+      }
     },
   });
   Object.defineProperty(stub.child, "stdio", {
@@ -80,6 +89,7 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
     } else {
       control.push(Buffer.from(encodeServiceChildMessage(message)));
     }
+    return message;
   };
   emit({ type: "ready", commandPid: 1234, anchorPid: 1235 });
   const adapter = await starting;
@@ -125,7 +135,9 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
   cleanups.push(close);
   return {
     adapter,
+    start,
     cancellations,
+    acknowledgements,
     emit,
     completeRoot,
     endOutput,
@@ -324,6 +336,34 @@ it("bounds the newline search before inspecting an oversized control frame", asy
 });
 
 describe.each(["linux", "win32"] as const)("service closing authority (%s)", (platform) => {
+  it("acknowledges the exact POSIX receipt without certifying extinction", async () => {
+    const { adapter, start, acknowledgements, emit, completeRoot, close } =
+      await createRelay(platform);
+    expect(start.acknowledgeClosing).toBe(platform === "linux" ? true : undefined);
+    completeRoot();
+    await adapter.wait();
+    const closing = emit({ type: "closing", reason: "lineage-closed" });
+    const settled = vi.fn();
+    const extinction = adapter.waitForExtinction();
+    void extinction.then(settled, settled);
+    await nextTurn();
+    expect(acknowledgements).toEqual(
+      platform === "linux"
+        ? [
+            {
+              type: "closing-ack",
+              generation: closing.generation,
+              sequence: 1,
+              closingSequence: closing.sequence,
+            },
+          ]
+        : [],
+    );
+    expect(settled).not.toHaveBeenCalled();
+    close();
+    await expect(extinction).resolves.toBeUndefined();
+  });
+
   it.each([false, true])(
     "keeps root knowledge independent of failed extinction (root observed=%s)",
     async (rootObserved) => {

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -427,6 +427,19 @@ export async function createServiceChildRelayAdapter(
     } else if (message.type === "closing") {
       closingReceipt = true;
       state = "closing";
+      if (control) {
+        // Retire cancellation before acknowledging this exact POSIX receipt.
+        // The ACK releases the sender, not the independent native extinction join.
+        outboundSequence += 1;
+        void sendControlMessage({
+          type: "closing-ack",
+          generation,
+          sequence: outboundSequence,
+          closingSequence: message.sequence,
+        }).catch((error: unknown) => {
+          controlError ??= toErrorObject(error, "closing acknowledgement failed");
+        });
+      }
     } else if (message.type === "startup-error") {
       if (useWindowsJobAnchor) {
         startup.reject(new Error(message.error));
@@ -567,6 +580,7 @@ export async function createServiceChildRelayAdapter(
     stdinMode: params.stdinMode,
     secretFd: params.secretInput?.fd,
     controlFd,
+    ...(control ? { acknowledgeClosing: true as const } : {}),
     windowsShellCommand: params.windowsShellCommand,
   };
   const stdin = createManagedChildStdin(child.stdin);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a successful agent command or managed-service repair could receive a cleanup failure instead of the successful result. The POSIX process-group anchor could exit after writing its closing receipt but before the host consumed it. A crossing cancellation then failed with `EPIPE`, destroyed the host's unread control stream, and left cleanup correctly reported as uncertain.

## Why This Change Was Made

The anchor now stays alive until the host acknowledges the exact closing receipt on the existing private control channel. The host retires cancellation before acknowledging; process reaping and kernel-confirmed group disappearance remain independently required. Missing, stale, premature or lost acknowledgements use the original cleanup deadline and escalation path.

The private start envelope negotiates this behavior because documented `update --no-restart` can retain an older Gateway while worker files are replaced. A retained older host keeps its existing protocol until restart; newly started hosts request acknowledgements. Windows Job ownership is unchanged. No new configuration, persistent state, public RPC or protocol-version change.

Also corrects the handoff fixture's unrelated coupling between a hung diagnostic and the healthy recovery timeout, without increasing the diagnostic cap or weakening assertions. Production delta is +72 lines, tests +204 and test support +1: the growth implements the missing two-party retirement boundary using existing channels, deferreds and deadlines; no test-only production seam was added.

## User Impact

Successful POSIX commands and repairs retain their result when cleanup races with receipt delivery. Genuine missing ownership/closure evidence still fails cleanup. Gateways intentionally retained by `update --no-restart` gain the new behavior on their next restart.

## Evidence

- Captured the original race in the original handoff execution order: the anchor wrote its closing receipt, then the host cancelled before consuming it and recorded `service child cleanup identity lost: write EPIPE`. Nine regression scenarios fail against the original anchor and pass after the repair.
- Final source: all 29 normal `check-changed --base f2a629ea05ce3f46c3d89a6d45866c50ad2c04cf` checks passed; normal worker build and 18 targeted host/anchor/repair cases passed; independent Codex review clean through P2.
- Prior behavior-equivalent revision: original four-file ordered handoff run 226 passed/1 platform skip; five-file supervisor sibling run 102 passed/1 skip; isolated Linux Node 24.19 run 51 passed/1 Windows-only skip. The final revision only moves capability validation to raw IPC input for type-aware lint and removes unused test defaults; the final build and focused cases cover that delta.
- Actual Bun 1.4.2 worker coverage passed eight distinct retirement/compatibility scenarios. An initial observer incorrectly awaited `close` after parent IPC disconnect; its failed attempt is retained, and only the two unfinished scenarios were rerun with exit, pipe and IPC joins. The final rebuilt worker additionally passed matching-ACK and unsupported-capability cases, including import resolution. Owned groups, pipes, processes and remote leases were verified closed.

These are real built child-process and synthetic service/provider flows, not an operator Gateway deployment or a new live Windows run. Existing Windows host assertions verify that this POSIX negotiation and ACK are not sent to the Job worker.
