### PR TITLE
refactor(gateway): remove unused chat history config forwarding

### DIFF
--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -210,7 +210,7 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   const requested = typeof limit === "number" ? limit : defaultLimit;
   const max = Math.min(hardMax, requested);
   const maxHistoryBytes = rt.getMaxChatHistoryMessagesBytes();
-  const effectiveMaxChars = rt.resolveEffectiveChatHistoryMaxChars(cfg);
+  const effectiveMaxChars = rt.resolveEffectiveChatHistoryMaxChars();
   const page = await rt.readChatHistoryPage({
     entry: historyEntry,
     provider: resolvedSessionModel.provider,

--- a/src/gateway/chat-display-projection.helpers.ts
+++ b/src/gateway/chat-display-projection.helpers.ts
@@ -83,7 +83,7 @@ export function stripAssistantMediaDirectivesForDisplay(
 }
 
 /** Resolve the text cap used when projecting chat history for display. */
-export function resolveEffectiveChatHistoryMaxChars(_cfg: unknown, maxChars?: number): number {
+export function resolveEffectiveChatHistoryMaxChars(maxChars?: number): number {
   if (typeof maxChars === "number") {
     return maxChars;
   }

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -283,7 +283,7 @@ async function handleChatHistoryRequest({
   const requested = typeof limit === "number" ? limit : 200;
   const max = Math.min(CHAT_HISTORY_MAX_ENTRIES, requested);
   const maxHistoryBytes = Math.min(maxBytes ?? Infinity, getMaxChatHistoryMessagesBytes());
-  const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
+  const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(maxChars);
   const pendingInputs =
     sessionId && sessionId === entry?.sessionId
       ? readChatPendingInputs(

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -159,7 +159,7 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     // Broadcast to webchat for immediate UI update
     const message = projectChatDisplayMessage(appended.message, {
-      maxChars: resolveEffectiveChatHistoryMaxChars(cfg),
+      maxChars: resolveEffectiveChatHistoryMaxChars(),
     });
     const chatPayload = {
       runId: `inject-${appended.messageId}`,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2312,13 +2312,11 @@ describe("dropPreSessionStartAnnouncePairs (#85648)", () => {
 
 describe("resolveEffectiveChatHistoryMaxChars", () => {
   it("uses the RPC maxChars override when present", () => {
-    expect(resolveEffectiveChatHistoryMaxChars({}, 45)).toBe(45);
+    expect(resolveEffectiveChatHistoryMaxChars(45)).toBe(45);
   });
 
   it("falls back to the default hardcoded limit", () => {
-    expect(resolveEffectiveChatHistoryMaxChars({}, undefined)).toBe(
-      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
-    );
+    expect(resolveEffectiveChatHistoryMaxChars()).toBe(DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS);
   });
 });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -622,7 +622,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       typeof opts.limit === "number" ? opts.limit : 200,
     );
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
-    const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg);
+    const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars();
     const historyPage = await readChatHistoryPage({
       entry,
       provider: resolvedSessionModel.provider,


### PR DESCRIPTION
## What Problem This Solves

Chat-history limit selection carries an unused configuration argument through internal call sites, obscuring which inputs determine the limit.

## Why This Change Was Made

Remove the unused configuration parameter, update all four production callers, and update two existing test calls while preserving their assertions.

## User Impact

No intended user-visible change. The 8,000-character default, explicit RPC `maxChars` override, RPC validation, history projection, and full-message retrieval remain unchanged.

## Evidence

- 424 tests passed across five whole suites.
- Three targeted RPC cases passed; 135 other cases were explicitly filter-skipped.
- 29 changed checks passed, including three Knip scans with zero findings.
- Full build passed.
- P3 autoreview completed with no actionable findings.
