### PR TITLE
fix(ui): prevent scroll jumps when loading earlier messages

### DIFF
--- a/ui/src/e2e/chat-history-prepend-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-history-prepend-anchor.e2e.test.ts
@@ -1,0 +1,239 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  createChatFlowE2eSuite,
+  installMockGateway,
+  waitForChatScrollIdle,
+  waitForRequests,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+type AnchorFrames = { frame: number; positions: Array<number | null>; readerDelta: number };
+type AnchorWindow = typeof window & { prependFrames: AnchorFrames };
+
+suite.define(() => {
+  it.each([
+    { sharedGroup: false, manual: false, onlyGroup: false, more: false },
+    { sharedGroup: true, manual: false, onlyGroup: false, more: false },
+    { sharedGroup: false, manual: true, onlyGroup: false, more: false },
+    { sharedGroup: true, manual: true, onlyGroup: false, more: false },
+    { sharedGroup: true, manual: false, onlyGroup: true, more: false },
+    { sharedGroup: true, manual: false, onlyGroup: true, more: true },
+    { sharedGroup: true, manual: false, onlyGroup: true, more: false, persisted: false },
+    { sharedGroup: true, manual: false, onlyGroup: false, more: true, activeTouch: true },
+    {
+      sharedGroup: true,
+      manual: false,
+      onlyGroup: false,
+      more: true,
+      activeTouch: true,
+      momentum: true,
+    },
+  ])(
+    "anchors history prepend (shared=$sharedGroup, manual=$manual, onlyGroup=$onlyGroup, more=$more, persisted=$persisted, touch=$activeTouch, momentum=$momentum)",
+    async ({
+      sharedGroup,
+      manual,
+      onlyGroup,
+      more,
+      persisted = true,
+      activeTouch = false,
+      momentum = false,
+    }) => {
+      const artifactDir = createControlUiE2eArtifactDir("chat-history-prepend-anchor");
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        hasTouch: activeTouch,
+        ...(activeTouch
+          ? {
+              userAgent:
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1",
+            }
+          : {}),
+        viewport: { height: 900, width: 1280 },
+        recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
+      });
+      const page = await context.newPage();
+      const message = (seq: number) => ({
+        __openclaw: { ...(persisted ? { id: `prepend-${seq}` } : {}), seq },
+        role:
+          sharedGroup && seq >= 995 && seq <= 1005 ? "assistant" : seq % 2 ? "user" : "assistant",
+        content: [
+          {
+            type: "text",
+            text: `Transcript entry ${seq}. ${"History detail for the reader. ".repeat(8)}`,
+          },
+        ],
+        timestamp: 1_800_000_000_000 + seq,
+      });
+      const recent = Array.from({ length: 800 }, (_, index) => message(index + 1001));
+      const older = Array.from({ length: onlyGroup ? 6 : 1000 }, (_, index) =>
+        message(index + (onlyGroup ? 995 : 1)),
+      );
+      const loadedCount = recent.length + older.length;
+      const totalMessages = loadedCount + (more ? 10 : 0);
+      const gateway = await installMockGateway(page, {
+        sessionKey: "agent:main:main",
+        sessions: [{ key: "agent:main:main", sessionId: "prepend-session" }],
+        methodResponses: {
+          "chat.startup": {
+            messages: recent,
+            hasMore: true,
+            nextOffset: 800,
+            totalMessages,
+            sessionId: "prepend-session",
+          },
+          "chat.history": {
+            messages: older,
+            hasMore: more,
+            nextOffset: loadedCount,
+            totalMessages,
+            sessionId: "prepend-session",
+          },
+        },
+      });
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const pane = page.locator(".chat-pane-cache__pane--active");
+        const thread = pane.locator(".chat-thread");
+        await thread.getByText(/^Transcript entry 1800\./).waitFor();
+        await waitForChatScrollIdle(page);
+        await gateway.deferNext("chat.history");
+        await thread.hover();
+        await page.mouse.wheel(0, -1_000_000);
+        await waitForRequests(gateway, "chat.history", 1);
+        if (manual) {
+          // A failed automatic load exposes the explicit retry control without
+          // another upward gesture consuming history before the reader clicks.
+          await gateway.rejectDeferred("chat.history", {
+            message: "History temporarily unavailable",
+          });
+          const showEarlier = thread.getByRole("button", { name: "Show earlier", exact: true });
+          await expect.poll(() => showEarlier.isEnabled()).toBe(true);
+          await gateway.deferNext("chat.history");
+          await showEarlier.click();
+          await waitForRequests(gateway, "chat.history", 2);
+        }
+        await waitForChatScrollIdle(page);
+        const anchor = thread.locator(".chat-bubble").filter({ hasText: "Transcript entry 1001." });
+        await anchor.waitFor();
+        const before = await anchor.boundingBox();
+        expect(before).not.toBeNull();
+        await page.screenshot({ path: path.join(artifactDir, "before-prepend.png") });
+        await page.evaluate(
+          (messageKey) => {
+            const frames: AnchorFrames = { frame: 0, positions: [], readerDelta: 0 };
+            (window as AnchorWindow).prependFrames = frames;
+            const sample = () => {
+              const bubble = [
+                ...document.querySelectorAll<HTMLElement>(
+                  ".chat-pane-cache__pane--active .chat-bubble[data-message-id]",
+                ),
+              ].find((element) => element.dataset.messageId === messageKey);
+              frames.positions.push(
+                bubble ? bubble.getBoundingClientRect().top + frames.readerDelta : null,
+              );
+              frames.frame = requestAnimationFrame(sample);
+            };
+            sample();
+          },
+          await anchor.getAttribute("data-message-id"),
+        );
+        const heldOffset = await thread.evaluate((element) => element.scrollTop);
+        if (activeTouch) {
+          if (momentum) {
+            // Chromium emits scrollend itself; suppress delivery to model
+            // browsers that only provide the offset observer's idle callback.
+            await thread.evaluate((element) =>
+              element.addEventListener("scrollend", (event) => event.stopImmediatePropagation(), {
+                capture: true,
+              }),
+            );
+          }
+          await thread.dispatchEvent("touchstart");
+          if (momentum) {
+            await thread.evaluate((element) => {
+              (window as AnchorWindow).prependFrames.readerDelta += 20;
+              element.scrollTop += 20;
+              element.dispatchEvent(new Event("scroll"));
+            });
+          }
+        }
+        await gateway.resolveDeferred("chat.history");
+        await expect
+          .poll(() =>
+            pane.evaluate(
+              (element) =>
+                (element as HTMLElement & { state: { chatMessages: unknown[] } }).state.chatMessages
+                  .length,
+            ),
+          )
+          .toBe(loadedCount);
+        if (activeTouch) {
+          // Let the real projection commit before checking that compensation
+          // respects the dependency's active-touch deferral.
+          await page.evaluate(
+            () =>
+              new Promise<void>((resolve) => {
+                requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+              }),
+          );
+          expect(
+            await thread.evaluate((element) => element.scrollTop),
+            "a history prepend must not write the scroll offset during an active touch",
+          ).toBe(heldOffset + (momentum ? 20 : 0));
+          await thread.dispatchEvent("touchend");
+          if (momentum) {
+            // Synthetic offset events protect ownership ordering, not native
+            // Safari inertia. Natural reader movement is removed from samples.
+            await thread.evaluate((element) => {
+              (window as AnchorWindow).prependFrames.readerDelta += 20;
+              element.scrollTop += 20;
+              element.dispatchEvent(new Event("scroll"));
+            });
+            // Deliberately omit scrollend: the offset observer must release history.
+          }
+        }
+        await waitForChatScrollIdle(page);
+        // State can contain the fetched page while the rendered projection is
+        // still held. Require its added extent to reach the native viewport.
+        await expect
+          .poll(() => thread.evaluate((element) => element.scrollTop))
+          .toBeGreaterThan(heldOffset + (momentum ? 40 : 0) + 100);
+        await page.screenshot({ path: path.join(artifactDir, "after-prepend.png") });
+        const frames = await page.evaluate(() => {
+          const probe = (window as AnchorWindow).prependFrames;
+          cancelAnimationFrame(probe.frame);
+          return probe.positions;
+        });
+        const after = await anchor.boundingBox();
+        console.log(
+          JSON.stringify({
+            sharedGroup,
+            manual,
+            onlyGroup,
+            more,
+            before,
+            after,
+            frames,
+            artifactDir,
+          }),
+        );
+        expect(after, "the message being read must remain rendered").not.toBeNull();
+        expect(
+          Math.abs(after!.y + (momentum ? 40 : 0) - before!.y),
+          "loading older history must not move the message being read",
+        ).toBeLessThanOrEqual(2);
+        expect(frames.length).toBeGreaterThan(1);
+        expect(
+          frames.every((top) => top !== null && Math.abs(top - before!.y) <= 2),
+          "the message must stay anchored at every animation frame, not just after settling",
+        ).toBe(true);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -833,7 +833,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps the earlier-history action fixed while loading and reveals the fetched page", async () => {
+  it("keeps the earlier-history action fixed while loading and preserves the reader after retry", async () => {
     const page = await suite.browser.newPage({ viewport: { width: 1280, height: 800 } });
     const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot
@@ -955,6 +955,8 @@ suite.define(() => {
     await gateway.waitForRequest("chat.history", { after: failedRequestCount });
     await page.locator('.chat-history-boundary__action[aria-busy="true"]').waitFor();
     expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 1);
+    const readerAnchor = await captureTopVisibleVirtualRow(thread);
+    await startVirtualRowPaintProbe(thread, readerAnchor);
     await gateway.resolveDeferred("chat.history", {
       messages: older,
       hasMore: true,
@@ -974,9 +976,8 @@ suite.define(() => {
           ),
       )
       .toBe(1100);
-    const firstOlderMessage = page.getByText(/^older native message 1\n/);
-    await firstOlderMessage.waitFor();
-    await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBeLessThanOrEqual(1);
+    await waitForPaintedVirtualRowAnchor(thread, readerAnchor);
+    expectPaintedVirtualRowAnchor(readerAnchor, await stopVirtualRowPaintProbe(thread));
     if (artifactDir) {
       await page.screenshot({
         path: path.join(artifactDir, "02-native-history-prepended-visible.png"),
@@ -1000,8 +1001,11 @@ suite.define(() => {
     // Single staging slot: the parked page must not chain further prefetches.
     expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 2);
     // Consuming the staged page needs no round trip: the exhausted empty page
-    // applies instantly and removes the boundary and its sentinel.
-    await showEarlier.click();
+    // applies instantly and removes the boundary and its sentinel. Invoke the
+    // action without scrolling: renewed upward intent can itself consume it.
+    await thread.evaluate((element) => {
+      element.querySelector<HTMLButtonElement>(".chat-history-boundary__action")?.click();
+    });
     await expect.poll(() => page.locator(".chat-history-sentinel").count()).toBe(0);
     expect(await page.getByRole("button", { name: "Show earlier" }).count()).toBe(0);
     expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 2);

--- a/ui/src/pages/chat/chat-pane-history.test-support.ts
+++ b/ui/src/pages/chat/chat-pane-history.test-support.ts
@@ -50,7 +50,6 @@ export type TestChatPane = HTMLElement & {
   loadOlderMessages: () => Promise<boolean>;
   stagedOlderPage: unknown;
   stagedOlderLoad: Promise<void> | null;
-  showEarlierMessages: () => Promise<void>;
   requestReplyMessage: (messageId: string) => void;
   readReplyMessage: (messageId: string) => unknown;
   openReplyMessage: (messageId: string) => void;

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -253,7 +253,7 @@ describe("chat pane native history pagination", () => {
     expect(pane.hasOlderMessages()).toBe(false);
   });
 
-  it("loads at the top through the canonical path and reveals the prepended window", async () => {
+  it("loads at the top through the canonical path without commanding a viewport jump", async () => {
     const request = vi.fn(async () => ({
       messages: [nativeHistoryMessage(1), nativeHistoryMessage(2)],
       hasMore: true,
@@ -262,7 +262,7 @@ describe("chat pane native history pagination", () => {
     }));
     const { pane, scrollToOffset, state } = createNativeShowEarlierPane(request);
 
-    await pane.showEarlierMessages();
+    await pane.loadOlderMessages();
 
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: state.sessionKey,
@@ -270,10 +270,9 @@ describe("chat pane native history pagination", () => {
       offset: 2,
     });
     expect(state.chatMessages.map(nativeHistorySeq)).toEqual([1, 2, 3, 4]);
-    expect(scrollToOffset).toHaveBeenCalledWith(0);
-    expect(pane.transcriptScrollTop).toBe(0);
+    expect(scrollToOffset).not.toHaveBeenCalled();
     expect(pane.historyObserverArmed).toBe(false);
-    expect(pane.historyAutoLoadBlocked).toBe(true);
+    expect(pane.historyAutoLoadBlocked).toBe(false);
   });
 
   it("publishes prepended history to the shared session snapshot", async () => {
@@ -371,7 +370,7 @@ describe("chat pane native history pagination", () => {
     vi.spyOn(pane, "updateComplete", "get").mockReturnValue(Promise.resolve(true));
     const scrollToOffset = vi.spyOn(pane.transcript, "scrollToOffset");
 
-    await pane.showEarlierMessages();
+    await pane.loadOlderMessages();
 
     expect(request).toHaveBeenCalledWith(
       "sessions.catalog.read",
@@ -379,7 +378,7 @@ describe("chat pane native history pagination", () => {
     );
     expect(pane.catalogMessages).toHaveLength(1);
     expect(pane.catalogCursor).toBeUndefined();
-    expect(scrollToOffset).toHaveBeenCalledWith(0);
+    expect(scrollToOffset).not.toHaveBeenCalled();
   });
 
   it("keeps the viewport and pagination retryable when the older load fails", async () => {
@@ -388,7 +387,7 @@ describe("chat pane native history pagination", () => {
     });
     const { pane, scrollToOffset, state, thread } = createNativeShowEarlierPane(request);
 
-    await pane.showEarlierMessages();
+    await pane.loadOlderMessages();
 
     expect(thread.scrollTop).toBe(0);
     expect(state.chatHistoryPagination).toMatchObject({ hasMore: true });
@@ -403,14 +402,14 @@ describe("chat pane native history pagination", () => {
     const { pane, thread } = createNativeShowEarlierPane(request);
     pane.transcriptScrollTop = 500;
 
-    await pane.showEarlierMessages();
+    await pane.loadOlderMessages();
     pane.handleTranscriptScroll({ currentTarget: thread, target: thread } as unknown as Event);
 
     expect(pane.historyAutoLoadBlocked).toBe(true);
     expect(request).toHaveBeenCalledOnce();
   });
 
-  it("joins an in-flight canonical load before revealing its earlier window", async () => {
+  it("joins an in-flight canonical load without commanding a viewport jump", async () => {
     const deferred = createDeferred<{
       messages: unknown[];
       hasMore: boolean;
@@ -420,7 +419,7 @@ describe("chat pane native history pagination", () => {
     const { pane, scrollToOffset } = createNativeShowEarlierPane(request);
 
     const automaticLoad = pane.loadOlderMessages();
-    const manualNavigation = pane.showEarlierMessages();
+    const manualNavigation = pane.loadOlderMessages();
     deferred.resolve({
       messages: [nativeHistoryMessage(1), nativeHistoryMessage(2)],
       hasMore: false,
@@ -429,28 +428,18 @@ describe("chat pane native history pagination", () => {
     await Promise.all([automaticLoad, manualNavigation]);
 
     expect(request).toHaveBeenCalledOnce();
-    expect(scrollToOffset).toHaveBeenCalledOnce();
-    expect(scrollToOffset).toHaveBeenCalledWith(0);
+    expect(scrollToOffset).not.toHaveBeenCalled();
   });
 
-  it("does not navigate a replacement session after an older load settles", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client });
-    state.chatHistoryPagination = { hasMore: true, nextOffset: 2 };
-    appendChatThread(pane);
-    const loaded = createDeferred<boolean>();
-    const committed = createDeferred<boolean>();
-    vi.spyOn(pane, "loadOlderMessages").mockReturnValue(loaded.promise);
-    vi.spyOn(pane, "updateComplete", "get").mockReturnValue(committed.promise);
-    const scrollToOffset = vi.spyOn(pane.transcript, "scrollToOffset");
-
-    const navigation = pane.showEarlierMessages();
-    loaded.resolve(true);
-    await Promise.resolve();
+  it("does not apply older history to a replacement session", async () => {
+    const older = createDeferred<ChatHistoryResult>();
+    const { pane, state, scrollToOffset } = createNativeShowEarlierPane(vi.fn(() => older.promise));
+    const loading = pane.loadOlderMessages();
     state.sessionKey = "agent:main:replacement";
-    committed.resolve(true);
-    await navigation;
-
+    state.chatMessages = [];
+    older.resolve({ messages: [nativeHistoryMessage(1)], hasMore: false, totalMessages: 1 });
+    await loading;
+    expect(state.chatMessages).toEqual([]);
     expect(scrollToOffset).not.toHaveBeenCalled();
   });
 

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -279,32 +279,6 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
     this.syncHistoryObserver();
   }
 
-  protected async showEarlierMessages(): Promise<void> {
-    const state = this.state;
-    const root = this.transcript.scrollElement;
-    if (!state || !root) {
-      return;
-    }
-    const sessionKey = state.sessionKey;
-    const sessionStillCurrent = () =>
-      this.state === state && areUiSessionKeysEquivalent(state.sessionKey, sessionKey);
-    const loaded = await this.loadOlderMessages();
-    if (!loaded || !sessionStillCurrent()) {
-      return;
-    }
-    await this.updateComplete;
-    if (!sessionStillCurrent()) {
-      return;
-    }
-    // The explicit reveal can leave the sentinel visible. Disarm it before the
-    // programmatic jump so one click cannot chain another automatic page load.
-    this.transcriptScrollTop = 0;
-    this.historyObserverArmed = false;
-    this.historyAutoLoadBlocked = this.hasOlderMessages();
-    this.clearHistoryObserver();
-    this.transcript.scrollToOffset(0);
-  }
-
   protected async loadOlderMessages(): Promise<boolean> {
     if (this.activeOlderLoad) {
       return this.activeOlderLoad;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -404,7 +404,7 @@ export class ChatPane extends ChatPaneLayoutRender {
           ? {
               hasMore: historyHasMore,
               loading: this.loadingOlder,
-              onShowEarlier: () => void this.showEarlierMessages(),
+              onShowEarlier: () => void this.loadOlderMessages(),
             }
           : undefined,
       toolMessages: catalogKey ? [] : state.chatToolMessages,

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -44,7 +44,11 @@ describe("conversation position rail", () => {
       key: `row-${index}`,
       content: html`<div>${index}</div>`,
     }));
-    const { container, session } = await mountTestTranscript("rail-notification", rows, transcript);
+    const { container, session, renderRows } = await mountTestTranscript(
+      "rail-notification",
+      rows,
+      transcript,
+    );
     try {
       Object.defineProperties(container, {
         clientHeight: { configurable: true, value: 600 },
@@ -54,7 +58,11 @@ describe("conversation position rail", () => {
         observer.emitTarget(container, 800, 600);
       }
       const ids = rows.map((row) => row.key);
-      session.syncMessageRows(new Map(ids.map((id) => [id, id])));
+      session.syncMessageRows(
+        new Map(ids.map((id) => [id, id])),
+        new Map(ids.map((id) => [id, id])),
+      );
+      renderRows(rows);
       const currentId = () => session.activeMessageId(["row-2", "row-3"]);
       container.scrollTop = 50;
       container.dispatchEvent(new Event("scroll"));
@@ -99,7 +107,10 @@ describe("conversation position rail", () => {
       key: `row-${index}`,
       content: html`<div>${index}</div>`,
     }));
-    const { container, transcript, session } = await mountTestTranscript("rail-offset", rows);
+    const { container, transcript, session, renderRows } = await mountTestTranscript(
+      "rail-offset",
+      rows,
+    );
     try {
       Object.defineProperties(container, {
         clientHeight: { configurable: true, value: 600 },
@@ -110,7 +121,11 @@ describe("conversation position rail", () => {
         observer.emitTarget(container, 800, 600);
       }
       const ids = rows.map((row) => row.key);
-      session.syncMessageRows(new Map(ids.map((id) => [id, id])));
+      session.syncMessageRows(
+        new Map(ids.map((id) => [id, id])),
+        new Map(ids.map((id) => [id, id])),
+      );
+      renderRows(rows);
       // No scroll event or render between these queries: mounted rows are stale.
       container.scrollTop = 100;
       expect(session.activeMessageId(ids)).toBe("row-2");

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -167,6 +167,71 @@ describe("chat transcript controller", () => {
     expect(transcriptSize(container)).toBe(540);
   });
 
+  it.each([false, true])(
+    "keeps the committed rows and message lookup together while a touch holds a prepend, idle=%s",
+    async (idleBeforeRelease) => {
+      const initial: TestContentRow[] = [
+        {
+          kind: "content",
+          key: "retained-row",
+          content: html`<div class="chat-bubble" data-message-id="retained">retained</div>`,
+        },
+      ];
+      const next: TestContentRow[] = [
+        {
+          kind: "content",
+          key: "expanded-row",
+          content: html`<div class="chat-bubble" data-message-id="older">older</div>
+            <div class="chat-bubble" data-message-id="retained">retained</div>`,
+        },
+      ];
+      const { container, session, transcript, renderRows } = await mountTestTranscript(
+        "touch-map",
+        initial,
+      );
+      try {
+        session.syncMessageRows(
+          new Map([["retained", "retained-row"]]),
+          new Map([["retained", "retained-row"]]),
+        );
+        renderRows(initial);
+        container.dispatchEvent(new Event("touchstart"));
+        if (idleBeforeRelease) {
+          // The finger can remain down after native offset notifications settle.
+          vi.useFakeTimers();
+          container.scrollTop = 10;
+          container.dispatchEvent(new Event("scroll"));
+          await vi.advanceTimersByTimeAsync(200);
+        }
+        session.syncMessageRows(
+          new Map([["retained", "expanded-row"]]),
+          new Map([
+            ["older", "expanded-row"],
+            ["retained", "expanded-row"],
+          ]),
+        );
+        renderRows(next);
+        expect(transcriptRows(container).map((row) => row.dataset.virtualRowKey)).toEqual([
+          "retained-row",
+        ]);
+        expect(container.textContent).not.toContain("older");
+        expect(session.activeMessageId(["retained"])).toBe("retained");
+        container.dispatchEvent(new Event("touchend"));
+        renderRows(next);
+        expect(transcriptRows(container).map((row) => row.dataset.virtualRowKey)).toEqual([
+          "expanded-row",
+        ]);
+        expect(container.textContent).toContain("older");
+        expect(session.activeMessageId(["retained"])).toBe("retained");
+      } finally {
+        transcript.hostDisconnected();
+        if (idleBeforeRelease) {
+          vi.useRealTimers();
+        }
+      }
+    },
+  );
+
   it("does not teardown an MCP row retained by an append", async () => {
     const initialRows = [
       { kind: "content" as const, key: "app", content: html`<mcp-app-view></mcp-app-view>` },
@@ -860,7 +925,7 @@ describe("chat transcript controller", () => {
         key: id,
         content: html`<div class="chat-bubble" data-entry-id=${id}>${id}</div>`,
       }));
-      const { container, session } = await mountTestTranscript(
+      const { container, session, renderRows } = await mountTestTranscript(
         `reveal-${interruption}`,
         rows,
         transcript,
@@ -879,7 +944,12 @@ describe("chat transcript controller", () => {
             ["first", "first"],
             ["second", "second"],
           ]),
+          new Map([
+            ["first", "first"],
+            ["second", "second"],
+          ]),
         );
+        renderRows(rows);
         if (interruption === "idle at end") {
           vi.useFakeTimers();
         }

--- a/ui/src/pages/chat/components/chat-transcript-header.ts
+++ b/ui/src/pages/chat/components/chat-transcript-header.ts
@@ -1,0 +1,26 @@
+import type { Virtualizer } from "@tanstack/virtual-core";
+import { resolveTranscriptScrollMargin } from "./chat-transcript-geometry.ts";
+
+/** Compensate a header change when unchanged row keys do not trigger a prepend anchor. */
+export function reconcileTranscriptHeaderMargin(
+  virtualizer: Virtualizer<HTMLDivElement, HTMLElement>,
+  scrollElement: HTMLDivElement | null,
+  headerHeight: number,
+  appliedHeaderHeight: number,
+): number {
+  if (headerHeight === appliedHeaderHeight) {
+    return appliedHeaderHeight;
+  }
+  const delta = headerHeight - appliedHeaderHeight;
+  virtualizer.setOptions({
+    ...virtualizer.options,
+    scrollMargin: resolveTranscriptScrollMargin(scrollElement, headerHeight),
+  });
+  const offset = virtualizer.scrollOffset;
+  const next = offset === null ? null : Math.max(0, offset + delta);
+  if (next !== null && next !== offset) {
+    virtualizer.scrollOffset = next;
+    virtualizer.scrollToOffset(next);
+  }
+  return headerHeight;
+}

--- a/ui/src/pages/chat/components/chat-transcript-offset-observer.ts
+++ b/ui/src/pages/chat/components/chat-transcript-offset-observer.ts
@@ -1,0 +1,167 @@
+import { observeElementOffset, type Virtualizer } from "@tanstack/virtual-core";
+import { isTranscriptScrollKey } from "../chat-scroll-input.ts";
+import { maxTranscriptScrollOffset } from "./chat-transcript-geometry.ts";
+import type { ChatTranscriptInteractionAnchor } from "./chat-transcript-interaction-anchor.ts";
+import type { TranscriptPrependAnchor } from "./chat-transcript-prepend-anchor.ts";
+import type { ChatTranscriptPendingScrollOffset } from "./chat-transcript-session.ts";
+
+type TranscriptOffsetState = {
+  pendingScrollOffset: ChatTranscriptPendingScrollOffset | null;
+  scrollCommand:
+    | { behavior: ScrollBehavior; target: "end" | "index" }
+    | { behavior: ScrollBehavior; target: "message"; messageId: string }
+    | null;
+  touching: boolean;
+  touchScrolling: boolean;
+  pendingInteractionAnchor: ChatTranscriptInteractionAnchor | null;
+  syncNativeOffset: (() => void) | null;
+};
+
+/** Create the state shared by native input observation and transcript commands. */
+export function createTranscriptOffsetState(): TranscriptOffsetState {
+  return {
+    pendingScrollOffset: null,
+    scrollCommand: null,
+    touching: false,
+    touchScrolling: false,
+    pendingInteractionAnchor: null,
+    syncNativeOffset: null,
+  };
+}
+
+type OffsetOwner = {
+  state: TranscriptOffsetState;
+  getScrollElement(): HTMLDivElement | null;
+  readonly prependAnchor: TranscriptPrependAnchor;
+  cancelScroll(): void;
+  requestUpdate(): void;
+  onReaderScroll(): void;
+};
+
+/** Observe native offsets and input with the transcript's touch and command lifecycle. */
+export function observeTranscriptOffset(
+  owner: OffsetOwner,
+  instance: Virtualizer<HTMLDivElement, HTMLElement>,
+  callback: (offset: number, scrolling: boolean) => void,
+): () => void {
+  const element = owner.getScrollElement();
+  let nativeOffset = element?.scrollTop ?? 0;
+  const publishOffset = (offset: number, scrolling: boolean) => {
+    if (
+      scrolling &&
+      offset !== nativeOffset &&
+      (owner.state.touching || owner.state.touchScrolling)
+    ) {
+      owner.state.touchScrolling = true;
+      owner.prependAnchor.moveWithReader(offset - nativeOffset);
+    }
+    nativeOffset = offset;
+    const changed = offset !== instance.scrollOffset;
+    callback(offset, scrolling);
+    // Range notifications are memoized: the viewport midpoint can cross
+    // a rail landmark without changing the visible rows. Lit coalesces
+    // this request with the virtualizer's own update when both fire.
+    if (changed) {
+      owner.requestUpdate();
+    }
+  };
+  const syncOffset = () => {
+    if (!element || element !== owner.getScrollElement() || instance.scrollElement !== element) {
+      return;
+    }
+    const offset = element.scrollTop;
+    if (offset !== instance.scrollOffset) {
+      publishOffset(offset, instance.isScrolling);
+    }
+  };
+  owner.state.syncNativeOffset = syncOffset;
+  const finishTouch = () => {
+    owner.state.touching = false;
+    // Idle may have arrived while the finger was still down; no further
+    // offset notification is guaranteed after releasing a stationary touch.
+    if (!instance.isScrolling) {
+      owner.state.touchScrolling = false;
+    }
+    owner.requestUpdate();
+  };
+  const finishScroll = () => {
+    if (!owner.state.touching) {
+      owner.state.touchScrolling = false;
+      owner.requestUpdate();
+    }
+  };
+  const interrupt = (event: Event) => {
+    if (!element || element !== owner.getScrollElement() || instance.scrollElement !== element) {
+      return;
+    }
+    if (event instanceof KeyboardEvent && !isTranscriptScrollKey(event)) {
+      return;
+    }
+    if (event instanceof PointerEvent && event.target !== element) {
+      return;
+    }
+    if (event.type === "touchstart") {
+      owner.state.touching = true;
+    }
+    owner.state.pendingInteractionAnchor = null;
+    // Contact alone does not supersede a captured message. Actual native
+    // movement carries its viewport target through the gesture below.
+    if (
+      event.type !== "touchstart" ||
+      owner.state.scrollCommand ||
+      owner.state.pendingScrollOffset
+    ) {
+      owner.cancelScroll();
+    }
+    syncOffset();
+    owner.onReaderScroll();
+  };
+  for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
+    element?.addEventListener(type, interrupt, { passive: true });
+  }
+  element?.addEventListener("scrollend", finishScroll, { passive: true });
+  element?.addEventListener("touchend", finishTouch, { passive: true });
+  element?.addEventListener("touchcancel", finishTouch, { passive: true });
+  const cleanup = observeElementOffset(instance, (offset, scrolling) => {
+    if (element !== owner.getScrollElement()) {
+      return;
+    }
+    publishOffset(offset, scrolling);
+    // The offset observer already owns idle detection on browsers without
+    // scrollend. Release touch-held history through that same lifecycle.
+    if (!scrolling) {
+      finishScroll();
+    }
+    if (!scrolling && owner.prependAnchor.hasPrepend) {
+      owner.requestUpdate();
+    }
+    // Idle can arrive between smooth retargets. Completion needs the
+    // restore path's 1px precision, not the 8px UI-follow boundary.
+    // The input listeners above own reader takeover.
+    const settledAtEnd =
+      !scrolling &&
+      Math.abs((maxTranscriptScrollOffset(element) ?? 0) - (element?.scrollTop ?? 0)) <= 1;
+    // End-idle cannot retire a message reveal still waiting for its DOM commit.
+    if (settledAtEnd && owner.state.scrollCommand?.target === "end") {
+      if (owner.state.scrollCommand.behavior === "smooth") {
+        owner.cancelScroll();
+      } else {
+        owner.state.scrollCommand = null;
+      }
+    }
+  });
+  return () => {
+    if (owner.state.syncNativeOffset === syncOffset) {
+      owner.state.syncNativeOffset = null;
+    }
+    cleanup?.();
+    owner.state.touching = false;
+    owner.state.touchScrolling = false;
+    element?.removeEventListener("scrollend", finishScroll);
+    element?.removeEventListener("touchend", finishTouch);
+    element?.removeEventListener("touchcancel", finishTouch);
+    for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
+      element?.removeEventListener(type, interrupt);
+    }
+  };
+}

--- a/ui/src/pages/chat/components/chat-transcript-position.ts
+++ b/ui/src/pages/chat/components/chat-transcript-position.ts
@@ -1,0 +1,42 @@
+import type { Virtualizer } from "@tanstack/virtual-core";
+import { maxTranscriptScrollOffset } from "./chat-transcript-geometry.ts";
+
+/** Return the loaded message at or preceding the viewport midpoint. */
+export function activeTranscriptMessageId(
+  scrollElement: HTMLDivElement | null,
+  virtualizer: Virtualizer<HTMLDivElement, HTMLElement>,
+  messageIds: readonly string[],
+  messageRowKeysById: ReadonlyMap<string, string>,
+  rowIndexesByKey: ReadonlyMap<string, number>,
+): string | null {
+  if (!scrollElement || messageIds.length === 0) {
+    return null;
+  }
+  const maxOffset = maxTranscriptScrollOffset(scrollElement);
+  // At the end, the last section owns the position even if the midpoint
+  // still falls in the preceding row.
+  if (maxOffset !== null && Math.abs(maxOffset - scrollElement.scrollTop) <= 1) {
+    return messageIds.findLast((messageId) => messageRowKeysById.has(messageId)) ?? null;
+  }
+  // Measurements include scrollMargin; use the complete model rather than
+  // the rendered range, which may lag a jump or contain a focused outlier.
+  const activeRow = virtualizer.getVirtualItemForOffset(
+    scrollElement.scrollTop + scrollElement.clientHeight * 0.5,
+  );
+  if (!activeRow) {
+    return null;
+  }
+  let precedingId: string | null = null;
+  for (const messageId of messageIds) {
+    const rowKey = messageRowKeysById.get(messageId);
+    const rowIndex = rowKey ? rowIndexesByKey.get(rowKey) : undefined;
+    if (rowIndex === undefined) {
+      continue;
+    }
+    if (rowIndex > activeRow.index) {
+      return precedingId ?? messageId;
+    }
+    precedingId = messageId;
+  }
+  return precedingId;
+}

--- a/ui/src/pages/chat/components/chat-transcript-prepend-anchor.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-prepend-anchor.test.ts
@@ -1,0 +1,107 @@
+/* @vitest-environment jsdom */
+import type { Virtualizer } from "@tanstack/virtual-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TranscriptPrependAnchor } from "./chat-transcript-prepend-anchor.ts";
+
+function rect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    height,
+    width: 800,
+    left: 0,
+    right: 800,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+function fixture() {
+  const scroller = document.body.appendChild(document.createElement("div"));
+  scroller.getBoundingClientRect = () => rect(100, 500);
+  scroller.innerHTML =
+    '<div class="chat-virtual-row" data-index="4"><div class="chat-bubble" data-message-id="visible"></div></div>';
+  const row = scroller.firstElementChild as HTMLElement;
+  const bubble = row.firstElementChild as HTMLElement;
+  bubble.getBoundingClientRect = () => rect(90, 180);
+  const virtualizer = {
+    scrollToOffset: vi.fn((offset: number) => {
+      scroller.scrollTop = offset;
+    }),
+    scrollOffset: 200,
+  };
+  return {
+    scroller,
+    row,
+    bubble,
+    virtualizer,
+    instance: virtualizer as unknown as Virtualizer<HTMLDivElement, HTMLElement>,
+    anchor: new TranscriptPrependAnchor(),
+    measureRows: vi.fn(),
+  };
+}
+
+const messages = (...ids: string[]) => new Set(ids);
+afterEach(() => document.body.replaceChildren());
+
+describe("transcript prepend anchor", () => {
+  it("preserves a partially visible retained message rather than overscan across measurement and DOM replacement", () => {
+    const { scroller, row, bubble, virtualizer, instance, anchor, measureRows } = fixture();
+    const overscan = document.createElement("div");
+    overscan.className = "chat-bubble";
+    overscan.dataset.messageId = "above";
+    overscan.getBoundingClientRect = () => rect(-200, 100);
+    row.prepend(overscan);
+    anchor.messageKeys = messages("above", "visible");
+    anchor.capture(scroller, false);
+    anchor.messageKeys = messages("older", "above", "visible");
+    anchor.capture(scroller, false);
+    scroller.scrollTop = 200;
+    expect(anchor.update(scroller, instance, measureRows)).toBe(true);
+    expect(measureRows).toHaveBeenCalledOnce();
+    expect(scroller.scrollTop).toBe(200);
+    const committed = bubble.cloneNode() as HTMLElement;
+    committed.getBoundingClientRect = () => rect(390, 180);
+    bubble.replaceWith(committed);
+    expect(anchor.update(scroller, instance, measureRows)).toBe(true);
+    expect(scroller.scrollTop).toBe(500);
+    expect(virtualizer.scrollOffset).toBe(200);
+    expect(virtualizer.scrollToOffset).toHaveBeenCalledWith(500, { behavior: "instant" });
+    expect(anchor.update(scroller, instance, measureRows)).toBe(false);
+  });
+
+  it.each([
+    [messages(), messages("visible")],
+    [messages("visible"), messages("visible", "new")],
+    [messages("visible"), messages("replacement")],
+    [messages("removed", "visible"), messages("visible")],
+  ])("does not restore startup, append, replacement, or trimming", (previous, next) => {
+    const { scroller, instance, anchor, measureRows } = fixture();
+    anchor.messageKeys = previous;
+    anchor.capture(scroller, false);
+    anchor.messageKeys = next;
+    anchor.capture(scroller, false);
+    expect(anchor.update(scroller, instance, measureRows)).toBe(false);
+    expect(measureRows).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "retires restoration without a write when the bubble is stable or removed=$removed",
+    (removed) => {
+      const { scroller, bubble, instance, anchor, measureRows } = fixture();
+      anchor.messageKeys = messages("visible");
+      anchor.capture(scroller, false);
+      anchor.messageKeys = messages("older", "visible");
+      anchor.capture(scroller, false);
+      anchor.update(scroller, instance, measureRows);
+      if (removed) {
+        bubble.remove();
+      }
+      scroller.scrollTop = 200;
+      expect(anchor.update(scroller, instance, measureRows)).toBe(false);
+      expect(scroller.scrollTop).toBe(200);
+      expect(anchor.update(scroller, instance, measureRows)).toBe(false);
+    },
+  );
+});

--- a/ui/src/pages/chat/components/chat-transcript-prepend-anchor.ts
+++ b/ui/src/pages/chat/components/chat-transcript-prepend-anchor.ts
@@ -1,0 +1,140 @@
+import type { Virtualizer } from "@tanstack/virtual-core";
+
+type ChatTranscriptPrependAnchor = { messageKey: string; rowKey: string | null; top: number };
+
+/** Own the message anchor across projection capture, measurement, and restoration. */
+export class TranscriptPrependAnchor {
+  messageKeys: ReadonlySet<string> = new Set();
+  private firstMessageKey: string | undefined;
+  private pending: (ChatTranscriptPrependAnchor & { measured: boolean }) | null = null;
+
+  /** Stable message identity used to resolve its row in the committed projection. */
+  get messageKey(): string | null {
+    return this.pending?.messageKey ?? null;
+  }
+
+  /** Keep the retained row mounted while virtual and native offsets reconcile. */
+  get rowKey(): string | null {
+    return this.pending?.rowKey ?? null;
+  }
+
+  /** Whether the next projection inserts history before the committed first message. */
+  get hasPrepend(): boolean {
+    return Boolean(
+      this.firstMessageKey &&
+      this.firstMessageKey !== this.messageKeys.keys().next().value &&
+      this.messageKeys.has(this.firstMessageKey),
+    );
+  }
+
+  /** Capture only a committed prepend that is not superseded by a scroll command. */
+  capture(element: HTMLDivElement | null, commanded: boolean): void {
+    const anchor = commanded
+      ? null
+      : captureTranscriptPrependAnchor(element, this.firstMessageKey, this.messageKeys);
+    if (anchor) {
+      this.pending = { ...anchor, measured: false };
+    }
+    this.firstMessageKey = this.messageKeys.keys().next().value;
+  }
+
+  /** Measure estimated rows before restoring the retained message on the next commit. */
+  update(
+    element: HTMLDivElement | null,
+    virtualizer: Virtualizer<HTMLDivElement, HTMLElement>,
+    measureRows: () => void,
+  ): boolean {
+    const anchor = this.pending;
+    if (!anchor) {
+      return false;
+    }
+    if (!anchor.measured) {
+      measureRows();
+      anchor.measured = true;
+      return true;
+    }
+    this.pending = null;
+    return restoreTranscriptPrependAnchor(anchor, element, virtualizer);
+  }
+
+  /** Carry the viewport target with native reader movement, not layout growth. */
+  moveWithReader(delta: number): void {
+    if (this.pending) {
+      this.pending.top -= delta;
+    }
+  }
+
+  /** Retire pending restoration when the reader or another command takes over. */
+  clear(): void {
+    this.pending = null;
+  }
+
+  /** Drop projection identity when the owning session is disposed. */
+  reset(): void {
+    this.clear();
+    this.firstMessageKey = undefined;
+    this.messageKeys = new Set();
+  }
+}
+
+/** Capture the message being read before older history changes its containing row. */
+function captureTranscriptPrependAnchor(
+  scrollElement: HTMLDivElement | null,
+  previousFirstMessageKey: string | undefined,
+  next: ReadonlySet<string>,
+): ChatTranscriptPrependAnchor | null {
+  const first = previousFirstMessageKey;
+  if (!scrollElement || !first || first === next.keys().next().value || !next.has(first)) {
+    return null;
+  }
+  const viewport = scrollElement.getBoundingClientRect();
+  // Only rendered, retained bubbles can anchor the reader; overscan above the
+  // viewport and messages removed by the new projection are not candidates.
+  for (const bubble of scrollElement.querySelectorAll<HTMLElement>(
+    ".chat-bubble[data-message-id]",
+  )) {
+    const messageKey = bubble.dataset.messageId;
+    const rect = bubble.getBoundingClientRect();
+    if (
+      messageKey &&
+      next.has(messageKey) &&
+      rect.bottom > viewport.top &&
+      rect.top < viewport.bottom
+    ) {
+      return {
+        messageKey,
+        rowKey: bubble.closest<HTMLElement>(".chat-virtual-row")?.dataset.virtualRowKey ?? null,
+        top: rect.top,
+      };
+    }
+  }
+  return null;
+}
+
+/** Reconcile the inner-message anchor after the virtualizer commits its row anchor. */
+function restoreTranscriptPrependAnchor(
+  anchor: ChatTranscriptPrependAnchor | null,
+  scrollElement: HTMLDivElement | null,
+  virtualizer: Virtualizer<HTMLDivElement, HTMLElement>,
+): boolean {
+  if (!anchor || !scrollElement) {
+    return false;
+  }
+  // Group renderers may replace the bubble at an array index during prepend;
+  // resolve its stable render key in the committed DOM, not an old element.
+  const bubble = [
+    ...scrollElement.querySelectorAll<HTMLElement>(".chat-bubble[data-message-id]"),
+  ].find((element) => element.dataset.messageId === anchor.messageKey);
+  if (!bubble) {
+    return false;
+  }
+  const delta = bubble.getBoundingClientRect().top - anchor.top;
+  if (Math.abs(delta) <= 1) {
+    return false;
+  }
+  const offset = Math.max(0, scrollElement.scrollTop + delta);
+  // Commit one measured message target through the scroll owner. This also
+  // retires deferred row corrections already represented by the measured DOM.
+  virtualizer.scrollToOffset(offset, { behavior: "instant" });
+  return true;
+}

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -1,5 +1,5 @@
 // Chat-item projection, expansion, reply hydration, and guarded row rendering.
-import { nothing, type TemplateResult } from "lit";
+import { nothing } from "lit";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import { i18n, t } from "../../../i18n/index.ts";
 import { latestBrowserTabCards } from "../../../lib/chat/browser-tab-preview.ts";
@@ -62,19 +62,14 @@ import {
   guardChatRenderItems,
   trackTranscriptRenderDependencies,
 } from "./chat-transcript-render-guard.ts";
-import type { ChatTranscriptSession, TranscriptHeader } from "./chat-transcript-session.ts";
+import type {
+  ChatTranscriptProjection,
+  ChatTranscriptSession,
+  TranscriptHeader,
+} from "./chat-transcript-session.ts";
 import { renderChatTypingIndicator } from "./chat-typing-indicator.ts";
 import { resolveAssistantDisplayAvatar } from "./chat-welcome.ts";
 import { renderTurnRecapRow } from "./chat-working-indicator.ts";
-
-type ChatTranscriptProjection = {
-  positionMessages: readonly unknown[];
-  isDirectThread: boolean;
-  isEmpty: boolean;
-  showLoadingSkeleton: boolean;
-  searchOpen: boolean;
-  renderRows: (overlay?: unknown, header?: TranscriptHeader | null) => TemplateResult;
-};
 
 type ChatRenderItem = ReturnType<typeof coalesceAgentRunFrames>[number];
 
@@ -284,6 +279,7 @@ export function projectChatTranscript(
   const turnRecapByGroupKey = new Map<string, TurnRecap>();
   const loadedReplySources = new Map<string, LoadedReplySource>();
   const messageRowKeysById = new Map<string, string>();
+  const transcriptMessageKeys = new Map<string, string>();
   const resolveReplyPreview = createReplyPreviewResolver(loadedReplySources, props);
   const sharedMessageRenderOptions = {
     presented: props.presented,
@@ -582,6 +578,7 @@ export function projectChatTranscript(
     });
     for (const group of groups) {
       for (const source of group.messages) {
+        transcriptMessageKeys.set(source.key, item.key);
         const sourceMessageId = persistedMessageEntryId(source.message);
         // The preview resolves content lazily; indexing only needs persisted identities.
         if (sourceMessageId) {
@@ -595,7 +592,7 @@ export function projectChatTranscript(
       }
     }
   }
-  transcript.syncMessageRows(messageRowKeysById);
+  transcript.syncMessageRows(messageRowKeysById, transcriptMessageKeys);
   let turnRecapOwnerKey: string | null = null;
   if (turnRecap !== null && tailStatusOwner?.runId === turnRecap.runId) {
     turnRecapByGroupKey.set(tailStatusOwner.key, turnRecap);

--- a/ui/src/pages/chat/components/chat-transcript-session.ts
+++ b/ui/src/pages/chat/components/chat-transcript-session.ts
@@ -2,8 +2,17 @@
 // virtualizer host owned by ChatTranscriptController.
 import type { TemplateResult } from "lit";
 import type { AssistantMessageExpansionState } from "../chat-thread.ts";
+import type { ChatSessionScrollPosition } from "../scroll.ts";
 import type { TranscriptAnnouncement } from "./chat-transcript-announcement.ts";
 import type { TranscriptRow } from "./chat-transcript-layout.ts";
+
+/** A reader-position restoration that is waiting for stable transcript geometry. */
+export type ChatTranscriptPendingScrollOffset = {
+  offset: number;
+  stableFrames: number;
+  zeroMaxFrames: number;
+  onSettled?: (position: ChatSessionScrollPosition) => void;
+};
 
 export type TranscriptCallbacks = {
   onViewportResize?: () => void;
@@ -37,11 +46,36 @@ export type ChatTranscriptSession = {
     overlay?: unknown,
     header?: TranscriptHeader | null,
   ): TemplateResult;
-  syncMessageRows(messageRowKeysById: ReadonlyMap<string, string>): void;
+  syncMessageRows(
+    messageRowKeysById: ReadonlyMap<string, string>,
+    messageRowsByKey: ReadonlyMap<string, string>,
+  ): void;
   /** Returns the sampled loaded message at or preceding the viewport midpoint. */
   activeMessageId(messageIds: readonly string[]): string | null;
   revealMessage(messageId: string): boolean;
   setContentReady(ready: boolean): void;
   handleFocusIn(event: FocusEvent): void;
   handleFocusOut(event: FocusEvent): void;
+};
+
+/** Presentation contract produced by the chat-item projection. */
+export type ChatTranscriptProjection = {
+  positionMessages: readonly unknown[];
+  isDirectThread: boolean;
+  isEmpty: boolean;
+  showLoadingSkeleton: boolean;
+  searchOpen: boolean;
+  renderRows: (overlay?: unknown, header?: TranscriptHeader | null) => TemplateResult;
+};
+
+/** Rows and lookup identities that must be promoted as one rendered projection. */
+export type TranscriptRenderSnapshot<T> = {
+  rows: readonly TranscriptRow<T>[];
+  renderRow: (row: TranscriptRow<T>) => unknown;
+  announcement: TranscriptAnnouncement | null;
+  announce: boolean;
+  overlay: unknown;
+  header: TranscriptHeader | null;
+  messageRows: ReadonlyMap<string, string>;
+  renderKeyRows: ReadonlyMap<string, string>;
 };

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -2,8 +2,8 @@
 // for one transcript. Owned and swapped by ChatTranscriptController.
 import { VirtualizerController } from "@tanstack/lit-virtual";
 import {
+  type Range,
   measureElement as measureVirtualElement,
-  observeElementOffset,
   observeElementRect,
 } from "@tanstack/virtual-core";
 import {
@@ -14,7 +14,6 @@ import {
 } from "lit";
 import { McpAppUnmountGate } from "../../../components/mcp-app-unmount.ts";
 import { resolveScrollBehavior } from "../../../lib/scroll-behavior.ts";
-import { isTranscriptScrollKey } from "../chat-scroll-input.ts";
 import type { AssistantMessageExpansionState } from "../chat-thread.ts";
 import {
   CHAT_TRANSCRIPT_END_THRESHOLD_PX,
@@ -35,12 +34,18 @@ import {
   PositionRailGutterController,
   syncScrollMargin,
 } from "./chat-transcript-geometry.ts";
+import { reconcileTranscriptHeaderMargin } from "./chat-transcript-header.ts";
 import {
-  type ChatTranscriptInteractionAnchor,
   reconcileChatTranscriptInteractionResize,
   resolveChatTranscriptInteractionAnchor,
 } from "./chat-transcript-interaction-anchor.ts";
 import { renderChatTranscriptLayout, type TranscriptRow } from "./chat-transcript-layout.ts";
+import {
+  createTranscriptOffsetState,
+  observeTranscriptOffset,
+} from "./chat-transcript-offset-observer.ts";
+import { activeTranscriptMessageId } from "./chat-transcript-position.ts";
+import { TranscriptPrependAnchor } from "./chat-transcript-prepend-anchor.ts";
 import {
   extractTranscriptRange,
   previewTranscriptRowKeys,
@@ -54,9 +59,11 @@ import {
   type ChatTranscriptSession,
   type TranscriptCallbacks,
   type TranscriptHeader,
+  type TranscriptRenderSnapshot,
 } from "./chat-transcript-session.ts";
 
 export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscriptSession {
+  private readonly offsetState = createTranscriptOffsetState();
   expandedAssistantMessages = new Map<string, AssistantMessageExpansionState>();
   private readonly controllers = new Set<ReactiveController>();
   private readonly positionRail: PositionRailGutterController;
@@ -71,17 +78,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   private headerHeight = 0;
   private appliedHeaderHeight = 0;
   private implicitEndAnchorPending: boolean;
-  private pendingScrollOffset: {
-    offset: number;
-    stableFrames: number;
-    zeroMaxFrames: number;
-    onSettled?: (position: ChatSessionScrollPosition) => void;
-  } | null = null;
   private pendingScrollFrame: number | null = null;
-  private scrollCommand:
-    | { behavior: ScrollBehavior; target: "end" | "index" }
-    | { behavior: ScrollBehavior; target: "message"; messageId: string }
-    | null = null;
   private readonly messageReveal = new ChatMessageReveal();
   // Lit calls refs before newly rendered nodes are connected. Resolve the
   // scroll parent lazily or a stable ref can permanently capture null.
@@ -120,20 +117,20 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private pruneDetachedRowsQueued = false;
   private pendingRowMeasureFrame: number | null = null;
-  private syncNativeOffset: (() => void) | null = null;
-  private pendingInteractionAnchor: ChatTranscriptInteractionAnchor | null = null;
   private readonly captureInteractionResize = (event: Event) => {
     const anchor = resolveChatTranscriptInteractionAnchor(event);
     if (!anchor) {
       return;
     }
-    this.pendingInteractionAnchor = anchor;
-    queueMicrotask(() => this.pendingInteractionAnchor === anchor && this.host.requestUpdate());
+    this.offsetState.pendingInteractionAnchor = anchor;
+    queueMicrotask(
+      () => this.offsetState.pendingInteractionAnchor === anchor && this.host.requestUpdate(),
+    );
   };
   private measureConnectedRows(): void {
     // Native input can land after takeover but before its offset observer.
     // Refresh the offset and direction before compensating deferred row growth.
-    this.syncNativeOffset?.();
+    this.offsetState.syncNativeOffset?.();
     measureConnectedTranscriptRows(this.scrollElement, this.virtualizerController.getVirtualizer());
   }
   private readonly handleGeometryCommit = (event: Event) => {
@@ -168,8 +165,8 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       callback = (element?: Element) => {
         if (element instanceof HTMLElement) {
           if (
-            this.scrollCommand?.target === "message" &&
-            this.messageRowKeysById.get(this.scrollCommand.messageId) === key
+            this.offsetState.scrollCommand?.target === "message" &&
+            this.messageRowKeysById.get(this.offsetState.scrollCommand.messageId) === key
           ) {
             // The parent update can finish before a virtualized target mounts.
             queueMicrotask(() => this.completeMessageReveal());
@@ -215,6 +212,11 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   private rowKeys: readonly string[] = [];
   private rowIndexesByKey = new Map<string, number>();
   private messageRowKeysById: ReadonlyMap<string, string> = new Map();
+  private readonly prependAnchor = new TranscriptPrependAnchor();
+  private candidateMessageRowKeysById: ReadonlyMap<string, string> = new Map();
+  private candidateMessageRowsByKey: ReadonlyMap<string, string> = new Map();
+  private committedMessageRowsByKey: ReadonlyMap<string, string> = new Map();
+  private renderPreviousRows: (() => TemplateResult) | null = null;
   private focusedRowKey: string | null = null;
   private readonly announcement = new TranscriptAnnouncementState();
   private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
@@ -266,79 +268,21 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
             this.host.requestUpdate();
           }
         }),
-      observeElementOffset: (instance, callback) => {
-        const element = this.scrollElement;
-        const publishOffset = (offset: number, scrolling: boolean) => {
-          const changed = offset !== instance.scrollOffset;
-          callback(offset, scrolling);
-          // Range notifications are memoized: the viewport midpoint can cross
-          // a rail landmark without changing the visible rows. Lit coalesces
-          // this request with the virtualizer's own update when both fire.
-          if (changed) {
-            this.host.requestUpdate();
-          }
-        };
-        const syncOffset = () => {
-          if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
-            return;
-          }
-          const offset = element.scrollTop;
-          if (offset !== instance.scrollOffset) {
-            publishOffset(offset, instance.isScrolling);
-          }
-        };
-        this.syncNativeOffset = syncOffset;
-        const interrupt = (event: Event) => {
-          if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
-            return;
-          }
-          if (event instanceof KeyboardEvent && !isTranscriptScrollKey(event)) {
-            return;
-          }
-          if (event instanceof PointerEvent && event.target !== element) {
-            return;
-          }
-          this.pendingInteractionAnchor = null;
-          this.cancelScroll();
-          syncOffset();
-          this.callbacks.onReaderScroll?.();
-        };
-        for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
-          element?.addEventListener(type, interrupt, { passive: true });
-        }
-        const cleanup = observeElementOffset(instance, (offset, scrolling) => {
-          if (element !== this.scrollElement) {
-            return;
-          }
-          publishOffset(offset, scrolling);
-          // Idle can arrive between smooth retargets. Completion needs the
-          // restore path's 1px precision, not the 8px UI-follow boundary.
-          // The input listeners above own reader takeover.
-          const settledAtEnd =
-            !scrolling &&
-            Math.abs((maxTranscriptScrollOffset(element) ?? 0) - (element?.scrollTop ?? 0)) <= 1;
-          // End-idle cannot retire a message reveal still waiting for its DOM commit.
-          if (settledAtEnd && this.scrollCommand?.target === "end") {
-            if (this.scrollCommand.behavior === "smooth") {
-              this.cancelScroll();
-            } else {
-              this.scrollCommand = null;
-            }
-          }
-        });
-        return () => {
-          if (this.syncNativeOffset === syncOffset) {
-            this.syncNativeOffset = null;
-          }
-          cleanup?.();
-          for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
-            element?.removeEventListener(type, interrupt);
-          }
-        };
-      },
+      observeElementOffset: (instance, callback) =>
+        observeTranscriptOffset(
+          {
+            state: this.offsetState,
+            getScrollElement: () => this.scrollElement,
+            prependAnchor: this.prependAnchor,
+            cancelScroll: () => this.cancelScroll(),
+            requestUpdate: () => this.host.requestUpdate(),
+            onReaderScroll: () => this.callbacks.onReaderScroll?.(),
+          },
+          instance,
+          callback,
+        ),
       measureElement: measureVirtualElement,
-      rangeExtractor: (range) =>
-        extractTranscriptRange(range, this.rowIndexesByKey, this.focusedRowKey),
+      rangeExtractor: (range) => this.extractAnchoredRange(range, this.rowIndexesByKey),
       // Virtual distance omits real padding, pinning readers ~80px up past scroll.ts's follow-lock.
       // scheduleCommittedChatScroll owns end-follow on content changes and source: "resize".
       // Disable isAtEnd()'s default too; callers must supply an explicit threshold.
@@ -346,7 +290,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       overscan: CHAT_TRANSCRIPT_OVERSCAN,
     });
     if (initialOffset !== null) {
-      this.pendingScrollOffset = {
+      this.offsetState.pendingScrollOffset = {
         offset: initialOffset,
         stableFrames: 0,
         zeroMaxFrames: 0,
@@ -384,7 +328,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     for (const controller of this.controllers) {
       controller.hostConnected?.();
     }
-    if (this.pendingScrollOffset) {
+    if (this.offsetState.pendingScrollOffset) {
       this.host.requestUpdate();
     }
   }
@@ -394,6 +338,18 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       controller.hostUpdated?.();
     }
     this.reconcileInteractionResize();
+    if (
+      !this.offsetState.touching &&
+      !this.offsetState.touchScrolling &&
+      this.prependAnchor.update(
+        this.scrollElement,
+        this.virtualizerController.getVirtualizer(),
+        () => this.measureConnectedRows(),
+      )
+    ) {
+      this.offsetState.syncNativeOffset?.();
+      this.host.requestUpdate();
+    }
     this.reconcileImplicitEndAnchor();
     this.applyPendingScrollOffset();
   }
@@ -403,7 +359,11 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     // rows when this presentation reconnects with the same source messages.
     this.expandedAssistantMessages.clear();
     this.expandedAssistantMessages = new Map();
-    this.scrollCommand = null;
+    this.offsetState.scrollCommand = null;
+    this.prependAnchor.clear();
+    this.offsetState.touching = false;
+    this.offsetState.touchScrolling = false;
+    this.renderPreviousRows = null;
     this.messageReveal.clear();
     if (this.pendingRowMeasureFrame !== null) {
       cancelAnimationFrame(this.pendingRowMeasureFrame);
@@ -433,8 +393,9 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     this.rowKeys = [];
     this.rowIndexesByKey.clear();
     this.messageRowKeysById = new Map();
+    this.prependAnchor.reset();
     this.focusedRowKey = null;
-    this.pendingScrollOffset = null;
+    this.offsetState.pendingScrollOffset = null;
   }
 
   render<T>(
@@ -445,6 +406,40 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     overlay: unknown = nothing,
     header: TranscriptHeader | null = null,
   ): TemplateResult {
+    const virtualizer = this.virtualizerController.getVirtualizer();
+    // Keep old geometry during the gesture, while still virtualizing that old
+    // row model as the reader moves. Only the history insertion is held back.
+    if (
+      this.prependAnchor.hasPrepend &&
+      (this.offsetState.touching || this.offsetState.touchScrolling || virtualizer.isScrolling) &&
+      !this.offsetState.scrollCommand &&
+      !this.offsetState.pendingScrollOffset &&
+      this.renderPreviousRows
+    ) {
+      return this.renderPreviousRows();
+    }
+    return this.renderCommittedRows(
+      {
+        rows,
+        renderRow,
+        announcement,
+        announce,
+        overlay,
+        header,
+        messageRows: this.candidateMessageRowKeysById,
+        renderKeyRows: this.candidateMessageRowsByKey,
+      },
+      true,
+    );
+  }
+
+  /** Render one selected projection without admitting a held history insertion. */
+  private renderCommittedRows<T>(
+    snapshot: TranscriptRenderSnapshot<T>,
+    capturePrepend: boolean,
+  ): TemplateResult {
+    const { rows, renderRow, announcement, announce, overlay, header, messageRows, renderKeyRows } =
+      snapshot;
     const rowModelChanged =
       rows.length !== this.rowKeys.length ||
       rows.some((row, index) => row.key !== this.rowKeys[index]);
@@ -456,11 +451,28 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     return this.mcpAppUnmountGate.render(
       rowModelChanged ? nextKeys : JSON.stringify(nextRowKeys),
       () => {
+        // Rows, lookup maps, and the retained renderer commit together. A
+        // teardown-pending candidate must never replace the displayed model.
+        this.messageRowKeysById = messageRows;
+        this.committedMessageRowsByKey = renderKeyRows;
+        this.renderPreviousRows = () => this.renderCommittedRows(snapshot, false);
+        // Capture only after the unmount gate permits the projection to commit.
+        if (capturePrepend) {
+          this.prependAnchor.capture(
+            this.scrollElement,
+            Boolean(this.offsetState.pendingScrollOffset || this.offsetState.scrollCommand),
+          );
+        }
         this.headerHeight = header?.height ?? 0;
         if (rowModelChanged) {
           this.syncRows(nextKeys);
         } else {
-          this.syncHeaderMargin();
+          this.appliedHeaderHeight = reconcileTranscriptHeaderMargin(
+            virtualizer,
+            this.scrollElement,
+            this.headerHeight,
+            this.appliedHeaderHeight,
+          );
         }
         this.announcement.sync(announcement, announce);
         return renderChatTranscriptLayout({
@@ -498,34 +510,36 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     // committed viewport so the final event publishes the settled end policy.
     const distanceFromEnd = (maxTranscriptScrollOffset(element) ?? 0) - (element?.scrollTop ?? 0);
     return (
-      this.pendingScrollOffset !== null ||
-      (this.scrollCommand !== null && distanceFromEnd > CHAT_TRANSCRIPT_END_THRESHOLD_PX)
+      this.offsetState.pendingScrollOffset !== null ||
+      (this.offsetState.scrollCommand !== null &&
+        distanceFromEnd > CHAT_TRANSCRIPT_END_THRESHOLD_PX)
     );
   }
 
   scrollToEnd({ source = "manual", behavior = "auto" }: ChatScrollToEndOptions = {}): boolean {
     // Hydration/resize follow cannot replace a saved reader. A new latest
     // command intentionally supersedes restoration.
-    if (source === "auto" && this.pendingScrollOffset) {
+    if (source === "auto" && this.offsetState.pendingScrollOffset) {
       return false;
     }
     this.cancelScroll();
-    this.scrollCommand = { behavior, target: "end" };
+    this.offsetState.scrollCommand = { behavior, target: "end" };
     this.virtualizerController.getVirtualizer().scrollToEnd({ behavior });
     return true;
   }
 
   private cancelScroll(): void {
-    if (this.scrollCommand === null && !this.pendingScrollOffset) {
+    this.prependAnchor.clear();
+    if (this.offsetState.scrollCommand === null && !this.offsetState.pendingScrollOffset) {
       return;
     }
     // Only smooth commands skip row measurements. Replaying ordinary auto
     // scrolling's overscan sizes can move an already settled end anchor.
-    if (this.scrollCommand?.behavior === "smooth") {
+    if (this.offsetState.scrollCommand?.behavior === "smooth") {
       this.queueConnectedRowMeasure();
     }
-    this.scrollCommand = null;
-    this.pendingScrollOffset = null;
+    this.offsetState.scrollCommand = null;
+    this.offsetState.pendingScrollOffset = null;
     if (this.pendingScrollFrame !== null) {
       cancelAnimationFrame(this.pendingScrollFrame);
       this.pendingScrollFrame = null;
@@ -540,42 +554,23 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     }
   }
 
-  syncMessageRows(messageRowKeysById: ReadonlyMap<string, string>): void {
-    this.messageRowKeysById = messageRowKeysById;
+  syncMessageRows(
+    messageRowKeysById: ReadonlyMap<string, string>,
+    messageRowsByKey: ReadonlyMap<string, string>,
+  ): void {
+    this.candidateMessageRowKeysById = new Map(messageRowKeysById);
+    this.candidateMessageRowsByKey = new Map(messageRowsByKey);
+    this.prependAnchor.messageKeys = new Set(messageRowsByKey.keys());
   }
 
   activeMessageId(messageIds: readonly string[]): string | null {
-    const scrollElement = this.scrollElement;
-    if (!scrollElement || messageIds.length === 0) {
-      return null;
-    }
-    const virtualizer = this.virtualizerController.getVirtualizer();
-    const maxOffset = maxTranscriptScrollOffset(scrollElement);
-    // The reader has reached the final section even though the normal midpoint
-    // viewport anchor still points into the preceding row.
-    if (maxOffset !== null && Math.abs(maxOffset - scrollElement.scrollTop) <= 1) {
-      return messageIds.findLast((messageId) => this.messageRowKeysById.has(messageId)) ?? null;
-    }
-    // Measurements already include scrollMargin. Query the complete row model,
-    // not the rendered range, which can lag a jump or include a focused outlier.
-    const viewportAnchor = scrollElement.scrollTop + scrollElement.clientHeight * 0.5;
-    const activeRow = virtualizer.getVirtualItemForOffset(viewportAnchor);
-    if (!activeRow) {
-      return null;
-    }
-    let precedingId: string | null = null;
-    for (const messageId of messageIds) {
-      const rowKey = this.messageRowKeysById.get(messageId);
-      const rowIndex = rowKey ? this.rowIndexesByKey.get(rowKey) : undefined;
-      if (rowIndex === undefined) {
-        continue;
-      }
-      if (rowIndex > activeRow.index) {
-        return precedingId ?? messageId;
-      }
-      precedingId = messageId;
-    }
-    return precedingId;
+    return activeTranscriptMessageId(
+      this.scrollElement,
+      this.virtualizerController.getVirtualizer(),
+      messageIds,
+      this.messageRowKeysById,
+      this.rowIndexesByKey,
+    );
   }
 
   revealMessage(messageId: string): boolean {
@@ -585,7 +580,11 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       return false;
     }
     this.cancelScroll();
-    this.scrollCommand = { behavior: resolveScrollBehavior(), target: "message", messageId };
+    this.offsetState.scrollCommand = {
+      behavior: resolveScrollBehavior(),
+      target: "message",
+      messageId,
+    };
     this.virtualizerController.getVirtualizer().scrollToIndex(rowIndex, { align: "center" });
     this.host.requestUpdate();
     void this.host.updateComplete.then(() => this.completeMessageReveal());
@@ -593,12 +592,12 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   }
 
   private completeMessageReveal(): void {
-    const command = this.scrollCommand;
+    const command = this.offsetState.scrollCommand;
     if (
       command?.target === "message" &&
       this.messageReveal.reveal(this.threadInnerElement, command)
     ) {
-      this.scrollCommand = { behavior: command.behavior, target: "index" };
+      this.offsetState.scrollCommand = { behavior: command.behavior, target: "index" };
     }
   }
 
@@ -612,7 +611,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   ): void {
     this.cancelScroll();
     this.implicitEndAnchorPending = false;
-    this.pendingScrollOffset = { offset, stableFrames: 0, zeroMaxFrames: 0, onSettled };
+    this.offsetState.pendingScrollOffset = { offset, stableFrames: 0, zeroMaxFrames: 0, onSettled };
     if (this.connected) {
       this.host.requestUpdate();
     }
@@ -630,14 +629,27 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     const virtualizer = this.virtualizerController.getVirtualizer();
     if (
       reconcileChatTranscriptInteractionResize(
-        this.pendingInteractionAnchor,
+        this.offsetState.pendingInteractionAnchor,
         sidebarCommitTarget,
         this.scrollElement,
         virtualizer,
       )
     ) {
-      this.pendingInteractionAnchor = null;
+      this.offsetState.pendingInteractionAnchor = null;
     }
+  }
+
+  /** Preserve the retained bubble even when a deferred offset selects another range. */
+  private extractAnchoredRange(range: Range, indexes: ReadonlyMap<string, number>): number[] {
+    const visible = extractTranscriptRange(range, indexes, this.focusedRowKey);
+    const messageKey = this.prependAnchor.messageKey;
+    const rowKey =
+      (messageKey === null ? null : this.committedMessageRowsByKey.get(messageKey)) ??
+      this.prependAnchor.rowKey;
+    const anchorIndex = rowKey === null ? undefined : indexes.get(rowKey);
+    return anchorIndex === undefined || visible.includes(anchorIndex)
+      ? visible
+      : [...visible, anchorIndex].toSorted((left, right) => left - right);
   }
 
   private syncRows(nextKeys: readonly string[]): void {
@@ -646,7 +658,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       !this.rowIndexesByKey.has("presence:typing") && nextKeys.includes("presence:typing");
     const followTyping =
       typingAdded &&
-      !this.pendingScrollOffset &&
+      !this.offsetState.pendingScrollOffset &&
       virtualizer.isAtEnd(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
     this.rowKeys = Object.freeze(nextKeys);
     const rowIndexesByKey = new Map(this.rowKeys.map((key, index) => [key, index]));
@@ -665,36 +677,13 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       count: nextKeys.length,
       getItemKey: (index) => nextKeys[index] ?? `missing:${index}`,
       followOnAppend: false,
-      rangeExtractor: (range) => extractTranscriptRange(range, rowIndexesByKey, this.focusedRowKey),
+      rangeExtractor: (range) => this.extractAnchoredRange(range, rowIndexesByKey),
       scrollMargin: resolveTranscriptScrollMargin(this.scrollElement, this.headerHeight),
     });
     if (followTyping) {
       this.cancelScroll();
-      this.scrollCommand = { behavior: "auto", target: "index" };
+      this.offsetState.scrollCommand = { behavior: "auto", target: "index" };
       virtualizer.scrollToIndex(nextKeys.indexOf("presence:typing"), { align: "end" });
-    }
-  }
-
-  // Header toggled around an unchanged row model (exhaustion usually commits
-  // one render after its final prepend). No edge keys change, so no re-anchor
-  // runs; shift the offset by the header delta or every visible row jumps by
-  // the boundary height.
-  private syncHeaderMargin(): void {
-    if (this.headerHeight === this.appliedHeaderHeight) {
-      return;
-    }
-    const delta = this.headerHeight - this.appliedHeaderHeight;
-    this.appliedHeaderHeight = this.headerHeight;
-    const virtualizer = this.virtualizerController.getVirtualizer();
-    virtualizer.setOptions({
-      ...virtualizer.options,
-      scrollMargin: resolveTranscriptScrollMargin(this.scrollElement, this.headerHeight),
-    });
-    const offset = virtualizer.scrollOffset;
-    const next = offset === null ? null : Math.max(0, offset + delta);
-    if (next !== null && next !== offset) {
-      virtualizer.scrollOffset = next;
-      virtualizer.scrollToOffset(next);
     }
   }
 
@@ -724,7 +713,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   }
 
   private applyPendingScrollOffset(): void {
-    const pending = this.pendingScrollOffset;
+    const pending = this.offsetState.pendingScrollOffset;
     if (!pending || !this.connected) {
       return;
     }
@@ -771,15 +760,15 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     }
     this.pendingScrollFrame = requestAnimationFrame(() => {
       this.pendingScrollFrame = null;
-      if (this.connected && this.pendingScrollOffset) {
+      if (this.connected && this.offsetState.pendingScrollOffset) {
         this.host.requestUpdate();
       }
     });
   }
 
   private settlePendingScroll(scrollTop: number): void {
-    const pending = this.pendingScrollOffset;
-    this.pendingScrollOffset = null;
+    const pending = this.offsetState.pendingScrollOffset;
+    this.offsetState.pendingScrollOffset = null;
     if (!pending) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading older messages in the Control UI lose their place when another history page expands an existing message group. Row-level anchoring alone cannot preserve the position of a message inside that growing group.

## Why This Change Was Made

Preserve the visible message through a stable render identity, keep its virtual row mounted, and reconcile its measured position through the virtualizer's public scroll API. Older-history projections remain held during active touch/scrolling; rendered rows and their message lookup maps are promoted together after the interaction settles. Offset-observer idle notifications release held history even when the browser does not deliver `scrollend`, including when scrolling becomes idle before the finger lifts.

Manual **Show earlier** uses the canonical history-loading flow rather than a separate forced-top navigation. Explicit commands, reader takeover, session disposal, message reveal, and position-rail behavior retain their lifecycle ownership. No dependency patches, dependency declarations, timers, configuration, or persistent-store changes are added by this PR.

Production LOC: +583/-214 (net +369). Tests/test support: +465/-42 (net +423). Production growth adds the message-level anchor and atomic projection/gesture lifecycle that row-only anchoring cannot express; offset observation, header compensation, and active-position calculation are extracted into bounded owner modules.

## User Impact

Readers keep their place while older history is inserted, including same-role groups and sequence-only messages. Loading during a touch gesture waits for the interaction to settle instead of interrupting it. Deliberate reader movement is preserved rather than mistaken for layout drift.

## Evidence

Candidate: `2a1685db15f39ffbfa0587dddff9da872d61ab8f`, rebased onto `0a0074dc6aef73b5f6c71d02bad340314ca74f48`. The rebase was conflict-free and its stable patch ID matches the reviewed local candidate.

- 85 focused unit/pagination tests passed on the rebased candidate, including transcript controller, position rail, prepend anchor, and history loading.
- All 9 browser prepend scenarios passed on the rebased candidate. Coverage includes shared/non-shared groups, manual and automatic pagination, sequence-only identities, history exhaustion, touch, and synthetic momentum without `scrollend` delivery.
- Every sampled frame preserves the retained message within 2 px after accounting for deliberate reader movement; the stationary-touch recording preserves entry 1001 at y=119 before and after loading.
- Negative controls reproduced both lifecycle defects: missing idle release left new history withheld without `scrollend`; idle-before-touchend left the old projection held. Both tests passed with their fixes restored.
- The full changed-file gate passed on the rebased candidate: core/UI typechecks, formatting, lint, dead-export scans, and the remaining guards. A stale local proxyline install was synchronized to the existing frozen lockfile; this PR does not modify dependency declarations or the lockfile.
- Independent full-candidate autoreview was scoped-clean at P0–P2. The clean rebase preserved the reviewed patch unchanged.
- **Proof boundary:** real Control UI renderer and mocked Gateway in Chromium with synthetic history/touch/scroll events, not native Safari inertia or a live authenticated operator session. Native Safari momentum remains unverified. The operator Gateway was not modified or deployed.

### Video proof

Inspected transcript-only crop of the passing stationary-touch case. Entry 1001 remains in place as older history is inserted above it. This is a recording of the actual test run at original speed, not generated video. Raw recordings and frame-position evidence are retained locally. The recording predates the conflict-free, patch-identical rebase; the same nine scenarios passed again afterward.

https://github.com/user-attachments/assets/ab11c767-da74-4fd6-8000-ac118c95c1a5

### Earlier desktop before/after captures

These show the repaired build before and after loading, not two different revisions.

![Before loading earlier history](https://github.com/user-attachments/assets/60dc275e-c2e9-4988-8b7f-d6205ba2f0fd)

![After loading earlier history](https://github.com/user-attachments/assets/7d3df8a4-8c87-41f5-9355-e82ca61c2c86)

<details>
<summary>Changes walkthrough</summary>

| File | Change |
| --- | --- |
| `chat-transcript-virtualizer-host.ts` | Coordinate atomic projection, anchoring, and retained rows. |
| `chat-transcript-prepend-anchor.ts` | Capture, measure, and restore stable message anchors. |
| `chat-transcript-offset-observer.ts` | Own native touch, offset, idle, and command lifecycle. |
| `chat-transcript-header.ts` | Reconcile transcript header geometry. |
| `chat-transcript-position.ts` | Resolve the active loaded message. |
| `chat-transcript-projection.ts` | Map stable message identities to committed rows. |
| `chat-transcript-session.ts` | Carry atomic render snapshots and position contracts. |
| `chat-pane-history.ts` | Remove separate forced-top pagination. |
| `chat-pane-render.ts` | Use canonical earlier-history loading. |
| `chat-history-prepend-anchor.e2e.test.ts` | Assert frame stability and touch/idle release. |
| `claude-sessions.e2e.test.ts` | Verify reader position through pagination. |
| `chat-transcript-prepend-anchor.test.ts` | Cover anchor selection, correction, and retirement. |
| `chat-transcript-controller.test.ts` | Prove atomic rows/maps and touch release lifecycle. |
| `chat-position-rail.test.ts` | Commit projection before position/reveal lookup. |
| `chat-pane-history.test.ts` | Preserve loading, failure, and prefetch behavior. |
| `chat-pane-history.test-support.ts` | Align fixture with canonical pagination. |

</details>
