### PR TITLE
fix(doctor): avoid unnecessary database reopen work during updates

### DIFF
--- a/src/commands/doctor-agent-memory-schema.test.ts
+++ b/src/commands/doctor-agent-memory-schema.test.ts
@@ -5,8 +5,10 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { AGENT_DATABASE_MAINTENANCE_LEASE } from "../state/openclaw-agent-db-lease.js";
+import { invalidateRegisteredAgentDatabasesMemo } from "../state/openclaw-agent-db-registry-listing.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import {
@@ -279,6 +281,8 @@ describe("doctor agent memory schema repair", () => {
 
   it("leaves a fresh canonical database untouched", async () => {
     const { databasePath, env } = createRegisteredAgentDatabase();
+    const options = { agentId: "worker-1", env };
+    const admitted = openOpenClawAgentDatabase(options);
     const beforeSql = readMemoryChunkTableSql(databasePath);
     const beforeStat = fs.statSync(databasePath);
 
@@ -289,6 +293,8 @@ describe("doctor agent memory schema repair", () => {
 
     const afterStat = fs.statSync(databasePath);
     expect(report).toEqual({ repaired: [], warnings: [] });
+    expect(admitted.db.isOpen).toBe(true);
+    expect(openOpenClawAgentDatabase(options)).toBe(admitted);
     expect(readMemoryChunkTableSql(databasePath)).toBe(beforeSql);
     expect({ mtimeMs: afterStat.mtimeMs, size: afterStat.size }).toEqual({
       mtimeMs: beforeStat.mtimeMs,
@@ -325,4 +331,109 @@ describe("doctor agent memory schema repair", () => {
       repaired.close();
     }
   });
+
+  it.each(["already-repaired", "new-repair"])(
+    "rediscovers memory repairs after acquiring maintenance: %s",
+    async (change) => {
+      const { databasePath, env } = createRegisteredAgentDatabase();
+      const laterPath = openOpenClawAgentDatabase({ agentId: "worker-2", env }).path;
+      closeOpenClawAgentDatabasesForTest();
+      recreateUnreleasedInlineMemoryMetadata(databasePath);
+      const agentDatabase = await import("../state/openclaw-agent-db.js");
+      const withLease = agentDatabase.withAgentDatabaseMaintenanceLease;
+      const lease = vi
+        .spyOn(agentDatabase, "withAgentDatabaseMaintenanceLease")
+        .mockImplementationOnce((options, run) =>
+          withLease(options, async (maintenance) => {
+            if (change === "already-repaired") {
+              await agentDatabase.migrateOpenClawAgentDatabaseForMaintenance(
+                { agentId: "worker-1", pathname: databasePath },
+                maintenance,
+              );
+            } else {
+              recreateUnreleasedInlineMemoryMetadata(laterPath);
+            }
+            return run(maintenance);
+          }),
+        );
+      try {
+        const report = await noteDoctorAgentMemorySchemaHealth(
+          { env, shouldRepair: true },
+          { note: vi.fn() },
+        );
+        expect(report.warnings).toEqual([]);
+        expect(report.repaired.map((repair) => repair.path)).toEqual(
+          change === "already-repaired" ? [] : [databasePath, laterPath],
+        );
+        expect(readMemoryChunkColumns(databasePath)).not.toContain("importance");
+        expect(readMemoryChunkColumns(laterPath)).not.toContain("importance");
+      } finally {
+        lease.mockRestore();
+      }
+    },
+  );
+
+  it.each(["before-doctor", "before-lease"])(
+    "discovers a peer registration committed %s despite cached inventory",
+    async (timing) => {
+      const { databasePath, env } = createRegisteredAgentDatabase();
+      const peerPath = openOpenClawAgentDatabase({ agentId: "worker-2", env }).path;
+      closeOpenClawAgentDatabasesForTest();
+      recreateUnreleasedInlineMemoryMetadata(peerPath);
+      if (timing === "before-lease") {
+        recreateUnreleasedInlineMemoryMetadata(databasePath);
+      }
+      const state = openOpenClawStateDatabase({ env });
+      const row = state.db
+        .prepare(
+          "SELECT agent_id,path,schema_version,last_seen_at,size_bytes FROM agent_databases WHERE agent_id = ?",
+        )
+        .get("worker-2");
+      if (!row) {
+        throw new Error("missing peer fixture registration");
+      }
+      state.db.prepare("DELETE FROM agent_databases WHERE agent_id = ?").run("worker-2");
+      invalidateRegisteredAgentDatabasesMemo({ env });
+      expect(listOpenClawRegisteredAgentDatabases({ env }).map((entry) => entry.agentId)).toEqual([
+        "worker-1",
+      ]);
+      const publishPeerRegistration = () => {
+        // A peer commit does not invalidate this process's registry memo.
+        const peer = openNodeSqliteDatabase(state.path);
+        try {
+          peer
+            .prepare(
+              "INSERT INTO agent_databases(agent_id,path,schema_version,last_seen_at,size_bytes) VALUES(?,?,?,?,?)",
+            )
+            .run(...Object.values(row));
+        } finally {
+          peer.close();
+        }
+      };
+      const agentDatabase = await import("../state/openclaw-agent-db.js");
+      const withLease = agentDatabase.withAgentDatabaseMaintenanceLease;
+      const lease = vi.spyOn(agentDatabase, "withAgentDatabaseMaintenanceLease");
+      if (timing === "before-doctor") {
+        publishPeerRegistration();
+      } else {
+        lease.mockImplementationOnce((options, run) => {
+          publishPeerRegistration();
+          return withLease(options, run);
+        });
+      }
+      try {
+        const report = await noteDoctorAgentMemorySchemaHealth(
+          { env, shouldRepair: true },
+          { note: vi.fn() },
+        );
+        expect(report.warnings).toEqual([]);
+        expect(report.repaired.map((repair) => repair.path)).toEqual(
+          timing === "before-doctor" ? [peerPath] : [databasePath, peerPath],
+        );
+        expect(readMemoryChunkColumns(peerPath)).not.toContain("importance");
+      } finally {
+        lease.mockRestore();
+      }
+    },
+  );
 });

--- a/src/commands/doctor-agent-memory-schema.ts
+++ b/src/commands/doctor-agent-memory-schema.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { invalidateRegisteredAgentDatabasesMemo } from "../state/openclaw-agent-db-registry-listing.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   listOpenClawRegisteredAgentDatabases,
@@ -81,12 +82,32 @@ function inspectAgentMemoryRecallMetadataMigration(
   }
 }
 
+function needsAgentMemorySchemaMaintenance(env: NodeJS.ProcessEnv): boolean {
+  try {
+    // Doctor discovery must observe registrations committed by another process.
+    invalidateRegisteredAgentDatabasesMemo({ env });
+    return listOpenClawRegisteredAgentDatabases({
+      env,
+      includeIncompatibleSchemaVersions: true,
+    }).some((entry) => {
+      const state = inspectAgentMemoryRecallMetadataMigration(entry.path);
+      return Boolean(state && (state.columns.length > 0 || state.hasProvenanceTrigger));
+    });
+  } catch {
+    // Uncertain inspection must retain the maintenance path and its diagnostics.
+    return true;
+  }
+}
+
 /** Move the unreleased inline metadata shape into rollback-safe additive tables. */
 async function repairDoctorAgentMemorySchemas(
   options: { env?: NodeJS.ProcessEnv },
   maintenance: OpenClawStateLeaseContext,
 ): Promise<DoctorAgentMemorySchemaReport> {
   const env = options.env ?? process.env;
+  maintenance.assertOwned();
+  // The preliminary scan may have populated the memo before lease acquisition.
+  invalidateRegisteredAgentDatabasesMemo({ env });
   const repaired: DoctorAgentMemorySchemaRepair[] = [];
   const warnings: string[] = [];
   let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases>;
@@ -158,10 +179,16 @@ export async function noteDoctorAgentMemorySchemaHealth(
     report = await withDoctorSqliteMaintenanceLock({
       env: params.env,
       operation: "agent memory schema repair",
-      run: () =>
-        withAgentDatabaseMaintenanceLease({ env: params.env }, (maintenance) =>
+      run: () => {
+        // Acquiring the agent lease closes admitted writers. Keep a read-only
+        // no-op cheap; real repairs rediscover every target under that lease.
+        if (!needsAgentMemorySchemaMaintenance(params.env ?? process.env)) {
+          return { repaired: [], warnings: [] };
+        }
+        return withAgentDatabaseMaintenanceLease({ env: params.env }, (maintenance) =>
           repairDoctorAgentMemorySchemas({ env: params.env }, maintenance),
-        ),
+        );
+      },
     });
   } catch (error) {
     if (!(error instanceof DoctorSqliteMaintenanceLockUnavailableError)) {

--- a/src/flows/doctor-health-contributions-final.ts
+++ b/src/flows/doctor-health-contributions-final.ts
@@ -168,6 +168,7 @@ export function resolveFinalDoctorHealthContributions(params: {
     createDoctorHealthContribution({
       id: "doctor:github-projects",
       label: "GitHub projects",
+      updatePolicy: "standalone",
       run: runGitHubProjectHealth,
     }),
     createDoctorHealthContribution({
@@ -291,6 +292,7 @@ export function resolveFinalDoctorHealthContributions(params: {
     createDoctorHealthContribution({
       id: "doctor:bootstrap-size",
       label: "Bootstrap size",
+      updatePolicy: "standalone",
       healthCheckIds: ["core/doctor/bootstrap-size"],
       run: runBootstrapSizeHealth,
     }),

--- a/src/flows/doctor-health.update-scope.test.ts
+++ b/src/flows/doctor-health.update-scope.test.ts
@@ -37,6 +37,17 @@ vi.mock("../commands/doctor-db-bloat.js", () => ({
     obs.events.push("db-size-advice");
   },
 }));
+vi.mock("../commands/doctor-bootstrap-size.js", () => ({
+  noteBootstrapFileSize: () => {
+    obs.events.push("bootstrap-size-advice");
+  },
+}));
+vi.mock("../gateway/control-ui-github-api.js", () => ({
+  hasConfiguredGitHubApiCredential: () => {
+    obs.events.push("github-credential-advice");
+    return false;
+  },
+}));
 vi.mock("../commands/doctor/shared/active-tool-schema-warnings.js", () => ({
   collectActiveToolSchemaProjectionWarnings: async () => {
     obs.events.push("active-tool-schema");
@@ -91,6 +102,8 @@ describe("update Doctor diagnostic scope", () => {
         "doctor:db-bloat",
         "doctor:active-tool-schema-warnings",
         "doctor:workspace-suggestions",
+        "doctor:github-projects",
+        "doctor:bootstrap-size",
       ]);
       const selected = resolveDoctorHealthContributions().filter((c) => ids.has(c.id));
       expect(selected).toHaveLength(ids.size);
@@ -111,11 +124,13 @@ describe("update Doctor diagnostic scope", () => {
               "project-git",
               "project-git",
               "db-size-advice",
+              "github-credential-advice",
+              "bootstrap-size-advice",
               "workspace-suggestions",
             ]
           : [],
       );
-      expect(snapshot).toHaveBeenCalledTimes(mode === "standalone" ? 4 : 0);
+      expect(snapshot).toHaveBeenCalledTimes(mode === "standalone" ? ids.size : 0);
       if (mode === "standalone") {
         expect(obs.note).toHaveBeenCalledWith("synthetic advisory", "Doctor warnings");
         expect(obs.note).not.toHaveBeenCalledWith(expect.anything(), "Update Doctor scope");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Doctor during an update would incur unnecessary database reopen work even when agent memory schemas were already canonical. Updates also ran GitHub credential-presence and bootstrap-size advisories that cannot repair or block the update.

## Why This Change Was Made

Memory-schema Doctor now inspects for repair candidates under the existing Gateway/SQLite maintenance lock before acquiring the agent maintenance lease. A confirmed no-op preserves admitted database handles. A candidate or inspection error retains the existing maintenance path, including fresh inventory and schema inspection after lease acquisition. Both discovery points invalidate the registry memo so peer registrations remain visible.

GitHub and bootstrap advisories use the existing standalone-only policy. Standalone Doctor retains both; package-swap and post-core update modes skip their handlers and plugin snapshot acquisition.

Full integrity checks on physical writable opens, actual repairs, maintenance fencing, migration refusals, SQLite schemas, and persistent-state semantics are unchanged. This does not change updater automation, cutover, rollback, or live runtime state.

## User Impact

Healthy memory databases avoid a needless close/reopen cycle during no-op Doctor maintenance. Updates omit two advisory-only checks while standalone diagnostics remain available.

This removes reproduced work, but does not establish a fleet downtime reduction. Media-history scanning and post-plugin checks remain unchanged: current-schema history can still contain legacy content, and post-plugin work already has a change/readiness gate. The investigation did not establish a safe shortcut for either.

## Evidence

- The unmodified base reproduced both failures: no-op Doctor closed the healthy writer, and both update modes ran both advisories. Standalone remained a passing control.
- The proposed head preserved the same open writer and skipped the advisories only in update modes. Independent source-blind validation passed all five contract clauses twice with fresh synthetic state.
- 42 focused tests passed across memory-schema maintenance, SQLite lock/lease guards, update scope, and migration refusal handling. Coverage includes legacy v17/v18 row preservation, canonical no-op preservation, index repair, lost authority, inventory changes, and peer registrations before Doctor/lease acquisition. The new no-op and update-scope assertions fail on the base for the expected reasons.
- `check:changed` completed successfully. Final affected type checks, memory tests, formatting, and diff checks also passed after the fixture/type refinement. Independent autoreview reported no P0 findings; that review was P0-scoped, not an all-priority approval.
- Local proof used Node 24.20.0 and synthetic state. No full CLI/fleet update or production timing benchmark was run. The advisory adapter invokes the real handlers through the real dispatcher but records snapshot-callback acquisitions rather than creating real plugin database snapshots.

Before: healthy writer is closed; update advisories still run.

https://github.com/user-attachments/assets/e44a2910-9673-47e5-a627-d94814d0f6a5

After: healthy writer stays open; update advisories are skipped; standalone output is preserved.

https://github.com/user-attachments/assets/d6437e1a-1691-47e4-b37b-fb481872a155

### Artifact manifest

The recordings show real Doctor-owner boundary checks, not a complete update. Terminal output was captured without acceleration; the final frame is held for four seconds. Both MP4s were inspected before upload. No runtime logs, user data, or agent transcripts are included.

```json
{
  "contract": "Preserve the admitted writer on a canonical memory-schema no-op; run GitHub/bootstrap advisories only in standalone Doctor; preserve the synthetic workspace",
  "environment": "macOS, Node v24.20.0, synthetic isolated state, local execution",
  "base_sha": "ac0a263eebf99c5f532d2ae1b0c0eba7c5382c95",
  "head_sha": "72dfadcd841094f3e466e3010b79fb8b7629efd9",
  "base_exit": 1,
  "head_exit": 0,
  "base_video": {
    "url": "https://github.com/user-attachments/assets/e44a2910-9673-47e5-a627-d94814d0f6a5",
    "sha256": "676fcf6fef0658838c789a4835669ba45018bcc781005c5f09458ffb495fc308"
  },
  "head_video": {
    "url": "https://github.com/user-attachments/assets/d6437e1a-1691-47e4-b37b-fb481872a155",
    "sha256": "68c748f8f2ea2e2cde2c4a024fa18a838f672a56a15741b39afbe3a9d17c7791"
  }
}
```

The branch was created from freshly fetched canonical main and updated to `baf7c80c0c1ae9fd6b3b71469ab7742d6627b6c0` before publication. Intervening changes were confined to unrelated Android UI and DeepSeek test assertions; all four authored files were byte-identical after the rebase. The recorded head and both source-blind candidate runs are on the final commit above.
