### PR TITLE
fix(discord): refuse unavailable model runtime selections

### DIFF
--- a/extensions/discord/src/monitor/model-picker.runtime.ts
+++ b/extensions/discord/src/monitor/model-picker.runtime.ts
@@ -1,0 +1,11 @@
+import * as modelsProviderRuntime from "openclaw/plugin-sdk/models-provider-runtime";
+
+// The declared 2026.9.3 host lacks this reader. Keep it optional until that host is excluded.
+const hostSdk: Partial<Pick<typeof modelsProviderRuntime, "getModelsRuntimeChoices">> =
+  modelsProviderRuntime;
+
+export function getDiscordModelPickerRuntimeChoices(
+  ...args: Parameters<typeof modelsProviderRuntime.getModelsRuntimeChoices>
+): ReturnType<typeof modelsProviderRuntime.getModelsRuntimeChoices> {
+  return hostSdk.getModelsRuntimeChoices?.(...args);
+}

--- a/extensions/discord/src/monitor/model-picker.runtime.ts
+++ b/extensions/discord/src/monitor/model-picker.runtime.ts
@@ -1,8 +1,12 @@
 import * as modelsProviderRuntime from "openclaw/plugin-sdk/models-provider-runtime";
 
-// The declared 2026.9.3 host lacks this reader. Keep it optional until that host is excluded.
+// The shipped 2026.9.3 host supports model-only selection without this reader.
 const hostSdk: Partial<Pick<typeof modelsProviderRuntime, "getModelsRuntimeChoices">> =
   modelsProviderRuntime;
+
+export function supportsDiscordModelPickerRuntimeChoices(): boolean {
+  return hostSdk.getModelsRuntimeChoices !== undefined;
+}
 
 export function getDiscordModelPickerRuntimeChoices(
   ...args: Parameters<typeof modelsProviderRuntime.getModelsRuntimeChoices>

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -49,6 +49,7 @@ export type DiscordModelPickerState = {
   provider?: string;
   runtime?: string;
   runtimeIndex?: number;
+  runtimeToken?: string;
   page: number;
   providerPage?: number;
   modelIndex?: number;
@@ -73,13 +74,17 @@ const DISCORD_MODEL_PICKER_BUCKET_THRESHOLD = DISCORD_COMPONENT_MAX_SELECT_OPTIO
 
 /** Target items per alpha bucket. Discord caps selects at 25 options. */
 const DISCORD_MODEL_PICKER_BUCKET_TARGET_SIZE = 20;
-const DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN = /^[A-Za-z0-9_-]{8}$/u;
+const DISCORD_MODEL_PICKER_TOKEN_PATTERN = /^[A-Za-z0-9_-]{8}$/u;
 
 export function createDiscordModelPickerModelToken(provider: string, model: string): string {
   return createHash("sha256")
     .update(JSON.stringify([normalizeProviderId(provider), model]), "utf8")
     .digest("base64url")
     .slice(0, 8);
+}
+
+export function createDiscordModelPickerRuntimeToken(runtime: string): string {
+  return createHash("sha256").update(runtime, "utf8").digest("base64url").slice(0, 8);
 }
 
 export type DiscordModelPickerBucket = {
@@ -194,9 +199,12 @@ function paginateItems<T>(params: {
 export async function loadDiscordModelPickerData(
   cfg: OpenClawConfig,
   agentId?: string,
+  options?: Parameters<
+    typeof import("openclaw/plugin-sdk/models-provider-runtime").buildPreparedModelsProviderData
+  >[2],
 ): Promise<ModelsProviderData> {
   const { buildPreparedModelsProviderData } = await loadModelsProviderRuntime();
-  return buildPreparedModelsProviderData(cfg, agentId);
+  return buildPreparedModelsProviderData(cfg, agentId, options);
 }
 
 export function buildDiscordModelPickerCustomId(params: {
@@ -207,6 +215,7 @@ export function buildDiscordModelPickerCustomId(params: {
   provider?: string;
   runtime?: string;
   runtimeIndex?: number;
+  runtimeToken?: string;
   page?: number;
   providerPage?: number;
   modelIndex?: number;
@@ -226,7 +235,7 @@ export function buildDiscordModelPickerCustomId(params: {
   const modelIndex = normalizeOptionalModelPickerIndex(params.modelIndex);
   const recentSlot = normalizeOptionalModelPickerIndex(params.recentSlot);
   const modelToken = params.modelToken?.trim();
-  if (modelToken && !DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelToken)) {
+  if (modelToken && !DISCORD_MODEL_PICKER_TOKEN_PATTERN.test(modelToken)) {
     throw new Error("Discord model picker model token is invalid");
   }
 
@@ -243,6 +252,13 @@ export function buildDiscordModelPickerCustomId(params: {
   const runtime = params.runtime?.trim();
   if (runtime) {
     parts.push(`r=${encodeCustomIdComponent(runtime)}`);
+  }
+  const runtimeToken = params.runtimeToken?.trim();
+  if (runtimeToken && !DISCORD_MODEL_PICKER_TOKEN_PATTERN.test(runtimeToken)) {
+    throw new Error("Discord model picker runtime token is invalid");
+  }
+  if (runtimeToken) {
+    parts.push(`rt=${runtimeToken}`);
   }
   const runtimeIndex = normalizeOptionalModelPickerIndex(params.runtimeIndex);
   if (runtimeIndex) {
@@ -272,6 +288,20 @@ export function buildDiscordModelPickerCustomId(params: {
     parts.push(`mb=${encodeCustomIdComponent(modelBucket)}`);
   }
 
+  // Page one is already the parser default. A model token also identifies its provider.
+  if (parts.join(";").length > DISCORD_CUSTOM_ID_MAX_CHARS) {
+    for (let index = parts.length - 1; index >= 0; index -= 1) {
+      if (parts[index] === "g=1" || parts[index] === "pp=1") {
+        parts.splice(index, 1);
+      }
+    }
+  }
+  if (modelToken && parts.join(";").length > DISCORD_CUSTOM_ID_MAX_CHARS) {
+    const providerPart = parts.findIndex((part) => part.startsWith("p="));
+    if (providerPart >= 0) {
+      parts.splice(providerPart, 1);
+    }
+  }
   const customId = parts.join(";");
   if (customId.length > DISCORD_CUSTOM_ID_MAX_CHARS) {
     throw new Error(
@@ -293,11 +323,18 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
   const providerRaw = decodeCustomIdComponent(coerceString(data.p));
   const runtimeRaw = decodeCustomIdComponent(coerceString(data.r));
   const runtimeIndex = parseStrictPositiveInteger(data.ri);
+  const runtimeTokenRaw = coerceString(data.rt).trim();
+  if (runtimeTokenRaw && !DISCORD_MODEL_PICKER_TOKEN_PATTERN.test(runtimeTokenRaw)) {
+    return null;
+  }
+  if ([runtimeRaw.trim(), runtimeTokenRaw, runtimeIndex].filter(Boolean).length > 1) {
+    return null;
+  }
   const page = parseRawPage(data.g ?? data.pg);
   const providerPage = parseStrictPositiveInteger(data.pp);
   const modelIndex = parseStrictPositiveInteger(data.mi);
   const modelTokenRaw = coerceString(data.m).trim();
-  const modelToken = DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelTokenRaw)
+  const modelToken = DISCORD_MODEL_PICKER_TOKEN_PATTERN.test(modelTokenRaw)
     ? modelTokenRaw
     : undefined;
   const recentSlot = parseStrictPositiveInteger(data.rs);
@@ -323,6 +360,7 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
     userId: trimmedUserId,
     provider,
     runtime,
+    ...(runtimeTokenRaw ? { runtimeToken: runtimeTokenRaw } : {}),
     ...(typeof runtimeIndex === "number" ? { runtimeIndex } : {}),
     page,
     ...(typeof providerPage === "number" ? { providerPage } : {}),

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -202,7 +202,9 @@ export async function loadDiscordModelPickerData(
   options?: Parameters<
     typeof import("openclaw/plugin-sdk/models-provider-runtime").buildPreparedModelsProviderData
   >[2],
-): Promise<ModelsProviderData> {
+): ReturnType<
+  typeof import("openclaw/plugin-sdk/models-provider-runtime").buildPreparedModelsProviderData
+> {
   const { buildPreparedModelsProviderData } = await loadModelsProviderRuntime();
   return buildPreparedModelsProviderData(cfg, agentId, options);
 }

--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -1,5 +1,8 @@
 // Discord helper module supports model picker utils behavior.
-import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+import type {
+  ModelsProviderData,
+  ModelsRuntimeChoice,
+} from "openclaw/plugin-sdk/models-provider-runtime";
 
 export function createModelsProviderData(
   entries: Record<string, string[]>,
@@ -15,7 +18,21 @@ export function createModelsProviderData(
     opts?.defaultProviderOrder === "sorted"
       ? (providers[0] ?? "openai")
       : (insertionProvider ?? "openai");
+  const builtin = {
+    id: "openclaw",
+    label: "OpenClaw Default",
+    description: "Use the built-in OpenClaw runtime.",
+  };
+  const runtimeChoicesByProvider = new Map(providers.map((provider) => [provider, [builtin]]));
+  const runtimeChoicesByModel = new Map(
+    [...byProvider].flatMap(([provider, models]) =>
+      [...models].map((model) => [`${provider}/${model}`, [builtin]] as const),
+    ),
+  );
   return {
+    runtimeChoicesByProvider,
+    runtimeChoicesByModel,
+    isCurrent: () => true,
     byProvider,
     providers,
     resolvedDefault: {
@@ -24,4 +41,26 @@ export function createModelsProviderData(
     },
     modelNames: new Map<string, string>(),
   };
+}
+
+/** Uniform model facts for fixtures that do not vary runtime eligibility by model. */
+export function setFixtureRuntimeChoices(
+  data: ModelsProviderData,
+  choices: Map<string, ModelsRuntimeChoice[]>,
+) {
+  const byProvider = data.runtimeChoicesByProvider;
+  const byModel = data.runtimeChoicesByModel;
+  if (!byProvider || !byModel) {
+    throw new Error("Expected complete model-runtime fixture facts");
+  }
+  for (const [provider, runtimes] of choices) {
+    const models = data.byProvider.get(provider);
+    if (!models) {
+      throw new Error("Unknown fixture provider");
+    }
+    byProvider.set(provider, runtimes);
+    for (const model of models) {
+      byModel.set(`${provider}/${model}`, runtimes);
+    }
+  }
 }

--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -26,7 +26,10 @@ export function createModelsProviderData(
   const runtimeChoicesByProvider = new Map(providers.map((provider) => [provider, [builtin]]));
   const runtimeChoicesByModel = new Map(
     [...byProvider].flatMap(([provider, models]) =>
-      [...models].map((model) => [`${provider}/${model}`, [builtin]] as const),
+      [...models].map<[string, ModelsRuntimeChoice[]]>((model) => [
+        `${provider}/${model}`,
+        [builtin],
+      ]),
     ),
   );
   return {

--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -1,5 +1,6 @@
 // Discord helper module supports model picker utils behavior.
 import type {
+  buildPreparedModelsProviderData,
   ModelsProviderData,
   ModelsRuntimeChoice,
 } from "openclaw/plugin-sdk/models-provider-runtime";
@@ -7,7 +8,7 @@ import type {
 export function createModelsProviderData(
   entries: Record<string, string[]>,
   opts?: { defaultProviderOrder?: "insertion" | "sorted" },
-): ModelsProviderData {
+): Awaited<ReturnType<typeof buildPreparedModelsProviderData>> {
   const byProvider = new Map<string, Set<string>>();
   for (const [provider, models] of Object.entries(entries)) {
     byProvider.set(provider, new Set(models));
@@ -33,6 +34,9 @@ export function createModelsProviderData(
     ),
   );
   return {
+    modelCatalog: Object.entries(entries).flatMap(([provider, models]) =>
+      models.map((id) => ({ id, name: id, provider })),
+    ),
     runtimeChoicesByProvider,
     runtimeChoicesByModel,
     isCurrent: () => true,

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -7,6 +7,7 @@ import {
   DISCORD_MODEL_PICKER_CUSTOM_ID_KEY,
   buildDiscordModelPickerCustomId,
   createDiscordModelPickerModelToken,
+  createDiscordModelPickerRuntimeToken,
   getDiscordModelPickerModelPage,
   getDiscordModelPickerProviderPage,
   findProviderBucketId,
@@ -14,7 +15,7 @@ import {
   loadDiscordModelPickerData,
   parseDiscordModelPickerData,
 } from "./model-picker.state.js";
-import { createModelsProviderData } from "./model-picker.test-utils.js";
+import { createModelsProviderData, setFixtureRuntimeChoices } from "./model-picker.test-utils.js";
 import {
   renderDiscordModelPickerModelsView,
   renderDiscordModelPickerProvidersView,
@@ -36,12 +37,15 @@ function parseDiscordModelPickerCustomId(customId: string) {
 
 const buildPreparedModelsProviderDataMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/models-provider-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/models-provider-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/models-provider-runtime")>()),
   buildPreparedModelsProviderData: buildPreparedModelsProviderDataMock,
 }));
 
 type SerializedComponent = {
   type: number;
+  label?: string;
+  disabled?: boolean;
   custom_id?: string;
   options?: Array<{ label?: string; value: string; default?: boolean }>;
   components?: SerializedComponent[];
@@ -100,7 +104,7 @@ describe("loadDiscordModelPickerData", () => {
     const result = await loadDiscordModelPickerData(cfg, "support");
 
     expect(buildPreparedModelsProviderDataMock).toHaveBeenCalledTimes(1);
-    expect(buildPreparedModelsProviderDataMock).toHaveBeenCalledWith(cfg, "support");
+    expect(buildPreparedModelsProviderDataMock).toHaveBeenCalledWith(cfg, "support", undefined);
     expect(result).toBe(expected);
   });
 });
@@ -641,24 +645,27 @@ describe("Discord model picker rendering", () => {
   it("runtime select preserves bucket state without exceeding Discord's customId limit", () => {
     const models = Array.from({ length: 30 }, (_, i) => `qwen3-${String(i + 1).padStart(2, "0")}`);
     const data = createModelsProviderData({ google: models });
-    data.runtimeChoicesByProvider = new Map([
-      [
-        "google",
+    setFixtureRuntimeChoices(
+      data,
+      new Map([
         [
-          {
-            id: "google-gemini-cli",
-            label: "Google Gemini CLI",
-            description:
-              "Use the Google Gemini CLI runtime selected by the effective harness policy.",
-          },
-          {
-            id: "openclaw",
-            label: "OpenClaw Default",
-            description: "Use the built-in OpenClaw runtime.",
-          },
+          "google",
+          [
+            {
+              id: "google-gemini-cli",
+              label: "Google Gemini CLI",
+              description:
+                "Use the Google Gemini CLI runtime selected by the effective harness policy.",
+            },
+            {
+              id: "openclaw",
+              label: "OpenClaw Default",
+              description: "Use the built-in OpenClaw runtime.",
+            },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
 
     const rows = renderModelsViewRows({
       command: "models",
@@ -694,24 +701,27 @@ describe("Discord model picker rendering", () => {
   it("model bucket select keeps long runtime state compact", () => {
     const models = Array.from({ length: 30 }, (_, i) => `qwen3-${String(i + 1).padStart(2, "0")}`);
     const data = createModelsProviderData({ "google-gemini-cli": models });
-    data.runtimeChoicesByProvider = new Map([
-      [
-        "google-gemini-cli",
+    setFixtureRuntimeChoices(
+      data,
+      new Map([
         [
-          {
-            id: "google-gemini-cli",
-            label: "Google Gemini CLI",
-            description:
-              "Use the Google Gemini CLI runtime selected by the effective harness policy.",
-          },
-          {
-            id: "openclaw",
-            label: "OpenClaw Default",
-            description: "Use the built-in OpenClaw runtime.",
-          },
+          "google-gemini-cli",
+          [
+            {
+              id: "google-gemini-cli",
+              label: "Google Gemini CLI",
+              description:
+                "Use the Google Gemini CLI runtime selected by the effective harness policy.",
+            },
+            {
+              id: "openclaw",
+              label: "OpenClaw Default",
+              description: "Use the built-in OpenClaw runtime.",
+            },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
 
     const rows = renderModelsViewRows({
       command: "models",
@@ -741,7 +751,8 @@ describe("Discord model picker rendering", () => {
 
     expect(bucketCustomId.length).toBeLessThanOrEqual(DISCORD_CUSTOM_ID_MAX_CHARS);
     expect(parsed.runtime).toBeUndefined();
-    expect(parsed.runtimeIndex).toBe(1);
+    expect(parsed.runtimeIndex).toBeUndefined();
+    expect(parsed.runtimeToken).toBe(createDiscordModelPickerRuntimeToken("google-gemini-cli"));
   });
 
   it("model pagination derives provider buckets to stay under Discord's customId limit", () => {
@@ -1031,23 +1042,26 @@ describe("Discord model picker rendering", () => {
       openai: ["gpt-4.1", "gpt-4o", "o3"],
       anthropic: ["claude-sonnet-4-5"],
     });
-    data.runtimeChoicesByProvider = new Map([
-      [
-        "openai",
+    setFixtureRuntimeChoices(
+      data,
+      new Map([
         [
-          {
-            id: "codex",
-            label: "OpenAI Codex",
-            description: "Use the OpenAI Codex runtime selected by the effective harness policy.",
-          },
-          {
-            id: "openclaw",
-            label: "OpenClaw Default",
-            description: "Use the built-in OpenClaw runtime.",
-          },
+          "openai",
+          [
+            {
+              id: "codex",
+              label: "OpenAI Codex",
+              description: "Use the OpenAI Codex runtime selected by the effective harness policy.",
+            },
+            {
+              id: "openclaw",
+              label: "OpenClaw Default",
+              description: "Use the built-in OpenClaw runtime.",
+            },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
 
     const rows = renderModelsViewRows({
       command: "models",
@@ -1091,23 +1105,26 @@ describe("Discord model picker rendering", () => {
     const data = createModelsProviderData({
       openai: ["gpt-4.1", "gpt-4o"],
     });
-    data.runtimeChoicesByProvider = new Map([
-      [
-        "openai",
+    setFixtureRuntimeChoices(
+      data,
+      new Map([
         [
-          {
-            id: "codex",
-            label: "OpenAI Codex",
-            description: "Use the OpenAI Codex runtime selected by the effective harness policy.",
-          },
-          {
-            id: "openclaw",
-            label: "OpenClaw Default",
-            description: "Use the built-in OpenClaw runtime.",
-          },
+          "openai",
+          [
+            {
+              id: "codex",
+              label: "OpenAI Codex",
+              description: "Use the OpenAI Codex runtime selected by the effective harness policy.",
+            },
+            {
+              id: "openclaw",
+              label: "OpenClaw Default",
+              description: "Use the built-in OpenClaw runtime.",
+            },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
 
     const rows = renderModelsViewRows({
       command: "models",
@@ -1125,16 +1142,19 @@ describe("Discord model picker rendering", () => {
     );
     const modelSelectState = parseDiscordModelPickerCustomId(modelSelect?.custom_id ?? "");
     expect(modelSelectState?.runtime).toBeUndefined();
-    expect(modelSelectState?.runtimeIndex).toBe(2);
+    expect(modelSelectState?.runtimeIndex).toBeUndefined();
+    expect(modelSelectState?.runtimeToken).toBe("lqS8JgJl");
     const submitState = parseDiscordModelPickerCustomId(
       rows[3]?.components?.at(-1)?.custom_id ?? "",
     );
     expect(submitState?.runtime).toBeUndefined();
-    expect(submitState?.runtimeIndex).toBe(2);
+    expect(submitState?.runtimeIndex).toBeUndefined();
+    expect(submitState?.runtimeToken).toBe("lqS8JgJl");
     const resetState = parseDiscordModelPickerCustomId(rows[3]?.components?.[2]?.custom_id ?? "");
     expect(resetState?.action).toBe("reset");
     expect(resetState?.runtime).toBeUndefined();
-    expect(resetState?.runtimeIndex).toBe(2);
+    expect(resetState?.runtimeIndex).toBeUndefined();
+    expect(resetState?.runtimeToken).toBe("lqS8JgJl");
   });
 
   it("renders not-found model view with a back button", () => {
@@ -1400,7 +1420,7 @@ describe("Discord model picker recents view", () => {
       quickModels: ["google-gemini-cli/qwen3-02"],
       currentModel: "google-gemini-cli/qwen3-02",
       provider: "google-gemini-cli",
-      runtimeIndex: 1,
+      runtimeToken: "runtime1",
     });
 
     const states = rows.map((row) => {
@@ -1411,9 +1431,9 @@ describe("Discord model picker recents view", () => {
         "recents custom id should parse",
       );
     });
-    expect(states[0]?.runtimeIndex).toBe(1);
-    expect(states[1]?.runtimeIndex).toBe(1);
-    expect(states[2]?.runtimeIndex).toBe(1);
+    expect(states[0]?.runtimeToken).toBe("runtime1");
+    expect(states[1]?.runtimeToken).toBe("runtime1");
+    expect(states[2]?.runtimeToken).toBe("runtime1");
   });
 
   it("includes (default) suffix on default model button label", () => {
@@ -1466,3 +1486,67 @@ describe("Discord model picker recents view", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+describe("model-specific runtime view", () => {
+  const builtin = { id: "openclaw", label: "OpenClaw", description: "Built-in runtime" };
+  const native = { id: "codex", label: "Codex", description: "Native runtime" };
+  it("renders the selected model's choices instead of the provider union", () => {
+    const data = {
+      ...createModelsProviderData({ openai: ["gpt-4o", "gpt-4.1"] }),
+      runtimeChoicesByProvider: new Map([["openai", [native, builtin]]]),
+      runtimeChoicesByModel: new Map([
+        ["openai/gpt-4o", [builtin]],
+        ["openai/gpt-4.1", [native]],
+      ]),
+      isCurrent: () => true,
+    };
+    const rows = renderModelsViewRows({
+      command: "model",
+      userId: "owner",
+      data,
+      provider: "openai",
+      currentModel: "openai/gpt-4o",
+      pendingModel: "openai/gpt-4o",
+      pendingModelIndex: 2,
+    });
+    const runtime = rows
+      .flatMap((row) => row.components ?? [])
+      .find((c) => parseDiscordModelPickerCustomId(c.custom_id ?? "")?.action === "runtime");
+    expect(runtime?.options?.map((o) => o.value) ?? ["openclaw"]).not.toContain("codex");
+    const payload = JSON.stringify(
+      renderDiscordModelPickerModelsView({
+        command: "model",
+        userId: "owner",
+        data,
+        provider: "openai",
+        pendingModel: "openai/gpt-4o",
+        pendingModelIndex: 2,
+      }),
+    );
+    expect(payload).toContain("runtime openclaw");
+  });
+  it.each(["unknown", "empty", "retired"])(
+    "disables Submit for %s model runtime choices",
+    (mode) => {
+      const data = {
+        ...createModelsProviderData({ openai: ["gpt-4o"] }),
+        runtimeChoicesByProvider: new Map([["openai", [builtin]]]),
+        runtimeChoicesByModel: new Map(
+          mode === "unknown" ? [] : [["openai/gpt-4o", mode === "empty" ? [] : [builtin]]],
+        ),
+        isCurrent: () => mode !== "retired",
+      };
+      const rows = renderModelsViewRows({
+        command: "model",
+        userId: "owner",
+        data,
+        provider: "openai",
+        pendingModel: "openai/gpt-4o",
+        pendingModelIndex: 1,
+      });
+      expect(
+        rows.flatMap((row) => row.components ?? []).find((c) => c.label === "Submit")?.disabled,
+      ).toBe(true);
+    },
+  );
+});

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -1,6 +1,6 @@
 // Discord tests cover model picker plugin behavior.
 import { ComponentType } from "discord-api-types/v10";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseCustomId, serializePayload } from "../internal/discord.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
 import {
@@ -37,10 +37,22 @@ function parseDiscordModelPickerCustomId(customId: string) {
 
 const buildPreparedModelsProviderDataMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/models-provider-runtime", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/models-provider-runtime")>()),
-  buildPreparedModelsProviderData: buildPreparedModelsProviderDataMock,
-}));
+const hostSdk = vi.hoisted(() => ({ runtimeChoicesAvailable: true }));
+
+vi.mock("openclaw/plugin-sdk/models-provider-runtime", async (importOriginal) => {
+  const sdk = await importOriginal<typeof import("openclaw/plugin-sdk/models-provider-runtime")>();
+  return {
+    ...sdk,
+    get getModelsRuntimeChoices() {
+      return hostSdk.runtimeChoicesAvailable ? sdk.getModelsRuntimeChoices : undefined;
+    },
+    buildPreparedModelsProviderData: buildPreparedModelsProviderDataMock,
+  };
+});
+
+afterEach(() => {
+  hostSdk.runtimeChoicesAvailable = true;
+});
 
 type SerializedComponent = {
   type: number;
@@ -1549,4 +1561,26 @@ describe("model-specific runtime view", () => {
       ).toBe(true);
     },
   );
+});
+
+describe("declared minimum host", () => {
+  it("renders an unavailable runtime and disables Submit without the new SDK helper", () => {
+    hostSdk.runtimeChoicesAvailable = false;
+    const data = createModelsProviderData({ openai: ["gpt-4o"] });
+    delete data.runtimeChoicesByModel;
+    delete data.isCurrent;
+
+    const rows = renderModelsViewRows({
+      command: "model",
+      userId: "owner",
+      data,
+      provider: "openai",
+      pendingModel: "openai/gpt-4o",
+      pendingModelIndex: 1,
+    });
+
+    expect(
+      rows.flatMap((row) => row.components ?? []).find((c) => c.label === "Submit")?.disabled,
+    ).toBe(true);
+  });
 });

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -1564,7 +1564,7 @@ describe("model-specific runtime view", () => {
 });
 
 describe("declared minimum host", () => {
-  it("renders an unavailable runtime and disables Submit without the new SDK helper", () => {
+  it("keeps model-only Submit available without the new SDK helper", () => {
     hostSdk.runtimeChoicesAvailable = false;
     const data = createModelsProviderData({ openai: ["gpt-4o"] });
     delete data.runtimeChoicesByModel;
@@ -1579,8 +1579,13 @@ describe("declared minimum host", () => {
       pendingModelIndex: 1,
     });
 
+    const submit = rows.flatMap((row) => row.components ?? []).find((c) => c.label === "Submit");
+    expect(submit).toBeDefined();
+    expect(submit?.disabled).not.toBe(true);
     expect(
-      rows.flatMap((row) => row.components ?? []).find((c) => c.label === "Submit")?.disabled,
-    ).toBe(true);
+      rows
+        .flatMap((row) => row.components ?? [])
+        .find((c) => parseDiscordModelPickerCustomId(c.custom_id ?? "")?.action === "runtime"),
+    ).toBeUndefined();
   });
 });

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -1524,7 +1524,7 @@ describe("model-specific runtime view", () => {
     const runtime = rows
       .flatMap((row) => row.components ?? [])
       .find((c) => parseDiscordModelPickerCustomId(c.custom_id ?? "")?.action === "runtime");
-    expect(runtime?.options?.map((o) => o.value) ?? ["openclaw"]).not.toContain("codex");
+    expect(runtime).toBeUndefined();
     const payload = JSON.stringify(
       renderDiscordModelPickerModelsView({
         command: "model",

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -1,9 +1,10 @@
 // Discord plugin module implements model picker.view behavior.
 import type { APISelectMenuOption } from "discord-api-types/v10";
 import { ButtonStyle } from "discord-api-types/v10";
-import type {
-  ModelsProviderData,
-  ModelsRuntimeChoice,
+import {
+  getModelsRuntimeChoices,
+  type ModelsProviderData,
+  type ModelsRuntimeChoice,
 } from "openclaw/plugin-sdk/models-provider-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -20,6 +21,7 @@ import {
 import {
   buildDiscordModelPickerCustomId,
   createDiscordModelPickerModelToken,
+  createDiscordModelPickerRuntimeToken,
   getDiscordModelPickerModelPage,
   getDiscordModelPickerProviderPage,
   normalizeModelPickerPage,
@@ -48,7 +50,7 @@ type DiscordModelPickerCurrentModelRef = {
 type DiscordModelPickerRow = Row<Button> | Row<StringSelectMenu>;
 type CompactRuntimeState = {
   runtime?: string;
-  runtimeIndex?: number;
+  runtimeToken?: string;
 };
 
 type DiscordModelPickerRenderShellParams = {
@@ -168,7 +170,7 @@ function buildBucketSelectRow(params: {
   currentBucketId: string | undefined;
   provider?: string;
   runtime?: string;
-  runtimeIndex?: number;
+  runtimeToken?: string;
   providerPage?: number;
   modelIndex?: number;
   providerBucket?: string;
@@ -197,7 +199,7 @@ function buildBucketSelectRow(params: {
       page: 1,
       provider: params.provider,
       runtime: params.runtime,
-      runtimeIndex: params.runtimeIndex,
+      runtimeToken: params.runtimeToken,
       providerPage: params.providerPage,
       modelIndex: params.modelIndex,
     }),
@@ -213,54 +215,35 @@ function buildBucketSelectRow(params: {
 function getRuntimeChoices(params: {
   data: ModelsProviderData;
   provider: string;
-}): ModelsRuntimeChoice[] {
-  const choices = params.data.runtimeChoicesByProvider?.get(normalizeProviderId(params.provider));
-  if (choices?.length) {
-    return choices;
-  }
-  return [
-    {
-      id: "openclaw",
-      label: "OpenClaw Default",
-      description: "Use the built-in OpenClaw runtime.",
-    },
-  ];
+  modelRef?: string;
+}): ModelsRuntimeChoice[] | undefined {
+  const model = parseCurrentModelRef(params.modelRef);
+  return getModelsRuntimeChoices(
+    params.data,
+    params.provider,
+    model?.provider === normalizeProviderId(params.provider) ? model.model : undefined,
+  );
+}
+
+function resolveExplicitRuntimeState(params: {
+  currentRuntime?: string;
+  pendingRuntime?: string;
+}): string | undefined {
+  // Keep an unavailable explicit choice visible until the user confirms an eligible runtime.
+  const runtime = params.pendingRuntime?.trim() || params.currentRuntime?.trim();
+  return runtime && runtime !== "auto" && runtime !== "default" ? runtime : undefined;
 }
 
 function resolveSelectedRuntime(params: {
   data: ModelsProviderData;
   provider: string;
-  currentRuntime?: string;
-  pendingRuntime?: string;
-}): string {
-  const choices = getRuntimeChoices({ data: params.data, provider: params.provider });
-  const allowed = new Set(choices.map((choice) => choice.id));
-  const pending = params.pendingRuntime?.trim();
-  if (pending && allowed.has(pending)) {
-    return pending;
-  }
-  const current = params.currentRuntime?.trim();
-  if (current && allowed.has(current)) {
-    return current;
-  }
-  return choices[0]?.id ?? "openclaw";
-}
-
-function resolveExplicitRuntimeState(params: {
-  choices: ModelsRuntimeChoice[];
+  modelRef?: string;
   currentRuntime?: string;
   pendingRuntime?: string;
 }): string | undefined {
-  const allowed = new Set(params.choices.map((choice) => choice.id));
-  const pending = params.pendingRuntime?.trim();
-  if (pending && allowed.has(pending)) {
-    return pending;
-  }
-  const current = params.currentRuntime?.trim();
-  if (current && current !== "auto" && current !== "default" && allowed.has(current)) {
-    return current;
-  }
-  return undefined;
+  const choices = getRuntimeChoices(params);
+  const explicit = resolveExplicitRuntimeState(params);
+  return explicit ? choices?.find((choice) => choice.id === explicit)?.id : choices?.[0]?.id;
 }
 
 function getActiveBucketId(
@@ -270,18 +253,11 @@ function getActiveBucketId(
 }
 
 function resolveCompactRuntimeState(params: {
-  choices: ModelsRuntimeChoice[];
   currentRuntime?: string;
   pendingRuntime?: string;
 }): CompactRuntimeState {
-  const stateRuntime = resolveExplicitRuntimeState(params);
-  const stateRuntimeIndex = stateRuntime
-    ? params.choices.findIndex((choice) => choice.id === stateRuntime)
-    : -1;
-  if (stateRuntimeIndex >= 0) {
-    return { runtimeIndex: stateRuntimeIndex + 1 };
-  }
-  return stateRuntime ? { runtime: stateRuntime } : {};
+  const runtime = resolveExplicitRuntimeState(params);
+  return runtime ? { runtimeToken: createDiscordModelPickerRuntimeToken(runtime) } : {};
 }
 
 function buildRenderedShell(
@@ -366,7 +342,7 @@ function buildPaginationRow(params: {
   hasNext: boolean;
   provider?: string;
   runtime?: string;
-  runtimeIndex?: number;
+  runtimeToken?: string;
   providerPage?: number;
   modelIndex?: number;
   modelToken?: string;
@@ -468,20 +444,26 @@ function buildModelRows(params: {
   const runtimeChoices = getRuntimeChoices({
     data: params.data,
     provider: params.modelPage.provider,
+    modelRef: params.pendingModel ?? params.currentModel,
   });
+  const currentRuntime =
+    parsedCurrentModel?.provider === params.modelPage.provider ? params.currentRuntime : undefined;
   const selectedRuntime = resolveSelectedRuntime({
     data: params.data,
     provider: params.modelPage.provider,
-    currentRuntime: params.currentRuntime,
+    modelRef: params.pendingModel ?? params.currentModel,
+    currentRuntime,
     pendingRuntime: params.pendingRuntime,
   });
   const compactRuntime = resolveCompactRuntimeState({
-    choices: runtimeChoices,
-    currentRuntime: params.currentRuntime,
+    currentRuntime,
     pendingRuntime: params.pendingRuntime,
   });
 
-  if (runtimeChoices.length > 1) {
+  if (
+    runtimeChoices &&
+    (runtimeChoices.length > 1 || (runtimeChoices.length === 1 && selectedRuntime === undefined))
+  ) {
     // The selected runtime travels in the select interaction value; omitting
     // it here leaves enough customId budget to preserve the browse bucket.
     rows.push(
@@ -645,7 +627,7 @@ function buildModelRows(params: {
     createModelPickerButton({
       label: "Submit",
       style: ButtonStyle.Primary,
-      disabled: !hasPendingSelection,
+      disabled: !hasPendingSelection || selectedRuntime === undefined,
       customId: buildDiscordModelPickerCustomId({
         ...modelActionState,
         action: "submit",
@@ -780,14 +762,7 @@ export function renderDiscordModelPickerModelsView(
     quickModels: params.quickModels,
     providerBucket: params.providerBucket,
   });
-  const runtimeChoices = getRuntimeChoices({
-    data: params.data,
-    provider: modelPage.provider,
-  });
   const pendingRuntime = params.pendingRuntime?.trim();
-  const pendingRuntimeIndex = pendingRuntime
-    ? runtimeChoices.findIndex((choice) => choice.id === pendingRuntime)
-    : -1;
 
   const rows: DiscordModelPickerRow[] = [];
   const bucketRow = buildBucketSelectRow({
@@ -797,9 +772,8 @@ export function renderDiscordModelPickerModelsView(
     buckets: modelPage.buckets,
     currentBucketId: modelPage.bucket?.id,
     provider: modelPage.provider,
-    // Carry pending runtime through bucket changes as a compact choice index;
-    // raw provider+runtime pairs can exceed Discord's 100-char custom_id cap.
-    runtimeIndex: pendingRuntimeIndex >= 0 ? pendingRuntimeIndex + 1 : undefined,
+    // Keep the runtime identity stable when the current choice list changes.
+    runtimeToken: pendingRuntime ? createDiscordModelPickerRuntimeToken(pendingRuntime) : undefined,
     providerPage,
     providerBucket: params.providerBucket,
   });
@@ -809,14 +783,30 @@ export function renderDiscordModelPickerModelsView(
   rows.push(...modelRows);
 
   const defaultModel = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
-  const pendingLine = params.pendingModel
-    ? `Selected: ${params.pendingModel} · runtime ${resolveSelectedRuntime({
-        data: params.data,
-        provider: modelPage.provider,
-        currentRuntime: params.currentRuntime,
-        pendingRuntime: params.pendingRuntime,
-      })} (press Submit)`
-    : "Select a model, then press Submit.";
+  const choices = getRuntimeChoices({
+    data: params.data,
+    provider: modelPage.provider,
+    modelRef: params.pendingModel ?? params.currentModel,
+  });
+  const selectedRuntime = resolveSelectedRuntime({
+    data: params.data,
+    provider: modelPage.provider,
+    modelRef: params.pendingModel ?? params.currentModel,
+    currentRuntime:
+      parseCurrentModelRef(params.currentModel)?.provider === modelPage.provider
+        ? params.currentRuntime
+        : undefined,
+    pendingRuntime: params.pendingRuntime,
+  });
+  const pendingLine = !params.pendingModel
+    ? "Select a model, then press Submit."
+    : choices === undefined
+      ? "Runtime availability is not confirmed. Reopen /model to try again."
+      : choices.length === 0
+        ? "No runtime is available for the selected model. Choose another model."
+        : selectedRuntime
+          ? `Selected: ${params.pendingModel} · runtime ${selectedRuntime} (press Submit)`
+          : "Choose an available runtime for the selected model, then press Submit.";
 
   const detailLines = [formatCurrentModelLine(params.currentModel), `Default: ${defaultModel}`];
   if (modelPage.totalPages > 1) {
@@ -842,7 +832,7 @@ type DiscordModelPickerRecentsViewParams = {
   quickModels: string[];
   currentModel?: string;
   runtime?: string;
-  runtimeIndex?: number;
+  runtimeToken?: string;
   provider?: string;
   page?: number;
   providerPage?: number;
@@ -890,7 +880,7 @@ export function renderDiscordModelPickerRecentsView(
             modelToken: createModelRefToken(modelRef),
             provider: params.provider,
             runtime: params.runtime,
-            runtimeIndex: params.runtimeIndex,
+            runtimeToken: params.runtimeToken,
             page: params.page,
             providerPage: params.providerPage,
             userId: params.userId,
@@ -910,7 +900,7 @@ export function renderDiscordModelPickerRecentsView(
         view: "models",
         provider: params.provider,
         runtime: params.runtime,
-        runtimeIndex: params.runtimeIndex,
+        runtimeToken: params.runtimeToken,
         page: params.page,
         providerPage: params.providerPage,
         modelBucket: params.modelBucket,

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -1,10 +1,9 @@
 // Discord plugin module implements model picker.view behavior.
 import type { APISelectMenuOption } from "discord-api-types/v10";
 import { ButtonStyle } from "discord-api-types/v10";
-import {
-  getModelsRuntimeChoices,
-  type ModelsProviderData,
-  type ModelsRuntimeChoice,
+import type {
+  ModelsProviderData,
+  ModelsRuntimeChoice,
 } from "openclaw/plugin-sdk/models-provider-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -18,6 +17,7 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "../internal/discord.js";
+import { getDiscordModelPickerRuntimeChoices } from "./model-picker.runtime.js";
 import {
   buildDiscordModelPickerCustomId,
   createDiscordModelPickerModelToken,
@@ -218,7 +218,7 @@ function getRuntimeChoices(params: {
   modelRef?: string;
 }): ModelsRuntimeChoice[] | undefined {
   const model = parseCurrentModelRef(params.modelRef);
-  return getModelsRuntimeChoices(
+  return getDiscordModelPickerRuntimeChoices(
     params.data,
     params.provider,
     model?.provider === normalizeProviderId(params.provider) ? model.model : undefined,

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -17,7 +17,10 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "../internal/discord.js";
-import { getDiscordModelPickerRuntimeChoices } from "./model-picker.runtime.js";
+import {
+  getDiscordModelPickerRuntimeChoices,
+  supportsDiscordModelPickerRuntimeChoices,
+} from "./model-picker.runtime.js";
 import {
   buildDiscordModelPickerCustomId,
   createDiscordModelPickerModelToken,
@@ -256,6 +259,9 @@ function resolveCompactRuntimeState(params: {
   currentRuntime?: string;
   pendingRuntime?: string;
 }): CompactRuntimeState {
+  if (!supportsDiscordModelPickerRuntimeChoices()) {
+    return {};
+  }
   const runtime = resolveExplicitRuntimeState(params);
   return runtime ? { runtimeToken: createDiscordModelPickerRuntimeToken(runtime) } : {};
 }
@@ -627,7 +633,9 @@ function buildModelRows(params: {
     createModelPickerButton({
       label: "Submit",
       style: ButtonStyle.Primary,
-      disabled: !hasPendingSelection || selectedRuntime === undefined,
+      disabled:
+        !hasPendingSelection ||
+        (supportsDiscordModelPickerRuntimeChoices() && selectedRuntime === undefined),
       customId: buildDiscordModelPickerCustomId({
         ...modelActionState,
         action: "submit",
@@ -800,13 +808,15 @@ export function renderDiscordModelPickerModelsView(
   });
   const pendingLine = !params.pendingModel
     ? "Select a model, then press Submit."
-    : choices === undefined
-      ? "Runtime availability is not confirmed. Reopen /model to try again."
-      : choices.length === 0
-        ? "No runtime is available for the selected model. Choose another model."
-        : selectedRuntime
-          ? `Selected: ${params.pendingModel} · runtime ${selectedRuntime} (press Submit)`
-          : "Choose an available runtime for the selected model, then press Submit.";
+    : !supportsDiscordModelPickerRuntimeChoices()
+      ? `Selected: ${params.pendingModel} (press Submit)`
+      : choices === undefined
+        ? "Runtime availability is not confirmed. Reopen /model to try again."
+        : choices.length === 0
+          ? "No runtime is available for the selected model. Choose another model."
+          : selectedRuntime
+            ? `Selected: ${params.pendingModel} · runtime ${selectedRuntime} (press Submit)`
+            : "Choose an available runtime for the selected model, then press Submit.";
 
   const detailLines = [formatCurrentModelLine(params.currentModel), `Default: ${defaultModel}`];
   if (modelPage.totalPages > 1) {

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -6,8 +6,12 @@ import {
   type ChatCommandDefinition,
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
-import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+import {
+  getModelsRuntimeChoices,
+  type ModelsProviderData,
+} from "openclaw/plugin-sdk/models-provider-runtime";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   Button,
@@ -21,6 +25,7 @@ import { readDiscordModelPickerRecentModels } from "./model-picker-preferences.j
 import {
   DISCORD_MODEL_PICKER_CUSTOM_ID_KEY,
   createDiscordModelPickerModelToken,
+  createDiscordModelPickerRuntimeToken,
   findModelBucketId,
   findProviderBucketId,
   loadDiscordModelPickerData,
@@ -64,16 +69,17 @@ function resolveModelPickerSelectionValue(
   return trimmed || null;
 }
 
-function resolveModelPickerRuntimeByIndex(params: {
-  data: ModelsProviderData;
-  provider?: string;
-  runtimeIndex?: number;
-}): string | undefined {
-  if (!params.provider || typeof params.runtimeIndex !== "number") {
+function resolveRuntimeToken(
+  choices: ReturnType<typeof getModelsRuntimeChoices>,
+  token: string | undefined,
+): string | undefined {
+  if (!token) {
     return undefined;
   }
-  const choices = params.data.runtimeChoicesByProvider?.get(params.provider);
-  return choices?.[params.runtimeIndex - 1]?.id;
+  const matches = choices?.filter(
+    (choice) => createDiscordModelPickerRuntimeToken(choice.id) === token,
+  );
+  return matches?.length === 1 ? matches[0]?.id : undefined;
 }
 
 function resolveModelPickerProvider(params: {
@@ -102,33 +108,11 @@ function resolvePendingRuntime(params: {
 }): string | undefined {
   return (
     params.parsed.runtime ??
-    resolveModelPickerRuntimeByIndex({
-      data: params.data,
-      provider: params.provider,
-      runtimeIndex: params.parsed.runtimeIndex,
-    })
+    resolveRuntimeToken(
+      getModelsRuntimeChoices(params.data, params.provider),
+      params.parsed.runtimeToken,
+    )
   );
-}
-
-function resolveParsedRuntimeForSubmission(params: {
-  data: ModelsProviderData;
-  parsed: DiscordModelPickerState;
-  selectedProvider: string;
-}): string | undefined {
-  if (params.parsed.runtime) {
-    return params.parsed.runtime;
-  }
-  // runtimeIndex is compact state scoped to the provider encoded in the
-  // custom_id. Recents can submit a model from another provider, so do not
-  // decode that provider-local index against the wrong runtime choice list.
-  if (params.parsed.provider !== params.selectedProvider) {
-    return undefined;
-  }
-  return resolveModelPickerRuntimeByIndex({
-    data: params.data,
-    provider: params.selectedProvider,
-    runtimeIndex: params.parsed.runtimeIndex,
-  });
 }
 
 function resolveSubmittedModelRef(params: {
@@ -263,39 +247,6 @@ function resolveDiscordModelPickerModelSelection(params: {
   return models[params.modelIndex - 1] ?? null;
 }
 
-function resolveDiscordModelPickerRuntimeForProvider(params: {
-  data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
-  provider: string;
-  runtime?: string;
-  allowResetRuntime?: boolean;
-}): string | undefined {
-  const runtime = normalizeOptionalString(params.runtime);
-  if (!runtime) {
-    return undefined;
-  }
-  if (runtime === "auto" || runtime === "default") {
-    return params.allowResetRuntime ? runtime : undefined;
-  }
-  const choices = params.data.runtimeChoicesByProvider?.get(params.provider);
-  if (!choices?.length) {
-    return runtime === "openclaw" ? runtime : undefined;
-  }
-  return choices.some((choice) => choice.id === runtime) ? runtime : undefined;
-}
-
-function resolveDiscordModelPickerSubmissionRuntime(params: {
-  data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
-  provider: string;
-  parsedRuntime?: string;
-}): string | undefined {
-  return resolveDiscordModelPickerRuntimeForProvider({
-    data: params.data,
-    provider: params.provider,
-    runtime: params.parsedRuntime,
-    allowResetRuntime: true,
-  });
-}
-
 async function handleDiscordModelPickerInteraction(params: {
   interaction: ButtonInteraction | StringSelectMenuInteraction;
   data: ComponentData;
@@ -340,7 +291,16 @@ async function handleDiscordModelPickerInteraction(params: {
     accountId: ctx.accountId,
     threadBindings: ctx.threadBindings,
   });
-  const pickerData = await loadDiscordModelPickerData(cfg, route.agentId);
+  const sessionEntry = getSessionEntry({
+    storePath: resolveStorePath(cfg.session?.store, { agentId: route.agentId }),
+    sessionKey: route.sessionKey,
+    readConsistency: "latest",
+  });
+  const pickerData = await loadDiscordModelPickerData(cfg, route.agentId, { sessionEntry });
+  const tokenModel = parsed.modelToken
+    ? resolveDiscordModelPickerModelRefByToken(pickerData, parsed.modelToken)
+    : null;
+  const parsedProvider = parsed.provider ?? splitDiscordModelRef(tokenModel ?? "")?.provider;
   const currentModelRef = resolveDiscordModelPickerCurrentModel({
     cfg,
     route,
@@ -392,6 +352,25 @@ async function handleDiscordModelPickerInteraction(params: {
     return await updatePicker(toDiscordModelPickerMessagePayload(rendered));
   };
 
+  if (parsed.action !== "cancel" && pickerData.isCurrent?.() === false) {
+    await showNotice("That model picker expired. Reopen /model to try again.");
+    return;
+  }
+  if (parsed.runtimeIndex !== undefined && parsed.action !== "cancel") {
+    await showNotice("That runtime selection expired. Reopen /model and choose a runtime again.");
+    return;
+  }
+
+  if (
+    parsed.runtimeToken &&
+    !["submit", "reset", "quick", "cancel"].includes(parsed.action) &&
+    parsedProvider &&
+    !resolvePendingRuntime({ data: pickerData, provider: parsedProvider, parsed })
+  ) {
+    await showNotice("That runtime selection expired. Reopen /model and choose a runtime again.");
+    return;
+  }
+
   if (parsed.action === "recents") {
     const rendered = renderDiscordModelPickerRecentsView({
       command: parsed.command,
@@ -400,7 +379,7 @@ async function handleDiscordModelPickerInteraction(params: {
       quickModels,
       currentModel: currentModelRef,
       runtime: parsed.runtime,
-      runtimeIndex: parsed.runtimeIndex,
+      runtimeToken: parsed.runtimeToken,
       provider: parsed.provider,
       page: parsed.page,
       providerPage: parsed.providerPage,
@@ -429,7 +408,7 @@ async function handleDiscordModelPickerInteraction(params: {
 
   if (parsed.action === "bucket" && parsed.view === "models") {
     const provider = resolveModelPickerProvider({
-      parsedProvider: parsed.provider,
+      parsedProvider,
       currentModelRef,
       data: pickerData,
     });
@@ -443,7 +422,7 @@ async function handleDiscordModelPickerInteraction(params: {
 
   if (parsed.action === "nav" && parsed.view === "models") {
     const provider = resolveModelPickerProvider({
-      parsedProvider: parsed.provider,
+      parsedProvider,
       currentModelRef,
       data: pickerData,
     });
@@ -472,7 +451,7 @@ async function handleDiscordModelPickerInteraction(params: {
 
   if (parsed.action === "back" && parsed.view === "models") {
     const provider = resolveModelPickerProvider({
-      parsedProvider: parsed.provider,
+      parsedProvider,
       currentModelRef,
       data: pickerData,
     });
@@ -498,7 +477,7 @@ async function handleDiscordModelPickerInteraction(params: {
 
   if (parsed.action === "model") {
     const selectedModel = resolveModelPickerSelectionValue(interaction);
-    const provider = parsed.provider;
+    const provider = parsedProvider;
     if (!provider || !selectedModel) {
       await showNotice("Sorry, I couldn't read that model selection.");
       return;
@@ -527,9 +506,8 @@ async function handleDiscordModelPickerInteraction(params: {
   }
 
   if (parsed.action === "runtime") {
-    const selectedRuntime =
-      resolveModelPickerSelectionValue(interaction) ?? parsed.runtime ?? "auto";
-    const provider = parsed.provider;
+    const selectedRuntime = resolveModelPickerSelectionValue(interaction) ?? parsed.runtime;
+    const provider = parsedProvider;
     if (!provider || !pickerData.byProvider.has(provider)) {
       await showNotice("Sorry, that provider isn't available anymore.");
       return;
@@ -543,6 +521,14 @@ async function handleDiscordModelPickerInteraction(params: {
     });
     if ((parsed.modelIndex || parsed.modelToken) && !selectedModel) {
       await showNotice("That selection expired. Please choose a model again.");
+      return;
+    }
+    const currentModel = splitDiscordModelRef(currentModelRef ?? "");
+    const runtimeModel =
+      selectedModel ?? (currentModel?.provider === provider ? currentModel.model : undefined);
+    const choices = getModelsRuntimeChoices(pickerData, provider, runtimeModel);
+    if (!selectedRuntime || !choices?.some((choice) => choice.id === selectedRuntime)) {
+      await showNotice("That runtime is not available for this model. Choose a runtime again.");
       return;
     }
     const pendingModel = selectedModel ? `${provider}/${selectedModel}` : undefined;
@@ -588,15 +574,30 @@ async function handleDiscordModelPickerInteraction(params: {
     }
 
     const resolvedModelRef = `${parsedModelRef.provider}/${parsedModelRef.model}`;
-    const selectedRuntime = resolveDiscordModelPickerSubmissionRuntime({
-      data: pickerData,
-      provider: parsedModelRef.provider,
-      parsedRuntime: resolveParsedRuntimeForSubmission({
-        data: pickerData,
-        parsed,
-        selectedProvider: parsedModelRef.provider,
-      }),
-    });
+    const choices = getModelsRuntimeChoices(
+      pickerData,
+      parsedModelRef.provider,
+      parsedModelRef.model,
+    );
+    if (choices === undefined) {
+      await showNotice("Runtime availability is not confirmed. Reopen /model to try again.");
+      return;
+    }
+    const selectedRuntime =
+      normalizeOptionalString(parsed.runtime) ?? resolveRuntimeToken(choices, parsed.runtimeToken);
+    if (
+      choices.length === 0 ||
+      (parsed.runtimeToken && selectedRuntime === undefined) ||
+      (selectedRuntime &&
+        selectedRuntime !== "auto" &&
+        selectedRuntime !== "default" &&
+        !choices.some((choice) => choice.id === selectedRuntime))
+    ) {
+      await showNotice(
+        "That runtime is not available for this model. Reopen /model and choose again.",
+      );
+      return;
+    }
     const selectionCommand = buildDiscordModelPickerSelectionCommand({
       modelRef: resolvedModelRef,
       runtime: selectedRuntime,
@@ -611,6 +612,10 @@ async function handleDiscordModelPickerInteraction(params: {
       return;
     }
 
+    if (pickerData.isCurrent?.() === false) {
+      await showNotice("That model picker expired. Reopen /model to try again.");
+      return;
+    }
     const applyResult = await applyDiscordModelPickerSelection({
       interaction,
       selectionCommand,

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -6,10 +6,7 @@ import {
   type ChatCommandDefinition,
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
-import {
-  getModelsRuntimeChoices,
-  type ModelsProviderData,
-} from "openclaw/plugin-sdk/models-provider-runtime";
+import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -22,6 +19,7 @@ import {
   type StringSelectMenuInteraction,
 } from "../internal/discord.js";
 import { readDiscordModelPickerRecentModels } from "./model-picker-preferences.js";
+import { getDiscordModelPickerRuntimeChoices } from "./model-picker.runtime.js";
 import {
   DISCORD_MODEL_PICKER_CUSTOM_ID_KEY,
   createDiscordModelPickerModelToken,
@@ -70,7 +68,7 @@ function resolveModelPickerSelectionValue(
 }
 
 function resolveRuntimeToken(
-  choices: ReturnType<typeof getModelsRuntimeChoices>,
+  choices: ReturnType<typeof getDiscordModelPickerRuntimeChoices>,
   token: string | undefined,
 ): string | undefined {
   if (!token) {
@@ -109,7 +107,7 @@ function resolvePendingRuntime(params: {
   return (
     params.parsed.runtime ??
     resolveRuntimeToken(
-      getModelsRuntimeChoices(params.data, params.provider),
+      getDiscordModelPickerRuntimeChoices(params.data, params.provider),
       params.parsed.runtimeToken,
     )
   );
@@ -526,7 +524,7 @@ async function handleDiscordModelPickerInteraction(params: {
     const currentModel = splitDiscordModelRef(currentModelRef ?? "");
     const runtimeModel =
       selectedModel ?? (currentModel?.provider === provider ? currentModel.model : undefined);
-    const choices = getModelsRuntimeChoices(pickerData, provider, runtimeModel);
+    const choices = getDiscordModelPickerRuntimeChoices(pickerData, provider, runtimeModel);
     if (!selectedRuntime || !choices?.some((choice) => choice.id === selectedRuntime)) {
       await showNotice("That runtime is not available for this model. Choose a runtime again.");
       return;
@@ -574,7 +572,7 @@ async function handleDiscordModelPickerInteraction(params: {
     }
 
     const resolvedModelRef = `${parsedModelRef.provider}/${parsedModelRef.model}`;
-    const choices = getModelsRuntimeChoices(
+    const choices = getDiscordModelPickerRuntimeChoices(
       pickerData,
       parsedModelRef.provider,
       parsedModelRef.model,

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -3,6 +3,7 @@ import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
   listChatCommands,
+  resolveEffectiveAgentRuntime,
   type ChatCommandDefinition,
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
@@ -19,7 +20,10 @@ import {
   type StringSelectMenuInteraction,
 } from "../internal/discord.js";
 import { readDiscordModelPickerRecentModels } from "./model-picker-preferences.js";
-import { getDiscordModelPickerRuntimeChoices } from "./model-picker.runtime.js";
+import {
+  getDiscordModelPickerRuntimeChoices,
+  supportsDiscordModelPickerRuntimeChoices,
+} from "./model-picker.runtime.js";
 import {
   DISCORD_MODEL_PICKER_CUSTOM_ID_KEY,
   createDiscordModelPickerModelToken,
@@ -577,19 +581,54 @@ async function handleDiscordModelPickerInteraction(params: {
       parsedModelRef.provider,
       parsedModelRef.model,
     );
-    if (choices === undefined) {
+    const modelOnlyHost = !supportsDiscordModelPickerRuntimeChoices();
+    const supportsModelOnlySelection = () => {
+      const currentEntry = getSessionEntry({
+        storePath: resolveStorePath(cfg.session?.store, { agentId: route.agentId }),
+        sessionKey: route.sessionKey,
+        readConsistency: "latest",
+      });
+      const override = currentEntry?.agentRuntimeOverride?.trim();
+      // The old command owner cannot validate native pins against a different model.
+      // Preserve those pins; model-only compatibility never invents a runtime choice.
+      if (override && !["auto", "default", "openclaw"].includes(override)) {
+        return false;
+      }
+      const model = pickerData.modelCatalog?.find(
+        (entry) => entry.provider === parsedModelRef.provider && entry.id === parsedModelRef.model,
+      );
+      return (
+        resolveEffectiveAgentRuntime({
+          cfg,
+          provider: parsedModelRef.provider,
+          modelId: parsedModelRef.model,
+          modelApi: model?.api,
+          modelBaseUrl: model?.baseUrl,
+          agentId: route.agentId,
+          sessionKey: route.sessionKey,
+          sessionEntry: currentEntry,
+        }) === "openclaw"
+      );
+    };
+    const legacyRuntimeNotice =
+      "This OpenClaw version supports model-only selection here. Update OpenClaw to change runtimes in the picker.";
+    if (modelOnlyHost && (parsed.runtime || parsed.runtimeToken || !supportsModelOnlySelection())) {
+      await showNotice(legacyRuntimeNotice);
+      return;
+    }
+    if (!modelOnlyHost && choices === undefined) {
       await showNotice("Runtime availability is not confirmed. Reopen /model to try again.");
       return;
     }
     const selectedRuntime =
       normalizeOptionalString(parsed.runtime) ?? resolveRuntimeToken(choices, parsed.runtimeToken);
     if (
-      choices.length === 0 ||
+      choices?.length === 0 ||
       (parsed.runtimeToken && selectedRuntime === undefined) ||
       (selectedRuntime &&
         selectedRuntime !== "auto" &&
         selectedRuntime !== "default" &&
-        !choices.some((choice) => choice.id === selectedRuntime))
+        !choices?.some((choice) => choice.id === selectedRuntime))
     ) {
       await showNotice(
         "That runtime is not available for this model. Reopen /model and choose again.",
@@ -612,6 +651,10 @@ async function handleDiscordModelPickerInteraction(params: {
 
     if (pickerData.isCurrent?.() === false) {
       await showNotice("That model picker expired. Reopen /model to try again.");
+      return;
+    }
+    if (modelOnlyHost && !supportsModelOnlySelection()) {
+      await showNotice(legacyRuntimeNotice);
       return;
     }
     const applyResult = await applyDiscordModelPickerSelection({

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -118,7 +118,7 @@ function resolvePendingRuntime(params: {
 }
 
 function resolveSubmittedModelRef(params: {
-  data: ModelsProviderData;
+  data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
   parsed: DiscordModelPickerState;
   quickModels: string[];
   requireModelToken: boolean;

--- a/extensions/discord/src/monitor/native-command-model-picker-ui.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-ui.ts
@@ -304,7 +304,12 @@ export async function replyWithDiscordModelPickerProviders(params: {
     accountId: params.accountId,
     threadBindings: params.threadBindings,
   });
-  const data = await loadDiscordModelPickerData(params.cfg, route.agentId);
+  const sessionEntry = getSessionEntry({
+    storePath: resolveStorePath(params.cfg.session?.store, { agentId: route.agentId }),
+    sessionKey: route.sessionKey,
+    readConsistency: "latest",
+  });
+  const data = await loadDiscordModelPickerData(params.cfg, route.agentId, { sessionEntry });
   const currentModel = resolveDiscordModelPickerCurrentModel({
     cfg: params.cfg,
     route,

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -10,15 +10,24 @@ import type {
   ModelsProviderData,
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ModelsRuntimeChoice } from "openclaw/plugin-sdk/models-provider-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import * as runtimeConfigSnapshotModule from "openclaw/plugin-sdk/runtime-config-snapshot";
 import * as commandTextModule from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseCustomId, serializePayload } from "../internal/discord.js";
 import { defineThrowingDiscordChannelGetter } from "../test-support/partial-channel.js";
 import { resolveDiscordChannelContext } from "./agent-components-context.js";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.state.js";
-import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
+import {
+  createModelsProviderData as createBaseModelsProviderData,
+  setFixtureRuntimeChoices,
+} from "./model-picker.test-utils.js";
+import {
+  renderDiscordModelPickerModelsView,
+  toDiscordModelPickerMessagePayload,
+} from "./model-picker.view.js";
 import type { DispatchDiscordCommandInteraction } from "./native-command-dispatch.js";
 import { applyDiscordModelPickerSelection } from "./native-command-model-picker-apply.js";
 import {
@@ -225,9 +234,11 @@ async function runSubmitButton(params: {
   data: PickerButtonData;
   dispatchCommandInteraction?: DispatchDiscordCommandInteraction;
   userId?: string;
+  interaction?: MockInteraction;
 }) {
   const button = createModelPickerFallbackButton(params.context, params.dispatchCommandInteraction);
-  const submitInteraction = createInteraction({ userId: params.userId ?? "owner" });
+  const submitInteraction =
+    params.interaction ?? createInteraction({ userId: params.userId ?? "owner" });
   await button.run(submitInteraction as unknown as PickerButtonInteraction, params.data);
   return submitInteraction;
 }
@@ -469,7 +480,7 @@ describe("Discord model picker interactions", () => {
       dispatchCommandInteraction: dispatchSpy,
     });
 
-    expect(loadSpy).toHaveBeenCalledWith(runtimeCfg, "main");
+    expect(loadSpy).toHaveBeenCalledWith(runtimeCfg, "main", { sessionEntry: undefined });
     expectDispatchedModelSelection({
       dispatchSpy,
       model: "openai/gpt-5.6-terra",
@@ -783,15 +794,18 @@ describe("Discord model picker interactions", () => {
     async (runtime) => {
       const context = createModelPickerContext();
       const pickerData = createDefaultModelPickerData();
-      pickerData.runtimeChoicesByProvider = new Map([
-        [
-          "openai",
+      setFixtureRuntimeChoices(
+        pickerData,
+        new Map([
           [
-            { id: "codex", label: "Codex", description: "Use Codex." },
-            { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
+            "openai",
+            [
+              { id: "codex", label: "Codex", description: "Use Codex." },
+              { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
+            ],
           ],
-        ],
-      ]);
+        ]),
+      );
       const modelCommand = createModelCommandDefinition();
 
       vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
@@ -820,15 +834,18 @@ describe("Discord model picker interactions", () => {
       defaults: { agentRuntime: { id: "codex" } },
     };
     const pickerData = createDefaultModelPickerData();
-    pickerData.runtimeChoicesByProvider = new Map([
-      [
-        "openai",
+    setFixtureRuntimeChoices(
+      pickerData,
+      new Map([
         [
-          { id: "codex", label: "Codex", description: "Use Codex." },
-          { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
+          "openai",
+          [
+            { id: "codex", label: "Codex", description: "Use Codex." },
+            { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
     const modelCommand = createModelCommandDefinition();
 
     vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
@@ -878,15 +895,18 @@ describe("Discord model picker interactions", () => {
       defaults: { agentRuntime: { id: "claude-cli" } },
     };
     const pickerData = createDefaultModelPickerData();
-    pickerData.runtimeChoicesByProvider = new Map([
-      [
-        "anthropic",
+    setFixtureRuntimeChoices(
+      pickerData,
+      new Map([
         [
-          { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
-          { id: "claude-cli", label: "Claude CLI", description: "Use Claude CLI." },
+          "anthropic",
+          [
+            { id: "openclaw", label: "OpenClaw Default", description: "Use OpenClaw." },
+            { id: "claude-cli", label: "Claude CLI", description: "Use Claude CLI." },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
     const modelCommand = createModelCommandDefinition();
 
     vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
@@ -1119,22 +1139,25 @@ describe("Discord model picker interactions", () => {
     ).toContain("selection expired");
   });
 
-  it("does not decode compact recents runtime against another provider", async () => {
+  it("refuses legacy compact recents runtime without dispatch", async () => {
     const context = createModelPickerContext();
     const pickerData = createModelsProviderData({
       openai: ["gpt-4o"],
       anthropic: ["claude-sonnet-4-5"],
     });
-    pickerData.runtimeChoicesByProvider = new Map([
-      ["openai", [{ id: "codex", label: "Codex", description: "Use Codex." }]],
-      [
-        "anthropic",
+    setFixtureRuntimeChoices(
+      pickerData,
+      new Map([
+        ["openai", [{ id: "codex", label: "Codex", description: "Use Codex." }]],
         [
-          { id: "codex", label: "Codex", description: "Use Codex." },
-          { id: "claude-cli", label: "Claude CLI", description: "Use Claude CLI." },
+          "anthropic",
+          [
+            { id: "codex", label: "Codex", description: "Use Codex." },
+            { id: "claude-cli", label: "Claude CLI", description: "Use Claude CLI." },
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
     const modelCommand = createModelCommandDefinition();
 
     vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
@@ -1156,11 +1179,7 @@ describe("Discord model picker interactions", () => {
       dispatchCommandInteraction: dispatchSpy,
     });
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expectDispatchedModelSelection({
-      dispatchSpy,
-      model: "anthropic/claude-sonnet-4-5",
-    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
   it("verifies the effective route returned by the core command", async () => {
@@ -1274,7 +1293,7 @@ describe("Discord model picker interactions", () => {
       safeInteractionCall: async (_label, fn) => await fn(),
     });
 
-    expect(loadSpy).toHaveBeenCalledWith(context.cfg, "worker");
+    expect(loadSpy).toHaveBeenCalledWith(context.cfg, "worker", { sessionEntry: undefined });
   });
 
   it("opens the first visible provider when the current model provider is filtered out", async () => {
@@ -1315,7 +1334,7 @@ describe("Discord model picker interactions", () => {
       safeInteractionCall: async (_label, fn) => await fn(),
     });
 
-    expect(loadSpy).toHaveBeenCalledWith(cfg, "main");
+    expect(loadSpy).toHaveBeenCalledWith(cfg, "main", { sessionEntry: undefined });
     const payload = JSON.stringify(firstMockArg(interaction.reply, "interaction.reply"));
     expect(payload).toContain("openai");
     expect(payload).toContain("gpt-5.5-codex");
@@ -1350,6 +1369,137 @@ describe("Discord model picker interactions", () => {
     expect(payload).toContain("provider-30");
     expect(payload).toContain(";a=back;v=providers;");
     expect(payload).toContain(";pb=");
+  });
+  describe("model-specific runtime selection", () => {
+    const builtin = { id: "openclaw", label: "OpenClaw", description: "Built-in runtime" };
+    const native = { id: "codex", label: "Codex", description: "Native runtime" };
+    function runtimeData(choices: ModelsRuntimeChoice[] | undefined, isCurrent = () => true) {
+      const byModel = new Map<string, ModelsRuntimeChoice[]>([["openai/gpt-4.1", [native]]]);
+      if (choices !== undefined) {
+        byModel.set("openai/gpt-4o", choices);
+      }
+      return {
+        ...createDefaultModelPickerData(),
+        runtimeChoicesByProvider: new Map([["openai", [native, builtin]]]),
+        runtimeChoicesByModel: byModel,
+        isCurrent,
+      };
+    }
+
+    it.each([
+      { label: "another model's runtime", choices: [builtin], runtime: "codex", current: true },
+      { label: "unknown choices", choices: undefined, runtime: "openclaw", current: true },
+      { label: "authoritative empty choices", choices: [], runtime: "openclaw", current: true },
+      { label: "retired choices", choices: [builtin], runtime: "openclaw", current: false },
+    ])("refuses $label without dispatch", async ({ choices, runtime, current }) => {
+      const context = createModelPickerContext();
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+        runtimeData(choices, () => current),
+      );
+      mockModelCommandPipeline(createModelCommandDefinition());
+      const dispatchSpy = createDispatchSpy();
+      const interaction = await runSubmitButton({
+        context,
+        data: { ...createModelsViewSubmitData(), r: runtime },
+        dispatchCommandInteraction: dispatchSpy,
+      });
+      expect(dispatchSpy).not.toHaveBeenCalled();
+      expect(JSON.stringify(firstMockArg(interaction.editReply, "runtime refusal"))).toMatch(
+        /runtime|expired/i,
+      );
+    });
+
+    it("keeps a selected runtime identity when current choices reorder", async () => {
+      const context = createModelPickerContext();
+      const data = runtimeData([native, builtin]);
+      const rendered = renderDiscordModelPickerModelsView({
+        command: "model",
+        userId: "owner",
+        data,
+        provider: "openai",
+        currentModel: "openai/gpt-4o",
+        pendingModel: "openai/gpt-4o",
+        pendingModelIndex: 2,
+        pendingRuntime: "codex",
+      });
+      type PickerComponent = { label?: string; custom_id?: string; components?: PickerComponent[] };
+      const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+        components: PickerComponent[];
+      };
+      const submit = payload.components
+        .flatMap((container) => container.components ?? [])
+        .flatMap((row) => row.components ?? [])
+        .find((component) => component.label === "Submit");
+      if (!submit?.custom_id) {
+        throw new Error("Expected a serialized Submit button");
+      }
+      data.runtimeChoicesByProvider.set("openai", [builtin, native]);
+      data.runtimeChoicesByModel.set("openai/gpt-4o", [builtin, native]);
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(data);
+      mockModelCommandPipeline(createModelCommandDefinition());
+      const dispatchSpy = createDispatchSpy();
+      await runSubmitButton({
+        context,
+        data: parseCustomId(submit.custom_id).data,
+        dispatchCommandInteraction: dispatchSpy,
+      });
+      expectDispatchedModelSelection({ dispatchSpy, model: "openai/gpt-4o", runtime: "codex" });
+    });
+
+    it("refuses an unconfirmed positional runtime submission", async () => {
+      const context = createModelPickerContext();
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+        runtimeData([native, builtin]),
+      );
+      mockModelCommandPipeline(createModelCommandDefinition());
+      const dispatchSpy = createDispatchSpy();
+      await runSubmitButton({
+        context,
+        data: { ...createModelsViewSubmitData(), ri: "1" },
+        dispatchCommandInteraction: dispatchSpy,
+      });
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+
+    it("refuses a generation retired while the applying notice is awaited", async () => {
+      const context = createModelPickerContext();
+      let current = true;
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+        runtimeData([builtin], () => current),
+      );
+      mockModelCommandPipeline(createModelCommandDefinition());
+      const interaction = createInteraction();
+      interaction.editReply.mockImplementation(async () => {
+        current = false;
+        return { ok: true };
+      });
+      const dispatchSpy = createDispatchSpy();
+      await runSubmitButton({
+        context,
+        interaction,
+        data: { ...createModelsViewSubmitData(), r: "openclaw" },
+        dispatchCommandInteraction: dispatchSpy,
+      });
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, "openclaw"])(
+      "dispatches an eligible model with runtime %s",
+      async (runtime) => {
+        const context = createModelPickerContext();
+        vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+          runtimeData([builtin]),
+        );
+        mockModelCommandPipeline(createModelCommandDefinition());
+        const dispatchSpy = createDispatchSpy();
+        await runSubmitButton({
+          context,
+          data: { ...createModelsViewSubmitData(), ...(runtime ? { r: runtime } : {}) },
+          dispatchCommandInteraction: dispatchSpy,
+        });
+        expectDispatchedModelSelection({ dispatchSpy, model: "openai/gpt-4o", runtime });
+      },
+    );
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -39,6 +39,18 @@ import { createNoopThreadBindingManager, type ThreadBindingManager } from "./thr
 
 vi.mock("openclaw/plugin-sdk/runtime-env", { spy: true });
 
+const hostSdk = vi.hoisted(() => ({ runtimeChoicesAvailable: true }));
+
+vi.mock("openclaw/plugin-sdk/models-provider-runtime", async (importOriginal) => {
+  const sdk = await importOriginal<typeof import("openclaw/plugin-sdk/models-provider-runtime")>();
+  return {
+    ...sdk,
+    get getModelsRuntimeChoices() {
+      return hostSdk.runtimeChoicesAvailable ? sdk.getModelsRuntimeChoices : undefined;
+    },
+  };
+});
+
 type ModelPickerContext = Parameters<typeof createDiscordModelPickerFallbackButton>[0]["ctx"];
 type PickerButton = ReturnType<typeof createDiscordModelPickerFallbackButton>;
 type PickerSelect = ReturnType<typeof createDiscordModelPickerFallbackSelect>;
@@ -316,6 +328,7 @@ function createBoundThreadBindingManager(params: {
 
 describe("Discord model picker interactions", () => {
   beforeEach(async () => {
+    hostSdk.runtimeChoicesAvailable = true;
     tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-discord-model-picker-"));
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -324,8 +337,31 @@ describe("Discord model picker interactions", () => {
   });
 
   afterEach(async () => {
+    hostSdk.runtimeChoicesAvailable = true;
     vi.useRealTimers();
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("refuses a declared minimum host submission without dispatch when the SDK helper is absent", async () => {
+    hostSdk.runtimeChoicesAvailable = false;
+    const context = createModelPickerContext();
+    const data = createDefaultModelPickerData();
+    delete data.runtimeChoicesByModel;
+    delete data.isCurrent;
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(data);
+    mockModelCommandPipeline(createModelCommandDefinition());
+    const dispatchSpy = createDispatchSpy();
+
+    const interaction = await runSubmitButton({
+      context,
+      data: { ...createModelsViewSubmitData(), r: "openclaw" },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(firstMockArg(interaction.editReply, "unconfirmed runtime notice")),
+    ).toContain("Runtime availability is not confirmed");
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -127,7 +127,9 @@ function createInteraction(params?: { userId?: string; values?: string[] }): Moc
     reply: vi.fn().mockResolvedValue({ ok: true }),
     followUp: vi.fn().mockResolvedValue({ ok: true }),
     update: vi.fn().mockResolvedValue({ ok: true }),
-    editReply: vi.fn().mockResolvedValue({ ok: true }),
+    editReply: vi
+      .fn<(_payload?: unknown) => Promise<{ ok: boolean }>>()
+      .mockResolvedValue({ ok: true }),
     acknowledge: vi.fn(),
     acknowledged: false,
     client: {},

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ModelsRuntimeChoice } from "openclaw/plugin-sdk/models-provider-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import * as runtimeConfigSnapshotModule from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import * as commandTextModule from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseCustomId, serializePayload } from "../internal/discord.js";
@@ -342,27 +343,85 @@ describe("Discord model picker interactions", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("refuses a declared minimum host submission without dispatch when the SDK helper is absent", async () => {
-    hostSdk.runtimeChoicesAvailable = false;
-    const context = createModelPickerContext();
-    const data = createDefaultModelPickerData();
-    delete data.runtimeChoicesByModel;
-    delete data.isCurrent;
-    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(data);
-    mockModelCommandPipeline(createModelCommandDefinition());
-    const dispatchSpy = createDispatchSpy();
+  it.each(["submit", "reset", "recents"])(
+    "dispatches declared minimum host %s through the built-in runtime",
+    async (action) => {
+      hostSdk.runtimeChoicesAvailable = false;
+      const context = createModelPickerContext();
+      const data = createDefaultModelPickerData();
+      delete data.runtimeChoicesByModel;
+      delete data.isCurrent;
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(data);
+      mockModelCommandPipeline(createModelCommandDefinition());
+      const dispatchSpy = createDispatchSpy();
 
-    const interaction = await runSubmitButton({
-      context,
-      data: { ...createModelsViewSubmitData(), r: "openclaw" },
-      dispatchCommandInteraction: dispatchSpy,
-    });
+      await runSubmitButton({
+        context,
+        data: {
+          ...createModelsViewSubmitData(),
+          p: "anthropic",
+          mi: "1",
+          ...(action === "reset" ? { act: "reset" } : {}),
+          ...(action === "recents" ? { view: "recents", rs: "1" } : {}),
+        },
+        dispatchCommandInteraction: dispatchSpy,
+      });
 
-    expect(dispatchSpy).not.toHaveBeenCalled();
-    expect(
-      JSON.stringify(firstMockArg(interaction.editReply, "unconfirmed runtime notice")),
-    ).toContain("Runtime availability is not confirmed");
-  });
+      expectDispatchedModelSelection({ dispatchSpy, model: "anthropic/claude-sonnet-4-5" });
+    },
+  );
+
+  it.each(["explicit runtime", "native model policy", "native session pin"])(
+    "preserves declared minimum host state with an unsupported %s",
+    async (mode) => {
+      hostSdk.runtimeChoicesAvailable = false;
+      const context = createModelPickerContext();
+      const data = createDefaultModelPickerData();
+      delete data.runtimeChoicesByModel;
+      delete data.isCurrent;
+      vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(data);
+      mockModelCommandPipeline(createModelCommandDefinition());
+      if (mode === "native model policy") {
+        context.cfg.agents = {
+          defaults: {
+            models: { "anthropic/claude-sonnet-4-5": { agentRuntime: { id: "claude-cli" } } },
+          },
+        };
+      }
+      const interaction = createInteraction();
+      context.cfg.session = { ...context.cfg.session, dmScope: "main" };
+      const store = {
+        storePath: path.join(tempDir, "sessions.json"),
+        sessionKey: "agent:main:main",
+      };
+      await upsertSessionEntry({
+        ...store,
+        entry: {
+          sessionId: "minimum-host-session",
+          updatedAt: 1,
+          ...(mode === "native session pin" ? { agentRuntimeOverride: "claude-cli" } : {}),
+        },
+      });
+      const before = getSessionEntry({ ...store, readConsistency: "latest" });
+      const dispatchSpy = createDispatchSpy();
+      await runSubmitButton({
+        context,
+        interaction,
+        data: {
+          ...createModelsViewSubmitData(),
+          p: "anthropic",
+          mi: "1",
+          ...(mode === "explicit runtime" ? { r: "claude-cli" } : {}),
+        },
+        dispatchCommandInteraction: dispatchSpy,
+      });
+      expect(dispatchSpy).not.toHaveBeenCalled();
+      expect(getSessionEntry({ ...store, readConsistency: "latest" })).toEqual(before);
+      expect(JSON.stringify(firstMockArg(interaction.editReply, "model-only notice"))).toContain(
+        "supports model-only selection",
+      );
+    },
+  );
 
   it("registers distinct fallback ids for button and select handlers", () => {
     const context = createModelPickerContext();

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -7,7 +7,6 @@ import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth-native"
 import type {
   ChatCommandDefinition,
   CommandArgsParsing,
-  ModelsProviderData,
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ModelsRuntimeChoice } from "openclaw/plugin-sdk/models-provider-runtime";
@@ -90,7 +89,7 @@ function createResolvedAgentRoute(overrides: Partial<ResolvedAgentRoute> = {}): 
   };
 }
 
-function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
+function createModelsProviderData(entries: Record<string, string[]>) {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
 }
 
@@ -154,7 +153,7 @@ function createInteraction(params?: { userId?: string; values?: string[] }): Moc
   return interaction;
 }
 
-function createDefaultModelPickerData(): ModelsProviderData {
+function createDefaultModelPickerData() {
   return createModelsProviderData({
     openai: ["gpt-4.1", "gpt-4o"],
     anthropic: ["claude-sonnet-4-5"],
@@ -539,10 +538,10 @@ describe("Discord model picker interactions", () => {
       ...context.cfg,
       agents: {
         defaults: {
-          model: { primary: "openai/gpt-5.6-terra" },
+          model: { primary: "openai/gpt-4.1" },
           models: {
             "openai/gpt-5.5": {},
-            "openai/gpt-5.6-terra": {},
+            "openai/gpt-4.1": {},
           },
         },
       },
@@ -555,9 +554,9 @@ describe("Discord model picker interactions", () => {
     const staleData = createModelsProviderData({ openai: ["gpt-5.5"] });
     staleData.resolvedDefault = { provider: "openai", model: "gpt-5.5" };
     const runtimeData = createModelsProviderData({
-      openai: ["gpt-5.5", "gpt-5.6-terra"],
+      openai: ["gpt-5.5", "gpt-4.1"],
     });
-    runtimeData.resolvedDefault = { provider: "openai", model: "gpt-5.6-terra" };
+    runtimeData.resolvedDefault = { provider: "openai", model: "gpt-4.1" };
     const loadSpy = vi
       .spyOn(modelPickerModule, "loadDiscordModelPickerData")
       .mockImplementation(async (cfg) => (cfg === runtimeCfg ? runtimeData : staleData));
@@ -580,7 +579,7 @@ describe("Discord model picker interactions", () => {
     expect(loadSpy).toHaveBeenCalledWith(runtimeCfg, "main", { sessionEntry: undefined });
     expectDispatchedModelSelection({
       dispatchSpy,
-      model: "openai/gpt-5.6-terra",
+      model: "openai/gpt-4.1",
     });
     const dispatchCall = firstMockArg(dispatchSpy, "dispatchCommandInteraction") as
       | Parameters<DispatchDiscordCommandInteraction>[0]
@@ -1361,6 +1360,19 @@ describe("Discord model picker interactions", () => {
 
   it("loads model picker data from the effective bound route", async () => {
     const context = createModelPickerContext();
+    const entry = {
+      sessionId: "bound-session",
+      updatedAt: 1,
+      providerOverride: "openai",
+      authProfileOverride: "openai:work",
+      authProfileOverrideSource: "user" as const,
+      agentRuntimeOverride: "openclaw",
+    };
+    await upsertSessionEntry({
+      storePath: path.join(tempDir, "sessions.json"),
+      sessionKey: "agent:worker:subagent:bound",
+      entry,
+    });
     context.threadBindings = createBoundThreadBindingManager({
       accountId: "default",
       threadId: "thread-bound",
@@ -1390,7 +1402,9 @@ describe("Discord model picker interactions", () => {
       safeInteractionCall: async (_label, fn) => await fn(),
     });
 
-    expect(loadSpy).toHaveBeenCalledWith(context.cfg, "worker", { sessionEntry: undefined });
+    expect(loadSpy).toHaveBeenCalledWith(context.cfg, "worker", {
+      sessionEntry: expect.objectContaining(entry),
+    });
   });
 
   it("opens the first visible provider when the current model provider is filtered out", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -68,7 +68,7 @@ type MockInteraction = {
   reply: ReturnType<typeof vi.fn>;
   followUp: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
-  editReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn<(_payload?: unknown) => Promise<{ ok: boolean }>>>;
   acknowledge: ReturnType<typeof vi.fn>;
   acknowledged: boolean;
   client: object;


### PR DESCRIPTION
Related: #136257, #143588.

## What Problem This Solves

Fixes an issue where the chat model picker retained a runtime for another model or selected a different runtime when an old menu’s choices were reordered.

## Why This Change Was Made

The picker consumes shared model-specific runtime choices with the effective session’s authentication context. Navigation carries stable runtime identities and rejects unavailable, retired or obsolete selections before command dispatch.

## User Impact

Valid choices remain selectable; stale choices show a notice without changing saved state. Older supported installations retain model-only selection and refuse unsupported explicit runtime changes.

Consumers: the channel picker uses shared model/runtime eligibility and stable identities.

## Evidence

Four rendering regressions failed before the fix. Targeted picker, catalog and authentication tests passed. Registered commands with a mocked Gateway proved available selection and unavailable/stale refusal with unchanged saved state. Live guild evidence covered replies and menu-component delivery; native commands and user component clicks were not driven.
