### PR TITLE
refactor: remove duplicate annotation composition tests

### DIFF
--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -191,37 +191,12 @@ describe("structured Goal admission", () => {
 });
 
 describe("composeBrowserAnnotationContext", () => {
-  it("materializes an annotation-only message", () => {
-    const attachment = createBrowserAnnotationAttachment("only", "Inspect the marked region.");
-
-    expect(composeBrowserAnnotationContext("", [attachment])).toBe("Inspect the marked region.");
-  });
-
-  it("prepends annotation context to the user's draft", () => {
-    const attachment = createBrowserAnnotationAttachment("mixed", "Browser context");
-
-    expect(composeBrowserAnnotationContext("Please fix this", [attachment])).toBe(
-      "Browser context\n\nPlease fix this",
-    );
-  });
-
   it("preserves attachment order across two annotations", () => {
     const first = createBrowserAnnotationAttachment("first", "First context");
     const second = createBrowserAnnotationAttachment("second", "Second context");
 
     expect(composeBrowserAnnotationContext("Compare them", [first, second])).toBe(
       "First context\n\nSecond context\n\nCompare them",
-    );
-  });
-
-  it("omits context for an annotation removed before submit", () => {
-    const removed = createBrowserAnnotationAttachment("removed", "Removed context");
-    const remaining = createBrowserAnnotationAttachment("remaining", "Remaining context");
-    const attachments = [removed, remaining];
-    attachments.splice(0, 1);
-
-    expect(composeBrowserAnnotationContext("Continue", attachments)).toBe(
-      "Remaining context\n\nContinue",
     );
   });
 });


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>
The branch is hosted in this repository and remains editable by repository maintainers.
</details>

## What Problem This Solves

The chat submission suite repeats annotation composition checks already enforced by retained outbound-send tests. Its apparent removal case only splices a local array before calling the pure composer, so it does not exercise annotation removal.

## Why This Change Was Made

Remove three redundant direct cases while retaining the distinct two-annotation ordering check, exact outbound annotation-only and mixed-message assertions, and real removal/Undo coverage. The fixture constructor returns plain objects without registration or payload side effects.

## User Impact

No product behavior changes. Developers maintain 25 fewer test lines and three fewer test invocations without losing the covered behavior.

## Evidence

- Complete submission and annotation-removal suites: 72/72 before, 69/69 after, zero skips. Exactly the three approved names disappeared; all retained case names and per-file order stayed unchanged.
- A temporary mutation suppressing annotation composition made both retained outbound-send assertions fail for missing annotation text. The production owner was restored byte-for-byte before the normal candidate run.
- Mapped changed checks, diff checks, and fresh independent review passed.
- No production, fixture, assertion, or dependency changes. No overall runtime-percentage claim.
