### PR TITLE
fix(agents): configured custom models request a 200,000-token completion budget

### DIFF
--- a/src/agents/embedded-agent-runner/model.inline-provider.test.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.test.ts
@@ -2,7 +2,14 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
-import { buildInlineProviderModels, resolveProviderModelInput } from "./model.inline-provider.js";
+import type { ModelDefinitionConfig } from "../../config/types.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
+import { SELF_HOSTED_DEFAULT_MAX_TOKENS } from "../self-hosted-provider-defaults.js";
+import {
+  buildInlineProviderModels,
+  completeInlineProviderModel,
+  resolveProviderModelInput,
+} from "./model.inline-provider.js";
 import { makeModel } from "./model.test-harness.js";
 
 describe("buildInlineProviderModels", () => {
@@ -319,6 +326,40 @@ describe("buildInlineProviderModels", () => {
     expect(expectDefined(result[0], "result[0] test invariant").headers).toEqual({
       "X-Static": "tenant-a",
     });
+  });
+});
+
+describe("completeInlineProviderModel", () => {
+  // models.providers.*.models[].maxTokens is optional in the config schema, so an
+  // authored row reaches the runtime without an output cap of its own.
+  const { maxTokens: _authoredCap, ...rowWithoutMaxTokens } = makeModel("custom-model");
+  const providerConfig = {
+    baseUrl: "http://alpha.local/v1",
+    api: "openai-completions" as const,
+    models: [rowWithoutMaxTokens as ModelDefinitionConfig],
+  };
+
+  function completeAlpha(providerMaxTokens?: number) {
+    const providers = {
+      alpha: { ...providerConfig, ...(providerMaxTokens ? { maxTokens: providerMaxTokens } : {}) },
+    };
+    return expectDefined(
+      buildInlineProviderModels(providers).map((model) =>
+        completeInlineProviderModel(model, providers.alpha),
+      )[0],
+      "completed alpha model",
+    );
+  }
+
+  it("caps output with the self-hosted output default when no row or provider sets one", () => {
+    const model = completeAlpha();
+
+    expect(model.maxTokens).toBe(SELF_HOSTED_DEFAULT_MAX_TOKENS);
+    expect(model.maxTokens).not.toBe(DEFAULT_CONTEXT_TOKENS);
+  });
+
+  it("keeps the provider-level output cap when one is configured", () => {
+    expect(completeAlpha(32_000).maxTokens).toBe(32_000);
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -17,6 +17,7 @@ import {
   resolveProviderRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "../provider-request-config.js";
+import { SELF_HOSTED_DEFAULT_MAX_TOKENS } from "../self-hosted-provider-defaults.js";
 
 /**
  * Normalizes inline `models.providers` config into runtime model entries.
@@ -226,7 +227,10 @@ export function completeInlineProviderModel(
     cost: model.cost ?? normalizeResolvedPricing({}),
     contextWindow: model.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
     contextTokens: model.contextTokens,
-    maxTokens: model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+    // maxTokens is an output cap, so it cannot fall back to the context-window
+    // default. Authored rows may omit it, and no provider accepts a whole context
+    // window as its completion budget.
+    maxTokens: model.maxTokens ?? SELF_HOSTED_DEFAULT_MAX_TOKENS,
     ...(providerConfig.authHeader !== undefined ? { authHeader: providerConfig.authHeader } : {}),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a model configured under `models.providers` without its own `maxTokens` claims a 200,000-token output cap, so requests to that endpoint ask for a completion budget no provider grants.

`maxTokens` is the completion budget — `src/config/types.models.ts` documents it as "Maximum completion/output token budget" — but `completeInlineProviderModel` filled an absent value with `DEFAULT_CONTEXT_TOKENS`, the context-window fallback (`src/agents/defaults.ts:6`, "Conservative fallback used when model metadata is unavailable"). The two adjacent lines used the same constant for two different quantities: `contextWindow`, where it belongs, and `maxTokens`, where it does not.

`maxTokens` is optional in the config schema (`src/config/zod-schema.core.ts:516`), and so is the provider-level default that fills it in (`models.providers.*.maxTokens`), so an authored row reaches the runtime with no output cap of its own. This is the ordinary shape for a custom or self-hosted endpoint.

## Why This Change Was Made

The completed model is what the transports read. `packages/ai/src/providers/anthropic.ts:645` sends `max_tokens: options?.maxTokens ?? model.maxTokens` verbatim, and `openai-completions-params.ts:92` falls through to `model.maxTokens` when no per-call value is set, so an operator configuring a custom `anthropic-messages` endpoint asks for 200,000 output tokens on every request. `clampMaxTokensToModel` (`packages/ai/src/providers/simple-options.ts:52-58`) also uses the model value as the ceiling a caller's request is clamped to, so a 200,000 ceiling clamps nothing.

This repository already owns a default for exactly this case: `SELF_HOSTED_DEFAULT_MAX_TOKENS` in `src/agents/self-hosted-provider-defaults.ts`, documented as the "Default output-token cap used for self-hosted provider catalog entries" and used by self-hosted discovery at `src/plugins/provider-self-hosted-discovery.ts:379`. This change uses it in the configured-model path too, so both routes into the same population agree. No new constant and no new configuration.

Only the fallback changes. An authored `maxTokens` on the model, and a provider-level `maxTokens`, both still win: `buildInlineProviderModels` resolves `model.maxTokens ?? entry?.maxTokens` before this function runs, and the completion only fills what is still absent.

## User Impact

Custom and self-hosted provider models configured without an explicit `maxTokens` now request a completion budget an endpoint can serve, instead of one that strict OpenAI-compatible and Anthropic-shaped servers reject. Operators whose endpoint supports a larger output set `maxTokens` on the model or on the provider, which is the documented control and the only way to raise the cap above a default in either direction today. Models that already declare `maxTokens`, and every model resolved from a static catalog, are unchanged.

## Evidence

**Production composition, before and after.** A probe running the exact composition used by the configured-model catalog (`src/agents/embedded-agent-runner/model.static-catalog.ts:443`: `buildInlineProviderModels(...).map((model) => completeInlineProviderModel(model, providerConfig))`) against a `models.providers` entry with no `maxTokens` on the model or the provider.

Before:

```
resolved model id      : internal-claude
api                    : anthropic-messages
contextWindow          : 200000
maxTokens (output cap) : 200000
max_tokens that would be sent with no per-call override: 200000
```

After:

```
resolved model id      : internal-claude
api                    : anthropic-messages
contextWindow          : 200000
maxTokens (output cap) : 8192
max_tokens that would be sent with no per-call override: 8192
```

`contextWindow` is unchanged, which is the point: the two quantities no longer share one constant.

**Regression coverage.** Two cells added to `src/agents/embedded-agent-runner/model.inline-provider.test.ts`. The first pins the output default and asserts it is not the context fallback; reverted, it fails with `expected 200000 to be 8192`. The second is a control: a provider-level `maxTokens` of 32,000 survives the completion, and it passes both before and after, so the change is confined to the absent-value path. The file passes 17/17.

**Neighbouring suites.** `model.static-catalog.test.ts`, `model.static-catalog.prepared.test.ts`, `prepared-model-runtime.configured-catalog.test.ts`, `model-catalog-entry.test.ts` and `models-config.merge.test.ts` pass, 54 tests across 5 files. No existing test asserted the previous value. `oxfmt --check`, the core typecheck lane and the `src` test typecheck lane are clean.

**Not claimed.** No live request against a provider endpoint; the probe shows the value the transport would send, read from the production model record, not a captured 400 response. Local runs used Node 22.23.2, below the supported floor, so hosted CI on this head remains the authority.
