### PR TITLE
fix(plugin-sdk): retain prepared models through host cleanup

### DIFF
--- a/docs/plugins/sdk-runtime/models.md
+++ b/docs/plugins/sdk-runtime/models.md
@@ -138,3 +138,16 @@ Call a model, resolve model-selection policy, and resolve provider auth without 
 
   </Accordion>
 </AccordionGroup>
+
+## Prepared completion SDK compatibility
+
+Prefer `api.runtime.llm.complete` for new plugin code. Existing callers of
+`openclaw/plugin-sdk/simple-completion-runtime` can continue to prepare a model
+with `prepareSimpleCompletionModelForAgent` and execute it with
+`completeWithPreparedSimpleCompletionModel`.
+
+These prepared results have no release method. Their original Gateway or CLI
+host retains the model resources until shutdown; standalone callers retain them
+for the process lifetime. A closed host rejects new preparation and execution.
+Shutdown waits for accepted provider callbacks and cancellation work before
+releasing the prepared resources, even when the completion has already returned.

--- a/src/agents/simple-completion-execution.ts
+++ b/src/agents/simple-completion-execution.ts
@@ -13,6 +13,7 @@ import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   bindModelLlmRuntime,
+  getModelCompletionOwner,
   getModelCompletionTransport,
   getModelLlmRuntime,
 } from "../llm/model-runtime-binding.js";
@@ -34,14 +35,34 @@ type SimpleCompletionModelOptions = {
   signal?: AbortSignal;
 };
 
-export async function completeWithPreparedSimpleCompletionModel(params: {
+type PreparedCompletionParams = {
   assertCurrent?: () => void;
   model: Model;
   auth: ResolvedProviderAuth;
   context: Parameters<typeof completeSimple>[1];
   cfg?: OpenClawConfig;
   options?: SimpleCompletionModelOptions;
-}): Promise<AssistantMessage> {
+};
+
+export async function completeWithPreparedSimpleCompletionModel(
+  params: PreparedCompletionParams,
+): Promise<AssistantMessage> {
+  const owner = getModelCompletionOwner(params.model);
+  if (!owner) {
+    return await completePreparedModel(params);
+  }
+  return await owner.run(() =>
+    completePreparedModel({
+      ...params,
+      assertCurrent: () => {
+        owner.assertCurrent();
+        params.assertCurrent?.();
+      },
+    }),
+  );
+}
+
+async function completePreparedModel(params: PreparedCompletionParams): Promise<AssistantMessage> {
   const runtime = getModelLlmRuntime(params.model);
   let completionModel =
     getModelCompletionTransport(params.model) ??

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -56,7 +56,7 @@ vi.mock("./sessions/model-registry-runtime.js", () => ({
 
 import {
   prepareSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
 function createOllamaModelResolver(): typeof resolveModelAsync {
@@ -212,20 +212,26 @@ it("selects an explicit agent completion model before runtime acquisition", asyn
     mode: "api-key",
   });
 
-  await prepareSimpleCompletionModelForAgent({
+  const result = await acquireSimpleCompletionModelForAgent({
     cfg: {},
     agentId: "main",
     modelRef: "ollama/qwen3:0.6b",
     modelResolver,
   });
 
-  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
-    expect.objectContaining({
-      runtimePluginSelections: [{ provider: "ollama", modelId: "qwen3:0.6b", agentId: "main" }],
-    }),
-    expect.objectContaining({ catalogMode: "static" }),
-  );
-  expect(modelResolver).toHaveBeenCalledOnce();
+  try {
+    expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimePluginSelections: [{ provider: "ollama", modelId: "qwen3:0.6b", agentId: "main" }],
+      }),
+      expect.objectContaining({ catalogMode: "static" }),
+    );
+    expect(modelResolver).toHaveBeenCalledOnce();
+  } finally {
+    if (!("error" in result)) {
+      result.release();
+    }
+  }
 });
 
 it("acquires the canonical manifest-derived utility model selection", async () => {
@@ -246,7 +252,7 @@ it("acquires the canonical manifest-derived utility model selection", async () =
   });
   mocks.resolvePluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
 
-  const result = await prepareSimpleCompletionModelForAgent({
+  const result = await acquireSimpleCompletionModelForAgent({
     cfg: {
       agents: { defaults: { model: "selected-provider/primary-model@work" } },
     },
@@ -260,26 +266,32 @@ it("acquires the canonical manifest-derived utility model selection", async () =
     })),
   });
 
-  expect(
-    mocks.resolvePluginMetadataSnapshot.mock.calls.filter(
-      ([params]) => (params as { pluginIdScope?: unknown } | undefined)?.pluginIdScope,
-    ),
-  ).toHaveLength(2);
-  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
-    expect.objectContaining({
-      runtimePluginSelections: [
-        { provider: "selected-provider", modelId: "utility-model", agentId: "main" },
-      ],
-      agentDir: "/tmp/canonical-agent",
-    }),
-    expect.objectContaining({ catalogMode: "static", pluginMetadataSnapshot: metadataSnapshot }),
-  );
-  expect(result).toMatchObject({
-    selection: {
-      provider: "selected-provider",
-      modelId: "utility-model",
-      profileId: "work",
-      agentDir: "/tmp/canonical-agent",
-    },
-  });
+  try {
+    expect(
+      mocks.resolvePluginMetadataSnapshot.mock.calls.filter(
+        ([params]) => (params as { pluginIdScope?: unknown } | undefined)?.pluginIdScope,
+      ),
+    ).toHaveLength(2);
+    expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimePluginSelections: [
+          { provider: "selected-provider", modelId: "utility-model", agentId: "main" },
+        ],
+        agentDir: "/tmp/canonical-agent",
+      }),
+      expect.objectContaining({ catalogMode: "static", pluginMetadataSnapshot: metadataSnapshot }),
+    );
+    expect(result).toMatchObject({
+      selection: {
+        provider: "selected-provider",
+        modelId: "utility-model",
+        profileId: "work",
+        agentDir: "/tmp/canonical-agent",
+      },
+    });
+  } finally {
+    if (!("error" in result)) {
+      result.release();
+    }
+  }
 });

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -26,7 +26,7 @@ import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 import {
   completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
 const tempRoots = createSyncSuiteTempRootTracker("openclaw-simple-completion-plugin-scope");
@@ -101,68 +101,43 @@ describe("simple completion prepared plugin scope", () => {
     {
       name: "direct provider and model",
       expectedModelId: "selected-model",
-      prepare: (params: {
-        config: OpenClawConfig;
-        modelResolver: typeof resolveModelAsync;
-        provider: string;
-        modelId: string;
-      }) =>
-        prepareSimpleCompletionModel({
-          cfg: params.config,
-          agentId: "main",
-          provider: params.provider,
-          modelId: params.modelId,
-          modelResolver: params.modelResolver,
-        }),
+      mode: "direct",
     },
     {
       name: "agent-selected manifest utility model",
       expectedModelId: "utility-model",
-      prepare: (params: {
-        config: OpenClawConfig;
-        modelResolver: typeof resolveModelAsync;
-        provider: string;
-        modelId: string;
-      }) =>
-        prepareSimpleCompletionModelForAgent({
-          cfg: params.config,
-          agentId: "main",
-          useUtilityModel: true,
-          modelResolver: params.modelResolver,
-        }),
+      mode: "agent",
     },
-  ])(
-    "loads only the selected plugin generation for $name",
-    async ({ expectedModelId, prepare }) => {
-      const tempRoot = tempRoots.makeTempDir();
-      const selectedRoot = path.join(tempRoot, "selected");
-      const unrelatedRoot = path.join(tempRoot, "unrelated");
-      fs.mkdirSync(selectedRoot, { recursive: true });
-      fs.mkdirSync(unrelatedRoot, { recursive: true });
-      const selected = createColdPluginFixture({
-        rootDir: selectedRoot,
-        pluginId: "selected-provider-plugin",
-        providerId: "selected-provider",
-        manifest: {
-          modelCatalog: {
-            providers: {
-              "selected-provider": {
-                defaultUtilityModel: "utility-model",
-                models: [{ id: "primary-model" }, { id: "utility-model" }],
-              },
+  ])("loads only the selected plugin generation for $name", async ({ expectedModelId, mode }) => {
+    const tempRoot = tempRoots.makeTempDir();
+    const selectedRoot = path.join(tempRoot, "selected");
+    const unrelatedRoot = path.join(tempRoot, "unrelated");
+    fs.mkdirSync(selectedRoot, { recursive: true });
+    fs.mkdirSync(unrelatedRoot, { recursive: true });
+    const selected = createColdPluginFixture({
+      rootDir: selectedRoot,
+      pluginId: "selected-provider-plugin",
+      providerId: "selected-provider",
+      manifest: {
+        modelCatalog: {
+          providers: {
+            "selected-provider": {
+              defaultUtilityModel: "utility-model",
+              models: [{ id: "primary-model" }, { id: "utility-model" }],
             },
           },
         },
-      });
-      const unrelated = createColdPluginFixture({
-        rootDir: unrelatedRoot,
-        pluginId: "unrelated-provider-plugin",
-        providerId: "unrelated-provider",
-        runtimeMessage: "unrelated provider runtime must remain cold",
-      });
-      fs.writeFileSync(
-        selected.runtimeSource,
-        `const fs = require("node:fs");
+      },
+    });
+    const unrelated = createColdPluginFixture({
+      rootDir: unrelatedRoot,
+      pluginId: "unrelated-provider-plugin",
+      providerId: "unrelated-provider",
+      runtimeMessage: "unrelated provider runtime must remain cold",
+    });
+    fs.writeFileSync(
+      selected.runtimeSource,
+      `const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(selected.runtimeMarker)}, "loaded", "utf8");
 module.exports = {
   id: ${JSON.stringify(selected.pluginId)},
@@ -171,48 +146,61 @@ module.exports = {
   },
 };
 `,
-        "utf8",
-      );
-      const config = {
-        agents: {
-          defaults: { model: `${selected.providerId}/primary-model@work` },
+      "utf8",
+    );
+    const config = {
+      agents: {
+        defaults: { model: `${selected.providerId}/primary-model@work` },
+      },
+      plugins: {
+        load: { paths: [selected.rootDir, unrelated.rootDir] },
+        slots: { memory: "none" },
+        entries: {
+          [selected.pluginId]: { enabled: true },
+          [unrelated.pluginId]: { enabled: true },
         },
-        plugins: {
-          load: { paths: [selected.rootDir, unrelated.rootDir] },
-          slots: { memory: "none" },
-          entries: {
-            [selected.pluginId]: { enabled: true },
-            [unrelated.pluginId]: { enabled: true },
-          },
-        },
-      } satisfies OpenClawConfig;
-      let preparedRuntime: PreparedModelRuntimeSnapshot | undefined;
-      const modelResolver: typeof resolveModelAsync = vi.fn(
-        async (provider, modelId, _agentDir, _cfg, options) => {
-          preparedRuntime = options?.preparedModelRuntime;
-          return {
-            error: `stop after selected resolver ${provider}/${modelId}`,
-            authStorage: options?.authStorage ?? AuthStorage.inMemory({}),
-            modelRegistry:
-              options?.modelRegistry ?? ModelRegistry.inMemory(AuthStorage.inMemory({})),
-          };
-        },
-      );
-      const env = {
-        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: tempRoots.makeTempDir() }),
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
-      };
+      },
+    } satisfies OpenClawConfig;
+    let preparedRuntime: PreparedModelRuntimeSnapshot | undefined;
+    const modelResolver: typeof resolveModelAsync = vi.fn(
+      async (provider, modelId, _agentDir, _cfg, options) => {
+        preparedRuntime = options?.preparedModelRuntime;
+        return {
+          error: `stop after selected resolver ${provider}/${modelId}`,
+          authStorage: options?.authStorage ?? AuthStorage.inMemory({}),
+          modelRegistry: options?.modelRegistry ?? ModelRegistry.inMemory(AuthStorage.inMemory({})),
+        };
+      },
+    );
+    const env = {
+      ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: tempRoots.makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+    };
 
-      const result = await withEnvAsync(env, () =>
-        prepare({
-          config,
+    let release: (() => void) | undefined;
+    try {
+      const result = await withEnvAsync(env, async () => {
+        if (mode === "agent") {
+          const acquired = await acquireSimpleCompletionModelForAgent({
+            cfg: config,
+            agentId: "main",
+            useUtilityModel: true,
+            modelResolver,
+          });
+          if (!("error" in acquired)) {
+            release = acquired.release;
+          }
+          return acquired;
+        }
+        return await prepareSimpleCompletionModel({
+          cfg: config,
+          agentId: "main",
           modelResolver,
           provider: selected.providerId,
           modelId: expectedModelId,
-        }),
-      );
-
+        });
+      });
       expect(result).toMatchObject({
         error: `stop after selected resolver ${selected.providerId}/${expectedModelId}`,
       });
@@ -224,8 +212,10 @@ module.exports = {
       expect(preparedRuntime?.metadataSnapshot.plugins.map((plugin) => plugin.id)).toEqual([
         selected.pluginId,
       ]);
-    },
-  );
+    } finally {
+      release?.();
+    }
+  });
 
   it.each(["acquired", "borrowed", "empty"] as const)(
     "keeps %s transport ownership across ambient replacement and repeated completion",

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -87,7 +87,7 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
 
 import {
   prepareSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent,
   resolveSimpleCompletionSelectionForAgent,
 } from "./simple-completion-runtime.js";
 
@@ -797,7 +797,7 @@ describe("prepareSimpleCompletionModel", () => {
   });
 });
 
-describe("prepareSimpleCompletionModelForAgent", () => {
+describe("acquireSimpleCompletionModelForAgent", () => {
   it("resolves explicit aliases in the selected agent scope", () => {
     const cfg = {
       agents: {
@@ -859,7 +859,7 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       mode: "api-key",
     });
 
-    const result = await prepareSimpleCompletionModelForAgent({
+    const result = await acquireSimpleCompletionModelForAgent({
       cfg,
       agentId: "main",
       useUtilityModel: true,
@@ -867,23 +867,29 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       modelResolver,
     });
 
-    expectPreparedModelResult(result);
-    expect(result.selection.provider).toBe("openai");
-    expect(result.selection.modelId).toBe("gpt-5.5");
-    expect(result.model).toMatchObject({
-      id: "gpt-5.5",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    });
-    expect(modelResolver).toHaveBeenCalledTimes(2);
-    expect(
-      (callArg(hoisted.getApiKeyForModelMock, 1) as { model?: { api?: string } }).model?.api,
-    ).toBe("openai-responses");
-    // Route materialization re-resolves the model on a multi-agent config; both
-    // calls must keep the authorized agentId or the second falls back to
-    // resolveDefaultAgentId, which throws on a multi-agent config.
-    expect(modelResolver.mock.calls[0]?.[4]).toMatchObject({ agentId: "main" });
-    expect(modelResolver.mock.calls[1]?.[4]).toMatchObject({ agentId: "main" });
+    try {
+      expectPreparedModelResult(result);
+      expect(result.selection.provider).toBe("openai");
+      expect(result.selection.modelId).toBe("gpt-5.5");
+      expect(result.model).toMatchObject({
+        id: "gpt-5.5",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      expect(modelResolver).toHaveBeenCalledTimes(2);
+      expect(
+        (callArg(hoisted.getApiKeyForModelMock, 1) as { model?: { api?: string } }).model?.api,
+      ).toBe("openai-responses");
+      // Route materialization re-resolves the model on a multi-agent config; both
+      // calls must keep the authorized agentId or the second falls back to
+      // resolveDefaultAgentId, which throws on a multi-agent config.
+      expect(modelResolver.mock.calls[0]?.[4]).toMatchObject({ agentId: "main" });
+      expect(modelResolver.mock.calls[1]?.[4]).toMatchObject({ agentId: "main" });
+    } finally {
+      if (!("error" in result)) {
+        result.release();
+      }
+    }
   });
 
   it("keeps the Codex route for OAuth auth", async () => {
@@ -901,7 +907,7 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       mode: "oauth",
     });
 
-    const result = await prepareSimpleCompletionModelForAgent({
+    const result = await acquireSimpleCompletionModelForAgent({
       cfg,
       agentId: "main",
       modelRef: "openai/gpt-5.5",
@@ -909,14 +915,20 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       modelResolver,
     });
 
-    expectPreparedModelResult(result);
-    expect(result.selection.modelId).toBe("gpt-5.5");
-    expect(result.model).toMatchObject({
-      api: "openai-chatgpt-responses",
-      baseUrl: "https://chatgpt.com/backend-api/codex",
-    });
-    expect(modelResolver).toHaveBeenCalledTimes(1);
-    expect(hoisted.getApiKeyForModelMock).toHaveBeenCalledTimes(2);
+    try {
+      expectPreparedModelResult(result);
+      expect(result.selection.modelId).toBe("gpt-5.5");
+      expect(result.model).toMatchObject({
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      });
+      expect(modelResolver).toHaveBeenCalledTimes(1);
+      expect(hoisted.getApiKeyForModelMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (!("error" in result)) {
+        result.release();
+      }
+    }
   });
 
   it("keeps an authored custom OpenAI route untouched", async () => {
@@ -942,19 +954,25 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       mode: "api-key",
     });
 
-    const result = await prepareSimpleCompletionModelForAgent({
+    const result = await acquireSimpleCompletionModelForAgent({
       cfg,
       agentId: "main",
       skipAgentDiscovery: true,
       modelResolver,
     });
 
-    expectPreparedModelResult(result);
-    expect(result.model).toMatchObject({
-      api: "openai-responses",
-      baseUrl: "https://relay.example/v1",
-    });
-    expect(modelResolver).toHaveBeenCalledTimes(1);
+    try {
+      expectPreparedModelResult(result);
+      expect(result.model).toMatchObject({
+        api: "openai-responses",
+        baseUrl: "https://relay.example/v1",
+      });
+      expect(modelResolver).toHaveBeenCalledTimes(1);
+    } finally {
+      if (!("error" in result)) {
+        result.release();
+      }
+    }
   });
 
   it("honors an explicit model ref while selecting its auth-compatible route", async () => {
@@ -971,7 +989,7 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       mode: "api-key",
     });
 
-    const result = await prepareSimpleCompletionModelForAgent({
+    const result = await acquireSimpleCompletionModelForAgent({
       cfg,
       agentId: "main",
       modelRef: "openai/gpt-5.5",
@@ -979,8 +997,14 @@ describe("prepareSimpleCompletionModelForAgent", () => {
       modelResolver,
     });
 
-    expectPreparedModelResult(result);
-    expect(result.selection).toMatchObject({ provider: "openai", modelId: "gpt-5.5" });
-    expect(result.model).toMatchObject({ id: "gpt-5.5", api: "openai-responses" });
+    try {
+      expectPreparedModelResult(result);
+      expect(result.selection).toMatchObject({ provider: "openai", modelId: "gpt-5.5" });
+      expect(result.model).toMatchObject({ id: "gpt-5.5", api: "openai-responses" });
+    } finally {
+      if (!("error" in result)) {
+        result.release();
+      }
+    }
   });
 });

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -65,38 +65,15 @@ import {
   createPreparedSimpleCompletionResolverContext,
   type PreparedSimpleCompletionResolverContext,
 } from "./simple-completion-scope.js";
+import type {
+  AgentSimpleCompletionSelection,
+  PreparedSimpleCompletionModel,
+  PreparedSimpleCompletionModelForAgent,
+  PrepareSimpleCompletionModelForAgentParams,
+} from "./simple-completion.types.js";
 import { resolveUtilityModelRefForAgent } from "./utility-model.js";
 
 type AllowedMissingApiKeyMode = ResolvedProviderAuth["mode"];
-
-export type PreparedSimpleCompletionModel =
-  | {
-      model: Model;
-      auth: ResolvedProviderAuth;
-      /** Non-reversible owner proof captured from the same auth snapshot. */
-      sourceAuthFingerprint?: string;
-    }
-  | {
-      error: string;
-      auth?: ResolvedProviderAuth;
-    };
-
-type AgentSimpleCompletionSelection = {
-  provider: string;
-  modelId: string;
-  /** Shipped SDK return field; new selections carry canonical identity in provider. */
-  runtimeProvider?: string;
-  profileId?: string;
-  agentDir: string;
-};
-
-type PreparedSimpleCompletionModelForAgent =
-  | (Extract<PreparedSimpleCompletionModel, { model: Model }> & {
-      selection: AgentSimpleCompletionSelection;
-    })
-  | (Extract<PreparedSimpleCompletionModel, { error: string }> & {
-      selection?: AgentSimpleCompletionSelection;
-    });
 
 type SimpleCompletionSelectionParams = {
   cfg: OpenClawConfig;
@@ -533,37 +510,13 @@ async function withPreparedSimpleCompletionRuntime<T>(
   }
 }
 
-export async function prepareSimpleCompletionModelForAgent(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  agentDir?: string;
-  modelRef?: string;
-  useUtilityModel?: boolean;
-  preferredProfile?: string;
-  allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
-  allowBundledStaticCatalogFallback?: boolean;
-  /** @deprecated no-op; kept for plugin-SDK source compatibility, remove at next SDK-breaking window. */
-  useAsyncModelResolution?: boolean;
-  skipAgentDiscovery?: boolean;
-  bindAuthOwner?: boolean;
-  modelResolver?: typeof resolveModelAsync;
-}): Promise<PreparedSimpleCompletionModelForAgent> {
-  const acquired = await acquireSimpleCompletionModelForAgent(params);
-  if ("error" in acquired) {
-    return acquired;
-  }
-  const { release, ...prepared } = acquired;
-  release();
-  return prepared;
-}
-
 type AcquiredSimpleCompletionModelForAgent =
   | (Extract<PreparedSimpleCompletionModelForAgent, { model: Model }> & { release: () => void })
   | Extract<PreparedSimpleCompletionModelForAgent, { error: string }>;
 
 /** Keeps prepared facts in use until the internal completion owner releases its lease. */
 export async function acquireSimpleCompletionModelForAgent(
-  params: Parameters<typeof prepareSimpleCompletionModelForAgent>[0],
+  params: PrepareSimpleCompletionModelForAgentParams,
 ): Promise<AcquiredSimpleCompletionModelForAgent> {
   const selectionParams = {
     cfg: params.cfg,

--- a/src/agents/simple-completion.types.ts
+++ b/src/agents/simple-completion.types.ts
@@ -1,0 +1,49 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { Model } from "../llm/types.js";
+import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import type { ResolvedProviderAuth } from "./model-auth.js";
+
+export type PreparedSimpleCompletionModel =
+  | {
+      model: Model;
+      auth: ResolvedProviderAuth;
+      /** Non-reversible owner proof captured from the same auth snapshot. */
+      sourceAuthFingerprint?: string;
+    }
+  | {
+      error: string;
+      auth?: ResolvedProviderAuth;
+    };
+
+export type AgentSimpleCompletionSelection = {
+  provider: string;
+  modelId: string;
+  /** Shipped SDK return field; new selections carry canonical identity in provider. */
+  runtimeProvider?: string;
+  profileId?: string;
+  agentDir: string;
+};
+
+export type PreparedSimpleCompletionModelForAgent =
+  | (Extract<PreparedSimpleCompletionModel, { model: Model }> & {
+      selection: AgentSimpleCompletionSelection;
+    })
+  | (Extract<PreparedSimpleCompletionModel, { error: string }> & {
+      selection?: AgentSimpleCompletionSelection;
+    });
+
+export type PrepareSimpleCompletionModelForAgentParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  agentDir?: string;
+  modelRef?: string;
+  useUtilityModel?: boolean;
+  preferredProfile?: string;
+  allowMissingApiKeyModes?: ReadonlyArray<ResolvedProviderAuth["mode"]>;
+  allowBundledStaticCatalogFallback?: boolean;
+  /** @deprecated no-op; kept for plugin-SDK source compatibility, remove at next SDK-breaking window. */
+  useAsyncModelResolution?: boolean;
+  skipAgentDiscovery?: boolean;
+  bindAuthOwner?: boolean;
+  modelResolver?: typeof resolveModelAsync;
+};

--- a/src/gateway/session-observer-preparation.test.ts
+++ b/src/gateway/session-observer-preparation.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./session-observer.test-utils.js";
 
 const runtimeMocks = vi.hoisted(() => ({
-  prepareDirect: vi.fn(),
   completeDirect: vi.fn(),
   selectModel: vi.fn(),
   prepareUtility: vi.fn(),
@@ -17,7 +16,6 @@ const runtimeMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent: runtimeMocks.prepareDirect,
   completeWithPreparedSimpleCompletionModel: runtimeMocks.completeDirect,
   resolveSimpleCompletionSelectionForAgent: runtimeMocks.selectModel,
 }));
@@ -55,11 +53,6 @@ describe("session observer model preparation", () => {
         agentId: "main",
         agentDir: "/tmp/agent",
       };
-      runtimeMocks.prepareDirect.mockResolvedValue({
-        selection: { provider, modelId: prepared.model, agentDir: prepared.agentDir },
-        model: { provider, id: prepared.model, maxTokens: 8192 },
-        auth: { apiKey: "openclaw:claude-cli-native-auth", mode: "oauth" },
-      });
       runtimeMocks.completeDirect
         .mockReset()
         .mockRejectedValue(new Error("HTTP 401 invalid credential"));

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -38,10 +38,8 @@ import {
 } from "../../agents/prepared-model-runtime.js";
 import { projectProviderModelRouteConfig } from "../../agents/provider-model-route.js";
 import { registerProviderStreamForModel } from "../../agents/provider-stream.js";
-import {
-  prepareSimpleCompletionModel,
-  type PreparedSimpleCompletionModel,
-} from "../../agents/simple-completion-runtime.js";
+import { prepareSimpleCompletionModel } from "../../agents/simple-completion-runtime.js";
+import type { PreparedSimpleCompletionModel } from "../../agents/simple-completion.types.js";
 import { normalizeUsage, hasObservedModelUsage } from "../../agents/usage.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";

--- a/src/llm/model-runtime-binding.ts
+++ b/src/llm/model-runtime-binding.ts
@@ -4,12 +4,29 @@ import type { Model } from "./types.js";
 const MODEL_LLM_RUNTIME = Symbol("openclaw.modelLlmRuntime");
 const streamLlmRuntimes = new WeakMap<object, LlmRuntime>();
 
-type RuntimeBoundModel = Model & {
-  [MODEL_LLM_RUNTIME]?: {
-    runtime: LlmRuntime;
-    completionTransport?: Model;
-  };
+type ModelCompletionOwner = {
+  run: <T>(run: () => Promise<T>) => Promise<T>;
+  assertCurrent: () => void;
 };
+
+type ModelRuntimeBinding = {
+  runtime?: LlmRuntime;
+  completionTransport?: Model;
+  completionOwner?: ModelCompletionOwner;
+};
+
+type RuntimeBoundModel = Model & {
+  [MODEL_LLM_RUNTIME]?: ModelRuntimeBinding;
+};
+
+function bindModelRuntime(model: Model, binding: ModelRuntimeBinding): Model {
+  const bound: RuntimeBoundModel = { ...model };
+  Object.defineProperty(bound, MODEL_LLM_RUNTIME, {
+    value: binding,
+    enumerable: false,
+  });
+  return bound;
+}
 
 /** Carries the prepared lifecycle runtime without changing the serialized model shape. */
 export function bindModelLlmRuntime(
@@ -17,12 +34,24 @@ export function bindModelLlmRuntime(
   runtime: LlmRuntime,
   completionTransport?: Model,
 ): Model {
-  const bound: RuntimeBoundModel = { ...model };
-  Object.defineProperty(bound, MODEL_LLM_RUNTIME, {
-    value: { runtime, completionTransport },
-    enumerable: false,
+  return bindModelRuntime(model, {
+    runtime,
+    completionTransport,
+    completionOwner: getModelCompletionOwner(model),
   });
-  return bound;
+}
+
+export function bindModelCompletionOwner(
+  model: RuntimeBoundModel,
+  completionOwner: ModelCompletionOwner,
+): Model {
+  return bindModelRuntime(model, { ...model[MODEL_LLM_RUNTIME], completionOwner });
+}
+
+export function getModelCompletionOwner(
+  model: RuntimeBoundModel,
+): ModelCompletionOwner | undefined {
+  return model[MODEL_LLM_RUNTIME]?.completionOwner;
 }
 
 export function getModelLlmRuntime(model: RuntimeBoundModel): LlmRuntime | undefined {

--- a/src/plugin-sdk/lazy-runtime-facades.test.ts
+++ b/src/plugin-sdk/lazy-runtime-facades.test.ts
@@ -81,6 +81,7 @@ const cases = [
   },
   {
     name: "prepareSimpleCompletionModelForAgent",
+    ownerExport: "acquireSimpleCompletionModelForAgent",
     owner: "../agents/simple-completion-runtime.js",
     args: [preparationParams],
     load: async () => {
@@ -119,7 +120,7 @@ describe("lazy SDK execution facades", () => {
       for (const entry of cases) {
         vi.doMock(entry.owner, () => {
           loaded.push(entry.owner);
-          return { [entry.name]: execute };
+          return { [entry.ownerExport ?? entry.name]: execute };
         });
       }
 

--- a/src/plugin-sdk/simple-completion-runtime.ts
+++ b/src/plugin-sdk/simple-completion-runtime.ts
@@ -1,5 +1,6 @@
 /** Runtime SDK subpath for prepared completions and assistant text extraction. */
-import { createLazyRuntimeMethod } from "../shared/lazy-runtime.js";
+import { bindModelCompletionOwner } from "../llm/model-runtime-binding.js";
+import { getLegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
 
 export { completeWithPreparedSimpleCompletionModel } from "../agents/simple-completion-execution.js";
 export { extractEmbeddedAssistantText as extractAssistantText } from "../agents/embedded-agent-utils.js";
@@ -7,7 +8,29 @@ export { runHostPreparedIsolatedCompletion } from "../agents/host-prepared-isola
 
 /** Preparation owns model/auth discovery; prepared execution must not cold-load it. */
 export const prepareSimpleCompletionModelForAgent: typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModelForAgent =
-  createLazyRuntimeMethod(
-    () => import("../agents/simple-completion-runtime.js"),
-    (runtime) => runtime.prepareSimpleCompletionModelForAgent,
-  );
+  async (params) => {
+    const host = getLegacyPluginSdkResourceHost();
+    return await host.track(async () => {
+      const { acquireSimpleCompletionModelForAgent } =
+        await import("../agents/simple-completion-runtime.js");
+      host.assertOpen();
+      const acquired = await acquireSimpleCompletionModelForAgent(params);
+      if ("error" in acquired) {
+        return acquired;
+      }
+      const claim = { release: async () => acquired.release() };
+      try {
+        host.assertOpen();
+        const { release: _release, ...prepared } = acquired;
+        const model = bindModelCompletionOwner(prepared.model, {
+          run: (run) => host.track(run),
+          assertCurrent: () => host.assertOpen(),
+        });
+        host.adopt(model, claim);
+        return { ...prepared, model };
+      } catch (error) {
+        host.releaseClaim(claim);
+        throw error;
+      }
+    });
+  };

--- a/src/plugin-sdk/simple-completion-runtime.ts
+++ b/src/plugin-sdk/simple-completion-runtime.ts
@@ -1,4 +1,8 @@
 /** Runtime SDK subpath for prepared completions and assistant text extraction. */
+import type {
+  PreparedSimpleCompletionModelForAgent,
+  PrepareSimpleCompletionModelForAgentParams,
+} from "../agents/simple-completion.types.js";
 import { bindModelCompletionOwner } from "../llm/model-runtime-binding.js";
 import { getLegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
 
@@ -7,30 +11,31 @@ export { extractEmbeddedAssistantText as extractAssistantText } from "../agents/
 export { runHostPreparedIsolatedCompletion } from "../agents/host-prepared-isolated-completion.js";
 
 /** Preparation owns model/auth discovery; prepared execution must not cold-load it. */
-export const prepareSimpleCompletionModelForAgent: typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModelForAgent =
-  async (params) => {
-    const host = getLegacyPluginSdkResourceHost();
-    return await host.track(async () => {
-      const { acquireSimpleCompletionModelForAgent } =
-        await import("../agents/simple-completion-runtime.js");
+export const prepareSimpleCompletionModelForAgent = async (
+  params: PrepareSimpleCompletionModelForAgentParams,
+): Promise<PreparedSimpleCompletionModelForAgent> => {
+  const host = getLegacyPluginSdkResourceHost();
+  return await host.track(async () => {
+    const { acquireSimpleCompletionModelForAgent } =
+      await import("../agents/simple-completion-runtime.js");
+    host.assertOpen();
+    const acquired = await acquireSimpleCompletionModelForAgent(params);
+    if ("error" in acquired) {
+      return acquired;
+    }
+    const claim = { release: async () => acquired.release() };
+    try {
       host.assertOpen();
-      const acquired = await acquireSimpleCompletionModelForAgent(params);
-      if ("error" in acquired) {
-        return acquired;
-      }
-      const claim = { release: async () => acquired.release() };
-      try {
-        host.assertOpen();
-        const { release: _release, ...prepared } = acquired;
-        const model = bindModelCompletionOwner(prepared.model, {
-          run: (run) => host.track(run),
-          assertCurrent: () => host.assertOpen(),
-        });
-        host.adopt(model, claim);
-        return { ...prepared, model };
-      } catch (error) {
-        host.releaseClaim(claim);
-        throw error;
-      }
-    });
-  };
+      const { release: _release, ...prepared } = acquired;
+      const model = bindModelCompletionOwner(prepared.model, {
+        run: (run) => host.track(run),
+        assertCurrent: () => host.assertOpen(),
+      });
+      host.adopt(model, claim);
+      return { ...prepared, model };
+    } catch (error) {
+      host.releaseClaim(claim);
+      throw error;
+    }
+  });
+};

--- a/src/plugins/legacy-sdk-resource-host.ts
+++ b/src/plugins/legacy-sdk-resource-host.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
@@ -10,6 +11,7 @@ type ResourceClaim = { release: () => Promise<void> };
 
 /** Owns resources borrowed by shipped SDK results that have no release method. */
 export class LegacyPluginSdkResourceHost {
+  private readonly work = new AsyncWorkScope();
   private readonly claims = new Map<object, ResourceClaim>();
   private readonly pending = new Set<Promise<void>>();
   private readonly failures: unknown[] = [];
@@ -23,6 +25,11 @@ export class LegacyPluginSdkResourceHost {
 
   run<T>(run: () => T): T {
     return hostContext.run(this, run);
+  }
+
+  track<T>(run: () => T | Promise<T>): Promise<T> {
+    this.assertOpen();
+    return this.work.track(() => this.run(run));
   }
 
   adopt(source: object, claim: ResourceClaim): void {
@@ -59,6 +66,7 @@ export class LegacyPluginSdkResourceHost {
     if (!this.closing) {
       // A projection getter can close this host before its temporary claim is adopted.
       this.closing = Promise.resolve().then(async () => {
+        await this.work.drain();
         const claims = [...this.claims.values()];
         this.claims.clear();
         for (const claim of claims) {

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -20,8 +20,15 @@ import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared
 import { AuthStorage } from "../../agents/sessions/auth-storage.js";
 import { ModelRegistry } from "../../agents/sessions/model-registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { bindModelLlmRuntime, getModelLlmRuntime } from "../../llm/model-runtime-binding.js";
+import {
+  completeWithPreparedSimpleCompletionModel,
+  extractAssistantText,
+  prepareSimpleCompletionModelForAgent,
+} from "../../plugin-sdk/simple-completion-runtime.js";
 import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { LegacyPluginSdkResourceHost } from "../legacy-sdk-resource-host.js";
 import { resetPluginLoaderTestStateForTest } from "../loader.test-fixtures.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugin-metadata-lifecycle.js";
 import {
@@ -43,7 +50,18 @@ it.each([
   "abort",
   "callback-drain",
   "cancel-drain",
-] as const)("keeps direct completion ownership coherent: %s", async (mode) => {
+  "sdk-overlap",
+  "sdk-config",
+  "sdk-auth",
+  "sdk-late-prepare",
+  "sdk-dispatch-close",
+  "sdk-current-check",
+  "sdk-nested-prepare",
+  "sdk-callback-drain",
+  "sdk-cancel-drain",
+] as const)("keeps completion ownership coherent: %s", async (testCase) => {
+  const sdk = testCase.startsWith("sdk-");
+  const mode = testCase.replace(/^sdk-/, "");
   const roots = createSyncSuiteTempRootTracker("runtime-llm-prepared-owner");
   const root = fs.realpathSync(roots.makeTempDir());
   fs.mkdirSync(path.join(root, "provider"));
@@ -157,15 +175,25 @@ it.each([
       const drainMode = mode === "callback-drain" || mode === "cancel-drain";
       const workStarted = createDeferred();
       let acceptedWorkStarted = false;
+      let nestedPreparationCompleted = false;
+      let nestedPreparationFailure: string | undefined;
       const finishWork = createDeferred();
       const workSettled = createDeferred();
       const parentWork = new AsyncWorkScope();
       let parentDrain: Promise<void> | undefined;
       let parentDrained = false;
+      const sdkHosts = [
+        new LegacyPluginSdkResourceHost(),
+        new LegacyPluginSdkResourceHost(),
+        new LegacyPluginSdkResourceHost(),
+        new LegacyPluginSdkResourceHost(),
+      ] as const;
+      const prepareStarted = createDeferred();
+      const finishPrepare = createDeferred();
       const responseFailure = new Error("fixture response callback failure");
       const cancellationFailure = new Error("fixture cancellation failure");
       const transportSpies: Array<{ mockRestore: () => void }> = [];
-      if (drainMode) {
+      if (drainMode || mode === "nested-prepare") {
         const { configureAiTransportRuntimeHost } =
           await import("../../agents/ai-transport-runtime-host.js");
         configureAiTransportRuntimeHost();
@@ -181,6 +209,21 @@ it.each([
                 onResponse: async (response, responseModel) => {
                   await options?.onResponse?.(response, responseModel);
                   if (++responses !== 1) {
+                    return;
+                  }
+                  if (mode === "nested-prepare") {
+                    const nested = await prepareSimpleCompletionModelForAgent({
+                      cfg,
+                      agentId: "main",
+                    }).catch((error: unknown) => {
+                      nestedPreparationFailure =
+                        error instanceof Error ? error.message : "Non-Error preparation failure";
+                      throw error;
+                    });
+                    if ("error" in nested) {
+                      throw new Error(nested.error);
+                    }
+                    nestedPreparationCompleted = true;
                     return;
                   }
                   if (mode === "cancel-drain") {
@@ -298,6 +341,213 @@ it.each([
           }),
         ]);
       try {
+        if (sdk) {
+          const [firstHost, secondHost, thirdHost, foreignHost] = sdkHosts;
+          await foreignHost.close();
+          const prepare = (host: LegacyPluginSdkResourceHost, gated = false) =>
+            host.run(() =>
+              prepareSimpleCompletionModelForAgent({
+                cfg: currentConfig,
+                agentId: "main",
+                ...(gated
+                  ? {
+                      modelResolver: async (...args) => {
+                        const resolved = await resolveModel(...args);
+                        prepareStarted.resolve();
+                        await finishPrepare.promise;
+                        return resolved;
+                      },
+                    }
+                  : {}),
+              }),
+            );
+          if (mode === "late-prepare") {
+            const preparing = prepare(firstHost, true);
+            pending.push(preparing);
+            await Promise.race([
+              prepareStarted.promise,
+              preparing.then(() => {
+                throw new Error("SDK preparation did not enter the real model resolver");
+              }),
+            ]);
+            const firstBuilds = create.mock.calls.length;
+            expect(firstBuilds).toBeGreaterThan(0);
+            let closed = false;
+            const closing = firstHost.close().then(() => {
+              closed = true;
+            });
+            const overlapping = await prepare(secondHost);
+            expect(overlapping).not.toHaveProperty("error");
+            await secondHost.close();
+            expect.soft(closed).toBe(false);
+            finishPrepare.resolve();
+            await expect(preparing.then(() => undefined)).rejects.toThrow(
+              "Plugin SDK resource host is closed",
+            );
+            await closing;
+            const next = await prepare(thirdHost);
+            expect(next).not.toHaveProperty("error");
+            expect(create.mock.calls.length).toBe(firstBuilds + 1);
+            expect(requests).toHaveLength(0);
+            return;
+          }
+          if (mode === "dispatch-close" || mode === "current-check") {
+            const prepared = await prepare(firstHost);
+            if ("error" in prepared) {
+              throw new Error(prepared.error);
+            }
+            const callerFailure = new Error("Caller completion authority closed");
+            const completion = completeWithPreparedSimpleCompletionModel({
+              ...prepared,
+              context: { messages: [{ role: "user", content: "check dispatch", timestamp: 0 }] },
+              assertCurrent:
+                mode === "current-check"
+                  ? () => {
+                      throw callerFailure;
+                    }
+                  : undefined,
+            });
+            pending.push(completion);
+            const closing = mode === "dispatch-close" ? firstHost.close() : undefined;
+            await Promise.race([
+              mode === "current-check"
+                ? expect(completion).rejects.toBe(callerFailure)
+                : expect(completion).rejects.toThrow("Plugin SDK resource host is closed"),
+              arrivals[0]!.promise.then(() => {
+                throw new Error("Closed completion reached the provider");
+              }),
+            ]);
+            await closing;
+            expect(requests).toHaveLength(0);
+            return;
+          }
+          const preparedModels: Array<
+            Parameters<typeof completeWithPreparedSimpleCompletionModel>[0]
+          > = [];
+          const startSdk = (
+            index: number,
+            host: LegacyPluginSdkResourceHost,
+            signal?: AbortSignal,
+          ) => {
+            const completion = (async () => {
+              const prepared = await prepare(host);
+              if ("error" in prepared) {
+                throw new Error(prepared.error);
+              }
+              expect(Object.keys(prepared).toSorted()).toEqual(["auth", "model", "selection"]);
+              const runtime = getModelLlmRuntime(prepared.model);
+              if (!runtime) {
+                throw new Error("SDK preparation did not bind its real model runtime");
+              }
+              const execution = {
+                ...prepared,
+                // Legitimate transport copies must carry the original completion owner.
+                model: bindModelLlmRuntime(prepared.model, runtime),
+                context: {
+                  messages: [{ role: "user" as const, content: `request-${index}`, timestamp: 0 }],
+                },
+                options: { signal },
+              };
+              preparedModels.push(execution);
+              const message = await foreignHost.run(() =>
+                completeWithPreparedSimpleCompletionModel(execution),
+              );
+              return { text: extractAssistantText(message) };
+            })();
+            pending.push(completion);
+            return completion;
+          };
+          const controller = mode === "callback-drain" ? new AbortController() : undefined;
+          const first = startSdk(0, firstHost, controller?.signal);
+          await waitForRequest(0, first);
+          const firstBuilds = create.mock.calls.length;
+          expect(firstBuilds).toBeGreaterThan(0);
+          let closed = false;
+          let closing: Promise<void> | undefined;
+          if (drainMode) {
+            finish(requests[0]!, 0);
+            await Promise.race([
+              workStarted.promise,
+              first.then(() => {
+                throw new Error("SDK completion settled before accepted work");
+              }),
+            ]);
+            controller?.abort();
+            await expect(first).resolves.toMatchObject({ text: "" });
+            closing = firstHost.close().then(() => {
+              closed = true;
+            });
+          }
+          if (mode === "config") {
+            currentConfig = {
+              ...cfg,
+              models: {
+                providers: {
+                  [fixture.providerId]: {
+                    ...cfg.models!.providers![fixture.providerId]!,
+                    baseUrl: `http://127.0.0.1:${address.port}/B/v1`,
+                    apiKey: "fixture-auth-B",
+                  },
+                },
+              },
+            };
+          }
+          if (mode === "auth") {
+            publishAuth("fixture-auth-B");
+            await prepareModelRuntimeSnapshot(input());
+          }
+          const second = startSdk(1, secondHost);
+          await waitForRequest(1, second);
+          if (mode === "overlap" || drainMode) {
+            expect.soft(create.mock.calls.length).toBe(firstBuilds);
+          }
+          expect(fork.mock.calls).toHaveLength(2);
+          expect(fork.mock.calls[0]![0]).not.toBe(fork.mock.calls[1]![0]);
+          if (drainMode) {
+            expect.soft(closed).toBe(false);
+            finishWork.resolve();
+            await workSettled.promise;
+            await closing;
+          } else {
+            finish(requests[0]!, 0);
+            const firstResult = await first;
+            expect(nestedPreparationFailure).toBeUndefined();
+            expect(firstResult).toMatchObject({
+              text: "result-0|/A/v1/chat/completions|Bearer fixture-auth-A",
+            });
+          }
+          if (mode === "nested-prepare") {
+            expect(nestedPreparationCompleted).toBe(true);
+          }
+          finish(requests[1]!, 1);
+          await expect(second).resolves.toMatchObject({
+            text: `result-1|/${mode === "config" ? "B" : "A"}/v1/chat/completions|Bearer fixture-auth-${mode === "config" || mode === "auth" ? "B" : "A"}`,
+          });
+          await firstHost.close();
+          await secondHost.close();
+          const staleCompletion = completeWithPreparedSimpleCompletionModel({
+            ...preparedModels[0]!,
+            options: {},
+          });
+          pending.push(staleCompletion);
+          await Promise.race([
+            expect(staleCompletion).rejects.toThrow("Plugin SDK resource host is closed"),
+            arrivals[2]!.promise.then(() => {
+              throw new Error("Closed SDK model reached the provider");
+            }),
+          ]);
+          expect(requests).toHaveLength(2);
+          if (mode === "config" || mode === "auth") {
+            return;
+          }
+          const beforeThird = create.mock.calls.length;
+          const third = startSdk(2, thirdHost);
+          await waitForRequest(2, third);
+          expect(create.mock.calls.length).toBe(beforeThird + 1);
+          finish(requests[2]!, 2);
+          await third;
+          return;
+        }
         if (mode === "fork" || mode === "prepare-error" || mode === "prepare-throw") {
           if (mode === "fork") {
             fork.mockImplementationOnce(() => {
@@ -484,6 +734,7 @@ it.each([
           });
         }
       } finally {
+        finishPrepare.resolve();
         finishWork.resolve();
         finishing = true;
         requests.forEach(finish);
@@ -493,6 +744,7 @@ it.each([
         }
         await parentDrain;
         await parentWork.drain();
+        await Promise.all(sdkHosts.map((host) => host.close()));
         for (const spy of transportSpies) {
           spy.mockRestore();
         }


### PR DESCRIPTION
Related: #140674. Internal caller migrations landed in #143302, #143307, and #143308.

## What Problem This Solves

Resolves a problem where plugins receive an executable prepared model after its preparation lease has already been released. Completion callbacks and nested preparation can then outlive the model's owner, particularly during cancellation or host shutdown.

## Why This Change Was Made

Keep the existing bare-result SDK API under its SDK host. Capture the host before lazy preparation, retain the successful model, and track actual completion and callback work through host closure. Re-enter that host for nested preparation without replacing Gateway request authority.

With all three internal callers using acquisition, delete the obsolete core bare adapter. Shared parameter and result types preserve the public fingerprint, optional selection fields, and deprecated parameter; the SDK runtime import remains lazy. Core preparation tests now release acquired results. The distinct direct preparation API remains unchanged.

## User Impact

Plugins keep their existing prepared-model API and gain reliable host-owned cleanup. Host closure joins pending work and refuses new requests afterward. Provider selection, authentication checks, and public result shapes are preserved.

## Evidence

The original native SDK regressions and a separately reproduced nested-callback host-context failure pass after repair. Final validation passed 166 focused tests, the unchanged export-collision guard, all selected changed-file gates, fresh isolated Codex review through P2, and a full build in 248.17 seconds.

A plain Node run of the built public SDK used actual ModelRegistry instances, a synthetic provider, and loopback HTTP. It exercised nested preparation in a real response callback, prompt cancellation while that callback remained held, host drainage, independent request stores, base-catalog reuse, post-close refusal, and fresh preparation after the last host closed. It also verified that the built core exposes acquisition and no longer exports the obsolete bare adapter.

That strict, joined run completed in 2.495 seconds, observing two base catalogs, four request forks, and three HTTP calls. All 21,093 build artifacts remained unchanged; 2,880 resolved modules had no application TypeScript/source fallback. Preparation samples were 145.059 / 3.162 / 5.768 ms for initial, retained, and fresh-after-closure preparations; these are local observations, not a comparative speedup benchmark.

After rebasing onto the three landed caller migrations, all 14 source files match the reviewed proof. The collision guard and 42 SDK composition tests passed again. This does not activate general run-registration physical disposal or claim a paid-provider or operator-Gateway test.
