### PR TITLE
fix(anthropic): recognize sdk-ts entrypoint in Claude session catalog

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -319,8 +319,8 @@ Code sessions on the Gateway and on connected node hosts:
 
 - Claude CLI sessions come from valid project-index records. For unindexed
   transcripts, a bounded metadata fallback recognizes concurrent non-sidechain
-  interactive (`cli`) and headless Agent SDK CLI (`sdk-cli`) sessions under
-  `~/.claude/projects/`.
+  interactive (`cli`), headless Agent SDK CLI (`sdk-cli`), and bidirectional
+  stream-json (`sdk-ts`) sessions under `~/.claude/projects/`.
 - Claude Desktop sessions use the Desktop title, activity time, and
   archive state when its metadata points to the same Claude Code session ID.
 - A CLI-only session has no archive flag, so it remains visible while its

--- a/extensions/anthropic/session-catalog-discovery.ts
+++ b/extensions/anthropic/session-catalog-discovery.ts
@@ -34,7 +34,7 @@ const MAX_CATALOG_DISCOVERY_FILES = 10_000;
 const MAX_CATALOG_DISCOVERY_CACHE_ENTRIES = 20_000;
 const MAX_CLAUDE_SESSION_SCAN_CACHE_ENTRIES = 8;
 const MAX_CATALOG_METADATA_SCAN_BYTES = 64 * 1024 * 1024;
-const CLI_ENTRYPOINTS = new Set(["cli", "sdk-cli"]);
+const CLI_ENTRYPOINTS = new Set(["cli", "sdk-cli", "sdk-ts"]);
 
 type CatalogDiscoveryCacheEntry = {
   // The module-global cache is keyed by canonical transcript path, so an entry must also record the

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1723,10 +1723,18 @@ describe("Claude session catalog", () => {
             isSidechain: true,
           },
         ],
+        "sdk-ts-session": [
+          {
+            ...message("sdk-ts-session", "user", "Bidirectional stream-json prompt", 1),
+            entrypoint: "sdk-ts",
+            cwd: "/work/sdk-ts",
+            version: "2.1.263",
+          },
+        ],
         "foreign-entrypoint-session": [
           {
-            ...message("foreign-entrypoint-session", "user", "SDK session", 1),
-            entrypoint: "sdk-ts",
+            ...message("foreign-entrypoint-session", "user", "Unrelated tool session", 1),
+            entrypoint: "some-other-tool",
           },
         ],
       },
@@ -1756,6 +1764,7 @@ describe("Claude session catalog", () => {
     expect(sessions.map((session) => session.threadId).toSorted()).toEqual([
       "cli-session",
       "sdk-cli-session",
+      "sdk-ts-session",
     ]);
     expect(sessions).toEqual(
       expect.arrayContaining([
@@ -1769,11 +1778,17 @@ describe("Claude session catalog", () => {
           name: "Headless CLI prompt",
           source: "claude-cli",
         }),
+        expect.objectContaining({
+          threadId: "sdk-ts-session",
+          name: "Bidirectional stream-json prompt",
+          source: "claude-cli",
+        }),
       ]),
     );
     for (const [threadId, text] of [
       ["cli-session", "Interactive CLI prompt"],
       ["sdk-cli-session", "Headless CLI prompt"],
+      ["sdk-ts-session", "Bidirectional stream-json prompt"],
     ] as const) {
       await expect(readLocalClaudeTranscriptPage({ threadId, limit: 1 }, home)).resolves.toEqual(
         expect.objectContaining({ items: [expect.objectContaining({ text })] }),


### PR DESCRIPTION
Closes #143236

## What Problem This Solves

Long-running Claude Code sessions adopted from the web Control UI disappear from
the session catalog. When the gateway's subprocess for an adopted session dies
(idle timeout, restart, crash) and the user sends another message, the anthropic
plugin spawns a fresh Claude Code subprocess in its bidirectional stream-json
mode. That subprocess's transcript is tagged `entrypoint: "sdk-ts"` by the
Claude Code binary itself. The catalog only recognized `entrypoint: "cli"` and
`"sdk-cli"`, so as soon as discovery reached the first `sdk-ts` line it treated
the file as a non-Claude-CLI transcript and stopped scanning — the session
never appeared in `listLocalClaudeSessionPage`/the web catalog again, even
though the transcript was otherwise valid and the underlying thread was alive
and responding. To the user this looked like the conversation was lost.

## Why This Change Was Made

`extensions/anthropic/session-catalog-discovery.ts:37` centralizes the accepted
transcript entrypoints in a single `CLI_ENTRYPOINTS` set (`isCliEntrypoint()`),
used both to decide whether to keep scanning a file and to build the catalog
record. `"sdk-ts"` is the entrypoint the vendored Claude Code CLI writes for
its own bidirectional stream-json subprocess mode
(`extensions/anthropic/cli-runtime-args.ts`), the same mode
`extensions/anthropic/cli-transport.ts` uses to drive adopted web sessions —
it is not a foreign/third-party transcript, just a different first-party
invocation mode from the already-accepted `"cli"` (interactive TTY) and
`"sdk-cli"` (headless `-p`) values. Adding it to `CLI_ENTRYPOINTS` closes the
gap with a single-line change; every consumer of `isCliEntrypoint()`
(discovery, sidechain detection, record construction) picks it up for free,
same as the earlier fix that added `"cli"` in #105162.

Genuinely unrelated/unrecognized entrypoints are still rejected — see the
renamed `foreign-entrypoint-session` fixture (now `entrypoint: "some-other-tool"`)
in the regression test, which keeps asserting that transcripts from an
unrecognized producer are excluded.

**Out of scope / follow-up:** the issue also raises whether the gateway should
`--resume` the original thread instead of starting a fresh one when it
re-spawns a died adopted-session subprocess, to avoid the thread fragmentation
in the first place. That is a separate, larger change to the agent-runtime
respawn path and is not addressed here; this PR only restores catalog
visibility for the `sdk-ts` transcripts that already exist on disk, whichever
path created them.

## User Impact

Claude Code sessions whose subprocess was re-spawned in bidirectional
stream-json mode (most commonly: an adopted web session recovering from a
dead process) now show up again in the session catalog and can be listed,
read, and continued from the Control UI, instead of silently disappearing.

## Evidence

- Root cause traced to `extensions/anthropic/session-catalog-discovery.ts:37,343`
  (`CLI_ENTRYPOINTS` / `isCliEntrypoint`), confirmed against
  `extensions/anthropic/cli-runtime-args.ts` and `cli-transport.ts` (the
  bidirectional stream-json subprocess used for adopted sessions).
- Added a `sdk-ts` fixture and assertions to the existing
  `extensions/anthropic/session-catalog.test.ts` regression test
  ("discovers CLI fallback transcripts and rejects sidechains, foreign
  entrypoints, and escapes"), and repurposed its `foreign-entrypoint-session`
  fixture to a clearly non-Anthropic entrypoint value so the "unrecognized
  entrypoints are rejected" coverage is preserved.
- RED: confirmed the new assertion failed against unmodified `main`
  (`sdk-ts-session` missing from the discovered session list).
- GREEN: `node scripts/run-vitest.mjs run extensions/anthropic/session-catalog.test.ts -t "discovers CLI fallback"`
  passes after the fix.
- Full file: `node scripts/run-vitest.mjs run extensions/anthropic/session-catalog.test.ts`
  — same 10 pre-existing timeouts on this sandboxed checkout reproduce
  identically on unmodified `main` (verified via `git stash`), confirming they
  are unrelated to this change.
