### PR TITLE
fix(crabbox): report completed source cleanup after capture cancellation

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-project.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-project.test.ts
@@ -504,6 +504,52 @@ describe("Crabbox project snapshot provisioning", () => {
     },
   );
 
+  it.each([false, true])(
+    "preserves capture uncertainty but reports the source cleanup result after cancellation (stopFails=%s)",
+    async (stopFails) => {
+      const controller = new AbortController();
+      const { options } = projectOptions([], controller);
+      const leaseId = operationLeaseId("cancelled-project-capture");
+      const { provider, calls, warn } = createWarmProvider(({ argv }) => {
+        if (argv[2] === "create") {
+          controller.abort();
+          return commandResult({ code: 2, stderr: "capture interrupted" });
+        }
+        if (argv[1] === "stop" && stopFails) {
+          return commandResult({ code: 5, stderr: "source cleanup still pending" });
+        }
+        return undefined;
+      });
+
+      await expect(
+        provider.provision(PROFILE, "cancelled-project-capture", options),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      const capture = listCrabboxWarmImages()[0]?.capture;
+      expect(capture).toMatchObject({ leaseId, phase: "uncertain" });
+      expect(options.beginNodeEnrollment).not.toHaveBeenCalled();
+      expect(calls.some(({ argv }) => argv[1] === "stop")).toBe(false);
+      calls.length = 0;
+      warn.mockClear();
+
+      const cleanup = provider.destroy({ leaseId, profile: PROFILE });
+      if (stopFails) {
+        await expect(cleanup).rejects.toThrow("source cleanup still pending");
+        expect(listCrabboxWarmImages()[0]?.allocations[leaseId]).toBeDefined();
+      } else {
+        await expect(cleanup).resolves.toBeUndefined();
+        expect(listCrabboxWarmImages()[0]?.allocations[leaseId]).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(capture!.selector));
+      }
+      expect(calls.map(({ argv }) => argv[1])).toEqual(["stop"]);
+      expect(listCrabboxWarmImages()[0]?.capture).toMatchObject({
+        selector: capture!.selector,
+        leaseId,
+        phase: "uncertain",
+      });
+      expect(options.beginNodeEnrollment).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves the lease when enrollment's owning operation has closed", async () => {
     const { provider, calls } = createWarmProvider();
     const beginNodeEnrollment = vi.fn(async () => {

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -640,9 +640,10 @@ export function createCrabboxWorkerProvider(
       }
       await stopLease(context);
       if (captureError) {
-        throw captureError instanceof Error
-          ? captureError
-          : new Error(coerceErrorMessage(captureError));
+        // Capture recovery remains recorded separately from confirmed source cleanup.
+        warn(
+          `Crabbox warm image capture failed during teardown: ${coerceErrorMessage(captureError)}`,
+        );
       }
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping a cloud session during project image capture reported worker cleanup as failed even after Crabbox confirmed the source VM was stopped.

## Why This Change Was Made

After successful source cleanup, report the optional capture error as a warning. Failed source cleanup still rejects. The uncertain capture reservation and the fence preventing node enrollment remain intact, so successful VM cleanup never claims that an interrupted snapshot was resolved.

## User Impact

Stop and reclaim can finish when the worker is actually gone. Operators still receive the existing guidance for reconciling an uncertain image capture.

## Evidence

Observed a real canceled project capture where the source lease reached released/cleanup-complete while the Gateway reported an unresolved-capture teardown error. The task-owned snapshot was subsequently identified and deleted; capture recovery state was retained.

The regression failed before the fix. Its successful-stop and failed-stop cases verify allocation retirement, retained capture uncertainty, no repeated capture, and no node enrollment. All 132 focused provider tests passed, the complete changed-file gate passed, and independent isolated P0–P2 review was clean. Existing warm-image documentation already specifies this behavior.
