### PR TITLE
feat(tui): answer agent questions in gateway and local modes

### DIFF
--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -90,6 +90,11 @@ Aliases: `openclaw chat` and `openclaw terminal` invoke this command with
 - Local mode adds `/auth [provider]` to the TUI command surface.
 - Plugin approval gates still apply in local mode: tools that require approval
   prompt for a decision in the terminal, nothing is silently auto-approved.
+- [`ask_user` questions](/web/tui#questions) appear as interactive prompts in
+  both modes. Esc collapses a prompt without answering; `/question` reopens it.
+- Gateway mode accepts [`secrets`](/tools/secrets) requests in a masked input
+  with a read-only allowed-host list. Local mode cannot fulfill store-bound
+  requests; use `openclaw secrets store` or the Control UI with a running Gateway.
 - Session [goals](/tools/goal) appear in the footer and can be managed with
   `/goal`.
 

--- a/docs/tools/ask-user.md
+++ b/docs/tools/ask-user.md
@@ -23,6 +23,11 @@ You can answer from any supported conversation surface:
   multi-question prompts, the panel shows one question at a time and advances
   through a short stepper. After resolution, the panel closes and the chat
   keeps only a compact answer summary.
+- The TUI shows a question prompt in both Gateway and local modes. Use arrow
+  keys or number keys to choose an option, **Other…** to type an answer, or
+  **Skip**. Multi-select prompts let you toggle choices before confirming;
+  multi-question prompts advance one question at a time. Press Esc to return
+  to the composer without answering, then `/question` to reopen the prompt.
 - Telegram renders each choice as a full-width native button for one
   single-select question. **Other…** switches to Telegram's reply input without
   resolving the question.
@@ -35,7 +40,7 @@ You can answer from any supported conversation surface:
 
 Questions from a standalone [attached MCP client](/cli/attach) do not carry an
 OpenClaw run's creator binding. Answer those using the question controls in the
-Control UI or native app, not an ordinary channel message.
+Control UI, TUI, or native app, not an ordinary channel message.
 
 OpenClaw always enables a free-text **Other** answer. The agent must not add an
 `Other` option to the authored option list.
@@ -46,15 +51,20 @@ without it entering the chat, the transcript, or the model's context.
 
 ## Platform behavior
 
-Answers work on every supported conversation surface. The web Control UI uses a
-docked stepper that replaces the composer while expanded; collapsing it restores
-the full composer beneath a slim question bar. iOS, macOS, and Android show
+Answers work on every supported conversation surface. The web Control UI and
+TUI show one question at a time; collapsing the prompt restores the composer
+with a slim pending-question indicator. The TUI's `/question` command reopens
+it, and a plain reply still answers an eligible pending question. iOS, macOS, and Android show
 inline cards; multiple questions stay stacked as an intentional touch-friendly
-idiom. Every platform keeps the question-to-answer summary in the active chat
-timeline without timed eviction, and **Skip** is available everywhere.
+idiom. The TUI keeps a compact resolution notice in the chat; other platforms
+keep the question-to-answer summary without timed eviction. **Skip** is
+available everywhere and declines the entire prompt.
 
 Multi-question and multi-select prompts degrade to readable text on messaging
-channels. The Control UI keeps the full structured stepper.
+channels. The Control UI and TUI keep the full structured stepper. The TUI shows
+the time remaining, dismisses expired prompts, and restores pending questions
+for the selected session after reconnecting or switching sessions. Local mode
+keeps questions in the running process; they do not survive exiting the TUI.
 
 ## Timeout and no answer
 

--- a/docs/tools/secrets.md
+++ b/docs/tools/secrets.md
@@ -60,8 +60,22 @@ agent's stated reason, and an editable list of allowed hosts, so you have the
 final say on where the credential may be used. If the name already exists, the
 prompt says so and shows when and by whom the entry was last updated;
 submitting replaces the stored value. The Gateway preserves submitted values
-exactly, including leading or trailing whitespace. Web and Apple request fields
+exactly, including leading or trailing whitespace. Web, TUI, and Apple request fields
 are single-line; use the CLI's `--value-file` input for multiline credentials.
+
+The Gateway-connected TUI also accepts requests through a masked input: typed
+characters appear as bullets and are never added to the chat log or input
+history. The prompt shows the entry name, reason, and proposed allowed hosts.
+The host list is read-only in the TUI; submitting accepts the displayed list.
+Use the Control UI if you need to edit it before submitting. **Skip** declines
+the request; Esc leaves it pending, and `/question` reopens it. Never enter a
+credential in the ordinary composer.
+
+Local mode (`openclaw chat` or `openclaw tui --local`) cannot fulfill store-bound
+requests. The agent receives a blocker directing the operator to run
+`openclaw secrets store` or use the Control UI with a running Gateway. The local
+question prompt supports masked input, but that alone does not provide the
+Gateway's secret-store write and runtime refresh flow.
 
 If the agent omits a host proposal, a replacement request starts with the entry's
 current hosts; a new entry starts with an empty list. An explicitly empty proposal
@@ -100,7 +114,7 @@ arrived (`no_answer`). It should state the blocker or continue with best judgmen
 never ask you to paste the credential into chat.
 
 iOS, macOS, and Android render the same card with a masked secret field.
-Control UI and native app cards arrive through the existing Gateway connection
+Control UI, TUI, and native app cards arrive through the existing Gateway connection
 and do not require `gateway.publicOrigin` or a public link.
 
 Chat channels never accept the value. On Telegram, Discord, and similar

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -86,11 +86,39 @@ openclaw tui --local
 
 Esc or Ctrl+C closes a picker. In the session picker, the first press clears a nonempty filter; press again to close it.
 
+## Questions
+
+When the agent calls [`ask_user`](/tools/ask-user), the TUI opens a question
+prompt for the active session. This works in Gateway mode and local mode
+(`openclaw chat` or `openclaw tui --local`). Prompts with up to three questions
+show one at a time, with a stepper and the time remaining.
+
+Use arrow keys or number keys to choose an option, then Enter to continue.
+For multi-select questions, toggle the choices you want and confirm them.
+**Other…** always lets you type your own answer, and **Skip** declines the entire prompt.
+After the final question, the TUI submits the answers and shows a compact
+system notice.
+
+Press Esc to collapse the prompt and return to the composer. The question
+stays pending with a slim status indicator; `/question` reopens it. A normal
+reply still answers eligible pending questions from an active run. Expired
+questions and questions answered elsewhere close automatically. Reconnecting
+or switching sessions restores pending questions for the selected session.
+In local mode, pending questions last only for the current TUI process.
+
+Gateway-connected [`secrets`](/tools/secrets) requests use a masked input that
+renders bullets and keeps the value out of chat and input history. The prompt
+shows the entry name, reason, and proposed allowed hosts. Hosts are read-only
+here: submitting accepts the displayed list; use the Control UI to edit it.
+Local mode cannot fulfill store-bound requests; use `openclaw secrets store`
+or the Control UI with a running Gateway. Enter credentials only in a masked
+prompt, never in the composer.
+
 ## Keyboard shortcuts
 
 - Enter: send message
 - Shift+Enter or Ctrl+J: insert a newline without sending
-- Esc: abort active run
+- Esc: collapse an open question prompt, or abort the active run from the composer
 - Ctrl+C: clear input (press twice to exit)
 - Ctrl+D: exit
 - Ctrl+L: model picker
@@ -113,6 +141,7 @@ Core:
 - `/agent <id>` (or `/agents`)
 - `/session <key>` (or `/sessions`)
 - `/model <provider/model|default>` (or `/models`; `default` clears the session override)
+- `/question` (reopen the active session's pending question)
 
 Gateway-connected model updates honor the optional
 [`agents.defaults.modelSelectionScope`](/gateway/config-agents/models#agentsdefaultsmodelselectionscope)

--- a/package.json
+++ b/package.json
@@ -2108,6 +2108,7 @@
     "tui:pty:test:watch:all": "node --import ./scripts/tsx.mjs scripts/dev/tui-pty-test-watch.ts --mode all",
     "tui:pty:test:watch:fake": "node --import ./scripts/tsx.mjs scripts/dev/tui-pty-test-watch.ts --mode fake",
     "tui:pty:test:watch:local": "node --import ./scripts/tsx.mjs scripts/dev/tui-pty-test-watch.ts --mode local",
+    "tui:questions:proof": "node --import ./scripts/tsx.mjs scripts/dev/tui-questions-proof.ts",
     "ui:boot-manifest:gen": "node --import ./scripts/tsx.mjs scripts/control-ui-boot-manifest.mts",
     "ui:build": "node scripts/ui.js build",
     "ui:check-performance": "node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts",

--- a/scripts/dev/tui-questions-proof.ts
+++ b/scripts/dev/tui-questions-proof.ts
@@ -1,0 +1,570 @@
+// Run with: node --import ./scripts/tsx.mjs scripts/dev/tui-questions-proof.ts --output <directory>
+// Exercises real source TUI backends with isolated state and a scripted loopback model.
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import type { QuestionWaitAnswerResult } from "../../packages/gateway-protocol/src/schema/questions.js";
+import { iterateAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import {
+  PtyTestScreen,
+  startPty,
+  waitFor,
+  type PtyRun,
+} from "../../src/tui/tui-pty-test-support.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const self = fileURLToPath(import.meta.url);
+const loader = path.join(root, "scripts/tsx.mjs");
+const sessionKey = "agent:main:main";
+const questionText = "Which color should this synthetic proof use?";
+const choices = [{ label: "Blue" }, { label: "Green" }];
+
+async function childMain(mode: string, args: string[]) {
+  if (mode === "--tui-child") {
+    const { Command } = await import("commander");
+    const { registerTuiCli } = await import("../../src/cli/tui-cli.js");
+    const program = new Command();
+    registerTuiCli(program);
+    await program.parseAsync([process.execPath, "openclaw", "tui", ...args]);
+    return;
+  }
+  if (mode === "--gateway-child") {
+    const { startGatewayServer } = await import("../../src/gateway/server.js");
+    const server = await startGatewayServer(Number(args[0]), {
+      bind: "loopback",
+      controlUiEnabled: false,
+    });
+    await server.startupSettled;
+    process.stdout.write("QUESTION_PROOF_GATEWAY_READY\n");
+    let closing = false;
+    const close = async () => {
+      if (closing) {
+        return;
+      }
+      closing = true;
+      await server.close({ reason: "question proof complete" });
+      process.exit(0);
+    };
+    process.once("SIGTERM", () => void close());
+    process.once("SIGINT", () => void close());
+    return;
+  }
+  if (mode === "--rpc-child") {
+    const { callGateway } = await import("../../src/gateway/call.js");
+    const config: OpenClawConfig = JSON.parse(
+      await readFile(process.env.OPENCLAW_CONFIG_PATH!, "utf8"),
+    );
+    const result = await callGateway({
+      url: `ws://127.0.0.1:${config.gateway?.port}`,
+      token: process.env.OPENCLAW_GATEWAY_TOKEN,
+      config,
+      method: args[0]!,
+      params: JSON.parse(args[1] ?? "{}"),
+      scopes: ["operator.admin"],
+      timeoutMs: 30_000,
+    });
+    process.stdout.write(`QUESTION_PROOF_RPC=${JSON.stringify(result)}\n`);
+    return;
+  }
+  throw new Error(`Unknown proof child mode: ${mode}`);
+}
+
+function startChild(args: string[], env: NodeJS.ProcessEnv) {
+  const child = spawn(process.execPath, args, { cwd: root, env, stdio: "pipe" });
+  let output = "";
+  let exited = false;
+  let failure: Error | undefined;
+  child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
+  child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+  child.on("error", (error) => (failure = error));
+  child.on("exit", () => (exited = true));
+  const wait = async (needle: string) =>
+    await waitFor({
+      timeoutMs: 60_000,
+      read: () => {
+        if (failure) {
+          throw failure;
+        }
+        if (output.includes(needle)) {
+          return output;
+        }
+        if (exited) {
+          throw new Error(`Proof child exited before ${needle}\n${output}`);
+        }
+        return null;
+      },
+      onTimeout: () => new Error(`Proof child did not emit ${needle}\n${output}`),
+    });
+  return { child, output: () => output, wait };
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams) {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  const deadline = Date.now() + 5_000;
+  while (child.exitCode === null && child.signalCode === null && Date.now() < deadline) {
+    await delay(25);
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+  }
+}
+
+async function freePort() {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert(address && typeof address !== "string");
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
+function frame(run: PtyRun) {
+  const screen = new PtyTestScreen(run);
+  let complete = "";
+  for (const segment of iterateAnsiSegments(run.output())) {
+    if (segment.kind === "text") {
+      screen.write(segment.value, true);
+    } else if (segment.value === "\x1b[?2026l") {
+      complete = screen.cells
+        .map((row) =>
+          row
+            .map((cell) => cell.text)
+            .join("")
+            .trimEnd(),
+        )
+        .join("\n");
+    } else if (segment.value.startsWith("\x1b[")) {
+      screen.applyCsi(segment.value, true);
+    }
+  }
+  return complete.trimEnd();
+}
+
+function hasAnswer(value: unknown, answer: string): boolean {
+  if (typeof value === "string") {
+    // ask_user's textResult contains its human-readable summary before the JSON payload.
+    const payloadStart = value.indexOf("\n\n{");
+    const candidate = payloadStart >= 0 ? value.slice(payloadStart + 2) : value;
+    try {
+      return hasAnswer(JSON.parse(candidate), answer);
+    } catch {
+      return false;
+    }
+  }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return Object.entries(value).some(([key, nested]) =>
+    key === "color" && Array.isArray(nested)
+      ? nested.length === 1 && nested[0] === answer
+      : hasAnswer(nested, answer),
+  );
+}
+
+function modelQuestionEvents(callId: string, question = questionText) {
+  const item = {
+    type: "function_call",
+    id: `fc_${callId}`,
+    call_id: callId,
+    name: "ask_user",
+    arguments: JSON.stringify({
+      questions: [{ id: "color", header: "Color", question, options: choices }],
+      timeoutSeconds: 120,
+    }),
+  };
+  return [
+    { type: "response.output_item.added", output_index: 0, item: { ...item, arguments: "" } },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: item.id,
+      output_index: 0,
+      delta: item.arguments,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_${callId}`,
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 32, output_tokens: 16, total_tokens: 48 },
+      },
+    },
+  ];
+}
+
+async function runProof(outputDir: string) {
+  const scratch = await mkdtemp(path.join(tmpdir(), "openclaw-question-proof-state-"));
+  const requestLog = path.join(scratch, "model-requests.jsonl");
+  const token = randomUUID();
+  const redact = (value: string) => value.replaceAll(token, "[isolated Gateway token]");
+  const describeFailure = (error: unknown) =>
+    redact(error instanceof Error ? (error.stack ?? error.message) : String(error));
+  const failures: string[] = [];
+  const children: ChildProcessWithoutNullStreams[] = [];
+  const terminals: PtyRun[] = [];
+  const report: string[] = [];
+  const cleanEnv: NodeJS.ProcessEnv = Object.fromEntries(
+    Object.keys(process.env).map((key) => [key, undefined]),
+  );
+  Object.assign(cleanEnv, {
+    PATH: process.env.PATH,
+    LANG: "en_US.UTF-8",
+    TERM: "xterm-256color",
+    OPENCLAW_THEME: "dark",
+    OPENCLAW_CODEX_DISCOVERY_LIVE: "0",
+    OPENCLAW_SKIP_CHANNELS: "1",
+    OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+    OPENCLAW_SKIP_CRON: "1",
+    OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+    OPENCLAW_SKIP_CANVAS_HOST: "1",
+    OPENCLAW_TUI_PTY_COLS: "100",
+    OPENCLAW_TUI_PTY_ROWS: "32",
+  });
+  const launch = (args: string[], env: NodeJS.ProcessEnv) => {
+    const child = startChild(args, env);
+    children.push(child.child);
+    return child;
+  };
+  const capture = async (name: string, run: PtyRun) => {
+    const text = redact(frame(run));
+    assert(text, `No completed terminal frame for ${name}`);
+    await writeFile(path.join(outputDir, `${name}.txt`), `${text}\n`);
+    report.push(`--- ${name} ---\n${text}`);
+  };
+  const terminalDiagnostic = (run: PtyRun) =>
+    frame(run) || run.visibleOutput().slice(-16_000) || "No terminal output received.";
+  const waitForText = async (run: PtyRun, needle: string) => {
+    const deadline = Date.now() + 60_000;
+    try {
+      await run.waitForOutput(needle);
+      await waitFor({
+        timeoutMs: Math.max(1, deadline - Date.now()),
+        read: () => (frame(run).includes(needle) ? true : null),
+        onTimeout: () => new Error(`Terminal frame did not show ${needle}`),
+      });
+    } catch {
+      throw new Error(`Terminal did not show ${needle}\n${terminalDiagnostic(run)}`);
+    }
+  };
+  const startTui = async (env: NodeJS.ProcessEnv, args: string[], ready: string) => {
+    const run = startPty(process.execPath, ["--import", loader, self, "--tui-child", ...args], {
+      cwd: root,
+      env,
+      exitTimeoutMs: 5_000,
+      outputTimeoutMs: 60_000,
+    });
+    terminals.push(run);
+    await waitForText(run, ready);
+    return run;
+  };
+  const waitForPrompt = async (run: PtyRun, question: string) =>
+    await waitFor({
+      timeoutMs: 60_000,
+      read: () => {
+        const text = frame(run);
+        return text.includes(question) && text.includes("Enter confirm") ? true : null;
+      },
+      onTimeout: () => new Error(`Question prompt did not open\n${terminalDiagnostic(run)}`),
+    });
+  try {
+    await mkdir(outputDir, { recursive: true });
+    const mockPort = await freePort();
+    const gatewayPort = await freePort();
+    const controlPath = path.join(scratch, "responses.json");
+    await writeFile(
+      controlPath,
+      JSON.stringify({
+        responses: [
+          { events: modelQuestionEvents("question_one") },
+          { text: "LOCAL_QUESTION_ANSWER_RECEIVED" },
+          {
+            events: modelQuestionEvents(
+              "question_two",
+              "Which color should the typed reply choose?",
+            ),
+          },
+          { text: "LOCAL_TYPED_ANSWER_RECEIVED" },
+        ],
+      }),
+    );
+    const mock = launch([path.join(root, "scripts/e2e/mock-openai-server.mjs")], {
+      ...cleanEnv,
+      MOCK_PORT: String(mockPort),
+      MOCK_RESPONSE_CONTROL: controlPath,
+      MOCK_REQUEST_LOG: requestLog,
+    });
+    await mock.wait("mock-openai listening on");
+
+    const modeEnv = async (mode: string) => {
+      const modeDir = path.join(scratch, mode);
+      await mkdir(path.join(modeDir, "workspace"), { recursive: true });
+      await mkdir(path.join(modeDir, "home"), { recursive: true });
+      const config: OpenClawConfig = {
+        gateway: { mode: "local", port: gatewayPort, auth: { mode: "token", token } },
+        discovery: { mdns: { mode: "off" } },
+        plugins: { enabled: false, slots: { memory: "none" } },
+        agents: {
+          defaults: {
+            workspace: path.join(modeDir, "workspace"),
+            skipBootstrap: true,
+            skills: [],
+            model: { primary: "question-proof/gpt-5.6-luna" },
+            models: {
+              "question-proof/gpt-5.6-luna": {
+                agentRuntime: { id: "openclaw" },
+                params: { transport: "sse", openaiWsWarmup: false },
+              },
+            },
+          },
+          entries: { main: { skills: [] } },
+        },
+        models: {
+          mode: "replace",
+          providers: {
+            "question-proof": {
+              baseUrl: `http://127.0.0.1:${mockPort}/v1`,
+              apiKey: "synthetic-proof-key",
+              api: "openai-responses",
+              request: { allowPrivateNetwork: true },
+              models: [
+                {
+                  id: "gpt-5.6-luna",
+                  name: "Synthetic question proof",
+                  api: "openai-responses",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      };
+      const configPath = path.join(modeDir, "openclaw.json");
+      await writeFile(configPath, JSON.stringify(config));
+      return {
+        ...cleanEnv,
+        HOME: path.join(modeDir, "home"),
+        OPENCLAW_HOME: path.join(modeDir, "home"),
+        OPENCLAW_STATE_DIR: path.join(modeDir, "state"),
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_GATEWAY_TOKEN: token,
+        XDG_CONFIG_HOME: path.join(modeDir, "xdg-config"),
+        XDG_CACHE_HOME: path.join(modeDir, "xdg-cache"),
+        XDG_DATA_HOME: path.join(modeDir, "xdg-data"),
+      };
+    };
+
+    const gatewayEnv = await modeEnv("gateway");
+    const gateway = launch(
+      ["--import", loader, self, "--gateway-child", String(gatewayPort)],
+      gatewayEnv,
+    );
+    await gateway.wait("QUESTION_PROOF_GATEWAY_READY");
+    const rpc = async (method: string, params: unknown): Promise<unknown> => {
+      const child = launch(
+        ["--import", loader, self, "--rpc-child", method, JSON.stringify(params)],
+        gatewayEnv,
+      );
+      const output = await child.wait("QUESTION_PROOF_RPC=");
+      const line = output.split("\n").find((value) => value.startsWith("QUESTION_PROOF_RPC="));
+      assert(line);
+      return JSON.parse(line.slice("QUESTION_PROOF_RPC=".length));
+    };
+    const gatewayTui = await startTui(
+      gatewayEnv,
+      ["--url", `ws://127.0.0.1:${gatewayPort}`, "--token", token, "--session", sessionKey],
+      "gateway connected",
+    );
+    await capture("gateway-before", gatewayTui);
+    await rpc("question.request", {
+      id: "tui-gateway-proof",
+      sessionKey,
+      agentId: "main",
+      questions: [
+        {
+          questionId: "color",
+          header: "Color",
+          question: questionText,
+          options: choices,
+          isOther: true,
+        },
+      ],
+      timeoutMs: 120_000,
+    });
+    await waitForPrompt(gatewayTui, questionText);
+    await capture("gateway-question", gatewayTui);
+    await gatewayTui.write("\r");
+    const result = await rpc("question.waitAnswer", { id: "tui-gateway-proof", timeoutMs: 5_000 });
+    const expected: QuestionWaitAnswerResult = {
+      status: "answered",
+      answers: { answers: { color: ["Blue"] } },
+    };
+    assert.deepEqual(result, expected);
+    await waitForText(gatewayTui, "Question: answered.");
+    await capture("gateway-after", gatewayTui);
+    report.push(
+      `Gateway question.request -> TUI -> question.waitAnswer: ${JSON.stringify(result)}`,
+    );
+    process.stdout.write("PASS: Gateway question.request -> TUI selection -> answered.\n");
+    await gatewayTui.dispose();
+    await stopChild(gateway.child);
+
+    const localEnv = await modeEnv("local");
+    const localTui = await startTui(localEnv, ["--local", "--session", sessionKey], "local ready");
+    await capture("local-before", localTui);
+    await localTui.write("Run the synthetic question proof.\r");
+    await waitForPrompt(localTui, questionText);
+    await capture("local-question", localTui);
+    await localTui.write("\r");
+    await waitForText(localTui, "LOCAL_QUESTION_ANSWER_RECEIVED");
+    await capture("local-after", localTui);
+    process.stdout.write("PASS: Local model ask_user -> TUI selection -> model completion.\n");
+    await localTui.write("Ask the second synthetic question.\r");
+    await waitForPrompt(localTui, "Which color should the typed reply choose?");
+    await localTui.write("\x1b");
+    await waitFor({
+      timeoutMs: 60_000,
+      read: () => {
+        const text = frame(localTui);
+        return text.includes("Question pending") && !text.includes("Enter confirm") ? true : null;
+      },
+      onTimeout: () =>
+        new Error(`Esc did not restore the composer\n${terminalDiagnostic(localTui)}`),
+    });
+    await capture("local-collapsed", localTui);
+    await localTui.write("Green\r");
+    await waitForText(localTui, "LOCAL_TYPED_ANSWER_RECEIVED");
+    await capture("local-typed-after", localTui);
+    const requests: unknown[] = (await readFile(requestLog, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert(hasAnswer(requests, "Blue"), "Model did not receive the selected answer");
+    assert(hasAnswer(requests, "Green"), "Model did not receive the typed answer");
+    report.push("Local model ask_user -> TUI selection -> model: Blue (verified request body)");
+    report.push(
+      "Local model ask_user -> Esc -> ordinary composer reply -> model: Green (verified request body)",
+    );
+    report.push(
+      "PASS: Gateway and local question round trips; no real credentials or live state used.",
+    );
+    await writeFile(path.join(outputDir, "proof.txt"), `${report.join("\n\n")}\n`);
+  } catch (error) {
+    failures.push(describeFailure(error));
+    try {
+      await mkdir(outputDir, { recursive: true });
+      for (const [index, terminal] of terminals.entries()) {
+        await writeFile(
+          path.join(outputDir, `failure-terminal-${index + 1}.txt`),
+          `${redact(terminalDiagnostic(terminal))}\n`,
+        );
+      }
+    } catch (captureError) {
+      failures.push(`Could not preserve terminal evidence: ${describeFailure(captureError)}`);
+    }
+  } finally {
+    // Keep only answer witnesses and call counts; mock requests contain full system prompts.
+    try {
+      const requestText = await readFile(requestLog, "utf8").catch((error: unknown) => {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+          return "";
+        }
+        throw error;
+      });
+      const entries: unknown[] = requestText
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+      await writeFile(
+        path.join(outputDir, "model-answer-evidence.json"),
+        `${JSON.stringify(
+          {
+            requestCount: entries.length,
+            requests: entries.map((entry, index) => ({
+              index,
+              containsBlueAnswer: hasAnswer(entry, "Blue"),
+              containsGreenAnswer: hasAnswer(entry, "Green"),
+            })),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } catch (evidenceError) {
+      failures.push(`Could not preserve mock answer evidence: ${describeFailure(evidenceError)}`);
+    }
+    const terminalCleanup = await Promise.allSettled(terminals.map((run) => run.dispose()));
+    const childCleanup = await Promise.allSettled(children.map((child) => stopChild(child)));
+    const cleanupFailures = [...terminalCleanup, ...childCleanup].flatMap((result) =>
+      result.status === "rejected" ? [describeFailure(result.reason)] : [],
+    );
+    if (cleanupFailures.length > 0) {
+      failures.push(
+        `Proof cleanup failed; isolated state retained at ${scratch}`,
+        ...cleanupFailures,
+      );
+    } else {
+      try {
+        await rm(scratch, { recursive: true, force: true });
+      } catch (stateCleanupError) {
+        failures.push(
+          `Could not remove isolated state at ${scratch}: ${describeFailure(stateCleanupError)}`,
+        );
+      }
+    }
+  }
+  if (failures.length > 0) {
+    const diagnostic = `${failures.join("\n\n")}\n`;
+    process.stderr.write(diagnostic);
+    process.exitCode = 1;
+    try {
+      await mkdir(outputDir, { recursive: true });
+      await writeFile(path.join(outputDir, "failure.txt"), diagnostic);
+    } catch (reportError) {
+      process.stderr.write(`Could not write failure report: ${describeFailure(reportError)}\n`);
+    }
+  } else {
+    process.stdout.write(`${report.slice(-4).join("\n")}\nEvidence: ${outputDir}\n`);
+  }
+}
+
+const args = process.argv.slice(2);
+if (args[0]?.endsWith("-child")) {
+  await childMain(args[0], args.slice(1));
+} else if (args.includes("--help")) {
+  process.stdout.write(
+    "Usage: node --import ./scripts/tsx.mjs scripts/dev/tui-questions-proof.ts [--output <directory>]\n",
+  );
+} else {
+  assert(
+    args.length === 0 || (args.length === 2 && args[0] === "--output" && args[1]),
+    "Expected --output <directory>",
+  );
+  const output = args[1]
+    ? path.resolve(args[1])
+    : await mkdtemp(path.join(tmpdir(), "openclaw-question-proof-evidence-"));
+  await runProof(output);
+}

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -7,8 +7,10 @@ import { markDiagnosticToolStartedForTest } from "../../logging/diagnostic-run-a
 import { resetDiagnosticSessionStateForTest } from "../../logging/diagnostic-session-state.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { QuestionAnswerUnconfirmedError } from "../harness/gateway-question-dispatch.js";
 import {
+  claimPendingEmbeddedAgentQuestionAnswer,
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
   preemptAndDrainEmbeddedHeartbeatRun,
@@ -35,7 +37,7 @@ describe("embedded-agent active-run steering", () => {
     async (capability) => {
       const queueMessage = vi.fn(async () => {});
       const claimPendingUserInputAnswer = vi.fn(async () => true);
-      const handle = createEmbeddedRunHandle({ queueMessage });
+      const handle = createEmbeddedRunHandle({ queueMessage, runId: "legacy-run" });
       handle.claimPendingUserInputAnswer = claimPendingUserInputAnswer;
       if (capability) {
         handle.messageInjection = { isAvailable: () => true, queueMessage };
@@ -53,9 +55,95 @@ describe("embedded-agent active-run steering", () => {
       expect(queueMessage).not.toHaveBeenCalled();
       expect(claimPendingUserInputAnswer).not.toHaveBeenCalled();
       await expect(
+        claimPendingEmbeddedAgentQuestionAnswer("legacy-sink", "unscoped"),
+      ).resolves.toBeNull();
+      expect(claimPendingUserInputAnswer).not.toHaveBeenCalled();
+      await expect(
         queueEmbeddedAgentMessageWithOutcomeAsync("legacy-sink", "unscoped"),
       ).resolves.toMatchObject({ queued: true });
       expect(queueMessage).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["claimed", "unmatched", "unconfirmed"] as const)(
+    "claims only a pending question without steering ordinary input: %s",
+    async (outcome) => {
+      const queueMessage = vi.fn(async () => {});
+      const error = new QuestionAnswerUnconfirmedError(new Error("answer receipt unavailable"));
+      const handle = createEmbeddedRunHandle({ runId: "question-owner", queueMessage });
+      handle.messageInjectionV2 = {
+        version: 2,
+        isAvailable: () => true,
+        queueMessage,
+        claimPendingUserInputAnswer: async (_text, options, assertCurrent) => {
+          assertCurrent();
+          if (options?.isInboundUserMessage !== true) {
+            return false;
+          }
+          if (outcome === "unconfirmed") {
+            throw error;
+          }
+          return outcome === "claimed";
+        },
+      };
+      setActiveEmbeddedRun("question-session", handle);
+      const result = claimPendingEmbeddedAgentQuestionAnswer("question-session", "Green");
+      if (outcome === "unconfirmed") {
+        await expect(result).rejects.toBe(error);
+      } else {
+        expect(await result).toEqual(outcome === "claimed" ? { runId: "question-owner" } : null);
+      }
+      expect(queueMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["availability", "claim"] as const)(
+    "refuses a pending question claim when the captured backend is replaced during %s",
+    async (stage) => {
+      const entered = createDeferredCore();
+      const released = createDeferredCore();
+      const queueMessage = vi.fn(async () => {});
+      const replacement = createEmbeddedRunHandle({ runId: "replacement", queueMessage });
+      const claim = vi.fn(
+        async (
+          _text: string,
+          _options: EmbeddedAgentQueueMessageOptions | undefined,
+          assertCurrent: () => void,
+        ) => {
+          entered.resolve();
+          await released.promise;
+          assertCurrent();
+          return true;
+        },
+      );
+      const handle = createEmbeddedRunHandle({ runId: "question-owner", queueMessage });
+      handle.messageInjectionV2 = {
+        version: 2,
+        isAvailable: () => {
+          if (stage === "availability") {
+            setActiveEmbeddedRun("question-session", replacement);
+          }
+          return true;
+        },
+        queueMessage,
+        claimPendingUserInputAnswer: claim,
+      };
+      setActiveEmbeddedRun("question-session", handle);
+      const result = claimPendingEmbeddedAgentQuestionAnswer("question-session", "Green");
+      try {
+        if (stage === "availability") {
+          await expect(result).resolves.toBeNull();
+          expect(claim).not.toHaveBeenCalled();
+        } else {
+          await entered.promise;
+          setActiveEmbeddedRun("question-session", replacement);
+          released.resolve();
+          await expect(result).rejects.toThrow("Message injection authority is no longer current");
+        }
+        expect(queueMessage).not.toHaveBeenCalled();
+      } finally {
+        released.resolve();
+      }
     },
   );
 

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -620,6 +620,42 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
   return queueEmbeddedAgentMessageAsync(sessionId, text, options);
 }
 
+/** Answers pending input without making ordinary messages bypass local queue policy. */
+export async function claimPendingEmbeddedAgentQuestionAnswer(
+  sessionId: string,
+  text: string,
+): Promise<{ runId: string } | null> {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (!handle?.runId?.trim() || handle.messageInjectionV2?.version !== 2) {
+    return null;
+  }
+  const runId = handle.runId;
+  const registration = ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle);
+  const injection = resolveEmbeddedInjection(sessionId, handle);
+  if (!injection?.claimPendingUserInputAnswer) {
+    return null;
+  }
+  try {
+    registration?.toolAuthority?.assertActive();
+  } catch {
+    return null;
+  }
+  if (
+    ACTIVE_EMBEDDED_RUNS.get(sessionId) !== handle ||
+    ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle) !== registration
+  ) {
+    return null;
+  }
+  // V2 carries the captured owner assertion through persistence and final dispatch.
+  // An unconfirmed answer must propagate; queue fallback could replay accepted input.
+  const claimed = await injection.claimPendingUserInputAnswer(text, { isInboundUserMessage: true });
+  if (!claimed) {
+    return null;
+  }
+  logActiveRunMessageAccepted(sessionId);
+  return { runId };
+}
+
 /** Source-bound callers require an explicitly guarded backend, never a V1 fallback. */
 export async function queueGuardedEmbeddedAgentMessageWithOutcomeAsync(
   sessionId: string,

--- a/src/agents/harness/gateway-question-dispatch.test.ts
+++ b/src/agents/harness/gateway-question-dispatch.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { createMessageInjectionAuthority } from "../../auto-reply/reply/message-injection-authority.js";
+import { isEmbeddedMode, setEmbeddedMode } from "../../infra/embedded-mode.js";
+import {
+  EmbeddedQuestionBroker,
+  clearEmbeddedQuestionBroker,
+  setEmbeddedQuestionBroker,
+} from "../../infra/embedded-question-broker.js";
 import { createDeferredCore as deferred } from "../../shared/deferred.js";
 import {
   createAskUserTool,
@@ -10,7 +16,9 @@ import {
 } from "../tools/ask-user-tool.js";
 import {
   QuestionAnswerUnconfirmedError,
+  resolveAgentQuestionGatewayCall,
   type AgentHarnessQuestionGatewayCall,
+  type AgentQuestionDispatcher,
 } from "./gateway-question-dispatch.js";
 import {
   cancelPendingAgentQuestionForSession,
@@ -29,6 +37,27 @@ const sessionKey = "agent:main:question-dispatch";
 const questions = [
   { id: "answer", header: "Answer", question: "Continue?", isOther: true, options: [] },
 ];
+const protocolQuestions = questions.map(({ id, ...question }) => ({ ...question, questionId: id }));
+
+async function withEmbeddedBroker(
+  embedded: boolean,
+  registered: boolean,
+  run: (broker: EmbeddedQuestionBroker) => Promise<void>,
+) {
+  const previousMode = isEmbeddedMode();
+  const broker = new EmbeddedQuestionBroker();
+  setEmbeddedMode(embedded);
+  if (registered) {
+    setEmbeddedQuestionBroker(broker);
+  }
+  try {
+    await run(broker);
+  } finally {
+    clearEmbeddedQuestionBroker(broker);
+    broker.stop();
+    setEmbeddedMode(previousMode);
+  }
+}
 
 function startQuestion(
   fixture: Fixture,
@@ -106,6 +135,144 @@ const ownerCases = (["harness", "ask_user"] as const).flatMap((owner) =>
 );
 
 describe("question dispatch ownership", () => {
+  it.each([
+    { embedded: true, registered: true },
+    { embedded: true, registered: false },
+    { embedded: false, registered: true },
+  ])("routes locally only for embedded=$embedded, registered=$registered", async (mode) => {
+    await withQuestionGateway(async (fixture) => {
+      await withEmbeddedBroker(mode.embedded, mode.registered, async (broker) => {
+        const call = resolveAgentQuestionGatewayCall();
+        await call(
+          "question.request",
+          {},
+          {
+            id: "routing-question",
+            questions: protocolQuestions,
+          },
+        );
+        const local = mode.embedded && mode.registered;
+        expect(broker.list().questions).toHaveLength(local ? 1 : 0);
+        expect(fixture.manager.list()).toHaveLength(local ? 0 : 1);
+        expect(fixture.requests.map((request) => request.method)).toEqual(
+          local ? [] : ["question.request"],
+        );
+        await call("question.resolve", {}, { id: "routing-question", cancel: true });
+      });
+    });
+  });
+
+  it.each(["legacy", "version-2"] as const)(
+    "preserves an explicit %s dispatcher while the embedded broker is registered",
+    async (kind) => {
+      await withEmbeddedBroker(true, true, async (broker) => {
+        const dispatched: string[] = [];
+        const custom: AgentHarnessQuestionGatewayCall = async (method) => {
+          dispatched.push(method);
+          return { questions: [] };
+        };
+        const dispatcher: AgentQuestionDispatcher = {
+          version: 2,
+          call: ({ method, options, params }) => custom(method, options, params),
+        };
+        const call = resolveAgentQuestionGatewayCall(kind === "legacy" ? custom : dispatcher);
+        expect(await call("question.list", {}, {})).toEqual({ questions: [] });
+        expect(dispatched).toEqual(["question.list"]);
+        expect(broker.list().questions).toEqual([]);
+      });
+    },
+  );
+
+  it("keeps plain replies answerable locally and refuses retired source input", async () => {
+    await withEmbeddedBroker(true, true, async (broker) => {
+      const requested = deferred();
+      broker.subscribe((event) => {
+        if (event.event === "question.requested") {
+          requested.resolve();
+        }
+      });
+      const run = createAskUserTool({ sessionKey }).execute("local-question", {
+        questions: [{ ...questions[0], options: [{ label: "Continue" }, { label: "Stop" }] }],
+      });
+      try {
+        await requested.promise;
+        await expect(
+          claimPendingAgentQuestionAnswer({
+            sessionKey,
+            text: "obsolete",
+            authority: {
+              kind: "source-bound",
+              assertCurrent: () => {
+                throw new Error("retired source");
+              },
+            },
+          }),
+        ).rejects.toThrow("retired source");
+        expect(broker.list().questions).toHaveLength(1);
+        await expect(
+          claimPendingAgentQuestionAnswer({ sessionKey, text: "Continue" }),
+        ).resolves.toBe(true);
+        expect((await run).details).toMatchObject({
+          status: "answered",
+          answers: { answers: { answer: ["Continue"] } },
+        });
+      } finally {
+        broker.stop();
+        await run;
+      }
+    });
+  });
+
+  it("rechecks source authority after loading the local dispatcher and before resolving", async () => {
+    await withEmbeddedBroker(true, true, async (broker) => {
+      const request = broker.request({
+        questions: protocolQuestions,
+      });
+      let active = true;
+      const resolving = resolveAgentQuestionGatewayCall()(
+        "question.resolve",
+        {},
+        { id: request.id, answers: { answers: { answer: ["obsolete"] } } },
+        {
+          dispatchAuthority: {
+            version: 2,
+            kind: "source-bound",
+            assertCurrent: () => {
+              if (!active) {
+                throw new Error("retired source");
+              }
+            },
+          },
+        },
+      );
+      active = false;
+      await expect(resolving).rejects.toThrow("retired source");
+      expect(broker.get({ id: request.id }).question.status).toBe("pending");
+    });
+  });
+
+  it("keeps shutdown cancellation on the original local owner after deregistration", async () => {
+    await withEmbeddedBroker(true, true, async (broker) => {
+      const call = resolveAgentQuestionGatewayCall();
+      await call(
+        "question.request",
+        {},
+        {
+          id: "shutdown-question",
+          questions: protocolQuestions,
+        },
+      );
+      clearEmbeddedQuestionBroker(broker);
+      setEmbeddedMode(false);
+      expect(await call("question.resolve", {}, { id: "shutdown-question", cancel: true })).toEqual(
+        {
+          status: "cancelled",
+        },
+      );
+      expect(broker.list().questions).toEqual([]);
+    });
+  });
+
   it.each(ownerCases)(
     "preserves $owner question ownership across $stage",
     async ({ owner, stage }) => {

--- a/src/agents/harness/gateway-question-dispatch.ts
+++ b/src/agents/harness/gateway-question-dispatch.ts
@@ -1,3 +1,5 @@
+import { isEmbeddedMode } from "../../infra/embedded-mode.js";
+import type { EmbeddedQuestionBroker } from "../../infra/embedded-question-broker.js";
 import type { GatewayQuestionCall } from "../tools/gateway-question-lifecycle.js";
 
 export type AgentHarnessQuestionGatewayCall = (
@@ -45,6 +47,7 @@ export function resolveAgentQuestionGatewayCall(
   if (dispatcher && typeof dispatcher !== "function" && dispatcher.version !== 2) {
     throw new Error("unsupported question dispatcher version");
   }
+  let embeddedBroker: EmbeddedQuestionBroker | null = null;
   return async (...args) => {
     const [method, options, params, extra] = args;
     if (typeof dispatcher === "function") {
@@ -68,6 +71,16 @@ export function resolveAgentQuestionGatewayCall(
             ? { kind: "source-bound", assertCurrent: extra.dispatchAuthority.assertCurrent }
             : { kind: "unscoped" },
       });
+    }
+    if (!embeddedBroker && isEmbeddedMode()) {
+      const { getEmbeddedQuestionBroker } = await import("../../infra/embedded-question-broker.js");
+      embeddedBroker = getEmbeddedQuestionBroker();
+    }
+    if (embeddedBroker) {
+      // Cancellation/readback stay with the original owner during backend shutdown.
+      extra?.signal?.throwIfAborted();
+      extra?.dispatchAuthority?.assertCurrent();
+      return embeddedBroker.call(method, params, extra);
     }
     // Keep tool/runtime dependencies out of question registration and SDK imports.
     const { callGatewayTool } = await import("./gateway-question-dispatch.runtime.js");

--- a/src/agents/tools/secrets-tool.test.ts
+++ b/src/agents/tools/secrets-tool.test.ts
@@ -4,6 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { SecretRefSchema } from "../../config/zod-schema.core.js";
+import { isEmbeddedMode, setEmbeddedMode } from "../../infra/embedded-mode.js";
+import {
+  EmbeddedQuestionBroker,
+  clearEmbeddedQuestionBroker,
+  setEmbeddedQuestionBroker,
+} from "../../infra/embedded-question-broker.js";
 import { isBuiltInDefaultSecretProviderRef } from "../../secrets/ref-contract.js";
 import { claimPendingAgentQuestionAnswer } from "../harness/gateway-question.js";
 import { reserveAskUserPromptDelivery, settleAskUserPromptDelivery } from "./ask-user-tool.js";
@@ -140,6 +146,31 @@ describe("secrets request normalization", () => {
 });
 
 describe("secrets tool", () => {
+  it("returns a clear local store blocker without publishing a credential prompt", async () => {
+    const previousMode = isEmbeddedMode();
+    const broker = new EmbeddedQuestionBroker();
+    const events: string[] = [];
+    broker.subscribe((event) => events.push(event.event));
+    setEmbeddedMode(true);
+    setEmbeddedQuestionBroker(broker);
+    try {
+      await expect(
+        createSecretsTool({ sessionKey: "agent:main:main" }).execute("local-secret", {
+          action: "request",
+          name: "SERVICE_API_KEY",
+        }),
+      ).rejects.toThrow(
+        "Secret store requests need a running Gateway; ask the operator to run `openclaw secrets store` or use the Control UI.",
+      );
+      expect(events).toEqual([]);
+      expect(broker.list().questions).toEqual([]);
+    } finally {
+      clearEmbeddedQuestionBroker(broker);
+      broker.stop();
+      setEmbeddedMode(previousMode);
+    }
+  });
+
   it.each<{ label: string; config: OpenClawConfig }>([
     { label: "built-in store", config: {} },
     { label: "renamed store default", config: { secrets: { defaults: { store: "teamstore" } } } },

--- a/src/agents/tools/secrets-tool.ts
+++ b/src/agents/tools/secrets-tool.ts
@@ -11,6 +11,7 @@ import { ENV_SECRET_REF_ID_RE, type SecretRef } from "../../config/types.secrets
 import { ADMIN_SCOPE } from "../../gateway/operator-scopes.js";
 import { resolveDefaultSecretProviderAlias } from "../../secrets/ref-contract.js";
 import { isDeliverableMessageChannel } from "../../utils/message-channel-normalize.js";
+import { resolveAgentQuestionGatewayCall } from "../harness/gateway-question-dispatch.js";
 import { stringEnum } from "../schema/string-enum.js";
 import { describeSecretsTool } from "../tool-description-presets.js";
 import { normalizeQuestionTimeoutSeconds } from "./ask-user-tool-normalization.js";
@@ -237,6 +238,7 @@ export function createSecretsTool(params: {
   questionPrompt?: QuestionPromptDelivery;
 }): AnyAgentTool {
   const gatewayCall: GatewayQuestionCall = params.gatewayCall ?? callGatewayTool;
+  const questionGatewayCall = params.gatewayCall ?? resolveAgentQuestionGatewayCall();
   const storeProvider = resolveDefaultSecretProviderAlias(params.config ?? {}, "store");
   // Native credential cards arrive through question.requested, not a public link, so a
   // channel that cannot carry a Control UI link gets no chat prompt here either.
@@ -297,7 +299,7 @@ export function createSecretsTool(params: {
       const timeoutMs = request.timeoutSeconds * 1_000;
       let registered = false;
       const cancelPendingQuestion = createGatewayQuestionCanceller({
-        gatewayCall,
+        gatewayCall: questionGatewayCall,
         questionId: delivery.questionId,
         beforeCancel: prompt.close,
       });
@@ -309,7 +311,7 @@ export function createSecretsTool(params: {
       try {
         signal?.throwIfAborted();
         const registration = asNullableRecord(
-          await gatewayCall(
+          await questionGatewayCall(
             "question.request",
             {},
             {
@@ -339,7 +341,7 @@ export function createSecretsTool(params: {
           signal.throwIfAborted();
         }
         const answerPromise = awaitGatewayQuestionAnswer({
-          gatewayCall,
+          gatewayCall: questionGatewayCall,
           questionId: delivery.questionId,
           timeoutMs,
           ...(signal ? { signal } : {}),

--- a/src/gateway/question-manager.test.ts
+++ b/src/gateway/question-manager.test.ts
@@ -45,6 +45,12 @@ const invalidAnswerCases: Array<[string, Question[], QuestionAnswers, string]> =
   ],
   ["an empty string", questions, { answers: { choice: ["  "] } }, "choice"],
   [
+    "an empty secret value",
+    [{ ...questions[0]!, options: [], isSecret: true }],
+    { answers: { choice: [""] } },
+    "choice",
+  ],
+  [
     "multiple values for a single-select question",
     questions,
     { answers: { choice: ["One", "Two"] } },
@@ -395,6 +401,31 @@ describe("QuestionManager", () => {
 });
 
 describe("answer canonicalization", () => {
+  it.each(["  synthetic-secret  ", "\tsynthetic-secret\n", "   "])(
+    "preserves exact secret bytes while normalizing ordinary answers: %j",
+    async (value) => {
+      const record = manager.request({
+        questions: [
+          {
+            questionId: "secret_value",
+            header: "Secret",
+            question: "Enter a synthetic secret.",
+            options: [],
+            isSecret: true,
+          },
+          ...questions,
+        ],
+        timeoutMs: 10_000,
+      });
+      const waiting = manager.waitAnswer(record.id);
+      manager.resolve(record.id, { answers: { secret_value: [value], choice: ["  Two  "] } });
+      expect(await waiting).toEqual({
+        status: "answered",
+        answers: { answers: { secret_value: [value], choice: ["Two"] } },
+      });
+    },
+  );
+
   it("stores declared option labels for trim-variant submissions", () => {
     const localManager = new QuestionManager();
     const record = localManager.request({

--- a/src/gateway/question-manager.ts
+++ b/src/gateway/question-manager.ts
@@ -349,7 +349,7 @@ export class QuestionManager {
       if (!values || values.length === 0) {
         throw this.invalidAnswer(question.questionId, "requires an answer");
       }
-      if (values.some((value) => !value.trim())) {
+      if (values.some((value) => (question.isSecret ? value.length === 0 : !value.trim()))) {
         throw this.invalidAnswer(question.questionId, "contains an empty answer");
       }
       if (!question.multiSelect && values.length > 1) {
@@ -358,6 +358,10 @@ export class QuestionManager {
       // Store the declared option label when a value matches trim-insensitively;
       // downstream renderers compare answers to option labels exactly.
       const canonicalValues = values.map((value) => {
+        // Masked free-text answers preserve exact bytes, including whitespace.
+        if (question.isSecret) {
+          return value;
+        }
         const matched = question.options.find((option) => option.label.trim() === value.trim());
         return matched ? matched.label : value.trim();
       });

--- a/src/infra/embedded-question-broker.test.ts
+++ b/src/infra/embedded-question-broker.test.ts
@@ -1,0 +1,298 @@
+import { Value } from "typebox/value";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  QuestionGetResultSchema,
+  QuestionListResultSchema,
+  QuestionRequestedEventSchema,
+  QuestionRequestResultSchema,
+  QuestionResolvedEventSchema,
+  QuestionResolveResultSchema,
+  QuestionWaitAnswerResultSchema,
+  type QuestionRequestParams,
+} from "../../packages/gateway-protocol/src/index.js";
+import { prepareSystemAgentRunAdmission } from "../agents/admitted-run-context.js";
+import { resolveActiveEmbeddedRunRecoveryBlocker } from "../agents/embedded-agent-runner/run-state.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+  type EmbeddedAgentQueueHandle,
+} from "../agents/embedded-agent-runner/runs.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "../agents/tools/gateway-caller-context.js";
+import { createGatewayQuestionCanceller } from "../agents/tools/gateway-question-lifecycle.js";
+import {
+  EmbeddedQuestionBroker,
+  clearEmbeddedQuestionBroker,
+  getEmbeddedQuestionBroker,
+  setEmbeddedQuestionBroker,
+} from "./embedded-question-broker.js";
+
+const brokers: EmbeddedQuestionBroker[] = [];
+
+function createBroker() {
+  const broker = new EmbeddedQuestionBroker();
+  brokers.push(broker);
+  return broker;
+}
+
+function requestParams(): QuestionRequestParams {
+  return {
+    id: "local-question",
+    sessionKey: "agent:main:main",
+    agentId: "main",
+    runId: "local-run",
+    timeoutMs: 5_000,
+    questions: [
+      {
+        questionId: "destination",
+        header: "Destination",
+        question: "Where should the preview run?",
+        options: [{ label: "Staging" }, { label: "Production" }],
+        isOther: true,
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  for (const broker of brokers.splice(0)) {
+    clearEmbeddedQuestionBroker(broker);
+    broker.stop();
+  }
+  vi.useRealTimers();
+});
+
+describe("EmbeddedQuestionBroker", () => {
+  it("publishes a protocol question and resolves its waiting tool with a correlated answer", async () => {
+    const broker = createBroker();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    broker.subscribe((event) => events.push(event));
+    const request = broker.request(requestParams());
+    const listed = broker.list();
+    const fetched = broker.get({ id: request.id });
+
+    expect(Value.Check(QuestionRequestResultSchema, request)).toBe(true);
+    expect(Value.Check(QuestionListResultSchema, listed)).toBe(true);
+    expect(Value.Check(QuestionGetResultSchema, fetched)).toBe(true);
+    expect(listed.questions).toEqual([fetched.question]);
+    expect(events).toEqual([{ event: "question.requested", payload: fetched.question }]);
+    expect(Value.Check(QuestionRequestedEventSchema, events[0]?.payload)).toBe(true);
+
+    const answer = broker.waitAnswer({ id: request.id, includeResolutionId: true });
+    const resolved = broker.resolve({
+      id: request.id,
+      answers: { answers: { destination: [" Staging "] } },
+      resolutionId: "local-answer",
+    });
+    expect(Value.Check(QuestionResolveResultSchema, resolved)).toBe(true);
+    expect(await answer).toEqual({
+      status: "answered",
+      answers: { answers: { destination: ["Staging"] } },
+      resolutionId: "local-answer",
+    });
+    expect(Value.Check(QuestionWaitAnswerResultSchema, await answer)).toBe(true);
+    expect(Value.Check(QuestionResolvedEventSchema, events[1]?.payload)).toBe(true);
+    expect(events[1]).toEqual({
+      event: "question.resolved",
+      payload: { id: request.id, ...resolved },
+    });
+    expect(broker.list().questions).toEqual([]);
+    expect(broker.get({ id: request.id }).question.status).toBe("answered");
+  });
+
+  it.each(["cancel", "expiry", "run-abort", "stop"] as const)(
+    "settles the waiter and dismisses the prompt on %s",
+    async (ending) => {
+      vi.useFakeTimers();
+      const broker = createBroker();
+      const events: Array<{ event: string; payload: unknown }> = [];
+      broker.subscribe((event) => events.push(event));
+      const run = new AbortController();
+      const request = broker.request(requestParams(), run.signal);
+      const answer = broker.waitAnswer({ id: request.id });
+      if (ending === "cancel") {
+        broker.resolve({ id: request.id, cancel: true });
+      } else if (ending === "expiry") {
+        await vi.advanceTimersByTimeAsync(5_000);
+      } else if (ending === "run-abort") {
+        run.abort();
+      } else {
+        broker.stop();
+      }
+      const status = ending === "expiry" ? "expired" : "cancelled";
+      expect(await answer).toEqual({ status });
+      expect(events.at(-1)).toEqual({
+        event: "question.resolved",
+        payload: { id: request.id, status },
+      });
+      expect(broker.list().questions).toEqual([]);
+    },
+  );
+
+  it("leaves an unanswered prompt pending when only the wait deadline ends", async () => {
+    vi.useFakeTimers();
+    const broker = createBroker();
+    const request = broker.request(requestParams());
+    const answer = broker.waitAnswer({ id: request.id, timeoutMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(await answer).toEqual({ status: "pending" });
+    expect(broker.get({ id: request.id }).question.status).toBe("pending");
+  });
+
+  it.each(["answer", "owner-close"] as const)(
+    "holds the admitted run's human-input wait until %s",
+    async (ending) => {
+      const broker = createBroker();
+      const sessionId = "embedded-question-session";
+      const sessionKey = "agent:main:embedded-question";
+      const admission = prepareSystemAgentRunAdmission({}, "question-run", "main", "test");
+      const admitted = await admission.admit("embedded");
+      const handle: EmbeddedAgentQueueHandle = {
+        runId: "question-run",
+        queueMessage: async () => {},
+        isStreaming: () => false,
+        isCompacting: () => false,
+        abort: () => {},
+      };
+      try {
+        const request = await withGatewayToolCallerIdentity(
+          createAdmittedGatewayToolCallerIdentity({
+            admittedRunContext: admitted,
+            agentId: "main",
+            sessionKey,
+          }),
+          () => {
+            setActiveEmbeddedRun(sessionId, handle, sessionKey);
+            return broker.request(requestParams());
+          },
+        );
+        const answer = broker.waitAnswer({ id: request.id });
+        expect(broker.get({ id: request.id }).question).toMatchObject({
+          sessionKey,
+          runId: "question-run",
+        });
+        expect(resolveActiveEmbeddedRunRecoveryBlocker(sessionId)).toBe("human_input_wait");
+        if (ending === "answer") {
+          broker.resolve({ id: request.id, answers: { answers: { destination: ["Staging"] } } });
+        } else {
+          admission.close();
+        }
+        expect(await answer).toMatchObject({
+          status: ending === "answer" ? "answered" : "cancelled",
+        });
+        expect(resolveActiveEmbeddedRunRecoveryBlocker(sessionId)).toBeUndefined();
+      } finally {
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+        admission.close();
+      }
+    },
+  );
+
+  it("supports plain secret protocol questions but refuses store-bound input before publication", async () => {
+    const broker = createBroker();
+    const events: string[] = [];
+    broker.subscribe((event) => events.push(event.event));
+    const question = {
+      questionId: "secret_value",
+      header: "Secret",
+      question: "Enter a synthetic secret.",
+      options: [],
+      isSecret: true,
+    };
+    await expect(
+      broker.call("question.request", {
+        questions: [{ ...question, secretStore: { name: "TEST_KEY", kind: "secret" } }],
+      }),
+    ).rejects.toThrow("Secret store requests need a running Gateway");
+    expect(events).toEqual([]);
+    const request = broker.request({ questions: [question] });
+    const answer = broker.waitAnswer({ id: request.id });
+    broker.resolve({
+      id: request.id,
+      answers: { answers: { secret_value: ["synthetic-secret"] } },
+    });
+    expect(await answer).toMatchObject({
+      status: "answered",
+      answers: { answers: { secret_value: ["synthetic-secret"] } },
+    });
+  });
+
+  it("retires a captured approval authority even without a caller run reference", async () => {
+    const broker = createBroker();
+    const admission = prepareSystemAgentRunAdmission({}, "authority-only-run", "main", "test");
+    const admitted = await admission.admit("embedded");
+    const caller = createAdmittedGatewayToolCallerIdentity({
+      admittedRunContext: admitted,
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    });
+    if (!caller?.approvalAuthority) {
+      throw new Error("expected an admitted approval authority");
+    }
+    try {
+      await withGatewayToolCallerIdentity(
+        {
+          agentId: caller.agentId,
+          sessionKey: caller.sessionKey,
+          approvalAuthority: caller.approvalAuthority,
+        },
+        async () => {
+          const request = broker.request(requestParams());
+          const answer = broker.waitAnswer({ id: request.id });
+          admission.close();
+          expect(await answer).toEqual({ status: "cancelled" });
+          expect(() => broker.request({ ...requestParams(), id: "retired-question" })).toThrow(
+            "no longer active",
+          );
+        },
+      );
+    } finally {
+      admission.close();
+    }
+  });
+
+  it("lets shared cancellation recover an answer that won the race", async () => {
+    const broker = createBroker();
+    const request = broker.request(requestParams());
+    broker.resolve({ id: request.id, answers: { answers: { destination: ["Staging"] } } });
+    const cancel = createGatewayQuestionCanceller({
+      questionId: request.id,
+      gatewayCall: (method, _options, params, extra) => broker.call(method, params, extra),
+    });
+    expect(await cancel("tool-timeout")).toEqual({
+      status: "answered",
+      answers: { answers: { destination: ["Staging"] } },
+    });
+  });
+
+  it("validates requests and answers without losing a pending prompt", async () => {
+    const broker = createBroker();
+    await expect(broker.call("question.request", { questions: [] })).rejects.toThrow(
+      "Invalid question.request params",
+    );
+    const request = broker.request(requestParams());
+    await expect(
+      broker.call("question.resolve", {
+        id: request.id,
+        answers: { answers: { destination: [] } },
+      }),
+    ).rejects.toMatchObject({ details: { reason: "QUESTION_INVALID_ANSWER" } });
+    expect(broker.list().questions).toHaveLength(1);
+    await expect(broker.call("question.get", { id: "missing" })).rejects.toMatchObject({
+      details: { reason: "QUESTION_NOT_FOUND" },
+    });
+  });
+
+  it("does not clear a replacement backend's registration when an older one stops", () => {
+    const first = createBroker();
+    const replacement = createBroker();
+    setEmbeddedQuestionBroker(first);
+    setEmbeddedQuestionBroker(replacement);
+    clearEmbeddedQuestionBroker(first);
+    expect(getEmbeddedQuestionBroker()).toBe(replacement);
+    clearEmbeddedQuestionBroker(replacement);
+    expect(getEmbeddedQuestionBroker()).toBeNull();
+  });
+});

--- a/src/infra/embedded-question-broker.ts
+++ b/src/infra/embedded-question-broker.ts
@@ -1,0 +1,249 @@
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
+import {
+  type QuestionGetResult,
+  type QuestionListResult,
+  type QuestionRequestedEvent,
+  type QuestionRequestResult,
+  type QuestionResolvedEvent,
+  type QuestionResolveResult,
+  type QuestionWaitAnswerResult,
+  validateQuestionGetParams,
+  validateQuestionListParams,
+  validateQuestionRequestParams,
+  validateQuestionResolveParams,
+  validateQuestionWaitAnswerParams,
+} from "../../packages/gateway-protocol/src/index.js";
+import { registerActiveEmbeddedRunHumanInputWait } from "../agents/embedded-agent-runner/run-state.js";
+import { getGatewayToolCallerIdentity } from "../agents/tools/gateway-caller-context.js";
+import {
+  QuestionManager,
+  QuestionManagerError,
+  QuestionManagerErrorCodes,
+} from "../gateway/question-manager.js";
+import { notifyListeners } from "../shared/listeners.js";
+import { racePromiseWithAbortSignal } from "./abort-signal.js";
+import {
+  getActiveAgentRunDelegatedAuthority,
+  registerAgentRunDelegatedAuthorityClosedHandler,
+  validateAgentRunDelegatedAuthority,
+} from "./agent-run-registry.js";
+
+const EMBEDDED_SECRET_STORE_REQUEST_BLOCKER =
+  "Secret store requests need a running Gateway; ask the operator to run `openclaw secrets store` or use the Control UI.";
+
+type QuestionEvent =
+  | { event: "question.requested"; payload: QuestionRequestedEvent }
+  | { event: "question.resolved"; payload: QuestionResolvedEvent };
+
+let activeBroker: EmbeddedQuestionBroker | null = null;
+
+function invalidRequest(message: string): GatewayClientRequestError {
+  return new GatewayClientRequestError({ code: "INVALID_REQUEST", message });
+}
+
+/** Serves the question RPC contract for one embedded backend lifetime. */
+export class EmbeddedQuestionBroker {
+  private readonly manager = new QuestionManager();
+  private readonly listeners = new Set<(event: QuestionEvent) => void>();
+  private stopped = false;
+  private readonly removeAuthorityListener = registerAgentRunDelegatedAuthorityClosedHandler(() => {
+    this.manager.cancelClosedAuthorities();
+  });
+
+  subscribe(listener: (event: QuestionEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  request(params: unknown, signal?: AbortSignal): QuestionRequestResult {
+    signal?.throwIfAborted();
+    if (this.stopped) {
+      throw new Error("Embedded question broker is stopped");
+    }
+    if (!validateQuestionRequestParams(params)) {
+      throw invalidRequest("Invalid question.request params");
+    }
+    if (params.questions.some((question) => question.secretStore)) {
+      // The Gateway owns admitted-run checks, atomic storage, and runtime refresh.
+      // A local prompt must not collect a value it cannot safely commit there.
+      throw invalidRequest(EMBEDDED_SECRET_STORE_REQUEST_BLOCKER);
+    }
+    const ids = new Set<string>();
+    for (const question of params.questions) {
+      if (ids.has(question.questionId)) {
+        throw invalidRequest(`duplicate question id '${question.questionId}'`);
+      }
+      ids.add(question.questionId);
+      if (question.options.length === 1) {
+        throw invalidRequest(
+          `question '${question.questionId}' must have either no options or 2 to 4 options`,
+        );
+      }
+      const labels = new Set<string>();
+      for (const option of question.options) {
+        const label = option.label.trim().toLowerCase();
+        if (labels.has(label)) {
+          throw invalidRequest(`question '${question.questionId}' has duplicate option labels`);
+        }
+        labels.add(label);
+      }
+    }
+    const caller = getGatewayToolCallerIdentity();
+    const authority =
+      caller?.approvalAuthority ??
+      (caller?.operationalRunInstance
+        ? getActiveAgentRunDelegatedAuthority(caller.operationalRunInstance)
+        : undefined);
+    const isRequesterActive = () => {
+      try {
+        return (
+          !signal?.aborted &&
+          !caller?.approvalSignals?.some((inputSignal) => inputSignal.aborted) &&
+          (!caller?.operationalRunInstance || authority !== undefined) &&
+          (!authority || validateAgentRunDelegatedAuthority(authority)) &&
+          caller?.approvalAuthorityCheck?.() !== false &&
+          caller?.receiptAuthority?.() !== false
+        );
+      } catch {
+        return false;
+      }
+    };
+    const abort = () => {
+      this.manager.get(record.id);
+    };
+    const record = this.manager.request({
+      ...structuredClone(params),
+      ...(caller
+        ? {
+            agentId: caller.agentId,
+            sessionKey: caller.sessionKey,
+            ...(caller.operationalRunInstance
+              ? { runId: caller.operationalRunInstance.runId }
+              : {}),
+          }
+        : {}),
+      timeoutMs: params.timeoutMs ?? 15 * 60 * 1_000,
+      isRequesterActive,
+      registerHumanInputWait: authority
+        ? (isPending) => registerActiveEmbeddedRunHumanInputWait(authority, isPending)
+        : undefined,
+      onResolved: (event) => {
+        signal?.removeEventListener("abort", abort);
+        this.emit({ event: "question.resolved", payload: event });
+      },
+    });
+    signal?.addEventListener("abort", abort, { once: true });
+    this.emit({ event: "question.requested", payload: record });
+    return { id: record.id, expiresAtMs: record.expiresAtMs };
+  }
+
+  async waitAnswer(params: unknown, signal?: AbortSignal): Promise<QuestionWaitAnswerResult> {
+    signal?.throwIfAborted();
+    if (!validateQuestionWaitAnswerParams(params)) {
+      throw invalidRequest("Invalid question.waitAnswer params");
+    }
+    return await racePromiseWithAbortSignal(
+      this.manager.waitAnswer(params.id, params.timeoutMs, params.includeResolutionId),
+      signal,
+    );
+  }
+
+  resolve(params: unknown): QuestionResolveResult {
+    if (!validateQuestionResolveParams(params)) {
+      throw invalidRequest("Invalid question.resolve params");
+    }
+    if ("cancel" in params) {
+      return this.manager.cancel(params.id, params.resolvedBy);
+    }
+    if (params.secretStoreAllowedHosts !== undefined) {
+      throw invalidRequest("Secret store allowed hosts require a store-bound question.");
+    }
+    return this.manager.resolve(params.id, params.answers, params.resolvedBy, {
+      resolutionId: params.resolutionId,
+    });
+  }
+
+  get(params: unknown): QuestionGetResult {
+    if (!validateQuestionGetParams(params)) {
+      throw invalidRequest("Invalid question.get params");
+    }
+    const question = this.manager.get(params.id);
+    if (!question) {
+      throw new QuestionManagerError(
+        QuestionManagerErrorCodes.NOT_FOUND,
+        `question '${params.id}' was not found`,
+      );
+    }
+    return { question };
+  }
+
+  list(params: unknown = {}): QuestionListResult {
+    if (!validateQuestionListParams(params)) {
+      throw invalidRequest("Invalid question.list params");
+    }
+    return { questions: this.manager.list() };
+  }
+
+  async call(method: string, params?: unknown, extra?: { signal?: AbortSignal }): Promise<unknown> {
+    extra?.signal?.throwIfAborted();
+    try {
+      switch (method) {
+        case "question.request":
+          return this.request(params, extra?.signal);
+        case "question.waitAnswer":
+          return await this.waitAnswer(params, extra?.signal);
+        case "question.resolve":
+          return this.resolve(params);
+        case "question.get":
+          return this.get(params);
+        case "question.list":
+          return this.list(params);
+        default:
+          throw invalidRequest(`Unsupported embedded question method: ${method}`);
+      }
+    } catch (error) {
+      if (error instanceof QuestionManagerError) {
+        // Shared tool cancellation/recovery reads these protocol error reasons.
+        throw new GatewayClientRequestError({
+          code: "INVALID_REQUEST",
+          message: error.message,
+          details: { reason: error.code },
+        });
+      }
+      throw error;
+    }
+  }
+
+  stop(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    this.removeAuthorityListener();
+    for (const question of this.manager.list()) {
+      this.manager.cancel(question.id, "tui:embedded:stopped");
+    }
+    this.manager.close();
+    this.listeners.clear();
+  }
+
+  private emit(event: QuestionEvent): void {
+    notifyListeners(this.listeners, event);
+  }
+}
+
+export function setEmbeddedQuestionBroker(broker: EmbeddedQuestionBroker | null): void {
+  activeBroker = broker;
+}
+
+export function clearEmbeddedQuestionBroker(broker: EmbeddedQuestionBroker): void {
+  if (activeBroker === broker) {
+    activeBroker = null;
+  }
+}
+
+export function getEmbeddedQuestionBroker(): EmbeddedQuestionBroker | null {
+  return activeBroker;
+}

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -91,6 +91,7 @@ type TuiCommandRow = readonly [
 
 const TUI_COMMAND_ROWS = [
   ["help", "Show slash command help", "/help"],
+  ["question", "Reopen the pending agent question", "/question"],
   [
     "commands",
     undefined,

--- a/src/tui/components/question-prompt.ts
+++ b/src/tui/components/question-prompt.ts
@@ -1,0 +1,414 @@
+// Interactive question input keeps answer drafts out of the chat composer and history.
+import {
+  CURSOR_MARKER,
+  Input,
+  Key,
+  Text,
+  decodeKittyPrintable,
+  isKeyRelease,
+  matchesKey,
+  type Component,
+  type Focusable,
+} from "@earendil-works/pi-tui";
+import type { QuestionAnswers, QuestionRecord } from "@openclaw/gateway-protocol";
+import { expectDefined } from "@openclaw/normalization-core";
+import { hasTerminalControl } from "../../../packages/terminal-core/src/safe-text.js";
+import { tuiTheme as theme } from "../theme/theme.js";
+import { sanitizeRenderableLine } from "../tui-formatters.js";
+
+function safeText(value: string): string {
+  return sanitizeRenderableLine(
+    value.replace(/[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, ""),
+  );
+}
+
+/** A secret editor has no undo/kill ring and never passes its value to a renderer. */
+class MaskedQuestionInput {
+  private characters: string[] = [];
+  private cursor = 0;
+
+  getValue(): string {
+    return this.characters.join("");
+  }
+
+  clear(): void {
+    this.characters = [];
+    this.cursor = 0;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.backspace)) {
+      if (this.cursor > 0) {
+        this.characters.splice(--this.cursor, 1);
+      }
+    } else if (matchesKey(data, Key.delete)) {
+      this.characters.splice(this.cursor, 1);
+    } else if (matchesKey(data, Key.left)) {
+      this.cursor = Math.max(0, this.cursor - 1);
+    } else if (matchesKey(data, Key.right)) {
+      this.cursor = Math.min(this.characters.length, this.cursor + 1);
+    } else if (matchesKey(data, Key.home) || matchesKey(data, Key.ctrl("a"))) {
+      this.cursor = 0;
+    } else if (matchesKey(data, Key.end) || matchesKey(data, Key.ctrl("e"))) {
+      this.cursor = this.characters.length;
+    } else if (matchesKey(data, Key.ctrl("u"))) {
+      this.characters.splice(0, this.cursor);
+      this.cursor = 0;
+    } else if (matchesKey(data, Key.ctrl("k"))) {
+      this.characters.splice(this.cursor);
+    } else {
+      const printable = decodeKittyPrintable(data) ?? data;
+      if (!hasTerminalControl(printable)) {
+        this.insert(printable);
+      }
+    }
+  }
+
+  insert(value: string): void {
+    const characters = Array.from(value);
+    this.characters.splice(this.cursor, 0, ...characters);
+    this.cursor += characters.length;
+  }
+
+  render(width: number, focused: boolean): string[] {
+    const available = Math.max(1, width - 3);
+    const start = Math.max(0, this.cursor - available + 1);
+    const before = "•".repeat(this.cursor - start);
+    const after = "•".repeat(
+      Math.min(this.characters.length - this.cursor, available - before.length),
+    );
+    return [`> ${before}${focused ? CURSOR_MARKER : ""}${after}`];
+  }
+}
+
+type QuestionPromptActions = {
+  onSubmit: (answers: QuestionAnswers) => void;
+  onSkip: () => void;
+  onCollapse: () => void;
+  requestRender: () => void;
+};
+type PromptRow =
+  | { kind: "option"; index: number; label: string }
+  | { kind: "other" | "confirm" | "skip" | "back"; label: string };
+
+/** One step at a time, with a separate masked editor for secret answers. */
+export class QuestionPrompt implements Component, Focusable {
+  focused = false;
+  private step = 0;
+  private selectedRow = 0;
+  private editing = false;
+  private closed = false;
+  private message = "";
+  private pasteBuffer: string | null = null;
+  private rejectedSecretPaste = false;
+  private readonly answers: Record<string, string[]> = {};
+  private readonly selections = new Map<number, Set<number>>();
+  private readonly freeText = new Map<number, string>();
+  private input = new Input();
+  private readonly secretInput = new MaskedQuestionInput();
+
+  constructor(
+    private readonly record: QuestionRecord,
+    private readonly actions: QuestionPromptActions,
+  ) {
+    this.enterStep();
+  }
+
+  private get question() {
+    return expectDefined(this.record.questions[this.step], "active question step");
+  }
+
+  private rows(): PromptRow[] {
+    return [
+      ...this.question.options.map((option, index) => ({
+        kind: "option" as const,
+        index,
+        label: `${index + 1}. ${safeText(option.label)}`,
+      })),
+      { kind: "other", label: `${this.question.options.length + 1}. Other…` },
+      {
+        kind: "confirm",
+        label: this.step < this.record.questions.length - 1 ? "Next" : "Confirm answer",
+      },
+      { kind: "skip", label: "Skip" },
+      ...(this.step > 0 ? [{ kind: "back" as const, label: "Back" }] : []),
+    ];
+  }
+
+  private enterStep(): void {
+    this.input = new Input();
+    this.secretInput.clear();
+    const draft = this.freeText.get(this.step) ?? "";
+    if (this.question.isSecret) {
+      this.secretInput.insert(draft);
+    } else {
+      this.input.setValue(draft);
+    }
+    this.selectedRow = this.selections.get(this.step)?.values().next().value ?? 0;
+    this.editing = this.question.options.length === 0;
+    this.message = "";
+    this.rejectedSecretPaste = false;
+  }
+
+  private draft(): string {
+    return this.question.isSecret ? this.secretInput.getValue() : this.input.getValue();
+  }
+
+  private saveDraft(): void {
+    this.freeText.set(this.step, this.draft());
+  }
+
+  private toggle(index: number): void {
+    const selected = this.selections.get(this.step) ?? new Set<number>();
+    if (selected.has(index)) {
+      selected.delete(index);
+    } else {
+      selected.add(index);
+    }
+    this.selections.set(this.step, selected);
+  }
+
+  private advance(singleOption?: number): void {
+    if (this.rejectedSecretPaste) {
+      this.message =
+        "Secret paste contains line breaks or unsupported control characters. Enter a single-line value.";
+      return;
+    }
+    this.saveDraft();
+    const question = this.question;
+    const selected =
+      singleOption === undefined ? this.selections.get(this.step) : new Set([singleOption]);
+    const values = question.options
+      .filter((_, index) => selected?.has(index))
+      .map((option) => option.label);
+    const value = this.draft();
+    if (singleOption === undefined && (question.isSecret ? value.length > 0 : value.trim())) {
+      values.push(question.isSecret ? value : value.trim());
+    }
+    if (values.length === 0) {
+      this.message = "Choose an option or enter an answer.";
+      return;
+    }
+    if (singleOption !== undefined) {
+      this.selections.set(this.step, new Set([singleOption]));
+      this.freeText.delete(this.step);
+    }
+    this.answers[question.questionId] = values;
+    if (this.step < this.record.questions.length - 1) {
+      this.step += 1;
+      this.enterStep();
+      return;
+    }
+    this.actions.onSubmit({ answers: { ...this.answers } });
+  }
+
+  private activate(): void {
+    const row = this.rows()[this.selectedRow];
+    if (!row) {
+      return;
+    }
+    if (row.kind === "option") {
+      if (this.question.multiSelect) {
+        this.toggle(row.index);
+      } else {
+        this.advance(row.index);
+      }
+    } else if (row.kind === "other") {
+      if (!this.question.multiSelect) {
+        this.selections.delete(this.step);
+      }
+      this.editing = true;
+    } else if (row.kind === "confirm") {
+      this.advance();
+    } else if (row.kind === "skip") {
+      this.actions.onSkip();
+    } else {
+      this.saveDraft();
+      this.step -= 1;
+      this.enterStep();
+    }
+  }
+
+  handleInput(data: string): void {
+    if (this.closed || isKeyRelease(data)) {
+      return;
+    }
+    // A paste may arrive in several terminal reads. Its newlines and escape bytes
+    // are text, never submit/collapse shortcuts.
+    if (this.editing && (this.pasteBuffer !== null || data.includes("\x1b[200~"))) {
+      this.pasteBuffer = (this.pasteBuffer ?? "") + data.replace("\x1b[200~", "");
+      const end = this.pasteBuffer.indexOf("\x1b[201~");
+      if (end >= 0) {
+        const paste = this.pasteBuffer.slice(0, end);
+        const remaining = this.pasteBuffer.slice(end + 6);
+        this.pasteBuffer = null;
+        if (this.question.isSecret) {
+          this.rejectedSecretPaste =
+            hasTerminalControl(paste.replaceAll("\t", "")) || /[\u2028\u2029]/.test(paste);
+          if (this.rejectedSecretPaste) {
+            this.message =
+              "Secret paste contains line breaks or unsupported control characters. Enter a single-line value.";
+          } else {
+            this.message = "";
+            this.secretInput.insert(paste);
+          }
+        } else {
+          this.input.handleInput(`\x1b[200~${paste}\x1b[201~`);
+        }
+        if (remaining) {
+          this.handleInput(remaining);
+        }
+      }
+      this.actions.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      this.saveDraft();
+      this.actions.onCollapse();
+      return;
+    }
+    this.message = "";
+    if (this.editing) {
+      if (matchesKey(data, Key.tab) || matchesKey(data, Key.shift("tab"))) {
+        this.saveDraft();
+        this.editing = false;
+        this.selectedRow = this.question.options.length + 1;
+      } else if (matchesKey(data, Key.enter) || data === "\n") {
+        this.advance();
+      } else if (this.question.isSecret) {
+        this.secretInput.handleInput(data);
+        const printable = decodeKittyPrintable(data) ?? data;
+        if (
+          !hasTerminalControl(printable) ||
+          matchesKey(data, Key.backspace) ||
+          matchesKey(data, Key.delete)
+        ) {
+          this.rejectedSecretPaste = false;
+        }
+      } else {
+        this.input.handleInput(data);
+      }
+    } else if (matchesKey(data, Key.up) || matchesKey(data, Key.shift("tab"))) {
+      this.selectedRow = (this.selectedRow + this.rows().length - 1) % this.rows().length;
+    } else if (matchesKey(data, Key.down) || matchesKey(data, Key.tab)) {
+      this.selectedRow = (this.selectedRow + 1) % this.rows().length;
+    } else if (matchesKey(data, Key.enter) || data === "\n") {
+      this.activate();
+    } else if (matchesKey(data, Key.space)) {
+      const row = this.rows()[this.selectedRow];
+      if (row?.kind === "option" && this.question.multiSelect) {
+        this.toggle(row.index);
+      }
+    } else {
+      const printable = decodeKittyPrintable(data) ?? data;
+      if (/^[1-5]$/.test(printable)) {
+        const index = Number(printable) - 1;
+        if (index <= this.question.options.length) {
+          this.selectedRow = index;
+          if (index === this.question.options.length) {
+            this.activate();
+          } else if (this.question.multiSelect) {
+            this.toggle(index);
+          }
+        }
+      }
+    }
+    this.actions.requestRender();
+  }
+
+  invalidate(): void {
+    this.input.invalidate();
+  }
+
+  render(width: number): string[] {
+    if (this.closed) {
+      return [];
+    }
+    const question = this.question;
+    const seconds = Math.max(0, Math.ceil((this.record.expiresAtMs - Date.now()) / 1_000));
+    const lines = [
+      theme.header(
+        `Question ${this.step + 1}/${this.record.questions.length} · ${safeText(question.header)}`,
+      ),
+      safeText(question.question),
+      theme.dim(`Expires in ${seconds}s`),
+    ];
+    const binding = question.secretStore;
+    if (binding) {
+      lines.push(`Secret store entry: ${safeText(binding.name)}`);
+      if (binding.reason) {
+        lines.push(`Reason: ${safeText(binding.reason)}`);
+      }
+      lines.push(
+        `Allowed hosts (accept as proposed): ${binding.allowedHosts?.map(safeText).join(", ") || "none"}`,
+      );
+      if (question.secretStoreExisting) {
+        lines.push(theme.accent("An existing value will be replaced."));
+      }
+    }
+    const rendered = new Text(lines.join("\n"), 0, 0).render(width);
+    for (const [index, row] of this.rows().entries()) {
+      const selected = !this.editing && index === this.selectedRow;
+      const checked = row.kind === "option" && this.selections.get(this.step)?.has(row.index);
+      const marker =
+        row.kind === "option" && question.multiSelect ? `[${checked ? "x" : " "}] ` : "";
+      rendered.push(
+        ...new Text(
+          (selected ? theme.accent : theme.fg)(`${selected ? "›" : " "} ${marker}${row.label}`),
+          0,
+          0,
+        ).render(width),
+      );
+      if (row.kind === "option") {
+        const description = question.options[row.index]?.description;
+        if (description) {
+          rendered.push(...new Text(theme.dim(`    ${safeText(description)}`), 0, 0).render(width));
+        }
+      }
+      if (row.kind === "other" && (this.editing || this.draft())) {
+        this.input.focused = this.focused && this.editing;
+        rendered.push(
+          ...(question.isSecret
+            ? this.secretInput.render(width, this.focused && this.editing)
+            : this.input.render(width)),
+        );
+      }
+    }
+    rendered.push(
+      ...new Text(
+        theme.dim(
+          this.editing
+            ? "Enter next/submit · Tab choices · Esc collapse"
+            : `↑/↓ or numbers select${question.multiSelect ? " · Space toggles" : ""} · Enter confirm · Esc collapse`,
+        ),
+        0,
+        0,
+      ).render(width),
+    );
+    if (question.isSecret) {
+      rendered.push(
+        ...new Text(
+          theme.dim("Masked entry · Answer through this prompt, not the composer."),
+          0,
+          0,
+        ).render(width),
+      );
+    }
+    if (this.message) {
+      rendered.push(...new Text(theme.error(this.message), 0, 0).render(width));
+    }
+    return rendered;
+  }
+
+  dispose(): void {
+    this.closed = true;
+    this.pasteBuffer = null;
+    this.input = new Input();
+    this.secretInput.clear();
+    this.freeText.clear();
+    this.selections.clear();
+    for (const key of Object.keys(this.answers)) {
+      delete this.answers[key];
+    }
+  }
+}

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -16,6 +16,10 @@ import {
   clearEmbeddedPluginApprovalBroker,
   getEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
+import {
+  clearEmbeddedQuestionBroker,
+  getEmbeddedQuestionBroker,
+} from "../infra/embedded-question-broker.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -35,6 +39,7 @@ let EmbeddedTuiBackend: typeof EmbeddedTuiBackendType;
 
 const agentCommandFromIngressMock = vi.fn();
 const queueEmbeddedAgentMessageWithOutcomeAsyncMock = vi.fn();
+const claimPendingEmbeddedAgentQuestionAnswerMock = vi.fn();
 const resolveActiveEmbeddedRunSessionIdMock = vi.fn();
 const runBtwSideQuestionMock = vi.fn();
 const formatSessionUsageCostSummaryMock = vi.fn();
@@ -156,6 +161,8 @@ vi.mock("../agents/agent-command.js", () => ({
 }));
 
 vi.mock("../agents/embedded-agent-runner/runs.js", () => ({
+  claimPendingEmbeddedAgentQuestionAnswer: (...args: unknown[]) =>
+    claimPendingEmbeddedAgentQuestionAnswerMock(...args),
   queueEmbeddedAgentMessageWithOutcomeAsync: (...args: unknown[]) =>
     queueEmbeddedAgentMessageWithOutcomeAsyncMock(...args),
 }));
@@ -406,6 +413,7 @@ describe("EmbeddedTuiBackend", () => {
     vi.setSystemTime(embeddedEventTimestamp);
     agentCommandFromIngressMock.mockReset();
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockReset();
+    claimPendingEmbeddedAgentQuestionAnswerMock.mockReset().mockResolvedValue(null);
     resolveActiveEmbeddedRunSessionIdMock.mockReset();
     resolveActiveEmbeddedRunSessionIdMock.mockReturnValue(undefined);
     runBtwSideQuestionMock.mockReset();
@@ -518,6 +526,11 @@ describe("EmbeddedTuiBackend", () => {
     broker?.stop();
     if (broker) {
       clearEmbeddedPluginApprovalBroker(broker);
+    }
+    const questionBroker = getEmbeddedQuestionBroker();
+    questionBroker?.stop();
+    if (questionBroker) {
+      clearEmbeddedQuestionBroker(questionBroker);
     }
     vi.useRealTimers();
     setEmbeddedMode(false);
@@ -714,6 +727,48 @@ describe("EmbeddedTuiBackend", () => {
     pending.resolve({ payloads: [{ text: "hello" }], meta: {} });
     await flushMicrotasks();
     await backend.stop();
+  });
+
+  it("bridges question events and answers through the registered local broker", async () => {
+    const backend = new EmbeddedTuiBackend();
+    const events = captureBackendEvents(backend);
+    backend.start();
+    try {
+      const broker = getEmbeddedQuestionBroker();
+      if (!broker) {
+        throw new Error("expected embedded question broker");
+      }
+      const { id } = broker.request({
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        questions: [
+          { questionId: "target", header: "Target", question: "Which target?", options: [] },
+        ],
+      });
+      const { questions } = await backend.listQuestions();
+      expect(questions).toHaveLength(1);
+      expect(events).toContainEqual({ event: "question.requested", payload: questions[0] });
+      const waiting = broker.waitAnswer({ id, includeResolutionId: true });
+      const answers = { answers: { target: ["Staging"] } };
+      await expect(
+        backend.resolveQuestion({ id, answers, resolutionId: "local-answer" }),
+      ).resolves.toEqual({ status: "answered", answers });
+      await expect(waiting).resolves.toEqual({
+        status: "answered",
+        answers,
+        resolutionId: "local-answer",
+      });
+      await expect(backend.getQuestion(id)).resolves.toMatchObject({
+        question: { id, status: "answered", answers },
+      });
+      expect(events).toContainEqual({
+        event: "question.resolved",
+        payload: { id, status: "answered", answers },
+      });
+    } finally {
+      await backend.stop();
+    }
+    expect(getEmbeddedQuestionBroker()).toBeNull();
   });
 
   it("bridges local plugin approvals without a Gateway", async () => {
@@ -2005,6 +2060,43 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it.each(["collect", "followup", "steer", "interrupt"] as const)(
+    "claims local question input before applying %s queue policy",
+    async (mode) => {
+      const first = deferred<EmbeddedAgentResult>();
+      agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
+      resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
+      loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+        cfg: { messages: { queue: { mode } } },
+        agentId: "main",
+        canonicalKey: sessionKey,
+        storePath: "/tmp/openclaw-sessions.json",
+        store: {},
+        entry: {},
+      }));
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      try {
+        await sendMainChat(backend, "ask a question", "question-owner");
+        claimPendingEmbeddedAgentQuestionAnswerMock.mockResolvedValue({ runId: "question-owner" });
+        await expect(sendMainChat(backend, "Green", "answer-send")).resolves.toEqual({
+          runId: "question-owner",
+        });
+        expect(claimPendingEmbeddedAgentQuestionAnswerMock).toHaveBeenCalledWith(
+          "active-session",
+          "Green",
+        );
+        expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
+        first.resolve({ payloads: [{ text: "answered" }], meta: {} });
+        await flushMicrotasks();
+        expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+      } finally {
+        first.resolve({ payloads: [], meta: {} });
+        await backend.stop();
+      }
+    },
+  );
+
   it("steers same-session sends into the active local run", async () => {
     const first = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
@@ -2046,29 +2138,35 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
-  it("surfaces uncertain question input without queuing it again", async () => {
-    const first = deferred<EmbeddedAgentResult>();
-    agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
-    resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
-    const error = new QuestionAnswerUnconfirmedError("synthetic-question");
-    queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockRejectedValue(error);
-    const backend = new EmbeddedTuiBackend();
-    backend.start();
-    await sendMainChat(backend, "first", "run-local-first");
-    try {
-      await expect(
-        backend.sendChat({
-          sessionKey: "agent:main:main",
-          message: "answer",
-          runId: "run-local-second",
-        }),
-      ).rejects.toBe(error);
-    } finally {
-      first.resolve({ payloads: [{ text: "done" }], meta: {} });
-      await flushMicrotasks();
-    }
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
-  });
+  it.each(["claim", "steer"])(
+    "surfaces uncertain question input from %s without queuing it again",
+    async (route) => {
+      const first = deferred<EmbeddedAgentResult>();
+      agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
+      resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
+      const error = new QuestionAnswerUnconfirmedError("synthetic-question");
+      (route === "claim"
+        ? claimPendingEmbeddedAgentQuestionAnswerMock
+        : queueEmbeddedAgentMessageWithOutcomeAsyncMock
+      ).mockRejectedValue(error);
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      await sendMainChat(backend, "first", "run-local-first");
+      try {
+        await expect(
+          backend.sendChat({
+            sessionKey: "agent:main:main",
+            message: "answer",
+            runId: "run-local-second",
+          }),
+        ).rejects.toBe(error);
+      } finally {
+        first.resolve({ payloads: [{ text: "done" }], meta: {} });
+        await flushMicrotasks();
+      }
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("queues local sends when active-runtime steering rejects them", async () => {
     const first = deferred<EmbeddedAgentResult>();
@@ -2127,7 +2225,6 @@ describe("EmbeddedTuiBackend", () => {
     await sendMainChat(backend, "first", "run-local-first");
     await sendMainChat(backend, "follow up later", "run-local-second");
 
-    expect(resolveActiveEmbeddedRunSessionIdMock).not.toHaveBeenCalled();
     expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
     first.resolve({ payloads: [{ text: "first done" }], meta: {} });

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1,6 +1,10 @@
 // Implements the embedded backend used by local TUI sessions.
 import { randomUUID } from "node:crypto";
-import type { ErrorShape, SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
+import type {
+  ErrorShape,
+  QuestionResolveParams,
+  SessionsPatchResult,
+} from "../../packages/gateway-protocol/src/index.js";
 import { CHAT_HISTORY_MAX_ENTRIES } from "../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
@@ -20,7 +24,10 @@ import {
 } from "../agents/agent-scope.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { resolveActiveEmbeddedRunSessionId } from "../agents/embedded-agent-runner/active-run-projections.js";
-import { queueEmbeddedAgentMessageWithOutcomeAsync } from "../agents/embedded-agent-runner/runs.js";
+import {
+  claimPendingEmbeddedAgentQuestionAnswer,
+  queueEmbeddedAgentMessageWithOutcomeAsync,
+} from "../agents/embedded-agent-runner/runs.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
 import { resolveThinkingDefault } from "../agents/model-selection.js";
 import { resolvePublishedModelCatalogOwner } from "../agents/prepared-model-catalog-owner.js";
@@ -93,6 +100,11 @@ import {
   EmbeddedPluginApprovalBroker,
   setEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
+import {
+  clearEmbeddedQuestionBroker,
+  EmbeddedQuestionBroker,
+  setEmbeddedQuestionBroker,
+} from "../infra/embedded-question-broker.js";
 import { logInfo, logWarn } from "../logger.js";
 import { agentSessionKeysMatchByRequestKey, normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -345,8 +357,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private seq = 0;
   private readonly pendingLifecycleErrors = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly pluginApprovalBroker = new EmbeddedPluginApprovalBroker();
+  private readonly questionBroker = new EmbeddedQuestionBroker();
   private readonly preparedModelRuntime = new EmbeddedPreparedModelRuntimeHost();
   private unsubscribePluginApprovals?: () => void;
+  private unsubscribeQuestions?: () => void;
   private unsubscribeConfigWrites?: () => void;
   // Resolves once the one-time session-key migration has run; store methods await it.
   private ready: Promise<void> = Promise.resolve();
@@ -367,6 +381,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.unsubscribe = onAgentEvent((evt) => this.handleAgentEvent(evt));
     setEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
     this.unsubscribePluginApprovals = this.pluginApprovalBroker.subscribe((event) => {
+      this.emit(event.event, event.payload);
+    });
+    setEmbeddedQuestionBroker(this.questionBroker);
+    this.unsubscribeQuestions = this.questionBroker.subscribe((event) => {
       this.emit(event.event, event.payload);
     });
     const config = getRuntimeConfig();
@@ -395,6 +413,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     clearEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
     this.unsubscribePluginApprovals?.();
     this.unsubscribePluginApprovals = undefined;
+    clearEmbeddedQuestionBroker(this.questionBroker);
+    this.unsubscribeQuestions?.();
+    this.unsubscribeQuestions = undefined;
     const maintenancePromises: Promise<void>[] = [];
     for (const [runId, run] of this.runs) {
       if (run.finishing || run.lifecycleEnded) {
@@ -407,6 +428,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       run.controller.abort();
     }
     this.pluginApprovalBroker.stop();
+    this.questionBroker.stop();
     const maintenanceCompleted = await waitForLocalRunShutdown(maintenancePromises);
     if (!maintenanceCompleted) {
       for (const run of this.runs.values()) {
@@ -460,13 +482,22 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (queuedAfter) {
       const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
       const { cfg, canonicalKey, entry } = loadSessionEntry(opts.sessionKey, loadOptions);
+      const activeSessionId = resolveActiveEmbeddedRunSessionId(canonicalKey);
+      if (activeSessionId) {
+        const claimed = await claimPendingEmbeddedAgentQuestionAnswer(
+          activeSessionId,
+          opts.message,
+        );
+        if (claimed) {
+          return claimed;
+        }
+      }
       let queueSettings = resolveQueueSettingsCore({
         cfg,
         channel: INTERNAL_MESSAGE_CHANNEL,
         sessionEntry: entry,
       });
       if (queueSettings.mode === "steer") {
-        const activeSessionId = resolveActiveEmbeddedRunSessionId(canonicalKey);
         if (activeSessionId) {
           const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
             activeSessionId,
@@ -894,6 +925,18 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async listPluginApprovals(): Promise<unknown> {
     return this.pluginApprovalBroker.listPending();
+  }
+
+  async listQuestions() {
+    return this.questionBroker.list();
+  }
+
+  async getQuestion(id: string) {
+    return this.questionBroker.get({ id });
+  }
+
+  async resolveQuestion(params: QuestionResolveParams) {
+    return this.questionBroker.resolve(params);
   }
 
   async resolvePluginApproval(id: string, decision: TuiApprovalDecision) {

--- a/src/tui/gateway-chat.scopes.test.ts
+++ b/src/tui/gateway-chat.scopes.test.ts
@@ -224,6 +224,74 @@ describe("GatewayChatClient operator scopes", () => {
         },
       });
       await approved.client.waitForReady();
+      const questionEvents = vi.fn();
+      approved.client.onEvent = questionEvents;
+      const question = {
+        id: "tui-question",
+        questions: [
+          { questionId: "target", header: "Target", question: "Which target?", options: [] },
+        ],
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        status: "pending",
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 60_000,
+      };
+      approved.socket.receive({ type: "event", event: "question.requested", payload: question });
+      expect(questionEvents).toHaveBeenCalledWith({
+        event: "question.requested",
+        payload: question,
+      });
+
+      const listing = approved.client.listQuestions();
+      const listRequest = approved.socket.sent.find((frame) => frame.method === "question.list");
+      expect(listRequest?.params).toEqual({});
+      approved.socket.receive({
+        type: "res",
+        id: listRequest?.id,
+        ok: true,
+        payload: { questions: [question] },
+      });
+      await expect(listing).resolves.toEqual({ questions: [question] });
+
+      const answers = { answers: { target: ["Staging"] } };
+      const resolution = approved.client.resolveQuestion({
+        id: question.id,
+        answers,
+        resolutionId: "tui-answer",
+      });
+      const resolveRequest = approved.socket.sent.find(
+        (frame) => frame.method === "question.resolve",
+      );
+      expect(resolveRequest?.params).toEqual({
+        id: question.id,
+        answers,
+        resolutionId: "tui-answer",
+      });
+      const resolved = { id: question.id, status: "answered", answers };
+      approved.socket.receive({ type: "event", event: "question.resolved", payload: resolved });
+      approved.socket.receive({
+        type: "res",
+        id: resolveRequest?.id,
+        ok: true,
+        payload: { status: "answered", answers },
+      });
+      await expect(resolution).resolves.toEqual({ status: "answered", answers });
+      expect(questionEvents).toHaveBeenCalledWith({
+        event: "question.resolved",
+        payload: resolved,
+      });
+      const recovery = approved.client.getQuestion(question.id);
+      const getRequest = approved.socket.sent.find((frame) => frame.method === "question.get");
+      expect(getRequest?.params).toEqual({ id: question.id });
+      const terminalQuestion = { ...question, status: "answered", answers };
+      approved.socket.receive({
+        type: "res",
+        id: getRequest?.id,
+        ok: true,
+        payload: { question: terminalQuestion },
+      });
+      await expect(recovery).resolves.toEqual({ question: terminalQuestion });
       expect(storeDeviceAuthToken).toHaveBeenCalledWith({
         deviceId: deviceIdentity.deviceId,
         role: "operator",

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -18,6 +18,10 @@ import {
   type CommandEntry,
   type CommandsListParams,
   type CommandsListResult,
+  type QuestionGetResult,
+  type QuestionListResult,
+  type QuestionResolveParams,
+  type QuestionResolveResult,
   type SessionsListParams,
   type SessionsResolveParams,
   type SessionsResolveResult,
@@ -464,6 +468,18 @@ export class GatewayChatClient implements TuiBackend {
 
   async listPluginApprovals() {
     return await this.client.request("plugin.approval.list", {});
+  }
+
+  async listQuestions(): Promise<QuestionListResult> {
+    return await this.client.request("question.list", {});
+  }
+
+  async getQuestion(id: string): Promise<QuestionGetResult> {
+    return await this.client.request("question.get", { id });
+  }
+
+  async resolveQuestion(params: QuestionResolveParams): Promise<QuestionResolveResult> {
+    return await this.client.request("question.resolve", params);
   }
 
   async resolvePluginApproval(id: string, decision: TuiApprovalDecision) {

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -4,6 +4,10 @@ import type {
   CommandEntry,
   CommandsListParams,
   ModelChoice,
+  QuestionGetResult,
+  QuestionListResult,
+  QuestionResolveParams,
+  QuestionResolveResult,
   SessionsListParams,
   SessionsPatchParams,
   SessionsPatchResult,
@@ -208,6 +212,9 @@ export type TuiBackend = {
   listCommands?: (opts?: CommandsListParams) => Promise<CommandEntry[]>;
   listPluginApprovals?: () => Promise<unknown>;
   resolvePluginApproval?: (id: string, decision: TuiApprovalDecision) => Promise<{ ok?: boolean }>;
+  listQuestions?: () => Promise<QuestionListResult>;
+  getQuestion?: (id: string) => Promise<QuestionGetResult>;
+  resolveQuestion?: (params: QuestionResolveParams) => Promise<QuestionResolveResult>;
   getTaskSuggestionActionCapabilities?: () => TuiTaskSuggestionActionCapabilities;
   listTaskSuggestions?: () => Promise<TaskSuggestion[]>;
   acceptTaskSuggestion?: (taskId: string) => Promise<TaskSuggestionsAcceptResult>;

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -126,6 +126,7 @@ function createHarness(params?: {
   consumeCompletedRunForPendingSend?: ConsumeCompletedRunMock;
   isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: FlushPendingHistoryRefreshMock;
+  reopenQuestion?: () => void;
   refreshAgents?: RefreshAgentsMock;
   agentDefaultId?: string;
   agents?: Array<{ id: string; kind?: "agent" | "system"; name?: string }>;
@@ -266,6 +267,7 @@ function createHarness(params?: {
     flushPendingHistoryRefreshIfIdle: params?.flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
     requestExit,
+    reopenQuestion: params?.reopenQuestion,
   });
 
   return {
@@ -317,6 +319,21 @@ function createHarness(params?: {
 }
 
 describe("tui command handlers", () => {
+  it.each([false, true])(
+    "reopens /question locally without sending a chat turn (local=%s)",
+    async (local) => {
+      const reopenQuestion = vi.fn();
+      const { handleCommand, sendChat, addPendingUser } = createHarness({
+        opts: { local },
+        reopenQuestion,
+      });
+      await handleCommand("/question");
+      expect(reopenQuestion).toHaveBeenCalledOnce();
+      expect(sendChat).not.toHaveBeenCalled();
+      expect(addPendingUser).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not open the agent picker from a cached roster after refresh failure", async () => {
     const refreshAgents = vi
       .fn()

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -93,6 +93,7 @@ type CommandHandlerContext = {
   consumeCompletedRunForPendingSend?: (runId: string) => boolean;
   isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: () => void;
+  reopenQuestion?: () => void | Promise<void>;
   runAuthFlow?: (params: { provider?: string }) => Promise<{
     exitCode: number | null;
     signal: NodeJS.Signals | null;
@@ -865,6 +866,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       await abortActive({ preferActive: true });
     },
     settings: () => openSettings(),
+    question: async () => {
+      if (context.reopenQuestion) {
+        await context.reopenQuestion();
+      } else {
+        chatLog.addSystem("no pending question");
+      }
+    },
     exit: () => requestExit(),
   } satisfies Record<TuiCommandHandlerName, CommandHandler>;
 

--- a/src/tui/tui-overlays.ts
+++ b/src/tui/tui-overlays.ts
@@ -6,8 +6,8 @@ type OverlayHost = Pick<TUI, "showOverlay" | "hideOverlay" | "hasOverlay" | "set
 
 /** Creates open/close handlers that restore focus when no overlay is active. */
 export function createOverlayHandlers(host: OverlayHost, fallbackFocus: Component) {
-  const openOverlay = (component: Component) => {
-    return host.showOverlay(component);
+  const openOverlay: TUI["showOverlay"] = (...args) => {
+    return host.showOverlay(...args);
   };
 
   const closeOverlay = (handle?: OverlayHandle) => {

--- a/src/tui/tui-questions.test.ts
+++ b/src/tui/tui-questions.test.ts
@@ -1,0 +1,697 @@
+import type { Component, OverlayHandle } from "@earendil-works/pi-tui";
+import type {
+  QuestionGetResult,
+  QuestionListResult,
+  QuestionRecord,
+  QuestionResolveParams,
+  QuestionResolveResult,
+} from "@openclaw/gateway-protocol";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { createTuiQuestionController } from "./tui-questions.js";
+
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+const ESC = "\x1b";
+const TAB = "\t";
+
+function questionRecord(overrides: Partial<QuestionRecord> = {}): QuestionRecord {
+  return {
+    id: "request-1",
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    createdAtMs: 1_000,
+    expiresAtMs: 61_000,
+    status: "pending",
+    questions: [
+      {
+        questionId: "target",
+        header: "Target",
+        question: "Where should the sample run?",
+        options: [
+          { label: "Staging", description: "Use the test environment" },
+          { label: "Production" },
+        ],
+        isOther: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+const controllers: Array<ReturnType<typeof createTuiQuestionController>> = [];
+
+function createHarness() {
+  let agentId = "main";
+  let sessionKey = "agent:main:main";
+  let shown: Component | undefined;
+  const addSystem = vi.fn<(line: string) => void>();
+  const onPendingChange = vi.fn<(text: string) => void>();
+  const closeOverlay = vi.fn(() => {
+    shown = undefined;
+  });
+  const openOverlay = vi.fn((component: Component) => {
+    shown = component;
+    return {
+      hide() {},
+      setHidden() {},
+      isHidden: () => false,
+      focus() {},
+      unfocus() {},
+      isFocused: () => true,
+    } satisfies OverlayHandle;
+  });
+  const listQuestions = vi
+    .fn<() => Promise<QuestionListResult>>()
+    .mockResolvedValue({ questions: [] });
+  const getQuestion = vi
+    .fn<(id: string) => Promise<QuestionGetResult>>()
+    .mockResolvedValue({ question: questionRecord() });
+  const resolveQuestion = vi
+    .fn<(params: QuestionResolveParams) => Promise<QuestionResolveResult>>()
+    .mockImplementation(async (params) =>
+      "cancel" in params
+        ? { status: "cancelled" }
+        : { status: "answered", answers: params.answers },
+    );
+  const controller = createTuiQuestionController({
+    client: { listQuestions, getQuestion, resolveQuestion },
+    chatLog: { addSystem },
+    getAgentId: () => agentId,
+    getSessionKey: () => sessionKey,
+    openOverlay,
+    closeOverlay,
+    onPendingChange,
+    requestRender: vi.fn(),
+  });
+  controllers.push(controller);
+  return {
+    controller,
+    addSystem,
+    onPendingChange,
+    openOverlay,
+    closeOverlay,
+    listQuestions,
+    getQuestion,
+    resolveQuestion,
+    request(record = questionRecord()) {
+      listQuestions.mockResolvedValue({ questions: [record] });
+      getQuestion.mockResolvedValue({ question: record });
+      controller.handleEvent("question.requested", record);
+    },
+    selectSession(agent: string, session: string) {
+      agentId = agent;
+      sessionKey = session;
+    },
+    input(...keys: string[]) {
+      for (const key of keys) {
+        if (!shown?.handleInput) {
+          throw new Error("question prompt is not open");
+        }
+        shown.handleInput(key);
+      }
+    },
+    rawRender(width = 100) {
+      return shown?.render(width).join("\n") ?? "";
+    },
+    render(width = 100) {
+      return stripAnsi(shown?.render(width).join("\n") ?? "");
+    },
+  };
+}
+
+async function settle() {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+});
+afterEach(() => {
+  for (const controller of controllers.splice(0)) {
+    controller.dispose();
+  }
+  vi.useRealTimers();
+});
+
+describe("TUI questions", () => {
+  it.each([
+    [DOWN, ENTER],
+    ["2", ENTER],
+  ])("answers using selection keys %j", async (...keys) => {
+    const harness = createHarness();
+    harness.request();
+    expect(harness.render()).toContain("Question 1/1 · Target");
+    expect(harness.render()).toContain("Use the test environment");
+    harness.input(...keys);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith({
+      id: "request-1",
+      answers: { answers: { target: ["Production"] } },
+      resolutionId: expect.any(String),
+    });
+    expect(harness.render()).toBe("");
+    expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith("Question: answered.");
+  });
+
+  it("advances three questions and submits Other text with the selected answers", async () => {
+    const harness = createHarness();
+    const first = questionRecord().questions[0]!;
+    harness.request(
+      questionRecord({
+        questions: [
+          first,
+          { ...first, questionId: "region", header: "Region" },
+          { ...first, questionId: "timing", header: "Timing" },
+        ],
+      }),
+    );
+    harness.input("2", ENTER);
+    expect(harness.render()).toContain("Question 2/3 · Region");
+    harness.input("3", "A custom region", ENTER);
+    expect(harness.render()).toContain("Question 3/3 · Timing");
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+    harness.input(ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        answers: {
+          answers: { target: ["Production"], region: ["A custom region"], timing: ["Staging"] },
+        },
+      }),
+    );
+  });
+
+  it("toggles multiple options, combines Other, and waits for explicit confirmation", async () => {
+    const harness = createHarness();
+    harness.request(
+      questionRecord({ questions: [{ ...questionRecord().questions[0]!, multiSelect: true }] }),
+    );
+    harness.input("1", "2", " ", " ");
+    expect(harness.render()).toContain("[x] 1. Staging");
+    expect(harness.render()).toContain("[x] 2. Production");
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+    harness.input("3", "Custom", TAB, ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        answers: { answers: { target: ["Staging", "Production", "Custom"] } },
+      }),
+    );
+  });
+
+  it("cancels the whole request with Skip without submitting partial answers", async () => {
+    const harness = createHarness();
+    harness.request();
+    harness.input(UP, ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledExactlyOnceWith({
+      id: "request-1",
+      cancel: true,
+    });
+    expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith("Question: skipped.");
+  });
+
+  it.each([false, true])(
+    "masks secret input, including a pasted value (store-bound=%s)",
+    async (storeBound) => {
+      const harness = createHarness();
+      const secret = "synthetic-secret-only";
+      harness.request(
+        questionRecord({
+          questions: [
+            {
+              questionId: "credential",
+              header: "Credential",
+              question: "Enter the synthetic value",
+              options: [],
+              isSecret: true,
+              ...(storeBound
+                ? {
+                    secretStore: {
+                      name: "EXAMPLE_KEY",
+                      kind: "secret" as const,
+                      reason: "Access the example service",
+                      allowedHosts: ["api.example.test"],
+                    },
+                    secretStoreExisting: { updatedAtMs: 0 },
+                  }
+                : {}),
+            },
+          ],
+        }),
+      );
+      harness.input(`\x1b[200~${secret}\x1b[201~`);
+      expect(harness.render()).toContain("•".repeat(secret.length));
+      expect(harness.render()).not.toContain(secret);
+      if (storeBound) {
+        expect(harness.render()).toContain("Secret store entry: EXAMPLE_KEY");
+        expect(harness.render()).toContain("Reason: Access the example service");
+        expect(harness.render()).toContain("Allowed hosts (accept as proposed): api.example.test");
+        expect(harness.render()).toContain("An existing value will be replaced.");
+        expect(harness.rawRender(80).split("\n").length).toBeLessThanOrEqual(24);
+      }
+      harness.input(ENTER);
+      await settle();
+      expect(harness.resolveQuestion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          answers: { answers: { credential: [secret] } },
+        }),
+      );
+      expect(harness.addSystem.mock.calls.flat().join("\n")).not.toContain(secret);
+      expect(harness.onPendingChange.mock.calls.flat().join("\n")).not.toContain(secret);
+    },
+  );
+
+  it.each([false, true])(
+    "buffers split bracketed paste without treating Enter as submit (secret=%s)",
+    async (isSecret) => {
+      const harness = createHarness();
+      harness.request(
+        questionRecord({
+          questions: [
+            {
+              questionId: "value",
+              header: "Value",
+              question: "Enter a value",
+              options: [],
+              isSecret,
+            },
+          ],
+        }),
+      );
+      harness.input("\x1b[200~first", "\r", "second\x1b[201~");
+      expect(harness.resolveQuestion).not.toHaveBeenCalled();
+      if (isSecret) {
+        expect(harness.render()).not.toContain("first");
+      }
+      harness.input(ENTER);
+      await settle();
+      if (isSecret) {
+        expect(harness.resolveQuestion).not.toHaveBeenCalled();
+        expect(harness.render()).toContain(
+          "Secret paste contains line breaks or unsupported control characters.",
+        );
+      } else {
+        expect(harness.resolveQuestion).toHaveBeenCalledTimes(1);
+      }
+    },
+  );
+
+  it("preserves tabs in secret paste and rejects unsupported bytes without submitting a partial value", async () => {
+    const harness = createHarness();
+    harness.request(
+      questionRecord({
+        questions: [
+          {
+            questionId: "value",
+            header: "Value",
+            question: "Enter a value",
+            options: [],
+            isSecret: true,
+          },
+        ],
+      }),
+    );
+    harness.input("\x1b[200~prefix\tsuffix\x1b[201~");
+    expect(harness.render()).not.toContain("prefix");
+    harness.input("\x1b[200~bad\nvalue\x1b[201~", ENTER);
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+    expect(harness.render()).toContain(
+      "Secret paste contains line breaks or unsupported control characters.",
+    );
+    expect(harness.render()).not.toContain("bad");
+    harness.input("\x15", "\x1b[200~prefix\tsuffix\x1b[201~", ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ answers: { answers: { value: ["prefix\tsuffix"] } } }),
+    );
+  });
+
+  it("preserves whitespace-only secret values", async () => {
+    const harness = createHarness();
+    harness.request(
+      questionRecord({
+        questions: [
+          {
+            questionId: "value",
+            header: "Value",
+            question: "Enter a value",
+            options: [],
+            isSecret: true,
+          },
+        ],
+      }),
+    );
+    harness.input("   ", ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ answers: { answers: { value: ["   "] } } }),
+    );
+  });
+
+  it("collapses without resolving, preserves the draft, and reopens with /question", async () => {
+    const harness = createHarness();
+    harness.request();
+    harness.input("3", "Draft answer", ESC);
+    expect(harness.render()).toBe("");
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+    expect(harness.onPendingChange).toHaveBeenLastCalledWith(
+      expect.stringContaining("/question to open"),
+    );
+    await harness.controller.reopen();
+    expect(harness.render()).toContain("Draft answer");
+    harness.input(ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ answers: { answers: { target: ["Draft answer"] } } }),
+    );
+  });
+
+  it("returns to the composer on Esc even with multiple pending requests", () => {
+    const harness = createHarness();
+    harness.request();
+    harness.controller.handleEvent("question.requested", questionRecord({ id: "second" }));
+    harness.input(ESC);
+    expect(harness.render()).toBe("");
+    expect(harness.onPendingChange).toHaveBeenLastCalledWith(
+      expect.stringContaining("Question pending (2)"),
+    );
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes terminal controls and bidirectional overrides in authored text", () => {
+    const harness = createHarness();
+    harness.request(
+      questionRecord({
+        questions: [
+          {
+            questionId: "target",
+            header: "Target",
+            question: "Question\u001b]52;c;YWJj\u0007\u202e",
+            options: [{ label: "Choice\u001b[2J\u2066", description: "Description\u0000" }],
+          },
+        ],
+      }),
+    );
+    const rendered = harness.rawRender();
+    expect(rendered).toContain("Question");
+    expect(rendered).toContain("Choice");
+    expect(rendered).not.toContain("\u001b]52");
+    expect(rendered).not.toContain("\u001b[2J");
+    expect(rendered).not.toContain("\u0000");
+    expect(rendered).not.toContain("\u0007");
+    expect(rendered).not.toContain("\u202e");
+    expect(rendered).not.toContain("\u2066");
+  });
+
+  it("restores only the active session and agent, including after switching sessions", async () => {
+    const harness = createHarness();
+    const foreign = questionRecord({
+      id: "other",
+      agentId: "other",
+      sessionKey: "agent:other:main",
+    });
+    harness.listQuestions.mockResolvedValue({ questions: [foreign, questionRecord()] });
+    await harness.controller.refresh();
+    expect(harness.render()).toContain("Target");
+    harness.selectSession("other", "agent:other:main");
+    await harness.controller.sessionChanged();
+    harness.input(ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(expect.objectContaining({ id: "other" }));
+    expect(harness.listQuestions).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects malformed records and contradictory session ownership", () => {
+    const harness = createHarness();
+    harness.controller.handleEvent("question.requested", { id: "malformed" });
+    harness.controller.handleEvent("question.requested", questionRecord({ agentId: "other" }));
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+  });
+
+  it.each(["answered", "cancelled", "expired"] as const)(
+    "dismisses questions %s elsewhere without showing answer values",
+    (status) => {
+      const harness = createHarness();
+      harness.request();
+      harness.controller.handleEvent("question.resolved", {
+        id: "request-1",
+        status,
+        ...(status === "answered"
+          ? { answers: { answers: { target: ["synthetic-private-answer"] } } }
+          : {}),
+      });
+      expect(harness.render()).toBe("");
+      expect(harness.onPendingChange).toHaveBeenLastCalledWith("");
+      expect(harness.addSystem.mock.calls.flat().join("\n")).not.toContain(
+        "synthetic-private-answer",
+      );
+      expect(harness.resolveQuestion).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps event requests and resolutions newer than an in-flight list snapshot", async () => {
+    const harness = createHarness();
+    const listing = deferred<QuestionListResult>();
+    harness.listQuestions.mockReturnValueOnce(listing.promise);
+    const refresh = harness.controller.refresh();
+    harness.controller.handleEvent("question.requested", questionRecord({ id: "newer" }));
+    harness.controller.handleEvent("question.resolved", { id: "request-1", status: "cancelled" });
+    listing.resolve({ questions: [questionRecord()] });
+    await refresh;
+    harness.input(ENTER);
+    await settle();
+    expect(harness.resolveQuestion).toHaveBeenCalledWith(expect.objectContaining({ id: "newer" }));
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates a resolution event and its RPC response, even with a concurrent refresh", async () => {
+    const harness = createHarness();
+    const submission = deferred<QuestionResolveResult>();
+    harness.resolveQuestion.mockReturnValueOnce(submission.promise);
+    harness.request();
+    harness.input(ENTER);
+    await harness.controller.refresh();
+    expect(harness.openOverlay).toHaveBeenCalledTimes(1);
+    harness.controller.handleEvent("question.resolved", {
+      id: "request-1",
+      status: "answered",
+      answers: { answers: { target: ["Staging"] } },
+    });
+    submission.resolve({ status: "answered", answers: { answers: { target: ["Staging"] } } });
+    await settle();
+    expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith("Question: answered.");
+  });
+
+  it("shows a countdown and expires a collapsed question without resolving it", async () => {
+    const harness = createHarness();
+    harness.request(questionRecord({ expiresAtMs: 3_000 }));
+    expect(harness.render()).toContain("Expires in 2s");
+    harness.input(ESC);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.onPendingChange).toHaveBeenLastCalledWith(expect.stringContaining("1s"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.onPendingChange).toHaveBeenLastCalledWith("");
+    expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith("Question: expired.");
+    expect(harness.resolveQuestion).not.toHaveBeenCalled();
+  });
+
+  it("does not print rejected secret values and leaves the question retryable", async () => {
+    const harness = createHarness();
+    harness.resolveQuestion.mockRejectedValueOnce(
+      new Error("invalid value: synthetic-secret-only"),
+    );
+    harness.request(
+      questionRecord({
+        questions: [
+          { questionId: "key", header: "Key", question: "Enter key", options: [], isSecret: true },
+        ],
+      }),
+    );
+    harness.input("synthetic-secret-only", ENTER);
+    await settle();
+    await harness.controller.refresh();
+    expect(harness.addSystem).toHaveBeenCalledWith(
+      "Question is still pending. Use /question to retry.",
+    );
+    expect(harness.addSystem.mock.calls.flat().join("\n")).not.toContain("synthetic-secret-only");
+    await harness.controller.reopen();
+    expect(harness.render()).toContain("Masked entry");
+    expect(harness.render()).not.toContain("•");
+  });
+
+  it.each(["answered", "cancelled", "expired"] as const)(
+    "recovers a %s result after a lost resolve acknowledgment",
+    async (status) => {
+      const harness = createHarness();
+      harness.request();
+      harness.resolveQuestion.mockRejectedValueOnce(new Error("connection closed"));
+      harness.getQuestion.mockResolvedValue({
+        question: questionRecord({
+          status,
+          ...(status === "answered"
+            ? { answers: { answers: { target: ["private answer"] } } }
+            : {}),
+        }),
+      });
+      harness.input(ENTER);
+      await settle();
+      expect(harness.getQuestion).toHaveBeenCalledWith("request-1");
+      expect(harness.render()).toBe("");
+      expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith(
+        `Question: ${status === "cancelled" ? "skipped" : status}.`,
+      );
+    },
+  );
+
+  it.each([true, false])(
+    "reports saved-secret refresh failures even when the resolved event arrives first (%s)",
+    async (eventFirst) => {
+      const harness = createHarness();
+      const submission = deferred<QuestionResolveResult>();
+      const secret = "synthetic-secret-with-private-suffix";
+      harness.request(
+        questionRecord({
+          questions: [
+            {
+              questionId: "key",
+              header: "Key",
+              question: "Enter the example key",
+              options: [],
+              isSecret: true,
+              secretStore: {
+                name: "EXAMPLE_KEY",
+                kind: "secret",
+                allowedHosts: ["api.example.test"],
+              },
+            },
+          ],
+        }),
+      );
+      harness.resolveQuestion.mockReturnValueOnce(submission.promise);
+      harness.input(secret, ENTER);
+      if (eventFirst) {
+        harness.controller.handleEvent("question.resolved", {
+          id: "request-1",
+          status: "answered",
+          answers: { answers: { key: ["stored"] } },
+        });
+      }
+      submission.reject(
+        new GatewayClientRequestError({
+          code: "UNAVAILABLE",
+          message: `Secret store entry was saved, but runtime refresh failed. ${secret}`,
+        }),
+      );
+      await settle();
+      expect(harness.addSystem.mock.calls.map(([line]) => line)).toEqual([
+        "Question: answered.",
+        "Secret stored, but runtime refresh failed. Run openclaw secrets reload; do not resubmit this answer.",
+      ]);
+      expect(harness.addSystem.mock.calls.flat().join("\n")).not.toContain(secret);
+      expect(harness.getQuestion).not.toHaveBeenCalled();
+      expect(harness.render()).toBe("");
+      expect(harness.onPendingChange).toHaveBeenLastCalledWith("");
+      harness.listQuestions.mockResolvedValue({ questions: [] });
+      await harness.controller.reopen();
+      expect(harness.render()).toBe("");
+      expect(harness.resolveQuestion).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["refresh", "reopen"] as const)(
+    "blocks retry while an answer is unconfirmed and reconciles on %s",
+    async (action) => {
+      const harness = createHarness();
+      harness.request();
+      harness.resolveQuestion.mockRejectedValueOnce(new Error("connection closed"));
+      harness.getQuestion.mockRejectedValue(new Error("disconnected"));
+      harness.input(ENTER);
+      await settle();
+      await harness.controller.reopen();
+      expect(harness.render()).toBe("");
+      expect(harness.resolveQuestion).toHaveBeenCalledTimes(1);
+      expect(harness.addSystem).toHaveBeenCalledExactlyOnceWith(
+        "Answer confirmation unavailable; use /question to check before retrying.",
+      );
+      harness.getQuestion.mockResolvedValue({
+        question: questionRecord({
+          status: "answered",
+          answers: { answers: { target: ["Staging"] } },
+        }),
+      });
+      harness.listQuestions.mockResolvedValue({ questions: [] });
+      await harness.controller[action]();
+      expect(
+        harness.addSystem.mock.calls.filter(([line]) => line === "Question: answered."),
+      ).toHaveLength(1);
+      expect(harness.onPendingChange).toHaveBeenLastCalledWith("");
+      expect(harness.render()).toBe("");
+    },
+  );
+
+  it.each(["not-found", "expiry"] as const)(
+    "dismisses unrecoverable confirmation on %s without claiming success or expiry",
+    async (reason) => {
+      const harness = createHarness();
+      harness.request(questionRecord({ expiresAtMs: 3_000 }));
+      harness.resolveQuestion.mockRejectedValueOnce(new Error("connection closed"));
+      harness.getQuestion.mockRejectedValue(
+        reason === "not-found"
+          ? Object.assign(new Error("question missing"), {
+              details: { reason: "QUESTION_NOT_FOUND" },
+            })
+          : new Error("disconnected"),
+      );
+      harness.input(ENTER);
+      await settle();
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(harness.onPendingChange).toHaveBeenLastCalledWith("");
+      expect(harness.render()).toBe("");
+      expect(
+        harness.addSystem.mock.calls.filter(
+          ([line]) =>
+            line ===
+            "Question outcome could not be recovered; check the conversation or secret store before requesting again.",
+        ),
+      ).toHaveLength(1);
+      expect(harness.addSystem.mock.calls.flat()).not.toContain("Question: expired.");
+      expect(harness.resolveQuestion).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("ignores late list and submission results after disposal", async () => {
+    const harness = createHarness();
+    const submission = deferred<QuestionResolveResult>();
+    const listing = deferred<QuestionListResult>();
+    harness.resolveQuestion.mockReturnValueOnce(submission.promise);
+    harness.request();
+    harness.input(ENTER);
+    harness.listQuestions.mockReturnValueOnce(listing.promise);
+    const refresh = harness.controller.refresh();
+    harness.controller.dispose();
+    listing.resolve({ questions: [questionRecord()] });
+    submission.resolve({ status: "answered", answers: { answers: { target: ["Staging"] } } });
+    await refresh;
+    await settle();
+    expect(harness.render()).toBe("");
+    expect(harness.addSystem).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/tui/tui-questions.ts
+++ b/src/tui/tui-questions.ts
@@ -1,0 +1,404 @@
+import { randomUUID } from "node:crypto";
+// Questions use the same session-scoped controller in Gateway and embedded TUI modes.
+import type { OverlayHandle, TUI } from "@earendil-works/pi-tui";
+import {
+  QuestionGetResultSchema,
+  QuestionListResultSchema,
+  QuestionRecordSchema,
+  QuestionResolvedEventSchema,
+  QuestionResolveResultSchema,
+  type QuestionRecord,
+  type QuestionResolveParams,
+  type QuestionStatus,
+} from "@openclaw/gateway-protocol";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
+import { Value } from "typebox/value";
+import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
+import { QuestionPrompt } from "./components/question-prompt.js";
+import type { TuiBackend } from "./tui-backend.js";
+import { matchesOwnedTuiSession } from "./tui-session-events.js";
+
+type TuiQuestionControllerDeps = {
+  client: Pick<TuiBackend, "listQuestions" | "getQuestion" | "resolveQuestion">;
+  chatLog: { addSystem: (line: string) => void };
+  getAgentId: () => string;
+  getSessionKey: () => string;
+  openOverlay: TUI["showOverlay"];
+  closeOverlay: (handle?: OverlayHandle) => void;
+  requestRender: () => void;
+  onPendingChange: (text: string) => void;
+};
+type QuestionMutation = { version: number; question: QuestionRecord | null };
+
+function isSecretStoreRefreshFailure(record: QuestionRecord, error: unknown): boolean {
+  return (
+    record.questions.some((question) => question.secretStore !== undefined) &&
+    error instanceof Error &&
+    asOptionalObjectRecord(error)?.gatewayCode === "UNAVAILABLE" &&
+    error.message.startsWith("Secret store entry was saved, but runtime refresh failed.")
+  );
+}
+
+export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
+  const pending = new Map<string, QuestionRecord>();
+  const collapsed = new Set<string>();
+  const drafts = new Map<string, QuestionPrompt>();
+  const resolving = new Set<string>();
+  const unconfirmed = new Map<string, QuestionRecord>();
+  const checking = new Map<string, Promise<"pending" | "terminal" | "unknown">>();
+  const mutations = new Map<string, QuestionMutation>();
+  let mutationVersion = 0;
+  let active: { id: string; handle: OverlayHandle } | null = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+  let pendingText = "";
+  const refreshRunner = createTuiRefreshCoalescer(refreshOnce, () => mutations.clear());
+
+  const matchesSession = (record: QuestionRecord) =>
+    matchesOwnedTuiSession(deps.getSessionKey(), deps.getAgentId(), record);
+
+  function closeActive() {
+    if (active) {
+      const handle = active.handle;
+      active = null;
+      deps.closeOverlay(handle);
+    }
+  }
+
+  function remember(id: string, question: QuestionRecord | null) {
+    if (refreshRunner.isRunning()) {
+      mutations.set(id, { version: ++mutationVersion, question });
+    }
+  }
+
+  function remove(id: string) {
+    pending.delete(id);
+    unconfirmed.delete(id);
+    collapsed.delete(id);
+    drafts.get(id)?.dispose();
+    drafts.delete(id);
+    remember(id, null);
+    if (active?.id === id) {
+      closeActive();
+    }
+  }
+
+  function finish(id: string, status: Exclude<QuestionStatus, "pending">) {
+    const record = pending.get(id);
+    remove(id);
+    if (record && matchesSession(record)) {
+      deps.chatLog.addSystem(`Question: ${status === "cancelled" ? "skipped" : status}.`);
+    }
+  }
+
+  function abandon(record: QuestionRecord) {
+    if (!pending.has(record.id)) {
+      return;
+    }
+    remove(record.id);
+    if (matchesSession(record)) {
+      deps.chatLog.addSystem(
+        "Question outcome could not be recovered; check the conversation or secret store before requesting again.",
+      );
+    }
+  }
+
+  async function recoverOnce(record: QuestionRecord): Promise<"pending" | "terminal" | "unknown"> {
+    if (disposed || !unconfirmed.has(record.id)) {
+      return "terminal";
+    }
+    if (record.expiresAtMs <= Date.now()) {
+      abandon(record);
+      return "terminal";
+    }
+    if (!deps.client.getQuestion) {
+      return "unknown";
+    }
+    try {
+      const result = await deps.client.getQuestion(record.id);
+      if (disposed || !unconfirmed.has(record.id)) {
+        return "terminal";
+      }
+      if (!Value.Check(QuestionGetResultSchema, result) || result.question.id !== record.id) {
+        return "unknown";
+      }
+      if (result.question.status !== "pending") {
+        finish(record.id, result.question.status);
+        return "terminal";
+      }
+      unconfirmed.delete(record.id);
+      pending.set(record.id, result.question);
+      remember(record.id, result.question);
+      return "pending";
+    } catch (error) {
+      if (disposed || !unconfirmed.has(record.id)) {
+        return "terminal";
+      }
+      const errorRecord = asOptionalObjectRecord(error);
+      const reason = asOptionalObjectRecord(errorRecord?.details)?.reason;
+      if (reason === "QUESTION_NOT_FOUND" || errorRecord?.code === "QUESTION_NOT_FOUND") {
+        abandon(record);
+        return "terminal";
+      }
+      return "unknown";
+    }
+  }
+
+  async function recover(record: QuestionRecord) {
+    const current = checking.get(record.id);
+    if (current) {
+      return current;
+    }
+    const recovery = recoverOnce(record);
+    checking.set(record.id, recovery);
+    try {
+      return await recovery;
+    } finally {
+      if (checking.get(record.id) === recovery) {
+        checking.delete(record.id);
+      }
+    }
+  }
+
+  function updatePendingText(records: QuestionRecord[]) {
+    const record = records[0];
+    const text = records.some((question) => unconfirmed.has(question.id))
+      ? "Answer confirmation unavailable · /question to check"
+      : record
+        ? `Question pending${records.length > 1 ? ` (${records.length})` : ""} · ${Math.max(0, Math.ceil((record.expiresAtMs - Date.now()) / 1_000))}s · /question to open`
+        : "";
+    if (text !== pendingText) {
+      pendingText = text;
+      deps.onPendingChange(text);
+    }
+  }
+
+  function present() {
+    if (disposed) {
+      return;
+    }
+    clearTimeout(timer);
+    timer = undefined;
+    const now = Date.now();
+    for (const record of pending.values()) {
+      if (record.expiresAtMs <= now) {
+        if (unconfirmed.has(record.id)) {
+          abandon(record);
+        } else if (!resolving.has(record.id)) {
+          finish(record.id, "expired");
+        }
+      }
+    }
+    const records = [...pending.values()]
+      .filter(matchesSession)
+      .toSorted((a, b) => a.createdAtMs - b.createdAtMs || a.id.localeCompare(b.id));
+    if (active && !records.some((record) => record.id === active?.id)) {
+      closeActive();
+    }
+    const record = records.find(
+      (entry) => !collapsed.has(entry.id) && !resolving.has(entry.id) && !unconfirmed.has(entry.id),
+    );
+    if (!active && record) {
+      let prompt = drafts.get(record.id);
+      if (!prompt) {
+        prompt = new QuestionPrompt(record, {
+          onSubmit: (answers) =>
+            void resolve(record, { id: record.id, answers, resolutionId: randomUUID() }),
+          onSkip: () => void resolve(record, { id: record.id, cancel: true }),
+          onCollapse: () => {
+            if (active?.id !== record.id) {
+              return;
+            }
+            for (const question of pending.values()) {
+              if (matchesSession(question)) {
+                collapsed.add(question.id);
+              }
+            }
+            closeActive();
+            present();
+          },
+          requestRender: deps.requestRender,
+        });
+        drafts.set(record.id, prompt);
+      }
+      active = { id: record.id, handle: deps.openOverlay(prompt, { width: "100%" }) };
+    }
+    updatePendingText(records);
+    const expiring = [...pending.values()].filter((entry) => !resolving.has(entry.id));
+    if (expiring.length > 0) {
+      const expiry = Math.min(...expiring.map((entry) => entry.expiresAtMs));
+      timer = setTimeout(present, Math.max(1, Math.min(1_000, expiry - now)));
+      timer.unref?.();
+    }
+    deps.requestRender();
+  }
+
+  async function resolve(record: QuestionRecord, params: QuestionResolveParams) {
+    if (disposed || active?.id !== record.id || resolving.has(record.id)) {
+      return;
+    }
+    if (record.expiresAtMs <= Date.now()) {
+      finish(record.id, "expired");
+      present();
+      return;
+    }
+    resolving.add(record.id);
+    closeActive();
+    drafts.get(record.id)?.dispose();
+    drafts.delete(record.id);
+    present();
+    try {
+      if (!deps.client.resolveQuestion) {
+        throw new Error("question resolution unavailable");
+      }
+      const result = await deps.client.resolveQuestion(params);
+      if (!Value.Check(QuestionResolveResultSchema, result)) {
+        throw new Error("invalid question resolution");
+      }
+      if (!disposed) {
+        finish(record.id, result.status);
+      }
+    } catch (error) {
+      // This Gateway error is emitted only after the store write commits; an
+      // earlier resolved event must not hide its remaining runtime refresh failure.
+      if (!disposed && isSecretStoreRefreshFailure(record, error)) {
+        finish(record.id, "answered");
+        if (matchesSession(record)) {
+          deps.chatLog.addSystem(
+            "Secret stored, but runtime refresh failed. Run openclaw secrets reload; do not resubmit this answer.",
+          );
+        }
+        return;
+      }
+      // RPC errors may include submitted values. Never copy them into the terminal or chat.
+      if (!disposed && pending.has(record.id)) {
+        collapsed.add(record.id);
+        unconfirmed.set(record.id, record);
+        const outcome = await recover(record);
+        if (!disposed && pending.has(record.id) && matchesSession(record)) {
+          if (outcome === "pending") {
+            deps.chatLog.addSystem("Question is still pending. Use /question to retry.");
+          } else if (outcome === "unknown") {
+            deps.chatLog.addSystem(
+              "Answer confirmation unavailable; use /question to check before retrying.",
+            );
+          }
+        }
+      }
+    } finally {
+      resolving.delete(record.id);
+      present();
+    }
+  }
+
+  async function refreshOnce(): Promise<void> {
+    if (disposed) {
+      return;
+    }
+    const startedAtVersion = mutationVersion;
+    await Promise.all([...unconfirmed.values()].map(recover));
+    if (disposed || !deps.client.listQuestions) {
+      present();
+      return;
+    }
+    const result = await deps.client.listQuestions();
+    if (disposed) {
+      return;
+    }
+    if (!Value.Check(QuestionListResultSchema, result)) {
+      throw new Error("invalid question list");
+    }
+    const next = new Map(
+      result.questions
+        .filter((question) => question.status === "pending")
+        .map((question) => [question.id, question]),
+    );
+    // The list snapshot predates any events received during its request.
+    for (const [id, mutation] of mutations) {
+      if (mutation.version > startedAtVersion) {
+        if (mutation.question) {
+          next.set(id, mutation.question);
+        } else {
+          next.delete(id);
+        }
+      }
+    }
+    for (const id of pending.keys()) {
+      if (!next.has(id) && !unconfirmed.has(id) && !resolving.has(id)) {
+        remove(id);
+      }
+    }
+    for (const [id, question] of next) {
+      pending.set(id, question);
+    }
+    present();
+  }
+
+  async function refresh(): Promise<void> {
+    if (!disposed) {
+      await refreshRunner.run();
+    }
+  }
+
+  return {
+    handleEvent(event: string, payload: unknown) {
+      if (disposed) {
+        return;
+      }
+      if (event === "question.requested" && Value.Check(QuestionRecordSchema, payload)) {
+        if (payload.status === "pending") {
+          pending.set(payload.id, payload);
+          remember(payload.id, payload);
+          present();
+        }
+      } else if (
+        event === "question.resolved" &&
+        Value.Check(QuestionResolvedEventSchema, payload)
+      ) {
+        finish(payload.id, payload.status);
+        present();
+      }
+    },
+    refresh,
+    sessionChanged() {
+      present();
+      return refresh();
+    },
+    async reopen() {
+      if (disposed) {
+        return;
+      }
+      await refresh();
+      for (const record of pending.values()) {
+        if (matchesSession(record) && !unconfirmed.has(record.id)) {
+          collapsed.delete(record.id);
+        }
+      }
+      present();
+      if (!disposed && ![...pending.values()].some(matchesSession)) {
+        deps.chatLog.addSystem("No pending question for this session.");
+        deps.requestRender();
+      }
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      clearTimeout(timer);
+      closeActive();
+      for (const prompt of drafts.values()) {
+        prompt.dispose();
+      }
+      drafts.clear();
+      pending.clear();
+      collapsed.clear();
+      resolving.clear();
+      unconfirmed.clear();
+      checking.clear();
+      mutations.clear();
+      deps.onPendingChange("");
+      deps.requestRender();
+    },
+  };
+}

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -73,6 +73,7 @@ import {
 import { createLocalShellRunner } from "./tui-local-shell.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
 import { createTuiPluginApprovalController } from "./tui-plugin-approvals.js";
+import { createTuiQuestionController } from "./tui-questions.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import { createTuiRunIdTracker } from "./tui-session-run-coordinator.js";
@@ -904,6 +905,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   const header = new Text("", 1, 0);
   const statusContainer = new Container();
   const footer = new Text("", 1, 0);
+  const questionStatus = new Text("", 1, 0);
   const chatLog = new ChatLog();
   const connectionNotices: string[] = [];
   const addConnectionNotice = (text: string) => {
@@ -924,6 +926,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   root.addChild(chatLog);
   root.addChild(statusContainer);
   root.addChild(footer);
+  root.addChild(questionStatus);
   root.addChild(editor);
 
   const resolveDynamicSlashCommandsKey = () => state.currentAgentId;
@@ -1409,6 +1412,27 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   };
 
   const { openOverlay, closeOverlay } = createOverlayHandlers(tui, editor);
+  const questions = createTuiQuestionController({
+    client,
+    chatLog,
+    getAgentId: () => state.currentAgentId,
+    getSessionKey: () => state.currentSessionKey,
+    openOverlay,
+    closeOverlay,
+    requestRender: () => tui.requestRender(),
+    onPendingChange: (text) => questionStatus.setText(theme.accent(text)),
+  });
+  const reportQuestionRefreshError = () => {
+    chatLog.addSystem("question refresh failed; reconnect or use /question to retry");
+    tui.requestRender();
+  };
+  const refreshQuestions = async () => {
+    try {
+      await questions.refresh();
+    } catch {
+      reportQuestionRefreshError();
+    }
+  };
   const pluginApprovals = createTuiPluginApprovalController({
     client,
     chatLog,
@@ -1486,6 +1510,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   });
   notifySessionChanged = () => {
     pluginApprovals.sessionChanged();
+    void questions.sessionChanged().catch(reportQuestionRefreshError);
     taskSuggestions.sessionChanged();
   };
 
@@ -1561,6 +1586,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     };
     disposeEventHandlers();
     pluginApprovals?.dispose();
+    questions.dispose();
     taskSuggestions?.dispose();
     beginTuiShutdown({
       stopCommandScopes: () => localShell.shutdown(),
@@ -1622,6 +1648,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     isRunObserved,
     flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
+    reopenQuestion: () => questions.reopen().catch(reportQuestionRefreshError),
     requestExit,
   });
 
@@ -1740,6 +1767,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       return;
     }
     pluginApprovals?.handleEvent(evt.event, evt.payload);
+    questions.handleEvent(evt.event, evt.payload);
     taskSuggestions?.handleEvent(evt.event, evt.payload);
     if (evt.event === "chat") {
       handleChatEvent(evt.payload);
@@ -1815,6 +1843,10 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       }
       updateHeader();
       updateAutocompleteProvider();
+      await refreshQuestions();
+      if (!ownsConnection()) {
+        return;
+      }
       try {
         await pluginApprovals?.refresh();
       } catch (err) {
@@ -1925,6 +1957,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     setConnectionStatus(`event gap: expected ${info.expected}, got ${info.received}`, 5000);
     addConnectionNotice(`gateway event gap: expected ${info.expected}, got ${info.received}`);
     reconcileHistoryAfterGap();
+    void refreshQuestions();
     void (async () => {
       try {
         await pluginApprovals?.refresh();
@@ -1960,6 +1993,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       disposeStatus();
       disposeEventHandlers();
       pluginApprovals?.dispose();
+      questions.dispose();
       taskSuggestions?.dispose();
       if (isLocalMode) {
         setConsoleSubsystemFilter(previousConsoleSubsystemFilter);


### PR DESCRIPTION
Related: #120656 #143238

## What Problem This Solves

Fixes an issue where an agent calling `ask_user` in the terminal UI left the user with nothing to answer: the TUI never rendered the question, only the raw tool call, and in local mode (`openclaw chat`, `openclaw tui --local`) the tool's question RPCs went to a Gateway that usually is not running, so the request failed outright. The `secrets` tool had the same gap, which is part of why the local TUI could only fall back to asking for credentials in chat (#120656). Ordinary answers typed while a question was pending in collect or followup queue mode also waited behind the blocked run.

## Why This Change Was Made

Both TUI backends now share one session-scoped question controller. Gateway mode uses the existing `question.*` RPCs and events under the scopes the TUI already holds. Local mode serves the same five methods in-process through an embedded question broker wrapping the Gateway's `QuestionManager`, registered like the existing embedded plugin-approval broker, and the question dispatcher routes there only when embedded mode has a broker. A typed reply is claimed by the pending question through the active run's guarded input owner before queue policy runs, which is what removed the collect/followup deadlock. Masked answers keep their exact bytes.

Store-bound `secrets` requests in local mode return a clear blocker to the model instead of collecting a value the process cannot commit, because the store write and runtime refresh are Gateway-owned. No protocol, schema, config, or Control UI changes.

## User Impact

- `ask_user` prompts render in the TUI in both modes: one question at a time with a stepper, arrow or number selection, Other… free text, multi-select toggles, Skip, and the time remaining.
- Esc collapses the prompt and returns the composer with a pending-question status line; `/question` reopens it; a plain reply still answers the pending question.
- Pending questions are restored after reconnects and session switches; questions answered elsewhere or expired close automatically.
- Gateway-connected `secrets` requests use a masked input that never touches the chat log or input history, showing the entry name, reason, and proposed allowed hosts (accepted as proposed; edit hosts in the Control UI).
- Local mode: store-bound `secrets` requests explain that they need a running Gateway; plain masked questions work.

## Evidence

Real-model live run on an isolated state directory and free port (never the operator's Gateway), model `anthropic/claude-fable-5-1`, driven through tmux; captures are text only and contain no credentials.

Local mode, prompt rendered from a real `ask_user` call:

```text
 openclaw tui - local embedded - agent main - session main
 ⠧ running • 7s | local ready
 Question pending · 898s · /question to open
───────────────Question 1/1 · Color                                                            ───────────────
               Which color do you prefer?
───────────────Expires in 898s                                                                 ───────────────
               › 1. Blue
                 2. Green
                 3. Other…
                 Confirm answer
                 Skip
               ↑/↓ or numbers select · Enter confirm · Esc collapse
```

After `1` + Enter: `Question: answered.` followed by the model's `You chose Blue.` A second question was collapsed with Esc (status line `Question pending · 899s · /question to open`), answered by typing `Large` into the composer, and the model replied `You chose Large.`

Gateway mode (`tui --url ws://127.0.0.1:<port>`): same prompt, answered `2` + Enter, model replied `You chose Green.` Then a real `secrets` request rendered the masked prompt:

```text
               Question 1/1 · API key
               Provide the secret for LIVE_TEST_TOKEN.
               Secret store entry: LIVE_TEST_TOKEN
               Reason: TUI live test
               Allowed hosts (accept as proposed): example.com
                 1. Other…
               > ••••••••••••••••••••
                 Confirm answer
                 Skip
               Enter next/submit · Tab choices · Esc collapse
               Masked entry · Answer through this prompt, not the composer.
```

After Enter: `Question: answered.` and the model replied `The credential is stored as LIVE_TEST_TOKEN with allowed host example.com.` The typed value did not appear in any capture (checked by grep across all frames).

Automated proof: `node --import ./scripts/tsx.mjs scripts/dev/tui-questions-proof.ts` runs an isolated Gateway plus TUI and a local TUI with a scripted OpenAI-compatible model, verifying option resolution and the Esc/plain-reply continuation from the model's request bodies.

Tests: 1,893 tests across 62 files in the TUI, infra, harness, tools, runner, and Gateway question suites, plus 102 PTY tests. The exact-secret-byte cases fail on the original `QuestionManager` and pass with the fix. `node scripts/check-changed.mjs` passed all selected gates; `pnpm build` clean; docs mdx, link audit, glossary, and markdownlint pass. Codex autoreview (P0–P2): scoped-clean.

Known limits: the overlay host composites prompts over the chat log, so long background lines show at the overlay margins, the same as the existing plugin-approval overlay; secret input is single-line (use the CLI `--value-file` route for multiline values); local-mode questions do not survive exiting the TUI.

Overlay update: question prompts now use Pi TUI's supported `width: "100%"` option, resolving the background-chat margin limitation noted above.

## Data-model compatibility evidence

The serialized writes in `scripts/dev/tui-questions-proof.ts` are isolated proof fixtures and requested evidence artifacts, not a runtime data-model change. The script [creates its own temporary state](https://github.com/openclaw/openclaw/blob/50e0096b033cd526b041544a3b679cbe8146c7d2/scripts/dev/tui-questions-proof.ts#L214) and [removes it after verified child cleanup](https://github.com/openclaw/openclaw/blob/50e0096b033cd526b041544a3b679cbe8146c7d2/scripts/dev/tui-questions-proof.ts#L519), retaining only terminal frames and answer witnesses in the requested output directory. The repeatable proof passed Gateway selection, local selection, and local Esc/plain-reply continuation.

Runtime questions remain in [QuestionManager's in-memory map](https://github.com/openclaw/openclaw/blob/50e0096b033cd526b041544a3b679cbe8146c7d2/src/gateway/question-manager.ts#L109). The embedded broker reuses that manager and [rejects store-bound requests](https://github.com/openclaw/openclaw/blob/50e0096b033cd526b041544a3b679cbe8146c7d2/src/infra/embedded-question-broker.ts#L68). The diff from the rebased parent leaves `packages/gateway-protocol`, `src/config`, `src/secrets`, and `src/gateway/server-methods/question.ts` unchanged. Existing persisted formats and the Gateway secret-store write path are preserved; this change requires no data migration or upgrade conversion.
