### PR TITLE
fix(agents): render provider auth and model-not-found copy on transcript surfaces

### DIFF
--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  AUTH_INVALID_TOKEN_USER_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
   renderFormatErrorCopy,
   renderBillingReplyCopy,
@@ -9,6 +10,7 @@ import {
   renderMissingApiKeyReplyCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
+  renderSanitizedUserFacingText,
 } from "./user-copy.js";
 
 describe("failover user copy", () => {
@@ -143,5 +145,34 @@ describe("failover user copy", () => {
     ).toBe(
       "⚠️ CLI turn (routing openai/gpt-5.6-sol): timed out after 90s (overall turn limit). The gateway is unaffected. It also stopped 2 CLI background tasks and 1 active CLI tool call; that work shares the parent CLI process. Effects may be partial; check before retrying. OpenClaw did not replay this turn automatically. For long work, use a detached OpenClaw sub-agent (no run timeout by default), or raise `agents.defaults.timeoutSeconds`.",
     );
+  });
+
+  // Session transcripts, run status, and the TUI render failed turns through this
+  // renderer; the channel reply path renders the same reason-level copy from failover
+  // facts, so every error grammar the harnesses emit must agree across surfaces.
+  it.each([
+    "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: a38749741971a37b-SEA, request id: req_21723077dbef46fc8a554a7f511bcb2f",
+    "status code 401: Incorrect API key provided",
+    "401 Unauthorized: invalid api key",
+  ])("renders the provider authentication copy for %j", (raw) => {
+    expect(renderSanitizedUserFacingText(raw, { errorContext: true })).toBe(
+      `⚠️ ${AUTH_INVALID_TOKEN_USER_TEXT}`,
+    );
+  });
+
+  it("renders the unavailable-model copy for provider model-not-found errors", () => {
+    expect(
+      renderSanitizedUserFacingText(
+        "unexpected status 404 Not Found: The model `gpt-x` does not exist",
+        { errorContext: true },
+      ),
+    ).toMatch(/^⚠️ The configured model is unavailable from the provider/);
+  });
+
+  it("keeps non-401 auth text and non-error context out of the provider copy", () => {
+    const forbidden = "unexpected status 403 Forbidden: insufficient permissions for this key";
+    expect(renderSanitizedUserFacingText(forbidden, { errorContext: true })).toBe(forbidden);
+    const unauthorized = "status code 401: Incorrect API key provided";
+    expect(renderSanitizedUserFacingText(unauthorized)).toBe(unauthorized);
   });
 });

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -285,6 +285,19 @@ export function renderSanitizedUserFacingText(
   if (reason === "billing" || reason === "rate_limit" || reason === "overloaded") {
     return renderFailoverBaseCopy(reason, { raw: trimmed }) ?? trimmed;
   }
+  // Reason-level provider copy is surface-independent: the channel reply path renders
+  // it from failover facts, while session transcripts, run status, and the TUI read
+  // this renderer. Facets stay null so the rate-limit/overload branches above keep
+  // provider retry detail; labeled statuses ("unexpected status 401 ...") never carry
+  // a leading code, so the status is re-read from the full error grammar here.
+  const providerRequestCopy = renderProviderRequestFailureCopy({
+    classification: reason ? { kind: "reason", reason } : null,
+    facet: null,
+    status: extractErrorHttpStatus(trimmed)?.code,
+  });
+  if (providerRequestCopy) {
+    return providerRequestCopy;
+  }
   if (isGenericProviderInternalError(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);
   }

--- a/src/gateway/session-lifecycle-run-failure.test.ts
+++ b/src/gateway/session-lifecycle-run-failure.test.ts
@@ -118,6 +118,26 @@ describe("durable pre-reply run failure", () => {
     });
   });
 
+  it("records provider authentication failures as operator copy, not raw provider text", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      const providerError =
+        "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, request id: req_401";
+      await persistGatewaySessionLifecycleEvent({
+        ...target,
+        event: { ...event, data: { ...event.data, error: providerError } },
+      });
+      const [report] = await reports();
+      expect(report).toMatchObject({
+        content: expect.stringMatching(
+          /^This turn ended before a reply: ⚠️ Authentication failed \(provider returned HTTP 401\)/,
+        ),
+        details: { runId, error: expect.stringMatching(/^⚠️ Authentication failed/) },
+      });
+      expect(JSON.stringify(report)).not.toContain("Missing bearer");
+    });
+  });
+
   it.each(["active", "inactive", "other-run"] as const)(
     "checks assistant output on the %s branch for this run",
     async (branch) => {

--- a/test/scripts/plugin-lifecycle-measure.test.ts
+++ b/test/scripts/plugin-lifecycle-measure.test.ts
@@ -406,7 +406,9 @@ describe("plugin lifecycle resource sampler", () => {
         },
       );
 
-      expect(waitForNonEmptyPath(readyFile, 1000)).toBe(true);
+      // Nested shell startup is not the latency under test; the prompt-exit clock
+      // below starts after readiness, so give startup the phase timeout budget.
+      expect(waitForNonEmptyPath(readyFile, 5000)).toBe(true);
       const started = Date.now();
       result.kill("SIGTERM");
       const close = await waitForChildClose(result, 5000);
@@ -445,7 +447,9 @@ describe("plugin lifecycle resource sampler", () => {
         },
       );
 
-      expect(waitForNonEmptyPath(readyFile, 1000)).toBe(true);
+      // Nested shell startup is not the latency under test; the prompt-exit clock
+      // below starts after readiness, so give startup the phase timeout budget.
+      expect(waitForNonEmptyPath(readyFile, 5000)).toBe(true);
       const started = Date.now();
       result.kill("SIGTERM");
       const close = await waitForChildClose(result, 5000);


### PR DESCRIPTION
## What Problem This Solves

A failed turn shows different text depending on where the operator is looking. When the model provider rejects the request with HTTP 401 (no credentials, expired token, revoked key) or reports the configured model as not found, a Telegram/Discord reply gets the actionable copy ("Authentication failed (provider returned HTTP 401) … re-authenticate this provider"), but the session transcript, the Control UI chat history, the TUI, session run status, and task status notes show the raw provider text:

```
This turn ended before a reply: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: …, request id: req_…
```

Observed live on an isolated dev gateway (fresh state, default OpenAI model on the Codex harness, no auth profiles): the webchat/TUI transcript carried the raw text above while the same failure on a channel would have rendered the auth copy.

## Why This Change Was Made

Both surfaces already share one owner for reason-level provider copy: `renderProviderRequestFailureCopy` in `src/agents/failover/user-copy.ts` (auth + 401 and model-not-found). The channel reply path calls it from failover facts (`resolveReplyFailoverFacts`), but the shared renderer `renderSanitizedUserFacingText` — used by `src/sessions/session-run-error.ts`, `src/sessions/session-agent-status.ts`, `src/tasks/task-status.ts`, and assistant error extraction — only handled billing / rate-limit / overloaded / context-overflow and fell through to the raw text for auth and model-not-found.

The renderer now reuses `renderProviderRequestFailureCopy` after its rate-limit/overload branch. The status is read with `extractErrorHttpStatus`, which understands the labeled grammar harnesses emit (`unexpected status 401 …`, `status code 401: …`) as well as leading and provider-wrapped forms; the renderer's existing leading-status check never matched those. Facets stay `null` on purpose so the renderer keeps its rate-limit branch, which preserves provider retry detail.

Named tradeoff: the renderer is also used with error context for non-zero-exit background command bodies and error-stopped assistant text. A command body that itself reads like a provider 401 now gets the provider-auth copy — the same class of rewrite the renderer already applies for billing and rate-limit text.

Not changed here (follow-ups): the `agent` Gateway RPC and `openclaw agent` CLI still return the raw provider message with crash framing, and a Codex-harness run with no credentials still spends ~39 s in the harness's own 401 retries before failing (upstream `codex-rs` treats `UnexpectedStatus` as retryable, `codex-rs/protocol/src/error.rs` `is_retryable`, and the websocket transport retries up to `stream_max_retries` before falling back to HTTPS, `codex-rs/core/src/responses_retry.rs`).

## User Impact

Session transcripts, Control UI chat history, TUI, session status, and task status now show the same actionable copy as channel replies for provider authentication failures and unavailable models, instead of raw provider error text with request ids. Channel reply copy is unchanged.

Production LOC: +13 in `src/agents/failover/user-copy.ts` (one reuse of the existing copy owner plus its invariant comment); tests +51.

## Evidence

- CI note: the first run failed only on `test/scripts/plugin-lifecycle-measure.test.ts` ("exits promptly when shell descendants drain"), a 1 s readiness wait for a node -> login shell -> bash chain on a saturated hosted runner. Fixed here (Pathfinder rule): both "exits promptly" cases now give startup the same 5 s budget as their phase timeout; the prompt-exit assertion keeps its own clock.

- Regression tests fail on pre-fix code and pass with the fix:
  - `src/agents/failover/user-copy.test.ts`: labeled / `status code` / leading 401 grammars render the auth copy; model-not-found renders the unavailable-model copy; 403 and non-error context stay untouched (4 failed pre-fix).
  - `src/gateway/session-lifecycle-run-failure.test.ts`: a failed-run lifecycle event carrying the observed 401 text records `This turn ended before a reply: ⚠️ Authentication failed (provider returned HTTP 401)…` in the transcript, with no request id (1 failed pre-fix).
- Sibling coverage green: `agent-runner-failure-reply`, `embedded-agent-helpers.formatassistanterrortext`, `embedded-agent-helpers.sanitizeuserfacingtext`, `assistant-request-failure-copy`, `assistant-message-failures`, `provider-runtime-failure`, `task-status`, `bash-tools.exec-approval-followup`, `embedded-agent-utils` (378 unit + 20 gateway + 39 agents-core tests).
- `node scripts/check-changed.mjs`: all lanes ok (conflict markers, ratchets, format, plugin boundaries, wrapper shadowing, core tsgo graph boundary, typecheck core, typecheck core tests after a test-typing fix).
- Codex autoreview (`--mode local`, P2 threshold, with the renderer, callers, reply path, and sibling formatter supplied as context): scoped-clean, no accepted or actionable findings ("patch is correct (0.98)").
- Live proof on an isolated dev gateway (own state dir, port 18921, no credentials): `openclaw agent --agent main --message ping --json` fails after ~46 s with the raw 401 at the RPC (unchanged, follow-up), and `gateway call chat.history` for `agent:main:main` — the same history the Control UI and TUI render — now records:

```
This turn ended before a reply: ⚠️ Authentication failed (provider returned HTTP 401). Your provider token may have expired — try the request again in a moment. If the failure persists, re-authenticate this provider.
```

  where the pre-fix gateway on the same scenario recorded the raw `unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: …, request id: …` line.
