### PR TITLE
test(ui): tolerate subpixel attachment geometry

### DIFF
--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -304,7 +304,9 @@ suite.define(() => {
           const rect = element.getBoundingClientRect();
           return { x: rect.x, y: rect.y, height: rect.height, width: rect.width };
         });
-      expect(actionSkeletonSize).toEqual(openButtonSize);
+      for (const axis of ["x", "y", "width", "height"] as const) {
+        expect(Math.abs(actionSkeletonSize[axis] - openButtonSize[axis])).toBeLessThanOrEqual(0.5);
+      }
       const finalActionWidths = await page
         .locator(
           ".chat-assistant-attachment-card--compact .chat-assistant-attachment-card__actions",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the hosted Control UI FRV lane intermittently fails the media-files chat flow: the attachment action row and its loading skeleton are visually identical, but the exact `getBoundingClientRect()` equality assertion rejects them when the browser rounds layout geometry at subpixel boundaries. The flake blocks otherwise-green FRV runs. This is a maintainer-directed FRV repair, not generic test loosening.

## Why This Change Was Made

The assertion now compares `x`, `y`, `width`, and `height` per axis with a hard 0.5 px tolerance instead of exact equality. Subpixel rounding differences pass; any visible drift (≥ 1 px on any axis) still fails. No production code changes.

## User Impact

No user-visible behavior change. Maintainers and contributors get a reliable media-files FRV lane that no longer fails on rendering-identical geometry.

## Evidence

Fresh proof on head `24e2ae1e6af` after rebase onto current `main` (`64c96eff6f7`):

- Focused UI E2E file `ui/src/e2e/chat-flow.media-files.e2e.test.ts` via the repository UI E2E Vitest config: 1 file passed, 9/9 tests passed.
- `oxfmt --check` clean on the changed file; targeted oxlint clean; `git diff --check` clean.

Prior pre-rebase proof on the reviewed patch (identical diff): focused UI E2E 1 passed / 8 skipped; format, oxlint, and diff-check clean; independent P0–P2 review clean.
