### PR TITLE
fix(browser): prevent premature existing-session timeouts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -90,7 +90,7 @@ extensions/browser/src/browser/pw-tools-core.snapshot.ts	1
 extensions/browser/src/browser/pw-tools-core.state.ts	2
 extensions/browser/src/browser/routes/agent.act.normalize.ts	1
 extensions/browser/src/browser/routes/agent.act.shared.ts	3
-extensions/browser/src/browser/routes/agent.act.ts	2
+extensions/browser/src/browser/routes/agent.act.ts	1
 extensions/browser/src/browser/routes/agent.shared.ts	2
 extensions/browser/src/browser/routes/agent.snapshot.ts	8
 extensions/browser/src/browser/routes/agent.storage.ts	2

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -17,7 +17,6 @@ extensions/browser/src/browser/chrome.internal.test.ts
 extensions/browser/src/browser/chrome.ts
 extensions/browser/src/browser/extension-relay/relay-bridge.ts
 extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
-extensions/browser/src/browser/routes/agent.act.ts
 extensions/browser/src/browser/routes/agent.snapshot.ts
 extensions/browser/src/cli/browser-cli-manage.ts
 extensions/codex/doctor-contract-api.test.ts

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -375,7 +375,7 @@ The default existing-session path is host-only Chrome MCP auto-connect. If the b
 Current existing-session limits:
 
 - Snapshot-driven actions use refs, not CSS selectors.
-- Supported `act` requests use a built-in 60000 ms default when callers omit `timeoutMs`; per-call `timeoutMs` still wins.
+- Supported `act` requests use a built-in 60000 ms default when callers omit `timeoutMs`; accepted per-call overrides set that action budget.
 - `click` is left-click only.
 - `type` does not support `slowly=true`.
 - `press` does not support `delayMs`.
@@ -386,6 +386,10 @@ Current existing-session limits:
 - Dialog hooks do not support `--timeout`.
 - Screenshots support page captures and `--ref`, but not CSS `--element`.
 - `responsebody`, download interception, PDF export, and batch actions still require a managed browser or raw CDP profile.
+
+Existing-session action steps share one execution budget: filling and submitting with `type` do not each receive a fresh timeout. A conditional `wait` allows its explicit `timeMs` delay plus the action budget (with a 250 ms minimum) to satisfy the condition. A pure timer wait reserves the larger of `timeMs` and the action budget.
+
+Navigation verification has a separate shared allowance of the action budget plus 1250 ms for scheduled delays; `resize` and `close` skip verification. Browser and tab preparation, execution, and final URL lookup share the overall request deadline. Internal calls and navigation probes do not renew it.
 
 ## Remote browser control (node host proxy)
 

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -33,7 +33,10 @@ import {
   wrapBrowserExternalJson,
   wrapBrowserExternalText,
 } from "./browser-tool.snapshot.js";
-import { resolveBrowserActRequestTimeoutMs } from "./browser/act-policy.js";
+import {
+  EXISTING_SESSION_TIMEOUT_OVERRIDE_KINDS,
+  resolveBrowserActRequestTimeoutMs,
+} from "./browser/act-policy.js";
 import type {
   BrowserBatchAbort,
   BrowserBatchActionResult,
@@ -73,14 +76,6 @@ const ACT_TIMEOUT_KINDS = new Set([
   "evaluate",
   "wait",
 ]);
-const EXISTING_SESSION_TIMEOUT_REJECTED_KINDS = new Set([
-  "type",
-  "hover",
-  "scrollIntoView",
-  "drag",
-  "select",
-  "fill",
-]);
 
 function normalizePositiveTimeoutMs(value: unknown): number | undefined {
   return readPositiveIntegerParam({ value }, "value", {
@@ -102,7 +97,7 @@ function withLocalActTimeout(
   if (
     normalizePositiveTimeoutMs(typedRequest.timeoutMs) !== undefined ||
     !ACT_TIMEOUT_KINDS.has(request.kind) ||
-    (usesChromeMcp && EXISTING_SESSION_TIMEOUT_REJECTED_KINDS.has(request.kind))
+    (usesChromeMcp && !EXISTING_SESSION_TIMEOUT_OVERRIDE_KINDS.has(request.kind))
   ) {
     return request;
   }

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3634,7 +3634,7 @@ describe("browser tool act compatibility", () => {
     });
 
     const { options, request } = lastNodeInvokeCall();
-    expect(options.timeoutMs).toBe(80_000);
+    expect(options.timeoutMs).toBe(126_250);
     expect(request.params?.path).toBe("/act");
     expect(request.params?.body).toEqual({
       kind: "wait",
@@ -3642,7 +3642,7 @@ describe("browser tool act compatibility", () => {
       text: "ready",
       timeoutMs: "45000",
     });
-    expect(request.params?.timeoutMs).toBe(70_000);
+    expect(request.params?.timeoutMs).toBe(116_250);
   });
 
   it("sizes node proxy calls for recursively nested batch execution", async () => {

--- a/extensions/browser/src/browser/act-policy.test.ts
+++ b/extensions/browser/src/browser/act-policy.test.ts
@@ -27,29 +27,35 @@ describe("browser action request deadlines", () => {
       textGone: "loading",
       selector: "#result",
       url: "**/done",
-      loadState: "load",
+      loadState: "networkidle",
       fn: "() => true",
     } as const;
 
     expect(resolveBrowserActRequestTimeoutMs({ ...wait, timeoutMs: 1 })).toBe(8_000);
-    expect(resolveBrowserActRequestTimeoutMs({ ...wait, timeoutMs: Number.MAX_VALUE })).toBe(
-      725_000,
-    );
-  });
-
-  it("matches runtime normalization for whitespace-only wait conditions", () => {
     expect(
       resolveBrowserActRequestTimeoutMs({
-        kind: "wait",
-        timeMs: 0,
-        text: " ",
-        textGone: " ",
-        selector: "",
-        url: " ",
-        fn: " ",
+        kind: "batch",
+        actions: [{ ...wait, timeoutMs: Number.MAX_VALUE }],
       }),
-    ).toBe(45_000);
-    expect(resolveBrowserActRequestTimeoutMs({ kind: "wait", timeMs: 0 })).toBe(5_000);
+    ).toBe(725_000);
+  });
+
+  it("keeps Playwright text whitespace in sequential batch budgets", () => {
+    const wait = {
+      kind: "wait",
+      timeMs: 0,
+      text: " ",
+      textGone: " ",
+      selector: "",
+      url: " ",
+      fn: " ",
+    } as const;
+    expect(
+      resolveBrowserActRequestTimeoutMs({
+        kind: "batch",
+        actions: [wait, wait],
+      }),
+    ).toBe(85_000);
   });
 
   it("recursively sums nested batch children in execution order", () => {
@@ -70,24 +76,30 @@ describe("browser action request deadlines", () => {
     ).toBe(95_000);
   });
 
-  it("keeps leaf defaults and adds outer slack once", () => {
-    expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1" })).toBe(65_000);
+  it("budgets action and verification defaults and adds outer slack once", () => {
+    expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1" })).toBe(126_250);
+    expect(resolveBrowserActRequestTimeoutMs({ kind: "wait", timeMs: 0 })).toBe(126_250);
     expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1", timeoutMs: 45_000 })).toBe(
-      50_250,
+      96_250,
     );
   });
 
   it("budgets sequential leaf phases and bounded delays", () => {
     expect(
       resolveBrowserActRequestTimeoutMs({
-        kind: "fill",
-        fields: [
-          { ref: "first", type: "text" },
-          { ref: "second", type: "text" },
+        kind: "batch",
+        actions: [
+          {
+            kind: "fill",
+            fields: [
+              { ref: "first", type: "text" },
+              { ref: "second", type: "text" },
+            ],
+            timeoutMs: 40_000,
+          },
         ],
-        timeoutMs: 20_000,
       }),
-    ).toBe(45_500);
+    ).toBe(85_500);
     expect(
       resolveBrowserActRequestTimeoutMs({
         kind: "type",
@@ -95,9 +107,9 @@ describe("browser action request deadlines", () => {
         text: "value",
         slowly: true,
         submit: true,
-        timeoutMs: 20_000,
+        timeoutMs: 60_000,
       }),
-    ).toBe(65_250);
+    ).toBe(185_250);
     expect(
       resolveBrowserActRequestTimeoutMs({
         kind: "click",
@@ -113,10 +125,26 @@ describe("browser action request deadlines", () => {
         y: 20,
         doubleClick: true,
         delayMs: 5_000,
-        timeoutMs: 20_000,
+        timeoutMs: 1_000,
       }),
-    ).toBe(40_250);
+    ).toBe(21_250);
   });
+
+  it.each([
+    { kind: "type", ref: "field", text: "value" },
+    { kind: "hover", ref: "field" },
+    { kind: "scrollIntoView", ref: "field" },
+    { kind: "drag", startRef: "first", endRef: "second" },
+    { kind: "select", ref: "field", values: ["value"] },
+    { kind: "fill", fields: [{ ref: "field", type: "text" }] },
+  ] satisfies BrowserActRequest[])(
+    "bounds $kind transport when only Playwright accepts the timeout override",
+    (request) => {
+      expect(
+        resolveBrowserActRequestTimeoutMs({ ...request, timeoutMs: Number.MAX_VALUE }),
+      ).toBeLessThanOrEqual(126_250);
+    },
+  );
 
   it("preserves the prior whole-request floor for batches", () => {
     expect(
@@ -148,9 +176,8 @@ describe("browser action request deadlines", () => {
     ).toBe(86_000);
     expect(
       resolveBrowserActRequestTimeoutMs({
-        kind: "scrollIntoView",
-        ref: "result",
-        timeoutMs: 120_000,
+        kind: "batch",
+        actions: [{ kind: "scrollIntoView", ref: "result", timeoutMs: 120_000 }],
       }),
     ).toBe(125_250);
   });

--- a/extensions/browser/src/browser/act-policy.ts
+++ b/extensions/browser/src/browser/act-policy.ts
@@ -14,6 +14,7 @@ import {
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { BrowserActRequest } from "./client-actions.types.js";
 import { DEFAULT_BROWSER_ACTION_TIMEOUT_MS } from "./constants.js";
+import { normalizeBrowserTimerDelayMs } from "./timer-delay.js";
 
 /** Maximum number of actions accepted in a batched browser action request. */
 export const ACT_MAX_BATCH_ACTIONS = 100;
@@ -25,6 +26,9 @@ export const ACT_MAX_CLICK_DELAY_MS = 5_000;
 export const ACT_MAX_WAIT_TIME_MS = 30_000;
 /** Maximum viewport side length accepted by resize actions. */
 export const ACT_MAX_VIEWPORT_DIMENSION = 8192;
+/** Existing-session actions whose runtime accepts a per-call timeout override. */
+export const EXISTING_SESSION_TIMEOUT_OVERRIDE_KINDS: ReadonlySet<BrowserActRequest["kind"]> =
+  new Set(["click", "clickCoords", "evaluate", "wait"]);
 
 const ACT_MIN_TIMEOUT_MS = 500;
 const ACT_MAX_INTERACTION_TIMEOUT_MS = 60_000;
@@ -36,6 +40,11 @@ const ACT_DEFAULT_WAIT_TIMEOUT_MS = 20_000;
 export const BROWSER_ACTION_TRANSPORT_SLACK_MS = 5_000;
 /** Post-action window that keeps navigation policy interception active. */
 export const BROWSER_ACTION_NAVIGATION_GRACE_MS = 250;
+/** Existing-session verification keeps observing after the action settles. */
+export const EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS = [0, 250, 500] as const;
+const EXISTING_SESSION_NAVIGATION_GRACE_MS =
+  EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS.reduce<number>((total, delay) => total + delay, 0) +
+  (EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS.at(-1) ?? 0);
 
 /** Keep navigation timeouts consistent across transports and browser backends. */
 export function resolveBrowserNavigationTimeoutMs(timeoutMs?: number): number {
@@ -202,6 +211,45 @@ function resolveExecutionBudgetMs(request: BrowserActRequest): number {
   );
 }
 
+/** Bound logical action and verification phases without renewing every MCP call's budget. */
+export function resolveExistingSessionActTimeouts(request: BrowserActRequest) {
+  const requestedTimeoutMs =
+    EXISTING_SESSION_TIMEOUT_OVERRIDE_KINDS.has(request.kind) && "timeoutMs" in request
+      ? parseTimerInteger(request.timeoutMs)
+      : undefined;
+  const timeoutMs = normalizeBrowserTimerDelayMs(
+    requestedTimeoutMs ?? DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
+  );
+  let actionTimeoutMs = timeoutMs;
+  let timerOnlyWait = false;
+  if (request.kind === "wait") {
+    const timeMs = resolveNonNegativeTimerMs(request.timeMs);
+    const hasCondition = [
+      request.text,
+      request.textGone,
+      request.selector,
+      request.url,
+      request.loadState,
+      request.fn,
+    ].some((value) => typeof value === "string" && Boolean(value.trim()));
+    timerOnlyWait = !hasCondition;
+    actionTimeoutMs = hasCondition
+      ? addExecutionBudgetMs(timeMs, Math.max(250, timeoutMs))
+      : Math.max(timeMs, timeoutMs);
+  }
+  const verificationTimeoutMs =
+    request.kind === "resize" || request.kind === "close"
+      ? 0
+      : addExecutionBudgetMs(timeoutMs, EXISTING_SESSION_NAVIGATION_GRACE_MS);
+  return {
+    timeoutMs,
+    // A pure wait's own cancellable timer must win at the requested delay boundary.
+    bodyTimeoutMs: timerOnlyWait ? undefined : actionTimeoutMs,
+    verificationTimeoutMs,
+    requestTimeoutMs: addExecutionBudgetMs(actionTimeoutMs, verificationTimeoutMs),
+  };
+}
+
 /**
  * Resolve the runtime budget before an outer transport watchdog is armed.
  * Wait phases and batch children execute serially, so maxima would abort valid work midway.
@@ -224,9 +272,11 @@ function resolveBrowserActExecutionBudgetMs(request: BrowserActRequest): number 
 
 /** Add action transport slack once after the full sequential runtime budget is known. */
 export function resolveBrowserActRequestTimeoutMs(request: BrowserActRequest): number {
+  const existingSessionBudgetMs =
+    request.kind === "batch" ? 0 : resolveExistingSessionActTimeouts(request).requestTimeoutMs;
   return (
     addTimerTimeoutGraceMs(
-      resolveBrowserActExecutionBudgetMs(request),
+      Math.max(resolveBrowserActExecutionBudgetMs(request), existingSessionBudgetMs),
       BROWSER_ACTION_TRANSPORT_SLACK_MS,
     ) ?? 1
   );

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -535,7 +535,7 @@ describe("browser client", () => {
     );
 
     expect(calls.map((call) => call.init?.timeoutMs)).toEqual([
-      65_000, 35_000, 50_000, 95_000, 12_345,
+      126_250, 56_250, 96_250, 95_000, 12_345,
     ]);
   });
 
@@ -564,7 +564,7 @@ describe("browser client", () => {
     });
 
     const actCalls = calls.filter((call) => call.url.endsWith("/act"));
-    expect(actCalls[0]?.init?.timeoutMs).toBe(125_000);
+    expect(actCalls[0]?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
     expect(actCalls[1]?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
     const screenshot = calls.find((call) => call.url.endsWith("/screenshot"));
     expect(screenshot?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover navigation guard plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError, type LookupFn } from "../infra/net/ssrf.js";
 import {
@@ -114,6 +115,54 @@ describe("browser navigation guard", () => {
       }),
     ).resolves.toBeUndefined();
     expect(lookupFn).toHaveBeenCalledWith("example.com", { all: true });
+  });
+
+  it.each([
+    { name: "requested navigation", check: assertBrowserNavigationAllowed },
+    { name: "final URL", check: assertBrowserNavigationResultAllowed },
+    {
+      name: "redirect chain",
+      check: (options: Parameters<typeof assertBrowserNavigationAllowed>[0]) =>
+        assertBrowserNavigationRedirectChainAllowed({
+          ...options,
+          request: {
+            url: () => options.url,
+            redirectedFrom: () => ({
+              url: () => "https://example.com/start",
+              redirectedFrom: () => null,
+            }),
+          },
+        }),
+    },
+  ])("cancels a stalled $name DNS check without waiting for lookup", async ({ check }) => {
+    const lookup = createDeferred<Awaited<ReturnType<LookupFn>>>();
+    const lookupFn = vi.fn<LookupFn>(() => lookup.promise);
+    const controller = new AbortController();
+    const reason = new Error("browser action deadline expired");
+    const rejected = vi.fn();
+    const options = {
+      url: "https://example.com/final",
+      lookupFn,
+      signal: controller.signal,
+    };
+    const completion = check(options).catch((error: unknown) => {
+      rejected(error);
+      return error;
+    });
+    try {
+      expect(lookupFn).toHaveBeenCalledOnce();
+
+      controller.abort(reason);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(rejected).toHaveBeenCalledWith(reason);
+      expect(await completion).toBe(reason);
+    } finally {
+      lookup.resolve([{ address: "93.184.216.34", family: 4 }]);
+      await completion;
+    }
   });
 
   it("blocks hostname navigation when strict SSRF policy is explicitly configured", async () => {

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -120,8 +120,10 @@ export async function assertBrowserNavigationAllowed(
   opts: {
     url: string;
     lookupFn?: LookupFn;
+    signal?: AbortSignal;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
+  opts.signal?.throwIfAborted();
   const parsed = parseBrowserNavigationUrl(opts.url);
 
   if (!NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol)) {
@@ -164,6 +166,7 @@ export async function assertBrowserNavigationAllowed(
   await resolvePinnedHostnameWithPolicy(parsed.hostname, {
     lookupFn: opts.lookupFn,
     policy: opts.ssrfPolicy,
+    signal: opts.signal,
   });
 }
 
@@ -177,8 +180,10 @@ export async function assertBrowserNavigationResultAllowed(
   opts: {
     url: string;
     lookupFn?: LookupFn;
+    signal?: AbortSignal;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
+  opts.signal?.throwIfAborted();
   const rawUrl = opts.url.trim();
   if (!rawUrl) {
     return;
@@ -202,8 +207,10 @@ export async function assertBrowserNavigationRedirectChainAllowed(
   opts: {
     request?: BrowserNavigationRequestLike | null;
     lookupFn?: LookupFn;
+    signal?: AbortSignal;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
+  opts.signal?.throwIfAborted();
   const chain: string[] = [];
   let current = opts.request ?? null;
   while (current) {
@@ -216,6 +223,7 @@ export async function assertBrowserNavigationRedirectChainAllowed(
       lookupFn: opts.lookupFn,
       ssrfPolicy: opts.ssrfPolicy,
       browserProxyMode: opts.browserProxyMode,
+      signal: opts.signal,
     });
   }
 }

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -1,21 +1,55 @@
 // Browser tests cover agent.act.existing session navigation guard plugin behavior.
+import { setTimeout as sleep } from "node:timers/promises";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChromeMcpOperationOptions } from "../chrome-mcp.js";
+import { browserAct } from "../client-actions-core.js";
+import type { BrowserActRequest } from "../client-actions.types.js";
+import type { BrowserDispatchRequest, BrowserDispatchResponse } from "./dispatcher.js";
 import {
   createExistingSessionAgentSharedModule,
   existingSessionRouteState,
 } from "./existing-session.test-support.js";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
+vi.mock("node:timers/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:timers/promises")>();
+  return {
+    ...actual,
+    // Drive both route sleeps and synthetic MCP work with the test's global clock.
+    setTimeout: <T = void>(
+      delay?: number,
+      value?: T,
+      options?: Parameters<typeof actual.setTimeout>[2],
+    ) =>
+      new Promise<T | undefined>((resolve, reject) => {
+        const signal = options?.signal;
+        signal?.throwIfAborted();
+        const abort = () => {
+          clearTimeout(timer);
+          reject(toErrorObject(signal?.reason, "Browser action cancelled"));
+        };
+        const timer = setTimeout(() => {
+          signal?.removeEventListener("abort", abort);
+          resolve(value);
+        }, delay);
+        signal?.addEventListener("abort", abort, { once: true });
+      }),
+  };
+});
+
 const chromeMcpMocks = vi.hoisted(() => ({
   ChromeMcpDocumentUnavailableError: class ChromeMcpDocumentUnavailableError extends Error {},
-  clickChromeMcpCoords: vi.fn(async () => {}),
-  clickChromeMcpElement: vi.fn(async () => {}),
+  clickChromeMcpCoords: vi.fn(async (_params: ChromeMcpOperationOptions) => {}),
+  clickChromeMcpElement: vi.fn(async (_params: ChromeMcpOperationOptions) => {}),
   dragChromeMcpElement: vi.fn(async () => {}),
-  evaluateChromeMcpScript: vi.fn(async (_params: unknown) => "https://example.com"),
-  fillChromeMcpElement: vi.fn(async () => {}),
+  evaluateChromeMcpScript: vi.fn(
+    async (_params: ChromeMcpOperationOptions) => "https://example.com",
+  ),
+  fillChromeMcpElement: vi.fn(async (_params: ChromeMcpOperationOptions) => {}),
   fillChromeMcpForm: vi.fn(async () => {}),
   hoverChromeMcpElement: vi.fn(async () => {}),
-  pressChromeMcpKey: vi.fn(async () => {}),
+  pressChromeMcpKey: vi.fn(async (_params: ChromeMcpOperationOptions) => {}),
   withChromeMcpDocument: vi.fn(
     async (_params: unknown, task: (document: { evaluate: (fn: string) => unknown }) => unknown) =>
       await task({
@@ -26,6 +60,29 @@ const chromeMcpMocks = vi.hoisted(() => ({
       }),
   ),
 }));
+
+const transportMocks = vi.hoisted(() => ({
+  dispatch: vi.fn<(request: BrowserDispatchRequest) => Promise<BrowserDispatchResponse>>(),
+}));
+
+vi.mock("../local-dispatch.runtime.js", () => ({
+  dispatchBrowserControlRequest: transportMocks.dispatch,
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  const syntheticConfig = {
+    browser: {
+      defaultProfile: "chrome-live",
+      profiles: { "chrome-live": { driver: "existing-session", color: "#123456" } },
+    },
+  };
+  return {
+    ...actual,
+    getRuntimeConfig: () => syntheticConfig,
+    loadConfig: () => syntheticConfig,
+  };
+});
 
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationAllowed: vi.fn(async () => {}),
@@ -65,7 +122,16 @@ const GUARDED_TARGET_REFRESH_ACTIONS = [
 ] as const;
 
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
+const { resolveSafeRouteTabUrl, withRouteTabContext } = await import("./agent.shared.js");
 const routeState = existingSessionRouteState;
+const defaultResolveSafeRouteTabUrl = vi.mocked(resolveSafeRouteTabUrl).getMockImplementation();
+if (!defaultResolveSafeRouteTabUrl) {
+  throw new Error("missing existing-session URL resolver mock");
+}
+const defaultWithRouteTabContext = vi.mocked(withRouteTabContext).getMockImplementation();
+if (!defaultWithRouteTabContext) {
+  throw new Error("missing existing-session route context mock");
+}
 
 function getActPostHandler(
   ssrfPolicy: { allowPrivateNetwork: false } | null = DEFAULT_SSRF_POLICY,
@@ -86,20 +152,36 @@ function getActPostHandler(
 }
 
 describe("existing-session interaction navigation guard", () => {
+  const clientControllers: AbortController[] = [];
+
   beforeEach(() => {
     vi.useFakeTimers();
     for (const fn of Object.values(chromeMcpMocks)) {
-      if ("mockClear" in fn) {
-        fn.mockClear();
+      if ("mockReset" in fn) {
+        fn.mockReset();
       }
     }
     for (const fn of Object.values(navigationGuardMocks)) {
-      fn.mockClear();
+      fn.mockReset();
     }
+    navigationGuardMocks.assertBrowserNavigationAllowed.mockResolvedValue(undefined);
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
       async (_opts?: { url: string; ssrfPolicy?: unknown }) => {},
     );
+    navigationGuardMocks.withBrowserNavigationPolicy.mockImplementation((ssrfPolicy?: unknown) =>
+      ssrfPolicy ? { ssrfPolicy } : {},
+    );
+    chromeMcpMocks.clickChromeMcpCoords.mockResolvedValue(undefined);
+    chromeMcpMocks.clickChromeMcpElement.mockResolvedValue(undefined);
+    chromeMcpMocks.dragChromeMcpElement.mockResolvedValue(undefined);
     chromeMcpMocks.evaluateChromeMcpScript.mockResolvedValue("https://example.com");
+    chromeMcpMocks.fillChromeMcpElement.mockResolvedValue(undefined);
+    chromeMcpMocks.fillChromeMcpForm.mockResolvedValue(undefined);
+    chromeMcpMocks.hoverChromeMcpElement.mockResolvedValue(undefined);
+    chromeMcpMocks.pressChromeMcpKey.mockResolvedValue(undefined);
+    transportMocks.dispatch.mockReset();
+    vi.mocked(resolveSafeRouteTabUrl).mockReset().mockImplementation(defaultResolveSafeRouteTabUrl);
+    vi.mocked(withRouteTabContext).mockReset().mockImplementation(defaultWithRouteTabContext);
     chromeMcpMocks.withChromeMcpDocument.mockImplementation(
       async (
         _params: unknown,
@@ -124,9 +206,76 @@ describe("existing-session interaction navigation guard", () => {
     ]);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  afterEach(async () => {
+    try {
+      for (const controller of clientControllers.splice(0)) {
+        controller.abort(new Error("test cleanup"));
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
+
+  async function startClientAction(
+    body: BrowserActRequest,
+    ssrfPolicy: { allowPrivateNetwork: false } | null = null,
+  ) {
+    const handler = getActPostHandler(ssrfPolicy);
+    if (!handler) {
+      throw new Error("missing /act handler");
+    }
+    transportMocks.dispatch.mockImplementation(async (request) => {
+      const response = createBrowserRouteResponse();
+      try {
+        await handler(
+          {
+            params: {},
+            query: request.query ?? {},
+            body: request.body,
+            signal: request.signal,
+          },
+          response.res,
+        );
+      } catch (error) {
+        response.res.status(500).json({ error: String(error) });
+      }
+      return { status: response.statusCode, body: response.body };
+    });
+    const controller = new AbortController();
+    clientControllers.push(controller);
+    const settled = vi.fn();
+    const completion = browserAct(undefined, body, {
+      profile: "chrome-live",
+      signal: controller.signal,
+    }).then(
+      (result) => {
+        settled();
+        return { result };
+      },
+      (error: unknown) => {
+        settled();
+        return { error };
+      },
+    );
+    await vi.dynamicImportSettled();
+    await vi.advanceTimersByTimeAsync(0);
+    return { completion, settled };
+  }
+
+  function setWaitReadyAfter(delayMs: number) {
+    const readyAt = Date.now() + delayMs;
+    chromeMcpMocks.withChromeMcpDocument.mockImplementation(async (_params, task) =>
+      task({
+        evaluate: async (fn) =>
+          fn.includes("globalThis.location.href")
+            ? "https://example.com"
+            : { kind: "result", ready: Date.now() >= readyAt },
+      }),
+    );
+  }
 
   async function runAction(
     body: Record<string, unknown>,
@@ -167,6 +316,269 @@ describe("existing-session interaction navigation guard", () => {
       ).toBe(url);
     }
   }
+
+  it("keeps a default existing-session wait alive past the managed wait deadline", async () => {
+    setWaitReadyAfter(30_000);
+    const request = await startClientAction({ kind: "wait", text: "ready" });
+
+    await vi.advanceTimersByTimeAsync(25_001);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(4_999);
+
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      result: { ok: true, targetId: "7", url: "https://example.com" },
+    });
+  });
+
+  it.each([
+    { name: "padded left button", input: { button: " left " } },
+    { name: "blank selector beside a ref", input: { selector: " " } },
+  ])("budgets a normalized click with $name through navigation verification", async ({ input }) => {
+    chromeMcpMocks.clickChromeMcpElement.mockImplementationOnce(async ({ signal }) => {
+      await sleep(40_000, undefined, { signal });
+    });
+    chromeMcpMocks.evaluateChromeMcpScript.mockImplementation(async ({ signal }) => {
+      await sleep(10_000, undefined, { signal });
+      return "https://example.com";
+    });
+    const request = await startClientAction(
+      { kind: "click", ref: "button", ...input },
+      DEFAULT_SSRF_POLICY,
+    );
+
+    await vi.advanceTimersByTimeAsync(65_001);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5_749);
+
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      result: { ok: true, targetId: "7", url: "https://example.com" },
+    });
+    expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
+    expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledTimes(3);
+  });
+
+  it("lets an existing-session evaluation use its requested timeout beyond two minutes", async () => {
+    chromeMcpMocks.evaluateChromeMcpScript.mockImplementationOnce(async ({ signal }) => {
+      await sleep(150_000, undefined, { signal });
+      return "evaluation complete";
+    });
+    const request = await startClientAction({
+      kind: "evaluate",
+      fn: "() => window.ready",
+      timeoutMs: 180_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(125_251);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(24_749);
+
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      result: { ok: true, result: "evaluation complete" },
+    });
+    expect(chromeMcpMocks.evaluateChromeMcpScript).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 180_000 }),
+    );
+  });
+
+  it("includes browser and tab preparation in the overall action deadline", async () => {
+    const preparationSteps: string[] = [];
+    vi.mocked(withRouteTabContext).mockImplementationOnce(async (params) => {
+      await sleep(55_000, undefined, { signal: params.req.signal });
+      preparationSteps.push("browser ready");
+      await sleep(55_000, undefined, { signal: params.req.signal });
+      preparationSteps.push("tab verified");
+      return await defaultWithRouteTabContext(params);
+    });
+    let evaluationSignal: AbortSignal | undefined;
+    chromeMcpMocks.evaluateChromeMcpScript.mockImplementationOnce(async ({ signal }) => {
+      evaluationSignal = signal;
+      await sleep(20_000, undefined, { signal });
+      return "evaluation complete";
+    });
+    const request = await startClientAction({ kind: "evaluate", fn: "() => document.title" });
+
+    await vi.advanceTimersByTimeAsync(121_249);
+    expect(preparationSteps).toEqual(["browser ready", "tab verified"]);
+    expect(evaluationSignal?.aborted).toBe(false);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(evaluationSignal?.aborted).toBe(true);
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("Browser action request timed out after 121250ms"),
+      }),
+    });
+    expect(transportMocks.dispatch.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+  });
+
+  it("cancels a slow submit at the shared body deadline after filling succeeds", async () => {
+    const completed: string[] = [];
+    let submitSignal: AbortSignal | undefined;
+    chromeMcpMocks.fillChromeMcpElement.mockImplementationOnce(async ({ signal }) => {
+      await sleep(45_000, undefined, { signal });
+      completed.push("fill");
+    });
+    chromeMcpMocks.pressChromeMcpKey.mockImplementationOnce(async ({ signal }) => {
+      submitSignal = signal;
+      await sleep(45_000, undefined, { signal });
+      completed.push("submit");
+    });
+    const request = await startClientAction({
+      kind: "type",
+      ref: "field",
+      text: "hello",
+      submit: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(completed).toEqual(["fill"]);
+    expect(submitSignal?.aborted).toBe(false);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(submitSignal?.aborted).toBe(true);
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("Browser action timed out after 60000ms"),
+      }),
+    });
+    expect(completed).toEqual(["fill"]);
+    expect(transportMocks.dispatch.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+  });
+
+  it("does not submit when filling completes after the body deadline before its timer runs", async () => {
+    chromeMcpMocks.fillChromeMcpElement.mockImplementationOnce(async () => {
+      vi.setSystemTime(Date.now() + 60_001);
+    });
+    const request = await startClientAction({
+      kind: "type",
+      ref: "field",
+      text: "hello",
+      submit: true,
+    });
+
+    expect(chromeMcpMocks.fillChromeMcpElement).toHaveBeenCalledOnce();
+    expect(chromeMcpMocks.pressChromeMcpKey).not.toHaveBeenCalled();
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("Browser action timed out after 60000ms"),
+      }),
+    });
+  });
+
+  it("bounds all post-action navigation probes by one verification deadline", async () => {
+    const completedProbes: number[] = [];
+    let probeSignal: AbortSignal | undefined;
+    chromeMcpMocks.evaluateChromeMcpScript
+      .mockResolvedValueOnce("evaluation complete")
+      .mockImplementation(async ({ signal }) => {
+        probeSignal = signal;
+        await sleep(30_000, undefined, { signal });
+        completedProbes.push(Date.now());
+        return "https://example.com";
+      });
+    const request = await startClientAction(
+      { kind: "evaluate", fn: "() => document.title" },
+      DEFAULT_SSRF_POLICY,
+    );
+
+    await vi.advanceTimersByTimeAsync(61_249);
+    expect(completedProbes).toHaveLength(2);
+    expect(probeSignal?.aborted).toBe(false);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(probeSignal?.aborted).toBe(true);
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("Browser navigation verification timed out after 61250ms"),
+      }),
+    });
+    expect(completedProbes).toHaveLength(2);
+    expect(transportMocks.dispatch.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+  });
+
+  it("cancels final URL resolution when the verification deadline expires", async () => {
+    const actual = await vi.importActual<typeof import("./agent.shared.js")>("./agent.shared.js");
+    let resolutionSignal: AbortSignal | undefined;
+    vi.mocked(resolveSafeRouteTabUrl).mockImplementationOnce((params) =>
+      actual.resolveSafeRouteTabUrl({
+        ...params,
+        profileCtx: {
+          ...params.profileCtx,
+          listTabs: async (options) => {
+            resolutionSignal = options?.signal;
+            await sleep(90_000, undefined, { signal: resolutionSignal });
+            return [{ targetId: "7", title: "Fixture", url: "https://example.com" }];
+          },
+        },
+      }),
+    );
+    const request = await startClientAction(
+      { kind: "evaluate", fn: "() => document.title" },
+      DEFAULT_SSRF_POLICY,
+    );
+
+    await vi.advanceTimersByTimeAsync(61_249);
+    expect(resolutionSignal?.aborted).toBe(false);
+    expect(request.settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(resolutionSignal?.aborted).toBe(true);
+    expect(request.settled).toHaveBeenCalledOnce();
+    expect(await request.completion).toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("Browser navigation verification timed out after 61250ms"),
+      }),
+    });
+    expect(transportMocks.dispatch.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+  });
+
+  it.each(
+    (
+      [
+        { name: "zero delay", body: { kind: "wait", timeMs: 0 }, durationMs: 0 },
+        { name: "pure delay", body: { kind: "wait", timeMs: 30_000 }, durationMs: 30_000 },
+        {
+          name: "pure delay longer than the call timeout",
+          body: { kind: "wait", timeMs: 1_000, timeoutMs: 500 },
+          durationMs: 1_000,
+        },
+        {
+          name: "condition after a delay",
+          body: { kind: "wait", timeMs: 1_000, text: "ready", timeoutMs: 500 },
+          durationMs: 1_250,
+        },
+      ] satisfies Array<{ name: string; body: BrowserActRequest; durationMs: number }>
+    ).flatMap((entry) => [
+      { ...entry, ssrfPolicy: null, verificationMs: 0 },
+      {
+        ...entry,
+        name: `${entry.name} with navigation verification`,
+        ssrfPolicy: DEFAULT_SSRF_POLICY,
+        verificationMs: 750,
+      },
+    ]),
+  )(
+    "completes a healthy existing-session $name through the client transport",
+    async ({ body, durationMs, ssrfPolicy, verificationMs }) => {
+      setWaitReadyAfter(durationMs);
+      const request = await startClientAction(body, ssrfPolicy);
+
+      await vi.advanceTimersByTimeAsync(durationMs + verificationMs);
+
+      expect(request.settled).toHaveBeenCalledOnce();
+      expect(await request.completion).toMatchObject({ result: { ok: true, targetId: "7" } });
+    },
+  );
 
   it("checks navigation after click and key-driven submit paths", async () => {
     const clickResponse = await runAction({ kind: "click", ref: "btn-1" });
@@ -282,32 +694,51 @@ describe("existing-session interaction navigation guard", () => {
     },
   );
 
-  it("threads one request budget through coordinate actions and navigation probes", async () => {
-    const handler = getActPostHandler();
-    const response = createBrowserRouteResponse();
-    const ctrl = new AbortController();
-    const pending = handler?.(
-      {
-        params: {},
-        query: {},
-        body: { kind: "clickCoords", x: 20, y: 30 },
-        signal: ctrl.signal,
-      },
-      response.res,
-    );
+  it.each(["coordinate action", "navigation verification"])(
+    "propagates caller cancellation during %s without changing the MCP call timeout",
+    async (phase) => {
+      let operation: ChromeMcpOperationOptions | undefined;
+      const pause = async (params: ChromeMcpOperationOptions) => {
+        operation = params;
+        await sleep(30_000, undefined, { signal: params.signal });
+      };
+      if (phase === "coordinate action") {
+        chromeMcpMocks.clickChromeMcpCoords.mockImplementationOnce(pause);
+      } else {
+        chromeMcpMocks.evaluateChromeMcpScript.mockImplementationOnce(async (params) => {
+          await pause(params);
+          return "https://example.com";
+        });
+      }
+      const handler = getActPostHandler();
+      const response = createBrowserRouteResponse();
+      const ctrl = new AbortController();
+      clientControllers.push(ctrl);
+      const reason = new Error("caller cancelled the browser action");
+      const completion = Promise.resolve(
+        handler?.(
+          {
+            params: {},
+            query: {},
+            body: { kind: "clickCoords", x: 20, y: 30 },
+            signal: ctrl.signal,
+          },
+          response.res,
+        ),
+      ).catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(operation?.timeoutMs).toBe(60_000);
+      expect(operation?.signal?.aborted).toBe(false);
 
-    await vi.runAllTimersAsync();
-    await pending;
+      ctrl.abort(reason);
+      await vi.advanceTimersByTimeAsync(0);
 
-    const expectedOptions = { signal: ctrl.signal, timeoutMs: 60_000 };
-    expect(chromeMcpMocks.clickChromeMcpCoords).toHaveBeenCalledWith(
-      expect.objectContaining(expectedOptions),
-    );
-    for (const [params] of chromeMcpMocks.evaluateChromeMcpScript.mock.calls) {
-      expect(params).toEqual(expect.objectContaining(expectedOptions));
-    }
-    expect(routeState.profileCtx.listTabs).toHaveBeenCalledWith(expectedOptions);
-  });
+      expect(operation?.signal?.aborted).toBe(true);
+      expect(operation?.signal?.reason).toBe(reason);
+      expect(await completion).toBe(reason);
+      expect(response.body).toBeUndefined();
+    },
+  );
 
   it("cancels a pending existing-session wait when its request aborts", async () => {
     const handler = getActPostHandler(null);
@@ -589,7 +1020,8 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.pressChromeMcpKey).toHaveBeenCalledOnce();
     expect(chromeMcpMocks.evaluateChromeMcpScript).not.toHaveBeenCalled();
-    expect(routeState.profileCtx.listTabs).not.toHaveBeenCalled();
+    expect(vi.mocked(resolveSafeRouteTabUrl)).toHaveBeenCalledOnce();
+    expect(routeState.profileCtx.listTabs).toHaveBeenCalledOnce();
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/routes/agent.act.existing-session.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session.ts
@@ -1,0 +1,297 @@
+/** Existing-session action waits, navigation verification, and deadline ownership. */
+import { setTimeout as sleep } from "node:timers/promises";
+import { EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS } from "../act-policy.js";
+import {
+  ChromeMcpDocumentUnavailableError,
+  evaluateChromeMcpScript,
+  withChromeMcpDocument,
+  type ChromeMcpOperationOptions,
+  type ChromeMcpProfileOptions,
+} from "../chrome-mcp.js";
+import { normalizeBrowserEvaluateFunctionSource } from "../evaluate-source.js";
+import {
+  assertBrowserNavigationResultAllowed,
+  type BrowserNavigationPolicyOptions,
+  withBrowserNavigationPolicy,
+} from "../navigation-guard.js";
+import { matchBrowserUrlPattern } from "../url-pattern.js";
+
+/** Abort nested operations without racing the route's response/error owner. */
+export function createExistingSessionDeadline(
+  timeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+  label: string,
+) {
+  const controller = new AbortController();
+  const signal = parentSignal
+    ? AbortSignal.any([parentSignal, controller.signal])
+    : controller.signal;
+  const error = new Error(`${label} timed out after ${timeoutMs}ms`);
+  const deadlineAt = Date.now() + timeoutMs;
+  const timer = setTimeout(() => controller.abort(error), timeoutMs);
+  timer.unref?.();
+  return {
+    signal,
+    throwIfAborted: () => {
+      // A busy event loop must not turn a late completion into a successful action.
+      if (Date.now() >= deadlineAt && !signal.aborted) {
+        controller.abort(error);
+      }
+      signal.throwIfAborted();
+    },
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+export type ExistingSessionOperation = ChromeMcpOperationOptions & {
+  profileName: string;
+  profile?: ChromeMcpProfileOptions;
+  userDataDir?: string;
+  targetId: string;
+};
+
+async function readExistingSessionLocationHref(params: ExistingSessionOperation): Promise<string> {
+  const currentUrl = await evaluateChromeMcpScript({
+    ...params,
+    fn: "() => window.location.href",
+  });
+  if (typeof currentUrl !== "string") {
+    throw new Error("Location probe returned a non-string result");
+  }
+  const normalizedUrl = currentUrl.trim();
+  if (!normalizedUrl) {
+    throw new Error("Location probe returned an empty URL");
+  }
+  return normalizedUrl;
+}
+
+export async function assertExistingSessionPostInteractionNavigationAllowed(
+  params: ExistingSessionOperation &
+    BrowserNavigationPolicyOptions & {
+      listTabs: () => Promise<Array<{ targetId: string; url: string }>>;
+      initialTabTargetIds: ReadonlySet<string>;
+    },
+): Promise<void> {
+  const navigationPolicy = withBrowserNavigationPolicy(params.ssrfPolicy, {
+    browserProxyMode: params.browserProxyMode,
+  });
+  if (!navigationPolicy.ssrfPolicy && !navigationPolicy.browserProxyMode) {
+    return;
+  }
+  const listTabs = params.listTabs;
+  const initialTabTargetIds = params.initialTabTargetIds;
+
+  const assertNewTabsAllowed = async () => {
+    const tabs = await listTabs();
+    for (const tab of tabs) {
+      if (initialTabTargetIds.has(tab.targetId)) {
+        continue;
+      }
+      await assertBrowserNavigationResultAllowed({
+        url: tab.url,
+        signal: params.signal,
+        ...navigationPolicy,
+      });
+    }
+  };
+
+  let lastObservedUrl: string | undefined;
+  let sawStableAllowedUrl = false;
+  for (const delayMs of EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS) {
+    if (delayMs > 0) {
+      await sleep(delayMs, undefined, { signal: params.signal });
+    }
+    let currentUrl: string;
+    try {
+      currentUrl = await readExistingSessionLocationHref(params);
+    } catch {
+      params.signal?.throwIfAborted();
+      sawStableAllowedUrl = false;
+      continue;
+    }
+    await assertBrowserNavigationResultAllowed({
+      url: currentUrl,
+      signal: params.signal,
+      ...navigationPolicy,
+    });
+    if (currentUrl === lastObservedUrl) {
+      sawStableAllowedUrl = true;
+    } else {
+      sawStableAllowedUrl = false;
+    }
+    lastObservedUrl = currentUrl;
+  }
+
+  if (sawStableAllowedUrl) {
+    await assertNewTabsAllowed();
+    return;
+  }
+
+  // If the loop exhausted without confirming stability but we did observe
+  // at least one allowed URL, run a single follow-up probe so a late URL
+  // transition that has already settled is not treated as a false failure.
+  if (lastObservedUrl) {
+    const lastDelay =
+      EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS[
+        EXISTING_SESSION_NAVIGATION_RECHECK_DELAYS_MS.length - 1
+      ];
+    await sleep(lastDelay, undefined, { signal: params.signal });
+    try {
+      const followUpUrl = await readExistingSessionLocationHref(params);
+      await assertBrowserNavigationResultAllowed({
+        url: followUpUrl,
+        signal: params.signal,
+        ...navigationPolicy,
+      });
+      if (followUpUrl === lastObservedUrl) {
+        await assertNewTabsAllowed();
+        return;
+      }
+    } catch {
+      params.signal?.throwIfAborted();
+      // Probe failed — fall through to throw
+    }
+  }
+
+  throw new Error("Unable to verify stable post-interaction navigation");
+}
+
+function buildExistingSessionWaitPredicate(params: {
+  text?: string;
+  textGone?: string;
+  selector?: string;
+  loadState?: "load" | "domcontentloaded" | "networkidle";
+  fn?: string;
+}): string | null {
+  const checks = [
+    params.text && `Boolean(document.body?.innerText?.includes(${JSON.stringify(params.text)}))`,
+    params.textGone && `!document.body?.innerText?.includes(${JSON.stringify(params.textGone)})`,
+    params.selector &&
+      `(function visible(node) {
+      if (!node) return false;
+      if (node.nodeType === 1) {
+        // Like managed waits, display:contents is visible through rendered children.
+        if (getComputedStyle(node).display === "contents") {
+          return Array.from(node.childNodes).some(visible);
+        }
+        if (!node.checkVisibility({ visibilityProperty: true })) return false;
+      } else if (node.nodeType !== 3) {
+        return false;
+      }
+      const range = document.createRange();
+      range.selectNode(node);
+      const rect = node.nodeType === 1 ? node.getBoundingClientRect() : range.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    })(document.querySelector(${JSON.stringify(params.selector)}))`,
+    params.loadState === "domcontentloaded" &&
+      `document.readyState === "interactive" || document.readyState === "complete"`,
+    params.loadState === "load" && `document.readyState === "complete"`,
+    // `fn` is admitted only by the same evaluateEnabled gate as evaluate.
+    // Preserve its async semantics; document binding guards scheduler rebinding.
+    params.fn && `Boolean(await (${normalizeBrowserEvaluateFunctionSource(params.fn)})())`,
+  ];
+  return (
+    checks
+      .filter(Boolean)
+      .map((check) => `(${check})`)
+      .join(" && ") || null
+  );
+}
+
+export async function waitForExistingSessionCondition(
+  params: ExistingSessionOperation & {
+    timeMs?: number;
+    text?: string;
+    textGone?: string;
+    selector?: string;
+    url?: string;
+    loadState?: "load" | "domcontentloaded" | "networkidle";
+    fn?: string;
+    ssrfPolicy?: BrowserNavigationPolicyOptions["ssrfPolicy"];
+    browserProxyMode?: BrowserNavigationPolicyOptions["browserProxyMode"];
+  },
+): Promise<void> {
+  if (params.timeMs && params.timeMs > 0) {
+    await sleep(params.timeMs, undefined, { signal: params.signal });
+  }
+  const predicate = buildExistingSessionWaitPredicate(params);
+  if (!predicate && !params.url) {
+    return;
+  }
+  const timeoutMs = Math.max(250, params.timeoutMs ?? 10_000);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const ready = await withChromeMcpDocument(params, async (document) => {
+        const readAllowedUrl = async () => {
+          const url = await document.evaluate(`(root) => {
+            const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
+            return boundDocument === globalThis.document ? globalThis.location.href : null;
+          }`);
+          if (typeof url !== "string" || !url.trim()) {
+            return null;
+          }
+          await assertBrowserNavigationResultAllowed({
+            url,
+            signal: params.signal,
+            ...withBrowserNavigationPolicy(params.ssrfPolicy, {
+              browserProxyMode: params.browserProxyMode,
+            }),
+          });
+          return url;
+        };
+        const currentUrl = await readAllowedUrl();
+        if (!currentUrl) {
+          return false;
+        }
+        if (params.url && !matchBrowserUrlPattern(params.url, currentUrl)) {
+          return false;
+        }
+        if (!predicate) {
+          return true;
+        }
+        const outcome = await document.evaluate(`async (root) => {
+          const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
+          if (boundDocument !== globalThis.document) return { kind: "navigation" };
+          try {
+            return { kind: "result", ready: Boolean(await (${predicate})) };
+          } catch (error) {
+            const message = error && typeof error === "object" && "message" in error
+              ? String(error.message)
+              : String(error);
+            return { kind: "error", message };
+          }
+        }`);
+        if (!outcome || typeof outcome !== "object") {
+          throw new Error("Document-bound wait returned an invalid result");
+        }
+        if ("kind" in outcome && outcome.kind === "error") {
+          throw new Error(
+            "message" in outcome && typeof outcome.message === "string"
+              ? outcome.message
+              : "Wait predicate failed",
+          );
+        }
+        const predicateReady =
+          "kind" in outcome &&
+          outcome.kind === "result" &&
+          "ready" in outcome &&
+          outcome.ready === true;
+        if (!predicateReady || !params.url) {
+          return predicateReady;
+        }
+        const finalUrl = await readAllowedUrl();
+        return finalUrl !== null && matchBrowserUrlPattern(params.url, finalUrl);
+      });
+      if (ready) {
+        return;
+      }
+    } catch (error) {
+      if (!(error instanceof ChromeMcpDocumentUnavailableError)) {
+        throw error;
+      }
+    }
+    await sleep(250, undefined, { signal: params.signal });
+  }
+  throw new Error("Timed out waiting for condition");
+}

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -1,4 +1,3 @@
-import { setTimeout as sleep } from "node:timers/promises";
 /**
  * Browser agent action route registration and existing-session execution.
  *
@@ -6,8 +5,8 @@ import { setTimeout as sleep } from "node:timers/promises";
  * control or Chrome MCP existing-session operations with navigation guards.
  */
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { resolveExistingSessionActTimeouts } from "../act-policy.js";
 import {
-  ChromeMcpDocumentUnavailableError,
   clickChromeMcpElement,
   clickChromeMcpCoords,
   dragChromeMcpElement,
@@ -17,27 +16,25 @@ import {
   hoverChromeMcpElement,
   pressChromeMcpKey,
   resizeChromeMcpPage,
-  withChromeMcpDocument,
   type ChromeMcpOperationOptions,
-  type ChromeMcpProfileOptions,
 } from "../chrome-mcp.js";
 import type { BrowserActRequest } from "../client-actions.types.js";
 import { normalizeBrowserEvaluateFunctionSource } from "../evaluate-source.js";
-import {
-  assertBrowserNavigationResultAllowed,
-  type BrowserNavigationPolicyOptions,
-  withBrowserNavigationPolicy,
-} from "../navigation-guard.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import type { BrowserRouteContext } from "../server-context.js";
 import { clearSnapshotKeysForTab } from "../snapshot-delta-cache.js";
-import { matchBrowserUrlPattern } from "../url-pattern.js";
 import { registerBrowserAgentActDownloadRoutes } from "./agent.act.download.js";
 import {
   ACT_ERROR_CODES,
   browserEvaluateDisabledMessage,
   jsonActError,
 } from "./agent.act.errors.js";
+import {
+  assertExistingSessionPostInteractionNavigationAllowed,
+  createExistingSessionDeadline,
+  waitForExistingSessionCondition,
+  type ExistingSessionOperation,
+} from "./agent.act.existing-session.js";
 import { registerBrowserAgentActHookRoutes } from "./agent.act.hooks.js";
 import { canonicalizeActTargetIds, normalizeActRequest } from "./agent.act.normalize.js";
 import { type ActKind, isActKind } from "./agent.act.shared.js";
@@ -45,6 +42,7 @@ import {
   browserNavigationPolicyForProfile,
   readBody,
   requirePwAi,
+  resolveProfileContext,
   resolveTargetIdFromBody,
   resolveSafeRouteTabUrl,
   withRouteTabContext,
@@ -54,261 +52,13 @@ import {
   captureBrowserOperationTarget,
   resolveOperationTargetOutcome,
 } from "./agent.snapshot-target.js";
-import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
+import {
+  EXISTING_SESSION_LIMITS,
+  getExistingSessionUnsupportedMessage,
+} from "./existing-session-limits.js";
 import { readRoutePositiveInteger, readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
 import { jsonError, toStringOrEmpty } from "./utils.js";
-
-const EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS = [0, 250, 500] as const;
-
-type ExistingSessionOperation = ChromeMcpOperationOptions & {
-  profileName: string;
-  profile?: ChromeMcpProfileOptions;
-  userDataDir?: string;
-  targetId: string;
-};
-
-async function readExistingSessionLocationHref(params: ExistingSessionOperation): Promise<string> {
-  const currentUrl = await evaluateChromeMcpScript({
-    ...params,
-    fn: "() => window.location.href",
-  });
-  if (typeof currentUrl !== "string") {
-    throw new Error("Location probe returned a non-string result");
-  }
-  const normalizedUrl = currentUrl.trim();
-  if (!normalizedUrl) {
-    throw new Error("Location probe returned an empty URL");
-  }
-  return normalizedUrl;
-}
-
-async function assertExistingSessionPostInteractionNavigationAllowed(
-  params: ExistingSessionOperation &
-    BrowserNavigationPolicyOptions & {
-      listTabs: () => Promise<Array<{ targetId: string; url: string }>>;
-      initialTabTargetIds: ReadonlySet<string>;
-    },
-): Promise<void> {
-  const navigationPolicy = withBrowserNavigationPolicy(params.ssrfPolicy, {
-    browserProxyMode: params.browserProxyMode,
-  });
-  if (!navigationPolicy.ssrfPolicy && !navigationPolicy.browserProxyMode) {
-    return;
-  }
-  const listTabs = params.listTabs;
-  const initialTabTargetIds = params.initialTabTargetIds;
-
-  const assertNewTabsAllowed = async () => {
-    const tabs = await listTabs();
-    for (const tab of tabs) {
-      if (initialTabTargetIds.has(tab.targetId)) {
-        continue;
-      }
-      await assertBrowserNavigationResultAllowed({
-        url: tab.url,
-        ...navigationPolicy,
-      });
-    }
-  };
-
-  let lastObservedUrl: string | undefined;
-  let sawStableAllowedUrl = false;
-  for (const delayMs of EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS) {
-    if (delayMs > 0) {
-      await sleep(delayMs, undefined, { signal: params.signal });
-    }
-    let currentUrl: string;
-    try {
-      currentUrl = await readExistingSessionLocationHref(params);
-    } catch {
-      params.signal?.throwIfAborted();
-      sawStableAllowedUrl = false;
-      continue;
-    }
-    await assertBrowserNavigationResultAllowed({
-      url: currentUrl,
-      ...navigationPolicy,
-    });
-    if (currentUrl === lastObservedUrl) {
-      sawStableAllowedUrl = true;
-    } else {
-      sawStableAllowedUrl = false;
-    }
-    lastObservedUrl = currentUrl;
-  }
-
-  if (sawStableAllowedUrl) {
-    await assertNewTabsAllowed();
-    return;
-  }
-
-  // If the loop exhausted without confirming stability but we did observe
-  // at least one allowed URL, run a single follow-up probe so a late URL
-  // transition that has already settled is not treated as a false failure.
-  if (lastObservedUrl) {
-    const lastDelay =
-      EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS[
-        EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS.length - 1
-      ];
-    await sleep(lastDelay, undefined, { signal: params.signal });
-    try {
-      const followUpUrl = await readExistingSessionLocationHref(params);
-      await assertBrowserNavigationResultAllowed({
-        url: followUpUrl,
-        ...navigationPolicy,
-      });
-      if (followUpUrl === lastObservedUrl) {
-        await assertNewTabsAllowed();
-        return;
-      }
-    } catch {
-      params.signal?.throwIfAborted();
-      // Probe failed — fall through to throw
-    }
-  }
-
-  throw new Error("Unable to verify stable post-interaction navigation");
-}
-
-function buildExistingSessionWaitPredicate(params: {
-  text?: string;
-  textGone?: string;
-  selector?: string;
-  loadState?: "load" | "domcontentloaded" | "networkidle";
-  fn?: string;
-}): string | null {
-  const checks = [
-    params.text && `Boolean(document.body?.innerText?.includes(${JSON.stringify(params.text)}))`,
-    params.textGone && `!document.body?.innerText?.includes(${JSON.stringify(params.textGone)})`,
-    params.selector &&
-      `(function visible(node) {
-      if (!node) return false;
-      if (node.nodeType === 1) {
-        // Like managed waits, display:contents is visible through rendered children.
-        if (getComputedStyle(node).display === "contents") {
-          return Array.from(node.childNodes).some(visible);
-        }
-        if (!node.checkVisibility({ visibilityProperty: true })) return false;
-      } else if (node.nodeType !== 3) {
-        return false;
-      }
-      const range = document.createRange();
-      range.selectNode(node);
-      const rect = node.nodeType === 1 ? node.getBoundingClientRect() : range.getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0;
-    })(document.querySelector(${JSON.stringify(params.selector)}))`,
-    params.loadState === "domcontentloaded" &&
-      `document.readyState === "interactive" || document.readyState === "complete"`,
-    params.loadState === "load" && `document.readyState === "complete"`,
-    // `fn` is admitted only by the same evaluateEnabled gate as evaluate.
-    // Preserve its async semantics; document binding guards scheduler rebinding.
-    params.fn && `Boolean(await (${normalizeBrowserEvaluateFunctionSource(params.fn)})())`,
-  ];
-  return (
-    checks
-      .filter(Boolean)
-      .map((check) => `(${check})`)
-      .join(" && ") || null
-  );
-}
-
-async function waitForExistingSessionCondition(
-  params: ExistingSessionOperation & {
-    timeMs?: number;
-    text?: string;
-    textGone?: string;
-    selector?: string;
-    url?: string;
-    loadState?: "load" | "domcontentloaded" | "networkidle";
-    fn?: string;
-    ssrfPolicy?: BrowserNavigationPolicyOptions["ssrfPolicy"];
-    browserProxyMode?: BrowserNavigationPolicyOptions["browserProxyMode"];
-  },
-): Promise<void> {
-  if (params.timeMs && params.timeMs > 0) {
-    await sleep(params.timeMs, undefined, { signal: params.signal });
-  }
-  const predicate = buildExistingSessionWaitPredicate(params);
-  if (!predicate && !params.url) {
-    return;
-  }
-  const timeoutMs = Math.max(250, params.timeoutMs ?? 10_000);
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const ready = await withChromeMcpDocument(params, async (document) => {
-        const readAllowedUrl = async () => {
-          const url = await document.evaluate(`(root) => {
-            const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
-            return boundDocument === globalThis.document ? globalThis.location.href : null;
-          }`);
-          if (typeof url !== "string" || !url.trim()) {
-            return null;
-          }
-          await assertBrowserNavigationResultAllowed({
-            url,
-            ...withBrowserNavigationPolicy(params.ssrfPolicy, {
-              browserProxyMode: params.browserProxyMode,
-            }),
-          });
-          return url;
-        };
-        const currentUrl = await readAllowedUrl();
-        if (!currentUrl) {
-          return false;
-        }
-        if (params.url && !matchBrowserUrlPattern(params.url, currentUrl)) {
-          return false;
-        }
-        if (!predicate) {
-          return true;
-        }
-        const outcome = await document.evaluate(`async (root) => {
-          const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
-          if (boundDocument !== globalThis.document) return { kind: "navigation" };
-          try {
-            return { kind: "result", ready: Boolean(await (${predicate})) };
-          } catch (error) {
-            const message = error && typeof error === "object" && "message" in error
-              ? String(error.message)
-              : String(error);
-            return { kind: "error", message };
-          }
-        }`);
-        if (!outcome || typeof outcome !== "object") {
-          throw new Error("Document-bound wait returned an invalid result");
-        }
-        if ("kind" in outcome && outcome.kind === "error") {
-          throw new Error(
-            "message" in outcome && typeof outcome.message === "string"
-              ? outcome.message
-              : "Wait predicate failed",
-          );
-        }
-        const predicateReady =
-          "kind" in outcome &&
-          outcome.kind === "result" &&
-          "ready" in outcome &&
-          outcome.ready === true;
-        if (!predicateReady || !params.url) {
-          return predicateReady;
-        }
-        const finalUrl = await readAllowedUrl();
-        return finalUrl !== null && matchBrowserUrlPattern(params.url, finalUrl);
-      });
-      if (ready) {
-        return;
-      }
-    } catch (error) {
-      if (!(error instanceof ChromeMcpDocumentUnavailableError)) {
-        throw error;
-      }
-    }
-    await sleep(250, undefined, { signal: params.signal });
-  }
-  throw new Error("Timed out waiting for condition");
-}
 
 const SELECTOR_ALLOWED_KINDS: ReadonlySet<string> = new Set([
   "batch",
@@ -324,71 +74,6 @@ const SELECTOR_ALLOWED_KINDS: ReadonlySet<string> = new Set([
 function shouldEnforceCurrentUrlForAct(action: BrowserActRequest): boolean {
   // Batch stays guarded because nested actions can read or return page data.
   return action.kind !== "resize" && action.kind !== "close";
-}
-
-function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string | null {
-  switch (action.kind) {
-    case "click":
-      if (action.selector) {
-        return EXISTING_SESSION_LIMITS.act.clickSelector;
-      }
-      if (
-        (action.button && action.button !== "left") ||
-        (Array.isArray(action.modifiers) && action.modifiers.length > 0)
-      ) {
-        return EXISTING_SESSION_LIMITS.act.clickButtonOrModifiers;
-      }
-      return null;
-    case "clickCoords":
-      return null;
-    case "type":
-      if (action.selector) {
-        return EXISTING_SESSION_LIMITS.act.typeSelector;
-      }
-      if (action.slowly) {
-        return EXISTING_SESSION_LIMITS.act.typeSlowly;
-      }
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.typeTimeout : null;
-    case "press":
-      return action.delayMs ? EXISTING_SESSION_LIMITS.act.pressDelay : null;
-    case "hover":
-      if (action.selector) {
-        return EXISTING_SESSION_LIMITS.act.hoverSelector;
-      }
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.hoverTimeout : null;
-    case "scrollIntoView":
-      if (action.selector) {
-        return EXISTING_SESSION_LIMITS.act.scrollSelector;
-      }
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.scrollTimeout : null;
-    case "drag":
-      if (action.startSelector || action.endSelector) {
-        return EXISTING_SESSION_LIMITS.act.dragSelector;
-      }
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.dragTimeout : null;
-    case "select":
-      if (action.selector) {
-        return EXISTING_SESSION_LIMITS.act.selectSelector;
-      }
-      if (action.values.length !== 1) {
-        return EXISTING_SESSION_LIMITS.act.selectSingleValue;
-      }
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.selectTimeout : null;
-    case "fill":
-      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.fillTimeout : null;
-    case "wait":
-      return action.loadState === "networkidle"
-        ? EXISTING_SESSION_LIMITS.act.waitNetworkIdle
-        : null;
-    case "evaluate":
-      return null;
-    case "batch":
-      return EXISTING_SESSION_LIMITS.act.batch;
-    case "resize":
-    case "close":
-      return null;
-  }
-  throw new Error("Unsupported browser act kind");
 }
 
 /** Register browser action endpoints, including hook and download subroutes. */
@@ -431,321 +116,400 @@ export function registerBrowserAgentActRoutes(
       );
     }
 
-    await withRouteTabContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
-      run: async ({ profileCtx, cdpUrl, tab, signal, resolveTabUrl }) => {
-        const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
-        const navigationPolicy = browserNavigationPolicyForProfile(ctx, profileCtx);
-        const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
-        const requestedTimeoutMs =
-          "timeoutMs" in action && typeof action.timeoutMs === "number"
-            ? action.timeoutMs
-            : undefined;
-        const existingSessionCallOptions: ChromeMcpOperationOptions = {
-          timeoutMs: requestedTimeoutMs ?? ctx.state().resolved.actionTimeoutMs,
-          signal,
-        };
-        const hasNavigationResultPolicy = Boolean(
-          navigationPolicy.ssrfPolicy || navigationPolicy.browserProxyMode,
-        );
-        const resolveRelayTarget = await captureBrowserOperationTarget({
-          ctx,
-          profileName: profileCtx.profile.name,
-          targetId: tab.targetId,
-        });
-        try {
-          const jsonOk = async (
-            extra?: Record<string, unknown>,
-            options?: { resolveCurrentTarget?: boolean; operationTargetId?: string },
-          ) => {
-            const shouldResolveCurrentTarget =
-              options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
-            const responseTargetId = shouldResolveCurrentTarget
-              ? await resolveOperationTargetOutcome({
-                  actedOnTargetId: tab.targetId,
-                  operationTargetId: options?.operationTargetId,
-                  resolveRelayTarget,
-                })
-              : tab.targetId;
-            const url =
-              responseTargetId === tab.targetId
-                ? await resolveTabUrl(tab.url)
-                : await resolveSafeRouteTabUrl({
-                    ctx,
-                    profileCtx,
-                    targetId: responseTargetId,
-                    fallbackUrl: tab.url,
-                    ...(isExistingSession ? existingSessionCallOptions : {}),
-                  });
-            return res.json({
-              ok: true,
-              targetId: responseTargetId,
-              ...(url ? { url } : {}),
-              ...extra,
-            });
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) {
+      return;
+    }
+    const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
+    const existingSessionTimeouts = resolveExistingSessionActTimeouts(action);
+    const requestDeadline = isExistingSession
+      ? createExistingSessionDeadline(
+          existingSessionTimeouts.requestTimeoutMs,
+          req.signal,
+          "Browser action request",
+        )
+      : undefined;
+    try {
+      await withRouteTabContext({
+        req: requestDeadline ? { ...req, signal: requestDeadline.signal } : req,
+        res,
+        ctx,
+        profileCtx,
+        targetId,
+        enforceCurrentUrlAllowed: shouldEnforceCurrentUrlForAct(action),
+        run: async ({ cdpUrl, tab, signal, resolveTabUrl }) => {
+          const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
+          const navigationPolicy = browserNavigationPolicyForProfile(ctx, profileCtx);
+          let verificationDeadline: ReturnType<typeof createExistingSessionDeadline> | undefined;
+          const existingSessionCallOptions: ChromeMcpOperationOptions = {
+            timeoutMs: existingSessionTimeouts.timeoutMs,
+            signal,
           };
-          // Nested batch aliases can differ from the request alias, so prefixes
-          // must stay unique across the full tab set before canonicalization.
-          const actionTabs =
-            action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
-          if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
-            actionTabs.unshift(tab);
-          }
-          const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
-          if (targetIdError) {
-            return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
-          }
-          const profileName = profileCtx.profile.name;
-          if (isExistingSession) {
-            const existingSessionTarget: ExistingSessionOperation = {
-              profileName,
-              profile: profileCtx.profile,
+          const hasNavigationResultPolicy = Boolean(
+            navigationPolicy.ssrfPolicy || navigationPolicy.browserProxyMode,
+          );
+          let resolveRelayTarget: Awaited<ReturnType<typeof captureBrowserOperationTarget>>;
+          try {
+            requestDeadline?.throwIfAborted();
+            resolveRelayTarget = await captureBrowserOperationTarget({
+              ctx,
+              profileName: profileCtx.profile.name,
               targetId: tab.targetId,
-              ...existingSessionCallOptions,
-            };
-            const initialTabTargetIds = hasNavigationResultPolicy
-              ? new Set(
-                  (await profileCtx.listTabs(existingSessionCallOptions)).map(
-                    (currentTab) => currentTab.targetId,
-                  ),
-                )
-              : new Set<string>();
-            const existingSessionNavigationGuard = {
-              ...existingSessionTarget,
-              ...navigationPolicy,
-              listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
-              initialTabTargetIds,
-            };
-            const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
-            if (unsupportedMessage) {
-              return jsonActError(
-                res,
-                501,
-                ACT_ERROR_CODES.unsupportedForExistingSession,
-                unsupportedMessage,
-              );
-            }
-            const runGuardedAction = async <T>(execute: () => Promise<T>): Promise<T> => {
-              let actionError: unknown;
-              let result: T | undefined;
-              try {
-                result = await execute();
-              } catch (error) {
-                actionError = error;
-              }
-              await assertExistingSessionPostInteractionNavigationAllowed(
-                existingSessionNavigationGuard,
-              );
-              if (actionError) {
-                throw toErrorObject(actionError, "Non-Error thrown");
-              }
-              return result as T;
-            };
-            switch (action.kind) {
-              case "click":
-                await runGuardedAction(() =>
-                  clickChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    doubleClick: action.doubleClick ?? false,
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "clickCoords":
-                await runGuardedAction(() =>
-                  clickChromeMcpCoords({
-                    ...existingSessionTarget,
-                    x: action.x,
-                    y: action.y,
-                    doubleClick: action.doubleClick ?? false,
-                    button: action.button as "left" | "right" | "middle" | undefined,
-                    delayMs: action.delayMs,
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "type":
-                await runGuardedAction(async () => {
-                  await fillChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    value: action.text,
-                  });
-                  if (action.submit) {
-                    await pressChromeMcpKey({
-                      ...existingSessionTarget,
-                      key: "Enter",
+            });
+            const jsonOk = async (
+              extra?: Record<string, unknown>,
+              options?: { resolveCurrentTarget?: boolean; operationTargetId?: string },
+            ) => {
+              const shouldResolveCurrentTarget =
+                options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
+              const responseTargetId = shouldResolveCurrentTarget
+                ? await resolveOperationTargetOutcome({
+                    actedOnTargetId: tab.targetId,
+                    operationTargetId: options?.operationTargetId,
+                    resolveRelayTarget,
+                  })
+                : tab.targetId;
+              const url =
+                !isExistingSession && responseTargetId === tab.targetId
+                  ? await resolveTabUrl(tab.url)
+                  : await resolveSafeRouteTabUrl({
+                      ctx,
+                      profileCtx,
+                      targetId: responseTargetId,
+                      fallbackUrl: tab.url,
+                      ...(isExistingSession
+                        ? {
+                            ...existingSessionCallOptions,
+                            timeoutMs:
+                              responseTargetId === tab.targetId
+                                ? ctx.state().resolved.actionTimeoutMs
+                                : existingSessionCallOptions.timeoutMs,
+                            signal: verificationDeadline?.signal ?? signal,
+                          }
+                        : {}),
                     });
-                  }
-                });
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "press":
-                await runGuardedAction(() =>
-                  pressChromeMcpKey({
-                    ...existingSessionTarget,
-                    key: action.key,
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "hover":
-                await runGuardedAction(() =>
-                  hoverChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "scrollIntoView":
-                await runGuardedAction(() =>
-                  evaluateChromeMcpScript({
-                    ...existingSessionTarget,
-                    fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
-                    args: [action.ref!],
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "drag":
-                await runGuardedAction(() =>
-                  dragChromeMcpElement({
-                    ...existingSessionTarget,
-                    fromUid: action.startRef!,
-                    toUid: action.endRef!,
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "select":
-                await runGuardedAction(() =>
-                  fillChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    value: action.values[0] ?? "",
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "fill":
-                await runGuardedAction(() =>
-                  fillChromeMcpForm({
-                    ...existingSessionTarget,
-                    elements: action.fields.map((field) => ({
-                      uid: field.ref,
-                      value: String(field.value ?? ""),
-                    })),
-                  }),
-                );
-                return await jsonOk(undefined, { resolveCurrentTarget: true });
-              case "resize":
-                await resizeChromeMcpPage({
-                  ...existingSessionTarget,
-                  width: action.width,
-                  height: action.height,
-                });
-                return await jsonOk();
-              case "wait":
-                await runGuardedAction(() =>
-                  waitForExistingSessionCondition({
-                    ...existingSessionTarget,
-                    timeMs: action.timeMs,
-                    text: action.text,
-                    textGone: action.textGone,
-                    selector: action.selector,
-                    url: action.url,
-                    loadState: action.loadState,
-                    fn: action.fn,
-                    ...navigationPolicy,
-                  }),
-                );
-                return await jsonOk();
-              case "evaluate": {
-                const result = await runGuardedAction(() =>
-                  evaluateChromeMcpScript({
-                    ...existingSessionTarget,
-                    fn: normalizeBrowserEvaluateFunctionSource(
-                      action.fn,
-                      action.ref ? { argumentName: "el" } : undefined,
-                    ),
-                    args: action.ref ? [action.ref] : undefined,
-                  }),
-                );
-                return await jsonOk({ result }, { resolveCurrentTarget: true });
+              verificationDeadline?.throwIfAborted();
+              requestDeadline?.throwIfAborted();
+              if (isExistingSession) {
+                signal.throwIfAborted();
               }
-              case "close":
-                await profileCtx.closeTab(tab.targetId, {
-                  ...existingSessionCallOptions,
-                  exactTargetId: true,
-                });
-                clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
-                return await jsonOk();
-              case "batch":
+              return res.json({
+                ok: true,
+                targetId: responseTargetId,
+                ...(url ? { url } : {}),
+                ...extra,
+              });
+            };
+            // Nested batch aliases can differ from the request alias, so prefixes
+            // must stay unique across the full tab set before canonicalization.
+            const actionTabs =
+              action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
+            if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
+              actionTabs.unshift(tab);
+            }
+            const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
+            if (targetIdError) {
+              return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
+            }
+            const profileName = profileCtx.profile.name;
+            if (isExistingSession) {
+              const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
+              if (unsupportedMessage) {
                 return jsonActError(
                   res,
                   501,
                   ACT_ERROR_CODES.unsupportedForExistingSession,
-                  EXISTING_SESSION_LIMITS.act.batch,
+                  unsupportedMessage,
                 );
+              }
+              const existingSessionTarget: ExistingSessionOperation = {
+                profileName,
+                profile: profileCtx.profile,
+                targetId: tab.targetId,
+                ...existingSessionCallOptions,
+              };
+              const initialTabTargetIds =
+                hasNavigationResultPolicy && existingSessionTimeouts.verificationTimeoutMs > 0
+                  ? new Set(
+                      (await profileCtx.listTabs(existingSessionCallOptions)).map(
+                        (currentTab) => currentTab.targetId,
+                      ),
+                    )
+                  : new Set<string>();
+              const runGuardedAction = async <T>(
+                execute: (
+                  target: ExistingSessionOperation,
+                  checkDeadline: () => void,
+                ) => Promise<T>,
+              ): Promise<T> => {
+                const bodyDeadline =
+                  existingSessionTimeouts.bodyTimeoutMs === undefined
+                    ? undefined
+                    : createExistingSessionDeadline(
+                        existingSessionTimeouts.bodyTimeoutMs,
+                        signal,
+                        "Browser action",
+                      );
+                const checkDeadline = () => {
+                  requestDeadline?.throwIfAborted();
+                  signal.throwIfAborted();
+                  bodyDeadline?.throwIfAborted();
+                };
+                let outcome: { result: T } | { error: unknown };
+                try {
+                  checkDeadline();
+                  const result = await execute(
+                    { ...existingSessionTarget, signal: bodyDeadline?.signal ?? signal },
+                    checkDeadline,
+                  );
+                  checkDeadline();
+                  outcome = { result };
+                } catch (error) {
+                  outcome = {
+                    error: bodyDeadline?.signal.aborted ? bodyDeadline.signal.reason : error,
+                  };
+                } finally {
+                  bodyDeadline?.cleanup();
+                }
+                if (existingSessionTimeouts.verificationTimeoutMs > 0) {
+                  verificationDeadline = createExistingSessionDeadline(
+                    existingSessionTimeouts.verificationTimeoutMs,
+                    signal,
+                    "Browser navigation verification",
+                  );
+                  verificationDeadline.throwIfAborted();
+                  const verificationOptions = {
+                    ...existingSessionCallOptions,
+                    signal: verificationDeadline.signal,
+                  };
+                  await assertExistingSessionPostInteractionNavigationAllowed({
+                    ...existingSessionTarget,
+                    ...verificationOptions,
+                    ...navigationPolicy,
+                    listTabs: () => profileCtx.listTabs(verificationOptions),
+                    initialTabTargetIds,
+                  });
+                }
+                if ("error" in outcome) {
+                  throw toErrorObject(outcome.error, "Non-Error thrown");
+                }
+                return outcome.result;
+              };
+              switch (action.kind) {
+                case "click":
+                  await runGuardedAction((target) =>
+                    clickChromeMcpElement({
+                      ...target,
+                      uid: action.ref!,
+                      doubleClick: action.doubleClick ?? false,
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "clickCoords":
+                  await runGuardedAction((target) =>
+                    clickChromeMcpCoords({
+                      ...target,
+                      x: action.x,
+                      y: action.y,
+                      doubleClick: action.doubleClick ?? false,
+                      button: action.button as "left" | "right" | "middle" | undefined,
+                      delayMs: action.delayMs,
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "type":
+                  await runGuardedAction(async (target, checkDeadline) => {
+                    await fillChromeMcpElement({
+                      ...target,
+                      uid: action.ref!,
+                      value: action.text,
+                    });
+                    if (action.submit) {
+                      checkDeadline();
+                      await pressChromeMcpKey({
+                        ...target,
+                        key: "Enter",
+                      });
+                    }
+                  });
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "press":
+                  await runGuardedAction((target) =>
+                    pressChromeMcpKey({
+                      ...target,
+                      key: action.key,
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "hover":
+                  await runGuardedAction((target) =>
+                    hoverChromeMcpElement({
+                      ...target,
+                      uid: action.ref!,
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "scrollIntoView":
+                  await runGuardedAction((target) =>
+                    evaluateChromeMcpScript({
+                      ...target,
+                      fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
+                      args: [action.ref!],
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "drag":
+                  await runGuardedAction((target) =>
+                    dragChromeMcpElement({
+                      ...target,
+                      fromUid: action.startRef!,
+                      toUid: action.endRef!,
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "select":
+                  await runGuardedAction((target) =>
+                    fillChromeMcpElement({
+                      ...target,
+                      uid: action.ref!,
+                      value: action.values[0] ?? "",
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "fill":
+                  await runGuardedAction((target) =>
+                    fillChromeMcpForm({
+                      ...target,
+                      elements: action.fields.map((field) => ({
+                        uid: field.ref,
+                        value: String(field.value ?? ""),
+                      })),
+                    }),
+                  );
+                  return await jsonOk(undefined, { resolveCurrentTarget: true });
+                case "resize":
+                  await runGuardedAction((target) =>
+                    resizeChromeMcpPage({
+                      ...target,
+                      width: action.width,
+                      height: action.height,
+                    }),
+                  );
+                  return await jsonOk();
+                case "wait":
+                  await runGuardedAction((target) =>
+                    waitForExistingSessionCondition({
+                      ...target,
+                      timeMs: action.timeMs,
+                      text: action.text,
+                      textGone: action.textGone,
+                      selector: action.selector,
+                      url: action.url,
+                      loadState: action.loadState,
+                      fn: action.fn,
+                      ...navigationPolicy,
+                    }),
+                  );
+                  return await jsonOk();
+                case "evaluate": {
+                  const result = await runGuardedAction((target) =>
+                    evaluateChromeMcpScript({
+                      ...target,
+                      fn: normalizeBrowserEvaluateFunctionSource(
+                        action.fn,
+                        action.ref ? { argumentName: "el" } : undefined,
+                      ),
+                      args: action.ref ? [action.ref] : undefined,
+                    }),
+                  );
+                  return await jsonOk({ result }, { resolveCurrentTarget: true });
+                }
+                case "close":
+                  await runGuardedAction((target) =>
+                    profileCtx.closeTab(tab.targetId, {
+                      timeoutMs: target.timeoutMs,
+                      signal: target.signal,
+                      exactTargetId: true,
+                    }),
+                  );
+                  clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
+                  return await jsonOk();
+                case "batch":
+                  return jsonActError(
+                    res,
+                    501,
+                    ACT_ERROR_CODES.unsupportedForExistingSession,
+                    EXISTING_SESSION_LIMITS.act.batch,
+                  );
+              }
             }
-          }
 
-          const pw = await requirePwAi(res, `act:${kind}`);
-          if (!pw) {
-            return;
-          }
-          const result = await pw.executeActViaPlaywright({
-            cdpUrl,
-            action,
-            targetId: tab.targetId,
-            evaluateEnabled,
-            ...navigationPolicy,
-            signal,
-          });
-          const resultTargetOptions = {
-            resolveCurrentTarget: true,
-            operationTargetId: result.targetId,
-          };
-          if (result.blockedByDialog) {
-            return await jsonOk({
-              blockedByDialog: true,
-              browserState: result.browserState,
+            const pw = await requirePwAi(res, `act:${kind}`);
+            if (!pw) {
+              return;
+            }
+            const result = await pw.executeActViaPlaywright({
+              cdpUrl,
+              action,
+              targetId: tab.targetId,
+              evaluateEnabled,
+              ...navigationPolicy,
+              signal,
             });
+            const resultTargetOptions = {
+              resolveCurrentTarget: true,
+              operationTargetId: result.targetId,
+            };
+            if (result.blockedByDialog) {
+              return await jsonOk({
+                blockedByDialog: true,
+                browserState: result.browserState,
+              });
+            }
+            const downloads = result.downloads;
+            if (action.kind === "close" || result.aborted?.reason === "closed") {
+              clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
+            }
+            switch (action.kind) {
+              case "batch":
+                return await jsonOk(
+                  {
+                    results: result.results ?? [],
+                    ...(result.aborted ? { aborted: result.aborted } : {}),
+                    ...(downloads ? { downloads } : {}),
+                  },
+                  {
+                    ...resultTargetOptions,
+                    resolveCurrentTarget: result.aborted?.reason !== "closed",
+                  },
+                );
+              case "evaluate":
+                return await jsonOk(
+                  { result: result.result, ...(downloads ? { downloads } : {}) },
+                  resultTargetOptions,
+                );
+              case "click":
+              case "clickCoords":
+                return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
+              case "resize":
+              case "close":
+                return await jsonOk(downloads ? { downloads } : undefined);
+              default:
+                return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
+            }
+          } catch (error) {
+            verificationDeadline?.throwIfAborted();
+            requestDeadline?.throwIfAborted();
+            throw error;
+          } finally {
+            verificationDeadline?.cleanup();
+            await resolveRelayTarget?.release();
           }
-          const downloads = result.downloads;
-          if (action.kind === "close" || result.aborted?.reason === "closed") {
-            clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
-          }
-          switch (action.kind) {
-            case "batch":
-              return await jsonOk(
-                {
-                  results: result.results ?? [],
-                  ...(result.aborted ? { aborted: result.aborted } : {}),
-                  ...(downloads ? { downloads } : {}),
-                },
-                {
-                  ...resultTargetOptions,
-                  resolveCurrentTarget: result.aborted?.reason !== "closed",
-                },
-              );
-            case "evaluate":
-              return await jsonOk(
-                { result: result.result, ...(downloads ? { downloads } : {}) },
-                resultTargetOptions,
-              );
-            case "click":
-            case "clickCoords":
-              return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
-            case "resize":
-            case "close":
-              return await jsonOk(downloads ? { downloads } : undefined);
-            default:
-              return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
-          }
-        } finally {
-          await resolveRelayTarget?.release();
-        }
-      },
-    });
+        },
+      });
+    } finally {
+      requestDeadline?.cleanup();
+    }
   });
 
   registerBrowserAgentActHookRoutes(app, ctx);
@@ -864,5 +628,3 @@ export function registerBrowserAgentActRoutes(
     });
   });
 }
-
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -418,9 +418,15 @@ describe("existing-session browser routes", () => {
     expect(response.statusCode).toBe(200);
     expect(routeState.profileCtx.closeTab).toHaveBeenCalledWith("7", {
       exactTargetId: true,
-      signal: ctrl.signal,
-      timeoutMs: undefined,
+      signal: expect.any(AbortSignal),
+      timeoutMs: 60_000,
     });
+    const reason = new Error("caller cancelled");
+    ctrl.abort(reason);
+    expect(routeState.profileCtx.closeTab).toHaveBeenCalledWith(
+      "7",
+      expect.objectContaining({ signal: expect.objectContaining({ aborted: true, reason }) }),
+    );
   });
 
   it("allows existing-session snapshots under the default SSRF policy object", async () => {
@@ -629,7 +635,10 @@ describe("existing-session browser routes", () => {
     expect(clickParams.uid).toBe("btn-1");
     expect(clickParams.doubleClick).toBe(false);
     expect(clickParams.timeoutMs).toBe(1234);
-    expect(clickParams.signal).toBe(ctrl.signal);
+    expect(clickParams.signal).toBeInstanceOf(AbortSignal);
+    const reason = new Error("caller cancelled");
+    ctrl.abort(reason);
+    expect(clickParams.signal).toMatchObject({ aborted: true, reason });
   });
 
   it("supports coordinate clicks for existing-session profiles", async () => {

--- a/extensions/browser/src/browser/routes/agent.shared.test.ts
+++ b/extensions/browser/src/browser/routes/agent.shared.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover agent.shared plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { BrowserProfileUnavailableError, toBrowserErrorResponse } from "../errors.js";
+import * as navigationGuard from "../navigation-guard.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
 import "../../test-support/browser-security.mock.js";
 import {
@@ -173,6 +174,32 @@ describe("browser route shared helpers", () => {
           targetId: "tab-1",
         }),
       ).resolves.toBeUndefined();
+    });
+
+    it("propagates cancelled URL verification instead of returning a redacted URL", async () => {
+      const controller = new AbortController();
+      const reason = new Error("browser navigation verification deadline expired");
+      const guard = vi
+        .spyOn(navigationGuard, "assertBrowserNavigationResultAllowed")
+        .mockImplementationOnce(async () => {
+          controller.abort(reason);
+          throw reason;
+        });
+      try {
+        await expect(
+          resolveSafeRouteTabUrl({
+            ctx: routeContext() as never,
+            profileCtx: profileContext([
+              { targetId: "tab-1", url: "https://example.com/current" },
+            ]) as never,
+            targetId: "tab-1",
+            signal: controller.signal,
+          }),
+        ).rejects.toBe(reason);
+        expect(guard).toHaveBeenCalledWith(expect.objectContaining({ signal: controller.signal }));
+      } finally {
+        guard.mockRestore();
+      }
     });
   });
 

--- a/extensions/browser/src/browser/routes/agent.shared.ts
+++ b/extensions/browser/src/browser/routes/agent.shared.ts
@@ -172,6 +172,7 @@ export async function withRouteTabContext<T>(
         if (params.enforceCurrentUrlAllowed) {
           await assertBrowserNavigationResultAllowed({
             url: tab.url,
+            signal,
             ...browserNavigationPolicyForProfile(params.ctx, profileCtx),
           });
         }
@@ -228,10 +229,12 @@ export async function resolveSafeRouteTabUrl(params: {
   try {
     await assertBrowserNavigationResultAllowed({
       url: candidateUrl,
+      signal: params.signal,
       ...browserNavigationPolicyForProfile(params.ctx, params.profileCtx),
     });
     return candidateUrl;
   } catch {
+    params.signal?.throwIfAborted();
     return undefined;
   }
 }

--- a/extensions/browser/src/browser/routes/existing-session-limits.ts
+++ b/extensions/browser/src/browser/routes/existing-session-limits.ts
@@ -1,3 +1,5 @@
+import type { BrowserActRequest } from "../client-actions.types.js";
+
 /**
  * Existing-session browser capability-limit messages.
  *
@@ -57,3 +59,69 @@ export const EXISTING_SESSION_LIMITS = {
   emulation:
     "emulate is not supported for existing-session profiles; use a managed browser profile for device, media, timezone, or locale settings.",
 } as const;
+
+/** Explain unsupported action shapes before existing-session dispatch. */
+export function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string | null {
+  switch (action.kind) {
+    case "click":
+      if (action.selector) {
+        return EXISTING_SESSION_LIMITS.act.clickSelector;
+      }
+      if (
+        (action.button && action.button !== "left") ||
+        (Array.isArray(action.modifiers) && action.modifiers.length > 0)
+      ) {
+        return EXISTING_SESSION_LIMITS.act.clickButtonOrModifiers;
+      }
+      return null;
+    case "clickCoords":
+      return null;
+    case "type":
+      if (action.selector) {
+        return EXISTING_SESSION_LIMITS.act.typeSelector;
+      }
+      if (action.slowly) {
+        return EXISTING_SESSION_LIMITS.act.typeSlowly;
+      }
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.typeTimeout : null;
+    case "press":
+      return action.delayMs ? EXISTING_SESSION_LIMITS.act.pressDelay : null;
+    case "hover":
+      if (action.selector) {
+        return EXISTING_SESSION_LIMITS.act.hoverSelector;
+      }
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.hoverTimeout : null;
+    case "scrollIntoView":
+      if (action.selector) {
+        return EXISTING_SESSION_LIMITS.act.scrollSelector;
+      }
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.scrollTimeout : null;
+    case "drag":
+      if (action.startSelector || action.endSelector) {
+        return EXISTING_SESSION_LIMITS.act.dragSelector;
+      }
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.dragTimeout : null;
+    case "select":
+      if (action.selector) {
+        return EXISTING_SESSION_LIMITS.act.selectSelector;
+      }
+      if (action.values.length !== 1) {
+        return EXISTING_SESSION_LIMITS.act.selectSingleValue;
+      }
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.selectTimeout : null;
+    case "fill":
+      return action.timeoutMs ? EXISTING_SESSION_LIMITS.act.fillTimeout : null;
+    case "wait":
+      return action.loadState === "networkidle"
+        ? EXISTING_SESSION_LIMITS.act.waitNetworkIdle
+        : null;
+    case "evaluate":
+      return null;
+    case "batch":
+      return EXISTING_SESSION_LIMITS.act.batch;
+    case "resize":
+    case "close":
+      return null;
+  }
+  throw new Error("Unsupported browser act kind");
+}

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -152,7 +152,9 @@ describe("browser element commands", () => {
     await program.parseAsync(argv, { from: "user" });
 
     expect(getLastActionBody()).toMatchObject(expectedBody);
-    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({
+      timeoutMs: 126_250,
+    });
   });
 
   it("rejects a blank required ref before dispatch", async () => {
@@ -245,6 +247,6 @@ describe("browser element commands", () => {
     const timeoutRequest = timeoutCall?.[1] as { body?: { timeoutMs?: number } } | undefined;
     const timeoutOptions = timeoutCall?.[2] as { timeoutMs?: number } | undefined;
     expect(timeoutRequest?.body?.timeoutMs).toBe(20_000);
-    expect(timeoutOptions?.timeoutMs).toBe(25_250);
+    expect(timeoutOptions?.timeoutMs).toBe(126_250);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -73,7 +73,7 @@ describe("browser action input fill command", () => {
       ],
       targetId: "tab-1",
     });
-    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 126_250 });
   });
 
   it("reports malformed fields without sending a browser request", async () => {
@@ -154,7 +154,7 @@ describe("browser action input wait command", () => {
     const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
       | { timeoutMs?: number }
       | undefined;
-    expect(options?.timeoutMs).toBe(26_000);
+    expect(options?.timeoutMs).toBe(127_250);
   });
 
   it("budgets every supplied wait condition before adding transport slack", async () => {
@@ -245,12 +245,12 @@ describe("browser action input evaluate command", () => {
       ref: "button-1",
       targetId: "tab-2",
     });
-    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 65_000 });
+    expect(mocks.callBrowserRequest.mock.calls.at(-1)?.[2]).toEqual({ timeoutMs: 126_250 });
   });
 
   it.each([
-    { rawTimeout: "+030000", actionTimeoutMs: 30_000, requestTimeoutMs: 35_250 },
-    { rawTimeout: "1", actionTimeoutMs: 1, requestTimeoutMs: 5_750 },
+    { rawTimeout: "+030000", actionTimeoutMs: 30_000, requestTimeoutMs: 66_250 },
+    { rawTimeout: "1", actionTimeoutMs: 1, requestTimeoutMs: 6_252 },
   ])(
     "preserves the $rawTimeout evaluate timeout and canonical outer deadline",
     async ({ rawTimeout, actionTimeoutMs, requestTimeoutMs }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where existing-session browser waits and evaluations could lose their transport before their advertised execution time elapsed. Regression cases demonstrate a default wait being cut off at 25 seconds and a requested 180-second evaluation being cut off at 125.25 seconds.

Nested action calls and navigation probes also renewed their individual timeouts, while cancellation could stop at a DNS lookup or disappear during final URL handling.

## Why This Change Was Made

The existing-session route now owns one overall deadline spanning tab preparation, action execution and response completion. Action steps share an execution window; navigation verification shares a separate bounded allowance. Cancellation reaches the existing MCP and DNS mechanisms, and late completion cannot dispatch another action step or produce success.

The shared transport calculation covers both browser backends while retaining Playwright's sequential action and batch accounting. Canonical timeout-capability metadata avoids misclassifying valid inputs before route normalization. Existing-session wait and navigation helpers now have a separate owning module.

## User Impact

Existing-session waits and evaluations can use their supported execution budgets. Filling and submitting with `type` share one action budget instead of receiving a fresh timeout for each internal step. Navigation probes share their verification allowance, and cancellation stops waiting on DNS through the existing resolver. The CLI reference documents these bounds.

## Evidence

The frozen runtime candidate passed 578 owner and sibling tests across 14 files on Linux with supported Node 24.19 and pnpm 12.3.4. Before/after cases cover transport truncation, action and verification cancellation, DNS and final URL cancellation, slow tab preparation, and normalized click inputs. Existing Playwright, CLI, client and tool cases are included.

Independent review completed with no accepted findings. A whitespace-input concern was rejected after real client/route checks confirmed that normalization removes blank text before execution. All 27 final changed-file check stages passed after removing an obsolete lint suppression and its baseline entry. Runtime and test bytes are unchanged from the 578-test candidate. These are synthetic client/route tests with mocked Chrome MCP operations, not a live browser session.
