### PR TITLE
fix(voice-call): stream consult results before completion

### DIFF
--- a/extensions/openai/realtime-voice-bridge.ts
+++ b/extensions/openai/realtime-voice-bridge.ts
@@ -128,7 +128,7 @@ export class OpenAIRealtimeBridge extends OpenAIRealtimeEvents implements Realti
     if (this.pendingToolCallIds.size > 0) {
       // Control/status speech must not wait behind the long-running consult whose
       // function output owns the default conversation response.
-      this.standaloneSpeechQueue.push(text);
+      this.standaloneSpeechQueue.push({ text });
       this.flushStandaloneSpeech();
       return;
     }

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -53,6 +53,7 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
       try {
         emitServerEvent();
       } finally {
+        this.settleStandaloneSpeech(new Error("OpenAI realtime out-of-band speech cancelled"));
         this.releaseResponseState();
       }
       return;
@@ -338,6 +339,17 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
       }
     };
     try {
+      if (this.standaloneSpeechActive) {
+        this.settleStandaloneSpeech(
+          outcome.status === "completed"
+            ? undefined
+            : new Error(
+                outcome.status === "cancelled"
+                  ? "OpenAI realtime out-of-band speech cancelled"
+                  : outcome.message,
+              ),
+        );
+      }
       // Terminal output still belongs to this response until observers retire its owner.
       invoke(() => {
         providerTerminated = this.handleCompletedResponse(event, connection);

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -266,14 +266,15 @@ export abstract class OpenAIRealtimeProtocol {
   }
 
   handleBargeIn(options?: RealtimeVoiceBargeInOptions): void {
-    this.clearPendingSpeech();
     // Wire observers can synchronously reenter while the sink still owns its snapshot.
     if (this.interruptingPlayback) {
       return;
     }
     this.interruptingPlayback = true;
     try {
-      this.interruptPlayback(options);
+      if (this.interruptPlayback(options)) {
+        this.clearPendingSpeech();
+      }
     } finally {
       this.interruptingPlayback = false;
     }
@@ -312,7 +313,7 @@ export abstract class OpenAIRealtimeProtocol {
     }
   }
 
-  private interruptPlayback(options?: RealtimeVoiceBargeInOptions): void {
+  private interruptPlayback(options?: RealtimeVoiceBargeInOptions): boolean {
     const assistantAudioItem = this.assistantAudioItem;
     const force = options?.force === true;
     const shouldInterruptProvider =
@@ -349,7 +350,7 @@ export abstract class OpenAIRealtimeProtocol {
         type: "conversation.item.truncate.skipped",
         detail: `reason=barge-in audioEndMs=${audioEndMs} minAudioEndMs=${minBargeInAudioEndMs}`,
       });
-      return;
+      return false;
     }
     // VAD suppression can notify observers before create is sent. Retire that
     // local reservation without awaiting a native terminal that cannot arrive.
@@ -385,6 +386,7 @@ export abstract class OpenAIRealtimeProtocol {
     }
     // The sink can request replacement generation when cleared; trim its history first.
     this.config.onClearAudio("barge-in");
+    return true;
   }
 
   protected requestResponseCreate(options?: OpenAIRealtimeUserMessageOptions): void {

--- a/extensions/openai/realtime-voice-protocol.ts
+++ b/extensions/openai/realtime-voice-protocol.ts
@@ -25,6 +25,12 @@ import {
   type RealtimeTurnDetectionConfig,
 } from "./realtime-voice-session-policy.js";
 
+type StandaloneSpeechRequest = {
+  text: string;
+  resolve?: () => void;
+  reject?: (error: Error) => void;
+};
+
 export abstract class OpenAIRealtimeProtocol {
   static readonly MAX_TOOL_ARGUMENT_BYTES = 256_000;
 
@@ -35,6 +41,8 @@ export abstract class OpenAIRealtimeProtocol {
   readonly supportsToolResultContinuation = true;
 
   readonly supportsToolResultSuppression = true;
+
+  readonly supportsOutOfBandSpeech = true;
 
   protected nextMarkSequence = 1;
 
@@ -74,11 +82,13 @@ export abstract class OpenAIRealtimeProtocol {
 
   protected completedToolCallIds = new Set<string>();
 
-  protected standaloneSpeechQueue: string[] = [];
+  protected standaloneSpeechQueue: StandaloneSpeechRequest[] = [];
 
   protected standaloneSpeechActive = false;
 
   protected standaloneSpeechEventId: string | null = null;
+
+  protected standaloneSpeechRequest: StandaloneSpeechRequest | null = null;
 
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
@@ -256,6 +266,7 @@ export abstract class OpenAIRealtimeProtocol {
   }
 
   handleBargeIn(options?: RealtimeVoiceBargeInOptions): void {
+    this.clearPendingSpeech();
     // Wire observers can synchronously reenter while the sink still owns its snapshot.
     if (this.interruptingPlayback) {
       return;
@@ -267,6 +278,38 @@ export abstract class OpenAIRealtimeProtocol {
       this.interruptingPlayback = false;
     }
     this.drainResponseQueue();
+  }
+
+  speakOutOfBand(text: string): Promise<void> {
+    if (this.pendingToolCallIds.size === 0) {
+      return Promise.reject(
+        new Error("OpenAI realtime out-of-band speech requires a pending tool call"),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.standaloneSpeechQueue.push({ text, resolve, reject });
+      this.flushStandaloneSpeech();
+    });
+  }
+
+  clearPendingSpeech(): void {
+    const error = new Error("OpenAI realtime out-of-band speech cancelled");
+    for (const request of this.standaloneSpeechQueue) {
+      request.reject?.(error);
+    }
+    this.standaloneSpeechQueue = [];
+    this.standaloneSpeechRequest?.reject?.(error);
+    this.standaloneSpeechRequest = null;
+  }
+
+  protected settleStandaloneSpeech(error?: Error): void {
+    const request = this.standaloneSpeechRequest;
+    this.standaloneSpeechRequest = null;
+    if (error) {
+      request?.reject?.(error);
+    } else {
+      request?.resolve?.();
+    }
   }
 
   private interruptPlayback(options?: RealtimeVoiceBargeInOptions): void {
@@ -386,13 +429,14 @@ export abstract class OpenAIRealtimeProtocol {
     ) {
       return;
     }
-    const text = this.standaloneSpeechQueue.shift();
-    if (!text) {
+    const request = this.standaloneSpeechQueue.shift();
+    if (!request) {
       return;
     }
     const eventId = `openclaw-standalone-speech-${randomUUID()}`;
     this.standaloneSpeechActive = true;
     this.standaloneSpeechEventId = eventId;
+    this.standaloneSpeechRequest = request;
     this.responseCreateState = "in-flight";
     this.sendEvent({
       type: "response.create",
@@ -404,7 +448,7 @@ export abstract class OpenAIRealtimeProtocol {
           {
             type: "message",
             role: "user",
-            content: [{ type: "input_text", text }],
+            content: [{ type: "input_text", text: request.text }],
           },
         ],
       },
@@ -438,6 +482,7 @@ export abstract class OpenAIRealtimeProtocol {
   }
 
   protected resetRealtimeSessionState(): void {
+    this.clearPendingSpeech();
     this.outputAudioGeneration += 1;
     this.clearOutstandingMarks();
     this.assistantAudioItem = null;
@@ -454,6 +499,7 @@ export abstract class OpenAIRealtimeProtocol {
     this.standaloneSpeechQueue = [];
     this.standaloneSpeechActive = false;
     this.standaloneSpeechEventId = null;
+    this.standaloneSpeechRequest = null;
   }
 
   protected createPlaybackMark(): string {

--- a/extensions/openai/realtime-voice-response-control.test.ts
+++ b/extensions/openai/realtime-voice-response-control.test.ts
@@ -445,6 +445,29 @@ describe("OpenAI realtime voice response control", () => {
     }
   });
 
+  it("backpressures awaited out-of-band speech until each response completes", async () => {
+    const bridge = createNativeBridge({ onToolCall: vi.fn() });
+    const socket = await connectReadyBridge(bridge);
+    emitCompletedToolCalls(socket);
+
+    const first = bridge.speakOutOfBand?.("first");
+    const second = bridge.speakOutOfBand?.("second");
+    expect(first).toBeInstanceOf(Promise);
+    expect(second).toBeInstanceOf(Promise);
+    expect(parseSent(socket).filter((event) => event.type === "response.create")).toHaveLength(1);
+
+    emitServerEvent(socket, {
+      type: "response.done",
+      response: { id: "resp_first", status: "completed", output: [] },
+    });
+    await expect(first).resolves.toBeUndefined();
+    expect(parseSent(socket).filter((event) => event.type === "response.create")).toHaveLength(2);
+
+    bridge.handleBargeIn?.({ audioPlaybackActive: true, force: true });
+    await expect(second).rejects.toThrow("cancelled");
+    expect(parseSent(socket).filter((event) => event.type === "response.cancel")).toHaveLength(1);
+  });
+
   it("drains deferred response.create after response.cancelled", async () => {
     const bridge = createNativeBridge();
     const socket = await connectReadyBridge(bridge);

--- a/extensions/openai/realtime-voice-response-control.test.ts
+++ b/extensions/openai/realtime-voice-response-control.test.ts
@@ -468,6 +468,36 @@ describe("OpenAI realtime voice response control", () => {
     expect(parseSent(socket).filter((event) => event.type === "response.cancel")).toHaveLength(1);
   });
 
+  it("keeps out-of-band speech active when short-prefix barge-in is skipped", async () => {
+    const bridge = createNativeBridge({ onToolCall: vi.fn() });
+    const socket = await connectReadyBridge(bridge);
+    emitCompletedToolCalls(socket);
+
+    const speech = bridge.speakOutOfBand?.("keep speaking");
+    let speechSettled = false;
+    void speech?.then(
+      () => {
+        speechSettled = true;
+      },
+      () => {
+        speechSettled = true;
+      },
+    );
+    bridge.setMediaTimestamp(1_000);
+    emitAssistantPlayback(socket);
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    await Promise.resolve();
+
+    expect(speechSettled).toBe(false);
+    expect(parseSent(socket).filter((event) => event.type === "response.cancel")).toHaveLength(0);
+
+    emitServerEvent(socket, {
+      type: "response.done",
+      response: { id: "resp_1", status: "completed", output: [] },
+    });
+    await expect(speech).resolves.toBeUndefined();
+  });
+
   it("drains deferred response.create after response.cancelled", async () => {
     const bridge = createNativeBridge();
     const socket = await connectReadyBridge(bridge);

--- a/extensions/voice-call/src/realtime-consult-speech-stream.test.ts
+++ b/extensions/voice-call/src/realtime-consult-speech-stream.test.ts
@@ -1,0 +1,139 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createRealtimeConsultSpeechStream } from "./realtime-consult-speech-stream.js";
+
+describe("createRealtimeConsultSpeechStream", () => {
+  it("deduplicates cumulative snapshots and true deltas before the final result", async () => {
+    const deliver = vi.fn(async (_text: string) => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    await stream.push({ runId: "run-1", text: "First segment.", delta: "First segment." });
+    await stream.push({ runId: "run-1", text: "First segment." });
+    await stream.push({ runId: "run-1", text: " Second segment.", delta: " Second segment." });
+
+    await expect(stream.finish("First segment. Second segment.")).resolves.toEqual({
+      suppressResponse: true,
+    });
+    expect(deliver.mock.calls.map(([text]) => text)).toEqual(["First segment.", "Second segment."]);
+  });
+
+  it("waits for each speech delivery before accepting the next partial", async () => {
+    const firstDelivery = createDeferred<void>();
+    const deliveries: string[] = [];
+    const deliver = vi.fn(async (text: string) => {
+      deliveries.push(text);
+      if (text === "First segment.") {
+        await firstDelivery.promise;
+      }
+    });
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    const firstPush = stream.push({ runId: "run-1", text: "First segment." });
+    await vi.waitFor(() => expect(deliveries).toEqual(["First segment."]));
+    const secondPush = stream.push({
+      runId: "run-1",
+      text: "First segment. Second segment.",
+    });
+    await Promise.resolve();
+    expect(deliveries).toEqual(["First segment."]);
+
+    firstDelivery.resolve();
+    await Promise.all([firstPush, secondPush]);
+    expect(deliveries).toEqual(["First segment.", "Second segment."]);
+  });
+
+  it("drops queued and late output immediately after cancellation", async () => {
+    const activeDelivery = createDeferred<void>();
+    const deliver = vi.fn(async () => await activeDelivery.promise);
+    const onCancel = vi.fn(() => activeDelivery.reject(new Error("cancelled")));
+    const stream = createRealtimeConsultSpeechStream({ deliver, onCancel });
+    stream.start("run-current");
+
+    const active = stream.push({ runId: "run-current", text: "Already active." });
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+    const queued = stream.push({ runId: "run-current", text: "Already active. Never speak." });
+    stream.cancel();
+
+    await expect(active).resolves.toBeUndefined();
+    await expect(queued).resolves.toBeUndefined();
+    await expect(stream.finish("Late final.")).resolves.toEqual({ suppressResponse: false });
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a retired run after a replacement starts", async () => {
+    const deliver = vi.fn(async (_text: string) => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-new");
+
+    await stream.push({ runId: "run-old", text: "Stale output." });
+    await stream.push({ runId: "run-new", text: "Current output." });
+    await expect(stream.finish("Current output.")).resolves.toEqual({ suppressResponse: true });
+
+    expect(deliver.mock.calls.map(([text]) => text)).toEqual(["Current output."]);
+  });
+
+  it("preserves the completed-result path when no partial was spoken", async () => {
+    const deliver = vi.fn(async () => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    await stream.push({ runId: "run-1", text: "Still incomplete" });
+
+    await expect(stream.finish("Still incomplete but now final.")).resolves.toEqual({
+      suppressResponse: false,
+    });
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("does not repeat a streamed sentence when its partial has trailing whitespace", async () => {
+    const deliver = vi.fn(async (_text: string) => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    await stream.push({ runId: "run-1", text: "First segment. " });
+
+    await expect(stream.finish("First segment.")).resolves.toEqual({ suppressResponse: true });
+    expect(deliver.mock.calls.map(([text]) => text)).toEqual(["First segment."]);
+  });
+
+  it("falls back to the completed result when streaming delivery fails", async () => {
+    const onCancel = vi.fn();
+    const stream = createRealtimeConsultSpeechStream({
+      deliver: async () => {
+        throw new Error("provider disconnected");
+      },
+      onCancel,
+    });
+    stream.start("run-1");
+
+    await expect(stream.push({ runId: "run-1", text: "Partial result." })).rejects.toThrow(
+      "provider disconnected",
+    );
+    await expect(stream.finish("Partial result. Final detail.")).resolves.toEqual({
+      suppressResponse: false,
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to only the unspoken suffix after a later delivery fails", async () => {
+    const deliver = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error("provider disconnected"));
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    await stream.push({ runId: "run-1", text: "First segment." });
+    await expect(
+      stream.push({ runId: "run-1", text: "First segment. Second segment." }),
+    ).rejects.toThrow("provider disconnected");
+
+    await expect(stream.finish("First segment. Second segment.")).resolves.toEqual({
+      suppressResponse: false,
+      fallbackText: "Second segment.",
+    });
+  });
+});

--- a/extensions/voice-call/src/realtime-consult-speech-stream.test.ts
+++ b/extensions/voice-call/src/realtime-consult-speech-stream.test.ts
@@ -99,6 +99,34 @@ describe("createRealtimeConsultSpeechStream", () => {
     expect(deliver.mock.calls.map(([text]) => text)).toEqual(["First segment."]);
   });
 
+  it("advances across paragraph boundaries while preserving delivery order", async () => {
+    const deliver = vi.fn(async (_text: string) => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    const text = "First paragraph\n\nSecond paragraph.";
+    await stream.push({ runId: "run-1", text });
+
+    await expect(stream.finish(text)).resolves.toEqual({ suppressResponse: true });
+    expect(deliver.mock.calls.map(([spoken]) => spoken)).toEqual([
+      "First paragraph",
+      "Second paragraph.",
+    ]);
+  });
+
+  it("does not repeat a streamed paragraph when the final trims its delimiter", async () => {
+    const deliver = vi.fn(async (_text: string) => {});
+    const stream = createRealtimeConsultSpeechStream({ deliver });
+    stream.start("run-1");
+
+    await stream.push({ runId: "run-1", text: "First paragraph\n\n" });
+
+    await expect(stream.finish("First paragraph\n\n")).resolves.toEqual({
+      suppressResponse: true,
+    });
+    expect(deliver.mock.calls.map(([spoken]) => spoken)).toEqual(["First paragraph"]);
+  });
+
   it("falls back to the completed result when streaming delivery fails", async () => {
     const onCancel = vi.fn();
     const stream = createRealtimeConsultSpeechStream({

--- a/extensions/voice-call/src/realtime-consult-speech-stream.ts
+++ b/extensions/voice-call/src/realtime-consult-speech-stream.ts
@@ -123,8 +123,9 @@ export function createRealtimeConsultSpeechStream(params: {
       }
       try {
         const final = finalText.trim();
-        if (final.startsWith(committedText)) {
-          await deliver(final.slice(committedText.length));
+        const spoken = committedText.trim();
+        if (final.startsWith(spoken)) {
+          await deliver(final.slice(spoken.length));
         } else if (delivered && final) {
           await deliver(`Correction: ${final}`);
         }
@@ -172,7 +173,7 @@ function findStableSpeechBoundary(text: string, start: number): number | undefin
   for (let index = start; index < text.length; index += 1) {
     const character = text[index];
     if (character === "\n" && text[index + 1] === "\n") {
-      return index;
+      return index + 2;
     }
     if (
       (character === "." || character === "!" || character === "?") &&
@@ -195,8 +196,9 @@ function truncateUtf16Safe(value: string, maxChars: number): string {
 
 function readUnspokenSuffix(spoken: string, finalText: string): string {
   const final = finalText.trim();
-  if (final.startsWith(spoken)) {
-    const suffix = final.slice(spoken.length).trim();
+  const normalizedSpoken = spoken.trim();
+  if (final.startsWith(normalizedSpoken)) {
+    const suffix = final.slice(normalizedSpoken.length).trim();
     if (suffix) {
       return suffix;
     }

--- a/extensions/voice-call/src/realtime-consult-speech-stream.ts
+++ b/extensions/voice-call/src/realtime-consult-speech-stream.ts
@@ -1,0 +1,205 @@
+type RealtimeConsultVisiblePartial = {
+  runId: string;
+  text: string;
+  delta?: string;
+  replace?: true;
+};
+
+export type RealtimeConsultSpeechStream = {
+  cancel(): void;
+  finish(finalText: string): Promise<{
+    suppressResponse: boolean;
+    fallbackText?: string;
+  }>;
+  push(partial: RealtimeConsultVisiblePartial): Promise<void>;
+  start(runId: string): void;
+};
+
+/**
+ * Turns cumulative or append-only visible-answer updates into ordered sentence speech.
+ * One instance belongs to one bridge generation and accepts exactly one agent run.
+ */
+export function createRealtimeConsultSpeechStream(params: {
+  deliver: (text: string) => Promise<void> | void;
+  maxChars?: number;
+  onCancel?: () => void;
+}): RealtimeConsultSpeechStream {
+  let activeRunId: string | undefined;
+  let currentText = "";
+  let committedText = "";
+  let delivered = false;
+  let cancelled = false;
+  let failed = false;
+  let cancellationNotified = false;
+  let deliveryTail = Promise.resolve();
+
+  const notifyCancellation = () => {
+    if (!cancellationNotified) {
+      cancellationNotified = true;
+      params.onCancel?.();
+    }
+  };
+
+  const deliver = async (text: string) => {
+    const speakable = text.trim();
+    if (!speakable || cancelled || failed) {
+      return;
+    }
+    await params.deliver(speakable);
+    if (!cancelled && !failed) {
+      delivered = true;
+    }
+  };
+
+  const flushStableText = async () => {
+    if (!currentText.startsWith(committedText)) {
+      return;
+    }
+    let cursor = committedText.length;
+    while (cursor < currentText.length) {
+      if (cancelled || failed) {
+        return;
+      }
+      const boundary = findStableSpeechBoundary(currentText, cursor);
+      if (boundary === undefined) {
+        return;
+      }
+      await deliver(currentText.slice(cursor, boundary));
+      cursor = boundary;
+      committedText = currentText.slice(0, cursor);
+    }
+  };
+
+  const enqueue = (task: () => Promise<void>): Promise<void> => {
+    const queued = deliveryTail.then(async () => {
+      if (!cancelled && !failed) {
+        await task();
+      }
+    });
+    deliveryTail = queued.catch(() => {});
+    return queued.catch((error: unknown) => {
+      if (cancelled) {
+        return;
+      }
+      failed = true;
+      notifyCancellation();
+      throw error;
+    });
+  };
+
+  return {
+    start(runId) {
+      if (!cancelled && !failed && !activeRunId) {
+        activeRunId = runId;
+      }
+    },
+    push(partial) {
+      return enqueue(async () => {
+        if (!activeRunId || partial.runId !== activeRunId) {
+          return;
+        }
+        currentText = truncateUtf16Safe(
+          mergePartialText(currentText, partial),
+          params.maxChars ?? 1_800,
+        );
+        await flushStableText();
+      });
+    },
+    async finish(finalText) {
+      await deliveryTail;
+      if (cancelled) {
+        return { suppressResponse: false };
+      }
+      if (failed) {
+        const fallbackText = delivered ? readUnspokenSuffix(committedText, finalText) : undefined;
+        return {
+          suppressResponse: false,
+          ...(fallbackText ? { fallbackText } : {}),
+        };
+      }
+      if (!delivered) {
+        cancelled = true;
+        return { suppressResponse: false };
+      }
+      try {
+        const final = finalText.trim();
+        if (final.startsWith(committedText)) {
+          await deliver(final.slice(committedText.length));
+        } else if (delivered && final) {
+          await deliver(`Correction: ${final}`);
+        }
+      } catch {
+        failed = true;
+        notifyCancellation();
+        return {
+          suppressResponse: false,
+          ...(delivered ? { fallbackText: readUnspokenSuffix(committedText, finalText) } : {}),
+        };
+      }
+      cancelled = true;
+      return { suppressResponse: delivered };
+    },
+    cancel() {
+      if (cancelled || failed) {
+        return;
+      }
+      cancelled = true;
+      notifyCancellation();
+    },
+  };
+}
+
+function mergePartialText(current: string, partial: RealtimeConsultVisiblePartial): string {
+  if (partial.replace) {
+    return partial.text;
+  }
+  if (partial.delta !== undefined) {
+    if (!current || partial.text.startsWith(current)) {
+      return partial.text;
+    }
+    return `${current}${partial.delta}`;
+  }
+  if (!current || partial.text.startsWith(current)) {
+    return partial.text;
+  }
+  if (current.startsWith(partial.text)) {
+    return current;
+  }
+  return `${current}${partial.text}`;
+}
+
+function findStableSpeechBoundary(text: string, start: number): number | undefined {
+  for (let index = start; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === "\n" && text[index + 1] === "\n") {
+      return index;
+    }
+    if (
+      (character === "." || character === "!" || character === "?") &&
+      (index === text.length - 1 || /\s/.test(text[index + 1]!))
+    ) {
+      return index + 1;
+    }
+  }
+  return undefined;
+}
+
+function truncateUtf16Safe(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  const sliced = value.slice(0, maxChars);
+  const last = sliced.charCodeAt(sliced.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+
+function readUnspokenSuffix(spoken: string, finalText: string): string {
+  const final = finalText.trim();
+  if (final.startsWith(spoken)) {
+    const suffix = final.slice(spoken.length).trim();
+    if (suffix) {
+      return suffix;
+    }
+  }
+  return "I lost the rest of that live update before it finished.";
+}

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -4,6 +4,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VoiceCallConfig } from "./config.js";
 import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+import type { ToolHandlerContext } from "./webhook/realtime-handler.js";
 
 const mocks = vi.hoisted(() => ({
   resolveVoiceCallConfig: vi.fn(),
@@ -157,7 +158,7 @@ function createExternalProviderConfig(params: {
 type RealtimeConsultToolHandler = (
   args: unknown,
   callId: string,
-  context: { partialUserTranscript?: string; abortSignal?: AbortSignal },
+  context: ToolHandlerContext,
 ) => Promise<unknown>;
 
 function firstMockCall(calls: readonly unknown[][], label: string): unknown[] {
@@ -620,10 +621,20 @@ describe("createVoiceCallRuntime lifecycle", () => {
       },
     ];
     const sessionStore: Record<string, unknown> = {};
-    const runEmbeddedAgent = vi.fn(async () => ({
-      payloads: [{ text: "Use the shipment status." }],
-      meta: {},
-    }));
+    const runEmbeddedAgent = vi.fn(
+      async (params?: {
+        onPartialReply?: (payload: { text: string; delta: string }) => Promise<void> | void;
+      }) => {
+        await params?.onPartialReply?.({
+          text: "Checking shipment status.",
+          delta: "Checking shipment status.",
+        });
+        return {
+          payloads: [{ text: "Use the shipment status." }],
+          meta: {},
+        };
+      },
+    );
     const agentRuntime = {
       defaults: { provider: "openai", model: "gpt-5.4" },
       resolveAgentDir: vi.fn(() => "/tmp/agent"),
@@ -665,9 +676,11 @@ describe("createVoiceCallRuntime lifecycle", () => {
       "custom_tool",
     ]);
     const handler = requireRealtimeConsultToolHandler();
+    const onVisiblePartial = vi.fn(async () => {});
     await expect(
       handler({ question: "What should I say?" }, "call-1", {
         partialUserTranscript: "Also check the ETA.",
+        onVisiblePartial,
       }),
     ).resolves.toEqual({
       text: "Use the shipment status.",
@@ -695,6 +708,12 @@ describe("createVoiceCallRuntime lifecycle", () => {
     expect(consultParams.extraSystemPrompt).toContain("one or two bounded read-only queries");
     expect(consultParams.prompt).toContain("Caller: Can you check shipment status?");
     expect(consultParams.prompt).toContain("Caller: Also check the ETA.");
+    expect(onVisiblePartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Checking shipment status.",
+        delta: "Checking shipment status.",
+      }),
+    );
   });
 
   it("always exposes the built-in end-call tool without allowing configured replacement", async () => {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -456,6 +456,7 @@ export async function createVoiceCallRuntime(params: {
             ),
             extraSystemPrompt: REALTIME_VOICE_CONSULT_SYSTEM_PROMPT,
             abortSignal: handlerContext.abortSignal,
+            onVisiblePartial: handlerContext.onVisiblePartial,
           });
         },
       );

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1806,6 +1806,73 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("does not replay a streamed long answer when the bounded final adds truncation", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const spoken: string[] = [];
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        speakOutOfBand: vi.fn(async (text: string) => {
+          spoken.push(text);
+        }),
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-streamed-long")) },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const streamedPrefix = `${"x".repeat(1_783)}.`;
+    const finalText = `${streamedPrefix}${" Final detail.".repeat(10)}`;
+    handler.registerToolHandler(
+      "openclaw_agent_consult",
+      async (_args: unknown, _callId: string, context: ToolHandlerContext) => {
+        await context.onVisiblePartial?.({ runId: "run-long", text: finalText });
+        return { text: finalText };
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-streamed-long", callSid: "CA-streamed-long" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-streamed-long",
+          callId: "call-streamed-long",
+          name: "openclaw_agent_consult",
+          args: { question: "Return a long answer." },
+        });
+
+        await waitForRealtimeTest(() => {
+          expect(submitToolResult).toHaveBeenLastCalledWith(
+            "call-streamed-long",
+            { text: `${streamedPrefix} [truncated]` },
+            { suppressResponse: true },
+          );
+        });
+        expect(spoken.filter((text) => text.includes(streamedPrefix))).toHaveLength(1);
+        expect(spoken.join("\n")).not.toContain("Correction:");
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("falls back to only the unspoken suffix when later speech disconnects", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
     const clearPendingSpeech = vi.fn();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1806,6 +1806,95 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("shares streamed speech suppression with a coalesced consult caller", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const releaseFinal = createDeferred<void>();
+    const spoken: string[] = [];
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        speakOutOfBand: vi.fn(async (text: string) => {
+          spoken.push(text);
+        }),
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-shared-stream")) },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.registerToolHandler(
+      "openclaw_agent_consult",
+      async (_args: unknown, _callId: string, context: ToolHandlerContext) => {
+        await context.onVisiblePartial?.({ runId: "run-shared", text: "Shared result." });
+        await releaseFinal.promise;
+        return { text: "Shared result." };
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-shared-stream", callSid: "CA-shared-stream" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-shared-1",
+          callId: "call-shared-1",
+          name: "openclaw_agent_consult",
+          args: { question: "Check once." },
+        });
+        await waitForRealtimeTest(() => expect(spoken).toHaveLength(1));
+        callbacks?.onToolCall?.({
+          itemId: "item-shared-2",
+          callId: "call-shared-2",
+          name: "openclaw_agent_consult",
+          args: { question: "Check once." },
+        });
+        releaseFinal.resolve();
+
+        await waitForRealtimeTest(() => {
+          expect(submitToolResult).toHaveBeenCalledWith(
+            "call-shared-1",
+            { text: "Shared result." },
+            { suppressResponse: true },
+          );
+          expect(submitToolResult).toHaveBeenCalledWith(
+            "call-shared-2",
+            {
+              status: "already_delivered",
+              message:
+                "OpenClaw already delivered this consult result internally. Do not repeat it.",
+            },
+            { suppressResponse: true },
+          );
+        });
+        expect(spoken).toHaveLength(1);
+        expect(
+          submitToolResult.mock.calls.filter(
+            ([, result]) => result && typeof result === "object" && "text" in result,
+          ),
+        ).toHaveLength(1);
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      releaseFinal.resolve();
+      await server.close();
+    }
+  });
+
   it("does not replay a streamed long answer when the bounded final adds truncation", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
     const spoken: string[] = [];

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -2102,6 +2102,97 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("delivers one fallback after continuity reset reconnects an active consult", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    let context: ToolHandlerContext | undefined;
+    const result = createDeferred<{ text: string }>();
+    const handleBargeIn = vi.fn();
+    const sendUserMessage = vi.fn();
+    const speakOutOfBand = vi.fn(async () => {});
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        handleBargeIn,
+        sendUserMessage,
+        speakOutOfBand,
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-reconnect-fallback")) },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.registerToolHandler(
+      "openclaw_agent_consult",
+      (_args: unknown, _callId: string, toolContext: ToolHandlerContext) => {
+        context = toolContext;
+        return result.promise;
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-reconnect-fallback", callSid: "CA-reconnect-fallback" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-reconnect-fallback",
+          callId: "call-reconnect-fallback",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the queue." },
+        });
+        await waitForRealtimeTest(() => expect(context).toBeDefined());
+        await context?.onVisiblePartial?.({ runId: "run-reconnect", text: "First result." });
+        expect(speakOutOfBand).toHaveBeenCalledOnce();
+
+        callbacks?.onEvent?.({ direction: "client", type: "session.continuity.reset" });
+        expect(handleBargeIn).toHaveBeenCalledOnce();
+        await context?.onVisiblePartial?.({
+          runId: "run-reconnect",
+          text: "First result. Stale result.",
+        });
+        expect(speakOutOfBand).toHaveBeenCalledOnce();
+        expect(sendUserMessage).not.toHaveBeenCalled();
+
+        callbacks?.onEvent?.({ direction: "client", type: "session.reconnect.ready" });
+        expect(sendUserMessage).toHaveBeenCalledOnce();
+        expect(sendUserMessage.mock.calls[0]?.[0]).toContain(
+          "I lost that supervisor update when the connection reset. Please ask me to try again.",
+        );
+        callbacks?.onEvent?.({ direction: "client", type: "session.reconnect.ready" });
+        result.resolve({ text: "First result. Late final." });
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+
+        expect(sendUserMessage).toHaveBeenCalledOnce();
+        expect(
+          submitToolResult.mock.calls.filter(
+            ([, toolResult]) =>
+              toolResult && typeof toolResult === "object" && "text" in toolResult,
+          ),
+        ).toHaveLength(0);
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      result.resolve({ text: "First result. Late final." });
+      await server.close();
+    }
+  });
+
   it("keeps the non-streaming final append bounded and minimal", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
     const submitToolResult = vi.fn();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -2193,7 +2193,7 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("keeps the non-streaming final append bounded and minimal", async () => {
+  it("preserves the existing non-streaming final result", async () => {
     let callbacks: RealtimeBridgeRequest | undefined;
     const submitToolResult = vi.fn();
     const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
@@ -2204,10 +2204,11 @@ describe("RealtimeCallHandler path routing", () => {
       manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-bounded-final")) },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    handler.registerToolHandler("openclaw_agent_consult", async () => ({
+    const originalResult = {
       text: "x".repeat(10_000),
       hiddenMetadata: "y".repeat(10_000),
-    }));
+    };
+    handler.registerToolHandler("openclaw_agent_consult", async () => originalResult);
     const server = await startRealtimeServer(handler);
 
     try {
@@ -2231,13 +2232,7 @@ describe("RealtimeCallHandler path routing", () => {
           const finalCall = submitToolResult.mock.calls.find(
             ([, result]) => result && typeof result === "object" && "text" in result,
           );
-          expect(finalCall).toBeDefined();
-          const result = finalCall?.[1] as Record<string, unknown>;
-          expect(Object.keys(result)).toEqual(["text"]);
-          expect(result.text).toEqual(expect.any(String));
-          expect((result.text as string).length).toBeLessThanOrEqual(1_800);
-          expect(result.text).toMatch(/\[truncated\]$/);
-          expect(finalCall?.[2]).toBeUndefined();
+          expect(finalCall).toEqual(["call-bounded", originalResult, undefined]);
         });
       } finally {
         if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1697,6 +1697,311 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("speaks visible consult segments before completion and suppresses duplicate final speech", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const releaseFinal = createDeferred<void>();
+    const spoken: string[] = [];
+    let startedAt: number;
+    let firstSpokenAt = 0;
+    let finalResponseAt = 0;
+    const submitToolResult = vi.fn((_callId: string, result: unknown) => {
+      if (result && typeof result === "object" && "text" in result) {
+        finalResponseAt = performance.now();
+      }
+    });
+    const speakOutOfBand = vi.fn(async (text: string) => {
+      firstSpokenAt ||= performance.now();
+      spoken.push(text);
+    });
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        speakOutOfBand,
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-streamed-consult")),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const consult = vi.fn(async (_args: unknown, _callId: string, context: ToolHandlerContext) => {
+      await context.onVisiblePartial?.({
+        runId: "run-streamed",
+        text: "First segment.",
+        delta: "First segment.",
+      });
+      await releaseFinal.promise;
+      await context.onVisiblePartial?.({
+        runId: "run-streamed",
+        text: "First segment. Second segment.",
+        delta: " Second segment.",
+      });
+      return {
+        text: "First segment. Second segment.",
+        hiddenMetadata: "x".repeat(10_000),
+      };
+    });
+    handler.registerToolHandler("openclaw_agent_consult", consult);
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-streamed-consult", callSid: "CA-streamed-consult" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+
+        startedAt = performance.now();
+        callbacks?.onToolCall?.({
+          itemId: "item-streamed",
+          callId: "call-streamed",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the queue." },
+        });
+        await waitForRealtimeTest(() => expect(spoken).toHaveLength(1));
+        expect(spoken[0]).toContain('Answer: "First segment."');
+        expect(
+          submitToolResult.mock.calls.filter(
+            ([, result]) => result && typeof result === "object" && "text" in result,
+          ),
+        ).toHaveLength(0);
+
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 100);
+        });
+        releaseFinal.resolve();
+        await waitForRealtimeTest(() => {
+          expect(spoken).toHaveLength(2);
+          expect(submitToolResult).toHaveBeenLastCalledWith(
+            "call-streamed",
+            { text: "First segment. Second segment." },
+            { suppressResponse: true },
+          );
+        });
+        expect(spoken[1]).toContain('Answer: "Second segment."');
+        expect(firstSpokenAt - startedAt).toBeLessThan(finalResponseAt - startedAt);
+        expect(finalResponseAt - firstSpokenAt).toBeGreaterThanOrEqual(90);
+        expect(
+          submitToolResult.mock.calls.filter(
+            ([, result]) => result && typeof result === "object" && "text" in result,
+          ),
+        ).toHaveLength(1);
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      releaseFinal.resolve();
+      await server.close();
+    }
+  });
+
+  it("falls back to only the unspoken suffix when later speech disconnects", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const clearPendingSpeech = vi.fn();
+    const submitToolResult = vi.fn();
+    const speakOutOfBand = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error("provider disconnected"));
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        clearPendingSpeech,
+        speakOutOfBand,
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-stream-fallback")),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.registerToolHandler("openclaw_agent_consult", async (_args, _callId, context) => {
+      await context.onVisiblePartial?.({ runId: "run-fallback", text: "First result." });
+      await context
+        .onVisiblePartial?.({
+          runId: "run-fallback",
+          text: "First result. Second result.",
+        })
+        .catch(() => {});
+      return { text: "First result. Second result." };
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-stream-fallback", callSid: "CA-stream-fallback" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-fallback",
+          callId: "call-fallback",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the queue." },
+        });
+
+        await waitForRealtimeTest(() => {
+          expect(submitToolResult).toHaveBeenLastCalledWith(
+            "call-fallback",
+            { text: "Second result." },
+            undefined,
+          );
+        });
+        expect(speakOutOfBand).toHaveBeenCalledTimes(2);
+        expect(clearPendingSpeech).toHaveBeenCalledOnce();
+        expect(
+          submitToolResult.mock.calls.filter(
+            ([, result]) => result && typeof result === "object" && "text" in result,
+          ),
+        ).toHaveLength(1);
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("submits one clear supervisor error after retiring streamed speech", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const handleBargeIn = vi.fn();
+    const submitToolResult = vi.fn();
+    const speakOutOfBand = vi.fn(async () => {});
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({
+        supportsOutOfBandSpeech: true,
+        supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        handleBargeIn,
+        speakOutOfBand,
+        submitToolResult,
+      });
+    });
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-stream-error")) },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.registerToolHandler("openclaw_agent_consult", async (_args, _callId, context) => {
+      await context.onVisiblePartial?.({ runId: "run-error", text: "Partial result." });
+      throw new Error("supervisor failed");
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-stream-error", callSid: "CA-stream-error" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-error",
+          callId: "call-error",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the queue." },
+        });
+
+        await waitForRealtimeTest(() => {
+          expect(submitToolResult).toHaveBeenLastCalledWith(
+            "call-error",
+            { error: "supervisor failed" },
+            undefined,
+          );
+        });
+        expect(speakOutOfBand).toHaveBeenCalledOnce();
+        expect(handleBargeIn).toHaveBeenCalledOnce();
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps the non-streaming final append bounded and minimal", async () => {
+    let callbacks: RealtimeBridgeRequest | undefined;
+    const submitToolResult = vi.fn();
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks = request;
+      return makeBridge({ supportsToolResultContinuation: true, submitToolResult });
+    });
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-bounded-final")) },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.registerToolHandler("openclaw_agent_consult", async () => ({
+      text: "x".repeat(10_000),
+      hiddenMetadata: "y".repeat(10_000),
+    }));
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-bounded-final", callSid: "CA-bounded-final" },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(callbacks).toBeDefined());
+        callbacks?.onToolCall?.({
+          itemId: "item-bounded",
+          callId: "call-bounded",
+          name: "openclaw_agent_consult",
+          args: { question: "Return a long answer." },
+        });
+
+        await waitForRealtimeTest(() => {
+          const finalCall = submitToolResult.mock.calls.find(
+            ([, result]) => result && typeof result === "object" && "text" in result,
+          );
+          expect(finalCall).toBeDefined();
+          const result = finalCall?.[1] as Record<string, unknown>;
+          expect(Object.keys(result)).toEqual(["text"]);
+          expect(result.text).toEqual(expect.any(String));
+          expect((result.text as string).length).toBeLessThanOrEqual(1_800);
+          expect(result.text).toMatch(/\[truncated\]$/);
+          expect(finalCall?.[2]).toBeUndefined();
+        });
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   describe.each(["forced", "native", "general"] as const)("%s host tool outcomes", (path) => {
     const cancelled = { status: "cancelled", message: "Cancelled the active OpenClaw run." };
     const outcomes = [
@@ -2674,13 +2979,23 @@ describe("RealtimeCallHandler path routing", () => {
     const callbacks: RealtimeBridgeRequest[] = [];
     const oldSubmitToolResult = vi.fn();
     const replacementSubmitToolResult = vi.fn();
+    const oldSpeakOutOfBand = vi.fn(async () => {});
+    const replacementSpeakOutOfBand = vi.fn(async () => {});
+    const oldHandleBargeIn = vi.fn();
     const bridges = [
       makeBridge({
+        supportsOutOfBandSpeech: true,
         supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        handleBargeIn: oldHandleBargeIn,
+        speakOutOfBand: oldSpeakOutOfBand,
         submitToolResult: oldSubmitToolResult,
       }),
       makeBridge({
+        supportsOutOfBandSpeech: true,
         supportsToolResultContinuation: true,
+        supportsToolResultSuppression: true,
+        speakOutOfBand: replacementSpeakOutOfBand,
         submitToolResult: replacementSubmitToolResult,
       }),
     ];
@@ -2700,10 +3015,18 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const oldResult = createDeferred<{ text: string }>();
     const replacementResult = createDeferred<{ text: string }>();
+    let oldContext: ToolHandlerContext | undefined;
+    let replacementContext: ToolHandlerContext | undefined;
     const consult = vi
       .fn()
-      .mockImplementationOnce(() => oldResult.promise)
-      .mockImplementationOnce(() => replacementResult.promise);
+      .mockImplementationOnce((_args, _callId, context: ToolHandlerContext) => {
+        oldContext = context;
+        return oldResult.promise;
+      })
+      .mockImplementationOnce((_args, _callId, context: ToolHandlerContext) => {
+        replacementContext = context;
+        return replacementResult.promise;
+      });
     handler.registerToolHandler("openclaw_agent_consult", consult);
     const oldServer = await startRealtimeServer(handler);
     let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
@@ -2730,6 +3053,8 @@ describe("RealtimeCallHandler path routing", () => {
         expect(consult).toHaveBeenCalledTimes(1);
         expect(oldSubmitToolResult).toHaveBeenCalledTimes(1);
       });
+      await oldContext?.onVisiblePartial?.({ runId: "run-old", text: "Old partial." });
+      expect(oldSpeakOutOfBand).toHaveBeenCalledOnce();
 
       replacementServer = await startRealtimeServer(handler);
       const replacementWs = await connectWs(replacementServer.url);
@@ -2752,6 +3077,18 @@ describe("RealtimeCallHandler path routing", () => {
         await waitForRealtimeTest(() => {
           expect(consult).toHaveBeenCalledTimes(2);
         });
+        expect(oldHandleBargeIn).toHaveBeenCalledOnce();
+
+        await oldContext?.onVisiblePartial?.({
+          runId: "run-old",
+          text: "Old partial. Stale after reconnect.",
+        });
+        await replacementContext?.onVisiblePartial?.({
+          runId: "run-replacement",
+          text: "The new deployment is healthy.",
+        });
+        expect(oldSpeakOutOfBand).toHaveBeenCalledOnce();
+        expect(replacementSpeakOutOfBand).toHaveBeenCalledOnce();
 
         oldResult.resolve({ text: "The old deployment is healthy." });
         await new Promise<void>((resolve) => {
@@ -2764,7 +3101,7 @@ describe("RealtimeCallHandler path routing", () => {
           expect(replacementSubmitToolResult).toHaveBeenLastCalledWith(
             "native-replacement",
             { text: "The new deployment is healthy." },
-            undefined,
+            { suppressResponse: true },
           );
         });
       } finally {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1958,7 +1958,18 @@ export class RealtimeCallHandler {
         if (outcome.kind === "cancelled") {
           return;
         }
-        await submitFinalToolResult(outcome.result);
+        if (existingNativeConsult.speechStream) {
+          await submitFinalToolResult(
+            {
+              status: "already_delivered",
+              message:
+                "OpenClaw already delivered this consult result internally. Do not repeat it.",
+            },
+            { suppressResponse: true },
+          );
+        } else {
+          await submitFinalToolResult(outcome.result);
+        }
         return;
       }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -72,6 +72,8 @@ const FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
 const FORCED_CONSULT_RESULT_MAX_CHARS = 1800;
 const FORCED_CONSULT_STREAM_MAX_CHARS = FORCED_CONSULT_RESULT_MAX_CHARS - 16;
 const FORCED_CONSULT_REASON = "provider_final_transcript_without_openclaw_agent_consult";
+const REALTIME_CONSULT_RECONNECT_FALLBACK_TEXT =
+  "I lost that supervisor update when the connection reset. Please ask me to try again.";
 const CONSULT_TRANSCRIPT_SETTLE_MS = 350;
 const CONSULT_TRANSCRIPT_SETTLE_MAX_MS = 1_000;
 const MAX_PARTIAL_USER_TRANSCRIPT_CHARS = 1_200;
@@ -874,6 +876,7 @@ export class RealtimeCallHandler {
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
     let provisionalCloseReason: RealtimeVoiceCloseReason | undefined;
     let sessionClosed = false;
+    let consultReconnectFallbackPending = false;
     // Provisional ownership accepts callbacks fired during createBridge. Commit
     // retires the predecessor only after creation succeeds; failure restores it.
     const userTranscriptAdoption = this.beginUserTranscriptOwnerAdoption(callId);
@@ -1037,8 +1040,14 @@ export class RealtimeCallHandler {
           const turnId = harness.talk.activeTurnId;
           const owner = nativeConsultOwner.current;
           if (owner && this.isActiveBridgeOwner(callId, owner)) {
+            const nativeConsult = this.nativeConsultsInFlightByCallId.get(callId);
+            const forcedConsult = this.forcedConsultsByCallId.get(callId);
+            const hadActiveConsult =
+              nativeConsult?.owner === owner || forcedConsult?.owner === owner;
             this.resetUserTranscriptState(callId, userTranscriptOwner);
-            this.resetConsultSessionForContinuity(callId, owner);
+            if (this.resetConsultSessionForContinuity(callId, owner) && hadActiveConsult) {
+              consultReconnectFallbackPending = true;
+            }
           }
           harness.flushOutput(() => {
             audioPacer.clearAudio();
@@ -1049,6 +1058,19 @@ export class RealtimeCallHandler {
               turnId,
               payload: { callId, providerCallId: callSid, reason: event.type },
             });
+          }
+          return;
+        }
+        if (event.direction === "client" && event.type === "session.reconnect.ready") {
+          const owner = nativeConsultOwner.current;
+          if (consultReconnectFallbackPending && owner && this.isActiveBridgeOwner(callId, owner)) {
+            consultReconnectFallbackPending = false;
+            owner.sendUserMessage(
+              buildRealtimeVoiceSpeakExactMessage({
+                text: REALTIME_CONSULT_RECONNECT_FALLBACK_TEXT,
+                surfaceLabel: "the caller",
+              }),
+            );
           }
           return;
         }
@@ -1097,6 +1119,7 @@ export class RealtimeCallHandler {
         });
       },
       onClose: (reason) => {
+        consultReconnectFallbackPending = false;
         harness.finishOutputAudio(reason);
         harness.emit({
           type: "session.closed",

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -2097,8 +2097,19 @@ export class RealtimeCallHandler {
         console.log(
           `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${failed ? "error" : "ok"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
         );
+        if (!speechStream) {
+          await submitFinalToolResult(result);
+          if (!failed) {
+            this.consumePartialUserTranscript(
+              callId,
+              userTranscriptOwner,
+              state.partialUserTranscript,
+            );
+          }
+          return;
+        }
         if (failed) {
-          speechStream?.cancel();
+          speechStream.cancel();
         }
         const finalText = failed
           ? undefined
@@ -2127,10 +2138,9 @@ export class RealtimeCallHandler {
           : failed
             ? { error: truncateRealtimeConsultResult(error ?? "unknown") }
             : result;
-        const speechFinish =
-          finalText && speechStream
-            ? await speechStream.finish(finalText)
-            : { suppressResponse: false };
+        const speechFinish = finalText
+          ? await speechStream.finish(finalText)
+          : { suppressResponse: false };
         const providerResult = speechFinish.fallbackText
           ? { text: speechFinish.fallbackText }
           : boundedResult;

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -70,6 +70,7 @@ const REALTIME_DISCONNECT_HANGUP_GRACE_MS = 2_000;
 const FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
 const FORCED_CONSULT_RESULT_MAX_CHARS = 1800;
+const FORCED_CONSULT_STREAM_MAX_CHARS = FORCED_CONSULT_RESULT_MAX_CHARS - 16;
 const FORCED_CONSULT_REASON = "provider_final_transcript_without_openclaw_agent_consult";
 const CONSULT_TRANSCRIPT_SETTLE_MS = 350;
 const CONSULT_TRANSCRIPT_SETTLE_MAX_MS = 1_000;
@@ -1990,7 +1991,7 @@ export class RealtimeCallHandler {
                   }),
                 );
               },
-              maxChars: FORCED_CONSULT_RESULT_MAX_CHARS,
+              maxChars: FORCED_CONSULT_STREAM_MAX_CHARS,
               onCancel: () => {
                 if (speechBridge.handleBargeIn) {
                   speechBridge.handleBargeIn({ audioPlaybackActive: true, force: true });

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildRealtimeVoiceAgentConsultWorkingResponse,
   buildRealtimeVoiceAgentErrorProviderResult,
+  buildRealtimeVoiceSpeakExactMessage,
   calculateMulawRms,
   createRealtimeVoiceSessionHarness,
   createSpeechThresholdGate,
@@ -20,10 +21,12 @@ import {
   readSpeakableRealtimeVoiceToolResult,
   type RealtimeVoiceForcedConsultHandle,
   type RealtimeVoiceBridgeSession,
+  type RealtimeVoiceAgentConsultVisiblePartial,
   type RealtimeVoiceCloseReason,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
   type RealtimeVoiceSessionHarness,
+  type RealtimeVoiceToolResultOptions,
   type TalkEvent,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -32,6 +35,10 @@ import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
+import {
+  createRealtimeConsultSpeechStream,
+  type RealtimeConsultSpeechStream,
+} from "../realtime-consult-speech-stream.js";
 import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
 import { WebSocket, WebSocketServer } from "../websocket.js";
@@ -46,6 +53,7 @@ import {
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
   abortSignal?: AbortSignal;
+  onVisiblePartial?: (partial: RealtimeVoiceAgentConsultVisiblePartial) => Promise<void>;
 };
 type ToolHandlerFn = (
   args: unknown,
@@ -224,12 +232,15 @@ function withFallbackConsultQuestion(args: unknown, fallback: string | undefined
     : { question };
 }
 
-function buildForcedConsultSpeechPrompt(result: string): string {
+function truncateRealtimeConsultResult(result: string): string {
   const trimmed = result.trim();
-  const bounded =
-    trimmed.length <= FORCED_CONSULT_RESULT_MAX_CHARS
-      ? trimmed
-      : `${truncateUtf16Safe(trimmed, FORCED_CONSULT_RESULT_MAX_CHARS - 16).trimEnd()} [truncated]`;
+  return trimmed.length <= FORCED_CONSULT_RESULT_MAX_CHARS
+    ? trimmed
+    : `${truncateUtf16Safe(trimmed, FORCED_CONSULT_RESULT_MAX_CHARS - 16).trimEnd()} [truncated]`;
+}
+
+function buildForcedConsultSpeechPrompt(result: string): string {
+  const bounded = truncateRealtimeConsultResult(result);
   return [
     "Internal OpenClaw consult result is ready.",
     "Do not call tools for this internal result.",
@@ -298,6 +309,7 @@ type NativeConsultState = {
   cancelled: boolean;
   cancel: () => void;
   partialUserTranscript?: string;
+  speechStream?: RealtimeConsultSpeechStream;
 };
 
 type NativeConsultOutcome = { kind: "completed"; result: unknown } | { kind: "cancelled" };
@@ -1431,6 +1443,7 @@ export class RealtimeCallHandler {
     }
     state.cancelled = true;
     this.nativeConsultsInFlightByCallId.delete(callId);
+    state.speechStream?.cancel();
     state.cancel();
   }
 
@@ -1856,9 +1869,13 @@ export class RealtimeCallHandler {
         final: true,
       });
     };
-    const submitFinalToolResult = async (result: unknown): Promise<void> => {
-      await bridge.submitToolResult(bridgeCallId, result);
-      emitFinalToolEvent(result);
+    const submitFinalToolResult = async (
+      result: unknown,
+      options?: RealtimeVoiceToolResultOptions,
+      eventResult: unknown = result,
+    ): Promise<void> => {
+      await bridge.submitToolResult(bridgeCallId, result, options);
+      emitFinalToolEvent(eventResult);
     };
     const submitWorkingResponse = async (): Promise<void> => {
       if (
@@ -1953,12 +1970,43 @@ export class RealtimeCallHandler {
       const consult = new Promise<unknown>((resolve) => {
         completeConsult = resolve;
       });
+      const speechBridge = bridge.bridge;
+      const speechStream =
+        speechBridge.supportsOutOfBandSpeech === true &&
+        speechBridge.supportsToolResultSuppression !== false &&
+        speechBridge.speakOutOfBand
+          ? createRealtimeConsultSpeechStream({
+              deliver: async (text) => {
+                if (
+                  this.activeBridgesByCallId.get(callId) !== bridge ||
+                  !speechBridge.isConnected()
+                ) {
+                  throw new DOMException("Realtime consult speech owner retired", "AbortError");
+                }
+                await speechBridge.speakOutOfBand?.(
+                  buildRealtimeVoiceSpeakExactMessage({
+                    text,
+                    surfaceLabel: "the caller",
+                  }),
+                );
+              },
+              maxChars: FORCED_CONSULT_RESULT_MAX_CHARS,
+              onCancel: () => {
+                if (speechBridge.handleBargeIn) {
+                  speechBridge.handleBargeIn({ audioPlaybackActive: true, force: true });
+                } else {
+                  speechBridge.clearPendingSpeech?.();
+                }
+              },
+            })
+          : undefined;
       const state: NativeConsultState = {
         owner: bridge,
         startedAt,
         promise: consult,
         cancellation,
         cancelled: false,
+        speechStream,
         // Provider continuity owns the consult lifetime, not only its eventual result.
         cancel: () => {
           abortController.abort(new Error("Realtime native consult owner was cancelled."));
@@ -1982,6 +2030,14 @@ export class RealtimeCallHandler {
           const context = {
             partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
             abortSignal: abortController.signal,
+            ...(speechStream
+              ? {
+                  onVisiblePartial: async (partial: RealtimeVoiceAgentConsultVisiblePartial) => {
+                    speechStream.start(partial.runId);
+                    await speechStream.push(partial);
+                  },
+                }
+              : {}),
           };
           state.partialUserTranscript = context.partialUserTranscript;
           const handlerArgs = withFallbackConsultQuestion(args, context.partialUserTranscript);
@@ -2006,7 +2062,48 @@ export class RealtimeCallHandler {
         console.log(
           `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${failed ? "error" : "ok"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
         );
-        await submitFinalToolResult(result);
+        if (failed) {
+          speechStream?.cancel();
+        }
+        const finalText = failed
+          ? undefined
+          : readSpeakableRealtimeVoiceToolResult(result, {
+              keys: ["text", "output"],
+              maxChars: FORCED_CONSULT_RESULT_MAX_CHARS,
+            });
+        const yielded =
+          result !== null &&
+          typeof result === "object" &&
+          !Array.isArray(result) &&
+          "yielded" in result &&
+          result.yielded === true;
+        const timedOut =
+          result !== null &&
+          typeof result === "object" &&
+          !Array.isArray(result) &&
+          "timedOut" in result &&
+          result.timedOut === true;
+        const boundedResult = finalText
+          ? {
+              text: finalText,
+              ...(yielded ? { yielded: true } : {}),
+              ...(timedOut ? { timedOut: true } : {}),
+            }
+          : failed
+            ? { error: truncateRealtimeConsultResult(error ?? "unknown") }
+            : result;
+        const speechFinish =
+          finalText && speechStream
+            ? await speechStream.finish(finalText)
+            : { suppressResponse: false };
+        const providerResult = speechFinish.fallbackText
+          ? { text: speechFinish.fallbackText }
+          : boundedResult;
+        await submitFinalToolResult(
+          providerResult,
+          speechFinish.suppressResponse ? { suppressResponse: true } : undefined,
+          boundedResult,
+        );
         if (!failed) {
           this.consumePartialUserTranscript(
             callId,

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -149,6 +149,7 @@ export {
   REALTIME_VOICE_AGENT_CONSULT_SENDER_AUTH_VERSION,
   type RealtimeVoiceAgentConsultResult,
   type RealtimeVoiceAgentConsultRuntime,
+  type RealtimeVoiceAgentConsultVisiblePartial,
 } from "../talk/agent-consult-runtime.js";
 export {
   createRealtimeVoiceAgentTalkbackQueue,

--- a/src/talk/agent-consult-runtime.test.ts
+++ b/src/talk/agent-consult-runtime.test.ts
@@ -395,6 +395,51 @@ describe("realtime voice agent consult runtime", () => {
     );
   });
 
+  it("forwards only visible partial replies before the final consult result", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime();
+    const started = createDeferred();
+    const release = createDeferred();
+    runEmbeddedAgent.mockImplementation(async (runParams?: RunEmbeddedAgentParams) => {
+      started.resolve();
+      await runParams?.onPartialReply?.({ text: "First segment.", delta: "First segment." });
+      await release.promise;
+      return { payloads: [{ text: "First segment. Second segment." }], meta: {} };
+    });
+    const visiblePartials: unknown[] = [];
+    const consult = consultRealtimeVoiceAgent({
+      cfg: {},
+      agentRuntime: runtime as never,
+      logger: { warn: vi.fn() },
+      sessionKey: "agent:main:voice",
+      messageProvider: "voice",
+      lane: "voice",
+      runIdPrefix: "voice-visible-partials",
+      args: { question: "Check the queue" },
+      transcript: [],
+      surface: "a live phone call",
+      userLabel: "Caller",
+      onVisiblePartial: async (partial) => {
+        visiblePartials.push(partial);
+      },
+    });
+
+    await started.promise;
+    try {
+      await vi.waitFor(() => {
+        expect(visiblePartials).toHaveLength(1);
+      });
+      const runParams = requireEmbeddedAgentCall(runEmbeddedAgent);
+      expect(runParams.onReasoningStream).toBeUndefined();
+      expect(runParams.onToolResult).toBeUndefined();
+      expect(visiblePartials).toEqual([
+        expect.objectContaining({ text: "First segment.", delta: "First segment." }),
+      ]);
+    } finally {
+      release.resolve();
+      await consult;
+    }
+  });
+
   it("carries current voice session permissions without enabling owner trace", async () => {
     const { runtime, runEmbeddedAgent, sessionStore } = createAgentRuntime();
     sessionStore["agent:main:voice"] = {

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -42,6 +42,14 @@ export type RealtimeVoiceAgentConsultRuntime = PluginRuntimeCore["agent"];
  */
 export type RealtimeVoiceAgentConsultResult = { text: string; yielded?: true };
 
+/** Sanitized user-visible assistant text emitted while a realtime consult is still running. */
+export type RealtimeVoiceAgentConsultVisiblePartial = {
+  runId: string;
+  text: string;
+  delta?: string;
+  replace?: true;
+};
+
 const REALTIME_VOICE_YIELD_ACK_MAX_CHARS = 500;
 const REALTIME_VOICE_YIELD_ACK_FALLBACK =
   "I started that work and will share the result when it is ready.";
@@ -387,6 +395,8 @@ export async function consultRealtimeVoiceAgent(params: {
   extraSystemPrompt?: string;
   fallbackText?: string;
   abortSignal?: AbortSignal;
+  /** Receives only the sanitized assistant-answer lane, never reasoning or tool payloads. */
+  onVisiblePartial?: (partial: RealtimeVoiceAgentConsultVisiblePartial) => Promise<void> | void;
   onRunStarted?: (params: {
     runId: string;
     sessionId: string;
@@ -487,6 +497,7 @@ export async function consultRealtimeVoiceAgent(params: {
       const abortSignal = runRegistration?.abortSignal
         ? AbortSignal.any([lifecycleAbortController.signal, runRegistration.abortSignal])
         : lifecycleAbortController.signal;
+      let visibleDeliveryFailed = false;
 
       // Voice consults suppress verbose/reasoning output because the bridge needs a short,
       // speakable answer, not agent-run diagnostics or hidden reasoning artifacts.
@@ -536,6 +547,34 @@ export async function consultRealtimeVoiceAgent(params: {
           "You are the configured OpenClaw agent receiving delegated requests from a live voice bridge. Act on behalf of the user, use available tools when appropriate, and return a brief speakable result.",
         agentDir,
         abortSignal,
+        onPartialReply: params.onVisiblePartial
+          ? async (payload) => {
+              if (visibleDeliveryFailed || abortSignal.aborted) {
+                return false;
+              }
+              const text = typeof payload.text === "string" ? payload.text : "";
+              if (!text.trim()) {
+                return false;
+              }
+              try {
+                await params.onVisiblePartial?.({
+                  runId,
+                  text,
+                  ...(typeof payload.delta === "string" ? { delta: payload.delta } : {}),
+                  ...(payload.replace ? { replace: true } : {}),
+                });
+                assertRealtimeVoiceConsultNotInterrupted(abortSignal);
+                return true;
+              } catch (error) {
+                assertRealtimeVoiceConsultNotInterrupted(abortSignal);
+                visibleDeliveryFailed = true;
+                params.logger.warn(
+                  `[talk] realtime agent consult streaming disabled after delivery failure: ${error instanceof Error ? error.message : String(error)}`,
+                );
+                return false;
+              }
+            }
+          : undefined,
       });
       const result = await runPromise
         .catch((error: unknown) => {

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -351,6 +351,8 @@ export type RealtimeVoiceBridge = {
   supportsToolResultContinuation?: boolean;
   /** False when the provider cannot accept a tool result without starting a response. */
   supportsToolResultSuppression?: boolean;
+  /** True when the provider can speak ordered text while a tool call remains pending. */
+  supportsOutOfBandSpeech?: boolean;
   /** Per-session override for provider-confirmed input-audio barge-in handling. */
   handlesInputAudioBargeIn?: boolean;
   connect(): Promise<void>;
@@ -360,8 +362,12 @@ export type RealtimeVoiceBridge = {
     text: string,
     options?: { toolChoice?: { type: "function"; name: string } },
   ): void;
+  /** Resolve only after provider-owned out-of-band speech reaches its terminal response. */
+  speakOutOfBand?(text: string): Promise<void>;
   triggerGreeting?(instructions?: string): void;
   handleBargeIn?(options?: RealtimeVoiceBargeInOptions): void;
+  /** Drop queued speech and release any caller waiting on active out-of-band speech. */
+  clearPendingSpeech?(): void;
   /**
    * Returns void when submission completes synchronously, or a Promise that resolves at the
    * asynchronous completion boundary exposed by the provider and rejects on submission failure.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where callers using GPT-Realtime heard no work-supervisor result until the embedded agent completed.

## Why This Change Was Made

Forward sanitized assistant partial replies through an awaited, cancellable speech queue that preserves order and deduplicates cumulative snapshots and true deltas. Append one bounded final tool result with response suppression after successful streaming, while retaining the existing non-streaming path and clear failure fallback.

## User Impact

Callers can hear completed supervisor segments while work continues, exactly once and in order, and can interrupt them immediately.

## Evidence

- Focused suite: 185 tests passed across the consult runtime, voice-call runtime/handler, stream reducer, and OpenAI Realtime bridge.
- Changed-file gate: formatting, core and extension type-checks, dead-export scan, lint, import-cycle checks, and repository guards passed.
- Autoreview: addressed cumulative/delta, whitespace, paragraph, bounded long-answer, coalesced-call, guarded-barge-in, reconnect-fallback, and non-streaming compatibility findings.

### Manual Test

Expected: With a 100 ms pause between two supervisor partial replies, the first segment reaches voice output before completion; both segments are heard once; one consolidated final result is appended without another response.

Actual: Before the change, first-spoken text did not occur before the final result. After the change, the controlled harness recorded first-spoken text at 1 ms and the final response at 104 ms, with both segments delivered once.

Generated with AI under the guidance of John.
