### PR TITLE
fix(matrix): steering coverage no longer races the cold first-turn dispatch

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
@@ -173,14 +173,12 @@ describe("Matrix active-turn steering admission", () => {
             body: "keep this run active",
           }),
         );
-        await vi.waitFor(() => expect(queuePolicyResolver).toHaveBeenCalledTimes(1), {
-          // This suite imports the full Matrix extension graph. Keep the
-          // active-turn admission assertion deterministic on saturated CI
-          // workers without weakening the behavior being asserted.
-          timeout: 10_000,
-          interval: 10,
-        });
+        // The first turn in a worker also pays the cold reply-dispatch path (module
+        // graph, session store, plugin discovery); on a starved 2-vCPU runner that
+        // alone exceeded a 10 s budget. The resolver signals its own admission, so
+        // wait on that signal instead of a wall-clock poll.
         await activeResolverStarted.promise;
+        expect(queuePolicyResolver).toHaveBeenCalledTimes(1);
 
         followupTurn = handler(
           "!room:example.org",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts` failed in CI on pull requests that did not touch Matrix at all: `expected "vi.fn()" to be called 1 times, but got 0 times` from the first `vi.waitFor` (line 176) on a 2-vCPU hosted runner (run [34359621941, job 102493298024](https://github.com/openclaw/openclaw/actions/runs/34359621941/job/102493298024), PR #143137, `changed-extensions-config-45`, `logicalCpuCount=2`). The rerun on a 4-CPU runner passed.

## Why This Change Was Made

The first inbound turn in a Vitest worker pays the cold reply-dispatch path once (module graph, session store, plugin discovery) before the queue-policy resolver runs. That cost, not the steering behavior, was racing the 10 s wall-clock budget: the same first case took 7,550 ms on the passing 4-CPU rerun and 5–8 s on a loaded 32-core Mac, while the second case (warm) takes 0.4–1 s. The resolver already signals its own admission through the `activeResolverStarted` deferred, which the test awaited right after the poll. The test now waits on that signal and then asserts the exact call count, so the cold-start cost no longer has a deadline while the assertion (`toHaveBeenCalledTimes(1)`) is unchanged. The follow-up assertion that steering reaches queue policy while the first turn is still active keeps its 500 ms deadline; that deadline detects the admission-blocking regression and was not implicated.

## User Impact

No product behavior changes. Matrix steering coverage stops failing on starved CI runners; the assertions it protects are the same.

## Evidence

- Failing CI attribution: the resolver's dispatch phases (`reply.load_runtime_plugin_registry_handle` and siblings) account for only ~250 ms of the first turn locally; the remainder is the cold inbound path before dispatch, which scales with CPU starvation.
- Local proof on the fixed test, five sequential cold runs (fresh worker each time) on a heavily loaded 32-core host: first case 7.9 s, 6.6 s, 13.8 s, 9.3 s, 10.6 s, all runs green. Two of those exceeded the old 10 s budget and would have failed the previous assertion.
- `oxfmt --check`, `git diff --check`, and the changed-file gate: see PR checks.
