### PR TITLE
improve(test): reduce worker preparation overhead

### DIFF
--- a/scripts/lib/vitest-worker-compiler.mts
+++ b/scripts/lib/vitest-worker-compiler.mts
@@ -106,8 +106,8 @@ async function compileVitestWorkerArtifacts(directory: string): Promise<void> {
           return null;
         },
         generateBundle(_options, bundle) {
-          for (const id of Object.keys(inputs)) {
-            let packageDirectory = path.dirname(id);
+          const packageDirectories = new Set(Object.keys(inputs).map((id) => path.dirname(id)));
+          for (let packageDirectory of packageDirectories) {
             while (packageDirectory.startsWith(root)) {
               const manifest = path.join(packageDirectory, "package.json");
               if (fs.existsSync(manifest)) {


### PR DESCRIPTION
## What Problem This Solves

Worker preparation repeatedly searches the same source directories for their nearest package manifest. In a measured preparation, the two compiler passes made 42,758 filesystem existence probes even though they visited only 238 and 258 distinct input directories.

This was found while investigating the Windows transform proof's 120-second timeout in [main run 34372522578](https://github.com/openclaw/openclaw/actions/runs/34372522578/job/102540152495). The five remaining launches each protect a distinct cache transition, so they stay intact.

## Why This Change Was Made

Deduplicate source directories within each `generateBundle` call. Files in the same directory have the same nearest package manifest. Rebuilding the set for each call preserves discovery during the second managed-handoff build; manifest recording, output hashing, and final verification remain unchanged.

## User Impact

Less filesystem work in every compiled worker preparation. This is a two-line replacement with zero net tooling growth. Product behavior, tests, deadlines, shard counts, and cache infrastructure are unchanged.

## Evidence

- A native preparation through the existing worker owner reduced manifest probes from **42,758 to 1,322**. Combined scan time fell from **86.7ms to 13.8ms** locally.
- Both preparations recorded exactly the same **8,681 input paths**, including **23 package manifests**, and emitted **4,370 outputs**. The only input-hash difference was the modified compiler itself. Both generations passed verification and canonical disposal.
- The complete compiler times were 4.418s and 3.269s, but this single pair includes warming and timing variance. Only the probe and scan-time reduction is attributed to this change; it does not establish a Windows deadline guarantee.
- Final uninstrumented owner/sibling tests passed: both transform layouts, stale-dist/private-package behavior, responsive verification, and input/output verification-drain cases (**6 selected tests across 3 files**, 72.38s). The remaining 33 cases were unselected by the explicit filter.
- Required changed-file checks passed. Independent review through P2 found no actionable issues.

Temporary profiling instrumentation was removed before tests and review. Native Windows validation passed at the exact candidate commit in [run 34381827560](https://github.com/openclaw/openclaw/actions/runs/34381827560). Both Windows test inventories and the Scheduled Task proof passed. The transform layouts took **107.354s** and **117.710s**, within the unchanged 120-second deadline. This used the existing hosted Windows probe with one Vitest worker, so it is native correctness evidence, not a controlled timing comparison with the failing Blacksmith run. The margin remains narrow; no permanent timeout-resolution claim is made.

Required [PR CI 34379071418](https://github.com/openclaw/openclaw/actions/runs/34379071418) also passed. Its automatic path filters did not select Windows. An initial dedicated Blacksmith probe was cancelled while still unassigned with zero steps; the existing hosted-runner option supplied the native validation instead. No workflow or capacity setting was changed.
