### PR TITLE
refactor(tests): share bound-turn client fixtures

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -456,6 +456,37 @@ function conversationThreadStartResult(threadId: string, canAcceptDirectInput?: 
   };
 }
 
+function createCompletingBoundTurnClient(turnStartParams: Record<string, unknown>[]) {
+  let notificationHandler: ((notification: unknown) => void) | undefined;
+  return {
+    request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+      if (method === "turn/start") {
+        turnStartParams.push(requestParams);
+        setImmediate(() =>
+          notificationHandler?.({
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+              },
+            },
+          }),
+        );
+        return { turn: { id: "turn-1" } };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    }),
+    addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+      notificationHandler = handler;
+      return () => undefined;
+    }),
+    addRequestHandler: vi.fn(() => () => undefined),
+  };
+}
+
 function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0): unknown {
   const call = mock.mock.calls[callIndex];
   if (!call) {
@@ -3665,35 +3696,10 @@ describe("codex conversation binding", () => {
       approvalPolicy: "never",
       sandbox: "danger-full-access",
     });
-    let notificationHandler: ((notification: unknown) => void) | undefined;
     const turnStartParams: Record<string, unknown>[] = [];
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        if (method === "turn/start") {
-          turnStartParams.push(requestParams);
-          setImmediate(() =>
-            notificationHandler?.({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-1",
-                turn: {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
-                },
-              },
-            }),
-          );
-          return { turn: { id: "turn-1" } };
-        }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
-        notificationHandler = handler;
-        return () => undefined;
-      }),
-      addRequestHandler: vi.fn(() => () => undefined),
-    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(
+      createCompletingBoundTurnClient(turnStartParams),
+    );
 
     const result = await handleCodexConversationInboundClaim(
       {
@@ -4488,35 +4494,10 @@ describe("codex conversation binding", () => {
       threadId: "thread-1",
       cwd: tempDir,
     });
-    let notificationHandler: ((notification: unknown) => void) | undefined;
     const turnStartParams: Record<string, unknown>[] = [];
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        if (method === "turn/start") {
-          turnStartParams.push(requestParams);
-          setImmediate(() =>
-            notificationHandler?.({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-1",
-                turn: {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
-                },
-              },
-            }),
-          );
-          return { turn: { id: "turn-1" } };
-        }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
-        notificationHandler = handler;
-        return () => undefined;
-      }),
-      addRequestHandler: vi.fn(() => () => undefined),
-    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(
+      createCompletingBoundTurnClient(turnStartParams),
+    );
 
     const result = await handleCodexConversationInboundClaim(
       {
@@ -4571,35 +4552,10 @@ describe("codex conversation binding", () => {
       networkProxyProfileName: NETWORK_PROXY_PROFILE_NAME,
       networkProxyConfigFingerprint: NETWORK_PROXY_CONFIG_FINGERPRINT,
     });
-    let notificationHandler: ((notification: unknown) => void) | undefined;
     const turnStartParams: Record<string, unknown>[] = [];
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        if (method === "turn/start") {
-          turnStartParams.push(requestParams);
-          setImmediate(() =>
-            notificationHandler?.({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-1",
-                turn: {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
-                },
-              },
-            }),
-          );
-          return { turn: { id: "turn-1" } };
-        }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
-        notificationHandler = handler;
-        return () => undefined;
-      }),
-      addRequestHandler: vi.fn(() => () => undefined),
-    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(
+      createCompletingBoundTurnClient(turnStartParams),
+    );
 
     const result = await handleCodexConversationInboundClaim(
       {
@@ -4817,35 +4773,10 @@ describe("codex conversation binding", () => {
       approvalPolicy: "never",
       sandbox: "danger-full-access",
     });
-    let notificationHandler: ((notification: unknown) => void) | undefined;
     const turnStartParams: Record<string, unknown>[] = [];
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        if (method === "turn/start") {
-          turnStartParams.push(requestParams);
-          setImmediate(() =>
-            notificationHandler?.({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-1",
-                turn: {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
-                },
-              },
-            }),
-          );
-          return { turn: { id: "turn-1" } };
-        }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
-        notificationHandler = handler;
-        return () => undefined;
-      }),
-      addRequestHandler: vi.fn(() => () => undefined),
-    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(
+      createCompletingBoundTurnClient(turnStartParams),
+    );
 
     const result = await handleCodexConversationInboundClaim(
       {
@@ -4899,35 +4830,10 @@ describe("codex conversation binding", () => {
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
     });
-    let notificationHandler: ((notification: unknown) => void) | undefined;
     const turnStartParams: Record<string, unknown>[] = [];
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        if (method === "turn/start") {
-          turnStartParams.push(requestParams);
-          setImmediate(() =>
-            notificationHandler?.({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-1",
-                turn: {
-                  id: "turn-1",
-                  status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
-                },
-              },
-            }),
-          );
-          return { turn: { id: "turn-1" } };
-        }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
-        notificationHandler = handler;
-        return () => undefined;
-      }),
-      addRequestHandler: vi.fn(() => () => undefined),
-    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(
+      createCompletingBoundTurnClient(turnStartParams),
+    );
 
     await expect(
       handleCodexConversationInboundClaim(


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five conversation-binding tests repeat the same mock client while exercising different prompt and permission policies.

## Why This Change Was Made

Use a local factory that receives each test's existing request array and owns a separate notification-handler closure. It preserves fresh mocks, request-object identity, late handler lookup inside the existing setImmediate callback, and the existing no-op disposers. All scenarios and independent assertions remain unchanged. This removes 94 net test lines.

## User Impact

No production or conversation behavior changes. The tests retain coverage for fallback prompt text, sandbox resolution, network-proxy permissions, and custom-provider policy handling.

## Evidence

- Complete conversation-binding and both turn-router suites before and after: the same 129 ordered cases passed, with no skipped cases.
- Source expansion and capture-binding checks reproduce the original source bytes and syntax tree.
- Two temporary controls using real Vitest mocks and real setImmediate verify original/candidate identities, handler replacement and late registration, callback ordering, fresh notification objects, and unknown-method rejection.
- Mapped changed-file gate and fresh independent P2 review passed.

The scheduling checks preserve the existing test fixture's behavior; they do not assert a native-server timing guarantee.
