### PR TITLE
fix(memory): preserve provenance per daily segment

### DIFF
--- a/extensions/memory-core/src/daily-provenance.test.ts
+++ b/extensions/memory-core/src/daily-provenance.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDailyProvenanceRecord,
+  hashDailyMemoryContent,
+  rebaseDailyProvenanceRecord,
+  resolveDailyLineProvenance,
+  resolveDailyRangeProvenance,
+  type DailyProvenanceRecord,
+} from "./daily-provenance.js";
+
+describe("daily memory provenance", () => {
+  it("keeps trusted lines promotable after a legacy quarantined file", () => {
+    const before = "untrusted line\n";
+    const after = `${before}trusted line\n`;
+    const legacy: DailyProvenanceRecord = {
+      fileHash: hashDailyMemoryContent(before),
+      originClass: "untrusted",
+      observedAt: 1,
+    };
+    const record = buildDailyProvenanceRecord({
+      existing: legacy,
+      contentBefore: before,
+      contentAfter: after,
+      originClass: "agent",
+      observedAt: 2,
+    });
+
+    expect(record.originClass).toBe("untrusted");
+    expect(
+      resolveDailyLineProvenance({ content: after, record, defaultObservedAt: 3 }).slice(0, 2),
+    ).toMatchObject([
+      { originClass: "untrusted", observedAt: 1 },
+      { originClass: "agent", observedAt: 2 },
+    ]);
+    expect(
+      resolveDailyRangeProvenance({
+        content: after,
+        record,
+        startLine: 2,
+        endLine: 2,
+        defaultObservedAt: 3,
+      }).originClass,
+    ).toBe("agent");
+  });
+
+  it("does not let an untrusted append taint earlier trusted lines", () => {
+    const before = "trusted line\n";
+    const first = buildDailyProvenanceRecord({
+      contentBefore: "",
+      contentAfter: before,
+      originClass: "agent",
+      observedAt: 1,
+    });
+    const after = `${before}untrusted line\n`;
+    const record = buildDailyProvenanceRecord({
+      existing: first,
+      contentBefore: before,
+      contentAfter: after,
+      originClass: "untrusted",
+      observedAt: 2,
+    });
+
+    expect(
+      resolveDailyLineProvenance({ content: after, record, defaultObservedAt: 3 }).slice(0, 2),
+    ).toMatchObject([{ originClass: "agent" }, { originClass: "untrusted" }]);
+  });
+
+  it("keeps a stale baseline quarantined while trusting the exact append", () => {
+    const recordedContent = "recorded line\n";
+    const record = buildDailyProvenanceRecord({
+      contentBefore: "",
+      contentAfter: recordedContent,
+      originClass: "untrusted",
+      observedAt: 1,
+    });
+    const contentBefore = "tampered line\n";
+    const contentAfter = `${contentBefore}trusted append\n`;
+    const next = buildDailyProvenanceRecord({
+      existing: record,
+      contentBefore,
+      contentAfter,
+      originClass: "agent",
+      observedAt: 2,
+    });
+
+    expect(
+      resolveDailyLineProvenance({
+        content: contentAfter,
+        record: next,
+        defaultObservedAt: 3,
+      }).slice(0, 2),
+    ).toMatchObject([{ originClass: "untrusted" }, { originClass: "agent" }]);
+  });
+
+  it("fails closed for a non-append rewrite", () => {
+    const record = buildDailyProvenanceRecord({
+      contentBefore: "trusted line\n",
+      contentAfter: "replacement line\n",
+      originClass: "agent",
+      observedAt: 2,
+    });
+
+    expect(record.originClass).toBe("untrusted");
+    expect(
+      resolveDailyRangeProvenance({
+        content: "replacement line\n",
+        record,
+        startLine: 1,
+        endLine: 1,
+        defaultObservedAt: 3,
+      }).originClass,
+    ).toBe("untrusted");
+  });
+
+  it("quarantines a line when trust changes in the middle of it", () => {
+    const before = "trusted";
+    const first = buildDailyProvenanceRecord({
+      contentBefore: "",
+      contentAfter: before,
+      originClass: "agent",
+      observedAt: 1,
+    });
+    const after = `${before} untrusted\n`;
+    const record = buildDailyProvenanceRecord({
+      existing: first,
+      contentBefore: before,
+      contentAfter: after,
+      originClass: "untrusted",
+      observedAt: 2,
+    });
+
+    expect(
+      resolveDailyRangeProvenance({
+        content: after,
+        record,
+        startLine: 1,
+        endLine: 1,
+        defaultObservedAt: 3,
+      }).originClass,
+    ).toBe("untrusted");
+  });
+
+  it("preserves existing line trust across a managed block replacement", () => {
+    const before = "trusted line\nquarantined line\n";
+    const base = buildDailyProvenanceRecord({
+      contentBefore: "",
+      contentAfter: "trusted line\n",
+      originClass: "agent",
+      observedAt: 1,
+    });
+    const mixed = buildDailyProvenanceRecord({
+      existing: base,
+      contentBefore: "trusted line\n",
+      contentAfter: before,
+      originClass: "untrusted",
+      observedAt: 2,
+    });
+    const after = "trusted line\nmanaged block\nquarantined line\n";
+    const rebased = rebaseDailyProvenanceRecord({
+      existing: mixed,
+      contentBefore: before,
+      contentAfter: after,
+      observedAt: 3,
+    });
+
+    expect(
+      resolveDailyLineProvenance({ content: after, record: rebased, defaultObservedAt: 4 }).slice(
+        0,
+        3,
+      ),
+    ).toMatchObject([
+      { originClass: "agent" },
+      { originClass: "untrusted" },
+      { originClass: "untrusted" },
+    ]);
+  });
+});

--- a/extensions/memory-core/src/daily-provenance.ts
+++ b/extensions/memory-core/src/daily-provenance.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import type { MemoryEntryProvenance } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
+export type DailyProvenanceOrigin = "agent" | "untrusted";
+
+export type DailyProvenanceSegment = {
+  startOffset: number;
+  endOffset: number;
+  contentHash: string;
+  originClass: DailyProvenanceOrigin;
+  observedAt: number;
+};
+
+export type DailyProvenanceRecord = {
+  fileHash: string;
+  originClass: DailyProvenanceOrigin;
+  observedAt: number;
+  segments?: DailyProvenanceSegment[];
+};
+
+export function hashDailyMemoryContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function segmentFor(params: {
+  content: string;
+  startOffset: number;
+  endOffset: number;
+  originClass: DailyProvenanceOrigin;
+  observedAt: number;
+}): DailyProvenanceSegment {
+  return {
+    startOffset: params.startOffset,
+    endOffset: params.endOffset,
+    contentHash: hashDailyMemoryContent(params.content.slice(params.startOffset, params.endOffset)),
+    originClass: params.originClass,
+    observedAt: params.observedAt,
+  };
+}
+
+function recordFromSegments(params: {
+  content: string;
+  segments: DailyProvenanceSegment[];
+  observedAt: number;
+}): DailyProvenanceRecord {
+  return {
+    fileHash: hashDailyMemoryContent(params.content),
+    originClass: params.segments.some((segment) => segment.originClass === "untrusted")
+      ? "untrusted"
+      : "agent",
+    observedAt: params.observedAt,
+    segments: params.segments,
+  };
+}
+
+function verifiedSegments(
+  content: string,
+  record: DailyProvenanceRecord,
+): DailyProvenanceSegment[] | null {
+  if (record.fileHash !== hashDailyMemoryContent(content)) {
+    return null;
+  }
+  if (!record.segments) {
+    return content.length === 0
+      ? []
+      : [
+          segmentFor({
+            content,
+            startOffset: 0,
+            endOffset: content.length,
+            originClass: record.originClass,
+            observedAt: record.observedAt,
+          }),
+        ];
+  }
+  let cursor = 0;
+  for (const segment of record.segments) {
+    if (
+      !Number.isInteger(segment.startOffset) ||
+      !Number.isInteger(segment.endOffset) ||
+      segment.startOffset !== cursor ||
+      segment.endOffset <= segment.startOffset ||
+      segment.endOffset > content.length ||
+      (segment.originClass !== "agent" && segment.originClass !== "untrusted") ||
+      !Number.isFinite(segment.observedAt) ||
+      segment.contentHash !==
+        hashDailyMemoryContent(content.slice(segment.startOffset, segment.endOffset))
+    ) {
+      return null;
+    }
+    cursor = segment.endOffset;
+  }
+  return cursor === content.length ? record.segments : null;
+}
+
+export function buildDailyProvenanceRecord(params: {
+  existing?: DailyProvenanceRecord;
+  contentBefore: string;
+  contentAfter: string;
+  originClass: DailyProvenanceOrigin;
+  observedAt: number;
+}): DailyProvenanceRecord {
+  const appendOnly = params.contentAfter.startsWith(params.contentBefore);
+  let segments: DailyProvenanceSegment[];
+
+  if (!appendOnly) {
+    segments =
+      params.contentAfter.length === 0
+        ? []
+        : [
+            segmentFor({
+              content: params.contentAfter,
+              startOffset: 0,
+              endOffset: params.contentAfter.length,
+              originClass: "untrusted",
+              observedAt: params.observedAt,
+            }),
+          ];
+  } else {
+    const verifiedExisting = params.existing
+      ? verifiedSegments(params.contentBefore, params.existing)
+      : undefined;
+    const baselineOrigin = params.existing?.originClass ?? "agent";
+    segments =
+      verifiedExisting ??
+      (params.contentBefore.length === 0
+        ? []
+        : [
+            segmentFor({
+              content: params.contentBefore,
+              startOffset: 0,
+              endOffset: params.contentBefore.length,
+              originClass: baselineOrigin,
+              observedAt: params.existing?.observedAt ?? params.observedAt,
+            }),
+          ]);
+    if (params.contentAfter.length > params.contentBefore.length) {
+      segments = [
+        ...segments,
+        segmentFor({
+          content: params.contentAfter,
+          startOffset: params.contentBefore.length,
+          endOffset: params.contentAfter.length,
+          originClass: params.originClass,
+          observedAt: params.observedAt,
+        }),
+      ];
+    }
+  }
+
+  return recordFromSegments({
+    content: params.contentAfter,
+    segments,
+    observedAt: params.observedAt,
+  });
+}
+
+function commonPrefixLength(a: string, b: string): number {
+  const limit = Math.min(a.length, b.length);
+  let index = 0;
+  while (index < limit && a[index] === b[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function commonSuffixLength(a: string, b: string, prefixLength: number): number {
+  const limit = Math.min(a.length, b.length) - prefixLength;
+  let count = 0;
+  while (count < limit && a[a.length - count - 1] === b[b.length - count - 1]) {
+    count += 1;
+  }
+  return count;
+}
+
+function clippedSegment(params: {
+  content: string;
+  source: DailyProvenanceSegment;
+  sourceStart: number;
+  sourceEnd: number;
+  targetStart: number;
+}): DailyProvenanceSegment | undefined {
+  const start = Math.max(params.source.startOffset, params.sourceStart);
+  const end = Math.min(params.source.endOffset, params.sourceEnd);
+  if (end <= start) {
+    return undefined;
+  }
+  const startOffset = params.targetStart + (start - params.sourceStart);
+  const endOffset = startOffset + (end - start);
+  return segmentFor({
+    content: params.content,
+    startOffset,
+    endOffset,
+    originClass: params.source.originClass,
+    observedAt: params.source.observedAt,
+  });
+}
+
+export function rebaseDailyProvenanceRecord(params: {
+  existing?: DailyProvenanceRecord;
+  contentBefore: string;
+  contentAfter: string;
+  observedAt: number;
+}): DailyProvenanceRecord {
+  const prior =
+    (params.existing && verifiedSegments(params.contentBefore, params.existing)) ??
+    (params.contentBefore.length === 0
+      ? []
+      : [
+          segmentFor({
+            content: params.contentBefore,
+            startOffset: 0,
+            endOffset: params.contentBefore.length,
+            originClass: params.existing?.originClass ?? "agent",
+            observedAt: params.existing?.observedAt ?? params.observedAt,
+          }),
+        ]);
+  const prefixLength = commonPrefixLength(params.contentBefore, params.contentAfter);
+  const suffixLength = commonSuffixLength(params.contentBefore, params.contentAfter, prefixLength);
+  const beforeSuffixStart = params.contentBefore.length - suffixLength;
+  const afterSuffixStart = params.contentAfter.length - suffixLength;
+  const prefixSegments = prior.flatMap((segment) => {
+    const clipped = clippedSegment({
+      content: params.contentAfter,
+      source: segment,
+      sourceStart: 0,
+      sourceEnd: prefixLength,
+      targetStart: 0,
+    });
+    return clipped ? [clipped] : [];
+  });
+  const changedSegments =
+    afterSuffixStart > prefixLength
+      ? [
+          segmentFor({
+            content: params.contentAfter,
+            startOffset: prefixLength,
+            endOffset: afterSuffixStart,
+            originClass: "untrusted",
+            observedAt: params.observedAt,
+          }),
+        ]
+      : [];
+  const suffixSegments = prior.flatMap((segment) => {
+    const clipped = clippedSegment({
+      content: params.contentAfter,
+      source: segment,
+      sourceStart: beforeSuffixStart,
+      sourceEnd: params.contentBefore.length,
+      targetStart: afterSuffixStart,
+    });
+    return clipped ? [clipped] : [];
+  });
+  return recordFromSegments({
+    content: params.contentAfter,
+    segments: [...prefixSegments, ...changedSegments, ...suffixSegments],
+    observedAt: params.observedAt,
+  });
+}
+
+function lineOffsetRanges(content: string): Array<{ startOffset: number; endOffset: number }> {
+  const ranges: Array<{ startOffset: number; endOffset: number }> = [];
+  let startOffset = 0;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] !== "\n") {
+      continue;
+    }
+    const contentEnd = index > startOffset && content[index - 1] === "\r" ? index - 1 : index;
+    ranges.push({ startOffset, endOffset: contentEnd });
+    startOffset = index + 1;
+  }
+  ranges.push({ startOffset, endOffset: content.length });
+  return ranges;
+}
+
+export function resolveDailyLineProvenance(params: {
+  content: string;
+  record?: DailyProvenanceRecord;
+  defaultObservedAt: number;
+}): MemoryEntryProvenance[] {
+  const ranges = lineOffsetRanges(params.content);
+  if (!params.record) {
+    return ranges.map(() => ({
+      originClass: "agent",
+      sessionKind: "unknown",
+      observedAt: params.defaultObservedAt,
+    }));
+  }
+
+  const segments = verifiedSegments(params.content, params.record);
+  if (!segments) {
+    const originClass = params.record.originClass === "untrusted" ? "untrusted" : "agent";
+    const observedAt =
+      originClass === "untrusted" ? params.record.observedAt : params.defaultObservedAt;
+    return ranges.map(() => ({ originClass, sessionKind: "unknown", observedAt }));
+  }
+
+  return ranges.map((range) => {
+    const overlapping = segments.filter((segment) => {
+      if (range.startOffset === range.endOffset) {
+        return segment.startOffset <= range.startOffset && segment.endOffset >= range.endOffset;
+      }
+      return segment.startOffset < range.endOffset && segment.endOffset > range.startOffset;
+    });
+    const originClass = overlapping.some((segment) => segment.originClass === "untrusted")
+      ? "untrusted"
+      : "agent";
+    const observedAt =
+      overlapping.length > 0
+        ? Math.max(...overlapping.map((segment) => segment.observedAt))
+        : params.defaultObservedAt;
+    return { originClass, sessionKind: "unknown", observedAt };
+  });
+}
+
+export function resolveDailyRangeProvenance(params: {
+  content: string;
+  record?: DailyProvenanceRecord;
+  startLine: number;
+  endLine: number;
+  defaultObservedAt: number;
+}): MemoryEntryProvenance {
+  const lines = resolveDailyLineProvenance(params).slice(
+    Math.max(0, params.startLine - 1),
+    Math.max(params.startLine, params.endLine),
+  );
+  return {
+    originClass: lines.some((line) => line.originClass === "untrusted") ? "untrusted" : "agent",
+    sessionKind: "unknown",
+    observedAt: Math.max(params.defaultObservedAt, ...lines.map((line) => line.observedAt)),
+  };
+}

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -12,7 +12,13 @@ import {
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { rebaseDailyProvenanceRecord, type DailyProvenanceRecord } from "./daily-provenance.js";
 import { updateDeepDreamsFile } from "./dreaming-dreams-file.js";
+import {
+  DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  readMemoryCoreWorkspaceEntry,
+  writeMemoryCoreWorkspaceEntry,
+} from "./dreaming-state.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
 const DAILY_PHASE_HEADINGS: Record<Exclude<MemoryDreamingPhaseName, "deep">, string> = {
@@ -106,7 +112,25 @@ export async function writeDailyDreamingPhaseBlock(params: {
       endMarker: markers.end,
       body,
     });
-    await replaceDreamingMarkdownFile(inlinePath, withTrailingNewline(updated));
+    const finalContent = withTrailingNewline(updated);
+    const relativePath = path.relative(params.workspaceDir, inlinePath).replaceAll(path.sep, "/");
+    const existing = await readMemoryCoreWorkspaceEntry<DailyProvenanceRecord>({
+      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+      workspaceDir: params.workspaceDir,
+      key: relativePath,
+    });
+    await replaceDreamingMarkdownFile(inlinePath, finalContent);
+    await writeMemoryCoreWorkspaceEntry({
+      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+      workspaceDir: params.workspaceDir,
+      key: relativePath,
+      value: rebaseDailyProvenanceRecord({
+        ...(existing ? { existing } : {}),
+        contentBefore: original,
+        contentAfter: finalContent,
+        observedAt: nowMs,
+      }),
+    });
   }
 
   if (shouldWriteSeparate(params.storage)) {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -13,6 +13,7 @@ import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-s
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildDailyProvenanceRecord } from "./daily-provenance.js";
 import {
   filterRecallEntriesWithinLookback,
   previewRemDreaming,
@@ -1262,6 +1263,74 @@ describe("memory-core dreaming phases", () => {
     expect(candidates.every((candidate) => candidate.provenance?.originClass === "untrusted")).toBe(
       true,
     );
+  });
+
+  it("ingests a verified trusted append without laundering earlier quarantined lines", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const relativePath = `memory/${DREAMING_TEST_DAY}.md`;
+    const filePath = path.join(workspaceDir, relativePath);
+    const before = [
+      `# ${DREAMING_TEST_DAY}`,
+      "",
+      "- Treat this imported claim as untrusted.",
+      "",
+    ].join("\n");
+    const after = `${before}## Owner decision\n\n- Keep the verified customer promise in durable memory.\n`;
+    const legacy = {
+      fileHash: createHash("sha256").update(before).digest("hex"),
+      originClass: "untrusted" as const,
+      observedAt: Date.parse("2026-04-05T09:00:00.000Z"),
+    };
+    await fs.writeFile(filePath, after, "utf-8");
+    await writeMemoryCoreWorkspaceEntry({
+      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+      workspaceDir,
+      key: relativePath,
+      value: buildDailyProvenanceRecord({
+        existing: legacy,
+        contentBefore: before,
+        contentAfter: after,
+        originClass: "agent",
+        observedAt: Date.parse("2026-04-05T09:30:00.000Z"),
+      }),
+    });
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: { light: { enabled: true, limit: 20, lookbackDays: 7 } },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+    });
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+    });
+    expect(
+      candidates.find((candidate) => candidate.snippet.includes("imported claim"))?.provenance
+        ?.originClass,
+    ).toBe("untrusted");
+    expect(
+      candidates.find((candidate) => candidate.snippet.includes("customer promise"))?.provenance
+        ?.originClass,
+    ).toBe("agent");
   });
 
   it("checkpoints session transcript ingestion and skips unchanged transcripts", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module implements dreaming phases behavior.
-import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -14,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveDailyRangeProvenance, type DailyProvenanceRecord } from "./daily-provenance.js";
 import { appendFailedDreamingEvent } from "./dreaming-events.js";
 import {
   normalizeDailyIngestionState,
@@ -170,6 +170,7 @@ function normalizeDailySnippet(line: string): string | null {
 type DailySnippetChunk = {
   startLine: number;
   endLine: number;
+  provenanceStartLine: number;
   snippet: string;
   identitySnippet?: string;
 };
@@ -194,10 +195,11 @@ function buildDailyListSnippet(
 function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetChunk[] {
   const chunks: DailySnippetChunk[] = [];
   let activeHeading: string | null = null;
+  let activeHeadingLine = 0;
   let chunkLines: string[] = [];
   let chunkStartLine = 0;
   let chunkEndLine = 0;
-  let listAncestors: Array<{ indent: number; text: string }> = [];
+  let listAncestors: Array<{ indent: number; text: string; startLine: number }> = [];
 
   const flushChunk = () => {
     if (chunkLines.length === 0) {
@@ -211,6 +213,7 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
       chunks.push({
         startLine: chunkStartLine,
         endLine: chunkEndLine,
+        provenanceStartLine: activeHeadingLine || chunkStartLine,
         snippet,
       });
     }
@@ -230,6 +233,7 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
     if (heading) {
       flushChunk();
       activeHeading = heading;
+      activeHeadingLine = index + 1;
       listAncestors = [];
       continue;
     }
@@ -302,13 +306,17 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
         chunks.push({
           startLine: index + 1,
           endLine: endIndex + 1,
+          provenanceStartLine: Math.min(
+            activeHeadingLine || index + 1,
+            listAncestors.at(0)?.startLine ?? index + 1,
+          ),
           snippet: contextualSnippet,
           // The rendered semantic context is part of claim identity, keeping
           // identical bullet text for different subjects or events separate.
           identitySnippet: contextualSnippet,
         });
       }
-      listAncestors.push({ indent, text: claimBody });
+      listAncestors.push({ indent, text: claimBody, startLine: index + 1 });
       index = nestedChildIndex === undefined ? endIndex : nestedChildIndex - 1;
       if (chunks.length >= limit) {
         break;
@@ -346,22 +354,6 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
 
   flushChunk();
   return chunks.slice(0, limit);
-}
-
-function resolveDailyFileProvenance(params: {
-  currentHash: string;
-  defaultObservedAt: number;
-  recorded?: { fileHash: string; originClass: "agent" | "untrusted"; observedAt: number };
-}): { originClass: "agent" | "untrusted"; observedAt: number } {
-  // Untracked workspace notes are operator-trusted; filesystem writers already
-  // own the host, while explicit flush quarantine stays sticky across edits.
-  if (params.recorded?.originClass === "untrusted") {
-    return { originClass: "untrusted", observedAt: params.recorded.observedAt };
-  }
-  if (params.recorded?.fileHash === params.currentHash) {
-    return { originClass: params.recorded.originClass, observedAt: params.recorded.observedAt };
-  }
-  return { originClass: "agent", observedAt: params.defaultObservedAt };
 }
 
 function findManagedDailyDreamingHeadingIndex(
@@ -430,18 +422,20 @@ function buildDailyIngestionResults(params: {
   path: string;
   limit: number;
   defaultObservedAt: number;
-  recorded?: { fileHash: string; originClass: "agent" | "untrusted"; observedAt: number };
+  recorded?: DailyProvenanceRecord;
 }): Array<MemorySearchResult & { identitySnippet?: string }> {
-  const provenance = resolveDailyFileProvenance({
-    currentHash: createHash("sha256").update(params.raw).digest("hex"),
-    defaultObservedAt: params.defaultObservedAt,
-    ...(params.recorded ? { recorded: params.recorded } : {}),
-  });
   return buildDailySnippetChunks(
     stripManagedDailyDreamingLines(params.raw.split(/\r?\n/)),
     params.limit,
-  ).map((chunk) =>
-    Object.assign(
+  ).map((chunk) => {
+    const provenance = resolveDailyRangeProvenance({
+      content: params.raw,
+      ...(params.recorded ? { record: params.recorded } : {}),
+      startLine: chunk.provenanceStartLine,
+      endLine: chunk.endLine,
+      defaultObservedAt: params.defaultObservedAt,
+    });
+    return Object.assign(
       {
         path: params.path,
         startLine: chunk.startLine,
@@ -452,8 +446,8 @@ function buildDailyIngestionResults(params: {
         provenance: { ...provenance, sessionKind: "unknown" as const },
       },
       chunk.identitySnippet ? { identitySnippet: chunk.identitySnippet } : {},
-    ),
-  );
+    );
+  });
 }
 
 function entryWithinLookback(entry: ShortTermRecallEntry, cutoffMs: number): boolean {
@@ -775,11 +769,10 @@ async function collectDailyIngestionBatches(params: {
   ingestionDreamingDay: string;
   state: DailyIngestionState;
 }): Promise<DailyIngestionCollectionResult> {
-  const provenanceEntries = await readMemoryCoreWorkspaceEntries<{
-    fileHash: string;
-    originClass: "agent" | "untrusted";
-    observedAt: number;
-  }>({ namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE, workspaceDir: params.workspaceDir });
+  const provenanceEntries = await readMemoryCoreWorkspaceEntries<DailyProvenanceRecord>({
+    namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+    workspaceDir: params.workspaceDir,
+  });
   const provenanceByPath = new Map(provenanceEntries.map((entry) => [entry.key, entry.value]));
   const memoryDir = path.join(params.workspaceDir, "memory");
   const cutoffMs = calculateLookbackCutoffMs(params.nowMs, params.lookbackDays);
@@ -953,11 +946,10 @@ export async function seedHistoricalDailyMemorySignals(params: {
       skippedPaths: [],
     };
   }
-  const provenanceEntries = await readMemoryCoreWorkspaceEntries<{
-    fileHash: string;
-    originClass: "agent" | "untrusted";
-    observedAt: number;
-  }>({ namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE, workspaceDir: params.workspaceDir });
+  const provenanceEntries = await readMemoryCoreWorkspaceEntries<DailyProvenanceRecord>({
+    namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+    workspaceDir: params.workspaceDir,
+  });
   const provenanceByPath = new Map(provenanceEntries.map((entry) => [entry.key, entry.value]));
 
   const resolved = normalizedPaths

--- a/extensions/memory-core/src/flush-plan.test.ts
+++ b/extensions/memory-core/src/flush-plan.test.ts
@@ -24,7 +24,7 @@ describe("buildMemoryFlushPlan", () => {
     expect(plan?.relativePath).toBe("memory/2026-05-30.md");
   });
 
-  it("records mixed trusted and untrusted writes as untrusted for the whole file", async () => {
+  it("records mixed writes with a conservative file summary and exact segments", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-flush-provenance-");
     const plan = buildMemoryFlushPlan({ nowMs: Date.UTC(2026, 6, 28, 12, 0, 0) });
     if (!plan?.recordWriteProvenance) {
@@ -46,16 +46,33 @@ describe("buildMemoryFlushPlan", () => {
       originClass: "untrusted",
       observedAt: 2,
     });
+    await plan.recordWriteProvenance({
+      workspaceDir,
+      relativePath: plan.relativePath,
+      contentBefore: "trusted line\nuntrusted line\n",
+      contentAfter: "trusted line\nuntrusted line\nlater trusted line\n",
+      originClass: "agent",
+      observedAt: 3,
+    });
 
     const records = await readMemoryCoreWorkspaceEntries<{
       fileHash: string;
       originClass: "agent" | "untrusted";
       observedAt: number;
+      segments?: Array<{ originClass: "agent" | "untrusted" }>;
     }>({ namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE, workspaceDir });
     expect(records).toEqual([
       expect.objectContaining({
         key: plan.relativePath,
-        value: expect.objectContaining({ originClass: "untrusted", observedAt: 2 }),
+        value: expect.objectContaining({
+          originClass: "untrusted",
+          observedAt: 3,
+          segments: [
+            expect.objectContaining({ originClass: "agent" }),
+            expect.objectContaining({ originClass: "untrusted" }),
+            expect.objectContaining({ originClass: "agent" }),
+          ],
+        }),
       }),
     ]);
   });

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module implements flush plan behavior.
-import { createHash } from "node:crypto";
 import {
   DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR,
   parseNonNegativeByteSize,
@@ -8,6 +7,7 @@ import {
   type MemoryFlushPlan,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { buildDailyProvenanceRecord, type DailyProvenanceRecord } from "./daily-provenance.js";
 import {
   DREAMING_DAILY_PROVENANCE_NAMESPACE,
   deleteMemoryCoreWorkspaceEntry,
@@ -160,30 +160,26 @@ export function buildMemoryFlushPlan(
       if (!writtenPath) {
         return undefined;
       }
-      const hash = (value: string) => createHash("sha256").update(value).digest("hex");
-      const existing = await readMemoryCoreWorkspaceEntry<{
-        fileHash: string;
-        originClass: "agent" | "untrusted";
-        observedAt: number;
-      }>({
+      const existing = await readMemoryCoreWorkspaceEntry<DailyProvenanceRecord>({
         namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
         workspaceDir: write.workspaceDir,
         key: writtenPath,
       });
-      const originClass =
-        write.originClass === "agent" &&
-        (!existing ||
-          (existing?.originClass === "agent" && existing.fileHash === hash(write.contentBefore)))
-          ? "agent"
-          : "untrusted";
-      // Provenance is file-level and therefore collapses to the least-trusted
-      // content in the file. Trusted lines in a downgraded file lose promotion
-      // eligibility; untrusted content must never ride an agent-trusted hash.
+      const record = buildDailyProvenanceRecord({
+        ...(existing ? { existing } : {}),
+        contentBefore: write.contentBefore,
+        contentAfter: write.contentAfter,
+        originClass: write.originClass,
+        observedAt: write.observedAt,
+      });
+      // Keep the least-trusted file summary for legacy readers, while verified
+      // append segments let ingestion preserve trusted material on either side
+      // of quarantined text. Non-append writes and hash mismatches still fail closed.
       await writeMemoryCoreWorkspaceEntry({
         namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
         workspaceDir: write.workspaceDir,
         key: writtenPath,
-        value: { fileHash: hash(write.contentAfter), originClass, observedAt: write.observedAt },
+        value: record,
       });
       return async () => {
         if (existing) {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -1096,12 +1096,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         triggers: null,
         projectKey: null,
       };
-      chunk.provenance = this.resolveChunkProvenance(
-        entry,
-        options.source,
-        chunk,
-        pathClassification.originClass,
-      );
+      chunk.provenance = this.resolveChunkProvenance(entry, chunk, pathClassification.originClass);
       return {
         entry,
         source: options.source,
@@ -1138,12 +1133,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         : chunkMarkdown(indexingContent, chunkOptions),
     );
     for (const chunk of baseChunks) {
-      chunk.provenance = this.resolveChunkProvenance(
-        entry,
-        options.source,
-        chunk,
-        pathClassification.originClass,
-      );
+      chunk.provenance = this.resolveChunkProvenance(entry, chunk, pathClassification.originClass);
     }
     const chunks = (
       generation?.kind === "semantic"
@@ -1174,12 +1164,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private resolveChunkProvenance(
     entry: MemoryIndexEntry,
-    source: MemorySource,
     chunk: MemoryChunk,
     pathOriginClass: MemoryEntryProvenance["originClass"],
   ): MemoryEntryProvenance {
     const lineProvenance = entry.lineProvenance?.slice(chunk.startLine - 1, chunk.endLine) ?? [];
-    if (source === "sessions" && lineProvenance.length > 0) {
+    if (lineProvenance.length > 0) {
       const originPriority = ["owner", "agent", "system", "untrusted"] as const;
       const originClass = originPriority.findLast((origin) =>
         lineProvenance.some((item) => item.originClass === origin),
@@ -1198,8 +1187,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
 
     // Workspace memory files are inside the operator trust boundary: any
-    // filesystem writer already owns the host. Defaulting them untrusted would
-    // silently make handwritten persona memory ineligible for dreaming.
+    // filesystem writer already owns the host. Daily files with recorded mixed
+    // provenance take the line-aware branch above; other workspace notes keep
+    // the trusted default so handwritten persona memory remains dream-eligible.
     return {
       originClass: pathOriginClass,
       sessionKind: "unknown",

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module owns memory and session source indexing.
+import fs from "node:fs/promises";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   buildSessionEntry,
@@ -11,6 +12,15 @@ import {
   MEMORY_INDEX_FTS_TABLE,
   runWithConcurrency,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  hashDailyMemoryContent,
+  resolveDailyLineProvenance,
+  type DailyProvenanceRecord,
+} from "../daily-provenance.js";
+import {
+  DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  readMemoryCoreWorkspaceEntries,
+} from "../dreaming-state.js";
 import { MemoryManagerSessionSyncOps } from "./manager-session-sync-ops.js";
 import { resolveMemorySessionSyncPlan } from "./manager-session-sync-state.js";
 import {
@@ -63,12 +73,38 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
       this.settings.extraPaths,
       this.settings.multimodal,
     );
+    const dailyProvenanceEntries = await readMemoryCoreWorkspaceEntries<DailyProvenanceRecord>({
+      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+      workspaceDir: this.workspaceDir,
+    });
+    const dailyProvenanceByPath = new Map(
+      dailyProvenanceEntries.map((entry) => [entry.key.replaceAll("\\", "/"), entry.value]),
+    );
     const fileEntries = (
       await runWithConcurrency(
-        files.map(
-          (file) => async () =>
-            await buildFileEntry(file, this.workspaceDir, this.settings.multimodal),
-        ),
+        files.map((file) => async () => {
+          const entry = await buildFileEntry(file, this.workspaceDir, this.settings.multimodal);
+          if (!entry || entry.kind !== "markdown") {
+            return entry;
+          }
+          const record = dailyProvenanceByPath.get(entry.path);
+          if (!record) {
+            return entry;
+          }
+          const content = await fs.readFile(entry.absPath, "utf-8").catch(() => undefined);
+          if (content === undefined || hashDailyMemoryContent(content) !== entry.hash) {
+            return entry;
+          }
+          return {
+            ...entry,
+            content,
+            lineProvenance: resolveDailyLineProvenance({
+              content,
+              record,
+              defaultObservedAt: entry.mtimeMs,
+            }),
+          };
+        }),
         this.getIndexConcurrency(),
       )
     ).filter((entry): entry is MemoryIndexEntry => entry !== null);

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -9,6 +9,7 @@ import {
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveDailyRangeProvenance, type DailyProvenanceRecord } from "./daily-provenance.js";
 import {
   appendConsolidationSkippedSummary,
   appendConsolidationSummary,
@@ -185,25 +186,50 @@ function withAuthoritativeProvenance(
   return next;
 }
 
-function withDailyFileQuarantine(
+function withDailyRangeQuarantine(
   candidate: PromotionCandidate,
-  provenanceByPath: ReadonlyMap<
-    string,
-    { fileHash: string; originClass: "agent" | "untrusted"; observedAt: number }
-  >,
+  record: DailyProvenanceRecord | undefined,
+  content: string | undefined,
 ): PromotionCandidate {
-  const record = provenanceByPath.get(candidate.path.replaceAll("\\", "/"));
   if (record?.originClass !== "untrusted") {
+    return candidate;
+  }
+  const provenance = content
+    ? resolveDailyRangeProvenance({
+        content,
+        record,
+        startLine: candidate.startLine,
+        endLine: candidate.endLine,
+        defaultObservedAt: record.observedAt,
+      })
+    : {
+        originClass: "untrusted" as const,
+        sessionKind: "unknown" as const,
+        observedAt: record.observedAt,
+      };
+  if (provenance.originClass !== "untrusted") {
     return candidate;
   }
   return {
     ...candidate,
-    provenance: {
-      originClass: "untrusted",
-      sessionKind: candidate.provenance?.sessionKind ?? "unknown",
-      observedAt: record.observedAt,
-    },
+    provenance,
   };
+}
+
+async function readPromotionSourceText(
+  workspaceDir: string,
+  candidatePath: string,
+): Promise<string | undefined> {
+  for (const sourcePath of resolveShortTermSourcePathCandidates(workspaceDir, candidatePath)) {
+    try {
+      return await fs.readFile(sourcePath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return undefined;
 }
 
 function recallStoreEntryFingerprint(entry: ShortTermRecallEntry | undefined): string {
@@ -258,33 +284,48 @@ export async function applyShortTermPromotions(
   const maxAgeDays = toFiniteNonNegativeInt(options.maxAgeDays, -1);
   const memoryPath = path.join(workspaceDir, "MEMORY.md");
 
-  const dailyProvenanceEntries = await readMemoryCoreWorkspaceEntries<{
-    fileHash: string;
-    originClass: "agent" | "untrusted";
-    observedAt: number;
-  }>({ namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE, workspaceDir });
+  const dailyProvenanceEntries = await readMemoryCoreWorkspaceEntries<DailyProvenanceRecord>({
+    namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+    workspaceDir,
+  });
   const dailyProvenanceByPath = new Map(
     dailyProvenanceEntries.map((entry) => [entry.key.replaceAll("\\", "/"), entry.value]),
   );
   const store = await withShortTermLock(workspaceDir, async () => readStore(workspaceDir, nowIso));
-  const currentCandidates = options.candidates.map((candidate) => {
-    const entry = store.entries[candidate.key];
-    const authoritative = entry
-      ? withAuthoritativeProvenance(
-          {
-            ...candidate,
-            path: entry.path,
-            startLine: entry.startLine,
-            endLine: entry.endLine,
-            snippet: entry.snippet,
-          },
-          entry.provenance,
-        )
-      : candidate;
-    // Flush quarantine is sticky at the daily-file boundary. This deliberately
-    // sacrifices trusted lines in a mixed file so untrusted text cannot promote.
-    return withDailyFileQuarantine(authoritative, dailyProvenanceByPath);
-  });
+  const dailySourceTextByPath = new Map<string, string | undefined>();
+  const currentCandidates = await Promise.all(
+    options.candidates.map(async (candidate) => {
+      const entry = store.entries[candidate.key];
+      const authoritative = entry
+        ? withAuthoritativeProvenance(
+            {
+              ...candidate,
+              path: entry.path,
+              startLine: entry.startLine,
+              endLine: entry.endLine,
+              snippet: entry.snippet,
+            },
+            entry.provenance,
+          )
+        : candidate;
+      const normalizedPath = authoritative.path.replaceAll("\\", "/");
+      const record = dailyProvenanceByPath.get(normalizedPath);
+      if (record?.originClass !== "untrusted") {
+        return authoritative;
+      }
+      if (!dailySourceTextByPath.has(normalizedPath)) {
+        dailySourceTextByPath.set(
+          normalizedPath,
+          await readPromotionSourceText(workspaceDir, normalizedPath),
+        );
+      }
+      return withDailyRangeQuarantine(
+        authoritative,
+        record,
+        dailySourceTextByPath.get(normalizedPath),
+      );
+    }),
+  );
   const selected = currentCandidates
     .filter((candidate) => {
       const latest = store.entries[candidate.key];


### PR DESCRIPTION
## Summary

- track provenance at line-segment granularity for daily memory files
- prevent an untrusted append from tainting previously trusted content
- prevent trusted appends from inheriting a legacy file-wide quarantine
- preserve fail-closed behavior for mixed or unverifiable ranges

## Problem

Daily memory provenance was stored as one file-wide class. Once any untrusted content caused a daily file to be marked `untrusted`, later agent- or user-grounded additions inherited that class permanently. Dreaming could keep staging valid candidates, but promotion would reject the whole file indefinitely.

## Verification

- `pnpm test:extension memory-core` (1,091 passed, 3 skipped)
- `pnpm check`

The regression tests cover trusted content after a quarantined legacy file, untrusted appends after trusted content, mixed-range fail-closed behavior, append rebasing, and promotion/source-sync consumers.
