### PR TITLE
improve(test): reuse initial egress proxy certificates

### DIFF
--- a/src/secrets/egress-proxy/proxy-server.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.test.ts
@@ -5,7 +5,8 @@ import net, { type Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import tls from "node:tls";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { generateLocalProxyLeaf } from "../../proxy-capture/ca.js";
 import {
   mintSecretSentinel,
@@ -30,6 +31,8 @@ const servers: Server[] = [];
 const proxies: SecretEgressProxyHandle[] = [];
 const sockets = new Set<Socket>();
 const tempDirs: string[] = [];
+const seedDirs = createTempDirTracker();
+let seed: { dir: string; leaf: Awaited<ReturnType<typeof generateLocalProxyLeaf>> } | undefined;
 let caDir: string;
 let auditEvents: SecretEgressProxyAuditEvent[];
 let originRequests: OriginRequest[];
@@ -51,6 +54,12 @@ function registerSentinel(params: {
       allowedHosts: params.allowedHosts,
     },
   ]);
+}
+
+function copyInitialCa(sourceDir: string, targetDir: string): void {
+  for (const file of ["root-ca.pem", "root-ca-key.pem", "leaf-key.pem"]) {
+    fs.copyFileSync(path.join(sourceDir, file), path.join(targetDir, file));
+  }
 }
 
 async function listen(server: Server): Promise<number> {
@@ -215,16 +224,21 @@ beforeEach(async () => {
   originRequests = [];
   caDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-egress-proxy-test-"));
   tempDirs.push(caDir);
+  if (seed) {
+    copyInitialCa(seed.dir, caDir);
+  }
   proxy = await startSecretEgressProxyServer({
     caDir,
     onAudit: (event) => auditEvents.push(event),
   });
   proxies.push(proxy);
-  const leaf = await generateLocalProxyLeaf({
-    certDir: caDir,
-    ca: { certPath: proxy.caCertPath, keyPath: path.join(caDir, "root-ca-key.pem") },
-    hostname: "localhost",
-  });
+  const leaf = seed
+    ? { cert: Buffer.from(seed.leaf.cert), key: Buffer.from(seed.leaf.key) }
+    : await generateLocalProxyLeaf({
+        certDir: caDir,
+        ca: { certPath: proxy.caCertPath, keyPath: path.join(caDir, "root-ca-key.pem") },
+        hostname: "localhost",
+      });
   originPort = await listen(
     createHttpsServer(leaf, (request, response) => {
       const chunks: Buffer[] = [];
@@ -242,7 +256,20 @@ beforeEach(async () => {
   );
   run = Object.freeze({ instanceId: "instance-1", runId: "run-1" });
   proxyEnv = proxy.registerRun(run);
+  if (!seed) {
+    // Capture after cold setup succeeds, before a case can mutate its files.
+    const dir = seedDirs.make("openclaw-egress-proxy-seed-");
+    try {
+      copyInitialCa(caDir, dir);
+      seed = { dir, leaf: { cert: Buffer.from(leaf.cert), key: Buffer.from(leaf.key) } };
+    } catch (error) {
+      seedDirs.cleanup();
+      throw error;
+    }
+  }
 });
+
+afterAll(() => seedDirs.cleanup());
 
 afterEach(async () => {
   for (const socket of sockets) {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The 20-case egress proxy suite repeats identical initial certificate generation,
adding avoidable time to local test runs.

## Why This Change Was Made

Keep the first selected case's complete cold setup, then capture a file-owned
certificate seed only after the origin is listening and the run is registered.
Later cases receive three ordinary private file copies and fresh certificate/key
buffers. A separate temporary-directory tracker removes partial captures and
cleans the completed seed after the file.

All 20 case bodies, assertions, deadlines, fresh proxies/origins, real TLS
verification, request-time issuance, authentication checks, and the independent
bypass CA remain. Only `src/secrets/egress-proxy/proxy-server.test.ts` changes
(33 additions, 6 deletions); no production or dependency changes.

## User Impact

No product behavior changes. Three matched local whole-file pairs show a median
paired reduction of **3.808859 seconds (36.7245%)** on Linux with Node 24.19.0.
This is not a CI, Windows, full-suite, or end-to-end speed claim.

## Evidence

All six uninstrumented runs passed all 20 cases in the same order, using normal
project workers/setup, equivalent prepared worker state, and fresh private
per-run caches. Wall time includes startup, the first cold setup, seed capture,
copies, hooks, teardown, and child exit.

| Pair order | Original wall | Candidate wall |
| --- | ---: | ---: |
| Original, candidate | 10.527423 s | 6.454448 s |
| Candidate, original | 10.357956 s | 6.610910 s |
| Original, candidate | 10.371426 s | 6.562567 s |

- Separate untimed attribution/control runs observed **109 to 33 asynchronous
  OpenSSL calls**: initial setup decreased from 80 to 4, with all 28 request-time
  calls and the independent bypass CA generation preserved. Neither variant
  uses a synchronous verify operation in this owner.
- The normal candidate control passed 20/20, with 60 ordinary copies and
  22 distinct roots. It verified file permissions, physical file independence,
  nonaliasing origin buffers, an unchanged seed across cases, and cleanup.
  The existing header case also passed alone through the complete cold path.
- A partial seed-copy fault produced the intended owner exit 1: the first case
  failed, the partial seed was removed, the next case performed cold setup,
  and the other 19 cases passed. All allocated roots were removed.
- The first trust-control receipt remains failed qualification because its
  formatted-error collector missed the required text; it has not been relabeled.
  A separately corrected collector used Vitest's maintained result API and
  qualified one rerun of only the same two cases. The exact failed header
  assertion's native cause and real TLS rejection both reported
  `UNABLE_TO_VERIFY_LEAF_SIGNATURE` on the reused fixture root. The cold case
  passed, the header case intentionally failed, 18 cases were skipped, and
  owner exit 1 was retained. An unrelated `ECONNRESET` collector input was
  rejected; no formatted-text fallback qualified the control.
- All **20 required changed-path checks** passed, including formatting, core
  graph/types, dead exports, and lint. Diff check passed.
- Fresh native P2 review returned scoped-clean with no P0-P2 findings. Its
  context was the exact diff, `src/proxy-capture/ca.ts`,
  `test/helpers/temp-dir.ts`, `src/proxy-capture/ca.test.ts`, and attributed
  audit/control evidence. It did **not** independently read the full changed
  test, secrets server/certificate owners, or secrets lifecycle sibling.

Raw evidence remains private. Identity checks cover selected sources and
artifacts, not every tree byte. Server close events preceded case-directory
removal; the rejected TLS client's close event followed its case-directory
removal by approximately 0.684 ms and preceded seed teardown. All owned roots
and scoped processes were absent afterward; no universal close-before-delete
ordering is claimed. A missing generic esbuild close event remains recorded
as a telemetry limitation rather than being inferred from process absence.
Exact-head [CI run 34384391612](https://github.com/openclaw/openclaw/actions/runs/34384391612) passed on `649f685b39e0d2665ad86f6deaeb6bb80ebf6450`, including the required `openclaw/ci-gate` (job 102578921158).
