### PR TITLE
feat(codex): add authorized capability dispatch runtime

### DIFF
--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -76,6 +76,7 @@
     "onCommands": ["codex"],
     "onConfigPaths": [
       "plugins.entries.codex.config.appServer.transport",
+      "plugins.entries.codex.config.capabilityDispatch.enabled",
       "plugins.entries.codex.config.sessionCatalog.enabled",
       "plugins.entries.codex.config.sessionCatalog.homes",
       "plugins.entries.codex.config.supervision.enabled"
@@ -115,6 +116,11 @@
         "type": "array",
         "items": { "type": "string" },
         "default": []
+      },
+      "capabilityDispatch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "enabled": { "type": "boolean", "default": false } }
       },
       "sessionCatalog": {
         "type": "object",

--- a/extensions/codex/src/app-server/capability-dispatch.test.ts
+++ b/extensions/codex/src/app-server/capability-dispatch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCodexCapabilityDispatchTool,
+  dispatchCodexCapability,
+} from "./capability-dispatch.js";
+import { readCodexPluginConfig } from "./config-parsing.js";
+import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
+
+function client(statuses: Array<{ name: string; tools: Record<string, unknown> }>) {
+  return {
+    request: vi.fn(async (method: string) =>
+      method === "mcpServerStatus/list"
+        ? { data: statuses }
+        : { content: [{ type: "text", text: "ok" }] },
+    ),
+  };
+}
+const status = (name: string, names: string[]) => ({
+  name,
+  tools: Object.fromEntries(names.map((name) => [name, {}])),
+});
+
+describe("owner-bound Codex capability dispatch", () => {
+  it("is an explicit runtime opt-in", () => {
+    expect(
+      readCodexPluginConfig({ capabilityDispatch: { enabled: true } }).capabilityDispatch,
+    ).toEqual({ enabled: true });
+  });
+  it.each([
+    ["create", "knowledge_create"],
+    ["update", "knowledge_update"],
+    ["append", "knowledge_append"],
+  ])("maps knowledge %s to %s", async (operation, expected) => {
+    const live = client([status("knowledge", [expected])]);
+    await dispatchCodexCapability({
+      client: live as never,
+      threadId: "owner-thread",
+      input: {
+        adapter: "knowledge",
+        operation,
+        authorization: { scope: "docs", purpose: "authorized test" },
+      },
+    });
+    expect(live.request).toHaveBeenLastCalledWith("mcpServer/tool/call", {
+      threadId: "owner-thread",
+      server: "knowledge",
+      tool: expected,
+      arguments: {},
+    });
+  });
+  it("rejects mutations before catalog access without authorization", async () => {
+    const live = client([status("knowledge", ["knowledge_create"])]);
+    const response = await dispatchCodexCapability({
+      client: live as never,
+      threadId: "owner-thread",
+      input: { adapter: "knowledge", operation: "create" },
+    });
+    expect(response.details).toEqual({ status: "permission_denied" });
+    expect(live.request).not.toHaveBeenCalled();
+  });
+  it("uses only the live owner thread and rejects an ambiguous catalog", async () => {
+    const live = client([status("one", ["knowledge_read"]), status("two", ["knowledge_read"])]);
+    const response = await dispatchCodexCapability({
+      client: live as never,
+      threadId: "owner-thread",
+      input: { adapter: "knowledge", operation: "read" },
+    });
+    expect(response.details).toEqual({ status: "unavailable" });
+    expect(live.request).toHaveBeenCalledWith("mcpServerStatus/list", {
+      threadId: "owner-thread",
+      detail: "full",
+    });
+    expect(live.request).toHaveBeenCalledTimes(1);
+  });
+  it("fails closed for an unsupported isolated Hindsight test scope", async () => {
+    const live = client([]);
+    const response = await dispatchCodexCapability({
+      client: live as never,
+      threadId: "owner-thread",
+      input: {
+        adapter: "hindsight",
+        operation: "test_scope",
+        authorization: { scope: "test", purpose: "verify isolation" },
+      },
+    });
+    expect(response.details).toEqual({ status: "unavailable" });
+    expect(live.request).not.toHaveBeenCalled();
+  });
+  it("cannot dispatch until the request controller supplies a live client", async () => {
+    const live = client([status("knowledge", ["knowledge_read"])]);
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createCodexCapabilityDispatchTool()],
+      signal: new AbortController().signal,
+    });
+    const denied = await bridge.handleToolCall({
+      threadId: "owner-thread",
+      turnId: "turn",
+      callId: "without",
+      tool: "capability_dispatch",
+      arguments: { adapter: "knowledge", operation: "read" },
+    });
+    expect(denied.success).toBe(false);
+    const accepted = await bridge.handleToolCall(
+      {
+        threadId: "owner-thread",
+        turnId: "turn",
+        callId: "with",
+        tool: "capability_dispatch",
+        arguments: { adapter: "knowledge", operation: "read" },
+      },
+      { runtimeClient: live as never },
+    );
+    expect(accepted.success).toBe(true);
+    expect(live.request).toHaveBeenCalledWith("mcpServerStatus/list", {
+      threadId: "owner-thread",
+      detail: "full",
+    });
+  });
+});

--- a/extensions/codex/src/app-server/capability-dispatch.ts
+++ b/extensions/codex/src/app-server/capability-dispatch.ts
@@ -1,0 +1,169 @@
+/** Owner-bound portable capability dispatcher for the live Codex MCP catalog. */
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexAppServerClient } from "./client.js";
+import type { CodexDynamicToolSpec, CodexMcpServerStatus, JsonObject } from "./protocol.js";
+
+export const CODEX_CAPABILITY_DISPATCH_TOOL_NAME = "capability_dispatch";
+type Adapter = "knowledge" | "hindsight";
+type Input = {
+  adapter: Adapter;
+  operation: string;
+  arguments?: JsonObject;
+  authorization?: { scope: string; purpose: string };
+};
+
+const tools: Record<Adapter, Record<string, string | undefined>> = {
+  knowledge: {
+    read: "knowledge_read",
+    search: "knowledge_search",
+    create: "knowledge_create",
+    update: "knowledge_update",
+    append: "knowledge_append",
+    commit: "knowledge_commit",
+  },
+  hindsight: { recall: "recall", retain: "sync_retain", reflect: "reflect", test_scope: undefined },
+};
+const mutating = new Set([
+  "knowledge:create",
+  "knowledge:update",
+  "knowledge:append",
+  "knowledge:commit",
+  "hindsight:retain",
+  "hindsight:reflect",
+  "hindsight:test_scope",
+]);
+
+function failed(
+  status: "unavailable" | "permission_denied",
+  text: string,
+): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text: `${status}: ${text}` }],
+    details: { status },
+    isError: true,
+  };
+}
+function permission(error: unknown) {
+  return /permission|forbidden|unauthori[sz]ed|access denied/i.test(
+    error instanceof Error ? error.message : String(error),
+  );
+}
+function parse(value: unknown): Input | undefined {
+  const record = asOptionalRecord(value);
+  const adapter = normalizeOptionalString(record?.adapter);
+  const operation = normalizeOptionalString(record?.operation);
+  if ((adapter !== "knowledge" && adapter !== "hindsight") || !operation) return undefined;
+  const auth = asOptionalRecord(record?.authorization);
+  const scope = normalizeOptionalString(auth?.scope);
+  const purpose = normalizeOptionalString(auth?.purpose);
+  return {
+    adapter,
+    operation,
+    ...(asOptionalRecord(record?.arguments)
+      ? { arguments: asOptionalRecord(record?.arguments) as JsonObject }
+      : {}),
+    ...(scope && purpose ? { authorization: { scope, purpose } } : {}),
+  };
+}
+
+export async function dispatchCodexCapability(params: {
+  client: Pick<CodexAppServerClient, "request">;
+  threadId: string;
+  input: unknown;
+}): Promise<AgentToolResult<unknown>> {
+  const input = parse(params.input);
+  if (!input) return failed("unavailable", "unsupported capability request");
+  const tool = tools[input.adapter][input.operation];
+  // test_scope has no fallback: a shared bank is never an isolated scope.
+  if (!tool) return failed("unavailable", "operation is not available on an isolated adapter");
+  if (mutating.has(`${input.adapter}:${input.operation}`) && !input.authorization) {
+    return failed("permission_denied", "explicit authorization with scope and purpose is required");
+  }
+  let statuses: CodexMcpServerStatus[];
+  try {
+    statuses = (
+      await params.client.request("mcpServerStatus/list", {
+        threadId: params.threadId,
+        detail: "full",
+      })
+    ).data;
+  } catch (error) {
+    return failed(
+      permission(error) ? "permission_denied" : "unavailable",
+      "MCP catalog unavailable",
+    );
+  }
+  const matches = statuses.filter((entry) =>
+    Object.prototype.hasOwnProperty.call(entry.tools, tool),
+  );
+  if (matches.length !== 1)
+    return failed(
+      "unavailable",
+      matches.length ? "required MCP tool is ambiguous" : "required MCP tool is unavailable",
+    );
+  try {
+    const response = await params.client.request("mcpServer/tool/call", {
+      threadId: params.threadId,
+      server: matches[0]!.name,
+      tool,
+      arguments: input.arguments ?? {},
+    });
+    const result = asOptionalRecord(response);
+    if (!result || !Array.isArray(result.content))
+      return failed("unavailable", "MCP tool returned an invalid response");
+    return {
+      content: result.content as AgentToolResult<unknown>["content"],
+      ...(result.structuredContent !== undefined
+        ? { details: { structuredContent: result.structuredContent } }
+        : {}),
+      ...(result.isError === true ? { isError: true } : {}),
+    };
+  } catch (error) {
+    return failed(
+      permission(error) ? "permission_denied" : "unavailable",
+      "MCP capability call failed",
+    );
+  }
+}
+
+export function createCodexCapabilityDispatchTool(): AnyAgentTool {
+  return {
+    name: CODEX_CAPABILITY_DISPATCH_TOOL_NAME,
+    description:
+      "Call an enabled portable knowledge or memory capability through the active Codex MCP catalog. Mutations require authorization.scope and authorization.purpose.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["adapter", "operation"],
+      properties: {
+        adapter: { type: "string", enum: ["knowledge", "hindsight"] },
+        operation: { type: "string" },
+        arguments: { type: "object", additionalProperties: true },
+        authorization: {
+          type: "object",
+          additionalProperties: false,
+          required: ["scope", "purpose"],
+          properties: {
+            scope: { type: "string", minLength: 1 },
+            purpose: { type: "string", minLength: 1 },
+          },
+        },
+      },
+    },
+    execute: async () => failed("unavailable", "active Codex runtime context is required"),
+  } as AnyAgentTool;
+}
+export function createCodexCapabilityDispatchSpec(): CodexDynamicToolSpec {
+  const tool = createCodexCapabilityDispatchTool();
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.parameters as JsonObject,
+  } as CodexDynamicToolSpec;
+}

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -227,6 +227,7 @@ export type CodexModelBackedReviewerContext = {
 export type CodexPluginConfig = {
   codexDynamicToolsLoading?: CodexDynamicToolsLoading;
   codexDynamicToolsExclude?: string[];
+  capabilityDispatch?: { enabled?: boolean };
   sessionCatalog?: z.infer<typeof codexSessionCatalogConfigSchema>;
   discovery?: z.infer<typeof codexDiscoveryConfigSchema>;
   computerUse?: CodexComputerUseConfig;

--- a/extensions/codex/src/app-server/config-parsing.ts
+++ b/extensions/codex/src/app-server/config-parsing.ts
@@ -137,6 +137,7 @@ const codexPluginConfigSchema = z
   .object({
     codexDynamicToolsLoading: codexDynamicToolsLoadingSchema.optional(),
     codexDynamicToolsExclude: z.array(z.string()).optional(),
+    capabilityDispatch: z.object({ enabled: z.boolean().optional() }).strict().optional(),
     sessionCatalog: codexSessionCatalogConfigSchema.optional(),
     discovery: codexDiscoveryConfigSchema.optional(),
     computerUse: z

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -18,6 +18,7 @@ import {
   parseStrictNonNegativeInteger,
 } from "openclaw/plugin-sdk/number-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { CodexAppServerClient } from "./client.js";
 import {
   createFailedDynamicToolResponse,
   type CodexDynamicToolRuntimeResponse,
@@ -151,6 +152,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
     Partial<Pick<CodexDynamicToolBridge, "sideEffectOwnerKeyForTool">>;
   signal: AbortSignal;
   timeoutMs: number;
+  runtimeClient?: CodexAppServerClient;
   toolMeta?: string;
   toolCallOrdinal?: number;
   onAgentToolResult?: EmbeddedRunAttemptParams["onAgentToolResult"];
@@ -283,6 +285,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
     const response = await Promise.race([
       params.toolBridge.handleToolCall(params.call, {
         signal: controller.signal,
+        ...(params.runtimeClient ? { runtimeClient: params.runtimeClient } : {}),
         onAgentToolResult: notifyAgentToolResult,
         toolCallOrdinal: params.toolCallOrdinal,
         retainExecutionSnapshot: true,

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -66,6 +66,11 @@ import {
   sliceToolResultTextToBudget,
   sliceUtf16Safe,
 } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  CODEX_CAPABILITY_DISPATCH_TOOL_NAME,
+  dispatchCodexCapability,
+} from "./capability-dispatch.js";
+import type { CodexAppServerClient } from "./client.js";
 import type { CodexDynamicToolsLoading } from "./config.js";
 import { createCodexAutomationsToolsAllowResolver } from "./dynamic-tool-automations-allowlist.js";
 import { finalizeCodexToolAvailability } from "./dynamic-tool-availability.js";
@@ -416,6 +421,7 @@ export type CodexDynamicToolBridge = {
     params: CodexDynamicToolCallParams,
     options?: {
       signal?: AbortSignal;
+      runtimeClient?: CodexAppServerClient;
       onAgentToolResult?: EmbeddedRunAttemptParams["onAgentToolResult"];
       toolCallOrdinal?: number;
       retainExecutionSnapshot?: boolean;
@@ -744,7 +750,16 @@ export function createCodexDynamicToolBridge(params: {
             }),
           );
         }
-        const rawResult = await Reflect.apply(tool.execute, tool, executionArgs);
+        const rawResult =
+          toolName === CODEX_CAPABILITY_DISPATCH_TOOL_NAME
+            ? options?.runtimeClient
+              ? await dispatchCodexCapability({
+                  client: options.runtimeClient,
+                  threadId: call.threadId,
+                  input: preparedArgs,
+                })
+              : failedToolResult("unavailable: active Codex runtime context is required", "failed")
+            : await Reflect.apply(tool.execute, tool, executionArgs);
         captureExecutionBoundary();
         // Delivery is committed before result middleware; presentation changes
         // cannot erase the source owner's confirmation or infer a new one.

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -232,6 +232,7 @@ export function createCodexAttemptServerRequestController(
             toolBridge,
             signal,
             timeoutMs: dynamicToolTimeoutMs,
+            runtimeClient: resourceState.client,
             toolMeta,
             toolCallOrdinal,
             onAgentToolResult: params.onAgentToolResult,

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -11,6 +11,10 @@ import {
   formatMcpCodexApprovalRemedy,
   materializeStaticMcpToolsForHarnessRun,
 } from "openclaw/plugin-sdk/codex-mcp-projection";
+import {
+  createCodexCapabilityDispatchSpec,
+  createCodexCapabilityDispatchTool,
+} from "./capability-dispatch.js";
 import { resolveCodexPluginsPolicy, shouldAutoApproveCodexAppServerApprovals } from "./config.js";
 import {
   buildDynamicTools,
@@ -322,6 +326,13 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         ignoreDisableMessageTool: true,
         ignoreRuntimePlan: true,
       });
+  const capabilityDispatchTool =
+    pluginConfig.capabilityDispatch?.enabled === true
+      ? createCodexCapabilityDispatchTool()
+      : undefined;
+  if (capabilityDispatchTool) {
+    nativeSpecs = [...(nativeSpecs ?? []), createCodexCapabilityDispatchSpec()];
+  }
   const policyContext = {
     config: params.config,
     sessionKey: sandboxSessionKey,
@@ -475,10 +486,16 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       [...(configuredMcp?.tools ?? []), ...(scopedMcpTools?.advertisedTools ?? [])],
       pluginConfig,
     );
-    const toolsWithScopedMcp =
-      scopedExecutable.length > 0 ? [...tools, ...scopedExecutable] : tools;
-    const registeredWithScopedMcp =
-      scopedAdvertised.length > 0 ? [...registeredTools, ...scopedAdvertised] : registeredTools;
+    const toolsWithScopedMcp = [
+      ...tools,
+      ...scopedExecutable,
+      ...(capabilityDispatchTool ? [capabilityDispatchTool] : []),
+    ];
+    const registeredWithScopedMcp = [
+      ...registeredTools,
+      ...scopedAdvertised,
+      ...(capabilityDispatchTool ? [capabilityDispatchTool] : []),
+    ];
     const hookContext = {
       agentId: sessionAgentId,
       config: params.config,


### PR DESCRIPTION
## Scope

Single cherry-pick of the runtime capability dispatcher from 9048c769.

## Live verification

- knowledge read path completed through capability dispatch.
- Hindsight recall completed through capability dispatch.
- A knowledge append without explicit authorization returned permission_denied before any mutation.

## Safety

The dispatcher is opt-in, owner-thread-bound, resolves only the active MCP catalog, and fails closed for unavailable capabilities, ambiguous mappings, or missing authorization.