### PR TITLE
improve(test): reduce media QA startup overhead

### DIFF
--- a/test/e2e/qa-lab/media/image-generation-lifecycle.e2e.test.ts
+++ b/test/e2e/qa-lab/media/image-generation-lifecycle.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   type MockOpenAiRequestSnapshot,
 } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const MODEL_REF = "mock-openai/gpt-5.6-luna";
@@ -210,7 +211,7 @@ describe("image generation task lifecycle through QA-channel", () => {
     cleanups.push(() => stopQaGatewayFixture(gatewayOwner));
     const gateway = await gatewayOwner.start({
       repoRoot: REPO_ROOT,
-      useRepoCli: true,
+      command: createQaPreparedRepoCliCommand(REPO_ROOT),
       providerBaseUrl: `${mock.baseUrl}/v1`,
       providerMode: "mock-openai",
       primaryModel: MODEL_REF,
@@ -301,9 +302,9 @@ describe("image generation task lifecycle through QA-channel", () => {
     const completionReentry = await vi.waitFor(
       async () => {
         const request = (await readMockRequests(mock.baseUrl)).find(
-          (request) =>
-            request.allInputText.includes("[Inter-session message]") &&
-            request.allInputText.includes("sourceTool=image_generate"),
+          (snapshot) =>
+            snapshot.allInputText.includes("[Inter-session message]") &&
+            snapshot.allInputText.includes("sourceTool=image_generate"),
         );
         if (!request) {
           throw new Error("image completion did not re-enter the agent session");

--- a/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
+++ b/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   startQaMockOpenAiServer,
 } from "../../../../extensions/qa-lab/api.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createQaPreparedRepoCliCommand } from "../../../helpers/qa-prepared-repo-cli.js";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const ACTIVE_MODEL_ID = "gpt-5.6-luna";
@@ -134,7 +135,7 @@ describe("QA-channel vision offload", () => {
     cleanups.push(() => stopQaGatewayFixture(gatewayOwner));
     const gateway = await gatewayOwner.start({
       repoRoot: REPO_ROOT,
-      useRepoCli: true,
+      command: createQaPreparedRepoCliCommand(REPO_ROOT),
       providerBaseUrl: `${mock.baseUrl}/v1`,
       providerMode: "mock-openai",
       primaryModel: ACTIVE_MODEL_REF,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Developers running the image-generation lifecycle and vision-offload QA tests
pay repeated startup overhead even after the E2E runtime has been prepared.
This slows feedback from two real Gateway-backed media workflows.

## Why This Change Was Made

Use the existing prepared-repository CLI helper in these two tests while keeping
every real CLI launch, independent fixture, assertion, deadline and cleanup.
The shared helper and production code are unchanged; a separately reviewed
predicate-parameter rename also resolves an existing lint error exposed by the
required changed-file checks.

## User Impact

Shorter local media QA feedback without reducing coverage. No product behavior,
dependency, test concurrency or timeout changes, and no claimed CI speedup.

## Evidence

One complete original/candidate/closing-original bracket per owner on Linux,
Node 24.19.0, using the runtime prepared at base `3e973bed5289`, with all six
case executions passing and zero skips:

| Complete invocation | Original | Candidate | Closing original |
| --- | ---: | ---: | ---: |
| Image-generation lifecycle | 116.086s | 110.667s | 115.999s |
| Vision channel offload | 113.058s | 107.687s | 112.738s |

These are bounded local shared-host observations, not a statistical or CI
estimate. Real runtime/UI preparation was outside the measurements; normal
worker preparation remained inside. Fresh per-leg caches and strict
source/dependency/artifact identities were retained. Fingerprinting warms OS
caches, and observer overhead was not independently measured. No avoided-build
claim is made.

- Coverage stays intact: IMAGE retains duplicate-request handling, one provider
  call, task/provenance assertions, exact image delivery and the final quiet
  window. VISION retains ordered model calls, image offload, message assertions
  and exactly one outbound reply.
- Separate grouped original/candidate diagnostic controls each passed both
  cases: ten outer operations and twelve actual inner CLI starts, including
  both real completion auxiliaries. Independent comparison matched all twelve
  CLI pairs and 26 selected environment fields, plus 111 selected load events
  and 19 captured payloads byte-for-byte within owner/process/thread roles.
- The 142 application streams per route retained matching broader recorded
  source-hash multisets. Six nested SQLite environment differences and 118
  readonly-helper argv suffix differences remain explicit; this is not a
  universal environment, module-set or load-order equivalence claim.
- Recorded Gateway processes, groups and listeners were drained before owned
  root deletion; final QA and worker roots were absent. Diagnostic preloading
  changes the loader path, so these controls are not additional timing samples.
- After measurements and controls, only an inner predicate parameter and its
  two references were renamed from `request` to `snapshot`. Reversing those
  three lines reproduces the measured IMAGE source exactly. The final IMAGE
  bytes were not benchmarked again; the rename was independently reviewed as
  behavior-neutral. Final scope is two files, +7/-5.
- Required changed checks are complete in aggregate: the initial run passed
  fourteen stages, including root-test typechecking and scripts lint, then
  failed its final scoped lint on that pre-existing shadow. After the rename,
  the exact two-file lint command, IMAGE format-check and diff-check passed.
  The original failure remains recorded; green stages were not repeated.
- Fresh independent P2 review of the complete final two-file diff:
  scoped-clean, no findings, with native capture, scanning and final source
  verification completed.
- Exact-head required CI passed: https://github.com/openclaw/openclaw/actions/runs/34390263206/job/102604763579
