### PR TITLE
refactor(tests): share mutable ACP metadata upserts

### DIFF
--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -1,6 +1,7 @@
 /** Tests ACP runtime mode/config option persistence and backend control calls. */
 import { describe, expect, it, vi } from "vitest";
 import {
+  installMutableAcpSessionMetaUpsert,
   type AcpRuntime,
   AcpRuntimeError,
   AcpSessionManager,
@@ -58,10 +59,12 @@ describe("AcpSessionManager runtime config", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta(),
-      runtimeOptions: {
-        runtimeMode: "plan",
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: {
+        ...readySessionMeta(),
+        runtimeOptions: {
+          runtimeMode: "plan",
+        },
       },
     };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
@@ -70,26 +73,10 @@ describe("AcpSessionManager runtime config", () => {
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await manager.setSessionConfigOption({
@@ -134,14 +121,16 @@ describe("AcpSessionManager runtime config", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta(),
-      identity: {
-        state: "resolved",
-        source: "status",
-        acpxSessionId: "acpx-stale",
-        agentSessionId: "agent-stale",
-        lastUpdatedAt: Date.now(),
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: {
+        ...readySessionMeta(),
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxSessionId: "acpx-stale",
+          agentSessionId: "agent-stale",
+          lastUpdatedAt: Date.now(),
+        },
       },
     };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
@@ -150,26 +139,10 @@ describe("AcpSessionManager runtime config", () => {
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await manager.runTurn({
@@ -182,8 +155,8 @@ describe("AcpSessionManager runtime config", () => {
     });
 
     expect(runtimeState.getStatus).toHaveBeenCalledTimes(1);
-    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-fresh");
-    expect(currentMeta.identity?.agentSessionId).toBe("agent-fresh");
+    expect(metaState.currentMeta.identity?.acpxSessionId).toBe("acpx-fresh");
+    expect(metaState.currentMeta.identity?.agentSessionId).toBe("agent-fresh");
   });
 
   it("reconciles oneshot ACP identity from runtime status before closing after a turn", async () => {
@@ -205,33 +178,17 @@ describe("AcpSessionManager runtime config", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta | undefined;
+    const metaState: { currentMeta: SessionAcpMeta | undefined } = { currentMeta: undefined };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
       const sessionKey =
         (paramsUnknown as { sessionKey?: string }).sessionKey ?? "agent:codex:acp:session-1";
       return {
         sessionKey,
         storeSessionKey: sessionKey,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await manager.initializeSession({
@@ -241,7 +198,7 @@ describe("AcpSessionManager runtime config", () => {
       mode: "oneshot",
     });
 
-    expectRecordFields(currentMeta?.identity, {
+    expectRecordFields(metaState.currentMeta?.identity, {
       state: "pending",
       acpxSessionId: "acpx-oneshot",
       source: "ensure",
@@ -265,7 +222,7 @@ describe("AcpSessionManager runtime config", () => {
       backendSessionId: "acpx-oneshot",
       agentSessionId: "agent-oneshot",
     });
-    expectRecordFields(currentMeta?.identity, {
+    expectRecordFields(metaState.currentMeta?.identity, {
       state: "resolved",
       acpxSessionId: "acpx-oneshot",
       agentSessionId: "agent-oneshot",
@@ -299,14 +256,16 @@ describe("AcpSessionManager runtime config", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta(),
-      agent: "gemini",
-      identity: {
-        state: "pending",
-        source: "ensure",
-        acpxSessionId: "acpx-stale",
-        lastUpdatedAt: Date.now(),
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: {
+        ...readySessionMeta(),
+        agent: "gemini",
+        identity: {
+          state: "pending",
+          source: "ensure",
+          acpxSessionId: "acpx-stale",
+          lastUpdatedAt: Date.now(),
+        },
       },
     };
     const sessionKey = "agent:gemini:acp:session-1";
@@ -315,26 +274,10 @@ describe("AcpSessionManager runtime config", () => {
       return {
         sessionKey: key,
         storeSessionKey: key,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await manager.runTurn({
@@ -346,9 +289,9 @@ describe("AcpSessionManager runtime config", () => {
       requestId: "run-prompt-learned-agent-id",
     });
 
-    expect(currentMeta.identity?.state).toBe("resolved");
-    expect(currentMeta.identity?.agentSessionId).toBe("gemini-session-1");
-    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-stale");
+    expect(metaState.currentMeta.identity?.state).toBe("resolved");
+    expect(metaState.currentMeta.identity?.agentSessionId).toBe("gemini-session-1");
+    expect(metaState.currentMeta.identity?.acpxSessionId).toBe("acpx-stale");
   });
 
   it("preserves existing ACP session identifiers when ensure returns none", async () => {

--- a/src/acp/control-plane/manager.runtime-handles.test.ts
+++ b/src/acp/control-plane/manager.runtime-handles.test.ts
@@ -1,6 +1,7 @@
 /** Tests ACP runtime handle caching, reuse, re-ensure, and lifecycle cleanup. */
 import { describe, expect, it, vi } from "vitest";
 import {
+  installMutableAcpSessionMetaUpsert,
   AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
@@ -971,15 +972,17 @@ describe("AcpSessionManager runtime handles", () => {
       runtime: runtimeState.runtime,
     });
     const sessionKey = "agent:codex:acp:binding:demo-binding:default:retry-fresh";
-    let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta(),
-      runtimeSessionName: sessionKey,
-      identity: {
-        state: "resolved",
-        source: "status",
-        acpxSessionId: "acpx-sid-stale",
-        agentSessionId: "agent-sid-stale",
-        lastUpdatedAt: Date.now(),
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: {
+        ...readySessionMeta(),
+        runtimeSessionName: sessionKey,
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxSessionId: "acpx-sid-stale",
+          agentSessionId: "agent-sid-stale",
+          lastUpdatedAt: Date.now(),
+        },
       },
     };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
@@ -987,26 +990,10 @@ describe("AcpSessionManager runtime handles", () => {
       return {
         sessionKey: key,
         storeSessionKey: key,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await manager.runTurn({
@@ -1031,7 +1018,7 @@ describe("AcpSessionManager runtime handles", () => {
       backendSessionId: "acpx-sid-fresh",
     });
     expect(handle.agentSessionId).toBeUndefined();
-    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-sid-fresh");
-    expect(currentMeta.identity?.agentSessionId).toBeUndefined();
+    expect(metaState.currentMeta.identity?.acpxSessionId).toBe("acpx-sid-fresh");
+    expect(metaState.currentMeta.identity?.agentSessionId).toBeUndefined();
   });
 });

--- a/src/acp/control-plane/manager.startup-identity-reconcile.test.ts
+++ b/src/acp/control-plane/manager.startup-identity-reconcile.test.ts
@@ -1,6 +1,7 @@
 /** Tests startup reconciliation of pending ACP session identities. */
 import { describe, expect, it } from "vitest";
 import {
+  installMutableAcpSessionMetaUpsert,
   AcpSessionManager,
   baseCfg,
   createRuntime,
@@ -27,13 +28,15 @@ describe("AcpSessionManager startup identity reconcile", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta(),
-      identity: {
-        state: "pending",
-        source: "ensure",
-        acpxSessionId: "acpx-stale",
-        lastUpdatedAt: Date.now(),
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: {
+        ...readySessionMeta(),
+        identity: {
+          state: "pending",
+          source: "ensure",
+          acpxSessionId: "acpx-stale",
+          lastUpdatedAt: Date.now(),
+        },
       },
     };
     const sessionKey = "agent:codex:acp:session-1";
@@ -46,9 +49,9 @@ describe("AcpSessionManager startup identity reconcile", () => {
         entry: {
           sessionId: "session-1",
           updatedAt: Date.now(),
-          acp: currentMeta,
+          acp: metaState.currentMeta,
         },
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       },
     ]);
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
@@ -56,35 +59,19 @@ describe("AcpSessionManager startup identity reconcile", () => {
       return {
         sessionKey: key,
         storeSessionKey: key,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     const result = await manager.reconcilePendingSessionIdentities({ cfg: baseCfg });
 
     expect(result).toEqual({ checked: 1, resolved: 1, failed: 0 });
-    expect(currentMeta.identity?.state).toBe("resolved");
-    expect(currentMeta.identity?.acpxRecordId).toBe("acpx-record-1");
-    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-session-1");
-    expect(currentMeta.identity?.agentSessionId).toBe("agent-session-1");
+    expect(metaState.currentMeta.identity?.state).toBe("resolved");
+    expect(metaState.currentMeta.identity?.acpxRecordId).toBe("acpx-record-1");
+    expect(metaState.currentMeta.identity?.acpxSessionId).toBe("acpx-session-1");
+    expect(metaState.currentMeta.identity?.agentSessionId).toBe("agent-session-1");
   });
 
   it("skips startup reconcile for pending identities without stable runtime ids", async () => {

--- a/src/acp/control-plane/manager.test-helpers.ts
+++ b/src/acp/control-plane/manager.test-helpers.ts
@@ -345,3 +345,25 @@ export function installAcpSessionManagerTestLifecycle(): void {
     resetAcpManagerTaskStateForTests();
   });
 }
+
+export function installMutableAcpSessionMetaUpsert(state: {
+  currentMeta: SessionAcpMeta | undefined;
+}): void {
+  hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+    const params = paramsUnknown as {
+      mutate: (
+        current: SessionAcpMeta | undefined,
+        entry: { acp?: SessionAcpMeta } | undefined,
+      ) => SessionAcpMeta | null | undefined;
+    };
+    const next = params.mutate(state.currentMeta, { acp: state.currentMeta });
+    if (next) {
+      state.currentMeta = next;
+    }
+    return {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      acp: state.currentMeta,
+    };
+  });
+}

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -14,6 +14,7 @@ import { listSessionStateEventsSince } from "../../sessions/session-state-events
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { isAcpTurnActive } from "./active-turns.js";
 import {
+  installMutableAcpSessionMetaUpsert,
   AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
@@ -1208,40 +1209,26 @@ describe("AcpSessionManager", () => {
       runtime: runtimeState.runtime,
     });
 
-    let currentMeta: SessionAcpMeta = readySessionMeta({
-      agent: "claude",
-      identity: {
-        state: "pending",
-        acpxRecordId: sessionKey,
-        source: "status",
-        lastUpdatedAt: Date.now(),
-      },
-    });
+    const metaState: { currentMeta: SessionAcpMeta } = {
+      currentMeta: readySessionMeta({
+        agent: "claude",
+        identity: {
+          state: "pending",
+          acpxRecordId: sessionKey,
+          source: "status",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
       const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? sessionKey;
       return {
         sessionKey: key,
         storeSessionKey: key,
-        acp: currentMeta,
+        acp: metaState.currentMeta,
       };
     });
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta } | undefined,
-        ) => SessionAcpMeta | null | undefined;
-      };
-      const next = params.mutate(currentMeta, { acp: currentMeta });
-      if (next) {
-        currentMeta = next;
-      }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
-    });
+    installMutableAcpSessionMetaUpsert(metaState);
 
     const manager = new AcpSessionManager();
     await expect(


### PR DESCRIPTION
Related: #139428.

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Seven ACP manager tests repeat the same persistent metadata upsert mock, making its state semantics harder to maintain consistently.

## Why This Change Was Made

Share the upsert implementation through the existing private test harness. Each case keeps its own explicitly typed state holder, initial metadata, read callbacks, and independent expectations. Preserve null/undefined retention, truthy replacement, timestamps, async settlement, and startup-list snapshots.

## User Impact

No production behavior changes. The cleanup removes 74 net test/support lines while retaining every scenario and assertion.

## Evidence

- Four complete suites passed 75 tests before and after, with identical ordered names and statuses.
- Seven original/new callback pairs matched replacement, null, undefined, in-place mutation, thrown errors, timestamps, live reads, initial-list snapshots, and microtask order.
- Expanded consumer ASTs match the originals; existing harness helpers remain intact.
- Mapped changed checks and independent review passed.

No runtime improvement is claimed.
