### PR TITLE
fix: sandboxed plugin agents can read listed skills

### DIFF
--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.owner.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.owner.test.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import { buildSkillSnapshot } from "../../../skills/loading/workspace-skill-prompt.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import {
   createOperationalRunInstanceRef,
@@ -39,23 +42,50 @@ vi.mock("../../runtime-plan/build.js", () => ({
 afterEach(() => setActivePluginRegistry(createEmptyPluginRegistry()));
 
 it.each([
-  { agentId: "main", sandboxSessionKey: undefined, remoteSkills: false, oneShotCliRun: undefined },
-  { agentId: "work", sandboxSessionKey: "global", remoteSkills: false, oneShotCliRun: true },
+  {
+    agentId: "main",
+    sandboxSessionKey: undefined,
+    remoteSkills: false,
+    skillCatalog: "host" as const,
+    oneShotCliRun: undefined,
+  },
+  {
+    agentId: "work",
+    sandboxSessionKey: "global",
+    remoteSkills: false,
+    skillCatalog: "sandbox" as const,
+    oneShotCliRun: true,
+  },
   {
     agentId: "work",
     sandboxSessionKey: "agent:main:policy",
     remoteSkills: false,
+    skillCatalog: "none" as const,
     oneShotCliRun: false,
   },
-  { agentId: "main", sandboxSessionKey: undefined, remoteSkills: true, oneShotCliRun: true },
+  {
+    agentId: "main",
+    sandboxSessionKey: undefined,
+    remoteSkills: true,
+    skillCatalog: "none" as const,
+    oneShotCliRun: true,
+  },
 ])(
-  "dispatches the generic harness for $agentId/global with policy $sandboxSessionKey, remote skills $remoteSkills, and one-shot $oneShotCliRun",
-  async ({ agentId, sandboxSessionKey, remoteSkills, oneShotCliRun }) => {
+  "dispatches the generic harness for $agentId/global with policy $sandboxSessionKey, $skillCatalog skills, remote skills $remoteSkills, and one-shot $oneShotCliRun",
+  async ({ agentId, sandboxSessionKey, remoteSkills, skillCatalog, oneShotCliRun }) => {
     const gitCoauthorPrompt =
       "Git co-authors: add these exact trailers to every commit you make from this session.\n" +
       "Co-authored-by: ada <20+ada@users.noreply.github.com>";
     vi.mocked(resolveSessionGitCoauthorPrompt).mockReturnValue(gitCoauthorPrompt);
     await withOpenClawTestState({ label: "harness-owner" }, async (state) => {
+      const skillDir = path.join(state.workspaceDir, "skills", "demo");
+      if (skillCatalog !== "none") {
+        await fs.mkdir(skillDir, { recursive: true });
+        await fs.writeFile(
+          path.join(skillDir, "SKILL.md"),
+          "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n",
+        );
+      }
       const config = {
         agents: {
           ownership: "explicit" as const,
@@ -66,6 +96,7 @@ it.each([
               mode: "off" as const,
               backend: "owner-fixture",
               scope: "agent" as const,
+              workspaceAccess: skillCatalog === "sandbox" ? ("rw" as const) : ("none" as const),
               workspaceRoot: state.path("sandbox"),
               prune: { idleHours: 0, maxAgeDays: 0 },
             },
@@ -124,6 +155,14 @@ it.each([
         runAttempt,
       });
       const runtimePluginToolGrant = { pluginId: "owner-tools", toolNames: ["owner_only"] };
+      const skillsSnapshot =
+        skillCatalog === "none"
+          ? undefined
+          : buildSkillSnapshot(state.workspaceDir, {
+              agentId,
+              bundledSkillsDir: state.path("missing-bundled-skills"),
+              managedSkillsDir: state.path("missing-managed-skills"),
+            });
       const params = {
         admittedRunContext,
         agentId,
@@ -135,6 +174,7 @@ it.each([
         workspaceDir: state.workspaceDir,
         sessionFile: "global",
         prompt: remoteSkills ? "Use the skill at /host/skills/demo/SKILL.md." : "hello",
+        ...(skillsSnapshot ? { skillsSnapshot } : {}),
         ...(remoteSkills
           ? {
               explicitSkillSelections: [
@@ -282,6 +322,18 @@ it.each([
           ]);
           expect(params.explicitSkillSelections?.[0]?.path).toBe("/host/skills/demo/SKILL.md");
           expect(sandbox).toEqual(remoteSandbox);
+        } else if (skillCatalog === "sandbox") {
+          const dispatched = runAttempt.mock.calls[0]?.[0];
+          const sandboxSkillPath = "/workspace/.openclaw/sandbox-skills/skills/demo/SKILL.md";
+          expect(dispatched?.skillsSnapshot?.prompt).toContain(
+            `<location>${sandboxSkillPath}</location>`,
+          );
+          expect(dispatched?.skillsSnapshot?.prompt).not.toContain(path.join(skillDir, "SKILL.md"));
+          expect(params.skillsSnapshot?.prompt).toBe(skillsSnapshot?.prompt);
+          expect(sandbox?.workspaceAccess).toBe("rw");
+        } else if (skillCatalog === "host") {
+          expect(runAttempt.mock.calls[0]?.[0].skillsSnapshot?.prompt).toBe(skillsSnapshot?.prompt);
+          expect(sandbox).toBeNull();
         } else if (agentId === "work" && sandboxSessionKey === "global") {
           expect(provisioned).toHaveLength(1);
           expect(provisioned[0]).toMatch(/^agent:work:workspace:/);

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -26,11 +26,8 @@ import {
 } from "../../tools/gateway-caller-context.js";
 import { resolveAttemptWorkspaceSandbox } from "../../workspace-sandbox.js";
 import type { EmbeddedRunReplayState } from "../replay-state.js";
-import {
-  resolveSandboxSkillRuntimeInputs,
-  mapSandboxSkillUsagePaths,
-  remapSkillReferencePaths,
-} from "../sandbox-skills.js";
+import { remapSkillReferencePaths } from "../sandbox-skills.js";
+import { prepareEmbeddedSkills } from "../skill-runtime.js";
 import { mapThinkingLevelForProvider } from "../utils.js";
 import { prepareExecApprovalContinuationForAttempt } from "./attempt-exec-approval-continuation.js";
 import { applyResolvedToolPromptFinalizer } from "./attempt-prompt-support.js";
@@ -351,22 +348,26 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
     skillFile: path.join(mount.hostPath, "SKILL.md"),
     readPath: path.posix.join(mount.containerPath, "SKILL.md"),
   }));
-  if (
-    pluginSandbox?.enabled &&
-    !pluginSandbox.readOnlyResourceMounts?.length &&
-    skillsSnapshot?.librarySelections?.length
-  ) {
-    const prepared = resolveSandboxSkillRuntimeInputs({
+  if (pluginSandbox?.enabled && !pluginSandbox.readOnlyResourceMounts?.length && skillsSnapshot) {
+    const prepared = prepareEmbeddedSkills({
+      applySkillEnvironment: false,
+      includeCodeModeSkills: false,
+      attempt: {
+        bootstrapWorkspaceDir,
+        config: params.config,
+        contextTokenBudget: runtime.contextTokenBudget,
+        skillsSnapshot,
+        toolExecutionAllow: params.toolExecutionAllow,
+      },
+      effectiveWorkspace: workspaceDir,
       sandbox: pluginSandbox,
-      skillsAnchorWorkspace: bootstrapWorkspaceDir ?? workspaceDir,
-      skillsSnapshot,
+      sessionAgentId: workspaceResolution.agentId,
     });
-    skillsSnapshot = prepared.skillsSnapshot;
-    skillReferencePaths = mapSandboxSkillUsagePaths({
-      paths: pluginSandbox.skillUsagePaths,
-      skillsWorkspaceDir: prepared.skillsWorkspaceDir,
-      skillsPromptWorkspaceDir: prepared.skillsPromptWorkspaceDir,
-    });
+    skillsSnapshot = {
+      ...(prepared.skillsSnapshotForRun ?? skillsSnapshot),
+      prompt: prepared.skillsPrompt,
+    };
+    skillReferencePaths = prepared.skillUsagePaths;
   }
   const attemptControls = createAttemptControls({
     admittedRunContext,

--- a/src/agents/embedded-agent-runner/skill-runtime.ts
+++ b/src/agents/embedded-agent-runner/skill-runtime.ts
@@ -17,6 +17,8 @@ import {
 
 /** Prepares readable skills and owns environment rollback until the caller takes custody. */
 export function prepareEmbeddedSkills(params: {
+  /** Prompt-only callers can skip process-wide environment overrides. */
+  applySkillEnvironment?: boolean;
   attempt: Pick<
     EmbeddedRunAttemptParams,
     | "config"
@@ -71,15 +73,18 @@ export function prepareEmbeddedSkills(params: {
         : { executionWorkspaceDir: params.effectiveWorkspace }),
       workspaceOnly,
     });
-  const restoreSkillEnv = skillsSnapshot
-    ? applySkillEnvOverridesFromSnapshot({
-        snapshot: skillsSnapshot,
-        config: params.attempt.config,
-      })
-    : applySkillEnvOverrides({
-        skills: skillEntries ?? [],
-        config: params.attempt.config,
-      });
+  const restoreSkillEnv =
+    params.applySkillEnvironment === false
+      ? () => {}
+      : skillsSnapshot
+        ? applySkillEnvOverridesFromSnapshot({
+            snapshot: skillsSnapshot,
+            config: params.attempt.config,
+          })
+        : applySkillEnvOverrides({
+            skills: skillEntries ?? [],
+            config: params.attempt.config,
+          });
   try {
     const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
       entries: shouldLoadSkillEntries ? skillEntries : undefined,


### PR DESCRIPTION
Closes #124555

Related: #132103

## What Problem This Solves

Fixes an issue where sandboxed agents using a plugin-owned harness received a skills catalog containing host-only file paths, so listed skills could not be opened inside the sandbox.

## Why This Change Was Made

Plugin-harness dispatch now uses the shared embedded skill-preparation path to project skill prompts and explicit skill references into the sandbox filesystem namespace. Prompt-only preparation skips process-wide skill environment mutation, and existing remote resource-mount handling remains unchanged.

The native embedded runtime already used this shared preparation path and was not affected. PR #132103 is adjacent because it expands the same preparation pipeline with environment-discovered skills; after rebasing, its async call-site change should compose with this projection.

## User Impact

Sandboxed plugin-backed agents can open the skills they are told are available. The fix applies to every plugin-owned harness, not only Codex.

## Evidence

- Regression test fails on unpatched `main` because the dispatched catalog contains the host path, then passes with the sandbox path after this fix.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/run-attempt-dispatch.owner.test.ts`: 4 tests passed.
- `node scripts/check-changed.mjs`: passed.
- `git diff --check`: passed.

<!-- openclaw-publication:f9638f41-e3d8-466c-bc45-987d0fa25a20 -->