### PR TITLE
fix(sessions): prevent excess cleanup after disk pressure clears

### DIFF
--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -309,6 +309,10 @@ until physical usage exceeds `maxDiskBytes`; disk-budget cleanup may then delete
 the oldest cap archives after cheaper artifacts and unreferenced history are
 exhausted. Sessions without a recorded archive reason remain protected.
 
+After skipping a history generation or archived session, disk-budget cleanup
+rechecks physical usage before considering another deletion. A measurement
+failure stops the sweep.
+
 If you previously used DM isolation and later returned `session.dmScope` to
 `main`, preview stale peer-keyed DM rows with
 `openclaw sessions cleanup --dry-run --fix-dm-scope`. Applying the same flag

--- a/src/config/sessions/session-history-eviction.protected-cancellation.test.ts
+++ b/src/config/sessions/session-history-eviction.protected-cancellation.test.ts
@@ -4,7 +4,7 @@ import type { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
-import { isSessionLifecycleMutationActive } from "../../sessions/session-lifecycle-admission.js";
+import * as lifecycle from "../../sessions/session-lifecycle-admission.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -51,9 +51,18 @@ describe("protected historical session cancellation", () => {
     await testState.cleanup();
   });
 
-  it.each([false, true])(
-    "cancels newly protected history before Worker admission and refreshes released pressure (measurement fails: %s)",
-    async (measurementFails) => {
+  it.each([
+    ["planning", false],
+    ["planning", true],
+    ["materialization", false],
+    ["materialization", true],
+    ["worker", false],
+    ["worker", true],
+    ["archived entry", false],
+    ["archived entry", true],
+  ] as const)(
+    "retains history after %s cancellation releases pressure (measurement fails: %s)",
+    async (stage, measurementFails) => {
       const dayMs = 24 * 60 * 60 * 1000;
       const oldestAt = Date.now() - 8 * dayMs;
       const histories = ["protected", "next"].map((name, index) => ({
@@ -64,7 +73,7 @@ describe("protected historical session cancellation", () => {
         content: `retain ${name} history`,
       }));
       for (const history of histories) {
-        await createHistoricalTranscript(history);
+        await createCandidateTranscript(history, stage === "archived entry");
       }
       const protectedHistory = histories[0]!;
       const beforeEvents = histories.map((history) =>
@@ -85,9 +94,9 @@ describe("protected historical session cancellation", () => {
       vi.spyOn(diskBudget, "measureSessionPhysicalDiskUsage").mockImplementation(
         async (pathname) => {
           if (protectionChanged) {
-            expect(isSessionLifecycleMutationActive(storePath, [protectedHistory.sessionId])).toBe(
-              false,
-            );
+            expect(
+              lifecycle.isSessionLifecycleMutationActive(storePath, [protectedHistory.sessionId]),
+            ).toBe(false);
             if (measurementFails) {
               throw measurementFailure;
             }
@@ -95,22 +104,72 @@ describe("protected historical session cancellation", () => {
           return await measure(pathname);
         },
       );
-      const archive = await import("./session-accessor.sqlite-archive.js");
-      const materialize = archive.materializeSessionStateDeletePlans;
-      vi.spyOn(archive, "materializeSessionStateDeletePlans").mockImplementationOnce(
-        async (plans) => {
-          expect(plans.map((plan) => plan.sessionId)).toEqual([protectedHistory.sessionId]);
-          const prepared = await materialize(plans);
-          replaceSessionEntrySync(
-            { sessionKey: protectedHistory.sessionKey, storePath },
-            { sessionId: protectedHistory.nextSessionId, updatedAt: Date.now() },
-          );
-          fs.unlinkSync(peerArtifact);
-          expect((await measure(storePath)).totalBytes).toBeLessThanOrEqual(highWaterBytes);
-          protectionChanged = true;
-          return prepared;
-        },
-      );
+      const releasePressure = () => {
+        expect(protectionChanged).toBe(false);
+        replaceSessionEntrySync(
+          { sessionKey: protectedHistory.sessionKey, storePath },
+          stage === "archived entry"
+            ? {
+                sessionId: protectedHistory.sessionId,
+                updatedAt: Date.now(),
+                archivedAt: protectedHistory.updatedAt,
+                archiveReason: "active-session-cap",
+              }
+            : { sessionId: protectedHistory.nextSessionId, updatedAt: Date.now() },
+        );
+        fs.unlinkSync(peerArtifact);
+        protectionChanged = true;
+      };
+      if (stage === "planning") {
+        const mutate = lifecycle.runExclusiveSessionLifecycleMutation;
+        vi.spyOn(lifecycle, "runExclusiveSessionLifecycleMutation").mockImplementation((params) =>
+          mutate({
+            ...params,
+            run: async () => {
+              if (
+                !protectionChanged &&
+                "scope" in params &&
+                params.scope === storePath &&
+                Array.from(params.identities).includes(protectedHistory.sessionId)
+              ) {
+                releasePressure();
+              }
+              return await params.run();
+            },
+          }),
+        );
+      }
+      if (stage === "materialization") {
+        const archive = await import("./session-accessor.sqlite-archive.js");
+        const materialize = archive.materializeSessionStateDeletePlans;
+        vi.spyOn(archive, "materializeSessionStateDeletePlans").mockImplementationOnce(
+          async (plans) => {
+            expect(plans.map((plan) => plan.sessionId)).toEqual([protectedHistory.sessionId]);
+            const prepared = await materialize(plans);
+            releasePressure();
+            return prepared;
+          },
+        );
+      }
+      const reclamation = await import("./session-accessor.sqlite-reclamation.js");
+      const reclaim = reclamation.runSqliteSessionReclamation;
+      const reclaimedHistories: Array<{ sessionId: string; deleted: boolean }> = [];
+      const reclaimedEntries: Array<{ sessionKey: string; deleted: boolean }> = [];
+      vi.spyOn(reclamation, "runSqliteSessionReclamation").mockImplementation(async (params) => {
+        const result = await reclaim(params);
+        if (params.plan.kind === "history-eviction" && result.kind === "history-eviction") {
+          reclaimedHistories.push({
+            sessionId: params.plan.sessionId,
+            deleted: result.value.deleted,
+          });
+        } else if (params.plan.kind === "entry" && result.kind === "entry") {
+          reclaimedEntries.push({
+            sessionKey: params.plan.deleteParams.target.canonicalKey,
+            deleted: result.value.deleted,
+          });
+        }
+        return result;
+      });
       const admissions: Array<{ workerThreadId: number; admissionId: number | undefined }> = [];
       const detachWorkerListeners: Array<() => void> = [];
       const observeWorker = (worker: Worker) => {
@@ -119,6 +178,9 @@ describe("protected historical session cancellation", () => {
           // Archive materialization and disk scans do not request reclamation write admission.
           if (message.type === "admission-request") {
             admissions.push({ workerThreadId, admissionId: message.admissionId });
+            if ((stage === "worker" || stage === "archived entry") && !protectionChanged) {
+              releasePressure();
+            }
           }
         };
         worker.on("message", observeMessage);
@@ -135,22 +197,50 @@ describe("protected historical session cancellation", () => {
             preserveRecentMs: 7 * dayMs,
           },
         });
+        let result: Awaited<ReturnType<typeof enforceSqliteSessionHistoryDiskBudget>> | undefined;
         if (measurementFails) {
           await expect(sweep).rejects.toBe(measurementFailure);
         } else {
-          const result = await sweep;
+          result = await sweep;
+        }
+        expect(protectionChanged).toBe(true);
+        expect(fs.existsSync(peerArtifact)).toBe(false);
+        if (stage === "worker") {
+          expect(admissions.length).toBeGreaterThan(0);
+          expect(reclaimedHistories[0]).toEqual({
+            sessionId: protectedHistory.sessionId,
+            deleted: false,
+          });
+        } else if (stage === "archived entry") {
+          expect(admissions.length).toBeGreaterThan(0);
+          expect(reclaimedEntries[0]).toEqual({
+            sessionKey: protectedHistory.sessionKey,
+            deleted: false,
+          });
+        }
+        for (const [index, history] of histories.entries()) {
+          expect(sessionExists(history.sessionId), history.sessionId).toBe(true);
+          expect(loadTranscriptEventsSync({ ...history, storePath })).toEqual(beforeEvents[index]);
+          expect(readArchiveNames(history.sessionId)).toEqual([]);
+        }
+        if (stage === "worker") {
+          expect(reclaimedHistories).toEqual([
+            { sessionId: protectedHistory.sessionId, deleted: false },
+          ]);
+        } else if (stage === "archived entry") {
+          expect(reclaimedEntries).toEqual([
+            { sessionKey: protectedHistory.sessionKey, deleted: false },
+          ]);
+          expect(reclaimedHistories).toEqual([]);
+        } else {
+          expect(admissions).toEqual([]);
+          expect(reclaimedHistories).toEqual([]);
+        }
+        if (!measurementFails) {
           expect(result).toMatchObject({ removedEntries: 0, removedFiles: 0 });
           expect(result?.totalBytesAfter).toBeLessThanOrEqual(highWaterBytes);
           expect(result?.totalBytesAfter).toBe((await measure(storePath)).totalBytes);
         }
-        expect(protectionChanged).toBe(true);
-        expect(fs.existsSync(peerArtifact)).toBe(false);
-        for (const [index, history] of histories.entries()) {
-          expect(sessionExists(history.sessionId)).toBe(true);
-          expect(loadTranscriptEventsSync({ ...history, storePath })).toEqual(beforeEvents[index]);
-          expect(readArchiveNames(history.sessionId)).toEqual([]);
-        }
-        expect(admissions).toEqual([]);
       } finally {
         process.off("worker", observeWorker);
         detachWorkerListeners.forEach((detach) => detach());
@@ -158,13 +248,16 @@ describe("protected historical session cancellation", () => {
     },
   );
 
-  async function createHistoricalTranscript(params: {
-    content: string;
-    nextSessionId: string;
-    sessionId: string;
-    sessionKey: string;
-    updatedAt: number;
-  }): Promise<void> {
+  async function createCandidateTranscript(
+    params: {
+      content: string;
+      nextSessionId: string;
+      sessionId: string;
+      sessionKey: string;
+      updatedAt: number;
+    },
+    archivedEntry: boolean,
+  ): Promise<void> {
     await replaceSessionEntry(
       { sessionKey: params.sessionKey, storePath },
       { sessionId: params.sessionId, updatedAt: params.updatedAt },
@@ -173,11 +266,26 @@ describe("protected historical session cancellation", () => {
       { sessionId: params.sessionId, sessionKey: params.sessionKey, storePath },
       { message: { role: "user", content: params.content } },
     );
-    await resetSessionEntryLifecycle({
-      storePath,
-      target: { canonicalKey: params.sessionKey, storeKeys: [params.sessionKey] },
-      buildNextEntry: () => ({ sessionId: params.nextSessionId, updatedAt: params.updatedAt + 1 }),
-    });
+    if (archivedEntry) {
+      await replaceSessionEntry(
+        { sessionKey: params.sessionKey, storePath },
+        {
+          sessionId: params.sessionId,
+          updatedAt: params.updatedAt,
+          archivedAt: params.updatedAt,
+          archiveReason: "active-session-cap",
+        },
+      );
+    } else {
+      await resetSessionEntryLifecycle({
+        storePath,
+        target: { canonicalKey: params.sessionKey, storeKeys: [params.sessionKey] },
+        buildNextEntry: () => ({
+          sessionId: params.nextSessionId,
+          updatedAt: params.updatedAt + 1,
+        }),
+      });
+    }
     setSessionUpdatedAt(params.sessionId, params.updatedAt);
   }
 

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -572,7 +572,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
             diagnostics,
           );
           if (!reclamationPlan) {
-            return { kind: "protected" as const };
+            return null;
           }
           const reclaimed = await runSqliteSessionReclamation({
             diagnostics,
@@ -588,18 +588,14 @@ async function enforceSessionHistoryMaintenanceSerialized(
             return null;
           }
           return {
-            kind: "reclaimed" as const,
             archivedTranscripts: reclaimed.value.archivedTranscripts,
           };
         });
       },
     });
     if (!eviction) {
-      continue;
-    }
-    if (eviction.kind === "protected") {
-      // A peer may have freed space during materialization. Recheck after both
-      // holds release so stale pressure cannot evict another candidate.
+      // A no-op can outlive a peer freeing space. Refresh after both holds
+      // release so the next candidate cannot use stale physical pressure.
       usage = await measureSessionPhysicalDiskUsage(params.storePath);
       continue;
     }
@@ -683,6 +679,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
             ),
         });
         if (!deletion.deleted) {
+          usage = await measureSessionPhysicalDiskUsage(params.storePath);
           continue;
         }
         removedEntries += 1;


### PR DESCRIPTION
Related: #142505

## What Problem This Solves

Resolves a problem where session cleanup could delete additional history or cap-archived sessions after concurrent work had already reduced disk usage below the cleanup target. A skipped candidate could leave the sweep using an older physical-byte total for the next deletion.

## Why This Change Was Made

Remeasure physical usage after a historical planning/reclamation no-op or a declined cap-archived entry deletion, once the existing lifecycle and writer holds have returned. Historical no-op outcomes now share one path; measurement failures still stop the sweep.

## User Impact

Cleanup preserves the next eligible history or archived session when disk pressure has cleared. Configured targets, retention and protection rules, archive ordering, and worker/integrity behavior remain unchanged.

## Evidence

- Before the historical repair, four synthetic cases—planning and actual Worker no-op, each with successful or failed remeasurement—deleted the next history. The two existing materialization-cancellation controls passed. Separately, both cap-entry cases failed with the historical repair already applied and the cap-entry branch unchanged.
- The tests use real SQLite, a real physical peer file, actual reclamation Workers and durable transcript assertions. Post-dispatch cases observe an actual `deleted: false` result before verifying that the next history remains intact. Measurement-error cases verify that cleanup stops without deleting that next history.
- All 56 focused tests pass across cancellation, eviction, ownership and parity suites, including the eight no-op cases. `node scripts/check-changed.mjs` passes, and independent P0–P2 review found no actionable issues.
- Exact-head CI [34382247348](https://github.com/openclaw/openclaw/actions/runs/34382247348) is green for `b6355f4ba64e50af63a28a16650fbbe9ae431e14`.
- The real cleanup CLI proof passed all four cases on Linux through Crabbox's Blacksmith Testbox provider ([run 34387658809](https://github.com/openclaw/openclaw/actions/runs/34387658809)). The same-run build, four seed commands and four cleanup commands all exited 0 with confirmed process cleanup. Each CLI finished in 17–19 seconds within its original 180-second deadline.

```text
pnpm --silent openclaw sessions cleanup --agent main --store <isolated-store> --enforce --json
```

| Real CLI case | Actual reclamation results | Removed entries | Physical bytes after | Durable result |
| --- | --- | ---: | ---: | --- |
| History, peer frees 8 MiB | A: deleted=false | 0 | 929,792 | A and B transcript hashes unchanged |
| History, pressure remains | A: deleted=false; B: deleted=true | 1 | 9,220,096 | A preserved; B history reclaimed |
| Cap-archived entry, peer frees 8 MiB | A: deleted=false, expectedEntryMismatch=true | 0 | 929,792 | A and B transcript hashes unchanged |
| Cap-archived entry, pressure remains | A: deleted=false; B: deleted=true | 1 | 9,220,096 | A preserved; B's reported session ID and durable deletion match |

Every case began at 9,318,400 physical bytes, with a 3,026,944-byte cleanup target. Relieved-pressure cases observed a fresh real measurement after the declined reclamation Worker exited. Controls kept the peer file and still reclaimed the next eligible candidate. The native artifact export preserved the raw CLI output, Worker results, before/after snapshots and cleanup receipts; all 80 manifest entries were hash-verified.

The first proof attempt produced the expected cleanup JSON but timed out. Investigation reproduced a harness liveness defect: its observer could keep an otherwise idle Worker referenced. A standalone old/new preload control confirmed that mechanism. The corrected observer only attaches where an owner already has a message listener; the fresh four-case run then passed without extending deadlines or changing production code. The failed attempt remains recorded as failed.

This is synthetic controlled-interleaving CLI evidence. It does not attribute a live incident, change retention or integrity policy, or demonstrate Worker-pool performance. `CHANGELOG.md` remains release-owned.
