### PR TITLE
fix(cli): retain local model resources through completion cleanup

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -108,7 +108,9 @@ const mocks = vi.hoisted(() => ({
   loadModelCatalog: vi.fn<
     typeof import("../agents/prepared-model-catalog.js").readPreparedModelCatalog
   >(async () => []),
-  prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+  releaseSimpleCompletion: vi.fn(),
+  acquireSimpleCompletionModelForAgent: vi.fn(async () => ({
+    release: () => mocks.releaseSimpleCompletion(),
     selection: {
       provider: "openai",
       modelId: "gpt-5.4",
@@ -348,8 +350,8 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
 }));
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent:
-    mocks.prepareSimpleCompletionModelForAgent as unknown as typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent:
+    mocks.acquireSimpleCompletionModelForAgent as unknown as typeof import("../agents/simple-completion-runtime.js").acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel:
     mocks.completeWithPreparedSimpleCompletionModel as unknown as typeof import("../agents/simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel,
 }));
@@ -641,7 +643,8 @@ describe("capability cli", () => {
         return store;
       });
     mocks.resolveMemorySearchConfig.mockReset().mockReturnValue(null);
-    mocks.prepareSimpleCompletionModelForAgent.mockClear();
+    mocks.acquireSimpleCompletionModelForAgent.mockClear();
+    mocks.releaseSimpleCompletion.mockClear();
     mocks.completeWithPreparedSimpleCompletionModel.mockClear();
     mocks.callGateway.mockReset().mockImplementation((async ({ method }: { method: string }) => {
       if (method === "tts.status") {
@@ -769,7 +772,7 @@ describe("capability cli", () => {
   }
 
   function firstPreparedModelParams() {
-    const calls = mocks.prepareSimpleCompletionModelForAgent.mock.calls as unknown as Array<
+    const calls = mocks.acquireSimpleCompletionModelForAgent.mock.calls as unknown as Array<
       [Record<string, unknown>]
     >;
     return calls[0]?.[0];
@@ -1218,7 +1221,7 @@ describe("capability cli", () => {
   it("defaults model run to local transport", async () => {
     await runCapability("model", "run", "--prompt", "hello", "--json");
 
-    expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.acquireSimpleCompletionModelForAgent).toHaveBeenCalledTimes(1);
     expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledTimes(1);
     expect(mocks.callGateway).not.toHaveBeenCalled();
     expect(firstJsonOutput()?.capability).toBe("model.run");
@@ -1311,7 +1314,7 @@ describe("capability cli", () => {
   it("does not enable bundled static catalog fallback without an explicit provider/model override", async () => {
     await runCapability("model", "run", "--prompt", "hello", "--json");
 
-    const calls = mocks.prepareSimpleCompletionModelForAgent.mock.calls as unknown as Array<
+    const calls = mocks.acquireSimpleCompletionModelForAgent.mock.calls as unknown as Array<
       [Record<string, unknown>]
     >;
     const params = calls[0]?.[0];
@@ -1341,7 +1344,8 @@ describe("capability cli", () => {
   });
 
   it("adds minimal instructions only for openai local model probes", async () => {
-    mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+    mocks.acquireSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      release: () => mocks.releaseSimpleCompletion(),
       selection: {
         provider: "openai",
         modelId: "gpt-5.5",
@@ -1519,7 +1523,8 @@ describe("capability cli", () => {
   });
 
   it("rejects local Codex provider probes before simple-completion dispatch", async () => {
-    mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+    mocks.acquireSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      release: () => mocks.releaseSimpleCompletion(),
       selection: {
         provider: "codex",
         modelId: "gpt-5.4",
@@ -1542,6 +1547,7 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Codex app-server agent runtime");
+    expect(mocks.releaseSimpleCompletion).toHaveBeenCalledTimes(1);
     expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
   });
@@ -1554,7 +1560,7 @@ describe("capability cli", () => {
       );
 
       expectRuntimeErrorContains("--prompt cannot be empty or whitespace-only.");
-      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
       expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
       expect(mocks.callGateway).not.toHaveBeenCalled();
       expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
@@ -1579,7 +1585,7 @@ describe("capability cli", () => {
       ).rejects.toThrow("exit 1");
 
       expectRuntimeErrorContains("Model overrides must use the form <provider/model>.");
-      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
       expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
       expect(mocks.callGateway).not.toHaveBeenCalled();
     },
@@ -1743,7 +1749,7 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Invalid thinking level.");
-    expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(mocks.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
     expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
     expect(mocks.callGateway).not.toHaveBeenCalled();
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();

--- a/src/cli/capability-cli/model.resources.test.ts
+++ b/src/cli/capability-cli/model.resources.test.ts
@@ -1,0 +1,292 @@
+import fs from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { getAiTransportHost } from "@openclaw/ai";
+import { Command } from "commander";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared-model-runtime.test-support.js";
+import { ModelRegistry } from "../../agents/sessions/model-registry.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetPluginLoaderTestStateForTest } from "../../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import {
+  createColdPluginFixture,
+  createColdPluginHermeticEnv,
+} from "../../plugins/test-helpers/cold-plugin-fixtures.js";
+import { createSyncSuiteTempRootTracker } from "../../plugins/test-helpers/fs-fixtures.js";
+import { defaultRuntime } from "../../runtime.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { registerModelCapabilityCommands } from "./model.js";
+import * as shared from "./shared.js";
+
+it.each(["overlap", "provider-error", "callback-drain", "cancel-drain"] as const)(
+  "retains local CLI completion resources through %s",
+  async (mode) => {
+    const roots = createSyncSuiteTempRootTracker("cli-model-owner");
+    const root = fs.realpathSync(roots.makeTempDir());
+    fs.mkdirSync(path.join(root, "provider"));
+    const fixture = createColdPluginFixture({
+      rootDir: path.join(root, "provider"),
+      pluginId: "cli-completion-fixture",
+      providerId: "cli-completion-provider",
+    });
+    fs.writeFileSync(
+      fixture.runtimeSource,
+      `module.exports = { id: ${JSON.stringify(fixture.pluginId)}, register(api) {
+        api.registerProvider({ id: ${JSON.stringify(fixture.providerId)}, label: "CLI fixture", auth: [] });
+      } };`,
+    );
+    const requests: ServerResponse[] = [];
+    const arrivals = [createDeferred(), createDeferred(), createDeferred()];
+    let finishing = false;
+    const finish = (response: ServerResponse, index: number) => {
+      if (response.writableEnded || response.destroyed) {
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `data: ${JSON.stringify({
+          id: "cli-response",
+          object: "chat.completion.chunk",
+          model: "cli-model",
+          choices: [{ index: 0, delta: { content: `reply-${index}` }, finish_reason: "stop" }],
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    };
+    const server = createServer((request, response) => {
+      request.resume();
+      const index = requests.push(response) - 1;
+      arrivals[index]?.resolve();
+      if (finishing) {
+        finish(response, index);
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("CLI fixture has no TCP port");
+      }
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { workspace: root, model: `${fixture.providerId}/cli-model` } },
+        models: {
+          providers: {
+            [fixture.providerId]: {
+              api: "openai-completions",
+              apiKey: "synthetic-cli-key",
+              baseUrl: `http://127.0.0.1:${address.port}/v1`,
+              models: [
+                {
+                  id: "cli-model",
+                  name: "CLI model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          load: { paths: [fixture.rootDir] },
+          slots: { memory: "none" },
+          entries: { [fixture.pluginId]: { enabled: true } },
+        },
+      };
+      await withEnvAsync(
+        {
+          ...createColdPluginHermeticEnv(root, { bundledPluginsDir: roots.makeTempDir() }),
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: path.join(root, "state"),
+        },
+        async () => {
+          const config = vi
+            .spyOn(shared, "resolveLocalCapabilityRuntimeConfig")
+            .mockResolvedValue(cfg);
+          const builds = vi.spyOn(ModelRegistry, "create");
+          const output = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+          const errors = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+          const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => {
+            throw new Error("CLI failed");
+          });
+          const finishCancel = createDeferred();
+          const callbackStarted = createDeferred();
+          const cancelStarted = createDeferred();
+          const parent = new AsyncWorkScope();
+          const pending: Promise<unknown>[] = [];
+          const transportSpies: Array<{ mockRestore(): void }> = [];
+          let drained = false;
+          let drainage: Promise<void> | undefined;
+          if (mode === "callback-drain" || mode === "cancel-drain") {
+            const { configureAiTransportRuntimeHost } =
+              await import("../../agents/ai-transport-runtime-host.js");
+            configureAiTransportRuntimeHost();
+            const plugin = getAiTransportHost().plugin;
+            const wrap = plugin.wrapSimpleCompletionStream;
+            let first = true;
+            transportSpies.push(
+              vi.spyOn(plugin, "wrapSimpleCompletionStream").mockImplementation((params) => {
+                const stream = wrap(params) ?? params.context.streamFn;
+                return (model, context, options) =>
+                  stream(model, context, {
+                    ...options,
+                    onResponse: async (response, responseModel) => {
+                      await options?.onResponse?.(response, responseModel);
+                      if (first) {
+                        first = false;
+                        if (mode === "cancel-drain") {
+                          throw new Error("fixture response rejected");
+                        }
+                        callbackStarted.resolve();
+                        await finishCancel.promise;
+                      }
+                    },
+                  });
+              }),
+            );
+          }
+          if (mode === "cancel-drain") {
+            const fetch = globalThis.fetch;
+            let wrapped = false;
+            transportSpies.push(
+              vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+                const response = await fetch(...args);
+                if (wrapped || !response.url.startsWith(`http://127.0.0.1:${address.port}/`)) {
+                  return response;
+                }
+                wrapped = true;
+                const reader = response.body?.getReader();
+                if (!reader) {
+                  throw new Error("Fixture response has no body");
+                }
+                return new Response(
+                  new ReadableStream<Uint8Array>({
+                    async pull(controller) {
+                      const { value, done } = await reader.read();
+                      if (done) {
+                        controller.close();
+                      } else {
+                        controller.enqueue(value);
+                      }
+                    },
+                    async cancel(reason) {
+                      cancelStarted.resolve();
+                      await finishCancel.promise;
+                      await reader.cancel(reason);
+                    },
+                  }),
+                  { status: response.status, headers: response.headers },
+                );
+              }),
+            );
+          }
+          const start = (managed = false) => {
+            const command = new Command();
+            registerModelCapabilityCommands(command);
+            const execute = async () => {
+              await command.parseAsync(["model", "run", "--prompt", "hello", "--json"], {
+                from: "user",
+              });
+            };
+            const run = managed ? parent.track(execute) : execute();
+            pending.push(run);
+            return run;
+          };
+          const arrive = (index: number, run: Promise<void>) =>
+            Promise.race([
+              arrivals[index]!.promise,
+              run.then(() => {
+                throw new Error("CLI settled before provider request");
+              }),
+            ]);
+          try {
+            const started = performance.now();
+            const first = start(true);
+            await arrive(0, first);
+            const coldMs = performance.now() - started;
+            const firstBuilds = builds.mock.calls.length;
+            expect(firstBuilds).toBeGreaterThan(0);
+            if (mode === "provider-error") {
+              requests[0]!.writeHead(400, { "content-type": "application/json" });
+              requests[0]!.end(
+                JSON.stringify({ error: { message: "fixture provider rejection" } }),
+              );
+              await expect(first).rejects.toThrow("CLI failed");
+              expect(errors.mock.calls.flat().join(" ")).toContain("fixture provider rejection");
+            } else if (mode === "callback-drain") {
+              finish(requests[0]!, 0);
+              await Promise.race([callbackStarted.promise, first]);
+            } else if (mode === "cancel-drain") {
+              finish(requests[0]!, 0);
+              await Promise.race([cancelStarted.promise, first]);
+              await expect(first).rejects.toThrow("CLI failed");
+              drainage = parent.drain().then(() => {
+                drained = true;
+              });
+            }
+            const nextStarted = performance.now();
+            const second = start();
+            await arrive(1, second);
+            console.info("CLI completion preparation", {
+              mode,
+              coldMs,
+              overlapMs: performance.now() - nextStarted,
+            });
+            expect
+              .soft(builds.mock.calls.length)
+              .toBe(firstBuilds + (mode === "provider-error" ? 1 : 0));
+            if (mode === "cancel-drain") {
+              expect.soft(drained).toBe(false);
+            }
+            finishCancel.resolve();
+            finish(requests[0]!, 0);
+            finish(requests[1]!, 1);
+            if (mode === "overlap" || mode === "callback-drain") {
+              await first;
+            }
+            await second;
+            await drainage;
+            expect(
+              output.mock.calls.some(([value]) => JSON.stringify(value).includes("reply-1")),
+            ).toBe(true);
+            const buildsBeforeThird = builds.mock.calls.length;
+            const third = start();
+            await arrive(2, third);
+            expect(builds.mock.calls.length).toBe(buildsBeforeThird + 1);
+            finish(requests[2]!, 2);
+            await third;
+          } finally {
+            finishCancel.resolve();
+            finishing = true;
+            requests.forEach(finish);
+            await Promise.allSettled(pending);
+            await parent.drain();
+            for (const spy of transportSpies) {
+              spy.mockRestore();
+            }
+            config.mockRestore();
+            builds.mockRestore();
+            output.mockRestore();
+            errors.mockRestore();
+            exit.mockRestore();
+            await resetPreparedModelRuntimeSnapshotsForTest();
+            clearPluginMetadataLifecycleCaches();
+            resetPluginLoaderTestStateForTest();
+          }
+        },
+      );
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      roots.cleanup();
+    }
+  },
+);

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -22,8 +22,8 @@ import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../../agents/model-selection.js";
 import { readPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import {
+  acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
 } from "../../agents/simple-completion-runtime.js";
 import { normalizeThinkLevel, type ThinkLevel } from "../../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../../config/config.js";
@@ -33,6 +33,8 @@ import { ADMIN_SCOPE } from "../../gateway/operator-scopes.js";
 import { convertHeicToJpeg } from "../../media/media-services.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
+import { AsyncWorkScope, captureAsyncWorkTracker } from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { collectOption } from "../program/helpers.js";
@@ -193,79 +195,100 @@ async function runModelRun(params: {
         ]
       : params.prompt;
   if (params.transport === "local") {
-    const prepared = await prepareSimpleCompletionModelForAgent({
-      cfg,
-      agentId,
-      modelRef,
-      allowMissingApiKeyModes: ["aws-sdk"],
-      ...(hasExplicitProviderModelOverride ? { allowBundledStaticCatalogFallback: true } : {}),
-      skipAgentDiscovery: true,
-    });
-    if ("error" in prepared) {
-      throw new Error(prepared.error);
-    }
-    if (prepared.selection.provider === "codex") {
-      throw new Error(
-        'The codex provider is served by the Codex app-server agent runtime, not the local simple-completion transport. Use an openai/<model> ref with provider/model agentRuntime.id: "codex", run through the gateway, or use /codex commands.',
-      );
-    }
-    const localModelRunSystemPrompt =
-      prepared.model.api === "openai-chatgpt-responses" ? LOCAL_MODEL_RUN_SYSTEM_PROMPT : undefined;
-    const result = await completeWithPreparedSimpleCompletionModel({
-      model: prepared.model,
-      auth: prepared.auth,
-      cfg,
-      context: {
-        ...(localModelRunSystemPrompt ? { systemPrompt: localModelRunSystemPrompt } : {}),
-        messages: [
-          {
-            role: "user",
-            content: messageContent,
-            timestamp: Date.now(),
-          },
-        ],
-      },
-      options: {
-        maxTokens:
-          typeof prepared.model.maxTokens === "number" && Number.isFinite(prepared.model.maxTokens)
-            ? prepared.model.maxTokens
-            : undefined,
-        ...(params.thinking ? { reasoning: params.thinking } : {}),
-      },
-    });
-    const text = collectModelRunText(result.content);
-    if (!text) {
-      const providerErrorMessage = (result as { errorMessage?: unknown }).errorMessage;
-      const detail =
-        typeof providerErrorMessage === "string" && providerErrorMessage.trim()
-          ? `: ${providerErrorMessage.trim()}`
-          : "";
-      throw new Error(
-        `No text output returned for provider "${prepared.selection.provider}" model "${prepared.selection.modelId}"${detail}.`,
-      );
-    }
-    return {
-      ok: true,
-      capability: "model.run",
-      transport: "local" as const,
-      provider: prepared.selection.provider,
-      model: prepared.selection.modelId,
-      attempts: [],
-      ...(imageFiles.length > 0
-        ? {
-            inputs: imageFiles.map((image) => ({
-              path: image.path,
-              mimeType: image.mimeType,
-            })),
-          }
-        : {}),
-      outputs: [
-        {
-          text,
-          mediaUrl: null,
-        },
-      ],
-    } satisfies CapabilityEnvelope;
+    const callerResult = createDeferredCore<CapabilityEnvelope>();
+    const trackOwner = captureAsyncWorkTracker();
+    // Command completion can precede response callbacks and cancellation drainage.
+    void trackOwner(async () => {
+      const prepared = await acquireSimpleCompletionModelForAgent({
+        cfg,
+        agentId,
+        modelRef,
+        allowMissingApiKeyModes: ["aws-sdk"],
+        ...(hasExplicitProviderModelOverride ? { allowBundledStaticCatalogFallback: true } : {}),
+        skipAgentDiscovery: true,
+      });
+      if ("error" in prepared) {
+        throw new Error(prepared.error);
+      }
+      const work = new AsyncWorkScope();
+      try {
+        callerResult.resolve(
+          await work.track(async () => {
+            if (prepared.selection.provider === "codex") {
+              throw new Error(
+                'The codex provider is served by the Codex app-server agent runtime, not the local simple-completion transport. Use an openai/<model> ref with provider/model agentRuntime.id: "codex", run through the gateway, or use /codex commands.',
+              );
+            }
+            const localModelRunSystemPrompt =
+              prepared.model.api === "openai-chatgpt-responses"
+                ? LOCAL_MODEL_RUN_SYSTEM_PROMPT
+                : undefined;
+            const result = await completeWithPreparedSimpleCompletionModel({
+              model: prepared.model,
+              auth: prepared.auth,
+              cfg,
+              context: {
+                ...(localModelRunSystemPrompt ? { systemPrompt: localModelRunSystemPrompt } : {}),
+                messages: [
+                  {
+                    role: "user",
+                    content: messageContent,
+                    timestamp: Date.now(),
+                  },
+                ],
+              },
+              options: {
+                maxTokens:
+                  typeof prepared.model.maxTokens === "number" &&
+                  Number.isFinite(prepared.model.maxTokens)
+                    ? prepared.model.maxTokens
+                    : undefined,
+                ...(params.thinking ? { reasoning: params.thinking } : {}),
+              },
+            });
+            const text = collectModelRunText(result.content);
+            if (!text) {
+              const providerErrorMessage = (result as { errorMessage?: unknown }).errorMessage;
+              const detail =
+                typeof providerErrorMessage === "string" && providerErrorMessage.trim()
+                  ? `: ${providerErrorMessage.trim()}`
+                  : "";
+              throw new Error(
+                `No text output returned for provider "${prepared.selection.provider}" model "${prepared.selection.modelId}"${detail}.`,
+              );
+            }
+            return {
+              ok: true,
+              capability: "model.run",
+              transport: "local" as const,
+              provider: prepared.selection.provider,
+              model: prepared.selection.modelId,
+              attempts: [],
+              ...(imageFiles.length > 0
+                ? {
+                    inputs: imageFiles.map((image) => ({
+                      path: image.path,
+                      mimeType: image.mimeType,
+                    })),
+                  }
+                : {}),
+              outputs: [
+                {
+                  text,
+                  mediaUrl: null,
+                },
+              ],
+            } satisfies CapabilityEnvelope;
+          }),
+        );
+      } catch (error) {
+        callerResult.reject(error);
+      } finally {
+        await work.drain();
+        prepared.release();
+      }
+    }).catch((error: unknown) => callerResult.reject(error));
+    return await callerResult.promise;
   }
 
   const { provider, model } = requireProviderModelOverride(modelRef) ?? {};


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Local model commands release their prepared model generation before sending the request. Overlapping commands can rebuild the same catalog, and callback or response-cancellation work can outlive the command result without retaining that generation.

## Why This Change Was Made

The local command uses the existing acquired model contract and admits its cleanup owner before preparation. It retains the lease through completion interpretation and actual callback/cancellation drainage. The existing command runtime owns that drainage independently of when the result becomes available.

## User Impact

Local model commands reuse their active prepared generation and finish cleanup before its final release. Existing output, errors, model/profile selection, unsupported-runtime handling and Gateway behavior remain unchanged.

## Evidence

- Three native regressions reproduced premature generation release during overlap, response callback and response-body cancellation; the provider-error control passed. All four pass with the repair, including fresh generation creation after final release.
- 277 relevant tests, the full changed-file gate and isolated Codex review through P2 passed. Build completed in 333.9 seconds.
- The actual built CLI completed synthetic loopback success/error/success commands in 1.365/1.598/1.622 seconds. Source and 12,109 built artifacts stayed unchanged, and all managed process trees terminated.
- Refreshed directly onto main, independently of the SDK PR: all three changed files are byte-identical to the reviewed/build-tested candidate, and 252 composition tests passed. General run-generation physical disposal remains a separate producer change.
