### PR TITLE
improve(android): make reply notifications session-aware across devices

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ConversationNotifications.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ConversationNotifications.kt
@@ -358,16 +358,18 @@ internal class ConversationReplyNotifier(
     owner: ChatComposerOwner,
     runId: String,
     assistantText: String,
+    agentName: String? = null,
+    sessionTitle: String? = null,
   ): Boolean {
     val target = ConversationNotificationTarget.from(owner, runId) ?: return false
     val text = assistantText.trim().takeIf(String::isNotEmpty) ?: return false
     if (!canPostNotifications()) return false
     ensureChannel()
-    ensureConversationShortcut(target)
+    ensureConversationShortcut(target, agentName, sessionTitle)
     notificationManager().notify(
       target.notificationTag,
       conversationNotificationId,
-      buildAssistantReplyNotification(target, text),
+      buildAssistantReplyNotification(target, text, agentName, sessionTitle),
     )
     return true
   }
@@ -390,18 +392,22 @@ internal class ConversationReplyNotifier(
   internal fun buildAssistantReplyNotification(
     target: ConversationNotificationTarget,
     assistantText: String,
+    agentName: String? = null,
+    sessionTitle: String? = null,
   ): Notification {
     val contentIntent = contentPendingIntent(target)
-    val assistant = assistantPerson()
+    val title = conversationNotificationTitle(target.agentId, agentName, sessionTitle)
+    val assistant = assistantPerson(target, agentName)
     val style =
       NotificationCompat
         .MessagingStyle(userPerson())
-        .setConversationTitle(nativeString("OpenClaw"))
-        .setGroupConversation(false)
+        .setConversationTitle(title)
+        // Android hides the conversation title for one-to-one MessagingStyle notifications.
+        .setGroupConversation(true)
         .addMessage(assistantText, System.currentTimeMillis(), assistant)
     return baseBuilder(target, contentIntent)
       .setStyle(style)
-      .setContentTitle(nativeString("OpenClaw"))
+      .setContentTitle(title)
       .setContentText(assistantText)
       .addPerson(assistant)
       .addAction(replyAction(target))
@@ -477,13 +483,17 @@ internal class ConversationReplyNotifier(
       PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
     )
 
-  private fun ensureConversationShortcut(target: ConversationNotificationTarget) {
+  private fun ensureConversationShortcut(
+    target: ConversationNotificationTarget,
+    agentName: String? = null,
+    sessionTitle: String? = null,
+  ) {
     val shortcut =
       ShortcutInfoCompat
         .Builder(context, target.shortcutId)
-        .setShortLabel(nativeString("OpenClaw"))
+        .setShortLabel(conversationNotificationTitle(target.agentId, agentName, sessionTitle))
         .setLongLived(true)
-        .setPerson(assistantPerson())
+        .setPerson(assistantPerson(target, agentName))
         .setLocusId(LocusIdCompat(target.shortcutId))
         .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
         .setIntent(conversationNotificationLaunchIntent(context, target))
@@ -491,10 +501,14 @@ internal class ConversationReplyNotifier(
     runCatching { ShortcutManagerCompat.pushDynamicShortcut(context, shortcut) }
   }
 
-  private fun assistantPerson(): Person =
+  private fun assistantPerson(
+    target: ConversationNotificationTarget,
+    agentName: String?,
+  ): Person =
     Person
       .Builder()
-      .setName(nativeString("OpenClaw"))
+      .setName(conversationAgentName(target.agentId, agentName))
+      .setKey("${target.gatewayStableId}:${target.agentId}")
       .setBot(true)
       .build()
 
@@ -523,6 +537,33 @@ internal class ConversationReplyNotifier(
   }
 
   private fun notificationManager(): NotificationManager = context.getSystemService(NotificationManager::class.java)
+}
+
+private fun conversationAgentName(
+  agentId: String,
+  agentName: String?,
+): String = agentName?.trim()?.takeIf(String::isNotEmpty) ?: agentId
+
+private fun conversationNotificationTitle(
+  agentId: String,
+  agentName: String?,
+  sessionTitle: String?,
+): String {
+  val name = conversationAgentName(agentId, agentName)
+  val title = sessionTitle?.trim()?.takeIf(String::isNotEmpty) ?: nativeString("Chat")
+  return "$name · $title"
+}
+
+/** Dreaming narration is archival background work, not a user-facing chat reply. */
+internal fun shouldPostConversationReplyNotification(
+  owner: ChatComposerOwner,
+  runId: String,
+  isReplyVisible: Boolean,
+): Boolean {
+  val sessionKey = owner.sessionKey.trim()
+  // Match the Gateway's dreaming-narrative session prefix, not arbitrary thread suffixes.
+  val session = if (sessionKey.startsWith("agent:")) sessionKey.substringAfter(':').substringAfter(':') else sessionKey
+  return !isReplyVisible && !session.startsWith("dreaming-narrative-") && !runId.trim().startsWith("dreaming-narrative-")
 }
 
 class ConversationReplyReceiver : BroadcastReceiver() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -926,6 +926,10 @@ class MainViewModel private constructor(
     ensureRuntime().setNotificationForwardingSessionKey(value)
   }
 
+  fun setChatScreenActive(active: Boolean) {
+    ensureRuntime().setChatScreenActive(active)
+  }
+
   fun setVoiceScreenActive(active: Boolean) {
     ensureRuntime().setVoiceScreenActive(active)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1545,6 +1545,7 @@ class NodeRuntime private constructor(
   private val healthLogsSummary = GatewaySummaryOwner<GatewayHealthLogsSummary>()
   val healthLogsState: StateFlow<GatewaySummaryState<GatewayHealthLogsSummary>> = healthLogsSummary.state
 
+  @Volatile private var chatScreenActive = false
   private val _isForeground = MutableStateFlow(initialForeground)
   val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
 
@@ -2146,11 +2147,7 @@ class NodeRuntime private constructor(
           recordModelRecent = prefs::recordModelRecent,
           onSessionDeleted = ::publishChatSessionDeletion,
           onOfflineDefaultAgentRestored = ::syncMainSessionKey,
-          onAssistantReplyFinalized = { owner, runId, text ->
-            if (!_isForeground.value) {
-              ConversationReplyNotifier(appContext).show(owner, runId, text)
-            }
-          },
+          onAssistantReplyFinalized = ::onConversationReplyFinalized,
         )
       }
 
@@ -3798,6 +3795,27 @@ class NodeRuntime private constructor(
     val normalized = value?.trim()?.takeIf(String::isNotEmpty)
     if (prefs.notificationForwardingSessionKey.value == normalized) return
     notificationOutbox.updatePolicy { prefs.setNotificationForwardingSessionKey(normalized) }
+  }
+
+  fun setChatScreenActive(active: Boolean) {
+    chatScreenActive = active
+  }
+
+  private fun onConversationReplyFinalized(
+    owner: ChatComposerOwner,
+    runId: String,
+    text: String,
+  ) {
+    val isReplyVisible = _isForeground.value && chatScreenActive && chat.isCurrentComposerOwner(owner)
+    if (!shouldPostConversationReplyNotification(owner, runId, isReplyVisible)) return
+    val agent = gatewayAgents.value.firstOrNull { it.id == owner.agentId }
+    val session = chatSessions.value.firstOrNull { it.key == owner.sessionKey }
+    val sessionTitle =
+      session?.let {
+        ai.openclaw.app.ui
+          .sessionPresentationTitle(it) { nativeString("Chat") }
+      }
+    ConversationReplyNotifier(appContext).show(owner, runId, text, agent?.name, sessionTitle)
   }
 
   fun setVoiceScreenActive(active: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -6989,6 +6989,8 @@ class ChatController internal constructor(
     owner: ChatComposerOwner?,
   ) {
     if (payload["state"].asStringOrNull() != "final") return
+    // This recipient hint silences notifications, not terminal processing or history synchronization.
+    if (payload["suppressNotification"].asBooleanOrNull() == true) return
     val normalizedRunId = runId?.trim()?.takeIf(String::isNotEmpty) ?: return
     val verifiedOwner = owner?.takeIf { it.routingVerified } ?: return
     val text = parseAssistantDeltaText(payload)?.trim()?.takeIf(String::isNotEmpty) ?: return

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -194,6 +195,11 @@ fun ShellScreen(
         }
         closeSidebar()
         viewModel.clearRequestedHomeDestination()
+      }
+
+      DisposableEffect(nav.activeTab, runtimeInitialized) {
+        if (runtimeInitialized) viewModel.setChatScreenActive(nav.activeTab == Tab.Chat)
+        onDispose { if (runtimeInitialized) viewModel.setChatScreenActive(false) }
       }
 
       LaunchedEffect(nav.activeTab, runtimeInitialized) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ConversationNotificationsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ConversationNotificationsTest.kt
@@ -1,12 +1,23 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.ChatController
+import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.chatTerminalPayload
+import ai.openclaw.app.gateway.GatewayEndpoint
 import android.app.Notification
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import androidx.core.app.NotificationCompat
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -21,6 +32,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import org.robolectric.util.ReflectionHelpers
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -213,6 +225,121 @@ class ConversationNotificationsTest {
     assertEquals(1, notification.actions.size)
     assertEquals("Reply", action.title.toString())
     assertEquals(1, action.remoteInputs.size)
+  }
+
+  @Test
+  fun notificationUsesConfiguredAgentNameAndSessionWithoutLeakingOnLockscreen() {
+    val names =
+      listOf(
+        Triple("main", "Assistant", "Assistant"),
+        Triple("reviewer", "Review agent", "Review agent"),
+        Triple("research", " Researcher ", "Researcher"),
+        Triple("unnamed", null, "unnamed"),
+        Triple("blank-name", "  ", "blank-name"),
+      )
+    for ((agentId, configuredName, name) in names) {
+      val notification =
+        ConversationReplyNotifier(context).buildAssistantReplyNotification(
+          target.copy(agentId = agentId, sessionKey = "agent:$agentId:review"),
+          "Done",
+          configuredName,
+          "Review",
+        )
+      val style = requireNotNull(NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(notification))
+      assertEquals("$name · Review", style.conversationTitle.toString())
+      assertEquals(
+        name,
+        style.messages
+          .single()
+          .person
+          ?.name
+          .toString(),
+      )
+      assertEquals(
+        "OpenClaw",
+        notification.publicVersion.extras
+          .getCharSequence(Notification.EXTRA_TITLE)
+          .toString(),
+      )
+      assertFalse(
+        notification.publicVersion.extras
+          .toString()
+          .contains("Review"),
+      )
+    }
+  }
+
+  @Test
+  fun finalGatewayEventsNotifyOtherSessionsWhileForegroundButSuppressVisibleChat() {
+    shadowOf(RuntimeEnvironment.getApplication()).grantPermissions(android.Manifest.permission.POST_NOTIFICATIONS)
+    val prefs = SecurePrefs(context, securePrefsOverride = context.getSharedPreferences("notification-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    val runtime = NodeRuntime(context, prefs)
+    val manager = context.getSystemService(NotificationManager::class.java)
+    try {
+      ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
+      val chat = ReflectionHelpers.getField<ChatController>(runtime, "chat")
+      chat.prepareMainSessionKey("agent:main:visible")
+      ChatController::class.java.getDeclaredMethod("publishSessions", List::class.java).apply { isAccessible = true }.invoke(
+        chat,
+        listOf(ChatSessionEntry(key = "agent:reviewer:background", updatedAtMs = null, label = "Troubleshooting")),
+      )
+      ReflectionHelpers.getField<MutableStateFlow<List<GatewayAgentSummary>>>(runtime, "_gatewayAgents").value =
+        listOf(GatewayAgentSummary(id = "reviewer", name = "Review agent", emoji = null))
+      runtime.setChatScreenActive(true)
+      val handler = NodeRuntime::class.java.getDeclaredMethod("handleGatewayEvent", String::class.java, String::class.java).apply { isAccessible = true }
+
+      fun finish(
+        session: String,
+        run: String,
+        suppressNotification: Boolean? = null,
+      ) {
+        val original = Json.parseToJsonElement(chatTerminalPayload(session, run, 1, assistantText = "Done")).jsonObject
+        val payload = JsonObject(original + (suppressNotification?.let { mapOf("suppressNotification" to JsonPrimitive(it)) } ?: emptyMap()))
+        handler.invoke(runtime, "chat", payload.toString())
+      }
+
+      finish("agent:reviewer:background", "laptop-viewed-run", suppressNotification = true)
+      assertTrue(manager.activeNotifications.isEmpty())
+
+      finish("agent:reviewer:background", "background-run")
+      val posted = manager.activeNotifications.single()
+      val style = requireNotNull(NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(posted.notification))
+      assertEquals("Review agent · Troubleshooting", style.conversationTitle.toString())
+      manager.cancelAll()
+
+      finish("agent:main:visible", "visible-run")
+      assertTrue(manager.activeNotifications.isEmpty())
+
+      runtime.setChatScreenActive(false)
+      finish("agent:main:visible", "settings-run")
+      assertEquals(1, manager.activeNotifications.size)
+      manager.cancelAll()
+
+      runtime.setChatScreenActive(true)
+      ReflectionHelpers.getField<MutableStateFlow<Boolean>>(runtime, "_isForeground").value = false
+      finish("agent:main:visible", "app-background-run")
+      assertEquals(1, manager.activeNotifications.size)
+      manager.cancelAll()
+
+      finish("agent:reviewer:background", "laptop-left-run", suppressNotification = false)
+      assertEquals(1, manager.activeNotifications.size)
+      manager.cancelAll()
+
+      finish("agent:main:dreaming-narrative-proof", "dream-run")
+      finish("agent:main:background", "dreaming-narrative-proof")
+      assertTrue(manager.activeNotifications.isEmpty())
+
+      finish("agent:main:custom:dreaming-narrative-note", "ordinary-run")
+      assertEquals(1, manager.activeNotifications.size)
+      manager.cancelAll()
+
+      shadowOf(RuntimeEnvironment.getApplication()).denyPermissions(android.Manifest.permission.POST_NOTIFICATIONS)
+      finish("agent:reviewer:background", "permission-denied-run")
+      assertTrue(manager.activeNotifications.isEmpty())
+    } finally {
+      manager.cancelAll()
+      closeNodeRuntimeTestFixture(runtime)
+    }
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTerminalAckTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTerminalAckTest.kt
@@ -8,8 +8,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -68,6 +70,81 @@ class ChatControllerTerminalAckTest {
         ),
         finalized,
       )
+    }
+
+  @Test
+  fun notificationSuppressionPreservesTerminalCompletionAndHistoryRefresh() =
+    runTest {
+      for (suppressNotification in listOf(null, false, true)) {
+        val finalized = mutableListOf<String>()
+        var clientRunId: String? = null
+        var historyReady = false
+        var historyRequests = 0
+        val controller =
+          createChatController(
+            cacheScope = { ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1) },
+            currentDefaultAgentId = { "main" },
+            onAssistantReplyFinalized = { _, _, text -> finalized += text },
+          ) { method, paramsJson ->
+            when (method) {
+              "chat.send" -> {
+                clientRunId =
+                  json
+                    .parseToJsonElement(requireNotNull(paramsJson))
+                    .jsonObject["idempotencyKey"]
+                    ?.jsonPrimitive
+                    ?.content
+                """{"runId":"run-notify","status":"started"}"""
+              }
+
+              "chat.history" -> {
+                historyRequests += 1
+                historyResponse(
+                  "session-notify",
+                  if (historyReady) {
+                    listOf(
+                      ReplayHistoryMessage("user", "status", 1_000, idempotencyKey = "$clientRunId:user"),
+                      ReplayHistoryMessage("assistant", "Authoritative reply", 2_000),
+                    )
+                  } else {
+                    emptyList()
+                  },
+                )
+              }
+
+              else -> {
+                emptyChatGatewayResponse(method)
+              }
+            }
+          }
+        controller.prepareMainSessionKey("agent:main:main")
+        controller.load(controller.sessionKey.value)
+        runCurrent()
+        assertTrue(controller.sendMessageAwaitAcceptance("status", "off", emptyList()))
+        runCurrent()
+        assertEquals(1, controller.pendingRunCount.value)
+        val previousHistoryRequests = historyRequests
+        historyReady = true
+        val terminal =
+          buildJsonObject {
+            val payload = chatTerminalPayload("agent:main:main", "run-notify", seq = 2, assistantText = "Done")
+            json.parseToJsonElement(payload).jsonObject.forEach { (key, value) -> put(key, value) }
+            if (suppressNotification != null) put("suppressNotification", suppressNotification)
+          }.toString()
+
+        controller.handleGatewayEvent("chat", terminal)
+        advanceUntilIdle()
+
+        assertEquals(if (suppressNotification == true) emptyList<String>() else listOf("Done"), finalized)
+        assertEquals(0, controller.pendingRunCount.value)
+        assertTrue(historyRequests > previousHistoryRequests)
+        assertTrue(
+          controller.messages.value.any { message ->
+            message.role == "assistant" && message.content.any { it.text == "Authoritative reply" }
+          },
+        )
+        assertNull(controller.errorText.value)
+      }
     }
 
   @Test

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -23668,6 +23668,7 @@ public struct ChatDeltaEvent: Codable, Sendable {
 }
 
 public struct ChatFinalEvent: Codable, Sendable {
+    public let suppressnotification: Bool?
     public let runid: String
     public let sessionkey: String
     public let agentid: String?
@@ -23680,6 +23681,7 @@ public struct ChatFinalEvent: Codable, Sendable {
     public let yielded: Bool?
 
     public init(
+        suppressnotification: Bool? = nil,
         runid: String,
         sessionkey: String,
         agentid: String? = nil,
@@ -23691,6 +23693,7 @@ public struct ChatFinalEvent: Codable, Sendable {
         stopreason: String? = nil,
         yielded: Bool? = nil)
     {
+        self.suppressnotification = suppressnotification
         self.runid = runid
         self.sessionkey = sessionkey
         self.agentid = agentid
@@ -23704,6 +23707,7 @@ public struct ChatFinalEvent: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case suppressnotification = "suppressNotification"
         case runid = "runId"
         case sessionkey = "sessionKey"
         case agentid = "agentId"

--- a/docs/gateway/protocol/presence.md
+++ b/docs/gateway/protocol/presence.md
@@ -136,3 +136,40 @@ otherwise they retain the agent-only request supported by stable `v2026.7.1-2`.
 That older response describes agent-wide availability, not a session's selected
 profile. Retire this negotiation only when the minimum supported Gateway contract
 guarantees session-scoped metadata. Method or event presence alone is insufficient.
+
+## Cross-device reply notifications
+
+Control UI uses `sessions.viewers.set` to declare the sessions it is actively
+viewing. Declarations create a 30-second, connection-owned notification lease.
+A visible, focused Control UI renews it every 10 seconds while user interaction
+is less than two minutes old. Hiding, blurring, or leaving the chat clears the
+viewing declaration; disconnected or unrenewed leases cannot suppress alerts.
+
+For a `chat` event with `state: "final"`, the Gateway may add the optional Boolean
+`suppressNotification: true` to an Android operator recipient's payload. This
+requires another live Control UI connection with the same authenticated profile
+and an unexpired lease for the exact canonical session key. Missing identity,
+unresolved aliases, other sessions, and expired leases retain normal notification
+behavior. The Gateway derives the hint per recipient rather than forwarding a
+producer-supplied value.
+
+Android skips only reply-notification publication when the hint is `true`.
+Terminal processing, chat content, history synchronization, access checks, and
+per-connection event sequencing continue normally. Absent or `false` hints use
+the existing notification behavior; the hint does not override Android's
+notification permissions.
+
+### Android notification presentation
+
+Android suppresses a reply only when its originating Gateway, agent, and session
+match the chat currently visible in the foreground. Replies from other sessions
+can notify while the app is open, including when a non-chat page is visible.
+Notifications identify the configured agent name and originating session title;
+missing names fall back to the agent ID and missing titles to **Chat**. Tapping
+or replying retains the original routing identity, independently of display names.
+The public lockscreen version remains generic and does not expose those labels
+or message content.
+
+Internal Dreaming narration sessions and runs use the canonical
+`dreaming-narrative-` prefix and do not publish chat-reply notifications. This
+does not exclude ordinary scheduled or background-session replies.

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -350,6 +350,8 @@ export const ChatDeltaEventSchema = closedObject({
 
 /** Successful terminal event for a completed chat run. */
 export const ChatFinalEventSchema = closedObject({
+  /** Recipient-specific hint; chat content still synchronizes normally. */
+  suppressNotification: Type.Optional(Type.Boolean()),
   ...ChatEventBaseSchema,
   state: Type.Literal("final"),
   message: Type.Optional(Type.Unknown()),

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -2,6 +2,7 @@ import {
   GATEWAY_CLIENT_CAPS,
   hasGatewayClientCap,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
 // Gateway WebSocket broadcaster.
@@ -36,6 +37,7 @@ import type { SessionMessageSubscriberRegistry } from "./server-chat-state.js";
 import { MAX_BUFFERED_BYTES, WEBSOCKET_OPEN_READY_STATE } from "./server-constants.js";
 import type { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import { shouldSuppressAndroidChatNotification } from "./session-viewer-presence.js";
 import { logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 // Pairing scope is for device-pairing handshakes only; chat transcript events
@@ -587,6 +589,19 @@ export function createGatewayBroadcaster(params: {
             ...presencePayload,
             presence: projectPresence(c),
           });
+        }
+        if (event === "chat" && isRecord(payload)) {
+          const chatPayload = payload;
+          if (chatPayload.state === "final") {
+            // Derive this per recipient after delivery gates; never trust a producer's hint.
+            const { suppressNotification: _untrustedHint, ...messagePayload } = chatPayload;
+            payloadFragment = serializeFrameField("payload", {
+              ...messagePayload,
+              ...(shouldSuppressAndroidChatNotification(params.clients, c, chatPayload.sessionKey)
+                ? { suppressNotification: true }
+                : {}),
+            });
+          }
         }
         frame = frameWithSequence(base, nextSeq, payloadFragment);
       } catch (err) {

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -44,6 +44,8 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   presenceKey?: string;
   /** Connection-owned timing facts, reconciled across live peers independently of the TTL cache. */
   personPresence?: { onlineSince: number; lastActivityAt?: number };
+  /** Server-owned short lease for declared visible sessions; never accepted from connect params. */
+  sessionViewerLease?: { sessionKeys: readonly string[]; expiresAt: number };
   authenticatedUserId?: string;
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
   authenticatedUserIsTailscaleProvider?: boolean;

--- a/src/gateway/session-viewer-presence.test.ts
+++ b/src/gateway/session-viewer-presence.test.ts
@@ -1,4 +1,6 @@
+import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatEventSchema } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listSystemPresence } from "../infra/system-presence.js";
@@ -8,6 +10,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createPresenceRecipientProjection } from "./presence-projection.js";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -201,6 +204,145 @@ describe("presence projection store admission", () => {
       } finally {
         prepare.mockRestore();
       }
+    });
+  });
+});
+
+const sessionKey = "agent:main:dashboard:test";
+function makeClient(
+  connId: string,
+  id: "openclaw-android" | "openclaw-control-ui",
+  profileId = "alice",
+) {
+  const send = vi.fn();
+  const client: GatewayWsClient = {
+    connId,
+    usesSharedGatewayAuth: false,
+    // SAFETY: this broadcaster fixture exercises only readyState, bufferedAmount, and send.
+    socket: { readyState: 1, bufferedAmount: 0, send } as unknown as GatewayWsClient["socket"],
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      role: "operator",
+      scopes: ["operator.read"],
+      client: { id, version: "test", platform: "test", mode: "webchat" },
+    },
+    authenticatedUserProfile: {
+      profileId,
+      displayName: null,
+      avatarRevision: "",
+      hasAvatar: false,
+      updatedAt: 0,
+    },
+  };
+  return { client, send };
+}
+function fixture() {
+  const phone = makeClient("phone", "openclaw-android");
+  const otherPhone = makeClient("other-phone", "openclaw-android", "bob");
+  const viewer = makeClient("viewer", "openclaw-control-ui");
+  const clients = new GatewayClientRegistry([phone.client, otherPhone.client, viewer.client]);
+  const broadcaster = createGatewayBroadcaster({ clients });
+  const declarations = createSessionViewerPresenceDeclarations({
+    clients,
+    broadcast: vi.fn(),
+    incrementPresenceVersion: () => 1,
+    getHealthVersion: () => 1,
+  });
+  declarations.replace("viewer", [sessionKey]);
+  const payload = {
+    runId: "run",
+    seq: 1,
+    sessionKey,
+    state: "final",
+    message: { role: "assistant", content: "done" },
+  };
+  return { phone, otherPhone, viewer, clients, broadcaster, declarations, payload };
+}
+function sentFrame(send: ReturnType<typeof makeClient>["send"], index = 0) {
+  const call = send.mock.calls[index];
+  if (!call) throw new Error(`Expected notification frame ${index}`);
+  return JSON.parse(call[0]);
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("recipient-specific chat notification suppression", () => {
+  it("suppresses only the matching human's phone while preserving content and sequence on fanout and targeted sends", () => {
+    const { phone, otherPhone, viewer, broadcaster, payload } = fixture();
+    broadcaster.broadcast("chat", payload);
+    broadcaster.broadcastToConnIds("chat", payload, new Set(["phone", "other-phone"]));
+    for (const [index, call] of phone.send.mock.calls.entries()) {
+      const frame = JSON.parse(call[0]);
+      expect(frame).toEqual({
+        type: "event",
+        event: "chat",
+        seq: index + 1,
+        payload: { ...payload, suppressNotification: true },
+      });
+      expect(Value.Check(ChatEventSchema, frame.payload)).toBe(true);
+    }
+    expect(phone.send).toHaveBeenCalledTimes(2);
+    expect(otherPhone.send.mock.calls.map(([frame]) => JSON.parse(frame).payload)).toEqual([
+      payload,
+      payload,
+    ]);
+    expect(sentFrame(viewer.send).payload).toEqual(payload);
+    expect(payload).not.toHaveProperty("suppressNotification");
+  });
+
+  it.each([
+    "other-session",
+    "missing-identity",
+    "expired",
+    "hidden",
+    "disconnected",
+    "invalidated",
+    "node-viewer",
+    "alias",
+    "stop",
+  ])("notifies for %s and discards a producer-supplied suppression hint", (reason) => {
+    const f = fixture();
+    if (reason === "other-session")
+      f.declarations.replace("viewer", ["agent:main:dashboard:other"]);
+    if (reason === "missing-identity") f.phone.client.authenticatedUserProfile = undefined;
+    if (reason === "expired") f.viewer.client.sessionViewerLease!.expiresAt = Date.now();
+    if (reason === "hidden") f.declarations.replace("viewer", []);
+    if (reason === "disconnected") f.clients.delete(f.viewer.client);
+    if (reason === "invalidated") f.viewer.client.invalidated = true;
+    if (reason === "node-viewer") f.viewer.client.connect.role = "node";
+    if (reason === "alias") f.payload.sessionKey = "main";
+    if (reason === "stop") f.declarations.stop();
+    f.broadcaster.broadcast("chat", { ...f.payload, suppressNotification: true });
+    expect(sentFrame(f.phone.send).payload).toEqual(f.payload);
+  });
+
+  it("renews unchanged declarations, expires them, and clears disconnected leases", () => {
+    vi.useFakeTimers();
+    const f = fixture();
+    vi.advanceTimersByTime(20_000);
+    f.declarations.replace("viewer", [sessionKey]);
+    vi.advanceTimersByTime(20_000);
+    f.broadcaster.broadcast("chat", f.payload);
+    expect(sentFrame(f.phone.send).payload.suppressNotification).toBe(true);
+    vi.advanceTimersByTime(10_000);
+    f.broadcaster.broadcast("chat", f.payload);
+    expect(sentFrame(f.phone.send, 1).payload.suppressNotification).toBeUndefined();
+    f.declarations.unsubscribe("viewer");
+    expect(f.viewer.client.sessionViewerLease).toBeUndefined();
+  });
+
+  it("keeps ACL rejection and non-final delivery behavior unchanged", () => {
+    const f = fixture();
+    createGatewayBroadcaster({ clients: f.clients, canReceiveSessionEvent: () => false }).broadcast(
+      "chat",
+      f.payload,
+    );
+    expect(f.phone.send).not.toHaveBeenCalled();
+    f.broadcaster.broadcast("chat", { ...f.payload, state: "delta" });
+    expect(sentFrame(f.phone.send).payload).toEqual({
+      ...f.payload,
+      state: "delta",
     });
   });
 });

--- a/src/gateway/session-viewer-presence.test.ts
+++ b/src/gateway/session-viewer-presence.test.ts
@@ -261,7 +261,9 @@ function fixture() {
 }
 function sentFrame(send: ReturnType<typeof makeClient>["send"], index = 0) {
   const call = send.mock.calls[index];
-  if (!call) throw new Error(`Expected notification frame ${index}`);
+  if (!call) {
+    throw new Error(`Expected notification frame ${index}`);
+  }
   return JSON.parse(call[0]);
 }
 
@@ -303,16 +305,33 @@ describe("recipient-specific chat notification suppression", () => {
     "stop",
   ])("notifies for %s and discards a producer-supplied suppression hint", (reason) => {
     const f = fixture();
-    if (reason === "other-session")
+    if (reason === "other-session") {
       f.declarations.replace("viewer", ["agent:main:dashboard:other"]);
-    if (reason === "missing-identity") f.phone.client.authenticatedUserProfile = undefined;
-    if (reason === "expired") f.viewer.client.sessionViewerLease!.expiresAt = Date.now();
-    if (reason === "hidden") f.declarations.replace("viewer", []);
-    if (reason === "disconnected") f.clients.delete(f.viewer.client);
-    if (reason === "invalidated") f.viewer.client.invalidated = true;
-    if (reason === "node-viewer") f.viewer.client.connect.role = "node";
-    if (reason === "alias") f.payload.sessionKey = "main";
-    if (reason === "stop") f.declarations.stop();
+    }
+    if (reason === "missing-identity") {
+      f.phone.client.authenticatedUserProfile = undefined;
+    }
+    if (reason === "expired") {
+      f.viewer.client.sessionViewerLease!.expiresAt = Date.now();
+    }
+    if (reason === "hidden") {
+      f.declarations.replace("viewer", []);
+    }
+    if (reason === "disconnected") {
+      f.clients.delete(f.viewer.client);
+    }
+    if (reason === "invalidated") {
+      f.viewer.client.invalidated = true;
+    }
+    if (reason === "node-viewer") {
+      f.viewer.client.connect.role = "node";
+    }
+    if (reason === "alias") {
+      f.payload.sessionKey = "main";
+    }
+    if (reason === "stop") {
+      f.declarations.stop();
+    }
     f.broadcaster.broadcast("chat", { ...f.payload, suppressNotification: true });
     expect(sentFrame(f.phone.send).payload).toEqual(f.payload);
   });

--- a/src/gateway/session-viewer-presence.ts
+++ b/src/gateway/session-viewer-presence.ts
@@ -1,10 +1,13 @@
 // Per-connection viewer presence declarations. Message subscriptions are transport state,
 // while this replace-set records only the sessions a client is actually rendering.
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { upsertPresence } from "../infra/system-presence.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import { WEBSOCKET_OPEN_READY_STATE } from "./server-constants.js";
 import { recordClientPresenceActivity } from "./server/client-presence.js";
 import type { GatewayClientRegistry } from "./server/client-registry.js";
 import { broadcastPresenceSnapshot } from "./server/presence-events.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
 
 type SessionViewerPresenceDeclarationsDeps = Parameters<typeof broadcastPresenceSnapshot>[0] & {
   clients: GatewayClientRegistry;
@@ -32,7 +35,10 @@ function sameKeys(left: readonly string[] | undefined, right: readonly string[])
 export function createSessionViewerPresenceDeclarations(
   deps: SessionViewerPresenceDeclarationsDeps,
 ): SessionViewerPresenceDeclarations {
-  const declarations = new Map<string, readonly string[]>();
+  const declarations = new Map<
+    string,
+    { client: GatewayWsClient; sessionKeys: readonly string[] }
+  >();
   let stopped = false;
 
   const replace = (connId: string, sessionKeys: readonly string[]): readonly string[] => {
@@ -45,14 +51,18 @@ export function createSessionViewerPresenceDeclarations(
       return [];
     }
     const next = normalizedSessionKeys(sessionKeys);
-    const previous = declarations.get(normalizedConnId);
+    const previous = declarations.get(normalizedConnId)?.sessionKeys;
+    client.sessionViewerLease =
+      next.length > 0
+        ? { sessionKeys: next, expiresAt: Date.now() + SESSION_VIEWER_LEASE_MS }
+        : undefined;
     if (sameKeys(previous, next) || (previous === undefined && next.length === 0)) {
       return next;
     }
     if (next.length === 0) {
       declarations.delete(normalizedConnId);
     } else {
-      declarations.set(normalizedConnId, next);
+      declarations.set(normalizedConnId, { client, sessionKeys: next });
     }
     if (client.presenceKey) {
       upsertPresence(client.presenceKey, {
@@ -71,14 +81,54 @@ export function createSessionViewerPresenceDeclarations(
     if (normalizedConnId) {
       // The websocket close boundary publishes reason=disconnect and clears watchedSessions.
       // Delete here first so a recycled connection id can never inherit an old declaration.
+      const declaration = declarations.get(normalizedConnId);
+      if (declaration) declaration.client.sessionViewerLease = undefined;
       declarations.delete(normalizedConnId);
     }
   };
 
   const stop = () => {
     stopped = true;
+    for (const declaration of declarations.values())
+      declaration.client.sessionViewerLease = undefined;
     declarations.clear();
   };
 
   return { replace, unsubscribe, stop };
+}
+
+const SESSION_VIEWER_LEASE_MS = 30_000;
+
+/** Fail open to notifications unless the same authenticated human is viewing this exact session. */
+export function shouldSuppressAndroidChatNotification(
+  clients: ReadonlySet<GatewayWsClient>,
+  recipient: GatewayWsClient,
+  sessionKey: unknown,
+): boolean {
+  const profileId = recipient.authenticatedUserProfile?.profileId;
+  if (
+    !profileId ||
+    recipient.connect.client?.id !== GATEWAY_CLIENT_IDS.ANDROID_APP ||
+    (recipient.connect.role ?? "operator") !== "operator" ||
+    typeof sessionKey !== "string" ||
+    !parseAgentSessionKey(sessionKey)
+  )
+    return false;
+  // Raw aliases such as main cannot be mapped without runtime agent configuration. Never guess.
+  const now = Date.now();
+  for (const viewer of clients) {
+    if (
+      viewer !== recipient &&
+      !viewer.invalidated &&
+      viewer.socket.readyState === WEBSOCKET_OPEN_READY_STATE &&
+      viewer.connect.client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
+      (viewer.connect.role ?? "operator") === "operator" &&
+      viewer.authenticatedUserProfile?.profileId === profileId &&
+      viewer.sessionViewerLease &&
+      viewer.sessionViewerLease.expiresAt > now &&
+      viewer.sessionViewerLease.sessionKeys.includes(sessionKey)
+    )
+      return true;
+  }
+  return false;
 }

--- a/src/gateway/session-viewer-presence.ts
+++ b/src/gateway/session-viewer-presence.ts
@@ -82,15 +82,18 @@ export function createSessionViewerPresenceDeclarations(
       // The websocket close boundary publishes reason=disconnect and clears watchedSessions.
       // Delete here first so a recycled connection id can never inherit an old declaration.
       const declaration = declarations.get(normalizedConnId);
-      if (declaration) declaration.client.sessionViewerLease = undefined;
+      if (declaration) {
+        declaration.client.sessionViewerLease = undefined;
+      }
       declarations.delete(normalizedConnId);
     }
   };
 
   const stop = () => {
     stopped = true;
-    for (const declaration of declarations.values())
+    for (const declaration of declarations.values()) {
       declaration.client.sessionViewerLease = undefined;
+    }
     declarations.clear();
   };
 
@@ -112,8 +115,9 @@ export function shouldSuppressAndroidChatNotification(
     (recipient.connect.role ?? "operator") !== "operator" ||
     typeof sessionKey !== "string" ||
     !parseAgentSessionKey(sessionKey)
-  )
+  ) {
     return false;
+  }
   // Raw aliases such as main cannot be mapped without runtime agent configuration. Never guess.
   const now = Date.now();
   for (const viewer of clients) {
@@ -127,8 +131,9 @@ export function shouldSuppressAndroidChatNotification(
       viewer.sessionViewerLease &&
       viewer.sessionViewerLease.expiresAt > now &&
       viewer.sessionViewerLease.sessionKeys.includes(sessionKey)
-    )
+    ) {
       return true;
+    }
   }
   return false;
 }

--- a/ui/src/lib/session-viewer-presence.test.ts
+++ b/ui/src/lib/session-viewer-presence.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../api/gateway.ts";
 import type { ApplicationGateway, ApplicationGatewaySnapshot } from "../app/gateway.ts";
 import { sessionViewerPresenceForGateway } from "./session-viewer-presence.ts";
@@ -68,9 +68,12 @@ function createGatewayHarness() {
 }
 
 async function flushSync() {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let turn = 0; turn < 8; turn += 1) await Promise.resolve();
 }
+
+beforeEach(() => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -199,7 +202,7 @@ describe("session viewer presence store", () => {
 
     await vi.advanceTimersByTimeAsync(30_000);
     await flushSync();
-    expect(harness.request).toHaveBeenCalledTimes(2);
+    expect(harness.request.mock.calls.length).toBeGreaterThanOrEqual(2);
 
     store.unwatch(owner);
     await flushSync();
@@ -274,13 +277,17 @@ describe("session viewer presence store", () => {
     await flushSync();
     store.unwatch(owner);
     await flushSync();
-    expect(harness.request).toHaveBeenCalledTimes(4);
+    // The clear waits for the active request; never race declarations on one connection.
+    expect(harness.request).toHaveBeenCalledTimes(3);
 
     document.dispatchEvent(new Event("visibilitychange"));
     await flushSync();
     expect(harness.unsubscribe).not.toHaveBeenCalled();
 
     resolveVisible({ sessionKeys: ["agent:main:visible"] });
+    await flushSync();
+    expect(harness.request).toHaveBeenCalledTimes(4);
+    expect(harness.unsubscribe).not.toHaveBeenCalled();
     rejectFinalClear(new Error("final clear temporarily unavailable"));
     await flushSync();
     await vi.advanceTimersByTimeAsync(30_000);
@@ -291,5 +298,84 @@ describe("session viewer presence store", () => {
       sessionKeys: [],
     });
     expect(harness.unsubscribe).toHaveBeenCalledOnce();
+  });
+  it("renews only focused visible watching, expires on human idle, and releases timers", async () => {
+    vi.useFakeTimers();
+    const harness = createGatewayHarness();
+    const store = sessionViewerPresenceForGateway(harness.gateway);
+    const owner = {};
+    store.watch(owner, ["main"]);
+    await flushSync();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(harness.request).toHaveBeenCalledTimes(2);
+    window.dispatchEvent(new Event("blur"));
+    await flushSync();
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: [],
+    });
+    const blurredCount = harness.request.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(harness.request).toHaveBeenCalledTimes(blurredCount);
+    window.dispatchEvent(new Event("focus"));
+    await flushSync();
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: ["agent:main:main"],
+    });
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: ["agent:main:main"],
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: [],
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    document.dispatchEvent(new Event("pointerdown"));
+    await flushSync();
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: ["agent:main:main"],
+    });
+    store.unwatch(owner);
+    await flushSync();
+    expect(vi.getTimerCount()).toBe(0);
+    const detachedCount = harness.request.mock.calls.length;
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("keydown"));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(harness.request).toHaveBeenCalledTimes(detachedCount);
+  });
+
+  it("stops renewal on disconnect and fences a delayed old-client acknowledgement", async () => {
+    vi.useFakeTimers();
+    const harness = createGatewayHarness();
+    let resolveOld!: (value: unknown) => void;
+    harness.request.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveOld = resolve;
+      }),
+    );
+    const store = sessionViewerPresenceForGateway(harness.gateway);
+    const owner = {};
+    store.watch(owner, ["main"]);
+    await flushSync();
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(harness.request).toHaveBeenCalledOnce();
+    harness.setSnapshot({ ...harness.gateway.snapshot, phase: "reconnecting", hello: null });
+    await flushSync();
+    expect(vi.getTimerCount()).toBe(0);
+    resolveOld({ sessionKeys: ["agent:main:main"] });
+    await flushSync();
+    harness.setSnapshot({
+      ...harness.gateway.snapshot,
+      phase: "connected",
+      hello: createHello("agent:main:new"),
+    });
+    await flushSync();
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_VIEWERS_SET_METHOD, {
+      sessionKeys: ["agent:main:new"],
+    });
+    store.unwatch(owner);
+    await flushSync();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/ui/src/lib/session-viewer-presence.test.ts
+++ b/ui/src/lib/session-viewer-presence.test.ts
@@ -68,7 +68,9 @@ function createGatewayHarness() {
 }
 
 async function flushSync() {
-  for (let turn = 0; turn < 8; turn += 1) await Promise.resolve();
+  for (let turn = 0; turn < 8; turn += 1) {
+    await Promise.resolve();
+  }
 }
 
 beforeEach(() => {

--- a/ui/src/lib/session-viewer-presence.ts
+++ b/ui/src/lib/session-viewer-presence.ts
@@ -5,6 +5,8 @@ import { createGatewaySetSyncLifecycle } from "./gateway-set-sync-lifecycle.ts";
 import { resolveSessionKey } from "./sessions/index.ts";
 
 const SESSION_VIEWERS_SET_METHOD = "sessions.viewers.set";
+const RENEW_MS = 10_000;
+const HUMAN_IDLE_MS = 120_000;
 
 type SessionViewerPresenceStore = {
   watch: (owner: object, sessionKeys: readonly string[]) => void;
@@ -21,6 +23,65 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   let acknowledgedSignature: string | null = null;
   let acknowledgedGeneration = 0;
   let requestGeneration = 0;
+
+  let focused = false;
+  let lastActivityAt = 0;
+  let renewAt = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: object | null = null;
+  let syncQueued = false;
+
+  const isViewing = () =>
+    isActive() &&
+    focused &&
+    typeof document !== "undefined" &&
+    document.visibilityState !== "hidden" &&
+    Date.now() - lastActivityAt < HUMAN_IDLE_MS;
+
+  function stopTimer() {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  }
+
+  function armTimer(available: boolean) {
+    stopTimer();
+    if (!available || !isViewing()) return;
+    timer = setTimeout(
+      () => {
+        timer = null;
+        lifecycle.sync();
+      },
+      Math.max(
+        1,
+        Math.min(
+          renewAt > Date.now() ? renewAt : Date.now() + RENEW_MS,
+          lastActivityAt + HUMAN_IDLE_MS,
+        ) - Date.now(),
+      ),
+    );
+  }
+
+  function onActivity() {
+    if (!focused || document.visibilityState === "hidden") return;
+    lastActivityAt = Date.now();
+    lifecycle.schedule();
+  }
+  function onFocus() {
+    focused = true;
+    onActivity();
+  }
+  function onBlur() {
+    focused = false;
+    lifecycle.sync();
+  }
+  function onVisibility() {
+    if (document.visibilityState !== "hidden" && document.hasFocus()) {
+      focused = true;
+      onActivity();
+    } else {
+      lifecycle.sync();
+    }
+  }
 
   const isActive = () => watchedByOwner.size > 0;
 
@@ -41,6 +102,20 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   const lifecycle = createGatewaySetSyncLifecycle(gateway, {
     sync,
     onAttach: () => {
+      focused = typeof document !== "undefined" && document.hasFocus();
+      lastActivityAt = Date.now();
+      renewAt = 0;
+      if (typeof window !== "undefined") {
+        window.addEventListener("focus", onFocus);
+        window.addEventListener("blur", onBlur);
+      }
+      if (typeof document !== "undefined") {
+        document.addEventListener("pointerdown", onActivity, true);
+        document.addEventListener("pointermove", onActivity, true);
+        document.addEventListener("keydown", onActivity, true);
+        document.addEventListener("scroll", onActivity, true);
+        document.addEventListener("visibilitychange", onVisibility);
+      }
       knownClient = gateway.snapshot.client;
       lastHello = null;
       lastSignature = null;
@@ -48,6 +123,20 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
       acknowledgedGeneration = 0;
     },
     onDetach: () => {
+      stopTimer();
+      inFlight = null;
+      syncQueued = false;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", onFocus);
+        window.removeEventListener("blur", onBlur);
+      }
+      if (typeof document !== "undefined") {
+        document.removeEventListener("pointerdown", onActivity, true);
+        document.removeEventListener("pointermove", onActivity, true);
+        document.removeEventListener("keydown", onActivity, true);
+        document.removeEventListener("scroll", onActivity, true);
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
       requestGeneration += 1;
       lastHello = null;
       lastSignature = null;
@@ -62,6 +151,9 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     const client = snapshot.client;
     if (client !== knownClient) {
       retry.reset();
+      inFlight = null;
+      syncQueued = false;
+      requestGeneration += 1;
       knownClient = client;
       lastHello = null;
       lastSignature = null;
@@ -74,6 +166,10 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
       snapshot.hello !== null &&
       isGatewayMethodAdvertised(snapshot, SESSION_VIEWERS_SET_METHOD) === true;
     if (!available) {
+      stopTimer();
+      inFlight = null;
+      syncQueued = false;
+      requestGeneration += 1;
       lastHello = null;
       lastSignature = null;
       acknowledgedSignature = null;
@@ -83,15 +179,21 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
       }
       return;
     }
-    const sessionKeys =
-      typeof document !== "undefined" && document.visibilityState === "hidden"
-        ? []
-        : visibleSessionKeys();
+    const sessionKeys = isViewing() ? visibleSessionKeys() : [];
     const agentId = sessionKeys.some((key) => !key.startsWith("agent:"))
       ? snapshot.assistantAgentId
       : undefined;
     const signature = JSON.stringify({ agentId, sessionKeys });
-    if (snapshot.hello === lastHello && signature === lastSignature) {
+    armTimer(available);
+    if (inFlight !== null) {
+      syncQueued = true;
+      return;
+    }
+    if (
+      snapshot.hello === lastHello &&
+      signature === lastSignature &&
+      (sessionKeys.length === 0 || Date.now() < renewAt)
+    ) {
       if (
         !isActive() &&
         acknowledgedSignature === signature &&
@@ -103,9 +205,17 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     }
     lastHello = snapshot.hello;
     lastSignature = signature;
+    renewAt = Date.now() + RENEW_MS;
+    armTimer(available);
+    const flight = {};
+    inFlight = flight;
+    syncQueued = false;
     const currentGeneration = ++requestGeneration;
     const isCurrentRequest = () =>
       lifecycle.attached &&
+      gateway.snapshot.client === client &&
+      gateway.snapshot.hello === snapshot.hello &&
+      gateway.snapshot.phase === "connected" &&
       currentGeneration === requestGeneration &&
       snapshot.hello === lastHello &&
       signature === lastSignature;
@@ -120,7 +230,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
           acknowledgedSignature = signature;
           acknowledgedGeneration = currentGeneration;
           retry.reset();
-          if (!isActive()) {
+          if (!isActive() && sessionKeys.length === 0) {
             lifecycle.detach();
           }
         }
@@ -131,6 +241,14 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
         }
         lastSignature = null;
         retry.schedule(lifecycle.schedule);
+      })
+      .finally(() => {
+        if (inFlight !== flight) return;
+        inFlight = null;
+        if (syncQueued) {
+          syncQueued = false;
+          lifecycle.schedule();
+        }
       });
   }
 

--- a/ui/src/lib/session-viewer-presence.ts
+++ b/ui/src/lib/session-viewer-presence.ts
@@ -39,13 +39,17 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     Date.now() - lastActivityAt < HUMAN_IDLE_MS;
 
   function stopTimer() {
-    if (timer !== null) clearTimeout(timer);
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
     timer = null;
   }
 
   function armTimer(available: boolean) {
     stopTimer();
-    if (!available || !isViewing()) return;
+    if (!available || !isViewing()) {
+      return;
+    }
     timer = setTimeout(
       () => {
         timer = null;
@@ -62,7 +66,9 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   }
 
   function onActivity() {
-    if (!focused || document.visibilityState === "hidden") return;
+    if (!focused || document.visibilityState === "hidden") {
+      return;
+    }
     lastActivityAt = Date.now();
     lifecycle.schedule();
   }
@@ -243,7 +249,9 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
         retry.schedule(lifecycle.schedule);
       })
       .finally(() => {
-        if (inFlight !== flight) return;
+        if (inFlight !== flight) {
+          return;
+        }
         inFlight = null;
         if (syncQueued) {
           syncQueued = false;


### PR DESCRIPTION
Closes #143387

## What Problem This Solves

Improves the existing Android reply-notification system: foreground suppression currently hides completions from other sessions, generic titles obscure the originating agent/chat, and laptop readers receive duplicate phone alerts for replies they are already viewing. Internal Dreaming narration should not produce ordinary conversation alerts.

## Why This Change Was Made

Reuses the existing session-viewer owner with a 30-second server-owned lease, renewed every 10 seconds while Control UI is visible, focused, and within two minutes of user interaction. Blur/hidden/unwatch clears viewing; disconnect or missed renewal expires it.

For final chat events, the Gateway derives an optional `suppressNotification` hint separately for each Android operator recipient after normal delivery gates. It requires an exact canonical session and matching authenticated profile, ignores producer-supplied hints, and defaults to notifying when presence or identity is uncertain. Android consumes the hint only at notification publication, preserving terminal handling and history synchronization. Swift protocol models are regenerated from the schema.

This does not add suppression support to iOS/macOS notifications.

### Existing notification system and scope

Upstream already owns Android conversation-reply notifications (`ConversationReplyNotifier`), including permission checks, private lockscreen content, and routed notification actions. This PR improves that existing system rather than introducing another notifier:

- Replace app-wide foreground suppression with exact visible Gateway/agent/session matching, with chat-screen disposal cleanup.
- Label notifications and shortcuts with the configured agent name and originating session title, using agent ID / Chat fallbacks.
- Suppress canonical internal Dreaming narration without blanket filtering scheduled work or background sessions.
- Add same-user cross-device suppression through the viewing lease and notification-only hint described above.

No personal agent aliases, unrelated custom app features, configuration, persistent schema, version changes, APKs, or deployment overlays are included. Notification taps/replies retain original routing, and the public lockscreen presentation remains generic.

## User Impact

- Reading a session in Control UI silences redundant phone alerts for that session.
- Other sessions notify even while Android is open on a different chat or non-chat page.
- Agent/session labels make the source recognizable without exposing it in the public lockscreen version.
- Internal Dreaming narration stays silent; normal scheduled/background replies remain eligible.
- Leaving or becoming idle in Control UI restores phone notifications after the declaration clears or expires.
- Messages continue to synchronize regardless of whether an alert is published.

## Evidence

- Focused Gateway broadcaster/viewer suites: 18 passed; includes recipient isolation, lease renewal/expiry, disconnect/clear, ACL gates, unchanged content/sequence, targeted and fanout delivery.
- Control UI viewer lifecycle suite: 9 passed; includes focus/visibility, idle expiry, disconnect and delayed acknowledgments.
- Android `ConversationNotificationsTest` + `ChatControllerTerminalAckTest`: 26 passed on the current-main third-party debug flavor, plus `ktlintCheck`. Covers source labels, generic public lockscreen, denied permission, visible/other session, non-chat page, app background, canonical Dreaming exclusion, and absent/false/true cross-device hints.
- The notification-only terminal regression failed without the Android hint guard (`expected [] but was [Done]`), then passed with it while asserting pending-run completion and authoritative history refresh.
- Changed-file validation passed core and core-test typechecks, UI typecheck, formatting, dead-code/export checks, protocol/native boundary checks, and the other pre-lint guards. The aggregate run stopped on curly-brace style violations; these were mechanically corrected and the targeted core/UI lint rerun passed. The full aggregate command was not repeated. Remaining native-state, UI-style, legacy-store, media-download, runtime-sidecar, import-cycle, webhook, and pairing/auth guards passed separately. SwiftLint/Swift compilation remain for macOS CI.
- Live user-observed validation of the feature on a v2026.9.3-based local build: laptop session active → phone silent; laptop page closed → phone notified; reopened → silent. The same local build also passed phone chat active → silent, app closed → notification, and viewing another session → notification. The current-main PR port and generic configured-name labels are validated separately by the automated checks above, not claimed to have been deployed; no fresh before/after notification screenshots are attached.
- Independent source review found a generated Swift field placement issue during porting; regeneration corrected it and follow-up review verified the correction. The repository autoreview CLI was attempted but could not start because its `codex` executable is unavailable; independent native source review was used instead. Swift compilation and the full repository suite were not run locally.

## Draft status and remaining validation

Kept in draft following review: maintainer agreement on the automatic notification defaults (including the 30-second lease / two-minute idle cutoff) and fresh real-device evidence for this exact current-main port remain outstanding. Requested evidence includes before/after notification captures, suppression/resumption diagnostics, and fresh-install plus upgrade checks. Earlier custom-build observations above are not substituted for that proof.

Independent upstream review reported no actionable code/security findings on the reviewed implementation; that is not a merge approval. Maintainer edits are enabled.
