### PR TITLE
refactor(doctor): reuse canonical dreaming statistics types

### DIFF
--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -75,15 +75,21 @@ type DoctorMemoryRemDreamingPayload = DoctorMemoryDreamingPhasePayload & {
   minPatternStrength: number;
 };
 
-type DoctorMemoryDreamingPayload = Omit<ShortTermDreamingStats, "storePath" | "phaseSignalPath"> & {
+type DreamingStoreStats = Omit<ShortTermDreamingStats, "storePath" | "phaseSignalPath"> & {
+  storePath?: string;
+  phaseSignalPath?: string;
+  storeError?: string;
+};
+
+type DoctorMemoryDreamingConfigPayload = {
   enabled: boolean;
   timezone?: string;
   verboseLogging: boolean;
   storageMode: "inline" | "separate" | "both";
   separateReports: boolean;
-  storePath?: string;
-  phaseSignalPath?: string;
-  storeError?: string;
+  shortTermEntries: ShortTermDreamingStatsEntry[];
+  signalEntries: ShortTermDreamingStatsEntry[];
+  promotedEntries: ShortTermDreamingStatsEntry[];
   phases: {
     light: DoctorMemoryLightDreamingPayload;
     deep: DoctorMemoryDeepDreamingPayload;
@@ -91,7 +97,7 @@ type DoctorMemoryDreamingPayload = Omit<ShortTermDreamingStats, "storePath" | "p
   };
 };
 
-type DoctorMemoryDreamingEntryPayload = ShortTermDreamingStatsEntry;
+type DoctorMemoryDreamingPayload = DoctorMemoryDreamingConfigPayload & DreamingStoreStats;
 
 export type DoctorMemoryStatusPayload = {
   agentId: string;
@@ -184,26 +190,7 @@ async function listWorkspaceDailyFiles(memoryDir: string): Promise<string[]> {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-function resolveDreamingConfig(
-  cfg: OpenClawConfig,
-): Omit<
-  DoctorMemoryDreamingPayload,
-  | "shortTermCount"
-  | "recallSignalCount"
-  | "dailySignalCount"
-  | "groundedSignalCount"
-  | "totalSignalCount"
-  | "phaseSignalCount"
-  | "lightPhaseHitCount"
-  | "remPhaseHitCount"
-  | "promotedTotal"
-  | "promotedToday"
-  | "storePath"
-  | "phaseSignalPath"
-  | "lastPromotedAt"
-  | "storeError"
-  | "phaseSignalError"
-> {
+function resolveDreamingConfig(cfg: OpenClawConfig): DoctorMemoryDreamingConfigPayload {
   const resolved = resolveMemoryDreamingConfig({
     pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
     cfg,
@@ -260,28 +247,6 @@ function resolveDreamingConfig(
   };
 }
 
-type DreamingStoreStats = Pick<
-  DoctorMemoryDreamingPayload,
-  | "shortTermCount"
-  | "recallSignalCount"
-  | "dailySignalCount"
-  | "groundedSignalCount"
-  | "totalSignalCount"
-  | "phaseSignalCount"
-  | "lightPhaseHitCount"
-  | "remPhaseHitCount"
-  | "promotedTotal"
-  | "promotedToday"
-  | "storePath"
-  | "phaseSignalPath"
-  | "lastPromotedAt"
-  | "storeError"
-  | "phaseSignalError"
-  | "shortTermEntries"
-  | "signalEntries"
-  | "promotedEntries"
->;
-
 const DREAMING_ENTRY_LIST_LIMIT = 8;
 
 // Keep malformed persisted timestamps behind valid entries; returning NaN here
@@ -291,8 +256,8 @@ function parseDreamingTimestampMs(value: string | undefined): number {
 }
 
 function compareDreamingEntryByRecency(
-  a: DoctorMemoryDreamingEntryPayload,
-  b: DoctorMemoryDreamingEntryPayload,
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
 ): number {
   const aMs = parseDreamingTimestampMs(a.lastRecalledAt);
   const bMs = parseDreamingTimestampMs(b.lastRecalledAt);
@@ -306,8 +271,8 @@ function compareDreamingEntryByRecency(
 }
 
 function compareDreamingEntryBySignals(
-  a: DoctorMemoryDreamingEntryPayload,
-  b: DoctorMemoryDreamingEntryPayload,
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
 ): number {
   if (b.totalSignalCount !== a.totalSignalCount) {
     return b.totalSignalCount - a.totalSignalCount;
@@ -319,8 +284,8 @@ function compareDreamingEntryBySignals(
 }
 
 function compareDreamingEntryByPromotion(
-  a: DoctorMemoryDreamingEntryPayload,
-  b: DoctorMemoryDreamingEntryPayload,
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
 ): number {
   const aMs = parseDreamingTimestampMs(a.promotedAt);
   const bMs = parseDreamingTimestampMs(b.promotedAt);
@@ -331,10 +296,10 @@ function compareDreamingEntryByPromotion(
 }
 
 function trimDreamingEntries(
-  entries: DoctorMemoryDreamingEntryPayload[],
-  compare: (a: DoctorMemoryDreamingEntryPayload, b: DoctorMemoryDreamingEntryPayload) => number,
-): DoctorMemoryDreamingEntryPayload[] {
-  const selected: DoctorMemoryDreamingEntryPayload[] = [];
+  entries: ShortTermDreamingStatsEntry[],
+  compare: (a: ShortTermDreamingStatsEntry, b: ShortTermDreamingStatsEntry) => number,
+): ShortTermDreamingStatsEntry[] {
+  const selected: ShortTermDreamingStatsEntry[] = [];
   for (const entry of entries) {
     // Keep the public status payload bounded while preserving the comparator's best entries.
     let insertAt = selected.length;
@@ -401,9 +366,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
   const phaseSignalPaths = new Set<string>();
   const storeErrors: string[] = [];
   const phaseSignalErrors: string[] = [];
-  const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
-  const signalEntries: DoctorMemoryDreamingEntryPayload[] = [];
-  const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
+  const shortTermEntries: ShortTermDreamingStatsEntry[] = [];
+  const signalEntries: ShortTermDreamingStatsEntry[] = [];
+  const promotedEntries: ShortTermDreamingStatsEntry[] = [];
 
   for (const stat of stats) {
     shortTermCount += stat.shortTermCount;


### PR DESCRIPTION
Related: #141873

## What Problem This Solves

Removes the remaining duplicated field inventories in Doctor's dreaming status types after the canonical stats contracts moved to the memory host SDK.

## Why This Change Was Made

Doctor now derives its aggregate stats directly from the canonical stats type, preserving its optional aggregate paths and local error field. Configuration output keeps a separate, explicitly enumerated type and an explicit resolver return annotation. The entry alias is replaced by the existing canonical entry type.

This preserves the independent configuration-output guard rather than replacing it with inferred runtime output. No runtime expression, protocol field, configuration, persistence operation, dependency or SDK export changes.

Production LOC: +25/-60 (net -35). Tests: unchanged. The earlier canonicalization in #141873 is not counted as part of this cleanup.

## User Impact

No intended user-visible change. Doctor's status payloads and error handling remain unchanged, while their types have fewer duplicate definitions to keep synchronized.

## Evidence

- Original and candidate native core/UI typechecks passed.
- Original and candidate Doctor suites passed all 45 cases, including workspace aggregation, errors, targeting and dreaming actions.
- Complete before/after emitted JavaScript buffers are byte-identical under the same owned TypeScript compiler and options; no application code was executed by that comparison.
- Formatting and diff checks passed. The normal 28-stage configured Linux Node24 changed gate passed, including core/test typechecks and architecture guards. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34396388503), native exit 0 and completed lease. A runner-portal reporting timeout was separate from the successful command.
- Managed precommit and separate read-only exact-commit Codex reviews through P2 found no actionable findings. Reviewed commit: c4982774a1ba8f6bfc439fa4517cf0a949f6e8ef.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34400234242) passed on that commit, attempt 1: 108 successful jobs and 17 conditional skips, including successful openclaw/ci-gate.

## Data-model Compatibility Disposition

The [review's compatibility item](https://github.com/openclaw/openclaw/pull/143368#issuecomment-5608209012) is not applicable to this diff. Only TypeScript declarations and annotations change; no schema, stored field, migration, repair operation, serializer or runtime import changes. The complete 26,308-byte JavaScript output before and after has the same SHA-256, `1a22b9ae6749140e1ba7101f798aac8889c6dfb46a31d31c450c57b818d1501f`. The existing repair/backfill function bodies remain unchanged.

The canonical field contracts, optional aggregate paths and mutable entry arrays were independently reviewed and verified by the original/candidate core and UI typechecks and 45-case Doctor suites. There is no new stored-data transition to exercise with an upgrade test. This is a source-backed disposition of the requested item, not a waiver of CI or a change to migration policy.
