### PR TITLE
fix(cli): recognize portable managed completion source lines as installed

### DIFF
--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -321,6 +321,68 @@ describe("completion-runtime", () => {
     },
   );
 
+  it("recognizes a portable [[ -f ... ]] home-relative source line as installed and preserves it", async () => {
+    const homeDir = tempDirs.make("openclaw-portable-completion-home-");
+    const stateDir = path.join(homeDir, ".openclaw");
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: undefined,
+        ZDOTDIR: undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath("bash", "openclaw");
+        expect(cachePath.startsWith(homeDir)).toBe(true);
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+
+        const portablePath = `\${HOME}${cachePath.slice(homeDir.length)}`;
+        const portableLine = `[[ -f "${portablePath}" ]] && source "${portablePath}"`;
+        const before = `# dotfiles-managed\n${portableLine}\n`;
+        const profilePath = path.join(homeDir, ".bashrc");
+        await fs.writeFile(profilePath, before, "utf-8");
+
+        await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+
+        await installCompletion("bash", true, "openclaw");
+
+        await expect(fs.readFile(profilePath, "utf-8")).resolves.toBe(before);
+      },
+    );
+  });
+
+  it("rejects portable source lines that point at a different completion file", async () => {
+    const homeDir = tempDirs.make("openclaw-portable-completion-other-");
+    const stateDir = path.join(homeDir, ".openclaw");
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: undefined,
+        ZDOTDIR: undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath("bash", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+
+        const profilePath = path.join(homeDir, ".bashrc");
+        await fs.writeFile(
+          profilePath,
+          '[[ -f "${HOME}/.openclaw/completions/other.bash" ]] && source "${HOME}/.openclaw/completions/other.bash"\n',
+          "utf-8",
+        );
+
+        await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
+      },
+    );
+  });
+
   it("prints the same canonical reload hint used by Doctor and onboarding", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       const cachePath = resolveCompletionCachePath("zsh", "openclaw");

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   formatCompletionReloadCommand,
   installCompletion,
   isCompletionInstalled,
+  isPortableCompletionSourceLine,
   resolveCompletionCachePath,
   resolveCompletionProfileHint,
   resolveCompletionProfilePath,
@@ -339,7 +340,10 @@ describe("completion-runtime", () => {
         await fs.mkdir(path.dirname(cachePath), { recursive: true });
         await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
 
-        const portablePath = `\${HOME}${cachePath.slice(homeDir.length)}`;
+        const portablePath = `\${HOME}/${path
+          .relative(homeDir, cachePath)
+          .split(path.sep)
+          .join("/")}`;
         const portableLine = `[[ -f "${portablePath}" ]] && source "${portablePath}"`;
         const before = `# dotfiles-managed\n${portableLine}\n`;
         const profilePath = path.join(homeDir, ".bashrc");
@@ -381,6 +385,101 @@ describe("completion-runtime", () => {
         await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(false);
       },
     );
+  });
+
+  it("cleans owned slow hooks but keeps the portable line without appending a copy", async () => {
+    const homeDir = tempDirs.make("openclaw-portable-completion-mixed-");
+    const stateDir = path.join(homeDir, ".openclaw");
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        XDG_CONFIG_HOME: undefined,
+        ZDOTDIR: undefined,
+      },
+      async () => {
+        const cachePath = resolveCompletionCachePath("bash", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+
+        const portablePath = `\${HOME}/${path
+          .relative(homeDir, cachePath)
+          .split(path.sep)
+          .join("/")}`;
+        const portableLine = `[[ -f "${portablePath}" ]] && source "${portablePath}"`;
+        const slowLine = "source <(openclaw completion --shell bash)";
+        const profilePath = path.join(homeDir, ".bashrc");
+        await fs.writeFile(profilePath, `${portableLine}\n${slowLine}\n`, "utf-8");
+
+        await installCompletion("bash", true, "openclaw");
+
+        const after = await fs.readFile(profilePath, "utf-8");
+        expect(after).toContain(portableLine);
+        expect(after).not.toContain(slowLine);
+        expect(after).not.toContain("# OpenClaw Completion");
+      },
+    );
+  });
+
+  it("rejects shell-invalid portable operands", () => {
+    const home = "/tmp/fake-home";
+    const cache = `${home}/.openclaw/completions/openclaw.bash`;
+    // Single quotes suppress expansion, so the shell would load a literal path.
+    expect(
+      isPortableCompletionSourceLine(
+        "[[ -f '${HOME}/.openclaw/completions/openclaw.bash' ]] && source '${HOME}/.openclaw/completions/openclaw.bash'",
+        cache,
+        home,
+      ),
+    ).toBe(false);
+    // Tilde does not expand inside double quotes.
+    expect(
+      isPortableCompletionSourceLine(
+        '[[ -f "~/.openclaw/completions/openclaw.bash" ]] && source "~/.openclaw/completions/openclaw.bash"',
+        cache,
+        home,
+      ),
+    ).toBe(false);
+    // Parent components may resolve elsewhere through symlinks.
+    expect(
+      isPortableCompletionSourceLine(
+        '[[ -f "${HOME}/linked/../.openclaw/completions/openclaw.bash" ]] && source "${HOME}/linked/../.openclaw/completions/openclaw.bash"',
+        cache,
+        home,
+      ),
+    ).toBe(false);
+    // Guard and source must point at the same file.
+    expect(
+      isPortableCompletionSourceLine(
+        '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/other.bash"',
+        cache,
+        home,
+      ),
+    ).toBe(false);
+    // Valid forms still recognized: unquoted tilde, double-quoted and bare $HOME.
+    expect(
+      isPortableCompletionSourceLine(
+        "[[ -f ~/.openclaw/completions/openclaw.bash ]] && source ~/.openclaw/completions/openclaw.bash",
+        cache,
+        home,
+      ),
+    ).toBe(true);
+    expect(
+      isPortableCompletionSourceLine(
+        '[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"',
+        cache,
+        home,
+      ),
+    ).toBe(true);
+    expect(
+      isPortableCompletionSourceLine(
+        "[[ -f $HOME/.openclaw/completions/openclaw.bash ]] && source $HOME/.openclaw/completions/openclaw.bash",
+        cache,
+        home,
+      ),
+    ).toBe(true);
   });
 
   it("prints the same canonical reload hint used by Doctor and onboarding", async () => {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -160,20 +160,37 @@ function isCompletionProfileHeader(line: string): boolean {
 }
 
 /**
- * Expands a leading portable home reference (`~/`, `$HOME/`, `${HOME}/`)
- * against the given home directory. Anything else is returned unchanged.
+ * Resolves a shell operand to an absolute path only when its quoting context
+ * actually performs the expansion: `~` expands solely unquoted, while
+ * `$HOME`/`${HOME}` expand unquoted or double-quoted — never single-quoted.
+ * Rejects parent (`..`) segments and unquoted shell metacharacters so two
+ * paths compare equal only when the shell would load the same file.
+ * Returns null for anything the shell would not resolve to `home`.
  */
-function expandPortableHomePrefix(value: string, home: string): string {
-  if (value.startsWith("~/")) {
-    return `${home}/${value.slice(2)}`;
+function resolvePortableOperand(raw: string, quote: string, home: string): string | null {
+  if (quote === "'") {
+    return null;
   }
-  if (value.startsWith("$HOME/")) {
-    return `${home}/${value.slice(6)}`;
+  let rest: string;
+  if (raw.startsWith("~/")) {
+    if (quote !== "") {
+      return null;
+    }
+    rest = raw.slice(2);
+  } else if (raw.startsWith("$HOME/")) {
+    rest = raw.slice(6);
+  } else if (raw.startsWith("${HOME}/")) {
+    rest = raw.slice(8);
+  } else {
+    return null;
   }
-  if (value.startsWith("${HOME}/")) {
-    return `${home}/${value.slice(8)}`;
+  if (!rest || rest.split("/").includes("..")) {
+    return null;
   }
-  return value;
+  if (quote === "" && /[*?[\]'"`$&;|<>(){}!]/.test(rest)) {
+    return null;
+  }
+  return path.join(home, rest);
 }
 
 const PORTABLE_COMPLETION_SOURCE_PATTERN =
@@ -196,15 +213,21 @@ export function isPortableCompletionSourceLine(
   if (!match) {
     return false;
   }
-  const guardPath = match[1] ?? match[2] ?? match[3] ?? "";
-  const sourcePath = match[4] ?? match[5] ?? match[6] ?? "";
-  if (!guardPath || !sourcePath) {
+  const guardRaw = match[1] ?? match[2] ?? match[3] ?? "";
+  const sourceRaw = match[4] ?? match[5] ?? match[6] ?? "";
+  if (!guardRaw || !sourceRaw) {
     return false;
   }
-  const expandedGuard = path.normalize(expandPortableHomePrefix(guardPath, home));
-  const expandedSource = path.normalize(expandPortableHomePrefix(sourcePath, home));
-  const normalizedCache = path.normalize(cachePath);
-  return expandedGuard === normalizedCache && expandedSource === normalizedCache;
+  const guardQuote = match[1] !== undefined ? '"' : match[2] !== undefined ? "'" : "";
+  const sourceQuote = match[4] !== undefined ? '"' : match[5] !== undefined ? "'" : "";
+  const expandedGuard = resolvePortableOperand(guardRaw, guardQuote, home);
+  const expandedSource = resolvePortableOperand(sourceRaw, sourceQuote, home);
+  return (
+    expandedGuard !== null &&
+    expandedSource !== null &&
+    expandedGuard === expandedSource &&
+    expandedGuard === cachePath
+  );
 }
 
 function isCompletionProfileLine(line: string, binName: string, cachePath: string): boolean {
@@ -336,15 +359,11 @@ function updateCompletionProfile(
   let hadExisting = false;
 
   // A portable home-relative source line is user-owned (dotfile managers):
-  // recognizing it as configured must preserve it, not replace it with an
-  // absolute-path copy.
-  if (
-    lines.some((line) =>
-      isPortableCompletionSourceLine(line, cachePath, process.env.HOME ?? os.homedir()),
-    )
-  ) {
-    return { next: content, changed: false, hadExisting: true };
-  }
+  // keep it while still cleaning owned stale hooks below; the canonical
+  // absolute-path block is appended only when no portable line exists.
+  const hasPortable = lines.some((line) =>
+    isPortableCompletionSourceLine(line, cachePath, process.env.HOME ?? os.homedir()),
+  );
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
@@ -368,6 +387,10 @@ function updateCompletionProfile(
   }
 
   const trimmed = filtered.join("\n").trimEnd();
+  if (hasPortable) {
+    const next = `${trimmed}\n`;
+    return { next, changed: next !== content, hadExisting: true };
+  }
   const block = `# OpenClaw Completion\n${formatCompletionSourceLine(shell, cachePath)}`;
   const next = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
   return { next, changed: next !== content, hadExisting };

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -159,6 +159,54 @@ function isCompletionProfileHeader(line: string): boolean {
   return line.trim() === "# OpenClaw Completion";
 }
 
+/**
+ * Expands a leading portable home reference (`~/`, `$HOME/`, `${HOME}/`)
+ * against the given home directory. Anything else is returned unchanged.
+ */
+function expandPortableHomePrefix(value: string, home: string): string {
+  if (value.startsWith("~/")) {
+    return `${home}/${value.slice(2)}`;
+  }
+  if (value.startsWith("$HOME/")) {
+    return `${home}/${value.slice(6)}`;
+  }
+  if (value.startsWith("${HOME}/")) {
+    return `${home}/${value.slice(8)}`;
+  }
+  return value;
+}
+
+const PORTABLE_COMPLETION_SOURCE_PATTERN =
+  /^\[\[\s+-f\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s+\]\]\s*&&\s*source\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/u;
+
+/**
+ * Recognizes a portable, home-relative guarded source line for the exact
+ * cached completion file, e.g.
+ * `[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "..."`.
+ * Such lines are user-owned (dotfile managers): detection treats them as
+ * installed, and installation preserves them instead of appending a copy.
+ */
+export function isPortableCompletionSourceLine(
+  line: string,
+  cachePath: string,
+  home: string = process.env.HOME ?? os.homedir(),
+): boolean {
+  const trimmed = line.trim();
+  const match = PORTABLE_COMPLETION_SOURCE_PATTERN.exec(trimmed);
+  if (!match) {
+    return false;
+  }
+  const guardPath = match[1] ?? match[2] ?? match[3] ?? "";
+  const sourcePath = match[4] ?? match[5] ?? match[6] ?? "";
+  if (!guardPath || !sourcePath) {
+    return false;
+  }
+  const expandedGuard = path.normalize(expandPortableHomePrefix(guardPath, home));
+  const expandedSource = path.normalize(expandPortableHomePrefix(sourcePath, home));
+  const normalizedCache = path.normalize(cachePath);
+  return expandedGuard === normalizedCache && expandedSource === normalizedCache;
+}
+
 function isCompletionProfileLine(line: string, binName: string, cachePath: string): boolean {
   if (isSlowDynamicCompletionLine(line, binName)) {
     return true;
@@ -286,6 +334,17 @@ function updateCompletionProfile(
   const lines = content.split("\n");
   const filtered: string[] = [];
   let hadExisting = false;
+
+  // A portable home-relative source line is user-owned (dotfile managers):
+  // recognizing it as configured must preserve it, not replace it with an
+  // absolute-path copy.
+  if (
+    lines.some((line) =>
+      isPortableCompletionSourceLine(line, cachePath, process.env.HOME ?? os.homedir()),
+    )
+  ) {
+    return { next: content, changed: false, hadExisting: true };
+  }
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
@@ -422,6 +481,7 @@ export function resolveCompletionProfileHint(shell: CompletionShell): string {
 export async function isCompletionInstalled(
   shell: CompletionShell,
   binName = "openclaw",
+  options: { home?: string } = {},
 ): Promise<boolean> {
   const profilePath = resolveCompletionProfilePath(shell);
 
@@ -431,8 +491,13 @@ export async function isCompletionInstalled(
   const cachePath = resolveCompletionCachePath(shell, binName);
   const { content } = await readCompletionProfile(profilePath, shell);
   const lines = content.split("\n");
+  const home = options.home ?? process.env.HOME ?? os.homedir();
   // A marker does not install completion; retain missing-cache source lines for doctor repair.
-  return lines.some((line) => isCompletionProfileLine(line, binName, cachePath));
+  return lines.some(
+    (line) =>
+      isCompletionProfileLine(line, binName, cachePath) ||
+      isPortableCompletionSourceLine(line, cachePath, home),
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #143267.

The installer didn't recognize portable `[[ -f ... ]]` source lines that use `${HOME}`, so it kept appending an absolute-path copy next to the user's managed line.

This change treats a portable guarded source line that resolves to the exact cached completion file as installed, and leaves it untouched instead of replacing it. Lines pointing anywhere else still get the normal install behavior.

Verified with two new tests in `completion-runtime.test.ts` (recognized + preserved, and a line pointing at a different file is still treated as missing). Full `completion-runtime` + `doctor-completion` suites pass (85 tests), oxfmt/oxlint clean.

## What Problem This Solves

`openclaw completion bash` duplicates the completion setup for anyone whose shell profile is managed by a dotfile manager (chezmoi, stow, Nix): the installer doesn't recognize a portable guarded source line like `[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source ...`, so every run appends an absolute-path copy next to the user's line. Worse, the absolute path bakes in a temp deploy dir (`/tmp/openclaw-chezmoi*/home/...`), so the duplicate is broken on the next shell.

## Evidence

Real patched-CLI run against a temp HOME (mixed profile: portable line + stale slow `source <(...)` line, cache file present):

```
$ isCompletionInstalled → true
$ installCompletion → Updating completion...

--- .bashrc after ---
[[ -f "${HOME}/.openclaw/completions/openclaw.bash" ]] && source "${HOME}/.openclaw/completions/openclaw.bash"

$ bash --noprofile --norc -c 'source ~/.bashrc; complete -p openclaw'
complete -W 'status' openclaw
```

The portable line is preserved byte-for-byte, the stale slow hook is removed, no absolute-path copy is appended, and a fresh Bash registers the completion from the cache file. (Paths use a temp HOME; no private data involved.)

Tests: `completion-runtime.test.ts` + `doctor-completion.test.ts` — 87/87 pass, including new cases for single-quoted operands, quoted tilde, `..` segments, guard/source mismatch, and mixed-profile cleanup. `oxfmt`/`oxlint` clean, no new `as` assertions (baseline-ratchets safe). No other open PR touches these files.

Addresses the ClawSweeper review findings: quoting-aware operand resolution, `..` rejection, owned-hook cleanup preserved alongside portable lines, and a platform-independent fixture.
