### PR TITLE
fix(workers): preserve useful cleanup failure diagnostics

### DIFF
--- a/docs/gateway/cloud-workers/session-lifecycle.md
+++ b/docs/gateway/cloud-workers/session-lifecycle.md
@@ -79,6 +79,8 @@ Crabbox lease teardown reserves time for the CLI's full bounded release attempts
 
 If provider teardown fails or times out during stop or move, the request reports the bounded, redacted provider cause even if recovery subsequently finishes cleanup. Retrying Stop on a failed placement reports that cleanup attempt's cause, which can differ from the original session failure. Follow the reported recovery guidance and check the current placement before retrying. A dedicated cloud worker can remain recorded as attached while destruction is uncertain, but its closed authority cannot resume remote workspace processes.
 
+While cleanup remains pending, the placement keeps the original failure and the latest cleanup cause. Repeated recovery checks do not append another copy of the same error, and long diagnostics retain the final provider cause.
+
 An ended or unusable provider lease is not proof that its machine was deleted. OpenClaw fences that worker, stops renewing the lease, and requests explicit provider teardown. Failed teardown stays retryable; a missing local claim or an earlier “not found” warning does not turn a failed stop into success.
 
 For automation, read the active placement's `generation`, `environmentId`, and `activeOwnerEpoch` from `sessions.describe`, then supply those exact source facts to `sessions.move`:

--- a/src/gateway/worker-environments/placement-dispatch-cleanup.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-cleanup.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import * as support from "./service.test-support.js";
+
+describe("worker placement cleanup", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("retries pending failed-environment teardown before clearing the placement", async () => {
+    const placementStore = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const harness = createHarness(placementStore, {
+      failAt: "sync",
+      destroyFails: true,
+      destroyFailureState: "destroying",
+    });
+    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("sync failed");
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining("environment destroy: destroy pending"),
+    });
+    const originalFailure = harness.placements.current()?.recoveryError;
+
+    await harness.service.reconcileActive();
+    await harness.service.reconcileActive();
+    expect(harness.placements.current()).toMatchObject({
+      recoveryError: originalFailure,
+      terminalReason: originalFailure,
+    });
+
+    const cleanupError = "release is pending; retry after provider cleanup advances";
+    vi.mocked(harness.environments.destroy).mockRejectedValueOnce(new Error(cleanupError));
+    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow(cleanupError);
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      environmentId: harness.attached.environmentId,
+      recoveryError: `${originalFailure}; environment destroy: ${cleanupError}`,
+      terminalReason: originalFailure,
+    });
+    expect(harness.environments.get(harness.attached.environmentId)).toMatchObject({
+      state: "destroying",
+    });
+
+    const latestCause = "provider cleanup rejected the resource identity";
+    const latestError = `provider cleanup ${"progress ".repeat(200)}${latestCause}`;
+    vi.mocked(harness.environments.destroy).mockRejectedValue(new Error(latestError));
+    await harness.service.reconcileActive();
+    const latestFailure = harness.placements.current()?.recoveryError;
+    expect(latestFailure).toContain("sync failed");
+    expect(latestFailure).toContain(latestCause);
+    expect(latestFailure).not.toContain(cleanupError);
+    expect(latestFailure!.length).toBeLessThanOrEqual(1_024);
+    await harness.service.reconcileActive();
+    expect(harness.placements.current()).toMatchObject({
+      recoveryError: latestFailure,
+      terminalReason: originalFailure,
+    });
+
+    vi.mocked(harness.environments.destroy).mockImplementationOnce(async () => {
+      harness.markEnvironmentDestroyed();
+      const destroyed = harness.environments.get(harness.attached.environmentId);
+      if (!destroyed) {
+        throw new Error("expected destroyed environment");
+      }
+      return destroyed;
+    });
+    await expect(
+      harness.service.reclaim({
+        sessionId: REQUEST.sessionId,
+        sessionKey: REQUEST.sessionKey,
+        agentId: REQUEST.agentId,
+      }),
+    ).resolves.toMatchObject({ state: "local" });
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(7);
+  });
+});

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -254,12 +254,22 @@ export function createPlacementFailureActions(deps: {
     // Forced abandonment is a committed decision used by Continue on Gateway. Retrying
     // physical cleanup must not replace that decision or advance its placement generation.
     if (teardownErrors.length > 0 && placement.recoveryError !== FORCED_WORKER_ABANDONMENT_ERROR) {
-      const recoveryError = [placement.recoveryError, ...teardownErrors].filter(Boolean).join("; ");
-      placements.fail({
-        sessionId: placement.sessionId,
-        expectedGeneration: placement.generation,
-        recoveryError: truncateUtf16Safe(recoveryError, RECOVERY_ERROR_LIMIT),
-      });
+      // The terminal cause is immutable; composing from retry output grows a new
+      // cleanup suffix on every sweep and eventually hides the latest diagnosis.
+      const originalError = placement.terminalReason ?? placement.recoveryError;
+      const recoveryError = boundedError(
+        [originalError, ...teardownErrors.filter((detail) => !originalError.includes(detail))]
+          .filter(Boolean)
+          .join("; "),
+        RECOVERY_ERROR_LIMIT,
+      );
+      if (recoveryError !== placement.recoveryError) {
+        placements.fail({
+          sessionId: placement.sessionId,
+          expectedGeneration: placement.generation,
+          recoveryError,
+        });
+      }
     }
     // The persisted failure may intentionally retain an earlier terminal cause.
     return teardownErrors.length > 0 ? boundedError(teardownErrors.join("; ")) : undefined;

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -468,47 +468,6 @@ describe("worker placement dispatch reclaim", () => {
     },
   );
 
-  it("retries pending failed-environment teardown before clearing the placement", async () => {
-    const harness = createHarness(placementStore, {
-      failAt: "sync",
-      destroyFails: true,
-      destroyFailureState: "destroying",
-    });
-    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("sync failed");
-    expect(harness.placements.current()).toMatchObject({
-      state: "failed",
-      recoveryError: expect.stringContaining("environment destroy: destroy pending"),
-    });
-
-    const cleanupError = "release is pending; retry after provider cleanup advances";
-    vi.mocked(harness.environments.destroy).mockRejectedValueOnce(new Error(cleanupError));
-    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow(cleanupError);
-    expect(harness.placements.current()).toMatchObject({
-      state: "failed",
-      environmentId: harness.attached.environmentId,
-    });
-    expect(harness.environments.get(harness.attached.environmentId)).toMatchObject({
-      state: "destroying",
-    });
-
-    vi.mocked(harness.environments.destroy).mockImplementationOnce(async () => {
-      harness.markEnvironmentDestroyed();
-      const destroyed = harness.environments.get(harness.attached.environmentId);
-      if (!destroyed) {
-        throw new Error("expected destroyed environment");
-      }
-      return destroyed;
-    });
-    await expect(
-      harness.service.reclaim({
-        sessionId: REQUEST.sessionId,
-        sessionKey: REQUEST.sessionKey,
-        agentId: REQUEST.agentId,
-      }),
-    ).resolves.toMatchObject({ state: "local" });
-    expect(harness.environments.destroy).toHaveBeenCalledTimes(3);
-  });
-
   it.each(["active", "failed"] as const)(
     "rejects %s reclaim before its first durable cleanup action when authorization changes",
     async (state) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed cloud session repeated the same provider cleanup error on every recovery check. The growing message could push the newest failure cause out of the error shown above the composer.

## Why This Change Was Made

Compose the recovery diagnostic from the original terminal failure and the current cleanup attempt, using the existing bounded error formatter to retain the latest cause. Skip unchanged diagnostic writes. Cleanup authority, placement generations, and successful reclaim behavior remain unchanged.

## User Impact

Failed worker sessions retain the original failure and current cleanup guidance without accumulating stale copies while recovery waits for provider cleanup.

## Evidence

The extended lifecycle regression failed against the original code after two repeated recovery sweeps. It verifies stable repeated errors, replacement with a newer cleanup cause, preservation of the diagnostic tail within the existing limit, and successful final reclaim. The existing shared harness and real placement store are retained.

Focused dispatch, recovery, and reclaim suites passed 136 tests. After extracting the extended case into a focused cleanup test file, the affected cleanup and reclaim suites passed 29 tests. The final candidate passed independent isolated P0–P2 review. The complete scoped changed-file gate passed, including production/test typechecks, lint, formatting, and boundary guards.
