### PR TITLE
fix(models): avoid provider loading during cold session resets

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -93,8 +93,9 @@ catalog is not ready. Retry after startup or an in-progress refresh finishes.
 Use an explicit Refresh action or `openclaw models list --refresh` to acquire
 provider inventory. Model selection, subagent capability checks, and hook-model
 validation also use the published inventory. Missing capability facts do not
-start another provider discovery. Native runtime observations keep their separate
-owner and authentication requirements.
+start another provider discovery. Without a published owner, turn-path thinking
+and input checks leave catalog facts absent instead of loading provider plugins.
+Native runtime observations keep their separate owner and authentication requirements.
 
 Internal catalog loads default to passive reads. Without a published owner they
 use existing read-only facts. The public SDK's `loadPreparedModelCatalog` and legacy

--- a/src/agents/prepared-model-catalog.scoped-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.scoped-thinking.test.ts
@@ -1,4 +1,4 @@
-// Capability reads retain published facts and use static ownership when no owner exists.
+// Capability reads retain published facts without acquiring missing inventory.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -27,6 +27,13 @@ const preparedSnapshotMock =
 const acquireSnapshotMock =
   vi.fn<(input: PreparedModelRuntimeInput) => Promise<PreparedModelRuntimeSnapshot>>();
 const releaseSnapshotMock = vi.fn();
+const augmentCatalogMock =
+  vi.fn<(params: { snapshot: ModelCatalogSnapshot }) => Promise<ModelCatalogSnapshot>>();
+
+vi.mock("./harness/model-catalog.js", () => ({
+  augmentModelCatalogWithAgentHarness: (params: { snapshot: ModelCatalogSnapshot }) =>
+    augmentCatalogMock(params),
+}));
 
 vi.mock("./model-catalog.js", () => ({ loadManifestModelCatalog: () => manifestCatalogMock() }));
 vi.mock("./prepared-model-runtime.js", async (importOriginal) => ({
@@ -90,6 +97,7 @@ describe("loadProviderScopedThinkingCatalog", () => {
       return published;
     });
     acquireSnapshotMock.mockImplementation(async (input) => owner(input.config, []));
+    augmentCatalogMock.mockImplementation(async ({ snapshot }) => snapshot);
   });
 
   it.each(["thinking", "input"] as const)(
@@ -192,7 +200,7 @@ describe("loadProviderScopedThinkingCatalog", () => {
     },
   );
 
-  it("uses and releases a static owner when no published owner exists", async () => {
+  it("leaves facts absent when no published owner exists", async () => {
     const config = {};
     const staticEntry = { ...entry, reasoning: true };
     acquireSnapshotMock.mockResolvedValue(owner(config, [staticEntry]));
@@ -203,8 +211,9 @@ describe("loadProviderScopedThinkingCatalog", () => {
         provider: entry.provider,
         model: entry.id,
       }),
-    ).toEqual([staticEntry]);
-    expect(releaseSnapshotMock).toHaveBeenCalledOnce();
+    ).toEqual([]);
+    expect(acquireSnapshotMock).not.toHaveBeenCalled();
+    expect(releaseSnapshotMock).not.toHaveBeenCalled();
     expect(manifestCatalogMock).not.toHaveBeenCalled();
     expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
@@ -219,6 +228,17 @@ describe("loadProviderScopedThinkingCatalog", () => {
       loadProviderScopedThinkingCatalog({ config, provider: entry.provider, model: entry.id }),
     ).rejects.toBeInstanceOf(PreparedModelCatalogConfigReplacedError);
     expect(scopedStaticMock).not.toHaveBeenCalled();
+    expect(scopedLiveMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps native harness observations available without a published owner", async () => {
+    const nativeEntry = { ...entry, nativeRuntime: "test-harness", reasoning: true };
+    augmentCatalogMock.mockResolvedValue({ entries: [nativeEntry], routeVariants: [nativeEntry] });
+    const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
+    await expect(
+      loadProviderScopedThinkingCatalog({ config: {}, provider: entry.provider, model: entry.id }),
+    ).resolves.toEqual([nativeEntry]);
+    expect(acquireSnapshotMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -231,27 +231,39 @@ export function getPreparedModelCatalogSnapshot(
   return owner?.readFullModelCatalog?.() ?? owner?.modelCatalog;
 }
 
+async function resolveReadOnlyPublishedModelCatalogOwner(
+  params: LoadPreparedModelCatalogParams,
+  configPolicy: PreparedModelCatalogConfigPolicy,
+): Promise<PreparedModelRuntimeSnapshot | undefined> {
+  const { activationFull, full } = resolveInputs(params);
+  const fullCandidates =
+    activationFull.workspaceDir === full.workspaceDir ? [full] : [full, activationFull];
+  for (const candidate of fullCandidates) {
+    try {
+      // Full lifecycle owners include provider augmentation omitted by read-only fallback builds.
+      const prepared = await prepareModelRuntimeSnapshot(candidate);
+      if (!acceptsPreparedSnapshotConfig(prepared, candidate, configPolicy)) {
+        throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
+      }
+      return prepared;
+    } catch (error) {
+      if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
+        throw error;
+      }
+    }
+  }
+  return undefined;
+}
+
 async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
 ): Promise<{ snapshot: PreparedModelRuntimeSnapshot; release?: () => void }> {
-  const { activationExact, activationFull, exact, full } = resolveInputs(params);
+  const { activationExact, activationFull, exact } = resolveInputs(params);
   if (params.readOnly) {
-    const fullCandidates =
-      activationFull.workspaceDir === full.workspaceDir ? [full] : [full, activationFull];
-    for (const candidate of fullCandidates) {
-      try {
-        // Full lifecycle owners include provider augmentation omitted by read-only fallback builds.
-        const prepared = await prepareModelRuntimeSnapshot(candidate);
-        if (!acceptsPreparedSnapshotConfig(prepared, candidate, configPolicy)) {
-          throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
-        }
-        return { snapshot: prepared };
-      } catch (error) {
-        if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
-          throw error;
-        }
-      }
+    const prepared = await resolveReadOnlyPublishedModelCatalogOwner(params, configPolicy);
+    if (prepared) {
+      return { snapshot: prepared };
     }
     const lease = await acquireReadOnlyPreparedModelRuntime(activationExact);
     if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationExact, configPolicy)) {
@@ -358,8 +370,8 @@ async function loadScopedReadOnlyModelCatalog(
 }
 
 /**
- * Missing turn-path capabilities do not authorize another inventory. Keep native harness
- * observations on their existing owner and hold temporary catalog reads through projection.
+ * Missing turn-path capabilities do not authorize another inventory, even without a published
+ * owner. Native harness observations keep their existing owner.
  */
 export async function loadProviderScopedThinkingCatalog(params: {
   config: OpenClawConfig;
@@ -371,42 +383,38 @@ export async function loadProviderScopedThinkingCatalog(params: {
   /** Input preparation must resolve modalities for this route, independently of reasoning. */
   requiredInputRoute?: Pick<ModelCatalogEntry, "api" | "baseUrl">;
 }): Promise<ModelCatalogEntry[]> {
-  return await withPreparedModelCatalogOwner(
-    {
-      config: params.config,
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      ...(params.agentDir ? { agentDir: params.agentDir } : {}),
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-      readOnly: true,
-    },
-    async (owner) => {
-      const agentId = params.agentId ?? resolveAmbientOwnerAgentId(params.config);
-      const { augmentModelCatalogWithAgentHarness } = await import("./harness/model-catalog.js");
-      const snapshot = await augmentModelCatalogWithAgentHarness({
-        cfg: params.config,
-        agentId,
-        agentDir: params.agentDir ?? resolveAgentDir(params.config, agentId),
-        workspaceDir:
-          params.workspaceDir ??
-          resolveAgentWorkspaceDir(params.config, agentId) ??
-          resolveDefaultAgentWorkspaceDir(),
-        defaultProvider: params.provider,
-        defaultModel: `${params.provider}/${params.model}`,
-        snapshot: owner.modelCatalog,
-      });
-      const entries = normalizeThinkingCatalogProviders(snapshot.entries);
-      if (params.requiredInputRoute !== undefined) {
-        const entry = findModelInCatalog(entries, params.provider, params.model);
-        if (
-          entry?.input === undefined ||
-          !modelTransportRoutesMatch(entry, params.requiredInputRoute)
-        ) {
-          return [];
-        }
-      }
-      return entries;
-    },
-  );
+  const request = { ...params, readOnly: true };
+  const publishedOwner = getPreparedModelCatalogOwnerSnapshot(request);
+  const owner = await resolveReadOnlyPublishedModelCatalogOwner(request, "exact");
+  const catalog = owner
+    ? (publishedOwner ? await materializeRequestedModelCatalog(owner, true, undefined) : owner)
+        .modelCatalog
+    : { entries: [], routeVariants: [] };
+  const agentId = params.agentId ?? resolveAmbientOwnerAgentId(params.config);
+  const { augmentModelCatalogWithAgentHarness } = await import("./harness/model-catalog.js");
+  const snapshot = await augmentModelCatalogWithAgentHarness({
+    cfg: params.config,
+    agentId,
+    agentDir: params.agentDir ?? resolveAgentDir(params.config, agentId),
+    workspaceDir:
+      params.workspaceDir ??
+      resolveAgentWorkspaceDir(params.config, agentId) ??
+      resolveDefaultAgentWorkspaceDir(),
+    defaultProvider: params.provider,
+    defaultModel: `${params.provider}/${params.model}`,
+    snapshot: catalog,
+  });
+  const entries = normalizeThinkingCatalogProviders(snapshot.entries);
+  if (params.requiredInputRoute !== undefined) {
+    const entry = findModelInCatalog(entries, params.provider, params.model);
+    if (
+      entry?.input === undefined ||
+      !modelTransportRoutesMatch(entry, params.requiredInputRoute)
+    ) {
+      return [];
+    }
+  }
+  return entries;
 }
 
 /** Keeps the exact catalog owner alive through an asynchronous read. */

--- a/src/agents/prepared-model-catalog.unpublished-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.unpublished-thinking.test.ts
@@ -1,0 +1,29 @@
+import { expect, it, vi } from "vitest";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { loadProviderScopedThinkingCatalog } from "./prepared-model-catalog.js";
+
+const discovery = vi.hoisted(() => vi.fn(() => []));
+vi.mock("../plugins/provider-discovery.runtime.js", () => ({
+  resolvePluginDiscoveryProvidersRuntime: discovery,
+}));
+
+it.each([
+  { provider: "anthropic", model: "claude-sonnet-5" },
+  { provider: "ollama", model: "catalog-probe:latest" },
+])("keeps unpublished $provider thinking reads off provider discovery", async (ref) => {
+  const state = await createOpenClawTestState({ label: "unpublished-thinking" });
+  try {
+    const catalog = await loadProviderScopedThinkingCatalog({
+      config: {},
+      agentId: "main",
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      ...ref,
+    });
+
+    expect(discovery).not.toHaveBeenCalled();
+    expect(catalog).toEqual([]);
+  } finally {
+    await state.cleanup();
+  }
+});


### PR DESCRIPTION
Related: #143183, #142877, #142470. Follow-up to #142375, #142557, and #142620.

## What Problem This Solves

Fixes an issue where users starting a new Discord session would wait for unrelated provider plugins to load when the process had no published model catalog. The same cold path makes the first native `/new` regression exceed its 120-second CI timeout in `checks-node-changed-extensions-bundle-13`, blocking otherwise unrelated PRs including #143183, #142877, and #142470.

## Why This Change Was Made

#142375 (`bdc55c47e30`) correctly moved thinking/input checks to published inventory, but the unpublished owner fallback acquired a read-only runtime whose default preparation mode loads every provider discovery module. This is synchronous module-loading cost, not a network hang. The later SDK-default changes did not repair that explicitly read-only path.

Share the existing published-owner lookup and keep cold thinking/input catalog facts absent when no lifecycle owner is published. This follows #142375's rule that missing facts do not authorize another inventory: the cold path starts neither static nor live provider discovery. Published configured/completed inventory, configuration replacement checks, and native harness observations retain their existing behavior. General leased catalog reads and explicit acquisition remain unchanged. No timeout, retry, cache, configuration, or storage change is involved.

## User Impact

Cold session resets and capability checks no longer pay for unrelated provider imports. Published capabilities remain available, and native harness observations still run without a published catalog. Until publication, missing catalog capabilities remain unknown instead of triggering acquisition.

## Evidence

- Same local command before/after: `time node scripts/run-vitest.mjs run extensions/discord/src/monitor/native-command.reset.test.ts --reporter=verbose`. First `/new`: **68.435s → 5.890s**; all 16 cases pass. Total wall time: **88.88s → 21.21s**. Peak RSS: **2.74 GB → 2.19 GB**.
- New real-owner regression failed before the repair because an unpublished Anthropic read entered provider discovery **14 times**. The repaired Anthropic and Ollama cases enter discovery **zero times**. A separate control preserves native harness observations without a published catalog.
- Wider proof: **335 tests across 16 files and five Vitest lanes passed in 110.68s**, covering prepared catalogs/workers, model selection, live model switches, startup publication, native harness catalogs, and Ollama probe controls. Published missing-fact and completed-inventory tests remain green.
- Independent Codex autoreview: **scoped-clean, no actionable P0–P2 findings**.
- `pnpm check:changed` passed, including core production/test typechecking and changed-file lint. `pnpm build` passed in **4m 4.8s**. `pnpm test:changed` passed **49 tests across three files in 7.58s**. `git diff --check` passed.

CI [run 34376267927](https://github.com/openclaw/openclaw/actions/runs/34376267927) passed the previously failing Discord bundle 13 on Linux. Its first attempt failed bundle 3 during synchronous collection of `extensions/deepinfra/provider.contract.test.ts`: both runner attempts emitted the same 900 passing cases from the other 84 selected files, then the no-output watchdog terminated them. No assertion failure was reported. The identical shard plan passed on #143183 ([baseline job](https://github.com/openclaw/openclaw/actions/runs/34369598642/job/102533682453)), and the isolated DeepInfra contract passed locally (two tests, 28.34s wall time). The targeted fresh-runner rerun passed on the unchanged head: **902 tests across 85 files**, then **839 voice-call tests across 70 files**. Attempt 2 and the required CI gate are green; the original failure evidence is retained. The exact 85-file shard also passed locally with two workers (901 passed, one existing platform skip). The repaired first Discord `/new` case took **14.198s on the Linux runner**, well below its 120s timeout.

The Discord proof uses the isolated native-command reply-pipeline harness; no live Discord service or provider inference was used.
