### PR TITLE
fix(plugins): preserve tool identity during managed cancellation

### DIFF
--- a/docs/plugins/sdk-overview/tools-and-commands.md
+++ b/docs/plugins/sdk-overview/tools-and-commands.md
@@ -17,6 +17,15 @@ Use [`defineToolPlugin`](/plugins/tool-plugins) for simple tool-only plugins
 with fixed tool names. Use `api.registerTool(...)` directly for mixed plugins
 or fully dynamic tool registration.
 
+When OpenClaw invokes a plugin tool with an `AbortSignal` inside a managed
+operation, cancellation callbacks retain the executing plugin's runtime context
+and the original cancellation reason. The tool can return a result before
+already-started SDK work finishes; that work remains owned until its cleanup
+settles. Cancellation cleanup does not authorize a new invocation after the
+plugin or operation has closed. Return or join background work your tool starts
+outside SDK-managed operations. Direct programmatic callers without a managed
+operation continue to own their signal and work lifetime.
+
 | Method                                   | What it registers                                                                                                                        |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `api.registerTool(tool, opts?)`          | Agent tool (required or `{ optional: true }`)                                                                                            |

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -13,7 +13,7 @@ import { routeLogsToStderr } from "../logging/console.js";
 import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginToolRegistryAcquisition } from "../plugins/tools.js";
-import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { AsyncWorkScope, runWithTrackedCancellation } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { VERSION } from "../version.js";
 import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
@@ -22,14 +22,14 @@ class ToolsMcpServer extends Server {
   #work = new AsyncWorkScope();
   #closing: Promise<void> | undefined;
 
-  runRequest<T>(run: (work: AsyncWorkScope) => Promise<T>, signal: AbortSignal): Promise<T> {
+  runRequest<T>(run: () => Promise<T>, signal: AbortSignal): Promise<T> {
     // SDK request callbacks are queued in microtasks and may enter after transport closure.
     if (this.#closing || !this.transport) {
       return Promise.reject(McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed"));
     }
     signal.throwIfAborted();
     const work = this.#work;
-    return work.track(() => run(work));
+    return work.track(run);
   }
 
   override close(): Promise<void> {
@@ -74,38 +74,13 @@ export function createToolsMcpServer(params: {
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     // Restore serving authority before runRequest installs the accepted-work scope.
     return await runInServingContext(() =>
-      server.runRequest(async (parentWork) => {
+      server.runRequest(async () => {
         if (!params.sdkResourceHost) {
           return await handlers.callTool(request.params, extra.signal);
         }
-        const work = new AsyncWorkScope();
-        const controller = new AbortController();
-        const requestContext = work.run(() => AsyncLocalStorage.snapshot());
-        // Protocol cancellation can arrive under another request or process event's context.
-        const abort = () => requestContext(() => controller.abort(extra.signal.reason));
-        const closeWork = () => requestContext(() => work.beginClose(parentWork.signal.reason));
-        extra.signal.addEventListener("abort", abort, { once: true });
-        parentWork.signal.addEventListener("abort", closeWork, { once: true });
-        if (extra.signal.aborted) {
-          abort();
-        }
-        if (parentWork.signal.aborted) {
-          closeWork();
-        }
-        const result = work.track(() => handlers.callTool(request.params, controller.signal));
-        // The result stays early; only the server parent owns this descendant-cleanup tail.
-        void parentWork.track(async () => {
-          try {
-            await AsyncWorkScope.runWhenAllIdle(
-              () => [work],
-              () => requestContext(() => work.drain()),
-            );
-          } finally {
-            extra.signal.removeEventListener("abort", abort);
-            parentWork.signal.removeEventListener("abort", closeWork);
-          }
-        });
-        return await result;
+        return await runWithTrackedCancellation(extra.signal, (signal) =>
+          handlers.callTool(request.params, signal),
+        );
       }, extra.signal),
     );
   });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1,7 +1,10 @@
 // Verifies optional plugin tool registration and absence handling.
+import { AsyncLocalStorage } from "node:async_hooks";
+import { getEventListeners } from "node:events";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { normalizeToolParameters } from "../agents/agent-tools.schema.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import { createInvalidConfigError, throwInvalidConfig } from "../config/io.invalid-config.js";
@@ -10,6 +13,7 @@ import type { SecretRef } from "../config/types.secrets.js";
 import { createDedupeCache } from "../infra/dedupe.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
+import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createPluginRecord } from "./loader-records.js";
 import type { PluginLoadOptions } from "./loader-types.js";
@@ -18,6 +22,8 @@ import {
   resolvePluginRuntimeArtifactSelection,
 } from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { markPluginRegistryRetired } from "./registry-lifecycle.js";
+import type { PluginRegistry } from "./registry-types.js";
 import { appendRuntimePluginToolGrant } from "./tool-grant-allowlist.js";
 
 type MockRegistryToolEntry = {
@@ -737,6 +743,150 @@ describe("resolvePluginTools optional tools", () => {
         pluginSource: "/tmp/optional-demo.js",
       },
     ]);
+  });
+
+  it.each(["same", "foreign", "already-aborted", "retired", "parent-close"] as const)(
+    "retains plugin cancellation context through late descendants: %s",
+    async (dispatch) => {
+      const work = new AsyncWorkScope();
+      const controller = new AbortController();
+      const reason = new Error("cancel the owned call");
+      const installListener = createDeferred();
+      const listening = createDeferred();
+      const observed = createDeferred();
+      const finishCleanup = createDeferred();
+      let invokeInPlugin: ReturnType<typeof AsyncLocalStorage.snapshot> | undefined;
+      let signalReceived: AbortSignal | undefined;
+      let workSignal: AbortSignal | undefined;
+      let callbackPlugin: string | undefined;
+      let callbackReason: unknown;
+      let callbackWork: AbortSignal | undefined;
+      let sourceRegistry: PluginRegistry | undefined;
+      let descendant: Promise<void> | undefined;
+      let cleanupFinished = false;
+      setRegistry([
+        createNamedToolEntry("multi", "owned_tool", {
+          factory: () => ({
+            ...makeTool("owned_tool"),
+            execute(_id: string, _args: unknown, signal?: AbortSignal) {
+              signalReceived = expectDefined(signal, "Expected the tool cancellation signal");
+              workSignal = expectDefined(getAsyncWorkSignal(), "Expected an admitted work scope");
+              sourceRegistry = expectDefined(
+                getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+                "Expected the executing tool registry",
+              );
+              invokeInPlugin = AsyncLocalStorage.snapshot();
+              const cancellation = dispatch === "parent-close" ? workSignal : signalReceived;
+              descendant = trackAsyncWork(async () => {
+                await installListener.promise;
+                const abort = () => {
+                  callbackPlugin = getPluginRuntimeGatewayRequestScope()?.pluginId;
+                  callbackReason = cancellation.reason;
+                  callbackWork = getAsyncWorkSignal();
+                  observed.resolve();
+                };
+                cancellation.addEventListener("abort", abort, { once: true });
+                if (cancellation.aborted) {
+                  abort();
+                }
+                listening.resolve();
+                try {
+                  await finishCleanup.promise;
+                } finally {
+                  cancellation.removeEventListener("abort", abort);
+                  cleanupFinished = true;
+                }
+              });
+              return Promise.resolve({ content: [{ type: "text" as const, text: "cached" }] });
+            },
+          }),
+        }),
+        createNamedToolEntry("optional-demo", "cancel_tool", {
+          factory: () => ({
+            ...makeTool("cancel_tool"),
+            async execute() {
+              controller.abort(reason);
+              return { content: [] };
+            },
+          }),
+        }),
+      ]);
+      const tools = resolvePluginTools(createResolveToolsParams());
+      const tool = expectDefined(
+        tools.find((candidate) => candidate.name === "owned_tool"),
+        "Expected the owned tool",
+      );
+      const cancel = expectDefined(
+        tools.find((candidate) => candidate.name === "cancel_tool"),
+        "Expected the cancelling tool",
+      );
+      try {
+        if (dispatch === "already-aborted") {
+          controller.abort(reason);
+        }
+        const result = await work.track(() => tool.execute("owned", {}, controller.signal));
+        expect(result.content).toEqual([{ type: "text", text: "cached" }]);
+        expect(cleanupFinished).toBe(false);
+        expect(workSignal?.aborted).toBe(false);
+        installListener.resolve();
+        await listening.promise;
+        if (dispatch === "foreign") {
+          await cancel.execute("cancel", {});
+        } else if (dispatch === "parent-close") {
+          work.beginClose(reason);
+        } else if (dispatch !== "already-aborted") {
+          if (dispatch === "retired") {
+            markPluginRegistryRetired(sourceRegistry);
+          }
+          expectDefined(
+            invokeInPlugin,
+            "Expected the captured plugin context",
+          )(() => controller.abort(reason));
+        }
+        await observed.promise;
+        expect(callbackPlugin).toBe("multi");
+        expect(callbackWork).toBe(workSignal);
+        expect(callbackReason).toBe(reason);
+        expect(cleanupFinished).toBe(false);
+        if (dispatch === "parent-close") {
+          expect(signalReceived?.aborted).toBe(false);
+        }
+        if (dispatch === "retired") {
+          await expect(tool.execute("new", {}, controller.signal)).rejects.toThrow(
+            "tool runtime is no longer active",
+          );
+        }
+      } finally {
+        installListener.resolve();
+        finishCleanup.resolve();
+        await descendant;
+        await work.drain();
+      }
+      expect(cleanupFinished).toBe(true);
+      expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+      expect(getEventListeners(work.signal, "abort")).toHaveLength(0);
+    },
+  );
+
+  it("refuses managed tool admission after the captured work owner closes", async () => {
+    const execute = vi.fn(async () => ({ content: [] }));
+    setRegistry([
+      createNamedToolEntry("multi", "owned_tool", {
+        factory: () => ({ ...makeTool("owned_tool"), execute }),
+      }),
+    ]);
+    const tool = expectDefined(
+      resolvePluginTools(createResolveToolsParams())[0],
+      "Expected the resolved tool",
+    );
+    const work = new AsyncWorkScope();
+    const controller = new AbortController();
+    const invoke = work.run(() =>
+      AsyncLocalStorage.bind(() => tool.execute("closed", {}, controller.signal)),
+    );
+    await work.drain();
+    await expect(invoke()).rejects.toThrow("Async work scope is closed");
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("wraps every array tool callback and restores caller scope after errors", async () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -8,6 +8,7 @@ import { normalizeConversationReadInvocationOrigin } from "../channels/plugins/c
 import { isInvalidConfigError } from "../config/io.invalid-config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { runWithTrackedCancellation } from "../shared/async-work-scope.js";
 import {
   getLoadedRuntimePluginRegistry,
   createRuntimePluginManifestLookup,
@@ -115,12 +116,16 @@ function wrapPluginToolCallbacks(
     signal?: AbortSignal,
     onUpdate?: unknown,
   ) =>
-    runScoped(
-      () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-          AnyAgentTool["execute"]
-        >,
-    );
+    runScoped(() => {
+      const execute = (executionSignal?: AbortSignal) =>
+        Reflect.apply(tool.execute, tool, [
+          toolCallId,
+          params,
+          executionSignal,
+          onUpdate,
+        ]) as ReturnType<AnyAgentTool["execute"]>;
+      return signal ? runWithTrackedCancellation(signal, execute) : execute();
+    });
   const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {
       if (prop === "prepareArguments" && scopedPrepareArguments) {

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -114,3 +114,49 @@ export function captureAsyncWorkTracker(): typeof trackAsyncWork {
 export function getAsyncWorkSignal(): AbortSignal | undefined {
   return currentWorkScope.getStore()?.signal;
 }
+
+/** Preserves cancellation context until cooperating work ends, without delaying its result. */
+export async function runWithTrackedCancellation<T>(
+  signal: AbortSignal,
+  run: (signal: AbortSignal) => T | Promise<T>,
+): Promise<T> {
+  const parentWork = currentWorkScope.getStore();
+  if (!parentWork) {
+    return await run(signal);
+  }
+  const result = createDeferredCore<T>();
+  // The parent owns cleanup before invocation, but the caller only waits for its result.
+  void parentWork
+    .track(async () => {
+      const work = new AsyncWorkScope();
+      const controller = new AbortController();
+      const context = work.run(() => AsyncLocalStorage.snapshot());
+      const abort = () => context(() => controller.abort(signal.reason));
+      const closeWork = () => context(() => work.beginClose(parentWork.signal.reason));
+      signal.addEventListener("abort", abort, { once: true });
+      parentWork.signal.addEventListener("abort", closeWork, { once: true });
+      if (signal.aborted) {
+        abort();
+      }
+      if (parentWork.signal.aborted) {
+        closeWork();
+      }
+      try {
+        result.resolve(await work.track(() => run(controller.signal)));
+      } catch (error) {
+        result.reject(error);
+      } finally {
+        try {
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [work],
+            () => context(() => work.drain()),
+          );
+        } finally {
+          signal.removeEventListener("abort", abort);
+          parentWork.signal.removeEventListener("abort", closeWork);
+        }
+      }
+    })
+    .catch(result.reject);
+  return await result.promise;
+}


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

A plugin tool's cancellation callback can run under the context that dispatched cancellation instead of the plugin that started the work. This can misidentify the caller of nested runtime operations, including when MCP relays cancellation while accepted work is still draining.

## Why This Change Was Made

The existing MCP cancellation owner moves into a small shared work helper. Signal-bearing managed plugin calls capture their context after the existing registration-authority check. The direct result remains independent of actual descendant cleanup, and the original abort reason is preserved.

## User Impact

Managed tool cancellation retains the executing plugin's identity through its existing work owner. Retired authority still refuses new invocation; raw and no-signal callers preserve their existing context behavior. No public API or registry resource manager is added.

## Evidence

- Native regressions reproduced foreign caller identity, parent-close identity and closed-parent admission failures. All six maintained cases pass alongside the initial 134 sibling tests.
- The five-file changed gate and independent Codex review through P2 passed. The composed MCP/plugin tool run passed 132 tests; counts overlap. Ordinary build passed in 203.75 seconds.
- A plain-Node compiled five-row probe exercised the actual emitted wrappers, work scope and LLM early-denial diagnostics in 1.44 seconds. It preserved original plugin/host/registry identity, abort reasons and early results, refused retired/new work, and made zero configuration, model or network requests. All 11,674 build artifacts stayed unchanged and the managed process group exited.
- Rebased onto the landed MCP parent: all five files match the verified candidate byte-for-byte. This is compiled ownership/identity proof; full MCP wire drainage remains covered by the parent PR.
