### PR TITLE
refactor: reuse Slack approval context fixtures

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1664,19 +1664,7 @@ describe("registerSlackInteractionEvents", () => {
       applied: false,
       approval: { status: "denied", decision: "deny" },
     });
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            execApprovals: {
-              enabled: true,
-              approvers: ["U123"],
-              target: "both",
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext();
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     const respond = vi.fn().mockResolvedValue(undefined);
@@ -1747,19 +1735,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("shows canonical typed approval truth when the clicked message update fails", async () => {
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            execApprovals: {
-              enabled: true,
-              approvers: ["U123"],
-              target: "both",
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext();
     app.client.chat.update.mockRejectedValueOnce(new Error("message update failed"));
     registerSlackInteractionEvents({ ctx: ctx as never });
     const respond = vi.fn().mockResolvedValue(undefined);
@@ -1790,19 +1766,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("tells the clicker when a typed approval is no longer pending", async () => {
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            execApprovals: {
-              enabled: true,
-              approvers: ["U123"],
-              target: "both",
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext();
     resolveApprovalOverGatewayMock.mockRejectedValueOnce(
       new Error("unknown or expired approval id"),
     );


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three Slack approval-result tests repeat the exact configuration already supplied by their existing context fixture.

## Why This Change Was Made

Use `createContext()` directly in those three cases. Its implementation is unchanged and still creates a fresh configuration for each call. All outcome setup, assertions, and case order remain intact, removing 36 net test lines.

## User Impact

No user-visible behavior or runtime improvement. Coverage for an already-resolved approval, failed message update, and expired approval remains unchanged.

## Evidence

The complete interactions suite passed all 75 cases before and after in the same order. Static parser comparison confirmed identical configuration fields, order, and absence, and restoring the three arguments reproduces the original source exactly.

Temporary observations in the three existing cases passed configuration equality, actual gateway-argument identity with `ctx.cfg`, and fresh five-node graphs across cases. These observations were removed and the exact candidate restored before mapped checks and fresh independent review, which both passed. This does not claim runtime property-descriptor verification. Production owners and the context helper are unchanged.
