### PR TITLE
test(ui): reuse deferred routing fixtures

### DIFF
--- a/ui/src/app/router-outlet-chat.test.ts
+++ b/ui/src/app/router-outlet-chat.test.ts
@@ -8,6 +8,7 @@ import {
 import { html, nothing, type LitElement } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../../src/shared/deferred.js";
 import {
   SESSION_COMPOSER_FOCUS_PARAM,
   SESSION_NAVIGATION_KEY_PARAM,
@@ -36,19 +37,6 @@ type RouterOutletElement = LitElement & {
   retryContext?: TestContext;
   retentionScope?: object;
 };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-}
 
 function location(pathname: string, search = ""): RouteLocation {
   return { pathname, search, hash: "" };
@@ -112,7 +100,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));
-    const refreshed = deferred<ChatRouteData>();
+    const refreshed = createDeferredCore<ChatRouteData>();
     const loader = vi
       .fn()
       .mockResolvedValueOnce(sessionData(sessionKey, "chat"))
@@ -178,7 +166,7 @@ describe("openclaw-router-outlet chat ownership", () => {
   it("keeps a parked session hidden until the requested session resolves", async () => {
     const firstKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
     const nextKey = "agent:main:dashboard:abcdef12-3456-7890-abcd-ef1234567890";
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     const teardown = vi.fn(async () => undefined);
     const render = ownedRenderer(teardown);
     const chatModule = await routeModule("chat", render);
@@ -231,9 +219,9 @@ describe("openclaw-router-outlet chat ownership", () => {
     let scope = { key: 1 };
     const oldKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
     const newKey = "agent:main:dashboard:abcdef12-3456-7890-abcd-ef1234567890";
-    const teardownDone = deferred<void>();
+    const teardownDone = createDeferredCore();
     const teardown = vi.fn(() => teardownDone.promise);
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     const loader = vi
       .fn()
       .mockResolvedValueOnce(sessionData(oldKey, "chat"))
@@ -295,8 +283,8 @@ describe("openclaw-router-outlet chat ownership", () => {
   it("keeps a pending destination and ignores its retired scope's late result", async () => {
     const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
     let scope = { key: 1 };
-    const oldResult = deferred<ChatRouteData>();
-    const newResult = deferred<ChatRouteData>();
+    const oldResult = createDeferredCore<ChatRouteData>();
+    const newResult = createDeferredCore<ChatRouteData>();
     const loader = vi
       .fn()
       .mockImplementationOnce(() => oldResult.promise)
@@ -343,8 +331,8 @@ describe("openclaw-router-outlet chat ownership", () => {
     let scope = { key: 1 };
     const render = ownedRenderer(async () => undefined);
     const chatModule = await routeModule("chat", render);
-    const dashboardModule = deferred<TestModule>();
-    const homeModule = deferred<TestModule>();
+    const dashboardModule = createDeferredCore<TestModule>();
+    const homeModule = createDeferredCore<TestModule>();
     const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
       routes: [
         definePage({
@@ -387,7 +375,7 @@ describe("openclaw-router-outlet chat ownership", () => {
 
   it("keeps a returning session inert until its pending MCP teardown completes", async () => {
     const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
-    const done = deferred<void>();
+    const done = createDeferredCore();
     const teardown = vi.fn(() => done.promise);
     const render = ownedRenderer(teardown);
     const module = await routeModule("chat", render);
@@ -473,7 +461,7 @@ describe("openclaw-router-outlet chat ownership", () => {
       fallbackAgentId: "main",
       row: { key: nextSessionKey, displayName: "Next retained board" },
     });
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     const teardown = vi.fn(async () => undefined);
     const render = ownedRenderer(teardown);
     const chatModule = await routeModule("chat", render);
@@ -533,7 +521,7 @@ describe("openclaw-router-outlet chat ownership", () => {
       `?${new URLSearchParams({ draft: "ship it", [SESSION_COMPOSER_FOCUS_PARAM]: "1" })}`,
     );
     const initial = { ...sessionData(sessionKey, "chat"), canonicalLocation: canonical };
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));
@@ -571,7 +559,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     const firstKey = "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001";
     const secondKey = "agent:main:dashboard:12345678-0bbb-4000-8000-000000000002";
     const pathname = "/chat/main/deploy-monitor-12345678";
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));
@@ -636,7 +624,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     },
   ])("retains an unresolved route until $label replaces it", async ({ result }) => {
     const sessionKey = "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001";
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferredCore<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));

--- a/ui/src/app/router-outlet-controller.test.ts
+++ b/ui/src/app/router-outlet-controller.test.ts
@@ -1,25 +1,13 @@
 // @vitest-environment node
 import { createRouter, definePage, type RouteLocation } from "@openclaw/uirouter";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../../src/shared/deferred.js";
 import { RouterOutletController, selectRenderedRouteMatch } from "./router-outlet-controller.ts";
 
 type RouteId = "first" | "second";
 type TestContext = { label: string };
 type TestModule = { render: (data: TestData | undefined) => unknown };
 type TestData = { label: string };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-}
 
 function location(pathname: string): RouteLocation {
   return { pathname, search: "", hash: "" };
@@ -42,8 +30,8 @@ afterEach(() => {
 describe("RouterOutletController pending presentation", () => {
   it("delays a cold-start fallback until the route has been pending for one second", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
-    const routeData = deferred<TestData>();
+    const routeModule = createDeferredCore<TestModule>();
+    const routeData = createDeferredCore<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -79,8 +67,8 @@ describe("RouterOutletController pending presentation", () => {
 
   it("carries the last settled match through a cold and module-loaded navigation", async () => {
     vi.useFakeTimers();
-    const secondModule = deferred<TestModule>();
-    const secondData = deferred<TestData>();
+    const secondModule = createDeferredCore<TestModule>();
+    const secondData = createDeferredCore<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -139,8 +127,8 @@ describe("RouterOutletController pending presentation", () => {
 
   it("restarts a canceled pending delay after reconnect", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
-    const routeData = deferred<TestData>();
+    const routeModule = createDeferredCore<TestModule>();
+    const routeData = createDeferredCore<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -230,7 +218,7 @@ describe("RouterOutletController not-found boundary", () => {
   });
 
   it("keeps a navigation started by an earlier not-found subscriber", async () => {
-    const secondModule = deferred<TestModule>();
+    const secondModule = createDeferredCore<TestModule>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({

--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -2,6 +2,7 @@ import { createRouter, definePage, type RouteMatch, type Router } from "@opencla
 import { html, nothing, type LitElement } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../../src/shared/deferred.js";
 import { settleLitElement } from "../test-helpers/lit-settle.ts";
 import "./router-outlet.ts";
 
@@ -22,22 +23,6 @@ type RouterOutletElement = LitElement & {
   retryContext?: TestContext;
   onNotFound?: () => void;
 };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (error: unknown) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-  return { promise, resolve, reject };
-}
 
 function createOutlet(router: TestRouter, context: TestContext): RouterOutletElement {
   const outlet = document.createElement("openclaw-router-outlet") as RouterOutletElement;
@@ -62,7 +47,7 @@ async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
 describe("openclaw-router-outlet", () => {
   it("retains MCP Apps across route IDs that share an explicit owner", async () => {
     const teardownView = vi.fn(async () => undefined);
-    const nextData = deferred<TestData>();
+    const nextData = createDeferredCore<TestData>();
     const renderOwnedRoute = vi.fn((data: TestData | undefined) =>
       data
         ? html`
@@ -124,7 +109,7 @@ describe("openclaw-router-outlet", () => {
 
   it("replaces the loading skeleton with the resolved route", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
+    const routeModule = createDeferredCore<TestModule>();
     const context = { label: "loaded" };
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
@@ -168,7 +153,7 @@ describe("openclaw-router-outlet", () => {
   });
 
   it("keeps the current route mounted until nested MCP Apps finish teardown", async () => {
-    const teardown = deferred<void>();
+    const teardown = createDeferredCore();
     const teardownView = vi.fn(() => teardown.promise);
     const context = { label: "loaded" };
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
@@ -244,7 +229,7 @@ describe("openclaw-router-outlet", () => {
   });
 
   it("keeps a loaded route visible with an error and retries through the latest context", async () => {
-    const firstLoad = deferred<TestData>();
+    const firstLoad = createDeferredCore<TestData>();
     let loadCount = 0;
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [


### PR DESCRIPTION
The router controller and its two outlet suites each copied a deferred-promise type and constructor. Reuse the existing `createDeferredCore` helper at their 24 allocation sites and remove the three local copies.

All 26 routing cases and 141 assertion sites remain, including pending-delay timing, rejection/retry, MCP teardown, session retention, stale results and reconnect behavior. Explicit void resolutions, rejection calls, timers, awaits and cleanup order are unchanged. No production code or UI behavior changes.

Validation: original and candidate 26/26 with identical subjects/statuses; all 18 normal changed checks passed; independent Codex review clean. The Node and jsdom Promise ownership was checked against the installed runtime/test environment. Tests net -39 lines; production delta 0.
