### PR TITLE
fix(macos): keep Apple Event permission probes off the cooperative thread pool

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppleEventPermission.swift
+++ b/apps/macos/Sources/OpenClaw/AppleEventPermission.swift
@@ -12,13 +12,113 @@ enum AppleEventPermissionState: Equatable, Sendable {
     case failed(OSStatus)
 }
 
+/// Runs the blocking Apple Event permission check off the Swift cooperative
+/// thread pool and coalesces concurrent callers onto one in-flight probe.
+///
+/// `AEDeterminePermissionToAutomateTarget` blocks the calling thread until the
+/// target app answers (and, when asking, until the user answers tccd). Running
+/// it from `Task.detached` pins a cooperative-pool thread for that whole time.
+/// Node refreshes fire from several notifications, so a slow target under load
+/// stacked enough blocked probes to exhaust the pool; every other async task in
+/// the app (gateway websocket receive, status item, node commands) then stalled
+/// until the process was killed. Dispatching to a dedicated serial queue keeps
+/// the pool free, single-flighting bounds the number of blocked threads to one,
+/// and a timeout on passive checks turns a hung probe into `.failed` instead of
+/// a wedge.
+actor AppleEventPermissionProbeCoordinator {
+    typealias DeterminePermission = AppleEventPermissionProbe.DeterminePermission
+
+    static let shared = AppleEventPermissionProbeCoordinator()
+
+    private let queue = DispatchQueue(
+        label: "ai.openclaw.apple-event-permission",
+        qos: .userInitiated)
+    private var inFlight: [Bool: Task<OSStatus, Never>] = [:]
+
+    init() {}
+
+    func status(
+        askUserIfNeeded: Bool,
+        timeout: Duration?,
+        determinePermission: @escaping DeterminePermission) async -> OSStatus
+    {
+        if let pending = self.inFlight[askUserIfNeeded] {
+            return await pending.value
+        }
+        let queue = self.queue
+        let task = Task<OSStatus, Never> {
+            await Self.determine(
+                askUserIfNeeded: askUserIfNeeded,
+                timeout: timeout,
+                on: queue,
+                determinePermission: determinePermission)
+        }
+        self.inFlight[askUserIfNeeded] = task
+        let status = await task.value
+        if self.inFlight[askUserIfNeeded] == task {
+            self.inFlight[askUserIfNeeded] = nil
+        }
+        return status
+    }
+
+    private static func determine(
+        askUserIfNeeded: Bool,
+        timeout: Duration?,
+        on queue: DispatchQueue,
+        determinePermission: @escaping DeterminePermission) async -> OSStatus
+    {
+        let box = ResumeOnce()
+        return await withCheckedContinuation { (continuation: CheckedContinuation<OSStatus, Never>) in
+            box.attach(continuation)
+            queue.async {
+                box.resume(with: determinePermission(askUserIfNeeded))
+            }
+            guard let timeout else { return }
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout.dispatchInterval) {
+                box.resume(with: AppleEventPermissionProbe.timedOutStatus)
+            }
+        }
+    }
+
+    private final class ResumeOnce: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<OSStatus, Never>?
+
+        func attach(_ continuation: CheckedContinuation<OSStatus, Never>) {
+            self.lock.withLock { self.continuation = continuation }
+        }
+
+        func resume(with status: OSStatus) {
+            let continuation = self.lock.withLock {
+                defer { self.continuation = nil }
+                return self.continuation
+            }
+            continuation?.resume(returning: status)
+        }
+    }
+}
+
 struct AppleEventPermissionProbe: Sendable {
     typealias DeterminePermission = @Sendable (_ askUserIfNeeded: Bool) -> OSStatus
 
-    private let determinePermission: DeterminePermission
+    /// Passive (non-prompting) checks should answer well within this; a target
+    /// app that does not service Apple Events for longer is reported as
+    /// `.failed(errAETimeout)`, which the capability layer maps to `.unknown`.
+    static let defaultPassiveTimeout: Duration = .seconds(10)
+    static let timedOutStatus = OSStatus(errAETimeout)
 
-    init(determinePermission: @escaping DeterminePermission) {
+    private let determinePermission: DeterminePermission
+    private let passiveTimeout: Duration?
+    private let coordinator: AppleEventPermissionProbeCoordinator
+
+    init(
+        determinePermission: @escaping DeterminePermission,
+        passiveTimeout: Duration? = Self.defaultPassiveTimeout,
+        coordinator: AppleEventPermissionProbeCoordinator = .shared)
+    {
         self.determinePermission = determinePermission
+        self.passiveTimeout = passiveTimeout
+        self.coordinator = coordinator
     }
 
     static var live: Self {
@@ -28,10 +128,11 @@ struct AppleEventPermissionProbe: Sendable {
     }
 
     func state(askUserIfNeeded: Bool) async -> AppleEventPermissionState {
-        let determinePermission = self.determinePermission
-        let status = await Task.detached(priority: .userInitiated) {
-            determinePermission(askUserIfNeeded)
-        }.value
+        // Prompting waits on the user; only passive checks are bounded.
+        let status = await self.coordinator.status(
+            askUserIfNeeded: askUserIfNeeded,
+            timeout: askUserIfNeeded ? nil : self.passiveTimeout,
+            determinePermission: self.determinePermission)
         return Self.state(for: status)
     }
 
@@ -159,5 +260,13 @@ enum TerminalAutomationPermission {
     @MainActor
     private static func openAutomationSettings() {
         SystemSettingsURLSupport.openFirst(SystemSettingsURLSupport.settingsCandidates(for: .appleScript))
+    }
+}
+
+extension Duration {
+    fileprivate var dispatchInterval: DispatchTimeInterval {
+        let (seconds, attoseconds) = self.components
+        let nanoseconds = seconds * 1_000_000_000 + attoseconds / 1_000_000_000
+        return .nanoseconds(Int(clamping: nanoseconds))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/AppleEventPermissionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppleEventPermissionTests.swift
@@ -24,6 +24,64 @@ struct AppleEventPermissionTests {
         #expect(recorder.snapshot().mainThreadCalls == [false])
     }
 
+    @Test func `concurrent passive checks share one blocking probe`() async {
+        let gate = BlockingProbeGate(status: noErr)
+        let probe = AppleEventPermissionProbe(
+            determinePermission: gate.determine,
+            passiveTimeout: .seconds(5),
+            coordinator: AppleEventPermissionProbeCoordinator())
+
+        let states = await withTaskGroup(of: AppleEventPermissionState.self) { group in
+            for _ in 0..<32 {
+                group.addTask { await probe.state(askUserIfNeeded: false) }
+            }
+            // Every caller is parked on the single in-flight probe; nothing else may block.
+            await gate.waitUntilEntered()
+            gate.release()
+            var collected: [AppleEventPermissionState] = []
+            for await state in group { collected.append(state) }
+            return collected
+        }
+
+        #expect(states.count == 32)
+        #expect(states.allSatisfy { $0 == .authorized })
+        #expect(gate.callCount == 1)
+    }
+
+    @Test func `a hung passive probe times out instead of blocking callers`() async {
+        let gate = BlockingProbeGate(status: noErr)
+        let probe = AppleEventPermissionProbe(
+            determinePermission: gate.determine,
+            passiveTimeout: .milliseconds(200),
+            coordinator: AppleEventPermissionProbeCoordinator())
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let state = await probe.state(askUserIfNeeded: false)
+        let elapsed = clock.now - start
+
+        #expect(state == .failed(OSStatus(errAETimeout)))
+        #expect(TerminalAutomationPermission.authorizationStatus(for: state) == .unknown)
+        #expect(elapsed < .seconds(3))
+        gate.release()
+    }
+
+    @Test func `interactive prompts are never timed out`() async {
+        let gate = BlockingProbeGate(status: noErr)
+        let probe = AppleEventPermissionProbe(
+            determinePermission: gate.determine,
+            passiveTimeout: .milliseconds(50),
+            coordinator: AppleEventPermissionProbeCoordinator())
+
+        async let pending = probe.state(askUserIfNeeded: true)
+        await gate.waitUntilEntered()
+        try? await Task.sleep(for: .milliseconds(300))
+        gate.release()
+
+        #expect(await pending == .authorized)
+        #expect(gate.callCount == 1)
+    }
+
     @Test func `target not running is an unknown capability state`() {
         #expect(TerminalAutomationPermission.authorizationStatus(for: .authorized) == .granted)
         #expect(TerminalAutomationPermission.authorizationStatus(for: .notDetermined) == .notGranted)
@@ -175,5 +233,44 @@ private final class PermissionUIRecorder {
 
     func openSettings() {
         self.settingsCount += 1
+    }
+}
+
+/// Blocks inside `determine` until released, mimicking `AEDeterminePermissionToAutomateTarget`
+/// waiting on a target app or on tccd.
+private final class BlockingProbeGate: @unchecked Sendable {
+    private let status: OSStatus
+    private let entered = DispatchSemaphore(value: 0)
+    private let gate = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var calls = 0
+
+    init(status: OSStatus) {
+        self.status = status
+    }
+
+    var callCount: Int {
+        self.lock.withLock { self.calls }
+    }
+
+    func determine(askUserIfNeeded _: Bool) -> OSStatus {
+        self.lock.withLock { self.calls += 1 }
+        self.entered.signal()
+        self.gate.wait()
+        return self.status
+    }
+
+    func waitUntilEntered() async {
+        let entered = self.entered
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                entered.wait()
+                continuation.resume()
+            }
+        }
+    }
+
+    func release() {
+        self.gate.signal()
     }
 }


### PR DESCRIPTION
## What Problem This Solves

On 2026.9.3 the macOS app periodically goes dead while still running: the paired node shows **offline** in the Gateway dashboard although the Mac is on and the TCP session to the Gateway is still ESTABLISHED (32 KB of unread bytes sitting in the receive queue), the menu bar item stops opening its menu, and the process ignores SIGTERM (needs SIGKILL). It "fixes itself" only when the app is relaunched.

## Root cause

`AppleEventPermissionProbe.state` runs the blocking `AEDeterminePermissionToAutomateTarget` in `Task.detached`, which schedules onto the Swift cooperative thread pool. The call blocks until Terminal answers the Apple Event handshake (and, when `askUserIfNeeded`, until the user answers tccd). `MacNodeModeCoordinator` re-probes permissions on every refresh trigger (`UserDefaults.didChangeNotification`, config change, permissions change, app activation, reconnect probe), so a slow Terminal under system load lets probes stack up.

A 3 s `sample` of the wedged process showed **all 16 cooperative threads** parked here, main thread idle:

```
DispatchQueue_18: com.apple.root.user-initiated-qos.cooperative
  closure #1 in AppleEventPermissionProbe.state(askUserIfNeeded:)
    AppleEventPermissionProbe.determineTerminalPermission(askUserIfNeeded:)
      AEDeterminePermissionToAutomateTarget
        _dispatch_semaphore_wait_slow
          semaphore_wait_trap
```

Terminal automation was already **granted** in TCC (`kTCCServiceAppleEvents ai.openclaw.mac → com.apple.Terminal = 2`), so this was not a pending prompt. Once the pool is exhausted nothing async in the app can run, including the gateway websocket receive and the status item, and any continuation the AE reply needs can never be scheduled.

## Fix

- Run the blocking probe on a dedicated `DispatchQueue` (concurrent, so a prompt is never queued behind a hung passive check), bridged with a `CheckedContinuation`, so it never pins a cooperative thread.
- Single-flight concurrent callers per `askUserIfNeeded` value through a small actor (`AppleEventPermissionProbeCoordinator`), so at most one probe blocks at a time regardless of how many refreshes fire.
- Bound passive (non-prompting) probes with a 10 s timeout that surfaces as `.failed(errAETimeout)` → capability `.unknown`, instead of hanging the caller. Prompting probes keep waiting on the user.

No change to call sites; `AppleEventPermissionProbe.live` and `TerminalAutomationPermission` keep their API.

## Evidence

- `concurrent passive checks share one blocking probe`: 32 concurrent passive `state` calls → exactly one `determine` call, all callers get the result.
- `a hung passive probe times out instead of blocking callers`: a `determine` that never returns yields `.failed(errAETimeout)` in ~200 ms with a 200 ms timeout.
- `interactive prompts are never timed out`.
- Existing suite unchanged and green (12/12).
- Live observation, 2026-09-09: reproduced twice on the same Mac (2026.9.3 release build). Both times `netstat -anv -p tcp` showed the OpenClaw-owned socket to the Gateway ESTABLISHED with 32,778 and 52,617 bytes in Recv-Q, and `sample <pid> 2` showed 16 and 17 frames in `AEDeterminePermissionToAutomateTarget`. The second occurrence started within 60 s of a Gateway restart, i.e. on the reconnect refresh path. `pkill -9` + relaunch cleared it each time.

`swift build --package-path apps/macos --build-system native --build-tests` ✅, `scripts/format-swift.sh macos` ✅, `scripts/lint-swift.sh macos` ✅ (Xcode 26.6 / Swift 6.3.3).

## Review follow-up (revision 3)

Both P2 findings are addressed:

- **Retain the in-flight operation after a caller times out.** The coordinator now keeps the operation in `inFlight` until the native call actually returns. Caller deadlines are measured from the operation's start, so once the deadline has passed later passive callers answer `errAETimeout` immediately and never enqueue a second native call. When the target replies, the tracked operation drains and the next probe runs fresh. Covered by the new test `timed-out callers never enqueue a second native call behind the hung one` (second caller answers in < 150 ms with `callCount == 1`, operation still in flight; after release the next probe runs and `callCount == 2`).
- **Synchronize overlapping callers before releasing the test probe.** The concurrency test now waits until all 32 callers are parked on the coordinator (`waiterCount == 32`) before releasing, and `BlockingProbeGate.release()` opens the gate permanently so every native call a test started completes during cleanup.

The probe queue is concurrent so an interactive prompt is never queued behind a hung passive check.

## After-fix native proof

Debug build of this branch on a second Mac (macOS 26.4.1, Xcode 26.6), run in a throwaway app profile pointed at a remote Gateway URL that refuses connections (so every reconnect attempt builds a manifest and evaluates permissions). Terminal.app, the Apple Event target, was frozen with `SIGSTOP` so the probe could not get a reply, then resumed with `SIGCONT`. The passive probe returned `noErr` on this host: its TCC database already holds an allowed `kTCCServiceAppleEvents` row for bundle id `ai.openclaw.mac` → `com.apple.Terminal`, which the debug build shares, so recovery shows as a normal `returned 0`.

| Phase | `sample` probe frames | Cooperative-pool frames in the probe | `openclaw-mac status` (control socket) |
|---|---|---|---|
| Baseline | 0 | 0 | ok |
| Terminal frozen, 55 s | 1, on `DispatchQueue: ai.openclaw.apple-event-permission (concurrent)` | 0 | ok |
| Terminal resumed, 50 s later | 0 | 0 | ok |

Unified log (`ai.openclaw`/`AppleEventPermissionProbe`), timestamps relative to the freeze:

```
-27 s  I  probe ask=false returned 0 after 0.172922083 seconds
-19 s  I  probe ask=false returned 0 after 0.033881875 seconds
-10 s  I  probe ask=false returned 0 after 0.208797417 seconds
  0 s     Terminal.app frozen (SIGSTOP)
+17 s  E  probe ask=false timed out after 10.0 seconds; operation retained
+58 s     Terminal.app resumed (SIGCONT)
+58 s  I  probe ask=false returned 0 after 50.992712958 seconds
+66 s  I  probe ask=false returned 0 after 0.032903625 seconds
+97 s  I  probe ask=false returned 0 after 0.137408166 seconds
```

No second native call started while the first was hung (the only lines between the freeze and the resume are the single timeout), the retained call returned as soon as Terminal answered, and the probes after it ran fresh.

The app answered its control socket throughout, kept exactly one blocked thread (on the private queue, never the cooperative pool), released it when Terminal answered, and quit within 1 s of `SIGTERM` afterwards. On the release build the same condition ends with 13 to 17 cooperative threads blocked, a dead status menu, and `SIGTERM` ignored (openclaw/openclaw#146030).

Filtered test run (`swift test --filter AppleEventPermissionTests`, private HOME, throwaway profile, `--skip-build`): 13 tests, 0 failures. Full native suite left to the `macos-swift` CI job per `apps/macos/AGENTS.md`.

### Signed-bundle run (signing provenance)

The run above used the bare SwiftPM debug binary (ad-hoc signed). Repeated on the same Mac with a full `scripts/package-mac-app.sh` bundle of head `621a4a4d8`, signed through `scripts/codesign-mac-app.sh` with a real Apple Development certificate and kept at the fixed path the permissions guide asks for (`<checkout>/dist/OpenClaw.app`). Provenance, identity details redacted:

```
Identifier=ai.openclaw.mac.debug
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 flags=0x10000(runtime)
Authority=Apple Development: <redacted>
Authority=Apple Worldwide Developer Relations Certification Authority
Authority=Apple Root CA
TeamIdentifier=<redacted, set>
Sealed Resources version=2 rules=13 files=42384
codesign --verify --deep --strict: OK
```

`ai.openclaw.mac.debug` has no Automation grant on this Mac, so the passive probe's real answer is `-1744` (`errAEEventWouldRequireUserConsent`), returned without a prompt once Terminal answers. Same procedure (throwaway profile, refusing Gateway URL, Terminal `SIGSTOP` for 55 s, then `SIGCONT`):

| Phase | `sample` probe frames | Cooperative-pool frames in the probe | `openclaw-mac status` (control socket) |
|---|---|---|---|
| Baseline | 0 | 0 | ok |
| Terminal frozen, 55 s | 1, on the private queue | 0 | ok |
| Terminal resumed, 50 s later | 0 | 0 | ok |

```
-28 s  I  probe ask=false returned -1744 after 0.207445334 seconds
  0 s     Terminal.app frozen (SIGSTOP)
+14 s  E  probe ask=false timed out after 10.0 seconds; operation retained
+58 s     Terminal.app resumed (SIGCONT)
+58 s  I  probe ask=false returned -1744 after 54.768811875 seconds
```

One blocked native call, no second call queued behind it, bounded caller wait, control socket answering throughout, the retained call returning the moment Terminal resumed, and the app quitting within 1 s of `SIGTERM` afterwards.

## Release note

Fix the macOS app wedging (node offline while TCP alive, menu bar item unresponsive, ignores SIGTERM) when concurrent Terminal Automation permission probes exhausted the Swift cooperative thread pool.

Diagnosed and written with Claude Code: https://claude.ai/code/session_014TmTvgdhcL7bPCwg3f8B6G
Review follow-up, after-fix proof, and this revision: https://claude.ai/code/session_01RW45HgmUaFSiM4DSZGrVSp


