### PR TITLE
fix(ci): reject duplicate deferred locale chunks

### DIFF
--- a/docs/ci/pipeline.md
+++ b/docs/ci/pipeline.md
@@ -188,6 +188,16 @@ and isolated-renderer ceilings still apply independently. Reports include exact
 bytes, base deltas, and remaining headroom, with an early warning when the largest
 CSS file has less than 1 KiB of headroom.
 
+JavaScript accounting separates ordinary chunks, deferred special-purpose
+chunks, startup assets, and the full bundle total. The 215 KiB ordinary-chunk
+ceiling excludes the isolated Mermaid renderer and configured locale catalogs.
+A locale catalog must match `assets/<locale>-<nonempty-suffix>.js`; each
+configured locale may produce one deferred chunk, with at most 20 locale chunks
+overall and a 300 KiB ceiling per chunk. Locale chunks remain forbidden in the
+startup asset set. Total JavaScript accounting includes ordinary, deferred, and
+startup assets for reporting while enforcement stays on the category-specific
+limits.
+
 CI builds the selected checkout and the exact preflight base with the same
 installed Node, Vite, and dependencies. The temporary base's CSS sidecars are
 normalized through the candidate's pinned compressor before comparison. The

--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -30,9 +30,10 @@ const MERMAID_RENDERER_ASSET = /^assets\/mermaid\.min-[\w-]+\.js$/u;
 const MERMAID_RENDERER_GZIP_BYTES = 960 * KIB;
 // Locale catalogs are named Vite chunks loaded only after a language selection.
 // Bound them separately so catalog growth cannot relax ordinary application chunks.
-const CONTROL_UI_LOCALE_ASSET_PREFIXES = CONTROL_UI_LOCALE_ENTRIES.map(
-  ({ locale }) => `assets/${locale}-`,
-);
+const CONTROL_UI_LOCALE_ASSET_PATTERNS = CONTROL_UI_LOCALE_ENTRIES.map(({ locale }) => ({
+  locale,
+  pattern: new RegExp(`^assets/${escapeRegExp(locale)}-[^/]+\\.js$`, "u"),
+}));
 const CONTROL_UI_LOCALE_GZIP_BYTES = 300 * KIB;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
@@ -120,11 +121,25 @@ function largestAsset(assets: Array<ReturnType<typeof readAssetMetrics>>) {
   )[0]!;
 }
 
-function isControlUiLocaleAsset(file: string): boolean {
-  return (
-    file.endsWith(".js") &&
-    CONTROL_UI_LOCALE_ASSET_PREFIXES.some((prefix) => file.startsWith(prefix))
-  );
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function controlUiLocaleForAsset(file: string): string | null {
+  return CONTROL_UI_LOCALE_ASSET_PATTERNS.find(({ pattern }) => pattern.test(file))?.locale ?? null;
+}
+
+function largestControlUiLocaleAssetCount(
+  assets: Array<ReturnType<typeof readAssetMetrics>>,
+): number {
+  const counts = new Map<string, number>();
+  for (const asset of assets) {
+    const locale = controlUiLocaleForAsset(asset.file);
+    if (locale) {
+      counts.set(locale, (counts.get(locale) ?? 0) + 1);
+    }
+  }
+  return Math.max(0, ...counts.values());
 }
 
 export function collectControlUiPerformanceMetrics(distDir: string) {
@@ -144,9 +159,10 @@ export function collectControlUiPerformanceMetrics(distDir: string) {
   });
   const jsAssets = assets.filter((asset) => asset.type === "js");
   const mermaidRenderer = jsAssets.filter((asset) => MERMAID_RENDERER_ASSET.test(asset.file));
-  const localeCatalogs = jsAssets.filter((asset) => isControlUiLocaleAsset(asset.file));
+  const localeCatalogs = jsAssets.filter((asset) => controlUiLocaleForAsset(asset.file) !== null);
   const ordinaryJsAssets = jsAssets.filter(
-    (asset) => !MERMAID_RENDERER_ASSET.test(asset.file) && !isControlUiLocaleAsset(asset.file),
+    (asset) =>
+      !MERMAID_RENDERER_ASSET.test(asset.file) && controlUiLocaleForAsset(asset.file) === null,
   );
   const cssAssets = assets.filter((asset) => asset.type === "css");
   if (ordinaryJsAssets.length === 0 || cssAssets.length === 0 || startup.length === 0) {
@@ -212,6 +228,12 @@ export function evaluateControlUiPerformanceBudgets(
       "count",
     ],
     [
+      "locale catalog JS assets per locale",
+      largestControlUiLocaleAssetCount(metrics.localeCatalogs),
+      1,
+      "count",
+    ],
+    [
       "largest locale catalog JS gzip",
       Math.max(0, ...metrics.localeCatalogs.map((asset) => asset.gzipBytes)),
       CONTROL_UI_LOCALE_GZIP_BYTES,
@@ -219,7 +241,7 @@ export function evaluateControlUiPerformanceBudgets(
     ],
     [
       "startup locale catalog JS assets",
-      metrics.startup.assets.filter((asset) => isControlUiLocaleAsset(asset.file)).length,
+      metrics.startup.assets.filter((asset) => controlUiLocaleForAsset(asset.file) !== null).length,
       0,
       "count",
     ],
@@ -379,7 +401,7 @@ export function formatControlUiPerformanceReport(
   if (metrics.localeCatalogs.length > 0) {
     const largestLocaleCatalog = largestAsset(metrics.localeCatalogs);
     lines.push(
-      `  locale catalog JS: ${formatAssetSummary(summarizeAssets(metrics.localeCatalogs))} (largest: ${largestLocaleCatalog.file}, ${formatControlUiPerformanceBytes(largestLocaleCatalog.gzipBytes)} gzip; limits: ${CONTROL_UI_LOCALE_ENTRIES.length} deferred assets, ${formatControlUiPerformanceBytes(CONTROL_UI_LOCALE_GZIP_BYTES)} each; forbidden at startup)`,
+      `  locale catalog JS: ${formatAssetSummary(summarizeAssets(metrics.localeCatalogs))} (largest: ${largestLocaleCatalog.file}, ${formatControlUiPerformanceBytes(largestLocaleCatalog.gzipBytes)} gzip; limits: ${CONTROL_UI_LOCALE_ENTRIES.length} deferred assets total, 1 per locale, ${formatControlUiPerformanceBytes(CONTROL_UI_LOCALE_GZIP_BYTES)} each; forbidden at startup)`,
     );
   }
   if (

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -287,10 +287,16 @@ describe("Control UI performance budgets", () => {
       violations: ["largest locale catalog JS gzip"],
     },
     {
-      name: "rejects duplicate locale catalog artifacts",
+      name: "rejects multiple deferred chunks for one locale",
+      gzipBytes: 200_000,
+      duplicateCount: 1,
+      violations: ["locale catalog JS assets per locale"],
+    },
+    {
+      name: "retains the 20-file aggregate locale catalog limit",
       gzipBytes: 200_000,
       duplicateCount: 20,
-      violations: ["locale catalog JS assets"],
+      violations: ["locale catalog JS assets", "locale catalog JS assets per locale"],
     },
     {
       name: "rejects a locale catalog in startup preloads",
@@ -308,6 +314,12 @@ describe("Control UI performance budgets", () => {
       name: "does not exempt unsupported locale chunks",
       gzipBytes: 300 * 1024,
       localeName: "en-a.js",
+      violations: ["largest JS gzip"],
+    },
+    {
+      name: "does not exempt locale chunks without a suffix",
+      gzipBytes: 300 * 1024,
+      localeName: "ru-.js",
       violations: ["largest JS gzip"],
     },
   ])(


### PR DESCRIPTION
Related: #143219

## What Problem This Solves

Resolves a CI coverage gap where duplicate deferred chunks for one configured
Control UI locale could pass while the aggregate locale chunk count remained at
or below 20.

## Why This Change Was Made

Locale assets are now classified only when they match the anchored
`assets/<locale>-<nonempty-suffix>.js` form, and each configured locale is
limited to one deferred chunk. The existing 20-file aggregate limit, 300 KiB
locale cap, startup prohibition, 215 KiB ordinary chunk cap, and total
JavaScript accounting remain unchanged. The CI pipeline documentation now
describes each accounting category.

## User Impact

There is no runtime behavior or production-output change. CI now rejects
duplicate deferred locale chunks before they can land.

## Evidence

- Before the fix, two `ru` chunks with fewer than 20 total locale assets
  produced no violation; after the fix they produce
  `locale catalog JS assets per locale`.
- Focused Control UI performance tests: 51/51 passed.
- Documentation checks, diff checks, formatting, targeted lint, and script
  erasability passed.
- Independent review completed cleanly.

`pnpm check:changed` reached `tsgo:scripts`, then refused the externally
symlinked `node_modules` used by the task worktree. Hosted exact-head CI remains
required.

## Change Size

- Runtime production LOC: 0
- Tooling: +34/-12
- Tests: +14/-2
- Documentation: +10
