### PR TITLE
fix(update): honor the update budget when probing the Windows Scheduled Task

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -162,6 +162,8 @@ regenerate the launcher if the update did not refresh it.
 
 Gateway status and Doctor read the Scheduled Task's numeric current state, independently of the Windows display language or console code page. A previous task exit result does not prove whether it is running now. Queued or unknown tasks do not count as safely stopped for Doctor maintenance. Stop a queued task through its service owner; if inspection is inaccessible, restore Task Scheduler inspection permissions before retrying.
 
+During update preflight, the Scheduled Task runtime probe uses the update's `--timeout` budget for each attempt and retries once on timeout; if it still times out, the refusal reports the probe budget and keeps code unchanged.
+
 Gateway startup creates private SQLite staging directories through Windows APIs,
 without compiling C# or launching PowerShell for their permissions. The owner,
 SYSTEM, and Administrators retain full access; other inherited access is removed

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
@@ -189,6 +190,86 @@ it.each(nativeOfflineCases)(
       expect(service.stage).not.toHaveBeenCalled();
       expect(service.install).not.toHaveBeenCalled();
     }),
+);
+
+it.each([
+  { code: "ETIMEDOUT", failures: 1, proceeds: true },
+  { code: "ETIMEDOUT", failures: 2, proceeds: false },
+  { code: "ETIMEDOUT", failures: 2, proceeds: false, admitted: true },
+  { code: "ENOENT", failures: 1, proceeds: false },
+])("handles Scheduled Task probe failures before update: %j", (scenario) =>
+  withServiceHome(async (home) => {
+    mockProcessPlatform("win32");
+    mocks.taskState = 4;
+    vi.mocked(spawnSync).mockReset();
+    for (let attempt = 0; attempt < scenario.failures; attempt++) {
+      vi.mocked(spawnSync).mockReturnValueOnce({
+        pid: 0,
+        output: [null, "", ""],
+        stdout: "",
+        stderr: "",
+        status: null,
+        signal: null,
+        error: Object.assign(new Error(`spawnSync powershell.exe ${scenario.code}`), {
+          code: scenario.code,
+        }),
+      });
+    }
+    const service = createMockGatewayService({
+      readCommand: vi.fn(async () => ({
+        programArguments: [process.execPath, path.join(process.cwd(), "openclaw.mjs"), "gateway"],
+        environment: { HOME: home },
+      })),
+      readRuntime: readScheduledTaskRuntime,
+      isLoaded: async () => true,
+    });
+    mocks.service.mockReturnValue(service);
+
+    const inspection = maybeStopManagedServiceBeforeMutableUpdate({
+      root: process.cwd(),
+      updateInstallKind: "package",
+      shouldRestart: true,
+      phase: "inspect",
+      jsonMode: true,
+      timeoutMs: 30_000,
+      expectedService: scenario.admitted
+        ? {
+            serviceUpdateVerdict: {
+              kind: "owned",
+              root: process.cwd(),
+              fingerprint: "admitted-definition",
+              refreshDefinition: true,
+            },
+          }
+        : undefined,
+    });
+
+    if (scenario.admitted) {
+      await expect(inspection).rejects.toThrow("Scheduled Task probe timed out after 30000 ms");
+    } else {
+      const inspected = await inspection;
+      if (scenario.proceeds) {
+        expect(inspected.serviceUpdateVerdict?.kind).toBe("owned");
+        expect(inspected.blockMessage).toBeUndefined();
+        expect(inspected.running).toBe(true);
+      } else {
+        expect(inspected.serviceUpdateVerdict?.kind).toBe("unavailable");
+        expect(inspected.blockMessage).toContain("Refusing to mutate code");
+        if (scenario.code === "ETIMEDOUT") {
+          expect(inspected.blockMessage).toContain("Scheduled Task probe timed out after 30000 ms");
+          expect(inspected.blockMessage).toContain("ETIMEDOUT");
+        }
+      }
+    }
+    const attempts = scenario.code === "ETIMEDOUT" ? 2 : 1;
+    expect(spawnSync).toHaveBeenCalledTimes(attempts);
+    expect(service.readCommand).toHaveBeenCalledTimes(attempts);
+    for (const call of vi.mocked(spawnSync).mock.calls) {
+      expect(call[2]?.timeout).toBe(30_000);
+    }
+    expect(service.stop).not.toHaveBeenCalled();
+    expect(service.install).not.toHaveBeenCalled();
+  }),
 );
 
 it

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -43,8 +43,6 @@ import {
 
 export { UpdateCommandAbort } from "./update-command-windows-task.js";
 
-const GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE =
-  "Gateway service management skipped: inspection is unavailable. Run `openclaw gateway status --deep` and restart the gateway manually when service access is restored.";
 const GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE =
   "Gateway service inspection is unavailable. Refusing to mutate code because managed service ownership cannot be verified. Run `openclaw gateway status --deep` and retry when service access is restored.";
 const JSON_MODE_SERVICE_STDOUT = new Writable({
@@ -52,6 +50,13 @@ const JSON_MODE_SERVICE_STDOUT = new Writable({
     callback();
   },
 });
+
+function serviceInspectionBlockMessage(state: GatewayServiceState): string {
+  const timeoutMs = state.runtime?.inspectionFailure?.timeoutMs;
+  return timeoutMs === undefined
+    ? GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE
+    : `Scheduled Task probe timed out after ${timeoutMs} ms (ETIMEDOUT). ${GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE}`;
+}
 
 export type PreManagedServiceStop = {
   stoppedAtMs?: number;
@@ -91,7 +96,7 @@ async function inspectManagedGatewayServiceBeforeUpdate(params: {
   const { command } = state;
   const unavailable = (): ManagedGatewayUpdateVerdict => ({
     kind: "unavailable",
-    message: GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE,
+    message: serviceInspectionBlockMessage(state),
   });
   if (!command) {
     return !state.installed &&
@@ -203,7 +208,10 @@ export async function revalidateManagedGatewayServiceAfterUpdate(params: {
     (inspection.kind !== verdict.kind || !matchesStoppedService(before, params.state, inspection))
   ) {
     throw new GatewayServiceUpdateOwnershipError(
-      "Gateway service ownership or manager identity changed; inspect it before restarting manually.",
+      inspection.kind === "unavailable" &&
+        params.state.runtime?.inspectionFailure?.timeoutMs !== undefined
+        ? inspection.message
+        : "Gateway service ownership or manager identity changed; inspect it before restarting manually.",
       undefined,
     );
   }
@@ -328,7 +336,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     ...base,
     serviceMutationAllowed: false,
     serviceUpdateVerdict: { kind: "unavailable", message },
-    blockMessage: GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE,
+    blockMessage: message,
   });
   const serviceMutationSkipMessage = resolveGatewayServiceManagementBlockMessageForUpdate(
     process.env,
@@ -346,11 +354,23 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       validateEnvBeforeStatusRead: assertGatewayServiceManagementAllowedForUpdate,
       timeoutMs: params.timeoutMs,
     });
+    if (
+      process.platform === "win32" &&
+      serviceState.runtime?.inspectionFailure?.timeoutMs !== undefined
+    ) {
+      // Re-read the definition too: a timed-out snapshot cannot grant service ownership.
+      serviceState = await readGatewayServiceState(service, {
+        env: process.env,
+        requireEffective: true,
+        validateEnvBeforeStatusRead: assertGatewayServiceManagementAllowedForUpdate,
+        timeoutMs: params.timeoutMs,
+      });
+    }
   } catch (err) {
     if (err instanceof GatewayServiceUpdateOwnershipError) {
       return { ...uninspected, serviceMutationAllowed: false, blockMessage: err.message };
     }
-    return markInspectionUnavailable(uninspected, GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE);
+    return markInspectionUnavailable(uninspected, GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE);
   }
   const serviceUpdateVerdict = await revalidateManagedGatewayServiceAfterUpdate({
     root: params.root,

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -39,6 +39,7 @@ import type {
   GatewayServiceCommandConfig,
   GatewayServiceEnv,
   GatewayServiceEnvArgs,
+  GatewayServiceReadOptions,
   GatewayServiceRestartResult,
 } from "./service-types.js";
 import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
@@ -420,15 +421,19 @@ export async function isScheduledTaskInstalled(args: GatewayServiceEnvArgs): Pro
 
 export async function readScheduledTaskRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+  opts?: GatewayServiceReadOptions,
 ): Promise<GatewayServiceRuntime> {
-  const probe = probeScheduledTaskState(resolveTaskName(env));
+  const probe = probeScheduledTaskState(resolveTaskName(env), opts?.timeoutMs);
   if (probe.status === "missing") {
     return (await isStartupEntryInstalled(env))
       ? resolveFallbackRuntime(env)
       : { status: "stopped", missingUnit: true };
   }
   if (probe.status === "unknown") {
-    return { ...createServiceRuntimeInspectionFailure(probe.detail), missingUnit: false };
+    return {
+      ...createServiceRuntimeInspectionFailure(probe.detail, probe.timeoutMs),
+      missingUnit: false,
+    };
   }
   // State owns current activity; LastTaskResult is history and can describe an older run.
   const status =

--- a/src/daemon/schtasks-state-probe.test.ts
+++ b/src/daemon/schtasks-state-probe.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { probeScheduledTaskState } from "./schtasks-state-probe.js";
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
+
+beforeEach(() => vi.mocked(spawnSync).mockReset());
+
+describe("Scheduled Task probe timeout", () => {
+  it.each([
+    { budget: undefined, expected: 5_000 },
+    { budget: 0, expected: 5_000 },
+    { budget: -1, expected: 5_000 },
+    { budget: Number.POSITIVE_INFINITY, expected: 5_000 },
+    { budget: 200, expected: 200 },
+    { budget: 30_000, expected: 30_000 },
+  ])("uses a bounded caller budget: $budget -> $expected ms", ({ budget, expected }) => {
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 0,
+      output: [null, "", ""],
+      stdout: "",
+      stderr: "",
+      status: null,
+      signal: "SIGTERM",
+      error: Object.assign(new Error("spawnSync powershell.exe ETIMEDOUT"), { code: "ETIMEDOUT" }),
+    });
+
+    const result = probeScheduledTaskState("OpenClaw Gateway", budget);
+
+    expect(vi.mocked(spawnSync).mock.calls[0]?.[2]?.timeout).toBe(expected);
+    expect(result).toEqual({
+      status: "unknown",
+      detail: `Scheduled Task probe timed out after ${expected} ms (ETIMEDOUT).`,
+      timeoutMs: expected,
+    });
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/daemon/schtasks-state-probe.ts
+++ b/src/daemon/schtasks-state-probe.ts
@@ -1,18 +1,21 @@
 /** Locale-independent Task Scheduler registration and runtime facts. */
 import { spawnSync } from "node:child_process";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { hasErrnoCode } from "../infra/errno.js";
 import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
 import { resolveServiceManagerEnv } from "./service-process-env.js";
 
 type ScheduledTaskStateProbe =
   | { status: "found"; state: number | null; lastRunResult?: string; lastRunTime?: string }
   | { status: "missing" }
-  | { status: "unknown"; detail: string };
+  | { status: "unknown"; detail: string; timeoutMs?: number };
 
 export function probeScheduledTaskState(
   taskName: string,
   timeoutMs?: number,
 ): ScheduledTaskStateProbe {
+  const probeTimeoutMs =
+    timeoutMs !== undefined && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 5_000;
   const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
   const script = [
     "$ErrorActionPreference='Stop'",
@@ -37,11 +40,18 @@ export function probeScheduledTaskState(
     {
       env: resolveServiceManagerEnv(),
       encoding: "utf8",
-      timeout: timeoutMs && timeoutMs > 0 ? Math.min(timeoutMs, 5_000) : 5_000,
+      timeout: probeTimeoutMs,
       windowsHide: true,
     },
   );
   if (probe.error) {
+    if (hasErrnoCode(probe.error, "ETIMEDOUT")) {
+      return {
+        status: "unknown",
+        detail: `Scheduled Task probe timed out after ${probeTimeoutMs} ms (ETIMEDOUT).`,
+        timeoutMs: probeTimeoutMs,
+      };
+    }
     return { status: "unknown", detail: probe.error.message };
   }
   if (probe.status === 0) {

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -31,6 +31,8 @@ export type GatewayServiceRuntime = {
   inspectionFailure?: {
     code: "service-runtime-inspection-failed";
     detail: string;
+    /** Present only when the native inspection timed out, with its enforced budget. */
+    timeoutMs?: number;
   };
   cachedLabel?: boolean;
   missingUnit?: boolean;
@@ -48,7 +50,10 @@ const SERVICE_RUNTIME_INSPECTION_ERROR_MAX_CHARS = 500;
 const SERVICE_RUNTIME_INSPECTION_FAILED_DETAIL = "service runtime inspection failed";
 
 /** Keeps native probe failures bounded and diagnostic-only for status presentation owners. */
-export function createServiceRuntimeInspectionFailure(error: unknown): GatewayServiceRuntime {
+export function createServiceRuntimeInspectionFailure(
+  error: unknown,
+  timeoutMs?: number,
+): GatewayServiceRuntime {
   const rawDetail = error instanceof Error ? error.message : String(error);
   return {
     status: "unknown",
@@ -58,6 +63,7 @@ export function createServiceRuntimeInspectionFailure(error: unknown): GatewaySe
       detail:
         truncateUtf16Safe(sanitizeForLog(rawDetail), SERVICE_RUNTIME_INSPECTION_ERROR_MAX_CHARS) ||
         "unknown error",
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     },
   };
 }


### PR DESCRIPTION
Fixes #143210

<details>
<summary>Additional instructions</summary>

Maintainers can update this branch in the OpenClaw repository.

</details>

## What Problem This Solves

Fixes an issue where Windows users running `openclaw update` would be refused at `managed-service-preflight` when the Scheduled Task runtime probe exceeded five seconds, even though the update allowed a longer timeout. The refusal hid the timeout behind generic service-access guidance.

## Why This Change Was Made

The Windows runtime reader now forwards the caller's timeout to the Scheduled Task probe, and the probe honors it instead of applying a hidden five-second ceiling. Calls without a valid positive finite budget retain the five-second default. Update entry points already pass their existing per-step budget.

An actual `ETIMEDOUT` carries structured timeout metadata into service inspection. Update preflight retries that inspection once, rereading the service definition and runtime before deciding ownership. Repeated timeouts still prevent mutation and report the enforced budget, including when revalidating previously admitted ownership. Other probe failures remain fail-closed without a retry. Only fixed timeout text and the numeric budget reach the refusal; arbitrary native error text is not added.

## User Impact

Slow Windows Scheduled Task queries can use the update's requested budget and recover from one timeout. A repeated timeout now explains why the update stopped. Each attempt receives the existing update step budget (`--timeout`, default 1800 seconds), so two hung probes can consume twice that allowance. Status calls also receive the timeout they already request; the probe itself does not retry.

## Evidence

Regression tests were run against the unchanged production implementation by temporarily reversing only the production patch, then restoring it byte-for-byte. Before the fix:

```text
Scheduled Task probe: expected 30000 ms, received 5000 ms
One ETIMEDOUT then success: expected owned, received unavailable
Two ETIMEDOUTs: refusal omitted the timeout and budget
Previously admitted service: refusal replaced timeout with ownership-changed text
Probe suite: 6 failed
Preflight suite: 4 failed, 24 passed
```

Post-fix validation: **282 tests passed across six files** (three routed Vitest shards):

```bash
node scripts/run-vitest.mjs src/daemon/schtasks-state-probe.test.ts src/daemon/schtasks.test.ts src/daemon/service.test.ts src/cli/update-cli/update-command-service-maintenance.test.ts src/cli/update-cli/update-command-service.integration.test.ts src/cli/update-cli/update-command-migrated-windows.test.ts
```

The suite covers the actual Windows runtime reader and update preflight with mocked `spawnSync`, including one-time timeout recovery, repeated-timeout refusal, preservation of timeout diagnostics after admission, and non-timeout refusal without retry. Existing numeric-state, ownership, activation, and recovery tests also pass.

The final `node scripts/check-changed.mjs` gate passed (including production/test typechecking, formatting, lint, and architecture guards), with a separate Vitest filesystem cache for the concurrent check process. `git diff --check` passed. The preflight suite passed all 28 tests again after a test-only lint cleanup.

Exact-head CI passed: [run 34383681387](https://github.com/openclaw/openclaw/actions/runs/34383681387), head `5488b201bae96f14fd732dfc03920e3e52de493a`. The bounded PR watcher completed with `GREEN` and zero pending checks; both Windows Node test shards completed successfully.

Known gaps: the tests exercise real runtime/preflight code with mocked Windows subprocess responses on macOS. No live Windows 11, PowerShell COM, antivirus-latency, or end-to-end package update proof was run. The separate missing-launcher existence-probe error path is outside this runtime-probe repair.

Thanks to @fanyuantaier for the detailed report and measurements.


## Review notes

No persisted state, install records, or config schema changes. Both Windows Node CI shards executed their suites natively on Windows and passed in run 34383681387. The probe timeout path uses Node's documented `spawnSync` timeout and `ETIMEDOUT` contract; the focused regressions mock subprocess results. A live antivirus-latency reproduction is unavailable, and native PowerShell latency/termination was not independently demonstrated. The maintainer accepts this disclosed validation limit for the bounded timeout repair; this is not a claim of live Windows update proof.

The ten regression cases cover omitted, zero, negative, infinite, 200 ms, and 30000 ms probe budgets; one timeout followed by success; two timeouts; two timeouts after prior ownership admission; and an `ENOENT` failure without retry. Fresh ownership checks and refusal on an unverifiable service remain enforced.
