### PR TITLE
fix(agents): terminate background CLI tasks on cron timeout

### DIFF
--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -51,7 +51,6 @@ import {
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
-  buildExecRuntimeErrorOutcome,
   runExecProcess,
   execSchema,
 } from "./bash-tools.exec-runtime.js";
@@ -62,6 +61,7 @@ import {
 import {
   attachExecApprovalReview,
   buildExecForegroundResult,
+  buildUnavailableWorkdirResult,
   createExecHostResolver,
   resolveExecElevatedMode,
   resolveExecReviewerDefaults,
@@ -76,8 +76,9 @@ import type {
   ExecToolDefaults,
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
-import { formatUnavailableWorkdirFailure, resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
+import { resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
 import { clampWithDefault, readEnvInt, truncateMiddle } from "./bash-tools.shared.js";
+import { isSignalTimeoutReason } from "./failover-error.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
 import { withoutGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
@@ -91,13 +92,16 @@ function createExecProcessSettlement() {
   const settlement: {
     outcome: ExecProcessOutcome | null;
     backgroundTask: BackgroundExecTaskHandle | null;
+    onSettled?: () => void;
     settle: (outcome: ExecProcessOutcome) => void;
   } = {
     outcome: null,
     backgroundTask: null,
+    onSettled: undefined,
     settle(outcome: ExecProcessOutcome) {
       settlement.outcome = outcome;
       finalizeBackgroundExecTask({ handle: settlement.backgroundTask, outcome });
+      settlement.onSettled?.();
     },
   };
   return settlement;
@@ -173,20 +177,6 @@ export function createExecTool(
     defaults?.agentId ??
     (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
   const resolveHostForParams = createExecHostResolver(defaults);
-  const buildUnavailableWorkdirResult = (params: {
-    cwd: string;
-    startedAt?: number;
-    warningText?: string;
-  }) =>
-    buildExecForegroundResult({
-      outcome: buildExecRuntimeErrorOutcome({
-        error: formatUnavailableWorkdirFailure(params.cwd),
-        aggregated: "",
-        durationMs: params.startedAt ? Date.now() - params.startedAt : 0,
-      }),
-      cwd: params.cwd,
-      warningText: params.warningText,
-    });
   const requestPreparation = createExecRequestPreparation({
     defaults,
     agentId,
@@ -636,7 +626,7 @@ export function createExecTool(
         // tool_execution_update events even for backgrounded sessions (which
         // retrieve output via process poll/log instead of onUpdate callbacks).
         run.disableUpdates();
-        if (yielded || run.session.backgrounded) {
+        if ((yielded || run.session.backgrounded) && !isSignalTimeoutReason(signal?.reason)) {
           return;
         }
         // Cancellation must win over foreground-to-background promotion while
@@ -649,10 +639,16 @@ export function createExecTool(
         run.kill();
       };
 
-      const cleanupToolRunListeners = () => {
-        run.disableUpdates();
+      const detachAbortListener = () => {
         registeredAbortSignal?.removeEventListener("abort", onAbortSignal);
         registeredAbortSignal = null;
+      };
+      settlement.onSettled = detachAbortListener;
+      const cleanupToolRunListeners = () => {
+        run.disableUpdates();
+        if (!run.session.backgrounded || settlement.outcome) {
+          detachAbortListener();
+        }
         if (yieldTimer) {
           clearTimeout(yieldTimer);
           yieldTimer = null;

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -4,12 +4,17 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { EXEC_RETENTION_CAP_NOTE, renderExecOutputText } from "./bash-tools.exec-output.js";
 import type { ExecToolArgs } from "./bash-tools.exec-request-preparation.js";
-import { type ExecProcessOutcome, resolveExecTarget } from "./bash-tools.exec-runtime.js";
+import {
+  buildExecRuntimeErrorOutcome,
+  type ExecProcessOutcome,
+  resolveExecTarget,
+} from "./bash-tools.exec-runtime.js";
 import type {
   ExecToolApprovalReview,
   ExecToolDefaults,
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
+import { formatUnavailableWorkdirFailure } from "./bash-tools.exec-workdir.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { failedTextResult, textResult } from "./tools/common.js";
 
@@ -112,4 +117,20 @@ export function createExecHostResolver(defaults?: ExecToolDefaults) {
       sandboxRequired: defaults?.sandboxRequired,
     }).effectiveHost;
   };
+}
+
+export function buildUnavailableWorkdirResult(params: {
+  cwd: string;
+  startedAt?: number;
+  warningText?: string;
+}): AgentToolResult<ExecToolDetails> {
+  return buildExecForegroundResult({
+    outcome: buildExecRuntimeErrorOutcome({
+      error: formatUnavailableWorkdirFailure(params.cwd),
+      aggregated: "",
+      durationMs: params.startedAt ? Date.now() - params.startedAt : 0,
+    }),
+    cwd: params.cwd,
+    warningText: params.warningText,
+  });
 }

--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -305,3 +305,51 @@ test("yieldMs exec without explicit timeout applies default timeout", async () =
     expectedTimeoutSec: YIELDED_BACKGROUND_TIMEOUT_SEC,
   });
 });
+
+test("background exec is killed when tool signal aborts with TimeoutError", async () => {
+  const tool = createTestExecTool({ allowBackground: true, backgroundMs: 0 });
+  const abortController = new AbortController();
+  const result = await tool.execute(
+    "toolcall",
+    { command: BACKGROUND_HOLD_CMD, background: true },
+    abortController.signal,
+  );
+  expect(result.details.status).toBe("running");
+  const sessionId = (result.details as { sessionId: string }).sessionId;
+
+  const timeoutError = new Error("timeout");
+  timeoutError.name = "TimeoutError";
+  abortController.abort(timeoutError);
+
+  const finished = await waitForFinishedSession(sessionId);
+  try {
+    expect(supervisorMockState.cancelReasons).toContain("manual-cancel");
+    expect(finished?.terminalStatus).toBe("failed");
+  } finally {
+    cleanupRunningSession(sessionId);
+  }
+});
+
+test("yielded background exec is killed when tool signal aborts with TimeoutError", async () => {
+  const tool = createTestExecTool({ allowBackground: true, backgroundMs: 10 });
+  const abortController = new AbortController();
+  const result = await tool.execute(
+    "toolcall",
+    { command: BACKGROUND_HOLD_CMD, yieldMs: 5 },
+    abortController.signal,
+  );
+  expect(result.details.status).toBe("running");
+  const sessionId = (result.details as { sessionId: string }).sessionId;
+
+  const timeoutError = new Error("timeout");
+  timeoutError.name = "TimeoutError";
+  abortController.abort(timeoutError);
+
+  const finished = await waitForFinishedSession(sessionId);
+  try {
+    expect(supervisorMockState.cancelReasons).toContain("manual-cancel");
+    expect(finished?.terminalStatus).toBe("failed");
+  } finally {
+    cleanupRunningSession(sessionId);
+  }
+});

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -1037,7 +1037,7 @@ describe("exec backgrounded onUpdate suppression", () => {
     expect(removeListenerSpy).toHaveBeenCalledWith("abort", abortListener);
   });
 
-  it("removes the abort listener when an exec process is backgrounded", async () => {
+  it("removes the abort listener when an exec process is backgrounded and exits", async () => {
     const abortController = new AbortController();
     const addListenerSpy = vi.spyOn(abortController.signal, "addEventListener");
     const removeListenerSpy = vi.spyOn(abortController.signal, "removeEventListener");
@@ -1053,6 +1053,16 @@ describe("exec backgrounded onUpdate suppression", () => {
     expect(readProcessStatus(result.details)).toBe(PROCESS_STATUS_RUNNING);
     const abortListener = addListenerSpy.mock.calls.find(([type]) => type === "abort")?.[1];
     expect(abortListener).toBeDefined();
+    expect(removeListenerSpy).not.toHaveBeenCalled();
+
+    const sessionId = requireSessionId(result.details as { sessionId?: string });
+    await expect
+      .poll(() => {
+        const finished = getFinishedSession(sessionId);
+        return Boolean(finished);
+      }, BACKGROUND_POLL_OPTIONS)
+      .toBe(true);
+
     expect(removeListenerSpy).toHaveBeenCalledWith("abort", abortListener);
   });
 

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -77,7 +77,7 @@ export type EmbeddedAgentQueueHandle = {
   /** True only when queueMessage preserves images supplied in its options. */
   supportsQueueMessageImages?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
-  abort: (reason?: "restart") => void;
+  abort: (reason?: "user_abort" | "restart" | "superseded" | "cron_timeout") => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   taskSuggestionDeliveryMode?: TaskSuggestionDeliveryMode;
 };

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -51,6 +51,7 @@ vi.mock("../../embedded-agent-subscribe.js", () => ({
 }));
 vi.mock("../runs.js", () => ({
   clearActiveEmbeddedRun: mocks.clearActiveRun,
+  markActiveEmbeddedRunAbandoned: vi.fn(),
   setActiveEmbeddedRun: mocks.setActiveRun,
 }));
 vi.mock("./tool-activity-heartbeat.js", () => ({
@@ -732,9 +733,16 @@ describe("prepareEmbeddedAttemptStream", () => {
   });
 
   it("processes cron_timeout abort through external-abort sequence as a timeout", () => {
-    const markExternalAbort = vi.fn();
-    const onAttemptAbort = vi.fn();
-    const abortRun = vi.fn();
+    const order: string[] = [];
+    const markExternalAbort = vi.fn(() => {
+      order.push("markExternalAbort");
+    });
+    const onAttemptAbort = vi.fn(() => {
+      order.push("onAttemptAbort");
+    });
+    const abortRun = vi.fn((_isTimeout?: boolean, _abortReason?: unknown) => {
+      order.push("abortRun");
+    });
     const prepared = prepareCatalogExecutor([], {
       markExternalAbort,
       onAttemptAbort,
@@ -744,12 +752,56 @@ describe("prepareEmbeddedAttemptStream", () => {
     prepared.queueHandle.abort("cron_timeout");
 
     expect(markExternalAbort).toHaveBeenCalledOnce();
-    expect(onAttemptAbort).toHaveBeenCalledOnce();
     expect(abortRun).toHaveBeenCalledOnce();
-    const [isTimeout, abortReason] = abortRun.mock.calls[0] ?? [];
-    expect(isTimeout).toBe(true);
-    expect(abortReason).toBeInstanceOf(Error);
-    expect((abortReason as Error).name).toBe("TimeoutError");
+    expect(onAttemptAbort).toHaveBeenCalledOnce();
+    expect(order).toEqual(["markExternalAbort", "abortRun", "onAttemptAbort"]);
+    const call = abortRun.mock.calls[0];
+    expect(call?.[0]).toBe(true);
+    expect(call?.[1]).toBeInstanceOf(Error);
+    if (call?.[1] instanceof Error) {
+      expect(call[1].name).toBe("TimeoutError");
+    }
+  });
+
+  it("preserves timeout classification when onAttemptAbort synchronously triggers re-entrant generic abort", () => {
+    const runAbortController = new AbortController();
+    const abortState: Parameters<typeof createEmbeddedAttemptRunAbort>[0]["state"] = {
+      terminal: { kind: "ok" },
+    };
+    const abortRunHolder: { current?: ReturnType<typeof createEmbeddedAttemptRunAbort> } = {};
+    const onAttemptAbort = vi.fn(() => {
+      // Simulates lane controller: synchronous re-entrant abort with generic reason
+      abortRunHolder.current?.(false, new Error("generic abort"));
+    });
+    const markExternalAbort = vi.fn();
+    const prepared = prepareCatalogExecutor([], {
+      markExternalAbort,
+      onAttemptAbort,
+      abortRun: (isTimeout, reason) => abortRunHolder.current?.(isTimeout, reason),
+    });
+    abortRunHolder.current = createEmbeddedAttemptRunAbort({
+      abortActiveSession: vi.fn(async () => {}),
+      activeSession: { abortCompaction: vi.fn(), isCompacting: false },
+      attempt: {
+        runId: "run-cron-timeout-reentrant",
+        sessionFile: "agent:main:main",
+        sessionId: "session-cron-timeout",
+        sessionKey: "agent:main:main",
+      },
+      getQueueHandle: () => prepared.queueHandle,
+      isProbeSession: true,
+      log: { warn: vi.fn() },
+      runAbortController,
+      state: abortState,
+    });
+
+    prepared.queueHandle.abort("cron_timeout");
+
+    expect(markExternalAbort).toHaveBeenCalledOnce();
+    expect(onAttemptAbort).toHaveBeenCalledOnce();
+    expect(runAbortController.signal.aborted).toBe(true);
+    expect((runAbortController.signal.reason as Error)?.name).toBe("TimeoutError");
+    expect(abortState.terminal).toMatchObject({ kind: "timeout" });
   });
 
   it("runs attempt cleanup once when reply cancellation re-enters through its abort signal", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -731,6 +731,27 @@ describe("prepareEmbeddedAttemptStream", () => {
     expect(isAgentRunRestartAbortReason(abortRun.mock.calls[0]?.[1])).toBe(true);
   });
 
+  it("processes cron_timeout abort through external-abort sequence as a timeout", () => {
+    const markExternalAbort = vi.fn();
+    const onAttemptAbort = vi.fn();
+    const abortRun = vi.fn();
+    const prepared = prepareCatalogExecutor([], {
+      markExternalAbort,
+      onAttemptAbort,
+      abortRun,
+    });
+
+    prepared.queueHandle.abort("cron_timeout");
+
+    expect(markExternalAbort).toHaveBeenCalledOnce();
+    expect(onAttemptAbort).toHaveBeenCalledOnce();
+    expect(abortRun).toHaveBeenCalledOnce();
+    const [isTimeout, abortReason] = abortRun.mock.calls[0] ?? [];
+    expect(isTimeout).toBe(true);
+    expect(abortReason).toBeInstanceOf(Error);
+    expect((abortReason as Error).name).toBe("TimeoutError");
+  });
+
   it("runs attempt cleanup once when reply cancellation re-enters through its abort signal", () => {
     const operation = createReplyOperation({
       sessionKey: "agent:main:main",

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -84,6 +84,9 @@ function prepareCatalogExecutor(
     sessionKey?: string;
     replyOperation?: ReplyOperation;
     onAttemptAbort?: () => void;
+    onDeferredLifecycleAbort?: (
+      reason?: "user_abort" | "restart" | "superseded" | "cron_timeout",
+    ) => void;
     abortRun?: (isTimeout?: boolean, reason?: unknown) => void;
     markExternalAbort?: () => void;
     toolProgressDetail?: "explain" | "raw";
@@ -99,6 +102,7 @@ function prepareCatalogExecutor(
       sessionKey: options?.sessionKey ?? "agent:main:main",
       replyOperation: options?.replyOperation,
       onAttemptAbort: options?.onAttemptAbort,
+      onDeferredLifecycleAbort: options?.onDeferredLifecycleAbort,
       toolProgressDetail: options?.toolProgressDetail,
       onAgentEvent: options?.onAgentEvent,
       ...options?.attempt,
@@ -737,6 +741,9 @@ describe("prepareEmbeddedAttemptStream", () => {
     const markExternalAbort = vi.fn(() => {
       order.push("markExternalAbort");
     });
+    const onDeferredLifecycleAbort = vi.fn((reason?: string) => {
+      order.push(`onDeferredLifecycleAbort:${reason}`);
+    });
     const onAttemptAbort = vi.fn(() => {
       order.push("onAttemptAbort");
     });
@@ -745,6 +752,7 @@ describe("prepareEmbeddedAttemptStream", () => {
     });
     const prepared = prepareCatalogExecutor([], {
       markExternalAbort,
+      onDeferredLifecycleAbort,
       onAttemptAbort,
       abortRun,
     });
@@ -753,8 +761,14 @@ describe("prepareEmbeddedAttemptStream", () => {
 
     expect(markExternalAbort).toHaveBeenCalledOnce();
     expect(abortRun).toHaveBeenCalledOnce();
+    expect(onDeferredLifecycleAbort).toHaveBeenCalledWith("cron_timeout");
     expect(onAttemptAbort).toHaveBeenCalledOnce();
-    expect(order).toEqual(["markExternalAbort", "abortRun", "onAttemptAbort"]);
+    expect(order).toEqual([
+      "markExternalAbort",
+      "abortRun",
+      "onDeferredLifecycleAbort:cron_timeout",
+      "onAttemptAbort",
+    ]);
     const call = abortRun.mock.calls[0];
     expect(call?.[0]).toBe(true);
     expect(call?.[1]).toBeInstanceOf(Error);

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -515,14 +515,13 @@ export function prepareEmbeddedAttemptStream(input: {
     }
     externalAbortAccepted = true;
     input.markExternalAbort();
-    if (reason !== "cron_timeout") {
-      attempt.onDeferredLifecycleAbort?.(reason);
-    }
-    attempt.onAttemptAbort?.();
     if (reason === "cron_timeout") {
       input.abortRun(true, createTimeoutAbortReason());
+      attempt.onAttemptAbort?.();
       return;
     }
+    attempt.onDeferredLifecycleAbort?.(reason);
+    attempt.onAttemptAbort?.();
     const abortReason =
       reason === "restart"
         ? createAgentRunRestartAbortError()

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -39,6 +39,7 @@ import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   createAgentRunRestartAbortError,
   createAgentRunSupersededAbortError,
+  createTimeoutAbortReason,
   isAgentRunRestartAbortReason,
 } from "../../run-termination.js";
 import type { AgentMessage } from "../../runtime/index.js";
@@ -504,7 +505,9 @@ export function prepareEmbeddedAttemptStream(input: {
   };
 
   let externalAbortAccepted = false;
-  const abortActiveRunExternally = (reason?: "user_abort" | "restart" | "superseded") => {
+  const abortActiveRunExternally = (
+    reason?: "user_abort" | "restart" | "superseded" | "cron_timeout",
+  ) => {
     // Reply cancellation can synchronously re-enter through this same backend.
     // Latch before callbacks so the first reason owns every abort side effect.
     if (externalAbortAccepted) {
@@ -512,8 +515,14 @@ export function prepareEmbeddedAttemptStream(input: {
     }
     externalAbortAccepted = true;
     input.markExternalAbort();
-    attempt.onDeferredLifecycleAbort?.(reason);
+    if (reason !== "cron_timeout") {
+      attempt.onDeferredLifecycleAbort?.(reason);
+    }
     attempt.onAttemptAbort?.();
+    if (reason === "cron_timeout") {
+      input.abortRun(true, createTimeoutAbortReason());
+      return;
+    }
     const abortReason =
       reason === "restart"
         ? createAgentRunRestartAbortError()

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -517,6 +517,7 @@ export function prepareEmbeddedAttemptStream(input: {
     input.markExternalAbort();
     if (reason === "cron_timeout") {
       input.abortRun(true, createTimeoutAbortReason());
+      attempt.onDeferredLifecycleAbort?.(reason);
       attempt.onAttemptAbort?.();
       return;
     }

--- a/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.ts
+++ b/src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.ts
@@ -9,6 +9,7 @@ import {
   createAgentRunDirectAbortError,
   createAgentRunRestartAbortError,
   createAgentRunSupersededAbortError,
+  createTimeoutAbortReason,
 } from "../../run-termination.js";
 import { log } from "../logger.js";
 import type { EmbeddedAgentQueueHandle } from "../run-state.js";
@@ -124,7 +125,7 @@ export function createEmbeddedAttemptDeferredLifecycleOwner(params: {
 
 export type DeferredEmbeddedRunLifecycleManager = {
   signal: AbortSignal;
-  abort: (reason?: "user_abort" | "restart" | "superseded") => void;
+  abort: (reason?: "user_abort" | "restart" | "superseded" | "cron_timeout") => void;
   adopt: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
   beginRetryWait: (
     deadlineAtMs: number,
@@ -147,7 +148,7 @@ export function createDeferredEmbeddedRunLifecycleManager(params: {
     ? AbortSignal.any([params.abortSignal, controller.signal])
     : controller.signal;
   let current: DeferredEmbeddedRunLifecycleOwner | undefined;
-  const abort = (reason?: "user_abort" | "restart" | "superseded") => {
+  const abort = (reason?: "user_abort" | "restart" | "superseded" | "cron_timeout") => {
     if (controller.signal.aborted) {
       return;
     }
@@ -156,7 +157,9 @@ export function createDeferredEmbeddedRunLifecycleManager(params: {
         ? createAgentRunRestartAbortError()
         : reason === "superseded"
           ? createAgentRunSupersededAbortError()
-          : createAgentRunDirectAbortError(),
+          : reason === "cron_timeout"
+            ? createTimeoutAbortReason()
+            : createAgentRunDirectAbortError(),
     );
   };
   let cliOwner: EmbeddedAgentQueueHandle | undefined;

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -58,7 +58,9 @@ export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
   /** Host-only transfer of attempt terminal resources to the logical turn. */
   onDeferredLifecycleOwner?: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
   /** Aborts the logical turn when its retained embedded handle is cancelled. */
-  onDeferredLifecycleAbort?: (reason?: "user_abort" | "restart" | "superseded") => void;
+  onDeferredLifecycleAbort?: (
+    reason?: "user_abort" | "restart" | "superseded" | "cron_timeout",
+  ) => void;
   /** Protects an admitted provider wait through the retained logical-turn owner. */
   onRetryWait?: (
     deadlineAtMs: number,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -222,7 +222,9 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   /** Signals an explicit cancellation through the active native run handle. */
   onAttemptAbort?: () => void;
   onDeferredLifecycleOwner?: (owner: DeferredEmbeddedRunLifecycleOwner) => void;
-  onDeferredLifecycleAbort?: (reason?: "user_abort" | "restart" | "superseded") => void;
+  onDeferredLifecycleAbort?: (
+    reason?: "user_abort" | "restart" | "superseded" | "cron_timeout",
+  ) => void;
   /** Host-requested runtime replacement takes effect after the current tool batch is persisted. */
   pluginRuntimeRefreshPending?: () => boolean;
   /** Registers the exact attempt owner able to stop before another model request. */

--- a/src/agents/embedded-agent-runner/runs.lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/runs.lifecycle.test.ts
@@ -33,7 +33,7 @@ type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 
 function createRunHandle(
   overrides: {
-    abort?: () => void;
+    abort?: RunHandle["abort"];
     isAbortable?: boolean;
     isAborted?: () => boolean;
     isCompacting?: boolean;
@@ -103,6 +103,34 @@ describe("embedded-agent runner run lifecycle", () => {
       expect(abortRun).toHaveBeenCalledTimes(1);
       expect(isEmbeddedAgentRunHandleActive("session-stuck")).toBe(false);
       expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("forwards cron_timeout reason to abortEmbeddedAgentRun", async () => {
+    vi.useFakeTimers();
+    try {
+      const abortRun = vi.fn();
+      setActiveEmbeddedRun(
+        "session-cron-abort",
+        createRunHandle({ abort: abortRun }),
+        "agent:main:cron",
+      );
+
+      const resultPromise = abortAndDrainEmbeddedAgentRun({
+        sessionId: "session-cron-abort",
+        sessionKey: "agent:main:cron",
+        settleMs: 100,
+        forceClear: true,
+        reason: "cron_timeout",
+      });
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultPromise;
+
+      expect(result.aborted).toBe(true);
+      expect(abortRun).toHaveBeenCalledWith("cron_timeout");
     } finally {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -899,14 +899,17 @@ function revokeCompletionClaim(sessionId: string, runId?: string): void {
  * - With a sessionId, aborts that single run.
  * - With no sessionId, supports targeted abort modes (for example, compacting runs only).
  */
-export function abortEmbeddedAgentRun(sessionId: string): boolean;
+export function abortEmbeddedAgentRun(
+  sessionId: string,
+  opts?: { reason?: "restart" | "cron_timeout" },
+): boolean;
 export function abortEmbeddedAgentRun(
   sessionId: undefined,
-  opts: { mode: "all" | "compacting"; reason?: "restart" },
+  opts: { mode: "all" | "compacting"; reason?: "restart" | "cron_timeout" },
 ): boolean;
 export function abortEmbeddedAgentRun(
   sessionId?: string,
-  opts?: { mode?: "all" | "compacting"; reason?: "restart" },
+  opts?: { mode?: "all" | "compacting"; reason?: "restart" | "cron_timeout" },
 ): boolean {
   if (typeof sessionId === "string" && sessionId.length > 0) {
     const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
@@ -1497,7 +1500,11 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
         setImmediate(resolve);
       });
     }
-    let aborted = abortEmbeddedAgentRun(params.sessionId) || expiredReplyRun;
+    let aborted =
+      abortEmbeddedAgentRun(
+        params.sessionId,
+        params.reason === "cron_timeout" ? { reason: "cron_timeout" } : undefined,
+      ) || expiredReplyRun;
     const embeddedDrained =
       aborted || stampedStaleReplyRun
         ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs)

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -45,6 +45,12 @@ export function createAgentRunDirectAbortError(): Error {
   return error;
 }
 
+export function createTimeoutAbortReason(detail?: string): Error {
+  const error = new Error(detail ?? "embedded run timed out");
+  error.name = "TimeoutError";
+  return error;
+}
+
 function hasAgentRunAbortCode(value: unknown, code: string): boolean {
   try {
     return value instanceof Error && "code" in value && value.code === code;

--- a/src/gateway/worker-environments/worker-turn-run-owner.ts
+++ b/src/gateway/worker-environments/worker-turn-run-owner.ts
@@ -8,6 +8,7 @@ import {
 import {
   createAgentRunRestartAbortError,
   createAgentRunSupersededAbortError,
+  createTimeoutAbortReason,
 } from "../../agents/run-termination.js";
 import type { SessionPlacementTurnParams } from "../../agents/session-placement-admission.js";
 import {
@@ -59,13 +60,15 @@ export function createWorkerTurnRunOwner(params: {
     sessionKey,
     runId: claim.runId,
   });
-  const cancel = (reason?: "user_abort" | "restart" | "superseded") => {
+  const cancel = (reason?: "user_abort" | "restart" | "superseded" | "cron_timeout") => {
     controller.abort(
       reason === "restart"
         ? createAgentRunRestartAbortError()
         : reason === "superseded"
           ? createAgentRunSupersededAbortError()
-          : undefined,
+          : reason === "cron_timeout"
+            ? createTimeoutAbortReason()
+            : undefined,
     );
   };
   const owner: WorkerRunOwner = {


### PR DESCRIPTION
Closes #138499

## What Problem This Solves

Resolves a problem where cron jobs running automated agent turns that launch background CLI tasks via the `exec` tool leave orphaned processes running on the host when the cron job times out, causing the Gateway restart drain loop to block and eventually force-shutdown.

## Why This Change Was Made

When a cron job hits its execution deadline, `cleanupTimedOutAgentRun` triggers an abort with reason `"cron_timeout"`. We ensure this timeout reason propagates through `abortEmbeddedAgentRun` and `EmbeddedAgentQueueHandle.abort` to `prepareEmbeddedAttemptStream`, where the abort is classified as a timeout with `TimeoutError`.

Key design decisions:
1. **Timeout reason ordering & re-entrancy**: In `prepareEmbeddedAttemptStream`, `input.abortRun(true, createTimeoutAbortReason())` and `attempt.onDeferredLifecycleAbort?.(reason)` are invoked before `attempt.onAttemptAbort?.()`, preventing re-entrant generic cancellation callbacks from the lane controller from latching first and discarding the `TimeoutError`.
2. **Selective background process termination**: In `bash-tools.exec-run.ts`, backgrounded execution retains its abort signal listener until process settlement (`settlement.onSettled = detachAbortListener;`), allowing `isSignalTimeoutReason(signal?.reason)` to terminate background processes on `TimeoutError` while preserving them across ordinary turn cancellations and restarts.
3. **Task settlement & restart unblocking**: Process settlement triggers `finalizeBackgroundExecTask`, recording the task's terminal state and clearing the `background-exec` active work restart blocker in `gateway-active-work.ts`.

## User Impact

Scheduled cron jobs that launch background CLI commands will no longer leak orphaned processes when the cron job reaches its execution deadline, preventing host resource exhaustion and enabling graceful Gateway restarts.

## Evidence

### 1. Real Behavior Runtime Verification
Executed an end-to-end integration test against the real process supervisor, real exec tool, real process registry, and real gateway active work monitor (`verify-cron-timeout-real.ts`):

```text
=== STEP 1: Setting up Embedded Agent Run & Tool Execution ===
=== STEP 2: Spawning Real Background CLI Task via Exec Tool ===
Exec tool result status: running
Background Session ID: plaid-tidepool
Child PID: 321092
Active background exec session count: 1
Gateway restart blocked before timeout? true
Active blocker before: 1 active background exec session(s)
Child process alive in OS before timeout: true

=== STEP 3: Triggering Cron Timeout Abort ===
Simulating cron scheduler: queueHandle.abort('cron_timeout')
[Attempt] External abort marked
Run abort signal aborted? true
Run abort signal reason: TimeoutError
Abort state terminal outcome: {"kind":"timeout","phase":"prompt","source":"runtime","aborted":true}

=== STEP 4: Waiting for Process Settlement & Task Finalization ===
Finished session found: true
Finished session terminal status: failed
Finished session exit signal/code: SIGTERM
Child process alive in OS after timeout: false
Active background exec session count after timeout: 0
Gateway restart blocked after timeout? false

=== VERIFICATION SUMMARY ===
Real cron timeout process cleanup verified: SUCCESS
```

### 2. Targeted Vitest Test Suites
All targeted suites pass cleanly (`node scripts/run-vitest.mjs <file>`):

- **`src/agents/bash-tools.exec.background-abort.test.ts`** (9/9 passed):
  - `background exec is not killed when tool signal aborts`
  - `pty background exec is not killed when tool signal aborts`
  - `background exec still times out after tool signal abort`
  - `background exec without explicit timeout applies default timeout`
  - `background exec with timeout zero bypasses default timeout`
  - `yielded background exec still times out`
  - `yieldMs exec without explicit timeout applies default timeout`
  - `background exec is killed when tool signal aborts with TimeoutError`
  - `yielded background exec is killed when tool signal aborts with TimeoutError`
- **`src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts`** (30/30 passed):
  - `processes cron_timeout abort through external-abort sequence as a timeout`
  - `preserves timeout classification when onAttemptAbort synchronously triggers re-entrant generic abort`
- **`src/agents/bash-tools.test.ts`** (33/33 passed):
  - `removes the abort listener when an exec process is backgrounded and exits`
- **`src/agents/embedded-agent-runner/runs.lifecycle.test.ts`** (23/23 passed):
  - `forwards cron_timeout reason to abortEmbeddedAgentRun`
- **`src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.test.ts`** (2/2 passed):
  - `publishes CLI cancellation authority before releasing the embedded attempt`
  - `records only the accepted candidate terminal trajectory`

### 3. Static Checks & Ratchets (`node scripts/check-changed.mjs --staged`)
- **Max-lines suppression ratchet**: 840 grandfathered suppressions (0 new)
- **Assertion SAFETY comment ratchet**: 11,704 grandfathered assertions (0 new)
- **Typecheck core & all test shards**: Passed
- **Dead code scan (`knip`)**: 0 unused exports
- **Linter (`oxlint --type-aware`)**: 0 warnings, 0 errors
