### PR TITLE
fix: honor steer mode for unmentioned task corrections

### DIFF
--- a/docs/channels/ambient-room-events.md
+++ b/docs/channels/ambient-room-events.md
@@ -70,6 +70,12 @@ Room events use strict visible delivery. Final assistant text is private. The ag
 
 Typing and lifecycle status reactions stay suppressed for room events. The one explicit receipt exception is `messages.ackReactionScope: "all"`, which sends the configured ack reaction; use any narrower scope or `"off"` when the room must remain completely silent.
 
+## Corrections during active work
+
+Without an explicit queue mode, room events wait for the active task to finish. To let accepted, unmentioned corrections steer ongoing work, select `messages.queue.mode: "steer"`, a channel override under `messages.queue.byChannel`, or `/queue steer` for the session. Existing sender and room allowlists still apply; mention gating must be off for the message to be accepted.
+
+Steering takes effect at the active runtime's supported boundary, not by interrupting an already-running tool. If the runtime cannot accept it, the correction waits for a later turn. Final replies, typing, and reactions retain the room's quiet-delivery rules. See [Steering queue](/concepts/queue-steering).
+
 ## Discord example
 
 ```json5

--- a/docs/concepts/queue-steering.md
+++ b/docs/concepts/queue-steering.md
@@ -12,6 +12,8 @@ When a normal prompt arrives while a session run is already streaming and the qu
 
 This page covers queue-mode steering for normal inbound messages in `steer` mode. In `followup` or `collect` mode, normal messages skip this path and wait until the active run finishes. For the explicit `/steer <message>` command, see [Steer](/tools/steer).
 
+[Ambient room events](/channels/ambient-room-events#corrections-during-active-work) are an exception to the default: they wait for follow-up unless steering is explicitly selected in configuration or for the session.
+
 ## Runtime boundary
 
 Steering does not interrupt a tool call that is already running. The OpenClaw runtime checks at tool-launch boundaries as well as model boundaries:

--- a/src/agents/sessions/agent-session-loop-next-turn.test.ts
+++ b/src/agents/sessions/agent-session-loop-next-turn.test.ts
@@ -496,7 +496,7 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
   });
 
   it.each([false, true])(
-    "keeps accepted steering bytes stable across transcript persistence (image: %s)",
+    "keeps steering bytes stable while persisting canonical text and images (image: %s)",
     async (withImage) => {
       const { session, sessionManager } = await createTestSession();
       const admittedAt = 1717570800000;
@@ -560,7 +560,9 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
       expect(guard.getEntry(entryId)).toMatchObject({
         message: {
           timestamp: admittedAt,
-          content: withImage ? message.content : "Visible transcript prompt",
+          content: withImage
+            ? [{ type: "text", text: "Visible transcript prompt" }, image]
+            : "Visible transcript prompt",
         },
       });
       if (withImage) {

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { buildCurrentInboundPrompt } from "../../agents/embedded-agent-runner/run/runtime-context-prompt.js";
 import { isIngressAdoptionLostError } from "../../channels/message/ingress-drain.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -144,7 +145,17 @@ export async function runActiveReplySteer(
     if (!injectionTarget) {
       return await fallback("no injectable reply operation");
     }
-    const injectionAttempt = beginReplyMessageInjectionTarget(injectionTarget, followupRun.prompt, {
+    const steerPrompt =
+      followupRun.currentInboundEventKind === "room_event"
+        ? buildCurrentInboundPrompt({
+            context: followupRun.currentInboundContext,
+            prompt: followupRun.prompt,
+            // The active backend already owns the conversation. Carry only the
+            // compact room-event wrapper plus the exact current message body.
+            preferResumableText: true,
+          })
+        : followupRun.prompt;
+    const injectionAttempt = beginReplyMessageInjectionTarget(injectionTarget, steerPrompt, {
       steeringMode: "all",
       isInboundUserMessage: true,
       toolAuthorityFingerprint: params.toolAuthorityFingerprint,

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -481,6 +481,59 @@ describe("runReplyAgent media path normalization", () => {
     expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { label: "task revision", body: "#123 Alice: use the Willow Glen branch instead" },
+    { label: "task cancellation", body: "#124 Alice: stop the current task" },
+  ])(
+    "steers a room-event $label with runtime context and the current body exactly once",
+    async ({ body: currentBody }) => {
+      queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(
+        async (sessionId: string) => ({
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+        }),
+      );
+      const roomEventContext = ["[OpenClaw room event]", "inbound_event_kind: room_event"].join(
+        "\n\n",
+      );
+      const followupRun = createMediaFollowupRun({ prompt: currentBody });
+      followupRun.currentInboundEventKind = "room_event";
+      followupRun.currentInboundContext = { text: roomEventContext };
+
+      await runReplyAgent(
+        makeRunReplyAgentParams({
+          resolvedQueue: { mode: "steer" } as QueueSettings,
+          shouldSteer: true,
+          shouldFollowup: true,
+          isActive: true,
+          followupRun,
+        }),
+      );
+
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenLastCalledWith(
+        "session",
+        `${roomEventContext}\n\n${currentBody}`,
+        {
+          abortSignal: undefined,
+          steeringMode: "all",
+          isInboundUserMessage: true,
+          waitForTranscriptCommit: true,
+          queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
+          onQueueAccepted: expect.any(Function),
+          taskSuggestionDeliveryMode: undefined,
+          toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(followupRun),
+        },
+      );
+      expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+      expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
+      expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
+      const injectedPrompt = queueEmbeddedAgentMessageWithOutcomeAsyncMock.mock.calls.at(-1)?.[1];
+      expect(injectedPrompt?.split(currentBody)).toHaveLength(2);
+    },
+  );
+
   it("steers ordered current-turn images with the active prompt", async () => {
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -357,6 +357,8 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
         channel: sessionCtx.Provider,
         sessionEntry,
         inlineMode: effectiveQueueMode,
+        // Preserve ambient follow-up unless the operator explicitly selects steering.
+        defaultMode: isRoomEvent ? "followup" : undefined,
         inlineOptions: perMessageQueueOptions,
       });
   const embeddedAgentRuntime = useFastReplyRuntime

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -556,7 +556,6 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
       : "steering";
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const shouldSteer =
-    !isRoomEvent &&
     queueAdmissionState !== "ready" &&
     activeRunAcceptsCurrentThread &&
     !context.isHeartbeat &&

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -31,6 +31,7 @@ import {
   resolveInboundUserContextPromptJoiner,
 } from "./inbound-meta.js";
 import { prepareReplyConversation } from "./prompt-session-context.js";
+import { resolveQueueSettingsCore } from "./queue/settings.js";
 import { REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS, createReplyOperation } from "./reply-run-registry.js";
 import { getActiveReplyRunCount } from "./reply-run-registry.registry.js";
 import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
@@ -3531,16 +3532,37 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.currentInboundContext?.text).not.toContain("Current event:");
   });
 
-  it("steers active room events with their runtime context", async () => {
+  it.each([
+    { name: "implicit default", queue: undefined, shouldSteer: false, mode: "followup" },
+    {
+      name: "explicit steering",
+      queue: { mode: "steer" as const },
+      shouldSteer: true,
+      mode: "steer",
+    },
+    {
+      name: "channel steering",
+      queue: { mode: "followup" as const, byChannel: { telegram: "steer" as const } },
+      shouldSteer: true,
+      mode: "steer",
+    },
+    {
+      name: "channel followup",
+      queue: { mode: "steer" as const, byChannel: { telegram: "followup" as const } },
+      shouldSteer: false,
+      mode: "followup",
+    },
+    {
+      name: "explicit collect",
+      queue: { mode: "collect" as const },
+      shouldSteer: false,
+      mode: "collect",
+    },
+  ])("preserves room context under $name", async ({ queue, shouldSteer, mode }) => {
     const queueSettings = await import("./queue/settings-runtime.js");
     const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
     const abortController = new AbortController();
-    vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
-      mode: "steer",
-      debounceMs: 500,
-      cap: 20,
-      dropPolicy: "summarize",
-    });
+    vi.mocked(queueSettings.resolveQueueSettings).mockImplementationOnce(resolveQueueSettingsCore);
     vi.mocked(embeddedAgentRuntime.resolveActiveEmbeddedRunSessionId)
       .mockReturnValueOnce("active-session")
       .mockReturnValueOnce("active-session");
@@ -3551,6 +3573,7 @@ describe("runPreparedReply media-only handling", () => {
     vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce("room context");
 
     await runPrepared({
+      cfg: { messages: { queue } },
       opts: { abortSignal: abortController.signal },
       ctx: {
         ...createInboundTurn("ambient", "telegram", "group"),
@@ -3564,10 +3587,10 @@ describe("runPreparedReply media-only handling", () => {
     });
 
     const call = requireLastRunReplyAgentCall();
-    expect(call.shouldSteer).toBe(true);
+    expect(call.shouldSteer).toBe(shouldSteer);
     expect(call.shouldFollowup).toBe(true);
     expect(call.isActive).toBe(true);
-    expect(call.resolvedQueue.mode).toBe("steer");
+    expect(call.resolvedQueue.mode).toBe(mode);
     expect(call.followupRun.prompt).toBe("#992 Alice: ambient");
     expect(call.followupRun.currentInboundEventKind).toBe("room_event");
     expect(call.followupRun.abortSignal).toBe(abortController.signal);

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -3531,7 +3531,7 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.currentInboundContext?.text).not.toContain("Current event:");
   });
 
-  it("queues active room events as followups instead of steering fake prompts", async () => {
+  it("steers active room events with their runtime context", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
     const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
     const abortController = new AbortController();
@@ -3564,7 +3564,7 @@ describe("runPreparedReply media-only handling", () => {
     });
 
     const call = requireLastRunReplyAgentCall();
-    expect(call.shouldSteer).toBe(false);
+    expect(call.shouldSteer).toBe(true);
     expect(call.shouldFollowup).toBe(true);
     expect(call.isActive).toBe(true);
     expect(call.resolvedQueue.mode).toBe("steer");

--- a/src/auto-reply/reply/queue.media-carrier.test.ts
+++ b/src/auto-reply/reply/queue.media-carrier.test.ts
@@ -92,6 +92,85 @@ afterEach(() => {
 });
 
 describe("followup prompt metadata carrier", () => {
+  it.each([
+    ["selection", "#1000000000000000001 Alice: Let's do Nick the Greek."],
+    ["revision", "#1000000000000000002 Alice: Use the Willow Glen location instead."],
+    ["cancel", "#1000000000000000003 Alice: Cancel that; do not send anything."],
+  ])(
+    "steers an active room-event %s with compact context and its exact body",
+    async (_name, body) => {
+      const key = `agent:main:room-event-${_name}`;
+      queueKeys.add(key);
+      const run = createQueueTestRun({ prompt: body, messageId: `message-${_name}` });
+      run.currentInboundEventKind = "room_event";
+      run.transcriptPrompt = body;
+      run.currentInboundContext = {
+        text: [
+          "[OpenClaw room event]",
+          "Room context:\nConversation info\n\nConversation context (chronological, selected for current message):\nstale lunch options",
+          "Stay silent unless useful.",
+        ].join("\n\n"),
+        resumableText: [
+          "[OpenClaw room event]",
+          "Room context:\nConversation info",
+          "Stay silent unless useful.",
+        ].join("\n\n"),
+      };
+      const operation = createReplyOperation({
+        sessionKey: key,
+        sessionId: run.run.sessionId,
+        resetTriggered: false,
+      });
+      operation.bindToolAuthoritySnapshot({
+        fingerprint: () => "room-authority",
+        project: () => "room-authority",
+      });
+      const queueMessage = vi.fn(
+        async (_text: string, options?: { onQueueAccepted?: (accepted: boolean) => void }) => {
+          options?.onQueueAccepted?.(true);
+        },
+      );
+      operation.attachBackend({
+        kind: "embedded",
+        toolAuthorityFingerprint: "room-authority",
+        cancel: vi.fn(),
+        messageInjection: { isAvailable: () => true, queueMessage },
+      });
+      operation.setPhase("running");
+      const typing = createMockTypingController();
+      try {
+        await expect(
+          runActiveReplySteer({
+            followupRun: run,
+            opts: undefined,
+            providedReplyOperation: operation,
+            queueKey: key,
+            releaseAdmissionTicket: vi.fn(),
+            replyOperationRunState: undefined,
+            resolvedQueue: { mode: "steer", debounceMs: 0 },
+            restartRecoverySourceTurnId: `source-${_name}`,
+            runFollowup: vi.fn(async () => {}),
+            sessionCtx: {},
+            sessionKey: key,
+            touchActiveSessionEntry: async () => {},
+            typing,
+            typingSignals: createTypingSignaler({ typing, mode: "never", isHeartbeat: false }),
+            toolAuthorityFingerprint: "room-authority",
+          }),
+        ).resolves.toBe("handled");
+        expect(queueMessage).toHaveBeenCalledOnce();
+        const injected = queueMessage.mock.calls[0]?.[0];
+        expect(injected).toContain("[OpenClaw room event]");
+        expect(injected).toContain("Room context:\nConversation info");
+        expect(injected).toContain(body);
+        expect(injected).not.toContain("stale lunch options");
+        expect(injected?.split(body)).toHaveLength(2);
+      } finally {
+        operation.complete();
+      }
+    },
+  );
+
   it("drains the complete parked image turn after active steering rejects it", async () => {
     const key = "agent:main:parked-media-fallback";
     queueKeys.add(key);

--- a/src/auto-reply/reply/queue/settings.test.ts
+++ b/src/auto-reply/reply/queue/settings.test.ts
@@ -13,6 +13,48 @@ describe("resolveQueueSettingsCore", () => {
     });
   });
 
+  it.each([
+    { name: "no selection", overrides: {}, mode: "followup" },
+    {
+      name: "global config",
+      overrides: { cfg: { messages: { queue: { mode: "steer" as const } } } },
+      mode: "steer",
+    },
+    {
+      name: "channel config",
+      overrides: {
+        cfg: {
+          messages: {
+            queue: { mode: "collect" as const, byChannel: { telegram: "steer" as const } },
+          },
+        },
+      },
+      mode: "steer",
+    },
+    {
+      name: "session override",
+      overrides: { sessionEntry: { sessionId: "test", updatedAt: 0, queueMode: "steer" as const } },
+      mode: "steer",
+    },
+    {
+      name: "inline directive",
+      overrides: {
+        inlineMode: "steer" as const,
+        sessionEntry: { sessionId: "test", updatedAt: 0, queueMode: "collect" as const },
+      },
+      mode: "steer",
+    },
+  ])("resolves the ambient queue policy from $name", ({ overrides, mode }) => {
+    expect(
+      resolveQueueSettingsCore({
+        cfg: {},
+        channel: "telegram",
+        defaultMode: "followup",
+        ...overrides,
+      }).mode,
+    ).toBe(mode);
+  });
+
   it("uses the short debounce when collect is selected globally", () => {
     expect(
       resolveQueueSettingsCore({

--- a/src/auto-reply/reply/queue/settings.ts
+++ b/src/auto-reply/reply/queue/settings.ts
@@ -33,6 +33,7 @@ export function resolveQueueSettingsCore(params: ResolveQueueSettingsParams): Qu
     normalizePersistedQueueMode(params.sessionEntry?.queueMode) ??
     normalizeQueueMode(providerModeRaw) ??
     normalizeQueueMode(queueCfg?.mode) ??
+    params.defaultMode ??
     "steer";
   const debounceRaw =
     params.inlineOptions?.debounceMs ??

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -59,6 +59,8 @@ export type ResolveQueueSettingsParams = {
   channel?: string;
   sessionEntry?: SessionEntry;
   inlineMode?: QueueMode;
+  /** Admission fallback when no directive, session override, or config selects a mode. */
+  defaultMode?: QueueMode;
   inlineOptions?: Partial<QueueSettings>;
   pluginDebounceMs?: number;
 };

--- a/src/sessions/user-turn-transcript.message.ts
+++ b/src/sessions/user-turn-transcript.message.ts
@@ -177,14 +177,6 @@ function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
   return marker !== undefined;
 }
 
-function userMessageHasImageContent(message: AgentMessage): boolean {
-  return (
-    isUserMessage(message) &&
-    Array.isArray(message.content) &&
-    message.content.some((block) => asOptionalRecord(block)?.type === "image")
-  );
-}
-
 // Runtime messages may lack transcript metadata because channel adapters prepare
 // display text separately. Merge only safe user messages, never block markers.
 export function mergePreparedUserTurnMessageForRuntime(params: {
@@ -200,12 +192,24 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   }
   const runtimeMeta = readOpenClawMessageMeta(params.runtimeMessage);
   const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
+  const images = Array.isArray(params.runtimeMessage.content)
+    ? params.runtimeMessage.content.filter((block) => block.type === "image")
+    : [];
+  // Keep hydrated images without persisting adjacent runtime-only prompt text.
+  const preparedContent = params.preparedMessage.content;
   return {
     ...params.runtimeMessage,
     ...params.preparedMessage,
     ...(preparedMeta ? { __openclaw: { ...runtimeMeta, ...preparedMeta } } : {}),
-    ...(userMessageHasImageContent(params.runtimeMessage)
-      ? { content: params.runtimeMessage.content }
+    ...(images.length > 0
+      ? {
+          content: [
+            ...(typeof preparedContent === "string"
+              ? [{ type: "text" as const, text: preparedContent }]
+              : preparedContent.filter((block) => block.type !== "image")),
+            ...images,
+          ],
+        }
       : {}),
   };
 }

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -208,14 +208,15 @@ describe("user turn transcript persistence", () => {
       ).toBe(blocked);
     });
 
-    it("preserves runtime multimodal content while merging prepared metadata", () => {
+    it("preserves ordered runtime images without persisting runtime-only text", () => {
       const recorder = createUserTurnTranscriptRecorder({
         input: { text: "canonical image caption", timestamp: 123 },
         target: unusedRecorderTarget,
       });
       const runtimeContent = [
-        { type: "text", text: "canonical image caption" },
+        { type: "text", text: "runtime-only room context\ncanonical image caption" },
         { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+        { type: "image", data: "d29ybGQ=", mimeType: "image/png" },
       ];
 
       expect(
@@ -228,7 +229,7 @@ describe("user turn transcript persistence", () => {
         }),
       ).toMatchObject({
         role: "user",
-        content: runtimeContent,
+        content: [{ type: "text", text: "canonical image caption" }, ...runtimeContent.slice(1)],
         timestamp: 123,
       });
     });

--- a/test/e2e/qa-lab/runtime/telegram-room-event-steering-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-room-event-steering-gateway.e2e.test.ts
@@ -1,0 +1,342 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { expect, test } from "vitest";
+import { createQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
+import { buildMockOpenAiResponsesProvider } from "../../../../src/gateway/test-openai-responses-model.js";
+import {
+  writeOpenAiResponsesSse,
+  writeOpenAiResponsesText,
+} from "../../../helpers/openai-responses-sse.js";
+import { createDeferred } from "../../../helpers/promise.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+const BOT_TOKEN = `424242:${"A".repeat(35)}`;
+const CHAT_ID = -1002468135790;
+const ORIGINAL = "Compare locations for the original request";
+const CORRECTION = "Only include locations open Sunday QA_ROOM_CORRECTION";
+const FINAL = "QA_ORIGINAL_RUN_FINISHED";
+type Json = Record<string, unknown>;
+
+async function readBody(req: IncomingMessage): Promise<Json> {
+  let raw = "";
+  for await (const chunk of req) {
+    raw += chunk;
+  }
+  return raw ? (JSON.parse(raw) as Json) : {};
+}
+
+function respond(res: ServerResponse, index: number, tool = false) {
+  if (!tool) {
+    writeOpenAiResponsesText(res, {
+      text: FINAL,
+      messageId: `msg_room_${index}`,
+      responseId: `resp_room_${index}`,
+    });
+    return;
+  }
+  const item = {
+    type: "function_call",
+    id: "fc_room_status",
+    call_id: "call_room_status",
+    name: "session_status",
+    arguments: "{}",
+    status: "completed",
+  };
+  writeOpenAiResponsesSse(res, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress", arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: item.id,
+      output_index: 0,
+      arguments: "{}",
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_room_${index}`,
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ]);
+}
+
+// Both transports are loopback servers; classification, dispatch, queue admission,
+// active agent execution, provider requests, and outbound policy are real code.
+test.each([true, false])(
+  "Telegram room corrections honor explicit steering without changing implicit defaults (explicit=%s)",
+  async (explicitSteer) => {
+    const firstResponse = createDeferred();
+    const secondResponse = createDeferred();
+    const requests: Json[] = [];
+    const telegramCalls: Array<{ method: string; body: Json }> = [];
+    const updates: Json[] = [];
+    const polls = new Set<ServerResponse>();
+    const chat = { id: CHAT_ID, type: "supergroup", title: "QA Steering Room" };
+    let updateId = 0;
+    const sendInbound = (text: string) => {
+      const update = {
+        update_id: ++updateId,
+        message: {
+          message_id: updateId,
+          date: Math.floor(Date.now() / 1000),
+          chat,
+          from: { id: 1357, is_bot: false, first_name: "QA Sender" },
+          text,
+        },
+      };
+      const poll = polls.values().next().value;
+      if (poll) {
+        polls.delete(poll);
+        writeJson(poll, 200, { ok: true, result: [update] });
+      } else {
+        updates.push(update);
+      }
+    };
+    await withServer(
+      (req, res) => {
+        void (async () => {
+          const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+          if (pathname === "/v1/models") {
+            writeJson(res, 200, { data: [{ id: "gpt-5.4", object: "model" }] });
+            return;
+          }
+          if (pathname === "/v1/responses") {
+            requests.push(await readBody(req));
+            const index = requests.length;
+            if (index === 1) {
+              await firstResponse.promise;
+            } else if (index === 2) {
+              await secondResponse.promise;
+            }
+            if (!res.destroyed) {
+              respond(res, index, index === 1);
+            }
+            return;
+          }
+          const [, token, method = ""] = pathname.match(/^\/bot([^/]+)\/([^/]+)$/) ?? [];
+          const body = await readBody(req);
+          telegramCalls.push({ method, body });
+          if (token !== BOT_TOKEN) {
+            writeJson(res, 401, { ok: false });
+          } else if (method === "getMe") {
+            writeJson(res, 200, {
+              ok: true,
+              result: { id: 424242, is_bot: true, first_name: "QA", username: "qa_steering_bot" },
+            });
+          } else if (method === "getUpdates") {
+            const update = updates.shift();
+            if (update) {
+              writeJson(res, 200, { ok: true, result: [update] });
+            } else {
+              polls.add(res);
+              res.on("close", () => polls.delete(res));
+            }
+          } else {
+            writeJson(res, 200, {
+              ok: true,
+              result:
+                method === "getChat"
+                  ? chat
+                  : method === "sendMessage"
+                    ? { message_id: 9000 + telegramCalls.length, chat, text: body.text, date: 1 }
+                    : true,
+            });
+          }
+        })().catch((error: unknown) => writeJson(res, 500, { error: String(error) }));
+      },
+      async (apiRoot) =>
+        await withTempDir("openclaw-telegram-room-steer-", async (workspace) => {
+          const owner = createQaGatewayChild();
+          let readRuntimeLogs = () => "";
+          const outputDir = path.join(
+            repoRoot,
+            ".artifacts/qa-e2e/telegram-room-event-steering",
+            explicitSteer ? "explicit" : "implicit",
+          );
+          const evidence: Json = { explicitSteer, passed: false };
+          try {
+            const provider = buildMockOpenAiResponsesProvider(`${apiRoot}/v1`);
+            const gateway = await owner.start({
+              repoRoot,
+              command: {
+                executablePath: process.execPath,
+                argsPrefix: [
+                  "--import",
+                  pathToFileURL(path.join(repoRoot, "scripts/tsx.mjs")).href,
+                  path.join(repoRoot, "scripts/run-with-env.mts"),
+                  `OPENCLAW_DEV_SOURCE_ROOT=${repoRoot}`,
+                  "--",
+                  process.execPath,
+                  path.join(repoRoot, "openclaw.mjs"),
+                ],
+                argsSuffix: ["--verbose"],
+                cwd: repoRoot,
+                usePackagedPlugins: true,
+              },
+              providerMode: "mock-openai",
+              providerBaseUrl: `${apiRoot}/v1`,
+              transportBaseUrl: apiRoot,
+              transport: {
+                requiredPluginIds: ["telegram"],
+                createGatewayConfig: () => ({
+                  messages: {
+                    ...(explicitSteer ? { queue: { mode: "steer" as const } } : {}),
+                    groupChat: { unmentionedInbound: "room_event", visibleReplies: "message_tool" },
+                  },
+                  channels: {
+                    telegram: {
+                      enabled: true,
+                      botToken: BOT_TOKEN,
+                      apiRoot,
+                      groupPolicy: "allowlist",
+                      groupAllowFrom: ["1357"],
+                      groups: { "*": { requireMention: false } },
+                      commands: { native: false },
+                      streaming: { mode: "off" },
+                    },
+                  },
+                }),
+              },
+              controlUiEnabled: false,
+              runtimeEnvPatch: {
+                OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+                TELEGRAM_BOT_TOKEN: undefined,
+              },
+              mutateConfig: (cfg) => {
+                cfg.agents!.defaults!.workspace = workspace;
+                cfg.agents!.defaults!.model = { primary: provider.modelRef };
+                cfg.agents!.defaults!.models = {
+                  [provider.modelRef]: {
+                    agentRuntime: { id: "openclaw" },
+                    params: { transport: "sse", openaiWsWarmup: false },
+                  },
+                };
+                cfg.agents!.entries!.qa!.model = { primary: provider.modelRef };
+                cfg.models = { providers: { [provider.providerId]: provider.config } };
+                cfg.tools = { profile: "minimal" };
+                cfg.logging = { level: "debug", file: path.join(workspace, "gateway.log") };
+                cfg.diagnostics = { enabled: true };
+                cfg.bindings = [{ agentId: "qa", match: { channel: "telegram" } }];
+                return cfg;
+              },
+            });
+            readRuntimeLogs = gateway.logs;
+            await expect.poll(() => polls.size, { timeout: 30_000 }).toBeGreaterThan(0);
+            sendInbound(ORIGINAL);
+            await expect.poll(() => requests.length, { timeout: 30_000 }).toBe(1);
+            const baseline = (await gateway.call("diagnostics.stability", { limit: 1 })) as {
+              lastSeq?: number;
+            };
+            sendInbound(CORRECTION);
+            // Wait for accepted ingress on either path. Steering dispatch completes
+            // only after transcript commitment at a later runtime boundary; its
+            // queue reservation is the earlier receipt. Default follow-up returns
+            // from dispatch without waiting for the held original turn.
+            await expect
+              .poll(
+                async () => {
+                  const snapshot = (await gateway.call("diagnostics.stability", {
+                    sinceSeq: baseline.lastSeq ?? 0,
+                    limit: 100,
+                  })) as { events: Array<{ type: string; channel?: string; source?: string }> };
+                  return snapshot.events.some(
+                    (event) =>
+                      event.channel === "telegram" &&
+                      (event.type === "message.dispatch.completed" ||
+                        (event.type === "message.queued" &&
+                          event.source === "followup-queue-steer")),
+                  );
+                },
+                { timeout: 30_000 },
+              )
+              .toBe(true);
+            expect(requests).toHaveLength(1);
+            const runId = /embedded run prompt start: runId=([a-z0-9-]+)/.exec(gateway.logs())?.[1];
+            expect(runId).toBeTruthy();
+            const originalRunFinished = () =>
+              gateway.logs().includes(`embedded run done: runId=${runId} `);
+            expect(originalRunFinished()).toBe(false);
+            firstResponse.resolve();
+            await expect.poll(() => requests.length, { timeout: 30_000 }).toBe(2);
+            const continuation = JSON.stringify(requests[1]);
+            expect(continuation).toContain("function_call_output");
+            expect(continuation).toContain("call_room_status");
+            expect(continuation.includes(CORRECTION)).toBe(explicitSteer);
+            // The continuation is inspected while its response is still held:
+            // the initial run cannot have terminated and started a follow-up.
+            expect(originalRunFinished()).toBe(false);
+            secondResponse.resolve();
+            await expect.poll(originalRunFinished, { timeout: 30_000 }).toBe(true);
+            if (!explicitSteer) {
+              await expect.poll(() => requests.length, { timeout: 30_000 }).toBe(3);
+              expect(JSON.stringify(requests[2])).toContain(CORRECTION);
+              const runStarts = Array.from(
+                gateway.logs().matchAll(/embedded run prompt start: runId=([a-z0-9-]+)/g),
+                (match) => match[1],
+              );
+              expect(runStarts).toHaveLength(2);
+              expect(runStarts[0]).toBe(runId);
+              expect(runStarts[1]).not.toBe(runId);
+              expect(gateway.logs().indexOf(`embedded run done: runId=${runId} `)).toBeLessThan(
+                gateway.logs().indexOf(`embedded run prompt start: runId=${runStarts[1]} `),
+              );
+            }
+            await expect
+              .poll(
+                async () => {
+                  const snapshot = (await gateway.call("diagnostics.stability", {
+                    type: "session.state",
+                    limit: 50,
+                  })) as {
+                    events: Array<{ outcome?: string; queueDepth?: number }>;
+                  };
+                  const latest = snapshot.events.at(-1);
+                  return latest?.outcome === "idle" && latest.queueDepth === 0;
+                },
+                { timeout: 30_000 },
+              )
+              .toBe(true);
+            expect(requests).toHaveLength(explicitSteer ? 2 : 3);
+            expect(
+              telegramCalls.filter((call) =>
+                ["sendMessage", "editMessageText", "sendPhoto", "sendDocument"].includes(
+                  call.method,
+                ),
+              ),
+            ).toEqual([]);
+            evidence.passed = true;
+            evidence.activeRunId = runId;
+            evidence.correctionInActiveContinuation = continuation.includes(CORRECTION);
+          } finally {
+            firstResponse.resolve();
+            secondResponse.resolve();
+            evidence.modelRequests = requests;
+            evidence.lifecycleEvents = readRuntimeLogs()
+              .split("\n")
+              .filter((line) => /embedded run (prompt start|done):/.test(line));
+            evidence.visibleCalls = telegramCalls.filter((call) =>
+              ["sendMessage", "editMessageText"].includes(call.method),
+            );
+            await mkdir(outputDir, { recursive: true });
+            await writeFile(
+              path.join(outputDir, "verdict.json"),
+              `${JSON.stringify(evidence, null, 2)}\n`,
+            );
+            await stopQaGatewayFixture(owner, { preserveToDir: path.join(outputDir, "gateway") });
+          }
+        }),
+    );
+  },
+  180_000,
+);


### PR DESCRIPTION
Closes #143265

## What Problem This Solves

Users who explicitly select queue mode `steer` cannot correct ongoing work through an accepted, unmentioned ambient message. The correction is forced into a later turn even when the active runtime can accept it. This includes Discord channels configured with `requireMention: false` and ambient room events.

## Why This Change Was Made

Honor explicitly selected steering for room events, and deliver the exact current message with compact room/sender context. Preserve canonical user text and attached images in the transcript without saving runtime-only context as the user's words.

Preserve the existing ambient default: when no directive, session override, channel setting, or global setting selects a queue mode, room events remain follow-up messages. The resolver accepts an internal admission fallback after all existing explicit selections. Other inbound messages retain their existing default.

This uses the existing steering path and runtime fallback. Other queue modes, admission checks, authorization, and quiet-reply policy remain unchanged. No new user-facing setting or conversation mode is introduced.

## User Impact

Users who select steering can correct active work through their configured mention-free conversation flow at the next supported runtime boundary. Operators who have not selected steering retain existing ambient behavior. Image-bearing corrections retain both their original words and images in history.

## Evidence

- The implicit-default regression fails on the original PR head and passes with the compatibility adjustment. Queue tests cover explicit global, channel, session, and directive precedence.
- 211 focused checks pass, including the admission/queue coverage and all native `/new` and `/reset` tests.
- A fresh-built isolated Gateway test exercises the real Telegram plugin, classification, dispatch, admission, active agent execution, provider request construction, and outbound policy. Telegram and model HTTP services are deterministic loopback fixtures; this is not a live Discord or external-model run.
- Restoring only the old `!isRoomEvent` admission exclusion and rebuilding makes the integrated explicit-steering case fail at the missing correction in the active continuation.
- With explicit `steer`, the correction appears in the original run's next provider request after its tool call, before that run finishes, with no extra follow-up run.
- With no queue setting, the original run receives no correction; the correction reaches a distinct run only after the original finishes.
- Both cases assert no visible channel sends or edits under `visibleReplies: message_tool`.
- Repository changed-file checks, a fresh runtime build, and independent P0–P2 review pass. The original steering/transcript change also passed 343 focused checks before publication.

### Captured runtime summary

```text
EXPLICIT — passed=True
  Provider requests: 2
  Correction in active continuation: True
  Runtime lifecycle: A: prompt start -> A: done
  Visible send/edit calls: 0
IMPLICIT — passed=True
  Provider requests: 3
  Correction in active continuation: False
  Runtime lifecycle: A: prompt start -> A: done -> B: prompt start -> B: done
  Visible send/edit calls: 0
OLD GUARD RESTORED + REBUILT — expected regression failure
  Provider requests before failing assertion: 2
  Active continuation contains correction: false (expected true)
  Final candidate restored byte-for-byte, rebuilt, and both cases passed.
```

### Reproduce the isolated Gateway proof

After building this checkout with the repository's normal runtime build:

```sh
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/telegram-room-event-steering-gateway.e2e.test.ts --reporter=dot
```

The committed test records provider requests and lifecycle evidence under `.artifacts/qa-e2e/telegram-room-event-steering/`. It uses no live account or external-model credentials.

Telegram Test Server verification is a separate remaining step requiring access to the OpenClaw team QA broker. The isolated Gateway proof above does not claim that live transport verification.

Prepared with AI assistance; changes and test evidence reviewed.
