### PR TITLE
fix(gateway): avoid repeated health refreshes on reconnect

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -115,6 +115,9 @@ When no `x-openclaw-session-key` header or `user` field is provided, `/v1/chat/c
 `openclaw health` asks the running gateway for its health snapshot (no direct channel
 sockets from the CLI). By default it returns a fresh cached gateway snapshot and the
 gateway refreshes that cache in the background; `--verbose` forces a live probe instead.
+Connections and cached health reads share a one-minute background refresh cadence, so
+repeated diagnostic connections do not each rebuild the health snapshot. Explicit live
+probes and refreshes for missing or stale health still run immediately.
 Snapshots describe loaded and configured channels. Stored credentials alone do not
 activate a channel or add it to Gateway health; use channel setup to enable it.
 The command reports linked creds/auth age when available, per-channel probe summaries,

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -10,32 +10,11 @@ import type { ChannelHealthSummary, HealthSummary } from "../health/types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { formatError } from "../server-utils.js";
+import { shouldScheduleBackgroundHealthRefresh } from "../server/health-refresh-admission.js";
 import { respondUnavailableOnThrow } from "./response.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
 const ADMIN_SCOPE = "operator.admin";
-const requestRefreshStartedAt = new WeakMap<
-  GatewayRequestContext["refreshHealthSnapshot"],
-  number
->();
-
-function shouldScheduleRequestRefresh(
-  refresh: GatewayRequestContext["refreshHealthSnapshot"],
-  now: number,
-): boolean {
-  const startedAt = requestRefreshStartedAt.get(refresh);
-  if (
-    startedAt !== undefined &&
-    !isFutureDateTimestampMs(startedAt, { nowMs: now }) &&
-    now - startedAt < HEALTH_REFRESH_INTERVAL_MS
-  ) {
-    return false;
-  }
-  // Scope the throttle to the Gateway refresh owner so independent servers do
-  // not suppress each other while request bursts share one cadence.
-  requestRefreshStartedAt.set(refresh, now);
-  return true;
-}
 
 function cachedLifecycleDiffersFromRuntime(params: {
   cachedAccount: ChannelHealthSummary | undefined;
@@ -169,7 +148,7 @@ export const healthHandlers: GatewayRequestHandlers = {
         undefined,
         { cached: true },
       );
-      if (shouldScheduleRequestRefresh(refreshHealthSnapshot, now)) {
+      if (shouldScheduleBackgroundHealthRefresh(refreshHealthSnapshot, now)) {
         void refreshHealthSnapshot({ probe: false, includeSensitive }).catch((err: unknown) =>
           logHealth.error(`background health refresh failed: ${formatError(err)}`),
         );

--- a/src/gateway/server/health-refresh-admission.ts
+++ b/src/gateway/server/health-refresh-admission.ts
@@ -1,0 +1,26 @@
+import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
+import type { GatewayRequestContext } from "../server-methods/types.js";
+
+const backgroundRefreshStartedAt = new WeakMap<
+  GatewayRequestContext["refreshHealthSnapshot"],
+  number
+>();
+
+/** Shares the existing background cadence across connections and cached health reads. */
+export function shouldScheduleBackgroundHealthRefresh(
+  refresh: GatewayRequestContext["refreshHealthSnapshot"],
+  now: number,
+): boolean {
+  const startedAt = backgroundRefreshStartedAt.get(refresh);
+  if (
+    startedAt !== undefined &&
+    !isFutureDateTimestampMs(startedAt, { nowMs: now }) &&
+    now - startedAt < HEALTH_REFRESH_INTERVAL_MS
+  ) {
+    return false;
+  }
+  // The lifecycle-owned function isolates independent Gateways without retaining them.
+  backgroundRefreshStartedAt.set(refresh, now);
+  return true;
+}

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -41,6 +41,7 @@ import {
 import { formatError } from "../../server-utils.js";
 import { allowedSessionVisibilities } from "../../session-sharing.js";
 import { formatForLog, logWs } from "../../ws-log.js";
+import { shouldScheduleBackgroundHealthRefresh } from "../health-refresh-admission.js";
 import { buildGatewaySnapshot, getHealthCache, getHealthVersion } from "../health-state.js";
 import { broadcastPresenceSnapshot } from "../presence-events.js";
 import { emitGatewayAuthSecurityEvent } from "./connect-auth-security.js";
@@ -406,9 +407,11 @@ export async function sendGatewayHello(
   // Post-connect refresh only needs a cached/config snapshot for UI state;
   // live channel probes here pulled slow Discord/Telegram HTTP checks into
   // reply-adjacent websocket handshakes.
-  void refreshHealthSnapshot({ probe: false }).catch((err: unknown) =>
-    logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
-  );
+  if (shouldScheduleBackgroundHealthRefresh(refreshHealthSnapshot, Date.now())) {
+    void refreshHealthSnapshot({ probe: false }).catch((err: unknown) =>
+      logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
+    );
+  }
   const client = context.handler.getClient();
   if (
     client?.presenceKey &&

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -34,9 +34,10 @@ import type { GatewayAttributedIngress } from "../../ingress-attribution.js";
 import { getGatewayLocalUserIngress } from "../../local-user-ingress.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { GatewayConnectionWork } from "../../server-connection-work.js";
-import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
+import { HEALTH_REFRESH_INTERVAL_MS, MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { resolveGatewayCronCreatorAuthorityAdmission } from "../../server-methods/cron-creator-authority-admission.js";
+import { healthHandlers } from "../../server-methods/health.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
 import {
   enforceSharedGatewaySessionGenerationForConfigWrite,
@@ -1035,6 +1036,84 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     });
     resolveRefresh?.();
   });
+
+  it.each(["connect", "cached health"] as const)(
+    "shares the background health cadence after %s without delaying explicit health",
+    async (first) => {
+      let now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+      const cached = createHealthSummary();
+      cached.ts = now;
+      const refreshHealthSnapshot = vi.fn<GatewayRequestContext["refreshHealthSnapshot"]>(
+        async () => cached,
+      );
+      let connection = 0;
+      const connect = async (refresh = refreshHealthSnapshot) => {
+        const id = `background-health-${++connection}`;
+        const harness = attachGatewayHarness({
+          connId: id,
+          connectNonce: id,
+          refreshHealthSnapshot: refresh,
+        });
+        harness.sendConnect(id, {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client: { id: "gateway-client", version: "dev", platform: "test", mode: "backend" },
+          role: "operator",
+          caps: [],
+        });
+        await waitForFast(() => expect(harness.socketSend).toHaveBeenCalled());
+        await nextTurn();
+        const hello = JSON.parse(harness.socketSend.mock.calls[0]![0]);
+        expect(hello.ok).toBe(true);
+      };
+      const health = async (probe = false, snapshot: HealthSummary | null = cached) => {
+        const respond = vi.fn();
+        await healthHandlers.health!({
+          params: { probe },
+          context: {
+            getHealthCache: () => snapshot,
+            getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
+            refreshHealthSnapshot,
+            logHealth: createLogger(),
+          },
+          respond,
+        } as never);
+        expect(respond.mock.calls[0]?.[0]).toBe(true);
+      };
+      try {
+        if (first === "connect") {
+          await connect();
+          await health();
+        } else {
+          await health();
+          await connect();
+        }
+        await connect();
+        expect(refreshHealthSnapshot).toHaveBeenCalledTimes(1);
+
+        await health(true);
+        await health(false, null);
+        await health(false, { ...cached, ts: now - HEALTH_REFRESH_INTERVAL_MS });
+        expect(refreshHealthSnapshot).toHaveBeenCalledTimes(4);
+        expect(refreshHealthSnapshot).toHaveBeenNthCalledWith(2, {
+          probe: true,
+          includeSensitive: false,
+        });
+
+        now += HEALTH_REFRESH_INTERVAL_MS;
+        await connect();
+        expect(refreshHealthSnapshot).toHaveBeenCalledTimes(5);
+        const otherOwner = vi.fn<GatewayRequestContext["refreshHealthSnapshot"]>(
+          async () => cached,
+        );
+        await connect(otherOwner);
+        expect(otherOwner).toHaveBeenCalledOnce();
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
 
   it("projects a stable durable profile into presence and refreshes avatar state on reconnect", async () => {
     const clock = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);


### PR DESCRIPTION
Related: #134488, #137614

## What Problem This Solves

Fixes unnecessary Gateway work when operators repeatedly run diagnostics or clients reconnect. Each accepted connection started another background health collection, even when the previous collection had just completed. Health collection still walks session keys and prepares agent and plugin summaries, so repeated connections amplified that work.

## Why This Change Was Made

Share the existing one-minute, Gateway-owned background admission rule between post-connect refreshes and cached health requests. Keep explicit probes, missing/stale/runtime-mismatched health refreshes, lifecycle refreshes, audience separation and generation ordering unchanged. The collector, session queries, canonical validation, event-loop sampler and CPU/readiness acceptance are unchanged. This builds on current main including #143319 and preserves its implicit-default account bindings.

## User Impact

Repeated diagnostic connections and cached health reads share the permitted background refresh instead of each rebuilding the health snapshot. Operators can still request immediate live health probes.

## Evidence

- The connection-first and cached-health-first regressions both failed before the fix: three background refreshes instead of one. Both pass after the fix, including explicit/missing/stale refreshes, cadence expiry and independent Gateway ownership.
- 83 focused connection, health-cache, refresh-strength, audience and generation tests passed.
- Independent review found no actionable P0–P2 issues.
- An ordinary synthetic macOS/Node 26.8.1 baseline with 10,000 valid sessions measured median full passive refreshes of 15.5 ms on a held handle and 54.6 ms on a fresh handle, including acquisition and canonical validation. This establishes repeatable collection cost; it does not attribute a production CPU event or promise a latency improvement of that size.
- Changed-file checks passed, including core/core-test types, lint, dead-export, import-cycle and repository guards.
- [Installed Linux Gateway/CLI comparison](https://github.com/openclaw/openclaw/actions/runs/34402364298) passed on Blacksmith Testbox with Node 24.19.0. Canonical full builds and tarball-integrity checks passed for both variants; the fixed materialized tree matches `7416444663d` exactly. After observer setup, `system.info` → connect-only `gateway status` → `channels.status` produced 3 public health publications before the fix and 0 after it; a cached health request changed from 1 to 0; an explicit public probe still produced 1 for each variant. Both task-owned foreground Gateways exited cleanly. The fixture had zero sessions and no configured channels, so this proves installed admission/publication behavior without claiming channel networking or production CPU causality.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34402840578) passed for `7416444663d`.
