### PR TITLE
fix: prevent cold archive pruning from blocking the Gateway

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -89,6 +89,14 @@ do not cause unnecessary archive deletion. Full logical deletion with resumable
 physical cleanup remains a separate design; existing deletion visibility and rollback
 semantics are unchanged.
 
+Queued archive pruning prepares cold connections through the same asynchronous
+admission owner while retaining its existing writer section. Each page-drain
+pass keeps its checkpoints, freelist reads, and bounded vacuum in one synchronous
+phase on the admitted connection. Archive-row and unpublished-name reads follow
+validation. After removing a derived archive file, pruning reacquires before the
+canonical row-deletion transaction; an acquisition failure propagates without
+deleting that recovery row.
+
 ### Preserve the data and concurrency contracts
 
 An adapter must make these contracts explicit and verify them against a real

--- a/src/config/sessions/session-history-archive-pruning.admission.test.ts
+++ b/src/config/sessions/session-history-archive-pruning.admission.test.ts
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import * as sqlite from "../../infra/node-sqlite.js";
+import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  appendTranscriptMessage,
+  deleteSessionEntryLifecycle,
+  replaceSessionEntry,
+} from "./session-accessor.js";
+import {
+  getSessionKysely,
+  runExclusiveSqliteSessionWrite,
+} from "./session-accessor.sqlite-scope.js";
+import {
+  pruneAllSessionTranscriptArchivesToHighWater,
+  reclaimSqliteFreePages,
+} from "./session-history-archive-pruning.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const hook = vi.hoisted(() => ({ afterMeasure: undefined as (() => void) | undefined }));
+vi.mock("./disk-budget.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./disk-budget.js")>();
+  return {
+    ...actual,
+    measureSessionPhysicalDiskUsage: async (
+      ...args: Parameters<typeof actual.measureSessionPhysicalDiskUsage>
+    ) => {
+      const result = await actual.measureSessionPhysicalDiskUsage(...args);
+      hook.afterMeasure?.();
+      return result;
+    },
+  };
+});
+
+let state: OpenClawTestState;
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realOpen = sqlite.openNodeSqliteDatabase;
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({
+    prefix: "archive-pruning-admission-",
+    layout: "state-only",
+  });
+});
+
+afterEach(async () => {
+  releases.splice(0).forEach((release) => release());
+  await Promise.allSettled(pending.splice(0));
+  hook.afterMeasure = undefined;
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  await state.cleanup();
+});
+
+function own<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  void promise.catch(() => {});
+  return promise;
+}
+
+const boundaries = ["drain", "presence", "row", "unpublished", "removed-file"] as const;
+
+it.each([
+  ...boundaries.flatMap((boundary) =>
+    [false, true].map((cold) => ({ boundary, cold, outcome: "complete" as const })),
+  ),
+  { boundary: "drain", cold: true, outcome: "revoked" },
+  { boundary: "removed-file", cold: true, outcome: "revoked" },
+  { boundary: "row", cold: true, outcome: "unpublished" },
+] as const)(
+  "keeps $boundary archive maintenance inside its writer FIFO (cold: $cold, outcome: $outcome)",
+  async ({ boundary, cold, outcome }) => {
+    const sessionsDir = state.sessionsDir();
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:archive-admission";
+    const sessionId = "archived-generation";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+    await appendTranscriptMessage(
+      { sessionKey, sessionId, storePath },
+      { message: { role: "user", content: "synthetic retained archive payload" } },
+    );
+    const deletion = await deleteSessionEntryLifecycle({
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+      archiveTranscript: true,
+    });
+    const archivePath = deletion.archivedTranscripts[0]?.archivedPath;
+    assert(archivePath);
+    const archivedBytes = fs.readFileSync(archivePath);
+    const target = resolveSqliteTargetFromSessionStorePath(storePath);
+    const options = { agentId: target.agentId ?? "main", path: target.path };
+    const database = openOpenClawAgentDatabase(options);
+    const markUnpublished = (db: DatabaseSync) => {
+      executeSqliteQuerySync(
+        db,
+        getSessionKysely(db)
+          .updateTable("session_transcript_archives")
+          .set({ published_at: null })
+          .where("session_id", "=", sessionId),
+      );
+    };
+    const readArchive = (db: DatabaseSync) =>
+      executeSqliteQuerySync(
+        db,
+        getSessionKysely(db)
+          .selectFrom("session_transcript_archives")
+          .selectAll()
+          .where("session_id", "=", sessionId),
+      ).rows[0];
+    if (boundary === "unpublished") {
+      markUnpublished(database.db);
+    }
+    const originalArchive = readArchive(database.db);
+    assert(originalArchive);
+    database.db.exec("PRAGMA incremental_vacuum;");
+    database.walMaintenance.checkpoint();
+    if (boundary === "drain") {
+      // sqlite-allow-raw -- Disposable bootstrap pages exercise multiple real vacuum passes.
+      database.db.exec(`CREATE TABLE cold_drain_fixture (payload BLOB);
+        INSERT INTO cold_drain_fixture VALUES (zeroblob(8388608));
+        DROP TABLE cold_drain_fixture;`);
+      database.walMaintenance.checkpoint();
+    }
+    const readFreePages = (db: DatabaseSync) =>
+      Number(db.prepare("PRAGMA freelist_count").get()?.freelist_count);
+    const initialFreePages = readFreePages(database.db);
+    if (boundary === "drain") {
+      expect(initialFreePages).toBeGreaterThan(512);
+    } else {
+      expect(initialFreePages).toBe(0);
+    }
+    const legacyPath = path.join(sessionsDir, "legacy.jsonl.deleted.2020-01-01T00-00-00.000Z");
+    if (boundary === "unpublished") {
+      fs.writeFileSync(legacyPath, "synthetic old archive");
+    }
+
+    const events: string[] = [];
+    let active = false;
+    let reached = false;
+    let closed = false;
+    let inTransaction = false;
+    let observing = false;
+    let parentChecks = 0;
+    let childChecks = 0;
+    let laterWriterRan = false;
+    let firstDrainedPages = 0;
+    const childEntered = createDeferred();
+    const releaseChild = createDeferred();
+    const blockerEntered = createDeferred();
+    const releaseBlocker = createDeferred();
+    releases.push(
+      () => releaseChild.resolve(),
+      () => releaseBlocker.resolve(),
+    );
+
+    const arrive = () => {
+      if (reached) {
+        return;
+      }
+      reached = true;
+      events.push("boundary");
+      inTransaction = database.db.isTransaction;
+      if (cold) {
+        closed = closeOpenClawAgentDatabaseByPath(database.path);
+      }
+      observing = true;
+    };
+    const observe = (db: DatabaseSync) => {
+      const prepare = db.prepare.bind(db);
+      vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        if (sql === "PRAGMA integrity_check;") {
+          const all = statement.all.bind(statement);
+          statement.all = () => {
+            if (observing) {
+              parentChecks += 1;
+            }
+            return all();
+          };
+        }
+        if (sql === "PRAGMA freelist_count" && boundary === "presence") {
+          const get = statement.get.bind(statement);
+          statement.get = () => {
+            const row = get();
+            if (active && !reached && Number(row?.freelist_count) === 0) {
+              queueMicrotask(arrive);
+            }
+            return row;
+          };
+        }
+        return statement;
+      });
+    };
+    observe(database.db);
+    vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, openOptions) => {
+      const opened = realOpen(pathname, openOptions);
+      if (pathname === database.path && !openOptions?.readOnly) {
+        observe(opened);
+      }
+      return opened;
+    });
+    vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation((...args) => {
+      const check = realIntegrity(...args);
+      if (!observing || args[0] !== database.path) {
+        return check;
+      }
+      childChecks += 1;
+      childEntered.resolve();
+      return Promise.all([check, releaseChild.promise]).then(() => undefined);
+    });
+    if (boundary === "row" || boundary === "unpublished") {
+      hook.afterMeasure = () => {
+        if (active) {
+          arrive();
+        }
+      };
+    }
+    const rm = fs.promises.rm.bind(fs.promises);
+    vi.spyOn(fs.promises, "rm").mockImplementation(async (...args) => {
+      const result = await rm(...args);
+      if (active && boundary === "removed-file" && args[0] === archivePath) {
+        arrive();
+      }
+      return result;
+    });
+
+    void own(
+      runExclusiveSqliteSessionWrite(options, async () => {
+        blockerEntered.resolve();
+        await releaseBlocker.promise;
+        events.push("blocker-released");
+      }),
+    );
+    await blockerEntered.promise;
+    const work = own(
+      runExclusiveSqliteSessionWrite(options, async () => {
+        active = true;
+        events.push("maintenance-entered");
+        try {
+          return boundary === "drain"
+            ? await reclaimSqliteFreePages(options)
+            : await pruneAllSessionTranscriptArchivesToHighWater({
+                archiveDirectory: path.dirname(archivePath),
+                databaseOptions: options,
+                highWaterBytes: 1,
+                storePath,
+              });
+        } finally {
+          active = false;
+          events.push("maintenance-exited");
+        }
+      }),
+    );
+    const later = own(
+      runExclusiveSqliteSessionWrite(options, async () => {
+        laterWriterRan = true;
+        events.push("later-writer");
+      }),
+    );
+    if (boundary === "drain") {
+      void own(
+        yieldToEventLoop().then(() => {
+          firstDrainedPages = initialFreePages - readFreePages(database.db);
+          arrive();
+        }),
+      );
+    }
+    releaseBlocker.resolve();
+    const completion = await Promise.race([
+      childEntered.promise.then(() => "child" as const),
+      work.then(() => "completed" as const),
+    ]);
+    if (completion === "child") {
+      await yieldToEventLoop();
+      expect(laterWriterRan).toBe(false);
+      if (outcome === "revoked") {
+        closeOpenClawAgentDatabaseByPath(database.path);
+      } else if (outcome === "unpublished") {
+        const peer = realOpen(database.path);
+        try {
+          markUnpublished(peer);
+        } finally {
+          peer.close();
+        }
+      }
+    }
+    releaseChild.resolve();
+    if (outcome === "revoked") {
+      await expect(work).rejects.toThrow(/revoked/);
+      expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+    } else if (boundary === "drain") {
+      await work;
+    } else {
+      await expect(work).resolves.toMatchObject({ removedFiles: outcome === "complete" ? 1 : 0 });
+    }
+    await later;
+    observing = false;
+    expect(reached).toBe(true);
+    expect(closed).toBe(cold);
+    expect(inTransaction).toBe(false);
+    expect(completion).toBe(cold ? "child" : "completed");
+    expect(parentChecks).toBe(0);
+    expect(childChecks).toBe(cold ? 1 : 0);
+    expect(events.indexOf("later-writer")).toBeGreaterThan(events.indexOf("maintenance-exited"));
+    const reopened = openOpenClawAgentDatabase(options);
+    const row = readArchive(reopened.db);
+    if (boundary === "drain" || boundary === "unpublished" || outcome !== "complete") {
+      expect(row).toEqual({
+        ...originalArchive,
+        ...(outcome === "unpublished" ? { published_at: null } : {}),
+      });
+      if (boundary === "removed-file") {
+        expect(fs.existsSync(archivePath)).toBe(false);
+      } else {
+        expect(fs.readFileSync(archivePath)).toEqual(archivedBytes);
+      }
+    } else {
+      expect(row).toBeUndefined();
+      expect(fs.existsSync(archivePath)).toBe(false);
+    }
+    if (boundary === "drain") {
+      expect(firstDrainedPages).toBeGreaterThan(0);
+      expect(firstDrainedPages).toBeLessThanOrEqual(512);
+      expect(readFreePages(reopened.db)).toBe(
+        outcome === "revoked" ? initialFreePages - firstDrainedPages : 0,
+      );
+    }
+  },
+);

--- a/src/config/sessions/session-history-archive-pruning.ts
+++ b/src/config/sessions/session-history-archive-pruning.ts
@@ -5,6 +5,7 @@ import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import {
@@ -12,7 +13,7 @@ import {
   pruneSessionTranscriptArchivesToHighWater,
   type SessionPhysicalDiskUsage,
 } from "./disk-budget.js";
-import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import { getSessionKysely, withSqliteSessionDatabase } from "./session-accessor.sqlite-scope.js";
 
 export async function reclaimSqliteFreePages(
   databaseOptions: OpenClawAgentDatabaseOptions,
@@ -22,25 +23,30 @@ export async function reclaimSqliteFreePages(
     if (remaining !== undefined) {
       await setImmediate();
     }
-    // Reacquire after yielding: idle cached handles can be evicted between passes.
-    const database = openOpenClawAgentDatabase(databaseOptions);
-    database.walMaintenance.checkpoint();
-    // sqlite-allow-raw -- Physical budget decisions need current SQLite page accounting.
-    const freePages = () =>
-      Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count ?? 0);
-    const before = freePages();
-    if (!Number.isSafeInteger(before) || before <= 0) {
+    // Reacquire after yielding while the caller retains its writer section.
+    const nextRemaining = await withSqliteSessionDatabase(databaseOptions, (database) => {
+      database.walMaintenance.checkpoint();
+      // sqlite-allow-raw -- Physical budget decisions need current SQLite page accounting.
+      const freePages = () =>
+        Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+      const before = freePages();
+      if (!Number.isSafeInteger(before) || before <= 0) {
+        return undefined;
+      }
+      // Bound the entire drain to its initial freelist, even if other writers free more pages.
+      const passRemaining = Math.min(remaining ?? before, before);
+      const pages = Math.min(512, passRemaining);
+      database.db.exec(`PRAGMA incremental_vacuum(${pages});`); // sqlite-allow-raw -- Bounded maintenance outside a transaction.
+      database.walMaintenance.checkpoint();
+      if (freePages() >= before) {
+        return undefined;
+      }
+      return passRemaining - pages;
+    });
+    if (nextRemaining === undefined) {
       return;
     }
-    // Bound the entire drain to its initial freelist, even if other writers free more pages.
-    remaining = Math.min(remaining ?? before, before);
-    const pages = Math.min(512, remaining);
-    database.db.exec(`PRAGMA incremental_vacuum(${pages});`); // sqlite-allow-raw -- Bounded maintenance outside a transaction.
-    database.walMaintenance.checkpoint();
-    remaining -= pages;
-    if (freePages() >= before) {
-      return;
-    }
+    remaining = nextRemaining;
   }
 }
 
@@ -48,7 +54,12 @@ export function hasCanonicalSessionTranscriptArchives(
   databaseOptions: OpenClawAgentDatabaseOptions,
 ): boolean {
   // openclaw-agent-db.ts cache rule: LRU eviction closes idle handles across awaits.
-  const database = openOpenClawAgentDatabase(databaseOptions);
+  return hasCanonicalSessionTranscriptArchivesInDatabase(
+    openOpenClawAgentDatabase(databaseOptions),
+  );
+}
+
+function hasCanonicalSessionTranscriptArchivesInDatabase(database: OpenClawAgentDatabase): boolean {
   const db = getSessionKysely(database.db);
   const table = executeSqliteQuerySync(
     database.db,
@@ -74,10 +85,8 @@ export function hasCanonicalSessionTranscriptArchives(
 }
 
 function readUnpublishedSessionTranscriptArchiveNames(
-  databaseOptions: OpenClawAgentDatabaseOptions,
+  database: OpenClawAgentDatabase,
 ): Set<string> {
-  // openclaw-agent-db.ts cache rule: LRU eviction closes idle handles across awaits.
-  const database = openOpenClawAgentDatabase(databaseOptions);
   const db = getSessionKysely(database.db);
   const table = executeSqliteQuerySync(
     database.db,
@@ -110,20 +119,20 @@ async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
   let usage = await measureSessionPhysicalDiskUsage(params.storePath);
   let removedFiles = 0;
   while (usage.totalBytes > params.highWaterBytes) {
-    // openclaw-agent-db.ts cache rule: LRU eviction closes idle handles across awaits.
-    const database = openOpenClawAgentDatabase(params.databaseOptions);
-    const db = getSessionKysely(database.db);
-    const row = executeSqliteQuerySync(
-      database.db,
-      db
-        .selectFrom("session_transcript_archives")
-        .select(["archive_name", "generation", "session_id"])
-        .where("published_at", "is not", null)
-        .orderBy("created_at", "asc")
-        .orderBy("session_id", "asc")
-        .orderBy("generation", "asc")
-        .limit(1),
-    ).rows[0];
+    const row = await withSqliteSessionDatabase(params.databaseOptions, (database) => {
+      const db = getSessionKysely(database.db);
+      return executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("session_transcript_archives")
+          .select(["archive_name", "generation", "session_id"])
+          .where("published_at", "is not", null)
+          .orderBy("created_at", "asc")
+          .orderBy("session_id", "asc")
+          .orderBy("generation", "asc")
+          .limit(1),
+      ).rows[0];
+    });
     if (!row) {
       break;
     }
@@ -145,16 +154,18 @@ async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
         break;
       }
     }
-    runOpenClawAgentWriteTransaction((transactionDb) => {
-      const transactionKysely = getSessionKysely(transactionDb.db);
-      executeSqliteQuerySync(
-        transactionDb.db,
-        transactionKysely
-          .deleteFrom("session_transcript_archives")
-          .where("session_id", "=", row.session_id)
-          .where("generation", "=", row.generation),
-      );
-    }, params.databaseOptions);
+    await withSqliteSessionDatabase(params.databaseOptions, () =>
+      runOpenClawAgentWriteTransaction((transactionDb) => {
+        const transactionKysely = getSessionKysely(transactionDb.db);
+        executeSqliteQuerySync(
+          transactionDb.db,
+          transactionKysely
+            .deleteFrom("session_transcript_archives")
+            .where("session_id", "=", row.session_id)
+            .where("generation", "=", row.generation),
+        );
+      }, params.databaseOptions),
+    );
     await reclaimSqliteFreePages(params.databaseOptions);
     usage = await measureSessionPhysicalDiskUsage(params.storePath);
   }
@@ -169,14 +180,20 @@ export async function pruneAllSessionTranscriptArchivesToHighWater(params: {
 }): Promise<{ removedFiles: number; usage: SessionPhysicalDiskUsage }> {
   // Reclaim committed free pages before pressure can destroy a retained archive.
   await reclaimSqliteFreePages(params.databaseOptions);
-  const canonical = hasCanonicalSessionTranscriptArchives(params.databaseOptions)
+  const canonical = (await withSqliteSessionDatabase(
+    params.databaseOptions,
+    hasCanonicalSessionTranscriptArchivesInDatabase,
+  ))
     ? await pruneCanonicalSessionTranscriptArchivesToHighWater(params)
     : { removedFiles: 0, usage: await measureSessionPhysicalDiskUsage(params.storePath) };
   if (canonical.usage.totalBytes <= params.highWaterBytes) {
     return canonical;
   }
   const legacy = await pruneSessionTranscriptArchivesToHighWater({
-    excludeNames: readUnpublishedSessionTranscriptArchiveNames(params.databaseOptions),
+    excludeNames: await withSqliteSessionDatabase(
+      params.databaseOptions,
+      readUnpublishedSessionTranscriptArchiveNames,
+    ),
     highWaterBytes: params.highWaterBytes,
     storePath: params.storePath,
   });


### PR DESCRIPTION
Related: #143332, #143285.

## What Problem This Solves

Resolves a problem where disk-budget archive pruning can pause the Gateway's main thread when its cached database connection closes between free-page drain steps, measurements, or archive file removal.

## Why This Change Was Made

Queued pruning now uses the existing guarded asynchronous acquisition owner for its cold database phases. Each free-page pass keeps its checkpoints, freelist reads, and bounded vacuum together on one admitted connection. Archive queries read current rows after validation, and the complete canonical transaction runs after reacquisition following file removal.

The existing writer sections, full integrity and foreign-key checks, initial freelist bound, 512-page steps, no-progress predicate, archive ordering, unpublished exclusions, and file-before-row recovery behavior are preserved. The synchronous archive-inspection export and the two advisory readers outside the writer queue remain unchanged.

## User Impact

Cold full-file validation at these five queued pruning boundaries no longer runs on the Gateway's main thread. Pruning continues to retain the canonical recovery row if acquisition fails after the derived file was removed. No retention policy, schema, retry behavior, Worker reuse, or new writer section is introduced.

## Evidence

- On original main, five warm controls pass and all five cold cases complete real maintenance but fail the off-parent validation assertion. The independent replay uses the exact final regression file.
- The final targeted proof passes all 13 new cases and the existing large-freelist regression. The new cases cover warm/cold free-page, canonical-presence, ordered-row, unpublished-name, and post-file-removal boundaries; FIFO exclusion; revocation during drain and after file removal; and fresh unpublished-row protection. The post-removal refusal preserves the exact canonical row and blob.
- Full-context independent P0–P2 autoreview found no actionable defects.
- The final changed-file gate passes, including core/test typechecks, lint, dependency/boundary guards, and runtime import-cycle checks.
- Linux Testbox verified the exact committed source and all three changed-file hashes, then passed all 99 tests across five suites and the full build; the workload wrapper exited successfully. [Run context](https://github.com/openclaw/openclaw/actions/runs/34401131913).
- This proof exercises real synthetic SQLite archives, filesystem removal, and the maintenance owner with real integrity checks. It does not establish production LRU frequency or Gateway latency; no CLI parser, production data, or managed Gateway was exercised.
