### PR TITLE
fix(codex): keep native tools available when sandbox policy allows them

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -55,6 +55,14 @@ unless you opt into the experimental sandbox exec-server path. Node-backed
 `remote-exec` on a paired device or cloud worker instead uses its
 placement-owned environment without that experimental flag.
 
+The Codex harness declares its native coding surface as the six canonical
+OpenClaw operations `exec`, `process`, `read`, `write`, `edit`, and
+`apply_patch`. A sandbox policy can retain that surface only when it allows all
+six operations. This coding-only declaration does not enable other Codex native
+capabilities: restricted turns continue to disable native image inspection,
+apps, plugins, hooks, and inherited MCP servers. If managed Codex policy disables
+native shell, OpenClaw falls back to its policy-filtered coding tools.
+
 Eligible native-shell turns also retain `gateway_exec` and `gateway_process`
 as a distinct OpenClaw execution path. Use `gateway_exec` only when a command
 needs OpenClaw-managed Gateway environment access, including Secret Store

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -67,6 +67,17 @@ describe("Codex agent harness supports()", () => {
     );
   });
 
+  it("declares the complete native coding tool surface", () => {
+    expect(harness.conversationToolPolicyNativeCodeToolNames).toEqual([
+      "exec",
+      "process",
+      "read",
+      "write",
+      "edit",
+      "apply_patch",
+    ]);
+  });
+
   const harness = createCodexAppServerAgentHarness({
     bindingStore: testCodexAppServerBindingStore,
   });

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -116,6 +116,14 @@ export function createCodexAppServerAgentHarness(
     contextEngineHostCapabilities: CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES,
     conversationToolPolicySupport: "exact",
     conversationToolPolicySafeDenyTools: CODEX_TOOL_POLICY_SAFE_DENY_NAMES,
+    conversationToolPolicyNativeCodeToolNames: [
+      "exec",
+      "process",
+      "read",
+      "write",
+      "edit",
+      "apply_patch",
+    ],
     deliveryDefaults: {
       visibleReplies: "message_tool",
     },

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -496,9 +496,10 @@ export async function startCodexAttemptThread(params: {
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
-                userMcpServersEnabled: params.configuredMcpDynamicSurface
-                  ? false
-                  : params.nativeToolSurfaceEnabled,
+                userMcpServersEnabled:
+                  !params.configuredMcpDynamicSurface &&
+                  params.nativeToolSurfaceEnabled &&
+                  attemptParams.pluginHarnessToolPolicyRestricted !== true,
                 mcpServersFingerprint: params.configuredMcpDynamicSurface
                   ? undefined
                   : params.bundleMcpThreadConfig.fingerprint,

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -391,6 +391,10 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
     params.pluginHarnessToolPolicyRestricted = true;
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    params.pluginHarnessNativeCodeToolPolicyRestricted = false;
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    params.pluginHarnessNativeCodeToolPolicyRestricted = true;
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
   it("keeps policy-filterable OpenClaw coding replacements when native tools are disabled", () => {
@@ -680,14 +684,29 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it.each([
-    { nativeToolSurfaceEnabled: true, expected: ["message"] },
-    { nativeToolSurfaceEnabled: false, expected: ["view_image", "message"] },
+    {
+      nativeToolSurfaceEnabled: true,
+      pluginHarnessToolPolicyRestricted: false,
+      expected: ["message"],
+    },
+    {
+      nativeToolSurfaceEnabled: false,
+      pluginHarnessToolPolicyRestricted: false,
+      expected: ["view_image", "message"],
+    },
+    {
+      nativeToolSurfaceEnabled: true,
+      pluginHarnessToolPolicyRestricted: true,
+      expected: ["view_image", "message"],
+    },
   ])(
-    "uses the active native image loader when native tools are $nativeToolSurfaceEnabled",
-    async ({ nativeToolSurfaceEnabled, expected }) => {
+    "uses the active native image loader when native=$nativeToolSurfaceEnabled restricted=$pluginHarnessToolPolicyRestricted",
+    async ({ nativeToolSurfaceEnabled, pluginHarnessToolPolicyRestricted, expected }) => {
       const workspaceDir = path.join(tempDir, "workspace");
       const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
       params.disableTools = false;
+      params.pluginHarnessToolPolicyRestricted = pluginHarnessToolPolicyRestricted;
+      params.pluginHarnessNativeCodeToolPolicyRestricted = false;
       params.model = createCodexTestModel("codex", ["text", "image"]);
       params.runtimePlan = createCodexRuntimePlanFixture();
       setOpenClawCodingToolsFactoryForTests(() => [

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -434,7 +434,8 @@ export async function buildDynamicTools(
   toolBuildStages.mark("codex-filtering");
   const visionFilteredTools = filterCodexVisionTools(codexFilteredTools, {
     modelHasVision,
-    nativeImageInspectionEnabled: input.nativeToolSurfaceEnabled === true,
+    nativeImageInspectionEnabled:
+      input.nativeToolSurfaceEnabled === true && params.pluginHarnessToolPolicyRestricted !== true,
   });
   toolBuildStages.mark("vision-filtering");
   const webSearchPresent = visionFilteredTools.some((tool) => tool.name === "web_search");
@@ -618,7 +619,10 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     sandboxExecServerEnabled?: boolean;
   } = {},
 ): boolean {
-  if (params.pluginHarnessToolPolicyRestricted === true) {
+  if (
+    (params.pluginHarnessNativeCodeToolPolicyRestricted ??
+      params.pluginHarnessToolPolicyRestricted) === true
+  ) {
     return false;
   }
   if (isCodexMemoryFlushRun(params)) {

--- a/extensions/codex/src/app-server/managed-native-tool-policy.ts
+++ b/extensions/codex/src/app-server/managed-native-tool-policy.ts
@@ -1,0 +1,71 @@
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { CodexAppServerClient } from "./client.js";
+import {
+  CODEX_SESSION_OVERRIDABLE_LAYER_TYPES,
+  readCodexEffectiveConfig,
+} from "./config-layer-policy.js";
+import type { CodexAppServerRuntimeOptions } from "./config.js";
+import { isJsonObject } from "./protocol.js";
+import {
+  releaseLeasedSharedCodexAppServerClient,
+  type CodexAppServerClientOptions,
+  type CodexAppServerClientFactory,
+} from "./shared-client.js";
+import { readCodexManagedRequirements } from "./thread-requests.js";
+
+function requirementsDisableNativeShell(requirements: Record<string, unknown> | null): boolean {
+  if (!requirements) {
+    return false;
+  }
+  const features = requirements.featureRequirements ?? requirements.feature_requirements;
+  return isJsonObject(features) && features.shell_tool === false;
+}
+
+/**
+ * Checks whether administrator-managed Codex policy disables native shell use.
+ * Unknown results remain fail-closed at the ordinary lifecycle preflight.
+ */
+export async function resolveCodexManagedNativeShellDenied(params: {
+  clientFactory: CodexAppServerClientFactory;
+  appServer: CodexAppServerRuntimeOptions;
+  authProfileId: string | null | undefined;
+  preparedAuth?: CodexAppServerClientOptions["preparedAuth"];
+  agentDir: string;
+  config: EmbeddedRunAttemptParams["config"] | undefined;
+  cwd: string;
+  signal: AbortSignal;
+}): Promise<boolean> {
+  let client: CodexAppServerClient | undefined;
+  try {
+    client = await params.clientFactory({
+      startOptions: params.appServer.start,
+      ...(params.preparedAuth
+        ? { preparedAuth: params.preparedAuth }
+        : { authProfileId: params.authProfileId }),
+      agentDir: params.agentDir,
+      config: params.config,
+      timeoutMs: params.appServer.requestTimeoutMs,
+    });
+    const requirements = await readCodexManagedRequirements(client, params.signal);
+    if (requirementsDisableNativeShell(requirements)) {
+      return true;
+    }
+    const effectiveConfig = await readCodexEffectiveConfig(client, params.cwd, {
+      signal: params.signal,
+    });
+    const features = effectiveConfig?.config.features;
+    return (
+      isJsonObject(features) &&
+      features.shell_tool === false &&
+      !CODEX_SESSION_OVERRIDABLE_LAYER_TYPES.has(
+        effectiveConfig?.origins?.["features.shell_tool"]?.name.type ?? "",
+      )
+    );
+  } catch {
+    return false;
+  } finally {
+    if (client) {
+      releaseLeasedSharedCodexAppServerClient(client);
+    }
+  }
+}

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -18,6 +18,7 @@ import {
   resolveCodexAppServerHookChannelId,
   shouldEnableCodexAppServerNativeToolSurface,
 } from "./dynamic-tool-build.js";
+import { resolveCodexManagedNativeShellDenied } from "./managed-native-tool-policy.js";
 import { resolveCodexProviderWebSearchSupport } from "./provider-capabilities.js";
 import { prewarmCodexAttemptClient } from "./run-attempt-client-prewarm.js";
 import type { CodexAttemptConnection } from "./run-attempt-connection.js";
@@ -223,11 +224,27 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     });
   preDynamicStartupStages.mark("bundle-mcp");
   const sandboxExecServerEnabled = isCodexSandboxExecServerEnabled(pluginConfig, sandbox);
-  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
+  const policyAllowsNativeToolSurface = shouldEnableCodexAppServerNativeToolSurface(
     runtimeParams,
     sandbox,
     { agentId: policyAgentId, runtimeSessionKey: sandboxSessionKey, sandboxExecServerEnabled },
   );
+  const managedNativeShellDenied =
+    policyAllowsNativeToolSurface &&
+    runtimeParams.pluginHarnessToolPolicyRestricted === true &&
+    runtimeParams.pluginHarnessNativeCodeToolPolicyRestricted === false
+      ? await resolveCodexManagedNativeShellDenied({
+          clientFactory: attemptClientFactory,
+          appServer,
+          authProfileId: startupClientAuthProfileId,
+          preparedAuth: startupPreparedAuth,
+          agentDir,
+          config: params.config,
+          cwd: effectiveWorkspace,
+          signal: runAbortController.signal,
+        })
+      : false;
+  const nativeToolSurfaceEnabled = policyAllowsNativeToolSurface && !managedNativeShellDenied;
   const configuredMcpSurface = scheduledConfiguredMcpSurface
     ? "scheduled"
     : !nativeToolSurfaceEnabled && bundleMcpThreadConfig.staticServerNames.length > 0

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2700,6 +2700,52 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.requests.map((request) => request.method)).not.toContain("thread/start");
   });
 
+  it("falls back to filtered OpenClaw coding tools when managed policy disables native shell", async () => {
+    const codingTools = ["exec", "process", "read", "write", "edit", "apply_patch"];
+    testing.setOpenClawCodingToolsFactoryForTests((options) =>
+      createOpenClawCodingTools(options).filter((tool) => codingTools.includes(tool.name)),
+    );
+    const params = createRunParams();
+    params.disableTools = false;
+    params.pluginHarnessToolPolicyRestricted = true;
+    params.pluginHarnessNativeCodeToolPolicyRestricted = false;
+    setCodexTestModelSupportsTools(params, true);
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "configRequirements/read") {
+        return { requirements: { featureRequirements: { shell_tool: false } } };
+      }
+      if (method === "config/read") {
+        return { config: {}, layers: [] };
+      }
+      if (method === "mcpServerStatus/list") {
+        return { data: [], nextCursor: null };
+      }
+      return undefined;
+    });
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    const startParams = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as
+      | { dynamicTools?: CodexDynamicToolSpec[]; environments?: unknown[]; config?: JsonObject }
+      | undefined;
+    expect(startParams?.environments).toEqual([]);
+    expect(
+      flattenSpecsWithNamespace(startParams?.dynamicTools ?? [])
+        .map((tool) => tool.name)
+        .toSorted(),
+    ).toEqual(codingTools.toSorted());
+    expect(startParams?.config).toMatchObject({
+      "features.code_mode": false,
+      "features.code_mode_only": false,
+      "features.shell_tool": false,
+      "features.unified_exec": false,
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(run).resolves.toBeDefined();
+  });
+
   it("overrides a user-level shell disable when native code mode is enabled", async () => {
     const params = createRunParams();
     params.disableTools = false;

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -544,6 +544,8 @@ export async function runCodexAppServerSideQuestion(
       pluginConfig,
       sessionAgentId,
       nativeToolSurfaceEnabled,
+      nativeImageInspectionEnabled:
+        nativeToolSurfaceEnabled && sideRunParams.pluginHarnessToolPolicyRestricted !== true,
       nativeProviderWebSearchSupport,
       sessionPermissionPolicy,
       runId,
@@ -1204,6 +1206,7 @@ async function createCodexSideToolBridge(input: {
   pluginConfig: ReturnType<typeof readCodexPluginConfig>;
   sessionAgentId: string;
   nativeToolSurfaceEnabled: boolean;
+  nativeImageInspectionEnabled: boolean;
   nativeProviderWebSearchSupport: CodexNativeWebSearchSupport;
   sessionPermissionPolicy?: CodexEffectiveSessionPermissionPolicy;
   runId: string;
@@ -1331,7 +1334,7 @@ async function createCodexSideToolBridge(input: {
     const codexFilteredTools = filterCodexDynamicTools(allTools, input.pluginConfig);
     tools = filterCodexVisionTools(codexFilteredTools, {
       modelHasVision: runtimeModel.input?.includes("image") ?? false,
-      nativeImageInspectionEnabled: input.nativeToolSurfaceEnabled,
+      nativeImageInspectionEnabled: input.nativeImageInspectionEnabled,
     });
   }
   const requestedWebSearchPlan = resolveCodexWebSearchPlan({

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -146,9 +146,6 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
     params.params.scheduledRuntimeAuthority === undefined;
   const imageGenerationDenied =
     params.params.pluginHarnessToolPolicySafeDeniedTools?.includes("image_generate") === true;
-  if (restrictedToolSurface && params.nativeCodeModeEnabled !== false) {
-    throw new Error("Codex restricted tool surfaces require native code mode to be disabled");
-  }
   if (!effectiveConfig) {
     effectiveConfig = await lifecycleTiming.measure("effective-config-read", () =>
       readCodexEffectiveConfig(params.client, params.cwd, { signal: params.signal }),
@@ -167,6 +164,7 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
         {
           restrictedToolSurface,
           requiredNativeShell: params.nativeCodeModeEnabled !== false,
+          nativeCodeModeEnabled: params.nativeCodeModeEnabled !== false,
           additionalDeniedFeatures: imageGenerationDenied ? ["image_generation"] : undefined,
           allowedManagedRequirementsFingerprint:
             readScheduledCodexAppManagedRequirementsFingerprint(

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -51,6 +51,7 @@ import { createClientHarness } from "./test-support.js";
 import { fingerprintEnvironmentSelection } from "./thread-fingerprints.js";
 import {
   buildThreadResumeParams,
+  buildThreadStartParams,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
 import { createLeasedCodexLifecycleHarness } from "./thread-lifecycle.test-fixtures.js";
@@ -3285,6 +3286,59 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
   });
 
+  it("keeps native coding tools while isolating denied ambient tools and inherited MCP", () => {
+    const params = createParams(
+      path.join(tempDir, "sandbox-policy-session.jsonl"),
+      path.join(tempDir, "sandbox-policy-workspace"),
+    );
+    params.pluginHarnessToolPolicyRestricted = true;
+    params.pluginHarnessNativeCodeToolPolicyRestricted = false;
+    const environmentSelection = [{ environmentId: "sandbox", cwd: "/workspace" }];
+    const threadOptions = {
+      cwd: "/workspace",
+      appServer: createThreadLifecycleAppServerOptions(),
+      dynamicTools: [],
+      config: {
+        "features.apps": true,
+        "features.code_mode": true,
+        "features.code_mode_only": true,
+        "features.hooks": true,
+        "features.plugins": true,
+        "features.shell_tool": true,
+        "features.unified_exec": true,
+        "features.view_image": true,
+        "orchestrator.mcp.enabled": true,
+        mcp_servers: { inherited: { command: "unsafe" } },
+      },
+      nativeCodeModeEnabled: true,
+      nativeCodeModeOnlyEnabled: true,
+      environmentSelection,
+      hostSystemAgentActive: false,
+      restrictedToolSurfaceInheritedMcpServerNames: ["inherited"],
+    };
+    const startRequest = buildThreadStartParams(params, threadOptions);
+    const resumeRequest = buildThreadResumeParams(params, {
+      ...threadOptions,
+      threadId: "existing-thread-after-policy-tightening",
+    });
+
+    expect(startRequest.environments).toEqual(environmentSelection);
+    for (const request of [startRequest, resumeRequest]) {
+      expect(request.config).toMatchObject({
+        "features.code_mode": expect.anything(),
+        "features.code_mode_only": true,
+        "features.shell_tool": true,
+        "features.unified_exec": true,
+        "features.view_image": false,
+        "features.apps": false,
+        "features.hooks": false,
+        "features.plugins": false,
+        "orchestrator.mcp.enabled": false,
+        mcp_servers: { inherited: { command: "unsafe", enabled: false } },
+      });
+    }
+  });
+
   it("starts a fresh restricted OpenClaw thread for a new app-server client", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -3650,6 +3704,40 @@ describe("Codex app-server thread lifecycle bindings", () => {
         hostSystemAgentActive: true,
       }),
     ).rejects.toThrow("cannot override required feature hooks");
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "config/read",
+      "configRequirements/read",
+    ]);
+  });
+
+  it("rejects required view_image while native coding remains enabled", async () => {
+    const sessionFile = path.join(tempDir, "plugin-native-code-session.jsonl");
+    const workspaceDir = path.join(tempDir, "plugin-native-code-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.pluginHarnessToolPolicyRestricted = true;
+    params.pluginHarnessNativeCodeToolPolicyRestricted = false;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config/read") {
+        return { config: {}, layers: [] };
+      }
+      if (method === "configRequirements/read") {
+        return { requirements: { featureRequirements: { view_image: true } } };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        nativeCodeModeEnabled: true,
+        userMcpServersEnabled: false,
+        hostSystemAgentActive: false,
+      }),
+    ).rejects.toThrow("cannot override required feature view_image");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "config/read",
       "configRequirements/read",

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -119,6 +119,15 @@ const CODEX_RING_ZERO_RESTRICTED_FEATURES = new Set([
   "workspace_dependencies",
 ]);
 
+// These features own only the declared native coding surface. A sandbox policy
+// may permit them while the broader native and inherited surfaces remain isolated.
+const CODEX_NATIVE_CODE_MODE_FEATURES = new Set([
+  "code_mode",
+  "code_mode_only",
+  "shell_tool",
+  "unified_exec",
+]);
+
 const CODEX_RING_ZERO_THREAD_CONFIG: JsonObject = {
   ...CODEX_DELEGATION_DISABLED_THREAD_CONFIG,
   ...Object.fromEntries(
@@ -460,6 +469,10 @@ export function buildCodexRuntimeThreadConfigForRun(
         ? buildRestrictedToolConfigPatch(
             restrictedToolSurfaceMcpServerNames,
             Boolean(params.scheduledRuntimeAuthority),
+            {
+              preserveNativeCodeMode:
+                !messageOnlySourceReply && options.nativeCodeModeEnabled === true,
+            },
           )
         : buildCodexRingZeroThreadConfigPatch(
             params,
@@ -499,6 +512,7 @@ export function buildCodexRingZeroThreadConfigPatch(
 function buildRestrictedToolConfigPatch(
   inheritedMcpServerNames: readonly string[],
   scheduledAppAuthorityActive = false,
+  options: { preserveNativeCodeMode?: boolean } = {},
 ): JsonObject {
   // Restricted turns already send environments: [] and disable native code mode.
   // Remove Codex-owned tool sources here; project-document suppression belongs to
@@ -506,8 +520,14 @@ function buildRestrictedToolConfigPatch(
   const mcpServers = Object.fromEntries(
     [...new Set(inheritedMcpServerNames)].toSorted().map((name) => [name, { enabled: false }]),
   );
+  const restrictedConfig = { ...CODEX_RING_ZERO_THREAD_CONFIG };
+  if (options.preserveNativeCodeMode) {
+    for (const feature of CODEX_NATIVE_CODE_MODE_FEATURES) {
+      delete restrictedConfig[`features.${feature}`];
+    }
+  }
   return {
-    ...CODEX_RING_ZERO_THREAD_CONFIG,
+    ...restrictedConfig,
     ...(scheduledAppAuthorityActive
       ? {
           "features.apps": true,
@@ -565,6 +585,7 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
   options: {
     restrictedToolSurface: boolean;
     requiredNativeShell?: boolean;
+    nativeCodeModeEnabled?: boolean;
     additionalDeniedFeatures?: readonly string[];
     allowedManagedRequirementsFingerprint?: string;
     allowConfiguredManagedHooks?: boolean;
@@ -621,7 +642,11 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
       }
       const deniedByToolPolicy =
         (options.restrictedToolSurface &&
-          CODEX_RING_ZERO_RESTRICTED_FEATURES.has(canonicalFeature)) ||
+          CODEX_RING_ZERO_RESTRICTED_FEATURES.has(canonicalFeature) &&
+          !(
+            options.nativeCodeModeEnabled === true &&
+            CODEX_NATIVE_CODE_MODE_FEATURES.has(canonicalFeature)
+          )) ||
         additionalDeniedFeatures.has(canonicalFeature);
       if (canonicalFeature === "hooks" && managedHooksAllowed) {
         continue;
@@ -649,7 +674,7 @@ export async function readCodexManagedRequirementsFingerprint(
   );
 }
 
-async function readCodexManagedRequirements(
+export async function readCodexManagedRequirements(
   client: Pick<CodexAppServerClient, "request">,
   signal?: AbortSignal,
 ): Promise<JsonObject | null> {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -154,6 +154,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   operation?: EmbeddedRunAttemptOperation;
   /** Core-prepared fact that explicit requester/config policy restricts plugin-native tools. */
   pluginHarnessToolPolicyRestricted?: boolean;
+  /** Core-prepared fact that policy restricts the harness's declared native coding tools. */
+  pluginHarnessNativeCodeToolPolicyRestricted?: boolean;
   /** Audited exact denies that the plugin harness must enforce against native equivalents. */
   pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
   preparedModelRuntime?: PreparedModelRuntimeSnapshot;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -80,7 +80,9 @@ import { ensureSelectedAgentHarnessPlugin } from "./runtime-plugin.js";
 import {
   agentHarnessBuildsOpenClawTools,
   agentHarnessExposesOpenClawTools,
+  resolveAgentHarnessNativeToolPolicyRestricted,
   resolveAvailableAgentHarnessPolicy,
+  resolvePluginHarnessToolPolicies,
   resolvePluginHarnessPolicyToolsAllow,
   runAgentHarnessAttempt,
   runAgentHarnessSettledTurnFinalization,
@@ -1868,6 +1870,105 @@ describe("runAgentHarnessAttempt", () => {
       true,
     ]);
     expect(received[0]?.safeDeniedTools).toEqual(["image_generate"]);
+  });
+
+  it("keeps declared native coding tools available while preserving ambient isolation", () => {
+    const declaredNativeTools = ["exec", "process", "read", "write", "edit", "apply_patch"];
+    const harness = {
+      id: "codex",
+      label: "Codex",
+      conversationToolPolicySupport: "exact",
+      conversationToolPolicyNativeCodeToolNames: declaredNativeTools,
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: async () => createAttemptResult("codex"),
+    } as AgentHarness;
+    const params = createAttemptParams({
+      agents: { defaults: { sandbox: { mode: "all" } } },
+      tools: { sandbox: { tools: { allow: declaredNativeTools, deny: [] } } },
+    } as OpenClawConfig);
+    params.sessionKey = "agent:main:session-1";
+
+    expect(resolveAgentHarnessNativeToolPolicyRestricted(params, harness)).toBe(true);
+    expect(
+      resolvePluginHarnessToolPolicies(
+        params,
+        harness.conversationToolPolicySafeDenyTools,
+        harness.conversationToolPolicyNativeCodeToolNames,
+      ).nativeCodeToolPolicyRestricted,
+    ).toBe(false);
+  });
+
+  it("fails closed for incomplete sandbox policy or malformed native tool declarations", () => {
+    const declaredNativeTools = ["exec", "process", "read", "write", "edit", "apply_patch"];
+    const resolveRestricted = (options: {
+      nativeToolNames?: unknown;
+      allow?: string[];
+      deny?: string[];
+      toolsAllow?: string[];
+      swarmCollector?: boolean;
+    }) => {
+      const harness = {
+        id: "codex",
+        label: "Codex",
+        conversationToolPolicySupport: "exact",
+        conversationToolPolicyNativeCodeToolNames: options.nativeToolNames,
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: async () => createAttemptResult("codex"),
+      } as AgentHarness;
+      const params = createAttemptParams({
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        tools: {
+          sandbox: {
+            tools: {
+              allow: options.allow ?? declaredNativeTools,
+              deny: options.deny ?? [],
+            },
+          },
+        },
+      } as OpenClawConfig);
+      params.sessionKey = "agent:main:session-1";
+      params.toolsAllow = options.toolsAllow;
+      params.swarmCollector = options.swarmCollector;
+      return {
+        ambient: resolveAgentHarnessNativeToolPolicyRestricted(params, harness),
+        nativeCode: resolvePluginHarnessToolPolicies(
+          params,
+          harness.conversationToolPolicySafeDenyTools,
+          harness.conversationToolPolicyNativeCodeToolNames,
+        ).nativeCodeToolPolicyRestricted,
+      };
+    };
+
+    const malformedDeclarations: unknown[] = [
+      undefined,
+      [],
+      [...declaredNativeTools, 7],
+      [...declaredNativeTools, "exec"],
+      [...declaredNativeTools, "not_a_core_tool"],
+      ["*"],
+    ];
+    expect(
+      malformedDeclarations.map((nativeToolNames) => resolveRestricted({ nativeToolNames })),
+    ).toEqual(malformedDeclarations.map(() => ({ ambient: true, nativeCode: true })));
+    expect(
+      declaredNativeTools.map((omitted) =>
+        resolveRestricted({
+          nativeToolNames: declaredNativeTools,
+          allow: declaredNativeTools.filter((name) => name !== omitted),
+        }),
+      ),
+    ).toEqual(declaredNativeTools.map(() => ({ ambient: true, nativeCode: true })));
+    expect(
+      declaredNativeTools.map((denied) =>
+        resolveRestricted({ nativeToolNames: declaredNativeTools, deny: [denied] }),
+      ),
+    ).toEqual(declaredNativeTools.map(() => ({ ambient: true, nativeCode: true })));
+    expect(
+      resolveRestricted({ nativeToolNames: declaredNativeTools, toolsAllow: ["read"] }),
+    ).toEqual({ ambient: true, nativeCode: true });
+    expect(
+      resolveRestricted({ nativeToolNames: declaredNativeTools, swarmCollector: true }),
+    ).toEqual({ ambient: true, nativeCode: true });
   });
 
   it("isolates collector runs and explicit restrictive policy layers for plugin harnesses", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -34,6 +34,7 @@ import {
   unwrapSecretSentinelsForProviderEgress,
 } from "../provider-secret-egress.js";
 import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
+import { isToolAllowed } from "../sandbox/tool-policy.js";
 import { isKnownCoreToolId } from "../tool-catalog.js";
 import {
   expandToolGroups,
@@ -170,6 +171,7 @@ type ResolvedPluginHarnessToolPolicies = {
   runtimePolicies: Array<PluginHarnessToolPolicy | undefined>;
   safeDeniedToolNames: string[];
   toolPolicyRestricted: boolean;
+  nativeCodeToolPolicyRestricted: boolean;
 };
 
 function listPluginAgentHarnesses(): AgentHarness[] {
@@ -509,7 +511,11 @@ export async function runAgentHarnessAttempt(
           : preparePluginHarnessParams(pluginAttempt.params, harness);
         const effectiveAttemptParams =
           hostOpenClawAuthority && preparedParams.pluginHarnessToolPolicyRestricted
-            ? { ...preparedParams, pluginHarnessToolPolicyRestricted: false }
+            ? {
+                ...preparedParams,
+                pluginHarnessToolPolicyRestricted: false,
+                pluginHarnessNativeCodeToolPolicyRestricted: false,
+              }
             : preparedParams;
         assertPluginHarnessConversationToolPolicySupport(
           harness,
@@ -760,11 +766,11 @@ function preparePluginHarnessParams(
     model === params.model && resolvedApiKey === params.resolvedApiKey
       ? params
       : { ...params, model, resolvedApiKey };
+  const exactPolicySupport = harness.conversationToolPolicySupport === "exact";
   const policies = resolvePluginHarnessToolPolicies(
     preparedParams,
-    harness.conversationToolPolicySupport === "exact"
-      ? harness.conversationToolPolicySafeDenyTools
-      : undefined,
+    exactPolicySupport ? harness.conversationToolPolicySafeDenyTools : undefined,
+    exactPolicySupport ? harness.conversationToolPolicyNativeCodeToolNames : undefined,
   );
   return applyPluginHarnessDenyAllToolPolicy(
     {
@@ -772,6 +778,7 @@ function preparePluginHarnessParams(
       pluginHarnessToolPolicySafeDeniedTools:
         policies.safeDeniedToolNames.length > 0 ? policies.safeDeniedToolNames : undefined,
       pluginHarnessToolPolicyRestricted: policies.toolPolicyRestricted,
+      pluginHarnessNativeCodeToolPolicyRestricted: policies.nativeCodeToolPolicyRestricted,
     },
     policies,
   );
@@ -831,11 +838,11 @@ export function resolveAgentHarnessNativeToolPolicyRestricted(
   params: PluginHarnessToolPolicyContext,
   harness: AgentHarness,
 ): boolean {
+  const exactPolicySupport = harness.conversationToolPolicySupport === "exact";
   return resolvePluginHarnessToolPolicies(
     params,
-    harness.conversationToolPolicySupport === "exact"
-      ? harness.conversationToolPolicySafeDenyTools
-      : undefined,
+    exactPolicySupport ? harness.conversationToolPolicySafeDenyTools : undefined,
+    exactPolicySupport ? harness.conversationToolPolicyNativeCodeToolNames : undefined,
   ).toolPolicyRestricted;
 }
 
@@ -859,6 +866,7 @@ function resolvePluginHarnessDenyAllToolPolicyPrompt(
 export function resolvePluginHarnessToolPolicies(
   params: PluginHarnessToolPolicyContext,
   safeDenyToolNames?: readonly string[],
+  nativeToolNames?: readonly string[],
 ): ResolvedPluginHarnessToolPolicies {
   const messageProvider = params.messageProvider ?? params.messageChannel;
   const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
@@ -923,22 +931,26 @@ export function resolvePluginHarnessToolPolicies(
       : params.toolsAllow
         ? { allow: params.toolsAllow }
         : undefined;
-  const explicitPolicies = [
+  const nonSandboxExplicitPolicies = [
     policy.globalPolicy,
     policy.globalProviderPolicy,
     policy.agentPolicy,
     policy.agentProviderPolicy,
     policy.groupPolicy,
     policy.senderPolicy,
-    policy.sandboxPolicy,
     policy.subagentPolicy,
     policy.inheritedToolPolicy,
     policy.runtimeToolPolicyForInheritance,
     requestedToolPolicy,
   ];
+  const explicitPolicies = [...nonSandboxExplicitPolicies, policy.sandboxPolicy];
   const safeDenyToolNameSet = safeDenyToolNames
     ? new Set(safeDenyToolNames.map(normalizeToolPolicyName))
     : undefined;
+  const sandboxNativeCodePolicyRestricted = sandboxPolicyRestrictsHarnessNativeTools(
+    policy.sandboxPolicy,
+    nativeToolNames,
+  );
   return {
     senderPolicy: policy.senderPolicy,
     senderScopedGroupPolicy: resolveSenderScopedGroupToolPolicy(
@@ -960,14 +972,62 @@ export function resolvePluginHarnessToolPolicies(
       requestedToolPolicy,
     ],
     safeDeniedToolNames: collectHarnessSafeDeniedToolNames(explicitPolicies, safeDenyToolNameSet),
-    // Native tools bypass the collector's noninteractive OpenClaw wrappers.
-    // Keep policy-allowed host replacements, without ambient input or approval surfaces.
+    // Preserve ambient native isolation whenever any effective policy restricts tools.
+    // A separate, narrower fact allows only the declared native coding surface through
+    // a sandbox policy that permits every one of those tools.
     toolPolicyRestricted:
       params.swarmCollector === true ||
       explicitPolicies.some((explicitPolicy) =>
         toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
       ),
+    nativeCodeToolPolicyRestricted:
+      params.swarmCollector === true ||
+      nonSandboxExplicitPolicies.some((explicitPolicy) =>
+        toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
+      ) ||
+      sandboxNativeCodePolicyRestricted,
   };
+}
+
+function normalizeHarnessNativeToolNames(
+  nativeToolNames: readonly string[] | undefined,
+): string[] | undefined {
+  if (!Array.isArray(nativeToolNames) || nativeToolNames.length === 0) {
+    return undefined;
+  }
+  const normalizedNames: string[] = [];
+  const seen = new Set<string>();
+  for (const nativeToolName of nativeToolNames) {
+    if (typeof nativeToolName !== "string") {
+      return undefined;
+    }
+    const normalizedName = normalizeToolPolicyName(nativeToolName);
+    if (
+      !normalizedName ||
+      normalizedName === "*" ||
+      !isKnownCoreToolId(normalizedName) ||
+      seen.has(normalizedName)
+    ) {
+      return undefined;
+    }
+    seen.add(normalizedName);
+    normalizedNames.push(normalizedName);
+  }
+  return normalizedNames;
+}
+
+function sandboxPolicyRestrictsHarnessNativeTools(
+  policy: PluginHarnessToolPolicy | undefined,
+  nativeToolNames: readonly string[] | undefined,
+): boolean {
+  if (!policy) {
+    return false;
+  }
+  const normalizedNames = normalizeHarnessNativeToolNames(nativeToolNames);
+  if (!normalizedNames) {
+    return true;
+  }
+  return normalizedNames.some((nativeToolName) => !isToolAllowed(policy, nativeToolName));
 }
 
 function collectHarnessSafeDeniedToolNames(

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -400,6 +400,12 @@ type AgentHarnessRunCapability<
    * against native equivalents. Every other deny remains fail-closed.
    */
   conversationToolPolicySafeDenyTools?: readonly string[];
+  /**
+   * Complete canonical OpenClaw tool names equivalent to the harness's native coding surface.
+   * Sandbox policy disables that surface unless every declared coding tool is allowed. Other
+   * native capabilities remain governed by pluginHarnessToolPolicyRestricted.
+   */
+  conversationToolPolicyNativeCodeToolNames?: readonly string[];
   supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;
   /** Synchronous private ownership read; no discovery, auth loading, or native connection setup. */
   resolveSessionRuntimeOwnership?(params: {


### PR DESCRIPTION
Closes #143357

## What Problem This Solves

Codex lost its native coding tools in an OpenClaw sandbox even when the effective sandbox policy allowed every declared coding operation.

## Why This Change Was Made

The Codex harness now declares the exact native coding inventory: `exec`, `process`, `read`, `write`, `edit`, and `apply_patch`. Harness selection evaluates every declared name and fails closed for incomplete or malformed declarations.

The public harness contract and Codex harness documentation name this as a coding-only surface. They explicitly keep every other native capability under the existing broad restriction.

The implementation keeps two policy facts separate:

- a narrow native-code restriction controls only those six coding operations;
- the existing broad restriction continues to isolate ambient native capabilities, including `view_image`, apps, hooks, plugins, and inherited MCP servers.

This preserves an explicit `view_image` deny while allowing the six coding tools. The same restricted configuration is rebuilt for fresh and resumed Codex threads. Before choosing the native surface, OpenClaw now checks administrator-managed shell requirements; when native shell is pinned off, the attempt uses the policy-filtered OpenClaw coding replacements instead of failing startup.

## User Impact

Sandboxed Codex sessions can use native coding operations when all six are allowed. Any missing or denied coding operation disables that native coding surface. Other restricted native capabilities remain disabled. When image inspection is policy-allowed, the policy-filtered OpenClaw `view_image` tool remains available while Codex's native image loader is isolated.

## Evidence

- Focused harness and native-surface suites pass: 2 files, 283 tests.
- The complete Codex dynamic-tool and vision suites pass: 2 files, 124 tests, including native image, OpenClaw fallback image, and native-coding-plus-ambient-isolation cases.
- A full attempt regression passes for managed `shell_tool=false`: native mode is disabled before thread creation, all six filtered OpenClaw coding tools remain, and managed shell features remain off.
- Fresh-thread and resumed-thread regression coverage verifies that native code features stay enabled while `view_image`, apps, hooks, plugins, and inherited MCP stay disabled.
- A managed-requirements regression verifies that `view_image=true` is rejected before `thread/start`, even while native code mode is enabled.
- The focused lifecycle assertions pass individually: 2 tests passed.
- Fresh `pnpm check` passes. After the managed-shell fallback and contract clarification, `pnpm check:changed` also passes all selected guards, type checks, dead-export scans, and lint lanes.
- Documentation link validation passes: 12,610 internal links checked, zero broken.
- Fresh `pnpm build` passes.
- A corrected bounded live run on exact revision `020a00167821ebf18b3d63c0da82021af0b1fd4a` used `openai/gpt-5.6-sol` through the Codex harness with no reroute. A fresh turn invoked native `bash` in the isolated container as uid 502, gid 20, in `/workspace` and wrote `FRESH_ALLOWED_WRITE`.
- The next turn resumed the same native session (`6a6e050b-5974-47f7-b6ff-1b5bb0056d06`), invoked native `bash`, and wrote `RESUMED_ALLOWED_WRITE`. After the cloned sandbox policy added explicit denies for `exec`, `process`, `write`, `edit`, and `apply_patch`, a third turn in that same session returned `DENIED_EXEC_UNAVAILABLE`, recorded zero successful tools, and left the protected marker exactly `DENIED_MUST_REMAIN`.
- The live proof ran with network disabled, a read-only container root, all Linux capabilities dropped, and `no-new-privileges`. Cleanup stopped only the container created by the attempt, stopped Colima, restored the original Colima configuration byte for byte, verified the qualified OpenClaw configuration was unchanged, deleted the cloned credential state, and released the exclusive QA lock.
- The earlier `pnpm test:changed` run selected 7,759 tests: 7,739 passed, 19 skipped, and one environment-only `C.UTF-8`/macOS `shasum` failure passed on exact rerun with `en_US.UTF-8`.
- The full `pnpm test` lane was not completed locally after it disclosed 661 shards; the repository's changed-test lane and focused suites were used.
