### PR TITLE
fix(exec): let commands omit unneeded secret proxy credentials

### DIFF
--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -24,6 +24,14 @@ Working directory for the command.
 Key/value environment overrides merged on top of the inherited environment.
 </ParamField>
 
+<ParamField path="secretEgress" type="boolean">
+Gateway only. Set `false` when this command needs no protected shared-store secrets:
+OpenClaw omits their sentinels and its secret-egress proxy credentials for this call.
+The call is refused if the running proxy has an explicit traffic allowlist (including
+`[]`) or bypass-host routing. Omitted/`true` keeps the default behavior. Ordinary
+store environment, inherited proxy/CA settings, and other authentication are unchanged.
+</ParamField>
+
 <ParamField path="yieldMs" type="number" default="10000">
 Auto-background the command after this delay (ms).
 </ParamField>

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -30,6 +30,8 @@ OpenClaw omits their sentinels and its secret-egress proxy credentials for this 
 The call is refused if the running proxy has an explicit traffic allowlist (including
 `[]`) or bypass-host routing. Omitted/`true` keeps the default behavior. Ordinary
 store environment, inherited proxy/CA settings, and other authentication are unchanged.
+Keep the default if the command needs a protected-store API key; this option omits
+that key's sentinel too.
 </ParamField>
 
 <ParamField path="yieldMs" type="number" default="10000">

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -104,17 +104,40 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
 
     const pinned = pinExecToolTarget(source, { host: "gateway", ask: "always" });
     await pinned.prepareBeforeToolCallParams?.(
-      { command: "echo hi", host: "node", node: "remote", security: "full", ask: "off" },
+      {
+        command: "echo hi",
+        secretEgress: false,
+        host: "node",
+        node: "remote",
+        security: "full",
+        ask: "off",
+      },
       { hookContext: undefined },
     );
-    pinned.finalizeBeforeToolCallParams?.({ command: "echo hi", host: "node", ask: "off" }, {});
+    pinned.finalizeBeforeToolCallParams?.(
+      { command: "echo hi", secretEgress: false, host: "node", ask: "off" },
+      {},
+    );
+
+    await pinned.execute("scope", {
+      command: "echo hi",
+      secretEgress: false,
+      host: "node",
+      ask: "off",
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "scope",
+      { command: "echo hi", secretEgress: false, host: "gateway", ask: "always" },
+      undefined,
+      undefined,
+    );
 
     expect(prepare).toHaveBeenCalledWith(
-      { command: "echo hi", host: "gateway", ask: "always" },
+      { command: "echo hi", secretEgress: false, host: "gateway", ask: "always" },
       { hookContext: undefined },
     );
     expect(finalize).toHaveBeenCalledWith(
-      { command: "echo hi", host: "gateway", ask: "always" },
+      { command: "echo hi", secretEgress: false, host: "gateway", ask: "always" },
       {},
     );
   });

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -37,6 +37,7 @@ export type ExecToolArgs = Record<string, unknown> & {
   command: string;
   workdir?: string;
   env?: Record<string, string>;
+  secretEgress?: boolean;
   yieldMs?: number;
   background?: boolean;
   timeoutSeconds?: number;
@@ -67,6 +68,9 @@ const resolvedExecWorkdirPreparedStates = new WeakMap<
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = ["command", "workdir", "host", "ask", "node"] as const;
 
 export function assertSupportedExecParams(args: unknown): void {
+  if (isRecord(args) && args.secretEgress !== undefined && typeof args.secretEgress !== "boolean") {
+    throw new ToolInputError('exec parameter "secretEgress" must be a boolean');
+  }
   if (isRecord(args) && Object.hasOwn(args, "timeout")) {
     throw new ToolInputError(
       'exec parameter "timeout" is unsupported; use "timeoutSeconds" instead',

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -384,6 +384,11 @@ export function resolvePreparedExecEnvironment(params: {
   if (params.localProcessEnv && params.host !== "gateway") {
     throw new Error(LOCAL_INSTALLATION_TARGET_UNSUPPORTED);
   }
+  if (params.execParams.secretEgress !== undefined && params.host !== "gateway") {
+    throw new ToolInputError('exec parameter "secretEgress" is only supported for host=gateway');
+  }
+  const storeSecretEnv =
+    params.execParams.secretEgress === false ? undefined : params.storeSecretEnv;
   const inheritedBaseEnv = coerceEnv(process.env);
   if (params.secretEgressEnv) {
     Object.assign(inheritedBaseEnv, params.secretEgressEnv);
@@ -432,8 +437,8 @@ export function resolvePreparedExecEnvironment(params: {
   const untrustedRequestedEnv: Record<string, string> | undefined = hasStoreEnv
     ? { ...storeEnv, ...explicitEnv }
     : explicitEnv;
-  const requestedEnv: Record<string, string> | undefined = params.storeSecretEnv
-    ? { ...storeEnv, ...params.storeSecretEnv, ...explicitEnv }
+  const requestedEnv: Record<string, string> | undefined = storeSecretEnv
+    ? { ...storeEnv, ...storeSecretEnv, ...explicitEnv }
     : untrustedRequestedEnv;
   const hostEnvResult =
     params.host === "sandbox"
@@ -516,10 +521,10 @@ export function resolvePreparedExecEnvironment(params: {
       }
     }
   }
-  if (params.storeSecretEnv) {
+  if (storeSecretEnv) {
     // Secret-kind entries are authenticated ciphertext, not active credentials.
     // Inject them after ordinary env filtering so names such as GH_TOKEN remain usable.
-    for (const [key, value] of Object.entries(params.storeSecretEnv)) {
+    for (const [key, value] of Object.entries(storeSecretEnv)) {
       if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
         env[key] = value;
       }

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -309,9 +309,6 @@ export function createExecTool(
         sandboxRequired: defaults?.sandboxRequired,
       });
       const host: ExecHost = target.effectiveHost;
-      if (params.secretEgress !== undefined && host !== "gateway") {
-        throw new Error('exec parameter "secretEgress" is only supported for host=gateway');
-      }
 
       const explicitSecurity = defaults?.security;
       const configuredSecurity = explicitSecurity ?? (host === "sandbox" ? "deny" : "full");
@@ -455,8 +452,7 @@ export function createExecTool(
           defaultPathPrepend,
           pluginEnv: resolvedExecEnvState?.pluginEnv,
           storeEnv: host === "gateway" ? storeEnv.env : undefined,
-          storeSecretEnv:
-            useSecretEgress && params.secretEgress !== false ? storeEnv.secretSentinels : undefined,
+          storeSecretEnv: useSecretEgress ? storeEnv.secretSentinels : undefined,
           secretEgressEnv,
           ...preparedRunEnvironment,
           warnings,

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -309,6 +309,9 @@ export function createExecTool(
         sandboxRequired: defaults?.sandboxRequired,
       });
       const host: ExecHost = target.effectiveHost;
+      if (params.secretEgress !== undefined && host !== "gateway") {
+        throw new Error('exec parameter "secretEgress" is only supported for host=gateway');
+      }
 
       const explicitSecurity = defaults?.security;
       const configuredSecurity = explicitSecurity ?? (host === "sandbox" ? "deny" : "full");
@@ -440,6 +443,7 @@ export function createExecTool(
           secretEgressEnv = registerSecretEgressProxyRun(
             defaults.operationalRunInstance,
             storeEnv.secretEgressBindings ?? [],
+            { secretEgress: params.secretEgress },
           );
         }
         const { env, requestedEnv } = resolvePreparedExecEnvironment({
@@ -451,7 +455,8 @@ export function createExecTool(
           defaultPathPrepend,
           pluginEnv: resolvedExecEnvState?.pluginEnv,
           storeEnv: host === "gateway" ? storeEnv.env : undefined,
-          storeSecretEnv: useSecretEgress ? storeEnv.secretSentinels : undefined,
+          storeSecretEnv:
+            useSecretEgress && params.secretEgress !== false ? storeEnv.secretSentinels : undefined,
           secretEgressEnv,
           ...preparedRunEnvironment,
           warnings,

--- a/src/agents/bash-tools.exec.store-env.test.ts
+++ b/src/agents/bash-tools.exec.store-env.test.ts
@@ -566,8 +566,9 @@ describe("exec store environment", () => {
     );
   });
 
-  it("preserves inherited proxy and trust settings when secret injection is disabled", async () => {
+  it("preserves inherited inference auth, proxy and trust settings when secret injection is disabled", async () => {
     const inherited = {
+      OPENAI_API_KEY: "operator-inference-fixture",
       HTTP_PROXY: "http://operator-proxy.test:8080",
       HTTPS_PROXY: "http://operator-proxy.test:8080",
       NODE_EXTRA_CA_CERTS: "/operator/ca.pem",

--- a/src/agents/bash-tools.exec.store-env.test.ts
+++ b/src/agents/bash-tools.exec.store-env.test.ts
@@ -572,7 +572,9 @@ describe("exec store environment", () => {
       HTTPS_PROXY: "http://operator-proxy.test:8080",
       NODE_EXTRA_CA_CERTS: "/operator/ca.pem",
     };
-    for (const [key, value] of Object.entries(inherited)) vi.stubEnv(key, value);
+    for (const [key, value] of Object.entries(inherited)) {
+      vi.stubEnv(key, value);
+    }
     await withTeamStoreEntries([], async () => {
       publishSecretEgressProxy(proxy);
       const tool = createExecTool({

--- a/src/agents/bash-tools.exec.store-env.test.ts
+++ b/src/agents/bash-tools.exec.store-env.test.ts
@@ -2,6 +2,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withInstallationTarget } from "../infra/installation-target-context.js";
+import {
+  clearSecretEgressProxy,
+  publishSecretEgressProxy,
+} from "../secrets/egress-proxy/registry.js";
 import { looksLikeSecretSentinel, resolveSecretSentinel } from "../secrets/sentinel.js";
 import { writeSecretStoreEntry } from "../secrets/store/secret-store.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -10,7 +14,6 @@ import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.t
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 const mocks = vi.hoisted(() => ({
-  egressActive: false,
   proxyUrl: ["http://openclaw:", "fixture-password", "@127.0.0.1:19090"].join(""),
   gatewayParams: [] as Array<{
     env: Record<string, string>;
@@ -29,21 +32,18 @@ vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunnerRegistry: () => null,
 }));
 
-vi.mock("../secrets/egress-proxy/registry.js", () => ({
-  isSecretEgressProxyActive: () => mocks.egressActive,
-  registerSecretEgressProxyRun: (_run: unknown, bindings: unknown) => {
+const proxy = {
+  caCertPath: "/state/secret-egress/root-ca.pem",
+  proxyOrigin: "http://127.0.0.1:19090",
+  requiresProxyWithoutBindings: false,
+  getCertificateStatus: vi.fn(),
+  revokeRun: vi.fn(),
+  stop: vi.fn(async () => {}),
+  registerRun: (_run: unknown, bindings: unknown) => {
     mocks.proxyBindings.push(bindings);
-    return {
-      HTTPS_PROXY: mocks.proxyUrl,
-      HTTP_PROXY: mocks.proxyUrl,
-      NODE_USE_ENV_PROXY: "1",
-      NODE_EXTRA_CA_CERTS: "/state/secret-egress/root-ca.pem",
-      SSL_CERT_FILE: "/state/secret-egress/root-ca.pem",
-      CURL_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
-      REQUESTS_CA_BUNDLE: "/state/secret-egress/root-ca.pem",
-    };
+    return { ...EGRESS_ENV };
   },
-}));
+};
 
 vi.mock("../infra/shell-env.js", () => ({
   getShellEnvAppliedKeys: vi.fn(() => []),
@@ -251,7 +251,10 @@ describe("exec store environment", () => {
       });
     },
   );
-  afterEach(() => vi.unstubAllEnvs());
+  afterEach(() => {
+    clearSecretEgressProxy(proxy);
+    vi.unstubAllEnvs();
+  });
   beforeAll(async () => {
     ({ createExecTool } = await import("./bash-tools.exec-run.js"));
     ({ createLazyExecTool } = await import("./lazy-exec-tool.js"));
@@ -259,7 +262,7 @@ describe("exec store environment", () => {
 
   beforeEach(() => {
     vi.stubEnv("AWS_REGION", undefined);
-    mocks.egressActive = false;
+    proxy.requiresProxyWithoutBindings = false;
     mocks.gatewayParams.length = 0;
     mocks.nodeHostParams.length = 0;
     mocks.spawnInputs.length = 0;
@@ -478,7 +481,7 @@ describe("exec store environment", () => {
           },
         ],
         async () => {
-          mocks.egressActive = true;
+          publishSecretEgressProxy(proxy);
           const env = await captureStoreExecEnvironment({
             host,
             callId: `call-egress-enabled-${host}`,
@@ -516,4 +519,112 @@ describe("exec store environment", () => {
       );
     },
   );
+  it("omits managed secrets for one command without changing the run's other commands", async () => {
+    for (const key of Object.keys(EGRESS_ENV)) {
+      vi.stubEnv(key, undefined);
+    }
+    await withTeamStoreEntries(
+      [
+        { name: "AWS_REGION", value: "us-west-2", kind: "env" },
+        {
+          name: "SERVICE_API_KEY",
+          value: "fixture-secret",
+          kind: "secret",
+          allowedHosts: ["api.example.com"],
+        },
+      ],
+      async () => {
+        publishSecretEgressProxy(proxy);
+        const tool = createExecTool({
+          host: "gateway",
+          security: "full",
+          ask: "off",
+          operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
+        });
+        await tool.execute("default-before", { command: "echo ok", yieldMs: 120_000 });
+        expect(mocks.proxyBindings).toHaveLength(1);
+        await tool.execute("no-secret", {
+          command: "echo ok",
+          secretEgress: false,
+          yieldMs: 120_000,
+        });
+        for (const env of [mocks.gatewayParams[1]?.env, mocks.spawnInputs[1]?.env]) {
+          expect(env?.AWS_REGION).toBe("us-west-2");
+          expect(env?.SERVICE_API_KEY === undefined).toBe(true);
+          for (const key of Object.keys(EGRESS_ENV)) {
+            expect(env?.[key] === undefined).toBe(true);
+          }
+        }
+        expect(mocks.proxyBindings).toHaveLength(1);
+        await tool.execute("default-after", { command: "echo ok", yieldMs: 120_000 });
+        expect(mocks.proxyBindings).toHaveLength(2);
+        expect(mocks.gatewayParams[2]?.env.SERVICE_API_KEY).toBe(
+          mocks.gatewayParams[0]?.env.SERVICE_API_KEY,
+        );
+        expect(mocks.gatewayParams[2]?.env).toMatchObject(EGRESS_ENV);
+      },
+    );
+  });
+
+  it("preserves inherited proxy and trust settings when secret injection is disabled", async () => {
+    const inherited = {
+      HTTP_PROXY: "http://operator-proxy.test:8080",
+      HTTPS_PROXY: "http://operator-proxy.test:8080",
+      NODE_EXTRA_CA_CERTS: "/operator/ca.pem",
+    };
+    for (const [key, value] of Object.entries(inherited)) vi.stubEnv(key, value);
+    await withTeamStoreEntries([], async () => {
+      publishSecretEgressProxy(proxy);
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
+      });
+      await tool.execute("inherited", {
+        command: "echo ok",
+        secretEgress: false,
+        yieldMs: 120_000,
+      });
+      expect(mocks.gatewayParams[0]?.env).toMatchObject(inherited);
+      expect(mocks.spawnInputs[0]?.env).toMatchObject(inherited);
+      expect(mocks.proxyBindings).toHaveLength(0);
+    });
+  });
+
+  it("refuses secretEgress false before approval or spawn when the live proxy requires routing", async () => {
+    await withTeamStoreEntries([], async () => {
+      proxy.requiresProxyWithoutBindings = true;
+      publishSecretEgressProxy(proxy);
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
+        config: { secrets: { egressProxy: { enabled: false } } },
+      });
+      await expect(
+        tool.execute("policy", { command: "echo ok", secretEgress: false }),
+      ).rejects.toThrow(/requires managed routing/);
+      expect(mocks.gatewayParams).toHaveLength(0);
+      expect(mocks.spawnInputs).toHaveLength(0);
+      expect(mocks.proxyBindings).toHaveLength(0);
+    });
+  });
+
+  it.each(["false", 0, null])("rejects invalid secretEgress input %j", async (secretEgress) => {
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+    await expect(
+      Reflect.apply(tool.execute, tool, ["invalid", { command: "echo ok", secretEgress }]),
+    ).rejects.toThrow(/must be a boolean/);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("rejects the Gateway-only option on a node execution", async () => {
+    const tool = createExecTool({ host: "node", security: "full", ask: "off" });
+    await expect(tool.execute("node", { command: "echo ok", secretEgress: false })).rejects.toThrow(
+      /only supported for host=gateway/,
+    );
+    expect(mocks.nodeHostParams).toHaveLength(0);
+  });
 });

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -35,6 +35,12 @@ export const execSchema = Type.Object({
       description: "Literal overrides; no expansion. Omit to inherit.",
     }),
   ),
+  secretEgress: Type.Optional(
+    Type.Boolean({
+      description:
+        "Gateway only: false omits protected store secrets and managed proxy injection for this command. Refused if proxy routing policy requires it. Inherited environment and other credentials are unchanged. Omit for default behavior.",
+    }),
+  ),
   yieldMs: Type.Optional(
     Type.Number({
       description: "Milliseconds before backgrounding; default 10000.",

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -32,13 +32,13 @@ export const execSchema = Type.Object({
   ),
   env: Type.Optional(
     Type.Record(Type.String(), Type.String(), {
-      description: "Literal overrides; no expansion. Omit to inherit.",
+      description: "Literal overrides; no expansion.",
     }),
   ),
   secretEgress: Type.Optional(
     Type.Boolean({
       description:
-        "Gateway only: false omits protected store secrets and managed proxy injection for this command. Refused if proxy routing policy requires it. Inherited environment and other credentials are unchanged. Omit for default behavior.",
+        "Gateway only: false omits protected store secrets/proxy; fails if routing required. Inherited env/auth unchanged. Default true.",
     }),
   ),
   yieldMs: Type.Optional(
@@ -53,31 +53,31 @@ export const execSchema = Type.Object({
   ),
   timeoutSeconds: Type.Optional(
     Type.Number({
-      description: "Process lifetime in seconds; 0 disables.",
+      description: "Lifetime seconds; 0 disables.",
     }),
   ),
   pty: Type.Optional(
     Type.Boolean({
-      description: "PTY for TTY-required CLIs/coding agents.",
+      description: "Use PTY.",
     }),
   ),
   elevated: Type.Optional(
     Type.Boolean({
-      description: "Host elevation if allowed.",
+      description: "Elevate if allowed.",
     }),
   ),
   host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
-    description: "Omit/auto: inherit configured host.",
+    description: "Omit/auto: configured host.",
   }),
   ask: Type.Optional(
     Type.String({
       description:
-        "Requests stricter approvals under tools.exec.mode and host policy; channel-origin calls cannot override host ask=off.",
+        "Stricter tools.exec.mode/host approvals; channel-origin cannot override ask=off.",
     }),
   ),
   node: Type.Optional(
     Type.String({
-      description: "Node id/name for host=node.",
+      description: "Node id/name.",
     }),
   ),
 });

--- a/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
@@ -14,6 +14,11 @@ import * as proxyCa from "../../proxy-capture/ca.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { mintSecretSentinel } from "../sentinel.js";
 import { startSecretEgressProxyServer, type SecretEgressProxyHandle } from "./proxy-server.js";
+import {
+  clearSecretEgressProxy,
+  publishSecretEgressProxy,
+  registerSecretEgressProxyRun,
+} from "./registry.js";
 
 const run = { instanceId: "instance-1", runId: "run-1" };
 const sibling = { instanceId: "instance-2", runId: "run-2" };
@@ -146,6 +151,7 @@ afterEach(async () => {
     socket.destroy();
   }
   sockets.clear();
+  clearSecretEgressProxy(proxy);
   await proxy?.stop();
   if (origin) {
     await new Promise<void>((resolve) => {
@@ -156,6 +162,36 @@ afterEach(async () => {
 });
 
 describe("secret egress registration lifecycle", () => {
+  it("keeps existing authorized traffic and revocation intact across a no-secret command", async () => {
+    publishSecretEgressProxy(proxy);
+    const existing = await openTlsTunnel();
+    expect(registerSecretEgressProxyRun(run, [], { secretEgress: false })).toEqual({});
+    await sendCredential(existing);
+    const later = await openTlsTunnel();
+    await sendCredential(later);
+    expect(observed.map(({ authorization }) => authorization)).toEqual([
+      `Bearer ${value}`,
+      `Bearer ${value}`,
+    ]);
+    proxy.revokeRun(run);
+    expect((await connectTunnel()).status).toBe(407);
+  });
+
+  it.each([
+    { allowedHosts: [] },
+    { allowedHosts: ["api.example.com"] },
+    { bypassHosts: ["api.example.com"] },
+  ])("refuses no-secret execution under captured routing policy %j", async (policy) => {
+    await proxy.stop();
+    proxy = await startSecretEgressProxyServer({ caDir, ...policy, onAudit: () => {} });
+    publishSecretEgressProxy(proxy);
+    expect(() => registerSecretEgressProxyRun(run, [], { secretEgress: false })).toThrow(
+      /requires managed routing/,
+    );
+    // Refusal must not create a usable registration or relax authentication.
+    expect((await connectTunnel({ HTTPS_PROXY: proxy.proxyOrigin })).status).toBe(407);
+  });
+
   it("keeps the process CA trusted beyond the first day", () => {
     const cert = new X509Certificate(fs.readFileSync(proxy.caCertPath));
     const afterOneDay = Math.floor(cert.validFromDate.getTime() / 1000) + 25 * 60 * 60;

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -55,6 +55,7 @@ export type SecretEgressSentinelBinding = Readonly<{
 export type SecretEgressProxyHandle = {
   caCertPath: string;
   proxyOrigin: string;
+  readonly requiresProxyWithoutBindings: boolean;
   getCertificateStatus: () => SecretEgressCertificateStatus;
   registerRun: (
     run: Readonly<{ instanceId: string; runId: string }>,
@@ -652,6 +653,8 @@ export async function startSecretEgressProxyServer(params: {
   return {
     caCertPath: certificates.caCertPath,
     proxyOrigin,
+    // Capture routing policy with the live proxy, including an explicit empty allowlist.
+    requiresProxyWithoutBindings: allowedHosts !== undefined || bypassHosts.size > 0,
     getCertificateStatus: certificates.getStatus,
     registerRun: (run, bindings = []) => {
       if (stopped) {

--- a/src/secrets/egress-proxy/registry.ts
+++ b/src/secrets/egress-proxy/registry.ts
@@ -39,10 +39,20 @@ export function getSecretEgressCertificateStatus() {
 export function registerSecretEgressProxyRun(
   run: Readonly<{ instanceId: string; runId: string }>,
   bindings: readonly SecretEgressSentinelBinding[],
+  options?: { secretEgress?: boolean },
 ): Record<string, string> {
   const proxy = getSecretEgressProxyRegistry().activeProxy;
   if (!proxy) {
     throw new Error("Secret egress proxy is not active in this Gateway process");
+  }
+  if (options?.secretEgress === false) {
+    if (proxy.requiresProxyWithoutBindings) {
+      throw new Error(
+        "This Gateway requires managed routing; secretEgress: false is unavailable under its active proxy policy. Omit secretEgress to use the authorized proxy.",
+      );
+    }
+    // Registration is shared by the run. Do not replace bindings used by sibling commands.
+    return {};
   }
   return proxy.registerRun(run, bindings);
 }


### PR DESCRIPTION
## Landing paused: scope reassessment

This PR implements an explicit per-call escape hatch, not an automatic repair of the proxy/autoreview integration. The requester has challenged the per-call flag as the right product solution. Do not land this as the canonical fix while that concern is unresolved.

The affected-server proof required `secretEgress: false` and independently available inference authentication. It does not prove the unchanged default invocation or protected-store-only inference. Available bindings are the run's protected store snapshot, not evidence that a particular command uses those secrets.

Current published head `314b1afcc09dae9711ffdbb291e8d0cb6d0bcdba` also has an actionable CI failure: three existing schema guidance assertions require "omit to inherit". A local description-only correction passes those three tests plus the 69 schema tests, but is not yet published. Required CI is not green.

Related: #143231

## What Problem This Solves

Fixes an issue where Gateway commands that need no protected store secrets still receive authenticated secret-egress proxy URLs when the shared store contains protected secrets. Hardened tools such as the unchanged autoreview helper reject those URLs before their reviewer starts.

The zero-binding guard in #143231 does not cover this case: the store can have bindings even when this particular command needs none.

## Why This Change Was Made

Adds one optional Gateway exec argument, `secretEgress: false`. It omits protected store sentinels and managed proxy injection for that invocation. It never re-registers or empties the run's existing bindings, so concurrent/background secret-using commands keep their authorization.

The running proxy captures whether its traffic allowlist (including `[]`) or bypass-host routing requires it. The new option refuses under that policy instead of silently taking a direct route. Defaults, proxy authentication, destination checks, revocation, approvals, and autoreview remain unchanged. No persistent configuration or additional proxy is introduced.

This is standalone on main. It shares the captured-policy fact proposed in #143231, but does not depend on or modify agent-skills #242.

## User Impact

A Gateway command that needs no protected secrets can request:

```json
{
  "command": ".agents/skills/autoreview/scripts/autoreview --mode local --max-priority P2",
  "secretEgress": false
}
```

This is not a promise of an entirely credential-free process: ordinary store environment, inherited proxy/CA settings, managed GitHub identity, and other authentication remain unchanged. The option is Gateway-only and does not bypass required routing policy.

Autoreview still needs inference authentication. This option works when that authentication is already available independently, such as an inherited API key or native Codex login. It is not sufficient when the only inference key is a protected-store entry requiring proxy substitution, and it does not automatically change existing exec calls. The caller must request the opt-out.

## Evidence

- Before production edits, three new regressions failed for the intended reasons; the 24 existing store-environment tests passed.
- After the patch: 78 focused checks passed across store-env, pinned tool lifecycle, proxy server, proxy lifecycle, and real-exec cancellation/closure suites. The same five-file command passed on the affected Linux server (Node 26.7.0).
- Real local exec → unchanged autoreview, using an isolated store with a synthetic protected secret and a real authenticated proxy:
  - Default: exit 1 with the exact `unsafe credentialed or malformed proxy URL in HTTP_PROXY` error.
  - `secretEgress: false`: completed the full independent P2 review, exit 0, scoped-clean. This was not a dry run.
- Real TLS lifecycle coverage proves an existing registration still substitutes its secret after a no-secret invocation, and revocation still returns 407. Explicit empty/nonempty allowlists and bypass-host policy refuse the option.
- Final independent P2 review of the full local candidate: scoped-clean, exit 0. Core and core-test typechecks passed; changed-file lint/format, architecture guards, dead-export and import-cycle checks passed after correcting two lint findings.

### Affected-server reproduction

Ran in a task-owned, isolated checkout on the affected server, without restarting or changing the live Gateway, its approval policy, credentials, or proxy configuration. Its configured secret-egress policy was enabled with no traffic allowlist or bypass hosts.

The harness used real run admission, `createExecTool`, store projection, process launch, and a real authenticated secret-egress proxy. It put one synthetic protected secret in isolated state and invoked the exact unchanged helper command shown above:

| Invocation | Result |
| --- | --- |
| Default secret egress | Exit 1: exact `unsafe credentialed or malformed proxy URL in HTTP_PROXY` rejection |
| `secretEgress: false` | Exit 0: full Codex P2 review completed, scoped-clean, no actionable findings |

The server's existing source base was `4a2917f033d6e42c8d46788072c13c7789ecf759`. All nine candidate files were made byte-identical to PR head `1c74d9720c22a75b2ee61fee0087a9a332377127`; their ordered path/content SHA-256 digest was verified on both machines: `23abf116302c554cdfdc1db194b52b7eca82027dc9fca194791700a6adf2a298`. This was an isolated source run on the actual server, not an in-place deployment of the live Roboclaw agent.

The unchanged helper's SHA-256 also matched on both machines: `7602619edff7e1c567f5c17ff0d206b698c93805d9f2a9c2ced4bf3a90fe80ca`. No proxy variable stripping, TLS relaxation, autoreview patch, or production configuration change was used.

### Landing review follow-up

CI caught a schema-description budget regression (773 characters against the existing <550 constraint). The descriptions were shortened without changing that constraint. Schema and store-environment suites then passed 100/100, including preservation of an inherited inference API key. The follow-up reviewer identified ambiguous routing wording; it now explicitly says the call fails when routing is required. Runtime behavior remains identical to the affected-server-tested head above; only schema descriptions, one regression case, and clarification text changed afterward.

The affected-server review used existing API-key authentication independent of the synthetic protected store. No new key, login, proxy policy, or credential-store change was made. This proves the opt-out for that setup, not proxy-backed inference with no alternative credential.

### Maintainer decision

@fuller-stack-dev explicitly confirmed security ownership and conditionally directed landing if the fix is appropriate and validated. The subsequent question challenges the per-call opt-out as the correct product solution. That conditional landing direction is not being treated as acceptance of this narrower workaround. Required CI and product-fit review remain unresolved.
