### PR TITLE
refactor(restart): keep continuation policy with update payloads

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -23,7 +23,6 @@ import { logVerbose } from "../../globals.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import {
-  buildRestartSuccessContinuation,
   clearRestartSentinel,
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
@@ -74,7 +73,7 @@ function buildRestartCommandSentinel(params: HandleCommandsParams): RestartSenti
     deliveryContext,
     threadId,
     message: "/restart",
-    continuation: buildRestartSuccessContinuation({ sessionKey }),
+    continuation: null,
     doctorHint: formatDoctorNonInteractiveHint(),
     stats: {
       mode: "gateway.restart",
@@ -539,9 +538,8 @@ export const handleRestartCommand: CommandHandler = defineGatewayControlCommand(
       let sentinelWritten = false;
       scheduleGatewaySigusr1Restart({
         reason: "/restart",
-        // Sibling session-routing guard: /restart writes a session-scoped sentinel
-        // with continuation, so the scheduler must own the pending slot under the
-        // same key to avoid cross-session continuation overwrite (#86742).
+        // The routed restart acknowledgement and scheduler must own the same
+        // pending session key to avoid cross-session overwrite (#86742).
         sessionKey: sentinelPayload?.sessionKey,
         emitHooks: sentinelPayload
           ? {

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -48,7 +48,6 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import {
-  buildRestartSuccessContinuation,
   clearRestartSentinel,
   clearRestartSentinelIfRevision,
   finalizeUpdateRestartSentinelRunningVersion,
@@ -819,28 +818,6 @@ describe("restart sentinel error visibility", () => {
         "Failed to check restart sentinel: SQLITE_BUSY: database is locked",
       );
     });
-  });
-});
-
-describe("restart success continuation", () => {
-  it("does not infer an agent turn from session context alone", () => {
-    expect(buildRestartSuccessContinuation({ sessionKey: "agent:main:main" })).toBeNull();
-  });
-
-  it("keeps explicit continuation messages", () => {
-    expect(
-      buildRestartSuccessContinuation({
-        sessionKey: "agent:main:main",
-        continuationMessage: "wake after restart",
-      }),
-    ).toEqual({
-      kind: "agentTurn",
-      message: "wake after restart",
-    });
-  });
-
-  it("stays silent without session context", () => {
-    expect(buildRestartSuccessContinuation({})).toBeNull();
   });
 });
 

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -21,7 +21,6 @@ import {
   writeRestartSentinelRowSync,
   writeUpdateInstallReceiptRowSync,
   type RestartSentinel,
-  type RestartSentinelContinuation,
   type RestartSentinelPayload,
 } from "./restart-sentinel-store.js";
 import {
@@ -451,17 +450,6 @@ export async function clearRestartSentinelIfRevision(
     { env },
     { operationLabel: "restart-sentinel.clear-if-revision" },
   );
-}
-
-export function buildRestartSuccessContinuation(params: {
-  sessionKey?: string;
-  continuationMessage?: string | null;
-}): RestartSentinelContinuation | null {
-  const message = params.continuationMessage?.trim();
-  if (message) {
-    return { kind: "agentTurn", message };
-  }
-  return null;
 }
 
 export async function readRestartSentinel(

--- a/src/infra/restart-sentinel.update-result.test.ts
+++ b/src/infra/restart-sentinel.update-result.test.ts
@@ -21,6 +21,20 @@ async function withRestartSentinelStateDir(run: () => Promise<void>): Promise<vo
 }
 
 describe("control-plane update restart sentinel", () => {
+  it.each([undefined, "agent:main:main"])(
+    "does not infer a continuation from an update's session route (%s)",
+    (sessionKey) => {
+      const payload = buildUpdateRestartSentinelPayload({
+        result: { status: "ok", mode: "npm", steps: [], durationMs: 1 },
+        meta: sessionKey ? { sessionKey } : {},
+        nowMs: 1,
+      });
+
+      expect(payload.sessionKey).toBe(sessionKey);
+      expect(payload.continuation).toBeUndefined();
+    },
+  );
+
   it("preserves advisory step classification through the typed sentinel round trip", async () => {
     await withRestartSentinelStateDir(async () => {
       await writeRestartSentinel(
@@ -156,7 +170,7 @@ describe("control-plane update restart sentinel", () => {
     const meta = {
       target: "version 2026.4.24",
       sessionKey: "agent:main:webchat:dm:user-123",
-      continuationMessage: "Check the running version and finish the update report.",
+      continuationMessage: "  Check the running version and finish the update report.\n",
     };
 
     const pendingResult = buildControlPlaneUpdateRestartHealthPendingResult(result);

--- a/src/infra/update-restart-sentinel-payload.ts
+++ b/src/infra/update-restart-sentinel-payload.ts
@@ -1,9 +1,5 @@
 // Builds restart sentinel payloads for update handoff reporting.
-import {
-  buildRestartSuccessContinuation,
-  formatDoctorNonInteractiveHint,
-  type RestartSentinelPayload,
-} from "./restart-sentinel.js";
+import { formatDoctorNonInteractiveHint, type RestartSentinelPayload } from "./restart-sentinel.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 // Update restart sentinel payloads carry update result details across a process
@@ -59,13 +55,10 @@ export function buildUpdateRestartSentinelPayload(params: {
   const result = normalizeControlPlaneUpdateResult(params.result);
   const recovery = resolvePersistedRecovery(result);
   const { meta } = params;
-  const continuation =
-    result.status === "ok"
-      ? buildRestartSuccessContinuation({
-          sessionKey: meta.sessionKey,
-          continuationMessage: meta.continuationMessage,
-        })
-      : null;
+  const continuationMessage = result.status === "ok" ? meta.continuationMessage?.trim() : undefined;
+  const continuation: RestartSentinelPayload["continuation"] = continuationMessage
+    ? { kind: "agentTurn", message: continuationMessage }
+    : null;
   return {
     kind: "update",
     status: result.status,


### PR DESCRIPTION
## What Problem This Solves

Restart acknowledgement handling retained a helper whose session-routing argument did nothing. Its three scalar tests obscured the actual contract: routing a restart notice must not request another agent turn, while a successful update may carry an explicitly requested continuation.

## Why This Change Was Made

Remove the internal helper and unused input, keep `/restart`'s existing explicit `null` continuation, and put message trimming beside the update payload's existing normalized-success gate. Session, delivery and thread routing remain intact. The two negative subjects now exercise the payload owner; the existing pending-to-success case also verifies trimming of the explicit message.

The current stable package, `2026.9.3`, has 340 explicit export keys. Its actual 492 exported files contain no named export of this helper and no wildcard re-export, so this does not retire a public SDK contract. Sentinel types and persisted representations are unchanged.

Production delta: -21 lines (-17 excluding import reformatting). Test delta: -9 lines and one fewer case. Persistence, malformed-row, revision, lifecycle and restart-command coverage is retained.

## User Impact

Behavior is preserved: `/restart` reports its routed acknowledgement without starting an implicit agent turn; successful updates retain trimmed explicit continuation messages. Pending or unsuccessful updates remain continuation-free. There is no new configuration, database change, compatibility shim or test-only production seam.

## Evidence

- Untouched baseline: 61 tests passed across `restart-sentinel.test.ts`, `restart-sentinel.update-result.test.ts` and `commands-session-restart.test.ts`.
- Candidate: 60 tests passed on the same three files, with both native shards completing on their first attempt. The exact case comparison maps three removed scalar cases to two payload cases and the strengthened existing explicit-message case; 58 case identities remain.
- Deliberate owner-level controls confirm coverage: reintroducing an implicit session-based turn fails the session-route payload assertion, and removing trimming fails the existing success assertion. Both temporary faults were removed and the final source hashes verified.
- Normal changed checks and independent review are recorded with the frozen candidate before publication. No operator Gateway was restarted: this is a behavior-preserving owner/test consolidation proved through the real payload, typed persistence and command-handler suites.
