### PR TITLE
fix: Doctor source-isolation tests fail on tmpfs

### DIFF
--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -501,7 +501,24 @@ describe("doctor lint state isolation", () => {
             },
           ]);
           const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+          const readFileSync = fs.readFileSync;
+          const mountInfo = vi.spyOn(fs, "readFileSync");
           try {
+            // Source isolation is independent of the temporary directory's backing filesystem.
+            mountInfo.mockImplementation(
+              (target, options?: fs.ReadFileSyncOptions | BufferEncoding | null) => {
+                if (typeof options === "string") {
+                  if (target === "/proc/self/mountinfo" && options === "utf8") {
+                    return "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw";
+                  }
+                  return readFileSync(target, options);
+                }
+                if (options == null) {
+                  return readFileSync(target, options);
+                }
+                return readFileSync(target, options);
+              },
+            );
             await runDoctorLintCli(runtime, { json: true, includeAllChecks: true });
             const findings = JSON.parse(String(stdout.mock.calls.at(-1)?.[0])).findings;
             expect(isolated).toBe(true);
@@ -510,6 +527,7 @@ describe("doctor lint state isolation", () => {
             );
             expect(fs.existsSync(credentials)).toBe(exists);
           } finally {
+            mountInfo.mockRestore();
             stdout.mockRestore();
           }
         },

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -274,7 +274,24 @@ describe("structured state integrity findings", () => {
         }
         return accessSync(target, mode);
       });
+      const readFileSync = fs.readFileSync;
+      const mountInfo = vi.spyOn(fs, "readFileSync");
       try {
+        // Source isolation is independent of the temporary directory's backing filesystem.
+        mountInfo.mockImplementation(
+          (target, options?: fs.ReadFileSyncOptions | BufferEncoding | null) => {
+            if (typeof options === "string") {
+              if (target === "/proc/self/mountinfo" && options === "utf8") {
+                return "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw";
+              }
+              return readFileSync(target, options);
+            }
+            if (options == null) {
+              return readFileSync(target, options);
+            }
+            return readFileSync(target, options);
+          },
+        );
         const issues = detectStateIntegrityHealthIssues(
           withMainAgentRoster({ session: { store } }),
           { env: { HOME: sourceHome, OPENCLAW_STATE_DIR: sourceState } },
@@ -287,6 +304,7 @@ describe("structured state integrity findings", () => {
           }),
         ]);
       } finally {
+        mountInfo.mockRestore();
         accessSpy.mockRestore();
       }
     },


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where four Doctor source-isolation tests fail on Linux hosts whose temporary directory uses tmpfs. The source paths are correct, but a legitimate volatile-storage warning adds unrelated findings and repair effects to the fixtures' exact expected results.

## Why This Change Was Made

Supply stable ext4 mount metadata only for the exact `/proc/self/mountinfo` UTF-8 read during these four cases. All other reads retain their original arguments, and the spy restores in `finally`. The real detector, source isolation, repair mapping and every existing assertion remain intact. Dedicated volatile-filesystem tests are unchanged.

## User Impact

No production behavior changes. Developers can run these source-isolation tests on tmpfs-backed test environments while retaining coverage of actual volatile-storage warnings. This correctness repair adds 36 test lines; it makes no overall runtime reduction claim.

## Evidence

- Unchanged Linux/Node 24.19 contrast: four cases passed on ext4 and the same four failed on tmpfs, with only the anticipated extra findings and correct source paths.
- Final candidate on actual Linux tmpfs: all four repaired cases passed; all nine unchanged volatile-filesystem cases passed separately. Native process groups were joined and the isolated lease was cleaned up.
- Complete local owner and sibling suites: 52 cases passed before and after with identical ordered names and statuses.
- Exact inverse checks preserve all original test code. Focused forwarding checks retain path/options identity, propagated errors and restoration on success/failure.
- Full changed gate and fresh independent review passed. The initial implicit spy callback failed TypeScript's overload check; the final callback explicitly models Node's actual options types without casts or argument normalization.
