### PR TITLE
refactor(synology): keep body failures with the response owner

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -306,6 +306,27 @@ describe("createWebhookHandler", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 without admission when the request stream fails", async () => {
+    const receive = vi.fn();
+    const handler = createWebhookHandlerWithIngress({
+      account: makeAccount(),
+      receive,
+      log,
+    });
+
+    const req = makeStalledReq("POST");
+    const res = makeRes();
+    const pending = handler(req, res);
+    req.emit("data", Buffer.from(validBody));
+    req.emit("error", new Error("request stream failed"));
+    await pending;
+
+    expect(res.status).toBe(400);
+    expect(res.body).toBe(JSON.stringify({ error: "Invalid request body" }));
+    expect(res.headers["x-openclaw-delivery-accepted"]).toBeUndefined();
+    expect(receive).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "413 when the upload exceeds the pre-auth body limit",

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -150,46 +150,6 @@ function getSynologyWebhookInFlightKey(account: ResolvedSynologyChatAccount): st
   return account.accountId;
 }
 
-/** Read the full request body as a string. */
-async function readBody(
-  req: IncomingMessage,
-  timeoutMs: number = PREAUTH_BODY_TIMEOUT_MS,
-): Promise<
-  | { ok: true; body: string }
-  | {
-      ok: false;
-      statusCode: number;
-      error: string;
-      /** Limit rejections own the connection, so their answer goes through the transport. */
-      closeAfterResponse: boolean;
-    }
-> {
-  try {
-    const body = await readRequestBodyWithLimit(req, {
-      maxBytes: PREAUTH_MAX_BODY_BYTES,
-      timeoutMs,
-      // Defer destruction so the caller can answer before the connection closes.
-      destroyOnLimit: false,
-    });
-    return { ok: true, body };
-  } catch (err) {
-    if (isRequestBodyLimitError(err)) {
-      return {
-        ok: false,
-        statusCode: err.statusCode,
-        error: requestBodyErrorToText(err.code),
-        closeAfterResponse: true,
-      };
-    }
-    return {
-      ok: false,
-      statusCode: 400,
-      error: "Invalid request body",
-      closeAfterResponse: false,
-    };
-  }
-}
-
 function firstNonEmptyString(value: unknown): string | undefined {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -414,26 +374,36 @@ async function parseWebhookPayloadRequest(params: {
 }): Promise<
   { ok: false } | { ok: true; payload: SynologyWebhookPayload; rawEvent: SynologyWebhookRawEvent }
 > {
-  const bodyResult = await readBody(params.req, params.bodyTimeoutMs);
-  if (!bodyResult.ok) {
-    params.log?.error("Failed to read request body", bodyResult.error);
-    if (bodyResult.closeAfterResponse) {
+  let body: string;
+  try {
+    body = await readRequestBodyWithLimit(params.req, {
+      maxBytes: PREAUTH_MAX_BODY_BYTES,
+      timeoutMs:
+        params.bodyTimeoutMs === undefined ? PREAUTH_BODY_TIMEOUT_MS : params.bodyTimeoutMs,
+      // Defer destruction so the rejection owner can flush its response before closing.
+      destroyOnLimit: false,
+    });
+  } catch (err) {
+    const limited = isRequestBodyLimitError(err);
+    const error = limited ? requestBodyErrorToText(err.code) : "Invalid request body";
+    params.log?.error("Failed to read request body", error);
+    if (limited) {
       await sendHttpRequestRejection(
         params.req,
         params.res,
-        bodyResult.statusCode,
-        JSON.stringify({ error: bodyResult.error }),
+        err.statusCode,
+        JSON.stringify({ error }),
         "application/json",
       );
       return { ok: false };
     }
-    respondJson(params.res, bodyResult.statusCode, { error: bodyResult.error });
+    respondJson(params.res, 400, { error });
     return { ok: false };
   }
 
   let raw: ReturnType<typeof parseRawEvent>;
   try {
-    raw = parseRawEvent(params.req, bodyResult.body);
+    raw = parseRawEvent(params.req, body);
   } catch (err) {
     params.log?.warn("Failed to parse webhook payload", err);
     respondJson(params.res, 400, { error: "Invalid request body" });


### PR DESCRIPTION
## What Problem This Solves

Keeps Synology Chat webhook body failures and their HTTP responses under one owner, removing a private adapter that converted the canonical bounded reader's outcome into another result envelope.

## Why This Change Was Made

The existing payload-response owner now calls the shared bounded reader directly. Size and timeout failures still use the rejection transport and await connection closure before releasing the pre-auth limiter. Ordinary stream errors still return JSON 400 without admitting an event. The 64 KiB cap, undefined-only timeout default, authentication, rate limits, durable admission and public SDK surface are unchanged.

Production LOC: +18/-48 (net -30). Tests: +21/-0. No configuration, dependency, protocol or storage change.

## User Impact

No intended user-visible behavior change. Oversized or stalled requests retain their complete rejection response and connection cleanup; failed streams cannot receive a durable-acceptance acknowledgement.

## Evidence

- Original handler suite: 27 passed, including real TCP 413/408 response-and-close cases.
- New ordinary stream-error preservation case passed against unchanged production before the refactor: 1 passed, 27 skipped.
- Candidate suite and the refreshed-main suite: 28 passed each, including the real TCP cases and the added error case.
- Formatting and diff checks passed. Independent precommit review and a separate read-only exact-commit Codex review through P2 found no actionable defects.
- The first changed gate stopped on an unrelated compatibility record whose removal date had elapsed. This branch was refreshed onto main's existing disposition; no date override, permission change or guard bypass was added. The patch and HTTP body/lifecycle owners remained byte-identical through that refresh.
- Refreshed configured changed gate: all 25 stages passed on Linux Node 24.19.0, including production/test typechecks, SDK boundary declarations, lint and architecture guards. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34396007639), native command exit 0; the one-shot lease stopped normally. A runner-portal reporting timeout did not affect that result.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34397428874) passed on c42a6503e1fcc9753e285e652b2555c4469b98cd, attempt 1: 29 successful jobs and 17 conditionally skipped jobs, including successful openclaw/ci-gate. Completed ClawSweeper review has no findings or before-merge moves.
- No NAS/vendor service execution is claimed; the changed transport boundary is exercised with real loopback HTTP connections.
