### PR TITLE
fix(tests): close pairing state before fixture cleanup

### DIFF
--- a/src/gateway/device-pairing-prune.test.ts
+++ b/src/gateway/device-pairing-prune.test.ts
@@ -12,6 +12,8 @@ import {
   requestDevicePairing,
 } from "../infra/device-pairing.js";
 import { loadApnsRegistration, registerApnsRegistration } from "../infra/push-apns.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { pruneSupersededSilentPairingsAfterApproval } from "./device-pairing-prune.js";
 import { drainNodePendingWork, enqueueNodePendingWork } from "./node-pending-work.js";
@@ -27,6 +29,7 @@ import {
 } from "./node-wake-state.test-support.js";
 import { bindDeviceWorkerReconciliation } from "./worker-environments/device-provider.js";
 
+const pairingStateDirs: string[] = [];
 const suiteRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-gateway-pairing-prune-" });
 
 type BroadcastCall = { event: string; payload: Record<string, unknown> };
@@ -136,6 +139,11 @@ describe("pruneSupersededSilentPairingsAfterApproval", () => {
   });
 
   afterAll(async () => {
+    for (const stateDir of pairingStateDirs) {
+      closeOpenClawStateDatabaseByPath(
+        resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: stateDir }),
+      );
+    }
     await suiteRootTracker.cleanup();
   });
 
@@ -145,6 +153,7 @@ describe("pruneSupersededSilentPairingsAfterApproval", () => {
 
   test("retires stale node siblings across both pairing stores", async () => {
     const baseDir = await suiteRootTracker.make("case");
+    pairingStateDirs.push(baseDir);
     await pairSilentDevice({
       baseDir,
       deviceId: "node-stale",
@@ -242,6 +251,7 @@ describe("pruneSupersededSilentPairingsAfterApproval", () => {
 
   test("keeps connected siblings and clears APNs for operator-only full prunes", async () => {
     const baseDir = await suiteRootTracker.make("case");
+    pairingStateDirs.push(baseDir);
     await pairSilentDevice({
       baseDir,
       deviceId: "cli-stale",


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

The branch is in this repository and remains editable by repository maintainers.

</details>

## What Problem This Solves

Resolves a problem where pairing-prune tests delete temporary state directories while their cached SQLite databases remain open.

## Why This Change Was Made

Track the two existing case state directories and close their canonical shared-state database paths before suite cleanup. A close failure propagates before directory deletion. This adds 10 test lines; production behavior is unchanged.

## User Impact

No user-facing behavior change. The test fixture releases database ownership before removing its files.

## Evidence

Both complete cases pass with unchanged names and assertions. The original lifecycle observation found two open handles with WAL/SHM files immediately before cleanup. The candidate observation found both handles closed before unlinking, without a safety-close fallback; the uninstrumented suite also passes. An injected close-failure control verifies error propagation and directory preservation, not a native SQLite failure. The mapped changed gate and independent P2 review pass. No runtime improvement is claimed.
