### PR TITLE
test: avoid cold plugin setup in fallback attribution

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -90,6 +90,7 @@ describe("anthropic provider replay hooks", () => {
     if (!backend) {
       throw new Error("Expected claude-cli backend");
     }
+    expect(backend.modelProvider).toBe("anthropic");
     expect(backend.bundleMcp).toBe(true);
     expectFields(backend.config, {
       command: "claude",

--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import { resolveFallbackTransition } from "../fallback-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
@@ -175,6 +176,23 @@ describe("buildSilentFallbackFailurePayload", () => {
   );
 
   it("uses the configured runtime alias when attributing a response", () => {
+    // Exercise attribution with setup metadata; the plugin registration test owns
+    // the real Claude CLI descriptor and its canonical provider binding.
+    onTestFinished(() => cliBackendsTesting.resetDepsForTest());
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [],
+      resolvePluginSetupCliBackend: ({ backend }) =>
+        backend === "claude-cli"
+          ? {
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+              },
+            }
+          : undefined,
+    });
     const cfg = { plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } } };
     const fallbackTransition = resolveFallbackTransition({
       selectedProvider: "anthropic",


### PR DESCRIPTION
## What Problem This Solves

Fallback-attribution coverage cold-loads the Anthropic plugin setup graph just to compare a configured CLI alias. The case took 12.265 seconds in main CI run 34398418654 and about 15 seconds in source-only local runs.

## Why This Change Was Made

Use the existing CLI-backend test dependency seam to provide the targeted setup descriptor, retaining the real alias comparison, fallback transition, and warning attribution. Reset the fixture after the case, including failures. The existing test router consequently selects the isolated auto-reply lane for this mutable fixture.

Extend the existing real Anthropic registration test to assert the canonical provider mapping used by the fixture. No production behavior, test deadlines, assertions, runner settings, or shard limits are removed or changed.

## User Impact

Developers get faster fallback-attribution coverage. There is no application behavior change. Production LOC: 0; tests: +20/-1.

## Evidence

- Source-only original/candidate/restored-original: the same 43 cases passed; the alias case took 15.012 / 2.160 / 15.543 seconds. Wrapper totals were 30.96 / 17.10 / 25.16 seconds, including the existing automatic lane selection.
- Exact-head Linux CI: all 43 warning-file cases passed; the alias case took 2.442 seconds versus 12.265 seconds in the sampled main run. [CI job](https://github.com/openclaw/openclaw/actions/runs/34403829837/job/102642131953).
- Final source-only proof: 153 tests passed across the fallback warning, fallback-state, runtime-alias, and real Anthropic registration files in 45.22 seconds. Alias case 2.225 seconds; real registration case 9 ms.
- Identical physical dependencies and Node 24.19.0/pnpm 12.3.4 for the local comparisons. Generated plugin builds were temporarily held outside the task checkout and restored after each run, so they could not mask source import cost. RSS remained approximately 2.28 GB; no memory saving is claimed.
- Managed independent review: no actionable P0–P2 findings. Required changed checks passed, including core/plugin test types, formatting, lint, and boundary/dependency guards.

This is a focused test-cost improvement, not a claim that the full CI pipeline is now under eight minutes.
