### PR TITLE
fix(tests): restore empty-transcript compaction hook coverage

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2993,19 +2993,12 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
 
   it("applies validated transcript before hooks even when it becomes empty", async () => {
     hookRunner.hasHooks.mockReturnValue(true);
-    const beforeMetrics = compactTesting.buildBeforeCompactionHookMetrics({
-      originalMessages: [],
-      currentMessages: [],
-      estimateTokensFn: estimateTokensMock as (message: AgentMessage) => number,
-    });
-    await compactTesting.runBeforeCompactionHooks({
-      hookRunner,
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionAgentId: "main",
-      workspaceDir: TEST_WORKSPACE_DIR,
-      metrics: beforeMetrics,
-    });
+    const { sanitizeSessionHistory } = await import("./replay-history.js");
+    vi.mocked(sanitizeSessionHistory).mockResolvedValueOnce([]);
+
+    const result = await compactEmbeddedAgentSessionDirect(wrappedCompactionArgs());
+
+    expect(result.ok).toBe(true);
 
     const beforeContext = sessionHook("compact:before")?.context;
     expectRecordFields(beforeContext, {


### PR DESCRIPTION
Related: #139428.

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

The empty-transcript hook test could pass even if compaction failed to apply an empty validated transcript before computing hook metrics. It called the metric and hook helpers directly with already-empty arrays.

## Why This Change Was Made

Restore the existing direct-compaction flow through the maintained harness, using its existing sanitizer mock to return an empty transcript. Keep the named case and four zero-metric assertions, and restore the success assertion. No production code, deadline, or harness export changes.

## User Impact

No production behavior changes. The test now detects the orchestration regression it names. The change removes seven net test lines; it is a coverage improvement, not a speedup claim.

## Evidence

- Both complete suites passed all 235 tests before and after with identical ordered names and statuses.
- A temporary mutation that skipped applying empty validated history left the old test green; the restored test failed on the intended before-hook metric (3 instead of 0).
- Production source was restored byte-for-byte before final validation.
- Mapped checks and independent review passed.

The restored case measured about 112 ms versus 60 ms in this single comparison. Full-suite timing was 60.10 s versus 69.15 s, with cache and ordering effects; no runtime gain is claimed.
