### PR TITLE
fix(cli): treat agent selection refusals as expected CLI conditions

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1102,10 +1102,15 @@ describe("capability cli", () => {
       },
     });
 
-    await expect(runCapability("audio", "providers", "--json")).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("inference provider inspection has no explicit owner");
-    expectRuntimeErrorContains("Pass --agent <id> or set agents.defaults.systemAgent.agentId");
+    // Agent selection is an expected CLI condition rendered by the root failure
+    // owner; the command rethrows instead of printing its own copy.
+    await expect(runCapability("audio", "providers", "--json")).rejects.toMatchObject({
+      name: "AgentSelectionRequiredError",
+      message: expect.stringMatching(
+        /inference provider inspection has no explicit owner[\s\S]*Pass --agent <id> or set agents\.defaults\.systemAgent\.agentId/,
+      ),
+    });
+    expect(runtimeErrorMessages()).toEqual([]);
     expect(mocks.loadAuthProfileStoreForRuntime).not.toHaveBeenCalled();
   });
 
@@ -1262,11 +1267,13 @@ describe("capability cli", () => {
 
     await expect(
       runCapability("model", "run", "--local", "--prompt", "hi", "--json"),
-    ).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("infer model run");
-    expectRuntimeErrorContains("--agent");
-    expectRuntimeErrorContains("agents.defaults.systemAgent.agentId");
+    ).rejects.toMatchObject({
+      name: "AgentSelectionRequiredError",
+      message: expect.stringMatching(
+        /infer model run[\s\S]*--agent[\s\S]*agents\.defaults\.systemAgent\.agentId/,
+      ),
+    });
+    expect(runtimeErrorMessages()).toEqual([]);
   });
 
   it("lets explicit model run agents override the system agent", async () => {
@@ -2149,9 +2156,11 @@ describe("capability cli", () => {
 
     await expect(
       runCapability("image", "generate", "--prompt", "friendly lobster", "--json"),
-    ).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("Multiple agents are configured");
+    ).rejects.toMatchObject({
+      name: "AgentSelectionRequiredError",
+      message: expect.stringContaining("Multiple agents are configured"),
+    });
+    expect(runtimeErrorMessages()).toEqual([]);
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 

--- a/src/cli/channel-auth.owner.integration.test.ts
+++ b/src/cli/channel-auth.owner.integration.test.ts
@@ -143,12 +143,15 @@ describe.each(["login", "logout"])("channels %s owner", (mode) => {
   });
 
   it("keeps an ownerless fleet from reaching either auth action", async () => {
-    await runAuth(mode);
+    // Agent selection is an expected CLI condition rendered by the root failure
+    // owner; the command rethrows instead of printing its own copy.
+    await expect(runAuth(mode)).rejects.toMatchObject({
+      name: "AgentSelectionRequiredError",
+      message: expect.stringContaining("no explicit owner"),
+    });
 
-    expect(fixture.runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("no explicit owner"),
-    );
-    expect(fixture.runtime.exit).toHaveBeenCalledWith(1);
+    expect(fixture.runtime.error).not.toHaveBeenCalled();
+    expect(fixture.runtime.exit).not.toHaveBeenCalled();
     expect(fixture.catalog).not.toHaveBeenCalled();
     expect(fixture.login).not.toHaveBeenCalled();
     expect(fixture.logout).not.toHaveBeenCalled();

--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,5 +1,6 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
+import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 import { ConfigReadOnlyError, NixModeConfigMutationError } from "../config/config-write-guard.js";
 import {
   GatewayCredentialsRequiredError,
@@ -228,6 +229,14 @@ describe("formatCliFailureLines", () => {
     {
       label: "Nix-managed config",
       createError: () => new NixModeConfigMutationError({ configPath: "/tmp/openclaw.json" }),
+    },
+    {
+      label: "missing agent selection",
+      createError: () =>
+        new AgentSelectionRequiredError(["main", "analyst"], {
+          surface: "the skills command",
+          hint: "Pass --agent <id>.",
+        }),
     },
     {
       label: "unreachable gateway",

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -91,6 +91,13 @@ function isGatewayExplicitAuthCliError(error: unknown): error is Error {
   return error instanceof Error && error.name === "GatewayExplicitAuthRequiredError";
 }
 
+function isAgentSelectionCliError(error: unknown): error is Error {
+  // Multi-agent selection refusals (src/agents/agent-scope-config.ts) already name
+  // the surface and its --agent remedy; crash framing would send operators to a
+  // stack trace and `openclaw doctor` for a missing flag.
+  return error instanceof Error && error.name === "AgentSelectionRequiredError";
+}
+
 function isImmutableConfigCliError(error: unknown): error is Error {
   // Config write-guard refusals (src/config/config-write-guard.ts) already carry the
   // redeploy remedy; crash framing would point operators at a stack trace and
@@ -107,6 +114,7 @@ export function isExpectedCliError(error: unknown): error is Error {
     isGatewayCredentialsCliError(error) ||
     isGatewayExplicitAuthCliError(error) ||
     isImmutableConfigCliError(error) ||
+    isAgentSelectionCliError(error) ||
     isGatewayTransportError(error)
   );
 }

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1848,17 +1848,21 @@ describe("skills cli commands", () => {
     expectStatusWorkspaceCall("/tmp/workspace-main");
   });
 
-  it("renders the supported skills escape without advertising --all-agents", async () => {
+  it("hands the supported skills escape to the CLI failure owner without --all-agents", async () => {
     resolveDefaultAgentIdMock.mockImplementationOnce((_config, context) => {
       throw new AgentSelectionRequiredError(["main", "helper", "third"], context);
     });
 
-    await expect(runCommand(["skills", "list"])).rejects.toThrow("__exit__:1");
-
-    expect(runtimeErrors).toStrictEqual([
-      "Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>.",
-    ]);
-    expect(runtimeErrors[0]).not.toContain("--all-agents");
+    // Agent selection is an expected CLI condition; the root failure owner renders it
+    // without crash framing, so the command must not print a second copy.
+    await expect(runCommand(["skills", "list"])).rejects.toThrow(
+      expect.objectContaining({
+        name: "AgentSelectionRequiredError",
+        message:
+          "Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>.",
+      }),
+    );
+    expect(runtimeErrors).toStrictEqual([]);
   });
 
   it("redacts secrets from rendered skills CLI errors", async () => {

--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -129,23 +129,19 @@ describe("system-cli", () => {
   it.each([
     { mode: "human", args: ["system", "event", "--text", "hello"] },
     { mode: "JSON", args: ["system", "event", "--text", "hello", "--json"] },
-  ])("renders named errors without class names in $mode mode", async ({ mode, args }) => {
+  ])("hands agent selection refusals to the CLI failure owner in $mode mode", async ({ args }) => {
     const error = new Error("Multiple agents are configured, but this operation has no owner.");
     error.name = "AgentSelectionRequiredError";
     callGatewayFromCli.mockRejectedValueOnce(error);
 
-    await runCli(args);
+    // The root failure owner renders expected conditions without crash framing;
+    // the command must rethrow instead of printing its own copy.
+    await expect(runCli(args)).rejects.toBe(error);
 
-    if (mode === "JSON") {
-      const payload = JSON.parse(runtimeLogs.at(-1) ?? "");
-      expect(payload).toEqual(jsonFailure(error.message));
-      expect(runtimeErrors).toEqual([]);
-    } else {
-      expect(runtimeErrors).toEqual([error.message]);
-      expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
-    }
-    expect([...runtimeLogs, ...runtimeErrors].join("\n")).not.toContain(error.name);
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(runtimeLogs).toEqual([]);
+    expect(runtimeErrors).toEqual([]);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
   });
 
   it("forwards --session-key on system event", async () => {

--- a/src/commands/session-store-targets.test.ts
+++ b/src/commands/session-store-targets.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import { resolveCommandSessionStoreTargets } from "./session-store-targets.js";
 
@@ -46,6 +47,21 @@ describe("resolveCommandSessionStoreTargets", () => {
 
     expect(targets).toEqual([{ agentId: "main", storePath: "/tmp/main-sessions.json" }]);
     expect(resolveSessionStoreTargetsMock).toHaveBeenCalledWith({}, {});
+  });
+
+  it("keeps agent selection refusals typed with the session-store surface", () => {
+    resolveSessionStoreTargetsMock.mockImplementation(() => {
+      throw new AgentSelectionRequiredError(["main", "analyst"]);
+    });
+    expect(() => resolveCommandSessionStoreTargets({ cfg: {}, opts: {} })).toThrow(
+      expect.objectContaining({
+        name: "AgentSelectionRequiredError",
+        agentIds: ["main", "analyst"],
+        message: expect.stringContaining(
+          "session-store selection has no explicit owner. Pass --agent <id> to select one agent, or --all-agents",
+        ),
+      }),
+    );
   });
 
   it("hands resolution errors to the CLI failure owner", () => {

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -117,11 +117,12 @@ export function resolveCommandSessionStoreTargets(params: {
       },
     ];
   } catch (error) {
-    const message = formatErrorMessage(
-      error instanceof AgentSelectionRequiredError
-        ? new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT)
-        : error,
-    );
+    // The shared CLI failure owner already treats agent selection as an operator
+    // error; only the session-store surface wording is added here.
+    if (error instanceof AgentSelectionRequiredError) {
+      throw new AgentSelectionRequiredError(error.agentIds, SESSION_STORE_SELECTION_CONTEXT);
+    }
+    const message = formatErrorMessage(error);
     throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
   }
 }

--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -1,6 +1,6 @@
 // Sessions default-agent store tests cover default session-store selection and runtime config loading.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ExpectedCliError } from "../cli/failure-output.js";
+import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn());
@@ -213,7 +213,7 @@ describe("sessionsCommand default store agent selection", () => {
     const { runtime } = createRuntime();
 
     const result = sessionsCommand({}, runtime);
-    await expect(result).rejects.toBeInstanceOf(ExpectedCliError);
+    await expect(result).rejects.toBeInstanceOf(AgentSelectionRequiredError);
     await expect(result).rejects.toMatchObject({
       message:
         "Multiple agents are configured, but session-store selection has no explicit owner. Pass --agent <id> to select one agent, or --all-agents to include every configured agent.",


### PR DESCRIPTION
## What Problem This Solves

On a config with more than one agent and no explicit owner, most CLI commands report the missing `--agent` selection as a crash. Observed live on an isolated two-agent state:

```
$ openclaw skills list --json
{ "ok": false, "error": { "type": "cli_error", "message": "Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>." } }
[openclaw] The CLI command failed.
[openclaw] Reason: Multiple agents are configured, but the skills command has no explicit owner. Pass --agent <id>.
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
```

`openclaw sessions list --json` printed the same class of refusal as a plain message, because the sessions command family wrapped it into an expected CLI error on its own. Every other surface that resolves an agent (skills, system, memory, and the rest of the `resolveAgentScope` callers) let the error reach the root handler unclassified, so operators were sent to a stack trace and `openclaw doctor` for a missing flag.

## Why This Change Was Made

Expected-condition classification for CLI errors lives in one owner, `isExpectedCliError` in `src/cli/failure-output.ts`; the root handlers in `src/entry.ts` and `src/index.ts` and every `rethrowExpectedCliError` / `runCommandWithRuntime` call site read it. The agent-selection refusal was the one operator-input error classified in a consumer instead of that owner.

- `src/cli/failure-output.ts`: `isAgentSelectionCliError` (lean name-based predicate, same shape as the gateway-auth and immutable-config predicates) joins `isExpectedCliError`. The producer message already names the surface and the `--agent` remedy.
- `src/commands/session-store-targets.ts`: the sessions family now rethrows the typed error with its session-store wording instead of flattening it into `ExpectedCliError`; other resolution errors keep the existing handoff.
- Commands that call `rethrowExpectedCliError` (`system`) or `runCommandWithRuntime` (`skills`) now hand the error to the root owner like every other expected condition, so their tests moved from "prints its own copy" to "rethrows"; the rendered output is covered once, in the failure-output table.

Production LOC: +8 / −5 across the two files (one predicate plus its invariant comment; the sessions wrapper lost the message flattening).

## User Impact

Every CLI command reports a missing agent selection the same way: the message with its `--agent` remedy, no stack-trace hint and no `openclaw doctor` suggestion. JSON mode still emits the same `cli_error` envelope. The sessions commands are unchanged in wording.

## Evidence

- Regression tests fail on pre-fix code and pass with the fix: `src/cli/failure-output.test.ts` (new "missing agent selection" row in the shared expected-condition table) and `src/commands/session-store-targets.test.ts` (typed rethrow keeps the session-store surface wording).
- Updated to the rethrow contract: `src/cli/skills-cli.commands.test.ts`, `src/cli/system-cli.test.ts`, and after the first full CI run also `src/cli/capability-cli.test.ts` (3 cases), `src/cli/channel-auth.owner.integration.test.ts` (2), `src/commands/sessions.default-agent-store.test.ts` (1) — every remaining test that encoded the old per-command rendering; sibling suites green: `directory-cli`, `export-trajectory`, `sessions-cleanup` (25 + 196 + 10 + 48 tests).
- `node scripts/check-changed.mjs`: all lanes ok (conflict markers, ratchets, format, plugin boundaries, wrapper shadowing, dead-export scans, core tsgo graph boundary, typecheck core, typecheck core tests).
- Codex autoreview (`--mode local`, P2, with the classifier, root handlers, command wrappers and producer supplied as context): scoped-clean, no accepted or actionable findings ("patch is correct (0.95)").
- Live proof (isolated two-agent state, built dist): `openclaw skills list --json` and `openclaw skills list` now print only the message with its `--agent` remedy (JSON mode keeps the same `cli_error` envelope); `openclaw sessions list --json` is unchanged; a gateway-unreachable error on `system event` still renders its own expected copy.
