### PR TITLE
improve(test): reuse initial egress lifecycle certificates

### DIFF
--- a/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
@@ -8,7 +8,8 @@ import type { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import tls from "node:tls";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as proxyCa from "../../proxy-capture/ca.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { mintSecretSentinel } from "../sentinel.js";
@@ -17,6 +18,9 @@ import { startSecretEgressProxyServer, type SecretEgressProxyHandle } from "./pr
 const run = { instanceId: "instance-1", runId: "run-1" };
 const sibling = { instanceId: "instance-2", runId: "run-2" };
 const value = "synthetic-lifecycle-credential";
+const seedDirs = createTempDirTracker();
+let seedDir: string;
+let originLeaf: Awaited<ReturnType<typeof proxyCa.generateLocalProxyLeaf>>;
 let caDir: string;
 let proxy: SecretEgressProxyHandle;
 let origin: Server;
@@ -89,16 +93,28 @@ function register(targetRun = run): Record<string, string> {
   ]);
 }
 
+beforeAll(async () => {
+  seedDir = seedDirs.make("openclaw-egress-lifecycle-seed-");
+  const ca = await proxyCa.ensureSecretEgressProxyCa(seedDir);
+  originLeaf = await proxyCa.generateLocalProxyLeaf({
+    certDir: seedDir,
+    ca,
+    hostname: "localhost",
+  });
+});
+
+afterAll(() => seedDirs.cleanup());
+
 beforeEach(async () => {
   vi.stubEnv("OPENCLAW_SECRET_SENTINELS", undefined);
   observed = [];
   caDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-egress-lifecycle-"));
+  // Reuse initial material only; request-time issuance and TLS state stay per case.
+  for (const file of ["root-ca.pem", "root-ca-key.pem", "leaf-key.pem"]) {
+    fs.copyFileSync(path.join(seedDir, file), path.join(caDir, file));
+  }
   proxy = await startSecretEgressProxyServer({ caDir, onAudit: () => {} });
-  const leaf = await proxyCa.generateLocalProxyLeaf({
-    certDir: caDir,
-    ca: { certPath: proxy.caCertPath, keyPath: path.join(caDir, "root-ca-key.pem") },
-    hostname: "localhost",
-  });
+  const leaf = { cert: Buffer.from(originLeaf.cert), key: Buffer.from(originLeaf.key) };
   origin = createHttpsServer(leaf, (request, response) => {
     const record = { authorization: request.headers.authorization, body: "" };
     observed.push(record);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The 17-case egress proxy lifecycle suite repeats the same initial
certificate-generation steps, adding avoidable time to local test runs.

## Why This Change Was Made

Generate one real, file-owned CA and origin certificate, then give each case
three ordinary private file copies and fresh certificate/key buffers. Track the
seed before asynchronous construction and remove it after the file, including
partial setup failure. All cases, assertions, deadlines, real proxies, TLS
verification, request-time issuance, renewal, and lifecycle fencing remain.
Only the lifecycle test file changes.

## User Impact

No product behavior changes. Three matched local whole-file pairs show a median
paired reduction of **3.532 seconds (33.25%)**. This is not a CI, Windows, or
end-to-end runtime claim.

## Evidence

Uninstrumented, same-host runs used fresh per-run caches and normal project
workers/setup. Wall time includes startup, seed construction, copies, hooks,
teardown, and child exit. Every run passed all 17 cases.

| Pair order | Original wall | Candidate wall |
| --- | ---: | ---: |
| Original, candidate | 10.904 s | 7.161 s |
| Candidate, original | 10.621 s | 7.089 s |
| Original, candidate | 10.683 s | 7.402 s |

- Separate untimed controls observed 128 to 64 asynchronous OpenSSL calls, with
  **all 60 request-time calls and the explicit synchronous verify preserved**.
  The candidate retained 18 real proxy starts, 51 independent file copies, and
  34 nonaliasing origin buffers. The unchanged seed survived per-case cleanup
  and was removed after the file.
- Partial seed publication failure produced the intended owner exit 1 with
  17 cases skipped, and removed the partial seed. A real TLS trust-mismatch
  control produced the intended selected-case failure, with 16 cases skipped;
  verification rejected the peer and all owned roots/processes were cleaned up.
- All **20 required changed-path checks** passed, including formatting,
  typechecking, lint, and dead exports. Both untouched siblings passed:
  `src/proxy-capture/ca.test.ts` (4) and
  `src/secrets/egress-proxy/proxy-server.test.ts` (20). Diff check passed.
- Fresh native P2 review returned scoped-clean with no P0-P2 findings. Its
  permitted context was the exact diff, CA implementation/test, temp-directory
  helper, and attributed audit/control narrative. It did **not** independently
  review the full changed test, secrets server/certificate owners, or secrets
  sibling source; those were outside its dataset policy.

Raw evidence is retained privately. Selected source identities were verified,
not a full-tree fingerprint. A missing generic esbuild close event in
instrumented evidence was retained as a telemetry limitation; process absence
was independently verified. CI and platform-wide proof are not yet claimed.
