### PR TITLE
fix(agents): resolve the CLI execution auth identity for native compaction

### DIFF
--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -41,6 +41,14 @@ export function resolveCliExecutionAuthProfileId(params: {
   config: OpenClawConfig;
   agentDir: string;
   selected?: CliExecutionAuthProfileSelection;
+  /**
+   * Callers that reuse an existing native session must not let automatic
+   * selection introduce a different stored account: the session keeps its
+   * original identity without a compatibility re-check, so discovery would
+   * hand that session to another credential. Such callers pass `false` and
+   * fall back to the CLI child's own login instead.
+   */
+  discoverFallbackAccount?: boolean;
   loadAuthProfileStoreForRuntime?: typeof loadAuthProfileStoreForRuntime;
 }): string | undefined {
   const loadStore = params.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
@@ -89,6 +97,13 @@ export function resolveCliExecutionAuthProfileId(params: {
         `CLI backend "${params.cliExecutionProvider}" cannot use auth profile "${selectedAuthProfileId}" owned by "${credential.provider}".`,
       );
     }
+  }
+
+  // Fallback discovery may only introduce a stored account when the caller
+  // revalidates the resulting identity against the session it resumes.
+  // Callers that decline discovery keep the CLI child's own login.
+  if (params.discoverFallbackAccount === false) {
+    return undefined;
   }
 
   const cliProfileId = resolveAuthProfileOrder({

--- a/src/agents/embedded-agent-runner/compact.native-cli.cli-child-auth.test.ts
+++ b/src/agents/embedded-agent-runner/compact.native-cli.cli-child-auth.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { PreparedAgentRunAdmission } from "../admitted-run-context.js";
 import { resolveAgentDir } from "../agent-scope-config.js";
 import { clearAuthProfileMigrationDiagnostics } from "../auth-profiles/legacy-source-diagnostic.js";
 import { updateAuthProfileStoreWithLock } from "../auth-profiles/store-runtime.js";
@@ -17,7 +18,7 @@ import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import { compactNativeCliSession } from "./compact.js";
 
 const { runCliAgentMock } = vi.hoisted(() => ({
-  runCliAgentMock: vi.fn(async () => ({
+  runCliAgentMock: vi.fn(async (_params: { preparedRunAdmission?: PreparedAgentRunAdmission }) => ({
     meta: {
       durationMs: 1,
       agentMeta: { sessionId: "native-session", provider: "claude-cli", model: "opus" },
@@ -58,30 +59,31 @@ describe("native CLI manual compaction: CLI child credential handoff", () => {
   }
 
   function registerScriptedClaudeCliBackend() {
-    const backend = {
-      id: "claude-cli",
-      modelProvider: "anthropic",
-      pluginId: "anthropic",
-      ownsNativeCompaction: true,
-      bundleMcp: false,
-      config: {
-        command: "claude",
-        args: ["-p"],
-        input: "stdin" as const,
-        output: "jsonl" as const,
-        sessionMode: "existing" as const,
-      },
-      manualCompaction: {
-        buildPrompt: (instructions?: string) =>
-          instructions ? `/compact ${instructions}` : "/compact",
-        input: "arg" as const,
-        validateOutput: () => ({ ok: true }),
-      },
-    };
     cliBackendsTesting.setDepsForTest({
-      resolvePluginSetupCliBackend: ({ backend: id }) =>
-        id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
-      resolveRuntimeCliBackends: () => [backend],
+      resolveRuntimeCliBackends: () =>
+        [
+          {
+            id: "claude-cli",
+            modelProvider: "anthropic",
+            pluginId: "anthropic",
+            ownsNativeCompaction: true,
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["-p"],
+              input: "stdin",
+              output: "jsonl",
+              sessionMode: "existing",
+            },
+            manualCompaction: {
+              buildPrompt: (instructions?: string) =>
+                instructions ? `/compact ${instructions}` : "/compact",
+              input: "arg",
+              validateOutput: () => ({ ok: true }),
+            },
+          },
+        ] as never,
+      resolvePluginSetupCliBackend: () => undefined,
     });
   }
 

--- a/src/agents/embedded-agent-runner/compact.native-cli.cli-child-auth.test.ts
+++ b/src/agents/embedded-agent-runner/compact.native-cli.cli-child-auth.test.ts
@@ -1,0 +1,160 @@
+// Proves the native compaction credential handoff at the real store boundary:
+// the compaction resolver reads a real on-disk auth-profile store seeded with a
+// model-provider key and a competing CLI-owned account. Dropping an automatic
+// model-provider pin must keep the native login (no discovered replacement
+// account reaches the CLI run), and an unavailable explicit selection must be
+// rejected before any child runs.
+import { mkdirSync } from "node:fs";
+import nodePath from "node:path";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveAgentDir } from "../agent-scope-config.js";
+import { clearAuthProfileMigrationDiagnostics } from "../auth-profiles/legacy-source-diagnostic.js";
+import { updateAuthProfileStoreWithLock } from "../auth-profiles/store-runtime.js";
+import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
+import { compactNativeCliSession } from "./compact.js";
+
+const { runCliAgentMock } = vi.hoisted(() => ({
+  runCliAgentMock: vi.fn(async () => ({
+    meta: {
+      durationMs: 1,
+      agentMeta: { sessionId: "native-session", provider: "claude-cli", model: "opus" },
+    },
+  })),
+}));
+
+vi.mock("../cli-runner.js", () => ({ runCliAgent: runCliAgentMock }));
+
+describe("native CLI manual compaction: CLI child credential handoff", () => {
+  let stateDir: string;
+  let agentDir: string;
+
+  beforeEach(() => {
+    stateDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-compact-child-auth-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    agentDir = resolveAgentDir({}, "agent");
+    mkdirSync(agentDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    clearAuthProfileMigrationDiagnostics();
+    cliBackendsTesting.resetDepsForTest();
+    runCliAgentMock.mockClear();
+  });
+
+  async function seedAuthProfile(profileId: string, credential: unknown) {
+    await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (store) => {
+        store.profiles[profileId] = credential as never;
+        return true;
+      },
+    });
+  }
+
+  function registerScriptedClaudeCliBackend() {
+    const backend = {
+      id: "claude-cli",
+      modelProvider: "anthropic",
+      pluginId: "anthropic",
+      ownsNativeCompaction: true,
+      bundleMcp: false,
+      config: {
+        command: "claude",
+        args: ["-p"],
+        input: "stdin" as const,
+        output: "jsonl" as const,
+        sessionMode: "existing" as const,
+      },
+      manualCompaction: {
+        buildPrompt: (instructions?: string) =>
+          instructions ? `/compact ${instructions}` : "/compact",
+        input: "arg" as const,
+        validateOutput: () => ({ ok: true }),
+      },
+    };
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: ({ backend: id }) =>
+        id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
+      resolveRuntimeCliBackends: () => [backend],
+    });
+  }
+
+  function compactParams(overrides: Record<string, unknown> = {}) {
+    return {
+      sessionId: "openclaw-session",
+      sessionKey: "agent:agent:main",
+      sessionTarget: {
+        agentId: "agent",
+        sessionId: "openclaw-session",
+        sessionKey: "agent:agent:main",
+        storePath: nodePath.join(stateDir, "openclaw.sqlite"),
+      },
+      sessionFile: "agent:agent:main",
+      agentId: "agent",
+      workspaceDir: nodePath.join(stateDir, "workspace"),
+      agentDir,
+      config: {},
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      trigger: "manual",
+      cliSessionId: "native-session",
+      cliSessionBinding: { sessionId: "native-session" },
+      sessionEntry: {},
+      customInstructions: "keep decisions",
+      preparedModelRuntime: {},
+      ...overrides,
+    } as never;
+  }
+
+  it("keeps the native login when a competing stored CLI account is eligible", async () => {
+    registerScriptedClaudeCliBackend();
+    await seedAuthProfile("anthropic:default", {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    });
+    await seedAuthProfile("claude-cli:work", {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "test-cli-work-token",
+      refresh: "test-cli-work-refresh",
+      expires: Date.now() + 3_600_000,
+    });
+
+    await compactNativeCliSession({
+      runtime: "claude-cli",
+      compactParams: compactParams({
+        authProfileId: "anthropic:default",
+        authProfileIdSource: "auto",
+      }),
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    const forwarded = runCliAgentMock.mock.calls[0]?.[0] as { authProfileId?: string };
+    // The auto model-provider pin is dropped, and the competing CLI-owned
+    // credential is not discovered as a replacement: the compaction child
+    // keeps its own native login instead of receiving another account.
+    expect(forwarded.authProfileId).toBeUndefined();
+  }, 60_000);
+
+  it("rejects an unavailable explicit selection before the compaction child runs", async () => {
+    registerScriptedClaudeCliBackend();
+
+    await expect(
+      compactNativeCliSession({
+        runtime: "claude-cli",
+        compactParams: compactParams({
+          authProfileId: "anthropic:missing",
+          authProfileIdSource: "user",
+        }),
+      }),
+    ).rejects.toThrow(/No credentials found for profile "anthropic:missing"/);
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+  }, 60_000);
+});

--- a/src/agents/embedded-agent-runner/compact.native-cli.test.ts
+++ b/src/agents/embedded-agent-runner/compact.native-cli.test.ts
@@ -3,20 +3,27 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
 import type { PreparedAgentRunAdmission } from "../admitted-run-context.js";
+import type { AuthProfileCredential } from "../auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-const { runCliAgentMock } = vi.hoisted(() => ({
+const { runCliAgentMock, authStoreProfiles } = vi.hoisted(() => ({
   runCliAgentMock: vi.fn(async (_params: { preparedRunAdmission?: PreparedAgentRunAdmission }) => ({
     meta: {
       durationMs: 1,
       agentMeta: { sessionId: "native-session", provider: "claude-cli", model: "opus" },
     },
   })),
+  authStoreProfiles: {} as Record<string, AuthProfileCredential>,
 }));
 
 vi.mock("../cli-runner.js", () => ({ runCliAgent: runCliAgentMock }));
+
+vi.mock("../auth-profiles/store-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth-profiles/store-runtime.js")>()),
+  loadAuthProfileStoreForRuntime: () => ({ version: 1, profiles: authStoreProfiles }),
+}));
 
 const { testing } = await import("./compact.js");
 
@@ -87,6 +94,9 @@ function compactParams(overrides: Record<string, unknown> = {}) {
 afterEach(() => {
   cliBackendsTesting.resetDepsForTest();
   runCliAgentMock.mockClear();
+  for (const profileId of Object.keys(authStoreProfiles)) {
+    delete authStoreProfiles[profileId];
+  }
 });
 
 describe("native CLI manual compaction", () => {
@@ -160,6 +170,70 @@ describe("native CLI manual compaction", () => {
         compactParams: compactParams(),
       }),
     ).resolves.toBeUndefined();
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("drops an auto session pin that names a model-provider credential", async () => {
+    // A native-login CLI session records no binding credential, so manual
+    // compaction falls back to the session pin. That pin names the model
+    // provider's stored API key; dispatching it to the CLI child would bill
+    // the stored key instead of the backend's own login.
+    registerBackend();
+    authStoreProfiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+
+    await testing.compactNativeCliSession({
+      runtime: "claude-cli",
+      compactParams: compactParams({
+        cliSessionBinding: { sessionId: "native-session" },
+        authProfileId: "anthropic:default",
+        authProfileIdSource: "auto",
+      }),
+    });
+
+    const forwarded = runCliAgentMock.mock.calls[0]?.[0] as { authProfileId?: string } | undefined;
+    expect(forwarded).toMatchObject({ provider: "claude-cli", controlOperation: "compact" });
+    expect(forwarded?.authProfileId).toBeUndefined();
+  });
+
+  it("keeps an explicitly selected model-provider credential for compaction", async () => {
+    registerBackend();
+    authStoreProfiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+
+    await testing.compactNativeCliSession({
+      runtime: "claude-cli",
+      compactParams: compactParams({
+        cliSessionBinding: { sessionId: "native-session" },
+        authProfileId: "anthropic:default",
+        authProfileIdSource: "user",
+      }),
+    });
+
+    expect(runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      authProfileId: "anthropic:default",
+    });
+  });
+
+  it("fails closed when an explicitly selected session pin has no stored credential", async () => {
+    registerBackend();
+
+    await expect(
+      testing.compactNativeCliSession({
+        runtime: "claude-cli",
+        compactParams: compactParams({
+          cliSessionBinding: { sessionId: "native-session" },
+          authProfileId: "anthropic:missing",
+          authProfileIdSource: "user",
+        }),
+      }),
+    ).rejects.toThrow(/No credentials found for profile "anthropic:missing"/);
     expect(runCliAgentMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/embedded-agent-runner/compact.native-cli.test.ts
+++ b/src/agents/embedded-agent-runner/compact.native-cli.test.ts
@@ -199,6 +199,40 @@ describe("native CLI manual compaction", () => {
     expect(forwarded?.authProfileId).toBeUndefined();
   });
 
+  it("keeps the native identity when dropping an auto pin despite an eligible CLI credential", async () => {
+    // Dropping the auto model-provider pin must fall back to the CLI child's
+    // own login, not to automatic discovery: control operations resume the
+    // recorded native session without an auth-profile compatibility re-check,
+    // so a discovered CLI-owned credential would receive a session produced
+    // under a different account.
+    registerBackend();
+    authStoreProfiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    authStoreProfiles["claude-cli:work"] = {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "test-cli-work-token",
+      refresh: "test-cli-work-refresh",
+      expires: Date.now() + 3_600_000,
+    };
+
+    await testing.compactNativeCliSession({
+      runtime: "claude-cli",
+      compactParams: compactParams({
+        cliSessionBinding: { sessionId: "native-session" },
+        authProfileId: "anthropic:default",
+        authProfileIdSource: "auto",
+      }),
+    });
+
+    const forwarded = runCliAgentMock.mock.calls[0]?.[0] as { authProfileId?: string } | undefined;
+    expect(forwarded).toMatchObject({ provider: "claude-cli", controlOperation: "compact" });
+    expect(forwarded?.authProfileId).toBeUndefined();
+  });
+
   it("keeps an explicitly selected model-provider credential for compaction", async () => {
     registerBackend();
     authStoreProfiles["anthropic:default"] = {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -18,6 +18,7 @@ import {
   resolveSessionAgentIds,
 } from "../agent-scope.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
+import { resolveCliExecutionAuthProfileId } from "../cli-execution-auth.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { coerceToFailoverError } from "../failover-error.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
@@ -115,6 +116,26 @@ export async function compactNativeCliSession(params: {
     config: params.compactParams.config,
     agentId: params.compactParams.agentId,
   }).sessionAgentId;
+  // The session pin names the model provider's credential (for example
+  // "anthropic:default"); forwarding it unchecked would bill the stored API key
+  // instead of the CLI child's own login. The binding pin records the credential
+  // this session's CLI runs last consumed, so it keeps resuming the native
+  // session under the identity that produced it.
+  const sessionAuthProfileId = params.compactParams.authProfileId?.trim() || undefined;
+  const cliForwardedAuthProfileId = sessionAuthProfileId
+    ? resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: runtime,
+        authProfileProvider: params.compactParams.provider ?? DEFAULT_PROVIDER,
+        config: params.compactParams.config ?? {},
+        agentDir:
+          params.compactParams.agentDir ??
+          resolveAgentDir(params.compactParams.config ?? {}, sessionAgentId),
+        selected: {
+          authProfileId: sessionAuthProfileId,
+          authProfileIdSource: params.compactParams.authProfileIdSource,
+        },
+      })
+    : undefined;
   const preparedRunAdmission = prepareSystemAgentRunAdmission(
     params.compactParams.config ?? {},
     runId,
@@ -144,8 +165,8 @@ export async function compactNativeCliSession(params: {
         ...(cliSessionBinding ? { cliSessionBinding } : {}),
         ...(cliSessionBinding?.authProfileId
           ? { authProfileId: cliSessionBinding.authProfileId }
-          : params.compactParams.authProfileId
-            ? { authProfileId: params.compactParams.authProfileId }
+          : cliForwardedAuthProfileId
+            ? { authProfileId: cliForwardedAuthProfileId }
             : {}),
         ...(params.compactParams.sessionEntry
           ? { sessionEntry: params.compactParams.sessionEntry }

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -134,6 +134,11 @@ export async function compactNativeCliSession(params: {
           authProfileId: sessionAuthProfileId,
           authProfileIdSource: params.compactParams.authProfileIdSource,
         },
+        // Control operations resume the recorded native session without an
+        // auth-profile compatibility re-check, so automatic selection must not
+        // discover a different stored account here; dropping the pin leaves the
+        // compaction under the CLI child's own login.
+        discoverFallbackAccount: false,
       })
     : undefined;
   const preparedRunAdmission = prepareSystemAgentRunAdmission(


### PR DESCRIPTION
Closes #143390

## What Problem This Solves

Manual compaction of a CLI-backed session forwarded the raw session pin into `runCliAgent` (`compactNativeCliSession`, `src/agents/embedded-agent-runner/compact.ts`). The pin names the model provider's credential — for example the auto-selected `anthropic:default` API key — so a claude CLI child ran its compaction turn under the stored OpenClaw API key instead of the backend's own login.

The reply dispatch (`agent-runner-cli-candidate.ts`), the gateway command path (`attempt-execution.ts`), and the system inference route (`inference-route.ts`) all convert the session pin through `resolveCliExecutionAuthProfileId` before reaching a CLI child; the native-compaction dispatch boundary was the remaining entry point that skipped the conversion. The defect contradicts the boundary's own stated intent: native control operations "reuse the backend's existing authenticated session" so subscription-only CLI sessions do not require an OpenClaw model API credential.

The review added a second, deeper boundary defect at the same call: with a native-login binding, an automatic `anthropic:default` pin, and an eligible stored `claude-cli:work` credential, the composed resolver call fell through to automatic fallback discovery and returned `claude-cli:work` — introducing a *different stored account* into compaction. Control operations reuse the recorded native session without the auth-profile/epoch compatibility re-check, so the discovered credential would receive a session produced under another identity.

## Solution

Compose the session-pin fallback through `resolveCliExecutionAuthProfileId` before dispatch, mirroring the reply boundary, and decline discovery for this caller:

- the binding pin still wins unchanged — it records the credential the session's CLI runs last consumed, so compaction resumes the native session under the identity that produced it;
- an automatic pin naming a foreign (model-provider) credential drops, and the resolver now accepts an explicit `discoverFallbackAccount: false` so automatic selection cannot discover a replacement account for a session it does not revalidate — the CLI child keeps its native login;
- an explicitly selected compatible credential still forwards (including the canonical-provider explicit case);
- an explicit selection with no stored credential fails closed via `CliExecutionAuthProfileError` — a user-locked profile must not run the compaction as another user.

Production delta is one composed call reusing the existing resolver at the dispatch boundary plus one documented opt-out parameter on that resolver; no new policy is invented. The existing dispatch (`attempt-execution.ts`) and inference-route callers keep the default discovery behavior unchanged.

## Evidence

**Competing-profile regression, pre-fix red.** With a native-login binding (no binding pin), an automatic `anthropic:default` session pin, and an eligible stored `claude-cli:work` credential:

- *mocked-store dispatch level* (`compact.native-cli.test.ts`, "keeps the native identity when dropping an auto pin despite an eligible CLI credential"): post-fix the dispatch forwards no `authProfileId`. On pre-fix code the same run forwarded `claude-cli:work` — the review's P1 scenario, red for the intended reason.
- *real-store dispatch level* (`compact.native-cli.cli-child-auth.test.ts`, "keeps the native login when a competing stored CLI account is eligible"): the auth store is a real on-disk SQLite store seeded through `updateAuthProfileStoreWithLock` with both `anthropic:default` (api_key) and the competing `claude-cli:work` (oauth); the resolver inside `compactNativeCliSession` reads that real store. Post-fix the run reaches `runCliAgent` with no forwarded `authProfileId`; on pre-fix code the same seeded store produced the forwarded `claude-cli:work` (`expected 'claude-cli:work' to be undefined`).

**Fail-closed before child I/O.** A `user`-sourced pin naming a missing profile rejects with `No credentials found for profile "anthropic:missing"` and never dispatches (`runCliAgent` not called) — observed at the dispatch seam in both suites, so the rejection happens before any child launch.

**Existing conversion behaviors stay green.** `compact.native-cli.test.ts`: 7 passed (binding-pin precedence, auto model-provider pin drop, explicit forwarding, explicit fail-closed). `cli-execution-auth.test.ts`: 16 passed — the resolver's default discovery behavior is unchanged for the existing callers. Sibling compaction suites from the earlier head: `compact.hooks.test.ts`, `compact.delegate.test.ts`, `cli-compaction.test.ts`: 32 passed.

**Child-level spawn proof boundary, stated honestly.** The desired child-level observation (a real spawned CLI child recording its credential env during a compaction turn) was attempted and does not run in this sandbox: driving the real `runCliAgent` with `controlOperation: "compact"` fails at process spawn (`spawn /bin/sh ENOENT` — also with the OOM wrapper disabled, `spawn <node> ENOENT` for the very interpreter running the suite), while the identical runner path through the reply dispatch (`executeAgentTurn` → `runCliAgent`, head 4af92255f6e) spawns the stub child successfully in the same environment. The spawn failure is environmental, not asserted by these tests; what the real-store suite proves is the credential *selection* — the value forwarded into the runner — under a real on-disk competing store, and that an unavailable explicit selection never reaches a launch.

**Types, format, lint.** `tsgo` core sources and the full core test-shard matrix (fresh cache names): green. `oxfmt` clean, `oxlint` clean on the changed files.

## Scope

- `src/agents/embedded-agent-runner/compact.ts` — compose the session pin through the existing resolver before the `runCliAgent` dispatch, with discovery declined for this control-operation caller.
- `src/agents/cli-execution-auth.ts` — new documented `discoverFallbackAccount` opt-out; callers that revalidate the resulting identity against the session keep the default.
- `src/agents/embedded-agent-runner/compact.native-cli.test.ts` — dispatch-level regression including the competing-profile case.
- `src/agents/embedded-agent-runner/compact.native-cli.cli-child-auth.test.ts` — real-store credential-selection regression at the same boundary.

The queued (budget) compaction path is unaffected: auto-reply maintenance skips CLI and native-compaction runtimes entirely, and the harness-owned native compaction bridge is Codex-only. The embedded context-engine fallback runs on OpenClaw's own runtime, where a stored model-provider API key is a legitimate credential.
