### PR TITLE
fix(docs): preserve fenced examples during formatting

### DIFF
--- a/scripts/lib/mintlify-accordion.mjs
+++ b/scripts/lib/mintlify-accordion.mjs
@@ -13,18 +13,30 @@ const MINTLIFY_REPAIRED_COMPONENTS = new Set([
   "Step",
 ]);
 
-function visitMintlifyComponentIndentation(raw, onMisindentedClose, onMisindentedOpen) {
+function processMintlifyComponentIndentation(raw, repair) {
   const lines = raw.split(/\r?\n/u);
   const componentStack = [];
-  let inCodeFence = false;
+  const errors = [];
+  let changed = false;
+  let fenceMarker = null;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (/^\s*(```|~~~)/u.test(line)) {
-      inCodeFence = !inCodeFence;
+    const trimmed = line.trimStart();
+    const marker = trimmed.match(/^(`{3,}|~{3,})/u)?.[1];
+    if (marker) {
+      if (!fenceMarker) {
+        fenceMarker = marker;
+      } else if (
+        marker[0] === fenceMarker[0] &&
+        marker.length >= fenceMarker.length &&
+        /^[ \t]*$/u.test(trimmed.slice(marker.length))
+      ) {
+        fenceMarker = null;
+      }
       continue;
     }
-    if (inCodeFence) {
+    if (fenceMarker) {
       continue;
     }
 
@@ -32,7 +44,10 @@ function visitMintlifyComponentIndentation(raw, onMisindentedClose, onMisindente
     if (openComponent && MINTLIFY_REPAIRED_COMPONENTS.has(openComponent[2])) {
       let indent = openComponent[1].length;
       if (componentStack.length === 0 && openComponent[2] === "ParamField" && indent > 0) {
-        onMisindentedOpen?.({ openComponent, index, line, lines });
+        if (repair) {
+          lines[index] = line.slice(indent);
+          changed = true;
+        }
         indent = 0;
       }
       componentStack.push({
@@ -43,55 +58,40 @@ function visitMintlifyComponentIndentation(raw, onMisindentedClose, onMisindente
     }
 
     const closeComponent = line.match(/^(\s*)<\/([A-Z][A-Za-z0-9]*)>/u);
-    if (!closeComponent || !MINTLIFY_REPAIRED_COMPONENTS.has(closeComponent[2])) {
+    if (!closeComponent) {
       continue;
     }
 
-    const opening = componentStack.pop();
+    const opening = MINTLIFY_REPAIRED_COMPONENTS.has(closeComponent[2])
+      ? componentStack.pop()
+      : undefined;
     if (opening?.name === closeComponent[2] && closeComponent[1].length > opening.indent) {
-      onMisindentedClose({ closeComponent, index, line, lines, opening });
+      errors.push({
+        line: index + 1,
+        column: closeComponent[1].length + 1,
+        message: MINTLIFY_ACCORDION_INDENT_MESSAGE,
+      });
+      if (repair) {
+        lines[index] = `${" ".repeat(opening.indent)}${line.slice(closeComponent[1].length)}`;
+        changed = true;
+      }
+    }
+    // Keep spacing repairs inside the same fence boundary as indentation repairs.
+    if (repair && /^\s*[-*+]\s+/u.test(lines[index - 1] ?? "")) {
+      lines[index] = `\n${lines[index]}`;
+      changed = true;
     }
   }
 
-  return lines;
+  return { errors, text: changed ? lines.join("\n") : raw };
 }
 
 /** Return indentation errors for Mintlify accordion-like components. */
 export function checkMintlifyAccordionIndentation(raw) {
-  const errors = [];
-  visitMintlifyComponentIndentation(raw, ({ closeComponent, index }) => {
-    errors.push({
-      line: index + 1,
-      column: closeComponent[1].length + 1,
-      message: MINTLIFY_ACCORDION_INDENT_MESSAGE,
-    });
-  });
-  return errors;
+  return processMintlifyComponentIndentation(raw, false).errors;
 }
 
 /** Repair Mintlify component indentation and list-adjacent closing tags when needed. */
 export function repairMintlifyAccordionIndentation(raw) {
-  let changed = false;
-  const lines = visitMintlifyComponentIndentation(
-    raw,
-    ({ closeComponent, index, line, lines: linesValue, opening }) => {
-      linesValue[index] = `${" ".repeat(opening.indent)}${line.slice(closeComponent[1].length)}`;
-      changed = true;
-    },
-    ({ openComponent, index, line, lines: linesLocal }) => {
-      linesLocal[index] = line.slice(openComponent[1].length);
-      changed = true;
-    },
-  );
-  for (let index = lines.length - 1; index > 0; index--) {
-    if (!/^\s*<\/[A-Z][A-Za-z0-9]*>/u.test(lines[index])) {
-      continue;
-    }
-    if (!/^\s*[-*+]\s+/u.test(lines[index - 1])) {
-      continue;
-    }
-    lines.splice(index, 0, "");
-    changed = true;
-  }
-  return changed ? lines.join("\n") : raw;
+  return processMintlifyComponentIndentation(raw, true).text;
 }

--- a/test/scripts/format-docs.test.ts
+++ b/test/scripts/format-docs.test.ts
@@ -10,6 +10,10 @@ import {
   resolveOxfmtInvocation,
   runOxfmt,
 } from "../../scripts/format-docs.mts";
+import {
+  checkMintlifyAccordionIndentation,
+  repairMintlifyAccordionIndentation,
+} from "../../scripts/lib/mintlify-accordion.mjs";
 import { outputTail } from "../../scripts/lib/output-tail.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -22,6 +26,34 @@ function writeDocsFixture(root: string): void {
 }
 
 describe("format-docs", () => {
+  it.each([
+    ["backtick fence", "```md", null, "```"],
+    ["tilde fence", "~~~md", null, "~~~"],
+    ["shorter nested fence", "````md", "```json", "````"],
+    ["different fence marker", "```md", "~~~", "```"],
+    ["suffixed closing marker", "~~~md", "~~~json", "~~~"],
+    ["nonbreaking-space suffix", "```md", "```\u00a0", "```"],
+    ["longer closing marker", "~~~md", null, "~~~~~\t"],
+    ["unclosed fence", "```md", null, null],
+  ])("preserves examples in a %s while repairing real components", (_label, open, inner, close) => {
+    const literal = [open, inner, "<Note>", "- literal item", "  </Note>", close]
+      .filter((line) => line !== null)
+      .join("\n");
+    const component =
+      "<Note>\n- real item\n  </Note>\n\n  <ParamField>\n  field body\n  </ParamField>";
+    const repairedComponent =
+      "<Note>\n- real item\n\n</Note>\n\n<ParamField>\n  field body\n</ParamField>";
+    const source = `${component}\n\n${literal}\n${close ? `\n${component}\n` : ""}`;
+    const expected = `${repairedComponent}\n\n${literal}\n${close ? `\n${repairedComponent}\n` : ""}`;
+
+    const repaired = repairMintlifyAccordionIndentation(source);
+
+    expect(repaired).toBe(expected);
+    expect(checkMintlifyAccordionIndentation(literal)).toEqual([]);
+    expect(checkMintlifyAccordionIndentation(repaired)).toEqual([]);
+    expect(repairMintlifyAccordionIndentation(repaired)).toBe(repaired);
+  });
+
   it("wraps the Windows oxfmt.cmd shim through cmd.exe", () => {
     const invocation = resolveOxfmtInvocation(["--write", "docs\\guide.mdx"], {
       comSpec: "C:\\Windows\\System32\\cmd.exe",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where formatting documentation could modify literal code examples containing list items and Mintlify closing tags. Shorter, mismatched or suffixed fence markers could also make the repair misread the rest of the document.

## Why This Change Was Made

Indentation and list-spacing repairs now share one fence-aware traversal. Closing fences must match the opening marker and length, with only spaces or tabs afterward. This removes the separate spacing pass that ignored code fences while preserving repairs to actual components.

## User Impact

Code examples retain their original content during local formatting and generated-locale processing. Existing component repairs and public helper APIs remain unchanged.

## Evidence

Eight regression cases fail on the original code and pass with the fix. All 33 focused and sibling tests pass, including the copied publishing-runtime check, along with all 18 changed-file checks. No live documentation publishing was performed.

Compatibility: the changed helper transforms Markdown text. It does not change runtime storage, schemas, migration logic or configuration formats. Existing component-repair behavior and helper interfaces remain covered by the retained tests; no migration or upgrade procedure is required.
