### PR TITLE
fix: preserve staged path replacements during worktree cleanup

### DIFF
--- a/src/agents/worktrees/service.provisioned.test.ts
+++ b/src/agents/worktrees/service.provisioned.test.ts
@@ -4,7 +4,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as commandRunner from "../../process/exec-runner.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { insertRegistryWorktree } from "./registry.js";
 import { ManagedWorktreeService } from "./service.js";
@@ -296,4 +297,172 @@ describe("ManagedWorktreeService provisioned state", () => {
       expect(await fs.readFile(restoredPath, "utf8")).toBe("local bytes\n");
     },
   );
+
+  it.each([
+    {
+      replacement: "file-to-directory",
+      originalPath: "entry",
+      replacementPath: "entry/child.txt",
+      snapshotPaths: ["README.md", "entry/child.txt"],
+      directory: true,
+      staged: false,
+    },
+    {
+      replacement: "directory-to-file",
+      originalPath: "entry/child.txt",
+      replacementPath: "entry",
+      snapshotPaths: ["README.md", "entry"],
+      directory: false,
+      staged: false,
+    },
+    {
+      replacement: "staged-file-to-directory",
+      originalPath: "entry",
+      replacementPath: "entry/child.txt",
+      snapshotPaths: ["README.md", "entry/child.txt"],
+      directory: true,
+      staged: true,
+    },
+    {
+      replacement: "staged-directory-to-file",
+      originalPath: "entry/child.txt",
+      replacementPath: "entry",
+      snapshotPaths: ["README.md", "entry"],
+      directory: false,
+      staged: true,
+    },
+  ])("round trips a tracked $replacement replacement", async (row) => {
+    const originalPath = path.join(repo, row.originalPath);
+    await fs.mkdir(path.dirname(originalPath), { recursive: true });
+    await fs.writeFile(originalPath, "original\n");
+    await git(repo, "add", row.originalPath);
+    await git(repo, "commit", "-m", "add original entry");
+    const created = await service.create({
+      repoRoot: repo,
+      name: row.replacement,
+      baseRef: "HEAD",
+    });
+    const originalHead = await git(created.path, "rev-parse", "HEAD");
+    await fs.rm(path.join(created.path, "entry"), { recursive: true });
+    const replacementPath = path.join(created.path, row.replacementPath);
+    await fs.mkdir(path.dirname(replacementPath), { recursive: true });
+    await fs.writeFile(replacementPath, "local replacement\n");
+    if (row.staged) {
+      await git(created.path, "add", "-A");
+    }
+
+    const removed = await service.remove({ id: created.id, reason: "test" });
+    expect(
+      (await git(repo, "ls-tree", "-r", "--name-only", removed.snapshotRef!)).split("\n"),
+    ).toEqual(row.snapshotPaths);
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+    const restored = await service.restore({ id: created.id });
+
+    expect(await git(restored.path, "rev-parse", "HEAD")).toBe(originalHead);
+    expect((await fs.stat(path.join(restored.path, "entry"))).isDirectory()).toBe(row.directory);
+    expect(await fs.readFile(path.join(restored.path, row.replacementPath), "utf8")).toBe(
+      "local replacement\n",
+    );
+    expect(await git(restored.path, "diff", "--cached", "--name-only")).toBe("");
+  });
+
+  it("snapshots a missing file that reappears before the index update", async () => {
+    const created = await service.create({
+      repoRoot: repo,
+      name: "reappearing-file",
+      baseRef: "HEAD",
+    });
+    const originalHead = await git(created.path, "rev-parse", "HEAD");
+    const localPath = path.join(created.path, "README.md");
+    await fs.rm(localPath);
+    const runCommand = commandRunner.runCommandWithTimeout;
+    let reappeared = false;
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
+    commandSpy.mockImplementation(async (...args) => {
+      const argv = args[0];
+      if (argv[0] === "git" && argv.includes("update-index") && argv.includes("--stdin")) {
+        expect(reappeared).toBe(false);
+        await expect(fs.stat(localPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await fs.writeFile(localPath, "reappeared contents\n");
+        reappeared = true;
+      }
+      return await runCommand(...args);
+    });
+
+    try {
+      const removed = await service.remove({ id: created.id, reason: "test" });
+      expect(reappeared).toBe(true);
+      expect(await git(repo, "show", `${removed.snapshotRef}:README.md`)).toBe(
+        "reappeared contents",
+      );
+      await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+      const restored = await service.restore({ id: created.id });
+
+      expect(await git(restored.path, "rev-parse", "HEAD")).toBe(originalHead);
+      expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+        "reappeared contents\n",
+      );
+      expect(await git(restored.path, "diff", "--cached", "--name-only")).toBe("");
+    } finally {
+      commandSpy.mockRestore();
+    }
+  });
+
+  it("snapshots a reappearing untracked child after its parent becomes a directory", async () => {
+    await fs.writeFile(path.join(repo, "entry"), "original file\n");
+    await git(repo, "add", "entry");
+    await git(repo, "commit", "-m", "add tracked parent");
+    const created = await service.create({
+      repoRoot: repo,
+      name: "reappearing-child",
+      baseRef: "HEAD",
+    });
+    const originalHead = await git(created.path, "rev-parse", "HEAD");
+    const parentPath = path.join(created.path, "entry");
+    const childPath = path.join(parentPath, "child.txt");
+    await fs.rm(parentPath);
+    await fs.mkdir(parentPath);
+    await fs.writeFile(childPath, "discovered child\n");
+    const runCommand = commandRunner.runCommandWithTimeout;
+    let disappeared = false;
+    let reappeared = false;
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
+    commandSpy.mockImplementation(async (...args) => {
+      const argv = args[0];
+      if (argv[0] === "git" && argv.includes("read-tree") && argv.at(-1) === "HEAD") {
+        const result = await runCommand(...args);
+        expect(result.code).toBe(0);
+        expect(disappeared).toBe(false);
+        await fs.rm(childPath);
+        disappeared = true;
+        return result;
+      }
+      if (argv[0] === "git" && argv.includes("update-index") && argv.includes("--stdin")) {
+        expect(disappeared).toBe(true);
+        expect(reappeared).toBe(false);
+        await expect(fs.stat(childPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await fs.writeFile(childPath, "reappeared child\n");
+        reappeared = true;
+      }
+      return await runCommand(...args);
+    });
+
+    try {
+      const removed = await service.remove({ id: created.id, reason: "test" });
+      expect(reappeared).toBe(true);
+      expect(
+        (await git(repo, "ls-tree", "-r", "--name-only", removed.snapshotRef!)).split("\n"),
+      ).toEqual(["README.md", "entry/child.txt"]);
+      const restored = await service.restore({ id: created.id });
+
+      expect(await git(restored.path, "rev-parse", "HEAD")).toBe(originalHead);
+      expect((await fs.stat(path.join(restored.path, "entry"))).isDirectory()).toBe(true);
+      expect(await fs.readFile(path.join(restored.path, "entry", "child.txt"), "utf8")).toBe(
+        "reappeared child\n",
+      );
+      expect(await git(restored.path, "diff", "--cached", "--name-only")).toBe("");
+    } finally {
+      commandSpy.mockRestore();
+    }
+  });
 });

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -648,7 +648,13 @@ async function snapshotWorktree(
       throw new Error("nested git repositories cannot be snapshotted losslessly");
     }
     commitGuard?.();
-    await prepareSnapshotIndex(stateEnv, record, snapshotPaths, provisionedPaths, env);
+    const { missing, tracked } = await prepareSnapshotIndex(
+      stateEnv,
+      record,
+      snapshotPaths,
+      provisionedPaths,
+      env,
+    );
     const provisionedState = await snapshotProvisionedFiles(
       stateEnv,
       record.id,
@@ -656,6 +662,21 @@ async function snapshotWorktree(
       provisionedPaths,
       commitGuard,
     );
+    const missingPaths: Buffer[] = [];
+    const trackedPaths: Buffer[] = [];
+    const addedPaths: Buffer[] = [];
+    for (const [key, entry] of snapshotPaths) {
+      if (missing.has(key)) {
+        missingPaths.push(entry);
+      } else if (tracked.has(key)) {
+        trackedPaths.push(entry);
+      } else {
+        addedPaths.push(entry);
+      }
+    }
+    // Update indexed paths before additions that can replace their file/directory shape.
+    // Missing entries are processed from the index tail to avoid shifting later entries.
+    missingPaths.sort((left, right) => Buffer.compare(right, left));
     // This index came from a tree, so it has no checkout-local skip-worktree
     // bits and update-index is independent of the source worktree's sparse cone.
     commitGuard?.();
@@ -667,7 +688,10 @@ async function snapshotWorktree(
         input:
           snapshotPaths.size > 0
             ? Buffer.concat(
-                [...snapshotPaths.values()].flatMap((entry) => [entry, Buffer.from([0])]),
+                [...missingPaths, ...trackedPaths, ...addedPaths].flatMap((entry) => [
+                  entry,
+                  Buffer.from([0]),
+                ]),
               )
             : Buffer.alloc(0),
       },
@@ -722,7 +746,7 @@ async function prepareSnapshotIndex(
   snapshotPaths: ReadonlyMap<string, Buffer>,
   provisioned: readonly string[],
   indexEnv: NodeJS.ProcessEnv,
-): Promise<void> {
+): Promise<{ missing: ReadonlySet<string>; tracked: ReadonlySet<string> }> {
   const headPaths = splitNullBuffer(
     await requireGitBuffer(record.path, ["ls-tree", "-r", "--name-only", "-z", "HEAD"]),
   );
@@ -736,6 +760,11 @@ async function prepareSnapshotIndex(
     true,
   );
   await requireGit(record.path, ["read-tree", "HEAD"], { env: indexEnv });
+  const tracked = new Set(
+    splitNullBuffer(
+      await requireGitBuffer(record.path, ["ls-files", "--cached", "-z"], { env: indexEnv }),
+    ).map(gitPathKey),
+  );
   // Compare against the same fresh index used by the writer: source-index flags
   // can hide edits, while an unrefreshed HEAD index falsely marks unchanged blobs.
   const changed = new Set(
@@ -757,7 +786,6 @@ async function prepareSnapshotIndex(
       ),
     ).map(gitPathKey),
   );
-  const tracked = new Set(headPaths.map(gitPathKey));
   const unique = new Map(
     [...snapshotPaths].filter(([key]) => changed.has(key) || !tracked.has(key)),
   );
@@ -765,6 +793,7 @@ async function prepareSnapshotIndex(
     unique.set(gitPathKey(Buffer.from(value)), Buffer.from(value));
   }
   const provisionedKeys = new Set(provisioned.map((value) => gitPathKey(Buffer.from(value))));
+  const missing = new Set<string>();
   let gitBytes = 0,
     provisionedBytes = 0;
   for (const [key, value] of unique) {
@@ -778,6 +807,9 @@ async function prepareSnapshotIndex(
     } catch (error) {
       if (!isMissingPathError(error)) {
         throw error;
+      }
+      if (tracked.has(key)) {
+        missing.add(key);
       }
     }
   }
@@ -793,6 +825,7 @@ async function prepareSnapshotIndex(
     "worktree safety snapshot",
     true,
   );
+  return { missing, tracked };
 }
 
 export class ManagedWorktreeService {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Fixes an issue where users removing a managed worktree can encounter Git index conflicts after staging a file-to-directory or directory-to-file replacement. Large deletion-heavy checkouts also spend substantial cleanup time updating the snapshot index.

## Why This Change Was Made

Order snapshot updates using membership read from the actual private index: missing indexed paths in reverse byte order, other indexed paths in their original order, then additions. This processes indexed file/directory conflicts before adding replacement paths. Missing observations only influence ordering; Git still reads current file contents. Snapshot publication, lease and capacity checks, and restore ancestry retain their existing behavior.

## User Impact

Managed worktrees with staged path replacements can be snapshotted and restored. Deletion-heavy snapshots avoid repeatedly moving index entries that will also be removed.

## Evidence

- Linux proof covered five complete owner suites with the same 96 case identities: original code passed 94 and failed the two new staged-transition regressions; the candidate passed all 96. The refreshed candidate passed all 96 again, preserving the upstream branch-inventory changes.
- Six real-Git boundary cases cover staged and unstaged transitions in both directions, tracked-file reappearance, and an untracked child disappearing and reappearing during a file-to-directory transition. Existing tests and the 180001-entry GC workload retain their assertions and deadlines.
- Global path reversal, forced removal of a reappearing file, and the previous all-missing ordering each produced their intended failures. The initial run stopped when its strict parser rejected Git's missing-blob wording and stack; that raw force-removal failure was independently reviewed. The first matrix remains recorded as incomplete, and a separate follow-up completed the outstanding all-missing control and verified candidate restoration. Native process groups were joined.
- With Git 2.53.0, the large-index GC case took 46.0 seconds on the original and 11.2 seconds on the candidate in one paired observation. The refreshed candidate took 12.7 seconds in the separate follow-up, without a fresh baseline. These are focused observations, not a whole-suite speedup measurement.
- The refreshed source passed the complete required changed gate and fresh P2 review.
