### PR TITLE
fix: keep multi-agent session lists working after model fallback

### DIFF
--- a/src/gateway/server.sessions.store-paths.test.ts
+++ b/src/gateway/server.sessions.store-paths.test.ts
@@ -4,6 +4,7 @@ import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import * as sessionDirs from "../agents/session-dirs.js";
+import type { InternalSessionEntry } from "../config/sessions.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -52,25 +53,24 @@ test("sessions.list reads completed models from each physical agent store", asyn
     const sessionKey = `agent:${agentId}:main`;
     const storePath = storeTemplate.replace("{agentId}", agentId);
     const runId = `run-${agentId}`;
+    const entry: InternalSessionEntry = {
+      sessionId,
+      updatedAt: 10,
+      status: "done",
+      lastRunId: runId,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.4",
+      modelProvider: "openai",
+      model: "gpt-5.4",
+      fallbackNotice: {
+        kind: "active",
+        selectedModel: "openai/gpt-5.4",
+        activeModel: "anthropic/claude-sonnet-4-6",
+      },
+    };
     await writeSessionStore({
       agentId,
-      entries: {
-        [sessionKey]: {
-          sessionId,
-          updatedAt: 10,
-          status: "done",
-          lastRunId: runId,
-          providerOverride: "openai",
-          modelOverride: "gpt-5.4",
-          modelProvider: "openai",
-          model: "gpt-5.4",
-          fallbackNotice: {
-            kind: "active",
-            selectedModel: "openai/gpt-5.4",
-            activeModel: "anthropic/claude-sonnet-4-6",
-          },
-        },
-      },
+      entries: { [sessionKey]: entry },
       storePath,
     });
     const scope = { agentId, sessionId, sessionKey, storePath };

--- a/src/gateway/server.sessions.store-paths.test.ts
+++ b/src/gateway/server.sessions.store-paths.test.ts
@@ -4,7 +4,11 @@ import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import * as sessionDirs from "../agents/session-dirs.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  loadSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import * as agentDatabaseRegistry from "../state/openclaw-agent-db-registry.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -35,7 +39,7 @@ test("session RPC paths name the physical SQLite store", async () => {
   expect(patched).toMatchObject({ ok: true, payload: { path: databasePath } });
 });
 
-test("sessions.list reports multiple physical agent stores", async () => {
+test("sessions.list reads completed models from each physical agent store", async () => {
   const stateDir = process.env.OPENCLAW_STATE_DIR;
   if (!stateDir) {
     throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
@@ -44,18 +48,66 @@ test("sessions.list reports multiple physical agent stores", async () => {
   testState.sessionConfig = { store: storeTemplate };
   testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "ops" }] };
   for (const agentId of ["main", "ops"]) {
+    const sessionId = `session-${agentId}`;
+    const sessionKey = `agent:${agentId}:main`;
+    const storePath = storeTemplate.replace("{agentId}", agentId);
+    const runId = `run-${agentId}`;
     await writeSessionStore({
       agentId,
       entries: {
-        [`agent:${agentId}:main`]: { sessionId: `session-${agentId}`, updatedAt: 10 },
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 10,
+          status: "done",
+          lastRunId: runId,
+          providerOverride: "openai",
+          modelOverride: "gpt-5.4",
+          modelProvider: "openai",
+          model: "gpt-5.4",
+          fallbackNotice: {
+            kind: "active",
+            selectedModel: "openai/gpt-5.4",
+            activeModel: "anthropic/claude-sonnet-4-6",
+          },
+        },
       },
-      storePath: storeTemplate.replace("{agentId}", agentId),
+      storePath,
+    });
+    const scope = { agentId, sessionId, sessionKey, storePath };
+    await appendTranscriptEvent(scope, { type: "session", version: 3, id: sessionId });
+    await appendTranscriptMessage(scope, {
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: `Completed ${agentId}` }],
+        provider: agentId === "main" ? "anthropic" : "openai",
+        model: agentId === "main" ? "claude-sonnet-4-6" : "gpt-5.4",
+        stopReason: "stop",
+        __openclaw: { runId },
+      },
     });
   }
 
-  const listed = await directSessionReq<{ path: string }>("sessions.list", {});
-
-  expect(listed).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+  // A bad relative selector must stay inside the disposable fixture if it regresses.
+  const cwd = vi.spyOn(process, "cwd").mockReturnValue(stateDir);
+  try {
+    const listed = await directSessionReq<{
+      path: string;
+      sessions: Array<{ key: string; activeModelProvider?: string; activeModel?: string }>;
+    }>("sessions.list", {});
+    expect(listed).toMatchObject({ ok: true, payload: { path: "(multiple)" } });
+    expect(listed.payload?.sessions.find((row) => row.key === "agent:main:main")).toMatchObject({
+      activeModelProvider: "anthropic",
+      activeModel: "claude-sonnet-4-6",
+    });
+    expect(
+      listed.payload?.sessions.find((row) => row.key === "agent:ops:main")?.activeModel,
+    ).toBeUndefined();
+    expect(fsSync.readdirSync(stateDir).filter((name) => name.startsWith("(multiple)"))).toEqual(
+      [],
+    );
+  } finally {
+    cwd.mockRestore();
+  }
 });
 
 test.runIf(process.platform !== "win32")(

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -592,7 +592,7 @@ export async function listSessionsFromStoreAsync(
       const includeTranscriptFields = i < list.transcriptFieldRows;
       const row = buildGatewaySessionRow({
         cfg,
-        storePath: target.storeKey ? target.storeTarget.storePath : list.storePath,
+        storePath: target.storeTarget.storePath, // Aggregate paths are display-only.
         store,
         modelSource: target.modelSource,
         key: target.storeKey ?? key,


### PR DESCRIPTION
Related: #141396

## What Problem This Solves

Fixes an issue where users could not load session lists or Workboard when a completed session had a model fallback and the list combined multiple agent stores. Writable installations could instead silently omit the completed fallback model and create an unintended empty database.

## Why This Change Was Made

Each listed row already carries its resolved physical store target. Pass that target to row projection for every session, keeping the aggregate path label solely as response metadata. This repairs the producer of the transcript-read scope and preserves the existing completed-model projection.

## User Impact

Multi-agent session lists load successfully and show the completed model from the correct agent transcript. The same shared listing path serves Workboard, embedded session tools, and the TUI.

## Evidence

- A live `sessions.list` request reproduced SQLite `CANTOPEN` on a sealed installation. Failed-open tracing showed the aggregate display label being interpreted as a relative database filename.
- The extended two-store regression writes actual completed transcript messages through the SQLite accessor. It fails before the fix because the completed model disappears, then passes with correct per-agent model results and no aggregate-label database creation.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.store-paths.test.ts src/gateway/session-utils.test.ts`: 261 passed.
- `node scripts/check-changed.mjs -- src/gateway/session-utils-list.ts src/gateway/server.sessions.store-paths.test.ts`: passed, including core/core-test types, targeted lint and storage/import guards.
- Independent review: no actionable P0-P2 findings on the final staged candidate.
- Production change: +1/-1 line. No schema, configuration, or protocol change.

## Post-merge live verification

Deployed main `10e57bf8ab38e3e52ebd4bbb5c1dae5465c04191`, which includes merge `401f390d58b79022ad4eaa71633b025fda899c48`, through the canonical release owner. The deployment completed successfully.

Both the default `sessions.list` request and Workboard's exact lifecycle query returned populated session lists, including active-model metadata. `workboard.cards.list` also succeeded. The serving process and build identity remained stable throughout verification. Schema compatibility, enabled channel connectivity, and served Control UI asset parity passed.

The initial strict health sample reported CPU/event-loop utilization pressure after the session reads. A bounded follow-up on the same process passed strict channel and readiness checks with no degradation and no performance waiver. This is backend/RPC and static-asset proof; it does not claim authenticated rendered-browser coverage.

A further bounded log observation spanning more than three Workboard polling intervals found no database-open, session-list, or Workboard lifecycle failure on the same serving process.
