### PR TITLE
feat(voice-call): add fixed realtime tool bindings

### DIFF
--- a/docs/plugins/voice-call/realtime-and-streaming.md
+++ b/docs/plugins/voice-call/realtime-and-streaming.md
@@ -91,6 +91,33 @@ When a host tool run reports cancellation, the realtime model receives a
 cancelled result and the phone call stays open. Timeouts and other tool failures
 remain errors; ending the phone session suppresses pending consult results.
 
+Configured `realtime.tools` are provider descriptors only unless the same tool
+name has a `realtime.toolBindings` entry. A binding fixes that tool to one
+Gateway method; model arguments cannot select another method. The bundled
+voice-call plugin invokes bindings in process with `operator.read` scope and
+adds trusted call, session, transcript, and tool-call context under
+`_openclawVoiceContext`. When the method returns a non-empty `spokenResponse`,
+the bridge submits the tool result without free-form continuation and asks the
+provider to speak that text through the exact-speech protocol.
+
+```json5
+{
+  realtime: {
+    tools: [
+      {
+        type: "function",
+        name: "queue_status",
+        description: "Read the queue status.",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+    toolBindings: {
+      queue_status: { gatewayMethod: "queue.status", timeoutMs: 5000 },
+    },
+  },
+}
+```
+
 ### Agent voice context
 
 Enable `realtime.agentContext` when the voice bridge should sound like the

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -268,6 +268,7 @@ export default definePluginEntry({
           coreConfig: api.config as OpenClawConfig,
           fullConfig: api.config,
           agentRuntime: api.runtime.agent,
+          gatewayRuntime: api.runtime.gateway,
           stateRuntime: api.runtime.state,
           ttsRuntime: api.runtime.tts,
           logger: api.logger,

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -18,6 +18,11 @@ import { z } from "zod";
 import { TtsConfigSchema } from "../api.js";
 import { TWILIO_REGIONS } from "./providers/twilio-region.js";
 import { DEFAULT_VOICE_CALL_REALTIME_INSTRUCTIONS } from "./realtime-defaults.js";
+import {
+  RealtimeToolBindingSchema,
+  type RealtimeToolConfig,
+  RealtimeToolSchema,
+} from "./realtime-tool-binding.js";
 import { isTailscalePortAllowed, VoiceCallTailscaleConfigSchema } from "./tailscale-config.js";
 
 // -----------------------------------------------------------------------------
@@ -204,20 +209,6 @@ const OutboundConfigSchema = z
 // Realtime Voice Configuration
 // -----------------------------------------------------------------------------
 
-const RealtimeToolSchema = z
-  .object({
-    type: z.literal("function"),
-    name: z.string().min(1),
-    description: z.string(),
-    parameters: z.object({
-      type: z.literal("object"),
-      properties: z.record(z.string(), z.unknown()),
-      required: z.array(z.string()).optional(),
-    }),
-  })
-  .strict();
-type RealtimeToolConfig = z.infer<typeof RealtimeToolSchema>;
-
 const VoiceCallRealtimeProvidersConfigSchema = z
   .record(z.string(), z.record(z.string(), z.unknown()))
   .default({});
@@ -309,6 +300,8 @@ const VoiceCallRealtimeConfigSchema = z
     consultFastMode: z.boolean().optional(),
     /** Tool definitions exposed to the realtime provider. */
     tools: z.array(RealtimeToolSchema).default([]),
+    /** Trusted handlers for configured tools, keyed by tool name. */
+    toolBindings: z.record(z.string(), RealtimeToolBindingSchema).default({}),
     /** Low-latency memory/session context for the consult tool. */
     fastContext: VoiceCallRealtimeFastContextConfigSchema,
     /** Bounded agent persona/context injection for the fast realtime voice path. */
@@ -323,6 +316,7 @@ const VoiceCallRealtimeConfigSchema = z
     toolPolicy: "safe-read-only",
     consultPolicy: "auto",
     tools: [],
+    toolBindings: {},
     fastContext: {
       enabled: false,
       timeoutMs: 800,
@@ -737,6 +731,9 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
         defaultRealtimeStreamPathForServePath(serve.path ?? defaults.serve.path),
       tools:
         (config.realtime?.tools as RealtimeToolConfig[] | undefined) ?? defaults.realtime.tools,
+      toolBindings:
+        (config.realtime?.toolBindings as VoiceCallRealtimeConfig["toolBindings"] | undefined) ??
+        defaults.realtime.toolBindings,
       consultThinkingLevel: VoiceCallRealtimeConsultThinkingLevelSchema.optional().parse(
         config.realtime?.consultThinkingLevel ?? defaults.realtime.consultThinkingLevel,
       ),

--- a/extensions/voice-call/src/realtime-bound-tool-result.ts
+++ b/extensions/voice-call/src/realtime-bound-tool-result.ts
@@ -1,0 +1,27 @@
+const GATEWAY_BOUND_EXACT_SPEECH = Symbol("voice-call.gateway-bound-exact-speech");
+
+/** Keep exact-speech authority internal while submitting the plain tool result to the provider. */
+export function markGatewayBoundRealtimeToolResult(result: unknown): unknown {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  // SAFETY: the guards above establish a non-array object before reading a string key.
+  const spokenResponse = (result as Record<string, unknown>).spokenResponse;
+  if (typeof spokenResponse !== "string" || !spokenResponse.trim()) {
+    return result;
+  }
+  Object.defineProperty(result, GATEWAY_BOUND_EXACT_SPEECH, {
+    value: spokenResponse.trim(),
+    enumerable: false,
+  });
+  return result;
+}
+
+export function readGatewayBoundExactSpeech(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+  // SAFETY: the guards above establish a non-array object before reading our private symbol.
+  const value = (result as Record<symbol, unknown>)[GATEWAY_BOUND_EXACT_SPEECH];
+  return typeof value === "string" ? value : undefined;
+}

--- a/extensions/voice-call/src/realtime-tool-binding.ts
+++ b/extensions/voice-call/src/realtime-tool-binding.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const RealtimeToolBindingSchema = z
+  .object({
+    gatewayMethod: z.string().min(1),
+    timeoutMs: z.number().int().positive().max(30_000).default(5_000),
+  })
+  .strict();
+
+export const RealtimeToolSchema = z
+  .object({
+    type: z.literal("function"),
+    name: z.string().min(1),
+    description: z.string(),
+    parameters: z.object({
+      type: z.literal("object"),
+      properties: z.record(z.string(), z.unknown()),
+      required: z.array(z.string()).optional(),
+    }),
+  })
+  .strict();
+
+export type RealtimeToolConfig = z.infer<typeof RealtimeToolSchema>;

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -619,6 +619,9 @@ describe("createVoiceCallRuntime lifecycle", () => {
         parameters: { type: "object", properties: {} },
       },
     ];
+    config.realtime.toolBindings = {
+      custom_tool: { gatewayMethod: "aq.currentWork", timeoutMs: 2_000 },
+    };
     const sessionStore: Record<string, unknown> = {};
     const runEmbeddedAgent = vi.fn(async () => ({
       payloads: [{ text: "Use the shipment status." }],
@@ -635,6 +638,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
       session: createMockSessionRuntime(sessionStore),
       runEmbeddedAgent,
     };
+    const gatewayRequest = vi.fn(async () => ({ spokenResponse: "Two tasks are active." }));
     mocks.managerGetCall.mockReturnValue({
       callId: "call-1",
       agentId: "support",
@@ -649,6 +653,7 @@ describe("createVoiceCallRuntime lifecycle", () => {
       config,
       coreConfig: {} as OpenClawConfig,
       agentRuntime: agentRuntime as never,
+      gatewayRuntime: { isAvailable: vi.fn(async () => true), request: gatewayRequest } as never,
     });
 
     const realtimeHandlerOptions = requireRecord(
@@ -664,6 +669,32 @@ describe("createVoiceCallRuntime lifecycle", () => {
       "openclaw_agent_consult",
       "custom_tool",
     ]);
+    const customRegistration = mocks.realtimeHandlerRegisterToolHandler.mock.calls.find(
+      ([name]) => name === "custom_tool",
+    );
+    if (!customRegistration || typeof customRegistration[1] !== "function") {
+      throw new Error("expected custom realtime tool handler callback");
+    }
+    await expect(
+      customRegistration[1]({ detail: "brief" }, "call-1", {
+        partialUserTranscript: "What is running?",
+        toolCallId: "tool-call-1",
+      }),
+    ).resolves.toEqual({ spokenResponse: "Two tasks are active." });
+    expect(gatewayRequest).toHaveBeenCalledWith(
+      "aq.currentWork",
+      {
+        detail: "brief",
+        _openclawVoiceContext: {
+          callId: "call-1",
+          sessionKey: "agent:support:voice:15550009999",
+          source: "voice",
+          toolCallId: "tool-call-1",
+          utterance: "What is running?",
+        },
+      },
+      { timeoutMs: 2_000, scopes: ["operator.read"] },
+    );
     const handler = requireRealtimeConsultToolHandler();
     await expect(
       handler({ question: "What should I say?" }, "call-1", {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -27,7 +27,11 @@ import { CallManager } from "./manager.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import { buildRealtimeVoiceInstructions } from "./realtime-agent-context.js";
-import { resolveVoiceCallRealtimeTools } from "./realtime-call-control.js";
+import { markGatewayBoundRealtimeToolResult } from "./realtime-bound-tool-result.js";
+import {
+  REALTIME_VOICE_END_CALL_TOOL_NAME,
+  resolveVoiceCallRealtimeTools,
+} from "./realtime-call-control.js";
 import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
 import { resolveCallAgentId, resolveVoiceCallAgentId } from "./resolve-call-agent-id.js";
 import { resolveVoiceResponseModel } from "./response-model.js";
@@ -286,6 +290,7 @@ export async function createVoiceCallRuntime(params: {
   coreConfig: OpenClawConfig;
   fullConfig?: OpenClawConfig;
   agentRuntime: OpenClawPluginApi["runtime"]["agent"];
+  gatewayRuntime?: OpenClawPluginApi["runtime"]["gateway"];
   stateRuntime?: VoiceCallStateRuntime["state"];
   ttsRuntime?: TelephonyTtsRuntime;
   logger?: Logger;
@@ -295,6 +300,7 @@ export async function createVoiceCallRuntime(params: {
     coreConfig,
     fullConfig,
     agentRuntime,
+    gatewayRuntime,
     stateRuntime,
     ttsRuntime,
     logger,
@@ -459,6 +465,62 @@ export async function createVoiceCallRuntime(params: {
           });
         },
       );
+    }
+    for (const [toolName, binding] of Object.entries(config.realtime.toolBindings)) {
+      if (!realtimeConfig.tools.some((tool) => tool.name === toolName)) {
+        throw new Error(
+          `Invalid voice-call config: realtime.toolBindings.${toolName} has no matching realtime.tools entry`,
+        );
+      }
+      if (
+        toolName === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME ||
+        toolName === REALTIME_VOICE_END_CALL_TOOL_NAME
+      ) {
+        throw new Error(
+          `Invalid voice-call config: realtime.toolBindings.${toolName} cannot replace a built-in tool`,
+        );
+      }
+      if (!gatewayRuntime) {
+        throw new Error(
+          `Invalid voice-call config: realtime.toolBindings.${toolName} requires the Gateway runtime`,
+        );
+      }
+      realtimeHandler.registerToolHandler(toolName, async (args, callId, handlerContext) => {
+        handlerContext.abortSignal?.throwIfAborted();
+        const call = manager.getCall(callId);
+        if (!call) {
+          return { error: `Call "${callId}" not found` };
+        }
+        const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
+        const effectiveConfig = resolveVoiceCallEffectiveConfig(config, numberRouteKey).config;
+        const agentId = resolveCallAgentId(call, effectiveConfig);
+        const sessionKey = resolveVoiceCallConsultSessionKey({
+          ...call,
+          config: { ...effectiveConfig, agentId },
+          coreSession: cfg.session,
+        });
+        let modelArgs: Record<string, unknown> = {};
+        if (args && typeof args === "object" && !Array.isArray(args)) {
+          // SAFETY: the guards establish a non-array object before spreading model arguments.
+          modelArgs = args as Record<string, unknown>;
+        }
+        return markGatewayBoundRealtimeToolResult(
+          await gatewayRuntime.request(
+            binding.gatewayMethod,
+            {
+              ...modelArgs,
+              _openclawVoiceContext: {
+                callId,
+                sessionKey,
+                source: "voice",
+                toolCallId: handlerContext.toolCallId,
+                utterance: handlerContext.partialUserTranscript,
+              },
+            },
+            { timeoutMs: binding.timeoutMs, scopes: ["operator.read"] },
+          ),
+        );
+      });
     }
     webhookServer.setRealtimeHandler(realtimeHandler);
   }

--- a/extensions/voice-call/src/test-fixtures.ts
+++ b/extensions/voice-call/src/test-fixtures.ts
@@ -54,6 +54,7 @@ export function createVoiceCallBaseConfig(params?: {
       toolPolicy: "safe-read-only",
       consultPolicy: "auto",
       tools: [],
+      toolBindings: {},
       fastContext: {
         enabled: false,
         timeoutMs: 800,

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -20,6 +20,7 @@ function createRealtimeConfig(): VoiceCallRealtimeConfig {
     toolPolicy: "safe-read-only",
     consultPolicy: "auto",
     tools: [],
+    toolBindings: {},
     fastContext: {
       enabled: false,
       timeoutMs: 800,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
+import { markGatewayBoundRealtimeToolResult } from "../realtime-bound-tool-result.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
@@ -126,6 +127,7 @@ function makeHandler(
     toolPolicy: overrides?.toolPolicy ?? "safe-read-only",
     consultPolicy: overrides?.consultPolicy ?? "auto",
     tools: overrides?.tools ?? [],
+    toolBindings: overrides?.toolBindings ?? {},
     fastContext: overrides?.fastContext ?? {
       enabled: false,
       timeoutMs: 800,
@@ -1493,18 +1495,11 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("submits continuing responses only for realtime agent consult calls", async () => {
-    let callbacks:
-      | {
-          onToolCall?: (event: {
-            itemId: string;
-            callId: string;
-            name: string;
-            args: unknown;
-          }) => void;
-          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
-        }
-      | undefined;
+    let callbacks: RealtimeBridgeRequest | undefined;
     let resolveConsult: ((value: unknown) => void) | undefined;
+    const resolveSlowLookups: Array<(value: unknown) => void> = [];
+    const slowLookupSignals: AbortSignal[] = [];
+    let resolveExactSpeechSubmission: (() => void) | undefined;
     let resolveWorkingSubmission: (() => void) | undefined;
     let rejectWorkingSubmission = false;
     const resolveFinalSubmissions: Array<() => void> = [];
@@ -1541,12 +1536,19 @@ describe("RealtimeCallHandler path routing", () => {
             resolveFinalSubmissions.push(resolve);
           });
         }
+        if (_callId === "custom-stale-exact-call") {
+          return new Promise<void>((resolve) => {
+            resolveExactSpeechSubmission = resolve;
+          });
+        }
         return undefined;
       },
     );
+    const sendUserMessage = vi.fn();
     const bridge = makeBridge({
       supportsToolResultContinuation: true,
       submitToolResult,
+      sendUserMessage,
     });
     const createBridge = vi.fn(
       (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
@@ -1571,7 +1573,17 @@ describe("RealtimeCallHandler path routing", () => {
       },
     );
     handler.registerToolHandler("openclaw_agent_consult", consultHandler);
-    handler.registerToolHandler("custom_lookup", async () => ({ ok: true }));
+    handler.registerToolHandler("custom_lookup", async () =>
+      markGatewayBoundRealtimeToolResult({ ok: true, spokenResponse: "Two tasks are active." }),
+    );
+    handler.registerToolHandler(
+      "custom_slow_lookup",
+      async (_args, _callId, context) =>
+        await new Promise((resolve) => {
+          slowLookupSignals.push(context.abortSignal);
+          resolveSlowLookups.push(resolve);
+        }),
+    );
     const server = await startRealtimeServer(handler);
 
     try {
@@ -1660,13 +1672,90 @@ describe("RealtimeCallHandler path routing", () => {
         });
 
         await waitForRealtimeTest(() => {
-          expect(submitToolResult).toHaveBeenCalledWith("custom-call", { ok: true }, undefined);
+          expect(submitToolResult).toHaveBeenCalledWith(
+            "custom-call",
+            { ok: true, spokenResponse: "Two tasks are active." },
+            { suppressResponse: true },
+          );
         });
         const customCallResults = submitToolResult.mock.calls.filter(
           ([callId]) => callId === "custom-call",
         );
         expect(customCallResults).toHaveLength(1);
-        expect(customCallResults[0]?.[2]).toBeUndefined();
+        expect(customCallResults[0]?.[2]).toEqual({ suppressResponse: true });
+        expect(sendUserMessage).toHaveBeenCalledWith(
+          'Internal OpenClaw voice playback result.\nDo not call openclaw_agent_consult or any other tool for this message.\nSpeak this exact OpenClaw answer to the caller, without adding, removing, or rephrasing words.\nAnswer: "Two tasks are active."',
+        );
+
+        submitToolResult.mockClear();
+        sendUserMessage.mockClear();
+        callbacks?.onToolCall?.({
+          itemId: "item-parallel-1",
+          callId: "custom-parallel-call-1",
+          name: "custom_slow_lookup",
+          args: {},
+        });
+        callbacks?.onToolCall?.({
+          itemId: "item-parallel-2",
+          callId: "custom-parallel-call-2",
+          name: "custom_slow_lookup",
+          args: {},
+        });
+        await waitForRealtimeTest(() => {
+          expect(slowLookupSignals).toHaveLength(2);
+        });
+        expect(slowLookupSignals[0]?.aborted).toBe(false);
+        expect(slowLookupSignals[1]?.aborted).toBe(false);
+        resolveSlowLookups[0]?.({ ok: "first" });
+        resolveSlowLookups[1]?.({ ok: "second" });
+        await waitForRealtimeTest(() => {
+          expect(submitToolResult).toHaveBeenCalledWith(
+            "custom-parallel-call-1",
+            { ok: "first" },
+            undefined,
+          );
+          expect(submitToolResult).toHaveBeenCalledWith(
+            "custom-parallel-call-2",
+            { ok: "second" },
+            undefined,
+          );
+        });
+
+        submitToolResult.mockClear();
+        callbacks?.onToolCall?.({
+          itemId: "item-slow",
+          callId: "custom-slow-call",
+          name: "custom_slow_lookup",
+          args: {},
+        });
+        await waitForRealtimeTest(() => {
+          expect(slowLookupSignals).toHaveLength(3);
+        });
+        expect(slowLookupSignals[2]?.aborted).toBe(false);
+        callbacks?.onClearAudio("barge-in");
+        expect(slowLookupSignals[2]?.aborted).toBe(true);
+        resolveSlowLookups[2]?.(
+          markGatewayBoundRealtimeToolResult({ ok: true, spokenResponse: "Stale result." }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(submitToolResult).not.toHaveBeenCalled();
+        expect(sendUserMessage).not.toHaveBeenCalled();
+
+        callbacks?.onToolCall?.({
+          itemId: "item-stale-exact",
+          callId: "custom-stale-exact-call",
+          name: "custom_lookup",
+          args: {},
+        });
+        await waitForRealtimeTest(() => {
+          expect(resolveExactSpeechSubmission).toBeTypeOf("function");
+        });
+        callbacks?.onClearAudio("barge-in");
+        resolveExactSpeechSubmission?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(sendUserMessage).not.toHaveBeenCalled();
 
         submitToolResult.mockClear();
         rejectWorkingSubmission = true;
@@ -1791,9 +1880,7 @@ describe("RealtimeCallHandler path routing", () => {
         }
         await vi.advanceTimersByTimeAsync(0);
         expect(hostTool).toHaveBeenCalledOnce();
-        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(
-          path === "general" ? undefined : false,
-        );
+        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(false);
 
         if ("error" in outcome && !synchronous) {
           pending.reject(outcome.error);
@@ -1826,9 +1913,7 @@ describe("RealtimeCallHandler path routing", () => {
         expect(sendUserMessage).not.toHaveBeenCalled();
         expect(closeBridge).not.toHaveBeenCalled();
         expect(ws.readyState).toBe(WebSocket.OPEN);
-        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(
-          path === "general" ? undefined : false,
-        );
+        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(false);
       } finally {
         warn.mockRestore();
         log.mockRestore();
@@ -2931,6 +3016,7 @@ describe("RealtimeCallHandler path routing", () => {
         expect(context).toEqual({
           partialUserTranscript: "Send a Discord message.",
           abortSignal: expect.any(AbortSignal),
+          toolCallId: "consult-call",
         });
         await waitForRealtimeTest(() => {
           expect(submitToolResult).toHaveBeenLastCalledWith(

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildRealtimeVoiceAgentConsultWorkingResponse,
   buildRealtimeVoiceAgentErrorProviderResult,
+  buildRealtimeVoiceSpeakExactMessage,
   calculateMulawRms,
   createRealtimeVoiceSessionHarness,
   createSpeechThresholdGate,
@@ -31,6 +32,7 @@ import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-util
 import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
+import { readGatewayBoundExactSpeech } from "../realtime-bound-tool-result.js";
 import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
 import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
@@ -46,6 +48,7 @@ import {
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
   abortSignal?: AbortSignal;
+  toolCallId?: string;
 };
 type ToolHandlerFn = (
   args: unknown,
@@ -388,6 +391,10 @@ export class RealtimeCallHandler {
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
+  private readonly boundToolExecutionsByCallId = new Map<
+    string,
+    Map<string, { owner: ActiveRealtimeVoiceBridge; abortController: AbortController }>
+  >();
   private readonly terminationAttempts = new Set<Promise<void>>();
   private closePromise: Promise<void> | null = null;
   private closing = false;
@@ -774,6 +781,7 @@ export class RealtimeCallHandler {
       interruptProvider?: (audioPlaybackActive: boolean) => void,
       clearedAudioBytes = 0,
     ): void => {
+      this.cancelBoundToolExecution(callId, nativeConsultOwner.current);
       const outputAudioActive = harness.talk.outputAudioActive;
       const pendingTelephonyAudio = audioPacer.hasPendingAudio();
       if (
@@ -1026,6 +1034,7 @@ export class RealtimeCallHandler {
           if (owner && this.isActiveBridgeOwner(callId, owner)) {
             this.resetUserTranscriptState(callId, userTranscriptOwner);
             this.resetConsultSessionForContinuity(callId, owner);
+            this.cancelBoundToolExecution(callId, owner);
           }
           harness.flushOutput(() => {
             audioPacer.clearAudio();
@@ -1099,6 +1108,7 @@ export class RealtimeCallHandler {
         const ownsCallState = this.isActiveBridgeOwner(callId, owner);
         this.clearActiveBridgeMappings(callId, callSid, owner);
         this.cancelConsultSession(callId, owner);
+        this.cancelBoundToolExecution(callId, owner);
         if (ownsCallState) {
           this.clearUserTranscriptState(callId, userTranscriptOwner);
         }
@@ -1183,6 +1193,7 @@ export class RealtimeCallHandler {
       } finally {
         this.clearActiveBridgeMappings(callId, callSid, session);
         this.cancelConsultSession(callId, session);
+        this.cancelBoundToolExecution(callId, session);
         this.clearUserTranscriptState(callId, userTranscriptOwner);
         harness.close();
         audioPacer.close();
@@ -1476,6 +1487,23 @@ export class RealtimeCallHandler {
       return;
     }
     this.consultSessionsByCallId.delete(callId);
+  }
+
+  private cancelBoundToolExecution(callId: string, owner?: ActiveRealtimeVoiceBridge): void {
+    const executions = this.boundToolExecutionsByCallId.get(callId);
+    if (!executions) {
+      return;
+    }
+    for (const [toolCallId, execution] of executions) {
+      if (owner && execution.owner !== owner) {
+        continue;
+      }
+      executions.delete(toolCallId);
+      execution.abortController.abort(new Error("Realtime bound tool execution was cancelled."));
+    }
+    if (executions.size === 0) {
+      this.boundToolExecutionsByCallId.delete(callId);
+    }
   }
 
   private isActiveBridgeOwner(callId: string, owner: ActiveRealtimeVoiceBridge): boolean {
@@ -1856,9 +1884,28 @@ export class RealtimeCallHandler {
         final: true,
       });
     };
-    const submitFinalToolResult = async (result: unknown): Promise<void> => {
-      await bridge.submitToolResult(bridgeCallId, result);
+    const submitFinalToolResult = async (
+      result: unknown,
+      isCurrent: () => boolean = () => true,
+    ): Promise<void> => {
+      if (this.activeBridgesByCallId.get(callId) !== bridge || !isCurrent()) {
+        return;
+      }
+      const exactSpeech = readGatewayBoundExactSpeech(result);
+      await bridge.submitToolResult(
+        bridgeCallId,
+        result,
+        exactSpeech ? { suppressResponse: true } : undefined,
+      );
+      if (this.activeBridgesByCallId.get(callId) !== bridge || !isCurrent()) {
+        return;
+      }
       emitFinalToolEvent(result);
+      if (exactSpeech) {
+        bridge.sendUserMessage(
+          buildRealtimeVoiceSpeakExactMessage({ text: exactSpeech, surfaceLabel: "the caller" }),
+        );
+      }
     };
     const submitWorkingResponse = async (): Promise<void> => {
       if (
@@ -1982,6 +2029,7 @@ export class RealtimeCallHandler {
           const context = {
             partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
             abortSignal: abortController.signal,
+            toolCallId: bridgeCallId,
           };
           state.partialUserTranscript = context.partialUserTranscript;
           const handlerArgs = withFallbackConsultQuestion(args, context.partialUserTranscript);
@@ -2024,8 +2072,25 @@ export class RealtimeCallHandler {
     console.log(
       `[voice-call] realtime tool call executing callId=${callId} tool=${name} hasHandler=${Boolean(handler)}`,
     );
+    if (this.activeBridgesByCallId.get(callId) !== bridge) {
+      return;
+    }
+    const abortController = new AbortController();
+    const execution = { owner: bridge, abortController };
+    const existingExecutions = this.boundToolExecutionsByCallId.get(callId);
+    if (existingExecutions?.has(bridgeCallId)) {
+      return;
+    }
+    const executions = existingExecutions ?? new Map();
+    executions.set(bridgeCallId, execution);
+    this.boundToolExecutionsByCallId.set(callId, executions);
+    const isCurrentExecution = (): boolean =>
+      !abortController.signal.aborted &&
+      this.boundToolExecutionsByCallId.get(callId)?.get(bridgeCallId) === execution;
     const context = {
       partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
+      abortSignal: abortController.signal,
+      toolCallId: bridgeCallId,
     };
     let result: unknown;
     try {
@@ -2033,7 +2098,17 @@ export class RealtimeCallHandler {
         ? { error: `Tool "${name}" not available` }
         : await handler(args, callId, context);
     } catch (error) {
+      if (abortController.signal.aborted) {
+        return;
+      }
       result = buildRealtimeVoiceAgentErrorProviderResult(error);
+    }
+    if (
+      abortController.signal.aborted ||
+      !isCurrentExecution() ||
+      this.activeBridgesByCallId.get(callId) !== bridge
+    ) {
+      return;
     }
     const error = hasResultError(result)
       ? formatErrorMessage(result.error ?? "unknown")
@@ -2041,7 +2116,16 @@ export class RealtimeCallHandler {
     console.log(
       `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${error === undefined ? "ok" : "error"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
     );
-    await submitFinalToolResult(result);
+    try {
+      await submitFinalToolResult(result, isCurrentExecution);
+    } finally {
+      if (executions.get(bridgeCallId) === execution) {
+        executions.delete(bridgeCallId);
+      }
+      if (executions.size === 0 && this.boundToolExecutionsByCallId.get(callId) === executions) {
+        this.boundToolExecutionsByCallId.delete(callId);
+      }
+    }
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Routine read-only voice requests currently require a full supervisor consultation, adding avoidable latency.

## Why This Change Was Made

Add configured realtime tools that bind to fixed Gateway methods, carry trusted call context, and speak marked results exactly once. Bound calls are cancelled on barge-in, continuity reset, bridge replacement, or close; arbitrary Gateway dispatch is not exposed.

## User Impact

Plugins can serve bounded, low-latency voice reads while unsupported providers and unbound tools keep the completed-result fallback.

## Evidence

- 97 focused voice-call tests pass.
- Extension production typecheck and targeted lint pass.
- Lifecycle tests cover parallel calls, exact-response deduplication, barge-in, replacement, and close.

Generated with AI under the guidance of John.
