### PR TITLE
refactor(test): remove duplicate flat usage-cost case

### DIFF
--- a/src/utils/usage-format.cost.test.ts
+++ b/src/utils/usage-format.cost.test.ts
@@ -8,15 +8,6 @@ import {
 type PricingTier = NonNullable<ModelCostConfig["tieredPricing"]>[number];
 
 describe("usage cost estimation", () => {
-  it("uses flat pricing when tieredPricing is absent", () => {
-    const cost = { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 };
-    const total = estimateUsageCost({
-      usage: { input: 1000, output: 500, cacheRead: 2000 },
-      cost,
-    });
-    expect(total).toBeCloseTo(0.003);
-  });
-
   it.each([
     {
       name: "recorded total",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Maintainer-requested test cleanup removes duplicate flat-pricing coverage that adds maintenance without protecting a distinct behavior.

## Why This Change Was Made

Remove `uses flat pricing when tieredPricing is absent`. The retained `resolves model cost config and estimates usage cost` case uses the same rates, usage buckets, and expected `0.003` cost while also checking the resolved pricing configuration. Tiered pricing, cached-token buckets, precision assertions, and all other cases remain unchanged.

## User Impact

No runtime behavior change. One redundant test case and nine lines are removed, with no additions or production/support changes.

## Evidence

- Both complete files, `src/utils/usage-format.cost.test.ts` and `src/utils/usage-format.test.ts`, passed: 23 + 33 = 56 tests, zero skips.
- The exact-path selected check plan completed all 20 steps successfully, without reruns.
- Fresh scanned two-pass P2 review was scoped-clean with no findings. Pricing owners, calculator, retained tests, and relevant context were included; one optional unchanged display formatter was omitted from review context.
- Targeted formatting, diff checks, and normal commit hooks passed; the reviewed patch is unchanged.
- This is local unit-test evidence, not a full-repository suite or live-provider claim.
