### PR TITLE
improve(test): reuse prepared repo CLI in Telegram QA

### DIFF
--- a/test/e2e/qa-lab/runtime/telegram-command-menu-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-command-menu-gateway.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   writeJson,
 } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 type BotCommand = { command: string; description: string };
 type Body = { commands?: BotCommand[]; language_code?: string; scope?: { type?: string } };
 const LOCALIZED_PLUGIN_ID = "telegram-menu-localization-e2e";
@@ -184,7 +185,7 @@ test("registers pressure-prioritized Telegram menus through a real Gateway", asy
           mock = await startQaMockOpenAiServer();
           await gatewayOwner.start({
             repoRoot,
-            useRepoCli: true,
+            command: createQaPreparedRepoCliCommand(repoRoot),
             providerBaseUrl: `${mock.baseUrl}/v1`,
             transportBaseUrl: apiRoot,
             transport: {

--- a/test/e2e/qa-lab/runtime/telegram-emoji-list-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-emoji-list-gateway.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   writeJson,
 } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 
 type JsonObject = Record<string, unknown>;
 type TelegramCall = { pathname: string; method: string; body: JsonObject };
@@ -246,7 +247,7 @@ test("binds Telegram emoji discovery to the current conversation before Bot API 
           mock = await startQaMockOpenAiServer();
           await gatewayOwner.start({
             repoRoot,
-            useRepoCli: true,
+            command: createQaPreparedRepoCliCommand(repoRoot),
             providerBaseUrl: `${apiRoot}/v1`,
             transportBaseUrl: apiRoot,
             transport: {

--- a/test/e2e/qa-lab/runtime/telegram-join-intro-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-join-intro-gateway.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   type QaGatewayChild,
 } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 
 type JsonObject = Record<string, unknown>;
 type TelegramCall = { method: string; body: JsonObject };
@@ -232,10 +233,11 @@ test("introduces itself once when Telegram reports joining an allowed supergroup
         const gatewayOwner = createQaGatewayChild();
         let gateway: QaGatewayChild | undefined;
         try {
+          const repoRoot = path.resolve(import.meta.dirname, "../../../..");
           mock = await startQaMockOpenAiServer();
           gateway = await gatewayOwner.start({
-            repoRoot: path.resolve(import.meta.dirname, "../../../.."),
-            useRepoCli: true,
+            repoRoot,
+            command: createQaPreparedRepoCliCommand(repoRoot),
             providerBaseUrl: `${apiRoot}/v1`,
             transportBaseUrl: apiRoot,
             transport: {

--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -4,6 +4,7 @@ import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { expect, test } from "vitest";
 import { createQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 
 type JsonObject = Record<string, unknown>;
 
@@ -115,7 +116,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
           const repoRoot = path.resolve(import.meta.dirname, "../../../..");
           await gatewayOwner.start({
             repoRoot,
-            useRepoCli: true,
+            command: createQaPreparedRepoCliCommand(repoRoot),
             providerBaseUrl: `${apiRoot}/v1`,
             transportBaseUrl: apiRoot,
             transport: {

--- a/test/helpers/qa-prepared-repo-cli.ts
+++ b/test/helpers/qa-prepared-repo-cli.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function createQaPreparedRepoCliCommand(repoRoot: string) {
+  return {
+    executablePath: process.execPath,
+    argsPrefix: [
+      "--import",
+      pathToFileURL(path.join(repoRoot, "scripts/tsx.mjs")).href,
+      path.join(repoRoot, "scripts/run-with-env.mts"),
+      `OPENCLAW_DEV_SOURCE_ROOT=${repoRoot}`,
+      "--",
+      process.execPath,
+      path.join(repoRoot, "openclaw.mjs"),
+    ],
+    cwd: repoRoot,
+    usePackagedPlugins: true,
+  };
+}


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Developers wait on repeated CLI startup preparation in four real-Gateway
Telegram E2E checks, even when the test runtime is already prepared. That adds
avoidable latency to feedback from the command-menu, emoji-list, join-intro, and
message-tool failure-settlement checks.

## Why This Change Was Made

Use a small stateless test helper to launch the prepared repository CLI through
the existing environment wrapper. The helper returns fresh command arguments,
uses a file URL for the Node preload, and applies the development source root
after the QA environment scrub.

All four cases keep their assertions, private workspaces/state, real CLI and
Gateway processes, mock transport boundaries, packaged plugin selection, and
existing lifecycle/deadlines. Each still runs two auth commands, repair help,
repair, and Gateway startup in order. No production or build configuration
changes; no shared Gateway, sharding, concurrency change, or reduced coverage.

## User Impact

No product behavior change. These four developer checks do less repeated launch
preparation while preserving their real-process coverage.

## Evidence

One original/candidate/closing-original bracket on Linux and Node 24.19.0:

| Qualified leg | Whole invocation | Sum of case times | Cases |
| --- | ---: | ---: | --- |
| Original | 270.540s | 211.886s | 4 passed |
| Candidate | 251.446s | 193.743s | 4 passed |
| Closing original | 272.693s | 213.668s | 4 passed |

This is an observed local reduction of roughly 19-21 seconds per invocation,
not a precise percentage or CI forecast. Case order differed and comparisons
were joined by owner, not position. Shared-host noise and warm-up remain
limitations.

- All reported legs retained 20 real outer operations, four independent case
  roots, zero skips, and unchanged source/dependency/artifact fingerprints.
- Separate untimed normal controls passed 4/4 on both routes. Independent
  comparison matched all 24 actual inner CLI argv/execArgv records and 26
  selected environment fields, required/common loaded implementation bytes,
  generated-plugin entry bytes, and all 60 reconstructed manifest/SKILL EOF
  streams. Recorder snapshots were not substituted for application loads/reads.
- One command-menu startup-negative control reached a listening Gateway, then
  failed with the intended `TG_CONTROL_ON_LISTENING` marker and exit 1. All
  recorded identities, process-group members, and listeners were gone before
  both owned roots were deleted. This proves cleanup at that reached state,
  not completed plugin loading or readiness.
- The five-file native changed gate passed, including formatting checks,
  root-test typecheck, script lint, and standard guards. `git diff --check`
  passed. Independent P2 review was scoped-clean. Final source hashes match the
  timed candidate; all temporary instrumentation was removed.

Proof limits: measurements used retained runtime artifacts at
`bc847251aab255bbe46115bf398ae4544b17d4c5`, ready Control UI assets, and fresh outer
caches. Full artifact fingerprints warm the OS cache outside timing. An earlier
opening that built missing UI output failed immutability and was excluded;
reported legs required real UI health/freshness checks. No avoided build,
cold-CI gain, fresh-main compiled proof, Windows execution, or live Telegram
service proof is claimed.

The normal comparison retained two candidate-only reexport-barrel loads in the
failure-settlement Gateway main thread; their underlying implementations already
loaded with identical bytes on both routes. Idle prewarming is a source-supported
inference, not a recorded timer event. It also retained 235 deeper SQLite child
argv records with fresh nested snapshot-path differences, 12 deeper selected
state-directory differences, and 39 partial read streams that are not EOF.
There is no full module-set, load-order, or all-descendant argv/env equality claim.
