### PR TITLE
fix(ci): distinguish watcher progress from raw GitHub status

### DIFF
--- a/docs/ci/watching-runs.md
+++ b/docs/ci/watching-runs.md
@@ -64,6 +64,14 @@ rollup observation before deciding. Each poll reads at most 32 missing run recor
 excess references stay pending and resume from the cache on the next poll. Known
 missing or foreign associations remain blocking, as do independent failed checks.
 
+`STATUS` lines report progress. In rollup mode, `rollup` is the effective check
+verdict and `github_rollup` is GitHub's raw aggregate. Superseded checks can leave
+`github_rollup=FAILURE` while `rollup=pending` or `rollup=green`. A green rollup
+still waits for the attached CI run to succeed. Terminal `GREEN` exits 0,
+`FAILING` exits 15, and `TIMEOUT` exits 16. Rollup timeouts include the last raw
+aggregate and pending count; `ci-run` timeouts identify that completion mode
+because it does not inspect the rollup.
+
 GitHub can retain queued rerun placeholders while omitting the successful
 same-name job from the rollup. The watcher reconciles a placeholder only after
 verifying the successful exact-head attempt, its complete same-name job group,

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -903,7 +903,7 @@ async function main(argv = process.argv.slice(2)) {
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
         console.log(
-          `STATUS state=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,
+          `STATUS rollup=${result.verdict.toLowerCase()} github_rollup=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,
         );
         if (result.verdict === "FAILING") {
           return emit(`FAILING checks=${result.failingNames.join(", ")}`, 15);
@@ -927,7 +927,12 @@ async function main(argv = process.argv.slice(2)) {
   if (watchResult !== undefined) {
     return watchResult;
   }
-  return emit(`TIMEOUT state=${lastState} pending=${lastPending}`, 16);
+  return emit(
+    args.completion === "rollup"
+      ? `TIMEOUT github_rollup=${lastState} pending=${lastPending}`
+      : "TIMEOUT completion=ci-run",
+    16,
+  );
 }
 
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -634,6 +634,14 @@ esac
         exitCode: 0,
         output: "GREEN",
       },
+      {
+        label: "pending ci-run completion policy",
+        status: "in_progress",
+        conclusion: null,
+        completion: "ci-run",
+        exitCode: 16,
+        output: "TIMEOUT completion=ci-run",
+      },
     ])(
       "preserves replacement ownership for $label",
       async ({
@@ -861,7 +869,9 @@ console.log(JSON.stringify(value));
         }
         const result = await replayPlaceholder(fixture, { watchTimeout: 5 });
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-        expect(result.stdout).toContain(`pending=0 superseded=${observed}`);
+        expect(result.stdout).toContain(
+          `STATUS rollup=green github_rollup=${state} pending=0 superseded=${observed}`,
+        );
         expect(result.stdout).toContain("GREEN");
         // Cost and ordering matter: direct proof precedes run revalidation and
         // a fresh PR snapshot, followed by the ordinary final CI-run check.
@@ -1072,6 +1082,7 @@ console.log(JSON.stringify(value));
         watchTimeout: 5,
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).toContain("STATUS rollup=green github_rollup=FAILURE pending=0");
       expect(result.stdout).not.toContain("GREEN");
     });
 
@@ -1268,8 +1279,12 @@ console.log(JSON.stringify(value));
       const result = await replayPlaceholder(fixture, { watchTimeout: 5 });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
       expect(result.stdout).not.toContain("GREEN");
+      expect(result.stdout).toContain(
+        `STATUS rollup=${exitCode === 16 ? "pending" : "failing"} github_rollup=FAILURE`,
+      );
       if (exitCode === 16) {
         expect(result.stdout).toContain("superseded=1");
+        expect(result.stdout).toContain("TIMEOUT github_rollup=FAILURE");
       }
     });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators watching a PR could mistake GitHub's raw aggregate `FAILURE` for a failed CI run after superseded checks were reconciled. A timeout in `ci-run` mode also reported an unobserved rollup state.

## Why This Change Was Made

Progress now labels the effective check verdict as `rollup` and GitHub's raw aggregate as `github_rollup`. Timeouts identify the observed rollup or the selected `ci-run` completion mode. The watcher keeps its existing classification, polling, deadlines, terminal markers and exit codes.

## User Impact

Operators can distinguish pending work from an actual failure. A lowercase `rollup=green` remains progress: the attached CI run must also succeed before the watcher emits terminal `GREEN`.

## Evidence

Ten regression cases failed on the original output and passed with the fix; all 180 cases in the watcher test file and all 20 selected changed-file checks passed. Existing replay fixtures cover reconciled checks, independent failure and pending status contexts, attached CI still running, and both timeout modes. Independent code review found no actionable issues through P2. No new live GitHub contract is introduced.
