### PR TITLE
fix: retain side-question resources through runtime cleanup

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1,5 +1,6 @@
 /** Tests BTW side-question execution, session context, auth, and harness routing. */
 
+import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +10,8 @@ import { onInternalDiagnosticEvent } from "../infra/diagnostic-events.js";
 import type { ProviderResolveModelRoutesContext } from "../plugin-sdk/provider-model-types.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
 import {
@@ -16,6 +19,8 @@ import {
   mintSecretSentinel,
   resolveSecretSentinel,
 } from "../secrets/sentinel.js";
+import { AsyncWorkScope, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -57,6 +62,7 @@ const migrateSessionEntriesMock = vi.fn();
 const buildSessionContextMock = vi.fn();
 const ensureOpenClawModelsJsonMock = vi.fn();
 const loadPreparedModelRuntimeSnapshotMock = vi.fn();
+let acquireSnapshotResources: (() => { release: () => void }) | undefined;
 const discoverAuthStorageMock = vi.fn();
 const discoverModelsMock = vi.fn();
 const getModelRegistryRuntimeMock = vi.fn();
@@ -144,9 +150,8 @@ vi.mock("./sessions/model-registry-runtime.js", () => ({
   getModelRegistryRuntime: (...args: unknown[]) => getModelRegistryRuntimeMock(...args),
 }));
 
-vi.mock("./prepared-model-runtime.js", () => ({
-  preparedModelRuntimeConfigsMatch: (left: unknown, right: unknown) => left === right,
-  loadPreparedModelRuntimeSnapshot: async (params: {
+vi.mock("./prepared-model-runtime.js", () => {
+  const loadSnapshot = async (params: {
     agentId?: string;
     agentDir: string;
     config: unknown;
@@ -179,8 +184,16 @@ vi.mock("./prepared-model-runtime.js", () => ({
       inlineProviderModels: [],
       createStores: () => ({ authStorage, modelRegistry }),
     };
-  },
-}));
+  };
+  return {
+    preparedModelRuntimeConfigsMatch: (left: unknown, right: unknown) => left === right,
+    loadPreparedModelRuntimeSnapshot: loadSnapshot,
+    acquirePublishedPreparedModelRuntime: async (params: Parameters<typeof loadSnapshot>[0]) => {
+      const snapshot = await loadSnapshot(params);
+      return { snapshot, release: acquireSnapshotResources?.().release ?? (() => {}) };
+    },
+  };
+});
 
 vi.mock("./model-discovery-context.js", () => ({
   resolveModelPluginMetadataSnapshot: () => undefined,
@@ -719,6 +732,7 @@ describe("runBtwSideQuestion", () => {
     buildSessionContextMock.mockReset();
     ensureOpenClawModelsJsonMock.mockReset();
     loadPreparedModelRuntimeSnapshotMock.mockReset();
+    acquireSnapshotResources = undefined;
     discoverAuthStorageMock.mockReset();
     discoverModelsMock.mockReset();
     getModelRegistryRuntimeMock.mockReset();
@@ -1032,6 +1046,121 @@ describe("runBtwSideQuestion", () => {
       "allowGatewaySubagentBinding",
     );
   });
+
+  it.each(["harness cleanup", "harness error", "stream output and transport"] as const)(
+    "keeps the source database through %s after its publication retires",
+    async (mode) => {
+      const file = state.path(`btw-${mode.replaceAll(" ", "-")}.sqlite`);
+      const database = new DatabaseSync(file);
+      database.exec("CREATE TABLE answer (value INTEGER); INSERT INTO answer VALUES (42)");
+      const source = new PluginRegistryInspectionResources();
+      source.attach(createEmptyPluginRegistry());
+      let disposals = 0;
+      source.runRegistration("btw-fixture", () =>
+        source.register("btw-fixture", {
+          id: "database",
+          dispose: () => {
+            disposals++;
+            database.close();
+          },
+        }),
+      );
+      acquireSnapshotResources = () => {
+        const claim = source.retain();
+        return {
+          release: () => {
+            void claim.release();
+          },
+        };
+      };
+      const entered = createDeferredCore();
+      const finish = createDeferredCore();
+      const tailEntered = createDeferredCore();
+      const finishTail = createDeferredCore();
+      const owner = new AsyncWorkScope();
+      let operation: Promise<unknown> | undefined;
+      let tailValue: unknown;
+      try {
+        if (mode !== "stream output and transport") {
+          const runHarness = registerCodexSideQuestionHarness();
+          runHarness.mockImplementationOnce(async () => {
+            try {
+              entered.resolve();
+              await finish.promise;
+              if (mode === "harness error") {
+                throw new Error("side question failed");
+              }
+              return { text: String(database.prepare("SELECT value FROM answer").get()?.value) };
+            } finally {
+              tailEntered.resolve();
+              await finishTail.promise;
+              tailValue = database.prepare("SELECT value FROM answer").get()?.value;
+            }
+          });
+          operation = owner.track(() => runSideQuestion());
+        } else {
+          streamSimpleMock.mockImplementationOnce(() => {
+            void trackAsyncWork(async () => {
+              tailEntered.resolve();
+              await finishTail.promise;
+              tailValue = database.prepare("SELECT value FROM answer").get()?.value;
+            });
+            return makeAsyncEvents([{ type: "text_start" }, createDoneEvent("The answer is 42.")]);
+          });
+          operation = owner.track(() =>
+            runSideQuestion({
+              opts: {
+                onAssistantMessageStart: async () => {
+                  entered.resolve();
+                  await finish.promise;
+                  expect(database.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+                },
+              },
+            }),
+          );
+        }
+        const outcome = operation.catch((error: unknown) => error);
+        await Promise.race([
+          entered.promise,
+          operation.then(() => {
+            throw new Error("Side question completed before its controlled operation");
+          }),
+        ]);
+        await source.release();
+        expect(database.isOpen).toBe(true);
+        expect(disposals).toBe(0);
+        finish.resolve();
+        await tailEntered.promise;
+        if (mode === "stream output and transport") {
+          expect(await outcome).toEqual({ text: "The answer is 42." });
+        }
+        expect(database.isOpen).toBe(true);
+        finishTail.resolve();
+        if (mode === "harness cleanup") {
+          expect(await outcome).toEqual({ text: "42" });
+        } else if (mode === "harness error") {
+          expect(await outcome).toEqual(new Error("side question failed"));
+        }
+        await owner.drain();
+        expect(tailValue).toBe(42);
+        await expect.poll(() => disposals).toBe(1);
+        expect(database.isOpen).toBe(false);
+        const reopened = new DatabaseSync(file, { readOnly: true });
+        try {
+          expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        finish.resolve();
+        finishTail.resolve();
+        await Promise.allSettled([operation, owner.drain(), source.release()]);
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+    },
+  );
 
   it("keeps model, runtime auth, and stream selection on prepared A after current advances to B", async () => {
     const cfg = { agents: { entries: { main: { default: true } } } } as never;

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 /**
  * Runs `/btw` side questions against the active conversation without resuming
@@ -27,6 +28,12 @@ import type {
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { isModelSelectionLocked } from "../sessions/model-overrides.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
@@ -70,7 +77,7 @@ import {
 } from "./model-runtime-aliases.js";
 import { isOpenAIProvider } from "./openai-routing.js";
 import {
-  loadPreparedModelRuntimeSnapshot,
+  acquirePublishedPreparedModelRuntime,
   preparedModelRuntimeConfigsMatch,
   type PreparedModelRuntimeSnapshot,
   type PreparedModelRuntimeStores,
@@ -710,6 +717,39 @@ async function runCliBtwSideQuestion(params: {
   }
 }
 
+/** The visible answer may finish before cooperating provider and cleanup work settles. */
+async function withBtwPreparedRuntime(
+  input: Parameters<typeof acquirePublishedPreparedModelRuntime>[0],
+  run: (snapshot: PreparedModelRuntimeSnapshot) => Promise<ReplyPayload | undefined>,
+): Promise<ReplyPayload | undefined> {
+  const result = createDeferredCore<ReplyPayload | undefined>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  void trackOwner(async () => {
+    const lease = await acquirePublishedPreparedModelRuntime(input);
+    const work = new AsyncWorkScope();
+    const runInScope = work.run(() =>
+      withPluginRuntimeGenerationScope(lease.snapshot, () => AsyncLocalStorage.snapshot()),
+    );
+    const closeWork = () => runInScope(() => work.beginClose(parentSignal?.reason));
+    parentSignal?.addEventListener("abort", closeWork, { once: true });
+    if (parentSignal?.aborted) {
+      closeWork();
+    }
+    try {
+      result.resolve(await runInScope(() => work.track(() => run(lease.snapshot))));
+    } catch (error) {
+      result.reject(error);
+    } finally {
+      await work.runWhenIdle(() => undefined);
+      await runInScope(() => work.drain());
+      parentSignal?.removeEventListener("abort", closeWork);
+      lease.release();
+    }
+  }).catch((error: unknown) => result.reject(error));
+  return await result.promise;
+}
+
 /** Answers a side question using sanitized session context and no tool execution. */
 export async function runBtwSideQuestion(
   paramsInput: RunBtwSideQuestionParams,
@@ -736,7 +776,7 @@ export async function runBtwSideQuestion(
   }
 
   const requestedWorkspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
-  const preparedModelRuntime = await loadPreparedModelRuntimeSnapshot({
+  const runtimeInput = {
     config: params.cfg,
     agentId: params.agentId,
     agentDir: params.agentDir,
@@ -744,8 +784,8 @@ export async function runBtwSideQuestion(
     // Gateway-published owners are keyed with this flag, so a gateway-hosted
     // request that omits it can never match one.
     ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true as const } : {}),
-  });
-  return await withPluginRuntimeGenerationScope(preparedModelRuntime, async () => {
+  };
+  return await withBtwPreparedRuntime(runtimeInput, async (preparedModelRuntime) => {
     const sessionAgentId = preparedModelRuntime.agentId ?? params.agentId;
     const workspaceDir =
       preparedModelRuntime.workspaceDir ??

--- a/src/agents/prepared-model-runtime.published-owner.ts
+++ b/src/agents/prepared-model-runtime.published-owner.ts
@@ -1,0 +1,71 @@
+import {
+  PreparedModelRuntimeOwnerNotPublishedError,
+  normalizePreparedModelRuntimeInput,
+  preparedModelRuntimeConfigsMatch,
+  resolvePublishedOwner,
+} from "./prepared-model-runtime.owner.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimeOwner,
+  PreparedModelRuntimeReplacement,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+
+type PublishedModelRuntimeContext = {
+  captureLifetime(): () => void;
+  getPendingReplacement(): PreparedModelRuntimeReplacement | undefined;
+  owners: Map<string, PreparedModelRuntimeOwner>;
+};
+
+/** Project or retain the exact published owner before its snapshot crosses an await. */
+export async function projectPublishedModelRuntimeOwner<T>(
+  rawInput: PreparedModelRuntimeInput,
+  context: PublishedModelRuntimeContext,
+  project: (owner: PreparedModelRuntimeOwner, snapshot: PreparedModelRuntimeSnapshot) => T,
+): Promise<T> {
+  const assertLifetime = context.captureLifetime();
+  const replacement = context.getPendingReplacement();
+  if (replacement) {
+    // Individual owners may finish before a multi-owner publication commits. The lifecycle gate
+    // makes the generation visible atomically only after every owner and auth mutation is ready.
+    await replacement.promise;
+    assertLifetime();
+    return await projectPublishedModelRuntimeOwner(rawInput, context, project);
+  }
+  const input = normalizePreparedModelRuntimeInput(rawInput);
+  const existing = resolvePublishedOwner(context.owners, input, {
+    allowConfiguredWorkspaceFallback:
+      rawInput.workspaceDir === undefined ||
+      rawInput.agentId === undefined ||
+      rawInput.runtimePluginSelections === undefined,
+  });
+  if (
+    input.readOnly &&
+    existing &&
+    !preparedModelRuntimeConfigsMatch(existing.input.config, input.config)
+  ) {
+    throw new PreparedModelRuntimeOwnerNotPublishedError(
+      `prepared read-only model runtime owner was not published for the requested config (${input.agentDir})`,
+    );
+  }
+  // Generated catalogs are lifecycle artifacts, not a live-edit surface. Config/plugin reload,
+  // doctor/auth repair, and auth publication replace owners; external edits require restart.
+  if (existing?.pending) {
+    try {
+      await existing.pending;
+    } catch {
+      // Re-read the owner below so a superseding generation wins over this result or error.
+    }
+    assertLifetime();
+    return await projectPublishedModelRuntimeOwner(rawInput, context, project);
+  }
+  if (existing?.needsRefresh) {
+    throw existing.refreshError ?? new Error("prepared model runtime refresh is pending");
+  }
+  if (existing?.snapshot) {
+    return project(existing, existing.snapshot);
+  }
+  throw new PreparedModelRuntimeOwnerNotPublishedError(
+    `prepared model runtime owner was not published for ${input.agentDir}`,
+  );
+}

--- a/src/agents/prepared-model-runtime.published-resources.test.ts
+++ b/src/agents/prepared-model-runtime.published-resources.test.ts
@@ -1,0 +1,290 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
+import { expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
+import { runBtwSideQuestion } from "./btw.js";
+import {
+  acquirePublishedPreparedModelRuntime,
+  acquireReadOnlyPreparedModelRuntime,
+} from "./prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+
+const selectedSource = vi.hoisted(() => {
+  const state: { input?: PreparedModelRuntimeInput } = {};
+  return state;
+});
+
+// Exercise BTW against an already-owned source without enabling configured producer disposal.
+vi.mock("./prepared-model-runtime.js", async (importOriginal) => {
+  const runtime = await importOriginal<typeof import("./prepared-model-runtime.js")>();
+  return {
+    ...runtime,
+    loadPreparedModelRuntimeSnapshot: (
+      input: Parameters<typeof runtime.loadPreparedModelRuntimeSnapshot>[0],
+    ) => runtime.loadPreparedModelRuntimeSnapshot(selectedSource.input ?? input),
+    acquirePublishedPreparedModelRuntime: (
+      input: Parameters<typeof runtime.acquirePublishedPreparedModelRuntime>[0],
+    ) => runtime.acquirePublishedPreparedModelRuntime(selectedSource.input ?? input),
+  };
+});
+
+it.each(["published borrow", "BTW harness cleanup", "BTW parent close"] as const)(
+  "retains an acquired SQLite source through %s and replacement",
+  async (mode) => {
+    await withOpenClawTestState({ label: "published-runtime-resources" }, async (state) => {
+      const pluginId = "published-runtime-provider";
+      const pluginRoot = state.path("plugin");
+      const emptyBundled = state.path("empty-bundled");
+      fs.mkdirSync(pluginRoot);
+      fs.mkdirSync(emptyBundled);
+      const fixture = createColdPluginFixture({
+        rootDir: pluginRoot,
+        pluginId,
+        providerId: pluginId,
+        manifest: {
+          channels: [],
+          channelConfigs: {},
+          providerAuthChoices: [],
+          startup: { agentHarnesses: [pluginId] },
+          modelCatalog: {
+            providers: {
+              [pluginId]: {
+                discovery: "static",
+                api: "openai-completions",
+                baseUrl: "https://fixture.invalid/v1",
+                models: [{ id: "model", name: "Fixture model", input: ["text"] }],
+              },
+            },
+          },
+        },
+      });
+      const key = `__published_runtime_resources_${path.basename(state.root)}`;
+      const connections: Array<{ file: string; database: DatabaseSync; disposals: number }> = [];
+      const requestSignal: { current?: AbortSignal } = {};
+      const abortRegistry: { current?: ReturnType<typeof getPluginRuntimeGenerationRegistry> } = {};
+      const bridge = {
+        connections,
+        getRequestSignal: getSessionMcpRequestSignal,
+        getRegistry: getPluginRuntimeGenerationRegistry,
+        requestSignal,
+        abortRegistry,
+        abortObserved: createDeferredCore(),
+        entered: createDeferredCore(),
+        finish: createDeferredCore(),
+        cleanupEntered: createDeferredCore(),
+        cleanupFinish: createDeferredCore(),
+      };
+      Object.defineProperty(globalThis, key, { configurable: true, value: bridge });
+      fs.writeFileSync(
+        fixture.runtimeSource,
+        `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    const bridge = globalThis[${JSON.stringify(key)}];
+    const connections = bridge.connections;
+    const file = ${JSON.stringify(state.root)} + "/registration-" + connections.length + ".sqlite";
+    const database = new DatabaseSync(file);
+    database.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+    const connection = { file, database, disposals: 0 };
+    connections.push(connection);
+    api.lifecycle.registerRuntimeLifecycle({ id: "database", dispose() {
+      connection.disposals++;
+      database.close();
+    } });
+    api.registerProvider({ id: ${JSON.stringify(pluginId)}, label: "Fixture provider", auth: [] });
+    api.registerAgentHarness({
+      id: ${JSON.stringify(pluginId)}, label: "Fixture harness", authBootstrap: "harness",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: async () => { throw new Error("Only side questions may run"); },
+      async runSideQuestion() {
+        try {
+          bridge.requestSignal.current = bridge.getRequestSignal();
+          bridge.requestSignal.current?.addEventListener("abort", () => {
+            bridge.abortRegistry.current = bridge.getRegistry();
+            bridge.abortObserved.resolve();
+          }, { once: true });
+          bridge.entered.resolve();
+          await bridge.finish.promise;
+          return { text: String(database.prepare("SELECT value FROM answer").get().value) };
+        } finally {
+          bridge.cleanupEntered.resolve();
+          await bridge.cleanupFinish.promise;
+          database.prepare("SELECT value FROM answer").get();
+        }
+      },
+    });
+  },
+};
+`,
+      );
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: `${pluginId}/model` },
+            workspace: state.workspaceDir,
+            agentRuntime: { id: pluginId },
+          },
+        },
+        models: {
+          providers: {
+            [pluginId]: {
+              api: "openai-completions",
+              apiKey: "synthetic-btw-fixture",
+              baseUrl: "https://fixture.invalid/v1",
+              models: [
+                {
+                  id: "model",
+                  name: "Fixture model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          load: { paths: [pluginRoot] },
+          slots: { memory: "none" },
+          entries: { [pluginId]: { enabled: true } },
+        },
+      };
+      const input = {
+        config,
+        agentId: "main",
+        agentDir: state.agentDir("main"),
+        workspaceDir: state.workspaceDir,
+        readOnly: true,
+        loadRuntimePlugins: true,
+        skipCredentials: true,
+        runtimePluginSelections: [{ provider: pluginId, modelId: "model", agentId: "main" }],
+      };
+      await withEnvAsync(
+        { OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundled, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+        async () => {
+          await resetPreparedModelRuntimeSnapshotsForTest();
+          clearPluginMetadataLifecycleCaches();
+          let first: Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>> | undefined;
+          let borrower:
+            | Awaited<ReturnType<typeof acquirePublishedPreparedModelRuntime>>
+            | undefined;
+          let replacement:
+            | Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>>
+            | undefined;
+          const owner = new AsyncWorkScope();
+          let sideQuestion: ReturnType<typeof runBtwSideQuestion> | undefined;
+          try {
+            first = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            expect(connections).toHaveLength(1);
+            const original = expectDefined(connections[0], "original provider registration");
+            if (mode === "published borrow") {
+              const pending = acquirePublishedPreparedModelRuntime(input);
+              first.release();
+              borrower = await pending;
+              expect(borrower.snapshot).toBe(first.snapshot);
+            } else {
+              selectedSource.input = input;
+              sideQuestion = owner.track(() =>
+                runBtwSideQuestion({
+                  cfg: config,
+                  agentId: "main",
+                  agentDir: input.agentDir,
+                  provider: pluginId,
+                  model: "model",
+                  question: "What is the answer?",
+                  sessionEntry: {
+                    sessionId: "btw-native-fixture",
+                    updatedAt: 1,
+                    agentHarnessId: pluginId,
+                  },
+                  sessionKey: "agent:main:btw-native-fixture",
+                  isNewSession: false,
+                  resolvedThinkLevel: "off",
+                  resolvedReasoningLevel: "off",
+                }),
+              );
+              await Promise.race([
+                bridge.entered.promise,
+                sideQuestion.then(() => {
+                  throw new Error("BTW did not enter the acquired harness");
+                }),
+              ]);
+              if (mode === "BTW parent close") {
+                const reason = new Error("BTW parent closed");
+                owner.beginClose(reason);
+                expect(bridge.requestSignal.current?.aborted).toBe(true);
+                expect(bridge.requestSignal.current?.reason).toBe(reason);
+              }
+              first.release();
+            }
+            expect(original.database.isOpen).toBe(true);
+            replacement = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            expect(connections).toHaveLength(2);
+            const successor = expectDefined(connections[1], "replacement provider registration");
+            expect(original.database.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+            if (mode !== "published borrow") {
+              bridge.finish.resolve();
+              await bridge.cleanupEntered.promise;
+              expect(original.database.isOpen).toBe(true);
+              bridge.cleanupFinish.resolve();
+              expect(await sideQuestion).toEqual({ text: "42" });
+              await bridge.abortObserved.promise;
+              expect(bridge.abortRegistry.current === first.snapshot.pluginRegistry).toBe(true);
+              await owner.drain();
+            } else {
+              borrower?.release();
+            }
+            await expect.poll(() => original.disposals).toBe(1);
+            expect(original.database.isOpen).toBe(false);
+            expect(successor.database.isOpen).toBe(true);
+            const reopened = new DatabaseSync(original.file, { readOnly: true });
+            try {
+              expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+            } finally {
+              reopened.close();
+            }
+            replacement.release();
+            await expect.poll(() => successor.disposals).toBe(1);
+          } finally {
+            bridge.finish.resolve();
+            bridge.cleanupFinish.resolve();
+            await Promise.allSettled([sideQuestion, owner.drain()]);
+            selectedSource.input = undefined;
+            first?.release();
+            borrower?.release();
+            replacement?.release();
+            await resetPreparedModelRuntimeSnapshotsForTest();
+            clearPluginMetadataLifecycleCaches();
+            resetPluginLoaderTestStateForTest();
+            cleanupPluginLoaderFixturesForTest();
+            for (const connection of connections) {
+              if (connection.database.isOpen) {
+                connection.database.close();
+              }
+            }
+            Reflect.deleteProperty(globalThis, key);
+          }
+        },
+      );
+    });
+  },
+);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -31,13 +31,11 @@ import {
   normalizeOptionalDir,
   normalizePreparedModelRuntimeInput,
   ownerKey,
-  preparedModelRuntimeConfigsMatch,
   publishPreparedModelRuntimeOwnerBatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
   resolvePreparedModelRuntimeOwnerBySnapshot,
   resolveConfiguredOwnerPublication,
-  resolvePublishedOwner,
   readPublishedModelRuntimeSnapshot,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
@@ -52,13 +50,17 @@ import {
   notifyPreparedModelRuntimePublication,
   resetPreparedModelRuntimePublicationListenersForTest,
 } from "./prepared-model-runtime.publication-events.js";
+import { projectPublishedModelRuntimeOwner } from "./prepared-model-runtime.published-owner.js";
 import {
   isPreparedModelRuntimeOwnerInRefreshScope,
   listConfiguredRefreshInputs,
   resolveSafeRefreshAgentIds,
   updateOwnersForScopedRefresh,
 } from "./prepared-model-runtime.refresh-scope.js";
-import { closeEphemeralPreparedModelRuntimeResources } from "./prepared-model-runtime.resources.js";
+import {
+  closeEphemeralPreparedModelRuntimeResources,
+  retainPreparedModelRuntimeGenerationResources,
+} from "./prepared-model-runtime.resources.js";
 import { PreparedModelRuntimeOwnerRetention } from "./prepared-model-runtime.retention.js";
 import type {
   PreparedModelRuntimeCatalogMode,
@@ -166,6 +168,27 @@ export function advancePreparedModelRuntimeConfig(config: OpenClawConfig): void 
 export async function loadPreparedModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeSnapshot> {
+  return await loadPreparedModelRuntimeOwner(rawInput, (_owner, snapshot) => snapshot);
+}
+
+/** Borrows the selected publication without changing its activation or retention policy. */
+export async function acquirePublishedPreparedModelRuntime(
+  rawInput: PreparedModelRuntimeInput,
+): Promise<PreparedModelRuntimeLease> {
+  return await loadPreparedModelRuntimeOwner(rawInput, (owner, snapshot) => {
+    const pluginGeneration = owner.pluginGeneration;
+    if (!pluginGeneration) {
+      throw new Error("Published model runtime has no plugin generation");
+    }
+    const claim = retainPreparedModelRuntimeGenerationResources(pluginGeneration);
+    return { snapshot, pluginGeneration, release: () => claim?.release() };
+  });
+}
+
+async function loadPreparedModelRuntimeOwner<T>(
+  rawInput: PreparedModelRuntimeInput,
+  project: (owner: PreparedModelRuntimeOwner, snapshot: PreparedModelRuntimeSnapshot) => T,
+): Promise<T> {
   const assertLifetime = captureModelRuntimeLifetime();
   let input = normalizePreparedModelRuntimeInput({
     ...rawInput,
@@ -184,7 +207,11 @@ export async function loadPreparedModelRuntimeSnapshot(
       continue;
     }
     try {
-      return await prepareModelRuntimeSnapshot(input);
+      return await projectPublishedModelRuntimeOwner(
+        input,
+        preparedModelRuntimeLeaseContext,
+        project,
+      );
     } catch (error) {
       if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
         throw error;
@@ -199,10 +226,18 @@ export async function loadPreparedModelRuntimeSnapshot(
       continue;
     }
     if (!activated) {
-      return await prepareModelRuntimeSnapshot(input);
+      return await projectPublishedModelRuntimeOwner(
+        input,
+        preparedModelRuntimeLeaseContext,
+        project,
+      );
     }
     try {
-      return await prepareModelRuntimeSnapshot(input);
+      return await projectPublishedModelRuntimeOwner(
+        input,
+        preparedModelRuntimeLeaseContext,
+        project,
+      );
     } catch (error) {
       if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
         throw error;
@@ -371,50 +406,10 @@ export async function acquireReadOnlyPreparedModelRuntime(
 export async function prepareModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeSnapshot> {
-  const assertLifetime = captureModelRuntimeLifetime();
-  const replacement = pendingModelRuntimeReplacement;
-  if (replacement) {
-    // Individual owners may finish before a multi-owner publication commits. The lifecycle gate
-    // makes the generation visible atomically only after every owner and auth mutation is ready.
-    await replacement.promise;
-    assertLifetime();
-    return await prepareModelRuntimeSnapshot(rawInput);
-  }
-  const input = normalizePreparedModelRuntimeInput(rawInput);
-  const existing = resolvePublishedOwner(owners, input, {
-    allowConfiguredWorkspaceFallback:
-      rawInput.workspaceDir === undefined ||
-      rawInput.agentId === undefined ||
-      rawInput.runtimePluginSelections === undefined,
-  });
-  if (
-    input.readOnly &&
-    existing &&
-    !preparedModelRuntimeConfigsMatch(existing.input.config, input.config)
-  ) {
-    throw new PreparedModelRuntimeOwnerNotPublishedError(
-      `prepared read-only model runtime owner was not published for the requested config (${input.agentDir})`,
-    );
-  }
-  // Generated catalogs are lifecycle artifacts, not a live-edit surface. Config/plugin reload,
-  // doctor/auth repair, and auth publication replace owners; external edits require restart.
-  if (existing?.pending) {
-    try {
-      await existing.pending;
-    } catch {
-      // Re-read the owner below so a superseding generation wins over this result or error.
-    }
-    assertLifetime();
-    return await prepareModelRuntimeSnapshot(rawInput);
-  }
-  if (existing?.needsRefresh) {
-    throw existing.refreshError ?? new Error("prepared model runtime refresh is pending");
-  }
-  if (existing?.snapshot) {
-    return existing.snapshot;
-  }
-  throw new PreparedModelRuntimeOwnerNotPublishedError(
-    `prepared model runtime owner was not published for ${input.agentDir}`,
+  return await projectPublishedModelRuntimeOwner(
+    rawInput,
+    preparedModelRuntimeLeaseContext,
+    (_owner, snapshot) => snapshot,
   );
 }
 


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Resolves a lifetime gap where `/btw` keeps using a published runtime without retaining its resources through the side question and cleanup. That prevents safe retirement of managed generations while admitted side work is still running.

## Why This Change Was Made

Acquire the exact generation at the synchronous published-owner read, then retain it through side-question output, harness cleanup, and tracked descendants. Existing publication, standalone activation, configuration replacement, model selection, and catalog policy remain unchanged. The shared read policy moves into one internal module.

Parent cancellation and normal cleanup run in the captured generation context. The caller can receive its result before physical cleanup finishes, while the parent work owner still joins that cleanup.

## User Impact

Side questions retain their prepared resources until admitted work finishes, including during replacement and cancellation. This prepares the path for managed resource disposal; ordinary configured/raw producer disposal is not enabled by this PR. No public option, backend policy, or database schema changes.

## Evidence

Four lifetime cases fail against both original production files with premature SQLite closure. The combined case uses a real acquired plugin registration, the actual published loader and BTW harness path, delayed cleanup, replacement, exactly-once disposal, and database reopening. A test-only input adapter selects the existing owned read-only source; it does not enable configured disposal.

Final validation passed 81 BTW/native tests, 156 affected sibling tests, source-affected type/lint/Knip and remaining guard coverage, fresh isolated Codex review through P2, and a full build in 243.30 seconds. Counts overlap. Regression coverage includes parent MCP cancellation and normal cleanup context.

A strict plain-Node compiled run passed in 2.886 seconds with 12,120 unchanged artifacts and no application TypeScript/source fallback. It exercises actual built BTW on normal standalone publication, cancellation and cleanup context, plus actual built owned read-only published borrowing with SQLite close/reopen. Combined managed-source BTW composition is covered by the maintained native test. Cold BTW admission measured 241.82 ms; a warm call plus cleanup took 3.69 ms. These are local samples, not a comparative performance benchmark.

After rebasing onto current main, all five source files match the reviewed proof and all 81 composition cases pass again. No real external provider, packaged CLI, or native Codex execution is claimed; existing Codex interrupt/unsubscribe contracts were inspected and backend behavior is unchanged.
