### PR TITLE
docs: refresh CI and plugin validation guidance

### DIFF
--- a/.agents/skills/openclaw-ci-limits/SKILL.md
+++ b/.agents/skills/openclaw-ci-limits/SKILL.md
@@ -56,10 +56,10 @@ availability, Blacksmith control-plane health, and downstream queue drains.
 Before changing CI, collect current pressure:
 
 ```bash
-ghx api rate_limit --jq '{core:.resources.core,graphql:.resources.graphql,search:.resources.search,actions_runner_registration:.resources.actions_runner_registration}'
-ghx run list -R openclaw/openclaw --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
-ghx run list -R openclaw/clawsweeper --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
-ghx api repos/openclaw/clawsweeper/actions/runs/<run-id>/jobs --paginate --jq '.jobs[] | {id,name,status,conclusion,labels,created_at,started_at,completed_at,runner_name,runner_group_name}'
+gh api rate_limit --jq '{core:.resources.core,graphql:.resources.graphql,search:.resources.search,actions_runner_registration:.resources.actions_runner_registration}'
+gh run list -R openclaw/openclaw --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
+gh run list -R openclaw/clawsweeper --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
+gh api repos/openclaw/clawsweeper/actions/runs/<run-id>/jobs --paginate --jq '.jobs[] | {id,name,status,conclusion,labels,created_at,started_at,completed_at,runner_name,runner_group_name}'
 blacksmith testbox list --all
 curl -fsS https://clawsweeper.openclaw.ai/api/status | jq '{generated_at,fleet,diagnostics:{errors:.diagnostics.errors}}'
 curl -fsS https://clawsweeper.openclaw.ai/api/exact-review-queue | jq '{generated_at,review:.lanes.review,publication:.lanes.publication,state_writer,state_append}'
@@ -380,11 +380,12 @@ git diff --check
 If `pnpm docs:list` tries to reconcile dependencies in a linked Codex worktree,
 stop and use `node scripts/docs-list.js`.
 
-For a PR before requesting maintainer approval:
+For a PR before requesting maintainer approval, bind the watcher to the PR's
+full 40-character head SHA:
 
 ```bash
 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
-ghx pr checks <pr> -R openclaw/openclaw --watch --interval 15
+node scripts/watch-pr-ci.mjs <pr> <head-sha> --repo openclaw/openclaw
 ```
 
 Use hosted exact-head gates for CI workflow tuning. Do not burn local
@@ -409,9 +410,9 @@ land the PR. Both commands mutate GitHub state.
 After merge, watch at least one fresh main cycle and the adjacent repos:
 
 ```bash
-ghx run list -R openclaw/openclaw --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
+gh run list -R openclaw/openclaw --limit 20 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
 for repo in openclaw/clawsweeper openclaw/clawhub openclaw/clownfish openclaw/openclaw-rtt openclaw/clawbench; do
-  ghx run list -R "$repo" --limit 12 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
+  gh run list -R "$repo" --limit 12 --json databaseId,status,conclusion,workflowName,event,headBranch,createdAt,updatedAt,url
 done
 curl -fsS https://clawsweeper.openclaw.ai/api/exact-review-queue | jq '.'
 ```

--- a/.agents/skills/release-openclaw-plugin-testing/SKILL.md
+++ b/.agents/skills/release-openclaw-plugin-testing/SKILL.md
@@ -30,15 +30,11 @@ From the OpenClaw repo root:
 ```bash
 pnpm docs:list
 git status --short --branch
-readlink node_modules
 pnpm changed:lanes --json
 ```
 
-In Codex worktrees under `.codex/worktrees`, `node_modules` must be a symlink to
-the main OpenClaw checkout. Do not run `pnpm install` there. For broad or
-package-heavy proof, use a prepared normal checkout on the current dedicated
-Linux worker, Blacksmith Testbox, or GitHub Actions according to the required
-artifact and capability boundary.
+Follow [`openclaw-testing`](../openclaw-testing/SKILL.md) for dependency
+ownership and the choice of local or remote proof.
 
 ## Runner Choice
 
@@ -68,7 +64,6 @@ pnpm run test:extensions:package-boundary:compile
 pnpm test:docker:plugins
 OPENCLAW_PLUGINS_E2E_CLAWHUB=0 pnpm test:docker:plugins
 pnpm test:docker:plugin-update
-pnpm test:docker:bundled-channel-deps:fast
 ```
 
 For full bundled install/uninstall proof, shard the packaged sweep:
@@ -79,7 +74,7 @@ OPENCLAW_BUNDLED_PLUGIN_SWEEP_INDEX=<0-7> \
 pnpm test:docker:bundled-plugin-install-uninstall
 ```
 
-Expected current packaged scope: 116 public bundled plugins over shards `0-7`.
+This example partitions the selected package's plugin inventory over shards `0-7`.
 Private QA plugins are source-mode only unless a package explicitly includes
 them.
 
@@ -88,18 +83,17 @@ them.
 Use this matrix for pre-release signoff. Record pass/fail, run URL/Testbox ID,
 package SHA/version, and skipped-live reason.
 
-| Surface              | Proof                                                           | Preferred runner                     |
-| -------------------- | --------------------------------------------------------------- | ------------------------------------ |
-| Package artifact     | Package Acceptance `suite_profile=package` or custom lanes      | GitHub Actions                       |
-| Bundled lifecycle    | 8-shard `test:docker:bundled-plugin-install-uninstall`          | Testbox or release Docker            |
-| External plugins     | `test:docker:plugins` and `plugins-offline`                     | Testbox/package acceptance           |
-| Update no-op         | `test:docker:plugin-update`                                     | Testbox/package acceptance           |
-| Channel runtime deps | `test:docker:bundled-channel-deps:fast` plus key channels       | Testbox/package acceptance           |
-| Doctor/fix           | seeded bad configs + `doctor --fix --non-interactive`           | new Docker/Testbox harness           |
-| Config round-trip    | `config set/get`, inspect, doctor, reload, diff hash            | new Docker/Testbox harness           |
-| Gateway bootstrap    | clean `HOME`, plugin groups enabled/disabled, status JSON       | new Docker/Testbox harness           |
-| SDK compatibility    | directory, tgz, and `file:` external plugins using SDK subpaths | `test:docker:plugins` plus new smoke |
-| Live-ish             | redacted provider/channel probes only for present env           | Testbox live lanes                   |
+| Surface           | Proof                                                           | Preferred runner                     |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------ |
+| Package artifact  | Package Acceptance `suite_profile=package` or custom lanes      | GitHub Actions                       |
+| Bundled lifecycle | Sharded `test:docker:bundled-plugin-install-uninstall`          | Testbox or release Docker            |
+| External plugins  | `test:docker:plugins` and `plugins-offline`                     | Testbox/package acceptance           |
+| Update no-op      | `test:docker:plugin-update`                                     | Testbox/package acceptance           |
+| Doctor/fix        | seeded bad configs + `doctor --fix --non-interactive`           | new Docker/Testbox harness           |
+| Config round-trip | `config set/get`, inspect, doctor, reload, diff hash            | new Docker/Testbox harness           |
+| Gateway bootstrap | clean `HOME`, plugin groups enabled/disabled, status JSON       | new Docker/Testbox harness           |
+| SDK compatibility | directory, tgz, and `file:` external plugins using SDK subpaths | `test:docker:plugins` plus new smoke |
+| Live-ish          | redacted provider/channel probes only for present env           | Testbox live lanes                   |
 
 ## Package Acceptance Plan
 
@@ -113,7 +107,7 @@ gh workflow run package-acceptance.yml \
   -f source=ref \
   -f package_ref=<branch-or-sha> \
   -f suite_profile=custom \
-  -f docker_lanes='plugins-offline plugin-update bundled-channel-deps-compat doctor-switch update-channel-switch config-reload mcp-channels npm-onboard-channel-agent' \
+  -f docker_lanes='plugins-offline plugin-update doctor-switch update-channel-switch config-reload mcp-channels npm-onboard-channel-agent' \
   -f telegram_mode=mock-openai
 ```
 
@@ -146,7 +140,7 @@ environment, secret, OIDC, npm mutation, or ClawHub mutation path:
 
 ```bash
 release_sha="$(git rev-parse origin/release/2026.7.1)"
-ghx workflow run plugin-npm-release.yml \
+gh workflow run plugin-npm-release.yml \
   --repo openclaw/openclaw \
   --ref main \
   -f preflight_only=true \
@@ -161,13 +155,15 @@ Do not pass `release_publish_run_id`. Require the workflow to finish
 and source SHA. The workflow first creates the staging/readback artifact
 `plugin-npm-package-source-<source-sha>-<extension-id>` containing
 `npm-pack.json`, `preflight-manifest.json`, and the tarball. It then uploads the
-final consumer artifact `plugin-npm-package-<extension-id>-<version>` containing
-the tarball and `plugin-npm-package-evidence.json`.
+final consumer artifact
+`plugin-npm-package-<extension-id>-<version>-<route>-<run-id>-<attempt>` containing
+the tarball and `plugin-publication-manifest.json`.
 
-Record the final artifact name and digest separately. In the v2 evidence,
-`publicationArtifact` binds the staging artifact id, name, digest, source and
-packed `package.json` hashes, and tarball hash. This proof is validation-only;
-it does not authorize or stage publication. For an already-published version,
+Record the final artifact name and digest separately. The manifest uses
+`openclaw.plugin-publication-artifact/v1` and records the target SHA, package
+manifest hashes, publication route and policy, and tarball hashes and inventory.
+This proof is validation-only; it does not authorize or stage publication.
+For an already-published version,
 require npm `dist.integrity` and `dist.shasum` to match the verified tarball.
 Treat only missing or provably older dist-tags as repairable; newer or
 incomparable selectors are a blocker.
@@ -186,8 +182,10 @@ that uses one package tarball and sharded plugin lists. Per plugin:
 7. `plugins registry --refresh`.
 8. `doctor --non-interactive`.
 9. `plugins uninstall <id> --force`.
-10. Assert no config entry, allow/deny residue, install record, managed dir, or
-    bundled `dist/extensions/...` load path remains.
+10. Assert the plugin's `plugins.entries` value is exactly `{ enabled: false }`,
+    while its allow/deny entries, install record, managed directory, and bundled
+    runtime load paths are gone. Use the existing harness's source-qualified
+    uninstall expectations for historical targets.
 11. Assert diagnostics contain no `level: "error"` and output redacts
     secret-looking values.
 

--- a/docs/ci/capacity.md
+++ b/docs/ci/capacity.md
@@ -9,7 +9,7 @@ read_when:
 ## Runner registration budget
 
 OpenClaw's current GitHub runner-registration bucket reports 10,000 self-hosted
-runner registrations per 5 minutes in `ghx api rate_limit`. Re-check
+runner registrations per 5 minutes in `gh api rate_limit`. Re-check
 `actions_runner_registration` before each tuning pass because GitHub can change
 this bucket. The limit is shared by all Blacksmith runner registrations in the
 `openclaw` organization, so adding another Blacksmith installation does not add


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CI and plugin-validation guides contained obsolete commands and expectations. The plugin guide selected a retired Docker lane, named an outdated artifact format, and expected uninstall to remove the explicit disabled marker that current packages retain.

## Why This Change Was Made

Use supported `gh` commands and the maintained exact-head watcher, and delegate dependency ownership to the testing guide. Remove retired checks, describe the current package inventory and publication manifest, and align uninstall expectations with the existing production and harness owners.

## User Impact

Operators get executable validation instructions and accurate artifact and cleanup expectations. Existing CI capacity settings, historical-target qualification and release approval boundaries are preserved.

## Evidence

- The real Docker planner accepts all seven documented custom lanes and rejects the retired compatibility lane. No workflow or Docker run was dispatched.
- Checked CLI flags, workflow artifact names, manifest schema and uninstall state directly against their owners; the explicit eight-way manual partition remains supported.
- Formatting, docs listing, link resolution and `git diff --check` passed.
- Independent P2 reviews of the original command repair and the plugin-guide increment found no actionable issues.
- [CI for the expanded three-file head](https://github.com/openclaw/openclaw/actions/runs/34385348387) passed on its first attempt.
