### PR TITLE
fix(cron): retire legacy owned rows on read-only store loads

### DIFF
--- a/src/cron/store.retired-review.test.ts
+++ b/src/cron/store.retired-review.test.ts
@@ -1,4 +1,7 @@
+import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { runDoctorConfigPreflight } from "../commands/doctor-config-preflight.js";
+import { prepareCronOwnerWriteRefusal } from "../config/io.cron-owner-refusal.js";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { writeCronJobScratch } from "./scratch-store.js";
@@ -27,18 +30,28 @@ function job(id: string): CronJob {
   };
 }
 
+function legacyReviewJob() {
+  return {
+    ...job("retired"),
+    name: "skill-collection-review-main",
+    declarationKey: "skill-collection-review:main",
+    systemOwned: true,
+    payload: { kind: "skillCollectionReview" },
+  };
+}
+
 describe("retired Workshop cron jobs", () => {
-  it.each(["async", "sync"])(
-    "retires legacy rows on an already-current database through %s load",
-    async (mode) => {
+  it.each(
+    ["async", "sync"].flatMap((mode) =>
+      ["both", "json-only", "column-only"].map((shape) => ({ mode, shape })),
+    ),
+  )(
+    "retires $shape legacy rows on an already-current database through $mode load",
+    async ({ mode, shape }) => {
       await withOpenClawTestState({ label: "retired-workshop-cron" }, async (state) => {
         const storePath = state.statePath("cron", "jobs.json");
         const otherStorePath = state.statePath("other-cron", "jobs.json");
-        const retired = {
-          ...job("retired"),
-          declarationKey: "skill-collection-review:main",
-          payload: { kind: "skillCollectionReview" },
-        };
+        const retired = legacyReviewJob();
         await saveCronJobsStore(storePath, { version: 1, jobs: [job("retired"), job("keep")] });
         await saveCronJobsStore(otherStorePath, { version: 1, jobs: [job("retired")] });
         for (const target of [storePath, otherStorePath]) {
@@ -52,8 +65,8 @@ describe("retired Workshop cron jobs", () => {
         const db = openOpenClawStateDatabase().db;
         const version = db.prepare("PRAGMA user_version").get();
         db.prepare("UPDATE cron_jobs SET payload_kind = ?, job_json = ? WHERE job_id = ?").run(
-          "skillCollectionReview",
-          JSON.stringify(retired),
+          shape === "json-only" ? "systemEvent" : "skillCollectionReview",
+          JSON.stringify(shape === "column-only" ? job("retired") : retired),
           "retired",
         );
         const count = (table: "cron_jobs" | "cron_job_scratch", target: string) =>
@@ -63,8 +76,14 @@ describe("retired Workshop cron jobs", () => {
             )
             .get(cronStoreKey(target), "retired");
 
-        await loadCronJobsStoreWithConfigJobsReadOnly(storePath, state.env);
+        const readOnly = await loadCronJobsStoreWithConfigJobsReadOnly(storePath, state.env);
+        expect(readOnly.invalidConfigRows).toEqual([]);
+        expect(readOnly.store.jobs.map((entry) => entry.id)).toEqual(["keep"]);
+        expect(readOnly.configJobs.map((entry) => entry.id)).toEqual(["keep"]);
+        const guard = await prepareCronOwnerWriteRefusal({}, { storePath, env: state.env });
+        await guard.recheck();
         expect(count("cron_jobs", storePath)).toEqual({ count: 1 });
+        expect(count("cron_job_scratch", storePath)).toEqual({ count: 1 });
         const loaded =
           mode === "sync"
             ? loadCronJobsStoreSync(storePath)
@@ -79,4 +98,45 @@ describe("retired Workshop cron jobs", () => {
       });
     },
   );
+
+  it("allows Doctor to persist config repair while the retired row remains on disk", async () => {
+    await withOpenClawTestState(
+      { label: "retired-workshop-doctor", env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" } },
+      async (state) => {
+        await state.writeConfig({
+          meta: { lastTouchedAt: "2026-09-01T00:00:00.000Z" },
+          gateway: { mode: "local" },
+          agents: { list: [{ id: "main", default: true }] },
+        });
+        const storePath = state.statePath("cron", "jobs.json");
+        await saveCronJobsStore(storePath, { version: 1, jobs: [job("retired")] });
+        const db = openOpenClawStateDatabase().db;
+        db.prepare("UPDATE cron_jobs SET payload_kind = ?, job_json = ? WHERE job_id = ?").run(
+          "skillCollectionReview",
+          JSON.stringify(legacyReviewJob()),
+          "retired",
+        );
+
+        await expect(
+          prepareCronOwnerWriteRefusal({}, { storePath, env: state.env }),
+        ).resolves.toHaveProperty("recheck");
+        const result = await runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        });
+
+        expect(result.snapshot.valid).toBe(true);
+        const persisted = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+        expect(persisted.agents.entries).toHaveProperty("main");
+        expect(persisted.agents).not.toHaveProperty("list");
+        expect(
+          db.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get("retired"),
+        ).toEqual({
+          job_json: JSON.stringify(legacyReviewJob()),
+        });
+      },
+    );
+  });
 });

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -118,12 +118,24 @@ function isRetiredCollectionReview(row: CronJobRow): boolean {
 }
 
 function loadMutableCronStore(storePath: string): LoadedCronStore {
-  const resolvedStorePath = path.resolve(storePath);
-  const storeKey = cronStoreKey(resolvedStorePath);
-  const database = openOpenClawStateDatabase().db;
+  return loadCronStoreFromDatabase(
+    openOpenClawStateDatabase().db,
+    cronStoreKey(path.resolve(storePath)),
+    false,
+  );
+}
+
+function loadCronStoreFromDatabase(
+  database: DatabaseSync,
+  storeKey: string,
+  readOnly: boolean,
+): LoadedCronStore {
   let rows = loadCronRows(database, storeKey);
   const retiredIds = new Set(rows.filter(isRetiredCollectionReview).map((row) => row.job_id));
-  if (retiredIds.size > 0) {
+  if (readOnly) {
+    // Hide retired jobs before validation; the next mutable load owns durable deletion.
+    rows = rows.filter((row) => !retiredIds.has(row.job_id));
+  } else if (retiredIds.size > 0) {
     // Retire generated jobs before runtime validation, including databases already
     // on v16. Gateway convergence recreates them with the isolated agent-turn target.
     const removed = runOpenClawStateWriteTransaction(
@@ -142,28 +154,21 @@ function loadMutableCronStore(storePath: string): LoadedCronStore {
     }
     rows = loadCronRows(database, storeKey);
   }
-  const jobsFingerprint = fingerprintCronJobRows(rows);
+  const loaded = loadedCronStoreFromRows(rows);
   if (rows.length > 0) {
-    const loaded = loadedCronStoreFromRows(rows);
     const authority = loadCronRuntimeAuthorities({
       db: database,
       storeKey,
       jobs: loaded.store.jobs,
     });
-    repairLoadedCronRuntimeAuthority({
-      storeKey,
-      jobIds: authority.repairJobIds,
-    });
-    return { ...loaded, jobsFingerprint };
+    if (!readOnly) {
+      repairLoadedCronRuntimeAuthority({
+        storeKey,
+        jobIds: authority.repairJobIds,
+      });
+    }
   }
-  return {
-    store: { version: 1, jobs: [] },
-    configJobs: [],
-    configJobIndexes: [],
-    configJobRuntimeEntries: [],
-    invalidConfigRows: [],
-    jobsFingerprint,
-  };
+  return readOnly ? loaded : { ...loaded, jobsFingerprint: fingerprintCronJobRows(rows) };
 }
 
 export class CronJobsStoreChangedError extends Error {
@@ -257,11 +262,7 @@ export async function loadCronJobsStoreWithConfigJobsReadOnly(
     const db = openNodeSqliteDatabase(prepared?.location ?? statePath, { readOnly: true });
     try {
       if (tableExists(db, "cron_jobs")) {
-        const rows = loadCronRows(db, storeKey);
-        if (rows.length > 0) {
-          loaded = loadedCronStoreFromRows(rows);
-          loadCronRuntimeAuthorities({ db, storeKey, jobs: loaded.store.jobs });
-        }
+        loaded = loadCronStoreFromDatabase(db, storeKey, true);
       }
     } finally {
       db.close();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading from 2026.9.2 could have Doctor refuse config writes when their SQLite cron store contained the generated, explicitly main-owned Skill Workshop review row. The campaign's Docker update-matrix cell (2026.9.2 → next release/main) observed Doctor exit 1, package rollback over forward-migrated Workshop state, and the restored Gateway failing with `no such column: workspace_dir`.

Refs #142770
Refs #139105 (related generated Workshop-job upgrade context; this PR does not resolve that broader report)

## Why This Change Was Made

Both store entry points now share retirement, decoding, and authority hydration. Read-only loads omit the same legacy rows in memory before validation; mutable loads retain the existing transaction that rechecks and deletes the job and scratch data. The ownership guard and Doctor need no compensating filters.

For SQLite-only state, preflight's legacy-file repair returns before loading the store, so the subsequent read-only ownership guard must observe the same retired job set. Doctor health and policy inspection also use this read-only seam; scheduler status continues to use mutable loading.

The tagged 2026.9.2 producer in `src/cron/skill-collection-review-monitor.ts` emits `skillCollectionReview` with explicit agent ownership and a main-session target. The existing retirement predicate recognizes both the indexed kind and the JSON payload kind. Both forms remain covered, including when only one representation identifies the retired row.

## User Impact

Release-note context: Updates from 2026.9.2 with generated Skill Workshop review jobs can complete Doctor's config repair without a false cron-ownership refusal. Read-only inspection preserves stored jobs and scratch data; the next mutable load performs the existing durable retirement, and Gateway convergence recreates the current isolated agent-turn job.

This removes the cron-triggered refusal; rollback safety itself remains tracked by #142770.

## Evidence

Before changing production code:

```text
node scripts/run-vitest.mjs src/cron/store.retired-review.test.ts
Tests 6 failed (6)
JSON/full rows: invalidConfigRows contained reason: "invalid-payload", agentId: "main"
Indexed-only rows: expected [ 'retired', 'keep' ] to deeply equal [ 'keep' ]

node scripts/run-vitest.mjs src/cron/store.retired-review.test.ts -t 'allows Doctor'
Tests 1 failed | 6 skipped (7)
CONFIG_WRITE_REJECTED / cron-owner-safety:
contains 1 corrupt row(s) whose ownership cannot be verified
```

After the fix:

```sh
node scripts/run-vitest.mjs src/cron/store.retired-review.test.ts src/cron/store.test.ts src/config/io.cron-owner-refusal.test.ts src/commands/doctor-config-preflight.test.ts src/commands/doctor-config-preflight.state-migration.test.ts src/commands/doctor-config-preflight.state-migration-input.test.ts
```

158 tests passed across six files and three routed suites. The regressions cover read-only omission, the real ownership guard and commit recheck, unchanged on-disk rows/scratch, async and sync durable retirement, partition isolation, and Doctor persisting a repaired config while the retired row remains stored.

`node scripts/check-changed.mjs` passed, including formatting, core/test typechecking, changed-file lint, schema checks, and repository guards. `git diff --check` passed.

Exact-head [CI run 34390193902](https://github.com/openclaw/openclaw/actions/runs/34390193902) completed successfully for `cb2243612100f5fd94882995513a9d6c6256d1b3`. ClawSweeper reviewed that head with no actionable findings.

Known gaps: This lane used isolated synthetic SQLite/config fixtures, not a fresh Docker update-matrix run. The campaign lead owns independent autoreview, final matrix verification, and landing. No contributor patch was incorporated.
