### PR TITLE
refactor(tests): remove unused channel catalog fixtures

### DIFF
--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -52,7 +52,6 @@ describeOfficialFallbackChannelCatalogContract({
   npmSpec: whatsappOfficialFallbackNpmSpec,
   meta: whatsappMeta,
   packageName: "@openclaw/whatsapp",
-  pluginId: "whatsapp",
   externalNpmSpec: "@vendor/whatsapp-fork",
   externalLabel: "WhatsApp Fork",
 });

--- a/src/channels/plugins/contracts/test-helpers/channel-catalog-contract.ts
+++ b/src/channels/plugins/contracts/test-helpers/channel-catalog-contract.ts
@@ -113,7 +113,6 @@ export function describeOfficialFallbackChannelCatalogContract(params: {
   npmSpec: string;
   meta: CatalogEntryMeta;
   packageName: string;
-  pluginId: string;
   externalNpmSpec: string;
   externalLabel: string;
 }) {
@@ -123,23 +122,6 @@ export function describeOfficialFallbackChannelCatalogContract(params: {
         path.join(resolvePreferredOpenClawTmpDir(), "openclaw-official-catalog-"),
       );
       const catalogPath = path.join(dir, "channel-catalog.json");
-      fs.writeFileSync(
-        catalogPath,
-        JSON.stringify({
-          entries: [
-            {
-              name: params.packageName,
-              openclaw: {
-                channel: params.meta,
-                install: {
-                  npmSpec: params.npmSpec,
-                  defaultChoice: "npm",
-                },
-              },
-            },
-          ],
-        }),
-      );
 
       const entry = listRawChannelPluginCatalogEntries({
         env: createCatalogFallbackOnlyEnv(),
@@ -155,46 +137,8 @@ export function describeOfficialFallbackChannelCatalogContract(params: {
       const dir = fs.mkdtempSync(
         path.join(resolvePreferredOpenClawTmpDir(), "openclaw-fallback-catalog-"),
       );
-      const bundledDir = path.join(dir, "dist", "extensions", params.pluginId);
       const officialCatalogPath = path.join(dir, "channel-catalog.json");
       const externalCatalogPath = path.join(dir, "catalog.json");
-      fs.mkdirSync(bundledDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(bundledDir, "package.json"),
-        JSON.stringify({
-          name: params.packageName,
-          openclaw: {
-            channel: {
-              ...params.meta,
-              label: `${params.meta.label} Bundled`,
-              selectionLabel: `${params.meta.label} Bundled`,
-              blurb: "bundled fallback",
-            },
-            install: { npmSpec: params.npmSpec },
-          },
-        }),
-        "utf8",
-      );
-      fs.writeFileSync(
-        officialCatalogPath,
-        JSON.stringify({
-          entries: [
-            {
-              name: params.packageName,
-              openclaw: {
-                channel: {
-                  ...params.meta,
-                  label: `${params.meta.label} Official`,
-                  selectionLabel: `${params.meta.label} Official`,
-                  blurb: "official fallback",
-                },
-                install: { npmSpec: params.npmSpec },
-              },
-            },
-          ],
-        }),
-        "utf8",
-      );
       fs.writeFileSync(
         externalCatalogPath,
         JSON.stringify({


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The maintainer-requested test audit found channel-catalog contract setup creating files that cannot influence the tested catalog result. These unused fixtures obscure which inputs the retained tests actually exercise.

## Why This Change Was Made

Remove the fallback plugin tree outside the selected discovery roots, official-catalog writes shadowed by built-in metadata, and the now-unused fallback helper parameter and caller argument. Preserve the live workspace fixture, external-catalog writes, explicit paths, environment setup, every assertion, and generated-file coverage.

## User Impact

No runtime behavior changes. Two test/support files lose 57 lines; no test cases are removed.

## Evidence

- Full channel-surface contract file: 12 passed. Full channel catalog file: 13 passed. Zero skipped tests; all four live-test selectors explicitly unset.
- All 32 selected `check:changed` steps passed with no retry.
- Fresh scanned P2 autoreview: two scoped-clean passes, no actionable findings.
- This is focused local test and static-check evidence, not live-channel, installed-package, or repository-wide runtime proof.

Data-model compatibility proof is not applicable. The removed JSON writes created synthetic fixtures under fresh mkdtempSync directories. No production serialization, schema, stored format, migration, or persistence semantics changed. All test cases/assertions and meaningful generated-file, workspace, and external-override coverage remain. The stored-data-model item in the review (https://github.com/openclaw/openclaw/pull/143373#issuecomment-5608336527) is rejected on that basis.
