### PR TITLE
test(wizard): reuse recommendation store fixture

### DIFF
--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -475,7 +475,7 @@ prompts to install the plugin (npm or local path) before channel configuration.
 
 ### Installed app recommendations
 
-After the model access check succeeds, classic interactive onboarding on macOS scans application names and bundle IDs without requesting macOS privacy permissions. It searches the official plugin catalogs and ClawHub, then asks the configured model to reject false name matches and recommend relevant plugins or skills. Recommended matches are selected by default; optional matches require an explicit selection.
+After the model access check succeeds, classic interactive onboarding on macOS scans application names and bundle IDs without requesting macOS privacy permissions. It searches the official plugin catalogs and ClawHub, then asks the configured model to reject false name matches and recommend relevant plugins or skills. Only recommended matches from official plugin catalogs are selected by default; optional matches and all ClawHub skills require an explicit selection.
 
 The results screen lists the detected applications and shows: "App names were matched using your configured model and ClawHub search." Set `wizard.appRecommendations` to `false` to disable both this onboarding step and Gateway access to node app inventories. The scan is not used in quickstart or non-macOS onboarding.
 

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -3,7 +3,6 @@ import { refreshOnboardRecommendationsCommand } from "../commands/onboard-recomm
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type {
-  OnboardingRecommendationMatch,
   OnboardingRecommendationsRecord,
   OnboardingRecommendationsStore,
 } from "../state/onboarding-recommendations.js";
@@ -547,60 +546,7 @@ describe("setupAppRecommendations", () => {
   });
 
   it("reoffers a failed install and consumes it after a successful retry", async () => {
-    const storeState: { current: OnboardingRecommendationsRecord | null } = { current: null };
-    let now = 0;
-    const writeOffer = vi.fn(
-      (params: Parameters<OnboardingRecommendationsStore["writeOffer"]>[0]) => {
-        now += 1;
-        storeState.current = {
-          inventoryHash: "hash",
-          matches: [...params.matches],
-          offeredAt: now,
-          acceptedAt: params.answered ? now : null,
-          updatedAt: now,
-        };
-        return storeState.current;
-      },
-    );
-    const acknowledgeStored = vi.fn(
-      (params: Parameters<OnboardingRecommendationsStore["acknowledge"]>[0] = {}) => {
-        if (
-          !storeState.current ||
-          (params.expected &&
-            (params.expected.inventoryHash !== storeState.current.inventoryHash ||
-              params.expected.updatedAt !== storeState.current.updatedAt))
-        ) {
-          return null;
-        }
-        now += 1;
-        storeState.current = { ...storeState.current, acceptedAt: now, updatedAt: now };
-        return storeState.current;
-      },
-    );
-    const updatePendingStored = vi.fn(
-      ({
-        matches,
-        expected,
-      }: {
-        matches: readonly OnboardingRecommendationMatch[];
-        expected: OnboardingRecommendationsRecord;
-      }) => {
-        if (
-          !storeState.current ||
-          expected.inventoryHash !== storeState.current.inventoryHash ||
-          expected.updatedAt !== storeState.current.updatedAt
-        ) {
-          return null;
-        }
-        now += 1;
-        storeState.current = {
-          ...storeState.current,
-          matches: [...matches],
-          updatedAt: now,
-        };
-        return storeState.current;
-      },
-    );
+    const store = storeDeps();
     const recommend = vi.fn(async () => recommendationResult());
     const installSkill = vi
       .fn()
@@ -618,11 +564,7 @@ describe("setupAppRecommendations", () => {
     const deps = {
       recommend,
       installSkill,
-      readStored: () => storeState.current,
-      writeOffer,
-      acknowledgeStored,
-      updatePendingStored,
-      deferOfferToBootstrap: () => false,
+      ...store,
     };
 
     await setupAppRecommendations({
@@ -635,7 +577,7 @@ describe("setupAppRecommendations", () => {
       deps,
     });
 
-    expect(storeState.current).toMatchObject({
+    expect(store.readStored()).toMatchObject({
       acceptedAt: null,
       matches: [expect.objectContaining({ candidateId: "@demo-owner/chat-skill" })],
     });
@@ -652,8 +594,8 @@ describe("setupAppRecommendations", () => {
 
     expect(recommend).toHaveBeenCalledOnce();
     expect(installSkill).toHaveBeenCalledTimes(2);
-    expect(acknowledgeStored).toHaveBeenCalledOnce();
-    expect(storeState.current?.acceptedAt).toBeTypeOf("number");
+    expect(store.acknowledgeStored).toHaveBeenCalledOnce();
+    expect(store.readStored()?.acceptedAt).toBeTypeOf("number");
   });
 
   it("consumes an exact installed skill left pending by an interrupted run", async () => {


### PR DESCRIPTION
The app-recommendation retry test duplicated the same in-memory store model already used by its neighboring cases. Reuse `storeDeps()` and remove the duplicate write, acknowledgment, pending-update logic and unused type import.

All 17 wizard cases and 61 assertions remain, including the failed-install/successful-retry sequence. The seven real recommendation-store tests remain independent and unchanged. A nearby guide sentence now accurately states that only recommended official-catalog matches are preselected; every ClawHub skill requires explicit selection, as the existing code and test already enforce.

Validation: baseline and candidate 24/24 with identical subjects/statuses; all 20 final combined changed checks passed; independent Codex reviews clean. Test/runtime bytes stayed unchanged for the docs correction. Production delta 0; tests net -58; docs one sentence corrected.
