### PR TITLE
fix: keep prepared video providers alive through background jobs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2027,7 +2027,7 @@ src/agents/tools/system-agent-tool.ts	1
 src/agents/tools/task-suggestion-tools.ts	2
 src/agents/tools/terminal-tool.ts	1
 src/agents/tools/tts-tool.ts	1
-src/agents/tools/video-generate-tool.ts	3
+src/agents/tools/video-generate-tool.ts	2
 src/agents/tools/web-fetch.ts	3
 src/agents/tools/web-guarded-fetch.ts	2
 src/agents/tools/web-search-output.ts	3

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -397,7 +397,6 @@ src/agents/tools/sessions-send-tool.ts
 src/agents/tools/sessions-spawn-tool.test.ts
 src/agents/tools/sessions.test.ts
 src/agents/tools/video-generate-tool.test.ts
-src/agents/tools/video-generate-tool.ts
 src/agents/tools/web-fetch.ts
 src/agents/transcript-redact.test.ts
 src/agents/workspace.ts

--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -69,7 +69,7 @@ override lookups. Returned audio buffers outlive registration disposal. The
 separate synchronous speech lookup and request-preparation APIs keep their
 existing caller lifetime; streaming speech is not part of this finite operation.
 
-For `image_generate` and `music_generate` tools prepared from an owned inspection,
+For `image_generate`, `music_generate`, and `video_generate` tools prepared from an owned inspection,
 resources remain held through preflight and, once accepted, through generation, media saving, and
 any rollback. A `started` result acknowledges acceptance; it does not mean the
 work or cleanup has finished. If the original inspection retires during

--- a/src/agents/tools/media-generate-tool.resources.test.ts
+++ b/src/agents/tools/media-generate-tool.resources.test.ts
@@ -26,17 +26,28 @@ import { createImageGenerateTool } from "./image-generate-tool.js";
 import {
   imageGenerationTaskLifecycle,
   musicGenerationTaskLifecycle,
+  videoGenerationTaskLifecycle,
 } from "./media-generate-background.js";
 import { createMusicGenerateTool } from "./music-generate-tool.js";
+import { createVideoGenerateTool } from "./video-generate-tool.js";
 
 const png = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMQVDL+DwACFAFmBODefwAAAABJRU5ErkJggg==",
   "base64",
 );
 
-type GenerationKind = "image" | "music";
+const mp4 = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+  0x69, 0x73, 0x6f, 0x6d, 0x6d, 0x70, 0x34, 0x31,
+]);
+type GenerationKind = "image" | "music" | "video";
 
-function createNativeFixture(kind: GenerationKind, edit = false, trackCount = 1) {
+function createNativeFixture(
+  kind: GenerationKind,
+  edit = false,
+  trackCount = 1,
+  holdLookup = false,
+) {
   const dir = makePluginLoaderTempDir();
   const key = `__openclaw_prepared_${kind}_${path.basename(dir)}`;
   const connections: Array<{
@@ -45,6 +56,11 @@ function createNativeFixture(kind: GenerationKind, edit = false, trackCount = 1)
     generated: number;
     projected: number;
   }> = [];
+  const lookupStarted = createDeferredCore();
+  const resumeLookup = createDeferredCore();
+  if (!holdLookup) {
+    resumeLookup.resolve();
+  }
   const generated = createDeferredCore();
   const resumeGeneration = createDeferredCore();
   Object.defineProperty(globalThis, key, {
@@ -53,7 +69,10 @@ function createNativeFixture(kind: GenerationKind, edit = false, trackCount = 1)
       connections,
       generated,
       resumeGeneration,
+      lookupStarted,
+      resumeLookup,
       png,
+      mp4,
       audio: Buffer.from("synthetic native music 42"),
     },
   });
@@ -106,7 +125,8 @@ ${
       },
     });
 `
-    : `
+    : kind === "music"
+      ? `
     api.registerMusicGenerationProvider({
       id: ${JSON.stringify(id)},
       defaultModel: "fixture-music",
@@ -131,6 +151,44 @@ ${
       },
     });
 `
+      : `
+    api.registerVideoGenerationProvider({
+      id: ${JSON.stringify(id)},
+      defaultModel: "fixture-video",
+      isConfigured() { return read() === 42; },
+      capabilities: { generate: { maxVideos: 2 }, imageToVideo: { enabled: ${edit}, maxInputImages: ${edit ? 1 : 0} } },
+      async resolveModelCapabilities() {
+        read();
+        state.lookupStarted.resolve();
+        await state.resumeLookup.promise;
+        read();
+        return {};
+      },
+      async generateVideo() {
+        read();
+        connection.generated++;
+        state.generated.resolve();
+        await state.resumeGeneration.promise;
+        read();
+        return {
+          videos: Array.from({ length: ${trackCount} }, (_, index) => ({
+            buffer: state.mp4,
+            mimeType: "video/mp4",
+            fileName: "native-" + index + ".mp4",
+          })),
+          metadata: {
+            supportedDurationSeconds: Object.assign([1], {
+              filter(predicate) {
+                connection.projected++;
+                read();
+                return Array.prototype.filter.call(this, predicate);
+              },
+            }),
+          },
+        };
+      },
+    });
+`
 }
   },
 };`,
@@ -150,10 +208,13 @@ ${
   return {
     dir,
     config,
-    output: kind === "image" ? png : Buffer.from("synthetic native music 42"),
+    output:
+      kind === "image" ? png : kind === "video" ? mp4 : Buffer.from("synthetic native music 42"),
     connections,
     generated,
     resumeGeneration,
+    lookupStarted,
+    resumeLookup,
     withEnvironment: (run: () => Promise<void>) =>
       withEnvAsync(
         {
@@ -164,6 +225,7 @@ ${
         run,
       ),
     cleanup() {
+      resumeLookup.resolve();
       resumeGeneration.resolve();
       for (const { database } of connections) {
         if (database.isOpen) {
@@ -219,79 +281,99 @@ afterEach(() => {
 });
 afterAll(cleanupPluginLoaderFixturesForTest);
 
-describe.each(["image", "music"] as const)("prepared %s job registration resources", (kind) => {
-  const createTool = kind === "image" ? createImageGenerateTool : createMusicGenerateTool;
-  const lifecycle = kind === "image" ? imageGenerationTaskLifecycle : musicGenerationTaskLifecycle;
-  it("refuses new paid admission when the prepared owner releases during reference loading", async () => {
-    const fixture = createNativeFixture(kind, true);
-    const referenceStarted = createDeferredCore();
-    const resumeReference = createDeferredCore();
-    try {
-      await fixture.withEnvironment(async () => {
-        useNoBundledPlugins();
-        const first = await acquirePluginRegistryForInspection({ config: fixture.config });
-        const referencePath = path.join(fixture.dir, "reference.png");
-        fs.writeFileSync(referencePath, png);
-        const snapshot = await prepareSnapshot(fixture, first.registry);
-        const createTask = vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
-          taskId: "preflight-image-task",
-          runId: "preflight-image-run",
-          requesterSessionKey: "agent:main:discord:direct:synthetic-media",
-          taskLabel: "Synthetic media edit",
+describe.each(["image", "music", "video"] as const)(
+  "prepared %s job registration resources",
+  (kind) => {
+    const createTool = {
+      image: createImageGenerateTool,
+      music: createMusicGenerateTool,
+      video: createVideoGenerateTool,
+    }[kind];
+    const lifecycle = {
+      image: imageGenerationTaskLifecycle,
+      music: musicGenerationTaskLifecycle,
+      video: videoGenerationTaskLifecycle,
+    }[kind];
+    it("refuses new paid admission when the prepared owner releases during reference loading", async () => {
+      const fixture = createNativeFixture(kind, true);
+      const referenceStarted = createDeferredCore();
+      const resumeReference = createDeferredCore();
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const first = await acquirePluginRegistryForInspection({ config: fixture.config });
+          const referencePath = path.join(fixture.dir, "reference.png");
+          fs.writeFileSync(referencePath, png);
+          const snapshot = await prepareSnapshot(fixture, first.registry);
+          const createTask = vi.spyOn(lifecycle, "createTaskRun").mockReturnValue({
+            taskId: "preflight-image-task",
+            runId: "preflight-image-run",
+            requesterSessionKey: "agent:main:discord:direct:synthetic-media",
+            taskLabel: "Synthetic media edit",
+          });
+          const schedule = vi.fn();
+          const loadReference = webMedia.loadWebMedia;
+          vi.spyOn(webMedia, "loadWebMedia").mockImplementation(async (...args) => {
+            referenceStarted.resolve();
+            await resumeReference.promise;
+            return loadReference(...args);
+          });
+          const tool = createTool({
+            config: fixture.config,
+            agentDir: snapshot.agentDir,
+            workspaceDir: fixture.dir,
+            preparedModelRuntime: snapshot,
+            agentSessionKey: "agent:main:discord:direct:synthetic-media",
+            scheduleBackgroundWork: schedule,
+          });
+          const outcome = tool!
+            .execute("preflight-image-call", {
+              prompt: "Synthetic media edit",
+              image: referencePath,
+            })
+            .then(
+              (value) => ({ value, error: undefined }),
+              (error: unknown) => ({ value: undefined, error }),
+            );
+          try {
+            await Promise.race([
+              referenceStarted.promise,
+              outcome.then(() => {
+                throw new Error("Media preflight settled before reading its reference");
+              }),
+            ]);
+            await first.release();
+            resumeReference.resolve();
+            const result = await outcome;
+            expect(result.error).toBeInstanceOf(Error);
+            expect(result.value).toBeUndefined();
+            expect(createTask).not.toHaveBeenCalled();
+            expect(schedule).not.toHaveBeenCalled();
+            expect(fixture.connections[0]!.generated).toBe(0);
+            expect(fixture.connections[0]!.database.isOpen).toBe(false);
+            expect(fixture.connections[0]!.disposals).toBe(1);
+          } finally {
+            resumeReference.resolve();
+            await outcome;
+            await first.release();
+          }
         });
-        const schedule = vi.fn();
-        const loadReference = webMedia.loadWebMedia;
-        vi.spyOn(webMedia, "loadWebMedia").mockImplementation(async (...args) => {
-          referenceStarted.resolve();
-          await resumeReference.promise;
-          return loadReference(...args);
-        });
-        const tool = createTool({
-          config: fixture.config,
-          agentDir: snapshot.agentDir,
-          workspaceDir: fixture.dir,
-          preparedModelRuntime: snapshot,
-          agentSessionKey: "agent:main:discord:direct:synthetic-media",
-          scheduleBackgroundWork: schedule,
-        });
-        const outcome = tool!
-          .execute("preflight-image-call", { prompt: "Synthetic media edit", image: referencePath })
-          .then(
-            (value) => ({ value, error: undefined }),
-            (error: unknown) => ({ value: undefined, error }),
-          );
-        try {
-          await Promise.race([
-            referenceStarted.promise,
-            outcome.then(() => {
-              throw new Error("Media preflight settled before reading its reference");
-            }),
-          ]);
-          await first.release();
-          resumeReference.resolve();
-          const result = await outcome;
-          expect(result.error).toBeInstanceOf(Error);
-          expect(result.value).toBeUndefined();
-          expect(createTask).not.toHaveBeenCalled();
-          expect(schedule).not.toHaveBeenCalled();
-          expect(fixture.connections[0]!.generated).toBe(0);
-          expect(fixture.connections[0]!.database.isOpen).toBe(false);
-          expect(fixture.connections[0]!.disposals).toBe(1);
-        } finally {
-          resumeReference.resolve();
-          await outcome;
-          await first.release();
-        }
-      });
-    } finally {
-      fixture.cleanup();
-    }
-  });
+      } finally {
+        fixture.cleanup();
+      }
+    });
 
-  it.each(["queued", "saving", "rollback"] as const)(
-    "retains the admitted provider through %s after its parent releases",
-    async (phase) => {
-      const fixture = createNativeFixture(kind, false, phase === "rollback" ? 2 : 1);
+    it.each(
+      kind === "video"
+        ? (["queued", "lookup", "saving", "rollback"] as const)
+        : (["queued", "saving", "rollback"] as const),
+    )("retains the admitted provider through %s after its parent releases", async (phase) => {
+      const fixture = createNativeFixture(
+        kind,
+        false,
+        phase === "rollback" ? 2 : 1,
+        phase === "lookup",
+      );
       const saveStarted = createDeferredCore();
       const resumeSave = createDeferredCore();
       const rollbackStarted = createDeferredCore();
@@ -329,7 +411,7 @@ describe.each(["image", "music"] as const)("prepared %s job registration resourc
             let savedPath: string | undefined;
             vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async (...args) => {
               saveCalls++;
-              if (phase === "rollback" && saveCalls === 1) {
+              if (phase === "rollback" && saveCalls === (kind === "video" ? 2 : 1)) {
                 throw new Error("synthetic first media persistence failure");
               }
               saveStarted.resolve();
@@ -369,6 +451,18 @@ describe.each(["image", "music"] as const)("prepared %s job registration resourc
               expect(connection.database.isOpen).toBe(true);
             }
             completion = scheduled[0]!();
+            if (phase === "lookup") {
+              await Promise.race([
+                fixture.lookupStarted.promise,
+                completion.then(() => {
+                  throw new Error("Video task settled before model capability lookup");
+                }),
+              ]);
+              await first.release();
+              expect(connection.database.isOpen).toBe(true);
+              expect(connection.generated).toBe(0);
+              fixture.resumeLookup.resolve();
+            }
             await Promise.race([
               fixture.generated.promise,
               completion.then(() => {
@@ -382,13 +476,18 @@ describe.each(["image", "music"] as const)("prepared %s job registration resourc
                 throw new Error("Media task settled before persisting its output");
               }),
             ]);
-            await first.release();
+            if (kind !== "video" || phase !== "rollback") {
+              await first.release();
+            }
             expect(connection.database.isOpen).toBe(true);
             expect(connection.disposals).toBe(0);
             expect(fixture.connections[1]!.generated).toBe(0);
             resumeSave.resolve();
             if (phase === "rollback") {
               await rollbackStarted.promise;
+              if (kind === "video") {
+                await first.release();
+              }
               expect(connection.database.isOpen).toBe(true);
               expect(savedPath && fs.existsSync(savedPath)).toBe(true);
               resumeRollback.resolve();
@@ -414,6 +513,7 @@ describe.each(["image", "music"] as const)("prepared %s job registration resourc
               expect(fs.readFileSync(savedPath!)).toEqual(fixture.output);
             }
           } finally {
+            fixture.resumeLookup.resolve();
             fixture.resumeGeneration.resolve();
             resumeSave.resolve();
             resumeRollback.resolve();
@@ -425,6 +525,6 @@ describe.each(["image", "music"] as const)("prepared %s job registration resourc
       } finally {
         fixture.cleanup();
       }
-    },
-  );
-});
+    });
+  },
+);

--- a/src/agents/tools/media-generation-tool-providers.ts
+++ b/src/agents/tools/media-generation-tool-providers.ts
@@ -6,7 +6,10 @@ import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generati
 import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.types.js";
 
-type MediaProviderKey = "imageGenerationProviders" | "musicGenerationProviders";
+type MediaProviderKey =
+  | "imageGenerationProviders"
+  | "musicGenerationProviders"
+  | "videoGenerationProviders";
 type MediaProviderOptions = { cfg: OpenClawConfig; prepared?: PreparedModelRuntimeSnapshot };
 
 export function acquireImageGenerationToolProviders(params: MediaProviderOptions) {
@@ -17,11 +20,19 @@ export function acquireMusicGenerationToolProviders(params: MediaProviderOptions
   return acquireMediaGenerationToolProviders("musicGenerationProviders", params);
 }
 
+export function acquireVideoGenerationToolProviders(params: MediaProviderOptions) {
+  return acquireMediaGenerationToolProviders("videoGenerationProviders", params);
+}
+
 async function acquireMediaGenerationToolProviders<K extends MediaProviderKey>(
   key: K,
   params: MediaProviderOptions,
 ) {
-  const label = key === "imageGenerationProviders" ? "Image" : "Music";
+  const label = {
+    imageGenerationProviders: "Image",
+    musicGenerationProviders: "Music",
+    videoGenerationProviders: "Video",
+  }[key];
   const work = new AsyncWorkScope();
   const prepared = params.prepared;
   const inGeneration = <T>(run: () => T): T =>

--- a/src/agents/tools/video-generate-tool.execution.ts
+++ b/src/agents/tools/video-generate-tool.execution.ts
@@ -1,0 +1,452 @@
+/** Completes video reference loading, generation, and ordered media persistence. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
+import { saveMediaBuffer } from "../../media/store.js";
+import { SaveMediaSourceError } from "../../media/store.shared.js";
+import { generateVideo } from "../../video-generation/runtime.js";
+import type {
+  GeneratedVideoAsset,
+  VideoGenerationIgnoredOverride,
+  VideoGenerationProvider,
+  VideoGenerationResolution,
+  VideoGenerationSourceAsset,
+} from "../../video-generation/types.js";
+import {
+  formatGeneratedAttachmentLines,
+  sanitizeGeneratedMediaDisplayText,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
+import { ToolInputError } from "./common.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
+import {
+  videoGenerationTaskLifecycle,
+  type VideoGenerationTaskHandle,
+} from "./media-generate-background.js";
+import {
+  buildMediaReferenceDetails,
+  buildTaskRunDetails,
+  createCapabilityProviderRuntimeDeps,
+  loadMediaToolReferences,
+  normalizeMediaReferenceInputs,
+  resolveMediaToolSandboxConfig,
+} from "./media-tool-shared.js";
+
+const GENERATED_VIDEO_MEDIA_SUBDIR = "tool-video-generation";
+const GENERATED_VIDEO_PROBE_BUDGET_MS = 3000;
+const GENERATED_VIDEO_PROBE_CONCURRENCY = 2;
+const MAX_GENERATED_VIDEO_PROBES = 8;
+
+export function normalizeReferenceInputs(params: {
+  args: Record<string, unknown>;
+  singularKey: "image" | "video" | "audioRef";
+  pluralKey: "images" | "videos" | "audioRefs";
+  maxCount: number;
+}): string[] {
+  return normalizeMediaReferenceInputs({
+    args: params.args,
+    singularKey: params.singularKey,
+    pluralKey: params.pluralKey,
+    maxCount: params.maxCount,
+    label: `reference ${params.pluralKey}`,
+  });
+}
+
+export function normalizeResolution(
+  raw: string | undefined,
+): VideoGenerationResolution | undefined {
+  const normalized = raw?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  const uppercase = normalized.toUpperCase();
+  if (/^\d+P$/.test(uppercase) || /^\d+K$/.test(uppercase)) {
+    return uppercase;
+  }
+  return normalized;
+}
+
+export function normalizeAspectRatio(raw: string | undefined): string | undefined {
+  const normalized = raw?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized;
+}
+
+// Extra roles cannot align to an asset; empty or non-string slots leave its role unset.
+export function parseRoleArray(params: {
+  raw: unknown;
+  kind: "imageRoles" | "videoRoles" | "audioRoles";
+  assetCount: number;
+}): string[] {
+  if (params.raw === undefined || params.raw === null) {
+    return [];
+  }
+  if (!Array.isArray(params.raw)) {
+    throw new ToolInputError(
+      `${params.kind} must be a JSON array of role strings, parallel to the reference list.`,
+    );
+  }
+  const roles = params.raw.map((entry) => (typeof entry === "string" ? entry.trim() : ""));
+  if (roles.length > params.assetCount) {
+    throw new ToolInputError(
+      `${params.kind} has ${roles.length} entries but only ${params.assetCount} reference ${params.kind === "imageRoles" ? "image" : params.kind === "videoRoles" ? "video" : "audio"}${params.assetCount === 1 ? "" : "s"} were provided; extra roles cannot be aligned positionally.`,
+    );
+  }
+  return roles;
+}
+
+function formatIgnoredVideoGenerationOverride(override: VideoGenerationIgnoredOverride): string {
+  return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(String(override.value))}`;
+}
+
+export async function loadReferenceAssets(params: {
+  inputs: string[];
+  expectedKind: "image" | "video" | "audio";
+  maxBytes: number;
+  workspaceDir?: string;
+  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
+  ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
+}): Promise<
+  Array<{
+    sourceAsset: VideoGenerationSourceAsset;
+    resolvedInput: string;
+    rewrittenFrom?: string;
+  }>
+> {
+  const loaded = await loadMediaToolReferences<VideoGenerationSourceAsset>({
+    inputs: params.inputs,
+    toolName: "video_generate",
+    expectedKind: params.expectedKind,
+    sandbox: params.sandboxConfig,
+    workspaceDir: params.workspaceDir,
+    maxBytes: params.maxBytes,
+    ssrfPolicy: params.ssrfPolicy,
+    signal: params.signal,
+    mapMedia: (media) => ({
+      buffer: media.buffer,
+      mimeType: "mimeType" in media ? media.mimeType : media.contentType,
+      fileName: "fileName" in media ? media.fileName : undefined,
+    }),
+    mapRemote: (url) => ({ url }),
+  });
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
+    Object.assign({ sourceAsset: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
+  );
+}
+
+type LoadedReferenceAsset = Awaited<ReturnType<typeof loadReferenceAssets>>[number];
+
+type ExecutedVideoGeneration = {
+  provider: string;
+  model: string;
+  /** URLs of url-only assets that were not saved locally. */
+  urlOnlyUrls: string[];
+  /** Total generated video count, including url-only assets. */
+  count: number;
+  mediaUrls: string[];
+  attachments: AgentGeneratedAttachment[];
+  contentText: string;
+  details: Record<string, unknown>;
+  wakeResult: string;
+};
+
+function hasVideoBuffer(
+  video: GeneratedVideoAsset,
+): video is GeneratedVideoAsset & { buffer: Buffer } {
+  return Boolean(video.buffer);
+}
+
+export async function executeVideoGenerationJob(params: {
+  effectiveCfg: OpenClawConfig;
+  prompt: string;
+  agentDir?: string;
+  model?: string;
+  size?: string;
+  aspectRatio?: string;
+  resolution?: VideoGenerationResolution;
+  durationSeconds?: number;
+  audio?: boolean;
+  watermark?: boolean;
+  filename?: string;
+  loadedReferenceImages: LoadedReferenceAsset[];
+  loadedReferenceVideos: LoadedReferenceAsset[];
+  loadedReferenceAudios: LoadedReferenceAsset[];
+  taskHandle?: VideoGenerationTaskHandle | null;
+  providerOptions?: Record<string, unknown>;
+  autoProviderFallback?: boolean;
+  timeoutMs?: number;
+  providers?: VideoGenerationProvider[];
+}): Promise<ExecutedVideoGeneration> {
+  if (params.taskHandle) {
+    videoGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Generating video",
+    });
+  }
+  const result = await generateVideo(
+    {
+      cfg: params.effectiveCfg,
+      prompt: params.prompt,
+      agentDir: params.agentDir,
+      modelOverride: params.model,
+      size: params.size,
+      aspectRatio: params.aspectRatio,
+      resolution: params.resolution,
+      durationSeconds: params.durationSeconds,
+      audio: params.audio,
+      watermark: params.watermark,
+      inputImages: params.loadedReferenceImages.map((entry) => entry.sourceAsset),
+      inputVideos: params.loadedReferenceVideos.map((entry) => entry.sourceAsset),
+      inputAudios: params.loadedReferenceAudios.map((entry) => entry.sourceAsset),
+      autoProviderFallback: params.autoProviderFallback,
+      providerOptions: params.providerOptions,
+      timeoutMs: params.timeoutMs,
+    },
+    createCapabilityProviderRuntimeDeps(params.providers),
+  );
+  if (params.taskHandle) {
+    videoGenerationTaskLifecycle.recordTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Saving generated video",
+    });
+  }
+
+  type UrlVideo = { url: string; mimeType: string; fileName?: string };
+  type PersistedVideo =
+    | { kind: "saved"; media: Awaited<ReturnType<typeof saveMediaBuffer>> }
+    | { kind: "url"; media: UrlVideo };
+  const videoOrder: Array<PersistedVideo | number> = [];
+  const bufferVideos: Array<GeneratedVideoAsset & { buffer: Buffer }> = [];
+  for (const video of result.videos) {
+    if (hasVideoBuffer(video)) {
+      videoOrder.push(bufferVideos.length);
+      bufferVideos.push(video);
+      continue;
+    }
+    if (video.url) {
+      videoOrder.push({
+        kind: "url",
+        media: { url: video.url, mimeType: video.mimeType, fileName: video.fileName },
+      });
+      continue;
+    }
+    throw new Error(
+      `Provider ${result.provider} returned a video asset with neither buffer nor url — cannot deliver.`,
+    );
+  }
+
+  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "video");
+  const persistedVideos = await persistGeneratedMediaBatch<PersistedVideo>({
+    subdir: GENERATED_VIDEO_MEDIA_SUBDIR,
+    mode: "sequential",
+    saves: bufferVideos.map((video) => async () => {
+      try {
+        const savedMedia = await saveMediaBuffer(
+          video.buffer,
+          video.mimeType,
+          GENERATED_VIDEO_MEDIA_SUBDIR,
+          mediaMaxBytes,
+          params.filename || video.fileName,
+        );
+        return {
+          value: { kind: "saved" as const, media: savedMedia },
+          savedMedia,
+        };
+      } catch (error) {
+        if (video.url && error instanceof SaveMediaSourceError && error.code === "too-large") {
+          return {
+            value: {
+              kind: "url" as const,
+              media: {
+                url: video.url,
+                mimeType: video.mimeType,
+                fileName: video.fileName,
+              },
+            },
+          };
+        }
+        throw error;
+      }
+    }),
+  });
+  // Preserve provider ordinals while replacing only buffer-backed slots with persistence results.
+  const deliveredVideos = videoOrder.map((video) =>
+    typeof video === "number" ? persistedVideos[video]! : video,
+  );
+  const requestedDurationSeconds =
+    result.normalization?.durationSeconds?.requested ??
+    (typeof result.metadata?.requestedDurationSeconds === "number" &&
+    Number.isFinite(result.metadata.requestedDurationSeconds)
+      ? result.metadata.requestedDurationSeconds
+      : params.durationSeconds);
+  const ignoredOverrides = result.ignoredOverrides ?? [];
+  const ignoredOverrideKeys = new Set(ignoredOverrides.map((entry) => entry.key));
+  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
+  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
+  const warning =
+    ignoredOverrides.length > 0
+      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredVideoGenerationOverride).join(", ")}.`
+      : undefined;
+  const normalizedDurationSeconds =
+    result.normalization?.durationSeconds?.applied ??
+    (typeof result.metadata?.normalizedDurationSeconds === "number" &&
+    Number.isFinite(result.metadata.normalizedDurationSeconds)
+      ? result.metadata.normalizedDurationSeconds
+      : requestedDurationSeconds);
+  const supportedDurationSeconds =
+    result.normalization?.durationSeconds?.supportedValues ??
+    (Array.isArray(result.metadata?.supportedDurationSeconds)
+      ? result.metadata.supportedDurationSeconds.filter(
+          (entry): entry is number => typeof entry === "number" && Number.isFinite(entry),
+        )
+      : undefined);
+  const normalizedSize =
+    result.normalization?.size?.applied ??
+    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
+      ? result.metadata.normalizedSize
+      : undefined);
+  const normalizedAspectRatio =
+    result.normalization?.aspectRatio?.applied ??
+    (typeof result.metadata?.normalizedAspectRatio === "string" &&
+    result.metadata.normalizedAspectRatio.trim()
+      ? result.metadata.normalizedAspectRatio
+      : undefined);
+  const normalizedResolution =
+    result.normalization?.resolution?.applied ??
+    (typeof result.metadata?.normalizedResolution === "string" &&
+    result.metadata.normalizedResolution.trim()
+      ? result.metadata.normalizedResolution
+      : undefined);
+  const sizeTranslatedToAspectRatio =
+    result.normalization?.aspectRatio?.derivedFrom === "size" ||
+    (!normalizedSize &&
+      typeof result.metadata?.requestedSize === "string" &&
+      result.metadata.requestedSize === params.size &&
+      Boolean(normalizedAspectRatio));
+  const allMediaUrls = deliveredVideos.map((video) =>
+    video.kind === "saved" ? video.media.path : video.media.url,
+  );
+  const savedVideoMetadata = await probeMediaFilesWithinBudget(
+    deliveredVideos.flatMap((video) =>
+      video.kind === "saved" ? [{ filePath: video.media.path, kind: "video" as const }] : [],
+    ),
+    {
+      budgetMs: GENERATED_VIDEO_PROBE_BUDGET_MS,
+      concurrency: GENERATED_VIDEO_PROBE_CONCURRENCY,
+      maxProbes: MAX_GENERATED_VIDEO_PROBES,
+    },
+  );
+  let savedMetadataIndex = 0;
+  const attachments: AgentGeneratedAttachment[] = deliveredVideos.map((video) => {
+    if (video.kind === "url") {
+      return {
+        type: "video" as const,
+        url: video.media.url,
+        mimeType: video.media.mimeType,
+        name: video.media.fileName,
+        ...(typeof normalizedDurationSeconds === "number"
+          ? { durationMs: normalizedDurationSeconds * 1000 }
+          : {}),
+      };
+    }
+    return Object.assign(
+      {
+        type: "video" as const,
+        path: video.media.path,
+        mimeType: video.media.contentType,
+        name: video.media.id,
+        sizeBytes: video.media.size,
+        ...(typeof normalizedDurationSeconds === "number"
+          ? { durationMs: normalizedDurationSeconds * 1000 }
+          : {}),
+      },
+      savedVideoMetadata[savedMetadataIndex++] ?? {},
+    );
+  });
+  const lines = [
+    `Generated ${deliveredVideos.length} video${deliveredVideos.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
+    ...(warning ? [`Warning: ${warning}`] : []),
+    typeof requestedDurationSeconds === "number" &&
+    typeof normalizedDurationSeconds === "number" &&
+    requestedDurationSeconds !== normalizedDurationSeconds
+      ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${normalizedDurationSeconds}s.`
+      : null,
+    ...formatGeneratedAttachmentLines(attachments),
+  ].filter((entry): entry is string => Boolean(entry));
+
+  return {
+    provider: result.provider,
+    model: result.model,
+    urlOnlyUrls: deliveredVideos.flatMap((video) =>
+      video.kind === "url" ? [video.media.url] : [],
+    ),
+    count: deliveredVideos.length,
+    mediaUrls: allMediaUrls,
+    attachments,
+    contentText: lines.join("\n"),
+    wakeResult: lines.join("\n"),
+    details: {
+      provider: result.provider,
+      model: result.model,
+      count: deliveredVideos.length,
+      media: {
+        mediaUrls: allMediaUrls,
+        attachments,
+      },
+      attachments,
+      paths: allMediaUrls,
+      ...buildTaskRunDetails(params.taskHandle),
+      ...buildMediaReferenceDetails({
+        entries: params.loadedReferenceImages,
+        singleKey: "image",
+        pluralKey: "images",
+        getResolvedInput: (entry) => entry.resolvedInput,
+      }),
+      ...buildMediaReferenceDetails({
+        entries: params.loadedReferenceVideos,
+        singleKey: "video",
+        pluralKey: "videos",
+        getResolvedInput: (entry) => entry.resolvedInput,
+        singleRewriteKey: "videoRewrittenFrom",
+      }),
+      ...(normalizedSize ||
+      (!ignoredOverrideKeys.has("size") && params.size && !sizeTranslatedToAspectRatio)
+        ? { size: normalizedSize ?? params.size }
+        : {}),
+      ...(normalizedAspectRatio || (!ignoredOverrideKeys.has("aspectRatio") && params.aspectRatio)
+        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
+        : {}),
+      ...(normalizedResolution || (!ignoredOverrideKeys.has("resolution") && params.resolution)
+        ? { resolution: normalizedResolution ?? params.resolution }
+        : {}),
+      ...(typeof normalizedDurationSeconds === "number"
+        ? { durationSeconds: normalizedDurationSeconds }
+        : {}),
+      ...(typeof requestedDurationSeconds === "number" &&
+      typeof normalizedDurationSeconds === "number" &&
+      requestedDurationSeconds !== normalizedDurationSeconds
+        ? { requestedDurationSeconds }
+        : {}),
+      ...(supportedDurationSeconds && supportedDurationSeconds.length > 0
+        ? { supportedDurationSeconds }
+        : {}),
+      ...(!ignoredOverrideKeys.has("audio") && typeof params.audio === "boolean"
+        ? { audio: params.audio }
+        : {}),
+      ...(!ignoredOverrideKeys.has("watermark") && typeof params.watermark === "boolean"
+        ? { watermark: params.watermark }
+        : {}),
+      ...(params.filename ? { filename: params.filename } : {}),
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      attempts: result.attempts,
+      ...(result.normalization ? { normalization: result.normalization } : {}),
+      metadata: result.metadata,
+      ...(warning ? { warning } : {}),
+      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
+    },
+  };
+}

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -2,40 +2,22 @@
 import { Type, type TSchema } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseVideoGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
-import { saveMediaBuffer } from "../../media/store.js";
-import { SaveMediaSourceError } from "../../media/store.shared.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
-import {
-  generateVideo,
-  listRuntimeVideoGenerationProviders,
-} from "../../video-generation/runtime.js";
-import type {
-  VideoGenerationIgnoredOverride,
-  VideoGenerationProvider,
-  VideoGenerationResolution,
-  VideoGenerationSourceAsset,
-} from "../../video-generation/types.js";
+import { listRuntimeVideoGenerationProviders } from "../../video-generation/runtime.js";
+import type { VideoGenerationProvider } from "../../video-generation/types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import {
-  formatGeneratedAttachmentLines,
-  sanitizeGeneratedMediaDisplayText,
-  type AgentGeneratedAttachment,
-} from "../generated-attachments.js";
 import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import { getCustomProviderApiKey } from "../model-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { ToolInputError, readNumberParam, readToolStringParam } from "./common.js";
-import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import {
   hasSnapshotCapabilityProviderAvailability,
   loadCapabilityMetadataSnapshot,
@@ -50,15 +32,12 @@ import {
   videoGenerationTaskLifecycle,
   type VideoGenerationTaskHandle,
 } from "./media-generate-background.js";
+import { acquireVideoGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
-  buildTaskRunDetails,
-  createCapabilityProviderRuntimeDeps,
   hasExplicitMediaModel,
   hasGenerationToolAvailability,
-  loadMediaToolReferences,
-  normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
   resolveMediaToolSandboxConfig,
   resolveCapabilityModelConfigForTool,
@@ -78,15 +57,19 @@ import {
   createVideoGenerateListActionResult,
   createVideoGenerateStatusActionResult,
 } from "./video-generate-tool.actions.js";
+import {
+  executeVideoGenerationJob,
+  loadReferenceAssets,
+  normalizeReferenceInputs,
+  normalizeResolution,
+  normalizeAspectRatio,
+  parseRoleArray,
+} from "./video-generate-tool.execution.js";
 
 const log = createSubsystemLogger("agents/tools/video-generate");
 const MAX_INPUT_IMAGES = 9;
 const MAX_INPUT_VIDEOS = 4;
 const MAX_INPUT_AUDIOS = 3;
-const GENERATED_VIDEO_MEDIA_SUBDIR = "tool-video-generation";
-const GENERATED_VIDEO_PROBE_BUDGET_MS = 3000;
-const GENERATED_VIDEO_PROBE_CONCURRENCY = 2;
-const MAX_GENERATED_VIDEO_PROBES = 8;
 
 const VideoGenerateToolProperties = {
   action: Type.Optional(
@@ -323,71 +306,6 @@ function shouldExposeVideoReferenceAudioParams(params: {
   return false;
 }
 
-function normalizeResolution(raw: string | undefined): VideoGenerationResolution | undefined {
-  const normalized = raw?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  const uppercase = normalized.toUpperCase();
-  if (/^\d+P$/.test(uppercase) || /^\d+K$/.test(uppercase)) {
-    return uppercase;
-  }
-  return normalized;
-}
-
-function normalizeAspectRatio(raw: string | undefined): string | undefined {
-  const normalized = raw?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized;
-}
-
-/**
- * Parse a `*Roles` parallel string array for `video_generate`. Throws when
- * the caller supplies more roles than assets so off-by-one alignment bugs
- * fail loudly at the tool boundary instead of silently dropping the
- * trailing roles. Empty strings in the array are allowed and mean "no
- * role at this position". Non-string entries are coerced to empty strings
- * and treated as "unset" so providers can leave individual slots empty.
- */
-function parseRoleArray(params: {
-  raw: unknown;
-  kind: "imageRoles" | "videoRoles" | "audioRoles";
-  assetCount: number;
-}): string[] {
-  if (params.raw === undefined || params.raw === null) {
-    return [];
-  }
-  if (!Array.isArray(params.raw)) {
-    throw new ToolInputError(
-      `${params.kind} must be a JSON array of role strings, parallel to the reference list.`,
-    );
-  }
-  const roles = params.raw.map((entry) => (typeof entry === "string" ? entry.trim() : ""));
-  if (roles.length > params.assetCount) {
-    throw new ToolInputError(
-      `${params.kind} has ${roles.length} entries but only ${params.assetCount} reference ${params.kind === "imageRoles" ? "image" : params.kind === "videoRoles" ? "video" : "audio"}${params.assetCount === 1 ? "" : "s"} were provided; extra roles cannot be aligned positionally.`,
-    );
-  }
-  return roles;
-}
-
-function normalizeReferenceInputs(params: {
-  args: Record<string, unknown>;
-  singularKey: "image" | "video" | "audioRef";
-  pluralKey: "images" | "videos" | "audioRefs";
-  maxCount: number;
-}): string[] {
-  return normalizeMediaReferenceInputs({
-    args: params.args,
-    singularKey: params.singularKey,
-    pluralKey: params.pluralKey,
-    maxCount: params.maxCount,
-    label: `reference ${params.pluralKey}`,
-  });
-}
-
 function resolveSelectedVideoGenerationProvider(params: {
   config?: OpenClawConfig;
   providers?: VideoGenerationProvider[];
@@ -402,359 +320,12 @@ function resolveSelectedVideoGenerationProvider(params: {
   });
 }
 
-function formatIgnoredVideoGenerationOverride(override: VideoGenerationIgnoredOverride): string {
-  return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(String(override.value))}`;
-}
-
 type VideoGenerateSandboxConfig = MediaToolSandbox;
 
 const defaultScheduleVideoGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
   toolName: "video_generate",
   onCrash: (message, meta) => log.error(message, meta),
 });
-
-async function loadReferenceAssets(params: {
-  inputs: string[];
-  expectedKind: "image" | "video" | "audio";
-  maxBytes: number;
-  workspaceDir?: string;
-  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
-  ssrfPolicy?: SsrFPolicy;
-  signal?: AbortSignal;
-}): Promise<
-  Array<{
-    sourceAsset: VideoGenerationSourceAsset;
-    resolvedInput: string;
-    rewrittenFrom?: string;
-  }>
-> {
-  const loaded = await loadMediaToolReferences<VideoGenerationSourceAsset>({
-    inputs: params.inputs,
-    toolName: "video_generate",
-    expectedKind: params.expectedKind,
-    sandbox: params.sandboxConfig,
-    workspaceDir: params.workspaceDir,
-    maxBytes: params.maxBytes,
-    ssrfPolicy: params.ssrfPolicy,
-    signal: params.signal,
-    mapMedia: (media) => ({
-      buffer: media.buffer,
-      mimeType: "mimeType" in media ? media.mimeType : media.contentType,
-      fileName: "fileName" in media ? media.fileName : undefined,
-    }),
-    mapRemote: (url) => ({ url }),
-  });
-  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
-    Object.assign({ sourceAsset: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
-  );
-}
-
-type LoadedReferenceAsset = Awaited<ReturnType<typeof loadReferenceAssets>>[number];
-
-type ExecutedVideoGeneration = {
-  provider: string;
-  model: string;
-  /** URLs of url-only assets that were not saved locally. */
-  urlOnlyUrls: string[];
-  /** Total generated video count, including url-only assets. */
-  count: number;
-  mediaUrls: string[];
-  attachments: AgentGeneratedAttachment[];
-  contentText: string;
-  details: Record<string, unknown>;
-  wakeResult: string;
-};
-
-async function executeVideoGenerationJob(params: {
-  effectiveCfg: OpenClawConfig;
-  prompt: string;
-  agentDir?: string;
-  model?: string;
-  size?: string;
-  aspectRatio?: string;
-  resolution?: VideoGenerationResolution;
-  durationSeconds?: number;
-  audio?: boolean;
-  watermark?: boolean;
-  filename?: string;
-  loadedReferenceImages: LoadedReferenceAsset[];
-  loadedReferenceVideos: LoadedReferenceAsset[];
-  loadedReferenceAudios: LoadedReferenceAsset[];
-  taskHandle?: VideoGenerationTaskHandle | null;
-  providerOptions?: Record<string, unknown>;
-  autoProviderFallback?: boolean;
-  timeoutMs?: number;
-  providers?: VideoGenerationProvider[];
-}): Promise<ExecutedVideoGeneration> {
-  if (params.taskHandle) {
-    videoGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Generating video",
-    });
-  }
-  const result = await generateVideo(
-    {
-      cfg: params.effectiveCfg,
-      prompt: params.prompt,
-      agentDir: params.agentDir,
-      modelOverride: params.model,
-      size: params.size,
-      aspectRatio: params.aspectRatio,
-      resolution: params.resolution,
-      durationSeconds: params.durationSeconds,
-      audio: params.audio,
-      watermark: params.watermark,
-      inputImages: params.loadedReferenceImages.map((entry) => entry.sourceAsset),
-      inputVideos: params.loadedReferenceVideos.map((entry) => entry.sourceAsset),
-      inputAudios: params.loadedReferenceAudios.map((entry) => entry.sourceAsset),
-      autoProviderFallback: params.autoProviderFallback,
-      providerOptions: params.providerOptions,
-      timeoutMs: params.timeoutMs,
-    },
-    createCapabilityProviderRuntimeDeps(params.providers),
-  );
-  if (params.taskHandle) {
-    videoGenerationTaskLifecycle.recordTaskProgress({
-      handle: params.taskHandle,
-      progressSummary: "Saving generated video",
-    });
-  }
-
-  type UrlVideo = { url: string; mimeType: string; fileName?: string };
-  type PersistedVideo =
-    | { kind: "saved"; media: Awaited<ReturnType<typeof saveMediaBuffer>> }
-    | { kind: "url"; media: UrlVideo };
-  const videoOrder: Array<PersistedVideo | number> = [];
-  const bufferVideos: Array<(typeof result.videos)[number] & { buffer: Buffer }> = [];
-  for (const video of result.videos) {
-    if (video.buffer) {
-      videoOrder.push(bufferVideos.length);
-      bufferVideos.push(video as (typeof result.videos)[number] & { buffer: Buffer });
-      continue;
-    }
-    if (video.url) {
-      videoOrder.push({
-        kind: "url",
-        media: { url: video.url, mimeType: video.mimeType, fileName: video.fileName },
-      });
-      continue;
-    }
-    throw new Error(
-      `Provider ${result.provider} returned a video asset with neither buffer nor url — cannot deliver.`,
-    );
-  }
-
-  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "video");
-  const persistedVideos = await persistGeneratedMediaBatch<PersistedVideo>({
-    subdir: GENERATED_VIDEO_MEDIA_SUBDIR,
-    mode: "sequential",
-    saves: bufferVideos.map((video) => async () => {
-      try {
-        const savedMedia = await saveMediaBuffer(
-          video.buffer,
-          video.mimeType,
-          GENERATED_VIDEO_MEDIA_SUBDIR,
-          mediaMaxBytes,
-          params.filename || video.fileName,
-        );
-        return {
-          value: { kind: "saved" as const, media: savedMedia },
-          savedMedia,
-        };
-      } catch (error) {
-        if (video.url && error instanceof SaveMediaSourceError && error.code === "too-large") {
-          return {
-            value: {
-              kind: "url" as const,
-              media: {
-                url: video.url,
-                mimeType: video.mimeType,
-                fileName: video.fileName,
-              },
-            },
-          };
-        }
-        throw error;
-      }
-    }),
-  });
-  // Preserve provider ordinals while replacing only buffer-backed slots with persistence results.
-  const deliveredVideos = videoOrder.map((video) =>
-    typeof video === "number" ? persistedVideos[video]! : video,
-  );
-  const requestedDurationSeconds =
-    result.normalization?.durationSeconds?.requested ??
-    (typeof result.metadata?.requestedDurationSeconds === "number" &&
-    Number.isFinite(result.metadata.requestedDurationSeconds)
-      ? result.metadata.requestedDurationSeconds
-      : params.durationSeconds);
-  const ignoredOverrides = result.ignoredOverrides ?? [];
-  const ignoredOverrideKeys = new Set(ignoredOverrides.map((entry) => entry.key));
-  const displayProvider = sanitizeGeneratedMediaDisplayText(result.provider);
-  const displayModel = sanitizeGeneratedMediaDisplayText(result.model);
-  const warning =
-    ignoredOverrides.length > 0
-      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredVideoGenerationOverride).join(", ")}.`
-      : undefined;
-  const normalizedDurationSeconds =
-    result.normalization?.durationSeconds?.applied ??
-    (typeof result.metadata?.normalizedDurationSeconds === "number" &&
-    Number.isFinite(result.metadata.normalizedDurationSeconds)
-      ? result.metadata.normalizedDurationSeconds
-      : requestedDurationSeconds);
-  const supportedDurationSeconds =
-    result.normalization?.durationSeconds?.supportedValues ??
-    (Array.isArray(result.metadata?.supportedDurationSeconds)
-      ? result.metadata.supportedDurationSeconds.filter(
-          (entry): entry is number => typeof entry === "number" && Number.isFinite(entry),
-        )
-      : undefined);
-  const normalizedSize =
-    result.normalization?.size?.applied ??
-    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
-      ? result.metadata.normalizedSize
-      : undefined);
-  const normalizedAspectRatio =
-    result.normalization?.aspectRatio?.applied ??
-    (typeof result.metadata?.normalizedAspectRatio === "string" &&
-    result.metadata.normalizedAspectRatio.trim()
-      ? result.metadata.normalizedAspectRatio
-      : undefined);
-  const normalizedResolution =
-    result.normalization?.resolution?.applied ??
-    (typeof result.metadata?.normalizedResolution === "string" &&
-    result.metadata.normalizedResolution.trim()
-      ? result.metadata.normalizedResolution
-      : undefined);
-  const sizeTranslatedToAspectRatio =
-    result.normalization?.aspectRatio?.derivedFrom === "size" ||
-    (!normalizedSize &&
-      typeof result.metadata?.requestedSize === "string" &&
-      result.metadata.requestedSize === params.size &&
-      Boolean(normalizedAspectRatio));
-  const allMediaUrls = deliveredVideos.map((video) =>
-    video.kind === "saved" ? video.media.path : video.media.url,
-  );
-  const savedVideoMetadata = await probeMediaFilesWithinBudget(
-    deliveredVideos.flatMap((video) =>
-      video.kind === "saved" ? [{ filePath: video.media.path, kind: "video" as const }] : [],
-    ),
-    {
-      budgetMs: GENERATED_VIDEO_PROBE_BUDGET_MS,
-      concurrency: GENERATED_VIDEO_PROBE_CONCURRENCY,
-      maxProbes: MAX_GENERATED_VIDEO_PROBES,
-    },
-  );
-  let savedMetadataIndex = 0;
-  const attachments: AgentGeneratedAttachment[] = deliveredVideos.map((video) => {
-    if (video.kind === "url") {
-      return {
-        type: "video" as const,
-        url: video.media.url,
-        mimeType: video.media.mimeType,
-        name: video.media.fileName,
-        ...(typeof normalizedDurationSeconds === "number"
-          ? { durationMs: normalizedDurationSeconds * 1000 }
-          : {}),
-      };
-    }
-    return Object.assign(
-      {
-        type: "video" as const,
-        path: video.media.path,
-        mimeType: video.media.contentType,
-        name: video.media.id,
-        sizeBytes: video.media.size,
-        ...(typeof normalizedDurationSeconds === "number"
-          ? { durationMs: normalizedDurationSeconds * 1000 }
-          : {}),
-      },
-      savedVideoMetadata[savedMetadataIndex++] ?? {},
-    );
-  });
-  const lines = [
-    `Generated ${deliveredVideos.length} video${deliveredVideos.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
-    ...(warning ? [`Warning: ${warning}`] : []),
-    typeof requestedDurationSeconds === "number" &&
-    typeof normalizedDurationSeconds === "number" &&
-    requestedDurationSeconds !== normalizedDurationSeconds
-      ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${normalizedDurationSeconds}s.`
-      : null,
-    ...formatGeneratedAttachmentLines(attachments),
-  ].filter((entry): entry is string => Boolean(entry));
-
-  return {
-    provider: result.provider,
-    model: result.model,
-    urlOnlyUrls: deliveredVideos.flatMap((video) =>
-      video.kind === "url" ? [video.media.url] : [],
-    ),
-    count: deliveredVideos.length,
-    mediaUrls: allMediaUrls,
-    attachments,
-    contentText: lines.join("\n"),
-    wakeResult: lines.join("\n"),
-    details: {
-      provider: result.provider,
-      model: result.model,
-      count: deliveredVideos.length,
-      media: {
-        mediaUrls: allMediaUrls,
-        attachments,
-      },
-      attachments,
-      paths: allMediaUrls,
-      ...buildTaskRunDetails(params.taskHandle),
-      ...buildMediaReferenceDetails({
-        entries: params.loadedReferenceImages,
-        singleKey: "image",
-        pluralKey: "images",
-        getResolvedInput: (entry) => entry.resolvedInput,
-      }),
-      ...buildMediaReferenceDetails({
-        entries: params.loadedReferenceVideos,
-        singleKey: "video",
-        pluralKey: "videos",
-        getResolvedInput: (entry) => entry.resolvedInput,
-        singleRewriteKey: "videoRewrittenFrom",
-      }),
-      ...(normalizedSize ||
-      (!ignoredOverrideKeys.has("size") && params.size && !sizeTranslatedToAspectRatio)
-        ? { size: normalizedSize ?? params.size }
-        : {}),
-      ...(normalizedAspectRatio || (!ignoredOverrideKeys.has("aspectRatio") && params.aspectRatio)
-        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
-        : {}),
-      ...(normalizedResolution || (!ignoredOverrideKeys.has("resolution") && params.resolution)
-        ? { resolution: normalizedResolution ?? params.resolution }
-        : {}),
-      ...(typeof normalizedDurationSeconds === "number"
-        ? { durationSeconds: normalizedDurationSeconds }
-        : {}),
-      ...(typeof requestedDurationSeconds === "number" &&
-      typeof normalizedDurationSeconds === "number" &&
-      requestedDurationSeconds !== normalizedDurationSeconds
-        ? { requestedDurationSeconds }
-        : {}),
-      ...(supportedDurationSeconds && supportedDurationSeconds.length > 0
-        ? { supportedDurationSeconds }
-        : {}),
-      ...(!ignoredOverrideKeys.has("audio") && typeof params.audio === "boolean"
-        ? { audio: params.audio }
-        : {}),
-      ...(!ignoredOverrideKeys.has("watermark") && typeof params.watermark === "boolean"
-        ? { watermark: params.watermark }
-        : {}),
-      ...(params.filename ? { filename: params.filename } : {}),
-      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
-      attempts: result.attempts,
-      ...(result.normalization ? { normalization: result.normalization } : {}),
-      metadata: result.metadata,
-      ...(warning ? { warning } : {}),
-      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
-    },
-  };
-}
 
 export function createVideoGenerateTool(options?: {
   config?: OpenClawConfig;
@@ -831,252 +402,316 @@ export function createVideoGenerateTool(options?: {
       }
 
       const model = readToolStringParam(args, "model");
-      const videoGenerationModelConfig = resolveCapabilityModelConfigForTool({
-        cfg,
-        workspaceDir: options?.workspaceDir,
-        agentDir: options?.agentDir,
-        authStore: options?.authProfileStore,
-        modelConfig: cfg.agents?.defaults?.mediaModels?.video,
-        modelOverride: model,
-        providers: () => listRuntimeVideoGenerationProviders({ config: cfg }),
-      });
-      if (!videoGenerationModelConfig) {
-        throw new ToolInputError("No video-generation model configured.");
-      }
       const explicitModelConfig = hasExplicitMediaModel(cfg.agents?.defaults?.mediaModels?.video);
-      const effectiveCfg =
-        applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig) ?? cfg;
-      const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
-      const prompt = readToolStringParam(args, "prompt", { required: true });
-
-      const activeDuplicateGuardResult = createVideoGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, agentId: options?.requesterAgentId },
-      );
-      if (activeDuplicateGuardResult) {
-        return activeDuplicateGuardResult;
-      }
-
-      const filename = readToolStringParam(args, "filename");
-      const size = readToolStringParam(args, "size");
-      const aspectRatio = normalizeAspectRatio(readToolStringParam(args, "aspectRatio"));
-      const resolution = normalizeResolution(readToolStringParam(args, "resolution"));
-      const durationSeconds = readNumberParam(args, "durationSeconds", {
-        positiveInteger: true,
-        strict: true,
-      });
-      if (
-        durationSeconds === undefined &&
-        readSnakeCaseParamRaw(args, "durationSeconds") !== undefined
-      ) {
-        throw new ToolInputError("durationSeconds must be a positive integer");
-      }
-      const audio = readBooleanParam(args, "audio");
-      const watermark = readBooleanParam(args, "watermark");
-      const timeoutMs = readGenerationTimeoutMs(args) ?? videoGenerationModelConfig.timeoutMs;
-      // providerOptions must be a plain object. Arrays are objects in JS, so
-      // exclude them explicitly — a bogus call like `providerOptions: ["seed", 42]`
-      // would otherwise be cast to `Record<string, unknown>` with numeric-string
-      // keys and silently forwarded to the provider.
-      const providerOptionsRaw = readSnakeCaseParamRaw(args, "providerOptions");
-      if (
-        providerOptionsRaw != null &&
-        (typeof providerOptionsRaw !== "object" || Array.isArray(providerOptionsRaw))
-      ) {
-        throw new ToolInputError(
-          "providerOptions must be a JSON object keyed by provider-specific option name.",
-        );
-      }
-      const providerOptions =
-        providerOptionsRaw != null ? (providerOptionsRaw as Record<string, unknown>) : undefined;
-      const imageInputs = normalizeReferenceInputs({
-        args,
-        singularKey: "image",
-        pluralKey: "images",
-        maxCount: MAX_INPUT_IMAGES,
-      });
-      // *Roles: parallel string arrays giving each asset a semantic role hint.
-      // Use readSnakeCaseParamRaw so both camelCase and snake_case keys are accepted.
-      const imageRoles = parseRoleArray({
-        raw: readSnakeCaseParamRaw(args, "imageRoles"),
-        kind: "imageRoles",
-        assetCount: imageInputs.length,
-      });
-      const videoInputs = normalizeReferenceInputs({
-        args,
-        singularKey: "video",
-        pluralKey: "videos",
-        maxCount: MAX_INPUT_VIDEOS,
-      });
-      const videoRoles = parseRoleArray({
-        raw: readSnakeCaseParamRaw(args, "videoRoles"),
-        kind: "videoRoles",
-        assetCount: videoInputs.length,
-      });
-      const audioInputs = normalizeReferenceInputs({
-        args,
-        singularKey: "audioRef",
-        pluralKey: "audioRefs",
-        maxCount: MAX_INPUT_AUDIOS,
-      });
-      const audioRoles = parseRoleArray({
-        raw: readSnakeCaseParamRaw(args, "audioRoles"),
-        kind: "audioRoles",
-        assetCount: audioInputs.length,
-      });
-
-      const selectedProvider = resolveSelectedVideoGenerationProvider({
-        config: effectiveCfg,
-        providers: preparedProviders,
-        videoGenerationModelConfig,
-        modelOverride: model,
-      });
-      const explicitModelRef = parseVideoGenerationModelRef(model);
-      const primaryModelRef = parseVideoGenerationModelRef(videoGenerationModelConfig.primary);
-      const requestKey = buildMediaGenerationRequestKey({
-        tool: "video_generate",
-        prompt,
-        provider: selectedProvider?.id ?? explicitModelRef?.provider ?? primaryModelRef?.provider,
-        model:
-          model !== undefined
-            ? (explicitModelRef?.model ?? model)
-            : (primaryModelRef?.model ??
-              videoGenerationModelConfig.primary ??
-              selectedProvider?.defaultModel),
-        size,
-        aspectRatio,
-        resolution,
-        durationSeconds,
-        audio,
-        watermark,
-        filename,
-        providerOptions,
-        imageInputs,
-        imageRoles,
-        videoInputs,
-        videoRoles,
-        audioInputs,
-        audioRoles,
-      });
-      const duplicateGuardResult = createVideoGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt, requestKey, agentId: options?.requesterAgentId },
-      );
-      if (duplicateGuardResult) {
-        return duplicateGuardResult;
-      }
-      const loadedReferenceImages = await loadReferenceAssets({
-        inputs: imageInputs,
-        expectedKind: "image",
-        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
-        workspaceDir: options?.workspaceDir,
-        sandboxConfig,
-        ssrfPolicy: remoteMediaSsrfPolicy,
-        signal,
-      });
-      // Attach roles to the loaded image assets (positional, by index into images[]).
-      for (let i = 0; i < loadedReferenceImages.length; i++) {
-        const role = imageRoles[i];
-        const asset = loadedReferenceImages.at(i);
-        if (role && asset) {
-          asset.sourceAsset.role = role;
-        }
-      }
-      const loadedReferenceVideos = await loadReferenceAssets({
-        inputs: videoInputs,
-        expectedKind: "video",
-        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "video"),
-        workspaceDir: options?.workspaceDir,
-        sandboxConfig,
-        ssrfPolicy: remoteMediaSsrfPolicy,
-        signal,
-      });
-      for (let i = 0; i < loadedReferenceVideos.length; i++) {
-        const role = videoRoles[i];
-        const asset = loadedReferenceVideos.at(i);
-        if (role && asset) {
-          asset.sourceAsset.role = role;
-        }
-      }
-      const loadedReferenceAudios = await loadReferenceAssets({
-        inputs: audioInputs,
-        expectedKind: "audio",
-        maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "audio"),
-        workspaceDir: options?.workspaceDir,
-        sandboxConfig,
-        ssrfPolicy: remoteMediaSsrfPolicy,
-        signal,
-      });
-      for (let i = 0; i < loadedReferenceAudios.length; i++) {
-        const role = audioRoles[i];
-        const asset = loadedReferenceAudios.at(i);
-        if (role && asset) {
-          asset.sourceAsset.role = role;
-        }
-      }
-      // Accepted tasks own their paid work independently; cancellation applies only before admission.
-      signal?.throwIfAborted();
-      return runMediaGenerationTask({
-        lifecycle: videoGenerationTaskLifecycle,
-        generationLabel: "video",
-        sessionKey: options?.agentSessionKey,
-        requesterAgentId: options?.requesterAgentId,
-        requesterOrigin: options?.requesterOrigin,
-        prompt,
-        requestKey,
-        providerId: selectedProvider?.id,
-        config: effectiveCfg,
-        scheduleBackgroundWork,
-        onAsyncTaskStarted: options?.onAsyncTaskStarted,
-        onFailure: (message, meta) => log.warn(message, meta),
-        detailExtras: {
-          ...buildMediaReferenceDetails({
-            entries: loadedReferenceImages,
-            singleKey: "image",
-            pluralKey: "images",
-            getResolvedInput: (entry) => entry.resolvedInput,
-          }),
-          ...buildMediaReferenceDetails({
-            entries: loadedReferenceVideos,
-            singleKey: "video",
-            pluralKey: "videos",
-            getResolvedInput: (entry) => entry.resolvedInput,
-            singleRewriteKey: "videoRewrittenFrom",
-          }),
-          ...(model ? { model } : {}),
-          ...(size ? { size } : {}),
-          ...(aspectRatio ? { aspectRatio } : {}),
-          ...(resolution ? { resolution } : {}),
-          ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-          ...(typeof audio === "boolean" ? { audio } : {}),
-          ...(typeof watermark === "boolean" ? { watermark } : {}),
-          ...(filename ? { filename } : {}),
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        },
-        run: (taskHandle) =>
-          executeVideoGenerationJob({
-            effectiveCfg,
+      const configuredModel =
+        model || explicitModelConfig
+          ? resolveCapabilityModelConfigForTool({
+              cfg,
+              modelConfig: cfg.agents?.defaults?.mediaModels?.video,
+              modelOverride: model,
+              providers: [],
+            })
+          : null;
+      const readRequest = () => {
+        const prompt = readToolStringParam(args, "prompt", { required: true });
+        return {
+          prompt,
+          duplicate: createVideoGenerateDuplicateGuardResult(options?.agentSessionKey, {
             prompt,
-            agentDir: options?.agentDir,
-            model,
-            size,
-            aspectRatio,
-            resolution,
-            durationSeconds,
-            audio,
-            watermark,
-            filename,
-            loadedReferenceImages,
-            loadedReferenceVideos,
-            loadedReferenceAudios,
-            taskHandle,
-            providerOptions,
-            autoProviderFallback: explicitModelConfig ? false : undefined,
-            timeoutMs,
-            providers: preparedProviders,
+            agentId: options?.requesterAgentId,
           }),
-      });
+        };
+      };
+      const configuredRequest = configuredModel ? readRequest() : undefined;
+      if (configuredRequest?.duplicate) {
+        return configuredRequest.duplicate;
+      }
+      const acquired = options?.preparedModelRuntime?.acquireMediaCapabilityProviders
+        ? await acquireVideoGenerationToolProviders({
+            cfg: configuredModel
+              ? (applyAgentDefaultModelConfig(cfg, "video", configuredModel) ?? cfg)
+              : cfg,
+            prepared: options.preparedModelRuntime,
+          })
+        : undefined;
+      const providers = acquired?.providers ?? preparedProviders;
+      const prepare = async () => {
+        const videoGenerationModelConfig =
+          configuredModel ??
+          resolveCapabilityModelConfigForTool({
+            cfg,
+            workspaceDir: options?.workspaceDir,
+            agentDir: options?.agentDir,
+            authStore: options?.authProfileStore,
+            modelConfig: cfg.agents?.defaults?.mediaModels?.video,
+            modelOverride: model,
+            providers:
+              acquired?.providers ?? (() => listRuntimeVideoGenerationProviders({ config: cfg })),
+          });
+        if (!videoGenerationModelConfig) {
+          throw new ToolInputError("No video-generation model configured.");
+        }
+        const effectiveCfg =
+          applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig) ?? cfg;
+        const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+        const { prompt, duplicate } = configuredRequest ?? readRequest();
+        if (duplicate) {
+          return { kind: "result" as const, result: duplicate };
+        }
+
+        const filename = readToolStringParam(args, "filename");
+        const size = readToolStringParam(args, "size");
+        const aspectRatio = normalizeAspectRatio(readToolStringParam(args, "aspectRatio"));
+        const resolution = normalizeResolution(readToolStringParam(args, "resolution"));
+        const durationSeconds = readNumberParam(args, "durationSeconds", {
+          positiveInteger: true,
+          strict: true,
+        });
+        if (
+          durationSeconds === undefined &&
+          readSnakeCaseParamRaw(args, "durationSeconds") !== undefined
+        ) {
+          throw new ToolInputError("durationSeconds must be a positive integer");
+        }
+        const audio = readBooleanParam(args, "audio");
+        const watermark = readBooleanParam(args, "watermark");
+        const timeoutMs = readGenerationTimeoutMs(args) ?? videoGenerationModelConfig.timeoutMs;
+        // providerOptions must be a plain object. Arrays are objects in JS, so
+        // exclude them explicitly — a bogus call like `providerOptions: ["seed", 42]`
+        // would otherwise be cast to `Record<string, unknown>` with numeric-string
+        // keys and silently forwarded to the provider.
+        const providerOptionsRaw = readSnakeCaseParamRaw(args, "providerOptions");
+        if (
+          providerOptionsRaw != null &&
+          (typeof providerOptionsRaw !== "object" || Array.isArray(providerOptionsRaw))
+        ) {
+          throw new ToolInputError(
+            "providerOptions must be a JSON object keyed by provider-specific option name.",
+          );
+        }
+        const providerOptions =
+          providerOptionsRaw != null ? (providerOptionsRaw as Record<string, unknown>) : undefined;
+        const imageInputs = normalizeReferenceInputs({
+          args,
+          singularKey: "image",
+          pluralKey: "images",
+          maxCount: MAX_INPUT_IMAGES,
+        });
+        // *Roles: parallel string arrays giving each asset a semantic role hint.
+        // Use readSnakeCaseParamRaw so both camelCase and snake_case keys are accepted.
+        const imageRoles = parseRoleArray({
+          raw: readSnakeCaseParamRaw(args, "imageRoles"),
+          kind: "imageRoles",
+          assetCount: imageInputs.length,
+        });
+        const videoInputs = normalizeReferenceInputs({
+          args,
+          singularKey: "video",
+          pluralKey: "videos",
+          maxCount: MAX_INPUT_VIDEOS,
+        });
+        const videoRoles = parseRoleArray({
+          raw: readSnakeCaseParamRaw(args, "videoRoles"),
+          kind: "videoRoles",
+          assetCount: videoInputs.length,
+        });
+        const audioInputs = normalizeReferenceInputs({
+          args,
+          singularKey: "audioRef",
+          pluralKey: "audioRefs",
+          maxCount: MAX_INPUT_AUDIOS,
+        });
+        const audioRoles = parseRoleArray({
+          raw: readSnakeCaseParamRaw(args, "audioRoles"),
+          kind: "audioRoles",
+          assetCount: audioInputs.length,
+        });
+
+        const selectedProvider = resolveSelectedVideoGenerationProvider({
+          config: effectiveCfg,
+          providers,
+          videoGenerationModelConfig,
+          modelOverride: model,
+        });
+        const explicitModelRef = parseVideoGenerationModelRef(model);
+        const primaryModelRef = parseVideoGenerationModelRef(videoGenerationModelConfig.primary);
+        const requestKey = buildMediaGenerationRequestKey({
+          tool: "video_generate",
+          prompt,
+          provider: selectedProvider?.id ?? explicitModelRef?.provider ?? primaryModelRef?.provider,
+          model:
+            model !== undefined
+              ? (explicitModelRef?.model ?? model)
+              : (primaryModelRef?.model ??
+                videoGenerationModelConfig.primary ??
+                selectedProvider?.defaultModel),
+          size,
+          aspectRatio,
+          resolution,
+          durationSeconds,
+          audio,
+          watermark,
+          filename,
+          providerOptions,
+          imageInputs,
+          imageRoles,
+          videoInputs,
+          videoRoles,
+          audioInputs,
+          audioRoles,
+        });
+        const duplicateGuardResult = createVideoGenerateDuplicateGuardResult(
+          options?.agentSessionKey,
+          { prompt, requestKey, agentId: options?.requesterAgentId },
+        );
+        if (duplicateGuardResult) {
+          return { kind: "result" as const, result: duplicateGuardResult };
+        }
+        const loadedReferenceImages = await loadReferenceAssets({
+          inputs: imageInputs,
+          expectedKind: "image",
+          maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
+          workspaceDir: options?.workspaceDir,
+          sandboxConfig,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          signal,
+        });
+        // Attach roles to the loaded image assets (positional, by index into images[]).
+        for (let i = 0; i < loadedReferenceImages.length; i++) {
+          const role = imageRoles[i];
+          const asset = loadedReferenceImages.at(i);
+          if (role && asset) {
+            asset.sourceAsset.role = role;
+          }
+        }
+        const loadedReferenceVideos = await loadReferenceAssets({
+          inputs: videoInputs,
+          expectedKind: "video",
+          maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "video"),
+          workspaceDir: options?.workspaceDir,
+          sandboxConfig,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          signal,
+        });
+        for (let i = 0; i < loadedReferenceVideos.length; i++) {
+          const role = videoRoles[i];
+          const asset = loadedReferenceVideos.at(i);
+          if (role && asset) {
+            asset.sourceAsset.role = role;
+          }
+        }
+        const loadedReferenceAudios = await loadReferenceAssets({
+          inputs: audioInputs,
+          expectedKind: "audio",
+          maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "audio"),
+          workspaceDir: options?.workspaceDir,
+          sandboxConfig,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          signal,
+        });
+        for (let i = 0; i < loadedReferenceAudios.length; i++) {
+          const role = audioRoles[i];
+          const asset = loadedReferenceAudios.at(i);
+          if (role && asset) {
+            asset.sourceAsset.role = role;
+          }
+        }
+        return {
+          kind: "task" as const,
+          params: {
+            lifecycle: videoGenerationTaskLifecycle,
+            generationLabel: "video" as const,
+            sessionKey: options?.agentSessionKey,
+            requesterAgentId: options?.requesterAgentId,
+            requesterOrigin: options?.requesterOrigin,
+            prompt,
+            requestKey,
+            providerId: selectedProvider?.id,
+            config: effectiveCfg,
+            scheduleBackgroundWork,
+            onAsyncTaskStarted: options?.onAsyncTaskStarted,
+            onFailure: (message: string, meta?: Record<string, unknown>) => log.warn(message, meta),
+            detailExtras: {
+              ...buildMediaReferenceDetails({
+                entries: loadedReferenceImages,
+                singleKey: "image",
+                pluralKey: "images",
+                getResolvedInput: (entry) => entry.resolvedInput,
+              }),
+              ...buildMediaReferenceDetails({
+                entries: loadedReferenceVideos,
+                singleKey: "video",
+                pluralKey: "videos",
+                getResolvedInput: (entry) => entry.resolvedInput,
+                singleRewriteKey: "videoRewrittenFrom",
+              }),
+              ...(model ? { model } : {}),
+              ...(size ? { size } : {}),
+              ...(aspectRatio ? { aspectRatio } : {}),
+              ...(resolution ? { resolution } : {}),
+              ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
+              ...(typeof audio === "boolean" ? { audio } : {}),
+              ...(typeof watermark === "boolean" ? { watermark } : {}),
+              ...(filename ? { filename } : {}),
+              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+            },
+            run: (taskHandle: VideoGenerationTaskHandle | null) =>
+              executeVideoGenerationJob({
+                effectiveCfg,
+                prompt,
+                agentDir: options?.agentDir,
+                model,
+                size,
+                aspectRatio,
+                resolution,
+                durationSeconds,
+                audio,
+                watermark,
+                filename,
+                loadedReferenceImages,
+                loadedReferenceVideos,
+                loadedReferenceAudios,
+                taskHandle,
+                providerOptions,
+                autoProviderFallback: explicitModelConfig ? false : undefined,
+                timeoutMs,
+                providers,
+              }),
+          },
+        };
+      };
+      let prepared: Awaited<ReturnType<typeof prepare>>;
+      try {
+        acquired?.assertOpen();
+        prepared = acquired ? await acquired.run(prepare) : await prepare();
+        if (prepared.kind === "task") {
+          // Accepted tasks own paid work independently; cancellation applies before admission.
+          signal?.throwIfAborted();
+          acquired?.assertOpen();
+        }
+      } catch (error) {
+        let cleanupFailure: { error: unknown } | undefined;
+        try {
+          await acquired?.release();
+        } catch (cleanupError) {
+          cleanupFailure = { error: cleanupError };
+        }
+        if (cleanupFailure) {
+          throw new AggregateError(
+            [error, cleanupFailure.error],
+            "Video preflight and cleanup failed",
+            {
+              cause: error,
+            },
+          );
+        }
+        throw error;
+      }
+      if (prepared.kind === "result") {
+        await acquired?.release();
+        return prepared.result;
+      }
+      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Prepared video tools can lose their original plugin resources while an accepted job is queued, generating, or saving its results. Preflight can also admit a new job after its original provider setup retires.

## Why This Change Was Made

Video uses the shared prepared-media acquisition owner already used by Image and Music. Preflight retains and checks the original setup, then transfers its claim to the existing accepted-job runner through actual capability lookup, generation, persistence and rollback. Completed media remains available after the provider resources close.

Existing execution and reference helpers move into a leaf module to keep the tool within its size limit. The buffer guard uses an actual type predicate while preserving the original asset objects and buffer-read timing. Both baseline changes are exact reductions.

## User Impact

Accepted prepared video jobs finish with the providers they captured, while new jobs refuse retired setups. Existing raw/default provider ownership, options, references, and mixed URL/file result ordering retain their behavior.

## Evidence

- Original production failed five native Video cases: retirement during local-reference preflight and premature SQLite closure while queued, resolving capabilities, saving, and rolling back. All eight Image/Music controls passed. All 13 cases pass with the repair.
- 137 relevant sibling tests and a final 62-test run passed; counts overlap. All required changed-file stages passed, including repaired lint and exact ratchet reductions. Independent Codex review through P2 found no actionable findings.
- Ordinary build passed in 295.13 seconds. The built public agent-harness SDK consumed source-produced prepared facts and acknowledged a detached job in 20.8 ms. It persisted a valid MP4, retained URL/file/URL order, completed late metadata access, disposed the original SQLite source once, and reopened its persisted marker. A replacement provider was never invoked; retired preflight refused new admission.
- The strict managed proof completed in 131.26 seconds with source and 11,681 built artifacts unchanged. Generation succeeded; without a delivery runtime, the existing 120-second handoff ended with blocked delivery and retained media. This is synthetic native-resource/built-SDK proof, not a paid-provider or packaged-only test.
