### PR TITLE
fix: retain speech providers until stream cleanup finishes

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -71,6 +71,15 @@ transcodes and saves those completed buffers after releasing the provider. The
 separate synchronous speech lookup and request-preparation APIs keep their
 existing caller lifetime; streaming speech is not part of this finite operation.
 
+Streaming speech owns its provider registrations until stream cleanup finishes.
+`api.runtime.tts.textToSpeechStream(...)` preserves an explicit provider
+`release()` callback's lifetime after EOF or a read error: callers must still
+invoke and await the returned `release()`. Without a provider release callback,
+EOF or a read error releases registrations automatically. Stream cancellation
+and explicit release start source cancellation and provider cleanup before
+joining both, including tracked producer work. Release also handles an unopened
+stream. Existing raw host registrations keep their host lifetime.
+
 For `image_generate`, `music_generate`, and `video_generate` tools prepared from an owned inspection,
 resources remain held through preflight and, once accepted, through generation, media saving, and
 any rollback. A `started` result acknowledges acceptance; it does not mean the

--- a/src/plugins/capability-provider-acquisition.ts
+++ b/src/plugins/capability-provider-acquisition.ts
@@ -150,7 +150,7 @@ export async function acquirePluginCapabilityProviders<
   }
 }
 
-async function finishCapabilityOperation<T>(
+export async function finishCapabilityOperation<T>(
   outcome: Result<T, unknown>,
   release: () => Promise<void>,
 ): Promise<T> {

--- a/src/tts/tts-runtime-models.test.ts
+++ b/src/tts/tts-runtime-models.test.ts
@@ -265,7 +265,8 @@ describe("TTS runtime voice model and streaming behavior", () => {
     expect(result.outputFormat).toBe("pcm");
     expect(result.fileExtension).toBe(".pcm");
     expect(result.target).toBe("audio-file");
-    expect(result.release).toBe(release);
+    await result.release?.();
+    expect(release).toHaveBeenCalledOnce();
     const skippedAttempt = requireAttempt(result.attempts, 0);
     expect(skippedAttempt).toMatchObject({
       provider: "buffered",
@@ -341,5 +342,6 @@ describe("TTS runtime voice model and streaming behavior", () => {
     expect(fallbackStreamSynthesize).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Keep streaming Markdown raw!" }),
     );
+    await result.release?.();
   });
 });

--- a/src/tts/tts-streaming-resources.ts
+++ b/src/tts/tts-streaming-resources.ts
@@ -1,0 +1,220 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Result } from "@openclaw/normalization-core/result";
+import { formatErrorMessage } from "../infra/errors.js";
+import { finishCapabilityOperation } from "../plugins/capability-provider-acquisition.js";
+import type { SpeechSynthesisStreamResult } from "./provider-types.js";
+import { throwTtsProjectionError } from "./tts-synthesis-support.js";
+
+type SpeechWorkOwner = {
+  run: <T>(operation: () => T | Promise<T>) => Promise<T>;
+  release: () => Promise<void>;
+};
+
+export async function captureSpeechProviderStream(
+  synthesis: SpeechSynthesisStreamResult,
+  owner: SpeechWorkOwner,
+) {
+  const captured = AsyncLocalStorage.snapshot();
+  const invoke = <T>(operation: () => T | Promise<T>) => captured(() => owner.run(operation));
+  let source: ReadableStream<Uint8Array> | undefined;
+  let providerRelease: (() => Promise<void>) | undefined;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let closed: Promise<Result<void, unknown>> | undefined;
+  const releaseReader = (active: ReadableStreamDefaultReader<Uint8Array>) => {
+    if (reader === active) {
+      reader = undefined;
+      active.releaseLock();
+    }
+  };
+  let completion: Promise<PromiseSettledResult<void>> | undefined;
+  const close = (reason?: unknown) =>
+    (completion ??= Promise.resolve().then(async () => {
+      const active = reader;
+      // Request release can abort a retained tee; start it before waiting for cancellation.
+      const cancellation = invoke(() => (active ? active.cancel(reason) : source?.cancel(reason)));
+      const cleanup = invoke(() => providerRelease?.());
+      if (active) {
+        releaseReader(active);
+      }
+      const [canceled, cleaned] = await Promise.allSettled([cancellation, cleanup]);
+      if (cleaned.status === "rejected") {
+        throw cleaned.reason;
+      }
+      return canceled;
+    }));
+  try {
+    // A failing stream getter must not hide its release callback, or vice versa.
+    const [releaseField, streamField] = await Promise.allSettled([
+      invoke(() => {
+        providerRelease = synthesis.release;
+      }),
+      invoke(() => {
+        source = synthesis.audioStream;
+      }),
+    ]);
+    const failures: unknown[] = [streamField, releaseField].flatMap((field) =>
+      field.status === "rejected" ? [field.reason] : [],
+    );
+    if (failures.length > 0) {
+      throw failures.length === 1
+        ? failures[0]
+        : new AggregateError(failures, formatErrorMessage(failures[0]), { cause: failures[0] });
+    }
+    reader = source?.getReader();
+    closed = reader?.closed.then(
+      () => ({ ok: true as const, value: undefined }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+  } catch (error) {
+    return await throwTtsProjectionError(error, async () => {
+      await close(error);
+    });
+  }
+  return {
+    available: Boolean(source),
+    requiresRelease: Boolean(providerRelease),
+    closed,
+    close,
+    async read(): Promise<ReadableStreamReadResult<Uint8Array>> {
+      const active = reader;
+      if (!active) {
+        return { done: true, value: undefined };
+      }
+      try {
+        const chunk = await invoke(() => active.read());
+        if (chunk.done) {
+          releaseReader(active);
+          source = undefined;
+        }
+        return chunk;
+      } catch (error) {
+        releaseReader(active);
+        source = undefined;
+        throw error;
+      }
+    },
+  };
+}
+
+export function ownSpeechStream(
+  transport: Awaited<ReturnType<typeof captureSpeechProviderStream>>,
+  owner: SpeechWorkOwner,
+) {
+  let activePull: Promise<void> | undefined;
+  const waitForPulls = async () => {
+    while (activePull) {
+      const pending = activePull;
+      await pending;
+      if (activePull === pending) {
+        activePull = undefined;
+      }
+    }
+  };
+  let completion: Promise<PromiseSettledResult<void>> | undefined;
+  const finish = (reason?: unknown) =>
+    (completion ??= Promise.resolve().then(async () => {
+      // Start transport cancellation before joining a read it may need to unblock.
+      const [closing, pulling] = await Promise.allSettled([
+        transport.close(reason),
+        waitForPulls(),
+      ]);
+      let outcome: Result<PromiseSettledResult<void>, unknown>;
+      if (closing.status === "rejected") {
+        outcome = {
+          ok: false,
+          error:
+            pulling.status === "rejected"
+              ? new AggregateError(
+                  [closing.reason, pulling.reason],
+                  formatErrorMessage(closing.reason),
+                  { cause: closing.reason },
+                )
+              : closing.reason,
+        };
+      } else if (pulling.status === "rejected") {
+        outcome = { ok: false, error: pulling.reason };
+      } else {
+        outcome = { ok: true, value: closing.value };
+      }
+      return await finishCapabilityOperation(outcome, owner.release);
+    }));
+  let terminal = false;
+  let output: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const audioStream = transport.available
+    ? new ReadableStream<Uint8Array>(
+        {
+          start(controller) {
+            output = controller;
+          },
+          pull(controller) {
+            const pending = (async () => {
+              try {
+                const chunk = await transport.read();
+                if (terminal) {
+                  return;
+                }
+                if (chunk.done) {
+                  if (transport.requiresRelease) {
+                    terminal = true;
+                    controller.close();
+                  }
+                } else {
+                  controller.enqueue(chunk.value);
+                }
+              } catch (error) {
+                if (!terminal && transport.requiresRelease) {
+                  terminal = true;
+                  controller.error(error);
+                }
+              }
+            })();
+            activePull = pending;
+            return pending;
+          },
+          async cancel(reason) {
+            terminal = true;
+            const canceled = await finish(reason);
+            if (canceled.status === "rejected") {
+              throw canceled.reason;
+            }
+          },
+        },
+        // Do not prefetch a returned but unopened stream.
+        { highWaterMark: 0 },
+      )
+    : undefined;
+  if (!transport.requiresRelease) {
+    // Observe termination after handoff; never put this finalizer in the pull it joins.
+    void transport.closed?.then(async (ending) => {
+      if (terminal) {
+        return;
+      }
+      try {
+        await finish(ending.ok ? undefined : ending.error);
+      } catch (error) {
+        if (ending.ok && !terminal) {
+          terminal = true;
+          output?.error(error);
+        }
+      }
+      if (!terminal) {
+        terminal = true;
+        if (ending.ok) {
+          output?.close();
+        } else {
+          output?.error(ending.error);
+        }
+      }
+    });
+  }
+  return {
+    audioStream,
+    async release() {
+      if (!terminal) {
+        terminal = true;
+        output?.close();
+      }
+      await finish(new Error("TTS stream released"));
+    },
+  };
+}

--- a/src/tts/tts-streaming.resources.test.ts
+++ b/src/tts/tts-streaming.resources.test.ts
@@ -1,0 +1,543 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { textToSpeechStream } from "./tts-streaming.js";
+
+const pcm = new Uint8Array([0, 0, 32, 0]);
+
+function createFixture(
+  options: {
+    id?: string;
+    explicitRelease?: boolean;
+    ending?: "eof" | "error" | "blocked";
+    initialState?: "empty" | "error" | "chunk";
+    projectionFailure?: "result" | "config-model" | "config-voice" | "audioStream" | "release";
+    holdRelease?: boolean;
+    invalidMetadata?: boolean;
+    releaseFailure?: boolean;
+  } = {},
+) {
+  const id = options.id ?? "native-stream";
+  const dir = makePluginLoaderTempDir();
+  const key = `__speech_stream_${path.basename(dir)}`;
+  const context = new AsyncLocalStorage<string>();
+  const started = createDeferredCore();
+  const aborted = createDeferredCore();
+  const tail = createDeferredCore();
+  const released = createDeferredCore();
+  const releaseResume = createDeferredCore();
+  if (!options.holdRelease) {
+    releaseResume.resolve();
+  }
+  const connections: Array<{ database: DatabaseSync; file: string; disposals: number }> = [];
+  const events: Array<{ phase: string; context: string | undefined }> = [];
+  const work: Promise<void>[] = [];
+  const state = {
+    dir,
+    options,
+    pcm,
+    context,
+    started,
+    aborted,
+    tail,
+    released,
+    releaseResume,
+    connections,
+    events,
+    work,
+    trackAsyncWork,
+    calls: 0,
+  };
+  Object.defineProperty(globalThis, key, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const file = require("node:path").join(state.dir, "stream-" + state.connections.length + ".sqlite");
+  const database = new DatabaseSync(file);
+  database.exec("CREATE TABLE fixture(value INTEGER); INSERT INTO fixture VALUES(42)");
+  const connection = { database, file, disposals: 0 }; state.connections.push(connection);
+  const record = (phase) => { database.prepare("SELECT value FROM fixture").get(); state.events.push({phase, context: state.context.getStore()}); };
+  api.lifecycle.registerRuntimeLifecycle({ id: "stream-db", dispose() { record("dispose"); connection.disposals++; database.close(); } });
+  api.registerSpeechProvider({ id: ${JSON.stringify(id)}, label: "Native stream", autoSelectOrder: 10,
+    resolveConfig() { record("config"); return { model: "native-model", voiceId: "native-voice" }; },
+    isConfigured() { record("configured"); return true; },
+    async synthesize() { throw new Error("Unexpected buffered speech"); },
+    async streamSynthesize(request) {
+      state.calls++; record("synthesis");
+      let index = 0;
+      let canceled = false;
+      const audioStream = new ReadableStream({
+        start(controller) {
+          if (state.options.initialState === "error") controller.error(new Error("native initial failure"));
+          else if (state.options.initialState) { if (state.options.initialState === "chunk") controller.enqueue(state.pcm); controller.close(); }
+        },
+        async pull(controller) {
+          record("pull"); state.started.resolve();
+          if (state.options.ending === "blocked") {
+            const pending = state.trackAsyncWork(async () => { await state.aborted.promise; await state.tail.promise; record("tail"); });
+            state.work.push(pending); await pending; if (!canceled) controller.close(); return;
+          }
+          if (index++ === 0) { controller.enqueue(state.pcm); return; }
+          if (state.options.ending === "error") { controller.error(new Error("native read failure")); return; }
+          controller.close();
+        },
+        async cancel() { canceled = true; record("cancel"); if (state.options.explicitRelease === false || state.options.projectionFailure === "release") state.aborted.resolve(); await state.aborted.promise; }
+      }, { highWaterMark: 0 });
+      let cleanup;
+      const release = () => cleanup ??= (async () => {
+        record("release"); state.released.resolve(); state.aborted.resolve();
+        await state.releaseResume.promise; record("released"); if (state.options.releaseFailure) throw new Error("native cleanup failure");
+      })();
+      if (state.options.projectionFailure?.startsWith("config-")) {
+        Object.defineProperty(request.providerConfig, state.options.projectionFailure === "config-model" ? "modelId" : "speakerVoiceId", { get() { throw new Error("native config projection failure"); } });
+      }
+      if (["audioStream", "release"].includes(state.options.projectionFailure)) {
+        state.work.push(state.trackAsyncWork(async () => { await state.aborted.promise; record("capture-tail"); }));
+        state.started.resolve();
+      }
+      return {
+        get audioStream() { if (state.options.projectionFailure === "audioStream") throw new Error("native audioStream projection failure"); return audioStream; },
+        get outputFormat() { record("metadata"); if (state.options.projectionFailure === "result") throw new Error("native result projection failure"); return "pcm"; },
+        fileExtension: state.options.invalidMetadata ? "" : ".pcm", voiceCompatible: false,
+        get release() { if (state.options.projectionFailure === "release") throw new Error("native release projection failure"); return state.options.explicitRelease === false ? undefined : release; },
+      };
+    }
+  });
+} };`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      contracts: { speechProviders: [id] },
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  const cfg: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+    tts: { provider: id, providers: { [id]: {} } },
+  };
+  const prefsPath = path.join(dir, "prefs.json");
+  fs.writeFileSync(prefsPath, "{}");
+  const run = () =>
+    context.run("source", () => textToSpeechStream({ text: "**native speech**", cfg, prefsPath }));
+  return {
+    id,
+    cfg,
+    prefsPath,
+    plugin,
+    state,
+    run,
+    withEnvironment: (operation: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        async () => {
+          useNoBundledPlugins();
+          await operation();
+        },
+      ),
+    async cleanup() {
+      aborted.resolve();
+      tail.resolve();
+      releaseResume.resolve();
+      await Promise.allSettled(work);
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+function expectClosed(fixture: ReturnType<typeof createFixture>) {
+  expect(fixture.state.connections.length).toBeGreaterThan(0);
+  for (const entry of fixture.state.connections) {
+    expect(entry.database.isOpen).toBe(false);
+    expect(entry.disposals).toBe(1);
+    const database = new DatabaseSync(entry.file, { readOnly: true });
+    try {
+      expect(database.prepare("SELECT value FROM fixture").get()?.value).toBe(42);
+    } finally {
+      database.close();
+    }
+  }
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("streaming speech registration ownership", () => {
+  it.each(["eof", "error"] as const)(
+    "keeps explicit cleanup after %s and closes on release",
+    async (ending) => {
+      const fixture = createFixture({ ending });
+      try {
+        await fixture.withEnvironment(async () => {
+          const result = await fixture.run();
+          expect(result.success).toBe(true);
+          const reader = result.audioStream!.getReader();
+          try {
+            expect((await reader.read()).value).toEqual(pcm);
+            if (ending === "error") {
+              await expect(reader.read()).rejects.toThrow("native read failure");
+            } else {
+              expect((await reader.read()).done).toBe(true);
+            }
+            expect(fixture.state.events.some((event) => event.phase === "release")).toBe(false);
+            expect(fixture.state.connections.every((entry) => entry.database.isOpen)).toBe(true);
+            await result.release?.();
+            await result.release?.();
+            expect(fixture.state.events.filter((event) => event.phase === "release").length).toBe(
+              1,
+            );
+            expectClosed(fixture);
+          } finally {
+            reader.releaseLock();
+            await result.release?.();
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["eof", "error"] as const)(
+    "releases a provider with no release callback after %s",
+    async (ending) => {
+      const fixture = createFixture({ ending, explicitRelease: false });
+      try {
+        await fixture.withEnvironment(async () => {
+          const result = await fixture.run();
+          const reader = result.audioStream!.getReader();
+          try {
+            expect((await reader.read()).value).toEqual(pcm);
+            if (ending === "error") {
+              await expect(reader.read()).rejects.toThrow("native read failure");
+            } else {
+              expect((await reader.read()).done).toBe(true);
+            }
+            expectClosed(fixture);
+          } finally {
+            reader.releaseLock();
+            await result.release?.();
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it("releases an unopened stream without requiring a reader", async () => {
+    const fixture = createFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        const result = await fixture.run();
+        await result.release?.();
+        expect(fixture.state.events.some((event) => event.phase === "pull")).toBe(false);
+        expectClosed(fixture);
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it.each(["managed", "raw"] as const)(
+    "preserves %s registration custody after stream handoff",
+    async (kind) => {
+      const fixture = createFixture();
+      try {
+        await fixture.withEnvironment(async () => {
+          const inspection =
+            kind === "managed"
+              ? await acquirePluginRegistryForInspection({ config: fixture.cfg })
+              : undefined;
+          const registry =
+            inspection?.registry ?? loadPluginRegistryHandle({ config: fixture.cfg });
+          const result = await withPluginRuntimeRegistryScope(registry, fixture.run);
+          await inspection?.release();
+          const reader = result.audioStream!.getReader();
+          try {
+            expect((await reader.read()).value).toEqual(pcm);
+            expect((await reader.read()).done).toBe(true);
+            await result.release?.();
+            if (kind === "managed") {
+              expectClosed(fixture);
+            } else {
+              expect(fixture.state.connections.every((entry) => entry.database.isOpen)).toBe(true);
+              expect(fixture.state.connections.every((entry) => entry.disposals === 0)).toBe(true);
+            }
+          } finally {
+            reader.releaseLock();
+            await result.release?.();
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["release", "cancel"] as const)(
+    "%s aborts before joining the blocked pull and retains its actual tail/context",
+    async (method) => {
+      const fixture = createFixture({ ending: "blocked" });
+      try {
+        await fixture.withEnvironment(async () => {
+          const result = await fixture.run();
+          const reader = result.audioStream!.getReader();
+          const read = reader.read();
+          await fixture.state.started.promise;
+          let settled = false;
+          const closing = fixture.state.context
+            .run("foreign", () => (method === "cancel" ? reader.cancel("stop") : result.release!()))
+            .then(() => {
+              settled = true;
+            });
+          try {
+            await nextTurn();
+            expect(fixture.state.events.some((event) => event.phase === "release")).toBe(true);
+            expect(settled).toBe(false);
+            expect(fixture.state.connections.every((entry) => entry.database.isOpen)).toBe(true);
+            fixture.state.tail.resolve();
+            await closing;
+            await read;
+            expect(
+              fixture.state.events
+                .filter((event) => ["cancel", "release", "tail"].includes(event.phase))
+                .every((event) => event.context === "source"),
+            ).toBe(true);
+            expectClosed(fixture);
+          } finally {
+            fixture.state.aborted.resolve();
+            fixture.state.tail.resolve();
+            await closing;
+            await read;
+            reader.releaseLock();
+            await result.release?.();
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it.each(["result", "config-model", "config-voice"] as const)(
+    "closes a stream when %s metadata projection fails before fallback",
+    async (projectionFailure) => {
+      const primary = createFixture({ id: "primary-stream", projectionFailure, holdRelease: true });
+      const fallback = createFixture({ id: "fallback-stream" });
+      try {
+        await primary.withEnvironment(async () => {
+          const cfg: OpenClawConfig = {
+            ...primary.cfg,
+            plugins: {
+              allow: [primary.id, fallback.id],
+              load: { paths: [primary.plugin.file, fallback.plugin.file] },
+              slots: { memory: "none" },
+            },
+            tts: { provider: primary.id, providers: { [primary.id]: {}, [fallback.id]: {} } },
+          };
+          const pending = textToSpeechStream({
+            text: "projection fallback",
+            cfg,
+            prefsPath: primary.prefsPath,
+          });
+          try {
+            await Promise.race([
+              primary.state.released.promise,
+              pending.then(() => {
+                throw new Error("Fallback returned before failed stream cleanup");
+              }),
+            ]);
+            expect(fallback.state.calls).toBe(0);
+            primary.state.releaseResume.resolve();
+            const result = await pending;
+            expect(result.success).toBe(true);
+            expect(result.provider).toBe(fallback.id);
+            expect(primary.state.events.some((event) => event.phase === "released")).toBe(true);
+            await result.release?.();
+            expectClosed(primary);
+            expectClosed(fallback);
+          } finally {
+            primary.state.releaseResume.resolve();
+            const result = await pending;
+            await result.release?.();
+          }
+        });
+      } finally {
+        await primary.cleanup();
+        await fallback.cleanup();
+      }
+    },
+  );
+  it("releases a successful provider result rejected by the public metadata guard", async () => {
+    const fixture = createFixture({ invalidMetadata: true });
+    try {
+      await fixture.withEnvironment(async () => {
+        const result = await fixture.run();
+        expect(result.success).toBe(false);
+        expect(result.error).toBe("Streaming TTS conversion failed");
+        expect(fixture.state.events.filter((event) => event.phase === "release").length).toBe(1);
+        expectClosed(fixture);
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("keeps a post-byte stream failure with the selected provider", async () => {
+    const primary = createFixture({ id: "primary-stream", ending: "error" });
+    const fallback = createFixture({ id: "fallback-stream" });
+    try {
+      await primary.withEnvironment(async () => {
+        const cfg: OpenClawConfig = {
+          ...primary.cfg,
+          plugins: {
+            allow: [primary.id, fallback.id],
+            load: { paths: [primary.plugin.file, fallback.plugin.file] },
+            slots: { memory: "none" },
+          },
+          tts: { provider: primary.id, providers: { [primary.id]: {}, [fallback.id]: {} } },
+        };
+        const result = await textToSpeechStream({
+          text: "partial failure",
+          cfg,
+          prefsPath: primary.prefsPath,
+        });
+        const reader = result.audioStream!.getReader();
+        try {
+          expect((await reader.read()).value).toEqual(pcm);
+          await expect(reader.read()).rejects.toThrow("native read failure");
+          expect(fallback.state.calls).toBe(0);
+        } finally {
+          reader.releaseLock();
+          await result.release?.();
+        }
+      });
+    } finally {
+      await primary.cleanup();
+      await fallback.cleanup();
+    }
+  });
+
+  it("preserves the projection error when its stream cleanup also fails", async () => {
+    const fixture = createFixture({ projectionFailure: "result", releaseFailure: true });
+    try {
+      await fixture.withEnvironment(async () => {
+        const result = await fixture.run();
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("native result projection failure");
+        expect(result.error).not.toContain("native cleanup failure");
+        expectClosed(fixture);
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+  it.each([
+    { projectionFailure: "audioStream", releaseFailure: false },
+    { projectionFailure: "audioStream", releaseFailure: true },
+    { projectionFailure: "release", releaseFailure: false },
+  ] as const)(
+    "uses the other cleanup field when $projectionFailure fails (cleanup rejects: $releaseFailure)",
+    async ({ projectionFailure, releaseFailure }) => {
+      const fixture = createFixture({ projectionFailure, releaseFailure });
+      try {
+        await fixture.withEnvironment(async () => {
+          const pending = fixture.run();
+          try {
+            await fixture.state.started.promise;
+            await nextTurn();
+            expect(
+              fixture.state.events.some(
+                (event) =>
+                  event.phase === (projectionFailure === "audioStream" ? "release" : "cancel"),
+              ),
+            ).toBe(true);
+            const result = await pending;
+            expect(result.success).toBe(false);
+            expect(result.error).toContain(`native ${projectionFailure} projection failure`);
+            expect(fixture.state.events.some((event) => event.phase === "capture-tail")).toBe(true);
+            expectClosed(fixture);
+          } finally {
+            fixture.state.aborted.resolve();
+            await pending;
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+  it.each(["empty", "error", "chunk"] as const)(
+    "finishes a no-release source in initial state %s without an extra EOF read",
+    async (initialState) => {
+      const fixture = createFixture({ explicitRelease: false, initialState });
+      try {
+        await fixture.withEnvironment(async () => {
+          const result = await fixture.run();
+          const reader = result.audioStream!.getReader();
+          let closed = false;
+          void reader.closed.then(
+            () => {
+              closed = true;
+            },
+            () => {
+              closed = true;
+            },
+          );
+          try {
+            if (initialState === "chunk") {
+              expect((await reader.read()).value).toEqual(pcm);
+            }
+            await nextTurn();
+            expect(closed).toBe(true);
+            expectClosed(fixture);
+            if (initialState === "error") {
+              await expect(reader.read()).rejects.toThrow("native initial failure");
+            } else {
+              expect((await reader.read()).done).toBe(true);
+            }
+          } finally {
+            reader.releaseLock();
+            await result.release?.();
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+});

--- a/src/tts/tts-streaming.ts
+++ b/src/tts/tts-streaming.ts
@@ -1,9 +1,12 @@
+import type { Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../config/types.js";
+import { finishCapabilityOperation } from "../plugins/capability-provider-acquisition.js";
 import type { TtsDirectiveOverrides } from "./provider-types.js";
 import { assertSpeechRuntimeAvailable } from "./runtime-availability.js";
 import { normalizeSpeechText } from "./speech-text.js";
 import type { TtsStreamResult, TtsSynthesisStreamResult } from "./tts-runtime-types.js";
-import { executeTtsProviderAttempts, resolveTtsRequestSetup } from "./tts-synthesis-support.js";
+import { captureSpeechProviderStream, ownSpeechStream } from "./tts-streaming-resources.js";
+import { executeTtsProviderAttempts, acquireTtsRequest } from "./tts-synthesis-support.js";
 import { resolveTtsSynthesisTarget } from "./tts-synthesis.js";
 
 export async function streamSpeech(params: {
@@ -18,7 +21,7 @@ export async function streamSpeech(params: {
   accountId?: string;
 }): Promise<TtsSynthesisStreamResult> {
   assertSpeechRuntimeAvailable();
-  const setup = resolveTtsRequestSetup({
+  const acquired = await acquireTtsRequest({
     text: params.text,
     cfg: params.cfg,
     prefsPath: params.prefsPath,
@@ -28,54 +31,80 @@ export async function streamSpeech(params: {
     channelId: params.channel,
     accountId: params.accountId,
   });
-  if ("error" in setup) {
-    return { success: false, error: setup.error };
+  if ("error" in acquired) {
+    return { success: false, error: acquired.error };
   }
 
-  const { cfg, config, persona, providers } = setup;
-  const target = resolveTtsSynthesisTarget(params.channel);
-  return await executeTtsProviderAttempts({
-    cfg,
-    config,
-    persona,
-    providers,
-    synthesisText: normalizeSpeechText(params.text),
-    providerOverrides: params.overrides?.providerOverrides,
-    timeoutMs: params.timeoutMs,
-    target,
-    logLabel: "TTS stream",
-    selectOperation: ({ provider, resolvedProvider }) => {
-      if (!resolvedProvider.provider.streamSynthesize) {
-        return {
-          kind: "skip",
-          reasonCode: "unsupported_for_streaming",
-          message: `${provider} does not support streaming TTS`,
-        };
-      }
-      return {
-        kind: "ready",
-        synthesize: ({ prepared, cfg: runtimeCfg, target: synthesisTarget, timeoutMs }) =>
-          resolvedProvider.provider.streamSynthesize!({
-            text: prepared.text,
-            cfg: runtimeCfg,
-            providerConfig: prepared.providerConfig,
-            target: synthesisTarget,
-            providerOverrides: prepared.providerOverrides,
-            timeoutMs,
-          }),
-      };
-    },
-    buildSuccess: ({ synthesis, ...metadata }) => ({
-      success: true,
-      ...metadata,
-      audioStream: synthesis.audioStream,
-      outputFormat: synthesis.outputFormat,
-      voiceCompatible: synthesis.voiceCompatible,
-      fileExtension: synthesis.fileExtension,
-      target,
-      release: synthesis.release,
-    }),
-  });
+  const { cfg, config, persona, providers } = acquired.setup;
+  let outcome: Result<TtsSynthesisStreamResult, unknown>;
+  try {
+    const result = await acquired.run(() => {
+      const target = resolveTtsSynthesisTarget(params.channel);
+      return executeTtsProviderAttempts({
+        cfg,
+        config,
+        persona,
+        providers,
+        synthesisText: normalizeSpeechText(params.text),
+        providerOverrides: params.overrides?.providerOverrides,
+        timeoutMs: params.timeoutMs,
+        target,
+        logLabel: "TTS stream",
+        prepareProviderRegistry: acquired.setup.prepareProviderRegistry,
+        selectOperation: ({ provider, resolvedProvider }) => {
+          if (!resolvedProvider.provider.streamSynthesize) {
+            return {
+              kind: "skip",
+              reasonCode: "unsupported_for_streaming",
+              message: `${provider} does not support streaming TTS`,
+            };
+          }
+          return {
+            kind: "ready",
+            synthesize: async ({
+              prepared,
+              cfg: runtimeCfg,
+              target: synthesisTarget,
+              timeoutMs,
+            }) => {
+              const synthesis = await resolvedProvider.provider.streamSynthesize!({
+                text: prepared.text,
+                cfg: runtimeCfg,
+                providerConfig: prepared.providerConfig,
+                target: synthesisTarget,
+                providerOverrides: prepared.providerOverrides,
+                timeoutMs,
+              });
+              return {
+                providerResult: synthesis,
+                transport: await captureSpeechProviderStream(synthesis, acquired),
+              };
+            },
+            cleanupFailedProjection: async ({ transport }) => {
+              await transport.close();
+            },
+          };
+        },
+        buildSuccess: ({ synthesis: { providerResult, transport }, ...metadata }) => ({
+          success: true as const,
+          ...metadata,
+          transport,
+          outputFormat: providerResult.outputFormat,
+          voiceCompatible: providerResult.voiceCompatible,
+          fileExtension: providerResult.fileExtension,
+          target,
+        }),
+      });
+    });
+    if (result.success) {
+      const { transport, ...metadata } = result;
+      return { ...metadata, ...ownSpeechStream(transport, acquired) };
+    }
+    outcome = { ok: true, value: result };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+  return await finishCapabilityOperation(outcome, acquired.release);
 }
 
 export async function textToSpeechStream(params: {
@@ -91,6 +120,7 @@ export async function textToSpeechStream(params: {
 }): Promise<TtsStreamResult> {
   const synthesis = await streamSpeech(params);
   if (!synthesis.success || !synthesis.audioStream || !synthesis.fileExtension) {
+    await synthesis.release?.();
     return {
       success: false,
       error: synthesis.error ?? "Streaming TTS conversion failed",

--- a/src/tts/tts-synthesis-support.ts
+++ b/src/tts/tts-synthesis-support.ts
@@ -13,7 +13,6 @@ import {
   createSpeechProviderRegistry,
   normalizeSpeechProviderId,
 } from "./provider-registry-core.js";
-import { canonicalizeSpeechProviderId, getSpeechProvider } from "./provider-registry.js";
 import type { SpeechProviderConfig, SpeechProviderOverrides } from "./provider-types.js";
 import {
   getResolvedSpeechProviderConfigForVoiceModel,
@@ -27,7 +26,6 @@ import {
 } from "./tts-provider-resolution.js";
 import type { TtsProviderAttempt } from "./tts-runtime-types.js";
 import {
-  getTtsPersona,
   readTtsPrefs,
   normalizeConfiguredSpeechProviderId,
   resolveTtsPersonaFromPrefs,
@@ -98,7 +96,7 @@ function buildTtsFailureResult(
 type TtsProviderReadyResolution =
   | {
       kind: "ready";
-      provider: NonNullable<ReturnType<typeof getSpeechProvider>>;
+      provider: SpeechProviderPlugin;
       providerConfig: SpeechProviderConfig;
       personaProviderConfig?: SpeechProviderConfig;
       synthesisPersona?: ResolvedTtsPersona;
@@ -118,12 +116,9 @@ function resolveReadySpeechProvider(params: {
   persona?: ResolvedTtsPersona;
   voiceModel?: VoiceModelRef;
   requireTelephony?: boolean;
-  providerRegistry?: TtsProviderRegistry;
+  providerRegistry: TtsProviderRegistry;
 }): TtsProviderReadyResolution {
-  const resolvedProvider = (params.providerRegistry?.getSpeechProvider ?? getSpeechProvider)(
-    params.provider,
-    params.cfg,
-  );
+  const resolvedProvider = params.providerRegistry.getSpeechProvider(params.provider, params.cfg);
   if (!resolvedProvider) {
     return {
       kind: "skip",
@@ -188,7 +183,7 @@ function resolveReadySpeechProvider(params: {
 }
 
 async function prepareSpeechSynthesis(params: {
-  provider: NonNullable<ReturnType<typeof getSpeechProvider>>;
+  provider: SpeechProviderPlugin;
   text: string;
   cfg: OpenClawConfig;
   providerConfig: SpeechProviderConfig;
@@ -260,39 +255,15 @@ function resolveTtsRequestConfig(
   return { cfg, config, prefsPath };
 }
 
-export function resolveTtsRequestSetup(params: TtsRequestSetupParams):
+type OwnedTtsRequestSetup =
+  | { error: string }
   | {
       cfg: OpenClawConfig;
       config: ResolvedTtsConfig;
       persona?: ResolvedTtsPersona;
       providers: VoiceProviderCandidate[];
-    }
-  | {
-      error: string;
-    } {
-  const facts = resolveTtsRequestConfig(params);
-  if ("error" in facts) {
-    return facts;
-  }
-  const { cfg, config, prefsPath } = facts;
-
-  const userProvider = resolveTtsProvider(config, prefsPath);
-  const provider = canonicalizeSpeechProviderId(params.providerOverride, cfg) ?? userProvider;
-  return {
-    cfg,
-    config,
-    persona: getTtsPersona(config, prefsPath),
-    providers: params.disableFallback
-      ? [resolvePrimaryTtsProviderCandidate(provider, cfg)]
-      : resolveTtsProviderCandidates(provider, cfg),
-  };
-}
-
-type OwnedTtsRequestSetup =
-  | { error: string }
-  | (Exclude<ReturnType<typeof resolveTtsRequestSetup>, { error: string }> & {
       prepareProviderRegistry: () => Promise<TtsProviderRegistry>;
-    });
+    };
 
 /** Keeps catalog and direct lookup selections in one explicit speech request owner. */
 export async function acquireTtsRequest(params: TtsRequestSetupParams) {
@@ -460,7 +431,7 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
   target: "audio-file" | "voice-note" | "telephony";
   logLabel: string;
   requireTelephony?: boolean;
-  prepareProviderRegistry?: () => Promise<TtsProviderRegistry>;
+  prepareProviderRegistry: () => Promise<TtsProviderRegistry>;
   selectOperation: (params: {
     provider: TtsProvider;
     resolvedProvider: ReadySpeechProvider;
@@ -485,9 +456,7 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
     attemptedProviders.push(provider);
     const providerStart = Date.now();
     try {
-      const providerRegistry = params.prepareProviderRegistry
-        ? await params.prepareProviderRegistry()
-        : undefined;
+      const providerRegistry = await params.prepareProviderRegistry();
       const resolvedProvider = resolveReadySpeechProvider({
         provider,
         cfg,

--- a/src/tts/tts-synthesis-support.ts
+++ b/src/tts/tts-synthesis-support.ts
@@ -1,9 +1,13 @@
+import type { Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString as readTtsResultString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig, ResolvedTtsPersona, TtsProvider } from "../config/types.js";
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
-import { withAcquiredPluginCapabilityProviders } from "../plugins/capability-provider-acquisition.js";
+import {
+  acquirePluginCapabilityProviders,
+  finishCapabilityOperation,
+} from "../plugins/capability-provider-acquisition.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import {
   createSpeechProviderRegistry,
@@ -56,6 +60,18 @@ export function formatTtsProviderError(provider: TtsProvider, err: unknown): str
 export function sanitizeTtsErrorForLog(err: unknown): string {
   const raw = formatErrorMessage(err);
   return redactSensitiveText(raw).replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+}
+
+/** Projection diagnostics remain primary when releasing an already-created synthesis also fails. */
+export async function throwTtsProjectionError(
+  error: unknown,
+  cleanup: () => void | Promise<void>,
+): Promise<never> {
+  const [result] = await Promise.allSettled([Promise.resolve().then(cleanup)]);
+  if (result.status === "rejected") {
+    throw new AggregateError([error, result.reason], formatErrorMessage(error), { cause: error });
+  }
+  throw error;
 }
 
 function buildTtsFailureResult(
@@ -278,21 +294,19 @@ type OwnedTtsRequestSetup =
       prepareProviderRegistry: () => Promise<TtsProviderRegistry>;
     });
 
-/** Keeps catalog and direct lookup selections separate for one finite speech request. */
-export async function withOwnedTtsRequest<T>(
-  params: TtsRequestSetupParams,
-  run: (setup: OwnedTtsRequestSetup) => T | Promise<T>,
-): Promise<T> {
+/** Keeps catalog and direct lookup selections in one explicit speech request owner. */
+export async function acquireTtsRequest(params: TtsRequestSetupParams) {
   const facts = resolveTtsRequestConfig(params);
   if ("error" in facts) {
-    return await run(facts);
+    return facts;
   }
   const { cfg, config, prefsPath } = facts;
   const prefs = readTtsPrefs(prefsPath);
   const persona = resolveTtsPersonaFromPrefs(config, prefs);
-  return await withAcquiredPluginCapabilityProviders(
-    { key: "speechProviders", cfg },
-    async (catalog, queries) => {
+  const queries = await acquirePluginCapabilityProviders({ key: "speechProviders", cfg });
+  try {
+    const setup = await queries.run(async () => {
+      const catalog = queries.providers;
       const defaultLookups = new Map<string, SpeechProviderPlugin | undefined>();
       let defaultCatalog: SpeechProviderPlugin[] = [];
       const preferred = normalizeSpeechProviderId(prefs.tts?.provider);
@@ -371,7 +385,7 @@ export async function withOwnedTtsRequest<T>(
       const userProvider = resolveTtsProvider(config, prefsPath, providerRegistry, prefs);
       const provider =
         providerRegistry.canonicalizeSpeechProviderId(params.providerOverride, cfg) ?? userProvider;
-      return await run({
+      return {
         cfg,
         config,
         persona,
@@ -379,9 +393,30 @@ export async function withOwnedTtsRequest<T>(
           ? [resolvePrimaryTtsProviderCandidate(provider, cfg, providerRegistry)]
           : resolveTtsProviderCandidates(provider, cfg, providerRegistry),
         prepareProviderRegistry,
-      });
-    },
-  );
+      };
+    });
+    return { setup, run: queries.run, release: queries.release };
+  } catch (error) {
+    return await finishCapabilityOperation<never>({ ok: false, error }, queries.release);
+  }
+}
+
+/** Finite speech calls finish their work before returning a materialized result. */
+export async function withOwnedTtsRequest<T>(
+  params: TtsRequestSetupParams,
+  run: (setup: OwnedTtsRequestSetup) => T | Promise<T>,
+): Promise<T> {
+  const acquired = await acquireTtsRequest(params);
+  if ("error" in acquired) {
+    return await run(acquired);
+  }
+  let outcome: Result<T, unknown>;
+  try {
+    outcome = { ok: true, value: await acquired.run(() => run(acquired.setup)) };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+  return await finishCapabilityOperation(outcome, acquired.release);
 }
 
 type ReadySpeechProvider = Extract<TtsProviderReadyResolution, { kind: "ready" }>;
@@ -395,6 +430,7 @@ type TtsProviderOperation<TSynthesis> =
         target: "audio-file" | "voice-note" | "telephony";
         timeoutMs: number;
       }) => Promise<TSynthesis>;
+      cleanupFailedProjection?: (synthesis: TSynthesis) => Promise<void>;
     }
   | {
       kind: "skip";
@@ -516,26 +552,32 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
         target: params.target,
         timeoutMs,
       });
-      const latencyMs = Date.now() - providerStart;
-      attempts.push({
-        provider,
-        outcome: "success",
-        reasonCode: "success",
-        persona: persona?.id,
-        personaBinding: resolvedProvider.personaBinding,
-        latencyMs,
-      });
-      return params.buildSuccess({
-        synthesis,
-        latencyMs,
-        provider,
-        providerModel: resolveTtsResultModel(prepared.providerConfig, prepared.providerOverrides),
-        providerVoice: resolveTtsResultVoice(prepared.providerConfig, prepared.providerOverrides),
-        persona: persona?.id,
-        fallbackFrom: provider !== primaryProvider ? primaryProvider : undefined,
-        attemptedProviders,
-        attempts,
-      });
+      try {
+        const latencyMs = Date.now() - providerStart;
+        attempts.push({
+          provider,
+          outcome: "success",
+          reasonCode: "success",
+          persona: persona?.id,
+          personaBinding: resolvedProvider.personaBinding,
+          latencyMs,
+        });
+        return params.buildSuccess({
+          synthesis,
+          latencyMs,
+          provider,
+          providerModel: resolveTtsResultModel(prepared.providerConfig, prepared.providerOverrides),
+          providerVoice: resolveTtsResultVoice(prepared.providerConfig, prepared.providerOverrides),
+          persona: persona?.id,
+          fallbackFrom: provider !== primaryProvider ? primaryProvider : undefined,
+          attemptedProviders,
+          attempts,
+        });
+      } catch (error) {
+        return await throwTtsProjectionError(error, () =>
+          operation.cleanupFailedProjection?.(synthesis),
+        );
+      }
     } catch (err) {
       const errorMsg = formatTtsProviderError(provider, err);
       const latencyMs = Date.now() - providerStart;


### PR DESCRIPTION
Related: #140674. Builds on telephony #143065 and buffered speech #143313.

## What Problem This Solves

Resolves a problem where speech streams outlive the provider registrations they use, or leave resources behind when metadata fails, cancellation is delayed, or an unopened stream has already ended.

## Why This Change Was Made

Transfer the existing owned speech acquisition to the returned stream. Retain it through metadata, reads, source cancellation, provider release, and tracked producer work. Start cancellation before waiting for reads it must unblock, preserve the last queued chunk, and finalize outside the work being drained.

Providers with an explicit release callback keep their existing contract: callers await release after EOF or read failure. Providers without one clean up automatically, including empty or failed unopened streams and a consumed final queued chunk. Failed metadata projection cleans up before fallback; errors after bytes have escaped do not start another provider.

All three synthesis paths now require an owned prepared registry. The unused raw setup function and its type-only coupling are removed; public synchronous provider lookup contracts remain unchanged.

## User Impact

Streaming speech retains its provider resources until actual cleanup finishes. It preserves explicit release, cancellation, provider selection and raw-host ownership, without adding a release obligation for providers that previously had none. Completed audio remains usable after disposal.

## Evidence

Native regressions cover retirement, cancellation, blocked producer work, metadata/getter failures, cleanup-error precedence, unopened termination, and final-chunk delivery. Final combined testing passes 48 distinct cases across streaming, telephony, buffered speech and Talk. The preceding ownership candidate also passed 141 sibling/E2E cases, including Discord voice and provider binary-stream controls.

Affected checks, fresh full-candidate Codex review through P2, and the final ordinary build passed. The final build took 298.41 seconds and emitted a non-fatal UI startup gzip warning of 29 bytes over its threshold; no UI source, baseline or guard was changed.

Both actual compiled public APIs passed on one sealed build: 21 streaming requests and nine buffered calls across cold, managed and raw ownership. They exercised real WAV/PCM roundtrips and SQLite reads through metadata, cleanup and delayed work, followed by close/reopen. All six process groups terminated; all 11,390 artifact hashes remained unchanged, with no application source fallback. These use synthetic local providers, not an external speech vendor, carrier or operator Gateway.

An additional 32 Web-reader cases covered pending reads, timed/gated cleanup and cleanup failures, preserving final chunks and errors. Timings are local observations, not a comparative speedup claim.
