### PR TITLE
perf: traverse shared SDK export graphs once

### DIFF
--- a/scripts/check-export-name-collisions.mts
+++ b/scripts/check-export-name-collisions.mts
@@ -627,27 +627,25 @@ export function resolveExportModulePath(
   return candidates.find((candidate) => modulesByPath.has(candidate)) ?? null;
 }
 
-function collectTransitiveExportNames(
-  modulePath: string,
-  modulesByPath: ReadonlyMap<string, ModuleExports>,
-  visiting = new Set<string>(),
-): Set<string> {
-  if (visiting.has(modulePath)) {
-    return new Set();
-  }
-  const moduleExports = modulesByPath.get(modulePath);
-  if (!moduleExports) {
-    return new Set();
-  }
-  const nextVisiting = new Set(visiting).add(modulePath);
-  const names = new Set(moduleExports.exportedNames);
-  for (const specifier of moduleExports.starExportSpecifiers) {
-    const targetPath = resolveExportModulePath(modulePath, specifier, modulesByPath);
-    if (!targetPath) {
+function collectSdkExportNames(modulesByPath: ReadonlyMap<string, ModuleExports>): Set<string> {
+  const names = new Set<string>();
+  const reachablePaths = new Set(
+    [...modulesByPath.keys()].filter((modulePath) => modulePath.startsWith("src/plugin-sdk/")),
+  );
+  // Set iteration visits newly added targets once, including shared and cyclic barrels.
+  for (const modulePath of reachablePaths) {
+    const moduleExports = modulesByPath.get(modulePath);
+    if (!moduleExports) {
       continue;
     }
-    for (const name of collectTransitiveExportNames(targetPath, modulesByPath, nextVisiting)) {
+    for (const name of moduleExports.exportedNames) {
       names.add(name);
+    }
+    for (const specifier of moduleExports.starExportSpecifiers) {
+      const targetPath = resolveExportModulePath(modulePath, specifier, modulesByPath);
+      if (targetPath) {
+        reachablePaths.add(targetPath);
+      }
     }
   }
   return names;
@@ -661,7 +659,6 @@ const intentionalSameNameFamilies = new Set(["testing", "testApi"]);
 function analyzeExportNames(modules: SourceModule[]) {
   const aliasingReExports: AliasingReExport[] = [];
   const filesByName = new Map<string, Set<string>>();
-  const sdkExportNames = new Set<string>();
   const modulesByPath = new Map<string, ModuleExports>();
   for (const sourceModule of modules.toSorted((left, right) =>
     left.path.localeCompare(right.path),
@@ -685,14 +682,7 @@ function analyzeExportNames(modules: SourceModule[]) {
       }
     }
   }
-  for (const modulePath of modulesByPath.keys()) {
-    if (!modulePath.startsWith("src/plugin-sdk/")) {
-      continue;
-    }
-    for (const name of collectTransitiveExportNames(modulePath, modulesByPath)) {
-      sdkExportNames.add(name);
-    }
-  }
+  const sdkExportNames = collectSdkExportNames(modulesByPath);
 
   const collisions: ExportNameCollision[] = [];
   for (const [name, fileSet] of filesByName) {

--- a/test/scripts/check-export-name-collisions.test.ts
+++ b/test/scripts/check-export-name-collisions.test.ts
@@ -300,6 +300,43 @@ describe("export name collision guard", () => {
     });
   });
 
+  it("marks only collisions reachable through shared and cyclic SDK barrels", () => {
+    const definitions = "export const cycleOnly = 1, extraOnly = 1, privateOnly = 1;";
+    expect(
+      findExportNameCollisions([
+        { path: "src/one.ts", content: definitions },
+        { path: "src/two.ts", content: definitions },
+        {
+          path: "src/plugin-sdk/first.ts",
+          content:
+            'export * from "../../packages/left.js"; export * from "../../packages/right.js";',
+        },
+        {
+          path: "src/plugin-sdk/second.ts",
+          content:
+            'export * from "../../packages/right.js"; export * from "../../packages/extra.js";',
+        },
+        ...(
+          [
+            ["packages/left.ts", 'export * from "./shared.js";'],
+            ["packages/right.ts", 'export * from "./shared.js";'],
+            ["packages/shared.ts", 'export * from "./left.js"; export const cycleOnly = 1;'],
+            ["packages/extra.ts", "export const extraOnly = 1;"],
+            ["packages/unreachable.ts", "export const privateOnly = 1;"],
+          ] as const
+        ).map(([modulePath, content]) => ({
+          path: modulePath,
+          content,
+          includeDefinitions: false,
+        })),
+      ]),
+    ).toEqual([
+      { name: "cycleOnly", files: ["src/one.ts", "src/two.ts"], sdk: true },
+      { name: "extraOnly", files: ["src/one.ts", "src/two.ts"], sdk: true },
+      { name: "privateOnly", files: ["src/one.ts", "src/two.ts"] },
+    ]);
+  });
+
   it("rejects debt-baseline updates with the collision trailer", () => {
     const result = spawnSync(
       process.execPath,


### PR DESCRIPTION
## What Problem This Solves

The export-collision guard repeatedly walks shared export graphs from every Plugin SDK root. Shared barrels are revisited and the recursive path copies a visiting set at each step, even though the guard only needs the union of reachable export names.

## Why This Change Was Made

Collect that union with one invocation-local worklist. Each reachable module is visited once, including shared and cyclic barrels. Keep module resolution, collision membership, diagnostic sorting, and exclusions unchanged. This removes ten lines of tooling; the additional preservation test covers overlapping SDK roots, a cycle, a diamond, a second-root-only export, and an unreachable collision.

## User Impact

Less redundant work in the developer collision check. No runtime, Gateway, SDK API, configuration, or diagnostic behavior changes.

## Evidence

- The two complete relevant test files passed on baseline and candidate: 40 tests in each run. The nonempty fixture verifies positive SDK collision classification and that unreachable collisions stay unmarked.
- Targeted changed-file checks passed across script/test typechecking, lint, formatting, and applicable guards. The first run caught a shadowed fixture variable; it was renamed and the failed lint plus formatting were rerun successfully. The original failed run is retained.
- Independent Codex review: no actionable P0–P2 findings.
- Real repository collision-check CLI on Linux x64 / Node 24.19.0, in an isolated Testbox container, using the same 9,932-module corpus (75,087,213 decoded UTF-8 bytes). Order was baseline, candidate, candidate, baseline. Wall times were 4.720, 4.681, 4.842, and 5.017 seconds. Complete stdout/stderr and before/after ordered corpus inventories match. These four observations suggest a modest improvement, not a statistically established speedup or a Gateway performance claim. The inventory warms filesystem caches; timings include managed-process joining overhead.
- Resource observations were mixed: total cgroup CPU changed +0.57% and -4.72% across the two orders; memory-current growth was higher for candidate in both pairs. There is no memory-saving claim. An independent audit verified all output bytes, corpus hashes, source images, limits, and cleanup.
- [Completed Testbox run](https://github.com/openclaw/openclaw/actions/runs/34402883274). The isolated container and one-shot lease were stopped after success. An earlier macOS cohort stopped incomplete due to local disk capacity and is excluded from these comparisons.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34403869615) passed: 76 jobs succeeded and 17 were scope-skipped. Native review, preparation, and merge completed; landed as `c7c2cf876ae0bd56782e6a702761ea6a6d2cbd7b`.
