### PR TITLE
fix: retain Anthropic requests through cancellation cleanup

### DIFF
--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { AssistantMessage, Model } from "@openclaw/llm-core";
 /**
  * Tests Anthropic Messages transport streaming.
@@ -6,6 +7,7 @@ import type { AssistantMessage, Model } from "@openclaw/llm-core";
  */
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import {
   configureAiTransportHost,
@@ -160,7 +162,9 @@ function createInterruptedThinkingEvents(): Record<string, unknown>[] {
   ];
 }
 
-function createStalledSseResponse(params: { onCancel: (reason: unknown) => void }): Response {
+function createStalledSseResponse(params: {
+  onCancel: (reason: unknown) => void | Promise<void>;
+}): Response {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -171,7 +175,7 @@ function createStalledSseResponse(params: { onCancel: (reason: unknown) => void 
       );
     },
     cancel(reason) {
-      params.onCancel(reason);
+      return params.onCancel(reason);
     },
   });
 
@@ -190,7 +194,7 @@ function createRawSseResponse(body: string): Response {
 
 function createOpenRawSseResponse(params: {
   body: string;
-  onCancel: (reason: unknown) => void;
+  onCancel: (reason: unknown) => void | Promise<void>;
 }): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
@@ -198,7 +202,7 @@ function createOpenRawSseResponse(params: {
       controller.enqueue(encoder.encode(params.body));
     },
     cancel(reason) {
-      params.onCancel(reason);
+      return params.onCancel(reason);
     },
   });
   return new Response(stream, {
@@ -3757,39 +3761,92 @@ describe("anthropic transport stream", () => {
     expect(toolResult.is_error).toBe(false);
   });
 
-  it("cancels stalled SSE body reads when the abort signal fires mid-stream", async () => {
-    const controller = new AbortController();
-    const abortReason = new Error("anthropic test abort");
-    let cancelReason: unknown;
-    guardedFetchMock.mockResolvedValueOnce(
-      createStalledSseResponse({
-        onCancel: (reason) => {
-          cancelReason = reason;
+  it.each(["resolve", "reject", "throw"] as const)(
+    "owns %s cancellation after reporting an abort from another context",
+    async (outcome) => {
+      const context = new AsyncLocalStorage<string>();
+      const controller = new AbortController();
+      const abortReason = new Error("anthropic test abort");
+      const finishCancellation = createDeferred();
+      const observed: Promise<unknown>[] = [];
+      const observerContexts: Array<string | undefined> = [];
+      let cancelReason: unknown;
+      let cancelContext: string | undefined;
+      let cancellationFinished = false;
+      configureAiTransportHost({
+        ...getAiTransportHost(),
+        observePendingProviderWork: (pending) => {
+          observerContexts.push(context.getStore());
+          observed.push(pending);
         },
-      }),
-    );
-
-    setTimeout(() => controller.abort(abortReason), 50);
-
-    const timedOut = Symbol("timed out");
-    const startedAt = Date.now();
-    const result = await Promise.race([
-      runTransportStream(
-        makeAnthropicTransportModel(),
-        { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
-        { apiKey: "sk-ant-api", signal: controller.signal } as AnthropicStreamOptions,
-      ),
-      delay(1_000, timedOut),
-    ]);
-
-    if (result === timedOut) {
-      throw new Error("Anthropic SSE stream did not abort within 1000ms");
-    }
-    expect(Date.now() - startedAt).toBeLessThan(1_000);
-    expect(result.stopReason).toBe("aborted");
-    expect(result.errorMessage).toBe("anthropic test abort");
-    expect(cancelReason).toBe(abortReason);
-  });
+      });
+      guardedFetchMock.mockResolvedValueOnce(
+        createStalledSseResponse({
+          onCancel: (reason) => {
+            cancelReason = reason;
+            cancelContext = context.getStore();
+            if (outcome === "throw") {
+              cancellationFinished = true;
+              throw new Error("synchronous cancellation cleanup failure");
+            }
+            return finishCancellation.promise.finally(() => {
+              cancellationFinished = true;
+            });
+          },
+        }),
+      );
+      const startedAt = Date.now();
+      const completion = context.run("origin", () =>
+        runTransportStream(
+          makeAnthropicTransportModel(),
+          { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+          { apiKey: "fixture", signal: controller.signal } as AnthropicStreamOptions,
+        ),
+      );
+      const abortTimer = setTimeout(
+        () => context.run("foreign", () => controller.abort(abortReason)),
+        50,
+      );
+      try {
+        const timedOut = Symbol("timed out");
+        const result = await Promise.race([completion, delay(1_000, timedOut)]);
+        if (result === timedOut) {
+          throw new Error("Anthropic SSE stream did not abort within 1000ms");
+        }
+        expect(Date.now() - startedAt).toBeLessThan(1_000);
+        expect(result.stopReason).toBe("aborted");
+        expect(result.errorMessage).toBe("anthropic test abort");
+        expect(cancelReason).toBe(abortReason);
+        expect.soft(cancelContext).toBe("origin");
+        expect(cancellationFinished).toBe(outcome === "throw");
+        expect.soft(observed.length).toBeGreaterThan(0);
+        expect.soft(observerContexts.every((owner) => owner === "origin")).toBe(true);
+        let joined = false;
+        const joining = Promise.allSettled(observed).then(() => {
+          joined = true;
+        });
+        if (outcome === "throw") {
+          await joining;
+        } else {
+          await Promise.resolve();
+          expect.soft(joined).toBe(false);
+        }
+        if (outcome === "reject") {
+          finishCancellation.reject(new Error("cancellation cleanup failed"));
+        } else {
+          finishCancellation.resolve();
+        }
+        await joining;
+        expect(cancellationFinished).toBe(true);
+        expect((await completion).errorMessage).toBe("anthropic test abort");
+      } finally {
+        clearTimeout(abortTimer);
+        finishCancellation.resolve();
+        await completion;
+        await Promise.allSettled(observed);
+      }
+    },
+  );
 
   it("treats already-aborted signals as abort errors before reading SSE chunks", async () => {
     const controller = new AbortController();
@@ -3845,26 +3902,39 @@ describe("anthropic transport stream", () => {
     await vi.waitFor(() => expect(cancelCalled).toBe(true));
   });
 
-  it("cancels open SSE bodies when Anthropic stream consumers throw", async () => {
-    let cancelCalled = false;
+  it("joins open SSE body cancellation when a non-abort stream consumer throws", async () => {
+    const cancelStarted = createDeferred();
+    const finishCancellation = createDeferred();
     guardedFetchMock.mockResolvedValueOnce(
       createOpenRawSseResponse({
         body: 'data: {"type":"error","error":{"message":"stream exploded"}}\n\n',
         onCancel: () => {
-          cancelCalled = true;
+          cancelStarted.resolve();
+          return finishCancellation.promise;
         },
       }),
     );
-
-    const result = await runTransportStream(
+    let settled = false;
+    const completion = runTransportStream(
       makeAnthropicTransportModel(),
       { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
-      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
-    );
-
-    expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toBe("stream exploded");
-    expect(cancelCalled).toBe(true);
+      { apiKey: "fixture" } as AnthropicStreamOptions,
+    ).then((result) => {
+      settled = true;
+      return result;
+    });
+    try {
+      await cancelStarted.promise;
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      finishCancellation.resolve();
+      const result = await completion;
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toBe("stream exploded");
+    } finally {
+      finishCancellation.resolve();
+      await completion;
+    }
   });
 
   it.each([

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -250,7 +250,6 @@ function readAnthropicSseChunk(
       }
       settled = true;
       signal.removeEventListener("abort", onAbort);
-      reader.cancel(signal.reason).catch(() => undefined);
       reject(createAbortError(signal));
     };
 
@@ -349,7 +348,13 @@ async function* parseAnthropicSseBody(
     }
   } finally {
     if (!completed) {
-      await reader.cancel(signal?.reason).catch(() => undefined);
+      const cancellation = reader.cancel(signal?.reason).catch(() => undefined);
+      if (signal?.aborted) {
+        // The read continuation retains the original owner even when abort fires elsewhere.
+        getAiTransportHost().observePendingProviderWork?.(cancellation);
+      } else {
+        await cancellation;
+      }
     }
     reader.releaseLock();
   }

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -26,7 +26,7 @@ import {
   extractAssistantText,
   prepareSimpleCompletionModelForAgent,
 } from "../../plugin-sdk/simple-completion-runtime.js";
-import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import { AsyncWorkScope, getAsyncWorkSignal } from "../../shared/async-work-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { LegacyPluginSdkResourceHost } from "../legacy-sdk-resource-host.js";
 import { resetPluginLoaderTestStateForTest } from "../loader.test-fixtures.js";
@@ -59,9 +59,11 @@ it.each([
   "sdk-nested-prepare",
   "sdk-callback-drain",
   "sdk-cancel-drain",
+  "anthropic-read-cancel",
 ] as const)("keeps completion ownership coherent: %s", async (testCase) => {
   const sdk = testCase.startsWith("sdk-");
   const mode = testCase.replace(/^sdk-/, "");
+  const anthropicReadCancel = mode === "anthropic-read-cancel";
   const roots = createSyncSuiteTempRootTracker("runtime-llm-prepared-owner");
   const root = fs.realpathSync(roots.makeTempDir());
   fs.mkdirSync(path.join(root, "provider"));
@@ -87,7 +89,41 @@ it.each([
     if (response.writableEnded || response.destroyed) {
       return;
     }
-    response.writeHead(200, { "content-type": "text/event-stream" });
+    if (!response.headersSent) {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+    }
+    if (anthropicReadCancel) {
+      const events = [
+        {
+          type: "message_start",
+          message: {
+            id: "lease-response",
+            role: "assistant",
+            model: "lease-model",
+            content: [],
+            usage: { input_tokens: 1, output_tokens: 0 },
+          },
+        },
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            text: `result-${index}|${requestFacts[index]?.url}|${requestFacts[index]?.authorization}`,
+          },
+        },
+        { type: "content_block_stop", index: 0 },
+        { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } },
+        { type: "message_stop" },
+      ];
+      if (index === 0 && !finishing) {
+        response.write(`data: ${JSON.stringify(events[0])}\n\n`);
+      } else {
+        response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+      }
+      return;
+    }
     response.end(
       `data: ${JSON.stringify({
         id: "completion-lease-response",
@@ -108,7 +144,12 @@ it.each([
   const server = createServer((request, response) => {
     request.resume();
     const index = requests.push(response) - 1;
-    requestFacts.push({ url: request.url ?? "/", authorization: request.headers.authorization });
+    const apiKey = request.headers["x-api-key"];
+    requestFacts.push({
+      url: request.url ?? "/",
+      authorization:
+        request.headers.authorization ?? (typeof apiKey === "string" ? apiKey : undefined),
+    });
     arrivals[index]?.resolve();
     if (finishing) {
       finish(response, index);
@@ -137,7 +178,8 @@ it.each([
       models: {
         providers: {
           [fixture.providerId]: {
-            api: "openai-completions",
+            api: anthropicReadCancel ? "anthropic-messages" : "openai-completions",
+            ...(anthropicReadCancel ? { request: { tls: { insecureSkipVerify: false } } } : {}),
             ...(mode === "auth" ? {} : { apiKey: "fixture-auth-A" }),
             baseUrl: `http://127.0.0.1:${address.port}/A/v1`,
             models: [
@@ -172,7 +214,10 @@ it.each([
       const setRuntimeKey = vi.spyOn(AuthStorage.prototype, "setRuntimeApiKey");
       const resolveModel = modelResolution.resolveModelAsync;
       const resolver = vi.spyOn(modelResolution, "resolveModelAsync");
-      const drainMode = mode === "callback-drain" || mode === "cancel-drain";
+      const drainMode = mode === "callback-drain" || mode === "cancel-drain" || anthropicReadCancel;
+      const bodyReadStarted = createDeferred();
+      const foreignWork = new AsyncWorkScope();
+      let cancelledInOrigin = false;
       const workStarted = createDeferred();
       let acceptedWorkStarted = false;
       let nestedPreparationCompleted = false;
@@ -208,7 +253,7 @@ it.each([
                 ...options,
                 onResponse: async (response, responseModel) => {
                   await options?.onResponse?.(response, responseModel);
-                  if (++responses !== 1) {
+                  if (++responses !== 1 || anthropicReadCancel) {
                     return;
                   }
                   if (mode === "nested-prepare") {
@@ -240,11 +285,12 @@ it.each([
               });
           }),
         );
-        if (mode === "cancel-drain") {
+        if (mode === "cancel-drain" || anthropicReadCancel) {
           const realFetch = globalThis.fetch;
           let wrappedResponse = false;
           transportSpies.push(
             vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+              const origin = getAsyncWorkSignal();
               const response = await realFetch(...args);
               if (
                 wrappedResponse ||
@@ -257,9 +303,13 @@ it.each([
               if (!reader) {
                 throw new Error("Fixture provider response has no body");
               }
+              let reads = 0;
               return new Response(
                 new ReadableStream<Uint8Array>({
                   async pull(controller) {
+                    if (++reads === 2) {
+                      bodyReadStarted.resolve();
+                    }
                     const { value, done } = await reader.read();
                     if (done) {
                       controller.close();
@@ -268,6 +318,7 @@ it.each([
                     }
                   },
                   async cancel(reason) {
+                    cancelledInOrigin = getAsyncWorkSignal() === origin;
                     acceptedWorkStarted = true;
                     workStarted.resolve();
                     try {
@@ -600,7 +651,9 @@ it.each([
           return;
         }
         const abortController =
-          mode === "abort" || mode === "callback-drain" ? new AbortController() : undefined;
+          mode === "abort" || mode === "callback-drain" || anthropicReadCancel
+            ? new AbortController()
+            : undefined;
         const firstStarted = performance.now();
         const first = drainMode
           ? parentWork.track(() => start(0, abortController?.signal))
@@ -611,6 +664,13 @@ it.each([
         expect(firstBuilds).toBeGreaterThan(0);
         if (drainMode) {
           finish(requests[0]!, 0);
+          if (anthropicReadCancel) {
+            await bodyReadStarted.promise;
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            foreignWork.run(() => abortController?.abort(new Error("foreign cancellation")));
+          }
           await Promise.race([
             workStarted.promise,
             first.then(() => {
@@ -625,6 +685,10 @@ it.each([
           const second = start(1);
           await waitForRequest(1, second);
           expect.soft(parentDrained).toBe(false);
+          if (anthropicReadCancel) {
+            expect.soft(cancelledInOrigin).toBe(true);
+            await foreignWork.drain();
+          }
           expect.soft(create.mock.calls.length).toBe(firstBuilds);
           expect(fork.mock.calls).toHaveLength(2);
           expect(fork.mock.calls[0]![0]).not.toBe(fork.mock.calls[1]![0]);
@@ -634,7 +698,9 @@ it.each([
           expect(parentDrained).toBe(true);
           finish(requests[1]!, 1);
           await expect(second).resolves.toMatchObject({
-            text: "result-1|/A/v1/chat/completions|Bearer fixture-auth-A",
+            text: anthropicReadCancel
+              ? "result-1|/A/v1/messages|fixture-auth-A"
+              : "result-1|/A/v1/chat/completions|Bearer fixture-auth-A",
           });
           const buildsAfterSecond = create.mock.calls.length;
           const third = start(2);
@@ -642,7 +708,9 @@ it.each([
           expect(create.mock.calls.length).toBe(buildsAfterSecond + 1);
           finish(requests[2]!, 2);
           await expect(third).resolves.toMatchObject({
-            text: "result-2|/A/v1/chat/completions|Bearer fixture-auth-A",
+            text: anthropicReadCancel
+              ? "result-2|/A/v1/messages|fixture-auth-A"
+              : "result-2|/A/v1/chat/completions|Bearer fixture-auth-A",
           });
           return;
         }
@@ -745,6 +813,7 @@ it.each([
         await parentDrain;
         await parentWork.drain();
         await Promise.all(sdkHosts.map((host) => host.close()));
+        await foreignWork.drain();
         for (const spy of transportSpies) {
           spy.mockRestore();
         }


### PR DESCRIPTION
Related: #140674.

## What Problem This Solves

Resolves a problem where an aborted Anthropic request can release its prepared runtime while the response body is still cancelling. Cancellation can also run in the aborting caller's context instead of the request's original context.

## Why This Change Was Made

Start body cancellation once, in the parser's original continuation, and give that actual promise to the existing host work observer before reporting the abort. Previously the abort listener started cancellation and discarded its promise; the parser's second cancellation was already resolved even though the first cleanup was still running.

The production repair is seven added and two removed lines. Normal non-abort cleanup remains awaited, and aborts preserve their original reason without waiting for cancellation to finish. No public API, dependency, or database policy changes.

## User Impact

Aborted Anthropic calls still return promptly, while their runtime remains alive until accepted cancellation work finishes. Cleanup failures do not replace the original abort reason.

## Evidence

Original code fails three transport regressions and the actual core ownership case: the parent drains early, cancellation runs in a foreign context, and a new ModelRegistry is built during held cleanup. The candidate passes all 148 transport and core cases. Affected checks, fresh isolated Codex review through P2, and the ordinary build (317.9 seconds) pass.

Compiled proof uses the actual exec reviewer and managed Anthropic transport against a local synthetic HTTP server. Abort reporting took 4.357 and 0.534 milliseconds for resolving and rejecting cancellation. The original owner stayed alive, overlapping preparation reused its generation, and final drainage followed the held cancellation's settlement. Non-abort cleanup and successful completion also passed.

All child processes exited; 12,119 build artifact hashes stayed unchanged and 2,872 resolved files used no application source fallback. No reviewed command was executed, and no real vendor credentials or production Gateway were used. These are individual correctness timings, not a comparative benchmark. The proof establishes ModelRegistry retention; general RUN SQLite physical disposal remains a separate prerequisite chain.

The final rebase combines the newly landed SDK cases with this cancellation regression. Both transport source files remain byte-identical to the reviewed build; all 157 transport/core composition cases and formatting checks pass on the refreshed head.
