### PR TITLE
fix(ui): preserve native menus for adopted sessions

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -32,7 +32,6 @@ import {
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
-  buildCatalogSessionMenuRequest,
   formatSidebarTimestamp,
   normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
@@ -554,15 +553,16 @@ function renderCatalogSessionRow(
     mainKey: params.mainKey,
   });
   const { href, options: navigation } = target;
-  const catalogMenu = buildCatalogSessionMenuRequest({
-    catalog,
-    session,
+  const catalogMenu: CatalogSessionMenuRequest = {
     key: catalogKey,
     agentId: params.newSessionAgentId,
     routeId,
     navigation,
+    canOpenTerminal: session.canOpenTerminal === true,
+    canDelete: session.canArchive && catalog.capabilities.archive,
+    name: session.name ?? session.threadId,
     meta,
-  });
+  };
   const menuOpen = params.isMenuOpen(catalogKey);
   const rowRef = catalogRowRef(identityKey, key, catalogKey, menuOpen, params);
   const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -32,6 +32,7 @@ import {
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import {
+  buildCatalogSessionMenuRequest,
   formatSidebarTimestamp,
   normalizeCatalogTimestamp,
   type CatalogBackingSessionDisplay,
@@ -542,20 +543,8 @@ function renderCatalogSessionRow(
   } satisfies CatalogSessionKey;
   const identityKey = buildCatalogSessionKey(catalogKey);
   const key = session.sessionKey ?? buildCatalogSessionKey(catalogKey, params.newSessionAgentId);
-  const menuOpen = params.isMenuOpen(catalogKey);
-  const rowRef = catalogRowRef(identityKey, key, catalogKey, menuOpen, params);
-  const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
-  if (adoptedRow) {
-    return params.renderLiveRow(adoptedRow, {
-      catalogIdentityKey: identityKey,
-      catalogMenuOpen: menuOpen,
-      ...(rowRef ? { rowRef } : {}),
-      ...(session.pullRequest ? { pullRequest: session.pullRequest } : {}),
-    });
-  }
   const label = session.name || session.threadId;
   const meta = formatSidebarTimestamp(timestamp);
-  const color = normalizeSessionColorValue(session.color ?? "");
   const routeId = "chat";
   const target = sessionNavigationTarget({
     face: routeId,
@@ -565,26 +554,34 @@ function renderCatalogSessionRow(
     mainKey: params.mainKey,
   });
   const { href, options: navigation } = target;
+  const catalogMenu = buildCatalogSessionMenuRequest({
+    catalog,
+    session,
+    key: catalogKey,
+    agentId: params.newSessionAgentId,
+    routeId,
+    navigation,
+    meta,
+  });
+  const menuOpen = params.isMenuOpen(catalogKey);
+  const rowRef = catalogRowRef(identityKey, key, catalogKey, menuOpen, params);
+  const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
+  if (adoptedRow) {
+    return params.renderLiveRow(adoptedRow, {
+      catalogIdentityKey: identityKey,
+      catalogMenuOpen: menuOpen,
+      catalogMenu,
+      ...(rowRef ? { rowRef } : {}),
+      ...(session.pullRequest ? { pullRequest: session.pullRequest } : {}),
+    });
+  }
+  const color = normalizeSessionColorValue(session.color ?? "");
   const active = key === params.routeSessionKey;
   const running = session.status === "active" || session.status === "running";
   const canOpenTerminal = session.canOpenTerminal === true && params.terminalAvailable;
   const openTerminal = () => params.onOpenTerminal(catalogKey, params.newSessionAgentId);
   const openMenu = (x: number, y: number, trigger?: HTMLElement) =>
-    params.onOpenMenu(
-      {
-        key: catalogKey,
-        agentId: params.newSessionAgentId,
-        routeId,
-        navigation,
-        canOpenTerminal: session.canOpenTerminal === true,
-        canDelete: session.canArchive && catalog.capabilities.archive,
-        name: session.name ?? session.threadId,
-        meta,
-      },
-      x,
-      y,
-      trigger,
-    );
+    params.onOpenMenu(catalogMenu, x, y, trigger);
   const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
     handleContextMenuEvent(
       event,

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -1,18 +1,14 @@
-// @vitest-environment jsdom
-import { html, render } from "lit";
+// @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   SessionCatalog,
   SessionCatalogHost,
 } from "../../../packages/gateway-protocol/src/index.ts";
 import { i18n } from "../i18n/index.ts";
-import { renderSessionCatalogGroups } from "./app-sidebar-session-catalog-render.ts";
 import {
-  buildCatalogSessionMenuRequest,
   findCatalogSessionHovercardRow,
   formatSidebarTimestamp,
   visibleCatalogHosts,
-  type CatalogBackingSessionDisplay,
 } from "./app-sidebar-session-catalogs.ts";
 
 describe("formatSidebarTimestamp", () => {
@@ -135,116 +131,6 @@ describe("findCatalogSessionHovercardRow", () => {
         sessionKey: "catalog:codex:gateway%3Acodex:pull-request",
       })?.workContext,
     ).toEqual({ kind: "project", name: "pull-request", path: "/work/pull-request" });
-  });
-});
-
-describe("buildCatalogSessionMenuRequest", () => {
-  it("preserves native lifecycle capabilities for adopted catalog rows", () => {
-    const session = {
-      threadId: "thread-1",
-      name: "Native session",
-      status: "idle" as const,
-      archived: false,
-      canContinue: true,
-      canArchive: false,
-      canOpenTerminal: true,
-    };
-    const request = buildCatalogSessionMenuRequest({
-      catalog: { capabilities: { continueSession: true, archive: true } },
-      session,
-      key: { catalogId: "codex", hostId: "gateway:local", threadId: session.threadId },
-      agentId: "main",
-      routeId: "chat",
-      navigation: {},
-      meta: "now",
-    });
-
-    expect(request).toMatchObject({
-      canOpenTerminal: true,
-      canDelete: false,
-      name: "Native session",
-      meta: "now",
-    });
-  });
-});
-
-describe("renderSessionCatalogGroups", () => {
-  it("routes adopted rows through the native catalog menu", () => {
-    const displays: CatalogBackingSessionDisplay[] = [];
-    const sessionKey = "agent:main:adopted";
-    const container = document.createElement("div");
-    render(
-      html`${renderSessionCatalogGroups({
-        catalogs: [
-          {
-            id: "codex",
-            label: "Codex",
-            capabilities: { continueSession: true, archive: true },
-            hosts: [
-              {
-                hostId: "gateway:local",
-                label: "Local Codex",
-                kind: "gateway",
-                connected: true,
-                sessions: [
-                  {
-                    threadId: "thread-1",
-                    sessionKey,
-                    name: "Native session",
-                    status: "idle",
-                    archived: false,
-                    canContinue: true,
-                    canArchive: false,
-                    canOpenTerminal: true,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        connected: true,
-        basePath: "",
-        routeSessionKey: "",
-        newSessionAgentId: "main",
-        mainKey: "agent:main:main",
-        collapsedSections: new Set(),
-        loadingMoreCatalogIds: new Set(),
-        visibleSessionLimits: new Map(),
-        projectGrouping: "none",
-        liveRows: [
-          { key: sessionKey, label: "OpenClaw row", hasAutomation: false, hasActiveRun: false },
-        ],
-        renderLiveRow: (_row: unknown, display: CatalogBackingSessionDisplay) => {
-          displays.push(display);
-          return null;
-        },
-        onToggleSection: () => {},
-        draggingSectionId: null,
-        sectionDropTarget: null,
-        onSectionDragOver: () => {},
-        onSectionDragLeave: () => {},
-        onSectionDrop: () => {},
-        onStartSectionDrag: () => {},
-        onFinishSectionDrag: () => {},
-        viewMenuOpenCatalogId: null,
-        ownerFilterActive: false,
-        onOpenViewMenu: () => {},
-        onLoadMore: () => {},
-        onSetVisibleSessionLimit: () => {},
-        catalogOpenTarget: "viewer",
-        terminalAvailable: true,
-        onOpenTerminal: () => {},
-        onOpenMenu: () => {},
-        onCatalogMenuTriggerRendered: () => {},
-        isMenuOpen: () => false,
-      } as never)}`,
-      container,
-    );
-
-    expect(displays[0]?.catalogMenu).toMatchObject({
-      canOpenTerminal: true,
-      canDelete: false,
-    });
   });
 });
 

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -1,14 +1,18 @@
-// @vitest-environment node
+// @vitest-environment jsdom
+import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   SessionCatalog,
   SessionCatalogHost,
 } from "../../../packages/gateway-protocol/src/index.ts";
 import { i18n } from "../i18n/index.ts";
+import { renderSessionCatalogGroups } from "./app-sidebar-session-catalog-render.ts";
 import {
+  buildCatalogSessionMenuRequest,
   findCatalogSessionHovercardRow,
   formatSidebarTimestamp,
   visibleCatalogHosts,
+  type CatalogBackingSessionDisplay,
 } from "./app-sidebar-session-catalogs.ts";
 
 describe("formatSidebarTimestamp", () => {
@@ -131,6 +135,116 @@ describe("findCatalogSessionHovercardRow", () => {
         sessionKey: "catalog:codex:gateway%3Acodex:pull-request",
       })?.workContext,
     ).toEqual({ kind: "project", name: "pull-request", path: "/work/pull-request" });
+  });
+});
+
+describe("buildCatalogSessionMenuRequest", () => {
+  it("preserves native lifecycle capabilities for adopted catalog rows", () => {
+    const session = {
+      threadId: "thread-1",
+      name: "Native session",
+      status: "idle" as const,
+      archived: false,
+      canContinue: true,
+      canArchive: false,
+      canOpenTerminal: true,
+    };
+    const request = buildCatalogSessionMenuRequest({
+      catalog: { capabilities: { continueSession: true, archive: true } },
+      session,
+      key: { catalogId: "codex", hostId: "gateway:local", threadId: session.threadId },
+      agentId: "main",
+      routeId: "chat",
+      navigation: {},
+      meta: "now",
+    });
+
+    expect(request).toMatchObject({
+      canOpenTerminal: true,
+      canDelete: false,
+      name: "Native session",
+      meta: "now",
+    });
+  });
+});
+
+describe("renderSessionCatalogGroups", () => {
+  it("routes adopted rows through the native catalog menu", () => {
+    const displays: CatalogBackingSessionDisplay[] = [];
+    const sessionKey = "agent:main:adopted";
+    const container = document.createElement("div");
+    render(
+      html`${renderSessionCatalogGroups({
+        catalogs: [
+          {
+            id: "codex",
+            label: "Codex",
+            capabilities: { continueSession: true, archive: true },
+            hosts: [
+              {
+                hostId: "gateway:local",
+                label: "Local Codex",
+                kind: "gateway",
+                connected: true,
+                sessions: [
+                  {
+                    threadId: "thread-1",
+                    sessionKey,
+                    name: "Native session",
+                    status: "idle",
+                    archived: false,
+                    canContinue: true,
+                    canArchive: false,
+                    canOpenTerminal: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        connected: true,
+        basePath: "",
+        routeSessionKey: "",
+        newSessionAgentId: "main",
+        mainKey: "agent:main:main",
+        collapsedSections: new Set(),
+        loadingMoreCatalogIds: new Set(),
+        visibleSessionLimits: new Map(),
+        projectGrouping: "none",
+        liveRows: [
+          { key: sessionKey, label: "OpenClaw row", hasAutomation: false, hasActiveRun: false },
+        ],
+        renderLiveRow: (_row: unknown, display: CatalogBackingSessionDisplay) => {
+          displays.push(display);
+          return null;
+        },
+        onToggleSection: () => {},
+        draggingSectionId: null,
+        sectionDropTarget: null,
+        onSectionDragOver: () => {},
+        onSectionDragLeave: () => {},
+        onSectionDrop: () => {},
+        onStartSectionDrag: () => {},
+        onFinishSectionDrag: () => {},
+        viewMenuOpenCatalogId: null,
+        ownerFilterActive: false,
+        onOpenViewMenu: () => {},
+        onLoadMore: () => {},
+        onSetVisibleSessionLimit: () => {},
+        catalogOpenTarget: "viewer",
+        terminalAvailable: true,
+        onOpenTerminal: () => {},
+        onOpenMenu: () => {},
+        onCatalogMenuTriggerRendered: () => {},
+        isMenuOpen: () => false,
+      } as never)}`,
+      container,
+    );
+
+    expect(displays[0]?.catalogMenu).toMatchObject({
+      canOpenTerminal: true,
+      canDelete: false,
+    });
   });
 });
 

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -145,7 +145,7 @@ export function visibleCatalogHosts(
 export type CatalogBackingSessionDisplay = {
   catalogIdentityKey: string;
   catalogMenuOpen: boolean;
-  catalogMenu?: CatalogSessionMenuRequest;
+  catalogMenu: CatalogSessionMenuRequest;
   rowRef?: (element: Element | undefined) => void;
   subtitle?: string;
   pullRequest?: SessionCatalogSession["pullRequest"];
@@ -161,27 +161,6 @@ export type CatalogSessionMenuRequest = {
   name: string;
   meta: string;
 };
-
-export function buildCatalogSessionMenuRequest(params: {
-  catalog: Pick<SessionCatalog, "capabilities">;
-  session: SessionCatalogSession;
-  key: CatalogSessionKey;
-  agentId: string;
-  routeId: CatalogSessionMenuRequest["routeId"];
-  navigation: ApplicationNavigationOptions;
-  meta: string;
-}): CatalogSessionMenuRequest {
-  return {
-    key: params.key,
-    agentId: params.agentId,
-    routeId: params.routeId,
-    navigation: params.navigation,
-    canOpenTerminal: params.session.canOpenTerminal === true,
-    canDelete: params.session.canArchive && params.catalog.capabilities.archive,
-    name: params.session.name ?? params.session.threadId,
-    meta: params.meta,
-  };
-}
 
 /** Stamps a freshly adopted session key onto its catalog row so the sidebar
     binds it before the next catalog poll confirms the adoption. */

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -145,6 +145,7 @@ export function visibleCatalogHosts(
 export type CatalogBackingSessionDisplay = {
   catalogIdentityKey: string;
   catalogMenuOpen: boolean;
+  catalogMenu?: CatalogSessionMenuRequest;
   rowRef?: (element: Element | undefined) => void;
   subtitle?: string;
   pullRequest?: SessionCatalogSession["pullRequest"];
@@ -160,6 +161,27 @@ export type CatalogSessionMenuRequest = {
   name: string;
   meta: string;
 };
+
+export function buildCatalogSessionMenuRequest(params: {
+  catalog: Pick<SessionCatalog, "capabilities">;
+  session: SessionCatalogSession;
+  key: CatalogSessionKey;
+  agentId: string;
+  routeId: CatalogSessionMenuRequest["routeId"];
+  navigation: ApplicationNavigationOptions;
+  meta: string;
+}): CatalogSessionMenuRequest {
+  return {
+    key: params.key,
+    agentId: params.agentId,
+    routeId: params.routeId,
+    navigation: params.navigation,
+    canOpenTerminal: params.session.canOpenTerminal === true,
+    canDelete: params.session.canArchive && params.catalog.capabilities.archive,
+    name: params.session.name ?? params.session.threadId,
+    meta: params.meta,
+  };
+}
 
 /** Stamps a freshly adopted session key onto its catalog row so the sidebar
     binds it before the next catalog poll confirms the adoption. */

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -113,7 +113,11 @@ export interface SessionListHost {
   handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession): void;
   toggleSessionChildren(session: SidebarRecentSession): void;
   toggleSessionPin(session: SidebarRecentSession): void;
-  toggleSessionMenu(session: SidebarRecentSession, trigger: HTMLElement): void;
+  toggleSessionMenu(
+    session: SidebarRecentSession,
+    trigger: HTMLElement,
+    catalogMenu?: CatalogSessionMenuRequest,
+  ): void;
   showMoreChildren(sessionKey: string): void;
   sectionDragOver(event: DragEvent, sectionId: string, group?: string): void;
   sectionDragLeave(event: DragEvent, sectionId: string, group?: string): void;
@@ -237,7 +241,13 @@ export function renderRecentSession(params: {
     handleContextMenuEvent(
       event,
       (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
-      (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
+      (trigger, x, y) => {
+        if (display?.catalogMenu) {
+          host.openCatalogMenu(display.catalogMenu, x, y, trigger ?? undefined);
+          return;
+        }
+        host.sidebarMenus.openSessionMenu(session, x, y, trigger);
+      },
     );
   const pinLabel = t(session.pinned ? "sessionsView.unpinSession" : "sessionsView.pinSession");
   const menuTooltip = t("chat.sidebar.openSessionMenu");
@@ -492,7 +502,7 @@ export function renderRecentSession(params: {
               @click=${(event: MouseEvent) => {
                 event.stopPropagation();
                 const trigger = event.currentTarget as HTMLElement;
-                host.toggleSessionMenu(session, trigger);
+                host.toggleSessionMenu(session, trigger, display?.catalogMenu);
               }}
             >
               ${icons.moreHorizontal}

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -384,7 +384,20 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     void this.sessionOrganizer.patchSession(session, { pinned: !session.pinned });
   }
 
-  toggleSessionMenu(session: SidebarRecentSession, trigger: HTMLElement): void {
+  toggleSessionMenu(
+    session: SidebarRecentSession,
+    trigger: HTMLElement,
+    catalogMenu?: CatalogSessionMenuRequest,
+  ): void {
+    if (catalogMenu) {
+      if (this.sidebarMenus.catalogMenu.isOpenFor(catalogMenu.key)) {
+        this.sidebarMenus.catalogMenu.close();
+        return;
+      }
+      const rect = trigger.getBoundingClientRect();
+      this.openCatalogMenu(catalogMenu, rect.right, rect.bottom + 4, trigger);
+      return;
+    }
     if (this.sidebarMenus.sessionMenu?.session.key === session.key) {
       this.sidebarMenus.closeSessionMenu();
       return;

--- a/ui/src/e2e/native-session-sidebar.e2e.test.ts
+++ b/ui/src/e2e/native-session-sidebar.e2e.test.ts
@@ -121,23 +121,27 @@ suite.define(() => {
     }
   });
 
-  it("routes adopted session menu buttons and context menus through the catalog menu", async () => {
+  it("preserves native actions across adopted session menu entry points", async () => {
     const adoptedKey = "agent:main:adopted-native-menu";
     const proofRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const proofDir = proofRoot
       ? createControlUiE2eArtifactDir("adopted-session-menu", proofRoot)
       : undefined;
-    const page = await suite.browser.newPage({
+    const context = await suite.newBrowserContext({
       deviceScaleFactor: 2,
+      locale: "en-US",
+      serviceWorkers: "block",
       viewport: { height: 1100, width: 1440 },
     });
+    const page = await context.newPage();
     await installMockGateway(page, {
       sessionKey: "agent:main:main",
+      terminalEnabled: true,
       sessions: [
         { key: "agent:main:main", kind: "direct", label: "Main session", updatedAt: 2 },
         { key: adoptedKey, kind: "direct", label: "Adopted native session", updatedAt: 1 },
       ],
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list", "terminal.open"],
       methodResponses: {
         "sessions.catalog.list": {
           catalogs: [
@@ -156,6 +160,7 @@ suite.define(() => {
                       threadId: "adopted-thread",
                       name: "Adopted native session",
                       status: "stored",
+                      archived: false,
                       sessionKey: adoptedKey,
                       canContinue: true,
                       canOpenTerminal: true,
@@ -187,6 +192,9 @@ suite.define(() => {
       const assertCatalogMenu = async (entryPoint: string) => {
         await expect.poll(() => catalogMenu().count()).toBe(1);
         await expect.poll(menuValues).toEqual(["viewer", "terminal"]);
+        await expect
+          .poll(() => catalogMenu().locator('[value="terminal"]').getAttribute("disabled"))
+          .toBeNull();
         console.info(`[catalog-menu-proof] ${entryPoint} values=${(await menuValues()).join(",")}`);
         if (proofDir) {
           await writeFile(
@@ -210,8 +218,16 @@ suite.define(() => {
       await assertCatalogMenu("02-context");
       await page.keyboard.press("Escape");
       await expect.poll(() => catalogMenu().count()).toBe(0);
+
+      for (const key of ["ContextMenu", "Shift+F10"]) {
+        await menuButton.focus();
+        await page.keyboard.press(key);
+        await assertCatalogMenu(key);
+        await page.keyboard.press("Escape");
+        await expect.poll(() => catalogMenu().count()).toBe(0);
+      }
     } finally {
-      await page.close();
+      await suite.closeBrowserContext(context);
     }
   });
 });

--- a/ui/src/e2e/native-session-sidebar.e2e.test.ts
+++ b/ui/src/e2e/native-session-sidebar.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -21,10 +23,13 @@ beforeEach(() => {
 
 suite.define(() => {
   it("hides empty native hosts and the empty Coding section", async () => {
-    const page = await suite.browser.newPage({
+    const context = await suite.newBrowserContext({
       deviceScaleFactor: 2,
+      locale: "en-US",
+      serviceWorkers: "block",
       viewport: { height: 1100, width: 1440 },
     });
+    const page = await context.newPage();
     await page.addInitScript(
       (key) => localStorage.removeItem(key),
       collapsedSessionSectionsStorageKey,
@@ -111,6 +116,100 @@ suite.define(() => {
       expect(await section.getByText("Shared gateway session", { exact: true }).count()).toBe(1);
       expect(await section.locator('[data-session-catalog-host="node:remote"]').count()).toBe(1);
       expect(await section.locator('[data-session-catalog-host="node:empty"]').count()).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("routes adopted session menu buttons and context menus through the catalog menu", async () => {
+    const adoptedKey = "agent:main:adopted-native-menu";
+    const proofRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const proofDir = proofRoot
+      ? createControlUiE2eArtifactDir("adopted-session-menu", proofRoot)
+      : undefined;
+    const page = await suite.browser.newPage({
+      deviceScaleFactor: 2,
+      viewport: { height: 1100, width: 1440 },
+    });
+    await installMockGateway(page, {
+      sessionKey: "agent:main:main",
+      sessions: [
+        { key: "agent:main:main", kind: "direct", label: "Main session", updatedAt: 2 },
+        { key: adoptedKey, kind: "direct", label: "Adopted native session", updatedAt: 1 },
+      ],
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "codex",
+              label: "Codex",
+              capabilities: { continueSession: true, archive: false },
+              hosts: [
+                {
+                  hostId: "gateway:local",
+                  label: "Gateway",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [
+                    {
+                      threadId: "adopted-thread",
+                      name: "Adopted native session",
+                      status: "stored",
+                      sessionKey: adoptedKey,
+                      canContinue: true,
+                      canOpenTerminal: true,
+                      canArchive: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const row = page.locator(`[data-session-key="${adoptedKey}"]`);
+      await row.waitFor({ state: "visible" });
+      const menuButton = row.locator('[data-session-menu="true"]');
+      const catalogMenu = () => page.locator("openclaw-catalog-session-menu");
+      const menuValues = async () =>
+        catalogMenu()
+          .locator("wa-dropdown-item")
+          .evaluateAll((items) =>
+            items
+              .map((item) => item.getAttribute("value"))
+              .filter((value): value is string => Boolean(value)),
+          );
+      const assertCatalogMenu = async (entryPoint: string) => {
+        await expect.poll(() => catalogMenu().count()).toBe(1);
+        await expect.poll(menuValues).toEqual(["viewer", "terminal"]);
+        console.info(`[catalog-menu-proof] ${entryPoint} values=${(await menuValues()).join(",")}`);
+        if (proofDir) {
+          await writeFile(
+            path.join(proofDir, `${entryPoint}.png`),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              row,
+              catalogMenu(),
+            ]),
+          );
+        }
+      };
+
+      await row.hover();
+      await menuButton.hover();
+      await menuButton.click();
+      await assertCatalogMenu("01-button");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => catalogMenu().count()).toBe(0);
+
+      await row.click({ button: "right" });
+      await assertCatalogMenu("02-context");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => catalogMenu().count()).toBe(0);
     } finally {
       await page.close();
     }

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -102,57 +102,82 @@ describe("AppSidebar catalog row lifecycle", () => {
     expect(document.activeElement).toBe(adoptedMenu);
   });
 
-  it("routes adopted row buttons and context menus through the catalog menu", async () => {
-    const adoptedKey = "agent:main:adopted-menu-triggers";
-    const { sidebar } = await mountSidebar(
-      createGateway({} as GatewayBrowserClient),
-      createSessions("main", ["agent:main:main", adoptedKey]),
-    );
-    const catalogs = catalogPage([
-      {
-        threadId: "thread-adopted-menu-triggers",
-        name: "Adopted menu",
-        sessionKey: adoptedKey,
-      },
-    ]).catalogs;
-    catalogs[0]!.hosts[0]!.sessions[0]!.canArchive = false;
-    sidebar.sessionData.sessionCatalogs = catalogs;
-    sidebar.sessionData.requestSessionDataUpdate();
-    await sidebar.updateComplete;
+  it.each([
+    { catalogArchive: false, sessionArchive: true, canDelete: false },
+    { catalogArchive: true, sessionArchive: false, canDelete: false },
+    { catalogArchive: true, sessionArchive: true, canDelete: true },
+  ])(
+    "preserves native menus when catalog archive=$catalogArchive and session archive=$sessionArchive",
+    async ({ catalogArchive, sessionArchive, canDelete }) => {
+      const adoptedKey = "agent:main:adopted-menu-triggers";
+      const { sidebar } = await mountSidebar(
+        createGateway({} as GatewayBrowserClient),
+        createSessions("main", ["agent:main:main", adoptedKey]),
+      );
+      const catalogs = catalogPage([
+        {
+          threadId: "thread-adopted-menu-triggers",
+          name: "Adopted menu",
+          sessionKey: adoptedKey,
+        },
+      ]).catalogs;
+      catalogs[0]!.capabilities.archive = catalogArchive;
+      const catalogSession = catalogs[0]!.hosts[0]!.sessions[0]!;
+      catalogSession.canArchive = sessionArchive;
+      catalogSession.canOpenTerminal = true;
+      sidebar.terminalAvailable = true;
+      sidebar.sessionData.sessionCatalogs = catalogs;
+      sidebar.sessionData.requestSessionDataUpdate();
+      await sidebar.updateComplete;
 
-    const row = sidebar.querySelector<HTMLElement>(`[data-session-key="${adoptedKey}"]`);
-    const menuButton = row?.querySelector<HTMLButtonElement>('[data-session-menu="true"]');
-    if (!row || !menuButton) {
-      throw new Error("expected adopted row menu button");
-    }
-    menuButton.getBoundingClientRect = () => ({ right: 200, bottom: 100 }) as DOMRect;
+      const row = sidebar.querySelector<HTMLElement>(`[data-session-key="${adoptedKey}"]`);
+      const menuButton = row?.querySelector<HTMLButtonElement>('[data-session-menu="true"]');
+      if (!row || !menuButton) {
+        throw new Error("expected adopted row menu button");
+      }
+      const expectCatalogMenu = () => {
+        const menu = sidebar.querySelector("openclaw-catalog-session-menu");
+        expect(menu).not.toBeNull();
+        expect(menu?.querySelector('wa-dropdown-item[value="viewer"]')).not.toBeNull();
+        expect(menu?.querySelector('wa-dropdown-item[value="terminal"]')).not.toBeNull();
+        expect(
+          menu?.querySelector('wa-dropdown-item[value="terminal"]')?.hasAttribute("disabled"),
+        ).toBe(false);
+        expect(menu?.querySelector('wa-dropdown-item[value="delete"]') !== null).toBe(canDelete);
+      };
 
-    const expectCatalogMenu = () => {
-      const menu = sidebar.querySelector("openclaw-catalog-session-menu");
-      expect(menu).not.toBeNull();
-      expect(menu?.querySelector('wa-dropdown-item[value="viewer"]')).not.toBeNull();
-      expect(menu?.querySelector('wa-dropdown-item[value="delete"]')).toBeNull();
-    };
+      menuButton.click();
+      await sidebar.updateComplete;
+      expectCatalogMenu();
 
-    menuButton.click();
-    await sidebar.updateComplete;
-    expectCatalogMenu();
+      menuButton.click();
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector("openclaw-catalog-session-menu")).toBeNull();
 
-    menuButton.click();
-    await sidebar.updateComplete;
-    expect(sidebar.querySelector("openclaw-catalog-session-menu")).toBeNull();
-
-    row.dispatchEvent(
-      new MouseEvent("contextmenu", {
-        bubbles: true,
-        cancelable: true,
-        clientX: 20,
-        clientY: 30,
-      }),
-    );
-    await sidebar.updateComplete;
-    expectCatalogMenu();
-  });
+      for (const event of [
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 20,
+          clientY: 30,
+        }),
+        new KeyboardEvent("keydown", { key: "ContextMenu", bubbles: true, cancelable: true }),
+        new KeyboardEvent("keydown", {
+          key: "F10",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ]) {
+        row.dispatchEvent(event);
+        await sidebar.updateComplete;
+        expectCatalogMenu();
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        await sidebar.updateComplete;
+        expect(sidebar.querySelector("openclaw-catalog-session-menu")).toBeNull();
+      }
+    },
+  );
 
   it("clears marquee state when a catalog label changes", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -102,6 +102,58 @@ describe("AppSidebar catalog row lifecycle", () => {
     expect(document.activeElement).toBe(adoptedMenu);
   });
 
+  it("routes adopted row buttons and context menus through the catalog menu", async () => {
+    const adoptedKey = "agent:main:adopted-menu-triggers";
+    const { sidebar } = await mountSidebar(
+      createGateway({} as GatewayBrowserClient),
+      createSessions("main", ["agent:main:main", adoptedKey]),
+    );
+    const catalogs = catalogPage([
+      {
+        threadId: "thread-adopted-menu-triggers",
+        name: "Adopted menu",
+        sessionKey: adoptedKey,
+      },
+    ]).catalogs;
+    catalogs[0]!.hosts[0]!.sessions[0]!.canArchive = false;
+    sidebar.sessionData.sessionCatalogs = catalogs;
+    sidebar.sessionData.requestSessionDataUpdate();
+    await sidebar.updateComplete;
+
+    const row = sidebar.querySelector<HTMLElement>(`[data-session-key="${adoptedKey}"]`);
+    const menuButton = row?.querySelector<HTMLButtonElement>('[data-session-menu="true"]');
+    if (!row || !menuButton) {
+      throw new Error("expected adopted row menu button");
+    }
+    menuButton.getBoundingClientRect = () => ({ right: 200, bottom: 100 }) as DOMRect;
+
+    const expectCatalogMenu = () => {
+      const menu = sidebar.querySelector("openclaw-catalog-session-menu");
+      expect(menu).not.toBeNull();
+      expect(menu?.querySelector('wa-dropdown-item[value="viewer"]')).not.toBeNull();
+      expect(menu?.querySelector('wa-dropdown-item[value="delete"]')).toBeNull();
+    };
+
+    menuButton.click();
+    await sidebar.updateComplete;
+    expectCatalogMenu();
+
+    menuButton.click();
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector("openclaw-catalog-session-menu")).toBeNull();
+
+    row.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 20,
+        clientY: 30,
+      }),
+    );
+    await sidebar.updateComplete;
+    expectCatalogMenu();
+  });
+
   it("clears marquee state when a catalog label changes", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));


### PR DESCRIPTION
Closes #143177

## What Problem This Solves

Fixes an issue where users continuing a native Codex or Claude session in OpenClaw would get the generic session menu from its native catalog row. That menu exposed OpenClaw lifecycle actions instead of the native provider's supported actions.

## Why This Change Was Made

The catalog renderer now carries one typed, capability-aware menu request through the adopted row. Its button, right-click, ContextMenu key, and Shift+F10 all use the existing catalog menu and action owner. The change also removes duplicate helper tests and covers the actual row interactions.

## User Impact

Native catalog rows keep their supported viewer and terminal actions after continuation. Providers that cannot archive do not expose Delete or Archive. Permitted archive still uses the native catalog owner and its existing confirmation and active-source guards. Ordinary session menus keep their current behavior.

## Evidence

- Real isolated Gateway and served Control UI: baseline `2393e17f27f23f729c57b1476c3ab46f7a822c08`, candidate `2559c12c93e3ecce9a7c4bc0133e5c71cfb5cd64`, with matching runtime/UI builds.
- Fresh independent browser validation used real native sessions created by both native clients, then normal OpenClaw continuation. All four menu entry points reproduced the generic menu on baseline and opened the native menu on the candidate.
- Both native viewers and terminal resumes worked; both native terminal continuations returned the expected reply.
- Claude omitted unsupported lifecycle actions. A permitted Codex archive used `sessions.catalog.archive`, passed through its confirmation, and remained absent after refresh and reload. No generic `sessions.delete` was sent.
- A separate active native source was rejected with `INVALID_REQUEST`: “Codex session is active in this App Server; wait for it to finish before archiving.” It remained unarchived.
- Ordinary-row and reload controls passed.
- Three regression cases fail on baseline at the missing native menu; all 363 focused owner/sibling tests pass on the candidate. The two browser cases pass across focused runs, including both keyboard paths and enabled terminal actions.
- Formatting, syntax and boundary lint, source-size and assertion checks, and the matching candidate build pass. Full hosted checks run on the published head.

AI-assisted.
