### PR TITLE
fix(tests): close Control UI fixture databases before cleanup

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -476,7 +476,7 @@ describe("handleControlUiHttpRequest", () => {
     }
   }
 
-  async function withPairedDeviceHome<T>(prefix: string, fn: () => Promise<T>): Promise<T> {
+  async function withControlUiHome<T>(prefix: string, fn: () => Promise<T>): Promise<T> {
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
     let databasePath: string | undefined;
     try {
@@ -498,7 +498,7 @@ describe("handleControlUiHttpRequest", () => {
     browserMetadata?: boolean;
     fn: (token: string) => Promise<T>;
   }) {
-    return await withPairedDeviceHome("openclaw-ui-device-token-", async () => {
+    return await withControlUiHome("openclaw-ui-device-token-", async () => {
       const deviceId = "control-ui-device";
       const requested = await requestDevicePairing({
         deviceId,
@@ -539,7 +539,7 @@ describe("handleControlUiHttpRequest", () => {
     scopes: string[];
     fn: (bearer: string) => Promise<T>;
   }) {
-    return await withPairedDeviceHome("openclaw-ui-scoped-device-", async () => {
+    return await withControlUiHome("openclaw-ui-scoped-device-", async () => {
       const deviceId = `control-ui-device-${randomUUID()}`;
       const requested = await requestDevicePairing({
         deviceId,
@@ -2010,8 +2010,7 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("penalizes both credential scopes when a Control UI read token is invalid", async () => {
-    const tempHome = testTempDirs.make("openclaw-ui-invalid-token-");
-    await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
+    await withControlUiHome("openclaw-ui-invalid-token-", async () => {
       await withControlUiRoot({
         fn: async (tmp) => {
           const rateLimiter = createAuthRateLimiterSpy();
@@ -2082,8 +2081,7 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("rejects a rate-limited Control UI read when no valid device token is presented", async () => {
-    const tempHome = testTempDirs.make("openclaw-ui-rate-limited-token-");
-    await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
+    await withControlUiHome("openclaw-ui-rate-limited-token-", async () => {
       await withControlUiRoot({
         fn: async (tmp) => {
           const rateLimiter = createAuthRateLimiterSpy();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Fixes a Control UI test-fixture lifetime bug: rejected and rate-limited token reads open a cached SQLite database, but their temporary HOME directories were removed without closing it. A full-suite diagnostic reported a WAL-sidecar identity failure under the invalid-token fixture after that HTTP case had passed.

## Why This Change Was Made

Reuse the existing HOME lifecycle helper for both failure cases and give it the general name `withControlUiHome`. It captures the selected database path inside the HOME scope, closes that exact owner before deleting the directory, and preserves the files if closing throws. Existing paired-device callers only change helper name.

## User Impact

Test cleanup now retires the fixture-owned database before unlinking its WAL files. Production authentication, rate limiting and HTTP assertions are unchanged.

## Evidence

- All 159 Control UI HTTP cases pass, with the same ordered case identities.
- Original observation of the two failure cases found one open database and WAL immediately before tracker cleanup. That diagnostic safely closed each exact owner before allowing deletion; it did not induce a guard failure or run an unmodified full-suite baseline.
- Candidate observation found both databases already closed and WAL files absent before unlink, using only the existing helper's close call. Both fixture roots were removed.
- The helper body is unchanged apart from its name, preserving the prior success, callback-error and close-error checks; a close failure still prevents directory removal.
- The required changed gate and fresh P2 review passed. No deadline, global tracker or production changes.
