### PR TITLE
fix(secrets): route auth-profile targets to the shared store owning the profile

### DIFF
--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -692,6 +692,84 @@ describe("secrets apply", () => {
     });
   });
 
+  it("routes auth-profiles targets to the shared store owning the profile", async () => {
+    // Issue #143173: with state-db shared ownership after the upgrade
+    // migration, the live profile sits in the shared store while the
+    // per-agent store is empty. Applying a SecretRef must replace the
+    // plaintext where it lives instead of writing the ref to the agent
+    // store and leaving the live key behind.
+    await writeJsonFile(fixture.authStorePath, { version: 1, profiles: {} });
+    const stateDatabase = openOpenClawStateDatabase({ env: fixture.env }).db;
+    stateDatabase
+      .prepare(
+        `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+         VALUES ('auth.sharedStore', ?, 1)`,
+      )
+      .run(JSON.stringify({ location: "state-db" }));
+    stateDatabase
+      .prepare(
+        "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, 1)",
+      )
+      .run(
+        "authProfiles.store",
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-ope...text", // pragma: allowlist secret
+            },
+          },
+        }),
+      );
+    noteCommittedSharedAuthStoreOwnership({ location: "state-db" }, fixture.env);
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          ref: OPENAI_API_KEY_ENV_REF,
+        },
+      ],
+      options: {
+        scrubEnv: false,
+        scrubAuthProfilesForProviderTargets: false,
+        scrubLegacyAuthJson: false,
+      },
+    };
+
+    const result = await runSecretsApply({ plan, env: fixture.env, write: true });
+    expect(result.changed).toBe(true);
+
+    expect(readPersistedSharedAuthProfileStoreRaw(fixture.env)).toMatchObject({
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: OPENAI_API_KEY_ENV_REF,
+        },
+      },
+    });
+    expect(
+      (
+        readPersistedSharedAuthProfileStoreRaw(fixture.env) as unknown as {
+          profiles: { "openai:default": { key?: string } };
+        }
+      ).profiles["openai:default"].key,
+    ).toBeUndefined();
+    expect(readPersistedAuthProfileStoreRaw(fixture.agentDir)).toEqual({
+      version: 1,
+      profiles: {},
+    });
+  });
+
   it("preserves relocated shared inheritance when applying an agent SecretRef", async () => {
     const sharedDir = path.join(fixture.rootDir, "relocated-shared");
     const agentDir = path.join(fixture.rootDir, "ops-agent");

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -5,7 +5,10 @@ import { isDeepStrictEqual } from "node:util";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "../agents/auth-profiles.js";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
-import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+} from "../agents/auth-profiles/path-resolve.js";
 import {
   coercePersistedAuthProfileStore,
   loadPersistedAuthProfileStore,
@@ -552,6 +555,7 @@ function ensureMutableAuthStore(
 
 function resolveAuthStoreForTarget(params: {
   target: SecretsPlanTarget;
+  resolved: ResolvedPlanTargetEntry["resolved"];
   nextConfig: OpenClawConfig;
   stateDir: string;
   env: NodeJS.ProcessEnv;
@@ -568,6 +572,43 @@ function resolveAuthStoreForTarget(params: {
     env: params.env,
     agentId,
   });
+  const profileId = params.resolved.pathSegments[1];
+  if (typeof profileId === "string" && profileId.length > 0) {
+    const sharedTarget = resolveSharedAuthStoreTarget({
+      stateDir: params.stateDir,
+      env: params.env,
+    });
+    // Only redirect under state-db shared ownership: with legacy-main
+    // ownership the shared path is just the main agent file, where a profile
+    // presence is normal and must not reroute other agents' targets.
+    if (
+      sharedTarget.path !== authStoreTarget.path &&
+      resolveSharedAuthStoreOwnership(sharedTarget.env).location === "state-db"
+    ) {
+      const agentProfiles = readProfileIds(
+        params.authStoreByPath.get(authStoreTarget.path) ??
+          loadPersistedAuthProfileStore(authStoreTarget.agentDir),
+      );
+      if (!agentProfiles.has(profileId)) {
+        const sharedProfiles = readProfileIds(
+          params.authStoreByPath.get(sharedTarget.path) ??
+            loadPersistedSharedAuthProfileStore(sharedTarget.env),
+        );
+        if (sharedProfiles.has(profileId)) {
+          // The profile lives in the shared store (e.g. state-db ownership
+          // after the upgrade migration) while the per-agent store does not
+          // have it: writing the SecretRef to the agent store would leave the
+          // live plaintext in place, so route to the owning shared store.
+          const existing = params.authStoreByPath.get(sharedTarget.path);
+          const loaded = existing ?? loadPersistedSharedAuthProfileStore(sharedTarget.env);
+          const store = ensureMutableAuthStore(isRecord(loaded) ? loaded : undefined);
+          params.authStoreByPath.set(sharedTarget.path, store);
+          params.authStoreTargetByPath.set(sharedTarget.path, sharedTarget);
+          return { path: sharedTarget.path, store };
+        }
+      }
+    }
+  }
   const authStorePath = authStoreTarget.path;
   const existing = params.authStoreByPath.get(authStorePath);
   const loaded = existing ?? loadPersistedAuthProfileStore(authStoreTarget.agentDir);
@@ -575,6 +616,34 @@ function resolveAuthStoreForTarget(params: {
   params.authStoreByPath.set(authStorePath, store);
   params.authStoreTargetByPath.set(authStorePath, authStoreTarget);
   return { path: authStorePath, store };
+}
+
+function resolveSharedAuthStoreTarget(params: {
+  stateDir: string;
+  env: NodeJS.ProcessEnv;
+}): Extract<AuthProfileStoreTarget, { kind: "shared" }> {
+  const scopedEnv = {
+    ...params.env,
+    OPENCLAW_STATE_DIR: params.stateDir,
+    OPENCLAW_AGENT_DIR: undefined,
+  };
+  return {
+    kind: "shared",
+    path: resolveSharedAuthStorePath(scopedEnv),
+    env: scopedEnv,
+    stateDir: params.stateDir,
+  };
+}
+
+function readProfileIds(store: unknown): Set<string> {
+  if (!isRecord(store)) {
+    return new Set();
+  }
+  const profiles = (store as { profiles?: unknown }).profiles;
+  if (!isRecord(profiles)) {
+    return new Set();
+  }
+  return new Set(Object.keys(profiles));
 }
 
 function resolveAuthStoreTargetForAgent(params: {
@@ -666,6 +735,7 @@ function applyAuthProfileTargetMutation(params: {
   }
   const { store } = resolveAuthStoreForTarget({
     target: params.target,
+    resolved: params.resolved,
     nextConfig: params.nextConfig,
     stateDir: params.stateDir,
     env: params.env,


### PR DESCRIPTION
Closes #143173

## What Problem This Solves

Fixes an issue where users running `openclaw secrets apply` for an auth profile would silently keep the live plaintext key: with `state-db` shared-store ownership (post-upgrade migration), the profile lives in the shared store while the per-agent store is empty, but apply wrote the SecretRef into the per-agent store — so `secrets audit` kept flagging `PLAINTEXT_FOUND` and the runtime kept reading the old key.

## Why This Change Was Made

The plan-target router always resolved an `agentId` to the per-agent store and never consulted store ownership, while the audit side already reads whichever store owns the profile — so apply and audit disagreed. Now, when the target profile is absent from the agent store but present in the shared store under `state-db` ownership, the write is routed to the owning shared store. Agent-owned profiles route exactly as before.

## Validation

- New regression test replicating the issue shape (empty agent store + state-db shared profile): fails before the fix, passes after.
- Full `src/secrets/apply.test.ts`: 39 passed. `tsgo --noEmit` clean for the touched files, `oxfmt`/`oxlint` clean, `git diff --check` clean.

## Evidence

- New regression test `routes auth-profiles targets to the shared store owning the profile` in `src/secrets/apply.test.ts` replicates the issue shape (empty per-agent store + `state-db` shared profile): it **fails** on `main` and **passes** with this fix.
- Full `src/secrets/apply.test.ts` shard: **39 passed** (`vitest --config test/vitest/vitest.secrets.config.ts`).
- `tsgo --noEmit` clean for the touched files; `oxfmt`/`oxlint` clean; `git diff --check` clean.
