### PR TITLE
fix(tooling): catch unused exports after script and test edits

### DIFF
--- a/docs/ci/local-proof.md
+++ b/docs/ci/local-proof.md
@@ -111,6 +111,11 @@ Local changed-lane logic lives in `scripts/changed-lanes.mjs` and is executed by
 - release metadata-only version bumps run targeted version/config/root-dependency checks;
 - unknown root/config changes fail safe to all check lanes.
 
+JavaScript and TypeScript changes under `src/`, `extensions/`, `ui/`, `packages/`,
+`scripts/`, and `test/` also run the existing full unused-export audit.
+Import-only edits and deleted source or test files can orphan exports in
+unchanged files.
+
 Schema dependency selection reuses the local relative-import graph, including re-exports and deleted leaf paths still referenced by surviving source. Shared SDK channel UI-hint and secret-input schema owners, plus the workspace sensitive-URL hint owner, are explicit roots across alias boundaries. Edits to their SDK facades are also selected without traversing unrelated facade runtime dependencies. This is not universal alias or computed-import resolution.
 
 Local changed-test routing lives in `scripts/test-projects.test-support.mts` and is intentionally cheaper than `check:changed`: direct test edits run themselves, source edits prefer explicit mappings, then sibling tests and import-graph dependents. Shared group-room delivery config is one of the explicit mappings: changes to the group visible-reply config, source reply delivery mode, or the message-tool system prompt route through the core reply tests plus Discord and Slack delivery regressions so a shared default change fails before the first PR push. Use `OPENCLAW_TEST_CHANGED_BROAD=1 pnpm test:changed` only when the change is harness-wide enough that the cheap mapped set is not a trustworthy proxy.

--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -11,12 +11,12 @@ const GIT_OUTPUT_MAX_BUFFER = 64 * 1024 * 1024;
 const IMPLAUSIBLE_NO_MERGE_BASE_DIFF_PATHS = 200;
 const RAW_SYNC_CHANGED_LANES_ENV = "OPENCLAW_CHANGED_LANES_RAW_SYNC";
 
-// Source files knip's production scan reads. Any edit to one of these can orphan
-// an export -- including an import-only edit that drops a barrel re-export's last
-// consumer -- so the scan is selected by path, not by inspecting changed lines.
-const DEADCODE_SOURCE_PATH_RE = /^(?:src|extensions|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
+// Application, script, and test sources read by the export scans. Import-only
+// edits and deleted tests can orphan exports in unchanged files, so select by
+// path rather than inspecting changed lines.
+const DEADCODE_SOURCE_PATH_RE = /^(?:src|extensions|ui|packages|scripts|test)\/.+\.[cm]?[jt]sx?$/u;
 
-/** Returns whether any changed path is production source knip scans. */
+/** Returns whether a changed source path selects the existing export scans. */
 export function hasDeadcodeScannedSource(changedPaths: string[]): boolean {
   return changedPaths.some((path) => DEADCODE_SOURCE_PATH_RE.test(path));
 }

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -166,7 +166,7 @@ function createRootTestLintFixture() {
     writeRepoFile(dir, file, source);
   }
   materializeNativeCompiler(dir);
-  for (const name of ["@types/node", "vitest"]) {
+  for (const name of ["@types/node", "vitest", "tsx"]) {
     const destination = path.join(dir, "node_modules", name);
     mkdirSync(path.dirname(destination), { recursive: true });
     symlinkSync(path.join(repoRoot, "node_modules", name), destination, "junction");
@@ -197,6 +197,8 @@ function createRootTestLintFixture() {
   }
   // Stub unrelated package gates at the executable boundary: real pnpm could
   // reconcile this partial install. The CLI and source-only lint wrapper stay real.
+  // The export audit is selected normally, but this fixture has only the lint graph.
+  writeRepoFile(dir, "scripts/check-deadcode-exports.mts", "export {};\n");
   const binDir = path.join(dir, "bin");
   for (const bin of ["pnpm", "corepack"]) {
     writeRepoFile(dir, `bin/${bin}`, "#!/bin/sh\nexit 0\n");
@@ -689,6 +691,7 @@ describe("scripts/changed-lanes", () => {
       "pnpm lint:tmp:tsgo-core-boundary",
       "pnpm tsgo:test:root",
       "pnpm check:coercion-helpers",
+      "node --import tsx scripts/check-deadcode-exports.mts",
       "pnpm lint:scripts",
       "node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/scripts/github-activity-helper.test.ts",
     ]);
@@ -1130,7 +1133,17 @@ describe("scripts/changed-lanes", () => {
     // touches, so selection is by path; inspecting changed lines would miss it.
     { name: "import-only edit", changedPaths: ["src/agents/tool-surface-plan.ts"], expected: true },
     { name: "docs tree", changedPaths: ["docs/example.ts"], expected: false },
-    { name: "scripts tree", changedPaths: ["scripts/check-changed.mjs"], expected: false },
+    { name: "script entry", changedPaths: ["scripts/check-changed.mjs"], expected: true },
+    {
+      name: "script helper",
+      changedPaths: ["scripts/lib/budget-number-args.mts"],
+      expected: true,
+    },
+    {
+      name: "root test consumer",
+      changedPaths: ["test/scripts/test-perf-budget.test.ts"],
+      expected: true,
+    },
     // knip never reads these, so they must not pull in the scan.
     { name: "markdown under src", changedPaths: ["src/README.md"], expected: false },
     { name: "sql under src", changedPaths: ["src/state/schema.sql"], expected: false },
@@ -1962,23 +1975,26 @@ describe("scripts/changed-lanes", () => {
     expect(shouldDelegateChangedCheckToCrabbox([], {}, { result })).toBe(false);
   });
 
-  it("adds the dead export scan only for production source changes", () => {
+  it.each([
+    ["core source", "src/config/config.ts"],
+    ["script consumer", "scripts/test-perf-budget.mts"],
+    ["root test consumer", "test/scripts/test-perf-budget.test.ts"],
+  ])("adds the dead export scan for %s changes", (_name, changedPath) => {
     const command = {
       name: "dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)",
       bin: "node",
       args: ["--import", "tsx", "scripts/check-deadcode-exports.mts"],
-      env: expect.any(Object),
     };
-    const sourceResult = detectChangedLanes(["src/config/config.ts"]);
-    const toolingResult = detectChangedLanes(["scripts/check-changed.mjs"]);
+    const sourceResult = detectChangedLanes([changedPath]);
+    const commands = (env = {}) =>
+      createChangedCheckPlan(sourceResult, { env }).commands.map(({ name, bin, args }) => ({
+        name,
+        bin,
+        args,
+      }));
 
-    expect(createChangedCheckPlan(sourceResult).commands).toContainEqual(command);
-    expect(createChangedCheckPlan(toolingResult).commands).not.toContainEqual(command);
-    expect(
-      createChangedCheckPlan(sourceResult, {
-        env: { OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE: "1" },
-      }).commands,
-    ).not.toContainEqual(command);
+    expect(commands()).toContainEqual(command);
+    expect(commands({ OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE: "1" })).not.toContainEqual(command);
   });
 
   it("keeps classified changed gates local", () => {


### PR DESCRIPTION
Related: #143237

## What Problem This Solves

Resolves a problem where script-only or root-test-only edits could pass `pnpm check:changed` but then fail CI for an unused export. Removing an import can orphan an export in an untouched module; the local check selected only application source paths.

## Why This Change Was Made

Include JavaScript and TypeScript files under `scripts/` and `test/` in the existing export-audit selector. Reuse the canonical scanner and its existing skip control, extend the routing regressions, and document the local check behavior. The partial lint fixture supplies a stub for this newly selected, unrelated check while its CLI and lint execution stay real.

## User Impact

Developers catch these unused exports before pushing. Script and root-test edits now incur the existing full export audit, which took about 46 seconds in the local validation run. No runtime behavior changes.

## Evidence

- Five new routing cases failed on the original selector while twelve controls passed; all seventeen passed after the repair.
- All 367 owner and scanner tests passed. The broader run first exposed one stale command expectation and ten incomplete lint fixtures; those were updated at their owning test boundary.
- All 22 selected checks passed in 106 seconds, including all three real Knip scans with zero findings. No audit skip was used.
- Independent review found no actionable issues through P2.
- The motivating CI failure is [the original parser PR check](https://github.com/openclaw/openclaw/actions/runs/34373209421/job/102539648203); its unused parser export is repaired separately in #143237.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34378245632) is green.
