### PR TITLE
fix(cli): recognize managed portable Bash completion hooks without rewriting them

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -44,6 +44,8 @@ Profile changes are staged beside the destination and atomically replace it only
 
 Installed source lines preserve literal cache paths, including spaces, quotes, dollar signs, and backslashes. Reinstalling replaces OpenClaw's previous source line after the state directory changes.
 
+A user-managed portable hook for the same cached script (for example `[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"`, as a dotfile manager would write) is recognized as completion being configured. Doctor and `completion --install` leave such managed lines byte-for-byte untouched instead of appending a duplicate literal-path block.
+
 ## Permission failures
 
 If Doctor or onboarding cannot update your shell profile, completion remains

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -849,4 +849,256 @@ describe("completion-runtime", () => {
       );
     });
   });
+
+  it
+    .skipIf(process.platform === "win32")
+    .each([
+      '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+      '[ -f "$HOME/.openclaw/completions/openclaw.bash" ] && source "$HOME/.openclaw/completions/openclaw.bash"',
+    ])(
+    "preserves a managed portable Bash hook byte-for-byte across installs: %s",
+    async (portableHook) => {
+      const homeDir = tempDirs.make("openclaw-bash-portable-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          USERPROFILE: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const profilePath = path.join(homeDir, ".bashrc");
+          const cachePath = resolveCompletionCachePath("bash", "openclaw");
+          expect(cachePath).toBe(path.join(stateDir, "completions", "openclaw.bash"));
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "complete -W 'completion doctor' openclaw\n", "utf-8");
+          await fs.writeFile(profilePath, `${portableHook}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+
+          await installCompletion("bash", true, "openclaw");
+          await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(`${portableHook}\n`);
+
+          await installCompletion("bash", true, "openclaw");
+          await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(`${portableHook}\n`);
+
+          const freshBash = spawnSync(
+            "bash",
+            ["-c", `source "${profilePath}" && complete -p openclaw`],
+            { encoding: "utf8" },
+          );
+          expect(freshBash.stderr).toBe("");
+          expect(freshBash.status).toBe(0);
+          expect(freshBash.stdout).toContain("openclaw");
+        },
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves a managed portable Zsh hook without appending a literal block",
+    async () => {
+      const homeDir = tempDirs.make("openclaw-zsh-portable-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          ZDOTDIR: undefined,
+          XDG_CONFIG_HOME: undefined,
+        },
+        async () => {
+          const portableHook =
+            '[[ -f "${HOME}/.openclaw/completions/openclaw.zsh" ]] && source "${HOME}/.openclaw/completions/openclaw.zsh"';
+          const profilePath = path.join(homeDir, ".zshrc");
+          const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "# cached zsh completion\n", "utf-8");
+          await fs.writeFile(profilePath, `${portableHook}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("zsh", "openclaw")).resolves.toBe(true);
+          await installCompletion("zsh", true, "openclaw");
+          await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(`${portableHook}\n`);
+        },
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves a managed portable Fish hook without appending a literal block",
+    async () => {
+      const homeDir = tempDirs.make("openclaw-fish-portable-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const portableHook =
+            'test -f "$HOME/.openclaw/completions/openclaw.fish"; and source "$HOME/.openclaw/completions/openclaw.fish"';
+          const profilePath = path.join(homeDir, ".config", "fish", "config.fish");
+          const cachePath = resolveCompletionCachePath("fish", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "# cached fish completion\n", "utf-8");
+          await fs.mkdir(path.dirname(profilePath), { recursive: true });
+          await fs.writeFile(profilePath, `${portableHook}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("fish", "openclaw")).resolves.toBe(true);
+          await installCompletion("fish", true, "openclaw");
+          await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(`${portableHook}\n`);
+        },
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does not claim a portable hook for a different state location",
+    async () => {
+      const homeDir = tempDirs.make("openclaw-bash-other-state-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const otherHook =
+            '[[ -f "${HOME}/.other/completions/openclaw.bash" ]] && source "${HOME}/.other/completions/openclaw.bash"';
+          const profilePath = path.join(homeDir, ".bashrc");
+          const cachePath = resolveCompletionCachePath("bash", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+          await fs.writeFile(profilePath, `${otherHook}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
+          await installCompletion("bash", true, "openclaw");
+
+          const profile = await fs.readFile(profilePath, "utf8");
+          expect(profile).toContain(`${otherHook}\n`);
+          expect(profile).toContain("# OpenClaw Completion");
+          expect(profile).toContain(cachePath);
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+        },
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves compound portable-looking Bash statements without claiming them",
+    async () => {
+      const homeDir = tempDirs.make("openclaw-bash-compound-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const compoundLine =
+            '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"; export OPENCLAW_KEEP=1';
+          const profilePath = path.join(homeDir, ".bashrc");
+          const cachePath = resolveCompletionCachePath("bash", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+          await fs.writeFile(profilePath, `${compoundLine}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
+          await installCompletion("bash", true, "openclaw");
+
+          const profile = await fs.readFile(profilePath, "utf8");
+          expect(profile).toContain(`${compoundLine}\n`);
+          expect(profile).toContain(cachePath);
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+        },
+      );
+    },
+  );
+
+  it
+    .skipIf(process.platform === "win32")
+    .each([
+      '[ -f "$HOME/.openclaw/completions/openclaw.bash"] && source "$HOME/.openclaw/completions/openclaw.bash"',
+      '[[ -f "${HOME}/.openclaw/completions/openclaw.bash"]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+    ])(
+    "does not claim a malformed portable guard whose closing bracket is not a separate token: %s",
+    async (brokenHook) => {
+      const homeDir = tempDirs.make("openclaw-bash-broken-guard-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const profilePath = path.join(homeDir, ".bashrc");
+          const cachePath = resolveCompletionCachePath("bash", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+          await fs.writeFile(profilePath, `${brokenHook}\n`, "utf-8");
+
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
+
+          await installCompletion("bash", true, "openclaw");
+
+          const profile = await fs.readFile(profilePath, "utf8");
+          expect(profile).toContain(`${brokenHook}\n`);
+          expect(profile).toContain("# OpenClaw Completion");
+          expect(profile).toContain(cachePath);
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+        },
+      );
+    },
+  );
+
+  it
+    .skipIf(process.platform === "win32")
+    .each([
+      '[ -f "$HOME/.openclaw/completions/openclaw.bash"] && source "$HOME/.openclaw/completions/openclaw.bash"',
+      '[[ -f "${HOME}/.openclaw/completions/openclaw.bash"]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+    ])(
+    "keeps a working literal install beside a malformed portable guard: %s",
+    async (brokenHook) => {
+      const homeDir = tempDirs.make("openclaw-bash-broken-guard-literal-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          XDG_CONFIG_HOME: undefined,
+          ZDOTDIR: undefined,
+        },
+        async () => {
+          const profilePath = path.join(homeDir, ".bashrc");
+          const cachePath = resolveCompletionCachePath("bash", "openclaw");
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+          // The malformed guard alone must not count as installed, so the first
+          // install appends the CLI's literal block on top of it.
+          await fs.writeFile(profilePath, `${brokenHook}\n`, "utf-8");
+          await installCompletion("bash", true, "openclaw");
+          const first = await fs.readFile(profilePath, "utf8");
+          expect(first).toContain(`${brokenHook}\n`);
+          expect(first).toContain("# OpenClaw Completion");
+          expect(first).toContain(cachePath);
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+
+          // A later install must keep the working literal block instead of removing
+          // it and leaving only the malformed portable guard behind.
+          await installCompletion("bash", true, "openclaw");
+          await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(first);
+        },
+      );
+    },
+  );
 });

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -855,6 +855,9 @@ describe("completion-runtime", () => {
     .each([
       '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
       '[ -f "$HOME/.openclaw/completions/openclaw.bash" ] && source "$HOME/.openclaw/completions/openclaw.bash"',
+      '# OpenClaw Completion\n[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+      '# OpenClaw Completion\n[ -f "$HOME/.openclaw/completions/openclaw.bash" ] && source "$HOME/.openclaw/completions/openclaw.bash"',
+      '[\t-f\t"$HOME/.openclaw/completions/openclaw.bash"\t]&& source "$HOME/.openclaw/completions/openclaw.bash"\t',
     ])(
     "preserves a managed portable Bash hook byte-for-byte across installs: %s",
     async (portableHook) => {
@@ -1025,50 +1028,17 @@ describe("completion-runtime", () => {
 
   it
     .skipIf(process.platform === "win32")
-    .each([
-      '[ -f "$HOME/.openclaw/completions/openclaw.bash"] && source "$HOME/.openclaw/completions/openclaw.bash"',
-      '[[ -f "${HOME}/.openclaw/completions/openclaw.bash"]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
-    ])(
-    "does not claim a malformed portable guard whose closing bracket is not a separate token: %s",
-    async (brokenHook) => {
-      const homeDir = tempDirs.make("openclaw-bash-broken-guard-home-");
-      const stateDir = path.join(homeDir, ".openclaw");
-      await withEnvAsync(
-        {
-          HOME: homeDir,
-          OPENCLAW_STATE_DIR: stateDir,
-          XDG_CONFIG_HOME: undefined,
-          ZDOTDIR: undefined,
-        },
-        async () => {
-          const profilePath = path.join(homeDir, ".bashrc");
-          const cachePath = resolveCompletionCachePath("bash", "openclaw");
-          await fs.mkdir(path.dirname(cachePath), { recursive: true });
-          await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
-          await fs.writeFile(profilePath, `${brokenHook}\n`, "utf-8");
-
-          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
-
-          await installCompletion("bash", true, "openclaw");
-
-          const profile = await fs.readFile(profilePath, "utf8");
-          expect(profile).toContain(`${brokenHook}\n`);
-          expect(profile).toContain("# OpenClaw Completion");
-          expect(profile).toContain(cachePath);
-          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
-        },
-      );
-    },
-  );
-
-  it
-    .skipIf(process.platform === "win32")
-    .each([
-      '[ -f "$HOME/.openclaw/completions/openclaw.bash"] && source "$HOME/.openclaw/completions/openclaw.bash"',
-      '[[ -f "${HOME}/.openclaw/completions/openclaw.bash"]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
-    ])(
-    "keeps a working literal install beside a malformed portable guard: %s",
-    async (brokenHook) => {
+    .each(
+      [
+        '[ -f "$HOME/.openclaw/completions/openclaw.bash"] && source "$HOME/.openclaw/completions/openclaw.bash"',
+        '[[ -f "${HOME}/.openclaw/completions/openclaw.bash"]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+        '[ -f "$HOME/.openclaw/completions/openclaw.bash"\u00a0] && source "$HOME/.openclaw/completions/openclaw.bash"',
+        '\u00a0[ -f "$HOME/.openclaw/completions/openclaw.bash" ] && source "$HOME/.openclaw/completions/openclaw.bash"',
+        '[ -f "$HOME/.other/completions/openclaw.bash" ] && source "$HOME/.other/completions/openclaw.bash"',
+      ].flatMap((brokenHook) => [false, true].map((marked) => ({ brokenHook, marked }))),
+    )(
+    "preserves unrecognized portable hooks across literal installs (marked=$marked): $brokenHook",
+    async ({ brokenHook, marked }) => {
       const homeDir = tempDirs.make("openclaw-bash-broken-guard-literal-home-");
       const stateDir = path.join(homeDir, ".openclaw");
       await withEnvAsync(
@@ -1083,9 +1053,12 @@ describe("completion-runtime", () => {
           const cachePath = resolveCompletionCachePath("bash", "openclaw");
           await fs.mkdir(path.dirname(cachePath), { recursive: true });
           await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
-          // The malformed guard alone must not count as installed, so the first
-          // install appends the CLI's literal block on top of it.
-          await fs.writeFile(profilePath, `${brokenHook}\n`, "utf-8");
+          await fs.writeFile(
+            profilePath,
+            `${marked ? "# OpenClaw Completion\n" : ""}${brokenHook}\n`,
+            "utf-8",
+          );
+          await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
           await installCompletion("bash", true, "openclaw");
           const first = await fs.readFile(profilePath, "utf8");
           expect(first).toContain(`${brokenHook}\n`);
@@ -1093,8 +1066,6 @@ describe("completion-runtime", () => {
           expect(first).toContain(cachePath);
           await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
 
-          // A later install must keep the working literal block instead of removing
-          // it and leaving only the malformed portable guard behind.
           await installCompletion("bash", true, "openclaw");
           await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(first);
         },

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -214,6 +214,7 @@ function isPreviousCompletionSourceLine(
   }
   const sourcePaths = sourcePath.includes("\\") ? path.win32 : path;
   return (
+    sourcePaths.isAbsolute(sourcePath) &&
     sourcePaths.basename(sourcePaths.dirname(sourcePath)) === "completions" &&
     sourcePaths.basename(sourcePath) === path.basename(currentCachePath)
   );
@@ -280,20 +281,18 @@ function isPortableCompletionSourceLine(
   if (PORTABLE_PATH_UNSAFE.test(suffix) || suffix === "") {
     return false;
   }
-  const trimmed = line.trim();
+  const trimmed = line.replace(/^[ \t]+|[ \t]+$/gu, "");
   let guardOperand: string | undefined;
   let sourceOperand: string | undefined;
   if (shell === "fish") {
-    const hook = /^test\s+-f\s+(.+?)\s*;\s*and\s+source\s+(.+)$/u.exec(trimmed);
+    const hook = /^test[ \t]+-f[ \t]+(.+?)[ \t]*;[ \t]*and[ \t]+source[ \t]+(.+)$/u.exec(trimmed);
     guardOperand = hook?.[1];
     sourceOperand = hook?.[2];
   } else {
-    // The closing bracket must be a whitespace-delimited token: Bash requires it to be
-    // a separate argument, so guards like `[ -f "$HOME/cache.bash"]` are syntax errors
-    // and must never count as installed.
+    // Shell token separators are spaces and tabs, not JavaScript's Unicode whitespace.
     const hook =
-      /^\[\s+-f\s+(.+?)\s+\]\s*&&\s+source\s+(.+)$/u.exec(trimmed) ??
-      /^\[\[\s+-f\s+(.+?)\s+\]\]\s*&&\s+source\s+(.+)$/u.exec(trimmed);
+      /^\[[ \t]+-f[ \t]+(.+?)[ \t]+\][ \t]*&&[ \t]+source[ \t]+(.+)$/u.exec(trimmed) ??
+      /^\[\[[ \t]+-f[ \t]+(.+?)[ \t]+\]\][ \t]*&&[ \t]+source[ \t]+(.+)$/u.exec(trimmed);
     guardOperand = hook?.[1];
     sourceOperand = hook?.[2];
   }
@@ -375,15 +374,17 @@ function updateCompletionProfile(
   const filtered: string[] = [];
   let hadExisting = false;
   let portableCoversCurrent = false;
-  let removedOwnedLine = false;
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     if (isCompletionProfileHeader(line)) {
-      hadExisting = true;
-      removedOwnedLine = true;
-      // An orphaned marker owns no following user line; remove only a recognized source line.
       const following = lines[i + 1] ?? "";
+      if (isPortableCompletionSourceLine(following, shell, cachePath, homeDir)) {
+        filtered.push(line);
+        continue;
+      }
+      hadExisting = true;
+      // An orphaned marker owns no following user line; remove only a recognized source line.
       if (
         isCompletionProfileLine(following, binName, cachePath) ||
         isPreviousCompletionSourceLine(following, cachePath, shell)
@@ -394,7 +395,6 @@ function updateCompletionProfile(
     }
     if (isCompletionProfileLine(line, binName, cachePath)) {
       hadExisting = true;
-      removedOwnedLine = true;
       continue;
     }
     if (isPortableCompletionSourceLine(line, shell, cachePath, homeDir)) {
@@ -407,13 +407,11 @@ function updateCompletionProfile(
     filtered.push(line);
   }
 
-  const trimmed = filtered.join("\n").trimEnd();
   if (portableCoversCurrent) {
-    // The user-managed portable hook already sources this cache script; appending the CLI's
-    // literal block would duplicate it and dirty dotfile-managed profiles.
-    const next = removedOwnedLine ? `${trimmed}\n` : content;
+    const next = filtered.join("\n");
     return { next, changed: next !== content, hadExisting };
   }
+  const trimmed = filtered.join("\n").trimEnd();
   const block = `# OpenClaw Completion\n${formatCompletionSourceLine(shell, cachePath)}`;
   const next = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
   return { next, changed: next !== content, hadExisting };

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -219,6 +219,92 @@ function isPreviousCompletionSourceLine(
   );
 }
 
+const PORTABLE_HOOK_SHELLS: ReadonlySet<CompletionShell> = new Set(["bash", "zsh", "fish"]);
+
+/** Characters that would change meaning if a literal shell operand were expanded or globbed. */
+const PORTABLE_PATH_UNSAFE = /[\s"'`$\\|&;<>()*?[\]{}]/u;
+
+/**
+ * Expands a guarded-source operand that is a portable `$HOME`-rooted path, or returns undefined
+ * when the operand is not one of the supported safe forms. The operand may be double-quoted or
+ * unquoted; single quotes prevent expansion and are never treated as portable. Expansion is
+ * purely textual (`${HOME}`/`$HOME` token + literal suffix); nothing is evaluated.
+ */
+function expandPortableHomeOperand(
+  operand: string,
+  homeDir: string,
+  shell: CompletionShell,
+): string | undefined {
+  const doubleQuoted = operand.length >= 2 && operand.startsWith('"') && operand.endsWith('"');
+  const inner = doubleQuoted ? operand.slice(1, -1) : operand;
+  if (doubleQuoted ? inner.includes('"') : /["'`]/u.test(inner)) {
+    return undefined;
+  }
+  if (!doubleQuoted && PORTABLE_PATH_UNSAFE.test(homeDir)) {
+    // An unquoted ${HOME} prefix would be split or globbed for such homes.
+    return undefined;
+  }
+  const token = shell === "fish" ? "$HOME" : inner.startsWith("${HOME}") ? "${HOME}" : "$HOME";
+  if (!inner.startsWith(token)) {
+    return undefined;
+  }
+  const suffix = inner.slice(token.length);
+  if (PORTABLE_PATH_UNSAFE.test(suffix)) {
+    return undefined;
+  }
+  return suffix.startsWith("/") ? `${homeDir}${suffix}` : undefined;
+}
+
+/**
+ * Recognizes a user-managed portable completion hook such as
+ * `[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"`.
+ * Dotfile managers own these lines, so recognition is kept separate from rewrite ownership:
+ * portable hooks are never deleted or rewritten by the installer. The anchored parser only
+ * accepts guarded forms whose guard and source operands both expand to the current cache path;
+ * compound commands and mismatched paths are left alone.
+ */
+function isPortableCompletionSourceLine(
+  line: string,
+  shell: CompletionShell,
+  cachePath: string,
+  homeDir: string,
+): boolean {
+  if (!PORTABLE_HOOK_SHELLS.has(shell)) {
+    return false;
+  }
+  const homePrefix = homeDir.endsWith(path.sep) ? homeDir : `${homeDir}${path.sep}`;
+  if (!cachePath.startsWith(homePrefix)) {
+    return false;
+  }
+  const suffix = cachePath.slice(homePrefix.length);
+  if (PORTABLE_PATH_UNSAFE.test(suffix) || suffix === "") {
+    return false;
+  }
+  const trimmed = line.trim();
+  let guardOperand: string | undefined;
+  let sourceOperand: string | undefined;
+  if (shell === "fish") {
+    const hook = /^test\s+-f\s+(.+?)\s*;\s*and\s+source\s+(.+)$/u.exec(trimmed);
+    guardOperand = hook?.[1];
+    sourceOperand = hook?.[2];
+  } else {
+    // The closing bracket must be a whitespace-delimited token: Bash requires it to be
+    // a separate argument, so guards like `[ -f "$HOME/cache.bash"]` are syntax errors
+    // and must never count as installed.
+    const hook =
+      /^\[\s+-f\s+(.+?)\s+\]\s*&&\s+source\s+(.+)$/u.exec(trimmed) ??
+      /^\[\[\s+-f\s+(.+?)\s+\]\]\s*&&\s+source\s+(.+)$/u.exec(trimmed);
+    guardOperand = hook?.[1];
+    sourceOperand = hook?.[2];
+  }
+  return (
+    guardOperand !== undefined &&
+    sourceOperand !== undefined &&
+    expandPortableHomeOperand(guardOperand, homeDir, shell) === cachePath &&
+    expandPortableHomeOperand(sourceOperand, homeDir, shell) === cachePath
+  );
+}
+
 function isOwnedCompletionInvocation(invocation: string, binName: string): boolean {
   const [command, action, ...args] = invocation.trim().split(/\s+/u);
   if (command !== binName || action !== "completion") {
@@ -281,16 +367,21 @@ function updateCompletionProfile(
   binName: string,
   cachePath: string,
   shell: CompletionShell,
+  homeDir: string,
 ): { next: string; changed: boolean; hadExisting: boolean } {
-  // Remove both cached and old dynamic blocks so installs converge to one fast source line.
+  // Remove both cached and old dynamic blocks so installs converge to one fast source line,
+  // while preserving user-managed portable hooks byte-for-byte.
   const lines = content.split("\n");
   const filtered: string[] = [];
   let hadExisting = false;
+  let portableCoversCurrent = false;
+  let removedOwnedLine = false;
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     if (isCompletionProfileHeader(line)) {
       hadExisting = true;
+      removedOwnedLine = true;
       // An orphaned marker owns no following user line; remove only a recognized source line.
       const following = lines[i + 1] ?? "";
       if (
@@ -303,12 +394,26 @@ function updateCompletionProfile(
     }
     if (isCompletionProfileLine(line, binName, cachePath)) {
       hadExisting = true;
+      removedOwnedLine = true;
+      continue;
+    }
+    if (isPortableCompletionSourceLine(line, shell, cachePath, homeDir)) {
+      // A portable hook for the current cache counts as configured and stays untouched.
+      hadExisting = true;
+      portableCoversCurrent = true;
+      filtered.push(line);
       continue;
     }
     filtered.push(line);
   }
 
   const trimmed = filtered.join("\n").trimEnd();
+  if (portableCoversCurrent) {
+    // The user-managed portable hook already sources this cache script; appending the CLI's
+    // literal block would duplicate it and dirty dotfile-managed profiles.
+    const next = removedOwnedLine ? `${trimmed}\n` : content;
+    return { next, changed: next !== content, hadExisting };
+  }
   const block = `# OpenClaw Completion\n${formatCompletionSourceLine(shell, cachePath)}`;
   const next = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
   return { next, changed: next !== content, hadExisting };
@@ -429,10 +534,16 @@ export async function isCompletionInstalled(
     return false;
   }
   const cachePath = resolveCompletionCachePath(shell, binName);
+  const homeDir = process.env.HOME || os.homedir();
   const { content } = await readCompletionProfile(profilePath, shell);
   const lines = content.split("\n");
   // A marker does not install completion; retain missing-cache source lines for doctor repair.
-  return lines.some((line) => isCompletionProfileLine(line, binName, cachePath));
+  // Managed portable hooks for the same cache script count as installed but are never rewritten.
+  return lines.some(
+    (line) =>
+      isCompletionProfileLine(line, binName, cachePath) ||
+      isPortableCompletionSourceLine(line, shell, cachePath, homeDir),
+  );
 }
 
 /**
@@ -479,6 +590,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 
   const profilePath = resolveCompletionProfilePath(shell);
+  const homeDir = process.env.HOME || os.homedir();
 
   try {
     let content: string;
@@ -495,7 +607,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       content = "";
     }
 
-    const update = updateCompletionProfile(content, binName, cachePath, shell);
+    const update = updateCompletionProfile(content, binName, cachePath, shell, homeDir);
     if (!update.changed) {
       if (!yes) {
         console.log(`Completion already installed in ${profilePath}`);

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -71,6 +71,34 @@ describe("shell completion health mapping", () => {
     });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "recognizes a managed portable Bash source line as installed",
+    async () => {
+      const homeDir = tempDirs.make("openclaw-bash-portable-profile-home-");
+      const stateDir = path.join(homeDir, ".openclaw");
+      setTestEnvValue("HOME", homeDir);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      setTestEnvValue("SHELL", "/bin/bash");
+
+      const cachePath = path.join(stateDir, "completions", "openclaw.bash");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+      await fs.writeFile(
+        path.join(homeDir, ".bashrc"),
+        '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"\n',
+        "utf-8",
+      );
+
+      await expect(checkShellCompletionStatus("openclaw", { shell: "bash" })).resolves.toEqual({
+        shell: "bash",
+        profileInstalled: true,
+        cacheExists: true,
+        cachePath,
+        usesSlowPattern: false,
+      });
+    },
+  );
+
   it("reports slow dynamic Bash completion from the documented login profile", async () => {
     const homeDir = tempDirs.make("openclaw-bash-slow-profile-home-");
     const stateDir = tempDirs.make("openclaw-bash-slow-profile-state-");


### PR DESCRIPTION
## What Problem This Solves

Closes #143267.

Completion installation can append a duplicate absolute-path hook to a working Bash profile managed by a dotfile tool. The installer does not recognize guarded `HOME`-relative hooks for the same completion cache, so a repeated install changes a profile the user owns.

## Why This Change Was Made

Recognition and rewrite ownership are separate. Supported portable hooks remain byte-identical, including an existing OpenClaw marker. Old generated literal and dynamic hooks still migrate. Previous literal-hook detection requires an absolute path, so it cannot consume a user-managed portable line. Shell token boundaries use spaces and tabs, preventing malformed Unicode-whitespace guards from suppressing a needed installation.

## User Impact

Running `openclaw completion --shell bash --install --yes` twice preserves a working portable profile. When only the cache is missing, `openclaw doctor --fix --non-interactive` regenerates it without rewriting the profile. Mismatched, compound, single-quoted, unsafe, and malformed hooks remain user-owned.

## Evidence

- Built and deployed the pinned main baseline and candidate with the installed package entrypoint resolved before changing the child home.
- The real baseline CLI appended a duplicate literal block. The corrected installed CLI preserved the profile across both installs, including marked single- and double-bracket hooks.
- Fresh Bash processes registered the generated completion. After deleting only the cache, the public Doctor command regenerated it and left the profile unchanged.
- Real malformed-whitespace controls failed in Bash before installation. The corrected installer preserved those user lines and added the existing literal hook instead of falsely reporting the malformed hook as sufficient.
- Focused checks passed: 109 CLI tests, 20 Doctor tests, 17 setup tests, formatting, syntax lint, and `git diff --check`. The corrected regression suite failed eight cases with the incoming runtime for the intended errors.
- Bash is the required live-shell proof. Zsh and Fish recognition have supplemental test coverage; this does not claim arbitrary shell syntax, portable PowerShell hooks, or universal dotfile-manager compatibility.

Related: #136241 covers earlier literal-path quoting and migration. #143306 is a later implementation of the same issue.

Independent installed CLI validation also passed portable variants, owned-hook migrations, and twelve negative forms. Doctor cache repair used an explicit `SHELL=/bin/bash` environment; the raw evidence retains the initial omitted-shell setup failure separately. Zsh and Fish executables were unavailable.
