### PR TITLE
fix(test): subagent announce seam coverage runs on an isolated module graph

### DIFF
--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -21,6 +21,7 @@ const coreIsolatedFiles = [
   "src/agents/model-selection.plugin-runtime.test.ts",
   "src/agents/models-config.runtime-source-snapshot.test.ts",
   "src/agents/openai-transport-stream.streaming.test.ts",
+  "src/agents/subagents/announce/subagent-announce.test.ts",
   "src/agents/subagents/registry/subagent-registry.announce-loop-guard.test.ts",
   "src/agents/subagents/registry/subagent-registry-restart-recovery-notice.test.ts",
   "src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `src/agents/subagents/announce/subagent-announce.test.ts` failed in CI on a pull request that only touched Skill Workshop doctor files: `steers active announcements despite channel-specific followup mode` returned `retryable` instead of `delivered` (run [34360197443, job 102495177238](https://github.com/openclaw/openclaw/actions/runs/34360197443/job/102495177238), shard `agentic-agents-support-hosted-2`). The test's own stderr shows why: `Subagent announce failed: GatewayCredentialsRequiredError: gateway chat.history requires credentials before opening a websocket`, meaning the announce output collector reached the real Gateway client even though the file mocks `./subagent-announce.runtime.js`. The rerun passed.

## Why This Change Was Made

The failure has the shared-worker mock-defeat signature already documented for `isolate: false` lanes: in the same run, the sibling seam in `subagent-announce.ts` was mocked (the `sessions.delete` expectations passed), while the transitively imported `subagent-announce-output.ts` was bound to the real runtime barrel. Both import the same specifier from the same directory, so the only ways this happens are a stale evaluated module instance across a file boundary or an evaluation that raced the file's mock registration. The file is the only announce test that reaches `chat.history`, and in that shard it ran immediately after `subagent-orphan-recovery.restart-integration.test.ts` (real registry sweeper, fire-and-forget cleanup tails) in the same worker.

Local reproduction did not surface the leak: nine full-shard runs with the CI include list (fresh and warm transform caches, three concurrent), thirty-four single-worker iterations of the exact CI file adjacency, and runner probes for in-flight evaluations at reset and pre-evaluated announce/registry modules at collect start all came back clean with correct mock bindings. Rather than keep the file exposed to the shared module graph, this moves it to the existing `agents-core-isolated` lane (fresh module graph per file, isolated runner), the repository's established remedy for this class. No assertion changes.

## User Impact

No product behavior changes. The announce seam test stops depending on module state left by earlier files in a shared Vitest worker.

## Evidence

- CI log evidence above (real Gateway client reached from the output collector while the same file's other Gateway mock worked).
- Local proof of the isolated lane: three sequential runs of the file under `test/vitest/vitest.agents-core-isolated.config.ts` (16 tests each, all green); routing and plan tests (`test/vitest-scoped-config.test.ts`, `test/scripts/test-projects.test.ts`, `test/scripts/test-projects-routing.test.ts`, `test/scripts/ci-node-test-plan.test.ts`): 751 tests green.
- Negative local evidence (nine full-shard runs, thirty-four adjacency iterations, runner probes) recorded so the isolation is not mistaken for a root-cause proof; the shared-worker leak itself remains unlocated.
