### PR TITLE
test(providers): reuse required thinking guards

### DIFF
--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -1,4 +1,3 @@
-// Meta tests cover plugin registration and catalog shape.
 import {
   configureAiTransportHost,
   createApiRegistry,
@@ -11,6 +10,8 @@ import {
   type StreamFunction,
 } from "@openclaw/ai";
 import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
+// Meta tests cover plugin registration and catalog shape.
+import { expectDefined } from "@openclaw/normalization-core";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple, type Context, type Model } from "openclaw/plugin-sdk/llm";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -67,15 +68,6 @@ function requireSynchronousStream(
     throw new Error("Expected synchronous assistant event stream");
   }
   return stream as AssistantMessageEventStreamContract;
-}
-
-function requireThinkingProfileResolver(
-  provider: ReturnType<typeof capturePluginRegistration>["providers"][number],
-) {
-  if (!provider.resolveThinkingProfile) {
-    throw new Error("Expected resolveThinkingProfile on Meta provider");
-  }
-  return provider.resolveThinkingProfile;
 }
 
 describe("meta provider", () => {
@@ -501,7 +493,10 @@ describe("meta provider", () => {
     if (!provider) {
       throw new Error("Expected Meta provider");
     }
-    const resolveThinkingProfile = requireThinkingProfileResolver(provider);
+    const resolveThinkingProfile = expectDefined(
+      provider.resolveThinkingProfile,
+      "Meta thinking profile resolver",
+    );
     const reasoningModels = buildMetaProvider().models.filter((model) => model.reasoning);
     expect(reasoningModels.map((model) => model.id)).toEqual([
       "muse-spark-1.3",
@@ -540,7 +535,10 @@ describe("meta provider", () => {
     if (!provider) {
       throw new Error("Expected Meta provider");
     }
-    const resolveThinkingProfile = requireThinkingProfileResolver(provider);
+    const resolveThinkingProfile = expectDefined(
+      provider.resolveThinkingProfile,
+      "Meta thinking profile resolver",
+    );
     expect(
       resolveThinkingProfile({
         provider: "meta",

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -1,11 +1,11 @@
 // Xiaomi tests cover index plugin behavior.
+import { expectDefined } from "@openclaw/normalization-core";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import {
   registerProviderPlugin,
   requireRegisteredProvider,
   resolveProviderPluginChoice,
-  type RegisteredProviderCollections,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
 import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
@@ -34,17 +34,7 @@ type ReplayToolCall = {
   };
 };
 
-type RegisteredProvider = RegisteredProviderCollections["providers"][number];
 const emptyUsage = createZeroUsageFixture();
-
-function requireThinkingProfileResolver(
-  provider: RegisteredProvider,
-): NonNullable<RegisteredProvider["resolveThinkingProfile"]> {
-  if (!provider.resolveThinkingProfile) {
-    throw new Error("Xiaomi provider did not register a thinking profile resolver");
-  }
-  return provider.resolveThinkingProfile;
-}
 
 const readToolCall = { type: "toolCall", id: "call_1", name: "read", arguments: {} };
 const readToolResult = {
@@ -154,16 +144,6 @@ function createPayloadCapturingStream(capture: PayloadCapture, model: OpenAIComp
     queueMicrotask(() => stream.end());
     return stream;
   };
-}
-
-function requireThinkingWrapper(
-  wrapper: ReturnType<typeof createMiMoThinkingWrapper>,
-  label: string,
-): NonNullable<ReturnType<typeof createMiMoThinkingWrapper>> {
-  if (!wrapper) {
-    throw new Error(`expected MiMo thinking wrapper for ${label}`);
-  }
-  return wrapper;
 }
 
 function readThinking(payload: Record<string, unknown> | undefined): ThinkingPayload | undefined {
@@ -470,7 +450,10 @@ describe("xiaomi provider plugin", () => {
 
   it("advertises thinking profiles for MiMo reasoning models only", async () => {
     const provider = await getXiaomiProvider();
-    const resolveThinkingProfile = requireThinkingProfileResolver(provider);
+    const resolveThinkingProfile = expectDefined(
+      provider.resolveThinkingProfile,
+      "Xiaomi thinking profile resolver",
+    );
     const expectedLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
     for (const modelId of ["mimo-v2.5", "mimo-v2.5-pro", "mimo-v2.6-pro"]) {
@@ -511,9 +494,9 @@ describe("xiaomi provider plugin", () => {
     );
     const baseStreamFn = createPayloadCapturingStream(capture, model);
 
-    const wrapThinkingHigh = requireThinkingWrapper(
+    const wrapThinkingHigh = expectDefined(
       createMiMoThinkingWrapper(baseStreamFn as never, "high"),
-      "high",
+      "MiMo thinking wrapper for high",
     );
     await wrapThinkingHigh(model, context, {});
 
@@ -533,9 +516,9 @@ describe("xiaomi provider plugin", () => {
     const context = mimoReasoningToolReplayContext("xiaomi-token-plan");
     const baseStreamFn = createPayloadCapturingStream(capture, model);
 
-    const wrapThinkingHigh = requireThinkingWrapper(
+    const wrapThinkingHigh = expectDefined(
       createMiMoThinkingWrapper(baseStreamFn as never, "high"),
-      "high",
+      "MiMo thinking wrapper for high",
     );
     await wrapThinkingHigh(model, context, {});
 
@@ -555,9 +538,9 @@ describe("xiaomi provider plugin", () => {
     const context = mimoReasoningToolReplayContext();
     const baseStreamFn = createPayloadCapturingStream(capture, model);
 
-    const wrapThinkingNone = requireThinkingWrapper(
+    const wrapThinkingNone = expectDefined(
       createMiMoThinkingWrapper(baseStreamFn as never, "none" as never),
-      "none",
+      "MiMo thinking wrapper for none",
     );
     await wrapThinkingNone(model, context, {});
 


### PR DESCRIPTION
Xiaomi and Meta index tests duplicated required-value guards for optional thinking hooks. Reuse the canonical `expectDefined` helper at six sites and remove the three local guards plus Xiaomi's unused type alias/import.

All 30 test definitions, 117 assertions, and direct hook calls remain. Meta's separate synchronous-stream guard is unchanged: it rejects promises and verifies callable `push`/`end`, which a definedness check cannot replace. No production, model, API, or configuration change; tests net -19 lines.

Validation: baseline and candidate pass the same 34 cases; all 19 changed checks passed; independent Codex review found no actionable issues.
