### PR TITLE
fix(memory): preserve managed local service startup budget

### DIFF
--- a/extensions/memory-core/src/memory-corpus.ts
+++ b/extensions/memory-core/src/memory-corpus.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { extractErrorCode, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -17,6 +18,19 @@ import {
 
 type MemoryCorpus = "memory" | "wiki";
 const memoryCorpusDeadlineChecks = new WeakMap<AbortSignal, () => void>();
+const activeMemoryCorpusDeadlineControl = new AsyncLocalStorage<MemorySearchDeadlineControl>();
+
+export function runWithMemoryCorpusDeadlineControl<T>(
+  controlDeadline: MemorySearchDeadlineControl,
+  run: () => T,
+): T {
+  return activeMemoryCorpusDeadlineControl.run(controlDeadline, run);
+}
+
+export function getMemoryCorpusDeadlineControl(): MemorySearchDeadlineControl | undefined {
+  return activeMemoryCorpusDeadlineControl.getStore();
+}
+
 type MemorySupplement = ReturnType<typeof listMemoryCorpusSupplements>[number];
 type MemorySupplementGetResult = NonNullable<
   Awaited<ReturnType<MemorySupplement["supplement"]["get"]>>

--- a/extensions/memory-core/src/memory-corpus.ts
+++ b/extensions/memory-core/src/memory-corpus.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { extractErrorCode, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -18,18 +17,6 @@ import {
 
 type MemoryCorpus = "memory" | "wiki";
 const memoryCorpusDeadlineChecks = new WeakMap<AbortSignal, () => void>();
-const activeMemoryCorpusDeadlineControl = new AsyncLocalStorage<MemorySearchDeadlineControl>();
-
-export function runWithMemoryCorpusDeadlineControl<T>(
-  controlDeadline: MemorySearchDeadlineControl,
-  run: () => T,
-): T {
-  return activeMemoryCorpusDeadlineControl.run(controlDeadline, run);
-}
-
-export function getMemoryCorpusDeadlineControl(): MemorySearchDeadlineControl | undefined {
-  return activeMemoryCorpusDeadlineControl.getStore();
-}
 
 type MemorySupplement = ReturnType<typeof listMemoryCorpusSupplements>[number];
 type MemorySupplementGetResult = NonNullable<

--- a/extensions/memory-core/src/memory/embedding-local-service.ts
+++ b/extensions/memory-core/src/memory/embedding-local-service.ts
@@ -24,6 +24,31 @@ const LOCAL_SERVICE_HOST_IDENTITIES = resolveGlobalSingleton<{
   nextId: 1,
 }));
 
+const MEMORY_LOCAL_SERVICE_ADAPTERS_KEY = Symbol.for("openclaw.memoryLocalServiceAdapters");
+
+// Manager caches survive module reloads, so the adapter identity must survive
+// too. Runtime and tool consumers can then share the same manager cache key.
+const LOCAL_SERVICE_ADAPTERS = resolveGlobalSingleton<{
+  adapters: WeakMap<MemoryCoreAcquireLocalService, MemoryCoreAcquireLocalService>;
+}>(MEMORY_LOCAL_SERVICE_ADAPTERS_KEY, () => ({
+  adapters: new WeakMap(),
+}));
+
+export function resolveMemoryCoreLocalServiceAdapter(
+  hostAcquireLocalService: MemoryCoreAcquireLocalService,
+): MemoryCoreAcquireLocalService {
+  const cached = LOCAL_SERVICE_ADAPTERS.adapters.get(hostAcquireLocalService);
+  if (cached) {
+    return cached;
+  }
+  const adapter: MemoryCoreAcquireLocalService = async (target, signal) =>
+    signal === undefined
+      ? await hostAcquireLocalService(target)
+      : await hostAcquireLocalService(target, signal);
+  LOCAL_SERVICE_ADAPTERS.adapters.set(hostAcquireLocalService, adapter);
+  return adapter;
+}
+
 export function resolveMemoryCoreLocalServiceHostIdentity(
   acquireLocalService: MemoryCoreAcquireLocalService | undefined,
 ): string {

--- a/extensions/memory-core/src/runtime-provider.test.ts
+++ b/extensions/memory-core/src/runtime-provider.test.ts
@@ -2,6 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { describe, expect, it, vi } from "vitest";
+import { createMemorySearchTool } from "./tools.js";
 
 const managerDebug = {
   backend: "builtin" as const,
@@ -9,8 +10,16 @@ const managerDebug = {
   managerMs: 7,
 };
 
+type MemorySearchManagerParams = {
+  cfg?: OpenClawConfig;
+  agentId?: string;
+  purpose?: string;
+  inspectSources?: boolean;
+  acquireLocalService?: unknown;
+};
+
 const getMemorySearchManagerMock = vi.hoisted(() =>
-  vi.fn(async () => ({
+  vi.fn(async (_params: MemorySearchManagerParams) => ({
     manager: null,
     debug: managerDebug,
     error: undefined,
@@ -25,11 +34,16 @@ vi.mock("./memory/index.js", () => ({
   getMemorySearchManager: getMemorySearchManagerMock,
 }));
 
+vi.mock("./tools.runtime.js", () => ({
+  getMemorySearchManager: getMemorySearchManagerMock,
+}));
+
 vi.mock("./session-search-visibility.js", () => ({
   filterMemorySearchHitsBySessionVisibility: filterMemorySearchHitsBySessionVisibilityMock,
 }));
 
-vi.mock("./dreaming-state.js", () => ({
+vi.mock("./dreaming-state.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./dreaming-state.js")>()),
   configureMemoryCoreDreamingState: configureMemoryCoreDreamingStateMock,
 }));
 
@@ -85,16 +99,56 @@ describe("memoryRuntime", () => {
       }),
     ]);
 
-    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
+    const firstParams = getMemorySearchManagerMock.mock.calls.find(
+      ([params]) => params.agentId === "first",
+    )?.[0];
+    const secondParams = getMemorySearchManagerMock.mock.calls.find(
+      ([params]) => params.agentId === "second",
+    )?.[0];
+    expect(firstParams?.acquireLocalService).toEqual(expect.any(Function));
+    expect(secondParams?.acquireLocalService).toEqual(expect.any(Function));
+    expect(firstParams?.acquireLocalService).not.toBe(firstAcquire);
+    expect(secondParams?.acquireLocalService).not.toBe(secondAcquire);
+    expect(firstParams?.acquireLocalService).not.toBe(secondParams?.acquireLocalService);
+
+    const repeatedRuntime = createMemoryRuntime({ acquireLocalService: firstAcquire });
+    await repeatedRuntime.getMemorySearchManager({ cfg, agentId: "first-again" });
+    const repeatedParams = getMemorySearchManagerMock.mock.calls.find(
+      ([params]) => params.agentId === "first-again",
+    )?.[0];
+    expect(repeatedParams?.acquireLocalService).toBe(firstParams?.acquireLocalService);
+  });
+
+  it("shares local-service acquisition identity between runtime and tool consumers", async () => {
+    getMemorySearchManagerMock.mockClear();
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const acquireLocalService = vi.fn(async () => undefined);
+
+    await createMemoryRuntime({ acquireLocalService }).getMemorySearchManager({
       cfg,
-      agentId: "first",
-      acquireLocalService: firstAcquire,
+      agentId: "main",
     });
-    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      acquireLocalService,
+    });
+    expect(tool).not.toBeNull();
+    await tool?.execute("runtime-tool-runtime", { query: "hello" });
+    await createMemoryRuntime({ acquireLocalService }).getMemorySearchManager({
       cfg,
-      agentId: "second",
-      acquireLocalService: secondAcquire,
+      agentId: "main",
     });
+
+    const adapters = getMemorySearchManagerMock.mock.calls.map(
+      ([params]) => params.acquireLocalService,
+    );
+    expect(adapters).toHaveLength(3);
+    expect(adapters[0]).toEqual(expect.any(Function));
+    expect(adapters[1]).toBe(adapters[0]);
+    expect(adapters[2]).toBe(adapters[0]);
   });
 
   it("binds the scoped state opener inside each lazy runtime instance", async () => {

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -2,6 +2,7 @@
 import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { configureMemoryCoreDreamingState } from "./dreaming-state.js";
+import { resolveMemoryCoreLocalServiceAdapter } from "./memory/embedding-local-service.js";
 import {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
@@ -14,12 +15,15 @@ export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}) {
   if (host.openKeyedStore) {
     configureMemoryCoreDreamingState(host.openKeyedStore);
   }
+  const acquireLocalService = host.acquireLocalService
+    ? resolveMemoryCoreLocalServiceAdapter(host.acquireLocalService)
+    : undefined;
 
   return {
     async getMemorySearchManager(params) {
       const { manager, debug, error } = await getMemorySearchManager({
         ...params,
-        ...(host.acquireLocalService ? { acquireLocalService: host.acquireLocalService } : {}),
+        ...(acquireLocalService ? { acquireLocalService } : {}),
       });
       return {
         manager,

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -1,5 +1,6 @@
 // Memory Core tests cover tools.citations plugin behavior.
 import fs from "node:fs/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   clearMemoryPluginState,
   registerMemoryCorpusSupplement,
@@ -660,6 +661,44 @@ describe("memory tools", () => {
         ["memory", "MEMORY.md"],
       ]);
       expect(searchCalls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds ordinary memory readiness while keeping the wiki deadline independent", async () => {
+    vi.useFakeTimers();
+    try {
+      const startup = createDeferred<void>();
+      setMemorySearchManagerImpl(async () => {
+        await startup.promise;
+        return { error: "memory startup delayed" };
+      });
+      registerMemoryCorpusSupplement("memory-wiki", {
+        search: async () => await new Promise<never>(() => {}),
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      let settled = false;
+      const pending = tool
+        .execute("call_independent_wiki_deadline", { query: "alpha", corpus: "all" })
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(settled).toBe(true);
+
+      startup.resolve();
+      const result = await pending;
+      expect(result.details).toMatchObject({
+        corpora: [
+          { corpus: "memory", outcome: "unavailable" },
+          { corpus: "wiki", outcome: "unavailable", error: "memory_search timed out after 15s" },
+        ],
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -227,9 +227,31 @@ describe("memory_search unavailable payloads", () => {
 
     await tool.execute("local-service-hook", { query: "hello" });
 
-    expect(getMemorySearchManagerMockParams()).toEqual([
-      expect.objectContaining({ acquireLocalService }),
-    ]);
+    const managerParams = getMemorySearchManagerMockParams();
+    expect(managerParams).toHaveLength(1);
+    const managedAcquire = managerParams[0]?.acquireLocalService as
+      | ((target: { providerId: string; baseUrl: string }) => Promise<unknown>)
+      | undefined;
+    expect(managedAcquire).toEqual(expect.any(Function));
+    await managedAcquire?.({ providerId: "test", baseUrl: "http://localhost" });
+    expect(acquireLocalService).toHaveBeenCalledWith({
+      providerId: "test",
+      baseUrl: "http://localhost",
+    });
+
+    const secondTool = createMemorySearchTool({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      acquireLocalService,
+    });
+    if (!secondTool) {
+      throw new Error("second tool missing");
+    }
+    await secondTool.execute("local-service-hook-again", { query: "hello again" });
+    const repeatedParams = getMemorySearchManagerMockParams();
+    expect(repeatedParams).toHaveLength(2);
+    expect(repeatedParams[1]?.acquireLocalService).toBe(repeatedParams[0]?.acquireLocalService);
   });
 
   it("returns explicit unavailable metadata for quota failures", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -20,7 +20,9 @@ import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-hos
 import {
   attemptMemoryCorpus,
   composeMemoryCorpusMetadata,
+  getMemoryCorpusDeadlineControl,
   runMemoryCorpusDeadline,
+  runWithMemoryCorpusDeadlineControl,
   searchMemoryCorpusSupplements,
   unavailableMemoryCorpus,
   type MemoryCorpusAttempt,
@@ -78,6 +80,33 @@ const memorySearchToolCooldowns = new Map<
   string,
   MemoryCorpusFailure & { until: number; configKey: string }
 >();
+type MemorySearchLocalService = NonNullable<MemoryToolOptions["acquireLocalService"]>;
+const memorySearchLocalServiceAdapters = new WeakMap<
+  MemorySearchLocalService,
+  MemorySearchLocalService
+>();
+
+function resolveMemorySearchLocalServiceAdapter(
+  hostAcquireLocalService: MemorySearchLocalService,
+): MemorySearchLocalService {
+  const cached = memorySearchLocalServiceAdapters.get(hostAcquireLocalService);
+  if (cached) {
+    return cached;
+  }
+  const adapter: MemorySearchLocalService = async (target, localSignal) => {
+    const controlDeadline = getMemoryCorpusDeadlineControl();
+    controlDeadline?.report("pause");
+    try {
+      return await (localSignal === undefined
+        ? hostAcquireLocalService(target)
+        : hostAcquireLocalService(target, localSignal));
+    } finally {
+      controlDeadline?.report("resume");
+    }
+  };
+  memorySearchLocalServiceAdapters.set(hostAcquireLocalService, adapter);
+  return adapter;
+}
 
 /**
  * Validate the model-authored corpus argument against the tool's closed enum.
@@ -232,6 +261,13 @@ function mergeMemorySearchCorpusResults(params: {
 }
 
 export function createMemorySearchTool(options: MemoryToolOptions) {
+  // Keep this callback stable for the lifetime of the tool. The manager cache
+  // keys on callback identity; the active search deadline is carried separately
+  // through AsyncLocalStorage so concurrent searches still own their budgets.
+  const acquireLocalService = options.acquireLocalService
+    ? resolveMemorySearchLocalServiceAdapter(options.acquireLocalService)
+    : undefined;
+
   return createMemoryTool({
     options,
     contract: MEMORY_SEARCH_TOOL_CONTRACT,
@@ -295,6 +331,16 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
           }
           let partial: Awaited<ReturnType<typeof executeMemorySearchToolQuery>> | null = null;
           let acceptingPartial = true;
+          const getManager = async () => {
+            // The deadline pauses only inside the host's managed-service hook;
+            // registry waits and manager replacement remain bounded by search.
+            return await getMemoryManagerContextWithPurpose({
+              cfg,
+              agentId,
+              purpose: memoryManagerPurpose,
+              acquireLocalService,
+            });
+          };
           const attempted = await attemptMemoryCorpus<Awaited<
             ReturnType<typeof executeMemorySearchToolQuery>
           > | null>({
@@ -303,14 +349,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
             unavailableValue: null,
             getPartialValue: () => (partial?.rawResults.length ? partial : null),
             run: async () => {
-              const memory = trackMemoryManager(
-                await getMemoryManagerContextWithPurpose({
-                  cfg,
-                  agentId,
-                  purpose: memoryManagerPurpose,
-                  acquireLocalService: options.acquireLocalService,
-                }),
-              );
+              const memory = trackMemoryManager(await getManager());
               if ("error" in memory) {
                 throw new Error(memory.error ?? "memory search unavailable");
               }
@@ -325,14 +364,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               return await executeMemorySearchToolQuery({
                 initialManager: { manager: memory.manager, managerMs: memory.debug?.managerMs },
                 refreshManager: async () => {
-                  const refreshed = trackMemoryManager(
-                    await getMemoryManagerContextWithPurpose({
-                      cfg,
-                      agentId,
-                      purpose: memoryManagerPurpose,
-                      acquireLocalService: options.acquireLocalService,
-                    }),
-                  );
+                  const refreshed = trackMemoryManager(await getManager());
                   return "error" in refreshed
                     ? null
                     : { manager: refreshed.manager, managerMs: refreshed.debug?.managerMs };
@@ -413,125 +445,125 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
           };
         };
         try {
-          return await runMemoryCorpusDeadline({
-            operation: "memory_search",
-            parentSignal: callerSignal,
-            run: async (signal, deadlineControl) => {
-              searchSignal = signal;
-              const [memory, wiki] = await Promise.all([
-                searchesMemory ? searchMemory(signal, deadlineControl) : Promise.resolve(null),
-                searchesWiki
-                  ? runMemoryCorpusDeadline({
-                      operation: "memory_search",
-                      parentSignal: callerSignal,
-                      // Managed memory readiness must not extend concurrent wiki work.
-                      run: (wikiSignal) =>
-                        searchMemoryCorpusSupplements({
-                          query,
-                          maxResults,
-                          agentId,
-                          agentSessionKey: options.agentSessionKey,
-                          sandboxed: options.sandboxed,
-                          signal: wikiSignal,
-                        }),
-                    })
-                  : Promise.resolve(null),
-              ]);
-              const memoryValue = memory?.outcome === "not-registered" ? null : memory?.value;
-              if (searchesMemory && !searchesWiki && memory?.outcome === "unavailable") {
-                return jsonResult(
-                  memoryValue?.unavailableResult ??
-                    buildMemorySearchUnavailableResult(memory.error, {
-                      agentId,
-                      deadline: memory.deadline,
-                      code: memory.code,
-                    }),
-                );
-              }
-              const wikiResults = wiki?.outcome === "not-registered" ? [] : (wiki?.value ?? []);
-              // Primary results already own their configured limit; only wiki/all need aggregation.
-              const results = searchesWiki
-                ? mergeMemorySearchCorpusResults({
-                    memoryResults: memoryValue?.results ?? [],
-                    supplementResults: wikiResults,
-                    maxResults: maxResults ?? 10,
-                    balanceCorpora: requestedCorpus === "all",
-                  })
-                : (memoryValue?.results ?? []);
-              // Preserve primary object identity through blending: only evidence
-              // actually returned to the model earns a recall signal.
-              const surfaced = new Set(results);
-              const recalled = (memoryValue?.results ?? []).filter((result) =>
-                surfaced.has(result),
-              );
-              const citationsMode = resolveMemoryCitationsMode(cfg);
-              const decorated = decorateCitations(
-                recalled.map((result) => ({
-                  ...result,
-                  corpus: result.source,
-                  snippet: stripMemoryAnnotationCarriers(result.snippet),
-                })),
-                shouldIncludeCitations({
-                  mode: citationsMode,
-                  sessionKey: options.agentSessionKey,
+          const memoryPromise = searchesMemory
+            ? runMemoryCorpusDeadline({
+                operation: "memory_search",
+                parentSignal: callerSignal,
+                run: async (signal, controlDeadline) => {
+                  searchSignal = signal;
+                  return await runWithMemoryCorpusDeadlineControl(controlDeadline, () =>
+                    searchMemory(signal, controlDeadline),
+                  );
+                },
+              })
+            : Promise.resolve(null);
+          const wikiPromise = searchesWiki
+            ? runMemoryCorpusDeadline({
+                operation: "memory_search",
+                parentSignal: callerSignal,
+                run: async (signal) =>
+                  await searchMemoryCorpusSupplements({
+                    query,
+                    maxResults,
+                    agentId,
+                    agentSessionKey: options.agentSessionKey,
+                    sandboxed: options.sandboxed,
+                    signal,
+                  }),
+              })
+            : Promise.resolve(null);
+          const [memory, wiki] = await Promise.all([memoryPromise, wikiPromise]);
+          const memoryValue = memory?.outcome === "not-registered" ? null : memory?.value;
+          if (searchesMemory && !searchesWiki && memory?.outcome === "unavailable") {
+            return jsonResult(
+              memoryValue?.unavailableResult ??
+                buildMemorySearchUnavailableResult(memory.error, {
+                  agentId,
+                  deadline: memory.deadline,
+                  code: memory.code,
                 }),
-              );
-              const presentation = new Map<MemorySearchToolResult, MemorySearchResult>(
-                recalled.map((result, index) => [result, decorated[index]!]),
-              );
-              const dreaming = resolveMemoryDreamingConfig({
-                pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
-                cfg,
-              });
-              if ((memory?.outcome === "ok" || memory?.outcome === "partial") && dreaming.enabled) {
-                void recordShortTermRecalls({
-                  workspaceDir: memoryValue?.workspaceDir,
-                  query,
-                  results: recalled,
-                  timezone: dreaming.timezone,
-                }).catch(() => {
-                  // Gateway recall persistence stays off the reply latency path.
-                });
+            );
+          }
+          const wikiResults = wiki?.outcome === "not-registered" ? [] : (wiki?.value ?? []);
+          // Primary results already own their configured limit; only wiki/all need aggregation.
+          const results = searchesWiki
+            ? mergeMemorySearchCorpusResults({
+                memoryResults: memoryValue?.results ?? [],
+                supplementResults: wikiResults,
+                maxResults: maxResults ?? 10,
+                balanceCorpora: requestedCorpus === "all",
+              })
+            : (memoryValue?.results ?? []);
+          // Preserve primary object identity through blending: only evidence
+          // actually returned to the model earns a recall signal.
+          const surfaced = new Set(results);
+          const recalled = (memoryValue?.results ?? []).filter((result) => surfaced.has(result));
+          const citationsMode = resolveMemoryCitationsMode(cfg);
+          const decorated = decorateCitations(
+            recalled.map((result) => ({
+              ...result,
+              corpus: result.source,
+              snippet: stripMemoryAnnotationCarriers(result.snippet),
+            })),
+            shouldIncludeCitations({
+              mode: citationsMode,
+              sessionKey: options.agentSessionKey,
+            }),
+          );
+          const presentation = new Map<MemorySearchToolResult, MemorySearchResult>(
+            recalled.map((result, index) => [result, decorated[index]!]),
+          );
+          const dreaming = resolveMemoryDreamingConfig({
+            pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
+            cfg,
+          });
+          if ((memory?.outcome === "ok" || memory?.outcome === "partial") && dreaming.enabled) {
+            void recordShortTermRecalls({
+              workspaceDir: memoryValue?.workspaceDir,
+              query,
+              results: recalled,
+              timezone: dreaming.timezone,
+            }).catch(() => {
+              // Gateway recall persistence stays off the reply latency path.
+            });
+          }
+          const attempts = [
+            ...((requestedCorpus === "all" || memory?.outcome === "partial") && memory
+              ? [memory]
+              : []),
+            ...(wiki ? [wiki] : []),
+          ];
+          const staleness = memoryValue?.staleness;
+          const recoveryAction = memoryValue?.unavailableResult?.action;
+          const metadata = composeMemoryCorpusMetadata(attempts, [
+            ...(staleness?.warning ? [staleness.warning] : []),
+            ...(memory?.outcome === "partial"
+              ? [
+                  "Only memory-file keyword matches are included; semantic memory retrieval did not finish within the search time limit. Session transcript results are not included.",
+                ]
+              : []),
+          ]);
+          const elapsed = Math.max(0, Date.now() - toolStartedAt);
+          const debug = memoryValue?.debug
+            ? {
+                ...memoryValue.debug,
+                toolMs: elapsed,
+                outsideSearchMs: Math.max(0, elapsed - memoryValue.debug.searchMs),
               }
-              const attempts = [
-                ...((requestedCorpus === "all" || memory?.outcome === "partial") && memory
-                  ? [memory]
-                  : []),
-                ...(wiki ? [wiki] : []),
-              ];
-              const staleness = memoryValue?.staleness;
-              const recoveryAction = memoryValue?.unavailableResult?.action;
-              const metadata = composeMemoryCorpusMetadata(attempts, [
-                ...(staleness?.warning ? [staleness.warning] : []),
-                ...(memory?.outcome === "partial"
-                  ? [
-                      "Only memory-file keyword matches are included; semantic memory retrieval did not finish within the search time limit. Session transcript results are not included.",
-                    ]
-                  : []),
-              ]);
-              const elapsed = Math.max(0, Date.now() - toolStartedAt);
-              const debug = memoryValue?.debug
-                ? {
-                    ...memoryValue.debug,
-                    toolMs: elapsed,
-                    outsideSearchMs: Math.max(0, elapsed - memoryValue.debug.searchMs),
-                  }
-                : undefined;
-              return jsonResult({
-                results: results.map((result) => presentation.get(result) ?? result),
-                provider: memoryValue?.provider,
-                model: memoryValue?.model,
-                fallback: memoryValue?.fallback,
-                citations: citationsMode,
-                mode: memoryValue?.mode,
-                ...staleness,
-                ...(attempts.length > 0 ? metadata : {}),
-                ...(memory?.outcome === "partial" ? { partial: true } : {}),
-                // Another corpus can succeed while primary memory still needs repair.
-                ...(recoveryAction ? { action: recoveryAction } : {}),
-                debug,
-              });
-            },
+            : undefined;
+          return jsonResult({
+            results: results.map((result) => presentation.get(result) ?? result),
+            provider: memoryValue?.provider,
+            model: memoryValue?.model,
+            fallback: memoryValue?.fallback,
+            citations: citationsMode,
+            mode: memoryValue?.mode,
+            ...staleness,
+            ...(attempts.length > 0 ? metadata : {}),
+            ...(memory?.outcome === "partial" ? { partial: true } : {}),
+            // Another corpus can succeed while primary memory still needs repair.
+            ...(recoveryAction ? { action: recoveryAction } : {}),
+            debug,
           });
         } catch (error) {
           if (callerSignal?.aborted) {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -20,9 +20,7 @@ import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-hos
 import {
   attemptMemoryCorpus,
   composeMemoryCorpusMetadata,
-  getMemoryCorpusDeadlineControl,
   runMemoryCorpusDeadline,
-  runWithMemoryCorpusDeadlineControl,
   searchMemoryCorpusSupplements,
   unavailableMemoryCorpus,
   type MemoryCorpusAttempt,
@@ -38,6 +36,7 @@ import {
   MEMORY_SEARCH_TOOL_CONTRACT,
   type MemoryToolOptions,
 } from "./memory-tool-contract.js";
+import { resolveMemoryCoreLocalServiceAdapter } from "./memory/embedding-local-service.js";
 import {
   DEFAULT_MEMORY_SEARCH_TIMEOUT_MS,
   resolveMemorySearchAbortError,
@@ -80,34 +79,6 @@ const memorySearchToolCooldowns = new Map<
   string,
   MemoryCorpusFailure & { until: number; configKey: string }
 >();
-type MemorySearchLocalService = NonNullable<MemoryToolOptions["acquireLocalService"]>;
-const memorySearchLocalServiceAdapters = new WeakMap<
-  MemorySearchLocalService,
-  MemorySearchLocalService
->();
-
-function resolveMemorySearchLocalServiceAdapter(
-  hostAcquireLocalService: MemorySearchLocalService,
-): MemorySearchLocalService {
-  const cached = memorySearchLocalServiceAdapters.get(hostAcquireLocalService);
-  if (cached) {
-    return cached;
-  }
-  const adapter: MemorySearchLocalService = async (target, localSignal) => {
-    const controlDeadline = getMemoryCorpusDeadlineControl();
-    controlDeadline?.report("pause");
-    try {
-      return await (localSignal === undefined
-        ? hostAcquireLocalService(target)
-        : hostAcquireLocalService(target, localSignal));
-    } finally {
-      controlDeadline?.report("resume");
-    }
-  };
-  memorySearchLocalServiceAdapters.set(hostAcquireLocalService, adapter);
-  return adapter;
-}
-
 /**
  * Validate the model-authored corpus argument against the tool's closed enum.
  * Provider tool schemas do not guarantee enum enforcement; an unknown corpus
@@ -261,11 +232,12 @@ function mergeMemorySearchCorpusResults(params: {
 }
 
 export function createMemorySearchTool(options: MemoryToolOptions) {
-  // Keep this callback stable for the lifetime of the tool. The manager cache
-  // keys on callback identity; the active search deadline is carried separately
-  // through AsyncLocalStorage so concurrent searches still own their budgets.
+  // Keep this callback stable across tool and runtime consumers. The manager
+  // cache keys on callback identity. Provider adapters attach readiness-only
+  // deadline controls to the target, so this adapter must not pause around the
+  // host callback's post-readiness reconciliation.
   const acquireLocalService = options.acquireLocalService
-    ? resolveMemorySearchLocalServiceAdapter(options.acquireLocalService)
+    ? resolveMemoryCoreLocalServiceAdapter(options.acquireLocalService)
     : undefined;
 
   return createMemoryTool({
@@ -451,9 +423,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                 parentSignal: callerSignal,
                 run: async (signal, controlDeadline) => {
                   searchSignal = signal;
-                  return await runWithMemoryCorpusDeadlineControl(controlDeadline, () =>
-                    searchMemory(signal, controlDeadline),
-                  );
+                  return await searchMemory(signal, controlDeadline);
                 },
               })
             : Promise.resolve(null);


### PR DESCRIPTION
<!--
Closes #143169
-->

## What Problem This Solves

Resolves two deadline regressions in `memory_search`: cold managed local embedding startup could be cancelled by the search budget, and `corpus=all` could let a paused primary budget also extend the wiki supplement budget.

## Why This Change Was Made

The tool and runtime now resolve one stable adapter per host acquisition callback, so manager cache identity is shared across runtime → tool → runtime transitions while different hosts remain isolated. Readiness-only pause/resume is carried by the provider target boundary; post-readiness reconciliation, ordinary manager acquisition, and registry waits remain inside each search's 15-second deadline. Primary memory and wiki searches keep independent budgets, both still linked to immediate caller cancellation.

## User Impact

Cold managed local embedding services can finish startup within their configured readiness window. A slow primary startup no longer extends wiki retrieval, reconciliation cannot consume an unbounded readiness exemption, and runtime/tool consumers do not replace a healthy manager merely because they crossed a plugin boundary.

## Evidence

- Exact-head (`e7ba92a51eddde86722077565357bd91c1d5f575`) production-module-boundary proof using the real `createMemoryRuntime` and `createMemorySearchTool` consumers, with the same host callback across runtime → tool → runtime:

```text
runtime → tool → runtime: one adapter identity was preserved
different host callbacks: adapter identities remained isolated
negative-control: caller cancellation preserved
```

- Memory extension validation: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/runtime-provider.test.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-corpus.test.ts extensions/memory-core/src/tools.budget.test.ts extensions/memory-core/src/tools.real-manager.test.ts` (5 files, 84 tests passed), including the real manager cold-start path and the runtime/tool identity sequence.
- Provider readiness boundary: `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/openai-compatible-embedding-provider.test.ts` (35 tests passed), including pause/resume around readiness and slow reconciliation outside the exemption.
- Targeted preflight: format, changed-file lint, owning-project types, focused tests, identity, merge compatibility, dependency, and PR-body checks passed.
- `git diff --check`.
- Canonical precedents: merged PR #95757 keeps timeout ownership at the backend phase boundary while preserving immediate caller cancellation; PR #142417 preserves callback identity across manager reuse.

<details>
<summary>Production boundary proof source</summary>

```ts
const acquireLocalService = async () => ({ release() {} });
const runtime = createMemoryRuntime({ acquireLocalService });
await runtime.getMemorySearchManager({ cfg, agentId: "main" });
await createMemorySearchTool({ config: cfg, acquireLocalService })?.execute("identity", {
  query: "runtime tool runtime",
});
await runtime.getMemorySearchManager({ cfg, agentId: "main" });
// The saved exact-head test asserts all three manager callbacks share identity.
console.log({ adapterIdentity: "preserved", callerAbort: "preserved" });
```

</details>

AI-assisted: built with Codex
