### PR TITLE
fix: retain approval classification resources through cleanup

### DIFF
--- a/src/system-agent/approval-intent.resources.test.ts
+++ b/src/system-agent/approval-intent.resources.test.ts
@@ -1,0 +1,343 @@
+import fs from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import { getAiTransportHost } from "@openclaw/ai";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../agents/prepared-model-runtime.test-support.js";
+import { ModelRegistry } from "../agents/sessions/model-registry.js";
+import {
+  acquireSimpleCompletionModelForAgent,
+  completeWithPreparedSimpleCompletionModel,
+} from "../agents/simple-completion-runtime.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { classifySystemAgentApprovalIntent } from "./approval-intent.js";
+import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
+import {
+  createSystemAgentVerifiedInferenceBinding,
+  resolveSystemAgentVerifiedInferenceRoute,
+} from "./verified-inference.js";
+
+it.each(["overlap", "cancel-drain", "route-drift"] as const)(
+  "retains verified approval completion resources through %s",
+  async (mode) => {
+    await withOpenClawTestState(
+      { label: "approval-owner", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+      async (state) => {
+        const pluginRoot = state.path("provider");
+        fs.mkdirSync(pluginRoot);
+        const fixture = createColdPluginFixture({
+          rootDir: pluginRoot,
+          pluginId: "approval-fixture",
+          providerId: "approval-provider",
+        });
+        fs.writeFileSync(
+          fixture.runtimeSource,
+          `module.exports = { id: "approval-fixture", register(api) {
+        api.registerProvider({ id: "approval-provider", label: "Approval fixture", auth: [] });
+      } };`,
+        );
+        const requests: ServerResponse[] = [];
+        const arrivals = Array.from({ length: 4 }, () => createDeferred());
+        let finishing = false;
+        const finish = (response: ServerResponse) => {
+          if (response.writableEnded || response.destroyed) {
+            return;
+          }
+          response.writeHead(200, { "content-type": "text/event-stream" });
+          response.end(
+            `data: ${JSON.stringify({ id: "approval-response", object: "chat.completion.chunk", model: "approval-model", choices: [{ index: 0, delta: { content: "approve" }, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+          );
+        };
+        const server = createServer((request, response) => {
+          request.resume();
+          const index = requests.push(response) - 1;
+          arrivals[index]?.resolve();
+          if (finishing || index === 0) {
+            finish(response);
+          }
+        });
+        await new Promise<void>((resolve) => {
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const pending: Promise<unknown>[] = [];
+        const finishCancel = createDeferred();
+        const cancelStarted = createDeferred();
+        const parent = new AsyncWorkScope();
+        const spies: Array<{ mockRestore(): void }> = [];
+        let drained = false;
+        let drainage: Promise<void> | undefined;
+        try {
+          const address = server.address();
+          if (!address || typeof address === "string") {
+            throw new Error("Approval fixture has no TCP port");
+          }
+          const profileId = `${fixture.providerId}:verified`;
+          const cfg: OpenClawConfig = {
+            agents: {
+              defaults: {
+                workspace: state.workspaceDir,
+                model: `${fixture.providerId}/approval-model@${profileId}`,
+                models: {
+                  [`${fixture.providerId}/approval-model`]: { agentRuntime: { id: "openclaw" } },
+                },
+              },
+            },
+            auth: { profiles: { [profileId]: { provider: fixture.providerId, mode: "api_key" } } },
+            models: {
+              providers: {
+                [fixture.providerId]: {
+                  api: "openai-completions",
+                  baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                  models: [
+                    {
+                      id: "approval-model",
+                      name: "Approval model",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 8192,
+                      maxTokens: 1024,
+                    },
+                  ],
+                },
+              },
+            },
+            plugins: {
+              allow: [fixture.pluginId],
+              load: { paths: [fixture.rootDir] },
+              slots: { memory: "none" },
+              entries: { [fixture.pluginId]: { enabled: true } },
+            },
+          };
+          await state.writeConfig(cfg);
+          const authDatabase = await state.writeAuthProfiles({
+            version: 1,
+            profiles: {
+              [profileId]: {
+                type: "api_key",
+                provider: fixture.providerId,
+                key: "synthetic-approval-key",
+              },
+            },
+          });
+          expect(fs.existsSync(authDatabase)).toBe(true);
+          const snapshot = await readConfigFileSnapshot();
+          if (!snapshot.valid) {
+            throw new Error("Approval fixture config is invalid");
+          }
+          const route = await resolveSystemAgentConfiguredRouteFromConfig(
+            snapshot.runtimeConfig ?? snapshot.config,
+            undefined,
+            {},
+            snapshot,
+          );
+          if (
+            !route ||
+            route.runner !== "embedded" ||
+            route.agentHarnessRuntimeOverride !== "openclaw"
+          ) {
+            throw new Error("Approval fixture did not select the embedded OpenClaw route");
+          }
+          const probe = await acquireSimpleCompletionModelForAgent({
+            cfg: route.runConfig,
+            agentId: route.agentId,
+            agentDir: route.agentDir,
+            modelRef: `${route.modelLabel}@${profileId}`,
+            preferredProfile: profileId,
+            bindAuthOwner: true,
+          });
+          if ("error" in probe) {
+            throw new Error(probe.error);
+          }
+          const verifiedInference = await (async () => {
+            try {
+              const response = await completeWithPreparedSimpleCompletionModel({
+                model: probe.model,
+                auth: probe.auth,
+                cfg: route.runConfig,
+                context: {
+                  messages: [{ role: "user", content: "verify synthetic inference", timestamp: 0 }],
+                },
+              });
+              expect(
+                response.content.some((part) => part.type === "text" && part.text === "approve"),
+              ).toBe(true);
+              if (!probe.sourceAuthFingerprint) {
+                throw new Error("Probe has no bound auth fingerprint");
+              }
+              return await createSystemAgentVerifiedInferenceBinding({
+                configuredRoute: route,
+                executionRoute: route,
+                auth: {
+                  authProfileId: profileId,
+                  authFingerprint: probe.sourceAuthFingerprint,
+                  agentHarnessId: "openclaw",
+                  modelId: probe.model.id,
+                  modelApi: probe.model.api,
+                },
+              });
+            } finally {
+              probe.release();
+            }
+          })();
+          expect(
+            (await resolveSystemAgentVerifiedInferenceRoute(verifiedInference))?.provider,
+          ).toBe(fixture.providerId);
+          const builds = vi.spyOn(ModelRegistry, "create");
+          spies.push(builds);
+          if (mode === "cancel-drain") {
+            const plugin = getAiTransportHost().plugin;
+            const wrap = plugin.wrapSimpleCompletionStream;
+            let first = true;
+            spies.push(
+              vi.spyOn(plugin, "wrapSimpleCompletionStream").mockImplementation((params) => {
+                const stream = wrap(params) ?? params.context.streamFn;
+                return (model, context, options) =>
+                  stream(model, context, {
+                    ...options,
+                    onResponse: async (response, responseModel) => {
+                      await options?.onResponse?.(response, responseModel);
+                      if (first) {
+                        first = false;
+                        throw new Error("fixture response rejected");
+                      }
+                    },
+                  });
+              }),
+            );
+            const fetch = globalThis.fetch;
+            let wrapped = false;
+            spies.push(
+              vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+                const response = await fetch(...args);
+                if (wrapped || !response.url.startsWith(`http://127.0.0.1:${address.port}/`)) {
+                  return response;
+                }
+                wrapped = true;
+                const reader = response.body?.getReader();
+                if (!reader) {
+                  throw new Error("Approval response has no body");
+                }
+                return new Response(
+                  new ReadableStream<Uint8Array>({
+                    async pull(controller) {
+                      const { value, done } = await reader.read();
+                      if (done) {
+                        controller.close();
+                      } else {
+                        controller.enqueue(value);
+                      }
+                    },
+                    async cancel(reason) {
+                      cancelStarted.resolve();
+                      await finishCancel.promise;
+                      await reader.cancel(reason);
+                    },
+                  }),
+                  { status: response.status, headers: response.headers },
+                );
+              }),
+            );
+          }
+          const start = (managed = false) => {
+            const run = () =>
+              classifySystemAgentApprovalIntent({
+                message: "alright, ship that change",
+                proposal: "a synthetic pending change",
+                verifiedInference,
+              });
+            const result = managed ? parent.track(run) : run();
+            pending.push(result);
+            return result;
+          };
+          const arrive = (index: number, result: Promise<unknown>) =>
+            Promise.race([
+              arrivals[index]!.promise,
+              result.then(() => {
+                throw new Error("Classifier settled before its provider request");
+              }),
+            ]);
+          const started = performance.now();
+          const first = start(true);
+          await arrive(1, first);
+          const coldMs = performance.now() - started;
+          const firstBuilds = builds.mock.calls.length;
+          expect(firstBuilds).toBeGreaterThan(0);
+          if (mode === "cancel-drain") {
+            finish(requests[1]!);
+            await Promise.race([cancelStarted.promise, first]);
+            await expect(first).resolves.toBe("other");
+            drainage = parent.drain().then(() => {
+              drained = true;
+            });
+          }
+          const secondStarted = performance.now();
+          const second = start();
+          await arrive(2, second);
+          console.info("approval completion preparation", {
+            mode,
+            coldMs,
+            overlapMs: performance.now() - secondStarted,
+          });
+          expect.soft(builds.mock.calls.length).toBe(firstBuilds);
+          if (mode === "cancel-drain") {
+            expect.soft(drained).toBe(false);
+          }
+          if (mode === "route-drift") {
+            await state.writeAuthProfiles({
+              version: 1,
+              profiles: {
+                [profileId]: {
+                  type: "api_key",
+                  provider: fixture.providerId,
+                  key: "rotated-synthetic-key",
+                },
+              },
+            });
+          }
+          finishCancel.resolve();
+          requests.forEach(finish);
+          if (mode !== "cancel-drain") {
+            await expect(first).resolves.toBe(mode === "route-drift" ? "other" : "approve");
+          }
+          await expect(second).resolves.toBe(mode === "route-drift" ? "other" : "approve");
+          await drainage;
+          if (mode === "route-drift") {
+            const count = requests.length;
+            await expect(start()).resolves.toBe("other");
+            expect(requests).toHaveLength(count);
+          } else {
+            const beforeThird = builds.mock.calls.length;
+            const third = start();
+            await arrive(3, third);
+            expect(builds.mock.calls.length).toBe(beforeThird + 1);
+            finish(requests[3]!);
+            await expect(third).resolves.toBe("approve");
+          }
+        } finally {
+          finishCancel.resolve();
+          finishing = true;
+          requests.forEach(finish);
+          await Promise.allSettled(pending);
+          await parent.drain();
+          for (const spy of spies) {
+            spy.mockRestore();
+          }
+          await resetPreparedModelRuntimeSnapshotsForTest();
+          clearPluginMetadataLifecycleCaches();
+          resetPluginLoaderTestStateForTest();
+          server.closeAllConnections();
+          await new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          });
+        }
+      },
+    );
+  },
+);

--- a/src/system-agent/approval-intent.test.ts
+++ b/src/system-agent/approval-intent.test.ts
@@ -83,11 +83,12 @@ function completionDeps(replyText: string, binding: SystemAgentVerifiedInference
     resolveVerifiedInferenceRoute: vi.fn<
       NonNullable<SystemAgentApprovalIntentDeps["resolveVerifiedInferenceRoute"]>
     >(async () => route),
-    prepareSimpleCompletionModelForAgent: vi.fn<
-      NonNullable<SystemAgentApprovalIntentDeps["prepareSimpleCompletionModelForAgent"]>
+    acquireSimpleCompletionModelForAgent: vi.fn<
+      NonNullable<SystemAgentApprovalIntentDeps["acquireSimpleCompletionModelForAgent"]>
     >(
       async () =>
         ({
+          release: () => {},
           model: {},
           auth: { profileId: route.authProfileId },
           sourceAuthFingerprint: binding.auth.authFingerprint,
@@ -154,7 +155,7 @@ describe("classifySystemAgentApprovalIntent", () => {
         deps,
       ),
     ).resolves.toBe("approve");
-    expect(deps.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+    expect(deps.acquireSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agentDir: binding.execution.agentDir,
         modelRef: "openai/gpt-5.5@openai:p2",
@@ -179,7 +180,7 @@ describe("classifySystemAgentApprovalIntent", () => {
     const binding = requireSharedVerifiedInference();
     const deps = {
       ...completionDeps("approve", binding),
-      prepareSimpleCompletionModelForAgent: vi.fn(async () => ({ error: "no model" })) as never,
+      acquireSimpleCompletionModelForAgent: vi.fn(async () => ({ error: "no model" })) as never,
     };
     await expect(
       classifySystemAgentApprovalIntent(
@@ -192,7 +193,8 @@ describe("classifySystemAgentApprovalIntent", () => {
   it("rejects a prepared auth owner that differs from the verified profile", async () => {
     const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
-    deps.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+    deps.acquireSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      release: () => {},
       model: {},
       auth: { profileId: "openai:p1" },
       selection: {
@@ -215,7 +217,8 @@ describe("classifySystemAgentApprovalIntent", () => {
   it("rejects a same-profile credential rotation during preparation", async () => {
     const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
-    deps.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+    deps.acquireSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      release: () => {},
       model: {},
       auth: { profileId: "openai:p2" },
       sourceAuthFingerprint: "different-p2-owner",
@@ -246,7 +249,7 @@ describe("classifySystemAgentApprovalIntent", () => {
         deps,
       ),
     ).resolves.toBe("other");
-    expect(deps.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(deps.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("rejects a verdict when the verified owner drifts during classification", async () => {

--- a/src/system-agent/approval-intent.ts
+++ b/src/system-agent/approval-intent.ts
@@ -1,9 +1,11 @@
 // Classifies whether a user's chat message approves a pending OpenClaw proposal.
 import { extractEmbeddedAssistantText } from "../agents/embedded-agent-utils.js";
 import {
+  acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
 } from "../agents/simple-completion-runtime.js";
+import { AsyncWorkScope, captureAsyncWorkTracker } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   classifySystemAgentApprovalText,
   type SystemAgentApprovalIntent,
@@ -45,7 +47,7 @@ const APPROVAL_INTENT_SYSTEM_PROMPT = [
 
 export type SystemAgentApprovalIntentDeps = {
   resolveVerifiedInferenceRoute?: typeof resolveSystemAgentVerifiedInferenceRoute;
-  prepareSimpleCompletionModelForAgent?: typeof prepareSimpleCompletionModelForAgent;
+  acquireSimpleCompletionModelForAgent?: typeof acquireSimpleCompletionModelForAgent;
   completeWithPreparedSimpleCompletionModel?: typeof completeWithPreparedSimpleCompletionModel;
 };
 
@@ -80,70 +82,94 @@ export async function classifySystemAgentApprovalIntent(
     const modelRef = route.authProfileId
       ? `${route.modelLabel}@${route.authProfileId}`
       : route.modelLabel;
-    const prepared = await (
-      deps.prepareSimpleCompletionModelForAgent ?? prepareSimpleCompletionModelForAgent
-    )({
-      cfg: route.runConfig,
-      agentId: route.agentId,
-      agentDir: route.agentDir,
-      modelRef,
-      ...(route.authProfileId ? { preferredProfile: route.authProfileId } : {}),
-      allowMissingApiKeyModes: ["aws-sdk"],
-      bindAuthOwner: true,
-    });
-    if ("error" in prepared) {
-      return "other";
-    }
-    const preparedProvider = prepared.selection.runtimeProvider ?? prepared.selection.provider;
-    if (
-      preparedProvider !== route.provider ||
-      prepared.selection.modelId !== route.model ||
-      prepared.selection.agentDir !== route.agentDir ||
-      prepared.selection.profileId !== route.authProfileId ||
-      prepared.auth.profileId !== route.authProfileId ||
-      !params.verifiedInference.auth.authFingerprint ||
-      prepared.sourceAuthFingerprint !== params.verifiedInference.auth.authFingerprint
-    ) {
-      return "other";
-    }
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), APPROVAL_INTENT_TIMEOUT_MS);
-    try {
-      const response = await (
-        deps.completeWithPreparedSimpleCompletionModel ?? completeWithPreparedSimpleCompletionModel
+    const callerResult = createDeferredCore<SystemAgentApprovalIntent>();
+    const trackOwner = captureAsyncWorkTracker();
+    // Reporting a verdict does not settle response callbacks or cancellation work.
+    void trackOwner(async () => {
+      const prepared = await (
+        deps.acquireSimpleCompletionModelForAgent ?? acquireSimpleCompletionModelForAgent
       )({
-        model: prepared.model,
-        auth: prepared.auth,
         cfg: route.runConfig,
-        context: {
-          systemPrompt: APPROVAL_INTENT_SYSTEM_PROMPT,
-          messages: [
-            {
-              role: "user",
-              content: [
-                `Pending change: ${params.proposal ?? "a configuration change proposed in this conversation"}`,
-                `User message: ${params.message}`,
-              ].join("\n"),
-              timestamp: Date.now(),
-            },
-          ],
-        },
-        options: {
-          maxTokens: APPROVAL_INTENT_MAX_TOKENS,
-          signal: controller.signal,
-        },
+        agentId: route.agentId,
+        agentDir: route.agentDir,
+        modelRef,
+        ...(route.authProfileId ? { preferredProfile: route.authProfileId } : {}),
+        allowMissingApiKeyModes: ["aws-sdk"],
+        bindAuthOwner: true,
       });
-      if (!(await resolveVerifiedRoute(params.verifiedInference))) {
-        return "other";
+      if ("error" in prepared) {
+        callerResult.resolve("other");
+        return;
       }
-      const verdict = extractEmbeddedAssistantText(response)?.trim().toLowerCase().split(/\s+/)[0];
-      if (verdict === "approve" || verdict === "decline") {
-        return verdict;
+      const work = new AsyncWorkScope();
+      try {
+        callerResult.resolve(
+          await work.track(async () => {
+            const preparedProvider =
+              prepared.selection.runtimeProvider ?? prepared.selection.provider;
+            if (
+              preparedProvider !== route.provider ||
+              prepared.selection.modelId !== route.model ||
+              prepared.selection.agentDir !== route.agentDir ||
+              prepared.selection.profileId !== route.authProfileId ||
+              prepared.auth.profileId !== route.authProfileId ||
+              !params.verifiedInference.auth.authFingerprint ||
+              prepared.sourceAuthFingerprint !== params.verifiedInference.auth.authFingerprint
+            ) {
+              return "other";
+            }
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), APPROVAL_INTENT_TIMEOUT_MS);
+            try {
+              const response = await (
+                deps.completeWithPreparedSimpleCompletionModel ??
+                completeWithPreparedSimpleCompletionModel
+              )({
+                model: prepared.model,
+                auth: prepared.auth,
+                cfg: route.runConfig,
+                context: {
+                  systemPrompt: APPROVAL_INTENT_SYSTEM_PROMPT,
+                  messages: [
+                    {
+                      role: "user",
+                      content: [
+                        `Pending change: ${params.proposal ?? "a configuration change proposed in this conversation"}`,
+                        `User message: ${params.message}`,
+                      ].join("\n"),
+                      timestamp: Date.now(),
+                    },
+                  ],
+                },
+                options: {
+                  maxTokens: APPROVAL_INTENT_MAX_TOKENS,
+                  signal: controller.signal,
+                },
+              });
+              if (!(await resolveVerifiedRoute(params.verifiedInference))) {
+                return "other";
+              }
+              const verdict = extractEmbeddedAssistantText(response)
+                ?.trim()
+                .toLowerCase()
+                .split(/\s+/)[0];
+              if (verdict === "approve" || verdict === "decline") {
+                return verdict;
+              }
+              return "other";
+            } finally {
+              clearTimeout(timer);
+            }
+          }),
+        );
+      } catch {
+        callerResult.resolve("other");
+      } finally {
+        await work.drain();
+        prepared.release();
       }
-      return "other";
-    } finally {
-      clearTimeout(timer);
-    }
+    }).catch(() => callerResult.resolve("other"));
+    return await callerResult.promise;
   } catch {
     // Approval must fail closed: an unreachable model means no arming.
     return "other";


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Resolves a problem where ambiguous approval classification releases its prepared model runtime before inference and transport cleanup finish. Concurrent classifications can rebuild a generation that should still be retained, and a timeout can leave callbacks running beyond their owner.

## Why This Change Was Made

Acquire the existing finite model contract and admit cleanup to the parent before preparation. Preserve the caller's result deadline while draining actual completion, response callbacks, and cancellation work before releasing the lease. This is the approval-classifier slice of #140674.

The closed-list shortcut, verified embedded route, exact provider/model/profile/auth matching, final route revalidation, and fail-closed policy remain intact. The ten-second timer still starts after route matching and clears after completion and revalidation, independently of drainage.

## User Impact

Approval classification keeps its model and authentication runtime available until its real work finishes, including after a timed-out verdict. Approval decisions, input limits, and timeout behavior are unchanged.

## Evidence

Three native regression cases fail against the original code and pass with the repair. They cover overlapping preparation, response-body cancellation, and credential rotation during pending verdicts. All 158 focused tests passed; changed-file gate coverage, isolated Codex review through P2, and the full build passed.

A plain Node run of the emitted classifier used real SQLite authentication state, the production verified-binding machinery, a synthetic plugin, and loopback HTTP. A real response callback remained held after the unchanged deadline returned `other` at 10,021 ms. Parent drainage, generation reuse, fresh preparation after release, and credential-rotation rejection passed. Strict process cleanup completed in 12.987 seconds; all 12,111 built artifacts remained unchanged. No pending mutation was executed.

These are local observations, not a comparative performance benchmark or paid-provider proof. Native cancellation coverage uses the declared hermetic test transport; the compiled proof uses the actual plugin callback and HTTP path. Broader run-registration physical disposal is a separate slice.
