### PR TITLE
fix(docs): respect fenced-code closing suffixes

### DIFF
--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -219,12 +219,16 @@ function extractHeadings(raw) {
 
   for (const rawLine of lines) {
     const trimmed = rawLine.trim();
-    const fenceMatch = /^(?<marker>`{3,}|~{3,})/u.exec(trimmed);
+    const fenceMatch = /^(?<marker>`{3,}|~{3,})(?<trailing>.*)$/u.exec(trimmed);
     if (fenceMatch) {
       const marker = fenceMatch.groups.marker;
       if (!fenceMarker) {
         fenceMarker = marker;
-      } else if (marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length) {
+      } else if (
+        marker[0] === fenceMarker[0] &&
+        marker.length >= fenceMarker.length &&
+        fenceMatch.groups.trailing.trim().length === 0
+      ) {
         fenceMarker = null;
       }
       continue;

--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -218,8 +218,8 @@ function extractHeadings(raw) {
   let fenceMarker = null;
 
   for (const rawLine of lines) {
-    const trimmed = rawLine.trim();
-    const fenceMatch = /^(?<marker>`{3,}|~{3,})(?<trailing>.*)$/u.exec(trimmed);
+    const trimmed = rawLine.trimStart();
+    const fenceMatch = /^(?<marker>`{3,}|~{3,})/u.exec(trimmed);
     if (fenceMatch) {
       const marker = fenceMatch.groups.marker;
       if (!fenceMarker) {
@@ -227,7 +227,7 @@ function extractHeadings(raw) {
       } else if (
         marker[0] === fenceMarker[0] &&
         marker.length >= fenceMarker.length &&
-        fenceMatch.groups.trailing.trim().length === 0
+        /^[ \t]*$/u.test(trimmed.slice(marker.length))
       ) {
         fenceMarker = null;
       }

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -103,6 +103,13 @@ summary: "Page"
 ### Hidden nested fenced heading
 \`\`\`
 \`\`\`\`
+
+~~~md
+### Hidden fenced heading with a suffixed closer
+~~~json
+### Still hidden after the invalid closer
+~~~
+# Visible after the fenced block
 `,
       "utf8",
     );
@@ -120,6 +127,8 @@ summary: "Page"
     expect(output).not.toContain("metadata comment must not become a heading");
     expect(output).not.toContain("Hidden fenced heading");
     expect(output).not.toContain("Hidden nested fenced heading");
+    expect(output).not.toContain("Still hidden after the invalid closer");
+    expect(output).toContain("  - H1: Visible after the fenced block");
     expect(output).not.toContain("AGENTS.md");
     expect(existsSync(path.join(tempRepoRoot, "docs", "docs_map.md"))).toBe(false);
   });

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -133,6 +133,46 @@ summary: "Page"
     expect(existsSync(path.join(tempRepoRoot, "docs", "docs_map.md"))).toBe(false);
   });
 
+  it.each([
+    ["backtick text suffix", "```md", "```json", "```"],
+    ["backtick nonbreaking space", "```md", "```\u00a0", "```"],
+    ["tilde nonbreaking space", "~~~md", "~~~\u00a0", "~~~"],
+    ["line separator in opening info", "```md\u2028info", "```json", "```"],
+    ["paragraph separator in opening info", "~~~md\u2029info", "~~~json", "~~~"],
+    ["different fence character", "```md", "~~~", "```"],
+  ])("keeps example headings hidden with %s", (_name, opening, invalidClosing, closing) => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-fence-");
+    mkdirSync(path.join(tempRepoRoot, "docs"));
+    writeFileSync(
+      path.join(tempRepoRoot, "docs", "page.md"),
+      `${opening}\n# Hidden example\n${invalidClosing}\n## Still hidden\n${closing}\n# Visible after close\n`,
+    );
+
+    const output = runDocsList(tempRepoRoot, ["--headings"]);
+
+    expect(output).not.toContain("H1: Hidden example");
+    expect(output).not.toContain("H2: Still hidden");
+    expect(output).toContain("H1: Visible after close");
+  });
+
+  it.each([
+    ["spaces", "~~~", "~~~   "],
+    ["tabs", "```", "```\t\t"],
+    ["a longer marker", "~~~", "~~~~~ \t"],
+  ])("resumes headings after a valid closing fence with %s", (_name, opening, closing) => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-fence-close-");
+    mkdirSync(path.join(tempRepoRoot, "docs"));
+    writeFileSync(
+      path.join(tempRepoRoot, "docs", "page.md"),
+      `${opening}\n# Hidden example\n${closing}\n# Visible after close\n`,
+    );
+
+    const output = runDocsList(tempRepoRoot, ["--headings"]);
+
+    expect(output).not.toContain("H1: Hidden example");
+    expect(output).toContain("H1: Visible after close");
+  });
+
   it("normalizes injected Windows paths for nested page routes", () => {
     const tempRepoRoot = makeTempRepoRoot("openclaw-docs-headings-windows-");
     const docsDir = path.join(tempRepoRoot, "docs");


### PR DESCRIPTION
## What Problem This Solves

The documentation heading map can list headings from inside code examples after a fence marker with trailing text. It can also lose real headings after the block. This affects the command-line map, published docs map, and packaged docs map.

## Why This Change Was Made

The shared extractor now closes a fence only when the marker has the same character, meets the opening length, and is followed only by spaces or tabs. It preserves the suffix before checking it and keeps the existing opening-marker recognition, including arbitrary opening info text.

## User Impact

Docs-aware tools find real page headings instead of headings that are only example content. Existing heading cleanup, HTML escaping, frontmatter handling, nested routes, and supported heading levels remain unchanged.

## Evidence

- The real `scripts/docs-list.js --headings` command on pinned main `fd490cf304fea7d4fd83c3a8643078ebe2884ff7` exposed example headings after invalid backtick and tilde closers. The corrected command keeps them hidden and preserves the real headings after valid closes.
- The corrected CLI test suite passed all 13 tests. The same suite failed six cases with the main extractor and four cases with the initial candidate extractor, including nonbreaking-space suffixes and opening info containing Unicode line separators.
- CLI, publisher, and package map callers produced identical complete maps for the same documentation inputs. Package restoration completed.
- Targeted formatting, syntax lint, and `git diff --check` passed. Full type-aware checks run in hosted CI.
- This is a bounded fence-suffix repair. It does not claim full CommonMark, MDX-container, or renderer conformance.

Related: merged #130207, which fixed fence-length handling and named suffix handling as follow-up work.

Independent behavior validation also passed ten fresh fixtures through the real CLI, publisher, and package callers, including CRLF and MDX file inputs. The tested file bytes are unchanged in commit `a0ded8791cc433bca552ace66fa98b6ae2d5e16f`.
