### PR TITLE
fix: support autoreview through managed secret egress

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -194,7 +194,16 @@ fails or returns an invalid report reports `reviewer_unavailable` with exit 1.
 A failed later pass never publishes a partial review report.
 
 ```json
-{"schema_version":1,"status":"reviewer_unavailable","exit_code":1,"engine":"codex","report_produced":false,"reason":"engine_failed","reviewer_exit_code":124,"timed_out":true}
+{
+  "schema_version": 1,
+  "status": "reviewer_unavailable",
+  "exit_code": 1,
+  "engine": "codex",
+  "report_produced": false,
+  "reason": "engine_failed",
+  "reviewer_exit_code": 124,
+  "timed_out": true
+}
 ```
 
 `reason` is `engine_failed`, `invalid_report`, or `runtime_validation_failed`

--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -41,7 +41,7 @@ PR base or `origin/main`. Clean main has no implicit review target.
 
 Registered nested linked checkouts from the same repository are outside the
 current review scope. Their presence or edits do not make the parent dirty;
-ordinary adjacent files remain included and scanned. Worktree boundaries are
+ordinary adjacent files remain included in the review. Worktree boundaries are
 revalidated without changing Git ignore rules.
 
 For a complete PR candidate **including dirty rewrites**, use local mode with
@@ -109,6 +109,15 @@ wrapper; omitted or empty `auth.args` are accepted. Omitted `wire_api` and
 `requires_openai_auth` retain Codex's `responses` and `false` defaults. Optional
 auth timing and context settings keep native defaults and semantics.
 
+On POSIX, a private launcher restores the validated caller `HOME` only for the
+selected authentication executable; the engine and reviewer tools retain their
+isolated environment and filesystem access. Caller `HOME` must be an available
+absolute directory with no repository-owned path or symlink provenance. Windows
+keeps the native executable route. Command-auth runs suppress raw provider
+diagnostics and report fixed failure categories, while retaining compact progress,
+usage and assistant report streaming. An empty final report fails without exposing
+captured stdout.
+
 Catalogue and authentication working-directory paths resolve relative to the
 operator config directory and must remain outside the reviewed repository.
 A supplied catalogue is copied byte-for-byte into the private client runtime;
@@ -128,11 +137,19 @@ split context overrides are unsupported when projection is selected.
 
 The helper owns reviewer isolation, sanitized authentication, process cleanup,
 Git scope, and structured result validation. Keep those controls enabled.
-TruffleHog must scan the complete frozen input for partitioned reviews and each
-exact outgoing pack before it is sent; missing or failed scanning stops the run.
-Source-controlled ignore tags cannot suppress this gate. Scanner refusals never
-echo input headings or finding payloads; remove credentials locally and rerun.
-Never reproduce credentials in findings or work around an isolation failure.
+Every reviewer pass must inspect its bundle for real credentials and report
+suspected credentials as P0 findings without reproducing their values. Harmless
+placeholders and test fixtures are not credentials. Autoreview does not require
+or invoke an external secret scanner. Never work around an isolation failure.
+
+### Intentional scanner-free policy
+
+TruffleHog is intentionally excluded because enterprise security teams may flag
+or restrict it. Keep approved scanning outside autoreview; reviewer findings
+happen after transmission. Reintroducing a scanner requires an explicit maintainer
+decision. See [#240](https://github.com/openclaw/agent-skills/pull/240) for rationale and history.
+
+### Reviewer isolation
 
 On macOS, reviewer tools cannot access the shared `/tmp` and `/var/tmp` trees
 (including their `/private` aliases). Codex preflight rejects those temporary
@@ -153,18 +170,52 @@ runs. `--dry-run` checks preparation and startup without contacting a reviewer.
 
 ## Results
 
-`--output` and `--json-output` paths must be outside the reviewed repository.
+`--output`, `--json-output`, and `--status-output` paths must be outside the
+reviewed repository. When using `--status-output`, all output paths must differ;
+case-only and Unicode normalization aliases are conservatively refused on every
+platform, even when the filesystem would permit distinct files.
 
 | Exit | Meaning                                                                         |
 | ---- | ------------------------------------------------------------------------------- |
 | `0`  | `scoped-clean`, or a correct verdict with only filtered lower-priority findings |
-| `1`  | Accepted findings or an incorrect provider verdict                              |
+| `1`  | Accepted findings, an incorrect provider verdict, or a failed review attempt    |
 | `2`  | Incomplete scope/attribution, or a missing required finding                     |
 
 Treat `scoped-clean` as clean only for the selected target and requested priority.
 `filtered` is not clean; resolve `incomplete` before claiming completion.
 Verify findings against the actual code and task before changing anything.
 No extra review rounds for a nicer verdict; follow the owning workflow after fixes.
+
+Use `--status-output /outside/repo/status.json` for a separate, versioned
+machine-readable outcome. It preserves the existing exit codes and
+`--json-output` validated-report format. Completed reviews report `scoped-clean`,
+`findings`, `filtered`, `incorrect`, or `incomplete`; a launched reviewer that
+fails or returns an invalid report reports `reviewer_unavailable` with exit 1.
+A failed later pass never publishes a partial review report.
+
+```json
+{"schema_version":1,"status":"reviewer_unavailable","exit_code":1,"engine":"codex","report_produced":false,"reason":"engine_failed","reviewer_exit_code":124,"timed_out":true}
+```
+
+`reason` is `engine_failed`, `invalid_report`, or `runtime_validation_failed`
+for unavailable reviewers and null for completed reviews. The last reason means
+Amp's post-launch isolation attestation or private-result validation refused
+the result; it is not a transient-provider classification. These guards still
+run before report acceptance and retain their existing failure diagnostics.
+`reviewer_exit_code` is the last reviewer process's exit code when retained,
+including zero for rejected output, otherwise null. `timed_out` identifies the
+helper's deadline, not a reviewer that happens to exit 124. Completed envelopes
+have `report_produced: true`; this means a validated final report exists, not
+that its verdict is clean. `--expect-findings` changes exit codes as before;
+inspect `status` independently of `exit_code`.
+
+The sidecar contains no provider logs, prompts, findings, or model identifiers.
+Existing bounded, display-safe diagnostics remain on stderr; command-auth
+diagnostic suppression remains in force. Use a fresh status path per invocation:
+after argument and output-path validation, a previous sidecar is removed before
+target selection. Dry runs, preflight refusals, pre-launch isolation failures, source mutations,
+interruptions, and output failures produce no new status. Absence means no
+outcome was published, never a clean review. No retry policy is added.
 
 Report material findings and status plainly. Do not add transcripts, proof
 ledgers, commits, pushes, or a new workstream unless requested.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -17,6 +17,7 @@ import os
 import queue
 import re
 import secrets
+import shlex
 import shutil
 import signal
 import stat
@@ -360,6 +361,14 @@ CODEX_TRUST_PATH_ENV_KEYS = {
     "SSL_CERT_DIR",
     "SSL_CERT_FILE",
 }
+PROXY_ENV_KEYS = (
+    "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY",
+    "all_proxy", "http_proxy", "https_proxy",
+)
+TRANSPORT_TRUST_PATH_ENV_KEYS = {
+    "NODE_EXTRA_CA_CERTS", "SSL_CERT_DIR", "SSL_CERT_FILE",
+    "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE",
+}
 CODEX_MACOS_SCRATCH_ROOTS = ("/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp")
 PROVIDER_CREDENTIAL_PATH_ENV_KEYS = {
     "AWS_CONFIG_FILE",
@@ -488,19 +497,32 @@ def run(
     check: bool = True,
     env: dict[str, str] | None = None,
     text_errors: str = SUBPROCESS_TEXT_ERRORS,
+    capture_dir: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        args,
-        cwd=cwd,
-        input=input_text,
-        stdin=stdin,
-        text=True,
-        encoding=SUBPROCESS_TEXT_ENCODING,
-        errors=text_errors,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-    )
+    with contextlib.ExitStack() as stack:
+        captures = [
+            stack.enter_context(tempfile.TemporaryFile(
+                mode="w+", encoding=SUBPROCESS_TEXT_ENCODING,
+                errors=text_errors, dir=capture_dir,
+            ))
+            for _ in range(2)
+        ] if capture_dir is not None else []
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            input=input_text,
+            stdin=stdin,
+            text=True,
+            encoding=SUBPROCESS_TEXT_ENCODING,
+            errors=text_errors,
+            stdout=captures[0] if captures else subprocess.PIPE,
+            stderr=captures[1] if captures else subprocess.PIPE,
+            env=env,
+        )
+        if captures:
+            for capture in captures:
+                capture.seek(0)
+            result.stdout, result.stderr = (capture.read() for capture in captures)
     if check and result.returncode != 0:
         cmd = " ".join(args)
         raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
@@ -667,22 +689,191 @@ def safe_temp_root(repo: Path, *, engine: str | None = None) -> Path:
 
 
 def safe_proxy_url(value: str) -> bool:
+    # A proxy is launcher-provided transport, like the provider URL and API
+    # authentication. URL shape is not proof that it belongs to any runtime.
+    # Check before urlsplit, which silently removes some control characters.
+    if not value or any(char.isspace() or ord(char) < 32 or ord(char) == 127 for char in value):
+        return False
+    if "\\" in value or re.search(r"%(?![0-9a-fA-F]{2})", value):
+        return False
     try:
         candidate = value if "://" in value else f"http://{value}"
         parsed = urllib.parse.urlsplit(candidate)
-        _ = parsed.port
+        port = parsed.port
+        hostname = urllib.parse.unquote(parsed.hostname or "")
+        for part in (parsed.username, parsed.password):
+            if part is not None and any(
+                byte < 32 or byte == 127 for byte in urllib.parse.unquote_to_bytes(part)
+            ):
+                return False
     except ValueError:
         return False
     return (
         parsed.scheme.lower()
         in {"http", "https", "socks", "socks4", "socks4a", "socks5", "socks5h"}
-        and bool(parsed.hostname)
-        and parsed.username is None
-        and parsed.password is None
+        and bool(hostname)
+        and not any(char.isspace() or ord(char) < 32 or ord(char) == 127
+                    or char in "/\\@?#" for char in hostname)
+        and parsed.netloc.count("@") <= 1
+        and not parsed.netloc.endswith(":")
+        and port != 0
         and parsed.path in {"", "/"}
         and not parsed.query
         and not parsed.fragment
     )
+
+
+@functools.lru_cache(maxsize=8)
+def proxy_credential_pattern(values: tuple[str, ...]) -> re.Pattern[str] | None:
+    forms: set[str] = set()
+    labeled_passwords: set[str] = set()
+    labeled_usernames: set[str] = set()
+    for value in values:
+        try:
+            parsed = urllib.parse.urlsplit(value if "://" in value else f"http://{value}")
+            if parsed.username is None:
+                continue
+            user = urllib.parse.unquote_to_bytes(parsed.username)
+            password = urllib.parse.unquote_to_bytes(parsed.password or "")
+        except ValueError:
+            continue
+        forms.add(value)
+        forms.add(base64.b64encode(user + b":" + password).decode("ascii"))
+        encoded_userinfo = parsed.netloc.rsplit("@", 1)[0]
+        raw_userinfo = user + (b":" + password if parsed.password is not None else b"")
+        # Always hide userinfo in URL contexts, even when it is a short public
+        # label such as "u" or "openclaw".
+        if encoded_userinfo:
+            forms.add(encoded_userinfo + "@")
+            forms.add(urllib.parse.quote_from_bytes(raw_userinfo, safe="") + "%40")
+            try:
+                forms.add(raw_userinfo.decode("utf-8") + "@")
+            except UnicodeDecodeError:
+                pass
+        if not parsed.password and user:
+            username_forms = {parsed.username, urllib.parse.quote_from_bytes(user, safe="")}
+            try:
+                username_forms.add(user.decode("utf-8"))
+            except UnicodeDecodeError:
+                pass
+            labeled_usernames.update(username_forms)
+            # Some proxies put their token in the username with no password.
+            # Hide standalone long values while preserving ordinary short labels.
+            if len(user) >= 16:
+                forms.update(username_forms)
+        if parsed.password:
+            forms.add(encoded_userinfo)
+            # Short bare passwords are indistinguishable from prose or enum
+            # values. Always hide them in auth/password contexts; additionally
+            # mask standalone longer values, including run-scoped proxy tokens.
+            if len(password) >= 8:
+                forms.add(parsed.password)
+            labeled_passwords.add(parsed.password)
+            for raw in (password, raw_userinfo):
+                try:
+                    decoded = raw.decode("utf-8")
+                    if raw != password or len(password) >= 8:
+                        forms.add(decoded)
+                    if raw == password:
+                        labeled_passwords.add(decoded)
+                except UnicodeDecodeError:
+                    pass
+                encoded = urllib.parse.quote_from_bytes(raw, safe="")
+                if raw != password or len(password) >= 8:
+                    forms.add(encoded)
+                if raw == password:
+                    labeled_passwords.add(encoded)
+    forms.discard("")
+    forms.update(urllib.parse.quote(form, safe="") for form in tuple(forms))
+    # Diagnostics and streamed JSON may escape strings before we see them.
+    forms.update(json.dumps(form, ensure_ascii=True)[1:-1] for form in tuple(forms))
+    if not forms:
+        return None
+    patterns = []
+    for form in sorted(forms, key=len, reverse=True):
+        escaped = re.escape(form)
+        # Percent escape casing is insignificant; credential casing is not.
+        escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
+        patterns.append(escaped)
+    for label, credentials in (("password", labeled_passwords),
+                               ("(?:username|user)", labeled_usernames)):
+        for credential in credentials:
+            escaped = re.escape(credential)
+            escaped = re.sub(r"%[0-9a-fA-F]{2}", lambda match: "(?i:" + match[0] + ")", escaped)
+            patterns.append(
+                r"(?i:\b(?:proxy[_-]?)?" + label + r"[\"']?[ \t]*[:=][ \t]*[\"']?)"
+                + escaped + r"(?=$|[\s\"',;\)\]}])"
+            )
+    return re.compile("|".join(patterns))
+
+
+def redact_proxy_credentials(text: str) -> str:
+    pattern = proxy_credential_pattern(tuple(os.environ.get(key, "") for key in PROXY_ENV_KEYS))
+    return pattern.sub("[REDACTED]", text) if pattern else text
+
+
+def redact_proxy_report(value: Any) -> Any:
+    # Redact after validation, at serialization only. Keep the original report
+    # and exit-status decisions intact; never edit source snapshots or auth.
+    if isinstance(value, str):
+        return redact_proxy_credentials(value)
+    if isinstance(value, list):
+        return [redact_proxy_report(item) for item in value]
+    if isinstance(value, dict):
+        enums = {"overall_correctness", "priority", "category", "review_status", "target", "side"}
+        return {key: item if key in enums else redact_proxy_report(item)
+                for key, item in value.items()}
+    return value
+
+
+class ProxyRedactedOutput:
+    """Cover plain progress/error prints as well as the formatted reports."""
+
+    def __init__(self, stream: Any) -> None:
+        self.stream = stream
+        self.pending = ""
+        self.discarding_line = False
+        self.lock = threading.Lock()
+
+    def write(self, text: str) -> int:
+        # print() and other writers can split a URL across writes. Emit whole
+        # lines only; flush must not expose a still-incomplete credential.
+        with self.lock:
+            parts = text.split("\n")
+            for index, part in enumerate(parts):
+                newline = index < len(parts) - 1
+                if self.discarding_line:
+                    self.discarding_line = not newline
+                    continue
+                if len(self.pending) + len(part) > 65_536:
+                    self.pending = ""
+                    self.discarding_line = not newline
+                    self.stream.write("[output line suppressed: exceeds redaction buffer]\n")
+                    continue
+                self.pending += part
+                if newline:
+                    self.stream.write(redact_proxy_credentials(self.pending) + "\n")
+                    self.pending = ""
+        return len(text)
+
+    def flush(self) -> None:
+        self.stream.flush()
+
+    @property
+    def encoding(self) -> str | None:
+        return self.stream.encoding
+
+    def isatty(self) -> bool:
+        return self.stream.isatty()
+
+    def fileno(self) -> int:
+        return self.stream.fileno()
+
+    def finish(self) -> None:
+        with self.lock:
+            self.stream.write(redact_proxy_credentials(self.pending))
+            self.pending = ""
+            self.stream.flush()
 
 
 def safe_engine_env(
@@ -705,6 +896,7 @@ def safe_engine_env(
         "LC_ALL",
         "LOGNAME",
         "NO_PROXY",
+        "NODE_USE_ENV_PROXY",
         "PATHEXT",
         "SHELL",
         "SYSTEMROOT",
@@ -865,19 +1057,11 @@ def safe_engine_env(
             )
         )
     }
-    for key in (
-        "ALL_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "all_proxy",
-        "http_proxy",
-        "https_proxy",
-    ):
+    for key in PROXY_ENV_KEYS:
         value = env.get(key)
         if value and not safe_proxy_url(value):
             raise SystemExit(
-                f"unsafe credentialed or malformed proxy URL in {key}; "
-                "configure a credential-free proxy URL before running autoreview"
+                f"malformed proxy URL in {key}; configure a valid proxy URL before running autoreview"
             )
     env["PATH"] = safe_engine_path(repo, extra_paths)
     for key in ("HOME", "USERPROFILE"):
@@ -893,6 +1077,11 @@ def safe_engine_env(
         value = os.environ.get(key)
         if value and external_env_path(repo, value):
             env[key] = value
+    for key in TRANSPORT_TRUST_PATH_ENV_KEYS:
+        value = os.environ.get(key)
+        normalized = normalize_external_env_path_value(repo, key, value) if value else None
+        if normalized:
+            env[key] = normalized
     if engine == "codex":
         dbus_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
         if dbus_address and safe_dbus_session_address(repo, dbus_address):
@@ -1182,6 +1371,21 @@ def emit_heartbeat(
     )
 
 
+class ReviewerUnavailable(SystemExit):
+    """A launched reviewer failed before returning a valid report."""
+
+    def __init__(self, message: str, *, reason: str = "engine_failed",
+                 result: subprocess.CompletedProcess[str] | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.returncode = result.returncode if result is not None else None
+        self.timed_out = isinstance(result, TimedOutEngineProcess)
+
+
+class TimedOutEngineProcess(subprocess.CompletedProcess[str]):
+    """Distinguish our deadline from a reviewer that itself exits 124."""
+
+
 class EngineRuntimeDeadline:
     """One absolute wall-clock deadline for an owned reviewer process."""
 
@@ -1226,7 +1430,7 @@ class EngineRuntimeDeadline:
     ) -> subprocess.CompletedProcess[str]:
         assert self.max_runtime_seconds is not None
         detail = f"{self.label} engine timed out after {self.max_runtime_seconds:g}s"
-        return subprocess.CompletedProcess(
+        return TimedOutEngineProcess(
             args,
             124,
             stdout,
@@ -1604,10 +1808,6 @@ def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> 
     return result.strip() if pin else ref
 
 
-TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
-TRUFFLEHOG_FINDINGS_EXIT_CODE = 183
-
-
 def git_bytes(
     repo: Path,
     *args: str,
@@ -1638,73 +1838,6 @@ def git_bytes(
     return result
 
 
-def safe_trufflehog_env(repo: Path) -> dict[str, str]:
-    env = safe_git_env(repo)
-    for key in (
-        "ALL_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "all_proxy",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-    ):
-        value = os.environ.get(key)
-        if not value:
-            continue
-        if key.casefold() != "no_proxy" and not safe_proxy_url(value):
-            raise SystemExit(
-                f"unsafe credentialed or malformed proxy URL in {key}; "
-                "configure a credential-free proxy URL before running autoreview"
-            )
-        env[key] = value
-    return env
-
-
-def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
-    trufflehog_bin = find_command("trufflehog", repo)
-    if not trufflehog_bin:
-        raise SystemExit(
-            "refusing to send review pack: TruffleHog is required but was not found. "
-            f"Install it using the official instructions, then rerun autoreview: {TRUFFLEHOG_INSTALL_URL}"
-        )
-    with tempfile.TemporaryDirectory(
-        prefix="autoreview-pack-scan.",
-        dir=safe_temp_root(repo),
-    ) as tempdir:
-        pack_path = Path(tempdir) / "review-pack.txt"
-        pack_path.write_bytes(prompt.encode("utf-8"))
-        pack_path.chmod(0o600)
-        scanner_env = safe_trufflehog_env(repo)
-        # Filesystem preserves read/extraction failures; stdin does not honor
-        # inline ignore tags, including decoded ones. Both must pass. A binary
-        # file descriptor preserves exact bytes and avoids stdin pipe buffering.
-        with pack_path.open("rb") as pack_input:
-            for source_args, scan_input in ((["filesystem", str(pack_path)], None), (["stdin"], pack_input)):
-                result = run(
-                    [
-                        trufflehog_bin, *source_args,
-                        "--json", "--no-color", "--results=verified,unknown",
-                        "--fail", "--fail-on-scan-errors", "--no-update",
-                    ],
-                    Path(tempdir),
-                    stdin=scan_input,
-                    check=False,
-                    env=scanner_env,
-                )
-                if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
-                    # Input headings, filenames, and scanner metadata can themselves contain credentials.
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog found credentials; "
-                        "remove credential material from selected changes, prompt files, and datasets, then rerun"
-                    )
-                if result.returncode != 0:
-                    raise SystemExit(
-                        "refusing to send review pack: TruffleHog could not complete the scan"
-                    )
-
-
 def bounded_field(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
@@ -1714,7 +1847,7 @@ def bounded_field(text: str, limit: int) -> str:
 
 def display_escape(text: object, limit: int, *, multiline: bool = False) -> str:
     parts: list[str] = []
-    for char in str(text):
+    for char in redact_proxy_credentials(str(text)):
         codepoint = ord(char)
         if multiline and char == "\n":
             parts.append(char)
@@ -3684,18 +3817,9 @@ def prepare_review_prompts(
     datasets: list[ReviewDataset],
     max_prompt_bytes: int,
 ) -> list[str] | list[ReviewPass]:
-    prompts = build_review_prompts(
+    return build_review_prompts(
         repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
     )
-    if len(prompts) > 1:
-        # A credential can span a partition boundary. Scan the complete frozen
-        # input before any send, in addition to each exact outgoing pack.
-        chunk = mixed_bundle_chunk(bundle) if isinstance(bundle, CapturedBundle) else ReviewChunk(bundle)
-        scan_outgoing_review_pack(repo, render_review_prompt(
-            current_branch(repo), target, target_ref, chunk,
-            extra_prompt, render_datasets(datasets),
-        ))
-    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -3891,6 +4015,35 @@ def codex_auth_config_flags(
     return flags
 
 
+def codex_auth_helper_home(repo: Path) -> Path:
+    try:
+        home = Path(os.environ.get("HOME", ""))
+        resolved = home.resolve(strict=True)
+        if not home.is_absolute() or not resolved.is_dir():
+            raise ValueError("unavailable HOME")
+        roots = (repo.absolute(), repo.resolve())
+        pending = [home, *home.parents]
+        seen: set[Path] = set()
+        while pending:
+            path = pending.pop()
+            if path in seen:
+                continue
+            seen.add(path)
+            if any(is_within(path, root) or is_within(path.resolve(), root) for root in roots):
+                raise ValueError("repository-owned HOME")
+            if path.is_symlink():
+                # Check intermediate link targets too: a repository-owned link
+                # can lead back outside the repository before final resolution.
+                target = path.parent / os.readlink(path)
+                pending.extend((target, *target.parents))
+        return resolved
+    except (OSError, RuntimeError, ValueError):
+        raise SystemExit(
+            "Codex inference configuration refused: auth helper requires an available "
+            "absolute trusted caller HOME outside the reviewed repository"
+        ) from None
+
+
 def load_codex_inference_route(
     repo: Path, overrides: Sequence[str] = (),
 ) -> tuple[list[str], bytes | None]:
@@ -3969,6 +4122,8 @@ def load_codex_inference_route(
     command = external_path(auth.get("command"), "authentication executable", absolute=True)
     if not os.access(command, os.X_OK):
         refuse("authentication executable is not executable")
+    if os.name != "nt":
+        codex_auth_helper_home(repo)
     auth_cwd = external_path(auth.get("cwd", str(source_home)), "authentication cwd", directory=True)
     for key, minimum in (("timeout_ms", 1), ("refresh_interval_ms", 0)):
         if key in auth and (type(auth[key]) is not int or not minimum <= auth[key] <= (1 << 64) - 1):
@@ -4010,6 +4165,27 @@ def prepare_codex_inference_config(
         output.write(catalogue_bytes)
     catalogue.chmod(0o600)
     return [*flags, "-c", f"model_catalog_json={toml_string(str(catalogue.resolve()))}"]
+
+
+def stage_codex_auth_helper(repo: Path, runtime_root: Path, flags: list[str]) -> list[str]:
+    if os.name == "nt":
+        return flags
+    staged = list(flags)
+    for index, flag in enumerate(flags):
+        key, separator, value = flag.partition("=")
+        if not separator or not re.fullmatch(r"model_providers\.[A-Za-z0-9_-]+\.auth\.command", key):
+            continue
+        # Route validation owns the absolute executable. Native command auth
+        # runs outside the tool sandbox; only its launcher restores caller HOME.
+        command = json.loads(value)
+        home = codex_auth_helper_home(repo)
+        with tempfile.NamedTemporaryFile(
+            "w", prefix="provider-auth.", dir=runtime_root, delete=False, encoding="utf-8",
+        ) as wrapper:
+            wrapper.write(f"#!/bin/sh\nexport HOME={shlex.quote(str(home))}\nexec {shlex.quote(command)}\n")
+            os.fchmod(wrapper.fileno(), 0o700)
+        staged[index] = f"{key}={toml_string(wrapper.name)}"
+    return staged
 
 
 def codex_file_auth_source(repo: Path) -> Path | None:
@@ -4221,7 +4397,12 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
             f"claude engine requires Claude Code >= {format_version(minimum_version)} "
             f"{version_reason} (found {format_version(version)})"
         )
-    help_result = run([claude_bin, "--help"], temp_root, check=False, env=engine_env)
+    # Claude can exit before flushing piped help; regular files preserve the
+    # complete capability list without weakening any required isolation flag.
+    help_result = run(
+        [claude_bin, "--help"], temp_root, check=False, env=engine_env,
+        capture_dir=temp_root,
+    )
     help_text = f"{help_result.stdout}\n{help_result.stderr}"
     required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools", "--tools"]
     missing = [flag for flag in required_flags if flag not in help_text]
@@ -4671,6 +4852,26 @@ def codex_model_access_failure(result: subprocess.CompletedProcess[str], model: 
     return False
 
 
+def codex_failure_category(result: subprocess.CompletedProcess[str]) -> str:
+    # Classify only; captured auth-helper diagnostics must never escape.
+    text = (result.stderr + "\n" + result.stdout).lower()
+    categories = (
+        ("provider-auth-helper", ("provider auth command", "external bearer")),
+        ("model-catalogue", ("model_catalog_json", "model catalog", "model catalogue")),
+        ("model-sandbox-policy", ("requires a sandbox", "reviewed escalations")),
+        ("cli-arguments", ("unexpected argument", "unrecognized option", "unrecognized subcommand")),
+        ("configuration", ("error loading config", "error parsing config", "failed to load config", "invalid configuration", "missing field", "unknown field")),
+        ("authentication", ("401 unauthorized", "http 401", "status code 401", "invalid api key", "missing bearer", "authentication failed")),
+        ("provider-access", ("403 forbidden", "http 403", "do not have access", "not supported when using codex")),
+        ("rate-limit", ("429 too many requests", "http 429", "rate limit", "rate_limit")),
+        ("transport", ("connection refused", "connection reset", "failed to connect", "stream disconnected", "certificate verify", "timed out")),
+    )
+    for category, markers in categories:
+        if any(marker in text for marker in markers):
+            return category
+    return "unclassified"
+
+
 def codex_command(
     args: argparse.Namespace,
     source_repo: Path,
@@ -4706,6 +4907,7 @@ def codex_command(
         auth_config = prepare_codex_inference_config(
             load_codex_inference_route(source_repo, overrides), runtime_root,
         )
+        auth_config = stage_codex_auth_helper(source_repo, runtime_root, auth_config)
     cmd.extend(auth_config)
     if force_file_auth:
         cmd.extend(["-c", 'cli_auth_credentials_store="file"'])
@@ -4762,6 +4964,8 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             runtime_codex_home = runtime_root / "codex-home"
             route = load_codex_inference_route(repo, codex_config_overrides(args))
             auth_config = prepare_codex_inference_config(route, runtime_root)
+            command_auth = any(flag.startswith("model_provider=") for flag in auth_config)
+            auth_config = stage_codex_auth_helper(repo, runtime_root, auth_config)
             file_auth_linked = prepare_codex_runtime_auth(repo, runtime_codex_home)
             for index, model in enumerate(models):
                 output_path.write_text("")
@@ -4776,10 +4980,6 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     force_file_auth=file_auth_linked,
                     auth_config=auth_config,
                 )
-                if index:
-                    # The initial send was scanned by run_reviewer; a retry is
-                    # a new provider invocation even with the same frozen pack.
-                    scan_outgoing_review_pack(repo, prompt)
                 result = run_with_heartbeat(
                     cmd,
                     review_root,
@@ -4787,7 +4987,7 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     label="codex",
                     max_runtime_seconds=getattr(args, "engine_timeout_seconds", None),
                     stream_output=args.stream_engine_output,
-                    stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+                    stream_display=CodexStreamDisplay(suppress_diagnostics=command_auth) if args.stream_engine_output else None,
                     env=codex_runtime_env(
                         repo,
                         runtime_root,
@@ -4795,8 +4995,15 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                         file_auth_linked=file_auth_linked,
                     ),
                 )
-                output = output_path.read_text()
+                try:
+                    output = output_path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    raise ReviewerUnavailable("codex engine returned non-UTF-8 report",
+                                              reason="invalid_report", result=result) from None
                 if result.returncode == 0:
+                    if command_auth and not output.strip():
+                        raise ReviewerUnavailable("codex engine failed: missing-report; provider diagnostics suppressed",
+                                                  reason="invalid_report", result=result)
                     return output or result.stdout
                 if (
                     index == 0
@@ -4810,14 +5017,19 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                         file=sys.stderr,
                     )
                     continue
+                if command_auth:
+                    raise ReviewerUnavailable(
+                        f"codex engine failed: {codex_failure_category(result)}; provider diagnostics suppressed",
+                        result=result,
+                    )
                 detail = result.stderr or result.stdout
                 if primary_failure is not None:
                     primary_detail = primary_failure.stderr or primary_failure.stdout
-                    raise SystemExit(
+                    raise ReviewerUnavailable(
                         f"codex engine failed with primary model ({primary_failure.returncode})\n{primary_detail}\n"
-                        f"codex fallback model failed ({result.returncode})\n{detail}"
+                        f"codex fallback model failed ({result.returncode})\n{detail}", result=result,
                     )
-                raise SystemExit(f"codex engine failed ({result.returncode})\n{detail}")
+                raise ReviewerUnavailable(f"codex engine failed ({result.returncode})\n{detail}", result=result)
     finally:
         schema_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
@@ -4870,7 +5082,7 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+        raise ReviewerUnavailable(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result)
     return result.stdout
 
 
@@ -4984,7 +5196,7 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
             raise SystemExit(
                 f"amp isolation attestation failed: stream line {line_number} is not an object"
             )
-        if event.get("type") not in {"system", "user", "assistant", "result"}:
+        if not isinstance(event.get("type"), str) or event["type"] not in {"system", "user", "assistant", "result"}:
             raise SystemExit(
                 "amp isolation attestation failed: unexpected stream event type "
                 f"{event.get('type')!r}"
@@ -5054,7 +5266,7 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
             if not isinstance(block, dict):
                 raise SystemExit("amp isolation attestation failed: message block was malformed")
             block_type = block.get("type")
-            if block_type not in {"text", "thinking", "tool_use", "tool_result"}:
+            if not isinstance(block_type, str) or block_type not in {"text", "thinking", "tool_use", "tool_result"}:
                 raise SystemExit(
                     f"amp isolation attestation failed: unexpected message block {block_type!r}"
                 )
@@ -5088,10 +5300,13 @@ def attest_amp_stream(output: str, review_root: Path) -> bool:
     tool_succeeded = tool_result.get("is_error") is False
     if tool_succeeded and tool_result.get("content") != "Adapter completed.":
         raise SystemExit("amp isolation attestation failed: adapter success result was malformed")
-    if not tool_succeeded and tool_result.get("content") not in {
-        "Autoreview generation failed.",
-        "Error: Autoreview generation failed.",
-    }:
+    if not tool_succeeded and (
+        not isinstance(tool_result.get("content"), str)
+        or tool_result["content"] not in {
+            "Autoreview generation failed.",
+            "Error: Autoreview generation failed.",
+        }
+    ):
         raise SystemExit("amp isolation attestation failed: adapter failure result was not sanitized")
 
     result_events = [event for event in events if event.get("type") == "result"]
@@ -5382,14 +5597,23 @@ def run_amp(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             stream_output=args.stream_engine_output,
             env=engine_env,
         )
+        return amp_review_result(result, review_root, error_path, result_path)
+
+
+def amp_review_result(result: subprocess.CompletedProcess[str], review_root: Path,
+                      error_path: Path, result_path: Path) -> str:
+    # This boundary is post-launch only. Attestation and private-file guards
+    # still run before report acceptance and retain their original diagnostics.
+    try:
         if result.returncode == 124:
             detail = result.stderr or result.stdout
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 f"amp engine failed ({result.returncode})\n"
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         if len(result.stdout) > AMP_MAX_OUTPUT_CHARS:
-            raise SystemExit("amp engine stream exceeds the output limit")
+            raise ReviewerUnavailable("amp engine stream exceeds the output limit",
+                                      reason="invalid_report", result=result)
         tool_succeeded = attest_amp_stream(result.stdout, review_root)
         if error_path.exists():
             detail = read_amp_private_file(
@@ -5397,23 +5621,27 @@ def run_amp(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                 label="error",
                 max_chars=4000,
             )
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 "amp direct generation failed: "
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         if not tool_succeeded:
-            raise SystemExit("amp adapter tool failed without producing an error file")
+            raise ReviewerUnavailable("amp adapter tool failed without producing an error file", result=result)
         if result.returncode != 0:
             detail = result.stderr or result.stdout
-            raise SystemExit(
+            raise ReviewerUnavailable(
                 f"amp engine failed ({result.returncode})\n"
-                + display_escape(detail, 4000, multiline=True)
+                + display_escape(detail, 4000, multiline=True), result=result,
             )
         return read_amp_private_file(
             result_path,
             label="result",
             max_chars=AMP_MAX_OUTPUT_CHARS,
         )
+    except ReviewerUnavailable:
+        raise
+    except (SystemExit, ValueError, RecursionError) as exc:
+        raise ReviewerUnavailable(str(exc), reason="runtime_validation_failed", result=result) from None
 
 
 def json_file_declares_hooks(path: Path) -> bool:
@@ -5465,7 +5693,7 @@ def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+        raise ReviewerUnavailable(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result)
     return result.stdout
 
 
@@ -5532,8 +5760,8 @@ def run_kimi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ),
         )
     if result.returncode != 0:
-        raise SystemExit(
-            f"kimi engine failed ({result.returncode})\n{result.stderr or result.stdout}"
+        raise ReviewerUnavailable(
+            f"kimi engine failed ({result.returncode})\n{result.stderr or result.stdout}", result=result,
         )
     # stream-json: one JSON object per line; assistant content carries the
     # reply, tool/meta lines are progress noise (there are no tools anyway).
@@ -5552,25 +5780,29 @@ def run_kimi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             if isinstance(content, str):
                 texts.append(content)
     if not texts:
-        raise SystemExit(
-            f"kimi engine returned no assistant output\n{result.stdout[:2000]}"
+        raise ReviewerUnavailable(
+            f"kimi engine returned no assistant output\n{result.stdout[:2000]}",
+            reason="invalid_report", result=result,
         )
     return "\n".join(texts)
 
 
 class CodexStreamDisplay:
-    def __init__(self, *, activity_seconds: int = 20) -> None:
+    def __init__(self, *, activity_seconds: int = 20, suppress_diagnostics: bool = False) -> None:
         self.activity_seconds = activity_seconds
+        self.suppress_diagnostics = suppress_diagnostics
         self.hidden_events = 0
         self.last_visible = time.monotonic()
 
     def __call__(self, name: str, line: str) -> str | None:
         if name != "stdout":
-            return stream_display_escape(line)
+            return self.hidden_activity() if self.suppress_diagnostics else stream_display_escape(line)
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
-            return self.visible(line)
+            return self.hidden_activity() if self.suppress_diagnostics else self.visible(line)
+        if not isinstance(event, dict):
+            return self.hidden_activity()
         event_type = event.get("type")
         if event_type == "thread.started":
             return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")
@@ -5785,9 +6017,11 @@ def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
             candidates.append(data["content"])
         message = event.get("message")
         if isinstance(message, dict):
-            for item in message.get("content", []):
-                if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
-                    assistant_candidates.append(item["text"])
+            content = message.get("content", [])
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+                        assistant_candidates.append(item["text"])
         if isinstance(event.get("result"), str):
             terminal_candidates.append(event["result"])
         if isinstance(event.get("result"), dict):
@@ -5864,9 +6098,9 @@ def validate_attribution_shape(value: Any, index: int) -> None:
     keys = {"target", "record_id", "source_id", "side", "column", "excerpt"}
     if not isinstance(value, dict) or set(value) != keys:
         raise SystemExit(f"finding {index} has invalid source_attribution keys")
-    if (value["target"] not in {"index", "working_tree"}
+    if (not all(isinstance(value[key], str) for key in ("target", "side", "record_id", "source_id", "excerpt"))
+            or value["target"] not in {"index", "working_tree"}
             or value["side"] not in {"present", "removed"}
-            or not all(isinstance(value[key], str) for key in ("record_id", "source_id", "excerpt"))
             or not isinstance(value["column"], int) or isinstance(value["column"], bool)
             or value["column"] < 1):
         raise SystemExit(f"finding {index} has invalid source_attribution")
@@ -5926,7 +6160,7 @@ def _validate_report(
             raise SystemExit(f"review JSON missing required key: {key}")
     if not isinstance(report["findings"], list):
         raise SystemExit("review JSON findings must be an array")
-    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+    if not isinstance(report.get("overall_correctness"), str) or report["overall_correctness"] not in {"patch is correct", "patch is incorrect"}:
         raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
     if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
         raise SystemExit("review JSON overall_explanation must be a non-empty string")
@@ -5956,12 +6190,12 @@ def _validate_report(
         if not isinstance(body, str) or not body or len(body) > 2000:
             raise SystemExit(f"finding {index} has invalid body")
         priority = finding.get("priority")
-        if priority not in {"P0", "P1", "P2", "P3"}:
+        if not isinstance(priority, str) or priority not in {"P0", "P1", "P2", "P3"}:
             raise SystemExit(f"finding {index} has invalid priority: {priority}")
         if not number_in_range(finding.get("confidence")):
             raise SystemExit(f"finding {index} has invalid confidence")
         category = finding.get("category")
-        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+        if not isinstance(category, str) or category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
             raise SystemExit(f"finding {index} has invalid category: {category}")
         location = finding.get("code_location")
         if not isinstance(location, dict):
@@ -6226,6 +6460,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output", help="Write human output to a file as well as stdout.")
     parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument("--status-output", help="Write a versioned status sidecar, including reviewer_unavailable; does not change report JSON or exit codes.")
     parser.add_argument(
         "--stream-engine-output",
         action="store_true",
@@ -6544,14 +6779,12 @@ def dry_run_preflight(
     # pass's capacity once combined with intact instructions/source context.
     if bundle_ok and inputs_ok:
         try:
-            with PreparationProgress("bundle/evidence preparation and scan"):
+            with PreparationProgress("bundle/evidence preparation"):
                 threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
-                prompts = prepare_review_prompts(
+                prepare_review_prompts(
                     repo, target, target_ref, captured, threshold_extra_prompt,
                     evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
                 )
-                for prompt in prompts:
-                    scan_outgoing_review_pack(repo, prompt.prompt if isinstance(prompt, ReviewPass) else prompt)
             with PreparationProgress("evidence verification"):
                 verify_evidence(repo, evidence.files)
                 verify_mixed_sources(repo, captured.mixed)
@@ -6592,14 +6825,20 @@ def run_reviewer(
     if mixed and not isinstance(prompt, ReviewPass):
         raise SystemExit("mixed review requires owner-built pass metadata")
     outgoing = prompt.prompt if isinstance(prompt, ReviewPass) else prompt
-    with PreparationProgress("outgoing pack scan and evidence verification"):
-        scan_outgoing_review_pack(repo, outgoing)
+    with PreparationProgress("evidence verification"):
         verify_evidence(repo, evidence or [])
         verify_mixed_sources(repo, mixed)
+    # Scanner-free operation is intentional for enterprise compatibility.
+    # Preserve SKILL.md's "Intentional scanner-free policy" when changing this path.
     raw = run_engine(args, repo, outgoing)
-    report = extract_json(raw)
-    provider_report = copy.deepcopy(report)
-    validate_report(report, repo, paths, [], mixed, available)
+    try:
+        report = extract_json(raw)
+        provider_report = copy.deepcopy(report)
+        validate_report(report, repo, paths, [], mixed, available)
+    except (SystemExit, ValueError, RecursionError) as exc:
+        # Only parsing/schema validation is inside this boundary. Scanner,
+        # isolation, attribution refusals, and required-finding gates stay distinct.
+        raise ReviewerUnavailable(str(exc), reason="invalid_report") from None
     filter_findings_by_priority(report, args.max_priority)
     report["provider_report"] = provider_report
     if mixed:
@@ -6706,9 +6945,11 @@ def run_review_passes(
 
 def reject_repo_output_paths(args: argparse.Namespace, repo: Path) -> None:
     repo_root_path = repo.resolve()
+    outputs: list[tuple[str, Path]] = []
     for option, value in (
         ("--json-output", getattr(args, "json_output", None)),
         ("--output", getattr(args, "output", None)),
+        ("--status-output", getattr(args, "status_output", None)),
     ):
         if not value:
             continue
@@ -6716,6 +6957,21 @@ def reject_repo_output_paths(args: argparse.Namespace, repo: Path) -> None:
         resolved = (
             path if path.is_absolute() else Path.cwd() / path
         ).resolve()
+        if getattr(args, "status_output", None):
+            for previous_option, previous in outputs:
+                # Refuse spelling aliases even before files exist, including
+                # macOS case/decomposition aliases and Windows case aliases.
+                same = (unicodedata.normalize("NFD", str(resolved)).casefold()
+                        == unicodedata.normalize("NFD", str(previous)).casefold())
+                if (not same and resolved.parent.exists() and previous.parent.exists()
+                        and unicodedata.normalize("NFD", resolved.name).casefold()
+                        == unicodedata.normalize("NFD", previous.name).casefold()):
+                    same = os.path.samefile(resolved.parent, previous.parent)
+                if not same and resolved.exists() and previous.exists():
+                    same = os.path.samefile(resolved, previous)
+                if same:
+                    raise SystemExit(f"{option} must use a different path from {previous_option}")
+            outputs.append((option, resolved))
         inside_repo = resolved.is_relative_to(repo_root_path)
         if not inside_repo:
             for ancestor in (resolved, *resolved.parents):
@@ -6748,6 +7004,23 @@ def atomic_write_text(path: Path, content: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def write_review_status(args: argparse.Namespace, status: str, exit_code: int,
+                        failure: ReviewerUnavailable | None = None) -> None:
+    if not getattr(args, "status_output", None):
+        return
+    envelope = {
+        "schema_version": 1,
+        "status": status,
+        "exit_code": exit_code,
+        "engine": args.engine,
+        "report_produced": failure is None,
+        "reason": failure.reason if failure else None,
+        "reviewer_exit_code": failure.returncode if failure else None,
+        "timed_out": failure.timed_out if failure else False,
+    }
+    atomic_write_text(Path(args.status_output).expanduser(), json.dumps(envelope, indent=2) + "\n")
+
+
 def main() -> int:
     with OwnedProcessSignalHandlers():
         try:
@@ -6765,6 +7038,8 @@ def main_impl() -> int:
     with PreparationProgress("target selection"):
         repo = repo_root()
         reject_repo_output_paths(args, repo)
+        if getattr(args, "status_output", None):
+            Path(args.status_output).expanduser().unlink(missing_ok=True)
         target, target_ref = choose_target(repo, args.mode, args.base)
         branch = current_branch(repo)
     print(f"autoreview target: {target}", flush=True)
@@ -6796,7 +7071,7 @@ def main_impl() -> int:
         evidence = capture_evidence_inputs(args, repo)
     with PreparationProgress("initial source snapshot") as progress:
         review_source_snapshot = source_tree_snapshot(repo, progress)
-    with PreparationProgress("bundle/evidence preparation and scan"):
+    with PreparationProgress("bundle/evidence preparation"):
         captured = build_bundle(repo, target, target_ref, args.commit)
         if target == "commit":
             target_ref = args.commit
@@ -6815,14 +7090,18 @@ def main_impl() -> int:
                 "source changed while the review bundle was being created; "
                 "rerun autoreview against the updated tree"
             )
-    chunk_reports = run_review_passes(
-        args,
-        reviewers,
-        repo,
-        prompts,
-        captured,
-        evidence.files,
-    )
+    try:
+        chunk_reports = run_review_passes(
+            args,
+            reviewers,
+            repo,
+            prompts,
+            captured,
+            evidence.files,
+        )
+    except ReviewerUnavailable as exc:
+        write_review_status(args, "reviewer_unavailable", 1, exc)
+        raise
     if len(chunk_reports) == 1 and not captured.mixed:
         report = chunk_reports[0][1]
     else:
@@ -6850,7 +7129,7 @@ def main_impl() -> int:
     if args.json_output:
         atomic_write_text(
             Path(args.json_output),
-            json.dumps(report, indent=2) + "\n",
+            json.dumps(redact_proxy_report(report), indent=2) + "\n",
         )
 
     if args.output:
@@ -6870,15 +7149,25 @@ def main_impl() -> int:
     has_findings = bool(report["findings"])
     overall_incorrect = report["overall_correctness"] == "patch is incorrect"
     if report["review_status"] == "incomplete":
-        return 2
-    if args.expect_findings:
-        return 0 if has_findings else 1
-    return 1 if has_findings or overall_incorrect else 0
+        exit_code = 2
+    elif args.expect_findings:
+        exit_code = 0 if has_findings else 1
+    else:
+        exit_code = 1 if has_findings or overall_incorrect else 0
+    write_review_status(args, report["review_status"], exit_code)
+    return exit_code
 
 
 def sanitized_main() -> int:
+    stdout = ProxyRedactedOutput(sys.stdout)
+    stderr = ProxyRedactedOutput(sys.stderr)
     try:
-        return main()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                return main()
+        finally:
+            stdout.finish()
+            stderr.finish()
     except SystemExit as exc:
         if isinstance(exc.code, str):
             raise SystemExit(

--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -52,6 +52,38 @@ DRAFT_REPORT = {
 
 
 class AutoreviewCursorTests(unittest.TestCase):
+    def test_parser_resource_errors_are_invalid_reports(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P2")
+        for raw in ("[" * 2000 + "]" * 2000, '{"findings":[],"number":' + "9" * 10000 + "}"):
+            with self.subTest(length=len(raw)), mock.patch.object(
+                AUTOREVIEW, "run_engine", return_value=raw,
+            ):
+                with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", set(), [])
+                self.assertEqual(caught.exception.reason, "invalid_report")
+
+    def test_container_valued_report_enums_are_invalid_reports(self) -> None:
+        args = argparse.Namespace(engine="codex", max_priority="P2")
+        finding = copy.deepcopy(DRAFT_REPORT["findings"][0])
+        finding["source_attribution"] = {
+            "target": "index", "record_id": "record", "source_id": "source",
+            "side": "present", "column": 1, "excerpt": "text",
+        }
+        for field in ("overall_correctness", "priority", "category", "target", "side"):
+            for value in ([], {}, None, 42, False):
+                report = copy.deepcopy(FINAL_REPORT)
+                report["findings"] = [copy.deepcopy(finding)]
+                owner = report if field == "overall_correctness" else report["findings"][0]
+                if field in {"target", "side"}:
+                    owner = owner["source_attribution"]
+                owner[field] = value
+                with self.subTest(field=field, value=value), mock.patch.object(
+                    AUTOREVIEW, "run_engine", return_value=json.dumps(report),
+                ):
+                    with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                        AUTOREVIEW.run_reviewer(args, Path.cwd(), "synthetic", {"draft.js"}, [])
+                    self.assertEqual(caught.exception.reason, "invalid_report")
+
     def test_extract_json_prefers_terminal_result_event(self) -> None:
         stream = "\n".join(
             [
@@ -158,9 +190,7 @@ class AutoreviewResultScopeTests(unittest.TestCase):
     def test_required_finding_must_survive_priority_filter_for_every_pass_count(self) -> None:
         args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
         for count in (1, 2):
-            with self.subTest(count=count), mock.patch.object(
-                AUTOREVIEW, "scan_outgoing_review_pack"
-            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
+            with self.subTest(count=count), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
                 reports = AUTOREVIEW.run_review_passes(
                     args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}
                 )
@@ -357,7 +387,6 @@ class AutoreviewTargetResultTests(unittest.TestCase):
                     "overall_correctness": "patch is incorrect", "overall_confidence": 0.43}
         for engine in AUTOREVIEW.ENGINES:
             with self.subTest(engine=engine), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(provider)), \
-                    mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"), \
                     mock.patch.object(AUTOREVIEW, "verify_mixed_sources"), contextlib.redirect_stderr(io.StringIO()):
                 report = AUTOREVIEW.run_reviewer(argparse.Namespace(engine=engine, max_priority="P0"),
                                                  Path.cwd(), prompt, captured, [])
@@ -845,6 +874,27 @@ class AutoreviewAmpTests(unittest.TestCase):
         self.assertIn("amp engine timed out after 0.01s", message)
         attest.assert_not_called()
 
+    def test_amp_failed_process_and_invalid_artifact_keep_runtime_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cases = (
+                (subprocess.CompletedProcess([], 7, "", "provider failed"), "expected exactly one leading"),
+                (subprocess.CompletedProcess([], 7, '{"type":"system","subtype":"init"}\n', ""), "unexpected adapter event sequence"),
+                (subprocess.CompletedProcess([], 0, amp_test_stream(root, tools=["shell_command"]), ""), "exposed tools"),
+                (subprocess.CompletedProcess([], 0, amp_test_stream(root), ""), "produced no result file"),
+                (subprocess.CompletedProcess([], 0, '{"type":[]}\n', ""), "unexpected stream event type"),
+            )
+            for result, diagnostic in cases:
+                with self.subTest(diagnostic=diagnostic), self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.amp_review_result(result, root, root / "error", root / "result")
+                self.assertEqual(caught.exception.reason, "runtime_validation_failed")
+                self.assertIn(diagnostic, str(caught.exception))
+                self.assertEqual(caught.exception.returncode, result.returncode)
+            for raw in ("[" * 2000 + "]" * 2000, '{"number":' + "9" * 10000 + "}"):
+                with self.subTest(length=len(raw)), self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                    AUTOREVIEW.amp_review_result(subprocess.CompletedProcess([], 0, raw, ""), root, root / "error", root / "result")
+                self.assertEqual(caught.exception.reason, "runtime_validation_failed")
+
     def test_amp_plugin_inventory_attestation_fails_closed(self) -> None:
         cwd = Path("/tmp/amp-review-empty")
         plugin_path = cwd.parent / "config" / "amp" / "plugins" / "autoreview-token.ts"
@@ -934,56 +984,21 @@ class AutoreviewAmpTests(unittest.TestCase):
                     AUTOREVIEW.run_amp(args, repo, "review")
 
 
-class AutoreviewTruffleHogTests(unittest.TestCase):
-    def test_refusal_does_not_echo_input_headings_or_scanner_fields(self) -> None:
-        marker = "SYNTHETIC_SCAN_SENTINEL_NOT_A_CREDENTIAL"
-        headings = [
-            f"# Dataset: {marker}",
-            f"# Prompt file: {marker}",
-            'Source snapshot: ' + json.dumps({"path": marker, "line_count": 0}),
-            'Removed source: ' + json.dumps({"path": marker}),
-            '# Untracked File\npath: ' + json.dumps(marker),
-            f"+++ b/{marker}",
-            f"diff --git a/old.txt b/{marker}\n--- a/old.txt\n+++ b/{marker}\n@@ -1 +1 @@\n+example",
-        ]
-        for heading in headings:
-            with self.subTest(heading=heading), tempfile.TemporaryDirectory() as tempdir:
-                prompt = "# Dataset: safe-evidence.txt\n" + heading
-                lines = [number for number, line in enumerate(prompt.splitlines(), 1) if marker in line]
-                output = json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": lines[-1]}}},
-                                     "Raw": marker, "RawV2": marker})
-                with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
-                        mock.patch.object(AUTOREVIEW, "run", return_value=subprocess.CompletedProcess(
-                            [], AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, output, marker,
-                        )), mock.patch.object(AUTOREVIEW, "run_engine") as provider:
-                    with self.assertRaises(SystemExit) as error:
-                        AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
-                                                 Path(tempdir), prompt, {"change.txt"}, [])
-                self.assertNotIn(marker, str(error.exception))
-                self.assertIn("remove credential material", str(error.exception))
-                provider.assert_not_called()
+class AutoreviewInputTests(unittest.TestCase):
 
-    def test_scanner_checks_stdin_without_literal_ignore_markers(self) -> None:
-        prompt = "unicode \u03c0\r\nsource without suppression instructions\n"
-        commands = []
-        with tempfile.TemporaryDirectory() as tempdir:
-            def scanner(command, cwd, **kwargs):
-                commands.append(command[1])
-                if command[1] == "filesystem":
-                    self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
-                    return subprocess.CompletedProcess(command, 0, "", "")
-                self.assertEqual(command[1], "stdin")
-                self.assertEqual(kwargs["stdin"].read(), prompt.encode("utf-8"))
-                return subprocess.CompletedProcess(command, AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "", "")
 
-            with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
-                    mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
-                    mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(FINAL_REPORT)) as provider:
-                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                    AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
-                                             Path(tempdir), prompt, {"change.txt"}, [])
-            self.assertEqual(commands, ["filesystem", "stdin"])
-            provider.assert_not_called()
+    def test_every_provider_reviews_each_pack_without_a_scanner(self) -> None:
+        for engine in ("codex", "claude", "amp", "pi", "kimi"):
+            with self.subTest(engine=engine), tempfile.TemporaryDirectory() as tempdir:
+                args = argparse.Namespace(engine=engine, max_priority="P0")
+                prompts = [f"complete pack {index}: unicode π\r\n-context\n+change\n" for index in range(2)]
+                with mock.patch.object(AUTOREVIEW, "find_command", side_effect=AssertionError("unexpected scanner lookup")), \
+                        mock.patch.object(AUTOREVIEW, "run", side_effect=AssertionError("unexpected scanner process")), \
+                        mock.patch.object(AUTOREVIEW, f"run_{engine}", return_value=json.dumps(FINAL_REPORT)) as provider:
+                    for prompt in prompts:
+                        report = AUTOREVIEW.run_reviewer(args, Path(tempdir), prompt, set(), [])
+                        self.assertEqual(report["findings"], [])
+                self.assertEqual([call.args[2] for call in provider.call_args_list], prompts)
 
     def test_binary_stdin_preserves_utf8_and_crlf_bytes(self) -> None:
         payload = "unicode \u03c0\r\nnext\n".encode("utf-8")
@@ -995,100 +1010,6 @@ class AutoreviewTruffleHogTests(unittest.TestCase):
                 Path(tempdir), stdin=source,
             )
         self.assertEqual(result.stdout.strip(), payload.hex())
-
-    def test_every_provider_scans_each_pack_and_refuses_scanner_failures(self) -> None:
-        for engine in ("codex", "claude", "amp", "pi", "kimi"):
-            for failed_source, failure in ((None, None), (None, "missing"),
-                                           ("filesystem", "finding"), ("filesystem", "error"),
-                                           ("stdin", "finding"), ("stdin", "error")):
-                with self.subTest(engine=engine, source=failed_source, failure=failure), tempfile.TemporaryDirectory() as tempdir:
-                    repo = Path(tempdir)
-                    args = argparse.Namespace(engine=engine, max_priority="P0")
-                    prompts = [f"complete pack {index}: unicode \u03c0\r\n-context\n+change\n" for index in range(2)]
-                    events: list[tuple[str, str]] = []
-                    packs: list[Path] = []
-
-                    def scanner(command, cwd, **kwargs):
-                        source = command[1]
-                        pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
-                        data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
-                        packs.append(pack)
-                        prompt = data.decode("utf-8")
-                        self.assertIn(prompt, prompts)
-                        self.assertEqual(cwd, pack.parent)
-                        if os.name != "nt":
-                            self.assertEqual(stat.S_IMODE(pack.stat().st_mode), 0o600)
-                            self.assertEqual(stat.S_IMODE(pack.parent.stat().st_mode), 0o700)
-                        events.append((source, prompt))
-                        code = 0
-                        if prompt == prompts[1] and source == failed_source:
-                            code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
-                        return subprocess.CompletedProcess(command, code, "", "")
-
-                    def provider(_args, _repo, prompt):
-                        events.append(("send", prompt))
-                        return json.dumps(FINAL_REPORT)
-
-                    with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
-                            mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), contextlib.ExitStack() as stack:
-                        providers = {
-                            name: stack.enter_context(mock.patch.object(AUTOREVIEW, f"run_{name}", side_effect=provider))
-                            for name in ("codex", "claude", "amp", "pi", "kimi")
-                        }
-                        AUTOREVIEW.run_reviewer(args, repo, prompts[0], set(), [])
-                        if failure == "missing":
-                            find.return_value = None
-                        if failure:
-                            with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                                AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
-                        else:
-                            AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
-                        for name, call in providers.items():
-                            self.assertEqual(call.call_count, (1 if failure else 2) if name == engine else 0)
-                    expected = [("filesystem", prompts[0]), ("stdin", prompts[0]), ("send", prompts[0])]
-                    if failure != "missing":
-                        expected.append(("filesystem", prompts[1]))
-                        if failed_source != "filesystem":
-                            expected.append(("stdin", prompts[1]))
-                    if not failure:
-                        expected.append(("send", prompts[1]))
-                    self.assertEqual(events, expected)
-                    self.assertTrue(all(not pack.parent.exists() for pack in packs))
-
-    def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
-        prompt = "review pack with redacted examples only"
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = Path(tempdir)
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                pack = Path(command[2]) if command[1] == "filesystem" else Path(kwargs["stdin"].name)
-                self.assertEqual(cwd, pack.parent)
-                data = pack.read_bytes() if command[1] == "filesystem" else kwargs["stdin"].read()
-                self.assertEqual(data, prompt.encode("utf-8"))
-                self.assertEqual(
-                    command[3:] if command[1] == "filesystem" else command[2:],
-                    [
-                        "--json",
-                        "--no-color",
-                        "--results=verified,unknown",
-                        "--fail",
-                        "--fail-on-scan-errors",
-                        "--no-update",
-                    ],
-                )
-                self.assertEqual(kwargs["check"], False)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.object(
-                AUTOREVIEW,
-                "find_command",
-                return_value="/trusted/trufflehog",
-            ), mock.patch.object(AUTOREVIEW, "run", side_effect=run_scanner):
-                AUTOREVIEW.scan_outgoing_review_pack(repo, prompt)
 
 
 class AutoreviewCompatibilityTests(unittest.TestCase):
@@ -1178,6 +1099,24 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
                 AUTOREVIEW.ensure_kimi_isolation_supported(args, Path(tmpdir)),
                 "/usr/bin/kimi",
             )
+
+    def test_kimi_invalid_streams_are_unavailable_after_launch(self) -> None:
+        args = argparse.Namespace(engine="kimi", kimi_bin="kimi", model="kimi-model",
+                                  stream_engine_output=False, thinking="on", max_priority="P2")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir) / "repo"
+            repo.mkdir()
+            for stream in ("malformed JSON", '{"role":"meta"}\n', '{"role":"assistant","content":"{}"}'):
+                with self.subTest(stream=stream), mock.patch.object(
+                    AUTOREVIEW, "ensure_kimi_isolation_supported", return_value="/usr/bin/kimi",
+                ), mock.patch.object(
+                    AUTOREVIEW, "load_kimi_review_config", return_value=({"telemetry": False}, None),
+                ), mock.patch.object(
+                    AUTOREVIEW, "run_with_heartbeat", return_value=subprocess.CompletedProcess([], 0, stream, ""),
+                ):
+                    with self.assertRaises(AUTOREVIEW.ReviewerUnavailable) as caught:
+                        AUTOREVIEW.run_reviewer(args, repo, "synthetic pack", set(), [])
+                    self.assertEqual(caught.exception.reason, "invalid_report")
 
     def test_kimi_runs_with_empty_tools_skills_and_mcp(self) -> None:
         args = argparse.Namespace(
@@ -1275,62 +1214,31 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             web_search=False,
         )
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
-        for failed_source, failure in ((None, None), (None, "missing"),
-                                       ("filesystem", "finding"), ("filesystem", "error"),
-                                       ("stdin", "finding"), ("stdin", "error")):
-            with self.subTest(source=failed_source, failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
-                events: list[str] = []
-                packs: list[Path] = []
+        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+            events = []
 
-                def scanner(command, _cwd, **kwargs):
-                    source = command[1]
-                    pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
-                    data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
-                    packs.append(pack)
-                    self.assertEqual(data, prompt.encode("utf-8"))
-                    events.append(source)
-                    code = 0
-                    if "gpt-5.6-sol" in events and source == failed_source:
-                        code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
-                    return subprocess.CompletedProcess(command, code, "", "")
+            def fake_run(command, _cwd, **kwargs):
+                self.assertEqual(kwargs["input_text"], prompt)
+                model = command[command.index("--model") + 1]
+                events.append(model)
+                if model == "gpt-5.6-sol":
+                    return subprocess.CompletedProcess(
+                        command, 1, "",
+                        "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                    )
+                output_path = Path(command[command.index("--output-last-message") + 1])
+                output_path.write_text(json.dumps(FINAL_REPORT))
+                return subprocess.CompletedProcess(command, 0, "", "")
 
-                def fake_run(command, _cwd, **kwargs):
-                    self.assertEqual(kwargs["input_text"], prompt)
-                    model = command[command.index("--model") + 1]
-                    events.append(model)
-                    if model == "gpt-5.6-sol":
-                        if failure == "missing":
-                            find.return_value = None
-                        return subprocess.CompletedProcess(
-                            command, 1, "",
-                            "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-                        )
-                    output_path = Path(command[command.index("--output-last-message") + 1])
-                    output_path.write_text(json.dumps(FINAL_REPORT))
-                    return subprocess.CompletedProcess(command, 0, "", "")
-
-                with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
-                        mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
-                        mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
-                        mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
-                        mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
-                        mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
-                        mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
-                    if failure:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                            AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                    else:
-                        report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                        self.assertEqual(report["findings"], [])
-                expected = ["filesystem", "stdin", "gpt-5.6-sol"]
-                if failure != "missing":
-                    expected.append("filesystem")
-                    if failed_source != "filesystem":
-                        expected.append("stdin")
-                if not failure:
-                    expected.append("gpt-5.6-terra")
-                self.assertEqual(events, expected)
-                self.assertTrue(all(not pack.parent.exists() for pack in packs))
+            with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
+                    mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                    mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                    mock.patch.object(AUTOREVIEW, "find_command", side_effect=AssertionError("unexpected scanner lookup")), \
+                    mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+                report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                self.assertEqual(report["findings"], [])
+            self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
 
     def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
         args = argparse.Namespace(

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import copy
 import io
@@ -18,6 +19,7 @@ import tempfile
 import threading
 import time
 import unittest
+import urllib.parse
 from unittest import mock
 from pathlib import Path, PureWindowsPath
 
@@ -265,18 +267,6 @@ def installed_java() -> str | None:
     except OSError:
         return None
     return java if probe.returncode == 0 else None
-
-
-def add_fake_trufflehog(
-    helper: dict[str, object],
-    root: Path,
-    env: dict[str, str],
-) -> None:
-    write_executable(
-        root / "trufflehog",
-        "#!/usr/bin/env python3\nraise SystemExit(0)\n",
-    )
-    env["PATH"] = f"{root}{os.pathsep}{env.get('PATH', '')}"
 
 
 def path_excluding_command(name: str) -> str:
@@ -700,7 +690,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                     path.unlink()
                 provider = mock.Mock()
                 with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                    "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                    "run_engine": provider,
                 }), contextlib.redirect_stderr(io.StringIO()):
                     refusal = "unsafe mixed source mode" if mutation.startswith("index ") else "mixed source changed|symlinked mixed source"
                     with self.assertRaisesRegex(SystemExit, refusal):
@@ -708,16 +698,14 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                                                      repo, passes[0], captured, [])
                 provider.assert_not_called()
 
-    def test_complete_and_per_pass_scans_include_new_authoritative_context(self):
+    def test_every_pass_sends_complete_authoritative_context(self):
         with self.migration(scan_sentinel=True) as (repo, *_):
-            # This unchanged line is outside every diff hunk, but now sent as
-            # authoritative source and therefore part of the frozen-input scan.
+            # Unchanged authoritative source outside diff hunks reaches the reviewer.
             captured = self.helper["local_bundle"](repo)
             self.assertNotIn("SOURCE_ONLY_SCAN_SENTINEL", captured.text)
             evidence = [self.helper["ReviewDataset"]("evidence.txt", "evidence\n" * 6000)]
-            scans, sends = [], []
+            sends = []
             with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "run_engine": lambda _args, _repo, prompt: sends.append(prompt) or json.dumps({
                     "findings": [], "overall_correctness": "patch is correct",
                     "overall_explanation": "Synthetic clean.", "overall_confidence": 0.9,
@@ -725,24 +713,21 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             }), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                 passes = self.helper["prepare_review_prompts"](repo, "local", None, captured, "", evidence, 30_000)
                 self.assertGreater(len(passes), 1)
-                self.assertEqual(len(scans), 1)
-                self.assertIn("SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n", scans[0])
-                self.assertIn(evidence[0].content, scans[0])
                 args = argparse.Namespace(engine="codex", max_priority="P0")
                 self.helper["run_review_passes"](args, [args], repo, passes, captured)
-            self.assertEqual(scans[1:], sends)
-            for item, scanned in zip(passes, scans[1:]):
-                self.assertEqual(item.prompt, scanned)
+            self.assertEqual(len(passes), len(sends))
+            for item, sent in zip(passes, sends):
+                self.assertEqual(item.prompt, sent)
                 for record in item.chunk.sources:
-                    self.assertIn(record.index.content, scanned)
-                    self.assertIn(record.working_tree.content, scanned)
+                    self.assertIn(record.index.content, sent)
+                    self.assertIn(record.working_tree.content, sent)
 
     def test_honest_capacity_refusal_and_no_legacy_metadata_bypass(self):
         with self.migration() as (repo, *_):
             captured = self.helper["local_bundle"](repo)
-            scan, provider = mock.Mock(), mock.Mock()
+            provider = mock.Mock()
             with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": scan, "run_engine": provider,
+                "run_engine": provider,
             }):
                 with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-0.py .*index=.*working_tree=.*prompt limit 1000"):
                     self.helper["prepare_review_prompts"](repo, "local", None, captured, "", [], 1000)
@@ -755,7 +740,6 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                 datasets = [self.helper["ReviewDataset"]("e" * 4000 + ".txt", "evidence")]
                 with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-\d.py .*prompt limit"):
                     self.helper["prepare_review_prompts"](repo, "local", None, captured, "", datasets, budget)
-            scan.assert_not_called()
             provider.assert_not_called()
 
 
@@ -802,7 +786,6 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "prepare_review_prompts": lambda *args: original_prepare(*args) * count,
-                            "scan_outgoing_review_pack": lambda *_: None,
                             "run_engine": lambda *_: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(text), \
                                 contextlib.redirect_stderr(io.StringIO()):
@@ -923,7 +906,7 @@ class AutoreviewMixedTargetTests(unittest.TestCase):
             self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
             provider = mock.Mock()
             with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                "run_engine": provider,
             }), contextlib.redirect_stderr(io.StringIO()):
                 with self.assertRaisesRegex(SystemExit, "evidence changed"):
                     self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, passes[0], captured, [],
@@ -982,7 +965,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / "source.md").write_text("after\n")
             (repo / "evidence").mkdir()
             (repo / "evidence/note.md").write_text("frozen evidence\r\n")
-            sends, scans = [], []
+            sends = []
             stdout, stderr = io.StringIO(), io.StringIO()
 
             def engine(_args, _repo, prompt):
@@ -997,16 +980,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
                 "repo_root": lambda: repo,
                 "run_engine": engine,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "resolve_engine_binary": lambda *_args: (True, None),
             }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
                     contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                yield repo, sends, scans, stdout, stderr
+                yield repo, sends, stdout, stderr
 
     def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
         for explicit in (False, True):
             options = ("--dataset", "note.md") if explicit else ()
-            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, _out, err):
                 (repo / "note.md").write_text("untracked evidence\n")
                 read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
                 fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
@@ -1014,7 +996,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
                 }):
                     self.assertEqual(self.helper["main_impl"](), 0)
-                self.assertEqual(scans, sends)
                 # Explicit evidence has its own initial capture and three fresh
                 # checks; finding membership never adds another content read.
                 self.assertEqual(read.call_count, 5 if explicit else 1)
@@ -1040,7 +1021,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(sends)
 
     def test_preparation_progress_precedes_snapshot(self):
-        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
+        with self.preparation_fixture() as (_repo, sends, _out, err):
             def snapshot(*_args, **_kwargs):
                 self.assertIn("preparation: initial source snapshot", err.getvalue())
                 self.assertFalse(sends)
@@ -1051,20 +1032,19 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     self.helper["main_impl"]()
 
     def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
-        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, *_):
             snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
             with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
                 self.assertEqual(self.helper["main_impl"](), 0)
             snapshot.assert_not_called()
-            self.assertTrue(scans)
             self.assertFalse(sends)
 
     def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
         for tracked in (False, True):
-            for timing in ("construction", "scan", "review", "between passes"):
+            for timing in ("construction", "preparation", "review", "between passes"):
                 with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
                     "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
-                ) as (repo, sends, _scans, out, _err):
+                ) as (repo, sends, out, _err):
                     evidence = repo / "evidence/note.md"
                     if tracked:
                         git(repo, "add", "-f", "evidence/note.md")
@@ -1092,8 +1072,13 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         return result
 
                     patches = {"run_engine": engine, "build_bundle": build}
-                    if timing == "scan":
-                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
+                    if timing == "preparation":
+                        original_prepare = self.helper["prepare_review_prompts"]
+                        def prepare(*args):
+                            result = original_prepare(*args)
+                            mutate()
+                            return result
+                        patches["prepare_review_prompts"] = prepare
                     if timing == "between passes":
                         original_prepare = self.helper["prepare_review_prompts"]
                         patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
@@ -1148,7 +1133,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with self.preparation_fixture(
             "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
             "--dataset", "evidence/note.md",
-        ) as (repo, sends, scans, *_):
+        ) as (repo, sends, *_):
             evidence = (repo / "evidence/note.md").read_bytes().decode()
             original = self.helper["prepare_review_prompts"]
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
@@ -1156,7 +1141,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             }):
                 self.assertEqual(self.helper["main_impl"](), 0)
             self.assertEqual(len(sends), 2)
-            self.assertEqual(scans, sends)
             for prompt in sends:
                 self.assertEqual(prompt.count(evidence), 3)
 
@@ -1280,155 +1264,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertEqual(captured.paths, {"task.md"})
                 self.assertIn("+task change", captured.text)
 
-    def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
-        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = root / "repo"
-            repo.mkdir()
-            write_executable(
-                root / "trufflehog",
-                r'''#!/usr/bin/env python3
-import json
-from pathlib import Path
-import sys
-
-args = sys.argv[1:]
-if "--no-update" not in args:
-    print("updater: cannot move binary: permission denied", file=sys.stderr)
-    raise SystemExit(1)
-source = args[0]
-assert source in {"filesystem", "stdin"}
-pack = Path(args[1]) if source == "filesystem" else None
-assert set(args[2:] if pack else args[1:]) == {
-    "--json", "--no-color", "--results=verified,unknown",
-    "--fail", "--fail-on-scan-errors", "--no-update",
-}
-payload = pack.read_bytes() if pack else sys.stdin.buffer.read()
-with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as records:
-    records.write(json.dumps({
-        "source": source,
-        "pack": str(pack) if pack else None,
-        "prompt": payload.decode("utf-8"),
-    }) + "\n")
-''',
-            )
-            with mock.patch.dict(
-                os.environ,
-                {"PATH": f"{root}{os.pathsep}{os.environ.get('PATH', '')}"},
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-
-            records = [json.loads(line) for line in (root / "scans.jsonl").read_text(encoding="utf-8").splitlines()]
-            self.assertEqual([record["source"] for record in records], ["filesystem", "stdin"])
-            self.assertEqual([record["prompt"] for record in records], [prompt, prompt])
-            self.assertFalse(Path(records[0]["pack"]).parent.exists())
-
-    def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            sources = []
-
-            def run_scanner(
-                command: list[str],
-                cwd: Path,
-                **kwargs: object,
-            ) -> subprocess.CompletedProcess[str]:
-                sources.append(command[1])
-                if command[1] == "filesystem":
-                    payload = Path(command[2]).read_bytes()
-                else:
-                    self.assertEqual(command[1], "stdin")
-                    payload = kwargs["stdin"].read()
-                self.assertEqual(payload, prompt.encode("utf-8"))
-                self.assertIn("-const apiKey", prompt)
-                return subprocess.CompletedProcess(command, 0, "", "")
-
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": run_scanner,
-                },
-            ):
-                self.helper["scan_outgoing_review_pack"](repo, prompt)
-            self.assertEqual(sources, ["filesystem", "stdin"])
-
-    def test_deleted_input_scan_refusal_is_redacted_and_blocks_provider(self) -> None:
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/config.ts b/config.ts\n"
-            "deleted file mode 100644\n"
-            "--- a/config.ts\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n"
-            "-const apiKey = \"removed-but-still-sensitive\";\n"
-        )
-        finding = {
-            "SourceMetadata": {
-                "Data": {
-                    "Filesystem": {
-                        "file": "review-pack.txt",
-                        "line": 7,
-                    }
-                }
-            },
-            "Raw": "must-not-be-printed",
-        }
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            packs = []
-            provider = mock.Mock()
-
-            def run_scanner(command, cwd, **_kwargs):
-                self.assertEqual(command[1], "filesystem")
-                pack = Path(command[2])
-                self.assertEqual(pack.parent, cwd)
-                self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
-                packs.append(pack)
-                return subprocess.CompletedProcess(
-                    command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(finding) + "\n", "",
-                )
-
-            with mock.patch.dict(
-                self.helper["run_reviewer"].__globals__,
-                {
-                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
-                    "run": run_scanner,
-                    "run_engine": provider,
-                },
-            ), contextlib.redirect_stderr(io.StringIO()):
-                with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials") as error:
-                    self.helper["run_reviewer"](
-                        argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
-                    )
-            self.assertEqual(len(packs), 1)
-            self.assertFalse(packs[0].parent.exists())
-            provider.assert_not_called()
-        self.assertEqual(
-            str(error.exception),
-            "refusing to send review pack: TruffleHog found credentials; "
-            "remove credential material from selected changes, prompt files, and datasets, then rerun",
-        )
-
-    def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            with mock.patch.dict(
-                self.helper["scan_outgoing_review_pack"].__globals__,
-                {"find_command": lambda _name, _repo: None},
-            ):
-                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                    self.helper["scan_outgoing_review_pack"](repo, "prompt")
 
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1517,7 +1352,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
 
     @contextlib.contextmanager
     def nested_worktree_fixture(self, *, linked_root=False, name="scratch/review branch"):
-        with self.preparation_fixture() as (main, sends, scans, out, err):
+        with self.preparation_fixture() as (main, sends, out, err):
             repo = main
             if linked_root:
                 repo = main.parent / "reviewed checkout"
@@ -1525,15 +1360,15 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 (repo / "source.md").write_text("outer linked change\n", encoding="utf-8")
             child = repo / name
             git(main, "worktree", "add", "--detach", str(child), "HEAD")
-            yield repo, child, sends, scans, out, err
+            yield repo, child, sends, out, err
 
-    def test_nested_worktree_keeps_neighboring_untracked_files_in_outgoing_scans(self):
+    def test_nested_worktree_keeps_neighboring_untracked_files_in_review(self):
         names = ["scratch/review branch"]
         if os.name != "nt":
             names.append("scratch/review\nbranch")
         for name in names:
             with self.subTest(name=name), self.nested_worktree_fixture(name=name) as (
-                repo, child, sends, scans, _out, _err,
+                repo, child, sends, _out, _err,
             ):
                 ordinary = {
                     ".worktrees/notes.md": "OUTER_WORKTREE_DIRECTORY_NOTE\n",
@@ -1549,9 +1384,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 captured = self.helper["local_bundle"](repo)
                 self.assertEqual(captured.paths, {"source.md", *ordinary})
                 self.assertEqual(self.helper["main_impl"](), 0)
-                self.assertEqual(scans, sends)
-                self.assertTrue(scans)
-                for pack in scans:
+                for pack in sends:
                     for marker in ordinary.values():
                         self.assertIn(marker.strip(), pack)
                     self.assertNotIn("CHILD_SOURCE_NOT_REVIEWED", pack)
@@ -1730,7 +1563,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
             unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
-            scanned: list[str] = []
             sent: list[str] = []
             report = {
                 "findings": [{
@@ -1753,7 +1585,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             main = self.helper["main_impl"]
             with mock.patch.dict(main.__globals__, {
                 "repo_root": lambda: repo,
-                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
                 "run_engine": run_engine,
                 "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
             }):
@@ -1765,7 +1596,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertEqual(main(), 0 if dry_run else 1)
 
             self.assertEqual(len(sent), 1)
-            self.assertEqual(scanned, [sent[0], sent[0]])
             self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
             self.assertIn(staged.rstrip(), sent[0])
             self.assertIn(unstaged.rstrip(), sent[0])
@@ -1893,7 +1723,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             for engine in ("codex", "claude", "amp", "pi", "kimi"):
                 for mode, ref, accepted, expected_exit in cases:
                     with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
-                        scans, sends = [], []
+                        sends = []
 
                         def run_engine(_args, _repo, prompt):
                             sends.append(prompt)
@@ -1907,7 +1737,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         output = io.StringIO()
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo, "run_engine": run_engine,
-                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), expected_exit)
                         result = json.loads((root / "result.json").read_text())
@@ -1922,7 +1751,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         self.assertNotIn("clean:", text)
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
-                        self.assertEqual(scans, sends)
                         self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
@@ -1971,7 +1799,8 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             "overall_explanation": "Synthetic provider explanation.", "overall_confidence": 0.61,
                         }
                         argv = [str(SCRIPT), "--engine", "codex", "--mode", "local", "--max-priority", priority,
-                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json")]
+                                "--output", str(root / "result.txt"), "--json-output", str(root / "result.json"),
+                                "--status-output", str(root / "status.json")]
                         for needle in required:
                             argv.extend(["--require-finding", needle])
                         if expect:
@@ -1979,11 +1808,16 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
-                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": lambda *_args: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
                         result = json.loads((root / "result.json").read_text())
+                        outcome = json.loads((root / "status.json").read_text())
+                        self.assertEqual(outcome, {
+                            "schema_version": 1, "status": expected_status, "exit_code": exit_code,
+                            "engine": "codex", "report_produced": True, "reason": None,
+                            "reviewer_exit_code": None, "timed_out": False,
+                        })
                         text = (root / "result.txt").read_text()
                         self.assertEqual(result["review_status"], expected_status)
                         self.assertEqual(result["overall_correctness"], verdict)
@@ -1997,70 +1831,128 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                         if required and expected_status == "incomplete":
                             self.assertEqual(result["missing_required_findings"], required)
 
-    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
-        source = "Sources/Configuration/CredentialFile.swift"
+    def test_status_unavailable_and_local_refusals_remain_distinct(self) -> None:
+        clean = json.dumps({"findings": [], "overall_correctness": "patch is correct",
+                            "overall_explanation": "Synthetic review.", "overall_confidence": 0.9})
+        unavailable = self.helper["ReviewerUnavailable"]
+        cases = (
+            ("engine", unavailable("DIAGNOSTIC_SENTINEL", result=subprocess.CompletedProcess([], 7, "", "")), "engine_failed"),
+            ("timeout", unavailable("DIAGNOSTIC_SENTINEL", result=self.helper["TimedOutEngineProcess"]([], 124, "", "")), "engine_failed"),
+            ("invalid-json", "not JSON", "invalid_report"),
+            ("invalid-schema", '{"findings": []}', "invalid_report"),
+            ("invalid-field-type", json.dumps({"findings": [], "overall_correctness": [],
+                                               "overall_explanation": "Invalid enum", "overall_confidence": 0.9}), "invalid_report"),
+            ("invalid-event-type", '[{"type":"assistant","message":{"content":null}}]', "invalid_report"),
+            ("isolation", SystemExit("isolation refused"), None),
+            ("spawn", OSError("cannot execute reviewer"), None),
+        )
         with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            path = repo / source
-            path.parent.mkdir(parents=True)
-            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
-            git(repo, "add", source)
-            git(repo, "commit", "-q", "-m", "base")
-            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
-            git(repo, "add", source)
-            untracked = repo / "Runtime/CredentialFile.swift"
-            untracked.parent.mkdir()
-            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
-            evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
-                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
-                dataset=[str(untracked.relative_to(repo))],
-            ), repo)
-            extra, datasets = evidence.prompt, evidence.datasets
-            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
-            pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
-            provider = mock.Mock(return_value=json.dumps({
-                "findings": [], "overall_correctness": "patch is correct",
-                "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
-            }))
-            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
-                events = []
+            root = Path(tempdir)
+            repo = init_repo(root)
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            (repo / "source.txt").write_text("changed\n")
+            for count in (1, 2):
+                for label, failure, reason in cases:
+                    with self.subTest(count=count, label=label):
+                        sidecar = root / "status.json"
+                        report = root / "result.json"
+                        sidecar.write_text('{"status":"scoped-clean"}')
+                        argv = [str(SCRIPT), "--mode", "local", "--engine", "codex",
+                                "--status-output", str(sidecar), "--json-output", str(report)]
+                        engine = mock.Mock(side_effect=[clean] * (count - 1) + [failure])
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo,
+                            "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
+                            "run_engine": engine,
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                            with self.assertRaises((SystemExit, OSError)):
+                                self.helper["main_impl"]()
+                        self.assertFalse(report.exists())
+                        self.assertEqual(sidecar.exists(), reason is not None)
+                        if reason:
+                            text = sidecar.read_text()
+                            outcome = json.loads(text)
+                            self.assertEqual(outcome["status"], "reviewer_unavailable")
+                            self.assertEqual(outcome["reason"], reason)
+                            self.assertFalse(outcome["report_produced"])
+                            self.assertEqual(outcome["timed_out"], label == "timeout")
+                            self.assertEqual(outcome["reviewer_exit_code"], {"engine": 7, "timeout": 124}.get(label))
+                            self.assertNotIn("DIAGNOSTIC_SENTINEL", text)
 
-                def scanner(command, _repo, **kwargs):
-                    source_kind = command[1]
-                    if source_kind == "filesystem":
-                        outgoing = Path(command[2])
-                        payload = outgoing.read_bytes()
-                    else:
-                        self.assertEqual(source_kind, "stdin")
-                        outgoing = Path(kwargs["stdin"].name)
-                        payload = kwargs["stdin"].read()
-                    self.assertEqual(payload, pack.encode("utf-8"))
-                    if os.name != "nt":
-                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
-                    self.assertIn("--results=verified,unknown", command)
-                    self.assertIn("--no-update", command)
-                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
-                        self.assertIn(token, pack)
-                    events.append(source_kind)
-                    if marker:
-                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
-                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
-                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
-                    return subprocess.CompletedProcess(command, 0, "", "")
+    def test_status_paths_reject_repo_and_aliases_before_removing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            existing = root / "status.json"
+            existing.write_text("keep existing output")
+            for first, second in (("result.json", "RESULT.json"), ("caf\u00e9.json", "cafe\u0301.json")):
+                args = argparse.Namespace(status_output=str(root / first), output=None, json_output=str(root / second))
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                self.assertFalse((root / first).exists())
+            for value in (str(repo / "result.json"), str(existing)):
+                args = argparse.Namespace(status_output=value, output=None, json_output=str(existing))
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                self.assertEqual(existing.read_text(), "keep existing output")
+            if os.name != "nt":
+                alias = root / "alias.json"
+                alias.symlink_to(existing)
+                args.status_output = str(alias)
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
+                alias.unlink()
+                os.link(existing, alias)
+                with self.assertRaises(SystemExit):
+                    self.helper["reject_repo_output_paths"](args, repo)
 
-                provider.reset_mock()
-                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
-                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
-                }):
-                    args = argparse.Namespace(engine="codex", max_priority="P2")
-                    if marker:
-                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
-                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_not_called()
-                    else:
-                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
-                        provider.assert_called_once_with(args, repo, pack)
-                    self.assertEqual(events, ["filesystem"] if marker else ["filesystem", "stdin"])
+    @unittest.skipUnless(sys.platform == "darwin", "macOS firmlink alias")
+    def test_status_rejects_absent_outputs_under_same_parent_inode(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir).resolve()
+            alias = Path("/System/Volumes/Data") / root.relative_to("/")
+            if not alias.exists() or not os.path.samefile(root, alias):
+                self.skipTest("temporary directory has no data-volume alias")
+            repo = init_repo(root)
+            args = argparse.Namespace(status_output=str(root / "result.json"),
+                                      json_output=str(alias / "result.json"), output=None)
+            with self.assertRaises(SystemExit):
+                self.helper["reject_repo_output_paths"](args, repo)
+            self.assertFalse((root / "result.json").exists())
+
+    @unittest.skipIf(os.name == "nt", "the executable fixtures are POSIX-only")
+    def test_cli_status_for_launched_codex_and_claude_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+            (repo / "source.txt").write_text("review me\n")
+            env = os.environ.copy()
+            env.update({"HOME": str(root), "USERPROFILE": str(root)})
+            for engine, source in (("codex", fake_codex_script()), ("claude", fake_claude_script())):
+                for timeout in (False, True):
+                    with self.subTest(engine=engine, timeout=timeout):
+                        # Help/version preflights succeed; only the launched review fails.
+                        injected = "import time; sys.stdin.read(); time.sleep(30)" if timeout else "print('DIAGNOSTIC_SENTINEL\\x1b[31m', file=sys.stderr); raise SystemExit(17)"
+                        executable = write_executable(root / engine, source.replace('record = os.environ["AUTOREVIEW_FAKE_RECORD"]', injected + '\nrecord = os.environ["AUTOREVIEW_FAKE_RECORD"]'))
+                        sidecar = root / "status.json"
+                        report = root / "result.json"
+                        argv = [sys.executable, str(SCRIPT), "--mode", "local", "--engine", engine,
+                                f"--{engine}-bin", str(executable), "--status-output", str(sidecar),
+                                "--json-output", str(report)]
+                        if timeout:
+                            argv += ["--engine-timeout-seconds", "0.2"]
+                        result = subprocess.run(argv, cwd=repo, env=env, text=True, capture_output=True, timeout=30)
+                        self.assertEqual(result.returncode, 1, result.stderr)
+                        outcome = json.loads(sidecar.read_text())
+                        self.assertEqual(outcome["status"], "reviewer_unavailable")
+                        self.assertEqual(outcome["engine"], engine)
+                        self.assertEqual(outcome["reviewer_exit_code"], 124 if timeout else 17)
+                        self.assertEqual(outcome["timed_out"], timeout)
+                        self.assertFalse(report.exists())
+                        self.assertNotIn("DIAGNOSTIC_SENTINEL", sidecar.read_text())
+                        self.assertNotIn("\x1b", result.stderr)
+
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2821,12 +2713,9 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             bundle = "diff --git a/code.py b/code.py\n" + "+review me\n" * 20_000
-            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
-                "scan_outgoing_review_pack": mock.Mock(),
-            }):
-                prompts = self.helper["prepare_review_prompts"](
-                    repo, "local", None, bundle, "", [], 120_000
-                )
+            prompts = self.helper["prepare_review_prompts"](
+                repo, "local", None, bundle, "", [], 120_000
+            )
             self.assertGreater(len(prompts), 1)
             for prompt in prompts:
                 self.assertIn(
@@ -2834,38 +2723,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                     prompt,
                 )
 
-    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
-            for source in ("diff", "dataset"):
-                with self.subTest(source=source):
-                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
-                    datasets = (
-                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
-                        if source == "dataset" else []
-                    )
-                    prompts = self.helper["build_review_prompts"](
-                        repo, "local", None, bundle, "", datasets, 120_000
-                    )
-                    self.assertGreater(len(prompts), 1)
-                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
-                    scanned = []
-
-                    def scan(_repo, prompt):
-                        scanned.append(prompt)
-                        if sentinel in prompt:
-                            raise SystemExit("complete input scanner rejection")
-
-                    with mock.patch.dict(
-                        self.helper["prepare_review_prompts"].__globals__,
-                        {"scan_outgoing_review_pack": scan},
-                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
-                        self.helper["prepare_review_prompts"](
-                            repo, "local", None, bundle, "", datasets, 120_000
-                        )
-                    self.assertEqual(len(scanned), 1)
-                    self.assertIn(sentinel, scanned[0])
 
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2899,15 +2756,11 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "category": "bug",
             "code_location": {"file_path": "source.txt", "line": 1},
         }
-        for failure in (None, "scan", "engine"):
+        for failure in (None, "engine"):
             with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 events = []
 
-                def scan(_repo, prompt):
-                    events.append(("scan", prompt))
-                    if failure == "scan" and prompt == prompts[8]:
-                        raise SystemExit("late scan failure")
 
                 def engine(_args, _repo, prompt):
                     events.append(("engine", prompt))
@@ -2927,7 +2780,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
 
                 with mock.patch.dict(
                     self.helper["run_review_passes"].__globals__,
-                    {"scan_outgoing_review_pack": scan, "run_engine": engine},
+                    {"run_engine": engine},
                 ), contextlib.redirect_stdout(io.StringIO()):
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
@@ -2945,10 +2798,10 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                             [item["title"] for item in report["findings"]], [finding["title"]]
                         )
                 expected = [
-                    (stage, prompt) for prompt in prompts for stage in ("scan", "engine")
+                    ("engine", prompt) for prompt in prompts
                 ]
                 if failure:
-                    expected = expected[:17 if failure == "scan" else 18]
+                    expected = expected[:9]
                 self.assertEqual(events, expected)
 
     def test_review_patch_does_not_disclose_controls_in_omitted_paths(self) -> None:
@@ -3298,28 +3151,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             patch,
         )
 
-    @unittest.skipUnless(
-        shutil.which("trufflehog"), "TruffleHog binary not installed"
-    )
-    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
-        # Live-scanner companion to the regression above: TruffleHog must not
-        # flag the benign "ok-token" status literal in a deleted-file bundle.
-        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
-            encoding="utf-8"
-        )
-        prompt = (
-            "# Change Bundle\n"
-            "diff --git a/apps/macos/MenuContentView.swift "
-            "b/apps/macos/MenuContentView.swift\n"
-            "deleted file mode 100644\n"
-            "--- a/apps/macos/MenuContentView.swift\n"
-            "+++ /dev/null\n"
-            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
-            + "".join(f"-{line}\n" for line in source.splitlines())
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            repo = init_repo(Path(tempdir))
-            self.helper["scan_outgoing_review_pack"](repo, prompt)
 
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
@@ -4247,7 +4078,6 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             )
             record_path = root / "record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_MUTATE": str(source),
@@ -4380,6 +4210,7 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "proxy.example.invalid:8080",
             "socks4://proxy.example.invalid",
             "socks4a://proxy.example.invalid",
+            "http://[fe80::1%25en0]:8080",
         ):
             with self.subTest(value=value):
                 self.assertTrue(self.helper["safe_proxy_url"](value))
@@ -4389,20 +4220,20 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
             "socks5://review-user:review-password@proxy.example.invalid:1080",
         ):
             with self.subTest(value=value):
-                self.assertFalse(self.helper["safe_proxy_url"](value))
+                self.assertTrue(self.helper["safe_proxy_url"](value))
 
-    def test_safe_engine_env_rejects_credentialed_proxy(self) -> None:
+    def test_safe_engine_env_rejects_malformed_proxy(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir, mock.patch.dict(
             os.environ,
             {
                 "HTTPS_PROXY": (
-                    "http://review-user:review-password@proxy.example.invalid:8080"
+                    "http://review-user:review-password@proxy.example.invalid:bad"
                 )
             },
             clear=False,
         ):
             repo = init_repo(Path(tempdir))
-            with self.assertRaisesRegex(SystemExit, "credentialed or malformed proxy"):
+            with self.assertRaisesRegex(SystemExit, "malformed proxy"):
                 self.helper["safe_engine_env"](repo, engine="codex")
 
     def test_safe_temp_root_rejects_reviewed_repo_parent(self) -> None:
@@ -4449,6 +4280,31 @@ with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as reco
                 SystemExit,
                 "2.1.170",
             ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
+    @unittest.skipIf(os.name == "nt", "POSIX executable fixture")
+    def test_claude_probe_captures_help_from_pipe_sensitive_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            cli = write_executable(root / "claude", r'''#!/usr/bin/env python3
+import os
+import stat
+import sys
+
+if "--version" in sys.argv:
+    print("2.1.226 (Claude Code)")
+else:
+    text = "Usage: claude\n" + " " * 16384
+    text += "--safe-mode --setting-sources --strict-mcp-config --disallowedTools --tools\n"
+    if stat.S_ISFIFO(os.fstat(1).st_mode):
+        text = text[:512]
+    sys.stdout.write(text)
+''')
+            args = argparse.Namespace(claude_bin=str(cli), model=None, fallback_model=None)
+            self.helper["ensure_claude_isolation_supported"](args, repo)
+            cli.write_text(cli.read_text().replace("--safe-mode", "--unsafe-mode"))
+            with self.assertRaisesRegex(SystemExit, "missing from --help: --safe-mode"):
                 self.helper["ensure_claude_isolation_supported"](args, repo)
 
     def test_claude_canonical_fable_model_uses_portable_cli_selector(self) -> None:
@@ -5635,7 +5491,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
 ''',
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "CODEX_HOME": str(source_home),
@@ -5732,7 +5587,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             invocations = root / "codex-invocations.jsonl"
             record = root / "codex-record.json"
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_CODEX_INVOCATIONS": str(invocations),
@@ -5844,10 +5698,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
-            # Dry run scans the exact prompt too, so use a deterministic
-            # scanner instead of relying on the host installation.
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5887,7 +5738,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             repo_temp = repo / "tmp"
             repo_temp.mkdir()
             env.update(
@@ -5918,7 +5768,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
+            self.assertIn("prompt: OK", result.stdout)
             self.assertIn("must be outside the reviewed repository", result.stdout)
             self.assertRegex(
                 result.stdout,
@@ -5926,8 +5776,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
-    def test_dry_run_flag_exits_nonzero_when_trufflehog_missing(self) -> None:
-        # Dry run applies the same exact-pack scan as a real provider call.
+    def test_dry_run_succeeds_without_trufflehog(self) -> None:
+        # Dry run needs only the reviewer CLI, with no external scanner.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)
@@ -5960,11 +5810,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 check=False,
             )
 
-            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: FAILED", result.stdout)
-            self.assertIn("TruffleHog is required but was not found", result.stdout)
-            self.assertIn(self.helper["TRUFFLEHOG_INSTALL_URL"], result.stdout)
-            # The engine itself still resolves; only trufflehog should fail.
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("prompt: OK", result.stdout)
             self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
@@ -6079,7 +5926,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 preflight.__globals__,
                 {
                     "build_review_prompts": capturing,
-                    "scan_outgoing_review_pack": lambda _repo, _prompt: None,
                 },
             ):
                 with contextlib.redirect_stdout(stdout):
@@ -6102,7 +5948,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6144,7 +5989,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_PI_VERSION"] = "0.50.0"
 
             result = subprocess.run(
@@ -6183,7 +6027,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6222,7 +6065,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_KIMI_VERSION"] = "0.10.0"
 
             result = subprocess.run(
@@ -6261,7 +6103,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Isolate KIMI_CODE_HOME to an empty, hermetic directory instead
             # of leaking the host's real ~/.kimi-code (which may or may not
             # exist) into this test; an empty source share has no
@@ -6309,7 +6150,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(repo / ".kimi-code")
 
             result = subprocess.run(
@@ -6364,7 +6204,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "device_id").write_text("not-a-valid-id!!", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6417,7 +6256,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "credentials").write_text("not-a-directory", encoding="utf-8")
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6469,7 +6307,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             (source_share / "credentials").mkdir()
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -6514,7 +6351,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_claude_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6557,7 +6393,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
             # Prompt limits must not depend on the host's Kimi configuration.
             env["KIMI_CODE_HOME"] = str(root / "kimi-empty-home")
             (root / "kimi-empty-home").mkdir()
@@ -6615,7 +6450,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6660,7 +6494,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = {**os.environ, "CODEX_HOME": str(root)}
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6701,7 +6534,6 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
-            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -6727,6 +6559,331 @@ os.execv(target, [str(target), *sys.argv[1:]])
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
             self.assertIn("inputs: FAILED", result.stdout)
             self.assertIn("missing-dataset.json", result.stdout)
+
+PROXY_KEYS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
+
+class AuthenticatedProxyTests(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_authenticated_proxy_urls_are_transport_not_openclaw_provenance(self):
+        for value in (
+            "http://user:password@proxy.example.invalid:8080",
+            "https://user:password@[::1]:8443/",
+            "socks5h://u:p%40ss%3Aword@proxy.example.invalid:1080",
+            "user:password@proxy.example.invalid:8080",
+            "http://user@proxy.example.invalid",
+            "http://:password@proxy.example.invalid",
+            "http://proxy.example.invalid:8080",
+            "proxy.example.invalid:8080",
+            "socks4a://proxy.example.invalid",
+        ):
+            with self.subTest(value=value):
+                self.assertTrue(self.helper["safe_proxy_url"](value))
+
+    def test_malformed_proxy_urls_still_fail_closed(self):
+        for value in (
+            "", "http://", "file:///proxy", "http://host:0", "http://host:65536",
+            "http://host:bad", "http://[::1", "http://host/path", "http://host?q=1",
+            "http://host#fragment", " http://host", "http://host\n", "http://ho\tst",
+            "http://user:p%0Ass@host", "http://user:p%00ss@host", "http://user:p%zz@host",
+            "http://user:p@ss@host", "http://user:p\\ass@host", "http://ho st",
+            "http://host%0a.example", "http://host%2f.example",
+        ):
+            with self.subTest(value=value):
+                self.assertFalse(self.helper["safe_proxy_url"](value))
+
+    def test_engine_env_preserves_authenticated_transport_without_marker_or_api_leak(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            repo = root / "repo"
+            repo.mkdir()
+            proxy = "http://fixture:transport-password@127.0.0.1:8080"
+            transport = {key: proxy for key in PROXY_KEYS}
+            transport.update({"NO_PROXY": "localhost", "NODE_USE_ENV_PROXY": "1"})
+            ca_keys = ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                       "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE")
+            transport.update({key: str(root / "trust.pem") for key in ca_keys})
+            inherited = {**transport, "OPENAI_API_KEY": "provider-auth-fixture",
+                         "UNRELATED_SECRET": "not-for-review", "NODE_OPTIONS": "--require hostile"}
+            for engine in self.helper["ENGINES"]:
+                with self.subTest(engine=engine), mock.patch.dict(os.environ, inherited, clear=True):
+                    env = self.helper["safe_engine_env"](repo, engine=engine)
+                    for key, value in transport.items():
+                        # Windows os.environ canonicalizes names to uppercase;
+                        # POSIX must retain each supplied casing independently.
+                        lookup_key = key.upper() if os.name == "nt" else key
+                        self.assertEqual(env.get(lookup_key), value, key)
+                    self.assertNotIn("UNRELATED_SECRET", env)
+                    self.assertNotIn("NODE_OPTIONS", env)
+                    if engine == "codex":
+                        self.assertEqual(env["OPENAI_API_KEY"], "provider-auth-fixture")
+                    elif engine in {"claude", "amp"}:
+                        self.assertNotIn("OPENAI_API_KEY", env)
+
+    def test_repository_ca_paths_are_not_inherited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            repo.mkdir()
+            certificate = repo / "trust.pem"
+            certificate.touch()
+            external_link = root / "trust-link.pem"
+            external_link.symlink_to(certificate)
+            for engine in self.helper["ENGINES"]:
+                for value in (str(certificate), str(external_link)):
+                    with self.subTest(engine=engine, value=value), mock.patch.dict(os.environ, {
+                        key: value for key in ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                                              "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE")
+                    }, clear=True):
+                        env = self.helper["safe_engine_env"](repo, engine=engine)
+                        for key in ("NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+                                    "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE"):
+                            self.assertNotIn(key, env)
+
+    def proxy_fixture(self):
+        username = "u"
+        password = 'synthetic-p@ss:/+%"\\word'
+        userinfo = f"{username}:{password}"
+        encoded = urllib.parse.quote(password, safe="")
+        proxy = f"http://{username}:{encoded}@127.0.0.1:8080"
+        basic = base64.b64encode(userinfo.encode()).decode()
+        forms = (proxy, userinfo, f"{username}:{encoded}", password, encoded,
+                 "Proxy-Authorization: Basic " + basic)
+        return proxy, forms
+
+    def test_proxy_credentials_are_redacted_in_diagnostics_not_short_user_labels(self):
+        proxy, forms = self.proxy_fixture()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            for form in (*forms, *(json.dumps(form)[1:-1] for form in forms)):
+                with self.subTest(form=form):
+                    rendered = self.helper["display_escape"]("failure: " + form, 4000, multiline=True)
+                    self.assertNotIn(form, rendered)
+                    self.assertIn("[REDACTED]", rendered)
+            self.assertEqual(self.helper["display_escape"]("user u requests an update", 100),
+                             "user u requests an update")
+            for display in (self.helper["CodexStreamDisplay"](), self.helper["ClaudeStreamDisplay"]()):
+                self.assertNotIn(forms[0], display("stderr", "failure: " + forms[0]))
+
+    def test_real_stream_and_buffered_failure_keep_exit_semantics_without_disclosure(self):
+        proxy, forms = self.proxy_fixture()
+        source = "import os,sys; print(os.environ['HTTPS_PROXY']); print(os.environ['HTTPS_PROXY'],file=sys.stderr); sys.exit(7)"
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=False):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                result = self.helper["run_with_heartbeat"](
+                    [sys.executable, "-c", source], Path(tmp), label="proxy-test", stream_output=True,
+                    env={"HTTPS_PROXY": proxy},
+                )
+            self.assertEqual(result.returncode, 7)
+            self.assertNotIn(proxy, stdout.getvalue() + stderr.getvalue())
+            failure = self.helper["ReviewerUnavailable"]("failed (7): " + result.stderr, result=result)
+            with mock.patch.dict(self.helper["sanitized_main"].__globals__, {
+                "main": mock.Mock(side_effect=failure),
+            }):
+                with self.assertRaises(SystemExit) as caught:
+                    self.helper["sanitized_main"]()
+            self.assertNotIn(proxy, str(caught.exception))
+            self.assertIn("failed (7)", str(caught.exception))
+            self.assertEqual(failure.returncode, 7)
+
+    def test_report_files_and_terminal_are_redacted_without_changing_verdict(self):
+        proxy, forms = self.proxy_fixture()
+        report = {"findings": [], "overall_correctness": "patch is incorrect",
+                  "overall_explanation": "provider says " + " | ".join(forms), "overall_confidence": 0.8}
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = Path(tmp) / "report.json"
+            self.helper["atomic_write_text"](output, json.dumps(self.helper["redact_proxy_report"](report)))
+            saved = json.loads(output.read_text())
+            terminal = io.StringIO()
+            with contextlib.redirect_stdout(terminal):
+                self.helper["print_report"](report)
+            for form in forms:
+                self.assertNotIn(form, saved["overall_explanation"])
+                self.assertNotIn(form, terminal.getvalue())
+            self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+            self.assertEqual(saved["findings"], [])
+            self.assertEqual(report["overall_explanation"], "provider says " + " | ".join(forms))
+
+    def test_codex_tools_do_not_inherit_transport_or_authentication(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            flags = self.helper["codex_config_isolation_flags"](root / "repo", root / "runtime")
+            self.assertIn('shell_environment_policy.inherit="core"', flags)
+            self.assertIn("shell_environment_policy.ignore_default_excludes=false", flags)
+            self.assertFalse(set(PROXY_KEYS) & self.helper["codex_tool_git_env"]().keys())
+
+    @unittest.skipIf(os.name == "nt", "POSIX executable fixture")
+    def test_cli_preserves_transport_and_redacts_streams_reports_and_failures(self):
+        proxy, forms = self.proxy_fixture()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            repo = root / "repo"
+            repo.mkdir()
+            def git(*args):
+                subprocess.run(["git", "-C", str(repo), "-c", "user.name=Proxy Test",
+                                "-c", "user.email=proxy@example.invalid", "-c", "commit.gpgsign=false",
+                                *args], check=True, capture_output=True)
+            git("init", "-q")
+            (repo / "source.txt").write_text("before\n")
+            git("add", ".")
+            git("commit", "-qm", "fixture")
+            (repo / "source.txt").write_text("after\n")
+            fake = root / "codex-fixture"
+            fake.write_text(f"#!{sys.executable}\n" + '''import json, os, sys
+from pathlib import Path
+if "--version" in sys.argv:
+    print("codex-cli 0.0.0-test")
+    raise SystemExit(0)
+Path(os.environ["AUTOREVIEW_FAKE_PROXY_RECORD"]).write_text(json.dumps({
+    "proxy": os.environ["HTTPS_PROXY"], "auth": os.environ.get("OPENAI_API_KEY"), "argv": sys.argv,
+}))
+print(os.environ["HTTPS_PROXY"])
+print(os.environ["HTTPS_PROXY"], file=sys.stderr)
+if os.environ.get("AUTOREVIEW_FAKE_PROXY_EXIT"):
+    raise SystemExit(7)
+flag = "--output-last-message" if "--output-last-message" in sys.argv else "-o"
+Path(sys.argv[sys.argv.index(flag) + 1]).write_text(json.dumps({
+    "findings": [], "overall_correctness": "patch is incorrect",
+    "overall_explanation": "transport diagnostics: " + os.environ["HTTPS_PROXY"], "overall_confidence": 0.8,
+}))
+''')
+            fake.chmod(0o755)
+            home = root / "home"
+            home.mkdir()
+            record = root / "record.json"
+            human, report, status = (root / name for name in ("report.txt", "report.json", "status.json"))
+            env = {key: value for key, value in os.environ.items() if key in {"PATH", "TMPDIR", "TEMP", "TMP"}}
+            env.update({"HOME": str(home), "HTTPS_PROXY": proxy, "OPENAI_API_KEY": "opaque-provider-fixture",
+                        "AUTOREVIEW_FAKE_PROXY_RECORD": str(record)})
+            command = [sys.executable, str(SCRIPT), "--mode", "local", "--codex-bin", str(fake),
+                       "--output", str(human), "--json-output", str(report), "--status-output", str(status),
+                       "--stream-engine-output"]
+            result = subprocess.run(command, cwd=repo, env=env, capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertTrue(report.exists(), result.stdout + result.stderr)
+            saved = json.loads(report.read_text())
+            self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+            captured = json.loads(record.read_text())
+            self.assertEqual(captured["proxy"], proxy)
+            self.assertEqual(captured["auth"], "opaque-provider-fixture")
+            self.assertIn('shell_environment_policy.inherit="core"', captured["argv"])
+            published = result.stdout + result.stderr + human.read_text() + report.read_text()
+            for form in forms:
+                self.assertNotIn(form, published)
+            self.assertEqual(json.loads(status.read_text())["exit_code"], result.returncode)
+            env["AUTOREVIEW_FAKE_PROXY_EXIT"] = "1"
+            failed = subprocess.run(command, cwd=repo, env=env, capture_output=True, text=True)
+            self.assertNotEqual(failed.returncode, 0)
+            self.assertNotIn(proxy, failed.stdout + failed.stderr)
+            self.assertEqual(json.loads(status.read_text())["reviewer_exit_code"], 7)
+
+    def test_serialized_redaction_does_not_turn_short_passwords_into_json_syntax(self):
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://u:1@localhost:8080"}, clear=True):
+            report = {"code": 1, "accepted": True, "explanation": "password=1", "u": "user u"}
+            saved = json.loads(json.dumps(self.helper["redact_proxy_report"](report)))
+            self.assertEqual(saved["code"], 1)
+            self.assertIs(saved["accepted"], True)
+            self.assertEqual(saved["explanation"], "[REDACTED]")
+            self.assertEqual(saved["u"], "user u")
+
+    def test_short_password_does_not_corrupt_prose_or_serialized_enums(self):
+        for password in ("a", "incorrect"):
+            with self.subTest(password=password), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://u:{password}@localhost:8080",
+            }, clear=True):
+                report = {"overall_correctness": "patch is incorrect", "review_status": "incomplete",
+                          "overall_explanation": "a branch has a bug", "findings": [{
+                              "priority": "P1", "category": "regression", "body": "password=" + password,
+                          }]}
+                saved = self.helper["redact_proxy_report"](report)
+                self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+                self.assertEqual(saved["review_status"], "incomplete")
+                self.assertEqual(saved["overall_explanation"], "a branch has a bug")
+                self.assertEqual(saved["findings"][0]["priority"], "P1")
+                self.assertEqual(saved["findings"][0]["category"], "regression")
+                self.assertNotIn("password=" + password, saved["findings"][0]["body"])
+
+    def test_username_only_and_empty_password_are_hidden_in_url_contexts(self):
+        for suffix in ("", ":"):
+            with self.subTest(suffix=suffix), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://u%40name{suffix}@localhost:8080",
+            }, clear=True):
+                diagnostic = f"proxy=http://u@name{suffix}@LOCALHOST:8080/; user u@name is configured"
+                redacted = self.helper["redact_proxy_credentials"](diagnostic)
+                self.assertNotIn(f"u@name{suffix}@", redacted)
+                self.assertIn("user u@name is configured", redacted)
+
+    def test_long_username_only_tokens_are_redacted_outside_url_contexts(self):
+        token = 'synthetic-user-token@/+"\\value'
+        encoded = urllib.parse.quote(token, safe="")
+        forms = (token, encoded, urllib.parse.quote(encoded, safe=""),
+                 json.dumps(token)[1:-1])
+        for suffix in ("", ":"):
+            with self.subTest(suffix=suffix), mock.patch.dict(os.environ, {
+                "HTTPS_PROXY": f"http://{encoded}{suffix}@localhost:8080",
+            }, clear=True):
+                for form in forms:
+                    with self.subTest(form=form):
+                        rendered = self.helper["display_escape"]("rejected credential " + form, 4000)
+                        self.assertNotIn(form, rendered)
+                        self.assertIn("[REDACTED]", rendered)
+                        report = {"overall_correctness": "patch is incorrect",
+                                  "overall_explanation": "rejected credential " + form}
+                        saved = self.helper["redact_proxy_report"](report)
+                        self.assertNotIn(form, saved["overall_explanation"])
+                        self.assertEqual(saved["overall_correctness"], "patch is incorrect")
+
+    def test_username_only_redaction_preserves_short_labels_and_report_enums(self):
+        for username in ("u", "openclaw", "review-bot", "incorrect"):
+            for suffix in ("", ":"):
+                with self.subTest(username=username, suffix=suffix), mock.patch.dict(os.environ, {
+                    "HTTPS_PROXY": f"http://{username}{suffix}@localhost:8080",
+                }, clear=True):
+                    prose = f"user {username} is configured"
+                    self.assertEqual(self.helper["redact_proxy_credentials"](prose), prose)
+                    for label in ("username", "proxy_user", "proxy-username"):
+                        diagnostic = f'{label}="{username}"'
+                        redacted = self.helper["redact_proxy_credentials"](diagnostic)
+                        self.assertNotIn(diagnostic, redacted)
+                        self.assertIn("[REDACTED]", redacted)
+                    report = {"overall_correctness": "patch is incorrect",
+                              "review_status": "incomplete", "overall_explanation": prose,
+                              "findings": [{"priority": "P1", "category": "regression"}]}
+                    self.assertEqual(self.helper["redact_proxy_report"](report), report)
+
+    def test_output_redaction_covers_split_writes_and_final_unterminated_line(self):
+        proxy, _forms = self.proxy_fixture()
+        stream = io.StringIO()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = self.helper["ProxyRedactedOutput"](stream)
+            for char in proxy:
+                output.write(char)
+                output.flush()
+            self.assertEqual(stream.getvalue(), "")
+            output.write("\n")
+            self.assertEqual(stream.getvalue(), "[REDACTED]\n")
+            output.write(proxy)
+            output.finish()
+            self.assertEqual(stream.getvalue(), "[REDACTED]\n[REDACTED]")
+
+    def test_redacting_output_bounds_unterminated_lines_and_retains_stream_interface(self):
+        proxy, _forms = self.proxy_fixture()
+        stream = io.StringIO()
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": proxy}, clear=True):
+            output = self.helper["ProxyRedactedOutput"](stream)
+            output.write("x" * 65_537 + proxy)
+            self.assertLessEqual(len(output.pending), 65_536)
+            output.write("still the suppressed line\nnext line\n")
+            output.finish()
+            self.assertEqual(stream.getvalue(),
+                             "[output line suppressed: exceeds redaction buffer]\nnext line\n")
+            self.assertFalse(output.isatty())
+            self.assertEqual(output.encoding, stream.encoding)
+            with self.assertRaises(io.UnsupportedOperation):
+                output.fileno()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/autoreview/tests/test_codex_inference_route.py
+++ b/.agents/skills/autoreview/tests/test_codex_inference_route.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import copy
+import io
 import json
 import os
+import shlex
+import stat
 import subprocess
 import sys
 import tempfile
@@ -89,7 +93,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         text += '\n[mcp_servers.unrelated]\ncommand = "must-not-execute"\n'
         (self.home / "config.toml").write_text(text, encoding="utf-8")
 
-    def run_review(self, *, prepare_auth=None, during_run=None, scan=None):
+    def run_review(self, *, prepare_auth=None, during_run=None):
         observed = {}
 
         def fake_run(command, cwd, **kwargs):
@@ -97,8 +101,14 @@ class CodexInferenceRouteTests(unittest.TestCase):
             observed["cwd"] = cwd
             observed["workspace"] = list(cwd.iterdir())
             observed["env"] = kwargs["env"]
+            observed["stream_display"] = kwargs["stream_display"]
             flags = [command[index + 1] for index, value in enumerate(command) if value == "-c"]
             observed["flags"] = dict(flag.split("=", 1) for flag in flags)
+            auth_command = observed["flags"].get("model_providers.review_api.auth.command")
+            if auth_command:
+                launcher = Path(tomllib.loads(f"value = {auth_command}")["value"])
+                observed["auth_command"] = launcher
+                observed["auth_launcher_text"] = launcher.read_text(encoding="utf-8")
             catalogue = observed["flags"].get("model_catalog_json")
             if catalogue:
                 file = Path(json.loads(catalogue))
@@ -116,15 +126,19 @@ class CodexInferenceRouteTests(unittest.TestCase):
             "ensure_codex_isolation_supported": mock.Mock(return_value="synthetic-codex"),
             "resolve_command": mock.Mock(return_value="synthetic-codex"),
             "run_with_heartbeat": fake_run,
-            "scan_outgoing_review_pack": mock.Mock(),
         }
         if prepare_auth is not None:
             replacements["prepare_codex_runtime_auth"] = prepare_auth
-        if scan is not None:
-            replacements["scan_outgoing_review_pack"] = scan
         with mock.patch.dict(self.helper["run_codex"].__globals__, replacements):
-            self.helper["run_codex"](self.args, self.repo, "synthetic review")
+            observed["report"] = self.helper["run_codex"](self.args, self.repo, "synthetic review")
         return observed
+
+    def assert_auth_command(self, observed, executable):
+        if os.name == "nt":
+            self.assertEqual(observed["auth_command"], executable.resolve())
+        else:
+            self.assertNotEqual(observed["auth_command"], executable.resolve())
+            self.assertIn(f"exec {shlex.quote(str(executable.resolve()))}\n", observed["auth_launcher_text"])
 
     def test_trusted_route_reaches_client_without_workspace_or_config_capabilities(self):
         self.write_config()
@@ -132,7 +146,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         flags = observed["flags"]
         self.assertEqual(flags.get("model_provider"), '"review_api"')
         self.assertEqual(flags.get("model_providers.review_api.base_url"), '"https://api.openai.com/v1"')
-        self.assertEqual(flags.get("model_providers.review_api.auth.command"), json.dumps(str(self.runtime_helper.resolve())))
+        self.assert_auth_command(observed, self.runtime_helper)
         self.assertEqual(flags.get("model_providers.review_api.auth.cwd"), json.dumps(str(self.home.resolve())))
         self.assertEqual(flags.get("model_providers.review_api.auth.timeout_ms"), "5000")
         self.assertEqual(flags.get("model_providers.review_api.auth.refresh_interval_ms"), "300000")
@@ -152,6 +166,8 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(observed["command"][observed["command"].index("--ask-for-approval") + 1], "never")
         self.assertFalse(observed["cwd"].exists())
         self.assertFalse(observed["catalogue_path"].exists())
+        if os.name != "nt":
+            self.assertFalse(observed["auth_command"].exists())
 
     def available(self):
         replacements = {
@@ -185,6 +201,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.write_config()
         original = self.catalogue_bytes
         events = []
+        launchers = []
 
         def respond(observed):
             command = observed["command"]
@@ -192,6 +209,8 @@ class CodexInferenceRouteTests(unittest.TestCase):
             events.append(selected)
             self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
             self.assertEqual(observed["catalogue"], original)
+            self.assert_auth_command(observed, self.runtime_helper)
+            launchers.append(observed["auth_command"])
             if selected == "gpt-5.6-sol":
                 # A retry keeps the prepared route even if operator files change.
                 self.catalogue.write_bytes(b"changed after primary send")
@@ -200,8 +219,9 @@ class CodexInferenceRouteTests(unittest.TestCase):
                     command, 1, "", "The model gpt-5.6-sol does not exist or you do not have access to it.",
                 )
 
-        self.run_review(during_run=respond, scan=lambda *_: events.append("scan"))
-        self.assertEqual(events, ["gpt-5.6-sol", "scan", "gpt-5.6-terra"])
+        self.run_review(during_run=respond)
+        self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
+        self.assertEqual(launchers[0], launchers[1])
 
     def test_primary_only_catalogue_does_not_block_successful_primary(self):
         self.use_default_models()
@@ -225,7 +245,13 @@ class CodexInferenceRouteTests(unittest.TestCase):
                     self.provider["base_url"] = "https://example.invalid/custom"
                     self.write_config()
                     modules = {"tomllib": None, "tomli": None} if without_parser else {}
-                    with mock.patch.dict(sys.modules, modules):
+                    with (
+                        mock.patch.dict(sys.modules, modules),
+                        mock.patch.dict(os.environ, {"HOME": str(self.repo)}),
+                        mock.patch.dict(self.helper["run_codex"].__globals__, {
+                            "codex_auth_helper_home": mock.Mock(side_effect=AssertionError("default route must not validate helper HOME")),
+                        }),
+                    ):
                         observed = self.run_review()
                         self.assertEqual(observed["flags"]["cli_auth_credentials_store"], '"file"')
                         self.assertEqual(observed["flags"]["forced_login_method"], '"api"')
@@ -384,7 +410,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.auth["command"] = str(executable)
         self.write_config()
         observed = self.run_review()
-        self.assertEqual(observed["flags"]["model_providers.review_api.auth.command"], json.dumps(str(executable.resolve())))
+        self.assert_auth_command(observed, executable)
         self.auth["command"] = executable.name
         self.write_config()
         self.assert_route_refused()
@@ -396,6 +422,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.auth.update(command=str(executable), cwd=str(working_dir))
         self.write_config()
         observed = self.run_review()
+        self.assert_auth_command(observed, executable)
 
         runtime = self.root / "runtime-🦞"
         runtime.mkdir()
@@ -405,7 +432,7 @@ class CodexInferenceRouteTests(unittest.TestCase):
         key, value = catalogue_flags[-1].split("=", 1)
         flags = {**observed["flags"], key: value}
         expected = {
-            "model_providers.review_api.auth.command": executable,
+            "model_providers.review_api.auth.command": observed["auth_command"],
             "model_providers.review_api.auth.cwd": working_dir,
             "model_catalog_json": runtime / "model-catalog.json",
         }
@@ -465,6 +492,193 @@ class CodexInferenceRouteTests(unittest.TestCase):
         self.assertEqual(observed["flags"].get("model_provider"), '"review_api"')
         self.assertEqual(json.loads(source_auth.read_text()), {"fixture": "refreshed"})
         self.assertEqual((self.home / "config.toml").read_bytes(), config_before)
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper launcher")
+    def test_launcher_restores_only_helper_home_with_literal_paths(self):
+        weird = " ' \" $(not-a-command) `not-a-command` ; & 🦞"
+        caller_home = self.root / ("caller" + weird)
+        caller_home.mkdir()
+        working_dir = self.home / ("working" + weird)
+        working_dir.mkdir()
+        executable = write_executable(
+            self.home / ("helper" + weird),
+            f"#!{sys.executable}\nimport json, os, sys\n"
+            "print(json.dumps({'env': dict(os.environ), 'cwd': os.getcwd(), 'args': sys.argv[1:]}))\n",
+        )
+        self.auth.update(command=str(executable), cwd=str(working_dir), args=[])
+        self.write_config()
+        originals = {path: path.read_bytes() for path in (self.home / "config.toml", self.catalogue, executable)}
+
+        def execute(observed):
+            launcher = observed["auth_command"]
+            runtime = Path(observed["env"]["HOME"]).parent
+            self.assertEqual(launcher.parent, runtime)
+            self.assertEqual(stat.S_IMODE(launcher.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(runtime.stat().st_mode), 0o700)
+            self.assertEqual(launcher.stat().st_uid, os.getuid())
+            self.assertFalse(launcher.is_relative_to(observed["cwd"]))
+            self.assertFalse(launcher.is_relative_to(self.repo))
+            before = dict(observed["env"])
+            cwd = tomllib.loads(f'value = {observed["flags"]["model_providers.review_api.auth.cwd"]}')["value"]
+            result = subprocess.run([str(launcher)], cwd=cwd, env=before, capture_output=True, text=True, check=True)
+            actual = json.loads(result.stdout)
+            self.assertEqual(actual["env"]["HOME"], str(caller_home.resolve()))
+            for key, value in before.items():
+                if key not in {"HOME", "PWD", "SHLVL", "_"}:
+                    self.assertEqual(actual["env"].get(key), value, key)
+            self.assertEqual(actual["cwd"], str(working_dir.resolve()))
+            self.assertEqual(actual["args"], [])
+            self.assertNotEqual(before["HOME"], str(caller_home.resolve()))
+            self.assertEqual(observed["env"], before)
+            self.assertEqual(list(observed["cwd"].iterdir()), [])
+            flags = observed["flags"]
+            self.assertEqual(flags["shell_environment_policy.set"], self.helper["toml_inline_string_table"](self.helper["codex_tool_git_env"]()))
+            filesystem = flags["permissions.autoreview.filesystem"]
+            for private_path in (caller_home, runtime, executable):
+                self.assertNotIn(str(private_path), filesystem)
+            self.assertEqual(flags["model_providers.review_api.auth.timeout_ms"], "5000")
+            self.assertEqual(flags["model_providers.review_api.auth.refresh_interval_ms"], "300000")
+
+        with mock.patch.dict(os.environ, {"HOME": str(caller_home)}):
+            observed = self.run_review(during_run=execute)
+        self.assert_auth_command(observed, executable)
+        self.assertEqual({path: path.read_bytes() for path in originals}, originals)
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper launcher")
+    def test_staged_launcher_path_uses_toml_unicode_encoder(self):
+        self.write_config()
+        runtime = self.root / "runtime ' \" 🦞"
+        runtime.mkdir(mode=0o700)
+        workspace = self.root / "workspace"
+        workspace.mkdir()
+        with mock.patch.dict(self.helper["codex_command"].__globals__, {"resolve_command": lambda *_: "synthetic-codex"}):
+            command = self.helper["codex_command"](
+                self.args, self.repo, workspace, runtime, runtime / "schema", runtime / "output", self.args.model,
+            )
+        flags = [command[index + 1] for index, part in enumerate(command) if part == "-c"]
+        flag = next(value for value in flags if value.startswith("model_providers.review_api.auth.command="))
+        launcher = Path(tomllib.loads("value=" + flag.partition("=")[2])["value"])
+        self.assertEqual(launcher.parent, runtime)
+        self.assertIn(f"exec {shlex.quote(str(self.runtime_helper.resolve()))}\n", launcher.read_text())
+
+    @unittest.skipIf(os.name == "nt", "POSIX auth helper HOME validation")
+    def test_unsafe_home_refused_in_run_and_dry_run_without_auth(self):
+        self.write_config()
+        external = self.root / "external"
+        external.mkdir()
+        repo_exit = self.repo / "exit-link"
+        repo_exit.symlink_to(external, target_is_directory=True)
+        final_link = self.root / "final-link"
+        final_link.symlink_to(self.repo, target_is_directory=True)
+        chain = self.root / "chain"
+        chain.symlink_to(repo_exit, target_is_directory=True)
+        loop = self.root / "loop"
+        loop.symlink_to(loop)
+        for home in (
+            str(self.repo), str(repo_exit), str(final_link), str(final_link / "exit-link"),
+            str(chain), str(self.repo / ".." / "external"), str(loop),
+            str(self.root / "missing"), str(self.catalogue), "relative-home", "",
+        ):
+            with self.subTest(home=home), mock.patch.dict(os.environ, {"HOME": home}):
+                self.args.dry_run = True
+                self.assert_route_refused()
+
+    def test_command_auth_failures_expose_only_fixed_categories(self):
+        self.write_config()
+        cases = {
+            "provider-auth-helper": "provider auth command failed",
+            "model-catalogue": "failed reading model_catalog_json",
+            "model-sandbox-policy": "requires a sandbox with reviewed escalations",
+            "cli-arguments": "unexpected argument",
+            "configuration": "Error parsing config: missing field",
+            "authentication": "HTTP 401 Unauthorized",
+            "provider-access": "HTTP 403 Forbidden",
+            "rate-limit": "HTTP 429 Too Many Requests",
+            "transport": "connection refused",
+            "unclassified": "unrecognized synthetic failure",
+        }
+        for category, diagnostic in cases.items():
+            for stream in ("stdout", "stderr"):
+                with self.subTest(category=category, stream=stream):
+                    def fail(observed):
+                        result = subprocess.CompletedProcess(observed["command"], 1, "", "")
+                        setattr(result, stream, diagnostic + "\nsynthetic-private-diagnostic\x1b[31m")
+                        return result
+
+                    with self.assertRaises(SystemExit) as caught:
+                        self.run_review(during_run=fail)
+                    self.assertEqual(str(caught.exception), f"codex engine failed: {category}; provider diagnostics suppressed")
+
+    def test_command_auth_stream_hides_diagnostics_but_preserves_progress_and_report(self):
+        self.write_config()
+        self.args.stream_engine_output = True
+        marker = "synthetic-private-diagnostic"
+
+        def stream(observed):
+            display = observed["stream_display"]
+            for name, line in (
+                ("stderr", marker), ("stdout", marker), ("stdout", '"' + marker + '"'),
+                ("stdout", "[]"), ("stdout", "null"),
+                ("stdout", json.dumps({"type": "error", "message": marker})),
+                ("stdout", json.dumps({"type": "turn.failed", "error": {"message": marker}})),
+            ):
+                self.assertNotIn(marker, display(name, line) or "")
+            self.assertIn("turn started", display("stdout", '{"type":"turn.started"}'))
+            usage = display("stdout", '{"type":"turn.completed","usage":{"input_tokens":2,"output_tokens":1}}')
+            self.assertIn("input_tokens=2", usage)
+            report = '{"findings": []}'
+            self.assertIn(report, display("stdout", json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": report}})))
+
+        self.assertEqual(self.run_review(during_run=stream)["report"], '{"findings": []}')
+
+    def test_command_auth_missing_report_and_failed_retry_do_not_return_diagnostics(self):
+        self.write_config()
+        marker = "synthetic-private-diagnostic"
+        for stream_output in (False, True):
+            for empty in ("", " \n"):
+                with self.subTest(stream_output=stream_output, empty=empty):
+                    self.args.stream_engine_output = stream_output
+                    def no_report(observed):
+                        command = observed["command"]
+                        Path(command[command.index("--output-last-message") + 1]).write_text(empty)
+                        return subprocess.CompletedProcess(command, 0, marker, marker)
+
+                    with self.assertRaises(SystemExit) as caught:
+                        self.run_review(during_run=no_report)
+                    self.assertEqual(str(caught.exception), "codex engine failed: missing-report; provider diagnostics suppressed")
+
+        self.use_default_models()
+        attempts = []
+        def fail_retry(observed):
+            attempts.append(observed["command"])
+            diagnostic = (f"The model {self.args.model} does not exist or you do not have access to it."
+                          if len(attempts) == 1 else "provider auth command failed")
+            return subprocess.CompletedProcess(observed["command"], 1, marker, diagnostic + "\n" + marker)
+
+        console = io.StringIO()
+        with contextlib.redirect_stderr(console), self.assertRaises(SystemExit) as caught:
+            self.run_review(during_run=fail_retry)
+        self.assertEqual(len(attempts), 2)
+        self.assertNotIn(marker, console.getvalue())
+        self.assertEqual(str(caught.exception), "codex engine failed: provider-auth-helper; provider diagnostics suppressed")
+
+    def test_default_route_keeps_diagnostic_streaming_and_stdout_fallback(self):
+        self.args.codex_config = []
+        self.args.stream_engine_output = True
+        self.write_config()
+        marker = "synthetic-default-diagnostic"
+
+        def respond(observed):
+            for name in ("stdout", "stderr"):
+                self.assertIn(marker, observed["stream_display"](name, marker))
+            return subprocess.CompletedProcess(observed["command"], returncode, marker, marker)
+
+        returncode = 0
+        self.assertEqual(self.run_review(during_run=respond)["report"], marker)
+        returncode = 1
+        with self.assertRaises(SystemExit) as caught:
+            self.run_review(during_run=respond)
+        self.assertIn(marker, str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -406,7 +406,7 @@ Current limits:
 
 - The traffic allowlist constrains only cooperating clients that honor the proxy environment (`HTTPS_PROXY` and the CA variables). A subprocess can ignore those variables and open raw sockets, so the allowlist is defense in depth; destination-bound sentinels remain the primary defense because they survive proxy bypass.
 - HTTP/2 upstream connections are not supported; the proxy uses HTTP/1.1 upstream.
-- WebSocket rewriting is not supported.
+- WebSocket upgrades support secret substitution in the handshake URL and headers. Message frames pass through unchanged; sentinels inside WebSocket messages are not substituted.
 - Non-443 HTTPS substitution is not a supported compatibility target.
 - Identity-scoped secrets are not supported; only the team store participates.
 - Allowed-host policy is exact-hostname authorization only. It does not validate the resolved IP or prevent an allowed origin from reflecting credentials.

--- a/src/secrets/egress-proxy/proxy-forward.ts
+++ b/src/secrets/egress-proxy/proxy-forward.ts
@@ -1,0 +1,210 @@
+import { ServerResponse, type IncomingHttpHeaders, type IncomingMessage } from "node:http";
+import { request as httpsRequest, type Agent as HttpsAgent } from "node:https";
+import { PassThrough, type Readable, type Writable } from "node:stream";
+import {
+  createSecretEgressBodyTransform,
+  SecretEgressSubstitutionError,
+  type SecretEgressRefusalReason,
+} from "./stream-substitution.js";
+
+export const REFUSAL_BODY = "Secret egress proxy refused the request.\n";
+const UPSTREAM_ERROR_BODY = "Secret egress proxy could not reach the upstream host.\n";
+
+export type UpgradeRequest = { stream: PassThrough };
+export type RequestHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+  upgrade?: UpgradeRequest,
+) => void;
+
+export function sendHttpRefusal(res: ServerResponse, status = 502, body = REFUSAL_BODY): void {
+  if (res.destroyed || res.writableEnded) {
+    return;
+  }
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  res.writeHead(status, {
+    Connection: "close",
+    "Content-Length": Buffer.byteLength(body),
+    "Content-Type": "text/plain; charset=utf-8",
+  });
+  res.end(body);
+}
+
+export function handleUpgradeRequest(
+  handler: RequestHandler,
+  request: IncomingMessage,
+  head: Buffer,
+): void {
+  // Reuse normal HTTP refusals and upstream non-101 responses. Node relinquishes
+  // HTTP ownership on upgrade, so close these responses unless forwarding detaches it.
+  const response = new ServerResponse(request);
+  try {
+    response.assignSocket(request.socket);
+  } catch {
+    // A pipelined upgrade can arrive before the previous HTTP response releases
+    // this socket. Do not steal it or let Node's ownership error crash the Gateway.
+    request.socket.destroy();
+    return;
+  }
+  // Buffer early frames with stream backpressure while waiting for the upstream
+  // handshake. Unlike a paused socket, this still observes a disconnect with no data.
+  const stream = new PassThrough();
+  request.socket.once("close", () => stream.destroy());
+  response.once("finish", () => {
+    if (response.socket) {
+      stream.destroy();
+      response.socket.end();
+    }
+  });
+  if (head.length > 0) {
+    stream.write(head);
+  }
+  request.socket.pipe(stream);
+  handler(request, response, { stream });
+}
+
+/** Forwards one authorized HTTPS request, retaining ownership across a WebSocket upgrade. */
+export function forwardSecretEgressRequest(forward: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  upgrade?: UpgradeRequest;
+  target: URL;
+  headers: IncomingHttpHeaders;
+  host: string;
+  substituted: boolean;
+  upstreamTlsAgent: HttpsAgent;
+  isActive: () => boolean;
+  ownResource: <T extends Readable | Writable>(resource: T) => T;
+  releaseResponse: () => void;
+  resolveSentinel: (sentinel: string) => string | undefined;
+  audit: (event: {
+    kind: "forwarded" | "refused";
+    host: string;
+    substituted: boolean;
+    reason?: SecretEgressRefusalReason;
+  }) => void;
+}): void {
+  const { target, headers, host } = forward;
+  let { substituted } = forward;
+  const bodyTransform = forward.ownResource(
+    createSecretEgressBodyTransform({
+      onSubstitution: () => {
+        substituted = true;
+      },
+      resolveSentinel: forward.resolveSentinel,
+    }),
+  );
+  let refused = false;
+  let upgraded = false;
+  const upstream = forward.ownResource(
+    httpsRequest(
+      {
+        hostname: target.hostname,
+        port: target.port || 443,
+        path: `${target.pathname}${target.search}`,
+        method: forward.request.method,
+        headers,
+        agent: forward.upstreamTlsAgent,
+      },
+      (upstreamResponse) => {
+        forward.ownResource(upstreamResponse);
+        if (refused || !forward.isActive()) {
+          upstreamResponse.destroy();
+          return;
+        }
+        upstreamResponse.once("error", () => forward.response.destroy());
+        forward.response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+        upstreamResponse.pipe(forward.response);
+      },
+    ),
+  );
+  forward.request.once("error", () => forward.response.destroy());
+  const onResponseClose = () => {
+    refused = true;
+    forward.request.unpipe(bodyTransform);
+    bodyTransform.destroy();
+    upstream.destroy();
+  };
+  forward.response.once("close", onResponseClose);
+  if (forward.upgrade) {
+    forward.request.socket.once("end", () => {
+      if (!upgraded) {
+        forward.response.destroy();
+      }
+    });
+  }
+  // Upgrade handshakes have no transformed body. Record their credential egress
+  // when the request is sent, even if the upstream rejects or stalls the upgrade.
+  (forward.upgrade ? upstream : bodyTransform).once("finish", () => {
+    if (!refused && forward.isActive()) {
+      forward.audit({ kind: "forwarded", host, substituted });
+    }
+  });
+  bodyTransform.once("error", (error) => {
+    if (refused || !forward.isActive()) {
+      return;
+    }
+    refused = true;
+    forward.request.unpipe(bodyTransform);
+    forward.request.resume();
+    upstream.destroy();
+    const reason =
+      error instanceof SecretEgressSubstitutionError ? error.reason : "unresolved-sentinel";
+    forward.audit({ kind: "refused", host, substituted, reason });
+    sendHttpRefusal(
+      forward.response,
+      502,
+      error instanceof SecretEgressSubstitutionError ? `${error.message}\n` : REFUSAL_BODY,
+    );
+  });
+  upstream.once("error", () => {
+    if (refused || !forward.isActive()) {
+      return;
+    }
+    refused = true;
+    forward.audit({ kind: "refused", host, substituted, reason: "upstream-error" });
+    sendHttpRefusal(forward.response, 502, UPSTREAM_ERROR_BODY);
+  });
+  upstream.once("upgrade", (response, upstreamSocket, head) => {
+    forward.ownResource(upstreamSocket);
+    if (refused || !forward.isActive()) {
+      upstreamSocket.destroy();
+      return;
+    }
+    if (
+      !forward.upgrade ||
+      response.statusCode !== 101 ||
+      response.headers.upgrade?.toLowerCase() !== "websocket"
+    ) {
+      refused = true;
+      forward.audit({ kind: "refused", host, substituted, reason: "upstream-error" });
+      upstreamSocket.destroy();
+      sendHttpRefusal(forward.response);
+      return;
+    }
+    const clientSocket = forward.ownResource(forward.request.socket);
+    // The handshake is an HTTP request; subsequent bytes are WebSocket frames,
+    // not HTTP bodies. Forward them opaquely, including both parsers' head buffers.
+    forward.response.off("close", onResponseClose);
+    upgraded = true;
+    forward.response.writeHead(101, response.headers);
+    forward.response.end();
+    forward.response.detachSocket(clientSocket);
+    forward.releaseResponse();
+    bodyTransform.destroy();
+    clientSocket.once("close", () => upstreamSocket.destroy());
+    upstreamSocket.once("close", () => clientSocket.destroy());
+    if (head.length > 0) {
+      clientSocket.write(head);
+    }
+    forward.upgrade.stream.pipe(upstreamSocket).pipe(clientSocket);
+  });
+  if (forward.upgrade) {
+    upstream.end();
+  } else {
+    forward.request.pipe(bodyTransform).pipe(upstream);
+  }
+}

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -2,15 +2,11 @@ import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import {
   createServer as createHttpServer,
+  type ServerResponse,
   type IncomingHttpHeaders,
   type IncomingMessage,
-  type ServerResponse,
 } from "node:http";
-import {
-  Agent as HttpsAgent,
-  createServer as createHttpsServer,
-  request as httpsRequest,
-} from "node:https";
+import { Agent as HttpsAgent, createServer as createHttpsServer } from "node:https";
 import net, { type Socket } from "node:net";
 import path from "node:path";
 import type { Duplex, Readable, Writable } from "node:stream";
@@ -29,15 +25,20 @@ import {
   type SecretEgressTlsContext,
 } from "./certificates.js";
 import {
-  createSecretEgressBodyTransform,
+  forwardSecretEgressRequest,
+  handleUpgradeRequest,
+  REFUSAL_BODY,
+  sendHttpRefusal,
+  type RequestHandler,
+  type UpgradeRequest,
+} from "./proxy-forward.js";
+import {
   SecretEgressSubstitutionError,
   type SecretEgressRefusalReason,
 } from "./stream-substitution.js";
 
 const PROXY_AUTH_USERNAME = "openclaw";
 const PROXY_AUTH_REALM = "OpenClaw secret egress";
-const REFUSAL_BODY = "Secret egress proxy refused the request.\n";
-const UPSTREAM_ERROR_BODY = "Secret egress proxy could not reach the upstream host.\n";
 
 type SecretEgressProxyAuditEvent = {
   kind: "forwarded" | "refused";
@@ -133,22 +134,6 @@ function sendProxyAuthRequired(socket: Duplex): void {
   socket.end(
     `HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="${PROXY_AUTH_REALM}"\r\nConnection: close\r\nContent-Length: ${Buffer.byteLength(REFUSAL_BODY)}\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n${REFUSAL_BODY}`,
   );
-}
-
-function sendHttpRefusal(res: ServerResponse, status = 502, body = REFUSAL_BODY): void {
-  if (res.destroyed || res.writableEnded) {
-    return;
-  }
-  if (res.headersSent) {
-    res.destroy();
-    return;
-  }
-  res.writeHead(status, {
-    Connection: "close",
-    "Content-Length": Buffer.byteLength(body),
-    "Content-Type": "text/plain; charset=utf-8",
-  });
-  res.end(body);
 }
 
 function resolveRegisteredSentinel(params: {
@@ -361,10 +346,22 @@ export async function startSecretEgressProxyServer(params: {
     target: URL;
     host: string;
     registered: RegisteredRun;
+    upgrade?: UpgradeRequest;
   }) => {
     ownResource(forward.registered, forward.request);
     ownResource(forward.registered, forward.response);
+    if (forward.upgrade) {
+      ownResource(forward.registered, forward.upgrade.stream);
+    }
     if (!forward.registered.isActive()) {
+      return;
+    }
+    if (
+      forward.upgrade &&
+      (forward.request.method !== "GET" ||
+        forward.request.headers.upgrade?.toLowerCase() !== "websocket")
+    ) {
+      sendHttpRefusal(forward.response, 400);
       return;
     }
     const { host } = forward;
@@ -417,78 +414,24 @@ export async function startSecretEgressProxyServer(params: {
       return;
     }
 
-    const bodyTransform = ownResource(
-      forward.registered,
-      createSecretEgressBodyTransform({
-        onSubstitution: () => {
-          substituted = true;
-        },
-        resolveSentinel: (sentinel) =>
-          resolveRegisteredSentinel({ sentinel, host, registered: forward.registered }),
-      }),
-    );
-    let refused = false;
-    const upstream = ownResource(
-      forward.registered,
-      httpsRequest(
-        {
-          hostname: target.hostname,
-          port: target.port || 443,
-          path: `${target.pathname}${target.search}`,
-          method: forward.request.method,
-          headers,
-          agent: upstreamTlsAgent,
-        },
-        (upstreamResponse) => {
-          ownResource(forward.registered, upstreamResponse);
-          if (refused || !forward.registered.isActive()) {
-            upstreamResponse.destroy();
-            return;
-          }
-          upstreamResponse.once("error", () => forward.response.destroy());
-          forward.response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
-          upstreamResponse.pipe(forward.response);
-        },
-      ),
-    );
-    forward.request.once("error", () => forward.response.destroy());
-    forward.response.once("close", () => {
-      refused = true;
-      forward.request.unpipe(bodyTransform);
-      bodyTransform.destroy();
-      upstream.destroy();
+    forwardSecretEgressRequest({
+      request: forward.request,
+      response: forward.response,
+      upgrade: forward.upgrade,
+      target,
+      headers,
+      host,
+      substituted,
+      upstreamTlsAgent,
+      isActive: forward.registered.isActive,
+      ownResource: (resource) => ownResource(forward.registered, resource),
+      releaseResponse: () => {
+        forward.registered.resources.delete(forward.response);
+      },
+      resolveSentinel: (sentinel) =>
+        resolveRegisteredSentinel({ sentinel, host, registered: forward.registered }),
+      audit,
     });
-    bodyTransform.once("finish", () => {
-      if (!refused && forward.registered.isActive()) {
-        audit({ kind: "forwarded", host, substituted });
-      }
-    });
-    bodyTransform.once("error", (error) => {
-      if (refused || !forward.registered.isActive()) {
-        return;
-      }
-      refused = true;
-      forward.request.unpipe(bodyTransform);
-      forward.request.resume();
-      upstream.destroy();
-      const reason =
-        error instanceof SecretEgressSubstitutionError ? error.reason : "unresolved-sentinel";
-      audit({ kind: "refused", host, substituted, reason });
-      sendHttpRefusal(
-        forward.response,
-        502,
-        error instanceof SecretEgressSubstitutionError ? `${error.message}\n` : REFUSAL_BODY,
-      );
-    });
-    upstream.once("error", () => {
-      if (refused || !forward.registered.isActive()) {
-        return;
-      }
-      refused = true;
-      audit({ kind: "refused", host, substituted, reason: "upstream-error" });
-      sendHttpRefusal(forward.response, 502, UPSTREAM_ERROR_BODY);
-    });
-    forward.request.pipe(bodyTransform).pipe(upstream);
   };
 
   const tlsServerFor = (target: ConnectTarget, registered: RegisteredRun) => {
@@ -498,24 +441,30 @@ export async function startSecretEgressProxyServer(params: {
       context = certificates.createContext({
         hostname: target.hostname,
         isActive: registered.isActive,
-        createServer: (leaf) =>
-          createHttpsServer(leaf, (request, response) => {
+        createServer: (leaf) => {
+          const handleRequest: RequestHandler = (request, response, upgrade) => {
             const parsed = parseRequestTarget(
               request,
               response,
               `https://${target.hostname}${target.port === 443 ? "" : `:${target.port}`}`,
             );
             if (parsed) {
-              forwardRequest({ request, response, ...parsed, registered });
+              forwardRequest({ request, response, ...parsed, registered, upgrade });
             }
-          }).on("secureConnection", (socket) => ownResource(registered, socket)),
+          };
+          return createHttpsServer(leaf, handleRequest)
+            .on("upgrade", (request, _socket, head) =>
+              handleUpgradeRequest(handleRequest, request, head),
+            )
+            .on("secureConnection", (socket) => ownResource(registered, socket));
+        },
       });
       registered.tlsServers.set(key, context);
     }
     return context.get();
   };
 
-  const proxy = createHttpServer((request, response) => {
+  const handleProxyRequest: RequestHandler = (request, response, upgrade) => {
     const parsed = parseRequestTarget(request, response);
     if (!parsed) {
       return;
@@ -534,8 +483,11 @@ export async function startSecretEgressProxyServer(params: {
       request.resume();
       return;
     }
-    forwardRequest({ request, response, ...parsed, registered: authorization });
-  });
+    forwardRequest({ request, response, ...parsed, registered: authorization, upgrade });
+  };
+  const proxy = createHttpServer(handleProxyRequest).on("upgrade", (request, _socket, head) =>
+    handleUpgradeRequest(handleProxyRequest, request, head),
+  );
 
   proxy.on("connection", (socket) => {
     sockets.add(socket);

--- a/src/secrets/egress-proxy/proxy-server.websocket.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.websocket.test.ts
@@ -162,7 +162,7 @@ beforeEach(async () => {
   });
   observed = [];
   origin = createHttpsServer(leaf, (_request, response) => response.end("ordinary-https"));
-  wss = new WebSocketServer({ noServer: true });
+  wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 });
   wss.on("connection", (socket) => {
     socket.on("error", () => {});
     socket.send("ready");

--- a/src/secrets/egress-proxy/proxy-server.websocket.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.websocket.test.ts
@@ -1,0 +1,416 @@
+import { once } from "node:events";
+import fs from "node:fs";
+import { request as httpRequest } from "node:http";
+import { createServer as createHttpsServer, type Server } from "node:https";
+import net, { type Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import tls from "node:tls";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { ensureSecretEgressProxyCa, generateLocalProxyLeaf } from "../../proxy-capture/ca.js";
+import { sealSecretSentinel } from "../sentinel.js";
+import { startSecretEgressProxyServer, type SecretEgressProxyHandle } from "./proxy-server.js";
+
+type AuditEvent = Parameters<Parameters<typeof startSecretEgressProxyServer>[0]["onAudit"]>[0];
+
+const run = { instanceId: "websocket-instance", runId: "websocket-run" };
+const value = "synthetic-websocket-credential";
+const seedDirs = createTempDirTracker();
+const sockets = new Set<Socket>();
+const clients = new Set<WebSocket>();
+let seedDir: string;
+let leaf: Awaited<ReturnType<typeof generateLocalProxyLeaf>>;
+let caDir: string;
+let proxy: SecretEgressProxyHandle;
+let origin: Server;
+let wss: WebSocketServer;
+let port: number;
+let sentinel: string;
+let proxyEnv: Record<string, string>;
+let auditEvents: AuditEvent[];
+let observed: Array<{
+  authorization: string | undefined;
+  url: string;
+  proxyAuth: string | undefined;
+}>;
+
+function track<T extends Socket>(socket: T): T {
+  sockets.add(socket);
+  socket.once("close", () => sockets.delete(socket));
+  socket.on("error", () => {});
+  return socket;
+}
+
+function connectTunnel(auth = new URL(proxyEnv.HTTPS_PROXY!).password) {
+  const proxyUrl = new URL(proxy.proxyOrigin);
+  return new Promise<{ status: number; socket: Socket }>((resolve, reject) => {
+    const request = httpRequest({
+      hostname: proxyUrl.hostname,
+      port: proxyUrl.port,
+      method: "CONNECT",
+      path: `localhost:${port}`,
+      headers: auth
+        ? { "Proxy-Authorization": `Basic ${Buffer.from(`openclaw:${auth}`).toString("base64")}` }
+        : {},
+    });
+    request.once("socket", track);
+    request.once("connect", (response, socket) =>
+      resolve({ status: response.statusCode ?? 0, socket: track(socket) }),
+    );
+    request.once("error", reject);
+    request.end();
+  });
+}
+
+async function connectTls(): Promise<tls.TLSSocket> {
+  const connected = await connectTunnel();
+  expect(connected.status).toBe(200);
+  const socket = track(
+    tls.connect({
+      socket: connected.socket,
+      servername: "localhost",
+      ca: fs.readFileSync(proxy.caCertPath),
+    }),
+  );
+  await once(socket, "secureConnect");
+  expect(socket.authorized).toBe(true);
+  return socket;
+}
+
+async function websocket(
+  params: { direct?: boolean; credential?: string; pathname?: string } = {},
+) {
+  const socket = params.direct ? undefined : await connectTls();
+  const client = new WebSocket(`wss://localhost:${port}${params.pathname ?? "/"}`, {
+    ...(socket ? { createConnection: () => socket } : {}),
+    ca: fs.readFileSync(proxy.caCertPath),
+    headers: { Authorization: `Bearer ${params.credential ?? sentinel}` },
+    handshakeTimeout: 2_000,
+  });
+  clients.add(client);
+  client.on("error", () => {});
+  return client;
+}
+
+async function rawUpgrade(
+  params: {
+    credential?: string;
+    pathname?: string;
+    head?: Buffer;
+    upgrade?: string;
+    forward?: boolean;
+    auth?: string;
+  } = {},
+) {
+  const socket = params.forward
+    ? await new Promise<Socket>((resolve, reject) => {
+        const endpoint = new URL(proxy.proxyOrigin);
+        const connected = track(net.connect(Number(endpoint.port), endpoint.hostname));
+        connected.once("connect", () => resolve(connected));
+        connected.once("error", reject);
+      })
+    : await connectTls();
+  const received: Buffer[] = [];
+  socket.on("data", (chunk: Buffer) => received.push(chunk));
+  const closed = new Promise<void>((resolve) => {
+    socket.once("close", () => resolve());
+  });
+  const auth = params.auth ?? new URL(proxyEnv.HTTPS_PROXY!).password;
+  const proxyAuth =
+    params.forward && auth
+      ? `Proxy-Authorization: Basic ${Buffer.from(`openclaw:${auth}`).toString("base64")}\r\n`
+      : "";
+  const target = params.forward
+    ? `https://localhost:${port}${params.pathname ?? "/"}`
+    : (params.pathname ?? "/");
+  socket.write(
+    Buffer.concat([
+      Buffer.from(
+        `GET ${target} HTTP/1.1\r\nHost: localhost:${port}\r\n${proxyAuth}Connection: Upgrade\r\nUpgrade: ${params.upgrade ?? "websocket"}\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nAuthorization: Bearer ${params.credential ?? sentinel}\r\n\r\n`,
+      ),
+      params.head ?? Buffer.alloc(0),
+    ]),
+  );
+  return { socket, received, closed };
+}
+
+async function receive(request: Awaited<ReturnType<typeof rawUpgrade>>, text: string) {
+  while (!Buffer.concat(request.received).includes(Buffer.from(text))) {
+    await once(request.socket, "data");
+  }
+  return Buffer.concat(request.received).toString();
+}
+
+beforeAll(async () => {
+  seedDir = seedDirs.make("openclaw-egress-websocket-seed-");
+  const ca = await ensureSecretEgressProxyCa(seedDir);
+  leaf = await generateLocalProxyLeaf({ certDir: seedDir, ca, hostname: "localhost" });
+});
+afterAll(() => seedDirs.cleanup());
+
+beforeEach(async () => {
+  caDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-egress-websocket-"));
+  for (const file of ["root-ca.pem", "root-ca-key.pem", "leaf-key.pem"]) {
+    fs.copyFileSync(path.join(seedDir, file), path.join(caDir, file));
+  }
+  auditEvents = [];
+  proxy = await startSecretEgressProxyServer({
+    caDir,
+    onAudit: (event) => auditEvents.push(event),
+  });
+  observed = [];
+  origin = createHttpsServer(leaf, (_request, response) => response.end("ordinary-https"));
+  wss = new WebSocketServer({ noServer: true });
+  wss.on("connection", (socket) => {
+    socket.on("error", () => {});
+    socket.send("ready");
+    socket.on("message", (data, binary) => socket.send(data, { binary }));
+  });
+  origin.on("connection", track);
+  origin.on("upgrade", (request, socket, head) => {
+    observed.push({
+      authorization: request.headers.authorization,
+      url: request.url ?? "",
+      proxyAuth: request.headers["proxy-authorization"],
+    });
+    if (request.url === "/reject") {
+      socket.end(
+        "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 6\r\n\r\ndenied",
+      );
+      return;
+    }
+    if (request.url === "/reset") {
+      socket.destroy();
+      return;
+    }
+    if (request.url === "/invalid-upgrade") {
+      socket.end(
+        "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: other\r\n\r\n",
+      );
+      return;
+    }
+    if (request.url === "/pending") {
+      return;
+    }
+    socket.cork();
+    wss.handleUpgrade(request, socket, head, (client) => wss.emit("connection", client, request));
+    socket.uncork();
+  });
+  origin.listen(0, "127.0.0.1");
+  await once(origin, "listening");
+  const address = origin.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Origin did not bind");
+  }
+  port = address.port;
+  sentinel = sealSecretSentinel(value, { label: "websocket-test" });
+  proxyEnv = proxy.registerRun(run, [
+    { name: "SERVICE_KEY", sentinel, allowedHosts: ["localhost"] },
+  ]);
+});
+
+afterEach(async () => {
+  for (const client of clients) {
+    client.terminate();
+  }
+  clients.clear();
+  for (const client of wss.clients) {
+    client.terminate();
+  }
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  sockets.clear();
+  await proxy.stop();
+  await new Promise<void>((resolve) => {
+    wss.close(() => resolve());
+  });
+  await new Promise<void>((resolve) => {
+    origin.close(() => resolve());
+  });
+  fs.rmSync(caDir, { recursive: true, force: true });
+});
+
+describe("secret egress WebSocket forwarding", () => {
+  it("closes a pipelined upgrade while a previous HTTP response owns the socket", async () => {
+    const endpoint = new URL(proxy.proxyOrigin);
+    const socket = track(net.connect(Number(endpoint.port), endpoint.hostname));
+    socket.resume();
+    await once(socket, "connect");
+    const closed = once(socket, "close");
+    // No proxy credentials: neither request may reach the origin. Both arrive
+    // before the first response finishes, while Node still owns its socket.
+    socket.write(
+      `GET https://localhost:${port}/ HTTP/1.1\r\nHost: localhost:${port}\r\n\r\n` +
+        `GET https://localhost:${port}/socket HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n`,
+    );
+    await closed;
+    expect(observed).toEqual([]);
+  });
+
+  it("substitutes handshake credentials and preserves bidirectional framed data", async () => {
+    const direct = await websocket({ direct: true, credential: value });
+    expect((await once(direct, "message"))[0].toString()).toBe("ready");
+    direct.close();
+
+    const client = await websocket({ pathname: `/socket?key=${sentinel}` });
+    expect((await once(client, "message"))[0].toString()).toBe("ready");
+    expect(observed).toEqual([
+      { authorization: `Bearer ${value}`, url: "/", proxyAuth: undefined },
+      { authorization: `Bearer ${value}`, url: `/socket?key=${value}`, proxyAuth: undefined },
+    ]);
+    // Frames are opaque, not HTTP bodies: masked/fragmented payloads must not be rewritten.
+    const payload = `opaque:${sentinel}`;
+    const echoed = once(client, "message");
+    client.send(payload.slice(0, 10), { fin: false });
+    client.send(payload.slice(10), { fin: true });
+    expect((await echoed)[0].toString()).toBe(payload);
+    const binary = once(client, "message");
+    client.send(Buffer.from([0, 255, 128, 1]));
+    expect((await binary)[0]).toEqual(Buffer.from([0, 255, 128, 1]));
+    const clientClosed = once(client, "close");
+    client.close(1000, "done");
+    expect((await clientClosed)[0]).toBe(1000);
+    expect(auditEvents).toEqual([{ kind: "forwarded", host: "localhost", substituted: true }]);
+  });
+
+  it.each(["missing", "wrong", "revoked"])(
+    "refuses %s proxy credentials before WSS origin access",
+    async (kind) => {
+      if (kind === "revoked") {
+        proxy.revokeRun(run);
+      }
+      const auth = kind === "missing" ? "" : kind === "wrong" ? "A".repeat(43) : undefined;
+      expect((await connectTunnel(auth)).status).toBe(407);
+      const forwarded = await rawUpgrade({ forward: true, auth });
+      await forwarded.closed;
+      expect(Buffer.concat(forwarded.received).toString()).toMatch(/^HTTP\/1\.1 407 /);
+      expect(observed).toEqual([]);
+    },
+  );
+
+  it("authenticates and substitutes an absolute-HTTPS forwarded upgrade", async () => {
+    const request = await rawUpgrade({ forward: true });
+    expect(await receive(request, "ready")).toMatch(/^HTTP\/1\.1 101 /);
+    expect(observed).toEqual([
+      { authorization: `Bearer ${value}`, url: "/", proxyAuth: undefined },
+    ]);
+  });
+
+  it.each(["unknown", "wrong-host", "unbound"])(
+    "refuses a %s handshake sentinel without contacting the origin",
+    async (kind) => {
+      if (kind !== "unknown") {
+        proxy.registerRun(run, [
+          {
+            name: "SERVICE_KEY",
+            sentinel,
+            allowedHosts: kind === "unbound" ? [] : ["other.example"],
+          },
+        ]);
+      }
+      const credential =
+        kind === "unknown"
+          ? sealSecretSentinel("other-secret", { label: "unregistered" })
+          : sentinel;
+      const request = await rawUpgrade({ credential });
+      await request.closed;
+      expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 502 /);
+      expect(observed).toEqual([]);
+    },
+  );
+
+  it("preserves an upstream non-upgrade HTTP rejection", async () => {
+    const request = await rawUpgrade({ pathname: "/reject" });
+    await request.closed;
+    expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 401 [\s\S]*denied$/);
+    expect(observed).toEqual([
+      { authorization: `Bearer ${value}`, url: "/reject", proxyAuth: undefined },
+    ]);
+    expect(auditEvents).toEqual([{ kind: "forwarded", host: "localhost", substituted: true }]);
+  });
+
+  it("audits a forwarded handshake and refusal when the upstream returns an invalid upgrade", async () => {
+    const request = await rawUpgrade({ pathname: "/invalid-upgrade" });
+    await request.closed;
+    expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 502 /);
+    expect(observed).toEqual([
+      { authorization: `Bearer ${value}`, url: "/invalid-upgrade", proxyAuth: undefined },
+    ]);
+    expect(auditEvents).toEqual([
+      { kind: "forwarded", host: "localhost", substituted: true },
+      { kind: "refused", host: "localhost", substituted: true, reason: "upstream-error" },
+    ]);
+  });
+
+  it("returns a bounded HTTP failure when the upstream resets during upgrade", async () => {
+    const request = await rawUpgrade({ pathname: "/reset" });
+    await request.closed;
+    expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 502 /);
+  });
+
+  it("rejects an upgrade target outside the configured traffic allowlist", async () => {
+    await proxy.stop();
+    proxy = await startSecretEgressProxyServer({
+      caDir,
+      allowedHosts: ["localhost"],
+      onAudit: () => {},
+    });
+    proxyEnv = proxy.registerRun(run);
+    const request = await rawUpgrade({
+      pathname: "https://other.example/socket",
+      credential: "ordinary-value",
+    });
+    await request.closed;
+    expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 403 /);
+    expect(observed).toEqual([]);
+  });
+
+  it("does not open an opaque tunnel for a non-WebSocket upgrade", async () => {
+    const request = await rawUpgrade({ upgrade: "another-protocol" });
+    await request.closed;
+    expect(Buffer.concat(request.received).toString()).toMatch(/^HTTP\/1\.1 400 /);
+    expect(observed).toEqual([]);
+  });
+
+  it.each(["revocation", "client disconnect"])("aborts a pending upgrade on %s", async (action) => {
+    const arrived = once(origin, "upgrade");
+    const request = await rawUpgrade({ pathname: "/pending" });
+    const [, originSocket] = await arrived;
+    const originClosed = new Promise<void>((resolve) => {
+      originSocket.once("close", resolve);
+    });
+    if (action === "revocation") {
+      proxy.revokeRun(run);
+    } else {
+      request.socket.destroy();
+    }
+    await Promise.all([request.closed, originClosed]);
+    expect(Buffer.concat(request.received)).toHaveLength(0);
+  });
+
+  it("forwards both head buffers without dropping the first WebSocket frames", async () => {
+    const payload = Buffer.from("first-frame");
+    const mask = Buffer.from([1, 2, 3, 4]);
+    const frame = Buffer.concat([
+      Buffer.from([0x81, 0x80 | payload.length]),
+      mask,
+      Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]!)),
+    ]);
+    const request = await rawUpgrade({ head: frame });
+    expect(await receive(request, "first-frame")).toMatch(/^HTTP\/1\.1 101 [\s\S]*ready/);
+  });
+
+  it("closes both ends of an established WebSocket when the owning run is revoked", async () => {
+    const client = await websocket();
+    await once(client, "message");
+    const originClient = [...wss.clients][0]!;
+    const originClosed = once(originClient, "close");
+    const clientClosed = once(client, "close");
+    proxy.revokeRun(run);
+    await Promise.all([originClosed, clientClosed]);
+    expect((await connectTunnel()).status).toBe(407);
+  });
+});


### PR DESCRIPTION
Related: #143304
Companion: https://github.com/openclaw/agent-skills/pull/243, merged as `567e63060e03503e965e91f0af06c5633be1221f`. Canonical subtree verified identical to the synchronized reviewed commit.

## What Problem This Solves

Fixes an issue where commands using WebSocket inference stall through the managed secret-egress proxy even after the upstream accepts their substituted API credential. Ordinary HTTPS succeeds, but the proxy does not forward the HTTP upgrade or subsequent WebSocket frames.

## Why This Change Was Made

Forward an authorized WebSocket handshake through the same run authentication, destination checks, secret substitution, and resource ownership used for HTTPS. After a valid 101 response, relay frames unchanged, preserve both parsers' buffered data, and close both peers on disconnect or run revocation.

The shared HTTPS forwarder is extracted to keep the existing proxy module within its file-size limit. Pipelined upgrade ownership errors fail closed instead of crashing the Gateway. Handshakes are audited when sent, including upstream rejections; malformed upstream upgrades also emit a refusal.

## User Impact

Existing managed-proxy clients can use WebSockets with protected API credentials without a new flag, another proxy, or disabling secret access. WebSocket message frames remain opaque; substitution occurs in the handshake, not in frames.

The bundled autoreview directory is synchronized byte-for-byte with canonical `openclaw/agent-skills` commit `0105cca4009c9f6fbe9fac5f44f88efb4938b046`, including the authenticated-proxy repair in openclaw/agent-skills#243. Normal invocations consume the update without a per-call flag or setup step. The earlier opt-out in #143304 is not part of this solution.

The full-directory sync also includes already-landed canonical changes, including the upstream removal of TruffleHog and command-auth isolation fixes. Those are not repo-local variants or claimed proxy repairs. The affected-host integration proof deliberately retains its original scanner-enabled helper and applies only the proxy compatibility changes, so removing a scanner cannot account for that proof.

## Evidence

- Before the repair: direct WebSocket control succeeds, proxied HTTPS substitutes the protected credential successfully, and the same proxied WebSocket handshake stalls despite upstream authentication succeeding.
- 55 focused proxy, WebSocket, and lifecycle tests pass both locally and on the affected host. Coverage includes missing/wrong/revoked authorization, destination restrictions, ordinary HTTPS, opaque binary frames, early buffered frames, upstream errors, disconnects, revocation, pipelined requests, and audit events.
- Runtime-only changed-file checks passed, including core/test typechecking, formatting, lint, import cycles, and repository guards. The final audit correction also passed focused tests, formatting, and lint. The canonical helper has 293 tests run with one skipped and no failures; its sync passes formatting after correcting an upstream JSON example in the canonical copy. Hosted CI covers the combined final head.
- Fresh full-candidate autoreview found a missing audit event on non-101 responses. Regressions demonstrated the omission, and the final candidate fixes it.
- Protected-store-only live autoreview completed inference in an isolated affected-host checkout, with no native login files, no raw inference key in the child environment, and no opt-out. The proxy recorded a substituted request and no credential output leak. The reviewer reported a username-only proxy-token redaction gap; it is fixed in the final canonical helper. The final repeat completed in 219 seconds with one substituted request, enforced destination refusals and no captured credential leak. It returned exit 1 for a short-password redaction finding, assessed below, not a transport/authentication failure. The original helper separately reproduces the exact HTTP_PROXY rejection with the same protected-key fixture. No production Gateway or configuration was changed.
- The full canonical sync received a fresh CLI review. Its sole reported command-auth argument issue was checked and rejected: route validation explicitly rejects nonempty `auth.args` before launcher creation, with an existing passing run/preflight regression test.

```sh
node scripts/run-vitest.mjs src/secrets/egress-proxy/proxy-server.websocket.test.ts src/secrets/egress-proxy/proxy-server.test.ts src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
node scripts/check-changed.mjs -- docs/gateway/secrets.md src/secrets/egress-proxy/proxy-server.ts src/secrets/egress-proxy/proxy-forward.ts src/secrets/egress-proxy/proxy-server.websocket.test.ts
```

## Final review disposition and limits

The final live reviewer correctly observed that arbitrary bare passwords shorter than 8 bytes are not globally replaced. It did not establish its claimed reviewer-induced extraction path: reviewer tool environments do not inherit proxy authentication. Known URL, userinfo, Basic-auth and labeled-password forms are redacted; OpenClaw generates a 32-byte proxy token, which is also redacted when standalone. The inspected Codex proxy failures use fixed/redacted errors. No supported-client path emitting a bare short password was demonstrated. Four focused redaction/isolation tests passed, and this finding was not accepted as a source defect.

This is a diagnostic limit, not a universal no-disclosure claim. A demonstrated client error emitting a bare short credential should be addressed at that diagnostic boundary. The final live review's nonzero verdict remains recorded; it is not being reported as a clean tool verdict. The runtime/inference acceptance behavior passed without a per-call flag or alternate API-key source.

Final exact-head CI: all 125 jobs in [run34398557725](https://github.com/openclaw/openclaw/actions/runs/34398557725) passed, including required `openclaw/ci-gate`, on `ce5051041cf1877043964d120c17bd7c284b5eb6`.
