### PR TITLE
refactor: skip unused binding work in agent-list JSON and tree output

### DIFF
--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -11,7 +11,7 @@ import {
   type AgentProvenance,
 } from "../state/agent-provenance.js";
 import { shortenHomePath } from "../utils.js";
-import { describeBinding } from "./agents.bindings.js";
+import { describeBinding } from "./agents.binding-format.js";
 import type { AgentSummary } from "./agents.config.js";
 import { buildAgentSummaries } from "./agents.config.js";
 import {
@@ -143,35 +143,35 @@ export async function agentsListCommand(
       }
     }
   }
-  const bindingMap = new Map<string, AgentRouteBinding[]>();
-  for (const binding of listRouteBindings(cfg)) {
-    const agentId = normalizeAgentId(binding.agentId);
-    const list = bindingMap.get(agentId) ?? [];
-    list.push(binding);
-    bindingMap.set(agentId, list);
-  }
-
-  if (opts.bindings) {
-    for (const summary of summaries) {
-      const bindings = bindingMap.get(summary.id) ?? [];
-      if (bindings.length > 0) {
-        summary.bindingDetails = bindings.map((binding) => describeBinding(binding));
-      }
-    }
-  }
-
   // Provider details are only used for human text output
   // (`summary.providers` is rendered in the text formatter). JSON callers
   // (dashboards, monitors, IDE plugins) poll the config/state-derived fields, so
   // skip the provider detail pass unless they explicitly ask for enrichment.
   // This keeps JSON and tree output off the bundled plugin runtime path.
   const includeProviderDetails = (!opts.json && !opts.tree) || opts.bindings === true;
-  const providerStatus = includeProviderDetails ? await buildProviderStatusIndex(cfg) : null;
-  const providerMetadata = includeProviderDetails ? buildProviderSummaryMetadataIndex(cfg) : null;
+  if (includeProviderDetails) {
+    const bindingMap = new Map<string, AgentRouteBinding[]>();
+    for (const binding of listRouteBindings(cfg)) {
+      const agentId = normalizeAgentId(binding.agentId);
+      const list = bindingMap.get(agentId) ?? [];
+      list.push(binding);
+      bindingMap.set(agentId, list);
+    }
 
-  for (const summary of summaries) {
-    const bindings = bindingMap.get(summary.id) ?? [];
-    if (includeProviderDetails && providerStatus && providerMetadata) {
+    if (opts.bindings) {
+      for (const summary of summaries) {
+        const bindings = bindingMap.get(summary.id) ?? [];
+        if (bindings.length > 0) {
+          summary.bindingDetails = bindings.map((binding) => describeBinding(binding));
+        }
+      }
+    }
+
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    const providerMetadata = buildProviderSummaryMetadataIndex(cfg);
+
+    for (const summary of summaries) {
+      const bindings = bindingMap.get(summary.id) ?? [];
       const routes = summarizeBindings(cfg, bindings, providerMetadata);
       if (routes.length > 0) {
         summary.routes = routes;


### PR DESCRIPTION
**Held after adverse measurements. The current version is not proposed for landing as a performance improvement.**

## What Problem This Solves

`openclaw agents list --json` and `--tree` group route bindings even when those output modes do not use the resulting detail map. The list command also reaches its binding formatter through the broader binding-command module.

## Why This Change Was Made

The experiment builds the binding map only inside the existing provider/detail-enrichment branch and imports the unchanged formatter directly from its owning module. Human output and explicit `--bindings` enrichment retain their existing path. The one-file change is net zero production lines (23 added, 23 removed), with no test changes or new dependency.

## User Impact

Output preservation passed, but this version did not demonstrate a command-level speed benefit. All six measured wall-time medians were slower. With no LOC reduction to justify that tradeoff, the experiment is held. No allocation, full-CLI, or Gateway improvement is claimed.

## Evidence

171 tests passed across six existing files, with one existing Windows-only home-casing test skipped on macOS. Seven supplemental guards, the full candidate build, and Codex review passed. Exact-head CI also passed its 21 mapped ordinary obligations, but the required gate failed on a separate Windows checkout-process ownership test in [run 34390092356](https://github.com/openclaw/openclaw/actions/runs/34390092356). That failure is preserved and is not labelled a flake or fixed by this change.

A separate Linux x64 / Node 24.19.0 comparison completed the fixed B0/C0/C1/B1 cohort: 132 real awaited command calls, comprising 96 measured calls, 12 initial calls, and 24 warmups. Independent audit verified every literal output/input and 198 cross-phase graph comparisons, including property/Map order and within-snapshot aliases. Synthetic acquisition backends were used; imports, serialization, and actual terminal/JSON I/O were outside the per-call clocks.

Eight measured samples per task produced these candidate-relative median changes:

| Task | B0 → C0 | B1 → C1 |
|---|---:|---:|
| JSON, 24 agents | +14.49% | +23.18% |
| Tree, 24 agents | +0.53% | +2.04% |
| JSON with bindings, 3 agents | +8.76% | +9.64% |

All samples and adverse comparisons are retained. Per-call CPU results were mixed. Whole managed-phase wall changes were −11.47% and +0.41%; those include startup/orchestration and do not establish faster command execution. Container memory observations are not independent phase RSS measurements. No statistical-significance or population-tail claim is made.

The successful delegated Testbox command is associated with [run 34391767601](https://github.com/openclaw/openclaw/actions/runs/34391767601). Its four phases, container, and lease closed; the candidate was restored. The backing Actions lifecycle can show cancellation during successful delegated cleanup.

Earlier attempts remain separate: the first macOS run captured only 33 unpaired baseline calls before a disk refusal; the second refused before any call. The first Linux attempt failed on task-mount permissions before installation or measurement. Its replacement used the actual nonroot mount owner and a writable Corepack shim directory, retaining dropped capabilities, resource limits, assertions, and the identical workload. None of those earlier attempts was pooled into the comparison.
