### PR TITLE
refactor(tests): remove unused doctor catalog fixture

### DIFF
--- a/src/commands/doctor/channel-capabilities.packaged.test.ts
+++ b/src/commands/doctor/channel-capabilities.packaged.test.ts
@@ -1,4 +1,4 @@
-// Packaged doctor capability tests cover generated catalog lookup without plugin runtime loading.
+// Packaged doctor capability tests cover built-in official metadata without plugin runtime loading.
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -40,25 +40,6 @@ beforeEach(() => {
   const root = makeTempRepoRoot(tempDirs, "doctor-channel-packaged-");
   packageRootMock.value = root;
   writeJsonFile(path.join(root, "package.json"), { name: "openclaw" });
-  writeJsonFile(path.join(root, "dist", "channel-catalog.json"), {
-    entries: [
-      {
-        name: "@openclaw/discord",
-        openclaw: {
-          channel: {
-            id: "discord",
-            label: "Discord",
-            doctorCapabilities: {
-              dmAllowFromMode: "topOnly",
-              groupModel: "route",
-              groupAllowFromFallbackToAllowFrom: false,
-              warnOnEmptyGroupSenderAllowlist: false,
-            },
-          },
-        },
-      },
-    ],
-  });
   clearPluginMetadataLifecycleCaches();
   channelPluginMocks.getBundledChannelPlugin.mockReset().mockReturnValue(undefined);
   channelPluginMocks.getChannelPlugin.mockReset().mockReturnValue(undefined);
@@ -72,7 +53,7 @@ afterEach(() => {
 });
 
 describe("doctor channel capabilities in a packaged install", () => {
-  it("reads Discord semantics from the generated catalog without loading a plugin", () => {
+  it("reads Discord semantics from built-in official metadata without loading a plugin", () => {
     expect(getDoctorChannelCapabilities("discord")).toEqual({
       dmAllowFromMode: "topOnly",
       groupModel: "route",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The packaged doctor capabilities test had misleading fixture setup and wording, making its actual coverage harder to understand during maintainer-requested test cleanup.

## Why This Change Was Made

Higher-precedence built-in official metadata supplies the asserted Discord capabilities, so the generated catalog fixture was unused. Remove that write and correct the case name/comment while preserving the package fixture, missing-plugin setup, mocks, lifecycle cleanup and every assertion.

Generated-catalog fallback, precedence and cache-reset coverage remains in the unchanged catalog-reader tests.

## User Impact

No runtime behavior changes. This is a one-file test cleanup (+2/-21 lines), with zero test cases removed and no production changes.

## Evidence

- Full packaged doctor, source doctor and bundled-channel-catalog-reader files through `node scripts/run-vitest.mjs ... --reporter=verbose`: **21 passed, 0 skipped** (11 in the commands project and 10 in channels).
- Exact-path `check:changed` at base `a57c799c86dfa3b08e1994b75700bda6ffced01f`: all **20 selected steps passed**, with no retries.
- Targeted formatting and `git diff --check` passed.
- Fresh P2 review with the full relevant source context: scoped-clean, no accepted/actionable findings.

This is focused local test evidence, not an installed-package, live-channel or full-repository validation claim.
