### PR TITLE
refactor(tests): share Feishu fetched-message inputs

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -90,6 +90,21 @@ vi.mock("./channel.runtime.js", () => ({
   },
 }));
 
+function createFetchedTextMessage(
+  messageId: string,
+  chatId: string,
+  chatType: "group" | "private",
+  content: string,
+) {
+  return {
+    messageId,
+    chatId,
+    chatType,
+    content,
+    contentType: "text",
+  };
+}
+
 function describeFeishuMessageTool(cfg: OpenClawConfig, accountId?: string) {
   return feishuPlugin.actions?.describeMessageTool?.({ cfg, accountId });
 }
@@ -2489,13 +2504,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("reads messages", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_1", "oc_group_1", "group", "hello"),
+    );
 
     const result = await feishuPlugin.actions?.handleAction?.({
       action: "read",
@@ -2517,13 +2528,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("reads an explicit group target authorized only by groupAllowFrom", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_group_allow_from",
-      chatId: "oc_group_allow_from",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_group_allow_from", "oc_group_allow_from", "group", "hello"),
+    );
 
     await expect(
       feishuPlugin.actions?.handleAction?.({
@@ -2571,13 +2578,9 @@ describe("feishuPlugin actions", () => {
       chat_mode: "group",
       chat_type: "private",
     });
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_open_group",
-      chatId: "oc_open_group",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_open_group", "oc_open_group", "group", "hello"),
+    );
 
     await expect(
       feishuPlugin.actions?.handleAction?.({
@@ -2646,13 +2649,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("resolves private message visibility before applying read policy", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_private_group",
-      chatId: "oc_group_1",
-      chatType: "private",
-      content: "hidden",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_private_group", "oc_group_1", "private", "hidden"),
+    );
 
     await expect(
       feishuPlugin.actions?.handleAction?.({
@@ -2698,13 +2697,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("edits messages", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_2",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "before",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_2", "oc_group_1", "group", "before"),
+    );
     editMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_2", contentType: "post" });
 
     const result = await feishuPlugin.actions?.handleAction?.({
@@ -2973,13 +2968,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("creates pins", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_pin",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "pin me",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_pin", "oc_group_1", "group", "pin me"),
+    );
     createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
 
     const result = await feishuPlugin.actions?.handleAction?.({
@@ -3032,13 +3023,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("removes pins", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_pin",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "unpin me",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_pin", "oc_group_1", "group", "unpin me"),
+    );
     const result = await feishuPlugin.actions?.handleAction?.({
       action: "unpin",
       params: { messageId: "om_pin" },
@@ -3369,13 +3356,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("adds a reaction after authorizing the direct operator's ID-only target", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_msg1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_msg1", "oc_group_1", "group", "hello"),
+    );
 
     const result = await feishuPlugin.actions?.handleAction?.({
       action: "react",
@@ -3395,13 +3378,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("allows explicit clearAll=true when removing all bot reactions", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_msg1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_msg1", "oc_group_1", "group", "hello"),
+    );
     listReactionsFeishuMock.mockResolvedValueOnce([
       { reactionId: "r1", operatorType: "app", operatorId: "cli_main" },
       { reactionId: "r2", operatorType: "app", operatorId: "cli_main" },
@@ -3440,13 +3419,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("removes an own reaction from an authorized Feishu message", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_msg1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_msg1", "oc_group_1", "group", "hello"),
+    );
     listReactionsFeishuMock.mockResolvedValueOnce([
       { reactionId: "r-other", operatorType: "app", operatorId: "cli_other" },
       { reactionId: "r1", operatorType: "app", operatorId: "cli_main" },
@@ -3474,13 +3449,9 @@ describe("feishuPlugin actions", () => {
   });
 
   it("does not remove another app's matching reaction", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_msg1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_msg1", "oc_group_1", "group", "hello"),
+    );
     listReactionsFeishuMock.mockResolvedValueOnce([
       { reactionId: "r-other", operatorType: "app", operatorId: "cli_other" },
       { reactionId: "r-user", operatorType: "user", operatorId: "ou_user" },
@@ -3504,13 +3475,9 @@ describe("feishuPlugin actions", () => {
 
   it("lists reactions from an authorized Feishu message", async () => {
     const reactions = [{ reactionId: "r1", operatorType: "app", operatorId: "cli_main" }];
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_msg1",
-      chatId: "oc_group_1",
-      chatType: "group",
-      content: "hello",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_msg1", "oc_group_1", "group", "hello"),
+    );
     listReactionsFeishuMock.mockResolvedValueOnce(reactions);
 
     const result = await feishuPlugin.actions?.handleAction?.({
@@ -3711,13 +3678,9 @@ describe("feishuPlugin actions", () => {
   );
 
   it("rejects a Feishu message returned from a different chat than the authorized target", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_other",
-      chatId: "oc_other",
-      chatType: "group",
-      content: "hidden",
-      contentType: "text",
-    });
+    getMessageFeishuMock.mockResolvedValueOnce(
+      createFetchedTextMessage("om_other", "oc_other", "group", "hidden"),
+    );
 
     await expect(
       feishuPlugin.actions?.handleAction?.({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Feishu action tests repeat the same five-field fetched-message structure around different read, edit, pin, and reaction scenarios.

## Why This Change Was Made

Use a local text-message fixture with four required arguments. All 13 input sites retain their message ID, chat ID, chat type, and content, including the noncanonical private type and wrong-chat response. Every case and independent assertion remains unchanged. This removes 37 net test lines.

## User Impact

No runtime, authentication, or action behavior changes. Existing target-binding, metadata classification, reaction ownership, and call-order checks remain intact.

## Evidence

- Complete channel, read-policy, and reactions suites before and after: the same 281 ordered cases passed, with no skipped cases.
- Parser-derived expansion reproduces the original syntax tree and source, including all 13 inputs.
- Fresh-object checks preserve five-key order, descriptors, field absence, and mutation independence.
- Mapped changed-file gate and fresh independent P2 review passed.
