### PR TITLE
refactor(cli): share node command payload assembly

### DIFF
--- a/src/cli/nodes-cli/register.location.ts
+++ b/src/cli/nodes-cli/register.location.ts
@@ -1,10 +1,10 @@
 // Node location commands: invokes location.get on a paired node and formats the location payload.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
-import { randomIdempotencyKey } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
 import { runNodesCommand } from "./cli-utils.js";
 import {
+  buildNodeInvokeParams,
   callNodesGatewayCli,
   nodesCallOpts,
   parseOptionalNodeNonNegativeInteger,
@@ -52,19 +52,16 @@ export function registerNodesLocationCommands(nodes: Command) {
           );
           const nodeId = await resolveCliNodeId(opts, opts.node ?? "");
 
-          const invokeParams: Record<string, unknown> = {
+          const invokeParams = buildNodeInvokeParams({
             nodeId,
             command: "location.get",
             params: {
-              maxAgeMs: Number.isFinite(maxAgeMs) ? maxAgeMs : undefined,
+              maxAgeMs,
               desiredAccuracy,
-              timeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : undefined,
+              timeoutMs,
             },
-            idempotencyKey: randomIdempotencyKey(),
-          };
-          if (typeof invokeTimeoutMs === "number" && Number.isFinite(invokeTimeoutMs)) {
-            invokeParams.timeoutMs = invokeTimeoutMs;
-          }
+            timeoutMs: invokeTimeoutMs,
+          });
 
           const raw = await callNodesGatewayCli("node.invoke", opts, invokeParams);
           const res = typeof raw === "object" && raw !== null ? (raw as { payload?: unknown }) : {};

--- a/src/cli/nodes-cli/register.notify.ts
+++ b/src/cli/nodes-cli/register.notify.ts
@@ -1,10 +1,10 @@
 // Local notification command for paired nodes.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { type Command, Option } from "commander";
-import { randomIdempotencyKey } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import {
+  buildNodeInvokeParams,
   callNodesGatewayCli,
   nodesCallOpts,
   parseOptionalNodePositiveInteger,
@@ -47,7 +47,7 @@ export function registerNodesNotifyCommand(nodes: Command) {
             "--invoke-timeout",
           );
           const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
-          const invokeParams: Record<string, unknown> = {
+          const invokeParams = buildNodeInvokeParams({
             nodeId,
             command: "system.notify",
             params: {
@@ -57,11 +57,9 @@ export function registerNodesNotifyCommand(nodes: Command) {
               priority: opts.priority,
               delivery: opts.delivery,
             },
-            idempotencyKey: opts.idempotencyKey ?? randomIdempotencyKey(),
-          };
-          if (typeof invokeTimeout === "number" && Number.isFinite(invokeTimeout)) {
-            invokeParams.timeoutMs = invokeTimeout;
-          }
+            idempotencyKey: opts.idempotencyKey,
+            timeoutMs: invokeTimeout,
+          });
 
           const result = await callNodesGatewayCli("node.invoke", opts, invokeParams);
           if (opts.json) {


### PR DESCRIPTION
## What Problem This Solves

The location and notification commands duplicated node payload construction, including idempotency generation and optional invoke timeouts, despite an existing shared builder.

## Why This Change Was Made

Use that builder in both object-payload callers and remove redundant finite checks after strict numeric parsing. The generic invoke command retains its broader JSON contract.

## User Impact

Behavior is unchanged: validation still precedes node lookup, keys are generated afterward, notification key overrides retain their nullish fallback, and response formatting stays the same.

## Evidence

The same 86 tests passed before and after across command, builder and real-registration coverage. All 28 changed-file checks and independent review through P2 passed. No tests or helper APIs changed. This removes five production lines without claiming a startup performance improvement.
