### PR TITLE
fix(chat): clear previews from stopped typing connections

### DIFF
--- a/src/gateway/server-methods/sessions-suggestions.ts
+++ b/src/gateway/server-methods/sessions-suggestions.ts
@@ -582,10 +582,6 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
       ...(params.typing && params.preview ? { preview: params.preview } : {}),
       now,
     });
-    if (!params.typing && effectiveTyping) {
-      respond(true, { ok: true, broadcast: false });
-      return;
-    }
     const broadcast = broadcastTypingThrottled({
       key: typingKey,
       typing: effectiveTyping,

--- a/src/gateway/server-methods/sessions-typing.test.ts
+++ b/src/gateway/server-methods/sessions-typing.test.ts
@@ -197,7 +197,7 @@ describe("session typing handler", () => {
     });
   });
 
-  it("keeps a live draft preview when another connection sends boolean-only typing", async () => {
+  it("keeps a draft beside boolean-only typing until its connection stops", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       vi.useFakeTimers();
       vi.setSystemTime(40_000);
@@ -243,8 +243,62 @@ describe("session typing handler", () => {
         typing: true,
         preview: "still drafting",
       });
+
+      await vi.advanceTimersByTimeAsync(100);
+      await callTyping({
+        ...params,
+        typing: false,
+        client: client("alice", "alice-preview-tab"),
+      });
+      await vi.advanceTimersByTimeAsync(900);
+      expect(broadcast.mock.lastCall?.[1]).toMatchObject({ typing: true });
+      expect(broadcast.mock.lastCall?.[1]).not.toHaveProperty("preview");
     });
   });
+
+  it.each([
+    { state: "queued", delayMs: 100 },
+    { state: "published", delayMs: 250 },
+  ])(
+    "replaces a stopped connection's $state preview with the live draft",
+    async ({ state, delayMs }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(50_000);
+        const sessionKey = `agent:main:stopped-${state}-preview`;
+        const sessionId = `session-stopped-${state}-preview`;
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId,
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: "owner" },
+            visibility: "shared",
+          },
+        );
+        mocks.presence = [
+          { user: profileUser("alice"), watchedSessions: [sessionKey] },
+          { user: profileUser("owner"), watchedSessions: [sessionKey] },
+        ];
+        const broadcast = vi.fn();
+        const params = { sessionKey, sessionId, context: context(broadcast) };
+        const liveTab = client("alice", "live-tab");
+        const stoppedTab = client("alice", "stopped-tab");
+        await callTyping({ ...params, typing: true, preview: "live draft", client: liveTab });
+        await vi.advanceTimersByTimeAsync(delayMs);
+        await callTyping({ ...params, typing: true, preview: "stopped draft", client: stoppedTab });
+        await vi.advanceTimersByTimeAsync(50);
+        await callTyping({ ...params, typing: false, client: stoppedTab });
+        const callsBeforeFlush = broadcast.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(250);
+
+        expect(broadcast.mock.lastCall?.[1]).toMatchObject({ typing: true, preview: "live draft" });
+        expect(
+          broadcast.mock.calls.slice(callsBeforeFlush).map((call) => call[1].preview),
+        ).not.toContain("stopped draft");
+      });
+    },
+  );
 
   it.each([
     { agentId: "main", expected: ["agent:main:global"] },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where another viewer could see an outdated draft after a user cleared, sent or blurred their composer in one tab while another tab remained typing. The stopped tab's preview could remain visible or even be broadcast afterward.

## Why This Change Was Made

The connection tracker already removes the stopped tab and selects the remaining draft. The handler now passes that aggregate state through the existing throttle instead of returning early whenever another tab is still active. This removes four production lines without adding state or timers.

## User Impact

Typing presence now reflects the user's remaining active tabs at the existing broadcast cadence. Session replacement, actor attribution and recipient scope remain unchanged.

## Evidence

Three real-handler regressions fail before the fix and pass afterward, alongside 18 controls. Six UI/protocol cases also pass, for 27 distinct tests. All 29 changed-file checks and independent review through P2 pass. Tests use isolated synthetic sessions; no live Gateway or browser session was used.
