### PR TITLE
test(chutes): use native JSON responses

### DIFF
--- a/extensions/chutes/implicit-provider.test.ts
+++ b/extensions/chutes/implicit-provider.test.ts
@@ -8,14 +8,6 @@ import { refreshChutesOAuthCredential } from "./oauth.js";
 
 const CHUTES_OAUTH_MARKER = resolveOAuthApiKeyMarker("chutes");
 
-function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(payload), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    ...init,
-  });
-}
-
 async function runChutesCatalog(params: { apiKey?: string; discoveryApiKey?: string }) {
   const provider = await registerSingleProviderPlugin(plugin);
   const result = await provider.catalog?.run({
@@ -42,7 +34,7 @@ async function withRealChutesDiscovery<T>(
   const originalFetch = globalThis.fetch;
   const fetchMock = vi
     .fn()
-    .mockResolvedValue(jsonResponse({ data: [{ id: "chutes/private-model" }] }));
+    .mockResolvedValue(Response.json({ data: [{ id: "chutes/private-model" }] }));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
 
   try {

--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -20,14 +20,6 @@ const EXPECTED_STATIC_MODEL_IDS = [
   "Qwen/Qwen3.5-397B-A17B-TEE",
 ];
 
-function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(payload), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    ...init,
-  });
-}
-
 async function withLiveChutesDiscovery<T>(
   fetchMock: ReturnType<typeof vi.fn>,
   run: () => Promise<T>,
@@ -195,7 +187,7 @@ describe("chutes-models", () => {
 
   it("preserves native per-million prices and exact zero rates during discovery", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
-      jsonResponse({
+      Response.json({
         data: [
           {
             id: "fixture-provider/zero-input",
@@ -263,7 +255,7 @@ describe("chutes-models", () => {
     },
   ])("keeps an unknown runtime price, not partial paid rates, for $label", async ({ pricing }) => {
     const mockFetch = vi.fn().mockResolvedValue(
-      jsonResponse({
+      Response.json({
         data: [{ id: "fixture-provider/unpriced-model", pricing }],
       }),
     );
@@ -282,7 +274,7 @@ describe("chutes-models", () => {
 
   it("selects Chutes context limits in provider precedence order", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
-      jsonResponse({
+      Response.json({
         data: [
           {
             id: "provider/context-primary",
@@ -317,7 +309,7 @@ describe("chutes-models", () => {
 
   it("falls back from malformed live token metadata", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
-      jsonResponse({
+      Response.json({
         data: [
           {
             id: "provider/bad-window",
@@ -370,20 +362,20 @@ describe("chutes-models", () => {
       const auth = readAuthorizationHeader(init);
       if (auth === "Bearer chutes-token-a") {
         return Promise.resolve(
-          jsonResponse({
+          Response.json({
             data: [{ id: "private/model-a" }],
           }),
         );
       }
       if (auth === "Bearer chutes-token-b") {
         return Promise.resolve(
-          jsonResponse({
+          Response.json({
             data: [{ id: "private/model-b" }],
           }),
         );
       }
       return Promise.resolve(
-        jsonResponse({
+        Response.json({
           data: [{ id: "public/model" }],
         }),
       );
@@ -405,7 +397,7 @@ describe("chutes-models", () => {
         return Promise.resolve(new Response("", { status: 401 }));
       }
       return Promise.resolve(
-        jsonResponse({
+        Response.json({
           data: [{ id: "public/model" }],
         }),
       );


### PR DESCRIPTION
The Chutes model and implicit-provider tests each wrapped native response construction in the same private `jsonResponse` helper. Use `Response.json` directly at their nine existing object-payload call sites and delete both wrappers and their unused response-init parameter.

The fixtures remain real responses. Status 200, JSON content type and the actual payload serialization are preserved, including nested undefined and nonfinite values. Direct 401/503 responses, pricing/default checks, token-scoped caches, authenticated request order and proxy cleanup remain unchanged. This does not claim equivalence for arbitrary top-level undefined payloads, which these tests never use.

Validation: baseline and candidate 26/26 with identical cases; all 19 normal changed checks passed; direct installed Node/Undici source inspection and independent Codex review clean. All 16 static definitions and 56 assertion sites remain. Tests net -16 lines; production delta 0.
