### PR TITLE
fix: prevent cold history planning from blocking the Gateway

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -38,13 +38,15 @@ admission. Publish live session changes and other dependent effects only after
 the durable write succeeds. A future network-backed owner must preserve that
 ordering while awaiting its driver.
 
-Explicit session deletion and lifecycle-artifact cleanup prepare their plans
-inside the session writer queue. When the parent database handle is cold, its
+Explicit session deletion, lifecycle-artifact cleanup, and history disk-budget
+eviction prepare their plans inside the session writer queue. When the parent database handle is cold, its
 existing asynchronous admission owner runs the full integrity and foreign-key
 checks in a read-only child, moving those full checks off the main thread while
 retaining that queue position. A supplied caller guard is rechecked before the open
 resumes into index repair, schema work, or registration, and before that caller
-uses the admitted handle. Coalesced callers retain their own guards.
+uses the admitted handle. Coalesced callers retain their own guards. History
+eviction also uses this admission when reopening after archive materialization,
+then rereads candidate protection before preparing reclamation.
 
 Session reclamation keeps its deletion transaction on a worker connection.
 The worker opens its database under the session writer, then releases that writer

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -11,12 +11,9 @@ import { deletePersonalGitHubSessionReceipts } from "../../state/github-personal
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   deferOpenClawAgentPostCommitPublication,
-  getOpenClawAgentDatabaseIfOpen,
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
-  withOpenClawAgentDatabaseAsync,
   type OpenClawAgentDatabase,
-  type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import { resolveStateDir } from "../paths.js";
 import type { ResetSessionEntryLifecycleMutation } from "./session-accessor.lifecycle-types.js";
@@ -72,6 +69,7 @@ import {
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
   type ResolvedSqliteReadScope,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
@@ -91,19 +89,6 @@ function captureLifecycleDatabaseScope<T extends ResolvedSqliteReadScope>(scope:
     env,
     path: resolveOpenClawAgentSqlitePath(toDatabaseOptions({ ...scope, env })),
   };
-}
-
-function withLifecycleDatabase<T>(
-  options: OpenClawAgentDatabaseOptions,
-  operation: (database: OpenClawAgentDatabase) => T,
-  assertCurrent?: () => void,
-): T | Promise<T> {
-  assertCurrent?.();
-  if (getOpenClawAgentDatabaseIfOpen(options)) {
-    return operation(openOpenClawAgentDatabase(options));
-  }
-  // The caller keeps its FIFO section while the existing owner joins the integrity child.
-  return withOpenClawAgentDatabaseAsync(options, operation, assertCurrent);
 }
 
 async function withCommittedHistoryMaintenance<T>(
@@ -157,7 +142,7 @@ export async function cleanupSessionLifecycleArtifactsCore(
     return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
   }
   const cleanupPlan = await runExclusiveSqliteSessionWrite(resolved, async () =>
-    withLifecycleDatabase(databaseOptions, (database) =>
+    withSqliteSessionDatabase(databaseOptions, (database) =>
       planSessionLifecycleArtifactCleanup(database, {
         ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
         archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
@@ -339,7 +324,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const databaseOptions = toDatabaseOptions(resolved);
   const prepared = await runExclusiveSqliteSessionWrite(resolved, async () =>
-    withLifecycleDatabase(
+    withSqliteSessionDatabase(
       databaseOptions,
       (database) => {
         const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
@@ -440,7 +425,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
       for (const sessionId of prepared.historicalGenerationIds) {
         const plan = await runExclusiveSqliteSessionWrite(resolved, async () =>
-          withLifecycleDatabase(
+          withSqliteSessionDatabase(
             databaseOptions,
             (database) => {
               const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
@@ -490,7 +475,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
             async () =>
-              withLifecycleDatabase(
+              withSqliteSessionDatabase(
                 databaseOptions,
                 (database) => {
                   const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -18,8 +18,11 @@ import { runQueuedStoreWrite, type StoreWriterTiming } from "../../shared/store-
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
   resolveIncognitoOpenClawAgentSqlitePath,
   resolveOpenClawAgentSqlitePath,
+  withOpenClawAgentDatabaseAsync,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
@@ -118,6 +121,19 @@ export function transcriptWriteScopeIsCurrent(
 
 export function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+export function withSqliteSessionDatabase<T>(
+  options: OpenClawAgentDatabaseOptions,
+  operation: (database: OpenClawAgentDatabase) => T,
+  assertCurrent?: () => void,
+): T | Promise<T> {
+  assertCurrent?.();
+  if (getOpenClawAgentDatabaseIfOpen(options)) {
+    return operation(openOpenClawAgentDatabase(options));
+  }
+  // The caller keeps its FIFO section while the existing owner joins the integrity child.
+  return withOpenClawAgentDatabaseAsync(options, operation, assertCurrent);
 }
 
 export async function runExclusiveSqliteSessionWrite<T>(

--- a/src/config/sessions/session-history-eviction.admission.test.ts
+++ b/src/config/sessions/session-history-eviction.admission.test.ts
@@ -1,0 +1,313 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import * as sqlite from "../../infra/node-sqlite.js";
+import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import { isSessionLifecycleMutationActive } from "../../sessions/session-lifecycle-admission.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  appendTranscriptMessage,
+  loadSessionEntryReadOnly,
+  loadTranscriptEventsSync,
+  replaceSessionEntry,
+  resetSessionEntryLifecycle,
+} from "./session-accessor.js";
+import {
+  getSessionKysely,
+  runExclusiveSqliteSessionWrite,
+} from "./session-accessor.sqlite-scope.js";
+import { enforceSqliteSessionHistoryDiskBudget } from "./session-history-eviction.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const hook = vi.hoisted(() => ({
+  beforePlan: undefined as (() => Promise<void>) | undefined,
+  afterMaterialize: undefined as (() => Promise<void>) | undefined,
+}));
+vi.mock("../../sessions/session-lifecycle-admission.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../sessions/session-lifecycle-admission.js")>();
+  return {
+    ...actual,
+    runExclusiveSessionLifecycleMutation: <T>(
+      params: Parameters<typeof actual.runExclusiveSessionLifecycleMutation<T>>[0],
+    ) =>
+      actual.runExclusiveSessionLifecycleMutation({
+        ...params,
+        run: async () => {
+          await hook.beforePlan?.();
+          return params.run();
+        },
+      }),
+  };
+});
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    materializeSessionStateDeletePlans: async (
+      ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
+    ) => {
+      const result = await actual.materializeSessionStateDeletePlans(...args);
+      await hook.afterMaterialize?.();
+      return result;
+    },
+  };
+});
+
+let testState: OpenClawTestState;
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realOpen = sqlite.openNodeSqliteDatabase;
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    prefix: "history-cold-parent-repro-",
+    layout: "state-only",
+  });
+});
+
+afterEach(async () => {
+  releases.splice(0).forEach((release) => release());
+  await Promise.allSettled(pending.splice(0));
+  hook.beforePlan = undefined;
+  hook.afterMaterialize = undefined;
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  await testState.cleanup();
+});
+
+function own<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  void promise.catch(() => {});
+  return promise;
+}
+
+it.each([
+  { boundary: "initial", cold: false, outcome: "reclaim" },
+  { boundary: "initial", cold: true, outcome: "reclaim" },
+  { boundary: "replan", cold: false, outcome: "reclaim" },
+  { boundary: "replan", cold: true, outcome: "reclaim" },
+  { boundary: "initial", cold: true, outcome: "protected" },
+  { boundary: "replan", cold: true, outcome: "protected" },
+  { boundary: "initial", cold: true, outcome: "revoked" },
+  { boundary: "replan", cold: true, outcome: "revoked" },
+] as const)(
+  "keeps $boundary history preparation and $outcome inside its writer FIFO (cold: $cold)",
+  async ({ boundary: preparationBoundary, cold, outcome }) => {
+    const sessionsDir = testState.sessionsDir();
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:cold-history-repro";
+    const oldSessionId = "old-generation";
+    const currentSessionId = "current-generation";
+    const dayMs = 24 * 60 * 60 * 1000;
+    const oldAt = Date.now() - 8 * dayMs;
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: oldSessionId, updatedAt: oldAt },
+    );
+    await appendTranscriptMessage(
+      { sessionKey, sessionId: oldSessionId, storePath },
+      {
+        message: { role: "user", content: "synthetic historical payload " + "x".repeat(64 * 1024) },
+      },
+    );
+    await resetSessionEntryLifecycle({
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+      buildNextEntry: () => ({ sessionId: currentSessionId, updatedAt: oldAt + 1 }),
+    });
+    const target = resolveSqliteTargetFromSessionStorePath(storePath);
+    const options = { agentId: target.agentId ?? "main", path: target.path };
+    const database = openOpenClawAgentDatabase(options);
+    const historyBefore = loadTranscriptEventsSync({
+      sessionKey,
+      sessionId: oldSessionId,
+      storePath,
+    });
+    expect(historyBefore.length).toBeGreaterThan(0);
+    const currentEntry = loadSessionEntryReadOnly({ sessionKey, storePath });
+    expect(currentEntry).toMatchObject({ sessionId: currentSessionId });
+    // Synthetic bootstrap fixes victim age; it does not change the cleanup algorithm.
+    database.db
+      .prepare("UPDATE session_windows SET updated_at = ? WHERE session_id = ?")
+      .run(oldAt, oldSessionId);
+    database.walMaintenance.checkpoint();
+    const peerBytes = 2 * 1024 * 1024;
+    fs.writeFileSync(path.join(sessionsDir, "synthetic-pressure.bin"), Buffer.alloc(peerBytes));
+    const { measureSessionPhysicalDiskUsage } = await import("./disk-budget.js");
+    const before = await measureSessionPhysicalDiskUsage(storePath);
+
+    const events: string[] = [];
+    let observingAdmission = false;
+    let parentChecks = 0;
+    let childChecks = 0;
+    let laterWriterRan = false;
+    const preparationReady = createDeferred();
+    const blockerEntered = createDeferred();
+    const releaseBlocker = createDeferred();
+    const childEntered = createDeferred();
+    const releaseChild = createDeferred();
+    releases.push(
+      () => releaseBlocker.resolve(),
+      () => releaseChild.resolve(),
+    );
+
+    vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, openOptions) => {
+      const opened = realOpen(pathname, openOptions);
+      if (pathname === database.path && !openOptions?.readOnly) {
+        const prepare = opened.prepare.bind(opened);
+        opened.prepare = (sql) => {
+          const statement = prepare(sql);
+          if (sql === "PRAGMA integrity_check;") {
+            const all = statement.all.bind(statement);
+            statement.all = () => {
+              if (observingAdmission) {
+                parentChecks += 1;
+                events.push("parent-full-integrity-check");
+              }
+              return all();
+            };
+          }
+          return statement;
+        };
+      }
+      return opened;
+    });
+    vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation((...args) => {
+      const check = realIntegrity(...args);
+      if (!observingAdmission || args[0] !== database.path) {
+        return check;
+      }
+      childChecks += 1;
+      events.push("child-integrity-entered");
+      childEntered.resolve();
+      return Promise.all([check, releaseChild.promise]).then(() => undefined);
+    });
+
+    const beforePreparation = async () => {
+      hook.beforePlan = undefined;
+      hook.afterMaterialize = undefined;
+      events.push("preparation-ready");
+      expect(database.db.isTransaction).toBe(false);
+      if (cold) {
+        closeOpenClawAgentDatabaseByPath(database.path);
+        expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+        events.push("parent-handle-closed");
+      }
+      observingAdmission = true;
+      void own(
+        runExclusiveSqliteSessionWrite(options, async () => {
+          events.push("blocker-entered");
+          blockerEntered.resolve();
+          await releaseBlocker.promise;
+          events.push("blocker-released");
+        }),
+      );
+      await blockerEntered.promise;
+      preparationReady.resolve();
+    };
+    if (preparationBoundary === "initial") {
+      hook.beforePlan = beforePreparation;
+    } else {
+      hook.afterMaterialize = beforePreparation;
+    }
+
+    const work = own(
+      enforceSqliteSessionHistoryDiskBudget({
+        storePath,
+        mode: "enforce",
+        maintenance: {
+          maxDiskBytes: before.totalBytes - 1,
+          highWaterBytes: before.totalBytes - peerBytes / 2,
+          preserveRecentMs: 7 * dayMs,
+        },
+      }),
+    );
+    await preparationReady.promise;
+    await yieldToEventLoop();
+    const laterWriter = own(
+      runExclusiveSqliteSessionWrite(options, async () => {
+        laterWriterRan = true;
+        events.push("later-writer");
+      }),
+    );
+    expect(laterWriterRan).toBe(false);
+    releaseBlocker.resolve();
+    const boundary = await Promise.race([
+      childEntered.promise.then(() => "child" as const),
+      work.then(() => "completed" as const),
+    ]);
+    if (boundary === "child") {
+      await yieldToEventLoop();
+      expect(laterWriterRan).toBe(false);
+      expect(isSessionLifecycleMutationActive(storePath, [oldSessionId])).toBe(true);
+      if (outcome === "protected") {
+        // A peer connection can refresh the live entry while the parent validates.
+        const peer = realOpen(database.path);
+        try {
+          const updatedAt = Date.now();
+          executeSqliteQuerySync(
+            peer,
+            getSessionKysely(peer)
+              .updateTable("session_nodes")
+              .set({
+                updated_at: updatedAt,
+                entry_json: JSON.stringify({ ...currentEntry, updatedAt }),
+              })
+              .where("session_key", "=", sessionKey),
+          );
+          // Match the canonical writer's validity settlement after its payload/projection update.
+          executeSqliteQuerySync(
+            peer,
+            getSessionKysely(peer)
+              .updateTable("session_nodes")
+              .set({ entry_valid: 1 })
+              .where("session_key", "=", sessionKey),
+          );
+        } finally {
+          peer.close();
+        }
+      } else if (outcome === "revoked") {
+        closeOpenClawAgentDatabaseByPath(database.path);
+      }
+    }
+    releaseChild.resolve();
+    if (outcome === "revoked") {
+      await expect(work).rejects.toThrow(/revoked/);
+      expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+    } else {
+      await expect(work).resolves.toMatchObject({
+        removedEntries: outcome === "reclaim" ? 1 : 0,
+      });
+    }
+    await laterWriter;
+    observingAdmission = false;
+    expect(boundary).toBe(cold ? "child" : "completed");
+    expect(events.indexOf("later-writer")).toBeGreaterThan(events.indexOf("blocker-released"));
+    expect(parentChecks).toBe(0);
+    expect(childChecks).toBe(cold ? 1 : 0);
+    expect(isSessionLifecycleMutationActive(storePath, [oldSessionId])).toBe(false);
+    expect(loadSessionEntryReadOnly({ sessionKey, storePath })).toMatchObject({
+      sessionId: currentSessionId,
+    });
+    if (outcome !== "reclaim") {
+      expect(loadTranscriptEventsSync({ sessionKey, sessionId: oldSessionId, storePath })).toEqual(
+        historyBefore,
+      );
+    }
+  },
+);

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -39,6 +39,7 @@ import {
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
 } from "./session-accessor.sqlite-scope.js";
 import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import {
@@ -514,32 +515,32 @@ async function enforceSessionHistoryMaintenanceSerialized(
       scope: params.storePath,
       identities: [sessionId],
       run: async () => {
-        const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
-          // openclaw-agent-db.ts cache rule: LRU eviction closes idle handles across awaits.
-          const database = openOpenClawAgentDatabase(databaseOptions);
-          const protectedBeforeArchive = collectCandidateAdditionalProtection({
-            database,
-            preserveRecentMs: params.maintenance.preserveRecentMs,
-            sessionId,
-            storePath: params.storePath,
-          });
-          for (const referenced of readReferencedSessionIds(
-            database,
-            undefined,
-            [sessionId],
-            params.maintenance,
-          )) {
-            protectedBeforeArchive.add(referenced);
-          }
-          return planSessionStateDeleteIfUnreferenced({
-            archiveDirectory,
-            archiveTranscript: true,
-            database,
-            reason: "deleted",
-            referencedSessionIds: protectedBeforeArchive,
-            sessionId,
-          });
-        });
+        const plan = await runExclusiveSqliteSessionWrite(resolved, async () =>
+          withSqliteSessionDatabase(databaseOptions, (database) => {
+            const protectedBeforeArchive = collectCandidateAdditionalProtection({
+              database,
+              preserveRecentMs: params.maintenance.preserveRecentMs,
+              sessionId,
+              storePath: params.storePath,
+            });
+            for (const referenced of readReferencedSessionIds(
+              database,
+              undefined,
+              [sessionId],
+              params.maintenance,
+            )) {
+              protectedBeforeArchive.add(referenced);
+            }
+            return planSessionStateDeleteIfUnreferenced({
+              archiveDirectory,
+              archiveTranscript: true,
+              database,
+              reason: "deleted",
+              referencedSessionIds: protectedBeforeArchive,
+              sessionId,
+            });
+          }),
+        );
         if (!plan) {
           return null;
         }
@@ -550,25 +551,25 @@ async function enforceSessionHistoryMaintenanceSerialized(
           const diagnostics: SqliteSessionReclamationDiagnostics = {};
           const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
-            async () => {
-              const database = openOpenClawAgentDatabase(databaseOptions);
-              const protectedSessionIds = collectCandidateAdditionalProtection({
-                database,
-                preserveRecentMs: params.maintenance.preserveRecentMs,
-                sessionId,
-                storePath: params.storePath,
-              });
-              if (protectedSessionIds.has(sessionId)) {
-                return null;
-              }
-              return createHistoryEvictionReclamationPlan({
-                databaseOptions,
-                diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
-                materializedPlans: materialized,
-                protectedSessionIds,
-                sessionId,
-              });
-            },
+            async () =>
+              withSqliteSessionDatabase(databaseOptions, (database) => {
+                const protectedSessionIds = collectCandidateAdditionalProtection({
+                  database,
+                  preserveRecentMs: params.maintenance.preserveRecentMs,
+                  sessionId,
+                  storePath: params.storePath,
+                });
+                if (protectedSessionIds.has(sessionId)) {
+                  return null;
+                }
+                return createHistoryEvictionReclamationPlan({
+                  databaseOptions,
+                  diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
+                  materializedPlans: materialized,
+                  protectedSessionIds,
+                  sessionId,
+                });
+              }),
             diagnostics,
           );
           if (!reclamationPlan) {


### PR DESCRIPTION
Related: #143226, #143285.

## What Problem This Solves

Resolves a problem where history disk-budget eviction planning can pause the Gateway's main thread when its cached parent database handle becomes cold while waiting for lifecycle ownership or archive materialization.

## Why This Change Was Made

Both history-planning callbacks now use the existing guarded database acquisition flow used by explicit session deletion. The helper is shared through the session database scope module. Warm acquisition stays synchronous; cold acquisition runs full integrity and foreign-key checks in the existing read-only child while retaining the same writer FIFO and lifecycle ownership. Candidate protection is read from the admitted database after validation.

## User Impact

These two planning stages no longer run cold full-file validation on the Gateway's main thread. Retention, deletion, full validation, current authority checks, and reclamation Worker policy are unchanged. Candidate-discovery and archive-pruning cold opens remain separate follow-ups; this change does not remove Worker validation costs or establish a quantified production speedup.

## Evidence

- Independent P0–P2 autoreview of the final rebased candidate found no actionable findings, including publication-borrow lifetime, current authority, FIFO ordering, and fresh protection reads.
- The final changed-file gate passes, including core and test typechecks, lint, dependency/boundary guards, and runtime import-cycle checks.
- On the original source, both warm controls passed and both cold boundaries completed real cleanup but failed the off-main-thread admission assertion. The regression preserves the original queued-writer order.
- All 27 focused tests pass after rebasing onto #143285, covering both cold boundaries, warm acquisition, protection changes during validation, pending-open revocation, and existing lifecycle/database-authority contracts.
- A frozen Linux Blacksmith Testbox run passed 70 tests across five suites and the full `pnpm build`. The wrapper verified the source/tree and all five changed-file hashes; the lease stopped successfully. This proof preceded a patch-identical rebase, plus two mechanical test lint fixes. [Run context](https://github.com/openclaw/openclaw/actions/runs/34389789780).
- The Linux tests exercised real synthetic SQLite history, archive materialization, reclamation Workers, publication, and remeasurement through the maintenance owner. The cold-boundary wrappers call the real implementations. No CLI parser, managed Gateway, or production data was exercised.
